### PR TITLE
RUE-396: refresh tutorial ownership progression

### DIFF
--- a/website/content/tutorial/07-structs.md
+++ b/website/content/tutorial/07-structs.md
@@ -74,6 +74,10 @@ fn area(rect: Rectangle) -> i32 {
     rect.width * rect.height
 }
 
+fn origin_x(borrow rect: Rectangle) -> i32 {
+    rect.origin.x
+}
+
 fn main() -> i32 {
     let rect = Rectangle {
         origin: Point { x: 10, y: 20 },
@@ -81,8 +85,8 @@ fn main() -> i32 {
         height: 50,
     };
 
-    @dbg(area(rect));          // prints: 5000
-    @dbg(rect.origin.x);       // prints: 10
+    @dbg(origin_x(borrow rect));  // prints: 10
+    @dbg(area(rect));             // prints: 5000
 
     0
 }
@@ -107,9 +111,11 @@ fn main() -> i32 {
 }
 ```
 
-## Move Semantics
+## Ownership: Moves and Copies
 
-By default, structs *move* when assigned or passed to functions. After a move, the original variable can't be used:
+Integers and booleans are copied when you use them. Structs are different:
+unless you opt in to copying, a struct value is *moved* when it is assigned or
+passed by value. After a move, the old place no longer owns a live value.
 
 ```rue
 struct Point {
@@ -122,15 +128,35 @@ fn use_point(p: Point) {
 }
 
 fn main() -> i32 {
-    let p1 = Point { x: 1, y: 2 };
-    use_point(p1);    // p1 moves here
-    // use_point(p1); // ERROR: value already moved
+    let p = Point { x: 1, y: 2 };
+    use_point(p);     // p moves here
+    // use_point(p);  // ERROR: value already moved
 
     0
 }
 ```
 
-If you want a type to be copyable instead, mark it with `@copy`:
+The same rule applies to assignment:
+
+```rue
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn main() -> i32 {
+    let p1 = Point { x: 1, y: 2 };
+    let p2 = p1;      // p1 moves into p2
+
+    @dbg(p2.x);       // prints: 1
+    // @dbg(p1.x);    // ERROR: p1 was moved
+
+    0
+}
+```
+
+If a struct is just data and duplicating it is safe, mark it with `@copy`.
+Copies leave the source usable:
 
 ```rue
 @copy
@@ -141,7 +167,7 @@ struct Point {
 
 fn main() -> i32 {
     let p1 = Point { x: 1, y: 2 };
-    let mut p2 = p1;  // p2 is a copy of p1
+    let mut p2 = p1;  // p2 is a copy; p1 is still valid
 
     p2.x = 100;
 
@@ -151,3 +177,7 @@ fn main() -> i32 {
     0
 }
 ```
+
+Use the default move behavior for values that represent ownership, resources, or
+anything that should not be duplicated accidentally. Use `@copy` only for small
+plain-data structs whose fields can all be copied.

--- a/website/content/tutorial/09-borrow-and-inout.md
+++ b/website/content/tutorial/09-borrow-and-inout.md
@@ -8,6 +8,10 @@ template = "tutorial/page.html"
 
 When you read code, you want to understand what it does without tracing through every function. Rue helps by making mutation visible at the call site.
 
+This chapter builds on ownership from the structs chapter. Passing a non-`@copy`
+struct by value moves it into the callee. `borrow` and `inout` are how you let a
+function access a value without taking ownership of it.
+
 ## Reading Code at a Glance
 
 Look at this code:
@@ -17,6 +21,14 @@ fn main() -> i32 {
     let mut values = [10, 20, 30];
     double_all(inout values);
     values[0]
+}
+
+fn double_all(inout arr: [i32; 3]) {
+    let mut i: u64 = 0;
+    while i < 3 {
+        arr[i] = arr[i] * 2;
+        i = i + 1;
+    }
 }
 ```
 
@@ -90,6 +102,29 @@ fn main() -> i32 {
 
 With `borrow`, you know the function won't change your data.
 
+Borrowing also keeps non-copy structs usable after the call:
+
+```rue
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn sum_point(borrow p: Point) -> i32 {
+    p.x + p.y
+}
+
+fn main() -> i32 {
+    let p = Point { x: 10, y: 20 };
+    let sum = sum_point(borrow p);
+
+    @dbg(sum);  // prints: 30
+    @dbg(p.x);  // still valid: p was borrowed, not moved
+
+    sum
+}
+```
+
 ## Combining Them
 
 You can mix borrow and inout in a single function:
@@ -118,6 +153,28 @@ fn main() -> i32 {
 ```
 
 Reading the call site, you immediately know: `source` is read, `dest` is modified.
+
+Rue enforces the same rule inside one call: any number of `borrow` accesses, or
+one `inout` access, but not both for the same value at the same time.
+
+```rue
+fn observe(borrow old: i32, inout new: i32) -> i32 {
+    old + new
+}
+
+fn main() -> i32 {
+    let mut x = 1;
+
+    // ERROR: cannot borrow x while it is also passed as inout
+    // observe(borrow x, inout x);
+
+    0
+}
+```
+
+Uncommenting the `observe` call makes the example invalid. The compiler rejects
+it because the callee would have both read-only and mutable access to `x` during
+the same call.
 
 ## With Structs
 
@@ -149,3 +206,49 @@ fn main() -> i32 {
     0
 }
 ```
+
+## Destructors and Early Drop
+
+Some move-only values need cleanup when they go out of scope. Define that cleanup
+with a `drop fn` named after the struct:
+
+```rue
+struct Guard {
+    value: i32,
+}
+
+drop fn Guard(self) {
+    @dbg(self.value);
+}
+
+fn main() -> i32 {
+    let _guard = Guard { value: 42 };
+    @dbg(1);
+
+    0
+}  // prints: 42 when _guard is dropped
+```
+
+You can also drop a value early with `@drop`. Dropping consumes the value, so it
+cannot be used afterward:
+
+```rue
+struct Guard {
+    value: i32,
+}
+
+drop fn Guard(self) {
+    @dbg(self.value);
+}
+
+fn main() -> i32 {
+    let guard = Guard { value: 42 };
+    @drop(guard);       // prints: 42 here
+
+    // guard.value      // ERROR: guard was moved into @drop
+    0
+}
+```
+
+A type with a destructor represents ownership of cleanup work, so it should stay
+move-only. Do not mark destructor-bearing types with `@copy`.


### PR DESCRIPTION
## Summary
- tighten the structs tutorial ownership section around move-by-value, assignment moves, and `@copy`
- fix an invalid nested-struct example by borrowing before the final move
- expand the borrow/inout chapter with ownership-preserving access, exclusivity, destructors, and early `@drop`

## Validation
- `scripts/rue fmt`
- compiled every `rue` code fence from `website/content/tutorial/07-structs.md` and `website/content/tutorial/09-borrow-and-inout.md` with `scripts/rue-bin`
- probed invalid examples locally: move-after-use reports E0205; conflicting `borrow`/`inout` reports E0430

Note: local `website/build.sh` reaches Zola but fails in these jj-only worktrees because `scripts/generate-site-status.py` calls `git` to populate `commit_date`, and the homepage template cannot date-parse the fallback `today`. CI runs in a Git checkout and should cover the full site build.
