### PR TITLE
RUE-202: align checked and comptime block prose

### DIFF
--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -17,7 +17,11 @@ comptime_expr = "comptime" "{" block "}" ;
 block         = { statement } [ expression ] ;
 ```
 
-The block inside a comptime expression is evaluated during compilation. It may contain `let` statements followed by a tail expression; the comptime expression evaluates to the value of the tail expression. The following operations are supported within comptime blocks:
+The block inside a comptime expression is evaluated during compilation using
+the ordinary block-expression value rules (4.5): a tail expression supplies the
+block's value, and a block without a tail expression evaluates to `()`. The
+comptime expression evaluates to that compile-time value. The following
+operations are supported within comptime blocks:
 
 - Integer literals
 - Boolean literals (`true`, `false`)

--- a/docs/spec/src/09-unchecked-code/01-syntax.md
+++ b/docs/spec/src/09-unchecked-code/01-syntax.md
@@ -46,7 +46,10 @@ checked_expr = "checked" "{" block "}" ;
 
 {{ rule(id="9.1:6", cat="dynamic-semantics") }}
 
-A `checked` block evaluates its body and returns the value of the final expression. The type of a `checked` block is the type of its body expression.
+A `checked` block evaluates its body block using the ordinary block-expression
+rules (4.5). Its value is the body block's value: the tail expression's value
+when present, or `()` when the body has no tail expression. The type of a
+`checked` block is the type of that body block.
 
 {{ rule(id="9.1:7", cat="example") }}
 


### PR DESCRIPTION
## Summary
- route `checked` block value/type prose through the ordinary block-expression rules
- route `comptime` block value prose through the same block-expression rules
- avoid local “return/final expression” wording that duplicates the formal core

Linear: RUE-202

## Validation
- website/build.sh
- git diff --check