### PR TITLE
RUE-411: share aggregate equality lowering

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3824,73 +3824,7 @@ impl<'a> CfgLower<'a> {
         ty: Type,
         invert: bool,
     ) {
-        let result_vreg = self.mir.alloc_vreg();
-        self.value_map.insert(value, result_vreg);
-
-        let leaf_types = types::aggregate_leaf_types(self.ctx.type_pool, ty);
-
-        if leaf_types.is_empty() {
-            // Zero-slot aggregate (empty struct, zero-length array): always equal.
-            self.mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(result_vreg),
-                imm: if invert { 0 } else { 1 },
-            });
-            return;
-        }
-
-        // Flattened slot vregs, one per leaf.
-        let lhs_slots = self
-            .get_or_compute_field_vregs(lhs)
-            .expect("aggregate should have slot vregs");
-        let rhs_slots = self
-            .get_or_compute_field_vregs(rhs)
-            .expect("aggregate should have slot vregs");
-        debug_assert_eq!(lhs_slots.len(), leaf_types.len());
-        debug_assert_eq!(rhs_slots.len(), leaf_types.len());
-
-        // Start with 1 (true), AND each slot comparison result.
-        self.mir.push(Aarch64Inst::MovImm {
-            dst: Operand::Virtual(result_vreg),
-            imm: 1,
-        });
-
-        for (i, leaf_ty) in leaf_types.iter().enumerate() {
-            let lhs_slot_vreg = lhs_slots[i];
-            let rhs_slot_vreg = rhs_slots[i];
-            let cmp_vreg = self.mir.alloc_vreg();
-
-            if types::slot_needs_wide_compare(*leaf_ty) {
-                self.mir.push(Aarch64Inst::Cmp64RR {
-                    src1: Operand::Virtual(lhs_slot_vreg),
-                    src2: Operand::Virtual(rhs_slot_vreg),
-                });
-            } else {
-                self.mir.push(Aarch64Inst::CmpRR {
-                    src1: Operand::Virtual(lhs_slot_vreg),
-                    src2: Operand::Virtual(rhs_slot_vreg),
-                });
-            }
-            self.mir.push(Aarch64Inst::Cset {
-                dst: Operand::Virtual(cmp_vreg),
-                cond: Cond::Eq,
-            });
-
-            // AND with accumulator
-            self.mir.push(Aarch64Inst::AndRR {
-                dst: Operand::Virtual(result_vreg),
-                src1: Operand::Virtual(result_vreg),
-                src2: Operand::Virtual(cmp_vreg),
-            });
-        }
-
-        // Invert result if needed (for !=)
-        if invert {
-            self.mir.push(Aarch64Inst::EorImm {
-                dst: Operand::Virtual(result_vreg),
-                src: Operand::Virtual(result_vreg),
-                imm: 1,
-            });
-        }
+        crate::aggregate_eq::emit_aggregate_equality(self, value, lhs, rhs, ty, invert);
     }
 
     /// Emit a call to __rue_str_eq for string-like comparison.
@@ -4843,6 +4777,58 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     }
     fn emit_place_addr(&mut self, dst: VReg, place: &Place) {
         CfgLower::lower_place_addr(self, dst, place)
+    }
+}
+
+impl crate::aggregate_eq::AggregateEqBackend for CfgLower<'_> {
+    fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
+        &self.ctx
+    }
+    fn alloc_vreg(&mut self) -> VReg {
+        self.mir.alloc_vreg()
+    }
+    fn map_value(&mut self, value: CfgValue, vreg: VReg) {
+        self.value_map.insert(value, vreg);
+    }
+    fn aggregate_slots(&mut self, value: CfgValue) -> Option<Vec<VReg>> {
+        self.get_or_compute_field_vregs(value)
+    }
+    fn emit_bool_const(&mut self, dst: VReg, value: bool) {
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(dst),
+            imm: if value { 1 } else { 0 },
+        });
+    }
+    fn emit_slot_eq(&mut self, dst: VReg, lhs: VReg, rhs: VReg, wide: bool) {
+        if wide {
+            self.mir.push(Aarch64Inst::Cmp64RR {
+                src1: Operand::Virtual(lhs),
+                src2: Operand::Virtual(rhs),
+            });
+        } else {
+            self.mir.push(Aarch64Inst::CmpRR {
+                src1: Operand::Virtual(lhs),
+                src2: Operand::Virtual(rhs),
+            });
+        }
+        self.mir.push(Aarch64Inst::Cset {
+            dst: Operand::Virtual(dst),
+            cond: Cond::Eq,
+        });
+    }
+    fn emit_bool_and(&mut self, acc: VReg, rhs: VReg) {
+        self.mir.push(Aarch64Inst::AndRR {
+            dst: Operand::Virtual(acc),
+            src1: Operand::Virtual(acc),
+            src2: Operand::Virtual(rhs),
+        });
+    }
+    fn emit_bool_not(&mut self, value: VReg) {
+        self.mir.push(Aarch64Inst::EorImm {
+            dst: Operand::Virtual(value),
+            src: Operand::Virtual(value),
+            imm: 1,
+        });
     }
 }
 

