### PR TITLE
RUE-409: share stack verifier shell

### DIFF
--- a/crates/rue-codegen/src/aarch64/verify.rs
+++ b/crates/rue-codegen/src/aarch64/verify.rs
@@ -31,9 +31,8 @@
 //!
 //! The prologue's alignment is correct by construction (see `emit_prologue` in emit.rs).
 
-use std::collections::HashMap;
-
 use super::mir::{Aarch64Inst, Aarch64Mir, LabelId, Operand, Reg};
+use crate::stack_verify::{self, StackVerifyAdapter};
 use rue_error::{CompileError, CompileResult, ErrorKind};
 
 /// Verifies that the stack is properly aligned throughout function execution.
@@ -52,44 +51,28 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 /// `Ok(())` if verification passes, or `Err(CompileError)` with details about
 /// the first alignment violation found.
 pub fn verify_stack_alignment(mir: &Aarch64Mir) -> CompileResult<()> {
-    let mut verifier = StackVerifier::new();
-    verifier.verify(mir)
+    stack_verify::verify(&Aarch64StackVerifyAdapter { mir })
 }
 
-/// Internal state for stack verification.
-struct StackVerifier {
-    /// Stack depth at each label (for join point verification).
-    /// After prologue, depth should be 0 (aligned).
-    label_depths: HashMap<LabelId, i64>,
-    /// Current stack depth in bytes relative to 16-byte aligned SP.
-    /// 0 = aligned, 8 = misaligned by 8, etc.
-    current_depth: i64,
+struct Aarch64StackVerifyAdapter<'a> {
+    mir: &'a Aarch64Mir,
 }
 
