### PR TITLE
RUE-202: align expression prose with formal core

### DIFF
--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -1328,11 +1328,11 @@ witness of the dynamic semantics (RUE-50), cited inline in each §6 rule group.
 | §6.2 evaluation order (contexts, left-to-right) | 4.0:3–9 |
 | §6.3 dynamic use: copy vs. move; equality borrows | 3.8:5/7/22, 4.3:3f |
 | §6.4 operator dynamics: arith/div/mod, compare, bitwise/shift | 4.2:1, 4.3:1/2, 4.3a:10, 3.1:6/13 |
-| §6.5 aggregate intro + projection (bounds) | 3.5:2, 3.6:16, 8.2 |
-| §6.6 enum intro + match dynamics | 6.3:17, 4.7 |
+| §6.5 aggregate intro + projection (bounds) | 3.5:2, 3.6:16, 4.11:14, 4.12:9, 8.2 |
+| §6.6 enum intro + match dynamics | 6.3:17, 4.7:16 |
 | §6.7/§6.8 let/seq/scope-drop, assignment overwrite-drop | 4.5:3, 3.8:55/64, 3.9 |
 | §6.9 call / return / inout copy-out | 6.1:4/5/18, 4.9:1/7 |
-| §6.10 loop / break dynamics | 4.9 (loop), 3.4:2 |
+| §6.10 loop / break dynamics | 4.8:18/21, 4.9 (loop), 3.4:2 |
 | §6.11 drop relation (active enum payload; skip moved; explicit `@drop`) | 3.9, 6.3:20 |
 | §6.12 overflow/bounds/div-zero panics + exit code | 3.1:6/13, 8.1, 8.2, 8.3, Appendix B |
 | §7 soundness | the informal safety intent throughout ch. 3 and 8 |

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -83,8 +83,9 @@ All match arms **MUST** have the same type. The type of the match expression is 
 
 {{ rule(id="4.7:13", cat="normative") }}
 
-The type of each pattern **MUST** be compatible with the type of the scrutinee.
-A pattern with an incompatible type is rejected with a compile-time error.
+The type of each pattern **MUST** be identical to the type of the scrutinee, up
+to the one admitted never-type coercion (3.4:3). A pattern with any other type
+difference is rejected with a compile-time error.
 
 ## Arm Bodies
 
