### PR TITLE
RUE-399: check tutorial Rue snippets

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -38,6 +38,13 @@ filegroup(
     srcs = glob(["examples/**"]),
 )
 
+# Tutorial markdown is an input to the snippet checker. The checker only
+# compiles fences explicitly marked with `rue check` or `rue compile-fail`.
+filegroup(
+    name = "tutorial",
+    srcs = glob(["website/content/tutorial/**"]),
+)
+
 sh_test(
     name = "spec-tests",
     test = "//crates/rue-spec:rue-spec",
@@ -67,5 +74,17 @@ sh_test(
         "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
         "RUE_EXAMPLES_DIR": "$(location :examples)/examples",
         "RUE_STD_DIR": "$(location :std)/std",
+    },
+)
+
+sh_test(
+    name = "tutorial-snippet-tests",
+    test = "scripts/check-tutorial-snippets.py",
+    args = [
+        "--quiet",
+        "$(location :tutorial)/website/content/tutorial",
+    ],
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
     },
 )

--- a/docs/development.md
+++ b/docs/development.md
@@ -80,6 +80,35 @@ treats an unexpected pass as a failure so obsolete markers cannot linger.
 Preview-language cases must enable their feature explicitly and do not count as
 stable normative coverage.
 
+## Tutorial snippets
+
+Tutorial Rue fences are checked when their info string opts in:
+
+- ````markdown
+  ```rue check
+  ```
+  ```` compiles successfully.
+- ````markdown
+  ```rue compile-fail
+  ```
+  ```` must fail compilation, for intentionally invalid examples.
+- ````markdown
+  ```rue skip
+  ```
+  ```` is an explicit prose-only or context-dependent snippet.
+
+Run the checker directly while editing tutorial chapters:
+
+```bash
+scripts/check-tutorial-snippets.py
+```
+
+Or run the Buck target used by CI-style validation:
+
+```bash
+./buck2 test //:tutorial-snippet-tests
+```
+
 During implementation, use the narrowest relevant command. Before submitting:
 
 ```bash

--- a/scripts/check-tutorial-snippets.py
+++ b/scripts/check-tutorial-snippets.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Check opted-in Rue code fences from the website tutorial.
+
+Tutorial fences are prose first, so the checker is intentionally marker-driven:
+
+* ```rue check        compiles successfully
+* ```rue compile-fail must fail compilation
+* ```rue skip         ignored with an explicit reason in prose nearby
+
+Unmarked ```rue fences are left alone. This lets chapter-refresh work opt
+snippets in as they become complete, self-contained examples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FENCE_RE = re.compile(r"^```(?P<info>.*)$")
+CHECK_ATTRS = {"check", "compile-fail", "skip"}
+
+
+@dataclass(frozen=True)
+class Snippet:
+    path: Path
+    line: int
+    action: str
+    source: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.path}:{self.line}"
+
+
+def parse_info_string(info: str) -> tuple[str, set[str]]:
+    parts = re.split(r"[\s,]+", info.strip())
+    parts = [part for part in parts if part]
+    if not parts:
+        return "", set()
+
+    language = parts[0]
+    attrs = set(parts[1:])
+    return language, attrs
+
+
+def collect_snippets(root: Path) -> tuple[list[Snippet], int]:
+    snippets: list[Snippet] = []
+    unmarked_rue_fences = 0
+
+    for path in sorted(root.glob("*.md")):
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        i = 0
+        while i < len(lines):
+            match = FENCE_RE.match(lines[i])
+            if not match:
+                i += 1
+                continue
+
+            language, attrs = parse_info_string(match.group("info"))
+            fence_line = i + 1
+            i += 1
+            body: list[str] = []
+            while i < len(lines) and not lines[i].startswith("```"):
+                body.append(lines[i])
+                i += 1
+
+            if language == "rue":
+                actions = attrs & CHECK_ATTRS
+                if len(actions) > 1:
+                    raise ValueError(
+                        f"{path}:{fence_line}: use only one of {sorted(CHECK_ATTRS)}"
+                    )
+                if actions:
+                    action = next(iter(actions))
+                    if action != "skip":
+                        snippets.append(
+                            Snippet(
+                                path=path,
+                                line=fence_line,
+                                action=action,
+                                source="".join(body),
+                            )
+                        )
+                else:
+                    unmarked_rue_fences += 1
+
+            # Skip the closing fence if present.
+            if i < len(lines):
+                i += 1
+
+    return snippets, unmarked_rue_fences
+
+
+def compile_snippet(rue_binary: str, snippet: Snippet, tempdir: Path) -> subprocess.CompletedProcess[str]:
+    source_path = tempdir / f"{snippet.path.stem}-{snippet.line}.rue"
+    output_path = tempdir / f"{snippet.path.stem}-{snippet.line}"
+    source_path.write_text(snippet.source, encoding="utf-8")
+
+    return subprocess.run(
+        [rue_binary, str(source_path), "-o", str(output_path)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def find_rue_binary() -> str:
+    env_binary = os.environ.get("RUE_BINARY")
+    if env_binary:
+        return env_binary
+
+    helper = Path("scripts/rue-bin")
+    if helper.exists():
+        result = subprocess.run(
+            [str(helper)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+        raise SystemExit(result.stderr)
+
+    raise SystemExit("RUE_BINARY is not set and scripts/rue-bin was not found")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default="website/content/tutorial",
+        type=Path,
+        help="tutorial markdown directory to scan",
+    )
+    parser.add_argument("--quiet", action="store_true", help="only print failures")
+    args = parser.parse_args()
+
+    snippets, unmarked = collect_snippets(args.root)
+    rue_binary = find_rue_binary()
+
+    failures = 0
+    with tempfile.TemporaryDirectory(prefix="rue-tutorial-snippets-") as temp:
+        tempdir = Path(temp)
+        for snippet in snippets:
+            result = compile_snippet(rue_binary, snippet, tempdir)
+            compiled = result.returncode == 0
+            expected_success = snippet.action == "check"
+
+            if compiled == expected_success:
+                if not args.quiet:
+                    print(f"ok {snippet.label} ({snippet.action})")
+                continue
+
+            failures += 1
+            expectation = "compile" if expected_success else "fail compilation"
+            print(f"FAIL {snippet.label}: expected snippet to {expectation}", file=sys.stderr)
+            if result.stdout:
+                print(result.stdout, file=sys.stderr)
+            if result.stderr:
+                print(result.stderr, file=sys.stderr)
+
+    if failures:
+        return 1
+
+    if not args.quiet:
+        print(
+            f"checked {len(snippets)} tutorial snippet(s); "
+            f"{unmarked} unmarked rue fence(s) left prose-only"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test.sh
+++ b/test.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 # Run all tests for the rue compiler.
 #
 # Every suite is a Buck test target, so one `buck2 test //...` runs the unit
-# tests for ALL crates plus the spec/UI/CLI harness suites (the root BUCK
-# file's sh_tests, which declare the rue binary, cases/, and std/ as inputs —
-# Buck owns the binary handoff instead of a shell pipeline). Using //...
+# tests for ALL crates plus the spec/UI/CLI harness suites and tutorial snippet
+# checker (the root BUCK file's sh_tests, which declare the rue binary, cases/,
+# std/, and tutorial markdown as inputs — Buck owns the binary handoff instead
+# of a shell pipeline). Using //...
 # rather than a hand-maintained target list also keeps new crates from being
 # silently omitted. (RUE-132, RUE-144)
 #

--- a/website/content/tutorial/02-hello-world.md
+++ b/website/content/tutorial/02-hello-world.md
@@ -8,7 +8,7 @@ template = "tutorial/page.html"
 
 Let's start with the simplest possible program. Create a file called `hello.rue`:
 
-```rue
+```rue check
 fn main() -> i32 {
     0
 }
@@ -32,7 +32,7 @@ The compiler takes the source file (`hello.rue`) and produces an executable (`he
 
 To see output, use the `@dbg` intrinsic:
 
-```rue
+```rue check
 fn main() -> i32 {
     @dbg(42);
     0

--- a/website/content/tutorial/03-variables-and-types.md
+++ b/website/content/tutorial/03-variables-and-types.md
@@ -12,7 +12,7 @@ Rue is statically typed—every variable has a type known at compile time.
 
 Rue has the integer types you'd expect:
 
-```rue
+```rue check
 fn main() -> i32 {
     // Signed integers: i8, i16, i32, i64
     let x: i32 = 42;
@@ -33,7 +33,7 @@ The number after `i` or `u` is the bit width. Signed integers (`i`) can be negat
 
 You don't always need to write types explicitly. The compiler can often infer them:
 
-```rue
+```rue check
 fn main() -> i32 {
     let x = 42;        // inferred as i32 (the default)
     let y = true;      // inferred as bool
@@ -49,7 +49,7 @@ When there's no context, integer literals default to `i32`.
 
 Boolean values are either `true` or `false`:
 
-```rue
+```rue check
 fn main() -> i32 {
     let flag: bool = true;
     let done = false;
@@ -65,7 +65,7 @@ fn main() -> i32 {
 
 Variables are immutable by default. Use `let mut` to make them mutable:
 
-```rue
+```rue check
 fn main() -> i32 {
     let mut count = 0;
     count = count + 1;
@@ -77,7 +77,7 @@ fn main() -> i32 {
 
 Trying to assign to an immutable variable is a compile error:
 
-```rue
+```rue compile-fail
 fn main() -> i32 {
     let x = 42;
     x = 43;  // Error: cannot assign to immutable variable

--- a/website/content/tutorial/04-functions.md
+++ b/website/content/tutorial/04-functions.md
@@ -10,7 +10,7 @@ Functions are declared with `fn`, followed by parameters and a return type.
 
 ## Basic Functions
 
-```rue
+```rue check
 fn add(a: i32, b: i32) -> i32 {
     a + b
 }
@@ -34,7 +34,7 @@ fn main() -> i32 {
 
 The last expression in a function is its return value—no `return` keyword needed:
 
-```rue
+```rue skip
 fn double(x: i32) -> i32 {
     x * 2  // this value is returned
 }
@@ -46,7 +46,7 @@ Note the lack of a semicolon. Adding one would make it a statement instead of an
 
 You can use `return` for early exits:
 
-```rue
+```rue check
 fn absolute(n: i32) -> i32 {
     if n < 0 {
         return -n;

--- a/website/content/tutorial/05-control-flow.md
+++ b/website/content/tutorial/05-control-flow.md
@@ -12,7 +12,7 @@ Rue has three main control flow constructs: `if`, `while`, and `match`.
 
 `if` is an expression, not a statement—it returns a value:
 
-```rue
+```rue check
 fn max(a: i32, b: i32) -> i32 {
     if a > b { a } else { b }
 }
@@ -26,7 +26,7 @@ fn main() -> i32 {
 
 Because `if` is an expression, you can use it anywhere a value is expected:
 
-```rue
+```rue check
 fn main() -> i32 {
     let x = 5;
     let description = if x > 0 { 1 } else { 0 };
@@ -39,7 +39,7 @@ Both branches must have the same type.
 
 ## While Loops
 
-```rue
+```rue check
 fn main() -> i32 {
     let mut sum = 0;
     let mut i = 1;
@@ -58,7 +58,7 @@ fn main() -> i32 {
 
 For multi-way branching, use `match`:
 
-```rue
+```rue check
 fn day_type(day: i32) -> i32 {
     // 0 = weekend, 1 = weekday
     match day {
@@ -81,7 +81,7 @@ The `_` is a wildcard that matches anything. Match expressions must be exhaustiv
 
 Here's a classic example combining everything:
 
-```rue
+```rue check
 fn fizzbuzz(n: i32) -> i32 {
     let div_by_3 = n % 3 == 0;
     let div_by_5 = n % 5 == 0;

--- a/website/content/tutorial/06-arrays.md
+++ b/website/content/tutorial/06-arrays.md
@@ -10,7 +10,7 @@ Rue has fixed-size arrays with bounds checking at runtime.
 
 ## Creating Arrays
 
-```rue
+```rue check
 fn main() -> i32 {
     let numbers = [10, 20, 30, 40, 50];
 
@@ -28,7 +28,7 @@ Array indices are zero-based and must be `u64`.
 
 The type of an array includes its element type and length:
 
-```rue
+```rue check
 fn main() -> i32 {
     let a: [i32; 3] = [1, 2, 3];     // 3 elements
     let b: [bool; 2] = [true, false]; // 2 booleans
@@ -42,7 +42,7 @@ fn main() -> i32 {
 
 Use a while loop with an index:
 
-```rue
+```rue check
 fn main() -> i32 {
     let numbers = [10, 20, 30, 40, 50];
 
@@ -62,7 +62,7 @@ fn main() -> i32 {
 
 Arrays are mutable if declared with `let mut`:
 
-```rue
+```rue check
 fn main() -> i32 {
     let mut scores = [0, 0, 0];
     scores[0] = 100;
@@ -76,21 +76,22 @@ fn main() -> i32 {
 
 ## Bounds Checking
 
-Rue checks array bounds at runtime. Accessing an invalid index causes a panic:
+Rue checks array bounds. A constant out-of-bounds index is rejected at compile time:
 
-```rue
+```rue compile-fail
 fn main() -> i32 {
     let arr = [1, 2, 3];
-    @dbg(arr[10]);  // Runtime panic: index out of bounds
+    @dbg(arr[10]);  // Error: index out of bounds
     0
 }
 ```
 
-This prevents memory safety bugs common in C and C++.
+Dynamic out-of-bounds indexes are checked at runtime. Together, these checks
+prevent memory safety bugs common in C and C++.
 
 ## Example: Finding Maximum
 
-```rue
+```rue check
 fn main() -> i32 {
     let numbers = [64, 34, 25, 12, 22];
 

--- a/website/content/tutorial/08-enums.md
+++ b/website/content/tutorial/08-enums.md
@@ -10,7 +10,7 @@ Enums define types with a fixed set of possible values, called variants.
 
 ## Defining Enums
 
-```rue
+```rue check
 enum Color {
     Red,
     Green,
@@ -29,7 +29,7 @@ Variants are accessed with the `::` syntax: `EnumName::VariantName`.
 
 Use `match` to handle each variant:
 
-```rue
+```rue check
 enum Color {
     Red,
     Green,
@@ -56,7 +56,7 @@ fn main() -> i32 {
 
 Match expressions on enums must be exhaustive—you must handle all variants:
 
-```rue
+```rue check
 enum Direction {
     North,
     South,
@@ -72,11 +72,15 @@ fn to_degrees(d: Direction) -> i32 {
         Direction::West => 270,
     }
 }
+
+fn main() -> i32 {
+    to_degrees(Direction::North)
+}
 ```
 
 If you forget a variant, the compiler will tell you:
 
-```rue
+```rue skip
 fn to_degrees(d: Direction) -> i32 {
     match d {
         Direction::North => 0,
@@ -90,7 +94,7 @@ fn to_degrees(d: Direction) -> i32 {
 
 Enums can be fields in structs:
 
-```rue
+```rue check
 enum Status {
     Pending,
     Active,
@@ -122,7 +126,7 @@ fn main() -> i32 {
 
 ## Example: Simple State Machine
 
-```rue
+```rue check
 enum TrafficLight {
     Red,
     Yellow,
@@ -143,5 +147,9 @@ fn light_duration(light: TrafficLight) -> i32 {
         TrafficLight::Yellow => 5,
         TrafficLight::Green => 25,
     }
+}
+
+fn main() -> i32 {
+    light_duration(next_light(TrafficLight::Red))
 }
 ```

--- a/website/content/tutorial/10-putting-it-together.md
+++ b/website/content/tutorial/10-putting-it-together.md
@@ -17,7 +17,7 @@ Quicksort is a classic divide-and-conquer sorting algorithm:
 
 ## The Implementation
 
-```rue
+```rue check
 fn partition(inout arr: [i32; 5], lo: u64, hi: u64) -> u64 {
     let pivot = arr[hi];
     let mut i = lo;


### PR DESCRIPTION
## Summary
- add `scripts/check-tutorial-snippets.py` for opted-in tutorial `rue` fences
- add `//:tutorial-snippet-tests` so `./test.sh` / `buck2 test //...` cover checked snippets
- mark 26 tutorial snippets as `check` or `compile-fail`, with explicit `skip` for context-dependent prose snippets
- document the tutorial snippet workflow in the development guide

## Validation
- `scripts/check-tutorial-snippets.py --quiet`
- `./buck2 test //:tutorial-snippet-tests`
- `python3 -m py_compile scripts/check-tutorial-snippets.py`
- `./fmt.sh check`

Linear: RUE-399