### PR TITLE
RUE-376: centralize target constants

### DIFF
--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -786,7 +786,10 @@ impl ObjectBuilder {
         macho.extend_from_slice(&(MACHO64_BUILD_VERSION_CMD_SIZE as u32).to_le_bytes()); // cmdsize
         macho.extend_from_slice(&PLATFORM_MACOS.to_le_bytes()); // platform
         // minos/sdk: macOS minimum version (encoded as 0x00XXYYPP for major.minor.patch)
-        let macos_version = self.target.macos_min_version().unwrap_or(0x000B0000);
+        let macos_version = self
+            .target
+            .macos_min_version()
+            .expect("Mach-O emission requires a macOS target");
         macho.extend_from_slice(&macos_version.to_le_bytes()); // minos
         macho.extend_from_slice(&macos_version.to_le_bytes()); // sdk
         macho.extend_from_slice(&0_u32.to_le_bytes()); // ntools

--- a/crates/rue-linker/src/macho.rs
+++ b/crates/rue-linker/src/macho.rs
@@ -24,12 +24,13 @@
 
 use crate::constants::*;
 use crate::util::align_up;
+use rue_target::Target;
 
 /// ARM64 macOS page size (16KB).
-pub const PAGE_SIZE: u64 = 0x4000;
+pub const PAGE_SIZE: u64 = Target::Aarch64Macos.page_size();
 
 /// Default VM base address for executables.
-pub const VM_BASE: u64 = 0x100000000;
+pub const VM_BASE: u64 = Target::Aarch64Macos.default_base_addr();
 
 /// Computed file/VM layout for a dynamic executable — produced only by
 /// `compute_dynamic_layout` so relocation pre-pass and the actual build can

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -83,7 +83,7 @@ impl Target {
     /// Returns the default page size for this target in bytes.
     ///
     /// This is used for executable segment alignment.
-    pub fn page_size(&self) -> u64 {
+    pub const fn page_size(&self) -> u64 {
         match self {
             // x86-64 and AArch64 Linux typically use 4KB pages.
             Target::X86_64Linux | Target::Aarch64Linux => 0x1000, // 4KB
@@ -95,7 +95,7 @@ impl Target {
     /// Returns the default base address for executables on this target.
     ///
     /// This is the virtual address where the executable is loaded.
-    pub fn default_base_addr(&self) -> u64 {
+    pub const fn default_base_addr(&self) -> u64 {
         match self {
             // Standard Linux load address for both architectures.
             Target::X86_64Linux | Target::Aarch64Linux => 0x400000,
@@ -172,15 +172,20 @@ impl Target {
     pub fn all_names() -> &'static str {
         "x86-64-linux, aarch64-linux, aarch64-macos"
     }
+
+    /// Returns the canonical Rue spelling of this target.
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Target::X86_64Linux => "x86-64-linux",
+            Target::Aarch64Linux => "aarch64-linux",
+            Target::Aarch64Macos => "aarch64-macos",
+        }
+    }
 }
 
 impl fmt::Display for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Target::X86_64Linux => write!(f, "x86-64-linux"),
-            Target::Aarch64Linux => write!(f, "aarch64-linux"),
-            Target::Aarch64Macos => write!(f, "aarch64-macos"),
-        }
+        f.write_str(self.name())
     }
 }
 

--- a/crates/rue-test-runner/BUCK
+++ b/crates/rue-test-runner/BUCK
@@ -4,6 +4,7 @@ rue_crate(
     name = "rue-test-runner",
     deps = [
         "//crates/rue-error:rue-error",
+        "//crates/rue-target:rue-target",
         "//third-party:libc",
         "//third-party:serde",
         "//third-party:tempfile",

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -4,6 +4,7 @@
 //! including test case parsing, execution, and output comparison.
 
 use rue_error::PreviewFeature;
+use rue_target::Target;
 use serde::{Deserialize, Deserializer};
 
 /// Default timeout for test execution in milliseconds (10 seconds).
@@ -301,15 +302,15 @@ pub type TestResult = Result<(), String>;
 pub fn get_host_target() -> &'static str {
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     {
-        "x86-64-linux"
+        Target::X86_64Linux.name()
     }
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        "aarch64-linux"
+        Target::Aarch64Linux.name()
     }
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     {
-        "aarch64-macos"
+        Target::Aarch64Macos.name()
     }
     #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
     {
@@ -332,9 +333,11 @@ pub fn get_host_target() -> &'static str {
 /// silently run NOWHERE while still counting as spec coverage (the RUE-132
 /// skipped-test-counts-as-coverage class, via the platform axis).
 pub const KNOWN_TARGETS: &[&str] = &[
-    "x86-64-linux",
-    "aarch64-linux",
-    "aarch64-macos",
+    Target::X86_64Linux.name(),
+    Target::Aarch64Linux.name(),
+    Target::Aarch64Macos.name(),
+    // Host-only: Rue can run tests on Intel macOS, but does not currently have
+    // an x86-64 macOS compiler target.
     "x86-64-macos",
 ];
 
@@ -2567,5 +2570,15 @@ exit_code = 42
 "#;
         let tf: TestFile = toml::from_str(toml).expect("valid TOML");
         assert!(validate_compile_fail_assertions(&tf).is_empty());
+    }
+
+    #[test]
+    fn test_known_targets_cover_compiler_targets() {
+        for target in Target::all() {
+            assert!(
+                KNOWN_TARGETS.contains(&target.name()),
+                "test harness target whitelist is missing compiler target {target}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add `Target::name()` and use it for test-runner host target strings
- derive the test harness compiler-target whitelist from `rue-target`, while keeping `x86-64-macos` explicitly host-only
- add a drift test so every compiler target remains represented in the test runner
- use `Target::Aarch64Macos` page/base constants for Mach-O layout and require the target API for Mach-O min-version encoding

## Validation

- `scripts/rue fmt`
- `./buck2 test root//crates/rue-target:rue-target-test root//crates/rue-test-runner:rue-test-runner-test root//crates/rue-linker:rue-linker-test`
- `scripts/rue test`
