### PR TITLE
[codex] Add Buck targets for repo quality gates

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1,10 +1,10 @@
 # Repo-root test-suite targets (RUE-144 / RUE-132).
 #
 # Each sh_test ties a test-harness binary to the rue compiler and the on-disk
-# inputs the suite actually reads (cases/, std/), so Buck owns the binary
+# inputs the suite actually reads (cases/, std/, docs/), so Buck owns the binary
 # handoff and caches each suite against its real inputs:
 #
-#   buck2 test //...        # runs unit tests + spec + UI + CLI suites
+#   buck2 test //...        # runs unit tests + spec/UI/CLI suites + repo gates
 #
 # An edit under crates/rue-spec/cases/ re-runs only the spec suite; an edit
 # under std/ re-runs the CLI suite (std/ MUST be a declared input here or the
@@ -45,6 +45,16 @@ filegroup(
     srcs = glob(["website/content/tutorial/**"]),
 )
 
+filegroup(
+    name = "spec-docs",
+    srcs = glob(["docs/spec/src/**"]),
+)
+
+filegroup(
+    name = "adr-designs",
+    srcs = glob(["docs/designs/**"]),
+)
+
 sh_test(
     name = "spec-tests",
     test = "//crates/rue-spec:rue-spec",
@@ -52,6 +62,16 @@ sh_test(
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
+    },
+)
+
+sh_test(
+    name = "spec-traceability",
+    test = "//crates/rue-spec:rue-spec",
+    args = ["--traceability"],
+    env = {
+        "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
+        "RUE_SPEC_DIR": "$(location :spec-docs)/docs/spec/src",
     },
 )
 
@@ -87,4 +107,13 @@ sh_test(
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
     },
+)
+
+sh_test(
+    name = "adr-registry-validation",
+    test = "scripts/validate-adrs.py",
+    args = [
+        "--adr-dir",
+        "$(location :adr-designs)/docs/designs",
+    ],
 )

--- a/crates/rue-spec/README.md
+++ b/crates/rue-spec/README.md
@@ -167,12 +167,14 @@ Generate a report showing test coverage of spec paragraphs:
 ```bash
 # Summary report
 ./buck2 run //crates/rue-spec:rue-spec -- --traceability
+./buck2 test //:spec-traceability
 
 # Detailed matrix (shows all paragraphs and their covering tests)
 ./buck2 run //crates/rue-spec:rue-spec -- --traceability --detailed
 ```
 
