### PR TITLE
RUE-325: migrate mutable strings spec to StrBuf

### DIFF
--- a/crates/rue-spec/cases/types/mutable-strings.toml
+++ b/crates/rue-spec/cases/types/mutable-strings.toml
@@ -2,10 +2,10 @@
 id = "types.mutable_strings"
 spec_chapter = "3.10"
 name = "Mutable Strings"
-description = "Mutable string capabilities building on the core String type."
+description = "Mutable string capabilities building on the core StrBuf type."
 
 # =============================================================================
-# String Representation (3.10:1 - 3.10:3)
+# StrBuf Representation (3.10:1 - 3.10:3)
 # =============================================================================
 
 # Note: The three-field representation (ptr, len, cap) is tested indirectly
@@ -14,7 +14,7 @@ description = "Mutable string capabilities building on the core String type."
 [[case]]
 name = "string_representation_len_cap"
 spec = ["3.10:1", "3.10:2"]
-description = "String has length and capacity (proving three-field representation)"
+description = "StrBuf has length and capacity (proving three-field representation)"
 source = """
 fn main() -> i32 {
     let s = "hello";
@@ -44,15 +44,15 @@ fn main() -> i32 {
 exit_code = 0
 
 # =============================================================================
-# String Ownership (3.10:4 - 3.10:6)
+# StrBuf Ownership (3.10:4 - 3.10:6)
 # =============================================================================
 
 [[case]]
 name = "string_affine_move"
 spec = ["3.10:4", "3.10:5", "3.10:6"]
-description = "String is moved when passed to a function"
+description = "StrBuf is moved when passed to a function"
 source = """
