### PR TITLE
[codex] Expose source-level std.exit

### DIFF
--- a/crates/rue-cli-tests/cases/std_exit.toml
+++ b/crates/rue-cli-tests/cases/std_exit.toml
@@ -1,0 +1,23 @@
+# Standard-library process exit behavior.
+
+[section]
+id = "cli.std_exit"
+name = "Standard-library process exit"
+description = "Source-level std.exit terminates the process with the requested status."
+
+[[case]]
+name = "std_exit_terminates_with_status"
+description = "std.exit exits immediately with the provided status code."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    @dbg(1);
+    std.exit(7);
+    @dbg(2);
+    0
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdout = "1\n"
+exit_code = 7

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -228,6 +228,11 @@ A program **MUST** have a function named `main`.
 
 The `main` function **MUST** return either `i32` or `()`. When it returns `i32`, that value becomes the program's exit code. When it returns `()`, the exit code is 0.
 
+Programs can also terminate explicitly through the standard library:
+`std.exit(code)` terminates the process immediately with the provided `u64`
+status code and does not return. This bypasses `main`'s return value; if
+`std.exit` is reached, code after that call is not evaluated.
+
 {{ rule(id="6.1:9") }}
 
 ```rue

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -12,3 +12,32 @@
 pub const math = @import("math.rue");
 pub const option = @import("option.rue");
 pub const arraybuf = @import("arraybuf.rue");
+
+fn exit_syscall_number() -> u64 {
+    match @target_arch() {
+        Arch::X86_64 => {
+            match @target_os() {
+                Os::Linux => 60,
+                Os::Macos => 1,
+            }
+        },
+        Arch::Aarch64 => {
+            match @target_os() {
+                Os::Linux => 93,
+                Os::Macos => 1,
+            }
+        },
+    }
+}
+
+/// Exit the process with `code`.
+///
+/// This terminates immediately and does not return.
+pub fn exit(code: u64) -> ! {
+    let syscall_num = exit_syscall_number();
+    checked {
+        @syscall(syscall_num, code);
+    };
+
+    loop {}
+}


### PR DESCRIPTION
## Summary

- add `std.exit(code: u64) -> !` as a source-level standard-library exit API
- cover explicit non-zero process termination through the real stdlib in CLI tests
- document `std.exit` beside the existing `main` return-value exit-code behavior

## Notes

This intentionally exposes only the top-level `std.exit` spelling for now. While implementing it, I hit the current module-system limitation where same-named functions in imported std modules collide globally, so a separate `std.process.exit` wrapper would need that fixed first.

## Validation

- `scripts/rue fmt`
- `scripts/rue cli std_exit`
- `scripts/rue cli modules`
- `scripts/rue quick`
