### PR TITLE
RUE-413: remove dead ParamRef instruction

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -737,15 +737,6 @@ impl<'a> ConstraintGenerator<'a> {
                 }
             }
 
-            // Parameter reference
-            InstData::ParamRef { name, .. } => {
-                if let Some(param) = ctx.params.get(name) {
-                    param.ty.clone()
-                } else {
-                    InferType::Concrete(Type::ERROR)
-                }
-            }
-
             // Local variable allocation
             InstData::Alloc {
                 directives_start: _,
@@ -2250,7 +2241,7 @@ impl<'a> ConstraintGenerator<'a> {
             }
             // A struct/enum name or forwarded type parameter used as a value
             // parses as a variable reference, not a type literal.
-            InstData::VarRef { name } | InstData::ParamRef { name, .. } => {
+            InstData::VarRef { name } => {
                 // A local bound to a type value (`let X = i32; identity(X, 42)`
                 // or `let P = Pair(i32); f(P, ..)`) resolves to that bound type
                 // via the precomputed comptime-local-types map — the same map
@@ -2298,9 +2289,7 @@ impl<'a> ConstraintGenerator<'a> {
                     None
                 }
             }
-            InstData::VarRef { name } | InstData::ParamRef { name, .. } => {
-                self.const_values.and_then(|m| m.get(name).copied())
-            }
+            InstData::VarRef { name } => self.const_values.and_then(|m| m.get(name).copied()),
             _ => None,
         }
     }
