### PR TITLE
RUE-408: share liveness adapter orchestration

### DIFF
--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -6,6 +6,9 @@
 use std::collections::HashMap;
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg};
+use crate::liveness::{
+    LivenessAdapter, branch_successor, conditional_successors, fallthrough_successor,
+};
 use crate::vreg::{LabelId, VReg};
 
 // Re-export shared types from the regalloc module
@@ -14,57 +17,61 @@ pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo, Loo
 /// Type alias for aarch64-specific liveness info.
 pub type LivenessInfo = crate::regalloc::LivenessInfo<Reg>;
 
-/// Compute liveness information for Aarch64Mir.
-///
-/// This performs proper dataflow analysis that handles control flow:
-/// 1. Build a map of labels to instruction indices
-/// 2. For each instruction, compute successors (next instruction or branch targets)
-/// 3. Do backward dataflow to compute live-in/live-out sets
-/// 4. Build live ranges from the dataflow results
-pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
-    let instructions = mir.instructions();
-    let num_insts = instructions.len();
+struct Aarch64LivenessAdapter<'a> {
+    mir: &'a Aarch64Mir,
+}
 
-    crate::liveness::analyze(
-        instructions,
-        mir.vreg_count(),
-        get_label,
-        |idx, inst, label_to_idx| get_successors(idx, inst, label_to_idx, num_insts),
-        uses,
-        defs,
-        |inst| inst.clobbers().to_vec(),
-    )
+impl LivenessAdapter for Aarch64LivenessAdapter<'_> {
+    type Inst = Aarch64Inst;
+    type Reg = Reg;
+
+    fn instructions(&self) -> &[Self::Inst] {
+        self.mir.instructions()
+    }
+
+    fn vreg_count(&self) -> u32 {
+        self.mir.vreg_count()
+    }
+
+    fn label(&self, inst: &Self::Inst) -> Option<LabelId> {
+        get_label(inst)
+    }
+
+    fn successors(
+        &self,
+        idx: usize,
+        inst: &Self::Inst,
+        label_to_idx: &HashMap<LabelId, usize>,
+    ) -> Vec<usize> {
+        get_successors(idx, inst, label_to_idx, self.instructions().len())
+    }
+
+    fn uses(&self, inst: &Self::Inst) -> Vec<VReg> {
+        uses(inst)
+    }
+
+    fn defs(&self, inst: &Self::Inst) -> Vec<VReg> {
+        defs(inst)
+    }
+
+    fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
+        inst.clobbers().to_vec()
+    }
+}
+
+/// Compute liveness information for Aarch64Mir.
+pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
+    crate::liveness::analyze_adapter(&Aarch64LivenessAdapter { mir })
 }
 
 /// Compute detailed liveness debug information for Aarch64Mir.
-///
-/// This provides more detailed output than `analyze()`, including per-instruction
-/// live-in/live-out sets and def/use information. Used by `--emit liveness`.
 pub fn analyze_debug(mir: &Aarch64Mir) -> LivenessDebugInfo {
-    let instructions = mir.instructions();
-    let num_insts = instructions.len();
-
-    crate::liveness::analyze_debug::<_, Reg>(
-        instructions,
-        mir.vreg_count(),
-        get_label,
-        |idx, inst, label_to_idx| get_successors(idx, inst, label_to_idx, num_insts),
-        uses,
-        defs,
-    )
+    crate::liveness::analyze_debug_adapter(&Aarch64LivenessAdapter { mir })
 }
 
 /// Compute loop information for Aarch64Mir.
-///
-/// This detects loops by finding back-edges (jumps to earlier instructions)
-/// and returns loop depth information for each instruction.
 pub fn analyze_loops(mir: &Aarch64Mir) -> LoopInfo {
-    let instructions = mir.instructions();
-    let num_insts = instructions.len();
-
-    crate::liveness::analyze_loops(instructions, get_label, |idx, inst, label_to_idx| {
-        get_successors(idx, inst, label_to_idx, num_insts)
-    })
+    crate::liveness::analyze_loops_adapter(&Aarch64LivenessAdapter { mir })
 }
 
 // ============================================================================
