### PR TITLE
[codex] Add negative compiler stdout assertions

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -186,6 +186,11 @@ pub fn value() -> i32 {
     42
 }
 """ },
+    { path = "unused.rue", source = """
+pub fn unused() -> i32 {
+    99
+}
+""" },
 ]
 args = ["--emit", "deps", "main.rue"]
 compile_only = true
@@ -202,6 +207,7 @@ compile_stdout_contains = [
     "\"specifier\": \"leaf\"",
     "\"resolved\":",
 ]
+compile_stdout_not_contains = ["unused.rue"]
 
 [[case]]
 name = "emit_deps_rejects_mixed_emit_stages"

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -42,7 +42,8 @@
 //! - `stdin`: piped to the compiled program when it runs
 //! - `compile_fail` + `error_contains`: expect compilation failure
 //! - `compile_only`: don't run the produced binary
-//! - `compile_stdout_contains`: assert on compiler stdout (e.g. `--emit`)
+//! - `compile_stdout_contains`: substrings that must appear in compiler stdout (e.g. `--emit`)
+//! - `compile_stdout_not_contains`: substrings that must not appear in compiler stdout
 //! - `stdout` / `stdout_contains`: assert on the program's stdout
 //! - `runtime_error_contains`: assert on the program's stderr
 //! - `exit_code`: expected program exit code (default 0)
@@ -263,6 +264,9 @@ struct Case {
     /// Substrings expected in the compiler's stdout (e.g. `--emit` output).
     #[serde(default)]
     compile_stdout_contains: Vec<String>,
+    /// Substrings that must NOT appear in the compiler's stdout.
+    #[serde(default)]
+    compile_stdout_not_contains: Vec<String>,
     /// Substrings that MUST appear in the compiler's stderr, regardless of
     /// whether compilation succeeds or fails. Use for warnings that must
     /// survive a successful compile (e.g. under `--emit`).
@@ -457,6 +461,15 @@ fn run_case(
             return Err(format!(
                 "compiler stdout mismatch:\n  expected to contain: {}\n--- actual stdout ---\n{}",
                 expected, compile_stdout
+            ));
+        }
+    }
+
+    for forbidden in &case.compile_stdout_not_contains {
+        if compile_stdout.contains(forbidden) {
+            return Err(format!(
+                "compiler stdout contained forbidden substring: {}\n--- actual stdout ---\n{}",
+                forbidden, compile_stdout
             ));
         }
     }


### PR DESCRIPTION
## Summary

- adds `compile_stdout_not_contains` to the CLI test case schema
- documents the new field in the case-format comment
- uses it in the `--emit deps` JSON case to assert an unimported source file is absent from dependency output

## Why

RUE-453 identified that compiler-output modes could assert expected stdout substrings, but could not assert that unwanted output was absent. That made machine-readable outputs such as dependency JSON harder to pin precisely.

## Validation

- `./buck2 test //crates/rue-cli-tests:rue-cli-tests-test`
- `./buck2 test //:cli-tests`

Linear: RUE-453