### PR TITLE
RUE-405: drop nested payload enum fields

### DIFF
--- a/crates/rue-cli-tests/cases/enum_payloads.toml
+++ b/crates/rue-cli-tests/cases/enum_payloads.toml
@@ -71,6 +71,47 @@ fn main() -> i32 {
 stdout = "-1\n9\n"
 exit_code = 0
 
+# A payload enum nested inside a struct field must still run active-variant drop
+# glue when the containing struct is dropped. This used to leak because struct
+# drop glue skipped TypeKind::Enum fields.
+[[case]]
+name = "struct_field_enum_payload_drop_glue"
+description = "A droppable payload inside an enum field of a struct is dropped exactly once: prints -1 then 11."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+struct Box { e: E }
+fn main() -> i32 {
+    let b = Box { e: E::Has(D { v: 11 }) };
+    @dbg(-1);
+    0
+}
+""" }]
+stdout = "-1\n11\n"
+exit_code = 0
+
+# The same active-variant drop must happen when the payload enum is an array
+# element. This used to leak because array drop glue skipped TypeKind::Enum
+# elements.
+[[case]]
+name = "array_element_enum_payload_drop_glue"
+description = "Droppable payloads inside enum array elements are dropped exactly once in element order: prints -1, 21, 22."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+fn main() -> i32 {
+    let a = [E::Has(D { v: 21 }), E::Has(D { v: 22 })];
+    @dbg(-1);
+    0
+}
+""" }]
+stdout = "-1\n21\n22\n"
+exit_code = 0
+
 # The inactive (discriminant-only) variant has no payload to drop: only -1 prints.
 [[case]]
 name = "active_variant_drop_glue_none"

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -271,12 +271,24 @@ fn create_struct_drop_glue_function(
                     });
                     drop_statements.push(drop_ref);
                 }
-                // A payload-carrying enum *field* is not yet dropped by struct
-                // glue (RUE-221 follow-up): active-variant drop glue currently
-                // fires only for a top-level enum value at scope exit, not for
-                // one nested inside another aggregate. Such a field leaks (but
-                // never double-drops); `type_slot_count` still counts its slots
-                // so later fields stay correctly offset.
+                TypeKind::Enum(enum_id) => {
+                    // Payload-carrying enum field - load it and drop it. The
+                    // enum drop glue dispatches on the active discriminant and
+                    // drops only the selected variant's payload.
+                    let param_ref = air.add_inst(AirInst {
+                        data: AirInstData::Param {
+                            index: current_param_slot,
+                        },
+                        ty: Type::new_enum(enum_id),
+                        span,
+                    });
+                    let drop_ref = air.add_inst(AirInst {
+                        data: AirInstData::Drop { value: param_ref },
+                        ty: Type::UNIT,
+                        span,
+                    });
+                    drop_statements.push(drop_ref);
+                }
                 _ => {}
             }
         }
@@ -401,9 +413,21 @@ fn create_array_drop_glue_function(
                 });
                 drop_statements.push(drop_ref);
             }
-            // A payload-carrying enum element is not yet dropped by array glue
-            // (RUE-221 follow-up, same interim as struct glue above): it leaks
-            // rather than double-dropping.
+            TypeKind::Enum(enum_id) => {
+                let param_ref = air.add_inst(AirInst {
+                    data: AirInstData::Param {
+                        index: current_param_slot,
+                    },
+                    ty: Type::new_enum(enum_id),
+                    span,
+                });
+                let drop_ref = air.add_inst(AirInst {
+                    data: AirInstData::Drop { value: param_ref },
+                    ty: Type::UNIT,
+                    span,
+                });
+                drop_statements.push(drop_ref);
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

- fix RUE-405 by teaching synthesized struct and array drop glue to emit Drop for nested payload-enum fields/elements
- add CLI regressions for struct-field and array-element payload enum drops

## Root cause

Payload enums already generated active-variant drop glue for top-level values, but aggregate drop glue skipped `TypeKind::Enum` when reconstructing fields/elements from flattened parameter slots. A struct field or array element of enum type therefore leaked the active payload.

## Validation

- `./fmt.sh check`
- `./buck2 test //crates/rue-codegen:rue-codegen-test //crates/rue-compiler:rue-compiler-test //crates/rue-cfg:rue-cfg-test //:cli-tests`
- `./buck2 test //... && git diff --check`

Fixes RUE-405.