@@ -88,42 +95,21 @@ fn get_successors(
 ) -> Vec<usize> {
     match inst {
         // Unconditional branch - only successor is the target
-        Aarch64Inst::B { label } => label_to_idx.get(label).copied().into_iter().collect(),
+        Aarch64Inst::B { label } => branch_successor(*label, label_to_idx),
         // Conditional branches - successor is both target and fall-through
         Aarch64Inst::BCond { label, .. }
         | Aarch64Inst::Bvs { label }
         | Aarch64Inst::Bvc { label }
         | Aarch64Inst::Cbz { label, .. }
         | Aarch64Inst::Cbnz { label, .. } => {
-            let mut succs = Vec::with_capacity(2);
-            // Fall-through to next instruction
-            if idx + 1 < num_insts {
-                succs.push(idx + 1);
-            }
-            // Branch target
-            if let Some(&target) = label_to_idx.get(label) {
-                succs.push(target);
-            }
-            succs
+            conditional_successors(idx, *label, label_to_idx, num_insts)
         }
         // Return and trap have no successors
         Aarch64Inst::Ret | Aarch64Inst::Brk => Vec::new(),
         // Function calls fall through (callee returns)
-        Aarch64Inst::Bl { .. } => {
-            if idx + 1 < num_insts {
-                vec![idx + 1]
-            } else {
-                Vec::new()
-            }
-        }
+        Aarch64Inst::Bl { .. } => fallthrough_successor(idx, num_insts),
         // All other instructions fall through to the next
-        _ => {
-            if idx + 1 < num_insts {
-                vec![idx + 1]
-            } else {
-                Vec::new()
-            }
-        }
+        _ => fallthrough_successor(idx, num_insts),
     }
 }
 

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -26,6 +26,122 @@ use crate::index_map::IndexMap;
 use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo, LivenessInfo, LoopInfo};
 use crate::vreg::{LabelId, VReg};
 
+/// Backend-specific facts required by the shared liveness orchestration.
+///
+/// Backends own instruction semantics (`uses`, `defs`, labels, successors, and
+/// physical-register clobbers). This module owns the repeated wrapper shape:
+/// fetch the instruction slice and vreg count, then run normal liveness,
+/// debug-liveness, or loop analysis through the same callbacks.
+pub trait LivenessAdapter {
+    /// Backend MIR instruction type.
+    type Inst;
+    /// Backend physical register type.
+    type Reg: Copy + Eq + std::hash::Hash;
+
+    /// Instruction sequence to analyze.
+    fn instructions(&self) -> &[Self::Inst];
+
+    /// Number of virtual registers allocated in the MIR.
+    fn vreg_count(&self) -> u32;
+
+    /// Return the label ID if `inst` is a label.
+    fn label(&self, inst: &Self::Inst) -> Option<LabelId>;
+
+    /// Return successor instruction indices for `inst`.
+    fn successors(
+        &self,
+        idx: usize,
+        inst: &Self::Inst,
+        label_to_idx: &HashMap<LabelId, usize>,
+    ) -> Vec<usize>;
+
+    /// Return virtual registers read by `inst`.
+    fn uses(&self, inst: &Self::Inst) -> Vec<VReg>;
+
+    /// Return virtual registers written by `inst`.
+    fn defs(&self, inst: &Self::Inst) -> Vec<VReg>;
+
+    /// Return physical registers clobbered by `inst`.
+    fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg>;
+}
+
+/// Compute liveness for any backend implementing [`LivenessAdapter`].
+pub fn analyze_adapter<A>(adapter: &A) -> LivenessInfo<A::Reg>
+where
+    A: LivenessAdapter,
+{
+    analyze(
+        adapter.instructions(),
+        adapter.vreg_count(),
+        |inst| adapter.label(inst),
+        |idx, inst, label_to_idx| adapter.successors(idx, inst, label_to_idx),
+        |inst| adapter.uses(inst),
+        |inst| adapter.defs(inst),
+        |inst| adapter.clobbers(inst),
+    )
+}
+
+/// Compute detailed debug liveness for any backend implementing
+/// [`LivenessAdapter`].
+pub fn analyze_debug_adapter<A>(adapter: &A) -> LivenessDebugInfo
+where
+    A: LivenessAdapter,
+{
+    analyze_debug::<_, A::Reg>(
+        adapter.instructions(),
+        adapter.vreg_count(),
+        |inst| adapter.label(inst),
+        |idx, inst, label_to_idx| adapter.successors(idx, inst, label_to_idx),
+        |inst| adapter.uses(inst),
+        |inst| adapter.defs(inst),
+    )
+}
+
+/// Compute loop information for any backend implementing [`LivenessAdapter`].
+pub fn analyze_loops_adapter<A>(adapter: &A) -> LoopInfo
+where
+    A: LivenessAdapter,
+{
+    analyze_loops(
+        adapter.instructions(),
+        |inst| adapter.label(inst),
+        |idx, inst, label_to_idx| adapter.successors(idx, inst, label_to_idx),
+    )
+}
+
+/// Successor list for an instruction that falls through to the next
+/// instruction, if there is one.
+pub fn fallthrough_successor(idx: usize, num_insts: usize) -> Vec<usize> {
+    if idx + 1 < num_insts {
+        vec![idx + 1]
+    } else {
+        Vec::new()
+    }
+}
+
+/// Successor list for an unconditional branch to `label`.
+pub fn branch_successor(label: LabelId, label_to_idx: &HashMap<LabelId, usize>) -> Vec<usize> {
+    label_to_idx.get(&label).copied().into_iter().collect()
+}
+
+/// Successor list for a conditional branch: fall-through first, then branch
+/// target if the label was found.
+pub fn conditional_successors(
+    idx: usize,
+    label: LabelId,
+    label_to_idx: &HashMap<LabelId, usize>,
+    num_insts: usize,
+) -> Vec<usize> {
+    let mut succs = Vec::with_capacity(2);
+    if idx + 1 < num_insts {
+        succs.push(idx + 1);
+    }
+    if let Some(&target) = label_to_idx.get(&label) {
+        succs.push(target);
+    }
+    succs
+}
+
 /// Compute liveness information using the generic dataflow algorithm.
 ///
 /// This function performs backward dataflow analysis to compute which virtual

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -6,6 +6,9 @@
 use std::collections::HashMap;
 
 use super::mir::{Operand, Reg, X86Inst, X86Mir};