@@ -2330,9 +2319,7 @@ impl<'a> ConstraintGenerator<'a> {
         // here; richer scrutinees are left to sema's own selection.
         // `ConstValue` is `Copy`, so take an owned copy for the match below.
         let value: ConstValue = match &self.rir.get(scrutinee).data {
-            InstData::VarRef { name } | InstData::ParamRef { name, .. } => {
-                *self.comptime_values?.get(name)?
-            }
+            InstData::VarRef { name } => *self.comptime_values?.get(name)?,
             _ => return None,
         };
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1235,7 +1235,6 @@ pub(crate) fn root_variable_of(rir: &Rir, inst_ref: InstRef) -> Option<Spur> {
     let inst = rir.get(inst_ref);
     match &inst.data {
         InstData::VarRef { name } => Some(*name),
-        InstData::ParamRef { name, .. } => Some(*name),
         InstData::FieldGet { base, .. } => root_variable_of(rir, *base),
         InstData::IndexGet { base, .. } => root_variable_of(rir, *base),
         _ => None,

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -620,7 +620,7 @@ impl<'a> Sema<'a> {
     /// typed place chain rooted at a variable (call results, literals, ...).
     pub(super) fn peek_place_type(&self, inst_ref: InstRef, ctx: &AnalysisContext) -> Option<Type> {
         match &self.rir.get(inst_ref).data {
-            InstData::VarRef { name } | InstData::ParamRef { name, .. } => {
+            InstData::VarRef { name } => {
                 if let Some(local) = ctx.locals.get(name) {
                     return Some(local.ty);
                 }

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -23,7 +23,7 @@ impl<'a> Sema<'a> {
     /// - **Logical**: And, Or
     /// - **Unary**: Neg, Not, BitNot
     /// - **Control flow**: Branch, Loop, InfiniteLoop, Match, Break, Continue, Ret, Block
-    /// - **Variables**: Alloc, VarRef, ParamRef, Assign
+    /// - **Variables**: Alloc, VarRef, Assign
     /// - **Structs**: StructDecl, StructInit, FieldGet, FieldSet
     /// - **Arrays**: ArrayInit, IndexGet, IndexSet
     /// - **Enums**: EnumDecl, EnumVariant
@@ -122,10 +122,9 @@ impl<'a> Sema<'a> {
             | InstData::Block { .. } => self.analyze_control_flow(air, inst_ref, ctx),
 
             // Variable operations
-            InstData::Alloc { .. }
-            | InstData::VarRef { .. }
-            | InstData::ParamRef { .. }
-            | InstData::Assign { .. } => self.analyze_variable_ops(air, inst_ref, ctx),
+            InstData::Alloc { .. } | InstData::VarRef { .. } | InstData::Assign { .. } => {
+                self.analyze_variable_ops(air, inst_ref, ctx)
+            }
 
             // Struct operations
             InstData::StructDecl { .. }

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -474,7 +474,6 @@ impl<'a> Sema<'a> {
     ///
     /// Returns Some(symbol) for:
     /// - VarRef { name } -> the variable symbol
-    /// - ParamRef { name, .. } -> the parameter symbol
     /// - FieldGet { base, .. } -> recursively extract from base
     /// - IndexGet { base, .. } -> recursively extract from base
     ///

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6,7 +6,7 @@
 //! - [`analyze_literal`] - Integer, boolean, string, and unit constants
 //! - [`analyze_unary_op`] - Negation, logical NOT, bitwise NOT
 //! - [`analyze_control_flow`] - Branch, Loop, InfiniteLoop, Match, Break, Continue, Ret, Block
-//! - [`analyze_variable_ops`] - Alloc, VarRef, ParamRef, Assign
+//! - [`analyze_variable_ops`] - Alloc, VarRef, Assign
 //! - [`analyze_struct_ops`] - StructDecl, StructInit, FieldGet, FieldSet
 //! - [`analyze_array_ops`] - ArrayInit, IndexGet, IndexSet
 //! - [`analyze_enum_ops`] - EnumDecl, EnumVariant
@@ -145,7 +145,7 @@ impl<'a> Sema<'a> {
     /// Try to trace an RIR expression to a place (lvalue).
     ///
     /// This walks the RIR instruction chain backward from a `FieldGet` or `IndexGet`
-    /// to find the root `VarRef` or `ParamRef`, collecting projections along the way.
+    /// to find the root `VarRef`, collecting projections along the way.
     ///
     /// Returns `None` if the expression is not a place (e.g., a function call result).
     ///
@@ -218,21 +218,6 @@ impl<'a> Sema<'a> {
                 }
 
                 // Not a variable - might be a constant or type name
-                Ok(None)
-            }
-
-            // Base case: explicit parameter reference
-            InstData::ParamRef { name, .. } => {
-                if let Some(param_info) = ctx.params.iter().find(|p| p.name == *name) {
-                    return Ok(Some(PlaceTrace {
-                        base: AirPlaceBase::Param(param_info.abi_slot),
-                        base_type: param_info.ty,
-                        projections: Vec::new(),
-                        root_var: *name,
-                        is_root_mutable: matches!(param_info.mode, RirParamMode::Inout),
-                        is_borrow_param: matches!(param_info.mode, RirParamMode::Borrow),
-                    }));
-                }
                 Ok(None)
             }
 
@@ -2208,12 +2193,12 @@ impl<'a> Sema<'a> {
     }
 
     // ========================================================================
-    // Variable operations: Alloc, VarRef, ParamRef, Assign
+    // Variable operations: Alloc, VarRef, Assign
     // ========================================================================
 
     /// Analyze a variable operation instruction.
     ///
-    /// Handles: Alloc, VarRef, ParamRef, Assign
+    /// Handles: Alloc, VarRef, Assign
     pub(crate) fn analyze_variable_ops(
         &mut self,
         air: &mut Air,
@@ -2247,10 +2232,6 @@ impl<'a> Sema<'a> {
             InstData::VarRef { name } => {
                 let resolved_ty = ctx.resolved_types.get(&inst_ref).copied();
                 self.analyze_var_ref(air, *name, inst.span, resolved_ty, ctx)
-            }
-
-            InstData::ParamRef { index: _, name } => {
-                self.analyze_param_ref(air, *name, inst.span, ctx)
             }
 
             InstData::Assign { name, value } => {
@@ -2792,33 +2773,6 @@ impl<'a> Sema<'a> {
             ErrorKind::UndefinedVariable(name_str.to_string()),
             span,
         ))
-    }
-
-    /// Analyze a parameter reference.
-    fn analyze_param_ref(
-        &mut self,
-        air: &mut Air,
-        name: Spur,
-        span: Span,
-        ctx: &mut AnalysisContext,
-    ) -> CompileResult<AnalysisResult> {
-        let name_str = self.interner.resolve(&name);
-        let param_info = ctx
-            .params
-            .iter()
-            .find(|p| p.name == name)
-            .ok_or_compile_error(ErrorKind::UndefinedVariable(name_str.to_string()), span)?;
-
-        let ty = param_info.ty;
-
-        let air_ref = air.add_inst(AirInst {
-            data: AirInstData::Param {
-                index: param_info.abi_slot,
-            },
-            ty,
-            span,
-        });
-        Ok(AnalysisResult::new(air_ref, ty))
     }
 
     /// Analyze an assignment.
@@ -3704,7 +3658,7 @@ impl<'a> Sema<'a> {
 
     /// Analyze a field assignment.
     ///
-    /// This is a complex operation that handles VarRef, ParamRef, and chained field access.
+    /// This is a complex operation that handles VarRef and chained field access.
     /// The full implementation is in analysis.rs as it's quite large (~200 lines).
     fn analyze_field_set(
         &mut self,
@@ -4918,7 +4872,7 @@ impl<'a> Sema<'a> {
 
     /// Analyze an array index write.
     ///
-    /// This is a complex operation that handles VarRef and ParamRef bases.
+    /// This is a complex operation that handles VarRef bases.
     /// The full implementation is in analysis.rs as it's quite large.
     fn analyze_index_set(
         &mut self,

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -62,7 +62,6 @@ mod tests {
         "Intrinsic",
         "TypeIntrinsic",
         "OffsetOf",
-        "ParamRef",
         "Ret",
         // Blocks
         "Block",

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -2352,25 +2352,6 @@ mod tests {
     }
 
     #[test]
-    fn test_astgen_never_produces_param_ref() {
-        // AstGen lowers parameter references as `VarRef`; sema resolves them
-        // to parameters. `InstData::ParamRef` is never produced here — see the
-        // note on the variant definition in `inst.rs`.
-        let (rir, _interner) = gen_rir("fn add(x: i32, y: i32) -> i32 { x + y }");
-
-        assert!(
-            rir.iter()
-                .all(|(_, inst)| !matches!(inst.data, InstData::ParamRef { .. })),
-            "AstGen should not emit ParamRef"
-        );
-        assert!(
-            rir.iter()
-                .any(|(_, inst)| matches!(inst.data, InstData::VarRef { .. })),
-            "parameter references should be emitted as VarRef"
-        );
-    }
-
-    #[test]
     fn test_anon_struct_with_methods() {
         // Test that anonymous structs with methods generate AnonStructType with method references
         let source = r#"

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -731,10 +731,6 @@ impl Rir {
             InstData::UnitConst => InstData::UnitConst,
             InstData::Continue => InstData::Continue,
             InstData::VarRef { name } => InstData::VarRef { name: *name },
-            InstData::ParamRef { index, name } => InstData::ParamRef {
-                index: *index,
-                name: *name,
-            },
             InstData::EnumVariant {
                 module,
                 type_name,
@@ -1309,7 +1305,6 @@ impl Rir {
                 | InstData::Continue
                 | InstData::Ret(_)
                 | InstData::VarRef { .. }
-                | InstData::ParamRef { .. }
                 | InstData::Alloc { .. }
                 | InstData::Assign { .. }
                 | InstData::FnDecl { .. }
@@ -1561,20 +1556,6 @@ pub enum InstData {
         type_arg: Spur,
         /// Field name whose offset is requested.
         field: Spur,
-    },
-
-    /// Reference to a function parameter.
-    ///
-    /// NOTE: AstGen never produces this variant — parameter references are
-    /// emitted as [`InstData::VarRef`] and resolved to parameters during
-    /// semantic analysis (which handles `ParamRef` alongside `VarRef` in case
-    /// a future producer distinguishes them). The
-    /// `test_astgen_never_produces_param_ref` test in `astgen.rs` pins this.
-    ParamRef {
-        /// Parameter index (0-based)
-        index: u32,
-        /// Parameter name (for error messages)
-        name: Spur,
     },
 
     /// Return value from function (None for `return;` in unit-returning functions)
@@ -2138,9 +2119,6 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let type_str = self.interner.resolve(&*type_arg);
                     let field_str = self.interner.resolve(&*field);
                     writeln!(out, "offset_of @offset_of({}, {})", type_str, field_str).unwrap();
-                }
-                InstData::ParamRef { index, name } => {
-                    writeln!(out, "param {} ({})", index, self.interner.resolve(&*name)).unwrap();
                 }
                 InstData::Block { extra_start, len } => {
                     writeln!(out, "block({}, {})", extra_start, len).unwrap();
@@ -3191,21 +3169,6 @@ mod tests {
         let printer = RirPrinter::new(&rir, &interner);
         let output = printer.to_string();
         assert!(output.contains("type_intrinsic @size_of(i32)"));
-    }
-
-    #[test]
-    fn test_printer_param_ref() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let name = interner.get_or_intern("x");
-
-        rir.add_inst(Inst {
-            data: InstData::ParamRef { index: 0, name },
-            span: Span::new(0, 1),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("param 0 (x)"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove the never-produced `InstData::ParamRef` variant
- collapse defensive sema/inference handling to the live `VarRef` path
- remove printer/astgen/consistency-test coverage for the dead variant

## Validation
- `./buck2 test //crates/rue-rir:rue-rir-test //crates/rue-air:rue-air-test //:cli-tests`
- `./fmt.sh check`