### PR TITLE
RUE-173: support callable function const aliases

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -213,6 +213,9 @@ pub struct ConstraintGenerator<'a> {
     /// constraint generation (RUE-16). `None` only in unit tests; production
     /// passes the map via [`Self::with_const_values`].
     const_values: Option<&'a HashMap<Spur, i128>>,
+    /// Function-valued constants: alias name -> callee function name. These
+    /// let constraint generation type `alias(...)` as a direct call.
+    const_function_aliases: Option<&'a HashMap<Spur, Spur>>,
     /// Comptime *value* parameters known for the specialization currently being
     /// analyzed (`comptime n: i32` → `n = 0` for the call `f(0)`). Lets a
     /// `match` on a comptime-known scrutinee prune to its selected arm during
@@ -275,6 +278,7 @@ impl<'a> ConstraintGenerator<'a> {
             comptime_local_types: None,
             extra_method_sigs: None,
             const_values: None,
+            const_function_aliases: None,
             comptime_values: None,
             type_pool,
         }
@@ -346,6 +350,16 @@ impl<'a> ConstraintGenerator<'a> {
     /// `const_values` field (RUE-16).
     pub fn with_const_values(mut self, const_values: &'a HashMap<Spur, i128>) -> Self {
         self.const_values = Some(const_values);
+        self
+    }
+
+    /// Provide function-valued constants so `alias(...)` gets the callee's
+    /// signature during constraint generation.
+    pub fn with_const_function_aliases(
+        mut self,
+        const_function_aliases: &'a HashMap<Spur, Spur>,
+    ) -> Self {
+        self.const_function_aliases = Some(const_function_aliases);
         self
     }
 
@@ -848,6 +862,10 @@ impl<'a> ConstraintGenerator<'a> {
                 args_start,
                 args_len,
             } => {
+                let name = self
+                    .const_function_aliases
+                    .and_then(|aliases| aliases.get(name))
+                    .unwrap_or(name);
                 let args = self.rir.get_call_args(*args_start, *args_len);
                 // `print(s)` / `println(s)` builtin free functions (RUE-1):
                 // constrain the single argument to String and yield unit, so a

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -233,6 +233,12 @@ impl<'a> Sema<'a> {
                             inst.span,
                         ))
                     }
+                    Some(ConstValue::Function(_)) => Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: "function references cannot exist at runtime".to_string(),
+                        },
+                        inst.span,
+                    )),
                     Some(ConstValue::Unit) => {
                         let ty = Type::UNIT;
                         let air_ref = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -77,6 +77,7 @@ impl<'a> Sema<'a> {
         )
         .with_const_types(&infer_ctx.const_types)
         .with_const_values(&infer_ctx.const_values)
+        .with_const_function_aliases(&infer_ctx.const_function_aliases)
         .with_module_binding_types(&infer_ctx.module_binding_types)
         .with_comptime_local_types(&comptime_local_types)
         .with_comptime_values(value_subst)
@@ -123,6 +124,7 @@ impl<'a> Sema<'a> {
                     }
                     ConstValue::Bool(_) => Type::BOOL,
                     ConstValue::Type(t) => *t,
+                    ConstValue::Function(_) => Type::COMPTIME_TYPE,
                     ConstValue::Unit => Type::UNIT,
                 };
                 param_vars.entry(*name).or_insert(ParamVarInfo {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2454,6 +2454,9 @@ impl<'a> Sema<'a> {
             ConstValue::Integer(v) => (AirInstData::Const(v as u64), ty),
             ConstValue::Bool(b) => (AirInstData::BoolConst(b), Type::BOOL),
             ConstValue::Unit => (AirInstData::UnitConst, Type::UNIT),
+            ConstValue::Function(_) => unreachable!(
+                "function-valued constants are callable aliases and must not be materialized"
+            ),
             // Value constants never hold type values (declaration collection
             // rejects them); this arm only fires defensively.
             ConstValue::Type(t) => (AirInstData::TypeConst(t), ty),
@@ -2696,6 +2699,14 @@ impl<'a> Sema<'a> {
                     });
                     return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
                 }
+                ConstValue::Function(_) => {
+                    return Err(CompileError::new(
+                        ErrorKind::ConstExprNotSupported {
+                            expr_kind: "a function reference".to_string(),
+                        },
+                        span,
+                    ));
+                }
                 ConstValue::Unit => {
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::Const(0),
@@ -2740,6 +2751,14 @@ impl<'a> Sema<'a> {
                 const_info.is_pub,
                 span,
             )?;
+            if matches!(const_info.value, ConstValue::Function(_)) {
+                return Err(CompileError::new(
+                    ErrorKind::ConstExprNotSupported {
+                        expr_kind: "a function reference".to_string(),
+                    },
+                    span,
+                ));
+            }
             let (data, ty) = Self::materialize_const_value(const_info.value, const_info.ty);
             let air_ref = air.add_inst(AirInst { data, ty, span });
             return Ok(AnalysisResult::new(air_ref, ty));
@@ -3870,6 +3889,14 @@ impl<'a> Sema<'a> {
                     span,
                 });
                 return Ok(AnalysisResult::new(air_ref, module_ty));
+            }
+            if matches!(const_info.value, ConstValue::Function(_)) {
+                return Err(CompileError::new(
+                    ErrorKind::ConstExprNotSupported {
+                        expr_kind: "a function reference".to_string(),
+                    },
+                    span,
+                ));
             }
             // A value const (e.g. `pub const ANSWER = ...`) accessed as a
             // module member: materialize the value that was evaluated at
