### PR TITLE
[codex] Support module-qualified type paths

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -2411,7 +2411,7 @@ impl<'a> Sema<'a> {
     /// Ensure a free function's signature is available during const
     /// collection, which can run before the main declaration walk reaches the
     /// callee's `FnDecl`.
-    fn ensure_free_function_signature(
+    pub(crate) fn ensure_free_function_signature(
         &mut self,
         target: Spur,
         file_id: Option<FileId>,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -10,10 +10,12 @@ use std::collections::HashMap;
 
 use lasso::Spur;
 use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
-use rue_span::Span;
+use rue_rir::InstData;
+use rue_span::{FileId, Span};
 
 use super::Sema;
 use super::context::AnalysisContext;
+use super::info::ConstInfo;
 use crate::inference::InferType;
 use crate::sema::ConstValue;
 use crate::types::{
@@ -551,6 +553,10 @@ impl<'a> Sema<'a> {
                 if call_name == "Str" {
                     return self.resolve_str_fixed_type(&call_name, &arg_strs, span);
                 }
+                if call_name.contains('.') {
+                    return self
+                        .resolve_qualified_type_function_call(&call_name, &arg_strs, span, None);
+                }
                 // A type-function application written directly in type position
                 // (`Result(i32, i32)`; RUE-241). Reduce the comptime type call
                 // to its monomorphized concrete type. No analysis context is
@@ -561,6 +567,8 @@ impl<'a> Sema<'a> {
             } else if let Some(result) = self.try_resolve_slice_type(type_name, span) {
                 // Slice type `[T]` (ADR-0043, RUE-322): gated + not-yet-runnable.
                 result
+            } else if type_name.contains('.') {
+                self.resolve_qualified_type_name(type_name, span)
             } else {
                 Err(CompileError::new(
                     ErrorKind::UnknownType(type_name.to_string()),
@@ -635,6 +643,14 @@ impl<'a> Sema<'a> {
             if call_name == "Str" {
                 return self.resolve_str_fixed_type(&call_name, &arg_strs, span);
             }
+            if call_name.contains('.') {
+                return self.resolve_qualified_type_function_call(
+                    &call_name,
+                    &arg_strs,
+                    span,
+                    Some(ctx),
+                );
+            }
             // A type-function application in an annotation position whose
             // arguments may name enclosing comptime type parameters or local
             // comptime type variables (`let x: Option(T)` / `let x: Option(P)`).
@@ -648,6 +664,305 @@ impl<'a> Sema<'a> {
             // checks, and the E0204 on a genuinely-unknown name.
             self.resolve_type(type_sym, span)
         }
+    }
+
+    fn resolve_qualified_type_name(&mut self, path: &str, span: Span) -> CompileResult<Type> {
+        let segments: Vec<&str> = path.split('.').collect();
+        if segments.len() < 2 || segments.iter().any(|s| s.is_empty()) {
+            return Err(CompileError::new(
+                ErrorKind::UnknownType(path.to_string()),
+                span,
+            ));
+        }
+        let (module_id, module_file_id, _module_file_path) =
+            self.resolve_type_module_prefix(&segments[..segments.len() - 1], span)?;
+        let member = segments[segments.len() - 1];
+        let member_sym = self.interner.get_or_intern(member);
+
+        if let Some(&struct_id) = self.structs.get(&member_sym) {
+            let struct_def = self.type_pool.struct_def(struct_id);
+            if module_file_id == Some(struct_def.file_id) {
+                self.check_unqualified_visibility(
+                    "struct",
+                    member,
+                    struct_def.file_id,
+                    struct_def.is_pub,
+                    span,
+                )?;
+                return Ok(Type::new_struct(struct_id));
+            }
+        }
+        if let Some(&enum_id) = self.enums.get(&member_sym) {
+            let enum_def = self.type_pool.enum_def(enum_id);
+            if module_file_id == Some(enum_def.file_id) {
+                self.check_unqualified_visibility(
+                    "enum",
+                    member,
+                    enum_def.file_id,
+                    enum_def.is_pub,
+                    span,
+                )?;
+                return Ok(Type::new_enum(enum_id));
+            }
+        }
+        if let Some(info) = self.constants.get(&member_sym)
+            && module_file_id == Some(info.span.file_id)
+            && let ConstValue::Type(alias_ty) = info.value
+        {
+            self.check_unqualified_visibility(
+                "constant",
+                member,
+                info.span.file_id,
+                info.is_pub,
+                span,
+            )?;
+            return Ok(alias_ty);
+        }
+
+        let module_def = self.module_registry.get_def(module_id);
+        Err(CompileError::new(
+            ErrorKind::UnknownModuleMember {
+                module_name: module_def.import_path.clone(),
+                member_name: member.to_string(),
+            },
+            span,
+        ))
+    }
+
+    fn resolve_qualified_type_function_call(
+        &mut self,
+        call_path: &str,
+        arg_strs: &[String],
+        span: Span,
+        ctx: Option<&AnalysisContext>,
+    ) -> CompileResult<Type> {
+        let segments: Vec<&str> = call_path.split('.').collect();
+        if segments.len() < 2 || segments.iter().any(|s| s.is_empty()) {
+            return Err(CompileError::new(
+                ErrorKind::UnknownType(format!("{}(...)", call_path)),
+                span,
+            ));
+        }
+        let (_module_id, module_file_id, _module_file_path) =
+            self.resolve_type_module_prefix(&segments[..segments.len() - 1], span)?;
+        let member = segments[segments.len() - 1];
+        let member_sym = self.interner.get_or_intern(member);
+        if let Some(module_file_id) = module_file_id {
+            self.ensure_free_function_signature(member_sym, Some(module_file_id))?;
+        }
+
+        let Some(fn_info) = self
+            .functions
+            .get(&member_sym)
+            .copied()
+            .filter(|info| module_file_id == Some(info.file_id))
+        else {
+            return Err(CompileError::new(
+                ErrorKind::UnknownType(format!("{}(...)", call_path)),
+                span,
+            ));
+        };
+        self.check_unqualified_visibility(
+            "function",
+            member,
+            fn_info.file_id,
+            fn_info.is_pub,
+            span,
+        )?;
+        if fn_info.return_type != Type::COMPTIME_TYPE {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "'{}' is not a type: only a function returning `type` (a type \
+                         constructor) can be applied as a type here",
+                        call_path
+                    ),
+                },
+                span,
+            ));
+        }
+
+        let params = fn_info.params;
+        let param_names = self.param_arena.names(params).to_vec();
+        let param_comptime = self.param_arena.comptime(params).to_vec();
+        if arg_strs.len() != param_names.len()
+            || !(param_names.is_empty() || param_comptime.iter().all(|&c| c))
+        {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "type constructor '{}' expects {} comptime type argument(s), \
+                         but {} were provided",
+                        call_path,
+                        param_names.len(),
+                        arg_strs.len()
+                    ),
+                },
+                span,
+            ));
+        }
+
+        let mut callee_types: HashMap<Spur, Type> = HashMap::new();
+        for (i, arg) in arg_strs.iter().enumerate() {
+            let arg_sym = self.interner.get_or_intern(arg);
+            let arg_ty = match ctx {
+                Some(ctx) => self.resolve_type_with_ctx(arg_sym, span, ctx)?,
+                None => self.resolve_type(arg_sym, span)?,
+            };
+            callee_types.insert(param_names[i], arg_ty);
+        }
+        let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
+        match self.reduce_type_ctor_body(member_sym, &callee_types, &empty_values)? {
+            Some(ConstValue::Type(t)) => Ok(t),
+            _ => Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "the type constructor '{}' did not reduce to a concrete type \
+                         at compile time",
+                        call_path
+                    ),
+                },
+                span,
+            )),
+        }
+    }
+
+    fn resolve_type_module_prefix(
+        &mut self,
+        segments: &[&str],
+        span: Span,
+    ) -> CompileResult<(crate::types::ModuleId, Option<FileId>, String)> {
+        let Some((first, rest)) = segments.split_first() else {
+            return Err(CompileError::new(
+                ErrorKind::UnknownType(String::new()),
+                span,
+            ));
+        };
+        let first_sym = self.interner.get_or_intern(first);
+        let Some(binding) = self
+            .module_bindings
+            .get(&(span.file_id, first_sym))
+            .cloned()
+            .or_else(|| self.resolve_direct_import_module_binding(span.file_id, first_sym, span))
+        else {
+            return Err(CompileError::new(
+                ErrorKind::UnknownType((*first).to_string()),
+                span,
+            ));
+        };
+        let mut module_id = binding
+            .ty
+            .as_module()
+            .expect("module binding holds a module type");
+
+        for segment in rest {
+            let module_def = self.module_registry.get_def(module_id);
+            let module_file_id = self.canonical_file_id(&module_def.file_path);
+            let segment_sym = self.interner.get_or_intern(segment);
+            let Some(module_file_id) = module_file_id else {
+                return Err(CompileError::new(
+                    ErrorKind::UnknownModuleMember {
+                        module_name: module_def.import_path.clone(),
+                        member_name: (*segment).to_string(),
+                    },
+                    span,
+                ));
+            };
+            let Some(binding) = self
+                .module_bindings
+                .get(&(module_file_id, segment_sym))
+                .cloned()
+                .or_else(|| {
+                    self.resolve_direct_import_module_binding(module_file_id, segment_sym, span)
+                })
+            else {
+                return Err(CompileError::new(
+                    ErrorKind::UnknownModuleMember {
+                        module_name: module_def.import_path.clone(),
+                        member_name: (*segment).to_string(),
+                    },
+                    span,
+                ));
+            };
+            let (binding_is_pub, binding_ty) = (binding.is_pub, binding.ty);
+            self.check_unqualified_visibility(
+                "constant",
+                segment,
+                module_file_id,
+                binding_is_pub,
+                span,
+            )?;
+            module_id = binding_ty
+                .as_module()
+                .expect("module binding holds a module type");
+        }
+
+        let module_def = self.module_registry.get_def(module_id);
+        let module_file_id = self.canonical_file_id(&module_def.file_path);
+        let module_file_path = module_file_id
+            .and_then(|id| self.get_file_path(id))
+            .map(str::to_string)
+            .unwrap_or_else(|| module_def.file_path.clone());
+        Ok((module_id, module_file_id, module_file_path))
+    }
+
+    fn resolve_direct_import_module_binding(
+        &mut self,
+        file_id: FileId,
+        name: Spur,
+        _span: Span,
+    ) -> Option<ConstInfo> {
+        let found = self.rir.iter().find_map(|(_inst_ref, inst)| {
+            let InstData::ConstDecl {
+                is_pub,
+                name: const_name,
+                init,
+                ..
+            } = inst.data
+            else {
+                return None;
+            };
+            if inst.span.file_id != file_id || const_name != name {
+                return None;
+            }
+            Some((is_pub, init, inst.span))
+        })?;
+
+        let (is_pub, init, const_span) = found;
+        let init_inst = self.rir.get(init);
+        let InstData::Intrinsic {
+            name: intrinsic_name,
+            args_start,
+            args_len,
+        } = &init_inst.data
+        else {
+            return None;
+        };
+        if *intrinsic_name != self.known.import || *args_len != 1 {
+            return None;
+        }
+        let arg_refs = self.rir.get_inst_refs(*args_start, *args_len);
+        let arg_inst = self.rir.get(arg_refs[0]);
+        let InstData::StringConst(path_spur) = &arg_inst.data else {
+            return None;
+        };
+        let import_path = self.interner.resolve(path_spur).to_string();
+        let resolved_path = self
+            .resolve_import_path(&import_path, init_inst.span)
+            .ok()?;
+        let (module_id, _is_new) = self
+            .module_registry
+            .get_or_create(import_path, resolved_path);
+        let ty = Type::new_module(module_id);
+        let info = ConstInfo {
+            is_pub,
+            ty,
+            init,
+            value: ConstValue::Type(ty),
+            span: const_span,
+        };
+        self.module_bindings.insert((file_id, name), info.clone());
+        Some(info)
     }
 
     /// Resolve a type-function application written directly in type position

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -1146,15 +1146,19 @@ pub fn parse_type_call_syntax(type_name: &str) -> Option<(String, Vec<String>)> 
     }
     let open = s.find('(')?;
     let name = &s[..open];
