### PR TITLE
[codex] Document root-module driver contract

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -559,6 +559,41 @@ pub fn abs(x: i32) -> i32 {
 stdout = "35\n"
 
 [[case]]
+name = "root_module_graph_same_file_reached_by_normalized_paths"
+description = "Root-only import discovery treats two normalized paths to the same file as one loaded module, not two semantic roots."
+files = [
+    { path = "main.rue", source = """
+const left = @import("pkg/left");
+const right = @import("pkg/nested/right");
+
+fn main() -> i32 {
+    @dbg(left.left_value() + right.right_value());
+    0
+}
+""" },
+    { path = "pkg/left.rue", source = """
+const shared = @import("shared");
+
+pub fn left_value() -> i32 {
+    shared.value()
+}
+""" },
+    { path = "pkg/nested/right.rue", source = """
+const shared = @import("../shared.rue");
+
+pub fn right_value() -> i32 {
+    shared.value()
+}
+""" },
+    { path = "pkg/shared.rue", source = """
+pub fn value() -> i32 {
+    21
+}
+""" },
+]
+stdout = "42\n"
+
+[[case]]
 name = "root_module_graph_private_helper_not_visible_from_root"
 description = "A private helper loaded as part of the root module graph is not callable across the directory boundary."
 files = [

--- a/crates/rue-spec/cases/modules/resolution.toml
+++ b/crates/rue-spec/cases/modules/resolution.toml
@@ -114,3 +114,25 @@ pub fn go2() -> i32 { shared2.value() }
 pub fn value() -> i32 { 42 }
 """ }
 exit_code = 42
+
+[[case]]
+name = "normalized_relative_paths_load_same_file_once"
+spec = ["10.2:4"]
+description = "Two different relative import spellings that normalize to the same file refer to one loaded module"
+source = """
+fn main() -> i32 {
+    let left = @import("pkg/left");
+    let right = @import("pkg/nested/right");
+    left.left_value() + right.right_value()
+}
+"""
+aux_files = { "pkg/left.rue" = """
+const shared = @import("shared");
+pub fn left_value() -> i32 { shared.value() }
+""", "pkg/nested/right.rue" = """
+const shared = @import("../shared.rue");
+pub fn right_value() -> i32 { shared.value() }
+""", "pkg/shared.rue" = """
+pub fn value() -> i32 { 21 }
+""" }
+exit_code = 42

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,8 +33,11 @@ RUE="$(scripts/rue-bin)"
 "$RUE" --emit air --emit cfg main.rue
 ```
 
-Multiple source files require `-o`. Run `"$RUE" --help` for targets, preview
-features, optimization levels, logging, timing, and all emit stages.
+The normal model is one root source file per compile; additional files should
+be reached through `@import` and are discovered transitively from the root.
+Passing extra `.rue` files positionally is legacy flat-mode behavior being
+removed. Run `"$RUE" --help` for targets, preview features, optimization
+levels, logging, timing, and all emit stages.
 
 Long-form Buck commands remain useful when working on build targets:
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -66,9 +66,11 @@ rules.
 
 ## Modules and programs
 
-A program may span multiple files. `@import("path.rue")` introduces a module
-object, and public declarations can be selected from it or re-exported through
-public constants. The standard library is imported as `@import("std")`.
+A program may span multiple files. A normal compile names one root source file;
+that root's `@import` graph is discovered transitively. `@import("path.rue")`
+introduces a module object, and public declarations can be selected from it or
+re-exported through public constants. The standard library is imported as
+`@import("std")`.
 
 ```rue
 const math = @import("math.rue");
@@ -79,8 +81,8 @@ fn main() -> i32 {
 ```
 
 The transitional flat multi-file namespace is being removed; new code should
-use module imports rather than relying on unqualified names from separately
-listed files.
+compile the root source and use module imports rather than relying on
+unqualified names from separately listed files.
 
 ## Runtime and targets
 

--- a/docs/spec/src/10-modules/02-import-resolution.md
+++ b/docs/spec/src/10-modules/02-import-resolution.md
@@ -42,17 +42,20 @@ at the same relative path found relative to the root file.
 {{ rule(id="10.2:3", cat="normative") }}
 
 Importing a module loads it *transitively*: imports appearing in an imported
-file are themselves resolved and loaded, and so on, as if every reachable
-module had been listed on the command line. The importer of a transitively
-loaded file — not the root file — is the base for that file's own relative
-imports (per 10.2:2).
+file are themselves resolved and loaded, and so on, into the root module's
+import graph. Loading a file through this graph makes it available as a
+module; it does not inject the file's declarations into the importing
+scope. The importer of a transitively loaded file — not the root file — is
+the base for that file's own relative imports (per 10.2:2).
 
 {{ rule(id="10.2:4", cat="normative") }}
 
-Each source file is loaded at most once per compilation. An import that
-resolves to an already-loaded file refers to that same module. Import cycles
-are therefore legal: two modules may import each other, and a chain of
-imports may return to its starting file.
+Each source file is loaded at most once per compilation, after resolving the
+import path to the file's canonical location. An import that resolves to an
+already-loaded file refers to that same module, even if the import used a
+different relative spelling. Import cycles are therefore legal: two modules
+may import each other, and a chain of imports may return to its starting
+file.
 
 {{ rule(id="10.2:5", cat="example") }}
 

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -61,24 +61,26 @@ fn main() -> i32 {
 
 Visibility is uniform across every multi-file compilation: an item is
 visible outside its defining directory if and only if it is `pub`,
-whether its defining file was loaded via `@import` or only listed
-explicitly in the compilation. It is a compile-time error to reference a
-private item by its unqualified name from a source file in a different
-directory than the item's defining file (error E0460). This covers every
-form of unqualified reference: calling a private function, naming a
-private struct (in a type annotation, a signature, or a struct literal),
-naming a private enum (in a type annotation, a signature, a variant
+whether its defining file was loaded via `@import` or, while the legacy
+flat multi-file mode still exists, only listed explicitly in the
+compilation. It is a compile-time error to reference a private item by
+its unqualified name from a source file in a different directory than the
+item's defining file (error E0460). This covers every form of
+unqualified reference: calling a private function, naming a private
+struct (in a type annotation, a signature, or a struct literal), naming
+a private enum (in a type annotation, a signature, a variant
 construction, or a match pattern), and reading a private constant —
 including from another constant's initializer.
 
 {{ rule(id="10.3:8", cat="normative") }}
 
-The transitional flat namespace (10.5:2) affects only *name resolution*:
-an unqualified reference may resolve to an item in any file of the
-compilation without an import, but the visibility rules of this section
-apply regardless of how the item's file was loaded. A `pub` item in
-another directory is therefore usable unqualified without any import;
-a private one is not.
+The legacy flat namespace (10.5:2) affects only *name resolution*: an
+unqualified reference may currently resolve to an item in any explicitly
+loaded source file without an import, but the visibility rules of this
+section apply regardless of how the item's file was loaded. A `pub` item
+in another directory is therefore usable unqualified without any import
+only through this transitional mode; new code should use `@import`, and
+RUE-434 tracks removing the unqualified cross-file fallback.
 
 {{ rule(id="10.3:9", cat="example") }}
 
@@ -93,7 +95,7 @@ pub enum Level { Low, High, }
 const LIMIT: i32 = 8;           // private to sub/
 pub const MAX: i32 = 16;
 
-// main.rue — a different directory; no import needed (10.5:2)
+// main.rue — a different directory, relying on legacy flat mode (10.5:2)
 fn main() -> i32 {
     // secret()                  // error E0460: private to sub/lib.rue
     // let h = Hidden { n: 1 };  // error E0460: private to sub/lib.rue

--- a/docs/spec/src/10-modules/05-program-composition.md
+++ b/docs/spec/src/10-modules/05-program-composition.md
@@ -6,28 +6,42 @@ template = "spec/page.html"
 
 # Program Composition
 
-This section specifies how the set of loaded source files composes into one
-program: the (transitional) shared namespace and the extent of semantic
-analysis.
+This section specifies how the root source file, imported modules, and
+legacy explicitly listed source files compose into one program.
 
-## Name Collisions
+The intended driver contract is root-module based: a normal compiler
+invocation names one root source file, and that root's transitive
+`@import` graph determines the semantic module graph. Source files may
+also be declared to a build system as action inputs, but declaration as an
+available input is not a way to put names in scope. A source file affects
+name resolution only when the program reaches it through an explicit import
+or through the legacy flat multi-file mode described below.
+
+The current implementation still contains that legacy flat mode for
+additional source files listed explicitly on the command line. ADR-0046
+and ADR-0047 define its removal; RUE-434 tracks the implementation work.
+Until that removal lands, this section distinguishes the intended root
+module/import-graph contract from the transitional loaded-file namespace.
+
+## Legacy Name Collisions
 
 {{ rule(id="10.5:1", cat="legality-rule") }}
 
-It is a compile-time error for two loaded source files to define a top-level
-item with the same name (duplicate definition, E0436). This holds regardless
-of the items' visibility and regardless of whether the files are in the same
-directory. Module-binding constants (`const m = @import(...)`) are the
-exception: they are scoped per file (rule 10.4:8) and do not collide across
-files.
+In the legacy flat loaded-file namespace, it is a compile-time error for
+two loaded source files to define a top-level item with the same name
+(duplicate definition, E0436). This holds regardless of the items'
+visibility and regardless of whether the files are in the same directory.
+Module-binding constants (`const m = @import(...)`) are the exception:
+they are scoped per file (rule 10.4:8) and do not collide across files.
 
 {{ rule(id="10.5:2") }}
 
 Rule 10.5:1 is *transitional*: loaded files currently share one flat global
 namespace, so symbols collide program-wide even when each is only ever
-accessed through its own module. A future revision of the module system is
-expected to scope top-level names per module, relaxing this rule; programs
-should not be designed to rely on cross-file collisions being errors.
+accessed through its own module. This is not the long-term module model.
+The root-module contract scopes program structure through explicit imports,
+and programs should not be designed to rely on cross-file collisions being
+errors outside a single module.
 
 {{ rule(id="10.5:3", cat="example") }}
 
@@ -46,12 +60,17 @@ fn main() -> i32 {
 }
 ```
 
-## Extent of Analysis
+## Root Module and Extent of Analysis
 
 {{ rule(id="10.5:4") }}
 
-Every loaded source file is fully analyzed: a compile-time error anywhere in
-an imported module is reported even if the offending item is never
-referenced by the importing program. (ADR-0026 envisions lazy, on-demand
-analysis of imported modules; that is not implemented, and this paragraph is
-informative so that the eager behavior is not a guarantee either.)
+In the current implementation, every loaded source file is fully analyzed:
+a compile-time error anywhere in an imported module is reported even if the
+offending item is never referenced by the importing program.
+
+This eager behavior is an implementation property, not the semantic
+definition of a Rue program. The semantic compilation unit is the root
+module and its transitive import graph; ADR-0045 allows future lazy,
+on-demand analysis of imported modules, and ADR-0047 allows future
+build-system source manifests that constrain which files may be imported
+without turning every declared input into a semantic root.


### PR DESCRIPTION
## Summary

- document the root-module driver contract from ADR-0047 in the modules spec and developer/language docs
- clarify that legacy flat multi-file behavior is transitional and tracked separately by RUE-434
- tighten import-resolution wording so transitive loading does not imply flat scope
- add spec and CLI regressions for one source file reached through different normalized import paths

## Validation

- `scripts/rue spec modules.resolution`
- `scripts/rue cli modules`
- `scripts/rue spec -- --traceability`
