### PR TITLE
[codex] Allow module-local type identities

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -39,6 +39,7 @@ use std::collections::HashMap;
 use std::sync::{PoisonError, RwLock};
 
 use lasso::Spur;
+use rue_span::FileId;
 
 use crate::types::{
     ArrayTypeId, EnumDef, EnumId, PtrConstTypeId, PtrMutTypeId, StructDef, StructId, Type, TypeKind,
@@ -269,11 +270,23 @@ struct TypeInternPoolInner {
     /// Structural type deduplication: pointee -> InternedType for ptr mut.
     ptr_mut_map: HashMap<InternedType, InternedType>,
 
-    /// Nominal type lookup: name -> InternedType for structs.
+    /// Nominal type lookup for globally unique struct names.
+    ///
+    /// Module-local user types are keyed by `(defining file, source name)` in
+    /// `struct_by_file_name`. This compatibility map keeps unqualified lookup
+    /// working for names that are still unique across the loaded source graph.
     struct_by_name: HashMap<Spur, InternedType>,
 
-    /// Nominal type lookup: name -> InternedType for enums.
+    /// Nominal struct lookup: (defining file, source name) -> InternedType.
+    struct_by_file_name: HashMap<(FileId, Spur), InternedType>,
+
+    /// Nominal type lookup for globally unique enum names.
+    ///
+    /// See `struct_by_name` for the compatibility semantics.
     enum_by_name: HashMap<Spur, InternedType>,
+
+    /// Nominal enum lookup: (defining file, source name) -> InternedType.
+    enum_by_file_name: HashMap<(FileId, Spur), InternedType>,
 }
 
 impl TypeInternPool {
@@ -286,7 +299,9 @@ impl TypeInternPool {
                 ptr_const_map: HashMap::new(),
                 ptr_mut_map: HashMap::new(),
                 struct_by_name: HashMap::new(),
+                struct_by_file_name: HashMap::new(),
                 enum_by_name: HashMap::new(),
+                enum_by_file_name: HashMap::new(),
             }),
         }
     }
