### PR TITLE
[codex] Retire pass_aux_files fixtures

### DIFF
--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -464,10 +464,12 @@ exit_code = 42
 [[case]]
 name = "same_dir_private_assoc_fn_allowed"
 spec = ["10.4:19"]
-description = "Intra-directory visibility is unchanged: an associated-function call on a private struct in another listed file in the same directory is allowed"
+description = "Intra-directory visibility is unchanged: an associated-function call on a private struct in an imported same-directory module is allowed"
 source = """
+const lib = @import("lib");
+
 fn main() -> i32 {
-    let s = Secret::make();
+    let s = lib.Secret::make();
     s.n
 }
 """
@@ -477,7 +479,6 @@ struct Secret {
     fn make() -> Secret { Secret { n: 42 } }
 }
 """ }
-pass_aux_files = true
 exit_code = 42
 
 [[case]]

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -2,7 +2,7 @@
 id = "modules.composition"
 spec_chapter = "10.5"
 name = "Program Composition"
-description = "Cross-file name collisions in the (transitional) flat namespace (spec chapter 10.5)."
+description = "Cross-file name collisions among modules loaded through the root import graph (spec chapter 10.5)."
 
 [[case]]
 name = "duplicate_symbol_across_imported_files_error"
@@ -39,33 +39,3 @@ pub fn go2() -> i32 { LIMIT }
 """ }
 compile_fail = true
 error_contains = "duplicate"
-
-# Cross-KIND collisions across files: a top-level item is a function, struct,
-# enum, OR constant, and all four share one name space (RUE-239). A function
-# in one file and a struct with the same name in another collide (E0436),
-# regardless of order or visibility.
-[[case]]
-name = "duplicate_fn_and_struct_across_files_error"
-spec = ["10.5:1"]
-description = "A function and a struct with the same name collide across files (one shared top-level name space)"
-source = """
-fn Thing() -> i32 { 5 }
-fn main() -> i32 { Thing() }
-"""
-aux_files = { "other.rue" = "pub struct Thing { n: i32 }" }
-pass_aux_files = true
-compile_fail = true
-error_contains = "E0436"
-
-[[case]]
-name = "duplicate_enum_and_const_across_files_error"
-spec = ["10.5:1"]
-description = "An enum and a constant with the same name collide across files (E0436)"
-source = """
-enum Color { Red, Green }
-fn main() -> i32 { 0 }
-"""
-aux_files = { "other.rue" = "pub const Color: i32 = 5;" }
-pass_aux_files = true
-compile_fail = true
-error_contains = "E0436"

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -227,8 +227,8 @@ exit_code = 42
 # =============================================================================
 # Privacy is uniform (10.3:7): a private function in a file in another
 # directory is rejected when called unqualified (E0460), whether that file
-# was imported or only listed explicitly. The flat namespace (10.5:2) only
-# resolves names — pub items remain callable without imports (10.3:8).
+# was imported. The flat namespace (10.5:2) only resolves names — pub items
+# remain callable without qualification (10.3:8).
 
 [[case]]
 name = "cross_dir_unqualified_private_fn_error"
@@ -251,7 +251,7 @@ error_contains = "is private (defined in"
 
 [[case]]
 name = "cross_dir_unqualified_pub_fn_allowed"
-spec = ["10.3:7", "10.5:2"]
+spec = ["10.3:7", "10.3:8", "10.5:2"]
 description = "Unqualified call to a pub function of an imported module still resolves (transitional flat namespace)"
 source = """
 const utils = @import("subdir/utils");
@@ -285,64 +285,12 @@ fn internal_fn() -> i32 {
 """ }
 exit_code = 42
 
-[[case]]
-name = "flat_multifile_unqualified_private_fn_error"
-spec = ["10.3:7", "10.3:8"]
-description = "Uniform privacy (RUE-180): a never-imported file listed explicitly is still private — cross-directory unqualified private call is E0460"
-source = """
-fn main() -> i32 {
-    internal_fn()
-}
-"""
-aux_files = { "subdir/utils.rue" = """
-fn internal_fn() -> i32 {
-    42
-}
-""" }
-pass_aux_files = true
-compile_fail = true
-error_contains = "is private (defined in"
-
-[[case]]
-name = "flat_multifile_unqualified_pub_fn_allowed"
-spec = ["10.3:8", "10.5:2"]
-description = "The flat namespace still resolves names without imports: a pub function in another never-imported directory is callable unqualified"
-source = """
-fn main() -> i32 {
-    public_fn()
-}
-"""
-aux_files = { "subdir/utils.rue" = """
-pub fn public_fn() -> i32 {
-    42
-}
-""" }
-pass_aux_files = true
-exit_code = 42
-
-[[case]]
-name = "flat_multifile_same_dir_private_fn_allowed"
-spec = ["10.3:2", "10.3:8"]
-description = "Intra-directory visibility (ADR-0026) is unchanged: a private function in another listed file in the same directory is callable unqualified"
-source = """
-fn main() -> i32 {
-    internal_fn()
-}
-"""
-aux_files = { "utils.rue" = """
-fn internal_fn() -> i32 {
-    42
-}
-""" }
-pass_aux_files = true
-exit_code = 42
-
 # =============================================================================
 # Unqualified Cross-Directory Access: Structs and Constants (RUE-183)
 # =============================================================================
 # The uniform privacy rule (10.3:7) covers every item kind, not just
 # functions: naming a private struct (annotation or literal) or reading a
