### PR TITLE
[codex] Reject mixed positional/import-loaded sources

### DIFF
--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -238,7 +238,6 @@ pub fn ArrayBuf(comptime T: type) -> type {
 }
 """ },
 ]
-args = ["main.rue", "arraybuf.rue", "-o", "prog"]
 stdout = "3\n3\n4\n90\n91\n5\n6\n2\n"
 exit_code = 0
 
@@ -314,6 +313,5 @@ pub fn ArrayBuf(comptime T: type) -> type {
 }
 """ },
 ]
-args = ["main.rue", "arraybuf.rue", "-o", "prog"]
 stdout = "3\n10\n30\n60\n"
 exit_code = 60

--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -392,7 +392,6 @@ exit_code = 7
 [[case]]
 name = "move_out_of_inout_rejected_in_imported_module"
 description = "The lazy (import-driven) analysis path enforces the same rule as the single-file path."
-args = ["main.rue", "lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
 const lib = @import("lib.rue");

--- a/crates/rue-cli-tests/cases/comptime_value_params.toml
+++ b/crates/rue-cli-tests/cases/comptime_value_params.toml
@@ -128,7 +128,6 @@ pub fn scale(comptime k: i32, x: i32) -> i32 {
 }
 """ },
 ]
-args = ["main.rue", "util.rue", "-o", "prog"]
 stdout = "42\n"
 
 [[case]]

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -39,7 +39,7 @@ pub fn triple(x: i32) -> i32 {
 }
 """ },
 ]
-args = ["--emit", "air", "main.rue", "utils.rue"]
+args = ["--emit", "air", "main.rue"]
 compile_only = true
 compile_stdout_contains = ["=== AIR ==="]
 compile_stderr_not_contains = ["E0704"]

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -253,6 +253,27 @@ pub fn add(x: i32, y: i32) -> i32 {
 ]
 stdout = "42\n"
 
+[[case]]
+name = "mixed_positional_and_import_reachable_file_rejected"
+description = "RUE-434: a helper file must not be both listed positionally and loaded through the root import graph."
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper");
+
+fn main() -> i32 {
+    helper.value()
+}
+""" },
+    { path = "helper.rue", source = """
+pub fn value() -> i32 {
+    42
+}
+""" },
+]
+args = ["main.rue", "helper.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["must not also be loaded through @import", "rue main.rue -o prog"]
+
 # Direct member access on a loaded std (no const re-export chain): proves
 # std loading itself works; the re-export chain is RUE-136.
 [[case]]
@@ -387,7 +408,7 @@ error_contains = ["E0707", "has no member `abs`"]
 
 [[case]]
 name = "per_file_import_bindings_same_module"
-description = "Two files each bind `const utils = @import(...)` to the same module; all files hand-listed on the CLI (the original RUE-113 repro)."
+description = "Two files each bind `const utils = @import(...)` to the same module; the root import graph discovers both files."
 files = [
     { path = "main.rue", source = """
 const a = @import("a.rue");