-    // The callee name must be a bare identifier. This is what excludes
-    // anonymous type strings like `enum { Ok(i32) }`, whose text before the
-    // first `(` contains spaces/braces.
+    // The callee name must be a bare identifier or a dotted module-qualified
+    // identifier. This excludes anonymous type strings like
+    // `enum { Ok(i32) }`, whose text before the first `(` contains
+    // spaces/braces.
     let mut name_chars = name.chars();
     match name_chars.next() {
         Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
         _ => return None,
     }
-    if !name_chars.all(|c| c.is_ascii_alphanumeric() || c == '_') {
+    if name.ends_with('.') || name.contains("..") {
+        return None;
+    }
+    if !name_chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.') {
         return None;
     }
 

--- a/crates/rue-cli-tests/cases/std_type_paths.toml
+++ b/crates/rue-cli-tests/cases/std_type_paths.toml
@@ -1,0 +1,47 @@
+# Standard-library type paths in type position (RUE-419).
+
+[section]
+id = "cli.std_type_paths"
+name = "Standard-library type paths"
+description = "Module-qualified std paths work in type annotations and return types."
+
+[[case]]
+name = "std_option_type_path_in_return_type"
+description = "`std.option.Option(i64)` can be named directly in a function return type."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn read_num() -> std.option.Option(i64) {
+    let O = std.option.Option(i64);
+    O::None
+}
+
+fn main() -> i32 {
+    let O = std.option.Option(i64);
+    match read_num() {
+        O::None => 0,
+        O::Some(n) => @intCast(n),
+    }
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 0
+
+[[case]]
+name = "std_option_type_path_in_let_annotation"
+description = "`std.option.Option(i64)` can be named directly in a local type annotation."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let O = std.option.Option(i64);
+    let n: i64 = 42;
+    let x: std.option.Option(i64) = O::Some(n);
+    match x {
+        O::None => 0,
+        O::Some(n) => @intCast(n),
+    }
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 42

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -316,6 +316,8 @@ pub struct Ident {
 pub enum TypeExpr {
     /// A simple named type (e.g., i32, bool, MyStruct)
     Named(Ident),
+    /// A module-qualified named type (e.g., std.option.OptionAlias).
+    Qualified { segments: Vec<Ident>, span: Span },
     /// Unit type: ()
     Unit(Span),
     /// Never type: !
@@ -369,6 +371,13 @@ pub enum TypeExpr {
     /// (`Result(Option(i32), i32)`) compose.
     TypeCall {
         name: Ident,
+        args: Vec<TypeExpr>,
+        span: Span,
+    },
+    /// A module-qualified type-function application in type position:
+    /// `std.option.Option(i64)`.
+    QualifiedTypeCall {
+        segments: Vec<Ident>,
         args: Vec<TypeExpr>,
         span: Span,
     },
@@ -446,6 +455,7 @@ impl TypeExpr {
     pub fn span(&self) -> Span {
         match self {
             TypeExpr::Named(ident) => ident.span,
+            TypeExpr::Qualified { span, .. } => *span,
             TypeExpr::Unit(span) => *span,
             TypeExpr::Never(span) => *span,
             TypeExpr::Array { span, .. } => *span,
@@ -455,6 +465,7 @@ impl TypeExpr {
             TypeExpr::PointerConst { span, .. } => *span,
             TypeExpr::PointerMut { span, .. } => *span,
             TypeExpr::TypeCall { span, .. } => *span,
+            TypeExpr::QualifiedTypeCall { span, .. } => *span,
             TypeExpr::StrFixed { span, .. } => *span,
         }
     }
@@ -464,6 +475,15 @@ impl fmt::Display for TypeExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TypeExpr::Named(ident) => write!(f, "sym:{}", ident.name.into_usize()),
+            TypeExpr::Qualified { segments, .. } => {
+                for (i, segment) in segments.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ".")?;
+                    }
+                    write!(f, "sym:{}", segment.name.into_usize())?;
+                }
+                Ok(())
+            }
             TypeExpr::Unit(_) => write!(f, "()"),
             TypeExpr::Never(_) => write!(f, "!"),
             TypeExpr::Array {
@@ -512,6 +532,22 @@ impl fmt::Display for TypeExpr {
             TypeExpr::PointerMut { pointee, .. } => write!(f, "ptr mut {}", pointee),
             TypeExpr::TypeCall { name, args, .. } => {
                 write!(f, "sym:{}(", name.name.into_usize())?;
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", arg)?;
+                }
+                write!(f, ")")
+            }
+            TypeExpr::QualifiedTypeCall { segments, args, .. } => {
+                for (i, segment) in segments.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ".")?;
+                    }
+                    write!(f, "sym:{}", segment.name.into_usize())?;
+                }
+                write!(f, "(")?;
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -401,6 +401,27 @@ where
                 span: span_from_extra(e),
             });
 
