### PR TITLE
RUE-361: accumulate cross-file parse errors

### DIFF
--- a/crates/rue-cli-tests/cases/multifile_errors.toml
+++ b/crates/rue-cli-tests/cases/multifile_errors.toml
@@ -85,6 +85,31 @@ error_contains = ["E0102", "bad.rue:3:5"]
 compile_stderr_not_contains = ["good.rue"]
 
 [[case]]
+name = "lex_and_parse_errors_in_different_files_are_accumulated"
+description = """
+RUE-361: multi-file parsing used to fail fast on the first lex/parse error,
+so argument order determined which broken file was reported. Both broken files
+must now be diagnosed in one compiler invocation.
+"""
+files = [
+    { path = "lex_bad.rue", source = """
+fn lex_bad() -> i32 { $ }
+""" },
+    { path = "parse_bad.rue", source = """
+fn parse_bad( -> i32 { 2 }
+""" },
+]
+args = ["lex_bad.rue", "parse_bad.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "E0001",
+    "lex_bad.rue:1:23",
+    "E0100",
+    "parse_bad.rue:1:15",
+    "aborting due to 2 previous errors",
+]
+
+[[case]]
 name = "binary_expr_span_in_second_file"
 description = """
 RUE-175: make_binary built the merged span with Span::new, dropping the

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -306,19 +306,36 @@ pub fn parse_all_files(sources: &[SourceFile<'_>]) -> MultiErrorResult<ParsedPro
     // This ensures Spur values are consistent across files for cross-file symbol resolution
     let mut parsed_files = Vec::with_capacity(sources.len());
     let mut interner = ThreadedRodeo::new();
+    let mut errors = CompileErrors::new();
 
     for source in sources {
         // Create lexer with shared interner and file ID for proper error reporting
         let lexer = Lexer::with_interner_and_file_id(source.source, interner, source.file_id);
 
-        // Tokenize - propagate error immediately (interner is consumed)
-        let (tokens, returned_interner) = lexer.tokenize().map_err(CompileErrors::from)?;
-        interner = returned_interner;
+        let tokens = match lexer.tokenize_preserving_interner() {
+            Ok((tokens, returned_interner)) => {
+                interner = returned_interner;
+                tokens
+            }
+            Err((error, returned_interner)) => {
+                interner = returned_interner;
+                errors.push(error);
+                continue;
+            }
+        };
 
-        // Parse the tokens - propagate error immediately (interner is consumed)
         let parser = Parser::new(tokens, interner);
-        let (ast, returned_interner) = parser.parse()?;
-        interner = returned_interner;
+        let ast = match parser.parse_preserving_interner() {
+            Ok((ast, returned_interner)) => {
+                interner = returned_interner;
+                ast
+            }
+            Err((parse_errors, returned_interner)) => {
+                interner = returned_interner;
+                errors.extend(parse_errors);
+                continue;
+            }
+        };
 
         parsed_files.push(ParsedFile {
             path: source.path.to_string(),
@@ -328,6 +345,10 @@ pub fn parse_all_files(sources: &[SourceFile<'_>]) -> MultiErrorResult<ParsedPro
             // The real interner is in the returned ParsedProgram
             interner: ThreadedRodeo::new(),
         });
+    }
+
+    if !errors.is_empty() {
+        return Err(errors);
     }
 
     Ok(ParsedProgram {
@@ -3691,6 +3712,28 @@ mod integration_tests {
             // The error should still report, and we should get at least one error
             let errors = result.unwrap_err();
             assert!(!errors.is_empty());
+        }
+
+        #[test]
+        fn parse_all_files_collects_cross_file_lex_and_parse_errors() {
+            let sources = vec![
+                SourceFile::new("lex.rue", "fn lex() -> i32 { $ }", FileId::new(1)),
+                SourceFile::new("parse.rue", "fn parse( { }", FileId::new(2)),
+                SourceFile::new("good.rue", "fn good() -> i32 { 42 }", FileId::new(3)),
+            ];
+
+            let errors = parse_all_files(&sources).expect_err("both broken files should report");
+            assert_eq!(errors.len(), 2);
+            let file_ids: Vec<_> = errors
+                .iter()
+                .map(|error| {
+                    error
+                        .span()
+                        .expect("parse errors should be spanned")
+                        .file_id
+                })
+                .collect();
+            assert_eq!(file_ids, vec![FileId::new(1), FileId::new(2)]);
         }
 
         #[test]

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -148,6 +148,7 @@ impl<'src> CompilationUnit<'src> {
         // Parse all files with a shared interner
         let mut parsed_files = Vec::with_capacity(self.sources.len());
         let mut interner = ThreadedRodeo::new();
+        let mut errors = CompileErrors::new();
 
         for source in &self.sources {
             let _file_span = info_span!("parse_file", path = %source.path).entered();
@@ -156,15 +157,33 @@ impl<'src> CompilationUnit<'src> {
             let lexer = Lexer::with_interner_and_file_id(source.source, interner, source.file_id);
 
             // Tokenize
-            let (tokens, returned_interner) = lexer.tokenize().map_err(CompileErrors::from)?;
-            interner = returned_interner;
+            let tokens = match lexer.tokenize_preserving_interner() {
+                Ok((tokens, returned_interner)) => {
+                    interner = returned_interner;
+                    tokens
+                }
+                Err((error, returned_interner)) => {
+                    interner = returned_interner;
+                    errors.push(error);
+                    continue;
+                }
+            };
 
             info!(token_count = tokens.len(), "lexing complete");
 
             // Parse
             let parser = Parser::new(tokens, interner);
-            let (ast, returned_interner) = parser.parse()?;
-            interner = returned_interner;
+            let ast = match parser.parse_preserving_interner() {
+                Ok((ast, returned_interner)) => {
+                    interner = returned_interner;
+                    ast
+                }
+                Err((parse_errors, returned_interner)) => {
+                    interner = returned_interner;
+                    errors.extend(parse_errors);
+                    continue;
+                }
+            };
 
             info!(item_count = ast.items.len(), "parsing complete");
 
@@ -172,6 +191,10 @@ impl<'src> CompilationUnit<'src> {
                 path: source.path.to_string(),
                 ast,
             });
+        }
+
+        if !errors.is_empty() {
+            return Err(errors);
         }
 
         // Merge symbols and check for duplicates
@@ -633,6 +656,29 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("function"));
+    }
+
+    #[test]
+    fn test_parse_collects_cross_file_lex_and_parse_errors() {
+        let sources = vec![
+            SourceFile::new("lex.rue", "fn lex() -> i32 { $ }", FileId::new(1)),
+            SourceFile::new("parse.rue", "fn parse( { }", FileId::new(2)),
+            SourceFile::new("good.rue", "fn good() -> i32 { 42 }", FileId::new(3)),
+        ];
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+
+        let errors = unit.parse().expect_err("both broken files should report");
+        assert_eq!(errors.len(), 2);
+        let file_ids: Vec<_> = errors
+            .iter()
+            .map(|error| {
+                error
+                    .span()
+                    .expect("parse errors should be spanned")
+                    .file_id
+            })
+            .collect();
+        assert_eq!(file_ids, vec![FileId::new(1), FileId::new(2)]);
     }
 
     #[test]

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -577,6 +577,17 @@ impl<'a> LogosLexer<'a> {
 
     /// Tokenize the entire source, returning all tokens and the interner.
     pub fn tokenize(self) -> CompileResult<(Vec<Token>, ThreadedRodeo)> {
+        self.tokenize_preserving_interner()
+            .map_err(|(error, _interner)| error)
+    }
+
+    /// Tokenize the entire source, preserving the interner even on error.
+    ///
+    /// Multi-file compilation uses this to keep lexing later files after an
+    /// earlier file fails, while still sharing one interner across all files.
+    pub fn tokenize_preserving_interner(
+        self,
+    ) -> Result<(Vec<Token>, ThreadedRodeo), (CompileError, ThreadedRodeo)> {
         // Estimate capacity: source length / 4 is a rough heuristic for token density
         let mut tokens = Vec::with_capacity(self.source.len() / 4);
 
@@ -717,7 +728,7 @@ impl<'a> LogosLexer<'a> {
                                      mark (BOM); save the file without a BOM",
                                 );
                             }
-                            return Err(error);
+                            return Err((error, lexer.extras));
                         }
                     }
                 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -3126,7 +3126,18 @@ impl ChumskyParser {
     /// Parse the tokens into an AST, returning the AST and the interner.
     ///
     /// Returns all parse errors if parsing fails, not just the first one.
-    pub fn parse(mut self) -> MultiErrorResult<(Ast, ThreadedRodeo)> {
+    pub fn parse(self) -> MultiErrorResult<(Ast, ThreadedRodeo)> {
+        self.parse_preserving_interner()
+            .map_err(|(errors, _interner)| errors)
+    }
+
+    /// Parse the tokens into an AST, preserving the interner even on error.
+    ///
+    /// Multi-file compilation uses this to continue parsing later files after
+    /// an earlier file fails, while still sharing one interner across all files.
+    pub fn parse_preserving_interner(
+        mut self,
+    ) -> Result<(Ast, ThreadedRodeo), (CompileErrors, ThreadedRodeo)> {
         // Guard against pathologically nested input BEFORE handing tokens to
         // chumsky. The recursive-descent parser descends one level per opening
         // bracket, so combined bracket-nesting depth is an upper bound on
@@ -3134,7 +3145,7 @@ impl ChumskyParser {
         // every later pass, plus the recursive `Drop` of the AST) never sees a
         // tree deep enough to overflow the stack (RUE-42).
         if let Some(err) = check_nesting_depth(&self.tokens, self.file_id) {
-            return Err(CompileErrors::from(vec![err]));
+            return Err((CompileErrors::from(vec![err]), self.interner));
         }
 
         // Pre-intern primitive type symbols and create parser state with file ID
@@ -3185,14 +3196,17 @@ impl ChumskyParser {
             .join()
             .expect("parser thread panicked");
 
-        let ast = result?;
+        let ast = match result {
+            Ok(ast) => ast,
+            Err(errors) => return Err((errors, self.interner)),
+        };
 
         // Post-parse validation that needs the interner (e.g. resolving
         // directive names so the diagnostic can say which directive is
         // unknown). See the `validate` module.
         let validation_errors = crate::validate::check_directives(&ast, &self.interner);
         if !validation_errors.is_empty() {
-            return Err(CompileErrors::from(validation_errors));
+            return Err((CompileErrors::from(validation_errors), self.interner));
         }
 
         Ok((ast, self.interner))


### PR DESCRIPTION
## Summary

- preserve the shared interner when lexing or parsing fails, so multi-file parsing can continue to later files
- accumulate lex/parse errors in both `CompilationUnit::parse` and `parse_all_files` before returning
- add unit and CLI regressions covering a lex error and parse error in different files reported from one invocation

## Validation

- scripts/rue fmt
- ./buck2 test root//crates/rue-lexer:rue-lexer-test root//crates/rue-parser:rue-parser-test root//crates/rue-compiler:rue-compiler-test
- ./buck2 test root//:cli-tests
- scripts/rue test