@@ -417,7 +438,6 @@ pub fn one() -> i32 {
 }
 """ },
 ]
-args = ["main.rue", "a.rue", "b.rue", "utils.rue", "-o", "prog"]
 exit_code = 3
 
 [[case]]
@@ -686,7 +706,7 @@ error_contains = ["E0460", "function `secret` is private (defined in `sub/lib.ru
 
 [[case]]
 name = "private_fn_cross_dir_unqualified_rejected_when_also_listed"
-description = "Privacy does not depend on how the file was loaded: a file both listed on the CLI and imported is still private cross-directory (E0460)."
+description = "RUE-434: a file both listed on the CLI and imported is rejected before legacy flat name resolution runs."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -703,7 +723,7 @@ fn secret() -> i32 {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "function `secret` is private (defined in `sub/lib.rue`)"]
+error_contains = ["must not also be loaded through @import", "rue main.rue -o prog"]
 
 [[case]]
 name = "private_fn_same_dir_module_access_allowed"
@@ -1639,8 +1659,7 @@ exit_code = 7
 
 [[case]]
 name = "dotdot_import_reconciles_with_cli_listed_pub_fn"
-description = "RUE-317: `a/main.rue` @imports `../std/opt.rue` while `std/opt.rue` is also listed on the CLI; the pub fn member resolves through the module (single module identity, no E0707)."
-args = ["a/main.rue", "std/opt.rue", "-o", "prog"]
+description = "RUE-317: `a/main.rue` @imports `../std/opt.rue`; the pub fn member resolves through one normalized module identity."
 files = [
     { path = "a/main.rue", source = """
 fn main() -> i32 {
@@ -1658,8 +1677,7 @@ exit_code = 42
 
 [[case]]
 name = "dotdot_import_reconciles_with_cli_listed_pub_const"
-description = "RUE-317: same reconciliation for a pub const member accessed through a `../`-relative import that is also CLI-listed."
-args = ["a/main.rue", "std/opt.rue", "-o", "prog"]
+description = "RUE-317: same normalized-path reconciliation for a pub const member accessed through a `../`-relative import."
 files = [
     { path = "a/main.rue", source = """
 const opt = @import("../std/opt.rue");
@@ -1677,7 +1695,6 @@ exit_code = 7
 [[case]]
 name = "dotdot_import_unknown_member_still_errors"
 description = "RUE-317 negative control: path reconciliation must not mask a genuinely absent member — accessing a non-existent member of the reconciled module still fails with E0707."
-args = ["a/main.rue", "std/opt.rue", "-o", "prog"]
 files = [
     { path = "a/main.rue", source = """
 fn main() -> i32 {
@@ -1697,7 +1714,6 @@ error_contains = ["E0707", "has no member `nope`"]
 [[case]]
 name = "dotdot_import_private_member_cross_dir_still_rejected"
 description = "RUE-317 negative control: reconciling the path must not weaken privacy — a NON-pub member of the reconciled module in another directory is still private (E0706)."
-args = ["a/main.rue", "std/opt.rue", "-o", "prog"]
 files = [
     { path = "a/main.rue", source = """
 fn main() -> i32 {

--- a/crates/rue-cli-tests/cases/programs.toml
+++ b/crates/rue-cli-tests/cases/programs.toml
@@ -148,7 +148,6 @@ fn main() -> i32 {
 pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
 """ },
 ]
-args = ["main.rue", "opt.rue", "-o", "prog"]
 stdin = "yes"
 stdout = "affirmative\n"
 

--- a/crates/rue-cli-tests/cases/stdin.toml
+++ b/crates/rue-cli-tests/cases/stdin.toml
@@ -35,7 +35,6 @@ fn main() -> i32 {
 pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
 """ },
 ]
-args = ["main.rue", "opt.rue", "-o", "prog"]
 stdin = "42\n"
 stdout = "42\n"
 
@@ -75,7 +74,6 @@ fn main() -> i32 {
 pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
 """ },
 ]
-args = ["main.rue", "opt.rue", "-o", "prog"]
 stdin = "50\n90\n73\n"
 stdout = """
 Too low!
@@ -110,7 +108,6 @@ fn main() -> i32 {
 pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
 """ },
 ]
-args = ["main.rue", "opt.rue", "-o", "prog"]
 stdin = "banana\n"
 exit_code = 7
 
@@ -131,6 +128,5 @@ fn main() -> i32 {
 pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
 """ },
 ]
-args = ["main.rue", "opt.rue", "-o", "prog"]
 stdin = ""
 exit_code = 0

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -24,7 +24,6 @@ fn internal_helper() -> i32 {
     42
 }
 """ }
-pass_aux_files = true
 exit_code = 42
 
 [[case]]
@@ -42,7 +41,6 @@ pub fn public_helper() -> i32 {
     42
 }
 """ }
-pass_aux_files = true
 exit_code = 42
 
 [[case]]
@@ -61,7 +59,6 @@ aux_files = { "utils.rue" = """
 // Private struct - no pub keyword
 struct InternalPoint { x: i32, y: i32 }
 """ }
-pass_aux_files = true
 exit_code = 42
 
 [[case]]
@@ -82,7 +79,6 @@ aux_files = { "utils.rue" = """
 // Private enum - no pub keyword
 enum InternalStatus { Active, Inactive }
 """ }
-pass_aux_files = true
 exit_code = 42
 
 # =============================================================================
@@ -105,7 +101,6 @@ pub fn public_fn() -> i32 {
     42
 }
 """ }