+        // Module-qualified type-function application in type position:
+        // `std.option.Option(i64)` (RUE-419). Keep this distinct from the
+        // existing bare type-call node so downstream stages can resolve the
+        // module prefix before applying the constructor.
+        let qualified_type_call = ident_parser()
+            .separated_by(just(TokenKind::Dot))
+            .at_least(2)
+            .collect::<Vec<_>>()
+            .then(
+                ty.clone()
+                    .separated_by(just(TokenKind::Comma))
+                    .allow_trailing()
+                    .collect::<Vec<_>>()
+                    .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+            )
+            .map_with(|(segments, args), e| TypeExpr::QualifiedTypeCall {
+                segments,
+                args,
+                span: span_from_extra(e),
+            });
+
         // Fixed-capacity string type with a LITERAL capacity: `Str(8)`
         // (ADR-0043 Phase 5, RUE-326). The integer capacity is not a type, so
         // it cannot ride the `type_call` grammar (whose args are types); this
@@ -423,6 +444,16 @@ where
         // Named type: user-defined types like MyStruct
         let named_type = ident_parser().map(TypeExpr::Named);
 
+        // Module-qualified named type in type position: `lib.Point` (RUE-419).
+        let qualified_type = ident_parser()
+            .separated_by(just(TokenKind::Dot))
+            .at_least(2)
+            .collect::<Vec<_>>()
+            .map_with(|segments, e| TypeExpr::Qualified {
+                segments,
+                span: span_from_extra(e),
+            });
+
         // Self type: Self keyword used in methods to refer to the containing struct
         let self_type = just(TokenKind::SelfType).map_with(|_, e| {
             let span = span_from_extra(e);
@@ -442,8 +473,10 @@ where
             ptr_mut_type,
             primitive_type_parser(),
             self_type,
+            qualified_type_call,
             type_call,
             str_fixed_type,
+            qualified_type,
             named_type,
         ))
         // Summarize the whole type grammar as a single "type" expectation, so a

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -304,7 +304,10 @@ impl Validator<'_> {
     /// which carry directives and bodies of their own.
     fn check_type_expr(&mut self, ty: &TypeExpr) {
         match ty {
-            TypeExpr::Named(_) | TypeExpr::Unit(_) | TypeExpr::Never(_) => {}
+            TypeExpr::Named(_)
+            | TypeExpr::Qualified { .. }
+            | TypeExpr::Unit(_)
+            | TypeExpr::Never(_) => {}
             TypeExpr::Array { element, .. } => self.check_type_expr(element),
             TypeExpr::Slice { element, .. } => self.check_type_expr(element),
             TypeExpr::AnonymousStruct { methods, .. } => {
@@ -319,7 +322,7 @@ impl Validator<'_> {
                 self.check_type_expr(pointee)
             }
             // Type-function application: recurse into each type argument.
-            TypeExpr::TypeCall { args, .. } => {
+            TypeExpr::TypeCall { args, .. } | TypeExpr::QualifiedTypeCall { args, .. } => {
                 for arg in args {
                     self.check_type_expr(arg);
                 }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -80,6 +80,10 @@ impl<'a> AstGen<'a> {
     fn intern_type(&mut self, ty: &TypeExpr) -> Spur {
         match ty {
             TypeExpr::Named(ident) => ident.name, // Already a Spur
+            TypeExpr::Qualified { segments, .. } => {
+                let name = self.render_type_path(segments);
+                self.interner.get_or_intern(&name)
+            }
             TypeExpr::Unit(_) => self.interner.get_or_intern("()"),
             TypeExpr::Never(_) => self.interner.get_or_intern("!"),
             TypeExpr::Array {
@@ -184,6 +188,19 @@ impl<'a> AstGen<'a> {
                 s.push(')');
                 self.interner.get_or_intern(&s)
             }
+            TypeExpr::QualifiedTypeCall { segments, args, .. } => {
+                let mut s = self.render_type_path(segments);
+                s.push('(');
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        s.push_str(", ");
+                    }
+                    let arg_sym = self.intern_type(arg);
+                    s.push_str(self.interner.resolve(&arg_sym));
+                }
+                s.push(')');
+                self.interner.get_or_intern(&s)
+            }
             TypeExpr::StrFixed { name, length, .. } => {
                 // Fixed-capacity string `Str(N)` with a literal capacity
                 // (ADR-0043 Phase 5, RUE-326). Canonicalize to `Name(N)` — the
@@ -194,6 +211,17 @@ impl<'a> AstGen<'a> {
                 self.interner.get_or_intern(&s)
             }
         }
+    }
+
+    fn render_type_path(&self, segments: &[rue_parser::ast::Ident]) -> String {
+        let mut s = String::new();
+        for (i, segment) in segments.iter().enumerate() {
+            if i > 0 {
+                s.push('.');
+            }
+            s.push_str(self.interner.resolve(&segment.name));
+        }
+        s
     }
 
     /// Render an array-length component to its canonical string form for the
@@ -985,6 +1013,7 @@ impl<'a> AstGen<'a> {
                         // For named types, unit, never, arrays, and pointers, generate TypeConst
                         let type_name = match &type_lit.type_expr {
                             TypeExpr::Named(ident) => ident.name,
+                            TypeExpr::Qualified { .. } => self.intern_type(&type_lit.type_expr),
                             TypeExpr::Unit(_) => self.interner.get_or_intern_static("()"),
                             TypeExpr::Never(_) => self.interner.get_or_intern_static("!"),
                             TypeExpr::Array { .. } => {
@@ -1006,7 +1035,7 @@ impl<'a> AstGen<'a> {
                                 // Pointer types as values - use intern_type to get representation
                                 self.intern_type(&type_lit.type_expr)
                             }
-                            TypeExpr::TypeCall { .. } => {
+                            TypeExpr::TypeCall { .. } | TypeExpr::QualifiedTypeCall { .. } => {
                                 // A type-function application in *value* position
                                 // (`let R = Result(i32, i32)`) is parsed as an
                                 // ordinary call expression, not a TypeLit, so it

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -305,8 +305,8 @@ error_contains = "private"
 # =============================================================================
 # A module's types, enum variants, and associated functions are referenced
 # through a module binding in expression/pattern positions (10.4:15); a
-# qualified path is rejected in a type position (10.4:16); privacy is uniform
-# (10.4:18).
+# qualified path is also accepted in type position (10.4:16); privacy is
+# uniform (10.4:18).
 
 [[case]]
 name = "qualified_type_variant_and_assoc_fn_forms"
@@ -338,9 +338,9 @@ pub enum Color { Red, Green, Blue, }
 exit_code = 84
 
 [[case]]
-name = "qualified_path_in_type_position_rejected"
+name = "qualified_path_in_type_position_allowed"
 spec = ["10.4:16"]
-description = "A module-qualified path in a type-annotation position is a parse error (E0100); types are named by bare identifier only"
+description = "A module-qualified path in a type-annotation position resolves through the importing module."
 source = """
 const lib = @import("sub/lib");
 
@@ -352,8 +352,7 @@ fn main() -> i32 {
 aux_files = { "sub/lib.rue" = """
 pub struct Point { x: i32, y: i32, }
 """ }
-compile_fail = true
-error_contains = ["E0100"]
+exit_code = 3
 
 [[case]]
 name = "qualified_private_struct_literal_rejected"

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -156,13 +156,13 @@ match pattern (`m.Color::Red`), and an associated function in a call
 corresponding *bare* path — `Point { .. }`, `Color::Red`, `Point::origin()` —
 is accepted, and has the same meaning.
 
-{{ rule(id="10.4:16", cat="legality-rule") }}
+{{ rule(id="10.4:16", cat="normative") }}
 
-A module-qualified path is **not** accepted in a *type* position — a type
-annotation, a field type, or a parameter or return type. In those positions a
-type is named only by a bare identifier (resolved through the flat namespace,
-10.5:2); writing `m.Type` where a type is expected is a compile-time error
-reported during parsing (E0100).
+A module-qualified path **MAY** be used in a *type* position — a type
+annotation, a field type, or a parameter or return type. In those positions,
+`m.Type` names the type member reached through the module binding `m`, and
+`m.Type(T)` applies a module-qualified type constructor. This is the preferred
+form for referring to standard-library types such as `std.option.Option(i64)`.
 
 {{ rule(id="10.4:17") }}
 
@@ -217,9 +217,9 @@ fn main() -> i32 {
     let p = lib.Point { x: 40, y: 2 };     // qualified struct literal
     let q = lib.Point::origin();           // qualified associated fn
     let c = lib.Color::Green;              // qualified variant expression
-    // let bad: lib.Point = p;           // error E0100: no qualified path in a type position
+    let typed: lib.Point = p;           // qualified type annotation
     // let h = lib.Hidden::A;            // error E0706: `Hidden` is private outside sub/
-    let base = p.x + p.y + q.x + q.y;    // 40 + 2 + 30 + 12 = 84
+    let base = typed.x + typed.y + q.x + q.y; // 40 + 2 + 30 + 12 = 84
     match c {
         lib.Color::Red => 0,             // qualified variant pattern
         lib.Color::Green => base,        // 84

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -217,10 +217,11 @@ Notes:
   legality rule enforced during semantic analysis (6.1:17), not a syntactic
   restriction. A non-place argument such as `inout a + 1` parses but is
   rejected with an lvalue error (E0425).
-- **Type-function application in type position** (`type_call`): a name applied
-  to type arguments, e.g. `Pair(i32)` or `Result(Option(i32), i32)`, denotes
-  the type produced by a comptime `-> type` constructor (RUE-241). Nested
-  applications compose. Its result cannot yet head a struct literal
+- **Type-function application in type position** (`type_call`): a name or
+  module-qualified path applied to type arguments, e.g. `Pair(i32)`,
+  `Result(Option(i32), i32)`, or `std.option.Option(i64)`, denotes the type
+  produced by a comptime `-> type` constructor (RUE-241). Nested applications
+  compose. Its result cannot yet head a struct literal
   (`Pair(i32) { … }` does not parse); bind it via a `let` of that type instead.
 - **Anonymous struct types** carry inline methods only when a `struct { … }`
   appears as a *value* (e.g. the body of a comptime `-> type` function); in


### PR DESCRIPTION
## Summary

- allow module-qualified paths in type position, including `lib.Point` and `std.option.Option(i64)`
- resolve qualified type names and type constructors through module bindings, including std facade re-exports needed during signature collection
- update module spec prose/grammar notes and convert the old rejection spec case to an allowed case
- add CLI coverage for `std.option.Option(i64)` in return types and let annotations

## Validation

- `scripts/rue fmt`
- `scripts/rue cli std_type_paths`
- `scripts/rue spec modules.bindings`
- `scripts/rue quick`
