### PR TITLE
[codex] Silence std internal helper warning

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -323,6 +323,7 @@ fn main() -> i32 {
 }
 """ }]
 env = { RUE_STD_PATH = "${REAL_STD}" }
+compile_stderr_not_contains = ["unused function", "exit_syscall_number"]
 stdout = "5\n"
 
 # A genuinely missing module should be a clean error (works today).

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -13,7 +13,7 @@ pub const math = @import("math.rue");
 pub const option = @import("option.rue");
 pub const arraybuf = @import("arraybuf.rue");
 
-fn exit_syscall_number() -> u64 {
+fn _exit_syscall_number() -> u64 {
     match @target_arch() {
         Arch::X86_64 => {
             match @target_os() {
@@ -34,7 +34,7 @@ fn exit_syscall_number() -> u64 {
 ///
 /// This terminates immediately and does not return.
 pub fn exit(code: u64) -> ! {
-    let syscall_num = exit_syscall_number();
+    let syscall_num = _exit_syscall_number();
     checked {
         @syscall(syscall_num, code);
     };


### PR DESCRIPTION
## Summary

- renames the internal std exit syscall helper with a leading underscore
- adds a CLI regression asserting real-std imports do not leak `unused function` warnings for std internals

## Why

A clean user program importing `std` emitted an unused-function warning for `std/_std.rue:exit_syscall_number`. The helper is intentionally internal; ordinary std use should not make user builds noisy.

## Validation

- direct repro with `RUE_STD_PATH=std rue main.rue -o prog` now emits no warning
- `./buck2 test //crates/rue-cli-tests:rue-cli-tests-test`
- `./buck2 test //:cli-tests`

Linear: RUE-452