@@ -109,11 +110,12 @@ fn main() -> i32 {
 
 ## Execution
 
-{{ rule(id="4.7:16", cat="normative") }}
+{{ rule(id="4.7:16", cat="dynamic-semantics") }}
 
 Arms are evaluated in order. The first arm whose pattern matches the scrutinee value
 is selected, and its body expression is evaluated. The result of that evaluation
-becomes the value of the match expression.
+becomes the value of the match expression (core calculus
+`docs/formal/01-core-calculus.md` §6.6, rule `(D-Match)`).
 
 ## Unreachable Patterns
 
@@ -135,7 +137,7 @@ is unreachable, since the earlier pattern will match first.
 {{ rule(id="4.7:20", cat="normative") }}
 
 An unreachable pattern produces a compile-time warning. The program remains
-well-formed and the unreachable arm is not executed at runtime.
+well-formed and the unreachable arm body is not evaluated at runtime.
 
 {{ rule(id="4.7:21") }}
 

--- a/docs/spec/src/04-expressions/08-loop-expressions.md
+++ b/docs/spec/src/04-expressions/08-loop-expressions.md
@@ -10,9 +10,9 @@ template = "spec/page.html"
 
 {{ rule(id="4.8:1", cat="normative") }}
 
-A while loop repeatedly executes its body while a condition is true.
+A while loop repeatedly evaluates its body while a condition is true.
 
-{{ rule(id="4.8:2", cat="normative") }}
+{{ rule(id="4.8:2", cat="syntax") }}
 
 ```ebnf
 while_expr = "while" expression "{" block "}" ;
@@ -26,9 +26,12 @@ The condition expression **MUST** have type `bool`.
 
 A while expression has type `()`.
 
-{{ rule(id="4.8:5", cat="normative") }}
+{{ rule(id="4.8:5", cat="dynamic-semantics") }}
 
-The condition is evaluated before each iteration. If it is `true`, the body is executed and the condition is re-evaluated. If it is `false`, the loop terminates.
+The condition is evaluated before each iteration. If it is `true`, the body
+block is evaluated and the condition is re-evaluated. If it is `false`, the
+while expression evaluates to `()` (core calculus
+`docs/formal/01-core-calculus.md` §6.2 and §6.10).
 
 {{ rule(id="4.8:6") }}
 
@@ -50,7 +53,7 @@ fn main() -> i32 {
 
 An infinite loop repeatedly executes its body unconditionally.
 
-{{ rule(id="4.8:16", cat="normative") }}
+{{ rule(id="4.8:16", cat="syntax") }}
 
 ```ebnf
 loop_expr = "loop" "{" block "}" ;
@@ -60,9 +63,13 @@ loop_expr = "loop" "{" block "}" ;
 
 A loop expression that contains no `break` targeting it has type `!` (never), because it never produces a value.
 
-{{ rule(id="4.8:18", cat="normative") }}
+{{ rule(id="4.8:18", cat="dynamic-semantics") }}
 
-The only way to exit a `loop` is via `break` or `return`.
+The only way a `loop` yields a value to its enclosing expression is via
+`break`, which makes the `loop` evaluate to `()`. A `return` inside the loop
+exits the enclosing function instead (core calculus
+`docs/formal/01-core-calculus.md` §6.10, rule `(D-Break)`, and §6.9, rule
+`(D-Return)`).
 
 {{ rule(id="4.8:19") }}
 
@@ -113,9 +120,13 @@ Both `break` and `continue` **MUST** appear within a loop. Using them outside a 
 
 Both `break` and `continue` have the never type `!`.
 
-{{ rule(id="4.8:21", cat="normative") }}
+{{ rule(id="4.8:21", cat="dynamic-semantics") }}
 
-A `loop` expression that contains a `break` targeting it has type `()`: executing the `break` exits the loop, which then evaluates to `()`. This holds even if the `break` is unreachable.
+A `loop` expression that contains a `break` targeting it has type `()`.
+Executing the `break` exits the loop, runs the drops for scopes unwound by that
+exit, and makes the loop evaluate to `()` (core calculus
+`docs/formal/01-core-calculus.md` §6.10, rule `(D-Break)`). The static type is
+`()`, even if the `break` is unreachable.
 
 {{ rule(id="4.8:22", cat="legality-rule") }}
 
@@ -185,7 +196,7 @@ fn main() -> i32 {
 {{ rule(id="4.8:23", cat="normative") }}
 
 A `for` loop iterates over a built-in iterable, binding each element in turn and
-executing its body once per element (see ADR-0037).
+evaluating its body once per element (see ADR-0037).
 
 {{ rule(id="4.8:24", cat="syntax") }}
 

--- a/docs/spec/src/04-expressions/11-index-expressions.md
+++ b/docs/spec/src/04-expressions/11-index-expressions.md
@@ -10,7 +10,7 @@ template = "spec/page.html"
 
 An index expression accesses an element of an array.
 
-{{ rule(id="4.11:2", cat="normative") }}
+{{ rule(id="4.11:2", cat="syntax") }}
 
 ```ebnf
 index_expr = expression "[" expression "]" ;
@@ -36,7 +36,9 @@ The type of an index expression is the element type `T`.
 An index expression `base[index]` evaluates to the element stored at position
 `index` of the array denoted by `base` (elements are numbered from zero). The
 base expression is evaluated before the index expression (section 4.0), and the
-resulting index is bounds-checked (see below) before the element is read.
+resulting index is bounds-checked (see below) before the element is read (core
+calculus `docs/formal/01-core-calculus.md` §6.5, rules `(D-Index)` and
+`(D-Index-Trap)`).
 
 {{ rule(id="4.11:6") }}
 

--- a/docs/spec/src/04-expressions/12-field-access.md
+++ b/docs/spec/src/04-expressions/12-field-access.md
@@ -10,17 +10,17 @@ template = "spec/page.html"
 
 A field access expression accesses a field of a struct.
 
-{{ rule(id="4.12:2", cat="normative") }}
+{{ rule(id="4.12:2", cat="syntax") }}
 
 ```ebnf
 field_access = expression "." IDENT ;
 ```
 
-{{ rule(id="4.12:3", cat="normative") }}
+{{ rule(id="4.12:3", cat="legality-rule") }}
 
 The expression before the dot **MUST** have a struct type.
 
-{{ rule(id="4.12:4", cat="normative") }}
+{{ rule(id="4.12:4", cat="legality-rule") }}
 
 The identifier **MUST** be a valid field name for that struct type.
 
@@ -33,7 +33,9 @@ The type of a field access expression is the type of the accessed field.
 A field access expression `base.field` evaluates to the value currently held in
 the named `field` of the struct denoted by `base`. The base expression is
 evaluated first (section 4.0); the result is the value of that field at the
-point the access is evaluated.
+point the access is evaluated (core calculus
+`docs/formal/01-core-calculus.md` §6.5; projection in value context is governed
+by §6.3).
 
 {{ rule(id="4.12:6") }}
 


### PR DESCRIPTION
## Summary

Part of RUE-202.

- Reclassify expression grammar paragraphs as `syntax` and runtime paragraphs as `dynamic-semantics` where the prose was still generic `normative`.
- Add formal-core citations for match, loop/break, index, and field-access value denotation.
- Replace remaining folk phrasing in the touched expression prose (`executes`, `compatible with`) with the RUE-202 register.
- Extend the formal-core traceability table for the affected paragraph IDs.

## Validation

- `./buck2 run //crates/rue-spec:rue-spec -- --traceability`
- `./buck2 run //crates/rue-spec:rue-spec -- expressions`
- `git diff --check`

Traceability remains at the existing known state: 719/722 normative paragraphs covered, with only the three existing skipped 2.5 directive/allow items uncovered.