-pass_aux_files = true
 exit_code = 42
 
 [[case]]
@@ -123,7 +118,6 @@ fn private_fn() -> i32 {
     42
 }
 """ }
-pass_aux_files = true
 compile_fail = true
 error_contains = "private"
 
@@ -142,7 +136,6 @@ fn main() -> i32 {
 aux_files = { "subdir/utils.rue" = """
 pub struct PublicPoint { x: i32, y: i32 }
 """ }
-pass_aux_files = true
 exit_code = 42
 
 [[case]]
@@ -160,7 +153,6 @@ fn main() -> i32 {
 aux_files = { "subdir/utils.rue" = """
 struct PrivatePoint { x: i32, y: i32 }
 """ }
-pass_aux_files = true
 compile_fail = true
 error_contains = "private"
 
@@ -181,7 +173,6 @@ fn main() -> i32 {
 aux_files = { "subdir/utils.rue" = """
 pub enum PublicStatus { On, Off }
 """ }
-pass_aux_files = true
 exit_code = 42
 
 [[case]]
@@ -198,7 +189,6 @@ fn main() -> i32 {
 aux_files = { "subdir/utils.rue" = """
 enum PrivateStatus { On, Off }
 """ }
-pass_aux_files = true
 compile_fail = true
 error_contains = "private"
 
@@ -230,7 +220,6 @@ fn internal_format() -> i32 {
     42
 }
 """ }
