### PR TITLE
RUE-422: stop refreshing bin/rue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 The 9 commands that cover ~90% of work here (all runnable from anywhere in the repo):
 
 ```bash
-scripts/rue build                    # build the compiler -> refreshes bin/rue symlink
+scripts/rue build                    # build the compiler and print its path
 scripts/rue exec prog.rue            # compile prog.rue to a temp file AND run it (quick check)
 RUE="$(scripts/rue-bin)"; "$RUE" a.rue b.rue -o out   # drive the real CLI (modules, multi-file)
 scripts/rue test [pattern]           # full suite (= ./test.sh): unit + spec + UI + CLI + traceability

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -8,7 +8,7 @@ load("//crates:defs.bzl", "rue_binary")
 #    programs and cross-checks the oracle against the real compiler + native
 #    binary, reporting any exit/stdout disagreement as a miscompile with a
 #    seed-based repro. Driven by `.github/workflows/fuzz.yml` nightly; needs the
-#    `rue` binary via RUE_BINARY (or the bin/rue symlink).
+#    `rue` binary via RUE_BINARY.
 # The harness driver itself has no #[test] functions — it IS the harness — but
 # the `generator` module carries unit tests (determinism + always-emits-main),
 # so the rust_test target (`:rue-oracle-diff-test`) is kept enabled.

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -15,8 +15,8 @@
 //! Determinism: programs are a pure function of their `u64` seed, so the fuzzer
 //! is fully reproducible (`fuzz --start S --seeds 1` re-runs exactly seed `S`).
 //!
-//! The compiler binary is located via `RUE_BINARY` (what `scripts/rue` /
-//! `test.sh` set) or the `bin/rue` symlink, mirroring `rue-test-runner`.
+//! The compiler binary is located via `RUE_BINARY`, which `scripts/rue`,
+//! `test.sh`, and Buck test targets set from `scripts/rue-bin`.
 
 use crate::generator;
 use rue_oracle::run_source;
@@ -99,22 +99,14 @@ fn parse_args(args: &[String]) -> Result<Config, String> {
 }
 
 /// Locate the `rue` compiler binary the same way the rest of the test harness
-/// does: `RUE_BINARY` override, else the `bin/rue` symlink.
+/// does: via an explicit `RUE_BINARY` override.
 fn find_rue_binary() -> Result<PathBuf, String> {
     if let Ok(p) = std::env::var("RUE_BINARY") {
         return Ok(PathBuf::from(p));
     }
-    let sym = Path::new("bin/rue");
-    if sym.exists() {
-        // Canonicalize to an absolute path: each generated program is compiled
-        // with `current_dir` set to the temp workdir, so a relative `bin/rue`
-        // would no longer resolve. (The harness normally runs with an absolute
-        // RUE_BINARY; this keeps the bare `bin/rue` fallback working too.)
-        return Ok(sym.canonicalize().unwrap_or_else(|_| sym.to_path_buf()));
-    }
     Err(
         "cannot locate the rue compiler: set RUE_BINARY to an explicit path, \
-         or run `scripts/rue build` to refresh the bin/rue symlink"
+         for example `RUE_BINARY=$(scripts/rue-bin)`"
             .to_string(),
     )
 }

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -1797,23 +1797,19 @@ pub fn find_dir(env_var: &str, possible_paths: &[&str], fallback: &str) -> PathB
 /// this function selects the most recently modified binary to avoid using
 /// stale binaries from previous builds.
 pub fn find_rue_binary() -> PathBuf {
-    // 1. Explicit override — what test.sh and scripts/rue always set.
+    // Explicit override — what test.sh, Buck targets, and scripts/rue set.
     if let Ok(p) = std::env::var("RUE_BINARY") {
         return PathBuf::from(p);
     }
-    // 2. The stable symlink maintained by `scripts/rue build`.
-    let bin_rue = Path::new("bin/rue");
-    if bin_rue.exists() {
-        return bin_rue.to_path_buf();
-    }
-    // 3. Refuse to guess. The old fallback globbed every buck-out config-hash
+    // Refuse to guess. The old fallback globbed every buck-out config-hash
     // directory and picked the NEWEST binary by mtime — with debug/release/
     // historical configs side by side, that silently selected the wrong
-    // compiler and produced false test failures (a real incident). Guessing
-    // wrong silently is strictly worse than failing loudly.
+    // compiler and produced false test failures (a real incident). A repo-local
+    // bin/rue symlink had the same stale-binary and source-tree-churn risk.
+    // Guessing wrong silently is strictly worse than failing loudly.
     panic!(
         "cannot locate the rue compiler: set RUE_BINARY to an explicit path, \
-         or run `scripts/rue build` to refresh the bin/rue symlink"
+         for example `RUE_BINARY=$(scripts/rue-bin)`"
     );
 }
 

--- a/scripts/rue
+++ b/scripts/rue
@@ -3,7 +3,7 @@
 # rue — convenience wrapper around the common Buck2 targets, so you don't have
 # to memorize `//crates/...` paths. Run from anywhere in the repo.
 #