@@ -294,12 +309,14 @@ impl TypeInternPool {
     /// Register a new struct (nominal - no deduplication).
     ///
     /// Returns the `StructId` (containing the pool index) and whether it was newly inserted.
-    /// If a struct with this name already exists, returns the existing StructId.
+    /// If a struct with this name in the same defining file already exists, returns the existing
+    /// StructId.
     pub fn register_struct(&self, name: Spur, def: StructDef) -> (StructId, bool) {
+        let key = (def.file_id, name);
         // Fast path: check with read lock
         {
             let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-            if let Some(&existing) = inner.struct_by_name.get(&name) {
+            if let Some(&existing) = inner.struct_by_file_name.get(&key) {
                 // Convert InternedType back to StructId via pool_index
                 let pool_index = existing.pool_index().expect("struct must have pool index");
                 return (StructId::from_pool_index(pool_index), false);
@@ -310,7 +327,7 @@ impl TypeInternPool {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
 
         // Double-check after acquiring write lock
-        if let Some(&existing) = inner.struct_by_name.get(&name) {
+        if let Some(&existing) = inner.struct_by_file_name.get(&key) {
             let pool_index = existing.pool_index().expect("struct must have pool index");
             return (StructId::from_pool_index(pool_index), false);
         }
@@ -320,7 +337,16 @@ impl TypeInternPool {
         let interned = InternedType::from_pool_index(pool_index);
 
         inner.types.push(TypeData::Struct(StructData { name, def }));
-        inner.struct_by_name.insert(name, interned);
+        let name_was_unique = !inner
+            .struct_by_file_name
+            .keys()
+            .any(|(_, existing_name)| *existing_name == name);
+        inner.struct_by_file_name.insert(key, interned);
+        if name_was_unique {
+            inner.struct_by_name.insert(name, interned);
+        } else {
+            inner.struct_by_name.remove(&name);
+        }
 
         (StructId::from_pool_index(pool_index), true)
     }
@@ -412,27 +438,39 @@ impl TypeInternPool {
 
         // Check that a struct with this name doesn't already exist
         assert!(
-            !inner.struct_by_name.contains_key(&name),
+            !inner.struct_by_file_name.contains_key(&(def.file_id, name)),
             "Struct with this name already exists"
         );
 
         // Update the placeholder with actual data
+        let key = (def.file_id, name);
         inner.types[pool_index] = TypeData::Struct(StructData { name, def });
 
         // Register in the name lookup
         let interned = InternedType::from_pool_index(pool_index as u32);
-        inner.struct_by_name.insert(name, interned);
+        let name_was_unique = !inner
+            .struct_by_file_name
+            .keys()
+            .any(|(_, existing_name)| *existing_name == name);
+        inner.struct_by_file_name.insert(key, interned);
+        if name_was_unique {
+            inner.struct_by_name.insert(name, interned);
+        } else {
+            inner.struct_by_name.remove(&name);
+        }
     }
 
     /// Register a new enum (nominal - no deduplication).
     ///
     /// Returns the `EnumId` (containing the pool index) and whether it was newly inserted.
-    /// If an enum with this name already exists, returns the existing EnumId.
+    /// If an enum with this name in the same defining file already exists, returns the existing
+    /// EnumId.
     pub fn register_enum(&self, name: Spur, def: EnumDef) -> (EnumId, bool) {
+        let key = (def.file_id, name);
         // Fast path: check with read lock
         {
             let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-            if let Some(&existing) = inner.enum_by_name.get(&name) {
+            if let Some(&existing) = inner.enum_by_file_name.get(&key) {
                 let pool_index = existing.pool_index().expect("enum must have pool index");
                 return (EnumId::from_pool_index(pool_index), false);
             }
@@ -442,7 +480,7 @@ impl TypeInternPool {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
 
         // Double-check after acquiring write lock
-        if let Some(&existing) = inner.enum_by_name.get(&name) {
+        if let Some(&existing) = inner.enum_by_file_name.get(&key) {
             let pool_index = existing.pool_index().expect("enum must have pool index");
             return (EnumId::from_pool_index(pool_index), false);
         }
@@ -452,7 +490,16 @@ impl TypeInternPool {
         let interned = InternedType::from_pool_index(pool_index);
 
         inner.types.push(TypeData::Enum(EnumData { name, def }));
-        inner.enum_by_name.insert(name, interned);
+        let name_was_unique = !inner
+            .enum_by_file_name
+            .keys()
+            .any(|(_, existing_name)| *existing_name == name);
+        inner.enum_by_file_name.insert(key, interned);
+        if name_was_unique {
+            inner.enum_by_name.insert(name, interned);
+        } else {
+            inner.enum_by_name.remove(&name);
+        }
 
         (EnumId::from_pool_index(pool_index), true)
     }
@@ -559,10 +606,22 @@ impl TypeInternPool {
         inner.struct_by_name.get(&name).copied()
     }
 
+    /// Look up a struct by defining file and source name.
+    pub fn get_struct_by_file_name(&self, file_id: FileId, name: Spur) -> Option<InternedType> {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        inner.struct_by_file_name.get(&(file_id, name)).copied()
+    }
+
     /// Look up an enum by name.
     pub fn get_enum_by_name(&self, name: Spur) -> Option<InternedType> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.enum_by_name.get(&name).copied()
+    }
+
+    /// Look up an enum by defining file and source name.
+    pub fn get_enum_by_file_name(&self, file_id: FileId, name: Spur) -> Option<InternedType> {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        inner.enum_by_file_name.get(&(file_id, name)).copied()
     }
 
     /// Look up an array type by element and length.
@@ -932,19 +991,13 @@ impl TypeInternPool {
     /// structs (e.g., for drop glue synthesis).
     pub fn all_struct_ids(&self) -> Vec<StructId> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        // A struct may be reachable under more than one name (a deprecated
-        // type-name alias registered via `alias_struct_name`, e.g. ADR-0043's
-        // `String` -> `StrBuf`). De-duplicate by pool index so each struct is
-        // returned exactly once — callers such as drop-glue generation must not
-        // process the same struct twice.
-        let mut seen = std::collections::HashSet::new();
         inner
-            .struct_by_name
-            .values()
-            .filter_map(|interned| {
-                let pool_index = interned.pool_index().expect("struct must have pool index");
-                seen.insert(pool_index)
-                    .then(|| StructId::from_pool_index(pool_index))
+            .types
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, data)| match data {
+                TypeData::Struct(_) => Some(StructId::from_pool_index(idx as u32)),
+                _ => None,
             })
             .collect()
     }
@@ -956,11 +1009,12 @@ impl TypeInternPool {
     pub fn all_enum_ids(&self) -> Vec<EnumId> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner
-            .enum_by_name
-            .values()
-            .map(|interned| {
-                let pool_index = interned.pool_index().expect("enum must have pool index");
-                EnumId::from_pool_index(pool_index)
+            .types
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, data)| match data {
+                TypeData::Enum(_) => Some(EnumId::from_pool_index(idx as u32)),
+                _ => None,
             })
             .collect()
     }
@@ -1108,7 +1162,9 @@ impl Clone for TypeInternPool {
                 ptr_const_map: inner.ptr_const_map.clone(),
                 ptr_mut_map: inner.ptr_mut_map.clone(),
                 struct_by_name: inner.struct_by_name.clone(),
+                struct_by_file_name: inner.struct_by_file_name.clone(),
                 enum_by_name: inner.enum_by_name.clone(),
+                enum_by_file_name: inner.enum_by_file_name.clone(),
             }),
         }
     }

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -395,6 +395,7 @@ impl<'a> Sema<'a> {
         let comptime_type_vars = type_subst.map(|s| s.clone()).unwrap_or_else(HashMap::new);
         let comptime_value_vars = value_subst.map(|s| s.clone()).unwrap_or_else(HashMap::new);
         let mut ctx = AnalysisContext {
+            current_file_id: self.rir.get(body).span.file_id,
             locals: HashMap::new(),
             params: &param_vec,
             next_slot: 0,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2928,12 +2928,14 @@ impl<'a> Sema<'a> {
             }
 
             InstData::StructInit {
+                module,
                 type_name,
                 fields_start,
                 fields_len,
                 ..
             } => self.analyze_struct_init(
                 air,
+                *module,
                 *type_name,
                 *fields_start,
                 *fields_len,
@@ -2963,6 +2965,7 @@ impl<'a> Sema<'a> {
     fn analyze_struct_init(
         &mut self,
         air: &mut Air,
+        module: Option<InstRef>,
         type_name: Spur,
         fields_start: u32,
         fields_len: u32,
@@ -2973,7 +2976,36 @@ impl<'a> Sema<'a> {
         // Look up the struct type
         // First check if it's a comptime type variable (e.g., `let Point = make_point(); Point { ... }`)
         let type_name_str = self.interner.resolve(&type_name);
-        let struct_id = if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
+        let struct_id = if let Some(module_ref) = module {
+            let module_result = self.analyze_inst(air, module_ref, ctx)?;
+            let Some(module_id) = module_result.ty.as_module() else {
+                return Err(CompileError::new(
+                    ErrorKind::TypeMismatch {
+                        expected: "module".to_string(),
+                        found: module_result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                    },
+                    span,
+                ));
+            };
+            let module_def = self.module_registry.get_def(module_id);
+            let module_file_id = self.canonical_file_id(&module_def.file_path);
+            let struct_id = module_file_id
+                .and_then(|file_id| {
+                    self.structs_by_file_name
+                        .get(&(file_id, type_name))
+                        .copied()
+                })
+                .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
+            let def = self.type_pool.struct_def(struct_id);
+            self.check_unqualified_visibility(
+                "struct",
+                type_name_str,
+                def.file_id,
+                def.is_pub,
+                span,
+            )?;
+            struct_id
+        } else if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
             // Extract struct ID from the comptime type
             match ty.kind() {
                 TypeKind::Struct(id) => id,
@@ -3709,88 +3741,88 @@ impl<'a> Sema<'a> {
         // Get the accessing file's directory for visibility check
         let accessing_file_path = self.get_source_path(span).map(|s| s.to_string());
 
-        // First, try to find a struct with this name that belongs to the module's file
-        if let Some(&struct_id) = self.structs.get(&member_name) {
+        // First, try to find a struct with this name defined by the module's
+        // file. Same-named structs in sibling modules are distinct nominal
+        // types (RUE-454).
+        if let Some(struct_id) = module_file_id.and_then(|file_id| {
+            self.structs_by_file_name
+                .get(&(file_id, member_name))
+                .copied()
+        }) {
             let struct_def = self.type_pool.struct_def(struct_id);
 
-            // Check if this struct was defined in the module's file
-            {
-                if module_file_id == Some(struct_def.file_id) {
-                    // Check visibility: pub structs are visible to all, private only to same directory
-                    if !struct_def.is_pub {
-                        // Check if accessing from same directory
-                        let same_dir = match &accessing_file_path {
-                            Some(accessing) => {
-                                let accessing_dir = std::path::Path::new(accessing).parent();
-                                let module_dir = std::path::Path::new(&module_file_path).parent();
-                                accessing_dir == module_dir
-                            }
-                            None => true, // Be permissive if we can't determine the path
-                        };
-
-                        if !same_dir {
-                            return Err(CompileError::new(
-                                ErrorKind::PrivateMemberAccess {
-                                    item_kind: "struct".to_string(),
-                                    name: member_name_str,
-                                },
-                                span,
-                            ));
-                        }
+            // Check visibility: pub structs are visible to all, private only to same directory
+            if !struct_def.is_pub {
+                // Check if accessing from same directory
+                let same_dir = match &accessing_file_path {
+                    Some(accessing) => {
+                        let accessing_dir = std::path::Path::new(accessing).parent();
+                        let module_dir = std::path::Path::new(&module_file_path).parent();
+                        accessing_dir == module_dir
                     }
+                    None => true, // Be permissive if we can't determine the path
+                };
 
-                    // Return a TypeConst instruction with the struct type
-                    let struct_type = Type::new_struct(struct_id);
-                    let air_ref = air.add_inst(AirInst {
-                        data: AirInstData::TypeConst(struct_type),
-                        ty: Type::COMPTIME_TYPE,
+                if !same_dir {
+                    return Err(CompileError::new(
+                        ErrorKind::PrivateMemberAccess {
+                            item_kind: "struct".to_string(),
+                            name: member_name_str,
+                        },
                         span,
-                    });
-                    return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
+                    ));
                 }
             }
+
+            // Return a TypeConst instruction with the struct type
+            let struct_type = Type::new_struct(struct_id);
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::TypeConst(struct_type),
+                ty: Type::COMPTIME_TYPE,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
         }
 
-        // Next, try to find an enum with this name that belongs to the module's file
-        if let Some(&enum_id) = self.enums.get(&member_name) {
+        // Next, try to find an enum with this name defined by the module's file.
+        if let Some(enum_id) = module_file_id.and_then(|file_id| {
+            self.enums_by_file_name
+                .get(&(file_id, member_name))
+                .copied()
+        }) {
             let enum_def = self.type_pool.enum_def(enum_id);
 
-            // Check if this enum was defined in the module's file
-            {
-                if module_file_id == Some(enum_def.file_id) {
-                    // Check visibility: pub enums are visible to all, private only to same directory
-                    if !enum_def.is_pub {
-                        // Check if accessing from same directory
-                        let same_dir = match &accessing_file_path {
-                            Some(accessing) => {
-                                let accessing_dir = std::path::Path::new(accessing).parent();
-                                let module_dir = std::path::Path::new(&module_file_path).parent();
-                                accessing_dir == module_dir
-                            }
-                            None => true, // Be permissive if we can't determine the path
-                        };
-
-                        if !same_dir {
-                            return Err(CompileError::new(
-                                ErrorKind::PrivateMemberAccess {
-                                    item_kind: "enum".to_string(),
-                                    name: member_name_str,
-                                },
-                                span,
-                            ));
-                        }
+            // Check visibility: pub enums are visible to all, private only to same directory
+            if !enum_def.is_pub {
+                // Check if accessing from same directory
+                let same_dir = match &accessing_file_path {
+                    Some(accessing) => {
+                        let accessing_dir = std::path::Path::new(accessing).parent();
+                        let module_dir = std::path::Path::new(&module_file_path).parent();
+                        accessing_dir == module_dir
                     }
+                    None => true, // Be permissive if we can't determine the path
+                };
 
-                    // Return a TypeConst instruction with the enum type
-                    let enum_type = Type::new_enum(enum_id);
-                    let air_ref = air.add_inst(AirInst {
-                        data: AirInstData::TypeConst(enum_type),
-                        ty: Type::COMPTIME_TYPE,
+                if !same_dir {
+                    return Err(CompileError::new(
+                        ErrorKind::PrivateMemberAccess {
+                            item_kind: "enum".to_string(),
+                            name: member_name_str,
+                        },
                         span,
-                    });
-                    return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
+                    ));
                 }
             }
+
+            // Return a TypeConst instruction with the enum type
+            let enum_type = Type::new_enum(enum_id);
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::TypeConst(enum_type),
+                ty: Type::COMPTIME_TYPE,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
         }
 
         // Next, try a const defined in the module's file. The headline case is
@@ -5565,7 +5597,10 @@ impl<'a> Sema<'a> {
         {
             return ty.as_enum().map(|id| (id, true));
         }
-        self.enums.get(&type_name).map(|&id| (id, false))
+        self.enums_by_file_name
+            .get(&(ctx.current_file_id, type_name))
+            .or_else(|| self.enums.get(&type_name))
+            .map(|&id| (id, false))
     }
 
     /// Analyze an associated function call.

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -54,10 +54,13 @@ impl<'a> Sema<'a> {
 
             // Register in type pool and get pool-based StructId
             let name_spur = self.interner.get_or_intern(builtin.name);
+            let file_id = struct_def.file_id;
             let (struct_id, _) = self.type_pool.register_struct(name_spur, struct_def);
 
             // Register in struct lookup with pool-based StructId
             self.structs.insert(name_spur, struct_id);
+            self.structs_by_file_name
+                .insert((file_id, name_spur), struct_id);
 
             // Store special IDs for quick access
             if builtin.name == "StrBuf" {
@@ -71,6 +74,8 @@ impl<'a> Sema<'a> {
                 // (`is_reserved_type_name`) so users cannot shadow it.
                 let alias_spur = self.interner.get_or_intern(rue_builtins::STRING_ALIAS_NAME);
                 self.structs.insert(alias_spur, struct_id);
+                self.structs_by_file_name
+                    .insert((file_id, alias_spur), struct_id);
                 // Also alias the name in the type pool so pool-by-name lookups
                 // (`get_struct_by_name`) resolve `String`, keeping the
                 // registry/pool by-name invariant consistent.
@@ -101,10 +106,13 @@ impl<'a> Sema<'a> {
 
             // Register in type pool and get pool-based EnumId
             let name_spur = self.interner.get_or_intern(builtin_enum.name);
+            let file_id = enum_def.file_id;
             let (enum_id, _) = self.type_pool.register_enum(name_spur, enum_def);
 
             // Register in enum lookup
             self.enums.insert(name_spur, enum_id);
+            self.enums_by_file_name
+                .insert((file_id, name_spur), enum_id);
 
             // Store special IDs for quick access
             if builtin_enum.name == "Arch" {

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -10,7 +10,7 @@ use lasso::Spur;
 use rue_builtins::BuiltinTypeDef;
 use rue_error::CompileWarning;
 use rue_rir::RirParamMode;
-use rue_span::Span;
+use rue_span::{FileId, Span};
 
 use crate::scope::ScopedContext;
 use crate::types::{StructId, Type};
@@ -311,6 +311,8 @@ pub(crate) struct ParamInfo {
 /// Bundles together the mutable state that needs to be threaded through
 /// recursive `analyze_inst` calls.
 pub(crate) struct AnalysisContext<'a> {
+    /// File that owns the function body currently being analyzed.
+    pub current_file_id: FileId,
     /// Local variables in scope
     pub locals: HashMap<Spur, LocalVar>,
     /// Function parameters (immutable reference, shared across the function)
@@ -466,6 +468,7 @@ impl<'a> AnalysisContext<'a> {
     /// context.
     pub fn fork_for_loop_recheck(&self) -> AnalysisContext<'a> {
         AnalysisContext {
+            current_file_id: self.current_file_id,
             locals: self.locals.clone(),
             params: self.params,
             next_slot: self.next_slot,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -305,28 +305,19 @@ impl<'a> Sema<'a> {
             }
         }
 
-        // Type names stay global, and a top-level type still collides with
-        // any free function of the same source name. Free functions only
-        // duplicate-conflict with other free functions in the same defining
-        // file/module; distinct modules may each define a source-level `value`
-        // and receive different internal keys later.
-        let mut seen_types: HashMap<Spur, Span> = HashMap::new();
+        // Free functions duplicate-conflict only within their defining file
+        // (RUE-441). Types duplicate-conflict only within their defining file
+        // (RUE-454). Function/type cross-kind collisions remain global until
+        // the remaining flat-namespace compatibility rules are removed.
         let mut seen_function_names: HashMap<Spur, Span> = HashMap::new();
-        let mut seen_functions: HashMap<(FileId, Spur), Span> = HashMap::new();
+        let mut seen_functions_by_file: HashMap<(FileId, Spur), Span> = HashMap::new();
+        let mut seen_types: HashMap<Spur, Span> = HashMap::new();
+        let mut seen_types_by_file: HashMap<(FileId, Spur), Span> = HashMap::new();
         for (inst_ref, inst) in self.rir.iter() {
             match &inst.data {
                 InstData::StructDecl { name, .. } | InstData::EnumDecl { name, .. } => {
-                    if let Some(first_span) = seen_function_names.get(name) {
-                        let name_str = self.interner.resolve(name).to_string();
-                        return Err(CompileError::new(
-                            ErrorKind::DuplicateFunctionDefinition {
-                                function_name: name_str,
-                            },
-                            inst.span,
-                        )
-                        .with_label("first defined here".to_string(), *first_span));
-                    }
-                    if let Some(first_span) = seen_types.insert(*name, inst.span) {
+                    let key = (inst.span.file_id, *name);
+                    if let Some(first_span) = seen_types_by_file.get(&key).copied() {
                         let name_str = self.interner.resolve(name).to_string();
                         return Err(CompileError::new(
                             ErrorKind::DuplicateTypeDefinition {
@@ -336,12 +327,7 @@ impl<'a> Sema<'a> {
                         )
                         .with_label("first defined here".to_string(), first_span));
                     }
-                }
-                InstData::FnDecl { name, has_self, .. } => {
-                    if *has_self || method_refs.contains(&inst_ref) {
-                        continue;
-                    }
-                    if let Some(first_span) = seen_types.get(name) {
+                    if let Some(first_span) = seen_function_names.get(name).copied() {
                         let name_str = self.interner.resolve(name).to_string();
                         return Err(CompileError::new(
                             ErrorKind::DuplicateFunctionDefinition {
@@ -349,11 +335,28 @@ impl<'a> Sema<'a> {
                             },
                             inst.span,
                         )
-                        .with_label("first defined here".to_string(), *first_span));
+                        .with_label("first defined here".to_string(), first_span));
+                    }
+                    seen_types_by_file.insert(key, inst.span);
+                    seen_types.entry(*name).or_insert(inst.span);
+                }
+                InstData::FnDecl { name, has_self, .. } => {
+                    if *has_self || method_refs.contains(&inst_ref) {
+                        continue;
+                    }
+                    if let Some(first_span) = seen_types.get(name).copied() {
+                        let name_str = self.interner.resolve(name).to_string();
+                        return Err(CompileError::new(
+                            ErrorKind::DuplicateFunctionDefinition {
+                                function_name: name_str,
+                            },
+                            inst.span,
+                        )
+                        .with_label("first defined here".to_string(), first_span));
                     }
                     seen_function_names.entry(*name).or_insert(inst.span);
                     if let Some(first_span) =
-                        seen_functions.insert((inst.span.file_id, *name), inst.span)
+                        seen_functions_by_file.insert((inst.span.file_id, *name), inst.span)
                     {
                         let name_str = self.interner.resolve(name).to_string();
                         return Err(CompileError::new(
@@ -427,8 +430,14 @@ impl<'a> Sema<'a> {
                         ));
                     }
 
-                    // Check for duplicate type definitions (struct or enum with same name)
-                    if self.enums.contains_key(name) || self.structs.contains_key(name) {
+                    let key = (inst.span.file_id, *name);
+
+                    // Check for duplicate type definitions in this file
+                    // (struct or enum with same name). Same-named types in
+                    // different files have distinct module-local identities.
+                    if self.enums_by_file_name.contains_key(&key)
+                        || self.structs_by_file_name.contains_key(&key)
+                    {
                         return Err(CompileError::new(
                             ErrorKind::DuplicateTypeDefinition {
                                 type_name: enum_name,
@@ -475,8 +484,23 @@ impl<'a> Sema<'a> {
                     // Register in type pool and get pool-based EnumId
                     let (enum_id, _) = self.type_pool.register_enum(*name, enum_def);
 
-                    // Register in enum lookup with pool-based EnumId
-                    self.enums.insert(*name, enum_id);
+                    let name_was_unique = !self
+                        .enums_by_file_name
+                        .keys()
+                        .any(|(_, existing_name)| *existing_name == *name)
+                        && !self
+                            .structs_by_file_name
+                            .keys()
+                            .any(|(_, existing_name)| *existing_name == *name);
+
+                    // Register in enum lookups with pool-based EnumId.
+                    self.enums_by_file_name.insert(key, enum_id);
+                    if name_was_unique {
+                        self.enums.insert(*name, enum_id);
+                    } else {
+                        self.enums.remove(name);
+                        self.structs.remove(name);
+                    }
                 }
                 InstData::StructDecl {
                     directives_start,
@@ -498,8 +522,14 @@ impl<'a> Sema<'a> {
                         ));
                     }
 
-                    // Check for duplicate type definitions (struct or enum with same name)
-                    if self.structs.contains_key(name) || self.enums.contains_key(name) {
+                    let key = (inst.span.file_id, *name);
+
+                    // Check for duplicate type definitions in this file
+                    // (struct or enum with same name). Same-named types in
+                    // different files have distinct module-local identities.
+                    if self.structs_by_file_name.contains_key(&key)
+                        || self.enums_by_file_name.contains_key(&key)
+                    {
                         return Err(CompileError::new(
                             ErrorKind::DuplicateTypeDefinition {
                                 type_name: struct_name,
@@ -534,8 +564,23 @@ impl<'a> Sema<'a> {
                     // Register in type pool and get pool-based StructId
                     let (struct_id, _) = self.type_pool.register_struct(*name, struct_def);
 
-                    // Register in struct lookup with pool-based StructId
-                    self.structs.insert(*name, struct_id);
+                    let name_was_unique = !self
+                        .structs_by_file_name
+                        .keys()
+                        .any(|(_, existing_name)| *existing_name == *name)
+                        && !self
+                            .enums_by_file_name
+                            .keys()
+                            .any(|(_, existing_name)| *existing_name == *name);
+
+                    // Register in struct lookups with pool-based StructId.
+                    self.structs_by_file_name.insert(key, struct_id);
+                    if name_was_unique {
+                        self.structs.insert(*name, struct_id);
+                    } else {
+                        self.structs.remove(name);
+                        self.enums.remove(name);
+                    }
                 }
                 _ => {}
             }
@@ -631,7 +676,10 @@ impl<'a> Sema<'a> {
                 variant_payloads.push(payload);
             }
 
-            let enum_id = *self.enums.get(&name).expect("enum registered in phase 1");
+            let enum_id = *self
+                .enums_by_file_name
+                .get(&(span.file_id, name))
+                .expect("enum registered in phase 1");
             let mut def = self.type_pool.enum_def(enum_id);
             def.variant_payloads = variant_payloads;
             self.type_pool.update_enum_def(enum_id, def);
@@ -649,7 +697,7 @@ impl<'a> Sema<'a> {
     /// through arbitrarily deep nestings. The causing field is recorded in
     /// [`Sema::infectious_linear`] for diagnostics.
     pub(crate) fn propagate_field_linearity(&mut self) {
-        let struct_ids: Vec<StructId> = self.structs.values().copied().collect();
+        let struct_ids: Vec<StructId> = self.type_pool.all_struct_ids();
         loop {
             let mut changed = false;
             for &struct_id in &struct_ids {
@@ -688,39 +736,25 @@ impl<'a> Sema<'a> {
             } = &inst.data
             {
                 let name_str = self.interner.resolve(&*name).to_string();
-                // Verify the struct exists in our lookup table
-                if !self.structs.contains_key(name) {
-                    return Err(CompileError::new(
-                        ErrorKind::InternalError(
-                            ice!(
-                                "struct not found in struct map",
-                                phase: "sema/declarations",
-                                details: {
-                                    "struct_name" => name_str.to_string()
-                                }
-                            )
-                            .to_string(),
-                        ),
-                        inst.span,
-                    ));
-                }
-
                 // Get the struct ID from the lookup table
-                let struct_id = *self.structs.get(name).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::InternalError(
-                            ice!(
-                                "struct not found in structs map",
-                                phase: "sema/declarations",
-                                details: {
-                                    "struct_name" => name_str.to_string()
-                                }
-                            )
-                            .to_string(),
-                        ),
-                        inst.span,
-                    )
-                })?;
+                let struct_id = *self
+                    .structs_by_file_name
+                    .get(&(inst.span.file_id, *name))
+                    .ok_or_else(|| {
+                        CompileError::new(
+                            ErrorKind::InternalError(
+                                ice!(
+                                    "struct not found in structs map",
+                                    phase: "sema/declarations",
+                                    details: {
+                                        "struct_name" => name_str.to_string()
+                                    }
+                                )
+                                .to_string(),
+                            ),
+                            inst.span,
+                        )
+                    })?;
 
                 let struct_name = name_str.clone();
                 let fields = self.rir.get_field_decls(*fields_start, *fields_len);
@@ -807,9 +841,10 @@ impl<'a> Sema<'a> {
                 }
                 _ => continue,
             };
-            let start_ty = if let Some(&struct_id) = self.structs.get(&name_sym) {
+            let key = (span.file_id, name_sym);
+            let start_ty = if let Some(&struct_id) = self.structs_by_file_name.get(&key) {
                 Type::new_struct(struct_id)
-            } else if let Some(&enum_id) = self.enums.get(&name_sym) {
+            } else if let Some(&enum_id) = self.enums_by_file_name.get(&key) {
                 Type::new_enum(enum_id)
             } else {
                 continue;
@@ -1045,39 +1080,25 @@ impl<'a> Sema<'a> {
         }
 
         let struct_name = self.interner.resolve(&name).to_string();
-        // Verify struct exists in our lookup
-        if !self.structs.contains_key(&name) {
-            return Err(CompileError::new(
-                ErrorKind::InternalError(
-                    ice!(
-                        "struct not found during @copy validation",
-                        phase: "sema/declarations",
-                        details: {
-                            "struct_name" => struct_name.clone()
-                        }
-                    )
-                    .to_string(),
-                ),
-                span,
-            ));
-        }
-
         // Get the struct ID from the lookup table
-        let struct_id = *self.structs.get(&name).ok_or_else(|| {
-            CompileError::new(
-                ErrorKind::InternalError(
-                    ice!(
-                        "struct not found during @copy validation",
-                        phase: "sema/declarations",
-                        details: {
-                            "struct_name" => struct_name.clone()
-                        }
-                    )
-                    .to_string(),
-                ),
-                span,
-            )
-        })?;
+        let struct_id = *self
+            .structs_by_file_name
+            .get(&(span.file_id, name))
+            .ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::InternalError(
+                        ice!(
+                            "struct not found during @copy validation",
+                            phase: "sema/declarations",
+                            details: {
+                                "struct_name" => struct_name.clone()
+                            }
+                        )
+                        .to_string(),
+                    ),
+                    span,
+                )
+            })?;
 
         // Get struct definition from the pool
         let struct_def = self.type_pool.struct_def(struct_id);
@@ -1102,32 +1123,18 @@ impl<'a> Sema<'a> {
     fn collect_destructor(&mut self, type_name: Spur, span: Span) -> CompileResult<()> {
         let type_name_str = self.interner.resolve(&type_name).to_string();
 
-        // Verify the struct exists
-        if !self.structs.contains_key(&type_name) {
-            return Err(CompileError::new(
-                ErrorKind::DestructorUnknownType {
-                    type_name: type_name_str,
-                },
-                span,
-            ));
-        }
-
         // Get the struct ID from the lookup table
-        let struct_id = *self.structs.get(&type_name).ok_or_else(|| {
-            CompileError::new(
-                ErrorKind::InternalError(
-                    ice!(
-                        "struct not found during destructor collection",
-                        phase: "sema/declarations",
-                        details: {
-                            "struct_name" => type_name_str.to_string()
-                        }
-                    )
-                    .to_string(),
-                ),
-                span,
-            )
-        })?;
+        let struct_id = *self
+            .structs_by_file_name
+            .get(&(span.file_id, type_name))
+            .ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::DestructorUnknownType {
+                        type_name: type_name_str.clone(),
+                    },
+                    span,
+                )
+            })?;
 
         let mut struct_def = self.type_pool.struct_def(struct_id);
         if struct_def.destructor.is_some() {
@@ -1387,7 +1394,7 @@ impl<'a> Sema<'a> {
         methods_len: u32,
         span: Span,
     ) -> CompileResult<()> {
-        let struct_id = match self.structs.get(&type_name) {
+        let struct_id = match self.structs_by_file_name.get(&(span.file_id, type_name)) {
             Some(id) => *id,
             None => {
                 let type_name_str = self.interner.resolve(&type_name).to_string();

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::PreviewFeatures;
 use rue_rir::Rir;
+use rue_span::FileId;
 use rue_target::Target;
 
 use crate::intern_pool::TypeInternPool;
@@ -49,10 +50,14 @@ pub struct GatherOutput<'a> {
     pub rir: &'a Rir,
     /// Reference to the string interner.
     pub interner: &'a ThreadedRodeo,
-    /// Struct lookup: maps struct name symbol to StructId.
+    /// Compatibility struct lookup: maps globally unique struct name symbols to StructId.
     pub structs: HashMap<Spur, StructId>,
-    /// Enum lookup: maps enum name symbol to EnumId.
+    /// Module-local struct lookup: maps (defining file, source name) to StructId.
+    pub structs_by_file_name: HashMap<(FileId, Spur), StructId>,
+    /// Compatibility enum lookup: maps globally unique enum name symbols to EnumId.
     pub enums: HashMap<Spur, EnumId>,
+    /// Module-local enum lookup: maps (defining file, source name) to EnumId.
+    pub enums_by_file_name: HashMap<(FileId, Spur), EnumId>,
     /// Function lookup: maps function name to info.
     pub functions: HashMap<Spur, FunctionInfo>,
     /// Source-level function lookup keyed by defining file and source name.
@@ -97,7 +102,9 @@ impl<'a> GatherOutput<'a> {
             functions_by_file_name: self.functions_by_file_name,
             function_source_names: self.function_source_names,
             structs: self.structs,
+            structs_by_file_name: self.structs_by_file_name,
             enums: self.enums,
+            enums_by_file_name: self.enums_by_file_name,
             methods: self.methods,
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -77,10 +77,14 @@ pub struct Sema<'a> {
     pub(crate) functions_by_file_name: HashMap<(FileId, Spur), Spur>,
     /// Internal function key -> source-level function name.
     pub(crate) function_source_names: HashMap<Spur, Spur>,
-    /// Struct table: maps struct name symbols to their StructId
+    /// Compatibility struct table: maps globally unique struct name symbols to their StructId.
     pub(crate) structs: HashMap<Spur, StructId>,
-    /// Enum table: maps enum name symbols to their EnumId
+    /// Module-local struct table: maps (defining file, source name) to StructId.
+    pub(crate) structs_by_file_name: HashMap<(FileId, Spur), StructId>,
+    /// Compatibility enum table: maps globally unique enum name symbols to their EnumId.
     pub(crate) enums: HashMap<Spur, EnumId>,
+    /// Module-local enum table: maps (defining file, source name) to EnumId.
+    pub(crate) enums_by_file_name: HashMap<(FileId, Spur), EnumId>,
     /// Method table: maps (struct_id, method_name) to method info
     pub(crate) methods: HashMap<(StructId, Spur), MethodInfo>,
     /// Compatibility value-constant table for globally unique bare names.
@@ -183,7 +187,9 @@ impl<'a> Sema<'a> {
             functions_by_file_name: HashMap::new(),
             function_source_names: HashMap::new(),
             structs: HashMap::new(),
+            structs_by_file_name: HashMap::new(),
             enums: HashMap::new(),
+            enums_by_file_name: HashMap::new(),
             methods: HashMap::new(),
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -246,8 +246,11 @@ impl<'a> Sema<'a> {
             is_pub: true,
             file_id: rue_span::FileId::new(0),
         };
+        let file_id = struct_def.file_id;
         let (struct_id, _) = self.type_pool.register_struct(type_sym, struct_def);
         self.structs.insert(type_sym, struct_id);
+        self.structs_by_file_name
+            .insert((file_id, type_sym), struct_id);
         Ok(Type::new_struct(struct_id))
     }
 
@@ -295,8 +298,11 @@ impl<'a> Sema<'a> {
             is_pub: true,
             file_id: rue_span::FileId::new(0),
         };
+        let file_id = struct_def.file_id;
         let (struct_id, _) = self.type_pool.register_struct(type_sym, struct_def);
         self.structs.insert(type_sym, struct_id);
+        self.structs_by_file_name
+            .insert((file_id, type_sym), struct_id);
         let _ = span;
         Ok(Type::new_struct(struct_id))
     }
@@ -362,8 +368,11 @@ impl<'a> Sema<'a> {
             is_pub: true,
             file_id: rue_span::FileId::new(0),
         };
+        let file_id = struct_def.file_id;
         let (struct_id, _) = self.type_pool.register_struct(type_sym, struct_def);
         self.structs.insert(type_sym, struct_id);
+        self.structs_by_file_name
+            .insert((file_id, type_sym), struct_id);
         let _ = span;
         Ok(Type::new_struct(struct_id))
     }
@@ -475,7 +484,11 @@ impl<'a> Sema<'a> {
             return self.get_or_create_str_struct(span);
         }
 
-        if let Some(&struct_id) = self.structs.get(&type_sym) {
+        if let Some(&struct_id) = self
+            .structs_by_file_name
+            .get(&(span.file_id, type_sym))
+            .or_else(|| self.structs.get(&type_sym))
+        {
             // Privacy (E0460, RUE-183): an unqualified type reference must
             // not reach a private struct defined in another directory —
             // privacy is uniform across item kinds (spec 10.3:1, 10.3:7).
@@ -491,7 +504,11 @@ impl<'a> Sema<'a> {
                 span,
             )?;
             Ok(Type::new_struct(struct_id))
-        } else if let Some(&enum_id) = self.enums.get(&type_sym) {
+        } else if let Some(&enum_id) = self
+            .enums_by_file_name
+            .get(&(span.file_id, type_sym))
+            .or_else(|| self.enums.get(&type_sym))
+        {
             // Privacy (E0460, RUE-185): same rule for enums — an unqualified
             // type reference must not reach a private enum defined in another
             // directory.
@@ -679,31 +696,33 @@ impl<'a> Sema<'a> {
         let member = segments[segments.len() - 1];
         let member_sym = self.interner.get_or_intern(member);
 
-        if let Some(&struct_id) = self.structs.get(&member_sym) {
+        if let Some(struct_id) = module_file_id.and_then(|file_id| {
+            self.structs_by_file_name
+                .get(&(file_id, member_sym))
+                .copied()
+        }) {
             let struct_def = self.type_pool.struct_def(struct_id);
-            if module_file_id == Some(struct_def.file_id) {
-                self.check_unqualified_visibility(
-                    "struct",
-                    member,
-                    struct_def.file_id,
-                    struct_def.is_pub,
-                    span,
-                )?;
-                return Ok(Type::new_struct(struct_id));
-            }
+            self.check_unqualified_visibility(
+                "struct",
+                member,
+                struct_def.file_id,
+                struct_def.is_pub,
+                span,
+            )?;
+            return Ok(Type::new_struct(struct_id));
         }
-        if let Some(&enum_id) = self.enums.get(&member_sym) {
+        if let Some(enum_id) = module_file_id
+            .and_then(|file_id| self.enums_by_file_name.get(&(file_id, member_sym)).copied())
+        {
             let enum_def = self.type_pool.enum_def(enum_id);
-            if module_file_id == Some(enum_def.file_id) {
-                self.check_unqualified_visibility(
-                    "enum",
-                    member,
-                    enum_def.file_id,
-                    enum_def.is_pub,
-                    span,
-                )?;
-                return Ok(Type::new_enum(enum_id));
-            }
+            self.check_unqualified_visibility(
+                "enum",
+                member,
+                enum_def.file_id,
+                enum_def.is_pub,
+                span,
+            )?;
+            return Ok(Type::new_enum(enum_id));
         }
         if let Some(info) = module_file_id
             .and_then(|file_id| self.constants_by_file_name.get(&(file_id, member_sym)))

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -10,6 +10,7 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::FileId;
 
 use crate::types::EnumId;
+use rue_rir::InstData;
 
 use super::Sema;
 
@@ -114,16 +115,33 @@ impl Sema<'_> {
     /// Checks visibility: private enums are only accessible from the same directory.
     pub fn resolve_enum_through_module(
         &self,
-        _module_ref: rue_rir::InstRef,
+        module_ref: rue_rir::InstRef,
         type_name: lasso::Spur,
         span: rue_span::Span,
     ) -> CompileResult<EnumId> {
         let type_name_str = self.interner.resolve(&type_name);
 
-        // Try to find the enum globally
-        let enum_id = self.enums.get(&type_name).copied().ok_or_else(|| {
-            CompileError::new(ErrorKind::UnknownEnumType(type_name_str.to_string()), span)
-        })?;
+        let module_file_id = match &self.rir.get(module_ref).data {
+            InstData::VarRef { name } => self
+                .module_bindings
+                .get(&(span.file_id, *name))
+                .and_then(|binding| binding.ty.as_module())
+                .and_then(|module_id| {
+                    let module_def = self.module_registry.get_def(module_id);
+                    self.canonical_file_id(&module_def.file_path)
+                }),
+            _ => None,
+        };
+
+        // Try to find the enum in the referenced module. Fall back to the
+        // compatibility table for legacy/simple paths where the module
+        // expression is not a direct module binding.
+        let enum_id = module_file_id
+            .and_then(|file_id| self.enums_by_file_name.get(&(file_id, type_name)).copied())
+            .or_else(|| self.enums.get(&type_name).copied())
+            .ok_or_else(|| {
+                CompileError::new(ErrorKind::UnknownEnumType(type_name_str.to_string()), span)
+            })?;
 
         // Check visibility
         let enum_def = self.type_pool.enum_def(enum_id);

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -396,6 +396,34 @@ fn main() -> i32 {
 args = ["color.rue", "main.rue", "-o", "prog"]
 exit_code = 2
 
+[[case]]
+name = "same_named_structs_in_sibling_modules"
+description = "RUE-454: module-local type identity allows sibling modules to export same-named structs."
+files = [
+    { path = "a.rue", source = """
+pub struct Item {
+    a: i32,
+}
+""" },
+    { path = "b.rue", source = """
+pub struct Item {
+    b: i32,
+}
+""" },
+    { path = "main.rue", source = """
+const a = @import("a");
+const b = @import("b");
+
+fn main() -> i32 {
+    let x: a.Item = a.Item { a: 19 };
+    let y: b.Item = b.Item { b: 23 };
+    x.a + y.b
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+
 # Transitive discovery: main imports a, a imports b — only main.rue is on
 # the command line; the driver's import scan must load both (RUE-14).
 [[case]]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -398,10 +398,11 @@ pub(crate) struct DuplicateSymbolCheck {
 
 /// Detect duplicate symbol definitions across parsed files.
 ///
-/// Free functions are scoped to their defining file/module for duplicate
-/// detection, while structs and enums still share a flat type namespace.
-/// Every duplicate produces one error pointing at the redefinition, with a
-/// label at the first definition.
+/// Free functions and nominal types are scoped to their defining file/module
+/// for same-kind duplicate detection. Function/type cross-kind collisions
+/// remain global for the current transitional namespace. Every duplicate
+/// produces one error pointing at the redefinition, with a label at the first
+/// definition.
 ///
 /// This is the single source of truth for duplicate-symbol detection, shared
 /// by [`merge_symbols`] and `CompilationUnit::parse`.
@@ -413,8 +414,9 @@ pub(crate) fn detect_duplicate_symbols<'a>(
 
     let mut functions: HashMap<(String, String), SymbolDef> = HashMap::new();
     let mut function_names: HashMap<String, SymbolDef> = HashMap::new();
-    let mut structs: HashMap<String, SymbolDef> = HashMap::new();
-    let mut enums: HashMap<String, SymbolDef> = HashMap::new();
+    let mut type_names: HashMap<String, SymbolDef> = HashMap::new();
+    let mut structs: HashMap<(String, String), SymbolDef> = HashMap::new();
+    let mut enums: HashMap<(String, String), SymbolDef> = HashMap::new();
     let mut errors: Vec<CompileError> = Vec::new();
 
     for (file_path, ast) in files {
@@ -442,7 +444,7 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                             },
                         );
                     }
-                    if let Some(first) = structs.get(&name).or_else(|| enums.get(&name)) {
+                    if let Some(first) = type_names.get(&name) {
                         let err = CompileError::new(
                             ErrorKind::DuplicateFunctionDefinition {
                                 function_name: name.clone(),
@@ -461,16 +463,17 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                 }
                 Item::Struct(s) => {
                     let name = interner.resolve(&s.name.name).to_string();
+                    let key = (file_path.to_string(), name.clone());
                     if let Some(first) = function_names.get(&name) {
                         let err = CompileError::new(
                             ErrorKind::DuplicateFunctionDefinition {
-                                function_name: name,
+                                function_name: name.clone(),
                             },
                             s.span,
                         )
                         .with_label(format!("first defined in {}", first.file_path), first.span);
                         errors.push(err);
-                    } else if let Some(first) = structs.get(&name) {
+                    } else if let Some(first) = structs.get(&key) {
                         // Duplicate struct definition
                         let err = CompileError::new(
                             ErrorKind::DuplicateTypeDefinition {
@@ -480,7 +483,7 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                         )
                         .with_label(format!("first defined in {}", first.file_path), first.span);
                         errors.push(err);
-                    } else if let Some(first) = enums.get(&name) {
+                    } else if let Some(first) = enums.get(&key) {
                         // Struct name conflicts with enum
                         let err = CompileError::new(
                             ErrorKind::DuplicateTypeDefinition {
@@ -494,8 +497,12 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                         );
                         errors.push(err);
                     } else {
+                        type_names.entry(name.clone()).or_insert_with(|| SymbolDef {
+                            span: s.span,
+                            file_path: file_path.to_string(),
+                        });
                         structs.insert(
-                            name,
+                            key,
                             SymbolDef {
                                 span: s.span,
                                 file_path: file_path.to_string(),
@@ -505,16 +512,17 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                 }
                 Item::Enum(e) => {
                     let name = interner.resolve(&e.name.name).to_string();
+                    let key = (file_path.to_string(), name.clone());
                     if let Some(first) = function_names.get(&name) {
                         let err = CompileError::new(
                             ErrorKind::DuplicateFunctionDefinition {
-                                function_name: name,
+                                function_name: name.clone(),
                             },
                             e.span,
                         )
                         .with_label(format!("first defined in {}", first.file_path), first.span);
                         errors.push(err);
-                    } else if let Some(first) = enums.get(&name) {
+                    } else if let Some(first) = enums.get(&key) {
                         // Duplicate enum definition
                         let err = CompileError::new(
                             ErrorKind::DuplicateTypeDefinition {
@@ -524,7 +532,7 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                         )
                         .with_label(format!("first defined in {}", first.file_path), first.span);
                         errors.push(err);
-                    } else if let Some(first) = structs.get(&name) {
+                    } else if let Some(first) = structs.get(&key) {
                         // Enum name conflicts with struct
                         let err = CompileError::new(
                             ErrorKind::DuplicateTypeDefinition {
@@ -538,8 +546,12 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                         );
                         errors.push(err);
                     } else {
+                        type_names.entry(name.clone()).or_insert_with(|| SymbolDef {
+                            span: e.span,
+                            file_path: file_path.to_string(),
+                        });
                         enums.insert(
-                            name,
+                            key,
                             SymbolDef {
                                 span: e.span,
                                 file_path: file_path.to_string(),
@@ -1988,17 +2000,17 @@ mod tests {
 
     #[test]
     fn test_merge_symbols_duplicate_struct() {
-        let sources = vec![
-            SourceFile::new(
-                "a.rue",
-                "struct Point { x: i32 } fn main() -> i32 { 0 }",
-                FileId::new(1),
-            ),
-            SourceFile::new("b.rue", "struct Point { y: i32 }", FileId::new(2)),
-        ];
+        let sources = vec![SourceFile::new(
+            "a.rue",
+            "struct Point { x: i32 } struct Point { y: i32 } fn main() -> i32 { 0 }",
+            FileId::new(1),
+        )];
         let parsed = parse_all_files(&sources).unwrap();
         let result = merge_symbols(parsed);
-        assert!(result.is_err(), "merge should fail with duplicate struct");
+        assert!(
+            result.is_err(),
+            "merge should fail with duplicate struct in one file"
+        );
 
         let errors = result.unwrap_err();
         assert_eq!(errors.len(), 1, "should have 1 error");
@@ -2010,18 +2022,36 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_symbols_duplicate_enum() {
+    fn test_merge_symbols_same_struct_name_in_different_files_allowed() {
         let sources = vec![
             SourceFile::new(
                 "a.rue",
-                "enum Color { Red } fn main() -> i32 { 0 }",
+                "struct Point { x: i32 } fn main() -> i32 { 0 }",
                 FileId::new(1),
             ),
-            SourceFile::new("b.rue", "enum Color { Blue }", FileId::new(2)),
+            SourceFile::new("b.rue", "struct Point { y: i32 }", FileId::new(2)),
         ];
         let parsed = parse_all_files(&sources).unwrap();
         let result = merge_symbols(parsed);
-        assert!(result.is_err(), "merge should fail with duplicate enum");
+        assert!(
+            result.is_ok(),
+            "module-local structs in different files may share a source name"
+        );
+    }
+
+    #[test]
+    fn test_merge_symbols_duplicate_enum() {
+        let sources = vec![SourceFile::new(
+            "a.rue",
+            "enum Color { Red } enum Color { Blue } fn main() -> i32 { 0 }",
+            FileId::new(1),
+        )];
+        let parsed = parse_all_files(&sources).unwrap();
+        let result = merge_symbols(parsed);
+        assert!(
+            result.is_err(),
+            "merge should fail with duplicate enum in one file"
+        );
 
         let errors = result.unwrap_err();
         assert_eq!(errors.len(), 1, "should have 1 error");
@@ -2033,8 +2063,50 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_symbols_same_enum_name_in_different_files_allowed() {
+        let sources = vec![
+            SourceFile::new(
+                "a.rue",
+                "enum Color { Red } fn main() -> i32 { 0 }",
+                FileId::new(1),
+            ),
+            SourceFile::new("b.rue", "enum Color { Blue }", FileId::new(2)),
+        ];
+        let parsed = parse_all_files(&sources).unwrap();
+        let result = merge_symbols(parsed);
+        assert!(
+            result.is_ok(),
+            "module-local enums in different files may share a source name"
+        );
+    }
+
+    #[test]
     fn test_merge_symbols_struct_enum_conflict() {
-        // Struct and enum with the same name should conflict
+        // Struct and enum with the same name in one file should conflict.
+        let sources = vec![SourceFile::new(
+            "a.rue",
+            "struct Foo { x: i32 } enum Foo { Bar } fn main() -> i32 { 0 }",
+            FileId::new(1),
+        )];
+        let parsed = parse_all_files(&sources).unwrap();
+        let result = merge_symbols(parsed);
+        assert!(
+            result.is_err(),
+            "merge should fail when struct and enum have same name in one file"
+        );
+
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1, "should have 1 error");
+        let err_msg = errors.first().unwrap().to_string();
+        assert!(
+            err_msg.contains("Foo") && err_msg.contains("conflicts"),
+            "error should mention the conflict: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_merge_symbols_struct_enum_same_name_in_different_files_allowed() {
         let sources = vec![
             SourceFile::new(
                 "a.rue",
@@ -2046,17 +2118,8 @@ mod tests {
         let parsed = parse_all_files(&sources).unwrap();
         let result = merge_symbols(parsed);
         assert!(
-            result.is_err(),
-            "merge should fail when struct and enum have same name"
-        );
-
-        let errors = result.unwrap_err();
-        assert_eq!(errors.len(), 1, "should have 1 error");
-        let err_msg = errors.first().unwrap().to_string();
-        assert!(
-            err_msg.contains("Foo") && err_msg.contains("conflicts"),
-            "error should mention the conflict: {}",
-            err_msg
+            result.is_ok(),
+            "module-local types in different files may share a source name"
         );
     }
 

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -355,6 +355,58 @@ pub struct Point { x: i32, y: i32, }
 exit_code = 3
 
 [[case]]
+name = "same_named_structs_in_distinct_modules_are_distinct"
+spec = ["10.4:16"]
+description = "RUE-454: module-qualified type lookup uses the defining module, so sibling modules may each define `Point`."
+source = """
+const a = @import("a");
+const b = @import("b");
+
+fn main() -> i32 {
+    let p: a.Point = a.Point { x: 10 };
+    let q: b.Point = b.Point { y: 32 };
+    p.x + q.y
+}
+"""
+aux_files = { "a.rue" = """
+pub struct Point { x: i32, }
+""", "b.rue" = """
+pub struct Point { y: i32, }
+""" }
+exit_code = 42
+
+[[case]]
+name = "same_named_enums_in_distinct_modules_are_distinct"
+spec = ["10.4:15"]
+description = "RUE-454: module-qualified enum lookup uses the defining module, so sibling modules may each define `Color`."
+source = """
+const a = @import("a");
+const b = @import("b");
+
+fn main() -> i32 {
+    let left = a.pick_a();
+    let right = b.pick_b();
+    let x = match left {
+        a.Color::Red => 10,
+        a.Color::Green => 0,
+    };
+    let y = match right {
+        b.Color::Red => 0,
+        b.Color::Green => 32,
+    };
+    x + y
+}
+"""
+aux_files = { "a.rue" = """
+pub enum Color { Red, Green, }
+pub fn pick_a() -> Color { Color::Red }
+""", "b.rue" = """
+pub enum Color { Red, Green, }
+pub fn pick_b() -> Color { Color::Green }
+""" }
+exit_code = 42
+
+[[case]]
 name = "qualified_private_struct_literal_rejected"
 spec = ["10.4:18"]
 description = "A private struct named in a module-qualified struct literal from another directory is E0460 (resolves through the flat namespace)"


### PR DESCRIPTION
## Summary

- make nominal struct/enum identity file-scoped while keeping globally unique compatibility lookup for unqualified names
- resolve module-qualified type annotations, struct literals, module type members, and enum paths through the defining module file
- scope duplicate type detection to same-file definitions while preserving the current global function/type cross-kind collision rule
- add CLI/spec coverage for same-named structs/enums exported from sibling modules

Fixes RUE-454.

## Validation

- ./fmt.sh
- ./buck2 test //crates/rue-air:rue-air-test //:spec-tests //:cli-tests
- ./clippy.sh