### PR TITLE
RUE-121: share aggregate block-param slot preallocation

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -389,28 +389,7 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                // For any multi-slot aggregate (struct, builtin String,
-                // fixed-size array, or payload enum), also allocate vregs for
-                // each slot. Arrays included: their primary vreg is just a
-                // placeholder, so without slot vregs every element would be
-                // dropped at the join (RUE-167). Routed through the single
-                // is_multislot_aggregate predicate so enum payloads are handled
-                // by construction (RUE-248), matching the x86_64 backend.
-                // Exactly slot_count vregs: a zero-slot aggregate ([T; 0],
-                // fieldless struct) gets an EMPTY list, matching the empty
-                // slot lists its sources cache — a phantom slot here tripped
-                // the join's count assert (RUE-194).
-                if self.ctx.is_multislot_aggregate(*ty) {
-                    let slot_count = self.ctx.type_slot_count(*ty);
-                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
-                    if slot_count > 0 {
-                        slot_vregs.push(vreg); // First slot uses main vreg
-                    }
-                    for _ in 1..slot_count {
-                        slot_vregs.push(self.mir.alloc_vreg());
-                    }
-                    self.struct_slot_vregs.insert(*param_val, slot_vregs);
-                }
+                crate::agg_slots::preallocate_block_param_slots(&mut self, *param_val, *ty, vreg);
             }
         }
 
@@ -449,20 +428,7 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                if self.ctx.is_multislot_aggregate(*ty) {
-                    // Exactly slot_count vregs; zero-slot aggregates get an
-                    // empty list (RUE-194) — same as lower(). Single predicate
-                    // covers struct/array/payload-enum (RUE-248).
-                    let slot_count = self.ctx.type_slot_count(*ty);
-                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
-                    if slot_count > 0 {
-                        slot_vregs.push(vreg);
-                    }
-                    for _ in 1..slot_count {
-                        slot_vregs.push(self.mir.alloc_vreg());
-                    }
-                    self.struct_slot_vregs.insert(*param_val, slot_vregs);
-                }
+                crate::agg_slots::preallocate_block_param_slots(&mut self, *param_val, *ty, vreg);
             }
         }
 

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -28,7 +28,7 @@
 
 use std::collections::HashMap;
 
-use rue_air::TypeKind;
+use rue_air::{Type, TypeKind};
 use rue_cfg::{CfgInstData, CfgValue, Place, PlaceBase, Projection};
 
 use crate::cfg_lower::CfgLowerContext;
@@ -236,6 +236,36 @@ pub fn root_slot_count<B: SlotBackend>(b: &B, projections: &[Projection], fallba
         Some(Projection::Index { array_type, .. }) => b.ctx().type_slot_count(*array_type),
         None => fallback,
     }
+}
+
+/// Pre-allocate the per-slot vregs for an aggregate block parameter.
+///
+/// Block-parameter lowering is a special case: each backend has already
+/// allocated and mapped the parameter's primary vreg before aggregate-slot
+/// bookkeeping runs. For multi-slot aggregate params, the slot cache must hold
+/// exactly `type_slot_count(ty)` vregs, using the primary vreg for logical slot
+/// 0 and freshly-allocated vregs for the remaining slots. Zero-slot aggregates
+/// intentionally cache an empty list, matching their source values and keeping
+/// join-edge slot-count checks honest (RUE-167, RUE-194, RUE-248).
+pub fn preallocate_block_param_slots<B: SlotBackend>(
+    b: &mut B,
+    param_value: CfgValue,
+    ty: Type,
+    primary_vreg: VReg,
+) {
+    if !b.ctx().is_multislot_aggregate(ty) {
+        return;
+    }
+
+    let slot_count = b.ctx().type_slot_count(ty);
+    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
+    if slot_count > 0 {
+        slot_vregs.push(primary_vreg);
+    }
+    for _ in 1..slot_count {
+        slot_vregs.push(b.alloc_vreg());
+    }
+    b.slot_cache().insert(param_value, slot_vregs);
 }
 
 /// Lower a `StructInit`: flatten the field values into one vreg per slot,

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -562,25 +562,7 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                // For aggregate types (structs, builtin String, fixed-size
-                // arrays), also allocate vregs for each slot. Arrays included:
-                // their primary vreg is just a placeholder, so without slot
-                // vregs every element would be dropped at the join (RUE-167).
-                // Exactly slot_count vregs: a zero-slot aggregate ([T; 0],
-                // fieldless struct) gets an EMPTY list, matching the empty
-                // slot lists its sources cache — a phantom slot here tripped
-                // the join's count assert (RUE-194).
-                if self.ctx.is_multislot_aggregate(*ty) {
-                    let slot_count = self.ctx.type_slot_count(*ty);
-                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
-                    if slot_count > 0 {
-                        slot_vregs.push(vreg); // First slot uses main vreg
-                    }
-                    for _ in 1..slot_count {
-                        slot_vregs.push(self.mir.alloc_vreg());
-                    }
-                    self.struct_slot_vregs.insert(*param_val, slot_vregs);
-                }
+                crate::agg_slots::preallocate_block_param_slots(&mut self, *param_val, *ty, vreg);
             }
         }
 
@@ -619,19 +601,7 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                if self.ctx.is_multislot_aggregate(*ty) {
-                    // Exactly slot_count vregs; zero-slot aggregates get an
-                    // empty list (RUE-194) — same as lower().
-                    let slot_count = self.ctx.type_slot_count(*ty);
-                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
-                    if slot_count > 0 {
-                        slot_vregs.push(vreg);
-                    }
-                    for _ in 1..slot_count {
-                        slot_vregs.push(self.mir.alloc_vreg());
-                    }
-                    self.struct_slot_vregs.insert(*param_val, slot_vregs);
-                }
+                crate::agg_slots::preallocate_block_param_slots(&mut self, *param_val, *ty, vreg);
             }
         }
 


### PR DESCRIPTION
## Summary

- move aggregate block-parameter slot preallocation into the shared `agg_slots` module
- replace the duplicated x86_64/aarch64 `lower()` and `lower_with_debug()` slot-cache loops with the shared helper
- keep backend-specific primary-vreg/block-param bookkeeping local to each backend

## Rationale

This continues RUE-121 by shrinking another hand-mirrored aggregate-slot seam. The behavior is unchanged: multi-slot aggregate block params still cache exactly `type_slot_count(ty)` vregs, slot 0 uses the primary vreg, and zero-slot aggregates cache an empty slot list.

## Validation

- `./fmt.sh check`
- `./buck2 test //crates/rue-codegen:rue-codegen-test`
- `./buck2 test //... && git diff --check`