### PR TITLE
RUE-322: reject negative signed slice indices

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -4672,18 +4672,45 @@ impl<'a> Sema<'a> {
             span,
         });
 
-        // Runtime bounds check: `@assert(index < len)` traps (exit 101) when the
-        // index is out of range.
-        let cond_ref = air.add_inst(AirInst {
+        // Runtime bounds check: `@assert(index >= 0); @assert(index < len)`
+        // traps (exit 101) when the index is out of range. Unsigned indices only
+        // need the upper-bound check; signed indices also need the lower-bound
+        // check so `s[-1]` cannot pass the signed `index < len` comparison and
+        // read before the backing array.
+        let lower_assert_ref = if index_result.ty.is_signed() {
+            let zero_ref = air.add_inst(AirInst {
+                data: AirInstData::Const(0),
+                ty: index_result.ty,
+                span,
+            });
+            let lower_bound_ref = air.add_inst(AirInst {
+                data: AirInstData::Ge(index_result.air_ref, zero_ref),
+                ty: Type::BOOL,
+                span,
+            });
+            let assert_args = air.add_extra(&[lower_bound_ref.as_u32()]);
+            Some(air.add_inst(AirInst {
+                data: AirInstData::Intrinsic {
+                    name: self.known.assert,
+                    args_start: assert_args,
+                    args_len: 1,
+                },
+                ty: Type::UNIT,
+                span,
+            }))
+        } else {
+            None
+        };
+        let upper_bound_ref = air.add_inst(AirInst {
             data: AirInstData::Lt(index_result.air_ref, len_ref),
             ty: Type::BOOL,
             span,
         });
-        let assert_args = air.add_extra(&[cond_ref.as_u32()]);
-        let assert_ref = air.add_inst(AirInst {
+        let upper_assert_args = air.add_extra(&[upper_bound_ref.as_u32()]);
+        let upper_assert_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
                 name: self.known.assert,
-                args_start: assert_args,
+                args_start: upper_assert_args,
                 args_len: 1,
             },
             ty: Type::UNIT,
@@ -4715,11 +4742,16 @@ impl<'a> Sema<'a> {
         // Demand-driven lowering only pulls the returned value's dependencies,
         // so the bounds-check assertion (a pure side effect) must be an explicit
         // statement of the block that yields the element.
-        let stmts = air.add_extra(&[assert_ref.as_u32()]);
+        let stmt_refs: Vec<u32> = lower_assert_ref
+            .into_iter()
+            .chain(std::iter::once(upper_assert_ref))
+            .map(AirRef::as_u32)
+            .collect();
+        let stmts = air.add_extra(&stmt_refs);
         let block_ref = air.add_inst(AirInst {
             data: AirInstData::Block {
                 stmts_start: stmts,
-                stmts_len: 1,
+                stmts_len: stmt_refs.len() as u32,
                 value: elem_ref,
             },
             ty: elem_ty,

--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -55,6 +55,23 @@ fn main() -> i32 {
 args = ["main.rue", "--preview", "slices", "-o", "prog"]
 exit_code = 101
 
+# Signed negative indices must trap too. Slice indexing should match array
+# bounds semantics: any index below zero is out of bounds, not a huge pointer
+# offset or a read before the backing array.
+[[case]]
+name = "slice_param_negative_signed_index_traps"
+files = [{ path = "main.rue", source = """
+fn get(borrow s: [i32], i: i32) -> i32 {
+    s[i]
+}
+fn main() -> i32 {
+    let a: [i32; 3] = [10, 20, 30];
+    get(borrow a, -1)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 101
+
 # A constant read-index resolves the element position (discriminating value: the
 # middle element 5 catches an off-by-one or wrong-stride lowering).
 [[case]]


### PR DESCRIPTION
## Summary
- add a signed negative slice-index regression case
- emit an explicit lower-bound assert before signed slice pointer reads
- keep the existing upper-bound assert for all integer indices

Linear: RUE-322

## Validation
- ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- slices
- ./buck2 test //crates/rue-air:rue-air-test
- git diff --check