### PR TITLE
RUE-417: use requested target in sema intrinsics

### DIFF
--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -805,11 +805,10 @@ impl<'a> Sema<'a> {
             .builtin_arch_id
             .expect("Arch enum not injected - internal compiler error");
 
-        // Determine variant index based on host architecture (compile-time evaluation)
-        // Currently we always compile for the host architecture
-        let host = rue_target::Target::host()
-            .expect("@target_arch() requires a supported Rue host target");
-        let variant_index = match host.arch() {
+        // Determine variant index from the requested compilation target, not
+        // the host running the compiler. Cross-target `--emit` must specialize
+        // target intrinsics for the emitted target (RUE-417).
+        let variant_index = match self.target.arch() {
             Arch::X86_64 => 0,
             Arch::Aarch64 => 1,
         };
@@ -854,11 +853,10 @@ impl<'a> Sema<'a> {
             .builtin_os_id
             .expect("Os enum not injected - internal compiler error");
 
-        // Determine variant index based on host OS (compile-time evaluation)
-        // Currently we always compile for the host OS
-        let host =
-            rue_target::Target::host().expect("@target_os() requires a supported Rue host target");
-        let variant_index = match host.os() {
+        // Determine variant index from the requested compilation target, not
+        // the host running the compiler. Cross-target `--emit` must specialize
+        // target intrinsics for the emitted target (RUE-417).
+        let variant_index = match self.target.os() {
             Os::Linux => 0,
             Os::Macos => 1,
         };

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::PreviewFeatures;
 use rue_rir::Rir;
+use rue_target::Target;
 
 use crate::intern_pool::TypeInternPool;
 use crate::param_arena::ParamArena;
@@ -65,6 +66,8 @@ pub struct GatherOutput<'a> {
     pub module_bindings: HashMap<(rue_span::FileId, Spur), ConstInfo>,
     /// Enabled preview features.
     pub preview_features: PreviewFeatures,
+    /// Requested compilation target.
+    pub target: Target,
     /// StructId of the synthetic String type.
     pub builtin_string_id: Option<StructId>,
     /// EnumId of the synthetic Arch enum (for @target_arch intrinsic).
@@ -93,6 +96,7 @@ impl<'a> GatherOutput<'a> {
             constants: self.constants,
             module_bindings: self.module_bindings,
             preview_features: self.preview_features,
+            target: self.target,
             builtin_string_id: self.builtin_string_id,
             builtin_arch_id: self.builtin_arch_id,
             builtin_os_id: self.builtin_os_id,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -59,6 +59,7 @@ use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
 use rue_rir::Rir;
 use rue_span::{FileId, Span};
+use rue_target::Target;
 
 use crate::intern_pool::TypeInternPool;
 use crate::param_arena::ParamArena;
@@ -88,6 +89,8 @@ pub struct Sema<'a> {
     pub(crate) module_bindings: HashMap<(FileId, Spur), ConstInfo>,
     /// Enabled preview features
     pub(crate) preview_features: PreviewFeatures,
+    /// Requested compilation target.
+    pub(crate) target: Target,
     /// StructId of the synthetic String type.
     pub(crate) builtin_string_id: Option<StructId>,
     /// EnumId of the synthetic Arch enum (for @target_arch intrinsic).
@@ -147,6 +150,22 @@ impl<'a> Sema<'a> {
         interner: &'a ThreadedRodeo,
         preview_features: PreviewFeatures,
     ) -> Self {
+        Self::new_for_target(
+            rir,
+            interner,
+            preview_features,
+            Target::host()
+                .expect("Rue cannot choose a default sema target on this unsupported host"),
+        )
+    }
+
+    /// Create a new semantic analyzer for an explicit compilation target.
+    pub fn new_for_target(
+        rir: &'a Rir,
+        interner: &'a ThreadedRodeo,
+        preview_features: PreviewFeatures,
+        target: Target,
+    ) -> Self {
         Self {
             rir,
             interner,
@@ -157,6 +176,7 @@ impl<'a> Sema<'a> {
             constants: HashMap::new(),
             module_bindings: HashMap::new(),
             preview_features,
+            target,
             builtin_string_id: None,
             builtin_arch_id: None,
             builtin_os_id: None,

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -79,3 +79,33 @@ fn main() -> i32 { 42 }
 args = ["--emit", "asm", "-j1", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== Assembly", "main"]
+
+[[case]]
+name = "emit_air_target_arch_uses_requested_target"
+description = "@target_arch() in --emit uses --target, not the compiler host (RUE-417)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    match @target_arch() {
+        Arch::X86_64 => 86,
+        Arch::Aarch64 => 64,
+    }
+}
+""" }]
+args = ["--target", "aarch64-linux", "--emit", "air", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["enum_variant #1::1"]
+
+[[case]]
+name = "emit_air_target_os_uses_requested_target"
+description = "@target_os() in --emit uses --target, not the compiler host (RUE-417)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    match @target_os() {
+        Os::Linux => 1,
+        Os::Macos => 2,
+    }
+}
+""" }]
+args = ["--target", "aarch64-macos", "--emit", "air", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["enum_variant #2::1"]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -889,11 +889,12 @@ pub fn compile_frontend_from_ast_with_options(
     opt_level: OptLevel,
     preview_features: &PreviewFeatures,
 ) -> MultiErrorResult<CompileState> {
-    compile_frontend_from_ast_with_file_paths(
+    compile_frontend_from_ast_with_file_paths_and_target(
         ast,
         interner,
         opt_level,
         preview_features,
+        CompileOptions::default().target,
         std::collections::HashMap::new(),
     )
 }
@@ -909,6 +910,27 @@ pub fn compile_frontend_from_ast_with_file_paths(
     preview_features: &PreviewFeatures,
     file_paths: std::collections::HashMap<FileId, String>,
 ) -> MultiErrorResult<CompileState> {
+    compile_frontend_from_ast_with_file_paths_and_target(
+        ast,
+        interner,
+        opt_level,
+        preview_features,
+        CompileOptions::default().target,
+        file_paths,
+    )
+}
+
+/// Like [`compile_frontend_from_ast_with_file_paths`], but with the explicit
+/// target sema needs for target-dependent intrinsics such as `@target_arch()`
+/// and `@target_os()` under cross-target `--emit` (RUE-417).
+pub fn compile_frontend_from_ast_with_file_paths_and_target(
+    ast: Ast,
+    interner: ThreadedRodeo,
+    opt_level: OptLevel,
+    preview_features: &PreviewFeatures,
+    target: Target,
+    file_paths: std::collections::HashMap<FileId, String>,
+) -> MultiErrorResult<CompileState> {
     // AST to RIR (untyped IR)
     let (rir, interner) = {
         let _span = info_span!("astgen").entered();
@@ -921,7 +943,7 @@ pub fn compile_frontend_from_ast_with_file_paths(
     // Semantic analysis (RIR to AIR) - this now collects multiple errors
     let sema_output = {
         let _span = info_span!("sema").entered();
-        let mut sema = Sema::new(&rir, &interner, preview_features.clone());
+        let mut sema = Sema::new_for_target(&rir, &interner, preview_features.clone(), target);
         sema.set_file_paths(file_paths);
         let output = sema.analyze_all()?;
         info!(

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -288,7 +288,12 @@ impl<'src> CompilationUnit<'src> {
         // Semantic analysis
         let sema_output = {
             let _span = info_span!("sema").entered();
-            let mut sema = Sema::new(rir, interner, self.options.preview_features.clone());
+            let mut sema = Sema::new_for_target(
+                rir,
+                interner,
+                self.options.preview_features.clone(),
+                self.options.target,
+            );
             sema.set_file_paths(self.file_paths.clone());
             let output = sema.analyze_all()?;
             info!(

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1390,11 +1390,12 @@ fn handle_emit_multi_file(
             .iter()
             .map(|s| (s.file_id, s.path.to_string()))
             .collect();
-        let state = match rue_compiler::compile_frontend_from_ast_with_file_paths(
+        let state = match rue_compiler::compile_frontend_from_ast_with_file_paths_and_target(
             merged.ast,
             merged.interner,
             options.opt_level,
             &options.preview_features,
+            options.target,
             file_paths,
         ) {
             Ok(state) => state,


### PR DESCRIPTION
## Summary
- thread the requested compile target into semantic analysis
- evaluate `@target_arch()` and `@target_os()` from `CompileOptions.target` instead of the compiler host
- add cross-target `--emit air` CLI coverage for arch and OS

## Validation
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test //crates/rue-cli-tests:rue-cli-tests-test //:cli-tests`
- `./fmt.sh check`