-fn takes_string(s: String) -> i32 {
+fn takes_string(s: StrBuf) -> i32 {
     0
 }
 
@@ -66,9 +66,9 @@ exit_code = 0
 [[case]]
 name = "string_affine_use_after_move"
 spec = ["3.10:4", "3.10:5"]
-description = "Using a string after move is an error"
+description = "Using a StrBuf after move is an error"
 source = """
-fn takes_string(s: String) -> i32 { 0 }
+fn takes_string(s: StrBuf) -> i32 { 0 }
 
 fn main() -> i32 {
     let mut s = "hello";
@@ -86,10 +86,10 @@ error_contains = "use of moved value"
 [[case]]
 name = "string_new_empty"
 spec = ["3.10:7", "3.10:9"]
-description = "String::new() creates an empty string"
+description = "StrBuf::new() creates an empty string"
 source = """
 fn main() -> i32 {
-    let s = String::new();
+    let s = StrBuf::new();
     if s.is_empty() { 0 } else { 1 }
 }
 """
@@ -98,11 +98,11 @@ exit_code = 0
 [[case]]
 name = "string_with_capacity"
 spec = ["3.10:8", "3.10:9"]
-description = "String::with_capacity() pre-allocates"
+description = "StrBuf::with_capacity() pre-allocates"
 source = """
 fn main() -> i32 {
     let cap: u64 = 100;
-    let s = String::with_capacity(cap);
+    let s = StrBuf::with_capacity(cap);
     if s.capacity() >= cap { 0 } else { 1 }
 }
 """
@@ -202,7 +202,7 @@ spec = ["3.10:15", "3.10:19", "3.10:20"]
 description = "push_str() appends string content"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = StrBuf::new();
     s.push_str("hello");
     let five: u64 = 5;
     if s.len() == five { 0 } else { 1 }
@@ -216,7 +216,7 @@ spec = ["3.10:15", "3.10:20"]
 description = "Multiple push_str() calls accumulate"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = StrBuf::new();
     s.push_str("hello");
     s.push_str(" world");
     let eleven: u64 = 11;
@@ -231,7 +231,7 @@ spec = ["3.10:16", "3.10:19"]
 description = "push() appends a single byte"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = StrBuf::new();
     s.push_str("hello");
     let exclaim: u8 = 33;  // '!'
     s.push(exclaim);
@@ -248,7 +248,7 @@ description = "clear() removes content but retains capacity"
 source = """
 fn main() -> i32 {
     let cap: u64 = 100;
-    let mut s = String::with_capacity(cap);
+    let mut s = StrBuf::with_capacity(cap);
     s.push_str("hello");
     let cap_before = s.capacity();
     s.clear();
@@ -263,7 +263,7 @@ spec = ["3.10:18", "3.10:19"]
 description = "reserve() ensures additional capacity"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = StrBuf::new();
     s.push_str("hi");
     let additional: u64 = 100;
     s.reserve(additional);
@@ -279,7 +279,7 @@ spec = ["3.10:19"]
 description = "Mutation methods require let mut binding"
 source = """
 fn main() -> i32 {
-    let s = String::new();
+    let s = StrBuf::new();
     s.push_str("hello");
     0
 }
@@ -326,10 +326,10 @@ exit_code = 0
 [[case]]
 name = "string_growth_on_append"
 spec = ["3.10:24", "3.10:25"]
-description = "String grows capacity when needed"
+description = "StrBuf grows capacity when needed"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = StrBuf::new();
     s.push_str("hello");
     let cap1 = s.capacity();
     // Append enough to exceed initial capacity
@@ -449,7 +449,7 @@ spec = ["3.10:32"]
 description = "Strings are byte sequences"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = StrBuf::new();
     // Push some bytes
     let h: u8 = 72;   // 'H'
     let i: u8 = 105;  // 'i'
@@ -471,7 +471,7 @@ spec = ["3.10:15", "3.10:16", "3.10:20"]
 description = "Build a complete message through appending"
 source = """
 fn main() -> i32 {
-    let mut msg = String::new();
+    let mut msg = StrBuf::new();
     msg.push_str("Hello");
     msg.push_str(", ");
     msg.push_str("world");
@@ -490,7 +490,7 @@ spec = ["3.10:15", "3.7:9", "3.7:10"]
 description = "Mutated string can be compared"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = StrBuf::new();
     s.push_str("hello");
     if s == "hello" { 0 } else { 1 }
 }

--- a/docs/spec/src/03-types/10-mutable-strings.md
+++ b/docs/spec/src/03-types/10-mutable-strings.md
@@ -6,15 +6,15 @@ template = "spec/page.html"
 
 # Mutable Strings
 
-This section describes the mutable string capabilities, building on the core `String` type from section 3.7.
+This section describes the mutable string capabilities, building on the core `StrBuf` type from section 3.7.
 
 {{ preview_feature(feature="mutable_strings", adr="ADR-0014") }}
 
-## String Representation
+## StrBuf Representation
 
 {{ rule(id="3.10:1", cat="normative") }}
 
-A `String` value consists of three components: a pointer to the string data, the length in bytes, and the allocated capacity.
+A `StrBuf` value consists of three components: a pointer to the string data, the length in bytes, and the allocated capacity.
 
 {{ rule(id="3.10:2", cat="normative") }}
 
@@ -24,20 +24,20 @@ When capacity is zero, the string data points to read-only memory (a string lite
 
 This representation allows string literals to remain cheap (no allocation) while enabling mutation when needed. Mutation methods automatically promote read-only strings to the heap.
 
-## String Ownership
+## StrBuf Ownership
 
 {{ rule(id="3.10:4", cat="normative") }}
 
-`String` is an affine type: a `String` value is consumed when used and cannot be used again unless explicitly cloned.
+`StrBuf` is an affine type: a `StrBuf` value is consumed when used and cannot be used again unless explicitly cloned.
 
 {{ rule(id="3.10:5", cat="normative") }}
 
-`String` is not `@copy`. Passing a string to a function or assigning it to another binding moves the string.
+`StrBuf` is not `@copy`. Passing a string to a function or assigning it to another binding moves the string.
 
 {{ rule(id="3.10:6", cat="example") }}
 
 ```rue
-fn takes_string(s: String) -> i32 { 0 }
+fn takes_string(s: StrBuf) -> i32 { 0 }
 
 fn main() -> i32 {
     let mut s = "hello";
@@ -51,18 +51,18 @@ fn main() -> i32 {
 
 {{ rule(id="3.10:7", cat="normative") }}
 
-`String::new()` returns an empty string with no allocation.
+`StrBuf::new()` returns an empty string with no allocation.
 
 {{ rule(id="3.10:8", cat="normative") }}
 
-`String::with_capacity(cap: u64)` returns an empty string with pre-allocated capacity for `cap` bytes.
+`StrBuf::with_capacity(cap: u64)` returns an empty string with pre-allocated capacity for `cap` bytes.
 
 {{ rule(id="3.10:9", cat="example") }}
 
 ```rue
 fn main() -> i32 {
-    let empty = String::new();
-    let prealloc = String::with_capacity(1024);
+    let empty = StrBuf::new();
+    let prealloc = StrBuf::with_capacity(1024);
     0
 }
 ```
@@ -102,7 +102,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.10:15", cat="normative") }}
 
-`fn push_str(inout self, other: String)` appends the contents of `other` to the string. If the string is a literal (capacity zero), it is first promoted to the heap.
+`fn push_str(inout self, other: StrBuf)` appends the contents of `other` to the string. If the string is a literal (capacity zero), it is first promoted to the heap.
 
 {{ rule(id="3.10:16", cat="normative") }}
 
@@ -124,7 +124,7 @@ Mutation methods use `inout self` to modify the string in place. The variable mu
 
 ```rue
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = StrBuf::new();
     s.push_str("hello");
     s.push_str(" world");
     s.push(33);  // '!' character
@@ -171,7 +171,7 @@ The doubling growth strategy amortizes allocation cost over many appends, provid
 
 {{ rule(id="3.10:26", cat="normative") }}
 
-`fn clone(borrow self) -> String` creates a deep copy of the string, allocating a new heap buffer with the same content.
+`fn clone(borrow self) -> StrBuf` creates a deep copy of the string, allocating a new heap buffer with the same content.
 
 {{ rule(id="3.10:27", cat="informative") }}
 
@@ -192,7 +192,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.10:29", cat="dynamic-semantics") }}
 
-When a `String` value is dropped:
+When a `StrBuf` value is dropped:
 - If capacity is zero (literal), no action is taken
 - If capacity is greater than zero (heap-allocated), the heap buffer is freed
 


### PR DESCRIPTION
## Summary
- migrate the mutable-strings spec chapter from deprecated `String` spelling to canonical `StrBuf`
- update the corresponding rue-spec mutable string cases to exercise `StrBuf` constructors/types
- leave the `String` alias coverage in `strbuf_library` intact

Linear: RUE-325

## Validation
- `./buck2 run //crates/rue-spec:rue-spec -- mutable_strings`
- `./buck2 run //crates/rue-cli-tests:rue-cli-tests -- strbuf_library`
- `./fmt.sh check`
- `git diff --check`
