### PR TITLE
RUE-384: compare str values by content

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1081,8 +1081,9 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Eq(lhs, rhs) => {
                 let lhs_ty = self.ctx.cfg.get_inst(*lhs).ty;
 
-                if self.ctx.is_builtin_string(lhs_ty) {
-                    // String equality: call __rue_str_eq(ptr1, len1, ptr2, len2)
+                if self.ctx.is_string_like_for_equality(lhs_ty) {
+                    // String-like equality compares byte content, not the
+                    // pointer/len/cap fields structurally.
                     let vreg = self.emit_string_eq_call(*lhs, *rhs);
                     self.value_map.insert(value, vreg);
                 } else if lhs_ty == Type::UNIT {
@@ -1105,8 +1106,9 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Ne(lhs, rhs) => {
                 let lhs_ty = self.ctx.cfg.get_inst(*lhs).ty;
 
-                if self.ctx.is_builtin_string(lhs_ty) {
-                    // String inequality: call __rue_str_eq and invert result
+                if self.ctx.is_string_like_for_equality(lhs_ty) {
+                    // String-like inequality is the inverse of byte-content
+                    // equality.
                     let vreg = self.emit_string_eq_call(*lhs, *rhs);
                     self.value_map.insert(value, vreg);
                     // Invert result: 0 -> 1, 1 -> 0
@@ -3735,9 +3737,9 @@ impl<'a> CfgLower<'a> {
         let lhs_ty = self.ctx.cfg.get_inst(lhs).ty;
 
         // Special handling for string comparisons
-        if self.ctx.is_builtin_string(lhs_ty) {
-            // String comparison requires calling __rue_str_eq runtime function
-            // Strings are fat pointers: [ptr_vreg, len_vreg] in struct_slot_vregs
+        if self.ctx.is_string_like_for_equality(lhs_ty) {
+            // String-like comparison requires calling __rue_str_eq. Both
+            // `str`/`Str(N)` and `StrBuf` have ptr/len in the first two slots.
 
             // Get left string fat pointer
             let lhs_fields = self
@@ -3907,14 +3909,15 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Emit a call to __rue_str_eq for string comparison.
+    /// Emit a call to __rue_str_eq for string-like comparison.
     ///
     /// Returns the vreg containing the result (0 or 1).
     fn emit_string_eq_call(&mut self, lhs: CfgValue, rhs: CfgValue) -> VReg {
         let result_vreg = self.mir.alloc_vreg();
 
-        // Get string fields (ptr, len, cap) from struct_slot_vregs
-        // For comparison, we only use ptr and len (cap is not compared)
+        // Get string-like fields from struct_slot_vregs. For comparison, we
+        // use ptr and len: `str`/`Str(N)` have exactly those two slots, while
+        // `StrBuf` has an additional cap slot that is not compared.
         let lhs_fields = self
             .get_or_compute_field_vregs(lhs)
             .expect("string should have fat pointer fields");
@@ -3923,25 +3926,21 @@ impl<'a> CfgLower<'a> {
             .expect("string should have fat pointer fields");
 
         // Correctness guard (must run in release): reading ptr/len from a
-        // String with the wrong field count would index garbage, so plain
+        // string-like value with the wrong field count would index garbage, so plain
         // `assert!` not `debug_assert!` (RUE-45).
-        assert_eq!(
-            lhs_fields.len(),
-            3,
-            "string should have 3 fields (ptr, len, cap)"
+        assert!(
+            lhs_fields.len() >= 2,
+            "string-like value should have at least 2 fields (ptr, len)"
         );
-        assert_eq!(
-            rhs_fields.len(),
-            3,
-            "string should have 3 fields (ptr, len, cap)"
+        assert!(
+            rhs_fields.len() >= 2,
+            "string-like value should have at least 2 fields (ptr, len)"
         );
 
         let lhs_ptr = lhs_fields[0];
         let lhs_len = lhs_fields[1];
-        // lhs_fields[2] is cap, not used for comparison
         let rhs_ptr = rhs_fields[0];
         let rhs_len = rhs_fields[1];
-        // rhs_fields[2] is cap, not used for comparison
 
         // Move arguments to calling convention registers (AAPCS64)
         // X0 = ptr1, X1 = len1, X2 = ptr2, X3 = len2

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -515,6 +515,24 @@ impl<'a> CfgLowerContext<'a> {
         }
     }
 
+    /// Check if a type has string byte-content equality semantics.
+    ///
+    /// `StrBuf` is the growable string type. The `string_trio` preview also
+    /// represents `str` and `Str(N)` as synthetic structs, but equality for
+    /// those types is still byte-content equality, not structural pointer/len
+    /// equality.
+    pub fn is_string_like_for_equality(&self, ty: Type) -> bool {
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
+                let struct_def = self.type_pool.struct_def(struct_id);
+                self.is_builtin_string(ty)
+                    || struct_def.name == "str"
+                    || (struct_def.name.starts_with("Str(") && struct_def.name.ends_with(')'))
+            }
+            _ => false,
+        }
+    }
+
     /// Get the builtin operator runtime function for a type and operation.
     ///
     /// Returns `Some((runtime_fn, invert_result))` if the type has a builtin

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1566,8 +1566,13 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Eq(lhs, rhs) => {
                 let lhs_ty = self.ctx.cfg.get_inst(*lhs).ty;
 
-                // Check for builtin operator (e.g., String equality via __rue_str_eq)
-                if let Some((runtime_fn, invert)) = self.ctx.get_builtin_operator(lhs_ty, BinOp::Eq)
+                if self.ctx.is_string_like_for_equality(lhs_ty) {
+                    // String-like equality compares byte content, not the
+                    // pointer/len/cap fields structurally.
+                    let vreg = self.emit_builtin_eq_call(*lhs, *rhs, "__rue_str_eq");
+                    self.value_map.insert(value, vreg);
+                } else if let Some((runtime_fn, invert)) =
+                    self.ctx.get_builtin_operator(lhs_ty, BinOp::Eq)
                 {
                     let vreg = self.emit_builtin_eq_call(*lhs, *rhs, runtime_fn);
                     self.value_map.insert(value, vreg);
@@ -1601,8 +1606,17 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Ne(lhs, rhs) => {
                 let lhs_ty = self.ctx.cfg.get_inst(*lhs).ty;
 
-                // Check for builtin operator (e.g., String inequality via __rue_str_eq + invert)
-                if let Some((runtime_fn, invert)) = self.ctx.get_builtin_operator(lhs_ty, BinOp::Ne)
+                if self.ctx.is_string_like_for_equality(lhs_ty) {
+                    // String-like inequality is the inverse of byte-content
+                    // equality.
+                    let vreg = self.emit_builtin_eq_call(*lhs, *rhs, "__rue_str_eq");
+                    self.value_map.insert(value, vreg);
+                    self.mir.push(X86Inst::XorRI {
+                        dst: Operand::Virtual(vreg),
+                        imm: 1,
+                    });
+                } else if let Some((runtime_fn, invert)) =
+                    self.ctx.get_builtin_operator(lhs_ty, BinOp::Ne)
                 {
                     let vreg = self.emit_builtin_eq_call(*lhs, *rhs, runtime_fn);
                     self.value_map.insert(value, vreg);

--- a/crates/rue-spec/cases/types/str-fixed-type.toml
+++ b/crates/rue-spec/cases/types/str-fixed-type.toml
@@ -10,7 +10,8 @@
 # `str` view (§3.7:43) so it reads through the universal `str` interface.
 #
 # Gated behind `--preview string_trio` (shared with `str`). Deferred to later
-# phases: mutation/append to `Str(N)`, and methods beyond `.len()`/index/borrow.
+# phases: mutation/append to `Str(N)`, ordering comparison, and methods beyond
+# `.len()`/index/borrow.
 
 [section]
 id = "types.str_fixed_type"
@@ -179,6 +180,24 @@ fn first(s: str) -> u8 {
 fn main() -> i32 {
     let s: Str(8) = "hello";
     if len_of(s) == 5 && first(s) == 104 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# 3.7:10 / 4.3:3 — fixed string equality is byte-content equality, not
+# structural equality over the compiler's representation.
+[[case]]
+name = "str_fixed_equality_compares_byte_content"
+spec = ["3.7:10", "4.3:3"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn choose(c: bool) -> Str(8) {
+    if c { "hello" } else { "world" }
+}
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    if s == choose(true) { 0 } else { 1 }
 }
 """
 exit_code = 0

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -7,7 +7,7 @@
 # byte as `u8`, bounds-checked (an out-of-range index traps, exit 101).
 #
 # Gated behind `--preview string_trio`. Deferred to later phases: `str`
-# concatenation, comparison/equality, `str`<->`String` interop, methods beyond
+# concatenation, ordering comparison, `str`<->`String` interop, methods beyond
 # `.len()`/index, and char iteration.
 
 [section]
@@ -184,3 +184,38 @@ fn main() -> i32 {
 }
 """
 exit_code = 2
+
+# 3.7:10 / 4.3:3 — `str` equality is byte-content equality, not pointer+len
+# structural equality. The returned literal may occupy a distinct rodata slot.
+[[case]]
+name = "str_equality_compares_byte_content"
+spec = ["3.7:10", "4.3:3"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn choose(c: bool) -> str {
+    if c { "hello" } else { "world" }
+}
+fn main() -> i32 {
+    let s: str = "hello";
+    if s == choose(true) { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# 3.7:10 / 4.3:3 — `str != str` is the inverse of byte-content equality.
+[[case]]
+name = "str_inequality_compares_byte_content"
+spec = ["3.7:10", "4.3:3"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn choose(c: bool) -> str {
+    if c { "hello" } else { "world" }
+}
+fn main() -> i32 {
+    let s: str = "hello";
+    if s != choose(false) { 0 } else { 1 }
+}
+"""
+exit_code = 0


### PR DESCRIPTION
## Summary

- route `str`, `Str(N)`, and `StrBuf` equality through byte-content comparison before structural aggregate equality
- relax aarch64 string equality lowering to accept two-slot string-like values as well as three-slot growable strings
- add preview spec regressions for `str ==`, `str !=`, and `Str(N) ==` content equality

## Validation

- scripts/rue fmt
- ./buck2 test root//:spec-tests
- ./buck2 test root//crates/rue-codegen:rue-codegen-test
- scripts/rue test