### PR TITLE
RUE-196: accept dotted type-member aliases

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -21,6 +21,19 @@ impl<'a> Sema<'a> {
         let receiver_var = self.extract_root_variable(receiver);
         let method_name_str = self.interner.resolve(&method).to_string();
 
+        // RUE-196: `Type.function(args)` is an additive dotted alias for the
+        // existing `Type::function(args)` form. Preserve ordinary value-method
+        // dispatch when a runtime local/parameter shadows the type name; only
+        // reinterpret an unbound identifier receiver as a type namespace.
+        if let InstData::VarRef { name } = self.rir.get(receiver).data
+            && !self.is_runtime_value_binding(name, ctx)
+            && self
+                .resolve_type(name, span)
+                .is_ok_and(|ty| matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Enum(_)))
+        {
+            return self.analyze_assoc_fn_call(air, name, method, args_start, args_len, span, ctx);
+        }
+
         // Slice methods (ADR-0043, RUE-322): `s.len()` reads the fat pointer's
         // runtime `len` word. Detected from the receiver's type. The `str`
         // string type (RUE-324) shares this path; a `str` local's HM-inferred

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3360,6 +3360,14 @@ impl<'a> Sema<'a> {
         // We need to peek at the base type to detect module.Type access patterns.
         let base_inst = self.rir.get(base);
         if let InstData::VarRef { name } = &base_inst.data {
+            if !self.is_runtime_value_binding(*name, ctx) {
+                if let Some(result) =
+                    self.try_analyze_dotted_enum_variant(air, *name, field, span, ctx)?
+                {
+                    return Ok(result);
+                }
+            }
+
             // Check if this VarRef refers to a module
             if let Some(local) = ctx.locals.get(name) {
                 if let Some(module_id) = local.ty.as_module() {
@@ -3952,6 +3960,68 @@ impl<'a> Sema<'a> {
             ));
         }
         Ok(())
+    }
+
+    /// Return true when `name` is a runtime local or parameter in this function.
+    ///
+    /// Dotted type-member compatibility for RUE-196 (`Type.member`) must not
+    /// steal ordinary value field/method access when a binding shadows a type
+    /// name. Comptime type variables are intentionally not runtime bindings:
+    /// `let O = Option(i32); O.Some(1)` should behave like `O::Some(1)`.
+    pub(crate) fn is_runtime_value_binding(&self, name: Spur, ctx: &AnalysisContext) -> bool {
+        ctx.locals.contains_key(&name) || ctx.params.iter().any(|param| param.name == name)
+    }
+
+    /// Try to resolve `Enum.Variant` as an additive dotted alias for
+    /// `Enum::Variant` (RUE-196).
+    fn try_analyze_dotted_enum_variant(
+        &mut self,
+        air: &mut Air,
+        type_name: Spur,
+        variant: Spur,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<Option<AnalysisResult>> {
+        let Some((enum_id, via_comptime)) = self.resolve_enum_type_name(type_name, ctx) else {
+            return Ok(None);
+        };
+
+        let enum_def = self.type_pool.enum_def(enum_id);
+        let variant_name = self.interner.resolve(&variant);
+        let Some(variant_index) = enum_def.find_variant(variant_name) else {
+            return Ok(None);
+        };
+
+        if !via_comptime {
+            self.check_unqualified_visibility(
+                "enum",
+                self.interner.resolve(&type_name),
+                enum_def.file_id,
+                enum_def.is_pub,
+                span,
+            )?;
+        }
+
+        let expected = enum_def.variant_payload(variant_index).len();
+        if expected > 0 {
+            return Err(CompileError::new(
+                ErrorKind::WrongArgumentCount { expected, found: 0 },
+                span,
+            ));
+        }
+
+        let ty = Type::new_enum(enum_id);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::EnumVariant {
+                enum_id,
+                variant_index: variant_index as u32,
+                payload_start: 0,
+                payload_len: 0,
+            },
+            ty,
+            span,
+        });
+        Ok(Some(AnalysisResult::new(air_ref, ty)))
     }
 
     /// Analyze an array initialization.