@@ -5094,6 +5121,21 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        let mut name = name;
+        if let Some(const_info) = self.constants.get(&name)
+            && let Some(callee) = const_info.value.as_function()
+        {
+            let alias_name = self.interner.resolve(&name).to_string();
+            self.check_unqualified_visibility(
+                "constant",
+                &alias_name,
+                const_info.span.file_id,
+                const_info.is_pub,
+                span,
+            )?;
+            name = callee;
+        }
+
         // `print(s)` / `println(s)` are builtin free functions (RUE-1), not
         // user-defined ones: intercept them here before the function lookup,
         // but only when the program hasn't shadowed the name with its own

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -636,6 +636,12 @@ pub enum ConstValue {
     /// This is used when a `comptime T: type` parameter is instantiated
     /// with a specific type like `i32` or `bool`.
     Type(Type),
+    /// Function reference - stores the callee symbol.
+    ///
+    /// Function-valued constants are currently callable aliases only: they can
+    /// be used as the callee of a call expression, but cannot be materialized
+    /// as ordinary runtime values.
+    Function(lasso::Spur),
     /// Unit value - the value of `()`.
     // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
     #[allow(dead_code)]
@@ -683,6 +689,14 @@ impl ConstValue {
         }
     }
 
+    /// Try to extract a function reference.
+    pub fn as_function(self) -> Option<lasso::Spur> {
+        match self {
+            ConstValue::Function(name) => Some(name),
+            _ => None,
+        }
+    }
+
     /// Check if this is a unit value.
     // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
     #[allow(dead_code)]
@@ -698,6 +712,7 @@ impl ConstValue {
             ConstValue::Integer(_) => Type::I64, // Default to i64 for comptime integers
             ConstValue::Bool(_) => Type::BOOL,
             ConstValue::Type(_) => Type::COMPTIME_TYPE,
+            ConstValue::Function(_) => Type::COMPTIME_TYPE,
             ConstValue::Unit => Type::UNIT,
         }
     }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -135,6 +135,14 @@ impl<'a> Sema<'a> {
             .filter_map(|(name, info)| info.value.as_int_value().map(|v| (*name, v)))
             .collect();
 
+        // Function-valued constants are callable aliases only. Constraint
+        // generation uses this map to type `alias(...)` like the real callee.
+        let const_function_aliases: HashMap<Spur, Spur> = self
+            .constants
+            .iter()
+            .filter_map(|(name, info)| info.value.as_function().map(|callee| (*name, callee)))
+            .collect();
+
         // Module-binding types (`const utils = @import(...)`), keyed by the
         // declaring file: bindings are per-file scoped (RUE-113), so a
         // reference resolves against the file it appears in.
@@ -151,6 +159,7 @@ impl<'a> Sema<'a> {
             method_sigs,
             const_types,
             const_values,
+            const_function_aliases,
             module_binding_types,
         }
     }
@@ -1630,6 +1639,13 @@ impl<'a> Sema<'a> {
                     )?;
                     return Ok(ConstInit::Value(info.value));
                 }
+                if let Some((fn_file_id, is_pub)) = self.find_free_function_decl(name, None) {
+                    let fn_name = self.interner.resolve(&name).to_string();
+                    self.check_unqualified_visibility(
+                        "function", &fn_name, fn_file_id, is_pub, span,
+                    )?;
+                    return Ok(ConstInit::Value(ConstValue::Function(name)));
+                }
                 // Not a constant: let the comptime engine decide (it rejects
                 // unknown names and type names as non-evaluable).
                 self.eval_const_value_expr(init, file_id, st, span, declared_ty)
