### PR TITLE
RUE-395: add modules tutorial chapter

### DIFF
--- a/website/content/tutorial/11-modules.md
+++ b/website/content/tutorial/11-modules.md
@@ -1,0 +1,101 @@
++++
+title = "Modules"
+weight = 11
+template = "tutorial/page.html"
++++
+
+# Modules
+
+Rue programs can be split across files. A file imports another file with
+`@import("path.rue")`, binds the returned module object to a name, and then uses
+that name to access public declarations.
+
+## A Two-File Program
+
+Create a directory named `lib`, then create `lib/math.rue`:
+
+```rue
+pub fn double(x: i32) -> i32 {
+    x * 2
+}
+
+fn secret() -> i32 {
+    99
+}
+```
+
+Then create `main.rue` next to the `lib` directory:
+
+```rue
+const math = @import("lib/math.rue");
+
+fn main() -> i32 {
+    math.double(21)
+}
+```
+
+Compile and run it:
+
+```bash
+RUE="$(scripts/rue-bin)"
+"$RUE" main.rue -o main
+./main
+echo $?  # prints: 42
+```
+
+`@import("lib/math.rue")` loads the other file and returns a module object. The
+`const math = ...` binding gives that module object a local name.
+
+## Public and Private Declarations
+
+Across directory boundaries, only declarations marked `pub` are available
+through a module object. In the example above, `math.double(21)` works because
+`double` is public.
+
+This does not compile:
+
+```rue
+const math = @import("lib/math.rue");
+
+fn main() -> i32 {
+    math.secret()
+}
+```
+
+For the cross-directory import used above, `secret` is private to
+`lib/math.rue`, so the compiler reports that the function is private. Use `pub`
+only for declarations that are part of the imported file's interface.
+
+## Import Paths
+
+Relative import paths are resolved from the importing file's directory:
+
+```rue
+const math = @import("lib/math.rue");
+```
+
+The path string must be a string literal known at compile time. Rue does not
+dynamically load modules at runtime; imports are part of compilation.
+
+New code should prefer explicit imports. Rue still has some transitional
+support for compiling multiple files together, but relying on unqualified names
+from separately listed files is being removed.
+
+## Standard Library Status
+
+Rue's accepted standard-library direction is an explicit standard module:
+
+```rue
+const std = @import("std");
+```
+
+The intent is that standard-library types and functions are accessed through
+that namespace, for example `std.Option` or `std.ArrayBuf`.
+
+At the moment, this tutorial does not rely on `@import("std")`: the standard
+module is still being wired up, and a current compiler may report
+`standard library not found`. Until that lands, examples that need library
+helpers either define them inline or use checked-in example files directly.
+
+The important habit is still the same: use explicit module imports and
+namespace-qualified access rather than hidden global names.


### PR DESCRIPTION
Fixes RUE-395.

## Summary
- add a tutorial chapter for file imports with `@import("path.rue")`
- include a working two-file `lib/math.rue` example
- explain cross-directory `pub` visibility and private access failure
- document the accepted `@import("std")` direction while clearly noting current E0705 behavior

## Validation
- working two-file module example compiles and returns 42
- private cross-directory access example fails with E0706
- `@import("std")` probe currently fails with E0705, matching the chapter caveat
