### PR TITLE
[codex] Make --emit deps reject unresolved imports

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -210,6 +210,23 @@ compile_stdout_contains = [
 compile_stdout_not_contains = ["unused.rue"]
 
 [[case]]
+name = "emit_deps_rejects_unresolved_import"
+description = "RUE-450: --emit deps validates the loaded root import graph before printing dependency JSON."
+files = [
+    { path = "main.rue", source = """
+const missing = @import("missing");
+
+fn main() -> i32 {
+    missing.answer()
+}
+""" },
+]
+args = ["--emit", "deps", "main.rue"]
+compile_fail = true
+error_contains = ["E0704", "missing"]
+compile_stdout_not_contains = ["\"version\": 1"]
+
+[[case]]
 name = "emit_deps_rejects_mixed_emit_stages"
 description = "RUE-446: dependency JSON must not be interleaved with other --emit output."
 files = [

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -430,6 +430,24 @@ fn run_case(
         }
     }
 
+    for expected in &case.compile_stdout_contains {
+        if !compile_stdout.contains(expected) {
+            return Err(format!(
+                "compiler stdout mismatch:\n  expected to contain: {}\n--- actual stdout ---\n{}",
+                expected, compile_stdout
+            ));
+        }
+    }
+
+    for forbidden in &case.compile_stdout_not_contains {
+        if compile_stdout.contains(forbidden) {
+            return Err(format!(
+                "compiler stdout contained forbidden substring: {}\n--- actual stdout ---\n{}",
+                forbidden, compile_stdout
+            ));
+        }
+    }
+
     let compile_succeeded = compile_output.status.success();
 
     if case.compile_fail {
@@ -454,24 +472,6 @@ fn run_case(
             compile_stdout,
             compile_stderr
         ));
-    }
-
-    for expected in &case.compile_stdout_contains {
-        if !compile_stdout.contains(expected) {
-            return Err(format!(
-                "compiler stdout mismatch:\n  expected to contain: {}\n--- actual stdout ---\n{}",
-                expected, compile_stdout
-            ));
-        }
-    }
-
-    for forbidden in &case.compile_stdout_not_contains {
-        if compile_stdout.contains(forbidden) {
-            return Err(format!(
-                "compiler stdout contained forbidden substring: {}\n--- actual stdout ---\n{}",
-                forbidden, compile_stdout
-            ));
-        }
     }
 
     if case.compile_only {

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1403,34 +1403,6 @@ fn main() {
     }
     let sources = sources;
 
-    if options.emit_stages.contains(&EmitStage::Deps) {
-        if options.emit_stages.len() != 1 {
-            eprintln!("Error: --emit deps cannot be combined with other --emit stages");
-            std::process::exit(1);
-        }
-        if options.benchmark_json {
-            eprintln!(
-                "Error: --emit cannot be combined with --benchmark-json (both write to stdout)"
-            );
-            std::process::exit(1);
-        }
-        match serde_json::to_string_pretty(&dependency_graph.to_output()) {
-            Ok(json) => println!("{json}"),
-            Err(e) => {
-                eprintln!("Error emitting dependency graph: {e}");
-                std::process::exit(1);
-            }
-        }
-        print_timing_output(
-            &timing_data,
-            options.time_passes,
-            options.benchmark_json,
-            &options.target,
-            None,
-        );
-        return;
-    }
-
     // Build SourceFile structs for multi-file compilation
     let source_files: Vec<SourceFile<'_>> = sources
         .iter()
@@ -1452,6 +1424,37 @@ fn main() {
         })
         .collect();
     let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
+
+    if options.emit_stages.contains(&EmitStage::Deps) {
+        if options.emit_stages.len() != 1 {
+            eprintln!("Error: --emit deps cannot be combined with other --emit stages");
+            std::process::exit(1);
+        }
+        if options.benchmark_json {
+            eprintln!(
+                "Error: --emit cannot be combined with --benchmark-json (both write to stdout)"
+            );
+            std::process::exit(1);
+        }
+        if let Err(()) = validate_deps_emit_sources(&source_files, &options, &diagnostics) {
+            std::process::exit(1);
+        }
+        match serde_json::to_string_pretty(&dependency_graph.to_output()) {
+            Ok(json) => println!("{json}"),
+            Err(e) => {
+                eprintln!("Error emitting dependency graph: {e}");
+                std::process::exit(1);
+            }
+        }
+        print_timing_output(
+            &timing_data,
+            options.time_passes,
+            options.benchmark_json,
+            &options.target,
+            None,
+        );
+        return;
+    }
 
     // Compute source metrics if benchmark JSON is requested
     let source_metrics = if options.benchmark_json {
@@ -1596,6 +1599,48 @@ fn main() {
         Err(errors) => {
             diagnostics.print_errors(&errors);
             std::process::exit(1);
+        }
+    }
+}
+
+fn validate_deps_emit_sources(
+    sources: &[SourceFile<'_>],
+    options: &Options,
+    diagnostics: &DiagnosticOutput<'_>,
+) -> Result<(), ()> {
+    let parsed = match parse_all_files(sources) {
+        Ok(program) => program,
+        Err(errors) => {
+            diagnostics.print_errors(&errors);
+            return Err(());
+        }
+    };
+
+    let merged = match merge_symbols(parsed) {
+        Ok(merged) => merged,
+        Err(errors) => {
+            diagnostics.print_errors(&errors);
+            return Err(());
+        }
+    };
+
+    let file_paths: std::collections::HashMap<FileId, String> = sources
+        .iter()
+        .map(|source| (source.file_id, source.path.to_string()))
+        .collect();
+
+    match rue_compiler::compile_frontend_from_ast_with_file_paths_and_target(
+        merged.ast,
+        merged.interner,
+        options.opt_level,
+        &options.preview_features,
+        options.target,
+        file_paths,
+    ) {
+        Ok(_state) => Ok(()),
+        Err(errors) => {
+            diagnostics.print_errors(&errors);
+            Err(())
         }
     }
 }


### PR DESCRIPTION
Fixes RUE-450.

## Summary
- Validate the loaded root import graph before printing `--emit deps` JSON.
- Reuse the existing parse/merge/frontend path so unresolved imports report normal diagnostics on stderr.
- Make CLI `compile_stdout_*` assertions apply to failing compiler invocations too.
- Add a regression proving unresolved imports under `--emit deps` fail and do not emit dependency JSON.

## Validation
- `./fmt.sh`
- `./buck2 test //crates/rue-cli-tests:rue-cli-tests-test //:cli-tests`
- `./clippy.sh`