@@ -2140,24 +2156,20 @@ impl<'a> Sema<'a> {
             }
         }
 
-        // A function member is a value the constant machinery cannot hold:
-        // there is no function type or function const-value yet (fn-valued
-        // constants are a type-system gap, RUE-173). Diagnose it
-        // precisely rather than "unknown member". The RIR is scanned directly
-        // because function signatures are collected in the same declaration
-        // walk and may not have been reached yet.
+        // A function member yields a callable alias. It is intentionally not a
+        // first-class runtime value: call analysis rewrites calls through this
+        // ConstValue to the real callee, and expression materialization rejects
+        // it.
         if let Some(mfile) = module_file_id {
-            let is_fn = self.rir.iter().any(|(_, inst)| {
-                matches!(&inst.data, InstData::FnDecl { name, .. } if *name == member)
-                    && inst.span.file_id == mfile
-            });
-            if is_fn {
-                return Err(CompileError::new(
-                    ErrorKind::ConstExprNotSupported {
-                        expr_kind: "a function reference".to_string(),
-                    },
+            if let Some((_fn_file_id, is_pub)) = self.find_free_function_decl(member, Some(mfile)) {
+                self.check_const_member_visibility(
+                    is_pub,
+                    &member_str,
+                    &module_file_path,
+                    accessing_file,
                     span,
-                ));
+                )?;
+                return Ok(ConstInit::Value(ConstValue::Function(member)));
             }
         }
 
@@ -2179,6 +2191,35 @@ impl<'a> Sema<'a> {
             },
             span,
         ))
+    }
+
+    /// Find a free function declaration in RIR, optionally restricted to one
+    /// source file. This is used during const collection, which is
+    /// dependency-ordered and can run before the main function-signature pass
+    /// has populated `self.functions`.
+    fn find_free_function_decl(
+        &self,
+        target: Spur,
+        file_id: Option<FileId>,
+    ) -> Option<(FileId, bool)> {
+        self.rir.iter().find_map(|(_, inst)| {
+            let InstData::FnDecl {
+                is_pub,
+                name,
+                has_self,
+                ..
+            } = &inst.data
+            else {
+                return None;
+            };
+            if *has_self || *name != target {
+                return None;
+            }
+            if file_id.is_some_and(|wanted| inst.span.file_id != wanted) {
+                return None;
+            }
+            Some((inst.span.file_id, *is_pub))
+        })
     }
 
     /// The visibility rule for module members accessed in const context
@@ -2248,6 +2289,7 @@ impl<'a> Sema<'a> {
             }
             ConstValue::Bool(_) => Type::BOOL,
             ConstValue::Unit => Type::UNIT,
+            ConstValue::Function(_) => Type::COMPTIME_TYPE,
             // Type values are rejected before this point (and module
             // bindings never take this path); keep the type if one slips
             // through so the mismatch error below names it.
