### PR TITLE
[codex] Teach std Option in stats tutorial

### DIFF
--- a/examples/first/stats.rue
+++ b/examples/first/stats.rue
@@ -20,30 +20,25 @@
 // read a stream cleanly, with the postfix `?` doing the early-exit plumbing.
 //
 // The one rough edge that remains (RUE-287): no prelude yet, so `Option` is not
-// in scope automatically. Here it must be a *top-level* comptime-generic type
-// function, because a helper that returns `Option(i64)` names that type in its
-// signature — and an `@import`ed type cannot yet be named at a type position
-// (only bound to a local `let`). So `Option` is defined inline rather than
-// imported from the std library. Every peer language (Rust, Swift, Zig) has an
-// optional type built in.
+// in scope automatically. Import `std` explicitly, name the optional type as
+// `std.option.Option(i64)` in the helper signature, and use a local `OptInt`
+// alias for matching on `Some` and `None` in the loop below.
 //
 // Exercises the dogfooding set end to end: @read_line, @parse_i64, the `?`
-// operator, a generic Option, StrBuf concatenation + @to_string, println, a
+// operator, std.option.Option, StrBuf concatenation + @to_string, println, a
 // loop, and match.
 
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
+const std = @import("std");
 
 // Read one line and parse it as an integer. `?` on @read_line short-circuits to
 // None at end-of-input; the tail @parse_i64 is None if the line isn't a number.
-fn read_num() -> Option(i64) {
+fn read_num() -> std.option.Option(i64) {
     let line = @read_line()?;
     @parse_i64(line)
 }
 
 fn main() -> i32 {
-    let OptInt = Option(i64);
+    let OptInt = std.option.Option(i64);
 
     let mut count: i64 = 0;
     let mut sum: i64 = 0;

--- a/scripts/rue
+++ b/scripts/rue
@@ -36,7 +36,7 @@ case "$cmd" in
         # Compile via the real driver (so module resolution, -o, etc. behave
         # exactly as a user would see).
         bin="$(scripts/rue-bin)"
-        "$bin" "$@"
+        RUE_STD_PATH="${RUE_STD_PATH:-$repo_root/std}" "$bin" "$@"
         ;;
     exec)
         # Compile a single source to a temp executable and run it.
@@ -52,7 +52,7 @@ case "$cmd" in
         # skips a trailing `rm`, leaking the temp file (RUE-212). The trap
         # fires regardless of exit code, so cleanup always happens.
         trap 'rm -f "$out"' EXIT
-        "$bin" "$src" "$out"
+        RUE_STD_PATH="${RUE_STD_PATH:-$repo_root/std}" "$bin" "$src" "$out"
         # Run the program, capturing its exit code without letting `set -e`
         # abort first (`|| rc=$?`), then propagate it as our own exit code.
         rc=0

--- a/website/content/tutorial/10-putting-it-together.md
+++ b/website/content/tutorial/10-putting-it-together.md
@@ -17,17 +17,15 @@ loops, mutable accumulator state, string concatenation, and `println`.
 ## The Program
 
 ```rue check
-fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
+const std = @import("std");
 
-fn read_num() -> Option(i64) {
+fn read_num() -> std.option.Option(i64) {
     let line = @read_line()?;
     @parse_i64(line)
 }
 
 fn main() -> i32 {
-    let OptInt = Option(i64);
+    let OptInt = std.option.Option(i64);
 
     let mut count: i64 = 0;
     let mut sum: i64 = 0;
@@ -95,11 +93,11 @@ The complete checked-in version lives at
 
 ## Current Rough Edges
 
-There is no prelude yet, so `Option` is not automatically in scope. This example
-defines a small generic `Option(T)` inline because `read_num` names
-`Option(i64)` in its return type. As the standard library and type-position
-imports mature, tutorial code should move toward the explicit standard-library
-form taught in the modules and arrays chapters.
+There is no prelude yet, so `Option` is not automatically in scope. Import the
+standard library explicitly with `const std = @import("std");`, then name the
+standard-library optional type through that module: `std.option.Option(i64)`.
+The local `OptInt` binding is only a short alias for matching on `Some` and
+`None` without repeating the full module-qualified path.
 
 ## More Examples
 


### PR DESCRIPTION
## Summary

- update the first stats tutorial/example to use `std.option.Option(i64)` in type position
- keep the no-prelude note, but remove the stale inline `Option(T)` workaround
- make `scripts/rue run` and `scripts/rue exec` default `RUE_STD_PATH` to the checked-in `std/` directory so the documented command works

## Validation

- `scripts/check-tutorial-snippets.py`
- `printf '7\n5\n1\n' | scripts/rue exec examples/first/stats.rue` (prints the expected output and exits 3 because the example returns the count)