-pass_aux_files = true
 exit_code = 42
 
 # =============================================================================

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -234,8 +234,9 @@ impl ErrorFormat {
 }
 
 struct Options {
-    /// Source files to compile. In single-file mode, contains one path.
-    /// In multi-file mode, contains multiple paths.
+    /// Source files named positionally on the command line. The first path is
+    /// the root source; additional paths are legacy flat-mode inputs and must
+    /// not also be reachable through `@import`.
     source_paths: Vec<String>,
     output_path: String,
     emit_stages: Vec<EmitStage>,
@@ -270,10 +271,10 @@ fn print_version() {
 
 fn print_usage() {
     eprintln!("Usage: rue [options] <source.rue> [output]");
-    eprintln!("       rue [options] <source1.rue> <source2.rue> ... -o <output>");
+    eprintln!("       rue [options] <root.rue> -o <output>");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  -o, --output <path>  Set output path (required for multiple source files)");
+    eprintln!("  -o, --output <path>  Set output path");
     eprintln!("  --target <target>    Set compilation target (default: host)");
     eprintln!(
         "                       Valid targets: {}",
@@ -591,17 +592,20 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
                 "Error: refusing to use '{}' as the output path: it looks like a source file",
                 positional[1]
             );
-            eprintln!("To compile multiple source files, specify the output with -o:");
-            eprintln!("       rue {} {} -o <output>", positional[0], positional[1]);
+            eprintln!("Compile the root source and import helper modules with @import:");
+            eprintln!("       rue {} -o <output>", positional[0]);
             return ParseResult::Error;
         }
         let mut pos = positional;
         let out = pos.pop().unwrap();
         (pos, out)
     } else {
-        // Multiple source files without -o: error
-        eprintln!("Error: multiple source files require -o to specify output path");
-        eprintln!("Usage: rue a.rue b.rue -o output");
+        // Multiple source files without -o: error. The root-module workflow is
+        // `rue main.rue -o output`; helper modules are discovered through
+        // `@import`, not by listing them positionally.
+        eprintln!("Error: multiple source files require an explicit root-module compile");
+        eprintln!("Compile the root source and import helper modules with @import:");
+        eprintln!("       rue {} -o <output>", positional[0]);
         return ParseResult::Error;
     };
 
@@ -935,7 +939,7 @@ fn get_peak_memory_bytes() -> Option<u64> {
 
 /// Discover `@import("...")` references in the given sources and load the
 /// referenced module files from disk, transitively, appending them to
-/// `sources` as if the user had listed them on the command line.
+/// `sources`.
 ///
 /// Sema resolves import paths only against loaded files (see
 /// `resolve_import_path` in rue-air), so this is the step that makes
@@ -955,9 +959,13 @@ fn get_peak_memory_bytes() -> Option<u64> {
 ///
 /// Unresolvable imports are left for sema to report (E0704 with candidate
 /// context); this function only loads what it can find.
-fn discover_and_load_imports(sources: &mut Vec<(String, String)>) {
+///
+/// Returns non-root positional sources that were also reached through an
+/// import. That mixed mode is rejected by the CLI after discovery (RUE-434),
+/// because the file should be part of the root import graph, not also an
+/// additional flat positional input.
+fn discover_and_load_imports(sources: &mut Vec<(String, String)>) -> Vec<PathBuf> {
     use std::collections::HashSet;
-    use std::path::PathBuf;
 
     let root_dir = Path::new(&sources[0].0)
         .parent()
@@ -969,6 +977,13 @@ fn discover_and_load_imports(sources: &mut Vec<(String, String)>) {
         .iter()
         .filter_map(|(p, _)| fs::canonicalize(p).ok())
         .collect();
+    let explicit_non_root: HashSet<PathBuf> = sources
+        .iter()
+        .skip(1)
+        .filter_map(|(p, _)| fs::canonicalize(p).ok())
+        .collect();
+    let mut mixed_imports = Vec::new();
+    let mut mixed_seen = HashSet::new();
 
     let mut i = 0;
     while i < sources.len() {
@@ -1041,6 +1056,11 @@ fn discover_and_load_imports(sources: &mut Vec<(String, String)>) {
                         continue;
                     }
                     if loaded.contains(&canonical) {
+                        if explicit_non_root.contains(&canonical)
+                            && mixed_seen.insert(canonical.clone())
+                        {
+                            mixed_imports.push(canonical);
+                        }
                         group_hit = true; // already loaded (or a cycle)
                         continue;
                     }
@@ -1057,6 +1077,8 @@ fn discover_and_load_imports(sources: &mut Vec<(String, String)>) {
             }
         }
     }
+
+    mixed_imports
 }
 
 fn main() {
@@ -1121,7 +1143,22 @@ fn main() {
     // resolves imports only against already-loaded files, so without this
     // step `const utils = @import("utils")` fails with E0704 unless the
     // user hand-lists every module on the command line (RUE-14).
-    discover_and_load_imports(&mut sources);
+    let mixed_imports = discover_and_load_imports(&mut sources);
+    if !mixed_imports.is_empty() {
+        eprintln!(
+            "Error: source files listed after the root must not also be loaded through @import"
+        );
+        for path in &mixed_imports {
+            eprintln!("  imported and explicitly listed: {}", path.display());
+        }
+        eprintln!("Compile the root source only and let @import discover helper modules:");
+        eprintln!(
+            "       rue {} -o {}",
+            options.source_paths[0], options.output_path
+        );
+        eprintln!("Build-system source manifests are tracked separately from positional inputs.");
+        std::process::exit(1);
+    }
     let sources = sources;
 
     // Build SourceFile structs for multi-file compilation


### PR DESCRIPTION
## Summary

- Reject non-root positional source files when the same file is also loaded through the root module's `@import` graph.
- Update the CLI migration text toward root-only compilation and separate future build-system source manifests from positional inputs.
- Migrate CLI fixtures that were still hand-listing importable helper modules to root-only invocation, while keeping a focused mixed-mode rejection regression.

## Why

RUE-434 is part of removing the legacy flat multi-file model. A source file should either be a root positional input or be discovered by the import graph; listing helper modules positionally while also importing them preserves the old flat-world mental model and conflicts with ADR-0047's build-input direction.

## Validation

- `scripts/rue fmt`
- `scripts/rue cli modules`
- `scripts/rue cli emit_pipeline`
- `scripts/rue quick`
