### PR TITLE
RUE-385: fix inout str lowering ICE

### DIFF
--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -314,9 +314,18 @@ impl<'a> Sema<'a> {
             // indirection, so the slice value is passed BY VALUE through the
             // existing multi-slot aggregate ABI (2 slots) rather than as a
             // pointer-to-slice. The call site materializes the fat pointer.
+            //
+            // `str` intentionally diverges for `inout`: it is first-class and
+            // reassignable, so assigning to an `inout str` parameter must
+            // rebind the caller's `{ptr, len}` fat pointer. That requires a
+            // normal by-reference parameter slot; otherwise AIR emits
+            // ParamStore but codegen sees a by-value param slot and panics
+            // (RUE-385).
             let is_slice = self.slice_element_type(*ptype).is_some();
-            let is_by_ref =
-                (*mode == RirParamMode::Inout || *mode == RirParamMode::Borrow) && !is_slice;
+            let is_inout_str = *mode == RirParamMode::Inout && self.is_str_struct(*ptype);
+            let is_slice_by_value = is_slice && !is_inout_str;
+            let is_by_ref = (*mode == RirParamMode::Inout || *mode == RirParamMode::Borrow)
+                && !is_slice_by_value;
             let slot_count = if is_by_ref {
                 // By-ref parameters are always 1 slot (pointer)
                 1

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -604,8 +604,15 @@ impl<'a> Sema<'a> {
             // a `str` variable is passed through by value. Either way it flows
             // through the by-value aggregate ABI, so it is handled here before
             // the array→slice `borrow` coercion below.
+            //
+            // Exception (RUE-385): `inout str` must pass the caller's storage by
+            // address. Unlike a slice view, `str` is first-class and
+            // reassignable, so an assignment to the parameter rebinds the
+            // caller's fat pointer via ParamStore.
             let is_str_param = param_types.get(i).is_some_and(|pt| self.is_str_like(*pt));
-            if is_str_param {
+            let is_inout_str_param =
+                arg.is_inout() && param_types.get(i).is_some_and(|pt| self.is_str_struct(*pt));
+            if is_str_param && !is_inout_str_param {
                 let str_ty = param_types[i];
                 let prev_expected = ctx.expected_type.replace(str_ty);
                 let arg_result = self.analyze_inst(air, arg.value, ctx);
@@ -621,7 +628,7 @@ impl<'a> Sema<'a> {
             let is_slice_param = param_types
                 .get(i)
                 .is_some_and(|pt| self.slice_element_type(*pt).is_some());
-            if is_slice_param {
+            if is_slice_param && !is_inout_str_param {
                 let slice_ty = param_types[i];
                 let value = self.coerce_borrow_array_to_slice(air, arg, slice_ty, ctx)?;
                 air_args.push(AirCallArg {

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -110,6 +110,25 @@ fn main() -> i32 {
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 8
 
+# `inout str` rebinds the caller's first-class `{ptr, len}` value. This used to
+# ICE in both backends when the callee assigned to the parameter: sema emitted a
+# ParamStore, but function ABI lowering had treated `inout str` like a by-value
+# slice view (RUE-385).
+[[case]]
+name = "str_inout_rebinds_caller_fat_pointer"
+files = [{ path = "main.rue", source = """
+fn set_hi(inout s: str) {
+    s = "hi";
+}
+fn main() -> i32 {
+    let mut s: str = "hello";
+    set_hi(inout s);
+    @intCast(s.len())
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 2
+
 # Without the preview flag, `str` is gated with a clear diagnostic (not an ICE).
 [[case]]
 name = "str_requires_preview_flag"


### PR DESCRIPTION
## Summary
- keep slice-view parameters on the existing by-value fat-pointer path, but make `inout str` a true by-reference parameter
- keep `inout str` call arguments on the normal by-ref path instead of normalizing them through the str/slice by-value coercion
- add a CLI regression proving assignment to an `inout str` rebinds the caller's `{ptr, len}` value instead of ICEing

## Validation
- direct repro: mutating `inout str` compiles and exits 2 on x86_64
- direct repro: mutating `inout str` emits aarch64 assembly with `--emit asm`
- `scripts/rue fmt`
- `./buck2 test root//:cli-tests`
- `./buck2 test root//crates/rue-air:rue-air-test root//crates/rue-codegen:rue-codegen-test root//crates/rue-compiler:rue-compiler-test`
- `./clippy.sh`
