### PR TITLE
RUE-379: implement unused-function warning

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -116,6 +116,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
     let mut functions_with_strings: Vec<(AnalyzedFunction, Vec<String>)> = Vec::new();
     let mut errors = CompileErrors::new();
     let mut all_warnings = Vec::new();
+    let mut referenced_functions = HashSet::new();
 
     // Collect method refs from struct declarations to skip them when analyzing regular functions
     let mut method_refs: HashSet<InstRef> = HashSet::new();
@@ -195,9 +196,11 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 *body,
                 inst.span,
             ) {
-                Ok((analyzed, warnings, local_strings, _ref_fns, _ref_meths)) => {
+                Ok((analyzed, warnings, local_strings, mut ref_fns, _ref_meths)) => {
                     functions_with_strings.push((analyzed, local_strings));
                     all_warnings.extend(warnings);
+                    ref_fns.remove(name);
+                    referenced_functions.extend(ref_fns);
                 }
                 Err(e) => errors.push(e),
             }
@@ -263,9 +266,10 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                         *has_self,
                         *self_mode,
                     ) {
-                        Ok((analyzed, warnings, local_strings, _ref_fns, _ref_meths)) => {
+                        Ok((analyzed, warnings, local_strings, ref_fns, _ref_meths)) => {
                             functions_with_strings.push((analyzed, local_strings));
                             all_warnings.extend(warnings);
+                            referenced_functions.extend(ref_fns);
                         }
                         Err(e) => errors.push(e),
                     }
@@ -301,9 +305,10 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 inst.span,
                 struct_type,
             ) {
-                Ok((analyzed, warnings, local_strings, _ref_fns, _ref_meths)) => {
+                Ok((analyzed, warnings, local_strings, ref_fns, _ref_meths)) => {
                     functions_with_strings.push((analyzed, local_strings));
                     all_warnings.extend(warnings);
+                    referenced_functions.extend(ref_fns);
                 }
                 Err(e) => errors.push(e),
             }
@@ -441,7 +446,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                     param_modes_result,
                     warnings,
                     local_strings,
-                    _ref_fns,
+                    ref_fns,
                     _ref_meths,
                 )) => {
                     let analyzed = AnalyzedFunction {
@@ -453,6 +458,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                     };
                     functions_with_strings.push((analyzed, local_strings));
                     all_warnings.extend(warnings);
+                    referenced_functions.extend(ref_fns);
                 }
                 Err(e) => errors.push(e),
             }
@@ -484,6 +490,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         functions.push(analyzed);
     }
 
+    add_unused_function_warnings(sema, &referenced_functions, &mut all_warnings);
     all_warnings.sort_by_key(|w| w.span().map(|s| s.start));
 
     let mut output = SemaOutput {
@@ -511,6 +518,37 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
     output.type_pool = sema.type_pool.clone();
 
     errors.into_result_with(output)
+}
+
+/// Emit warnings for unused free functions.
+///
+/// This intentionally excludes methods/destructors; they have different
+/// reachability rules and are not covered by the current spec/UI cases.
+fn add_unused_function_warnings(
+    sema: &Sema<'_>,
+    referenced_functions: &HashSet<Spur>,
+    warnings: &mut Vec<CompileWarning>,
+) {
+    let main_sym = sema.interner.get("main");
+
+    for (name, info) in &sema.functions {
+        let name_str = sema.interner.resolve(name);
+        if Some(*name) == main_sym
+            || info.is_pub
+            || info.allow_unused_function
+            || name_str.starts_with('_')
+            || referenced_functions.contains(name)
+        {
+            continue;
+        }
+
+        warnings.push(
+            CompileWarning::new(WarningKind::UnusedFunction(name_str.to_string()), info.span)
+                .with_help(format!(
+                    "if this is intentional, prefix it with an underscore: `_{name_str}`"
+                )),
+        );
+    }
 }
 
 /// Lazy analysis path (Phase 3 of module system, ADR-0026).
@@ -895,6 +933,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
         functions.push(analyzed);
     }
 
