### PR TITLE
RUE-393: refresh tutorial build workflow

### DIFF
--- a/website/content/tutorial/01-installation.md
+++ b/website/content/tutorial/01-installation.md
@@ -10,19 +10,62 @@ Rue is currently in early development. To try it out, you'll need to build from 
 
 ## Prerequisites
 
-- [dotslash](https://dotslash-cli.com) - Used to bootstrap Buck2 and the Rust toolchain
-- `clang` - Used as the linker (install via your system package manager)
+- [Dotslash](https://dotslash-cli.com/) - Used to bootstrap Buck2 and
+  the Rust toolchain
+- `clang` - Used as the system linker on platforms where the internal linker is
+  not used
 
-The repository includes everything else: Buck2 is bootstrapped via dotslash, and a hermetic Rust toolchain is downloaded automatically on first build.
+The repository includes everything else. Buck2 and the Rust toolchain are
+bootstrapped hermetically, and the first build downloads what it needs.
 
 ## Building from Source
 
 ```bash
 git clone https://github.com/rue-language/rue
 cd rue
-./buck2 build //crates/rue:rue
+scripts/rue build
 ```
 
-The first build will download the Rust toolchain, which may take a minute. Subsequent builds are fast.
+The first build may take a minute. Subsequent builds are fast.
 
-That's it! You now have a working Rue compiler. In the next chapter, we'll write our first program.
+## Running an Example
+
+Try one of the checked-in examples:
+
+```bash
+scripts/rue exec examples/hello.rue
+```
+
+`scripts/rue exec` builds the compiler if needed, compiles the Rue source to a
+temporary executable, and runs it.
+
+## Compiling Manually
+
+When you want to keep the executable, ask the wrapper for the compiler path and
+run the compiler directly:
+
+```bash
+RUE="$(scripts/rue-bin)"
+"$RUE" examples/hello.rue -o hello
+./hello
+```
+
+Rue currently supports native code generation for `x86-64-linux`,
+`aarch64-linux`, and `aarch64-macos`. Cross-target assembly and machine-code
+emission are available, but producing an executable may require target-specific
+system tools.
+
+## Lower-Level Buck2 Commands
+
+Most users should start with `scripts/rue`. If you're working on the compiler
+itself, you may also see lower-level Buck2 commands such as:
+
+```bash
+./buck2 build root//crates/rue:rue
+./buck2 test root//:spec-tests
+```
+
+The `./buck2` binary is also bootstrapped by Dotslash.
+
+That's it! You now have a working Rue compiler. In the next chapter, we'll
+write our first program.

--- a/website/content/tutorial/02-hello-world.md
+++ b/website/content/tutorial/02-hello-world.md
@@ -21,12 +21,22 @@ Every Rue program needs a `main` function that returns an `i32`. This return val
 Compile and run it:
 
 ```bash
-./buck2 run //crates/rue:rue -- hello.rue hello
+RUE="$(scripts/rue-bin)"
+"$RUE" hello.rue -o hello
 ./hello
 echo $?  # prints: 0
 ```
 
-The compiler takes the source file (`hello.rue`) and produces an executable (`hello`).
+The compiler takes the source file (`hello.rue`) and produces an executable
+(`hello`).
+
+For quick experiments, you can also let the repository wrapper build the
+compiler, compile your file to a temporary executable, and run it:
+
+```bash
+scripts/rue exec hello.rue
+echo $?  # prints: 0
+```
 
 ## Printing Output
 


### PR DESCRIPTION
Fixes RUE-393.

## Summary
- update tutorial installation instructions to prefer `scripts/rue build` and `scripts/rue exec`
- document `scripts/rue-bin` for keeping a compiled executable
- keep lower-level `./buck2` commands for compiler-development context
- update hello-world compile/run instructions away from stale `buck2 run` usage

## Validation
- `scripts/rue build`
- `scripts/rue exec examples/hello.rue`
- manual compile/run with `RUE=$(scripts/rue-bin); "$RUE" hello.rue -o hello; ./hello`
- `./buck2 build root//crates/rue:rue`
