### PR TITLE
RUE-397: refresh arrays and collections tutorial

### DIFF
--- a/scripts/check-tutorial-snippets.py
+++ b/scripts/check-tutorial-snippets.py
@@ -98,7 +98,20 @@ def collect_snippets(root: Path) -> tuple[list[Snippet], int]:
     return snippets, unmarked_rue_fences
 
 
-def compile_snippet(rue_binary: str, snippet: Snippet, tempdir: Path) -> subprocess.CompletedProcess[str]:
+def snippet_env() -> dict[str, str]:
+    env = os.environ.copy()
+    std_path = Path("std")
+    if std_path.is_dir():
+        env.setdefault("RUE_STD_PATH", str(std_path.resolve()))
+    return env
+
+
+def compile_snippet(
+    rue_binary: str,
+    snippet: Snippet,
+    tempdir: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
     source_path = tempdir / f"{snippet.path.stem}-{snippet.line}.rue"
     output_path = tempdir / f"{snippet.path.stem}-{snippet.line}"
     source_path.write_text(snippet.source, encoding="utf-8")
@@ -108,6 +121,7 @@ def compile_snippet(rue_binary: str, snippet: Snippet, tempdir: Path) -> subproc
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=env,
         check=False,
     )
 
@@ -149,10 +163,11 @@ def main() -> int:
     rue_binary = find_rue_binary()
 
     failures = 0
+    env = snippet_env()
     with tempfile.TemporaryDirectory(prefix="rue-tutorial-snippets-") as temp:
         tempdir = Path(temp)
         for snippet in snippets:
-            result = compile_snippet(rue_binary, snippet, tempdir)
+            result = compile_snippet(rue_binary, snippet, tempdir, env)
             compiled = result.returncode == 0
             expected_success = snippet.action == "check"
 

--- a/website/content/tutorial/06-arrays.md
+++ b/website/content/tutorial/06-arrays.md
@@ -22,7 +22,8 @@ fn main() -> i32 {
 }
 ```
 
-Array indices are zero-based and must be `u64`.
+Array indices are zero-based and must have an integer type. Loop examples often
+use `u64` because lengths are represented as `u64`.
 
 ## Array Types
 
@@ -108,3 +109,47 @@ fn main() -> i32 {
     max
 }
 ```
+
+## Fixed Arrays vs Growable Buffers
+
+Fixed arrays are best when the length is known at compile time. Their length is
+part of the type: `[i32; 3]` and `[i32; 5]` are different types.
+
+When you need a collection that grows at runtime, use the standard library's
+`ArrayBuf(T)`. Import the standard library explicitly and access the buffer
+through the `std.arraybuf` namespace:
+
+```rue check
+const std = @import("std");
+
+fn main() -> i32 {
+    let Buffer = std.arraybuf.ArrayBuf(i32);
+    let MaybeI32 = std.option.Option(i32);
+
+    let mut values = Buffer::new();
+    values.push(10);
+    values.push(20);
+    values.push(30);
+
+    println("len = " + @to_string(values.len()));
+
+    let second = match values.get(1) {
+        MaybeI32::Some(n) => n,
+        MaybeI32::None => -1,
+    };
+    println("second = " + @to_string(second));
+
+    second
+}
+```
+
+`ArrayBuf(i32)` owns heap storage and frees it automatically when the buffer is
+dropped. Its `get` method returns `Option(i32)` rather than trapping:
+
+- `Option::Some(value)` means the index was in bounds.
+- `Option::None` means there was no element at that index.
+
+Use fixed arrays for small, known-size data and `ArrayBuf(T)` when the program
+discovers the number of elements as it runs. The slice and growable string parts
+of Rue's collection/string design are still in progress, so this tutorial keeps
+to the implemented fixed-array and `ArrayBuf` path.

--- a/website/content/tutorial/11-modules.md
+++ b/website/content/tutorial/11-modules.md
@@ -90,12 +90,13 @@ const std = @import("std");
 ```
 
 The intent is that standard-library types and functions are accessed through
-that namespace, for example `std.Option` or `std.ArrayBuf`.
+that namespace, for example `std.option.Option` or
+`std.arraybuf.ArrayBuf`.
 
-At the moment, this tutorial does not rely on `@import("std")`: the standard
-module is still being wired up, and a current compiler may report
-`standard library not found`. Until that lands, examples that need library
-helpers either define them inline or use checked-in example files directly.
+The repository wrapper commands know where the checked-in `std/` directory
+lives. If you invoke the compiler binary directly from somewhere else and see
+`standard library not found`, set `RUE_STD_PATH` to the repository's `std`
+directory.
 
 The important habit is still the same: use explicit module imports and
 namespace-qualified access rather than hidden global names.


### PR DESCRIPTION
## Summary
- correct the arrays tutorial index-type guidance to match the current spec
- add a checked `ArrayBuf(i32)` example using `@import("std")` and `Option(i32)`
- update the modules tutorial std namespace examples to `std.option.Option` and `std.arraybuf.ArrayBuf`
- teach the tutorial snippet checker to set `RUE_STD_PATH` when the repo `std/` directory is present

## Validation
- `scripts/check-tutorial-snippets.py`
- `./buck2 test //:tutorial-snippet-tests`