-#   scripts/rue build              Build the compiler (refreshes bin/rue)
+#   scripts/rue build              Build the compiler and print its path
 #   scripts/rue run prog.rue out   Compile a program (then run ./out yourself)
 #   scripts/rue exec prog.rue      Compile prog.rue to a temp file AND run it
 #   scripts/rue test [pattern]     Full suite (./test.sh), optional filter
@@ -26,8 +26,8 @@ shift || true
 
 case "$cmd" in
     build)
-        scripts/rue-bin "$@" >/dev/null
-        echo "Built: bin/rue -> $(readlink bin/rue)"
+        bin="$(scripts/rue-bin "$@")"
+        echo "Built: $bin"
         ;;
     path)
         scripts/rue-bin "$@"

--- a/scripts/rue-bin
+++ b/scripts/rue-bin
@@ -4,13 +4,11 @@
 #
 # Buck2's `--show-output` prints a path relative to the repo root, and that
 # path contains a toolchain hash, so it is neither stable nor usable once the
-# working directory changes. This script resolves it to an absolute path,
-# refreshes a stable `bin/rue` symlink, and prints the absolute path on stdout
-# (all build chatter goes to stderr), so callers can do:
+# working directory changes. This script resolves it to an absolute path and
+# prints that path on stdout (all build chatter goes to stderr), so callers can do:
 #
 #   RUE_BINARY="$(scripts/rue-bin)"        # for the test harnesses
 #   "$(scripts/rue-bin)" prog.rue out      # to compile directly
-#   bin/rue prog.rue out                   # via the stable symlink
 #
 # Any extra arguments are passed through to `buck2 build`, e.g. a release build:
 #
@@ -38,13 +36,6 @@ abs_path="$repo_root/$rel_path"
 if [[ ! -x "$abs_path" ]]; then
     echo "rue-bin: built path is not executable: $abs_path" >&2
     exit 1
-fi
-
-# Refresh the stable symlink (only for the default/no-extra-args build, so a
-# release build doesn't clobber the debug symlink and vice versa).
-if [[ $# -eq 0 ]]; then
-    mkdir -p "$repo_root/bin"
-    ln -sfn "$abs_path" "$repo_root/bin/rue"
 fi
 
 echo "$abs_path"


### PR DESCRIPTION
## Summary
- stop `scripts/rue-bin` from mutating the repo by refreshing `bin/rue`
- make `scripts/rue build` print the built absolute path instead of reporting a symlink
- remove `bin/rue` fallback lookup from test/oracle helpers in favor of explicit `RUE_BINARY`
- update nearby docs/comments that mentioned the symlink fallback

## Validation
- `scripts/rue-bin` returns an executable path and leaves `bin/` unchanged
- `scripts/rue build`
- `./buck2 test //crates/rue-test-runner:rue-test-runner-test //crates/rue-oracle-diff:rue-oracle-diff-test`
- `scripts/rue-bin >/dev/null && ./buck2 run //crates/rue:rue -- --help` with no `root//bin/...` events
- `bash -n scripts/rue scripts/rue-bin`