### PR TITLE
RUE-406: remove stale drop comments

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2330,7 +2330,8 @@ impl<'a> CfgBuilder<'a> {
     /// recursively check if struct fields or array elements need drop.
     ///
     /// A type needs drop if dropping it requires cleanup actions:
-    /// - Primitives, bool, unit, never, error, enums: trivially droppable (no)
+    /// - Primitives, bool, unit, never, error: trivially droppable (no)
+    /// - Enum: needs drop if any variant payload needs drop
     /// - String: will need drop when mutable strings land (currently no)
     /// - Struct: needs drop if any field needs drop
     /// - Array: needs drop if element type needs drop

--- a/crates/rue-cli-tests/cases/drop_moves.toml
+++ b/crates/rue-cli-tests/cases/drop_moves.toml
@@ -25,9 +25,9 @@
 # full paths of any depth (`eat(o.a.b)`, RUE-157), with each affected
 # field's scope-exit drop guarded by its own flag.
 #
-# Known residual: assigning over a still-owned struct FIELD does not drop
-# the old field value (pre-existing drop-on-overwrite gap, tracked
-# separately); these cases avoid pinning that behavior.
+# Assignment-overwrite drops are covered separately in `overwrite_drops.toml`
+# (RUE-64), including field and array-element writes. This file stays focused
+# on move/drop suppression rather than the overwrite matrix.
 
 [section]
 id = "cli.drop_moves"


### PR DESCRIPTION
## Summary

- remove a stale `drop_moves.toml` note claiming field overwrite drops are still a known residual
- update the `rue-cfg` `type_needs_drop` docs to match current enum payload drop behavior

## Why

Current trunk already tests field and element overwrite drops in `overwrite_drops.toml`, and `type_needs_drop` correctly treats payload enums as needing active-variant drop glue. These stale comments made fixed behavior look unfinished.

Linear: RUE-406

## Validation

- `./fmt.sh check`
- `./buck2 test //crates/rue-cfg:rue-cfg-test //:cli-tests`