@@ -2255,6 +2297,9 @@ impl<'a> Sema<'a> {
         };
 
         let Some(ty_sym) = ty_sym else {
+            if matches!(value, ConstValue::Function(_)) {
+                return Ok(inferred);
+            }
             // Type values are not annotatable (no syntax names them), so a
             // hypothetical unannotated type-valued constant is not an
             // annotation error; today they are rejected upstream anyway.

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -46,6 +46,9 @@ pub struct InferenceContext {
     /// (`[i32; K]`) can be resolved to a concrete length during constraint
     /// generation (RUE-16). Only integer-valued constants appear here.
     pub const_values: HashMap<Spur, i128>,
+    /// Function-valued constants: alias name -> callee function name. These
+    /// are callable aliases only, not first-class runtime values.
+    pub const_function_aliases: HashMap<Spur, Spur>,
     /// Module-binding types (`const utils = @import(...)`): (declaring file,
     /// name) -> module type. Module bindings are per-file scoped (RUE-113),
     /// so they're keyed by file rather than living in `const_types`.

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -27,7 +27,7 @@
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
-use lasso::{Spur, ThreadedRodeo};
+use lasso::{Key, Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_rir::RirParamMode;
 use rue_span::Span;
@@ -65,6 +65,8 @@ const CV_TAG_BOOL: u32 = 1;
 const CV_TAG_UNIT: u32 = 2;
 /// Tag for `ConstValue::Type` (payload: 1 word, `Type::as_u32`).
 const CV_TAG_TYPE: u32 = 3;
+/// Tag for `ConstValue::Function` (payload: 1 word, interned symbol key).
+const CV_TAG_FUNCTION: u32 = 4;
 
 /// Encode comptime value arguments as a tagged `u32` word stream for the AIR
 /// extra array. Decoded by [`decode_const_values`].
@@ -87,6 +89,10 @@ pub fn encode_const_values(values: &[ConstValue]) -> Vec<u32> {
             ConstValue::Type(ty) => {
                 words.push(CV_TAG_TYPE);
                 words.push(ty.as_u32());
+            }
+            ConstValue::Function(name) => {
+                words.push(CV_TAG_FUNCTION);
+                words.push(name.into_usize() as u32);
             }
         }
     }
@@ -119,6 +125,12 @@ pub fn decode_const_values(words: &[u32]) -> Vec<ConstValue> {
                 let ty = Type::from_u32(words[i]);
                 i += 1;
                 ConstValue::Type(ty)
+            }
+            CV_TAG_FUNCTION => {
+                let name = lasso::Spur::try_from_usize(words[i] as usize)
+                    .expect("invalid function symbol key in extra array");
+                i += 1;
+                ConstValue::Function(name)
             }
             _ => unreachable!("invalid ConstValue tag {tag} in extra array"),
         };
@@ -377,6 +389,7 @@ fn mangle_const_value(value: &ConstValue) -> String {
         ConstValue::Bool(b) => format!("v{}", b),
         ConstValue::Unit => "vunit".to_string(),
         ConstValue::Type(ty) => format!("v{}", mangle_type(*ty)),
+        ConstValue::Function(name) => format!("vfn{}", name.into_usize()),
     }
 }
 

--- a/crates/rue-cli-tests/cases/module_consts.toml
+++ b/crates/rue-cli-tests/cases/module_consts.toml
@@ -217,16 +217,15 @@ pub fn touch() -> i32 { SECRET }
 ]
 exit_code = 33
 
-# Binding a FUNCTION member in a const is a type-system gap (RUE-173): it
-# must be diagnosed precisely (E0434 "a function reference"), not as a
-# bogus "no member" (E0707).
+# Binding a FUNCTION member in a const creates a callable alias (RUE-173).
 [[case]]
-name = "fn_member_in_const_precise_error"
+name = "fn_member_const_alias_call"
+description = "A module-member function const creates a callable alias (spec 6.5:15), and calling the alias is equivalent to calling the function (spec 4.10:12)."
 files = [
     { path = "main.rue", source = """
-const abs = @import("math").abs;
+const abs_alias = @import("math").abs;
 
-fn main() -> i32 { 0 }
+fn main() -> i32 { abs_alias(0 - 42) }
 """ },
     { path = "math.rue", source = """
 pub fn abs(x: i32) -> i32 {
@@ -234,6 +233,36 @@ pub fn abs(x: i32) -> i32 {
 }
 """ },
 ]
+exit_code = 42
+
+# The same callable-alias machinery supports local function aliases.
+[[case]]
+name = "local_fn_const_alias_call"
+description = "A local function const creates a callable alias (spec 6.5:15), and calling the alias is equivalent to calling the function (spec 4.10:12)."
+files = [{ path = "main.rue", source = """
+const f = answer;
+
+fn answer() -> i32 { 42 }
+
+fn main() -> i32 { f() }
+""" }]
+exit_code = 42
+
+# Function-valued constants are callable aliases only, not first-class runtime
+# values.
+[[case]]
+name = "fn_const_alias_not_runtime_value"
+description = "Function-valued constants are callable aliases only, not first-class runtime values (spec 6.5:15)."
+files = [{ path = "main.rue", source = """
+const f = answer;
+
+fn answer() -> i32 { 42 }
+
+fn main() -> i32 {
+    let x = f;
+    0
+}
+""" }]
 compile_fail = true
 error_contains = ["E0434", "a function reference is not supported in const context"]
 

--- a/crates/rue-spec/cases/expressions/call.toml
+++ b/crates/rue-spec/cases/expressions/call.toml
@@ -129,3 +129,33 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+[[case]]
+name = "callable_const_alias_invokes_function"
+spec = ["4.10:12", "6.5:15"]
+description = "A function-valued const is a callable alias, and calling it is equivalent to calling the aliased function."
+source = """
+const f = answer;
+
+fn answer() -> i32 { 42 }
+
+fn main() -> i32 { f() }
+"""
+exit_code = 42
+
+[[case]]
+name = "callable_const_alias_not_runtime_value"
+spec = ["6.5:15"]
+description = "A function-valued const is not a first-class runtime value."
+source = """
+const f = answer;
+
+fn answer() -> i32 { 42 }
+
+fn main() -> i32 {
+    let x = f;
+    0
+}
+"""
+compile_fail = true
+error_contains = "[E0434]"

