### PR TITLE
RUE-332: collect multiple lexer errors

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -329,9 +329,9 @@ pub fn parse_all_files(sources: &[SourceFile<'_>]) -> MultiErrorResult<ParsedPro
                 interner = returned_interner;
                 tokens
             }
-            Err((error, returned_interner)) => {
+            Err((lex_errors, returned_interner)) => {
                 interner = returned_interner;
-                errors.push(error);
+                errors.extend(lex_errors);
                 continue;
             }
         };
@@ -3579,6 +3579,21 @@ mod integration_tests {
                 })
                 .collect();
             assert_eq!(file_ids, vec![FileId::new(1), FileId::new(2)]);
+        }
+
+        #[test]
+        fn parse_all_files_collects_multiple_lex_errors_in_one_file() {
+            let sources = vec![SourceFile::new(
+                "lex.rue",
+                "fn lex() -> i32 { $ # }",
+                FileId::new(1),
+            )];
+
+            let errors = parse_all_files(&sources).expect_err("both lexer errors should report");
+            assert_eq!(errors.len(), 2);
+            let kinds: Vec<_> = errors.iter().map(|error| &error.kind).collect();
+            assert!(matches!(kinds[0], ErrorKind::UnexpectedCharacter('$')));
+            assert!(matches!(kinds[1], ErrorKind::UnexpectedCharacter('#')));
         }
 
         #[test]

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -161,9 +161,9 @@ impl<'src> CompilationUnit<'src> {
                     interner = returned_interner;
                     tokens
                 }
-                Err((error, returned_interner)) => {
+                Err((lex_errors, returned_interner)) => {
                     interner = returned_interner;
-                    errors.push(error);
+                    errors.extend(lex_errors);
                     continue;
                 }
             };
@@ -600,6 +600,30 @@ mod tests {
             })
             .collect();
         assert_eq!(file_ids, vec![FileId::new(1), FileId::new(2)]);
+    }
+
+    #[test]
+    fn test_parse_collects_multiple_lex_errors_in_one_file() {
+        let sources = vec![SourceFile::new(
+            "lex.rue",
+            "fn lex() -> i32 { $ # }",
+            FileId::new(1),
+        )];
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+
+        let errors = unit
+            .parse()
+            .expect_err("both lexer errors in one file should report");
+        assert_eq!(errors.len(), 2);
+        let kinds: Vec<_> = errors.iter().map(|error| &error.kind).collect();
+        assert!(matches!(
+            kinds[0],
+            crate::ErrorKind::UnexpectedCharacter('$')
+        ));
+        assert!(matches!(
+            kinds[1],
+            crate::ErrorKind::UnexpectedCharacter('#')
+        ));
     }
 
     #[test]

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -5,7 +5,7 @@
 
 use lasso::{Spur, ThreadedRodeo};
 use logos::Logos;
-use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind};
 use rue_span::{FileId, Span};
 
 /// Error type for lexing failures.
@@ -578,7 +578,7 @@ impl<'a> LogosLexer<'a> {
     /// Tokenize the entire source, returning all tokens and the interner.
     pub fn tokenize(self) -> CompileResult<(Vec<Token>, ThreadedRodeo)> {
         self.tokenize_preserving_interner()
-            .map_err(|(error, _interner)| error)
+            .map_err(|(errors, _interner)| CompileError::from(errors))
     }
 
     /// Tokenize the entire source, preserving the interner even on error.
@@ -587,9 +587,10 @@ impl<'a> LogosLexer<'a> {
     /// earlier file fails, while still sharing one interner across all files.
     pub fn tokenize_preserving_interner(
         self,
-    ) -> Result<(Vec<Token>, ThreadedRodeo), (CompileError, ThreadedRodeo)> {
+    ) -> Result<(Vec<Token>, ThreadedRodeo), (CompileErrors, ThreadedRodeo)> {
         // Estimate capacity: source length / 4 is a rough heuristic for token density
         let mut tokens = Vec::with_capacity(self.source.len() / 4);
+        let mut errors = CompileErrors::new();
 
         let mut lexer = LogosTokenKind::lexer_with_extras(self.source, self.interner);
 
@@ -728,7 +729,7 @@ impl<'a> LogosLexer<'a> {
                                      mark (BOM); save the file without a BOM",
                                 );
                             }
-                            return Err((error, lexer.extras));
+                            errors.push(error);
                         }
                     }
                 }
@@ -745,6 +746,10 @@ impl<'a> LogosLexer<'a> {
 
         // Extract the interner from the logos lexer
         let interner = lexer.extras;
+
+        if !errors.is_empty() {
+            return Err((errors, interner));
+        }
 
         Ok((tokens, interner))
     }
@@ -794,6 +799,19 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err.kind, ErrorKind::UnexpectedCharacter('$')));
+    }
+
+    #[test]
+    fn test_logos_collects_multiple_unexpected_characters() {
+        let lexer = LogosLexer::new("fn main() { $ # }");
+        let (errors, _interner) = lexer
+            .tokenize_preserving_interner()
+            .expect_err("both invalid characters should report");
+
+        assert_eq!(errors.len(), 2);
+        let kinds: Vec<_> = errors.iter().map(|error| &error.kind).collect();
+        assert!(matches!(kinds[0], ErrorKind::UnexpectedCharacter('$')));
+        assert!(matches!(kinds[1], ErrorKind::UnexpectedCharacter('#')));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- collect all recoverable lexer errors from `tokenize_preserving_interner` instead of returning after the first one
- extend compiler frontend aggregation to include all lexer errors from a single file
- preserve `tokenize()` compatibility by returning the first collected lexer error for single-error callers
- add regressions for the lexer, `CompilationUnit::parse`, and `parse_all_files`

## Validation

- `./fmt.sh check`
- `git diff --check`
- `./buck2 test //crates/rue-lexer:rue-lexer-test //crates/rue-compiler:rue-compiler-test //:cli-tests`
- `./buck2 test //...`

Linear: RUE-332