@@ -5501,7 +5571,7 @@ impl<'a> Sema<'a> {
     /// Analyze an associated function call.
     ///
     /// This is a complex operation. The full implementation is in analysis.rs.
-    fn analyze_assoc_fn_call(
+    pub(crate) fn analyze_assoc_fn_call(
         &mut self,
         air: &mut Air,
         type_name: Spur,

--- a/crates/rue-cli-tests/cases/member_access_dot.toml
+++ b/crates/rue-cli-tests/cases/member_access_dot.toml
@@ -1,0 +1,69 @@
+[section]
+id = "cli.member_access_dot"
+name = "Dotted type-member access"
+description = "RUE-196 additive dotted aliases for enum variants, tuple variants, associated functions, and match patterns."
+
+[[case]]
+name = "enum_variant_expression_dot"
+files = [{ path = "main.rue", source = """
+enum Color { Red, Green, Blue }
+fn main() -> i32 {
+    let c = Color.Green;
+    match c {
+        Color.Red => 1,
+        Color.Green => 42,
+        Color.Blue => 3,
+    }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "tuple_variant_expression_dot"
+files = [{ path = "main.rue", source = """
+enum Opt { Some(i32), None }
+fn main() -> i32 {
+    let x = Opt.Some(42);
+    match x {
+        Opt.Some(n) => n,
+        Opt.None => 0,
+    }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "associated_function_call_dot"
+files = [{ path = "main.rue", source = """
+struct Box {
+    value: i32,
+    fn make(v: i32) -> Box {
+        Box { value: v }
+    }
+}
+fn main() -> i32 {
+    let b = Box.make(42);
+    b.value
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "local_shadow_preserves_field_and_method_access"
+files = [{ path = "main.rue", source = """
+struct Box {
+    value: i32,
+    fn value(self) -> i32 {
+        self.value
+    }
+}
+fn main() -> i32 {
+    let Box = Box { value: 42 };
+    Box.value()
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 42

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -915,7 +915,7 @@ where
 
     // Simple path pattern: Enum::Variant (no module prefix), optionally with
     // payload bindings `Enum::Variant(a, b)`.
-    let simple_path_pat = ident_parser()
+    let simple_colon_path_pat = ident_parser()
         .then_ignore(just(TokenKind::ColonColon))
         .then(ident_parser())
         .then(pattern_bindings.clone())
@@ -932,10 +932,25 @@ where
             })
         });
 
+    // Dotted alias for a simple enum path pattern: Enum.Variant (RUE-196).
+    let simple_dot_path_pat = ident_parser()
+        .then_ignore(just(TokenKind::Dot))
+        .then(ident_parser())
+        .then(pattern_bindings.clone())
+        .map_with(|((type_name, variant), bindings), e| {
+            Pattern::Path(PathPattern {
+                base: None,
+                type_name,
+                variant,
+                bindings,
+                span: span_from_extra(e),
+            })
+        });
+
     // Qualified path pattern: module.Enum::Variant or module.sub.Enum::Variant
     // Parses: ident ("." ident)+ "::" ident
     // where the part before "::" is module.Type and after is Variant
-    let qualified_path_pat = ident_parser()
+    let qualified_colon_path_pat = ident_parser()
         .then(
             just(TokenKind::Dot)
                 .ignore_then(ident_parser())
@@ -945,7 +960,7 @@ where
         )
         .then_ignore(just(TokenKind::ColonColon))
         .then(ident_parser())
-        .then(pattern_bindings)
+        .then(pattern_bindings.clone())
         .map_with(|(((first, mut rest), variant), bindings), e| {
             // first is the first module identifier
             // rest contains all subsequent identifiers up to and including type_name
@@ -979,15 +994,60 @@ where
             })
         });
 
+    // Dotted alias for qualified enum path patterns:
+    // module.Enum.Variant or module.sub.Enum.Variant (RUE-196). The final two
+    // identifiers are the enum type and variant; any earlier identifiers form
+    // the module/member base expression.
+    let qualified_dot_path_pat = ident_parser()
+        .then(
+            just(TokenKind::Dot)
+                .ignore_then(ident_parser())
+                .repeated()
+                .at_least(2)
+                .collect::<Vec<_>>(),
+        )
+        .then(pattern_bindings)
+        .map_with(|((first, mut rest), bindings), e| {
+            let variant = rest.pop().expect("at_least(2) guarantees variant");
+            let type_name = rest.pop().expect("at_least(2) guarantees type name");
+
+            let base_expr = if rest.is_empty() {
+                Expr::Ident(first.clone())
+            } else {
+                let mut base = Expr::Ident(first.clone());
+                for field in rest {
+                    let span = base.span().extend_to(field.span.end);
+                    base = Expr::Field(FieldExpr {
+                        base: Box::new(base),
+                        field,
+                        span,
+                    });
+                }
+                base
+            };
+
+            Pattern::Path(PathPattern {
+                base: Some(Box::new(base_expr)),
+                type_name,
+                variant,
+                bindings,
+                span: span_from_extra(e),
+            })
+        });
+
     choice((
         wildcard,
         neg_int_pat,
         int_pat,
         bool_true,
         bool_false,
-        // Try qualified path first (has more structure), then simple path
-        qualified_path_pat,
-        simple_path_pat,
+        // Keep the existing `::` precedence, then accept the simple dotted
+        // alias. The qualified dotted parser is last so `Type.Variant` does
+        // not report a spurious "expected '.'" from the longer form.
+        qualified_colon_path_pat,
+        simple_colon_path_pat,
+        simple_dot_path_pat,
+        qualified_dot_path_pat,
     ))
 }
 


### PR DESCRIPTION
## Summary
- accept `Enum.Variant` as an additive alias for `Enum::Variant` in expressions and match patterns
- accept `Type.function(...)` as an additive alias for `Type::function(...)` / tuple-variant construction
- preserve ordinary field/method access when a runtime local or parameter shadows a type name

Linear: RUE-196

## Validation
- ./fmt.sh check
- ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- member_access_dot
- ./buck2 test //crates/rue-parser:rue-parser-test //crates/rue-air:rue-air-test
- git diff --check