-# private constant from another directory is E0460, imported or flat-listed.
+# private constant from another directory is E0460 through an imported module.
 
 [[case]]
 name = "cross_dir_unqualified_private_struct_error"
@@ -382,106 +330,12 @@ const LIMIT: i32 = 42;
 compile_fail = true
 error_contains = "constant `LIMIT` is private (defined in"
 
-[[case]]
-name = "flat_multifile_unqualified_private_struct_error"
-spec = ["10.3:7", "10.3:8"]
-description = "Uniform privacy: a private struct in a never-imported, explicitly listed file in another directory is not nameable unqualified"
-source = """
-fn main() -> i32 {
-    let p: Point = Point { x: 40, y: 2 };
-    p.x + p.y
-}
-"""
-aux_files = { "subdir/defs.rue" = """
-struct Point {
-    x: i32,
-    y: i32,
-}
-""" }
-pass_aux_files = true
-compile_fail = true
-error_contains = "struct `Point` is private (defined in"
-
-[[case]]
-name = "flat_multifile_unqualified_private_const_error"
-spec = ["10.3:7", "10.3:8"]
-description = "Uniform privacy: a private constant in a never-imported, explicitly listed file in another directory is not readable unqualified"
-source = """
-fn main() -> i32 {
-    LIMIT
-}
-"""
-aux_files = { "subdir/defs.rue" = """
-const LIMIT: i32 = 42;
-""" }
-pass_aux_files = true
-compile_fail = true
-error_contains = "constant `LIMIT` is private (defined in"
-
-[[case]]
-name = "cross_dir_const_initializer_private_const_error"
-spec = ["10.3:7"]
-description = "A constant initializer reading a private constant from another directory is rejected too"
-source = """
-const X: i32 = LIMIT;
-
-fn main() -> i32 {
-    X
-}
-"""
-aux_files = { "subdir/defs.rue" = """
-const LIMIT: i32 = 42;
-""" }
-pass_aux_files = true
-compile_fail = true
-error_contains = "constant `LIMIT` is private (defined in"
-
-[[case]]
-name = "flat_multifile_unqualified_pub_struct_and_const_allowed"
-spec = ["10.3:8", "10.5:2"]
-description = "The flat namespace still resolves pub structs and constants across directories without imports"
-source = """
-fn main() -> i32 {
-    let p: Point = Point { x: 30, y: 2 };
-    p.x + p.y + BONUS
-}
-"""
-aux_files = { "subdir/defs.rue" = """
-pub struct Point {
-    x: i32,
-    y: i32,
-}
-pub const BONUS: i32 = 10;
-""" }
-pass_aux_files = true
-exit_code = 42
-
-[[case]]
-name = "flat_multifile_same_dir_private_struct_and_const_allowed"
-spec = ["10.3:2", "10.3:8"]
-description = "Intra-directory visibility (ADR-0026) is unchanged: private structs and constants in another listed file in the same directory are usable unqualified"
-source = """
-fn main() -> i32 {
-    let p: Point = Point { x: 30, y: 2 };
-    p.x + p.y + BONUS
-}
-"""
-aux_files = { "defs.rue" = """
-struct Point {
-    x: i32,
-    y: i32,
-}
-const BONUS: i32 = 10;
-""" }
-pass_aux_files = true
-exit_code = 42
-
 # =============================================================================
 # Unqualified Cross-Directory Access: Enums (RUE-185)
 # =============================================================================
 # The uniform privacy rule (10.3:7) covers enums too: naming a private enum
 # from another directory — in a type annotation, a variant construction, or a
-# match pattern — is E0460, imported or flat-listed.
+# match pattern — is E0460 through an imported module.
 
 [[case]]
 name = "cross_dir_unqualified_private_enum_error"
