### PR TITLE
RUE-415: purge stale parsed interner state

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -257,8 +257,8 @@ impl<'a> SourceFile<'a> {
 
 /// Result of parsing a single file.
 ///
-/// Contains the AST and interner from parsing. The interner contains all
-/// string literals and identifiers interned during lexing.
+/// Per-file ASTs share the [`ParsedProgram::interner`] returned by
+/// [`parse_all_files`]; there is no per-file interner state.
 #[derive(Debug)]
 pub struct ParsedFile {
     /// Path to the source file.
@@ -267,18 +267,16 @@ pub struct ParsedFile {
     pub file_id: FileId,
     /// The parsed abstract syntax tree.
     pub ast: Ast,
-    /// String interner from lexing.
-    pub interner: ThreadedRodeo,
 }
 
 /// Result of parsing all source files.
 ///
-/// Contains all parsed files and a merged interner for use in later phases.
+/// Contains all parsed files and the shared interner for use in later phases.
 #[derive(Debug)]
 pub struct ParsedProgram {
     /// Parsed files with their ASTs.
     pub files: Vec<ParsedFile>,
-    /// Merged interner containing all symbols from all files.
+    /// Shared interner containing all symbols from all files.
     pub interner: ThreadedRodeo,
 }
 
@@ -287,10 +285,6 @@ pub struct ParsedProgram {
 /// Each file is lexed and parsed sequentially with a single shared interner.
 /// This ensures Spur values are consistent across all files, enabling cross-file
 /// symbol resolution during semantic analysis.
-///
-/// Note: This uses sequential parsing rather than parallel to share the interner.
-/// A future optimization could add parallel parsing with interner merging and
-/// AST Spur remapping.
 ///
 /// # Arguments
 ///
@@ -353,9 +347,6 @@ pub fn parse_all_files(sources: &[SourceFile<'_>]) -> MultiErrorResult<ParsedPro
             path: source.path.to_string(),
             file_id: source.file_id,
             ast,
-            // Note: interner is shared, but we store a dummy here for API compatibility
-            // The real interner is in the returned ParsedProgram
-            interner: ThreadedRodeo::new(),
         });
     }
 
@@ -371,13 +362,13 @@ pub fn parse_all_files(sources: &[SourceFile<'_>]) -> MultiErrorResult<ParsedPro
 
 /// Result of merging symbols from multiple parsed files.
 ///
-/// Contains a merged AST with all items from all files and the merged interner.
+/// Contains a merged AST with all items from all files and the shared interner.
 /// Used as input to RIR generation for multi-file compilation.
 #[derive(Debug)]
 pub struct MergedProgram {
     /// The merged AST containing items from all files.
     pub ast: Ast,
-    /// Merged interner containing all symbols from all files.
+    /// Shared interner containing all symbols from all files.
     pub interner: ThreadedRodeo,
 }
 
@@ -3618,7 +3609,7 @@ mod integration_tests {
 
             let program = parse_all_files(&sources).unwrap();
 
-            // The merged interner should contain both "foo" and "bar"
+            // The shared interner should contain both "foo" and "bar"
             let has_foo = program.interner.iter().any(|(_, s)| s == "foo");
             let has_bar = program.interner.iter().any(|(_, s)| s == "bar");
 

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -34,20 +34,11 @@ use crate::{
 };
 use rue_span::FileId;
 
-/// Result of parsing a single file within a compilation unit.
-#[derive(Debug)]
-struct ParsedFileData {
-    /// Path to the source file.
-    path: String,
-    /// The parsed abstract syntax tree.
-    ast: Ast,
-}
-
 /// A unified compilation unit that owns all artifacts from source to machine code.
 ///
 /// The compilation unit progresses through phases:
 /// 1. **New**: Just source files
-/// 2. **Parsed**: ASTs and interner from parsing
+/// 2. **Parsed**: merged AST and interner from parsing
 /// 3. **Lowered**: RIR (untyped intermediate representation)
 /// 4. **Analyzed**: AIR (typed IR) and CFGs for all functions
 ///
@@ -70,8 +61,6 @@ pub struct CompilationUnit<'src> {
     sources: Vec<SourceFile<'src>>,
 
     // === Phase 1: Parsing ===
-    /// Parsed ASTs for each file (populated by `parse()`).
-    parsed_files: Option<Vec<ParsedFileData>>,
     /// Merged AST containing all items (populated by `parse()`).
     merged_ast: Option<Ast>,
     /// String interner shared across all files.
@@ -114,7 +103,6 @@ impl<'src> CompilationUnit<'src> {
         Self {
             options,
             sources,
-            parsed_files: None,
             merged_ast: None,
             interner: None,
             file_paths,
@@ -186,10 +174,7 @@ impl<'src> CompilationUnit<'src> {
 
             info!(item_count = ast.items.len(), "parsing complete");
 
-            parsed_files.push(ParsedFileData {
-                path: source.path.to_string(),
-                ast,
-            });
+            parsed_files.push((source.path.to_string(), ast));
         }
 
         if !errors.is_empty() {
@@ -199,7 +184,6 @@ impl<'src> CompilationUnit<'src> {
         // Merge symbols and check for duplicates
         let merged_ast = self.merge_symbols(&parsed_files, &interner)?;
 
-        self.parsed_files = Some(parsed_files);
         self.merged_ast = Some(merged_ast);
         self.interner = Some(interner);
 
@@ -209,13 +193,13 @@ impl<'src> CompilationUnit<'src> {
     /// Merge symbols from all parsed files, checking for duplicates.
     fn merge_symbols(
         &self,
-        files: &[ParsedFileData],
+        files: &[(String, Ast)],
         interner: &ThreadedRodeo,
     ) -> MultiErrorResult<Ast> {
         let _span = info_span!("merge_symbols", file_count = files.len()).entered();
 
         let check = crate::detect_duplicate_symbols(
-            files.iter().map(|f| (f.path.as_str(), &f.ast)),
+            files.iter().map(|(path, ast)| (path.as_str(), ast)),
             interner,
         );
 
@@ -225,7 +209,7 @@ impl<'src> CompilationUnit<'src> {
 
         let all_items: Vec<_> = files
             .iter()
-            .flat_map(|file| file.ast.items.iter().cloned())
+            .flat_map(|(_, ast)| ast.items.iter().cloned())
             .collect();
 
         info!(


### PR DESCRIPTION
## Summary
- remove the dummy per-file `ParsedFile::interner` field from multi-file parsing
- stop retaining `CompilationUnit` parsed-file AST cache after merging
- clarify comments around the serial shared-interner frontend path

## Validation
- `./buck2 test //crates/rue-compiler:rue-compiler-test //:cli-tests`
- `./fmt.sh check`