### PR TITLE
RUE-418: ignore git metadata in Buck

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -28,6 +28,6 @@ materializations = deferred
 # Keep buck2 from parsing/watching non-source trees inside the project root:
 # .claude/worktrees holds agent worktrees (each with its own buck-out, whose
 # vendored prelude BUCK files break `//...` patterns and whose churn
-# continuously invalidates the root daemon's graph), and .jj's op store
-# writes on every command in this colocated repo.
-ignore = .claude, .jj
+# continuously invalidates the root daemon's graph), and .jj's op store and
+# colocated .git metadata both churn during ordinary repo operations.
+ignore = .claude, .jj, .git


### PR DESCRIPTION
## Summary
- add `.git` to Buck's project ignore list alongside `.jj`
- update the comment to explain colocated git metadata churn

## Validation
- `./buck2 kill && ./buck2 run //crates/rue:rue -- --help`
- synthetic `.git` churn followed by `./buck2 run //crates/rue:rue -- --help` did not report `.git` file events
- `touch crates/rue/src/main.rs && ./buck2 build //crates/rue:rue`