### PR TITLE
RUE-423: clarify parse parallelism docs

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -995,7 +995,7 @@ pub fn configure_thread_pool(jobs: usize) {
 /// Compile multiple source files to an ELF binary.
 ///
 /// This is the main entry point for multi-file compilation. It:
-/// 1. Parses all files in parallel
+/// 1. Parses all files sequentially with a shared interner
 /// 2. Merges symbols into a unified program
 /// 3. Performs semantic analysis across all files
 /// 4. Generates code for the combined program
@@ -3504,8 +3504,8 @@ mod integration_tests {
         }
 
         #[test]
-        fn parse_many_files_in_parallel() {
-            // Create 10 files to exercise parallel parsing
+        fn parse_many_files_with_shared_interner() {
+            // Create 10 files to exercise multi-file parsing with the shared interner.
             let sources: Vec<_> = (1..=10)
                 .map(|i| {
                     SourceFile::new(

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -97,8 +97,11 @@ relative profile (which passes dominate), not a hard threshold.**
    corpus time and rises to **48–79% of a single large compile**. Lexing itself
    is cheap (measured ~20 ms for the 12k-line `deep_nesting.rue`); the cost is
    in the recursive-descent **parser** and AST construction. This is the first
-   place to look for a speedup, and it is a good parallelization candidate
-   (files already parse in parallel; the win now is per-file parser throughput).
+   place to look for a speedup. It is also a good future parallelization
+   candidate, but files do **not** parse in parallel today: the compiler parses
+   them sequentially with a shared interner. Per-file parser throughput is the
+   immediate target; parse parallelism would also require interner merging and
+   AST symbol remapping.
 
 2. **`codegen` is second (~17%)**, concentrated where there is a lot of code to
    emit (`many_functions`, `large_structs`). This covers MIR lowering, register


### PR DESCRIPTION
## Summary
- correct the multi-file compiler driver docs to say parsing is sequential with a shared interner today
- rename the misleading multi-file parse test from “parallel” to “shared interner”
- update the perf baseline finding to distinguish current parser throughput work from future parse parallelism

## Validation
- `./buck2 test //crates/rue-compiler:rue-compiler-test`