### PR TITLE
[codex] Emit source dependency graph

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -141,6 +141,58 @@ args = ["--source-manifest", "sources.manifest", "main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["undefined function", "helper"]
 
+[[case]]
+name = "emit_deps_reports_root_and_import_graph"
+description = "RUE-446: --emit deps reports the observed root/import source graph as machine-readable JSON."
+files = [
+    { path = "main.rue", source = """
+const utils = @import("utils");
+
+fn main() -> i32 {
+    utils.answer()
+}
+""" },
+    { path = "utils.rue", source = """
+const leaf = @import("leaf");
+
+pub fn answer() -> i32 {
+    leaf.value()
+}
+""" },
+    { path = "leaf.rue", source = """
+pub fn value() -> i32 {
+    42
+}
+""" },
+]
+args = ["--emit", "deps", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "\"version\": 1",
+    "\"root\":",
+    "\"path\":",
+    "main.rue",
+    "\"kind\": \"root\"",
+    "utils.rue",
+    "\"kind\": \"import\"",
+    "leaf.rue",
+    "\"specifier\": \"utils\"",
+    "\"specifier\": \"leaf\"",
+    "\"resolved\":",
+]
+
+[[case]]
+name = "emit_deps_rejects_mixed_emit_stages"
+description = "RUE-446: dependency JSON must not be interleaved with other --emit output."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 { 0 }
+""" },
+]
+args = ["--emit", "deps", "--emit", "air", "main.rue"]
+compile_fail = true
+error_contains = ["--emit deps cannot be combined"]
+
 # The `.rue`-suffixed form resolves from disk (when the module is not used).
 [[case]]
 name = "import_with_rue_extension"

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -22,6 +22,7 @@ use rue_compiler::{
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
+use serde::Serialize;
 
 /// Compilation stages that can be emitted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +49,8 @@ enum EmitStage {
     Asm,
     /// Emit stack frame layout per function.
     StackFrame,
+    /// Emit the source dependency graph discovered while loading imports.
+    Deps,
 }
 
 /// Error returned when parsing an emit stage name fails.
@@ -78,6 +81,7 @@ impl std::str::FromStr for EmitStage {
             "regalloc" => Ok(EmitStage::RegAlloc),
             "asm" => Ok(EmitStage::Asm),
             "stackframe" => Ok(EmitStage::StackFrame),
+            "deps" => Ok(EmitStage::Deps),
             _ => Err(ParseEmitStageError(s.to_string())),
         }
     }
@@ -85,7 +89,7 @@ impl std::str::FromStr for EmitStage {
 
 impl EmitStage {
     fn all_names() -> &'static str {
-        "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe"
+        "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe, deps"
     }
 }
 
@@ -1040,6 +1044,82 @@ fn validate_manifest_allows_source(
     Err(())
 }
 
+#[derive(Debug, Clone, Serialize)]
+struct DependencySource {
+    path: String,
+    kind: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DependencyImport {
+    from: String,
+    specifier: String,
+    resolved: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DependencyOutput {
+    version: u32,
+    root: String,
+    sources: Vec<DependencySource>,
+    imports: Vec<DependencyImport>,
+}
+
+#[derive(Debug, Default)]
+struct DependencyGraph {
+    root: Option<PathBuf>,
+    sources: std::collections::BTreeMap<PathBuf, &'static str>,
+    imports: Vec<(PathBuf, String, PathBuf)>,
+    import_seen: std::collections::HashSet<(PathBuf, String, PathBuf)>,
+}
+
+impl DependencyGraph {
+    fn record_source(&mut self, path: PathBuf, kind: &'static str) {
+        if kind == "root" {
+            self.root = Some(path.clone());
+        }
+        self.sources.entry(path).or_insert(kind);
+    }
+
+    fn record_import(&mut self, from: PathBuf, specifier: &str, resolved: PathBuf) {
+        let key = (from.clone(), specifier.to_string(), resolved.clone());
+        if self.import_seen.insert(key.clone()) {
+            self.imports.push(key);
+        }
+    }
+
+    fn to_output(&self) -> DependencyOutput {
+        let sources = self
+            .sources
+            .iter()
+            .map(|(path, kind)| DependencySource {
+                path: path.display().to_string(),
+                kind,
+            })
+            .collect();
+        let imports = self
+            .imports
+            .iter()
+            .map(|(from, specifier, resolved)| DependencyImport {
+                from: from.display().to_string(),
+                specifier: specifier.clone(),
+                resolved: resolved.display().to_string(),
+            })
+            .collect();
+
+        DependencyOutput {
+            version: 1,
+            root: self
+                .root
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_default(),
+            sources,
+            imports,
+        }
+    }
+}
+
 /// Discover `@import("...")` references in the given sources and load the
 /// referenced module files from disk, transitively, appending them to
 /// `sources`.
@@ -1070,6 +1150,7 @@ fn validate_manifest_allows_source(
 fn discover_and_load_imports(
     sources: &mut Vec<(String, String)>,
     source_manifest: Option<&SourceManifest>,
+    dependency_graph: &mut DependencyGraph,
 ) -> Result<Vec<PathBuf>, ()> {
     use std::collections::HashSet;
 
@@ -1094,6 +1175,7 @@ fn discover_and_load_imports(
     let mut i = 0;
     while i < sources.len() {
         let (importer_path, content) = (sources[i].0.clone(), sources[i].1.clone());
+        let importer_canonical = fs::canonicalize(&importer_path).ok();
         i += 1;
 
         let lexer = Lexer::new(&content);
@@ -1161,6 +1243,13 @@ fn discover_and_load_imports(
                     if !canonical.is_file() {
                         continue;
                     }
+                    if let Some(importer_canonical) = &importer_canonical {
+                        dependency_graph.record_import(
+                            importer_canonical.clone(),
+                            import_str,
+                            canonical.clone(),
+                        );
+                    }
                     if let Some(manifest) = source_manifest
                         && !manifest.allows_canonical(&canonical)
                     {
@@ -1187,7 +1276,8 @@ fn discover_and_load_imports(
                     let Ok(module_content) = fs::read_to_string(&candidate) else {
                         continue;
                     };
-                    loaded.insert(canonical);
+                    loaded.insert(canonical.clone());
+                    dependency_graph.record_source(canonical, "import");
                     sources.push((candidate.to_string_lossy().into_owned(), module_content));
                     group_hit = true;
                 }
@@ -1280,7 +1370,19 @@ fn main() {
     // resolves imports only against already-loaded files, so without this
     // step `const utils = @import("utils")` fails with E0704 unless the
     // user hand-lists every module on the command line (RUE-14).
-    let mixed_imports = match discover_and_load_imports(&mut sources, source_manifest.as_ref()) {
+    let mut dependency_graph = DependencyGraph::default();
+    for (index, (path, _content)) in sources.iter().enumerate() {
+        if let Ok(canonical) = fs::canonicalize(path) {
+            let kind = if index == 0 { "root" } else { "positional" };
+            dependency_graph.record_source(canonical, kind);
+        }
+    }
+
+    let mixed_imports = match discover_and_load_imports(
+        &mut sources,
+        source_manifest.as_ref(),
+        &mut dependency_graph,
+    ) {
         Ok(mixed_imports) => mixed_imports,
         Err(()) => std::process::exit(1),
     };
@@ -1300,6 +1402,34 @@ fn main() {
         std::process::exit(1);
     }
     let sources = sources;
+
+    if options.emit_stages.contains(&EmitStage::Deps) {
+        if options.emit_stages.len() != 1 {
+            eprintln!("Error: --emit deps cannot be combined with other --emit stages");
+            std::process::exit(1);
+        }
+        if options.benchmark_json {
+            eprintln!(
+                "Error: --emit cannot be combined with --benchmark-json (both write to stdout)"
+            );
+            std::process::exit(1);
+        }
+        match serde_json::to_string_pretty(&dependency_graph.to_output()) {
+            Ok(json) => println!("{json}"),
+            Err(e) => {
+                eprintln!("Error emitting dependency graph: {e}");
+                std::process::exit(1);
+            }
+        }
+        print_timing_output(
+            &timing_data,
+            options.time_passes,
+            options.benchmark_json,
+            &options.target,
+            None,
+        );
+        return;
+    }
 
     // Build SourceFile structs for multi-file compilation
     let source_files: Vec<SourceFile<'_>> = sources
@@ -1764,6 +1894,7 @@ fn handle_emit_multi_file(
                     }
                 }
             }
+            EmitStage::Deps => unreachable!("--emit deps is handled before frontend emission"),
         }
     }
 
@@ -1973,6 +2104,12 @@ mod tests {
     fn parse_emit_asm() {
         let opts = unwrap_options(parse_args_from(&["--emit", "asm", "source.rue"]));
         assert_eq!(opts.emit_stages, vec![EmitStage::Asm]);
+    }
+
+    #[test]
+    fn parse_emit_deps() {
+        let opts = unwrap_options(parse_args_from(&["--emit", "deps", "source.rue"]));
+        assert_eq!(opts.emit_stages, vec![EmitStage::Deps]);
     }
 
     #[test]
@@ -2560,6 +2697,7 @@ mod tests {
             "stackframe".parse::<EmitStage>().unwrap(),
             EmitStage::StackFrame
         );
+        assert_eq!("deps".parse::<EmitStage>().unwrap(), EmitStage::Deps);
     }
 
     #[test]
@@ -2572,7 +2710,7 @@ mod tests {
     fn emit_stage_all_names() {
         assert_eq!(
             EmitStage::all_names(),
-            "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe"
+            "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe, deps"
         );
     }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,6 +49,18 @@ The manifest format is intentionally narrow: one source path per line, resolved
 relative to the manifest file; blank lines and `#` comments are ignored. Entries
 are allowed reads for `@import` resolution, not extra semantic roots.
 
+Build-system integrations can also ask Rue what it actually read while
+discovering the root import graph:
+
+```bash
+"$RUE" --emit deps main.rue
+```
+
+This prints JSON containing the canonical root source, all observed
+root/positional/imported source files, and resolved `@import` edges. It is the
+observed dependency graph; a source manifest is still the declared allowed-read
+set.
+
 Run `"$RUE" --help` for targets, preview features, optimization levels,
 logging, timing, manifests, and all emit stages.
 


### PR DESCRIPTION
## Summary

- add `--emit deps` as a JSON dependency-output mode for root-module builds
- report canonical root/positional/imported source files and resolved `@import` edges
- keep dependency output distinct from source manifests: manifests declare allowed reads; deps report observed reads
- document the build-system workflow and add CLI coverage for transitive imports and mixed emit rejection

## Validation

- `scripts/rue fmt`
- `./buck2 build //crates/rue:rue`
- `scripts/rue cli modules`
- `scripts/rue quick`
