### PR TITLE
RUE-327: make stable spec StrBuf terminology primary

### DIFF
--- a/docs/spec/src/01-introduction.md
+++ b/docs/spec/src/01-introduction.md
@@ -72,7 +72,7 @@ Beyond the paragraph categories above, this specification classifies the *behavi
 
 {{ rule(id="1.3:6", cat="informative") }}
 
-**Implementation-defined behavior** is behavior for which this specification permits a set of possibilities and requires the implementation to choose one and **document** its choice. Examples: the growth strategy and resulting capacity of `String` (3.7); the in-memory layout of struct and array types (3.6); the width of `usize` and `isize` on a target (3.1); and the implementation limits of Appendix C.
+**Implementation-defined behavior** is behavior for which this specification permits a set of possibilities and requires the implementation to choose one and **document** its choice. Examples: the growth strategy and resulting capacity of `StrBuf` (3.7); the in-memory layout of struct and array types (3.6); the width of `usize` and `isize` on a target (3.1); and the implementation limits of Appendix C.
 
 {{ rule(id="1.3:7", cat="informative") }}
 

--- a/docs/spec/src/04-expressions/01-literal-expressions.md
+++ b/docs/spec/src/04-expressions/01-literal-expressions.md
@@ -74,7 +74,7 @@ fn main() -> i32 {
 
 {{ rule(id="4.1:10", cat="normative") }}
 
-A string literal is a sequence of characters enclosed in double quotes, of type `String`.
+A string literal is a sequence of characters enclosed in double quotes, of type `StrBuf`.
 
 {{ rule(id="4.1:11", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -55,13 +55,13 @@ Expression intrinsics (usable in any expression position):
 | `@align_of` | Get type alignment in bytes | 1 type | `i32` |
 | `@offset_of` | Get a struct field's byte offset | 1 type, 1 field name | `u64` |
 | `@intCast` | Convert between integer types | 1 expression (integer) | inferred integer type |
-| `@to_string` | Format an integer as its decimal `String` | 1 expression (any integer) | `String` |
+| `@to_string` | Format an integer as its decimal `StrBuf` | 1 expression (any integer) | `StrBuf` |
 | `@drop` | Run a value's drop glue and consume it (RUE-187) | 1 expression (any type) | `()` |
-| `@read_line` | Read line from stdin | none | `Option(String)` |
-| `@parse_i32` | Parse string to i32 | 1 expression (`String`) | `Option(i32)` |
-| `@parse_i64` | Parse string to i64 | 1 expression (`String`) | `Option(i64)` |
-| `@parse_u32` | Parse string to u32 | 1 expression (`String`) | `Option(u32)` |
-| `@parse_u64` | Parse string to u64 | 1 expression (`String`) | `Option(u64)` |
+| `@read_line` | Read line from stdin | none | `Option(StrBuf)` |
+| `@parse_i32` | Parse string to i32 | 1 expression (`StrBuf`) | `Option(i32)` |
+| `@parse_i64` | Parse string to i64 | 1 expression (`StrBuf`) | `Option(i64)` |
+| `@parse_u32` | Parse string to u32 | 1 expression (`StrBuf`) | `Option(u32)` |
+| `@parse_u64` | Parse string to u64 | 1 expression (`StrBuf`) | `Option(u64)` |
 | `@random_u32` | Generate random u32 | none | `u32` |
 | `@random_u64` | Generate random u64 | none | `u64` |
 | `@target_arch` | Get target architecture | none | `Arch` |
@@ -110,7 +110,7 @@ from the normative inventory above, but they are no longer no-ops (RUE-319):
 
 The `@dbg` intrinsic prints a value to standard output for debugging purposes.
 It *borrows* its argument: the value is read but not consumed, so a non-`Copy`
-argument (such as a `String`) remains valid after the `@dbg` call and is dropped
+argument (such as a `StrBuf`) remains valid after the `@dbg` call and is dropped
 by its owner at the end of the enclosing scope, exactly as if the `@dbg` call had
 not occurred.
 
@@ -127,7 +127,7 @@ not occurred.
 The textual form `@dbg` prints for its argument is determined by the argument's
 type: an integer is printed in base 10, with a leading `-` when a signed integer
 is negative and no sign otherwise; a boolean is printed as `true` or `false`; a
-`String` is printed as its exact bytes, byte-for-byte, with no quoting or
+`StrBuf` is printed as its exact bytes, byte-for-byte, with no quoting or
 escaping (mirroring `print`, 3.7). The newline of 4.13:8 follows this text.
 
 {{ rule(id="4.13:9", cat="normative") }}
@@ -355,7 +355,7 @@ The `@read_line` intrinsic reads a line of text from standard input.
 
 {{ rule(id="4.13:35", cat="normative") }}
 
-The return type of `@read_line` is `Option(String)`, where `Option` is the ordinary comptime-generic library enum (`enum { Some(T), None }`, ADR-0038). The concrete `Option(String)` type is taken from the surrounding context — a `let` binding annotation, or the arms of a `match` on the result — so `Option` must be in scope (e.g. imported) at the call site. As a special case, when `@read_line()` is the operand of the `?` operator (§4.15), the context supplies no annotation, so the intrinsic instantiates its own `Option(String)` directly (see rule 4.15:9).
+The return type of `@read_line` is `Option(StrBuf)`, where `Option` is the ordinary comptime-generic library enum (`enum { Some(T), None }`, ADR-0038). The concrete `Option(StrBuf)` type is taken from the surrounding context — a `let` binding annotation, or the arms of a `match` on the result — so `Option` must be in scope (e.g. imported) at the call site. As a special case, when `@read_line()` is the operand of the `?` operator (§4.15), the context supplies no annotation, so the intrinsic instantiates its own `Option(StrBuf)` directly (see rule 4.15:9).
 
 {{ rule(id="4.13:36", cat="dynamic-semantics") }}
 
@@ -363,7 +363,7 @@ The return type of `@read_line` is `Option(String)`, where `Option` is the ordin
 
 {{ rule(id="4.13:37", cat="dynamic-semantics") }}
 
-On a successful read the result is `Some(line)`, where the `line` `String` does **not** include the trailing newline character.
+On a successful read the result is `Some(line)`, where the `line` `StrBuf` does **not** include the trailing newline character.
 
 {{ rule(id="4.13:38", cat="dynamic-semantics") }}
 
@@ -381,7 +381,7 @@ If a read error occurs, a runtime panic occurs with the message "input error". (
 
 ```rue
 fn main() -> i32 {
-    let Opt = @import("std/option.rue").Option(String);
+    let Opt = @import("std/option.rue").Option(StrBuf);
     @dbg("What is your name?");
     match @read_line() {
         Opt::Some(name) => @dbg(name),
@@ -397,7 +397,7 @@ Reading every line until end-of-input:
 
 ```rue
 fn main() -> i32 {
-    let Opt = @import("std/option.rue").Option(String);
+    let Opt = @import("std/option.rue").Option(StrBuf);
     loop {
         let line: Opt = @read_line();
         match line {
@@ -427,7 +427,7 @@ The concrete `Option(T)` type is taken from the surrounding context (a `let` ann
 
 {{ rule(id="4.13:45", cat="normative") }}
 
-Each parsing intrinsic accepts exactly one argument, which **MUST** be of type `String`.
+Each parsing intrinsic accepts exactly one argument, which **MUST** be of type `StrBuf`.
 
 {{ rule(id="4.13:46", cat="normative") }}
 
@@ -484,7 +484,7 @@ fn main() -> i32 {
 fn main() -> i32 {
     let Opt = @import("std/option.rue").Option(i32);
     let s = "42";
-    // String is borrowed, not consumed
+    // StrBuf is borrowed, not consumed
     let parsed: Opt = @parse_i32(s);
     @dbg(s);  // s is still valid
     match parsed {
@@ -558,7 +558,7 @@ Using `@random_u32` in a guessing game:
 
 ```rue
 fn main() -> i32 {
-    let OptStr = @import("std/option.rue").Option(String);
+    let OptStr = @import("std/option.rue").Option(StrBuf);
     let OptU32 = @import("std/option.rue").Option(u32);
     let secret: u32 = (@random_u32() % 100) + 1;  // 1-100
     @dbg("Guess the number between 1 and 100!");

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -46,13 +46,13 @@ User-defined type names (structs and enums) **MUST** be unique within a program.
 
 {{ rule(id="6.0:3", cat="legality-rule") }}
 
-User-defined types **MUST NOT** use names reserved for built-in types. Currently, the only reserved type name is `String`.
+User-defined types **MUST NOT** use names reserved for built-in types. Currently, the reserved growable-string type names are `StrBuf` and its deprecated alias `String`.
 
 {{ rule(id="6.0:4", cat="example") }}
 
 ```rue
 // Error: cannot define type with reserved name
-struct String { data: i32 }  // compile error
+struct StrBuf { data: i32 }  // compile error
 ```
 
 {{ rule(id="6.0:5", cat="legality-rule") }}

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -36,7 +36,7 @@ implementation:
 |----------|----------------------------------|
 | **Undefined** | None. A program that exhibits undefined behavior is invalid and the implementation may do anything. In Rue this arises **only within `unchecked` code** (see B.3). |
 | **Unspecified** | Choose from a permitted set of behaviors; no particular choice is required and none need be documented. Rue specifies most such choices (e.g. evaluation order §4.0, drop order §3.9), so this category has few instances today. |
-| **Implementation-defined** | Choose from a permitted set **and document** the choice. Examples: `String` growth/capacity (§3.7), struct and array layout (§3.6), the width of `usize`/`isize` (§3.1), and the limits of Appendix C. |
+| **Implementation-defined** | Choose from a permitted set **and document** the choice. Examples: `StrBuf` growth/capacity (§3.7), struct and array layout (§3.6), the width of `usize`/`isize` (§3.1), and the limits of Appendix C. |
 | **Erroneous** | Well-defined behavior that is nonetheless a program error a conforming implementation is encouraged to diagnose. Rue currently has **no** erroneous behavior — conditions other languages leave erroneous (e.g. integer overflow) Rue instead *traps* as a defined panic (see B.2). |
 
 {{ rule(id="B.1:3", cat="informative") }}


### PR DESCRIPTION
## Summary
- make stable spec pages refer to `StrBuf` as the primary growable string type
- update intrinsic return/argument prose and examples from `String` to `StrBuf`
- document both `StrBuf` and deprecated `String` as reserved type names

Linear: RUE-327

## Validation
- `./buck2 run //crates/rue-spec:rue-spec -- --traceability`
- `./fmt.sh check`
- `git diff --check`
