### PR TITLE
RUE-345: trap heap intrinsic size overflow

### DIFF
--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -104,6 +104,39 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = ["heap intrinsic `@alloc`", "checked"]
 
+# The hidden `count * size_of(T)` performed by heap intrinsics is part of the
+# runtime allocation ABI. It must trap instead of wrapping to a smaller byte
+# count, which would under-allocate the buffer the source pointer describes
+# (RUE-345).
+[[case]]
+name = "alloc_count_size_overflow_traps"
+description = "@alloc traps when count * size_of(T) overflows u64."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i64 = @alloc(2305843009213693952);
+        if @ptr_to_int(p) == 0 { 0 } else { 1 }
+    }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+
+[[case]]
+name = "realloc_count_size_overflow_traps"
+description = "@realloc traps when the new count * size_of(T) overflows u64."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i64 = @alloc(1);
+        let q: ptr mut i64 = @realloc(p, 1, 2305843009213693952);
+        if @ptr_to_int(q) == 0 { 0 } else { 1 }
+    }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 101
+
 # A near-usize::MAX @alloc once wrapped the arena's page round-up to zero,
 # handed out a huge block backed by a 64 KiB mapping, and let a later write
 # corrupt memory / SIGSEGV (rue-runtime component review, 2026-07-04). The
@@ -114,7 +147,7 @@ description = "A near-usize::MAX @alloc returns null instead of an unbacked poin
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc(18446744073709551491);
+        let p: ptr mut u8 = @alloc(2305843009213693951);
         let addr: u64 = @ptr_to_int(p);
         if addr == 0 { 0 } else { 1 }
     }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -134,7 +134,10 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Emit `count_vreg * element_size` (a compile-time constant stride) into a
-    /// fresh vreg. Mirrors the scaling used by `@ptr_offset`.
+    /// fresh vreg, trapping if the hidden byte-size computation overflows.
+    /// Mirrors the scaling used by `@ptr_offset`, but heap intrinsic sizes are
+    /// part of the runtime ABI: silently wrapping here would under-allocate or
+    /// pass the wrong size to free/realloc (RUE-345).
     fn scale_by_size(&mut self, count_vreg: VReg, element_size: u64) -> VReg {
         let out = self.mir.alloc_vreg();
         if element_size == 0 {
@@ -158,6 +161,21 @@ impl<'a> CfgLower<'a> {
                 src1: Operand::Virtual(count_vreg),
                 src2: Operand::Virtual(size_vreg),
             });
+            let high_vreg = self.mir.alloc_vreg();
+            self.mir.push(Aarch64Inst::UmulhRR {
+                dst: Operand::Virtual(high_vreg),
+                src1: Operand::Virtual(count_vreg),
+                src2: Operand::Virtual(size_vreg),
+            });
+
+            let ok_label = self.mir.alloc_label();
+            self.mir.push(Aarch64Inst::Cbz {
+                src: Operand::Virtual(high_vreg),
+                label: ok_label,
+            });
+            let symbol_id = self.intern_symbol("__rue_overflow");
+            self.mir.push(Aarch64Inst::Bl { symbol_id });
+            self.mir.push(Aarch64Inst::Label { id: ok_label });
         }
         out
     }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -137,7 +137,10 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Emit `count_vreg * element_size` (a compile-time constant stride) into a
-    /// fresh vreg. Mirrors the scaling used by `@ptr_offset`.
+    /// fresh vreg, trapping if the hidden byte-size computation overflows.
+    /// Mirrors the scaling used by `@ptr_offset`, but heap intrinsic sizes are
+    /// part of the runtime ABI: silently wrapping here would under-allocate or
+    /// pass the wrong size to free/realloc (RUE-345).
     fn scale_by_size(&mut self, count_vreg: VReg, element_size: u64) -> VReg {
         let out = self.mir.alloc_vreg();
         if element_size == 0 {
@@ -157,13 +160,24 @@ impl<'a> CfgLower<'a> {
                 imm: element_size as i64,
             });
             self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(out),
+                dst: Operand::Physical(Reg::Rax),
                 src: Operand::Virtual(count_vreg),
             });
-            self.mir.push(X86Inst::ImulRR64 {
-                dst: Operand::Virtual(out),
+            self.mir.push(X86Inst::Mul64R {
                 src: Operand::Virtual(size_vreg),
             });
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(out),
+                src: Operand::Physical(Reg::Rax),
+            });
+
+            // MOV does not modify flags, so MUL's carry flag still records
+            // whether the unsigned product's high half was non-zero.
+            let ok_label = self.new_label();
+            self.mir.push(X86Inst::Jae { label: ok_label });
+            let symbol_id = self.intern_symbol("__rue_overflow");
+            self.mir.push(X86Inst::CallRel { symbol_id });
+            self.mir.push(X86Inst::Label { id: ok_label });
         }
         out
     }


### PR DESCRIPTION
## Summary

- trap hidden `count * size_of(T)` overflow in heap intrinsic lowering on x86_64 and aarch64
- cover `@alloc` and `@realloc` overflow with CLI tests
- preserve the runtime page-rounding overflow test by using the largest non-wrapping heap count

## Root cause

`@alloc`, `@free`, and `@realloc` lowered their element counts to byte sizes with an unchecked backend multiply. If `count * size_of(T)` wrapped, the runtime only saw the already-wrapped byte count and could allocate or free the wrong size.

## Validation

- `./buck2 test //:cli-tests`
- `./fmt.sh check`
- `git diff --check`
- `./buck2 test //crates/rue-codegen:rue-codegen-test`
- `./buck2 test //:spec-tests`
- `./buck2 test //...`