+    add_unused_function_warnings(sema, &analyzed_functions, &mut all_warnings);
     all_warnings.sort_by_key(|w| w.span().map(|s| s.start));
 
     let mut output = SemaOutput {

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -851,6 +851,8 @@ impl<'a> Sema<'a> {
                 }
 
                 InstData::FnDecl {
+                    directives_start,
+                    directives_len,
                     is_pub,
                     is_unchecked,
                     name,
@@ -898,6 +900,8 @@ impl<'a> Sema<'a> {
                         inst.span,
                         *is_pub,
                         *is_unchecked,
+                        *directives_start,
+                        *directives_len,
                     )?;
                 }
 
@@ -1116,6 +1120,8 @@ impl<'a> Sema<'a> {
         span: Span,
         is_pub: bool,
         is_unchecked: bool,
+        directives_start: u32,
+        directives_len: u32,
     ) -> CompileResult<()> {
         // Reject user functions whose name collides with a runtime/codegen helper
         // symbol (e.g. `__rue_String_len`, `__rue_alloc`, `_start`). Without this, such a
@@ -1132,6 +1138,8 @@ impl<'a> Sema<'a> {
         }
 
         let params = self.rir.get_params(params_start, params_len);
+        let directives = self.rir.get_directives(directives_start, directives_len);
+        let allow_unused_function = self.has_allow_directive(&directives, "unused_function");
 
         let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
         let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
@@ -1226,6 +1234,7 @@ impl<'a> Sema<'a> {
                 is_generic,
                 is_pub,
                 is_unchecked,
+                allow_unused_function,
                 file_id: span.file_id,
             },
         );

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -35,6 +35,8 @@ pub struct FunctionInfo {
     /// Whether this function carries the `unchecked` modifier. Calling it
     /// requires a `checked` block at the call site (spec 9.1:1).
     pub is_unchecked: bool,
+    /// Whether `@allow(unused_function)` was applied to this function.
+    pub allow_unused_function: bool,
     /// File ID this function was declared in (for visibility checking)
     pub file_id: FileId,
 }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1796,10 +1796,11 @@ pub enum WarningKind {
 pub type CompileWarning = DiagnosticWrapper<WarningKind>;
 
 impl WarningKind {
-    /// Returns the variable name if this is an UnusedVariable warning.
+    /// Returns the declaration name for warning kinds that should use line
+    /// numbers to disambiguate duplicate names.
     pub fn unused_variable_name(&self) -> Option<&str> {
         match self {
-            WarningKind::UnusedVariable(name) => Some(name),
+            WarningKind::UnusedVariable(name) | WarningKind::UnusedFunction(name) => Some(name),
             _ => None,
         }
     }

--- a/crates/rue-spec/cases/lexical/builtins.toml
+++ b/crates/rue-spec/cases/lexical/builtins.toml
@@ -162,7 +162,6 @@ no_warnings = true
 [[case]]
 name = "allow_unused_function"
 spec = ["2.5:19"]
-skip = true  # TODO: Unused function warnings not yet implemented
 source = """
 @allow(unused_function)
 fn helper() -> i32 { 42 }

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -178,11 +178,6 @@ pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[
          (lexical/builtins.toml::allow_unused_variable_on_function, skipped)",
     ),
     (
-        "2.5:19",
-        "unused-function warning not implemented \
-         (lexical/builtins.toml::allow_unused_function, skipped)",
-    ),
-    (
         "2.5:21",
         "@allow(unreachable_code) suppression not implemented \
          (lexical/builtins.toml::allow_unreachable_code, skipped)",

--- a/crates/rue-ui-tests/cases/warnings/unused.toml
+++ b/crates/rue-ui-tests/cases/warnings/unused.toml
@@ -350,11 +350,8 @@ expected_warning_count = 1
 # Unused Functions
 # =============================================================================
 
-# TODO: Unused function warnings are defined but not yet implemented
-# See bd issue tree1-11z for warning suppression feature
 [[case]]
 name = "unused_function_warning"
-skip = true
 source = """
 fn unused_helper() -> i32 { 42 }
 
@@ -378,10 +375,8 @@ fn main() -> i32 {
 exit_code = 42
 no_warnings = true
 
-# TODO: Unused function warnings are defined but not yet implemented
 [[case]]
 name = "multiple_unused_functions"
-skip = true
 source = """
 fn helper1() -> i32 { 1 }
 fn helper2() -> i32 { 2 }
@@ -453,11 +448,8 @@ no_warnings = true
 # Mixed unused warnings
 # =============================================================================
 
-# TODO: Unused function warnings are defined but not yet implemented
-# Once implemented, this test should produce 2 warnings (function + variable)
 [[case]]
 name = "mixed_unused_warnings"
-skip = true
 source = """
 fn unused_fn() -> i32 { 42 }
 


### PR DESCRIPTION
## Summary

- emit `unused function` warnings for unused free functions
- exempt `main`, `pub`, underscore-prefixed names, and functions annotated with `@allow(unused_function)`
- use existing call-reference tracking in eager and lazy sema paths
- unskip existing unused-function UI/spec cases and remove spec 2.5:19 from the known-uncovered allowlist

## Validation

- `scripts/rue fmt`
- `./buck2 test root//crates/rue-error:rue-error-test root//crates/rue-air:rue-air-test root//crates/rue-compiler:rue-compiler-test root//:ui-tests root//:spec-tests`
- `scripts/rue test`
