### PR TITLE
[codex] Remove jobs from CompileOptions

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -622,7 +622,6 @@ impl Default for LinkerMode {
 ///     linker: LinkerMode::Internal,
 ///     opt_level: OptLevel::O1,
 ///     preview_features: PreviewFeatures::new(),
-///     jobs: 0, // 0 = auto-detect
 /// };
 /// let output = compile_with_options(source, &options)?;
 /// ```
@@ -636,8 +635,6 @@ pub struct CompileOptions {
     pub opt_level: OptLevel,
     /// Enabled preview features.
     pub preview_features: PreviewFeatures,
-    /// Number of parallel jobs (0 = auto-detect, use all cores).
-    pub jobs: usize,
 }
 
 impl Default for CompileOptions {
@@ -648,7 +645,6 @@ impl Default for CompileOptions {
             linker: LinkerMode::Internal,
             opt_level: OptLevel::default(),
             preview_features: PreviewFeatures::new(),
-            jobs: 0, // 0 = auto-detect
         }
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1506,7 +1506,6 @@ fn main() {
         linker: options.linker.clone(),
         opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
-        jobs: options.jobs,
     };
     match compile_multi_file_with_options(&source_files, &compile_options) {
         Ok(output) => {


### PR DESCRIPTION
## Summary

- remove the unused `jobs` field from `CompileOptions`
- keep CLI `-j/--jobs` as a driver-level option that configures the process-global Rayon pool
- update the `CompileOptions` example/default API surface accordingly

## Rationale

`CompileOptions.jobs` looked like a per-compilation library setting, but Rayon global pool configuration is process-wide and must happen once in the driver before compilation work begins. Keeping the field in the library API made the option misleading and easy to wire incorrectly.

Fixes RUE-466.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue-compiler:rue-compiler-test //crates/rue:rue-test //:cli-tests`
- `./clippy.sh`