-impl StackVerifier {
-    fn new() -> Self {
-        Self {
-            label_depths: HashMap::new(),
-            current_depth: 0,
-        }
+impl StackVerifyAdapter for Aarch64StackVerifyAdapter<'_> {
+    type Inst = Aarch64Inst;
+
+    fn instructions(&self) -> &[Self::Inst] {
+        self.mir.instructions()
     }
 
-    fn verify(&mut self, mir: &Aarch64Mir) -> CompileResult<()> {
-        // First pass: collect label positions and do basic verification
-        for (idx, inst) in mir.iter().enumerate() {
-            self.verify_instruction(idx, inst)?;
-        }
-        Ok(())
-    }
-
-    fn verify_instruction(&mut self, idx: usize, inst: &Aarch64Inst) -> CompileResult<()> {
+    fn stack_delta(&self, inst: &Self::Inst) -> i64 {
         match inst {
             // Store pair with pre-decrement: stp x1, x2, [sp, #offset]!
             // This pushes two registers onto the stack
             Aarch64Inst::StpPre { offset, .. } => {
                 // offset is typically negative (e.g., -16 to allocate 16 bytes)
                 // depth increases by |offset|
-                self.current_depth += (-*offset) as i64;
+                (-*offset) as i64
             }
 
             // Load pair with post-increment: ldp x1, x2, [sp], #offset
@@ -97,14 +80,16 @@ impl StackVerifier {
             Aarch64Inst::LdpPost { offset, .. } => {
                 // offset is typically positive (e.g., 16 to deallocate 16 bytes)
                 // depth decreases by offset
-                self.current_depth -= *offset as i64;
+                -(*offset as i64)
             }
 
             // SubImm on SP: allocates stack space
             Aarch64Inst::SubImm { dst, src, imm } => {
                 if is_sp(dst) && is_sp(src) {
                     // sub sp, sp, #imm → increases depth (allocates)
-                    self.current_depth += *imm as i64;
+                    *imm as i64
+                } else {
+                    0
                 }
             }
 
@@ -112,83 +97,64 @@ impl StackVerifier {
             Aarch64Inst::AddImm { dst, src, imm } => {
                 if is_sp(dst) && is_sp(src) {
                     // add sp, sp, #imm → decreases depth (deallocates)
-                    self.current_depth -= *imm as i64;
-                }
-            }
-
-            // Call instructions require 16-byte alignment
-            Aarch64Inst::Bl { .. } => {
-                // At a call site, SP must be 16-byte aligned.
-                // Unlike x86-64, the return address goes into LR, not pushed to stack,
-                // so the callee sees SP at the same alignment as the caller.
-                if self.current_depth % 16 != 0 {
-                    return Err(self.alignment_error(
-                        idx,
-                        inst,
-                        format!(
-                            "call requires 16-byte aligned SP, but stack is {} bytes off",
-                            self.current_depth % 16
-                        ),
-                    ));
-                }
-            }
-
-            // Labels mark potential join points
-            Aarch64Inst::Label { id } => {
-                if let Some(&expected_depth) = self.label_depths.get(id) {
-                    // We've seen a jump to this label before
-                    if expected_depth != self.current_depth {
-                        return Err(self.alignment_error(
-                            idx,
-                            inst,
-                            format!(
-                                "control flow join has inconsistent stack depth: expected {}, got {}",
-                                expected_depth, self.current_depth
-                            ),
-                        ));
-                    }
+                    -(*imm as i64)
                 } else {
-                    // First time seeing this label, record current depth
-                    self.label_depths.insert(*id, self.current_depth);
+                    0
                 }
             }
 
-            // Jump instructions record target depths
+            _ => 0,
+        }
+    }
+
+    fn label(&self, inst: &Self::Inst) -> Option<LabelId> {
+        match inst {
+            Aarch64Inst::Label { id } => Some(*id),
+            _ => None,
+        }
+    }
+
+    fn jump_targets<'a>(&self, inst: &'a Self::Inst) -> &'a [LabelId] {
+        match inst {
             Aarch64Inst::B { label }
             | Aarch64Inst::BCond { label, .. }
             | Aarch64Inst::Bvs { label }
             | Aarch64Inst::Bvc { label }
             | Aarch64Inst::Cbz { label, .. }
-            | Aarch64Inst::Cbnz { label, .. } => {
-                self.record_jump_target(*label);
-            }
-
-            // Ret doesn't affect our verification (epilogue handles cleanup)
-            Aarch64Inst::Ret => {
-                // The epilogue (generated by emitter) will restore SP.
-                // We don't verify epilogue correctness here since it's
-                // generated separately and correct by construction.
-            }
-
-            // All other instructions don't affect stack depth
-            _ => {}
+            | Aarch64Inst::Cbnz { label, .. } => std::slice::from_ref(label),
+            _ => &[],
         }
-
-        Ok(())
     }
 
-    fn record_jump_target(&mut self, label: LabelId) {
-        // Record the expected depth at this jump target.
-        // If we've already seen the label, the depth was recorded there.
-        // If not, this is a forward jump and we record the expected depth.
-        // Mismatches are caught when the label is encountered in verify_instruction.
-        self.label_depths.entry(label).or_insert(self.current_depth);
+    fn alignment_violation(&self, inst: &Self::Inst, current_depth: i64) -> Option<String> {
+        match inst {
+            Aarch64Inst::Bl { .. } => {
+                // At a call site, SP must be 16-byte aligned.
+                // Unlike x86-64, the return address goes into LR, not pushed to stack,
+                // so the callee sees SP at the same alignment as the caller.
+                if current_depth % 16 != 0 {
+                    Some(format!(
+                        "call requires 16-byte aligned SP, but stack is {} bytes off",
+                        current_depth % 16
+                    ))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 
-    fn alignment_error(&self, idx: usize, inst: &Aarch64Inst, message: String) -> CompileError {
+    fn error(
+        &self,
+        idx: usize,
+        inst: &Self::Inst,
+        current_depth: i64,
+        message: String,
+    ) -> CompileError {
         CompileError::without_span(ErrorKind::InternalCodegenError(format!(
             "stack alignment verification failed at instruction {}: {} (depth: {} bytes) - {}",
-            idx, inst, self.current_depth, message
+            idx, inst, current_depth, message
         )))
     }
 }

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -42,6 +42,7 @@ macro_rules! end_inst {
 }
 
 mod stack_frame;
+mod stack_verify;
 
 pub mod aarch64;
 pub mod agg_slots;

--- a/crates/rue-codegen/src/stack_verify.rs
+++ b/crates/rue-codegen/src/stack_verify.rs
@@ -1,0 +1,126 @@
+//! Shared stack-verifier shell.
+//!
+//! Backends supply target-specific instruction effects and error formatting;
+//! this module owns the common traversal, stack-depth tracking, and
+//! control-flow join bookkeeping.
+
+use std::collections::HashMap;
+
+use rue_error::{CompileError, CompileResult};
+
+use crate::vreg::LabelId;
+
+/// Target-specific facts required by the shared stack verifier.
+pub trait StackVerifyAdapter {
+    /// Backend MIR instruction type.
+    type Inst;
+
+    /// Instruction sequence to verify.
+    fn instructions(&self) -> &[Self::Inst];
+
+    /// Stack-depth delta caused by `inst`, in bytes. Positive values mean the
+    /// function body has moved the stack farther from the prologue-aligned
+    /// state; negative values mean stack space was released.
+    fn stack_delta(&self, inst: &Self::Inst) -> i64;
+
+    /// Label defined by `inst`, if any.
+    fn label(&self, inst: &Self::Inst) -> Option<LabelId>;
+
+    /// Jump target labels referenced by `inst`.
+    fn jump_targets<'a>(&self, inst: &'a Self::Inst) -> &'a [LabelId];
+
+    /// Return an alignment error message if `inst` observes an invalid stack
+    /// depth for this target.
+    fn alignment_violation(&self, inst: &Self::Inst, current_depth: i64) -> Option<String>;
+
+    /// Build the backend's structured compile error.
+    fn error(
+        &self,
+        idx: usize,
+        inst: &Self::Inst,
+        current_depth: i64,
+        message: String,
+    ) -> CompileError;
+}
+
+/// Verify stack alignment and control-flow join stack-depth consistency.
+pub fn verify<A>(adapter: &A) -> CompileResult<()>
+where
+    A: StackVerifyAdapter,
+{
+    let mut verifier = StackVerifier::new(adapter);
+    verifier.verify()
+}
+
+struct StackVerifier<'a, A: StackVerifyAdapter> {
+    adapter: &'a A,
+    /// Stack depth at each label (for join point verification).
+    label_depths: HashMap<LabelId, i64>,
+    /// Current stack depth in bytes relative to the prologue-aligned stack.
+    current_depth: i64,
+}
+
+impl<'a, A> StackVerifier<'a, A>
+where
+    A: StackVerifyAdapter,
+{
+    fn new(adapter: &'a A) -> Self {
+        Self {
+            adapter,
+            label_depths: HashMap::new(),
+            current_depth: 0,
+        }
+    }
+
+    fn verify(&mut self) -> CompileResult<()> {
+        for (idx, inst) in self.adapter.instructions().iter().enumerate() {
+            self.verify_instruction(idx, inst)?;
+        }
+        Ok(())
+    }
+
+    fn verify_instruction(&mut self, idx: usize, inst: &A::Inst) -> CompileResult<()> {
+        self.current_depth += self.adapter.stack_delta(inst);
+
+        if let Some(message) = self.adapter.alignment_violation(inst, self.current_depth) {
+            return Err(self.adapter.error(idx, inst, self.current_depth, message));
+        }
+
+        if let Some(label) = self.adapter.label(inst) {
+            self.verify_label(idx, inst, label)?;
+        }
+
+        for &target in self.adapter.jump_targets(inst) {
+            self.record_jump_target(target);
+        }
+
+        Ok(())
+    }
+
+    fn verify_label(&mut self, idx: usize, inst: &A::Inst, label: LabelId) -> CompileResult<()> {
+        if let Some(&expected_depth) = self.label_depths.get(&label) {
+            if expected_depth != self.current_depth {
+                return Err(self.adapter.error(
+                    idx,
+                    inst,
+                    self.current_depth,
+                    format!(
+                        "control flow join has inconsistent stack depth: expected {}, got {}",
+                        expected_depth, self.current_depth
+                    ),
+                ));
+            }
+        } else {
+            self.label_depths.insert(label, self.current_depth);
+        }
+        Ok(())
+    }
+
+    fn record_jump_target(&mut self, label: LabelId) {
+        // If this is a forward jump, record the expected depth now and check it
+        // when the label is encountered. If the label was already seen, the
+        // entry preserves that observed depth, matching the previous verifier
+        // behavior.
+        self.label_depths.entry(label).or_insert(self.current_depth);
+    }
+}

--- a/crates/rue-codegen/src/x86_64/verify.rs
+++ b/crates/rue-codegen/src/x86_64/verify.rs
@@ -31,9 +31,8 @@
 //!
 //! The prologue's alignment is correct by construction (see `emit_prologue` in emit.rs).
 
-use std::collections::HashMap;
-
 use super::mir::{LabelId, Operand, Reg, X86Inst, X86Mir};
+use crate::stack_verify::{self, StackVerifyAdapter};
 use rue_error::{CompileError, CompileResult, ice_error};
 
 /// Verifies that the stack is properly aligned throughout function execution.
@@ -52,103 +51,56 @@ use rue_error::{CompileError, CompileResult, ice_error};
 /// `Ok(())` if verification passes, or `Err(CompileError)` with details about
 /// the first alignment violation found.
 pub fn verify_stack_alignment(mir: &X86Mir) -> CompileResult<()> {
-    let mut verifier = StackVerifier::new();
-    verifier.verify(mir)
+    stack_verify::verify(&X86StackVerifyAdapter { mir })
 }
 
-/// Internal state for stack verification.
-struct StackVerifier {
-    /// Stack depth at each label (for join point verification).
-    /// After prologue, depth should be 0 (aligned).
-    label_depths: HashMap<LabelId, i64>,
-    /// Current stack depth in bytes relative to 16-byte aligned RSP.
-    /// 0 = aligned, 8 = misaligned by 8, etc.
-    current_depth: i64,
+struct X86StackVerifyAdapter<'a> {
+    mir: &'a X86Mir,
 }
 
-impl StackVerifier {
-    fn new() -> Self {
-        Self {
-            label_depths: HashMap::new(),
-            current_depth: 0,
-        }
+impl StackVerifyAdapter for X86StackVerifyAdapter<'_> {
+    type Inst = X86Inst;
+
+    fn instructions(&self) -> &[Self::Inst] {
+        self.mir.instructions()
     }
 
-    fn verify(&mut self, mir: &X86Mir) -> CompileResult<()> {
-        // First pass: collect label positions and do basic verification
-        for (idx, inst) in mir.iter().enumerate() {
-            self.verify_instruction(idx, inst)?;
-        }
-        Ok(())
-    }
-
-    fn verify_instruction(&mut self, idx: usize, inst: &X86Inst) -> CompileResult<()> {
+    fn stack_delta(&self, inst: &Self::Inst) -> i64 {
         match inst {
-            // Instructions that increase stack depth (push onto stack)
-            X86Inst::Push { .. } => {
-                self.current_depth += 8;
-            }
+            // Instructions that increase stack depth (push onto stack).
+            X86Inst::Push { .. } => 8,
 
-            // Instructions that decrease stack depth (pop from stack)
-            X86Inst::Pop { .. } => {
-                self.current_depth -= 8;
-                // Note: We allow negative depths since the epilogue may pop
-                // callee-saved registers before we've tracked their pushes
-                // (they're in the prologue which isn't in the MIR)
-            }
+            // Instructions that decrease stack depth (pop from stack). Negative
+            // depths are allowed: the epilogue may pop callee-saved registers
+            // before we've tracked their pushes (they're in the prologue, not
+            // MIR).
+            X86Inst::Pop { .. } => -8,
 
             // AddRI on RSP: used to deallocate stack space (positive imm) or
-            // allocate stack space (negative imm, though rare in current codegen)
+            // allocate stack space (negative imm, though rare in current codegen).
             X86Inst::AddRI { dst, imm } => {
                 if let Operand::Physical(Reg::Rsp) = dst {
                     // add rsp, N → decreases depth (deallocates)
                     // add rsp, -N → increases depth (allocates)
-                    self.current_depth -= *imm as i64;
-                }
-            }
-
-            // Call instructions require 16-byte alignment
-            X86Inst::CallRel { .. } => {
-                // At a call site, RSP must be 16-byte aligned.
-                // Since the call will push an 8-byte return address,
-                // the callee will see RSP 8 bytes below a 16-byte boundary,
-                // which is correct (they'll push RBP to realign).
-                //
-                // Our depth tracking starts at 0 (aligned after prologue).
-                // If depth % 16 != 0, we're misaligned.
-                if self.current_depth % 16 != 0 {
-                    return Err(self.alignment_error(
-                        idx,
-                        inst,
-                        format!(
-                            "call requires 16-byte aligned RSP, but stack is {} bytes off",
-                            self.current_depth % 16
-                        ),
-                    ));
-                }
-            }
-
-            // Labels mark potential join points
-            X86Inst::Label { id } => {
-                if let Some(&expected_depth) = self.label_depths.get(id) {
-                    // We've seen a jump to this label before
-                    if expected_depth != self.current_depth {
-                        return Err(self.alignment_error(
-                            idx,
-                            inst,
-                            format!(
-                                "control flow join has inconsistent stack depth: expected {}, got {}",
-                                expected_depth, self.current_depth
-                            ),
-                        ));
-                    }
+                    -(*imm as i64)
                 } else {
-                    // First time seeing this label, record current depth
-                    self.label_depths.insert(*id, self.current_depth);
+                    0
                 }
             }
 
-            // Jump instructions record target depths
+            _ => 0,
+        }
+    }
+
+    fn label(&self, inst: &Self::Inst) -> Option<LabelId> {
+        match inst {
+            X86Inst::Label { id } => Some(*id),
+            _ => None,
+        }
+    }
+
+    fn jump_targets<'a>(&self, inst: &'a Self::Inst) -> &'a [LabelId] {
+        match inst {
             X86Inst::Jz { label }
             | X86Inst::Jnz { label }
             | X86Inst::Jo { label }
@@ -158,40 +110,48 @@ impl StackVerifier {
             | X86Inst::Jbe { label }
             | X86Inst::Jge { label }
             | X86Inst::Jle { label }
-            | X86Inst::Jmp { label } => {
-                self.record_jump_target(*label);
-            }
-
-            // Ret doesn't affect our verification (epilogue handles cleanup)
-            X86Inst::Ret => {
-                // The epilogue (generated by emitter) will restore RSP.
-                // We don't verify epilogue correctness here since it's
-                // generated separately and correct by construction.
-            }
-
-            // All other instructions don't affect stack depth
-            _ => {}
+            | X86Inst::Jmp { label } => std::slice::from_ref(label),
+            _ => &[],
         }
-
-        Ok(())
     }
 
-    fn record_jump_target(&mut self, label: LabelId) {
-        // Record the expected depth at this jump target.
-        // If we've already seen the label, the depth was recorded there.
-        // If not, this is a forward jump and we record the expected depth.
-        // Mismatches are caught when the label is encountered in verify_instruction.
-        self.label_depths.entry(label).or_insert(self.current_depth);
+    fn alignment_violation(&self, inst: &Self::Inst, current_depth: i64) -> Option<String> {
+        match inst {
+            X86Inst::CallRel { .. } => {
+                // At a call site, RSP must be 16-byte aligned.
+                // Since the call will push an 8-byte return address,
+                // the callee will see RSP 8 bytes below a 16-byte boundary,
+                // which is correct (they'll push RBP to realign).
+                //
+                // Our depth tracking starts at 0 (aligned after prologue).
+                // If depth % 16 != 0, we're misaligned.
+                if current_depth % 16 != 0 {
+                    Some(format!(
+                        "call requires 16-byte aligned RSP, but stack is {} bytes off",
+                        current_depth % 16
+                    ))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 
-    fn alignment_error(&self, idx: usize, inst: &X86Inst, message: String) -> CompileError {
+    fn error(
+        &self,
+        idx: usize,
+        inst: &Self::Inst,
+        current_depth: i64,
+        message: String,
+    ) -> CompileError {
         ice_error!(
             "stack alignment verification failed",
             phase: "codegen/verify",
             details: {
                 "instruction_index" => idx.to_string(),
                 "instruction" => inst.to_string(),
-                "stack_depth_bytes" => self.current_depth.to_string(),
+                "stack_depth_bytes" => current_depth.to_string(),
                 "message" => message
             }
         )


### PR DESCRIPTION
## Summary

Fixes RUE-409 by extracting the duplicated stack-verifier traversal and control-flow join bookkeeping into a shared private codegen module.

## What changed

- Added a private shared `stack_verify` module with a `StackVerifyAdapter` trait.
- Moved traversal, current stack-depth tracking, jump-target recording, and label join-depth consistency checks into the shared verifier shell.
- Converted x86_64 and aarch64 verifier modules to provide only target-specific stack effects, labels/jumps, call-alignment rules, and error formatting.
- Preserved existing backend verifier behavior and tests.

## Validation

- `./fmt.sh check`
- `./buck2 test //crates/rue-codegen:rue-codegen-test`