@@ -504,158 +358,3 @@ enum Color {
 """ }
 compile_fail = true
 error_contains = "enum `Color` is private (defined in"
-
-[[case]]
-name = "flat_multifile_unqualified_private_enum_construction_error"
-spec = ["10.3:7", "10.3:8"]
-description = "Uniform privacy: constructing a variant of a private enum in a never-imported, explicitly listed file in another directory is rejected"
-source = """
-fn main() -> i32 {
-    let c = Color::Blue;
-    0
-}
-"""
-aux_files = { "subdir/defs.rue" = """
-enum Color {
-    Red,
-    Green,
-    Blue,
-}
-""" }
-pass_aux_files = true
-compile_fail = true
-error_contains = "enum `Color` is private (defined in"
-
-[[case]]
-name = "flat_multifile_private_enum_match_pattern_error"
-spec = ["10.3:7", "10.3:8"]
-description = "A match pattern names the enum unqualified too: matching on a private cross-directory enum is rejected even when the scrutinee arrives through a pub function"
-source = """
-fn main() -> i32 {
-    match make() {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
-    }
-}
-"""
-aux_files = { "subdir/defs.rue" = """
-enum Color {
-    Red,
-    Green,
-    Blue,
-}
-pub fn make() -> Color {
-    Color::Green
-}
-""" }
-pass_aux_files = true
-compile_fail = true
-error_contains = "enum `Color` is private (defined in"
-
-[[case]]
-name = "flat_multifile_unqualified_pub_enum_allowed"
-spec = ["10.3:8", "10.5:2"]
-description = "The flat namespace still resolves pub enums across directories without imports: annotation, construction, and match all work"
-source = """
-fn main() -> i32 {
-    let c: Color = Color::Blue;
-    match c {
-        Color::Red => 10,
-        Color::Green => 20,
-        Color::Blue => 42,
-    }
-}
-"""
-aux_files = { "subdir/defs.rue" = """
-pub enum Color {
-    Red,
-    Green,
-    Blue,
-}
-""" }
-pass_aux_files = true
-exit_code = 42
-
-[[case]]
-name = "flat_multifile_same_dir_private_enum_allowed"
-spec = ["10.3:2", "10.3:8"]
-description = "Intra-directory visibility (ADR-0026) is unchanged: a private enum in another listed file in the same directory is usable unqualified"
-source = """
-fn main() -> i32 {
-    let c: Color = Color::Green;
-    match c {
-        Color::Red => 1,
-        Color::Green => 42,
-        Color::Blue => 3,
-    }
-}
-"""
-aux_files = { "defs.rue" = """
-enum Color {
-    Red,
-    Green,
-    Blue,
-}
-""" }
-pass_aux_files = true
-exit_code = 42
-
-# The uniform privacy rule (10.3:7) also covers a comptime type constructor
-# (`fn Secret(comptime T) -> type`) applied in type-annotation position: naming
-# a private constructor from another directory in a `let x: Secret(i32)`
-# annotation is E0460, exactly as a value/call reference is. Before RUE-283 the
-# annotation path skipped this check, leaking the private constructor
-# cross-directory (a privacy-soundness hole).
-
-[[case]]
-name = "cross_dir_private_type_ctor_annotation_error"
-spec = ["10.3:7"]
-description = "Applying a private comptime type constructor in type-annotation position from another directory is rejected (E0460)"
-source = """
-fn main() -> i32 {
-    let s: Secret(i32) = mk();
-    s.v
-}
-"""
-aux_files = { "subdir/lib.rue" = """
-fn Secret(comptime T: type) -> type { struct { v: T } }
-pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
-""" }
-pass_aux_files = true
-compile_fail = true
-error_contains = "function `Secret` is private (defined in"
-
-[[case]]
-name = "cross_dir_pub_type_ctor_annotation_allowed"
-spec = ["10.3:7", "10.3:8"]
-description = "A pub comptime type constructor applied as an annotation across directories is allowed (flat namespace resolves the name)"
-source = """
-fn main() -> i32 {
-    let s: Secret(i32) = mk();
-    s.v
-}
-"""
-aux_files = { "subdir/lib.rue" = """
-pub fn Secret(comptime T: type) -> type { struct { v: T } }
-pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
-""" }
-pass_aux_files = true
-exit_code = 7
-
-[[case]]
-name = "same_dir_private_type_ctor_annotation_allowed"
-spec = ["10.3:2", "10.3:7"]
-description = "Intra-directory visibility (ADR-0026) is unchanged: a private comptime type constructor applied as an annotation in another listed file in the same directory is allowed"
-source = """
-fn main() -> i32 {
-    let s: Secret(i32) = mk();
-    s.v
-}
-"""
-aux_files = { "lib.rue" = """
-fn Secret(comptime T: type) -> type { struct { v: T } }
-pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
-""" }
-pass_aux_files = true
-exit_code = 7

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -240,11 +240,6 @@ pub struct Case {
     /// Example: `{ "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }`
     #[serde(default)]
     pub aux_files: HashMap<String, String>,
-    /// If true, pass aux_files to the compiler on the command line (multi-file compilation).
-    /// If false (default), aux_files are just written to disk for @import to find.
-    /// Use this when tests need to call functions from imported modules.
-    #[serde(default)]
-    pub pass_aux_files: bool,
     /// List of target triples on which this test should run.
     /// If specified, the test is skipped on hosts that don't match any of the targets.
     /// Example: `only_on = ["x86-64-linux", "aarch64-linux"]`
@@ -562,7 +557,6 @@ pub fn expand_case(case: Case) -> Vec<Case> {
                 opt_level: case.opt_level,
                 timeout_ms: case.timeout_ms,
                 aux_files: case.aux_files.clone(),
-                pass_aux_files: case.pass_aux_files,
                 only_on: case.only_on.clone(),
 
                 // Clear params on expanded case
@@ -1449,7 +1443,6 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         .map_err(|e| format!("Failed to write source: {}", e))?;
 
     // Write auxiliary files for multi-file tests (module imports)
-    let mut aux_paths = Vec::new();
     for (filename, content) in &case.aux_files {
         // Create subdirectories if needed (e.g., "foo/bar.rue")
         let aux_path = temp_dir.path().join(filename);
@@ -1459,7 +1452,6 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
         fs::write(&aux_path, content)
             .map_err(|e| format!("Failed to write aux file {}: {}", filename, e))?;
-        aux_paths.push(aux_path);
     }
 
     // Build base command with target, preview, and optimization flags if needed
@@ -1576,17 +1568,11 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
     }
 
-    // Compile with rue
-    // By default, aux_files are just written to disk for @import to find.
-    // When pass_aux_files is true, they're passed on the command line for
-    // multi-file compilation (needed when tests call functions from imported modules).
+    // Compile with rue. Auxiliary files are written to disk so the root
+    // module's import graph can discover them; they are not appended as
+    // positional source files.
     let mut compile_cmd = build_command(rue_binary);
     compile_cmd.arg(&source_path);
-    if case.pass_aux_files {
-        for aux_path in &aux_paths {
-            compile_cmd.arg(aux_path);
-        }
-    }
     compile_cmd.arg("-o").arg(&output_path);
     // Run the compiler under the same timeout as the golden emits and the
     // compiled program, so a compiler hang fails the case instead of wedging
@@ -1877,7 +1863,6 @@ mod tests {
             stderr_contains: None,
             params: vec![],
             aux_files: HashMap::new(),
-            pass_aux_files: false,
             only_on: vec![],
         };
 
@@ -1928,7 +1913,6 @@ mod tests {
             stderr_contains: None,
             params: vec![ParamSet { values: param1 }, ParamSet { values: param2 }],
             aux_files: HashMap::new(),
-            pass_aux_files: false,
             only_on: vec![],
         };
 
@@ -1987,7 +1971,6 @@ mod tests {
             stderr_contains: None,
             params: vec![ParamSet { values: params }],
             aux_files: HashMap::new(),
-            pass_aux_files: false,
             only_on: vec![],
         };
 
@@ -2038,7 +2021,6 @@ mod tests {
             stderr_contains: None,
             params: vec![ParamSet { values: params }],
             aux_files: HashMap::new(),
-            pass_aux_files: false,
             only_on: vec![],
         };
 
@@ -2440,7 +2422,6 @@ params = [
             stderr_contains: None,
             params: vec![],
             aux_files: HashMap::new(),
-            pass_aux_files: false,
             only_on: vec![],
         }
     }


### PR DESCRIPTION
Fixes RUE-457.

## Summary
- Remove the `pass_aux_files` TOML/harness flag so `aux_files` are only written for root import-graph discovery.
- Rewrite the remaining same-directory associated-function spec fixture to import its sibling module explicitly.
- Delete stale spec fixtures whose only purpose was exercising the old flat aux-file command-line model.
- Update module composition wording to describe root import graph-loaded modules instead of the transitional flat namespace.

## Validation
- `./fmt.sh`
- `./buck2 test //crates/rue-test-runner:rue-test-runner-test //:spec-tests`
- `./clippy.sh`
