### PR TITLE
RUE-402: honor function-level @allow(unused_variable)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -178,11 +178,12 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 continue;
             }
 
+            let Some(fn_info) = sema.functions.get(name).copied() else {
+                continue;
+            };
             // Skip functions with comptime parameters - they are analyzed per specialization
-            if let Some(fn_info) = sema.functions.get(name) {
-                if fn_info.is_generic {
-                    continue;
-                }
+            if fn_info.is_generic {
+                continue;
             }
 
             let fn_name = sema.interner.resolve(&*name).to_string();
@@ -195,6 +196,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 &params,
                 *body,
                 inst.span,
+                fn_info.allow_unused_variable,
             ) {
                 Ok((analyzed, warnings, local_strings, mut ref_fns, _ref_meths)) => {
                     functions_with_strings.push((analyzed, local_strings));
@@ -647,6 +649,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                             &params,
                             *body,
                             inst.span,
+                            fn_info.allow_unused_variable,
                         ) {
                             Ok((
                                 analyzed,

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -14,6 +14,7 @@ impl<'a> Sema<'a> {
         params: &[rue_rir::RirParam],
         body: InstRef,
         span: Span,
+        allow_unused_variable: bool,
     ) -> CompileResult<(
         AnalyzedFunction,
         Vec<CompileWarning>,
@@ -46,7 +47,13 @@ impl<'a> Sema<'a> {
             local_strings,
             ref_fns,
             ref_meths,
-        ) = self.analyze_function(infer_ctx, ret_type, &param_info, body)?;
+        ) = self.analyze_function(
+            infer_ctx,
+            ret_type,
+            &param_info,
+            body,
+            allow_unused_variable,
+        )?;
 
         Ok((
             AnalyzedFunction {
@@ -134,6 +141,7 @@ impl<'a> Sema<'a> {
             Some(&type_subst),
             None,
             false,
+            false,
         )?;
 
         Ok((
@@ -192,6 +200,7 @@ impl<'a> Sema<'a> {
             None,
             None,
             /* is_destructor */ true,
+            false,
         )?;
 
         reject_self_move_in_destructor(&air, full_name)?;
@@ -228,6 +237,7 @@ impl<'a> Sema<'a> {
         return_type: Type,
         params: &[(Spur, Type, RirParamMode, bool)], // (name, type, mode, is_comptime)
         body: InstRef,
+        allow_unused_variable: bool,
     ) -> CompileResult<(
         Air,
         u32,
@@ -238,7 +248,16 @@ impl<'a> Sema<'a> {
         HashSet<Spur>,
         HashSet<(StructId, Spur)>,
     )> {
-        self.analyze_function_internal(infer_ctx, return_type, params, body, None, None, false)
+        self.analyze_function_internal(
+            infer_ctx,
+            return_type,
+            params,
+            body,
+            None,
+            None,
+            false,
+            allow_unused_variable,
+        )
     }
 
     /// Internal function analysis with optional type substitutions.
@@ -262,6 +281,7 @@ impl<'a> Sema<'a> {
         type_subst: Option<&std::collections::HashMap<Spur, Type>>,
         value_subst: Option<&std::collections::HashMap<Spur, ConstValue>>,
         is_destructor: bool,
+        allow_unused_variable: bool,
     ) -> CompileResult<(
         Air,
         u32,
@@ -383,6 +403,7 @@ impl<'a> Sema<'a> {
             resolved_types: &resolved_types,
             moved_vars: HashMap::new(),
             warnings: Vec::new(),
+            allow_unused_variables: allow_unused_variable,
             local_string_table: HashMap::new(),
             local_strings: Vec::new(),
             comptime_type_vars,
@@ -515,6 +536,7 @@ impl<'a> Sema<'a> {
             Some(type_subst),
             Some(value_subst),
             false,
+            false,
         )
     }
 
@@ -558,6 +580,7 @@ impl<'a> Sema<'a> {
             body,
             Some(&type_subst),
             Some(captured_comptime_values),
+            false,
             false,
         )
     }
@@ -618,6 +641,7 @@ impl<'a> Sema<'a> {
             Some(&type_subst),
             Some(captured_comptime_values),
             /* is_destructor */ true,
+            false,
         )?;
 
         reject_self_move_in_destructor(&air, full_name)?;

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -36,6 +36,12 @@ impl<'a> Sema<'a> {
         };
 
         for (symbol, _old_value) in current_scope {
+            // A function-level `@allow(unused_variable)` suppresses unused
+            // variable warnings for all bindings in the function body.
+            if ctx.allow_unused_variables {
+                continue;
+            }
+
             // Skip if variable was used
             if ctx.used_locals.contains(symbol) {
                 continue;

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -348,6 +348,10 @@ pub(crate) struct AnalysisContext<'a> {
     /// Warnings collected during function analysis.
     /// This is per-function to enable future parallel analysis.
     pub warnings: Vec<CompileWarning>,
+    /// Whether the current function carries `@allow(unused_variable)`.
+    /// When set, every local unused-variable warning in this body is
+    /// suppressed (spec 2.5:17).
+    pub allow_unused_variables: bool,
     /// Local string table: maps string content to local index (for deduplication within function).
     /// This is per-function to enable parallel analysis - strings are merged globally after.
     pub local_string_table: HashMap<String, u32>,
@@ -474,6 +478,7 @@ impl<'a> AnalysisContext<'a> {
             resolved_types: self.resolved_types,
             moved_vars: self.moved_vars.clone(),
             warnings: Vec::new(),
+            allow_unused_variables: self.allow_unused_variables,
             local_string_table: self.local_string_table.clone(),
             local_strings: self.local_strings.clone(),
             comptime_type_vars: self.comptime_type_vars.clone(),

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1149,6 +1149,7 @@ impl<'a> Sema<'a> {
         let params = self.rir.get_params(params_start, params_len);
         let directives = self.rir.get_directives(directives_start, directives_len);
         let allow_unused_function = self.has_allow_directive(&directives, "unused_function");
+        let allow_unused_variable = self.has_allow_directive(&directives, "unused_variable");
 
         let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
         let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
@@ -1255,6 +1256,7 @@ impl<'a> Sema<'a> {
                 is_pub,
                 is_unchecked,
                 allow_unused_function,
+                allow_unused_variable,
                 file_id: span.file_id,
             },
         );

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -37,6 +37,8 @@ pub struct FunctionInfo {
     pub is_unchecked: bool,
     /// Whether `@allow(unused_function)` was applied to this function.
     pub allow_unused_function: bool,
+    /// Whether `@allow(unused_variable)` was applied to this function.
+    pub allow_unused_variable: bool,
     /// File ID this function was declared in (for visibility checking)
     pub file_id: FileId,
 }

--- a/crates/rue-spec/cases/lexical/builtins.toml
+++ b/crates/rue-spec/cases/lexical/builtins.toml
@@ -142,7 +142,6 @@ no_warnings = true
 [[case]]
 name = "allow_unused_variable_on_function"
 spec = ["2.5:17"]
-skip = true  # TODO: Function-level @allow not yet implemented
 source = """
 @allow(unused_variable)
 fn example() -> i32 {

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -168,11 +168,6 @@ pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[
          (lexical/builtins.toml::directive_must_precede_item, skipped)",
     ),
     (
-        "2.5:17",
-        "function-level @allow(unused_variable) not implemented \
-         (lexical/builtins.toml::allow_unused_variable_on_function, skipped)",
-    ),
-    (
         "2.5:21",
         "@allow(unreachable_code) suppression not implemented \
          (lexical/builtins.toml::allow_unreachable_code, skipped)",


### PR DESCRIPTION
## Summary

Implements RUE-402 by honoring `@allow(unused_variable)` when it is attached to a function definition.

The parser/validator already accepted `@allow` on functions, and spec rule `2.5:17` says the directive suppresses unused-variable warnings for bindings inside that function. The semantic analysis path only checked directives attached directly to each `let`, so the spec case was skipped.

## Changes

- Carry a function-level `allow_unused_variable` flag from declaration collection into function body analysis.
- Suppress unused-local warnings for all bindings in that function when the flag is set.
- Unskip `lexical.builtins::allow_unused_variable_on_function`.
- Remove `2.5:17` from the known-uncovered normative allowlist.

## Validation

- `./fmt.sh check`
- `git diff --check`
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-spec:rue-spec-test`
- `./buck2 run //crates/rue-spec:rue-spec -- --traceability`
- `./buck2 test //:spec-tests`
- `./buck2 test //...`