-The traceability check is run as part of `./test.sh` and fails if:
+The traceability check is run as the `//:spec-traceability` Buck target and is
+included in `./test.sh` and `./buck2 test //...`. It fails if:
 - Any spec paragraph has no covering test (coverage < 100%)
 - Any test references a non-existent spec paragraph ID
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -137,6 +137,13 @@ Or run the Buck target used by CI-style validation:
 ./buck2 test //:tutorial-snippet-tests
 ```
 
+Repository-wide quality gates are also Buck targets, so `./buck2 test //...`
+includes spec traceability and ADR registry validation. To run them directly:
+
+```bash
+./buck2 test //:spec-traceability //:adr-registry-validation
+```
+
 During implementation, use the narrowest relevant command. Before submitting:
 
 ```bash

--- a/scripts/validate-adrs.py
+++ b/scripts/validate-adrs.py
@@ -10,8 +10,6 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parent.parent
-ADR_DIR = ROOT / "docs" / "designs"
-README = ADR_DIR / "README.md"
 START = "<!-- ADR-INDEX:START -->"
 END = "<!-- ADR-INDEX:END -->"
 ALLOWED_STATUSES = {"proposal", "accepted", "implemented", "stable", "superseded", "rejected"}
@@ -73,22 +71,32 @@ def build_index(adrs: list[tuple[Path, dict[str, str]]]) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--write", action="store_true", help="regenerate the README index")
+    parser.add_argument(
+        "--adr-dir",
+        type=Path,
+        default=ROOT / "docs" / "designs",
+        help="directory containing ADR markdown files and README.md",
+    )
     args = parser.parse_args()
+
+    adr_dir = args.adr_dir.resolve()
+    readme_path = adr_dir / "README.md"
+    display_root = adr_dir.parent.parent
 
     errors: list[str] = []
     adrs: list[tuple[Path, dict[str, str]]] = []
     ids: dict[str, Path] = {}
-    paths = sorted(ADR_DIR.glob("[0-9][0-9][0-9][0-9]-*.md"))
+    paths = sorted(adr_dir.glob("[0-9][0-9][0-9][0-9]-*.md"))
 
     for path in paths:
         try:
             fields = parse_frontmatter(path)
         except ValueError as error:
-            errors.append(f"{path.relative_to(ROOT)}: {error}")
+            errors.append(f"{path.relative_to(display_root)}: {error}")
             continue
         for key in ("id", "title", "status", "tags", "created"):
             if not fields.get(key):
-                errors.append(f"{path.relative_to(ROOT)}: missing required field {key!r}")
+                errors.append(f"{path.relative_to(display_root)}: missing required field {key!r}")
         adr_id = unquote(fields.get("id", ""))
         status = unquote(fields.get("status", ""))
         fields["id"] = adr_id
@@ -111,11 +119,11 @@ def main() -> int:
                 by_filename = any(candidate.stem == normalized for candidate, _ in adrs)
                 if not by_filename:
                     errors.append(
-                        f"{path.relative_to(ROOT)}: {key} target {target!r} does not resolve"
+                        f"{path.relative_to(display_root)}: {key} target {target!r} does not resolve"
                     )
 
     expected = build_index(adrs)
-    readme = README.read_text()
+    readme = readme_path.read_text()
     if START not in readme or END not in readme:
         errors.append("docs/designs/README.md: missing generated index markers")
     else:
@@ -124,7 +132,7 @@ def main() -> int:
         actual = START + remainder.split(END, 1)[0] + END
         if actual != expected:
             if args.write:
-                README.write_text(before + expected + after)
+                readme_path.write_text(before + expected + after)
             else:
                 errors.append("docs/designs/README.md: ADR index is stale; run scripts/validate-adrs.py --write")
 

--- a/test.sh
+++ b/test.sh
@@ -4,10 +4,11 @@ set -euo pipefail
 # Run all tests for the rue compiler.
 #
 # Every suite is a Buck test target, so one `buck2 test //...` runs the unit
-# tests for ALL crates plus the spec/UI/CLI harness suites and tutorial snippet
-# checker (the root BUCK file's sh_tests, which declare the rue binary, cases/,
-# std/, and tutorial markdown as inputs — Buck owns the binary handoff instead
-# of a shell pipeline). Using //...
+# tests for ALL crates plus the spec/UI/CLI harness suites, tutorial snippet
+# checker, spec traceability gate, and ADR registry validator (the root BUCK
+# file's sh_tests, which declare the rue binary, cases/, std/, docs/, and
+# tutorial markdown as inputs — Buck owns the binary handoff instead of a shell
+# pipeline). Using //...
 # rather than a hand-maintained target list also keeps new crates from being
 # silently omitted. (RUE-132, RUE-144)
 #
@@ -45,13 +46,7 @@ else
     RUE_EXAMPLES_DIR="examples" \
     RUE_STD_DIR="std" \
     ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- --quiet "$@"
+
+    echo "Running repository quality gates..."
+    ./buck2 test //:spec-traceability //:adr-registry-validation
 fi
-
-# Run traceability check (fails if coverage < 100% or orphan references exist)
-echo "Running spec traceability check..."
-RUE_SPEC_DIR="docs/spec/src" \
-RUE_SPEC_CASES="crates/rue-spec/cases" \
-./buck2 run //crates/rue-spec:rue-spec -- --traceability
-
-echo "Validating ADR registry..."
-scripts/validate-adrs.py


### PR DESCRIPTION
## Summary

- Add root Buck `sh_test` targets for spec traceability and ADR registry validation.
- Declare spec docs and ADR docs as Buck inputs for those gates.
- Teach `scripts/validate-adrs.py` to accept an explicit ADR directory for Buck execution.
- Update `test.sh` and docs so `./buck2 test //...` is the complete test graph for these gates.

Fixes RUE-464.

## Validation

- `./fmt.sh`
- `scripts/validate-adrs.py`
- `scripts/validate-adrs.py --adr-dir docs/designs`
- `./buck2 test //:spec-traceability //:adr-registry-validation`
- `./buck2 test //...`
