### PR TITLE
RUE-394: refresh early tutorial output

### DIFF
--- a/website/content/tutorial/02-hello-world.md
+++ b/website/content/tutorial/02-hello-world.md
@@ -40,7 +40,25 @@ echo $?  # prints: 0
 
 ## Printing Output
 
-To see output, use the `@dbg` intrinsic:
+To print user-facing text, use `println`:
+
+```rue check
+fn main() -> i32 {
+    println("Hello, Rue!");
+    0
+}
+```
+
+Run this program and you'll see:
+
+```
+Hello, Rue!
+```
+
+`println` writes a string followed by a newline. Use `print` when you do not
+want the trailing newline.
+
+For quick debugging, Rue also provides the `@dbg` intrinsic:
 
 ```rue check
 fn main() -> i32 {
@@ -49,12 +67,12 @@ fn main() -> i32 {
 }
 ```
 
-This prints `42` to the console. The `@` prefix indicates a compiler intrinsic—a built-in operation provided by the compiler.
-
-Run this program and you'll see:
+This prints the value followed by a newline:
 
 ```
 42
 ```
 
-The `@dbg` intrinsic works with any type: integers, booleans, and more. It's your primary debugging tool while developing.
+The `@` prefix indicates a compiler intrinsic—a built-in operation provided by
+the compiler. Use `println` for normal program output and `@dbg` when you want
+to inspect a value while developing.

--- a/website/content/tutorial/03-variables-and-types.md
+++ b/website/content/tutorial/03-variables-and-types.md
@@ -22,7 +22,7 @@ fn main() -> i32 {
     let index: u64 = 0;
     let byte: u8 = 255;
 
-    @dbg(x);
+    println("x = " + @to_string(x));
     x
 }
 ```
@@ -38,7 +38,7 @@ fn main() -> i32 {
     let x = 42;        // inferred as i32 (the default)
     let y = true;      // inferred as bool
 
-    @dbg(x);
+    println("x = " + @to_string(x));
     x
 }
 ```
@@ -54,8 +54,8 @@ fn main() -> i32 {
     let flag: bool = true;
     let done = false;
 
-    @dbg(flag);   // prints: 1 (true)
-    @dbg(done);   // prints: 0 (false)
+    @dbg(flag);   // prints: true
+    @dbg(done);   // prints: false
 
     0
 }
@@ -70,7 +70,7 @@ fn main() -> i32 {
     let mut count = 0;
     count = count + 1;
     count = count + 1;
-    @dbg(count);  // prints: 2
+    println("count = " + @to_string(count));
     count
 }
 ```

--- a/website/content/tutorial/04-functions.md
+++ b/website/content/tutorial/04-functions.md
@@ -21,10 +21,10 @@ fn is_positive(n: i32) -> bool {
 
 fn main() -> i32 {
     let sum = add(3, 4);
-    @dbg(sum);  // prints: 7
+    println("sum = " + @to_string(sum));
 
-    @dbg(is_positive(sum));   // prints: 1 (true)
-    @dbg(is_positive(-5));    // prints: 0 (false)
+    @dbg(is_positive(sum));   // prints: true
+    @dbg(is_positive(-5));    // prints: false
 
     sum
 }
@@ -55,8 +55,8 @@ fn absolute(n: i32) -> i32 {
 }
 
 fn main() -> i32 {
-    @dbg(absolute(-42));  // prints: 42
-    @dbg(absolute(17));   // prints: 17
+    println("abs(-42) = " + @to_string(absolute(-42)));
+    println("abs(17) = " + @to_string(absolute(17)));
     0
 }
 ```
@@ -65,9 +65,9 @@ fn main() -> i32 {
 
 Functions that don't return a meaningful value return the unit type `()`:
 
-```rue
+```rue check
 fn greet() {
-    @dbg(42);  // side effect only
+    println("hello from greet");
 }
 
 fn main() -> i32 {


### PR DESCRIPTION
## Summary
- introduce `println`/`print` as normal output in the hello-world tutorial
- use `println` plus `@to_string` for integer output examples in variables/functions
- keep `@dbg` framed as debugging output and correct bool comments to `true`/`false`
- opt the complete `greet` example into tutorial snippet verification

## Validation
- `scripts/check-tutorial-snippets.py`
- `./buck2 test //:tutorial-snippet-tests`