### PR TITLE
[codex] Clean stale SemaContext references

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -588,9 +588,9 @@ impl Air {
 
     /// Remap string constant IDs using the provided mapping function.
     ///
-    /// This is used after parallel function analysis to convert local string IDs
-    /// (per-function) to global string IDs (across all functions). The mapping
-    /// function takes a local string ID and returns the global string ID.
+    /// This is used after per-function analysis to convert local string IDs
+    /// to global string IDs across all analyzed functions. The mapping function
+    /// takes a local string ID and returns the global string ID.
     pub fn remap_string_ids<F>(&mut self, map_fn: F)
     where
         F: Fn(u32) -> u32,

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -1097,8 +1097,8 @@ impl Default for TypeInternPool {
 impl Clone for TypeInternPool {
     /// Clone the pool by copying all type data into a new pool.
     ///
-    /// This is used when building `SemaContext` from `Sema`, as the context
-    /// needs its own copy of the pool for thread-safe sharing.
+    /// This is used when analysis needs an independent copy of the pool while
+    /// preserving the already-interned type data.
     fn clone(&self) -> Self {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         Self {

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -13,11 +13,11 @@
 mod inference;
 mod inst;
 mod intern_pool;
+mod module_registry;
 mod param_arena;
 mod path_norm;
 mod scope;
 mod sema;
-mod sema_context;
 pub mod specialize;
 mod types;
 
@@ -33,11 +33,11 @@ pub use inst::{
 pub use intern_pool::{
     EnumData, InternedType, StructData, TypeData, TypeInternPool, TypeInternPoolStats,
 };
+pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};
 pub use sema::{
     AnalyzedFunction, ConstValue, FunctionInfo, GatherOutput, MethodInfo, Sema, SemaOutput,
 };
-pub use sema_context::ModuleRegistry;
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,
     StructField, StructId, Type, TypeKind, parse_array_type_syntax,

--- a/crates/rue-air/src/module_registry.rs
+++ b/crates/rue-air/src/module_registry.rs
@@ -6,9 +6,6 @@
 //! `RwLock` with double-checked locking (read lock for lookups, write lock
 //! only for new insertions).
 //!
-//! The `SemaContext` type that gave this file its name was part of the dead
-//! parallel-analysis pipeline and was removed per ADR-0033 phase 1b.
-
 use std::collections::HashMap;
 use std::sync::{PoisonError, RwLock};
 
@@ -25,8 +22,8 @@ fn normalize_key(path: &str) -> String {
 
 /// Thread-safe registry for modules.
 ///
-/// This registry allows concurrent lookups and insertions of imported modules during
-/// parallel function analysis. It uses double-checked locking to minimize contention.
+/// This registry allows concurrent lookups and insertions of imported modules.
+/// It uses double-checked locking to minimize contention.
 #[derive(Debug)]
 pub struct ModuleRegistry {
     /// Maps a module's *resolved* file path (normalized) to its ModuleId.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -8,9 +8,7 @@
 //!
 //! Two drivers share these analysis functions: the eager path (single-file
 //! compilation analyzes every function) and the lazy path (multi-file
-//! compilation analyzes only reachable functions, per ADR-0026). A third,
-//! parallel `SemaContext`-based pipeline and its hand-mirrored `_ctx`
-//! function family were dead code and were removed per ADR-0033 phase 1.
+//! compilation analyzes only reachable functions, per ADR-0026).
 
 use std::collections::{HashMap, HashSet};
 
@@ -41,8 +39,8 @@ use crate::types::{ModuleId, StructField, StructId, Type, TypeKind};
 /// Main entry point for analyzing all function bodies.
 ///
 /// Called from Sema::analyze_all after declarations are collected.
-/// Currently uses the sequential analysis path while the parallel infrastructure
-/// is being completed.
+/// Uses the lazy driver for import graphs and the eager driver for single-file
+/// compilations.
 pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResult<SemaOutput> {
     // Use lazy analysis when imports are present (multi-file compilation)
     // This ensures only reachable code is analyzed, per ADR-0026

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -234,7 +234,7 @@ impl<'a> Sema<'a> {
     /// avoiding the cost of rebuilding maps for each function.
     ///
     /// Returns (air, num_locals, num_param_slots, param_modes, warnings).
-    /// Warnings are collected per-function to enable future parallel analysis.
+    /// Warnings are collected per-function and merged during finalization.
     pub(super) fn analyze_function(
         &mut self,
         infer_ctx: &InferenceContext,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -65,7 +65,7 @@ impl<'a> Sema<'a> {
                 continue;
             }
 
-            // Emit warning with help suggestion (to ctx.warnings for parallel safety)
+            // Emit warning with help suggestion into this function's warning buffer.
             ctx.warnings.push(
                 CompileWarning::new(WarningKind::UnusedVariable(name.to_string()), local.span)
                     .with_help(format!(

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -403,7 +403,7 @@ impl<'a> Sema<'a> {
                 } else {
                     self.builtin_string_type()
                 };
-                // Add string to the local string table (per-function for parallel analysis)
+                // Add string to the local per-function string table.
                 let string_content = self.interner.resolve(&*symbol).to_string();
 
                 // Capacity-fits legality (ADR-0043 Phase 5, RUE-326): a string

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -345,15 +345,15 @@ pub(crate) struct AnalysisContext<'a> {
     /// Variables that have been moved (for affine type checking).
     /// Maps variable symbol to move state (supports partial/field-level moves).
     pub moved_vars: HashMap<Spur, VariableMoveState>,
-    /// Warnings collected during function analysis.
-    /// This is per-function to enable future parallel analysis.
+    /// Warnings collected during this function's analysis.
+    /// Finalization merges these per-function warnings into the global output.
     pub warnings: Vec<CompileWarning>,
     /// Whether the current function carries `@allow(unused_variable)`.
     /// When set, every local unused-variable warning in this body is
     /// suppressed (spec 2.5:17).
     pub allow_unused_variables: bool,
     /// Local string table: maps string content to local index (for deduplication within function).
-    /// This is per-function to enable parallel analysis - strings are merged globally after.
+    /// Finalization merges these strings globally after body analysis.
     pub local_string_table: HashMap<String, u32>,
     /// Local string data indexed by local string table index.
     /// After analysis, these are merged into the global string table with ID remapping.

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -21,14 +21,14 @@ use super::{KnownSymbols, Sema};
 ///
 /// This contains the state built during declaration gathering that is needed
 /// for function body analysis. After gathering, this can be converted back
-/// into a `Sema` for sequential analysis, or used to drive parallel analysis.
+/// into a `Sema` for the eager or lazy analysis drivers.
 ///
 /// # Architecture
 ///
 /// The separation of declaration gathering from body analysis enables:
-/// 1. **Parallel type checking** - Each function can be analyzed independently
+/// 1. **Independent body analysis** - Each function body has an explicit analysis boundary
 /// 2. **Clearer architecture** - Separation of concerns
-/// 3. **Foundation for incremental** - Can cache SemaContext across compilations
+/// 3. **Foundation for incremental** - Gathered declarations can become cacheable inputs
 /// 4. **Better error recovery** - One function's error doesn't block others
 ///
 /// # Usage
@@ -38,12 +38,10 @@ use super::{KnownSymbols, Sema};
 /// let sema = Sema::new(rir, interner, preview);
 /// let output = sema.analyze_all()?;
 ///
-/// // Option B: Parallel path (work in progress)
-/// // Build SemaContext and analyze in parallel
-/// let ctx = sema.build_sema_context();
-/// let results: Vec<_> = functions.par_iter()
-///     .map(|f| analyze_function_body(&ctx, f))
-///     .collect();
+/// // Option B: Split path - gather declarations, then analyze bodies
+/// let gather = sema.gather_declarations()?;
+/// let sema = gather.into_sema();
+/// let output = sema.analyze_all()?;
 /// ```
 #[derive(Debug)]
 pub struct GatherOutput<'a> {
@@ -102,7 +100,7 @@ impl<'a> GatherOutput<'a> {
             builtin_os_id: self.builtin_os_id,
             known: KnownSymbols::new(self.interner),
             type_pool: self.type_pool,
-            module_registry: crate::sema_context::ModuleRegistry::new(),
+            module_registry: crate::module_registry::ModuleRegistry::new(),
             file_paths: HashMap::new(),
             param_arena: self.param_arena,
             anon_struct_method_sigs: HashMap::new(),

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -29,8 +29,8 @@ use lasso::{Spur, ThreadedRodeo};
 
 /// Pre-interned symbols for known strings.
 ///
-/// This struct is created once during `SemaContext` construction and provides
-/// fast symbol comparison for intrinsic dispatch and other common lookups.
+/// This struct is created once during semantic-analysis setup and provides fast
+/// symbol comparison for intrinsic dispatch and other common lookups.
 #[derive(Debug, Clone, Copy)]
 pub struct KnownSymbols {
     // Intrinsic names
@@ -117,7 +117,7 @@ pub struct KnownSymbols {
 impl KnownSymbols {
     /// Create a new `KnownSymbols` by interning all known strings.
     ///
-    /// This should be called once during `SemaContext` construction.
+    /// This should be called once during semantic-analysis setup.
     pub fn new(interner: &ThreadedRodeo) -> Self {
         Self {
             // Intrinsic names

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -100,7 +100,7 @@ pub struct Sema<'a> {
     /// Type intern pool for unified type representation (ADR-0024 Phase 1).
     pub(crate) type_pool: TypeInternPool,
     /// Module registry for tracking imported modules (Phase 1 modules).
-    pub(crate) module_registry: crate::sema_context::ModuleRegistry,
+    pub(crate) module_registry: crate::module_registry::ModuleRegistry,
     /// Maps FileId to source file paths (for module resolution).
     pub(crate) file_paths: HashMap<FileId, String>,
     /// Arena storage for function/method parameter data.
@@ -180,7 +180,7 @@ impl<'a> Sema<'a> {
             builtin_os_id: None,
             known: KnownSymbols::new(interner),
             type_pool: TypeInternPool::new(),
-            module_registry: crate::sema_context::ModuleRegistry::new(),
+            module_registry: crate::module_registry::ModuleRegistry::new(),
             file_paths: HashMap::new(),
             param_arena: ParamArena::new(),
             anon_struct_method_sigs: HashMap::new(),


### PR DESCRIPTION
## Summary

- Rename `sema_context.rs` to `module_registry.rs` now that the old SemaContext pipeline is gone.
- Update sema docs and comments to describe the current eager/lazy analysis drivers.
- Remove stale `SemaContext`, `build_sema_context`, and removed parallel-pipeline references from rue-air comments.

Fixes RUE-462.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue-air:rue-air-test`
- `./clippy.sh`
