### PR TITLE
RUE-375: purge dead span and target APIs

### DIFF
--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 use std::io::IsTerminal;
 
 use annotate_snippets::{Level, Renderer, Snippet};
+use rue_span::offset_to_line_col;
 
 use crate::{CompileError, CompileErrors, CompileWarning, Diagnostic, ErrorCode, FileId, Span};
 
@@ -771,32 +772,12 @@ impl<'a> JsonDiagnosticFormatter<'a> {
         Self { source_info }
     }
 
-    /// Calculate line and column for a byte offset.
-    fn offset_to_line_col(&self, offset: u32) -> (u32, u32) {
-        let offset = offset as usize;
-        let source = self.source_info.source;
-        let mut line = 1u32;
-        let mut col = 1u32;
-        for (i, ch) in source.char_indices() {
-            if i >= offset {
-                break;
-            }
-            if ch == '\n' {
-                line += 1;
-                col = 1;
-            } else {
-                col += 1;
-            }
-        }
-        (line, col)
-    }
-
     /// Format a compile error as JSON.
     pub fn format_error(&self, error: &CompileError) -> JsonDiagnostic {
         let diag = error.diagnostic();
         let (line, col) = error
             .span()
-            .map(|s| self.offset_to_line_col(s.start))
+            .map(|s| offset_to_line_col(self.source_info.source, s.start))
             .unwrap_or((1, 1));
 
         let primary_span = error.span().map(|span| JsonSpan {
@@ -813,7 +794,7 @@ impl<'a> JsonDiagnosticFormatter<'a> {
             .labels
             .iter()
             .map(|label| {
-                let (line, col) = self.offset_to_line_col(label.span.start);
+                let (line, col) = offset_to_line_col(self.source_info.source, label.span.start);
                 JsonSpan {
                     file: self.source_info.path.to_string(),
                     start: label.span.start,
@@ -858,7 +839,7 @@ impl<'a> JsonDiagnosticFormatter<'a> {
         let diag = warning.diagnostic();
         let (line, col) = warning
             .span()
-            .map(|s| self.offset_to_line_col(s.start))
+            .map(|s| offset_to_line_col(self.source_info.source, s.start))
             .unwrap_or((1, 1));
 
         let primary_span = warning.span().map(|span| JsonSpan {
@@ -875,7 +856,7 @@ impl<'a> JsonDiagnosticFormatter<'a> {
             .labels
             .iter()
             .map(|label| {
-                let (line, col) = self.offset_to_line_col(label.span.start);
+                let (line, col) = offset_to_line_col(self.source_info.source, label.span.start);
                 JsonSpan {
                     file: self.source_info.path.to_string(),
                     start: label.span.start,
@@ -990,25 +971,6 @@ impl<'a> MultiFileJsonFormatter<'a> {
         })
     }
 
-    /// Calculate line and column for a byte offset in a specific source.
-    fn offset_to_line_col(&self, source: &str, offset: u32) -> (u32, u32) {
-        let offset = offset as usize;
-        let mut line = 1u32;
-        let mut col = 1u32;
-        for (i, ch) in source.char_indices() {
-            if i >= offset {
-                break;
-            }
-            if ch == '\n' {
-                line += 1;
-                col = 1;
-            } else {
-                col += 1;
-            }
-        }
-        (line, col)
-    }
-
     /// Get the path and source for a span, using the span's file ID.
     fn source_for_span(&self, span: Span) -> Option<(&str, &str)> {
         self.get_source(span.file_id)
@@ -1022,7 +984,7 @@ impl<'a> MultiFileJsonFormatter<'a> {
 
         let primary_span = error.span().and_then(|span| {
             self.source_for_span(span).map(|(path, source)| {
-                let (line, col) = self.offset_to_line_col(source, span.start);
+                let (line, col) = offset_to_line_col(source, span.start);
                 JsonSpan {
                     file: path.to_string(),
                     start: span.start,
@@ -1040,7 +1002,7 @@ impl<'a> MultiFileJsonFormatter<'a> {
             .iter()
             .filter_map(|label| {
                 self.source_for_span(label.span).map(|(path, source)| {
-                    let (line, col) = self.offset_to_line_col(source, label.span.start);
+                    let (line, col) = offset_to_line_col(source, label.span.start);
                     JsonSpan {
                         file: path.to_string(),
                         start: label.span.start,
@@ -1090,7 +1052,7 @@ impl<'a> MultiFileJsonFormatter<'a> {
 
         let primary_span = warning.span().and_then(|span| {
             self.source_for_span(span).map(|(path, source)| {
-                let (line, col) = self.offset_to_line_col(source, span.start);
+                let (line, col) = offset_to_line_col(source, span.start);
                 JsonSpan {
                     file: path.to_string(),
                     start: span.start,
@@ -1108,7 +1070,7 @@ impl<'a> MultiFileJsonFormatter<'a> {
             .iter()
             .filter_map(|label| {
                 self.source_for_span(label.span).map(|(path, source)| {
-                    let (line, col) = self.offset_to_line_col(source, label.span.start);
+                    let (line, col) = offset_to_line_col(source, label.span.start);
                     JsonSpan {
                         file: path.to_string(),
                         start: label.span.start,

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -5,7 +5,8 @@
 
 mod logos_lexer;
 
-pub use lasso::{Key, Spur, ThreadedRodeo};
+use lasso::Key;
+pub use lasso::Spur;
 pub use logos_lexer::LogosLexer as Lexer;
 pub use rue_span::FileId;
 use rue_span::Span;

--- a/crates/rue-span/src/lib.rs
+++ b/crates/rue-span/src/lib.rs
@@ -88,18 +88,6 @@ impl Span {
         }
     }
 
-    /// Create a span covering two spans (from start of first to end of second).
-    ///
-    /// Uses the file ID from span `a`. Both spans should be from the same file.
-    #[inline]
-    pub const fn cover(a: Span, b: Span) -> Self {
-        Self {
-            file_id: a.file_id,
-            start: if a.start < b.start { a.start } else { b.start },
-            end: if a.end > b.end { a.end } else { b.end },
-        }
-    }
-
     /// Extend this span to a new end position, preserving the file ID.
     ///
     /// Creates a span from `self.start` to `end` with the same file ID.
@@ -130,56 +118,6 @@ impl Span {
         self.start == self.end
     }
 
-    /// Returns `true` if `other` is entirely contained within this span.
-    ///
-    /// A span `a` contains span `b` if `a.start <= b.start` and `b.end <= a.end`.
-    /// An empty span at a boundary is considered contained.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use rue_span::Span;
-    ///
-    /// let outer = Span::new(5, 20);
-    /// let inner = Span::new(10, 15);
-    /// let overlapping = Span::new(15, 25);
-    ///
-    /// assert!(outer.contains(inner));
-    /// assert!(!outer.contains(overlapping));
-    /// assert!(outer.contains(Span::point(10)));
-    /// ```
-    #[inline]
-    pub const fn contains(&self, other: Span) -> bool {
-        self.start <= other.start && other.end <= self.end
-    }
-
-    /// Returns `true` if this span contains the given byte position.
-    ///
-    /// The position is contained if `self.start <= pos < self.end`.
-    /// Note: the end position is exclusive, so `pos == self.end` returns `false`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use rue_span::Span;
-    ///
-    /// let span = Span::new(5, 10);
-    /// assert!(!span.contains_pos(4));  // before span
-    /// assert!(span.contains_pos(5));   // at start (inclusive)
-    /// assert!(span.contains_pos(7));   // in middle
-    /// assert!(!span.contains_pos(10)); // at end (exclusive)
-    /// ```
-    #[inline]
-    pub const fn contains_pos(&self, pos: u32) -> bool {
-        self.start <= pos && pos < self.end
-    }
-
-    /// Convert to a Range<usize> for slicing.
-    #[inline]
-    pub const fn as_range(&self) -> std::ops::Range<usize> {
-        self.start as usize..self.end as usize
-    }
-
     /// Compute the 1-based line number for this span's start position.
     ///
     /// Returns the line number (1-indexed) where this span begins.
@@ -196,191 +134,37 @@ impl Span {
             self.start,
             source.len()
         );
-        byte_offset_to_line(source, self.start as usize)
-    }
-
-    /// Compute the 1-based line and column numbers for this span's start position.
-    ///
-    /// Returns `(line, column)` where both are 1-indexed. The column is the
-    /// number of bytes from the start of the line, plus 1.
-    ///
-    /// # Panics
-    ///
-    /// In debug builds, panics if `self.start` exceeds `source.len()`.
-    /// In release builds, out-of-bounds offsets are clamped to `source.len()`.
-    #[inline]
-    pub fn line_col(&self, source: &str) -> (usize, usize) {
-        debug_assert!(
-            (self.start as usize) <= source.len(),
-            "span start {} exceeds source length {}",
-            self.start,
-            source.len()
-        );
-        byte_offset_to_line_col(source, self.start as usize)
+        source[..(self.start as usize).min(source.len())]
+            .bytes()
+            .filter(|&b| b == b'\n')
+            .count()
+            + 1
     }
 }
 
-/// Convert a byte offset to a 1-based line number.
+/// Convert a byte offset to 1-based line and character-column numbers.
 ///
-/// Counts the number of newlines before the given byte offset and adds 1.
-/// If `offset` exceeds `source.len()`, it is clamped to `source.len()`.
+/// Returns `(line, column)` where both are 1-indexed. The column counts Unicode
+/// scalar values, matching diagnostic rendering.
 ///
-/// **Performance note**: This function is O(n) in the source length.
-/// For repeated lookups on the same source, use [`LineIndex`] for O(log n) lookups.
+/// If `offset` exceeds `source.len()`, the final source position is returned.
 #[inline]
-pub fn byte_offset_to_line(source: &str, offset: usize) -> usize {
-    source[..offset.min(source.len())]
-        .bytes()
-        .filter(|&b| b == b'\n')
-        .count()
-        + 1
-}
-
-/// Convert a byte offset to 1-based line and column numbers.
-///
-/// Returns `(line, column)` where both are 1-indexed.
-/// The column is the number of bytes from the start of the line, plus 1.
-/// If `offset` exceeds `source.len()`, it is clamped to `source.len()`.
-///
-/// **Performance note**: This function is O(n) in the source length.
-/// For repeated lookups on the same source, use [`LineIndex`] for O(log n) lookups.
-#[inline]
-pub fn byte_offset_to_line_col(source: &str, offset: usize) -> (usize, usize) {
-    let offset = offset.min(source.len());
-    let prefix = &source[..offset];
-
-    // Find the last newline before offset
-    match prefix.rfind('\n') {
-        Some(newline_pos) => {
-            let line = prefix.bytes().filter(|&b| b == b'\n').count() + 1;
-            let col = offset - newline_pos; // offset - newline_pos gives bytes after newline
-            (line, col)
+pub fn offset_to_line_col(source: &str, offset: u32) -> (u32, u32) {
+    let offset = offset as usize;
+    let mut line = 1;
+    let mut col = 1;
+    for (i, ch) in source.char_indices() {
+        if i >= offset {
+            break;
         }
-        None => {
-            // No newline before offset, so we're on line 1
-            (1, offset + 1)
+        if ch == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
         }
     }
-}
-
-/// Precomputed line offset index for efficient byte offset to line number conversion.
-///
-/// Building the index is O(n) in source length, but subsequent lookups are O(log n).
-/// Use this when you need to perform multiple line number lookups on the same source.
-///
-/// # Example
-///
-/// ```
-/// use rue_span::LineIndex;
-///
-/// let source = "line1\nline2\nline3";
-/// let index = LineIndex::new(source);
-///
-/// assert_eq!(index.line_number(0), 1);  // Start of line 1
-/// assert_eq!(index.line_number(6), 2);  // Start of line 2
-/// assert_eq!(index.line_number(12), 3); // Start of line 3
-/// ```
-#[derive(Debug, Clone)]
-pub struct LineIndex {
-    /// Byte offsets where each line starts. line_starts[0] is always 0.
-    /// line_starts[i] is the byte offset of the start of line i+1 (1-indexed line number).
-    line_starts: Vec<u32>,
-    /// Total length of the source in bytes.
-    source_len: u32,
-}
-
-impl LineIndex {
-    /// Build a line index from source text.
-    ///
-    /// This scans the entire source once to find all newline positions.
-    /// Time complexity: O(n) where n is the source length.
-    pub fn new(source: &str) -> Self {
-        let mut line_starts = vec![0u32];
-        for (i, byte) in source.bytes().enumerate() {
-            if byte == b'\n' {
-                line_starts.push((i + 1) as u32);
-            }
-        }
-        Self {
-            line_starts,
-            source_len: source.len() as u32,
-        }
-    }
-
-    /// Get the 1-based line number for a byte offset.
-    ///
-    /// Time complexity: O(log n) where n is the number of lines.
-    ///
-    /// # Panics
-    ///
-    /// In debug builds, panics if `offset` exceeds the source length.
-    /// In release builds, out-of-bounds offsets are clamped to the source length.
-    #[inline]
-    pub fn line_number(&self, offset: u32) -> usize {
-        debug_assert!(
-            offset <= self.source_len,
-            "offset {} exceeds source length {}",
-            offset,
-            self.source_len
-        );
-        let offset = offset.min(self.source_len);
-
-        // Binary search for the line containing this offset.
-        // We want the largest line_start <= offset, which is partition_point - 1.
-        let line_idx = self.line_starts.partition_point(|&start| start <= offset);
-        // partition_point returns the first index where the predicate is false,
-        // so line_idx - 1 is the line containing offset (but line_idx is already 1-indexed)
-        line_idx
-    }
-
-    /// Get the 1-based line number for a span's start position.
-    #[inline]
-    pub fn span_line_number(&self, span: Span) -> usize {
-        self.line_number(span.start)
-    }
-
-    /// Get the 1-based line and column numbers for a byte offset.
-    ///
-    /// Returns `(line, column)` where both are 1-indexed. The column is the
-    /// number of bytes from the start of the line, plus 1.
-    ///
-    /// Time complexity: O(log n) where n is the number of lines.
-    ///
-    /// # Panics
-    ///
-    /// In debug builds, panics if `offset` exceeds the source length.
-    /// In release builds, out-of-bounds offsets are clamped to the source length.
-    #[inline]
-    pub fn line_col(&self, offset: u32) -> (usize, usize) {
-        debug_assert!(
-            offset <= self.source_len,
-            "offset {} exceeds source length {}",
-            offset,
-            self.source_len
-        );
-        let offset = offset.min(self.source_len);
-
-        // Binary search for the line containing this offset.
-        let line_idx = self.line_starts.partition_point(|&start| start <= offset);
-        // line_idx is 1-indexed (partition_point returns first index where predicate is false)
-        let line_start = self.line_starts[line_idx - 1];
-        let col = (offset - line_start) as usize + 1;
-        (line_idx, col)
-    }
-
-    /// Get the 1-based line and column numbers for a span's start position.
-    ///
-    /// Returns `(line, column)` where both are 1-indexed.
-    #[inline]
-    pub fn span_line_col(&self, span: Span) -> (usize, usize) {
-        self.line_col(span.start)
-    }
-
-    /// Returns the number of lines in the source.
-    #[inline]
-    pub fn line_count(&self) -> usize {
-        self.line_starts.len()
-    }
+    (line, col)
 }
 
 impl From<std::ops::Range<usize>> for Span {
@@ -411,7 +195,6 @@ mod tests {
 
     #[test]
     fn test_span_size() {
-        // Ensure Span stays small (12 bytes with file_id)
         assert_eq!(std::mem::size_of::<Span>(), 12);
     }
 
@@ -422,423 +205,96 @@ mod tests {
     }
 
     #[test]
-    fn test_span_with_file() {
-        let file = FileId::new(5);
-        let span = Span::with_file(file, 10, 20);
-        assert_eq!(span.file_id, file);
-        assert_eq!(span.start, 10);
-        assert_eq!(span.end, 20);
-    }
+    fn test_span_constructors_and_accessors() {
+        let span = Span::new(5, 10);
+        assert_eq!(span.file_id, FileId::DEFAULT);
+        assert_eq!(span.start(), 5);
+        assert_eq!(span.len(), 5);
+        assert!(!span.is_empty());
 
-    #[test]
-    fn test_span_point_in_file() {
-        let file = FileId::new(3);
-        let span = Span::point_in_file(file, 15);
-        assert_eq!(span.file_id, file);
-        assert_eq!(span.start, 15);
-        assert_eq!(span.end, 15);
-    }
-
-    #[test]
-    fn test_span_cover_preserves_file_id() {
         let file = FileId::new(7);
-        let a = Span::with_file(file, 5, 10);
-        let b = Span::with_file(file, 15, 20);
-        let covered = Span::cover(a, b);
-        assert_eq!(covered.file_id, file);
-        assert_eq!(covered.start, 5);
-        assert_eq!(covered.end, 20);
+        let with_file = Span::with_file(file, 11, 20);
+        assert_eq!(with_file.file_id, file);
+        assert_eq!(with_file.start, 11);
+        assert_eq!(with_file.end, 20);
+
+        let point = Span::point(3);
+        assert_eq!(point, Span::new(3, 3));
+        assert!(point.is_empty());
+
+        let point_in_file = Span::point_in_file(file, 4);
+        assert_eq!(point_in_file.file_id, file);
+        assert_eq!(point_in_file.start, 4);
+        assert_eq!(point_in_file.end, 4);
+
+        let extended = with_file.extend_to(30);
+        assert_eq!(extended.file_id, file);
+        assert_eq!(extended.start, 11);
+        assert_eq!(extended.end, 30);
     }
 
     #[test]
-    fn test_span_cover() {
-        let a = Span::new(5, 10);
-        let b = Span::new(15, 20);
-        let covered = Span::cover(a, b);
-        assert_eq!(covered, Span::new(5, 20));
-    }
-
-    #[test]
-    fn test_span_from_range() {
+    fn test_span_from_ranges() {
         let span: Span = (5usize..10usize).into();
-        assert_eq!(span.start, 5);
-        assert_eq!(span.end, 10);
-    }
+        assert_eq!(span, Span::new(5, 10));
 
-    #[test]
-    fn test_byte_offset_to_line() {
-        let source = "line1\nline2\nline3";
-        // First line (offset 0-4)
-        assert_eq!(byte_offset_to_line(source, 0), 1);
-        assert_eq!(byte_offset_to_line(source, 4), 1);
-        // Second line (offset 6-10)
-        assert_eq!(byte_offset_to_line(source, 6), 2);
-        assert_eq!(byte_offset_to_line(source, 10), 2);
-        // Third line (offset 12+)
-        assert_eq!(byte_offset_to_line(source, 12), 3);
-        assert_eq!(byte_offset_to_line(source, 16), 3);
+        let span: Span = (7u32..12u32).into();
+        assert_eq!(span, Span::new(7, 12));
     }
 
     #[test]
     fn test_span_line_number() {
         let source = "let x = 1;\nlet y = 2;\nlet z = 3;";
-        // Span on line 1
-        let span1 = Span::new(0, 10);
-        assert_eq!(span1.line_number(source), 1);
-        // Span on line 2
-        let span2 = Span::new(11, 21);
-        assert_eq!(span2.line_number(source), 2);
-        // Span on line 3
-        let span3 = Span::new(22, 32);
-        assert_eq!(span3.line_number(source), 3);
-    }
 
-    #[test]
-    fn test_byte_offset_to_line_at_bounds() {
-        let source = "hello";
-        // At exactly the end of source
-        assert_eq!(byte_offset_to_line(source, 5), 1);
-        // Beyond source bounds - should clamp to source length
-        assert_eq!(byte_offset_to_line(source, 100), 1);
-    }
-
-    #[test]
-    fn test_byte_offset_to_line_empty_source() {
-        let source = "";
-        // Empty source should return line 1
-        assert_eq!(byte_offset_to_line(source, 0), 1);
+        assert_eq!(Span::new(0, 10).line_number(source), 1);
+        assert_eq!(Span::new(11, 21).line_number(source), 2);
+        assert_eq!(Span::new(22, 32).line_number(source), 3);
     }
 
     #[test]
     fn test_span_line_number_at_newline() {
         let source = "a\nb";
-        // Span at the newline character itself
-        let span = Span::new(1, 2);
-        assert_eq!(span.line_number(source), 1);
-        // Span right after the newline
-        let span2 = Span::new(2, 3);
-        assert_eq!(span2.line_number(source), 2);
+        assert_eq!(Span::new(1, 2).line_number(source), 1);
+        assert_eq!(Span::new(2, 3).line_number(source), 2);
     }
 
-    // ========================================================================
-    // LineIndex tests
-    // ========================================================================
-
     #[test]
-    fn test_line_index_basic() {
+    fn test_offset_to_line_col_basic() {
         let source = "line1\nline2\nline3";
-        let index = LineIndex::new(source);
 
-        // First line (offset 0-4)
-        assert_eq!(index.line_number(0), 1);
-        assert_eq!(index.line_number(4), 1);
-
-        // Second line (offset 6-10)
-        assert_eq!(index.line_number(6), 2);
-        assert_eq!(index.line_number(10), 2);
-
-        // Third line (offset 12+)
-        assert_eq!(index.line_number(12), 3);
-        assert_eq!(index.line_number(16), 3);
+        assert_eq!(offset_to_line_col(source, 0), (1, 1));
+        assert_eq!(offset_to_line_col(source, 4), (1, 5));
+        assert_eq!(offset_to_line_col(source, 5), (1, 6));
+        assert_eq!(offset_to_line_col(source, 6), (2, 1));
+        assert_eq!(offset_to_line_col(source, 10), (2, 5));
+        assert_eq!(offset_to_line_col(source, 12), (3, 1));
+        assert_eq!(offset_to_line_col(source, 16), (3, 5));
     }
 
     #[test]
-    fn test_line_index_matches_byte_offset_to_line() {
-        let source = "let x = 1;\nlet y = 2;\nlet z = 3;";
-        let index = LineIndex::new(source);
-
-        // Verify LineIndex matches byte_offset_to_line for all offsets
-        for offset in 0..=source.len() {
-            assert_eq!(
-                index.line_number(offset as u32),
-                byte_offset_to_line(source, offset),
-                "mismatch at offset {}",
-                offset
-            );
-        }
+    fn test_offset_to_line_col_bounds() {
+        assert_eq!(offset_to_line_col("", 0), (1, 1));
+        assert_eq!(offset_to_line_col("hello", 0), (1, 1));
+        assert_eq!(offset_to_line_col("hello", 2), (1, 3));
+        assert_eq!(offset_to_line_col("hello", 5), (1, 6));
+        assert_eq!(offset_to_line_col("hello", 100), (1, 6));
     }
 
     #[test]
-    fn test_line_index_empty_source() {
-        let source = "";
-        let index = LineIndex::new(source);
-        assert_eq!(index.line_number(0), 1);
-        assert_eq!(index.line_count(), 1);
-    }
-
-    #[test]
-    fn test_line_index_single_line() {
-        let source = "hello";
-        let index = LineIndex::new(source);
-        assert_eq!(index.line_number(0), 1);
-        assert_eq!(index.line_number(4), 1);
-        assert_eq!(index.line_count(), 1);
-    }
-
-    #[test]
-    fn test_line_index_at_newline() {
+    fn test_offset_to_line_col_at_newline() {
         let source = "a\nb";
-        let index = LineIndex::new(source);
-        // At the newline character itself (offset 1)
-        assert_eq!(index.line_number(1), 1);
-        // Right after the newline (offset 2)
-        assert_eq!(index.line_number(2), 2);
+        assert_eq!(offset_to_line_col(source, 0), (1, 1));
+        assert_eq!(offset_to_line_col(source, 1), (1, 2));
+        assert_eq!(offset_to_line_col(source, 2), (2, 1));
     }
 
     #[test]
-    fn test_line_index_trailing_newline() {
-        let source = "line1\n";
-        let index = LineIndex::new(source);
-        assert_eq!(index.line_number(0), 1);
-        assert_eq!(index.line_number(5), 1); // At the newline
-        assert_eq!(index.line_number(6), 2); // After the newline
-        assert_eq!(index.line_count(), 2);
-    }
-
-    #[test]
-    fn test_line_index_span_line_number() {
-        let source = "let x = 1;\nlet y = 2;\nlet z = 3;";
-        let index = LineIndex::new(source);
-
-        let span1 = Span::new(0, 10);
-        assert_eq!(index.span_line_number(span1), 1);
-
-        let span2 = Span::new(11, 21);
-        assert_eq!(index.span_line_number(span2), 2);
-
-        let span3 = Span::new(22, 32);
-        assert_eq!(index.span_line_number(span3), 3);
-    }
-
-    #[test]
-    fn test_line_index_at_bounds() {
-        let source = "hello";
-        let index = LineIndex::new(source);
-        // At exactly the end of source
-        assert_eq!(index.line_number(5), 1);
-    }
-
-    #[test]
-    fn test_line_index_line_count() {
-        assert_eq!(LineIndex::new("").line_count(), 1);
-        assert_eq!(LineIndex::new("a").line_count(), 1);
-        assert_eq!(LineIndex::new("a\n").line_count(), 2);
-        assert_eq!(LineIndex::new("a\nb").line_count(), 2);
-        assert_eq!(LineIndex::new("a\nb\n").line_count(), 3);
-        assert_eq!(LineIndex::new("a\nb\nc").line_count(), 3);
-    }
-
-    // ========================================================================
-    // line_col tests
-    // ========================================================================
-
-    #[test]
-    fn test_byte_offset_to_line_col_basic() {
-        let source = "line1\nline2\nline3";
-        // "line1\nline2\nline3"
-        //  01234 5 6789A B CDEF0
-        // First line: offsets 0-4 are "line1", 5 is newline
-        assert_eq!(byte_offset_to_line_col(source, 0), (1, 1)); // 'l'
-        assert_eq!(byte_offset_to_line_col(source, 4), (1, 5)); // '1'
-        assert_eq!(byte_offset_to_line_col(source, 5), (1, 6)); // '\n' (still line 1)
-
-        // Second line: offsets 6-10 are "line2", 11 is newline
-        assert_eq!(byte_offset_to_line_col(source, 6), (2, 1)); // 'l'
-        assert_eq!(byte_offset_to_line_col(source, 10), (2, 5)); // '2'
-
-        // Third line: offsets 12-16 are "line3"
-        assert_eq!(byte_offset_to_line_col(source, 12), (3, 1)); // 'l'
-        assert_eq!(byte_offset_to_line_col(source, 16), (3, 5)); // '3'
-    }
-
-    #[test]
-    fn test_byte_offset_to_line_col_empty_source() {
-        let source = "";
-        assert_eq!(byte_offset_to_line_col(source, 0), (1, 1));
-    }
-
-    #[test]
-    fn test_byte_offset_to_line_col_single_line() {
-        let source = "hello";
-        assert_eq!(byte_offset_to_line_col(source, 0), (1, 1));
-        assert_eq!(byte_offset_to_line_col(source, 2), (1, 3));
-        assert_eq!(byte_offset_to_line_col(source, 4), (1, 5));
-        assert_eq!(byte_offset_to_line_col(source, 5), (1, 6)); // end of source
-    }
-
-    #[test]
-    fn test_byte_offset_to_line_col_at_newline() {
-        let source = "a\nb";
-        // offset 0: 'a' -> (1, 1)
-        // offset 1: '\n' -> (1, 2)
-        // offset 2: 'b' -> (2, 1)
-        assert_eq!(byte_offset_to_line_col(source, 0), (1, 1));
-        assert_eq!(byte_offset_to_line_col(source, 1), (1, 2));
-        assert_eq!(byte_offset_to_line_col(source, 2), (2, 1));
-    }
-
-    #[test]
-    fn test_span_line_col() {
-        let source = "let x = 1;\nlet y = 2;\nlet z = 3;";
-        // Line 1: "let x = 1;\n" (offsets 0-10, newline at 10)
-        // Line 2: "let y = 2;\n" (offsets 11-21, newline at 21)
-        // Line 3: "let z = 3;" (offsets 22-31)
-
-        let span1 = Span::new(0, 10);
-        assert_eq!(span1.line_col(source), (1, 1));
-
-        let span2 = Span::new(11, 21);
-        assert_eq!(span2.line_col(source), (2, 1));
-
-        let span3 = Span::new(22, 32);
-        assert_eq!(span3.line_col(source), (3, 1));
-
-        // Span starting in the middle of a line
-        let span_mid = Span::new(4, 10); // "x = 1;" on line 1
-        assert_eq!(span_mid.line_col(source), (1, 5)); // 'x' is at column 5
-    }
-
-    #[test]
-    fn test_line_index_line_col_basic() {
-        let source = "line1\nline2\nline3";
-        let index = LineIndex::new(source);
-
-        // First line
-        assert_eq!(index.line_col(0), (1, 1));
-        assert_eq!(index.line_col(4), (1, 5));
-
-        // Second line
-        assert_eq!(index.line_col(6), (2, 1));
-        assert_eq!(index.line_col(10), (2, 5));
-
-        // Third line
-        assert_eq!(index.line_col(12), (3, 1));
-        assert_eq!(index.line_col(16), (3, 5));
-    }
-
-    #[test]
-    fn test_line_index_line_col_matches_byte_offset() {
-        let source = "let x = 1;\nlet y = 2;\nlet z = 3;";
-        let index = LineIndex::new(source);
-
-        // Verify LineIndex matches byte_offset_to_line_col for all offsets
-        for offset in 0..=source.len() {
-            assert_eq!(
-                index.line_col(offset as u32),
-                byte_offset_to_line_col(source, offset),
-                "mismatch at offset {}",
-                offset
-            );
-        }
-    }
-
-    #[test]
-    fn test_line_index_span_line_col() {
-        let source = "let x = 1;\nlet y = 2;\nlet z = 3;";
-        let index = LineIndex::new(source);
-
-        let span1 = Span::new(0, 10);
-        assert_eq!(index.span_line_col(span1), (1, 1));
-
-        let span2 = Span::new(11, 21);
-        assert_eq!(index.span_line_col(span2), (2, 1));
-
-        let span3 = Span::new(22, 32);
-        assert_eq!(index.span_line_col(span3), (3, 1));
-
-        // Span starting in the middle of a line
-        let span_mid = Span::new(4, 10);
-        assert_eq!(index.span_line_col(span_mid), (1, 5));
-    }
-
-    #[test]
-    fn test_line_index_line_col_empty_source() {
-        let source = "";
-        let index = LineIndex::new(source);
-        assert_eq!(index.line_col(0), (1, 1));
-    }
-
-    #[test]
-    fn test_line_index_line_col_at_newline() {
-        let source = "a\nb";
-        let index = LineIndex::new(source);
-        assert_eq!(index.line_col(0), (1, 1)); // 'a'
-        assert_eq!(index.line_col(1), (1, 2)); // '\n'
-        assert_eq!(index.line_col(2), (2, 1)); // 'b'
-    }
-
-    // ========================================================================
-    // Span::contains tests
-    // ========================================================================
-
-    #[test]
-    fn test_span_contains_span() {
-        let outer = Span::new(5, 20);
-
-        // Inner span fully contained
-        assert!(outer.contains(Span::new(5, 20))); // exact match
-        assert!(outer.contains(Span::new(5, 10))); // at start
-        assert!(outer.contains(Span::new(15, 20))); // at end
-        assert!(outer.contains(Span::new(10, 15))); // in middle
-
-        // Not contained
-        assert!(!outer.contains(Span::new(0, 5))); // before (touching)
-        assert!(!outer.contains(Span::new(0, 10))); // overlaps start
-        assert!(!outer.contains(Span::new(15, 25))); // overlaps end
-        assert!(!outer.contains(Span::new(20, 25))); // after (touching)
-        assert!(!outer.contains(Span::new(0, 25))); // encompasses outer
-    }
-
-    #[test]
-    fn test_span_contains_point() {
-        let outer = Span::new(5, 20);
-
-        // Point spans (empty spans)
-        assert!(outer.contains(Span::point(5))); // at start
-        assert!(outer.contains(Span::point(10))); // in middle
-        assert!(outer.contains(Span::point(20))); // at end (point is contained)
-
-        // Point spans outside
-        assert!(!outer.contains(Span::point(4))); // before
-        assert!(!outer.contains(Span::point(21))); // after
-    }
-
-    #[test]
-    fn test_span_contains_empty_span() {
-        let empty = Span::point(10);
-
-        // Empty span only contains itself
-        assert!(empty.contains(Span::point(10)));
-        assert!(!empty.contains(Span::point(9)));
-        assert!(!empty.contains(Span::new(10, 11)));
-    }
-
-    #[test]
-    fn test_span_contains_pos() {
-        let span = Span::new(5, 10);
-
-        // Before span
-        assert!(!span.contains_pos(0));
-        assert!(!span.contains_pos(4));
-
-        // At boundaries and inside
-        assert!(span.contains_pos(5)); // start (inclusive)
-        assert!(span.contains_pos(7)); // middle
-        assert!(span.contains_pos(9)); // just before end
-        assert!(!span.contains_pos(10)); // end (exclusive)
-
-        // After span
-        assert!(!span.contains_pos(11));
-        assert!(!span.contains_pos(100));
-    }
-
-    #[test]
-    fn test_span_contains_pos_empty_span() {
-        let empty = Span::point(10);
-
-        // Empty span contains no positions (start == end)
-        assert!(!empty.contains_pos(9));
-        assert!(!empty.contains_pos(10));
-        assert!(!empty.contains_pos(11));
+    fn test_offset_to_line_col_counts_chars_not_bytes() {
+        let source = "éx\n🙂z";
+        assert_eq!(offset_to_line_col(source, 0), (1, 1));
+        assert_eq!(offset_to_line_col(source, 2), (1, 2)); // after `é`
+        assert_eq!(offset_to_line_col(source, 3), (1, 3)); // after `x`
+        assert_eq!(offset_to_line_col(source, 4), (2, 1)); // after newline
+        assert_eq!(offset_to_line_col(source, 8), (2, 2)); // after `🙂`
     }
 }

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -105,34 +105,6 @@ impl Target {
         }
     }
 
-    /// Returns the pointer size in bytes for this target.
-    pub fn pointer_size(&self) -> u32 {
-        match self.arch() {
-            Arch::X86_64 | Arch::Aarch64 => 8, // 64-bit architectures
-        }
-    }
-
-    /// Returns the required stack alignment in bytes for this target.
-    ///
-    /// This is the alignment required at function call boundaries.
-    pub fn stack_alignment(&self) -> u32 {
-        match self {
-            // System V AMD64, AAPCS64, and Apple's ABI all require 16-byte alignment.
-            Target::X86_64Linux | Target::Aarch64Linux | Target::Aarch64Macos => 16,
-        }
-    }
-
-    /// Returns the triple string for this target (e.g., "x86_64-unknown-linux-gnu").
-    ///
-    /// This can be useful for invoking external tools like system linkers.
-    pub fn triple(&self) -> &'static str {
-        match self {
-            Target::X86_64Linux => "x86_64-unknown-linux-gnu",
-            Target::Aarch64Linux => "aarch64-unknown-linux-gnu",
-            Target::Aarch64Macos => "aarch64-apple-darwin",
-        }
-    }
-
     /// Returns whether this target uses Mach-O object format (macOS).
     pub fn is_macho(&self) -> bool {
         matches!(self, Target::Aarch64Macos)
@@ -339,27 +311,6 @@ mod tests {
         assert_eq!(Target::X86_64Linux.os(), Os::Linux);
         assert_eq!(Target::Aarch64Linux.os(), Os::Linux);
         assert_eq!(Target::Aarch64Macos.os(), Os::Macos);
-    }
-
-    #[test]
-    fn test_pointer_size() {
-        assert_eq!(Target::X86_64Linux.pointer_size(), 8);
-        assert_eq!(Target::Aarch64Linux.pointer_size(), 8);
-        assert_eq!(Target::Aarch64Macos.pointer_size(), 8);
-    }
-
-    #[test]
-    fn test_stack_alignment() {
-        assert_eq!(Target::X86_64Linux.stack_alignment(), 16);
-        assert_eq!(Target::Aarch64Linux.stack_alignment(), 16);
-        assert_eq!(Target::Aarch64Macos.stack_alignment(), 16);
-    }
-
-    #[test]
-    fn test_triple() {
-        assert_eq!(Target::X86_64Linux.triple(), "x86_64-unknown-linux-gnu");
-        assert_eq!(Target::Aarch64Linux.triple(), "aarch64-unknown-linux-gnu");
-        assert_eq!(Target::Aarch64Macos.triple(), "aarch64-apple-darwin");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove dead `rue-span` location APIs (`LineIndex`, byte offset helpers, `Span::cover`, `line_col`, range/contains helpers) and compact the tests to the live surface
- hoist the live diagnostic JSON line/column helper into `rue_span::offset_to_line_col` with char-column tests, then reuse it from both JSON diagnostic formatters
- remove dead `Target::{pointer_size, stack_alignment, triple}` APIs/tests
- trim `rue-lexer` lasso re-exports to public `Spur`, keeping `Key` as a private import for `Display`

## Validation

- `scripts/rue fmt`
- `./buck2 test root//crates/rue-span:rue-span-test root//crates/rue-target:rue-target-test root//crates/rue-lexer:rue-lexer-test root//crates/rue-compiler:rue-compiler-test`
- `./buck2 test root//crates/rue-span:rue-span-test root//crates/rue-target:rue-target-test root//crates/rue-lexer:rue-lexer-test root//crates/rue-compiler:rue-compiler-test root//:ui-tests root//:spec-tests`

## Notes

I did not change `Span::len()` semantics in this PR; that optional invariant/saturating behavior is adjacent but separate from the verified dead-code purge.