### PR TITLE
RUE-407: validate deferred generic signature leaves

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1202,7 +1202,12 @@ impl<'a> Sema<'a> {
                     // for array lengths that do *not* depend on specialization:
                     // `[T; A]` with an undefined `A` should be E0481 here, not
                     // an ICE when the function is later instantiated (RUE-381).
-                    self.validate_deferred_signature_type_lengths(p.ty, &value_param_names, span)?;
+                    self.validate_deferred_signature_type_lengths(
+                        p.ty,
+                        &type_param_names,
+                        &value_param_names,
+                        span,
+                    )?;
                     Ok(Type::COMPTIME_TYPE)
                 } else {
                     // Regular params OR comptime VALUE params (comptime n: i32)
@@ -1223,6 +1228,7 @@ impl<'a> Sema<'a> {
             // RUE-16) - use placeholder, resolved at specialization.
             self.validate_deferred_signature_type_lengths(
                 return_type_sym,
+                &type_param_names,
                 &value_param_names,
                 span,
             )?;

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1182,8 +1182,8 @@ impl<'a> Sema<'a> {
         false
     }
 
-    /// Validate array lengths inside a signature type that will otherwise be
-    /// deferred until generic specialization.
+    /// Validate the non-deferred parts of a signature type that will otherwise
+    /// be deferred until generic specialization.
     ///
     /// A composite signature such as `[T; 3]` cannot be resolved at declaration
     /// time because the element type is a comptime type parameter. Its length is
@@ -1191,14 +1191,22 @@ impl<'a> Sema<'a> {
     /// an undefined `A` immediately instead of surviving until specialization
     /// and becoming an ICE (RUE-381). Lengths may be literals, file constants, or
     /// comptime value parameters owned by the same function.
+    ///
+    /// Non-deferred leaf types are declaration-time legality questions too:
+    /// `[i3; N]` mentions the comptime value parameter `N`, so the array type as
+    /// a whole is deferred, but the element type `i3` is not deferred and should
+    /// be reported as E0204 immediately instead of becoming a failed
+    /// specialization substitution later.
     pub(crate) fn validate_deferred_signature_type_lengths(
         &mut self,
         type_sym: Spur,
+        type_params: &[Spur],
         value_params: &[Spur],
         span: Span,
     ) -> CompileResult<()> {
         self.validate_deferred_signature_type_name_lengths(
             self.interner.resolve(&type_sym).to_string(),
+            type_params,
             value_params,
             span,
         )
@@ -1207,6 +1215,7 @@ impl<'a> Sema<'a> {
     fn validate_deferred_signature_type_name_lengths(
         &mut self,
         type_name: String,
+        type_params: &[Spur],
         value_params: &[Spur],
         span: Span,
     ) -> CompileResult<()> {
@@ -1219,6 +1228,7 @@ impl<'a> Sema<'a> {
             }
             return self.validate_deferred_signature_type_name_lengths(
                 element_type,
+                type_params,
                 value_params,
                 span,
             );
@@ -1230,6 +1240,7 @@ impl<'a> Sema<'a> {
         {
             return self.validate_deferred_signature_type_name_lengths(
                 pointee.to_string(),
+                type_params,
                 value_params,
                 span,
             );
@@ -1237,11 +1248,27 @@ impl<'a> Sema<'a> {
 
         if let Some((_call_name, arg_strs)) = parse_type_call_syntax(&type_name) {
             for arg in arg_strs {
-                self.validate_deferred_signature_type_name_lengths(arg, value_params, span)?;
+                self.validate_deferred_signature_type_name_lengths(
+                    arg,
+                    type_params,
+                    value_params,
+                    span,
+                )?;
+            }
+            return Ok(());
+        }
+
+        // A leaf that is one of this function's comptime type parameters is
+        // exactly what makes the signature deferred; leave it for
+        // specialization. Every other leaf must be a real declaration-time type.
+        if let Some(sym) = self.interner.get(&type_name) {
+            if type_params.contains(&sym) {
+                return Ok(());
             }
         }
 
-        Ok(())
+        let sym = self.interner.get_or_intern(&type_name);
+        self.resolve_type(sym, span).map(|_| ())
     }
 
     /// Get or create an array type for the given element type and length.

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -23,6 +23,20 @@ name = "ICE regressions"
 description = "Minimal programs that used to crash the compiler; each must now compile-or-cleanly-error with no signal (RUE-51)."
 
 [[case]]
+name = "generic_array_value_length_unknown_element_type_rue407"
+description = "RUE-407 / GitHub #1225: a deferred generic array type `[i3; N]` validated only the `N` length, then specialization panicked when the unknown element type failed substitution. Now it is a clean E0204."
+files = [{ path = "main.rue", source = """
+fn first(comptime N: i32, arr: [i3; N]) -> i32 {
+    arr[0]
+}
+fn main() -> i32 {
+    first(3, [42, 1, 2])
+}
+""" }]
+compile_fail = true
+error_contains = ["E0204", "unknown type 'i3'"]
+
+[[case]]
 name = "nested_struct_field_into_if_merge_rue24"
 description = "RUE-24: a nested struct field flowing into an if/else merge block had no field vregs -> SIGABRT at cfg_lower."
 files = [{ path = "main.rue", source = """


### PR DESCRIPTION
Summary:
- validate non-deferred leaf types inside deferred generic signatures
- add an ICE regression for fuzz crash #1225 (`[i3; N]`)

Root cause:
- `[i3; N]` was deferred because its length mentions comptime value parameter `N`
- the previous validation checked only the length expression, so the unknown element type escaped until specialization and triggered a panic

Validation:
- direct repro `[i3; N]` now reports E0204 instead of panicking
- direct repro `[i3i2; N]` now reports E0204 instead of panicking
- `./buck2 test //crates/rue-air:rue-air-test //:cli-tests`
- `./fmt.sh check && ./buck2 test //... && git diff --check`

Linear: RUE-407
Fixes #1225
