### PR TITLE
[codex] Reject stack-unbalanced returns

### DIFF
--- a/crates/rue-codegen/src/aarch64/verify.rs
+++ b/crates/rue-codegen/src/aarch64/verify.rs
@@ -126,6 +126,10 @@ impl StackVerifyAdapter for Aarch64StackVerifyAdapter<'_> {
         }
     }
 
+    fn is_return(&self, inst: &Self::Inst) -> bool {
+        matches!(inst, Aarch64Inst::Ret)
+    }
+
     fn alignment_violation(&self, inst: &Self::Inst, current_depth: i64) -> Option<String> {
         match inst {
             Aarch64Inst::Bl { .. } => {
@@ -355,5 +359,22 @@ mod tests {
         mir.push(Aarch64Inst::Ret);
 
         assert!(verify_stack_alignment(&mir).is_ok());
+    }
+
+    #[test]
+    fn test_unbalanced_sub_sp_before_return_fails() {
+        let mir = make_mir(vec![
+            Aarch64Inst::SubImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: 16,
+            },
+            Aarch64Inst::Ret,
+        ]);
+
+        let result = verify_stack_alignment(&mir);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("balanced stack depth"));
     }
 }

--- a/crates/rue-codegen/src/stack_verify.rs
+++ b/crates/rue-codegen/src/stack_verify.rs
@@ -29,6 +29,9 @@ pub trait StackVerifyAdapter {
     /// Jump target labels referenced by `inst`.
     fn jump_targets<'a>(&self, inst: &'a Self::Inst) -> &'a [LabelId];
 
+    /// Whether `inst` returns from the current function.
+    fn is_return(&self, inst: &Self::Inst) -> bool;
+
     /// Return an alignment error message if `inst` observes an invalid stack
     /// depth for this target.
     fn alignment_violation(&self, inst: &Self::Inst, current_depth: i64) -> Option<String>;
@@ -84,6 +87,18 @@ where
 
         if let Some(message) = self.adapter.alignment_violation(inst, self.current_depth) {
             return Err(self.adapter.error(idx, inst, self.current_depth, message));
+        }
+
+        if self.adapter.is_return(inst) && self.current_depth != 0 {
+            return Err(self.adapter.error(
+                idx,
+                inst,
+                self.current_depth,
+                format!(
+                    "return requires balanced stack depth, but depth is {} bytes",
+                    self.current_depth
+                ),
+            ));
         }
 
         if let Some(label) = self.adapter.label(inst) {

--- a/crates/rue-codegen/src/x86_64/verify.rs
+++ b/crates/rue-codegen/src/x86_64/verify.rs
@@ -115,6 +115,10 @@ impl StackVerifyAdapter for X86StackVerifyAdapter<'_> {
         }
     }
 
+    fn is_return(&self, inst: &Self::Inst) -> bool {
+        matches!(inst, X86Inst::Ret)
+    }
+
     fn alignment_violation(&self, inst: &Self::Inst, current_depth: i64) -> Option<String> {
         match inst {
             X86Inst::CallRel { .. } => {
@@ -324,5 +328,36 @@ mod tests {
 
         let result = verify_stack_alignment(&mir);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unbalanced_push_before_return_fails() {
+        let mir = make_mir(vec![
+            X86Inst::Push {
+                src: Operand::Physical(Reg::Rax),
+            },
+            X86Inst::Ret,
+        ]);
+
+        let result = verify_stack_alignment(&mir);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("balanced stack depth"));
+    }
+
+    #[test]
+    fn test_unbalanced_sub_rsp_before_return_fails() {
+        let mir = make_mir(vec![
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: -8,
+            },
+            X86Inst::Ret,
+        ]);
+
+        let result = verify_stack_alignment(&mir);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("balanced stack depth"));
     }
 }


### PR DESCRIPTION
## Summary

- Teach the shared stack verifier which target instructions return from the current function.
- Reject `ret` instructions when the tracked stack depth is nonzero.
- Add x86_64 and AArch64 verifier coverage for unbalanced return paths.

Fixes RUE-463.

## Validation

- `./buck2 test //crates/rue-codegen:rue-codegen-test`
- `./clippy.sh`