+use crate::liveness::{
+    LivenessAdapter, branch_successor, conditional_successors, fallthrough_successor,
+};
 use crate::vreg::{LabelId, VReg};
 
 // Re-export shared types from the regalloc module
@@ -14,57 +17,61 @@ pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo, Loo
 /// Type alias for x86_64-specific liveness info.
 pub type LivenessInfo = crate::regalloc::LivenessInfo<Reg>;
 
-/// Compute liveness information for X86Mir.
-///
-/// This performs proper dataflow analysis that handles control flow:
-/// 1. Build a map of labels to instruction indices
-/// 2. For each instruction, compute successors (next instruction or branch targets)
-/// 3. Do backward dataflow to compute live-in/live-out sets
-/// 4. Build live ranges from the dataflow results
-pub fn analyze(mir: &X86Mir) -> LivenessInfo {
-    let instructions = mir.instructions();
-    let num_insts = instructions.len();
+struct X86LivenessAdapter<'a> {
+    mir: &'a X86Mir,
+}
 
-    crate::liveness::analyze(
-        instructions,
-        mir.vreg_count(),
-        get_label,
-        |idx, inst, label_to_idx| get_successors(idx, inst, label_to_idx, num_insts),
-        uses,
-        defs,
-        |inst| inst.clobbers().to_vec(),
-    )
+impl LivenessAdapter for X86LivenessAdapter<'_> {
+    type Inst = X86Inst;
+    type Reg = Reg;
+
+    fn instructions(&self) -> &[Self::Inst] {
+        self.mir.instructions()
+    }
+
+    fn vreg_count(&self) -> u32 {
+        self.mir.vreg_count()
+    }
+
+    fn label(&self, inst: &Self::Inst) -> Option<LabelId> {
+        get_label(inst)
+    }
+
+    fn successors(
+        &self,
+        idx: usize,
+        inst: &Self::Inst,
+        label_to_idx: &HashMap<LabelId, usize>,
+    ) -> Vec<usize> {
+        get_successors(idx, inst, label_to_idx, self.instructions().len())
+    }
+
+    fn uses(&self, inst: &Self::Inst) -> Vec<VReg> {
+        uses(inst)
+    }
+
+    fn defs(&self, inst: &Self::Inst) -> Vec<VReg> {
+        defs(inst)
+    }
+
+    fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
+        inst.clobbers().to_vec()
+    }
+}
+
+/// Compute liveness information for X86Mir.
+pub fn analyze(mir: &X86Mir) -> LivenessInfo {
+    crate::liveness::analyze_adapter(&X86LivenessAdapter { mir })
 }
 
 /// Compute detailed liveness debug information for X86Mir.