--- a/crates/rue-codegen/src/aggregate_eq.rs
+++ b/crates/rue-codegen/src/aggregate_eq.rs
@@ -1,0 +1,87 @@
+//! Shared aggregate equality lowering.
+//!
+//! Structural equality for multi-slot aggregates is target-independent at the
+//! algorithm level: flatten both operands into storage slots, compare each slot
+//! using the leaf type's compare width, AND the per-slot results, and optionally
+//! invert for `!=`. Backends provide only the scalar instruction emission.
+
+use rue_cfg::{CfgValue, Type};
+
+use crate::cfg_lower::CfgLowerContext;
+use crate::types;
+use crate::vreg::VReg;
+
+/// Per-backend scalar operations required by aggregate equality lowering.
+pub trait AggregateEqBackend {
+    /// The shared lowering context.
+    fn ctx(&self) -> &CfgLowerContext<'_>;
+
+    /// Allocate a fresh virtual register.
+    fn alloc_vreg(&mut self) -> VReg;
+
+    /// Record `vreg` as the primary vreg for `value`.
+    fn map_value(&mut self, value: CfgValue, vreg: VReg);
+
+    /// Return the flattened slot vregs for an aggregate CFG value.
+    fn aggregate_slots(&mut self, value: CfgValue) -> Option<Vec<VReg>>;
+
+    /// Emit `dst = value` for boolean values represented as 0/1 integers.
+    fn emit_bool_const(&mut self, dst: VReg, value: bool);
+
+    /// Emit `dst = lhs == rhs`, comparing at the target's wide width when
+    /// `wide` is true and at the target's normal scalar width otherwise.
+    fn emit_slot_eq(&mut self, dst: VReg, lhs: VReg, rhs: VReg, wide: bool);
+
+    /// Emit `acc = acc & rhs`.
+    fn emit_bool_and(&mut self, acc: VReg, rhs: VReg);
+
+    /// Emit `value = !value` for a 0/1 boolean vreg.
+    fn emit_bool_not(&mut self, value: VReg);
+}
+
+/// Emit structural equality or inequality for a multi-slot aggregate.
+pub fn emit_aggregate_equality<B: AggregateEqBackend>(
+    b: &mut B,
+    value: CfgValue,
+    lhs: CfgValue,
+    rhs: CfgValue,
+    ty: Type,
+    invert: bool,
+) {
+    let result_vreg = b.alloc_vreg();
+    b.map_value(value, result_vreg);
+
+    let leaf_types = types::aggregate_leaf_types(b.ctx().type_pool, ty);
+
+    if leaf_types.is_empty() {
+        // Zero-slot aggregate (empty struct, zero-length array): always equal.
+        b.emit_bool_const(result_vreg, !invert);
+        return;
+    }
+
+    let lhs_slots = b
+        .aggregate_slots(lhs)
+        .expect("aggregate should have slot vregs");
+    let rhs_slots = b
+        .aggregate_slots(rhs)
+        .expect("aggregate should have slot vregs");
+    debug_assert_eq!(lhs_slots.len(), leaf_types.len());
+    debug_assert_eq!(rhs_slots.len(), leaf_types.len());
+
+    b.emit_bool_const(result_vreg, true);
+
+    for (i, leaf_ty) in leaf_types.iter().enumerate() {
+        let cmp_vreg = b.alloc_vreg();
+        b.emit_slot_eq(
+            cmp_vreg,
+            lhs_slots[i],
+            rhs_slots[i],
+            types::slot_needs_wide_compare(*leaf_ty),
+        );
+        b.emit_bool_and(result_vreg, cmp_vreg);
+    }
+
+    if invert {
+        b.emit_bool_not(result_vreg);
+    }
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -46,6 +46,7 @@ mod stack_verify;
 
 pub mod aarch64;
 pub mod agg_slots;
+pub mod aggregate_eq;
 pub mod byref_args;
 pub mod cfg_lower;
 pub mod index_map;

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3826,74 +3826,7 @@ impl<'a> CfgLower<'a> {
         ty: Type,
         invert: bool,
     ) {
-        let result_vreg = self.mir.alloc_vreg();
-        self.value_map.insert(value, result_vreg);
-
-        let leaf_types = types::aggregate_leaf_types(self.ctx.type_pool, ty);
-
-        if leaf_types.is_empty() {
-            // Zero-slot aggregate (empty struct, zero-length array): always equal.
-            self.mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(result_vreg),
-                imm: if invert { 0 } else { 1 },
-            });
-            return;
-        }
-
-        // Flattened slot vregs, one per leaf.
-        let lhs_slots = self
-            .get_or_compute_field_vregs(lhs)
-            .expect("aggregate should have slot vregs");
-        let rhs_slots = self
-            .get_or_compute_field_vregs(rhs)
-            .expect("aggregate should have slot vregs");
-        debug_assert_eq!(lhs_slots.len(), leaf_types.len());
-        debug_assert_eq!(rhs_slots.len(), leaf_types.len());
-
-        // Start with 1 (true), AND each slot comparison result.
-        self.mir.push(X86Inst::MovRI32 {
-            dst: Operand::Virtual(result_vreg),
-            imm: 1,
-        });
-
-        for (i, leaf_ty) in leaf_types.iter().enumerate() {
-            let lhs_slot_vreg = lhs_slots[i];
-            let rhs_slot_vreg = rhs_slots[i];
-            let cmp_vreg = self.mir.alloc_vreg();
-
-            if types::slot_needs_wide_compare(*leaf_ty) {
-                self.mir.push(X86Inst::Cmp64RR {
-                    src1: Operand::Virtual(lhs_slot_vreg),
-                    src2: Operand::Virtual(rhs_slot_vreg),
-                });
-            } else {
-                self.mir.push(X86Inst::CmpRR {
-                    src1: Operand::Virtual(lhs_slot_vreg),
-                    src2: Operand::Virtual(rhs_slot_vreg),
-                });
-            }
-            self.mir.push(X86Inst::Sete {
-                dst: Operand::Virtual(cmp_vreg),
-            });
-            self.mir.push(X86Inst::Movzx {
-                dst: Operand::Virtual(cmp_vreg),
-                src: Operand::Virtual(cmp_vreg),
-            });
-
-            // AND with accumulator
-            self.mir.push(X86Inst::AndRR {
-                dst: Operand::Virtual(result_vreg),
-                src: Operand::Virtual(cmp_vreg),
-            });
-        }
-
-        // Invert result if needed (for !=)
-        if invert {
-            self.mir.push(X86Inst::XorRI {
-                dst: Operand::Virtual(result_vreg),
-                imm: 1,
-            });
-        }
+        crate::aggregate_eq::emit_aggregate_equality(self, value, lhs, rhs, ty, invert);
     }
 
     /// Emit a call to a builtin equality function (e.g., __rue_str_eq).
