### PR TITLE
RUE-412: remove stale ModuleDef export tables

### DIFF
--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -93,12 +93,6 @@ impl ModuleRegistry {
             .expect("Invalid ModuleId")
     }
 
-    /// Update a module definition.
-    pub fn update_def(&self, id: ModuleId, def: ModuleDef) {
-        let mut defs = self.defs.write().unwrap_or_else(PoisonError::into_inner);
-        defs[id.index() as usize] = def;
-    }
-
     /// Get the number of modules in the registry.
     pub fn len(&self) -> usize {
         self.defs
@@ -110,13 +104,6 @@ impl ModuleRegistry {
     /// Check if the registry is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
-    }
-
-    /// Extract the module definitions (consumes the registry).
-    pub fn into_defs(self) -> Vec<ModuleDef> {
-        self.defs
-            .into_inner()
-            .unwrap_or_else(PoisonError::into_inner)
     }
 }
 

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -463,40 +463,24 @@ impl EnumDef {
 
 /// Definition of a module (imported file).
 ///
-/// A module contains the public declarations from an imported file.
-/// When code accesses `math.add()`, the module definition is consulted
-/// to find the corresponding function.
+/// A module records the import spelling and resolved file identity. Member
+/// lookup uses the compiler's global declaration tables plus this file identity
+/// for visibility checks; declarations are not duplicated here.
 #[derive(Debug, Clone)]
 pub struct ModuleDef {
     /// The path used in @import (e.g., "math.rue")
     pub import_path: String,
     /// The resolved absolute file path
     pub file_path: String,
-    /// Public functions in this module: name -> mangled name
-    /// The mangled name includes the module path (e.g., "math::add")
-    pub functions: std::collections::HashMap<String, String>,
-    /// Public structs in this module
-    pub structs: Vec<String>,
-    /// Public enums in this module
-    pub enums: Vec<String>,
 }
 
 impl ModuleDef {
-    /// Create a new empty module definition.
+    /// Create a new module definition.
     pub fn new(import_path: String, file_path: String) -> Self {
         Self {
             import_path,
             file_path,
-            functions: std::collections::HashMap::new(),
-            structs: Vec::new(),
-            enums: Vec::new(),
         }
-    }
-
-    /// Find a function by name in this module.
-    /// Returns the mangled function name if found.
-    pub fn find_function(&self, name: &str) -> Option<&str> {
-        self.functions.get(name).map(|s| s.as_str())
     }
 }
 


### PR DESCRIPTION
## Summary
- remove unpopulated `ModuleDef` function/type export tables
- clarify that module member lookup uses global declaration tables plus module file identity
- remove unused module definition mutation/extraction helpers

## Validation
- `./buck2 test //crates/rue-air:rue-air-test //:cli-tests`
- `./fmt.sh check`