### PR TITLE
RUE-322: allow empty array slices

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -730,34 +730,52 @@ impl<'a> Sema<'a> {
             return Err(self.type_mismatch_error(slice_ty, arr_ty, span));
         }
 
-        // ptr word = @raw(arr[0]) : ptr const T. Build a place read of element 0
-        // and take its address, exactly as source `@raw(arr[0])` would.
         let zero_ref = air.add_inst(AirInst {
             data: AirInstData::Const(0),
             ty: Type::U64,
             span,
         });
-        let mut projs: Vec<AirProjection> = trace.projections.iter().map(|p| p.proj).collect();
-        projs.push(AirProjection::Index {
-            array_type: arr_ty,
-            index: zero_ref,
-        });
-        let place_ref = air.make_place(trace.base, projs);
-        let elem0_read = air.add_inst(AirInst {
-            data: AirInstData::PlaceRead { place: place_ref },
-            ty: arr_elem,
-            span,
-        });
-        let raw_args = air.add_extra(&[elem0_read.as_u32()]);
-        let ptr_ref = air.add_inst(AirInst {
-            data: AirInstData::Intrinsic {
-                name: self.known.raw,
-                args_start: raw_args,
-                args_len: 1,
-            },
-            ty: ptr_ty,
-            span,
-        });
+        let ptr_ref = if arr_len == 0 {
+            // A zero-length slice never dereferences its pointer: every read is
+            // guarded by `i < len`, and `len` is 0. Do not form `@raw(arr[0])`
+            // for `[T; 0]`; that is not a valid place and underflows in some
+            // codegen paths. Use a conventional null pointer word instead.
+            let ptr_args = air.add_extra(&[zero_ref.as_u32()]);
+            air.add_inst(AirInst {
+                data: AirInstData::Intrinsic {
+                    name: self.known.int_to_ptr,
+                    args_start: ptr_args,
+                    args_len: 1,
+                },
+                ty: ptr_ty,
+                span,
+            })
+        } else {
+            // ptr word = @raw(arr[0]) : ptr const T. Build a place read of
+            // element 0 and take its address, exactly as source `@raw(arr[0])`
+            // would.
+            let mut projs: Vec<AirProjection> = trace.projections.iter().map(|p| p.proj).collect();
+            projs.push(AirProjection::Index {
+                array_type: arr_ty,
+                index: zero_ref,
+            });
+            let place_ref = air.make_place(trace.base, projs);
+            let elem0_read = air.add_inst(AirInst {
+                data: AirInstData::PlaceRead { place: place_ref },
+                ty: arr_elem,
+                span,
+            });
+            let raw_args = air.add_extra(&[elem0_read.as_u32()]);
+            air.add_inst(AirInst {
+                data: AirInstData::Intrinsic {
+                    name: self.known.raw,
+                    args_start: raw_args,
+                    args_len: 1,
+                },
+                ty: ptr_ty,
+                span,
+            })
+        };
 
         // len word = N (compile-time array length).
         let len_ref = air.add_inst(AirInst {

--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -126,6 +126,29 @@ fn main() -> i32 {
 args = ["main.rue", "--preview", "slices", "-o", "prog"]
 exit_code = 10
 
+# Borrowing a zero-length fixed array still produces a valid zero-length slice:
+# the pointer word is never dereferenced because `len()` is 0. This used to ICE
+# while trying to materialize the slice pointer as `@raw(arr[0])`.
+[[case]]
+name = "slice_param_empty_array_len_zero"
+files = [{ path = "main.rue", source = """
+fn sum(borrow s: [i32]) -> i32 {
+    let mut t = 0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        t = t + s[i];
+        i = i + 1;
+    }
+    t + @intCast(s.len())
+}
+fn main() -> i32 {
+    let a: [i32; 0] = [];
+    sum(borrow a)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 0
+
 # A slice parameter can be forwarded to another slice parameter (`borrow s`
 # where `s` is itself a slice): the fat pointer is passed through by value
 # rather than re-materialized.


### PR DESCRIPTION
## Summary
- allow `borrow [T; 0]` to materialize a valid zero-length `[T]` slice
- use a null pointer word for zero-length slices instead of forming invalid `@raw(arr[0])`
- add a CLI regression proving empty-array slices compile and report length zero

Linear: RUE-322

## Validation
- ./fmt.sh check
- ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- slices
- ./buck2 test //crates/rue-air:rue-air-test
- git diff --check