@@ -4862,6 +4795,59 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     }
     fn emit_place_addr(&mut self, dst: VReg, place: &Place) {
         CfgLower::lower_place_addr(self, dst, place)
+    }
+}
+
+impl crate::aggregate_eq::AggregateEqBackend for CfgLower<'_> {
+    fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
+        &self.ctx
+    }
+    fn alloc_vreg(&mut self) -> VReg {
+        self.mir.alloc_vreg()
+    }
+    fn map_value(&mut self, value: CfgValue, vreg: VReg) {
+        self.value_map.insert(value, vreg);
+    }
+    fn aggregate_slots(&mut self, value: CfgValue) -> Option<Vec<VReg>> {
+        self.get_or_compute_field_vregs(value)
+    }
+    fn emit_bool_const(&mut self, dst: VReg, value: bool) {
+        self.mir.push(X86Inst::MovRI32 {
+            dst: Operand::Virtual(dst),
+            imm: if value { 1 } else { 0 },
+        });
+    }
+    fn emit_slot_eq(&mut self, dst: VReg, lhs: VReg, rhs: VReg, wide: bool) {
+        if wide {
+            self.mir.push(X86Inst::Cmp64RR {
+                src1: Operand::Virtual(lhs),
+                src2: Operand::Virtual(rhs),
+            });
+        } else {
+            self.mir.push(X86Inst::CmpRR {
+                src1: Operand::Virtual(lhs),
+                src2: Operand::Virtual(rhs),
+            });
+        }
+        self.mir.push(X86Inst::Sete {
+            dst: Operand::Virtual(dst),
+        });
+        self.mir.push(X86Inst::Movzx {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(dst),
+        });
+    }
+    fn emit_bool_and(&mut self, acc: VReg, rhs: VReg) {
+        self.mir.push(X86Inst::AndRR {
+            dst: Operand::Virtual(acc),
+            src: Operand::Virtual(rhs),
+        });
+    }
+    fn emit_bool_not(&mut self, value: VReg) {
+        self.mir.push(X86Inst::XorRI {
+            dst: Operand::Virtual(value),
+            imm: 1,
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- add a shared aggregate equality lowering helper for flattened slot comparison
- adapt x86_64 and aarch64 CFG lowerers to provide only scalar compare/combine hooks
- preserve existing aggregate equality behavior and coverage

## Validation
- `./fmt.sh check`
- `./buck2 test //crates/rue-codegen:rue-codegen-test //:cli-tests`

Linear: RUE-411
