### PR TITLE
RUE-416: document indexed pseudo-instruction lifecycle

### DIFF
--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -363,8 +363,9 @@ impl<'a> Emitter<'a> {
 
     /// Internal implementation of emit.
     fn emit_internal(&mut self) -> CompileResult<()> {
-        // Verify no MovRMIndexed or MovMRIndexed survived into emission
-        // These should have been lowered by regalloc into MovRM/MovMR
+        // Verify no MovRMIndexed or MovMRIndexed survived into emission.
+        // These are pre-regalloc pseudos whose virtual address bases must have
+        // been lowered by regalloc into MovRM/MovMR with physical bases.
         for (i, inst) in self.mir.iter().enumerate() {
             if matches!(
                 inst,
@@ -1096,7 +1097,7 @@ impl<'a> Emitter<'a> {
             }
 
             X86Inst::MovRMIndexed { .. } | X86Inst::MovMRIndexed { .. } => {
-                // Regalloc lowers these into MovRM/MovMR (or the SIB variants), and
+                // Regalloc lowers these into MovRM/MovMR, and
                 // emit_internal() verifies none survive before this dispatch loop runs,
                 // returning an ICE instead of ever reaching this arm.
                 unreachable!("MovRMIndexed/MovMRIndexed rejected by pre-emission verification")

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -449,14 +449,22 @@ pub enum X86Inst {
     /// `shl dst, count` - Shift left (multiply by 2^count).
     Shl { dst: Operand, count: Operand },
 
-    /// `mov dst, [base]` - Load from memory via register.
+    /// `mov dst, [base]` - Load from memory via a virtual base register.
+    ///
+    /// This is a pre-register-allocation pseudo-instruction. CFG lowering uses
+    /// it when the address base is still a virtual register; register allocation
+    /// must lower it to `MovRM` with a physical base register before emission.
     MovRMIndexed {
         dst: Operand,
         base: VReg,
         offset: i32,
     },
 
-    /// `mov [base], src` - Store to memory via register.
+    /// `mov [base], src` - Store to memory via a virtual base register.
+    ///
+    /// This is a pre-register-allocation pseudo-instruction. CFG lowering uses
+    /// it when the address base is still a virtual register; register allocation
+    /// must lower it to `MovMR` with a physical base register before emission.
     MovMRIndexed {
         base: VReg,
         offset: i32,

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -721,6 +721,9 @@ impl RegAlloc {
             }
 
             X86Inst::MovRMIndexed { dst, base, offset } => {
+                // Lifecycle boundary: Mov*Indexed are pre-regalloc pseudos
+                // whose address base is still virtual. After this pass, emit
+                // only sees concrete memory operations with physical bases.
                 // Load base vreg into scratch register
                 let base_op = Operand::Virtual(base);
                 let base_reg = self.load_operand(mir, base_op, Reg::Rax)?;
@@ -763,6 +766,7 @@ impl RegAlloc {
             }
 
             X86Inst::MovMRIndexed { base, offset, src } => {
+                // Lifecycle boundary: see MovRMIndexed above.
                 let src_op = self.load_operand(mir, src, Reg::Rdx)?;
                 let base_op = Operand::Virtual(base);
                 let base_reg = self.load_operand(mir, base_op, Reg::Rax)?;
@@ -1289,6 +1293,69 @@ mod tests {
         };
 
         assert_ne!(d0, d1, "interfering vregs should get different registers");
+    }
+
+    #[test]
+    fn test_indexed_memory_pseudos_lowered_before_emit() {
+        let mut mir = X86Mir::new();
+        let base = mir.alloc_vreg();
+        let src = mir.alloc_vreg();
+        let loaded = mir.alloc_vreg();
+
+        mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(base),
+            imm: 1024,
+        });
+        mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(src),
+            imm: 7,
+        });
+        mir.push(X86Inst::MovRMIndexed {
+            dst: Operand::Virtual(loaded),
+            base,
+            offset: 16,
+        });
+        mir.push(X86Inst::MovMRIndexed {
+            base,
+            offset: 24,
+            src: Operand::Virtual(src),
+        });
+        mir.push(X86Inst::MovRR {
+            dst: Operand::Physical(Reg::Rdi),
+            src: Operand::Virtual(loaded),
+        });
+
+        let mir = RegAlloc::new(mir, 0).allocate().unwrap();
+
+        assert!(
+            mir.instructions().iter().all(|inst| !matches!(
+                inst,
+                X86Inst::MovRMIndexed { .. } | X86Inst::MovMRIndexed { .. }
+            )),
+            "regalloc must eliminate indexed memory pseudos before emit"
+        );
+        assert!(
+            mir.instructions().iter().any(|inst| matches!(
+                inst,
+                X86Inst::MovRM {
+                    dst: Operand::Physical(_),
+                    base,
+                    offset: 16,
+                } if *base != Reg::Rbp
+            )),
+            "MovRMIndexed should lower to MovRM with a physical address base"
+        );
+        assert!(
+            mir.instructions().iter().any(|inst| matches!(
+                inst,
+                X86Inst::MovMR {
+                    base,
+                    offset: 24,
+                    src: Operand::Physical(_),
+                } if *base != Reg::Rbp
+            )),
+            "MovMRIndexed should lower to MovMR with a physical address base"
+        );
     }
 
     // ========================================


### PR DESCRIPTION
## Summary

- Document `MovRMIndexed` / `MovMRIndexed` as pre-regalloc x86_64 pseudo-instructions.
- Clarify the regalloc-to-emit lifecycle boundary for those pseudos.
- Add a regalloc invariant test proving both indexed memory pseudos are lowered before emit.

## Validation

- `./buck2 test //crates/rue-codegen:rue-codegen-test`
- `./buck2 test //:cli-tests`
- `./fmt.sh check`