-///
-/// This provides more detailed output than `analyze()`, including per-instruction
-/// live-in/live-out sets and def/use information. Used by `--emit liveness`.
 pub fn analyze_debug(mir: &X86Mir) -> LivenessDebugInfo {
-    let instructions = mir.instructions();
-    let num_insts = instructions.len();
-
-    crate::liveness::analyze_debug::<_, Reg>(
-        instructions,
-        mir.vreg_count(),
-        get_label,
-        |idx, inst, label_to_idx| get_successors(idx, inst, label_to_idx, num_insts),
-        uses,
-        defs,
-    )
+    crate::liveness::analyze_debug_adapter(&X86LivenessAdapter { mir })
 }
 
 /// Compute loop information for X86Mir.
-///
-/// This detects loops by finding back-edges (jumps to earlier instructions)
-/// and returns loop depth information for each instruction.
 pub fn analyze_loops(mir: &X86Mir) -> LoopInfo {
-    let instructions = mir.instructions();
-    let num_insts = instructions.len();
-
-    crate::liveness::analyze_loops(instructions, get_label, |idx, inst, label_to_idx| {
-        get_successors(idx, inst, label_to_idx, num_insts)
-    })
+    crate::liveness::analyze_loops_adapter(&X86LivenessAdapter { mir })
 }
 
 // ============================================================================
@@ -88,7 +95,7 @@ fn get_successors(
 ) -> Vec<usize> {
     match inst {
         // Unconditional jump - only successor is the target
-        X86Inst::Jmp { label } => label_to_idx.get(label).copied().into_iter().collect(),
+        X86Inst::Jmp { label } => branch_successor(*label, label_to_idx),
         // Conditional branches - successor is both target and fall-through
         X86Inst::Jz { label }
         | X86Inst::Jnz { label }
@@ -98,36 +105,13 @@ fn get_successors(
         | X86Inst::Jae { label }
         | X86Inst::Jbe { label }
         | X86Inst::Jge { label }
-        | X86Inst::Jle { label } => {
-            let mut succs = Vec::with_capacity(2);
-            // Fall-through to next instruction
-            if idx + 1 < num_insts {
-                succs.push(idx + 1);
-            }
-            // Branch target
-            if let Some(&target) = label_to_idx.get(label) {
-                succs.push(target);
-            }
-            succs
-        }
+        | X86Inst::Jle { label } => conditional_successors(idx, *label, label_to_idx, num_insts),
         // Return has no successors
         X86Inst::Ret => Vec::new(),
         // Function calls fall through (callee returns)
-        X86Inst::CallRel { .. } => {
-            if idx + 1 < num_insts {
-                vec![idx + 1]
-            } else {
-                Vec::new()
-            }
-        }
+        X86Inst::CallRel { .. } => fallthrough_successor(idx, num_insts),
         // All other instructions fall through to the next
-        _ => {
-            if idx + 1 < num_insts {
-                vec![idx + 1]
-            } else {
-                Vec::new()
-            }
-        }
+        _ => fallthrough_successor(idx, num_insts),
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes RUE-408 by moving the duplicated backend liveness wrapper orchestration into the shared liveness module.

## What changed

- Added a shared `LivenessAdapter` trait that owns the repeated `analyze`, `analyze_debug`, and `analyze_loops` orchestration.
- Added shared successor helpers for fall-through, unconditional branch, and conditional branch successor lists.
- Converted x86_64 and aarch64 liveness modules to supply backend-specific instruction facts through small adapters.
- Preserved existing backend use/def and branch liveness test coverage.

## Validation

- `./fmt.sh check`
- `./buck2 test //crates/rue-codegen:rue-codegen-test`
