### PR TITLE
[codex] Remove empty sema airgen module

### DIFF
--- a/crates/rue-air/src/sema/airgen.rs
+++ b/crates/rue-air/src/sema/airgen.rs
@@ -1,4 +1,0 @@
-//! AIR generation helpers.
-//!
-//! This module is kept for future expansion but currently most AIR generation
-//! is handled directly in the analysis module.

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -11,8 +11,7 @@
 //! - [`declarations`] - Declaration gathering (register_type_names, resolve_declarations)
 //! - [`builtins`] - Built-in type injection (String, etc.)
 //! - [`typeck`] - Type resolution and checking helpers
-//! - [`analysis`] - Function analysis and type inference coordination
-//! - [`airgen`] - RIR instruction to AIR instruction lowering
+//! - [`analysis`] - Function analysis, type inference coordination, and RIR-to-AIR lowering
 //! - [`info`] - Function, method, and constant info types
 //! - [`gather`] - Declaration gathering output
 //! - [`output`] - Semantic analysis output types
@@ -26,7 +25,6 @@
 //! - [`Sema::analyze_all`] - Perform full semantic analysis
 //! - [`Sema::analyze_all_bodies`] - Analyze function bodies after declarations
 
-mod airgen;
 mod analysis;
 mod analyze_ops;
 mod anon_structs;


### PR DESCRIPTION
## Summary

- removes the empty `sema::airgen` placeholder module
- updates sema module docs to point at `analysis` as the current home for RIR-to-AIR lowering

## Why

RUE-458 identified `airgen.rs` as vestigial structure: it had no implementation and no users beyond the module declaration and docs. Keeping it made the sema package look more factored than it is and sent contributors toward the wrong file.

## Validation

- `./buck2 test //crates/rue-air:rue-air-test`

Linear: RUE-458