### PR TITLE
[codex] Add module-qualified function identity

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -170,13 +170,17 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 continue;
             }
 
+            let function_key = sema
+                .resolve_function_name_in_file(*name, inst.span.file_id)
+                .unwrap_or(*name);
+
             // Skip FnDecls that are not in the functions table.
             // These are anonymous struct methods which are analyzed separately.
-            if !sema.functions.contains_key(name) {
+            if !sema.functions.contains_key(&function_key) {
                 continue;
             }
 
-            let Some(fn_info) = sema.functions.get(name).copied() else {
+            let Some(fn_info) = sema.functions.get(&function_key).copied() else {
                 continue;
             };
             // Skip functions with comptime parameters - they are analyzed per specialization
@@ -184,7 +188,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 continue;
             }
 
-            let fn_name = sema.interner.resolve(&*name).to_string();
+            let fn_name = sema.interner.resolve(&function_key).to_string();
             let params = sema.rir.get_params(*params_start, *params_len);
 
             match sema.analyze_single_function(
@@ -200,7 +204,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 Ok((analyzed, warnings, local_strings, mut ref_fns, _ref_meths)) => {
                     functions_with_strings.push((analyzed, local_strings));
                     all_warnings.extend(warnings);
-                    ref_fns.remove(name);
+                    ref_fns.remove(&function_key);
                     referenced_functions.extend(ref_fns);
                 }
                 Err(e) => errors.push(e),
@@ -552,7 +556,8 @@ fn add_unused_function_warnings(
     let main_sym = sema.interner.get("main");
 
     for (name, info) in &sema.functions {
-        let name_str = sema.interner.resolve(name);
+        let source_name = sema.source_function_name(*name);
+        let name_str = sema.interner.resolve(&source_name);
         if Some(*name) == main_sym
             || info.is_pub
             || info.allow_unused_function
@@ -656,7 +661,10 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                     ..
                 } = &inst.data
                 {
-                    if *name == fn_name && !method_refs.contains(&inst_ref) {
+                    let function_key = sema
+                        .resolve_function_name_in_file(*name, inst.span.file_id)
+                        .unwrap_or(*name);
+                    if function_key == fn_name && !method_refs.contains(&inst_ref) {
                         found = true;
                         let params = sema.rir.get_params(*params_start, *params_len);
 

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -354,13 +354,14 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Look up the function in the global function table. Not finding it
-        // there means the module certainly has no such member.
         let fn_name_str = self.interner.resolve(&function_name).to_string();
         let module_def = self.module_registry.get_def(module_id);
+        let module_file_id = self.canonical_file_id(&module_def.file_path);
+        let function_key = module_file_id
+            .and_then(|file_id| self.resolve_function_name_in_file(function_name, file_id));
         let fn_info = self
             .functions
-            .get(&function_name)
+            .get(&function_key.unwrap_or(function_name))
             .ok_or_compile_error(
                 ErrorKind::UnknownModuleMember {
                     module_name: module_def.import_path.clone(),
@@ -371,7 +372,8 @@ impl<'a> Sema<'a> {
             .clone();
 
         // Track this function as referenced (for lazy analysis)
-        ctx.referenced_functions.insert(function_name);
+        let function_key = function_key.unwrap_or(function_name);
+        ctx.referenced_functions.insert(function_key);
 
         let param_types = self.param_arena.types(fn_info.params).to_vec();
         let param_modes = self.param_arena.modes(fn_info.params).to_vec();
@@ -380,7 +382,7 @@ impl<'a> Sema<'a> {
         check_module_member_call(
             self.rir,
             &module_def.import_path,
-            self.canonical_file_id(&module_def.file_path),
+            module_file_id,
             fn_info.file_id,
             &fn_name_str,
             &param_types,
@@ -396,7 +398,7 @@ impl<'a> Sema<'a> {
         // RUE-166). Delegate to the unqualified call path, which emits
         // CallGeneric; module membership and accessibility were checked above.
         if fn_info.is_generic {
-            return self.analyze_call(air, function_name, args_start, args_len, span, ctx);
+            return self.analyze_call(air, function_key, args_start, args_len, span, ctx);
         }
 
         // Check for exclusive access violation. (The old, pre-deduplication
@@ -408,7 +410,7 @@ impl<'a> Sema<'a> {
 
         Ok(emit_module_member_call(
             air,
-            function_name,
+            function_key,
             &air_args,
             fn_info.return_type,
             span,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5087,6 +5087,9 @@ impl<'a> Sema<'a> {
             )?;
             name = callee;
         }
+        name = self
+            .resolve_function_name_in_file(name, span.file_id)
+            .unwrap_or(name);
 
         // `print(s)` / `println(s)` are builtin free functions (RUE-1), not
         // user-defined ones: intercept them here before the function lookup,
@@ -5100,7 +5103,8 @@ impl<'a> Sema<'a> {
         }
 
         // Look up the function
-        let fn_name_str = self.interner.resolve(&name).to_string();
+        let source_name = self.source_function_name(name);
+        let fn_name_str = self.interner.resolve(&source_name).to_string();
         let fn_info = self
             .functions
             .get(&name)

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -32,6 +32,55 @@ enum TypeNode {
 }
 
 impl<'a> Sema<'a> {
+    pub(crate) fn source_function_name(&self, internal_name: Spur) -> Spur {
+        self.function_source_names
+            .get(&internal_name)
+            .copied()
+            .unwrap_or(internal_name)
+    }
+
+    fn internal_function_name(&self, source_name: Spur, file_id: FileId) -> Spur {
+        let source = self.interner.resolve(&source_name);
+        if source == "main" {
+            return source_name;
+        }
+        let mut count = 0;
+        for (_, inst) in self.rir.iter() {
+            let InstData::FnDecl { name, has_self, .. } = &inst.data else {
+                continue;
+            };
+            if !*has_self && *name == source_name {
+                count += 1;
+                if count > 1 {
+                    break;
+                }
+            }
+        }
+        if count > 1 {
+            self.interner
+                .get_or_intern(&format!("__rue_fn_f{}_{}", file_id.index(), source))
+        } else {
+            source_name
+        }
+    }
+
+    pub(crate) fn resolve_function_name_in_file(
+        &self,
+        source_name: Spur,
+        file_id: FileId,
+    ) -> Option<Spur> {
+        self.functions_by_file_name
+            .get(&(file_id, source_name))
+            .copied()
+            .or_else(|| {
+                if self.functions.contains_key(&source_name) {
+                    Some(source_name)
+                } else {
+                    None
+                }
+            })
+    }
+
     /// Build an `InferenceContext` from the collected type information.
     ///
     /// This should be called after the collection phase and builds the
@@ -246,43 +295,67 @@ impl<'a> Sema<'a> {
             }
         }
 
-        // For each name, whether the first item seen was a type (struct/enum);
-        // the alternative is a function.
-        let mut seen: HashMap<Spur, (bool, Span)> = HashMap::new();
+        // Type names stay global, and a top-level type still collides with
+        // any free function of the same source name. Free functions only
+        // duplicate-conflict with other free functions in the same defining
+        // file/module; distinct modules may each define a source-level `value`
+        // and receive different internal keys later.
+        let mut seen_types: HashMap<Spur, Span> = HashMap::new();
+        let mut seen_function_names: HashMap<Spur, Span> = HashMap::new();
+        let mut seen_functions: HashMap<(FileId, Spur), Span> = HashMap::new();
         for (inst_ref, inst) in self.rir.iter() {
-            let (name, is_type) = match &inst.data {
+            match &inst.data {
                 InstData::StructDecl { name, .. } | InstData::EnumDecl { name, .. } => {
-                    (*name, true)
+                    if let Some(first_span) = seen_function_names.get(name) {
+                        let name_str = self.interner.resolve(name).to_string();
+                        return Err(CompileError::new(
+                            ErrorKind::DuplicateFunctionDefinition {
+                                function_name: name_str,
+                            },
+                            inst.span,
+                        )
+                        .with_label("first defined here".to_string(), *first_span));
+                    }
+                    if let Some(first_span) = seen_types.insert(*name, inst.span) {
+                        let name_str = self.interner.resolve(name).to_string();
+                        return Err(CompileError::new(
+                            ErrorKind::DuplicateTypeDefinition {
+                                type_name: name_str,
+                            },
+                            inst.span,
+                        )
+                        .with_label("first defined here".to_string(), first_span));
+                    }
                 }
                 InstData::FnDecl { name, has_self, .. } => {
                     if *has_self || method_refs.contains(&inst_ref) {
                         continue;
                     }
-                    (*name, false)
-                }
-                _ => continue,
-            };
-
-            match seen.get(&name).copied() {
-                None => {
-                    seen.insert(name, (is_type, inst.span));
-                }
-                Some((first_is_type, first_span)) => {
-                    let name_str = self.interner.resolve(&name).to_string();
-                    // Two types collide as a duplicate type (E0405); any pair
-                    // involving a function is a duplicate function (E0436).
-                    let err_kind = if first_is_type && is_type {
-                        ErrorKind::DuplicateTypeDefinition {
-                            type_name: name_str,
-                        }
-                    } else {
-                        ErrorKind::DuplicateFunctionDefinition {
-                            function_name: name_str,
-                        }
-                    };
-                    return Err(CompileError::new(err_kind, inst.span)
+                    if let Some(first_span) = seen_types.get(name) {
+                        let name_str = self.interner.resolve(name).to_string();
+                        return Err(CompileError::new(
+                            ErrorKind::DuplicateFunctionDefinition {
+                                function_name: name_str,
+                            },
+                            inst.span,
+                        )
+                        .with_label("first defined here".to_string(), *first_span));
+                    }
+                    seen_function_names.entry(*name).or_insert(inst.span);
+                    if let Some(first_span) =
+                        seen_functions.insert((inst.span.file_id, *name), inst.span)
+                    {
+                        let name_str = self.interner.resolve(name).to_string();
+                        return Err(CompileError::new(
+                            ErrorKind::DuplicateFunctionDefinition {
+                                function_name: name_str,
+                            },
+                            inst.span,
+                        )
                         .with_label("first defined here".to_string(), first_span));
+                    }
                 }
+                _ => {}
             }
         }
         Ok(())
@@ -1269,8 +1342,13 @@ impl<'a> Sema<'a> {
             param_comptime.into_iter(),
         );
 
+        let internal_name = self.internal_function_name(name, span.file_id);
+        self.functions_by_file_name
+            .insert((span.file_id, name), internal_name);
+        self.function_source_names.insert(internal_name, name);
+
         self.functions.insert(
-            name,
+            internal_name,
             FunctionInfo {
                 params: params_range,
                 return_type: ret_type,
@@ -1670,11 +1748,14 @@ impl<'a> Sema<'a> {
                     return Ok(ConstInit::Value(info.value));
                 }
                 if let Some((fn_file_id, is_pub)) = self.find_free_function_decl(name, None) {
+                    let function_key = self
+                        .resolve_function_name_in_file(name, span.file_id)
+                        .unwrap_or_else(|| self.internal_function_name(name, fn_file_id));
                     let fn_name = self.interner.resolve(&name).to_string();
                     self.check_unqualified_visibility(
                         "function", &fn_name, fn_file_id, is_pub, span,
                     )?;
-                    return Ok(ConstInit::Value(ConstValue::Function(name)));
+                    return Ok(ConstInit::Value(ConstValue::Function(function_key)));
                 }
                 // Not a constant: let the comptime engine decide (it rejects
                 // unknown names and type names as non-evaluable).
@@ -2222,7 +2303,8 @@ impl<'a> Sema<'a> {
                     accessing_file,
                     span,
                 )?;
-                return Ok(ConstInit::Value(ConstValue::Function(member)));
+                let function_key = self.internal_function_name(member, mfile);
+                return Ok(ConstInit::Value(ConstValue::Function(function_key)));
             }
         }
 
@@ -2297,7 +2379,10 @@ impl<'a> Sema<'a> {
             span,
         )?;
 
-        let Some(fn_info) = self.functions.get(&member) else {
+        let function_key = self
+            .resolve_function_name_in_file(member, mfile)
+            .unwrap_or_else(|| self.internal_function_name(member, mfile));
+        let Some(fn_info) = self.functions.get(&function_key) else {
             return Err(CompileError::new(
                 ErrorKind::UnknownModuleMember {
                     module_name: import_path,
@@ -2364,7 +2449,7 @@ impl<'a> Sema<'a> {
             }
         }
 
-        match self.reduce_type_ctor_body(member, &callee_types, &callee_values)? {
+        match self.reduce_type_ctor_body(function_key, &callee_types, &callee_values)? {
             Some(ConstValue::Type(ty)) => Ok(ConstInit::Value(ConstValue::Type(ty))),
             _ => Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
@@ -2465,7 +2550,8 @@ impl<'a> Sema<'a> {
             return Ok(None);
         };
 
-        if !self.functions.contains_key(&target) {
+        let internal_target = self.internal_function_name(target, span.file_id);
+        if !self.functions.contains_key(&internal_target) {
             self.collect_function_signature(
                 target,
                 params_start,

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -55,6 +55,10 @@ pub struct GatherOutput<'a> {
     pub enums: HashMap<Spur, EnumId>,
     /// Function lookup: maps function name to info.
     pub functions: HashMap<Spur, FunctionInfo>,
+    /// Source-level function lookup keyed by defining file and source name.
+    pub functions_by_file_name: HashMap<(rue_span::FileId, Spur), Spur>,
+    /// Internal function key -> source-level function name.
+    pub function_source_names: HashMap<Spur, Spur>,
     /// Method lookup: maps (struct_id, method_name) to info.
     pub methods: HashMap<(StructId, Spur), MethodInfo>,
     /// Constant lookup: maps const name to info (value constants only).
@@ -88,6 +92,8 @@ impl<'a> GatherOutput<'a> {
             rir: self.rir,
             interner: self.interner,
             functions: self.functions,
+            functions_by_file_name: self.functions_by_file_name,
+            function_source_names: self.function_source_names,
             structs: self.structs,
             enums: self.enums,
             methods: self.methods,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -67,8 +67,16 @@ use crate::types::{EnumId, StructId, Type};
 pub struct Sema<'a> {
     pub(crate) rir: &'a Rir,
     pub(crate) interner: &'a ThreadedRodeo,
-    /// Function table: maps function name symbols to their info
+    /// Function table: maps internal function name symbols to their info.
+    ///
+    /// The internal key is normally the source name, but functions with the
+    /// same source name in distinct files get deterministic module-qualified
+    /// keys so they can coexist without colliding in AIR/codegen.
     pub(crate) functions: HashMap<Spur, FunctionInfo>,
+    /// Source-level function lookup keyed by defining file and source name.
+    pub(crate) functions_by_file_name: HashMap<(FileId, Spur), Spur>,
+    /// Internal function key -> source-level function name.
+    pub(crate) function_source_names: HashMap<Spur, Spur>,
     /// Struct table: maps struct name symbols to their StructId
     pub(crate) structs: HashMap<Spur, StructId>,
     /// Enum table: maps enum name symbols to their EnumId
@@ -168,6 +176,8 @@ impl<'a> Sema<'a> {
             rir,
             interner,
             functions: HashMap::new(),
+            functions_by_file_name: HashMap::new(),
+            function_source_names: HashMap::new(),
             structs: HashMap::new(),
             enums: HashMap::new(),
             methods: HashMap::new(),

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -479,6 +479,22 @@ mod tests {
     }
 
     #[test]
+    fn test_function_and_type_name_collision() {
+        let result = compile_to_air(
+            "struct Foo { x: i32 }
+             fn Foo() -> i32 { 1 }
+             fn main() -> i32 { 0 }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::DuplicateFunctionDefinition { .. }
+        ));
+    }
+
+    #[test]
     fn test_duplicate_struct_field() {
         // Duplicate field names in a struct should error
         let result = compile_to_air(

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1000,9 +1000,12 @@ impl<'a> Sema<'a> {
         ctx: Option<&AnalysisContext>,
     ) -> CompileResult<Type> {
         let name_sym = self.interner.get_or_intern(call_name);
+        let name_key = self
+            .resolve_function_name_in_file(name_sym, span.file_id)
+            .unwrap_or(name_sym);
 
         // The callee must be a known `-> type` constructor.
-        let Some(fn_info) = self.functions.get(&name_sym) else {
+        let Some(fn_info) = self.functions.get(&name_key) else {
             return Err(CompileError::new(
                 ErrorKind::UnknownType(format!("{}(...)", call_name)),
                 span,
@@ -1068,7 +1071,7 @@ impl<'a> Sema<'a> {
         // Reduce the constructor body under the substitution. Shares the exact
         // reduction path (and E1200 recursion guard) with value-position calls.
         let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
-        match self.reduce_type_ctor_body(name_sym, &callee_types, &empty_values)? {
+        match self.reduce_type_ctor_body(name_key, &callee_types, &empty_values)? {
             Some(ConstValue::Type(t)) => Ok(t),
             _ => Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
@@ -1376,7 +1379,10 @@ impl<'a> Sema<'a> {
             |reason: String| CompileError::new(ErrorKind::InvalidArrayLength { reason }, span);
 
         let callee_sym = self.interner.get_or_intern(callee);
-        let Some(fn_info) = self.functions.get(&callee_sym) else {
+        let callee_key = self
+            .resolve_function_name_in_file(callee_sym, span.file_id)
+            .unwrap_or(callee_sym);
+        let Some(fn_info) = self.functions.get(&callee_key) else {
             return Err(invalid(format!(
                 "'{callee}' is not a function; array lengths must be an integer literal, a \
                  `const`, a `comptime` value parameter, or a call to a comptime function"
@@ -1413,7 +1419,7 @@ impl<'a> Sema<'a> {
             callee_values.insert(param_names[i], ConstValue::Integer(v as i128));
         }
         let empty_types: HashMap<Spur, Type> = HashMap::new();
-        match self.reduce_type_ctor_body(callee_sym, &empty_types, &callee_values)? {
+        match self.reduce_type_ctor_body(callee_key, &empty_types, &callee_values)? {
             Some(ConstValue::Integer(n)) if n >= 0 => u64::try_from(n)
                 .map_err(|_| invalid(format!("array length '{callee}(...)' ({n}) is too large"))),
             Some(ConstValue::Integer(n)) => Err(invalid(format!(

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -783,7 +783,6 @@ pub fn value() -> i32 {
 ]
 stdout = "30\n"
 exit_code = 30
-known_bug = "RUE-440"
 
 [[case]]
 name = "root_module_graph_same_file_reached_by_normalized_paths"

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -398,11 +398,10 @@ pub(crate) struct DuplicateSymbolCheck {
 
 /// Detect duplicate symbol definitions across parsed files.
 ///
-/// All functions, structs, and enums share a single flat global namespace
-/// (no modules yet), so each name may be defined only once across all files;
-/// structs and enums also conflict with each other. Every duplicate produces
-/// one error pointing at the redefinition, with a label at the first
-/// definition.
+/// Free functions are scoped to their defining file/module for duplicate
+/// detection, while structs and enums still share a flat type namespace.
+/// Every duplicate produces one error pointing at the redefinition, with a
+/// label at the first definition.
 ///
 /// This is the single source of truth for duplicate-symbol detection, shared
 /// by [`merge_symbols`] and `CompilationUnit::parse`.
@@ -412,7 +411,8 @@ pub(crate) fn detect_duplicate_symbols<'a>(
 ) -> DuplicateSymbolCheck {
     use std::collections::HashMap;
 
-    let mut functions: HashMap<String, SymbolDef> = HashMap::new();
+    let mut functions: HashMap<(String, String), SymbolDef> = HashMap::new();
+    let mut function_names: HashMap<String, SymbolDef> = HashMap::new();
     let mut structs: HashMap<String, SymbolDef> = HashMap::new();
     let mut enums: HashMap<String, SymbolDef> = HashMap::new();
     let mut errors: Vec<CompileError> = Vec::new();
@@ -422,11 +422,12 @@ pub(crate) fn detect_duplicate_symbols<'a>(
             match item {
                 Item::Function(func) => {
                     let name = interner.resolve(&func.name.name).to_string();
-                    if let Some(first) = functions.get(&name) {
+                    let key = (file_path.to_string(), name.clone());
+                    if let Some(first) = functions.get(&key) {
                         // Duplicate function definition
                         let err = CompileError::new(
                             ErrorKind::DuplicateFunctionDefinition {
-                                function_name: name,
+                                function_name: name.clone(),
                             },
                             func.span,
                         )
@@ -434,17 +435,42 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                         errors.push(err);
                     } else {
                         functions.insert(
-                            name,
+                            key,
                             SymbolDef {
                                 span: func.span,
                                 file_path: file_path.to_string(),
                             },
                         );
                     }
+                    if let Some(first) = structs.get(&name).or_else(|| enums.get(&name)) {
+                        let err = CompileError::new(
+                            ErrorKind::DuplicateFunctionDefinition {
+                                function_name: name.clone(),
+                            },
+                            func.span,
+                        )
+                        .with_label(format!("first defined in {}", first.file_path), first.span);
+                        errors.push(err);
+                    }
+                    function_names
+                        .entry(name.clone())
+                        .or_insert_with(|| SymbolDef {
+                            span: func.span,
+                            file_path: file_path.to_string(),
+                        });
                 }
                 Item::Struct(s) => {
                     let name = interner.resolve(&s.name.name).to_string();
-                    if let Some(first) = structs.get(&name) {
+                    if let Some(first) = function_names.get(&name) {
+                        let err = CompileError::new(
+                            ErrorKind::DuplicateFunctionDefinition {
+                                function_name: name,
+                            },
+                            s.span,
+                        )
+                        .with_label(format!("first defined in {}", first.file_path), first.span);
+                        errors.push(err);
+                    } else if let Some(first) = structs.get(&name) {
                         // Duplicate struct definition
                         let err = CompileError::new(
                             ErrorKind::DuplicateTypeDefinition {
@@ -479,7 +505,16 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                 }
                 Item::Enum(e) => {
                     let name = interner.resolve(&e.name.name).to_string();
-                    if let Some(first) = enums.get(&name) {
+                    if let Some(first) = function_names.get(&name) {
+                        let err = CompileError::new(
+                            ErrorKind::DuplicateFunctionDefinition {
+                                function_name: name,
+                            },
+                            e.span,
+                        )
+                        .with_label(format!("first defined in {}", first.file_path), first.span);
+                        errors.push(err);
+                    } else if let Some(first) = enums.get(&name) {
                         // Duplicate enum definition
                         let err = CompileError::new(
                             ErrorKind::DuplicateTypeDefinition {
@@ -1894,13 +1929,17 @@ mod tests {
 
     #[test]
     fn test_merge_symbols_duplicate_function() {
-        let sources = vec![
-            SourceFile::new("a.rue", "fn foo() -> i32 { 1 }", FileId::new(1)),
-            SourceFile::new("b.rue", "fn foo() -> i32 { 2 }", FileId::new(2)),
-        ];
+        let sources = vec![SourceFile::new(
+            "a.rue",
+            "fn foo() -> i32 { 1 } fn foo() -> i32 { 2 }",
+            FileId::new(1),
+        )];
         let parsed = parse_all_files(&sources).unwrap();
         let result = merge_symbols(parsed);
-        assert!(result.is_err(), "merge should fail with duplicate function");
+        assert!(
+            result.is_err(),
+            "merge should fail with duplicate function in one file"
+        );
 
         let errors = result.unwrap_err();
         assert_eq!(errors.len(), 1, "should have 1 error");
@@ -1910,6 +1949,41 @@ mod tests {
             "error should mention the duplicate function name: {}",
             err_msg
         );
+    }
+
+    #[test]
+    fn test_merge_symbols_same_function_name_in_different_files_allowed() {
+        let sources = vec![
+            SourceFile::new("a.rue", "fn value() -> i32 { 1 }", FileId::new(1)),
+            SourceFile::new("b.rue", "fn value() -> i32 { 2 }", FileId::new(2)),
+        ];
+        let parsed = parse_all_files(&sources).unwrap();
+        let result = merge_symbols(parsed);
+        assert!(
+            result.is_ok(),
+            "module-local functions in different files may share a source name"
+        );
+    }
+
+    #[test]
+    fn test_merge_symbols_function_type_conflict() {
+        let sources = vec![
+            SourceFile::new("a.rue", "fn Foo() -> i32 { 1 }", FileId::new(1)),
+            SourceFile::new("b.rue", "struct Foo { x: i32 }", FileId::new(2)),
+        ];
+        let parsed = parse_all_files(&sources).unwrap();
+        let result = merge_symbols(parsed);
+        assert!(
+            result.is_err(),
+            "merge should reject a top-level function/type name collision"
+        );
+
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1, "should have 1 error");
+        assert!(matches!(
+            errors.first().unwrap().kind,
+            ErrorKind::DuplicateFunctionDefinition { .. }
+        ));
     }
 
     #[test]
@@ -1989,18 +2063,11 @@ mod tests {
     #[test]
     fn test_merge_symbols_multiple_duplicates() {
         // Multiple duplicates should report multiple errors
-        let sources = vec![
-            SourceFile::new(
-                "a.rue",
-                "fn foo() -> i32 { 1 } fn bar() -> i32 { 2 }",
-                FileId::new(1),
-            ),
-            SourceFile::new(
-                "b.rue",
-                "fn foo() -> i32 { 3 } fn bar() -> i32 { 4 }",
-                FileId::new(2),
-            ),
-        ];
+        let sources = vec![SourceFile::new(
+            "a.rue",
+            "fn foo() -> i32 { 1 } fn bar() -> i32 { 2 } fn foo() -> i32 { 3 } fn bar() -> i32 { 4 }",
+            FileId::new(1),
+        )];
         let parsed = parse_all_files(&sources).unwrap();
         let result = merge_symbols(parsed);
         assert!(
@@ -2267,8 +2334,6 @@ mod tests {
     #[test]
     fn test_module_member_access() {
         // Test that @import returns a module type and member access works
-        // Note: In Phase 1, all files are merged into the same namespace,
-        // so math.add() looks up "add" in the global function table.
         let sources = vec![
             SourceFile::new(
                 "main.rue",
@@ -2288,6 +2353,29 @@ mod tests {
         assert!(
             result.is_ok(),
             "module member access should compile: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_module_member_access_same_function_names_in_distinct_modules() {
+        let sources = vec![
+            SourceFile::new(
+                "main.rue",
+                r#"fn main() -> i32 {
+                    let left = @import("left.rue");
+                    let right = @import("right.rue");
+                    left.value() + right.value()
+                }"#,
+                FileId::new(1),
+            ),
+            SourceFile::new("left.rue", "fn value() -> i32 { 10 }", FileId::new(2)),
+            SourceFile::new("right.rue", "fn value() -> i32 { 20 }", FileId::new(3)),
+        ];
+        let result = compile_multi_file_with_options(&sources, &CompileOptions::default());
+        assert!(
+            result.is_ok(),
+            "qualified calls to same-named functions in distinct modules should compile: {:?}",
             result.err()
         );
     }

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -556,10 +556,11 @@ mod tests {
 
     #[test]
     fn test_duplicate_function_error() {
-        let sources = vec![
-            SourceFile::new("a.rue", "fn foo() -> i32 { 1 }", FileId::new(1)),
-            SourceFile::new("b.rue", "fn foo() -> i32 { 2 }", FileId::new(2)),
-        ];
+        let sources = vec![SourceFile::new(
+            "a.rue",
+            "fn foo() -> i32 { 1 } fn foo() -> i32 { 2 }",
+            FileId::new(1),
+        )];
         let mut unit = CompilationUnit::new(sources, CompileOptions::default());
 
         let result = unit.parse();

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -5,9 +5,9 @@ name = "Program Composition"
 description = "Cross-file name collisions among modules loaded through the root import graph (spec chapter 10.5)."
 
 [[case]]
-name = "duplicate_symbol_across_imported_files_error"
+name = "same_named_functions_across_imported_files_ok"
 spec = ["10.5:1"]
-description = "Two loaded files defining the same top-level function name collide, even though each is only accessed through its own module"
+description = "Two loaded files may define the same top-level function name when each is accessed through its own module"
 source = """
 fn main() -> i32 {
     let a = @import("a");
@@ -16,8 +16,7 @@ fn main() -> i32 {
 }
 """
 aux_files = { "a.rue" = "pub fn shared() -> i32 { 1 }", "b.rue" = "pub fn shared() -> i32 { 2 }" }
-compile_fail = true
-error_contains = "duplicate"
+exit_code = 1
 
 [[case]]
 name = "duplicate_const_across_imported_files_error"


### PR DESCRIPTION
## Summary

- key free-function signatures by an internal module-qualified identity when duplicate source names exist across files
- resolve unqualified and module-qualified function references through the defining file before analysis/type-function reduction
- preserve existing type/function collision checks while allowing same-named functions in distinct modules
- add compiler and sema regressions for same-named module functions and function/type collisions

Fixes RUE-441.

## Validation

- ./fmt.sh
- ./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test
- ./buck2 test //:cli-tests
- ./clippy.sh