--- a/docs/designs/0026-module-system.md
+++ b/docs/designs/0026-module-system.md
@@ -102,11 +102,11 @@ add(1, 2)
 > RUE-136/RUE-122). Member access is also const-evaluable for modules and
 > value constants (RUE-160): `const math = std.math;` aliases a nested
 > module, and `const X = m.ANSWER;` / `m.ANSWER` at a use site resolve a
-> member value constant. The last form above — binding a *function* member
-> (`const add = @import("math.rue").add`) — is **not yet supported**:
-> fn-valued constants need function values in the type system (RUE-173;
-> diagnosed precisely as E0434 "a function reference is not supported in
-> const context").
+> member value constant. Binding a *function* member (`const add =
+> @import("math.rue").add`) is supported as a callable alias (RUE-173). These
+> aliases are not first-class runtime values: `add(1, 2)` is accepted, but
+> using `add` as an ordinary expression is still rejected as a function
+> reference in const/runtime value context.
 
 The key insight: `@import("foo.rue")` is equivalent to a struct containing the file's contents:
 

--- a/docs/spec/src/04-expressions/10-call-expressions.md
+++ b/docs/spec/src/04-expressions/10-call-expressions.md
@@ -10,6 +10,12 @@ template = "spec/page.html"
 
 A call expression invokes a function with a list of arguments.
 
+{{ rule(id="4.10:12", cat="normative") }}
+
+The callee may be either a function name or a callable function alias defined
+by a constant item (6.5:12). Calling an alias is equivalent to calling the
+function it aliases.
+
 {{ rule(id="4.10:2", cat="syntax") }}
 
 ```ebnf

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -24,9 +24,10 @@ forms are: literals (4.14:26); the arithmetic, comparison, logical, bitwise,
 and shift operators applied to comptime-evaluable operands (4.14:27);
 `comptime` block expressions (4.14:2, 4.14:27); references to other constants
 (4.14:26); and module expressions (`@import(...)` and module member access —
-chapter 10, 6.5:10). An initializer outside this set is a compile-time error
-(E0434) — the same diagnostic 4.14:29 names for a `const` initializer that is
-not comptime-evaluable.
+chapter 10, 6.5:10). A reference to a function item is comptime-evaluable only
+for the purpose of forming a callable alias (6.5:15). An initializer outside
+this set is a compile-time error (E0434) — the same diagnostic 4.14:29 names
+for a `const` initializer that is not comptime-evaluable.
 
 {{ rule(id="6.5:3", cat="example") }}
 
@@ -44,6 +45,15 @@ so it composes in any operand position of a constant initializer just like a
 reference to a local constant: `const N: i32 = m.LIMIT + 1;` is accepted, as
 is the whole-initializer form `const N: i32 = m.LIMIT;`.
 
+{{ rule(id="6.5:15", cat="normative") }}
+
+A constant initializer may name a function item, either directly (`const f =
+some_fn;`) or as a module member (`const f = @import("math").abs;`). Such a
+constant is a **callable alias**: it may appear as the callee of a call
+expression (`f(1, 2)`) and has the same call behavior as the aliased function.
+It is not a runtime value and may not be used as an ordinary expression,
+stored in a local, passed as an argument, or placed in an aggregate value.
+
 ## Types of Constants
 
 {{ rule(id="6.5:4", cat="legality-rule") }}
@@ -53,7 +63,9 @@ rather than a module — **MUST** have a type annotation. A value constant
 declared without one is a compile-time error (E0475). Module bindings
 (`const m = @import(...)`, aliases of module bindings, and re-exports —
 chapter 10) are not value constants: they take no annotation (no type
-annotation can name a module type) and require none.
+annotation can name a module type) and require none. Callable function aliases
+(6.5:15) likewise take no annotation because no source-level type names a
+function reference.
 
 {{ rule(id="6.5:11", cat="informative") }}
 


### PR DESCRIPTION
## Summary
- model function-valued constants as callable aliases that carry the callee symbol
- resolve direct and module-member aliases in call analysis and inference
- reject function aliases as first-class runtime values
- update CLI regressions and spec/design docs for RUE-173

## Validation
- ./fmt.sh check
- git diff --check
- ./buck2 test //crates/rue-air:rue-air-test //:cli-tests
- ./buck2 test //...

Fixes RUE-173.