### PR TITLE
[codex] Cover JSON warnings on successful compiles

### DIFF
--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -24,3 +24,26 @@ compile_stderr_not_contains = [
   "error[E0206]",
   "-->",
 ]
+
+[[case]]
+name = "successful_compile_warning_is_json"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let unused = 42;
+    0
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_only = true
+compile_stderr_contains = [
+  '"severity":"warning"',
+  "\"message\":\"unused variable 'unused'\"",
+  '"spans":[{',
+  '"primary":true',
+]
+compile_stderr_not_contains = [
+  "warning:",
+  "warning[",
+  "-->",
+  "  |",
+]


### PR DESCRIPTION
## Summary

- add CLI regression coverage for successful compiles that emit warnings under `--error-format json`
- assert the warning is machine-readable JSON, including severity/message/spans/primary fields
- assert human diagnostic framing such as `warning:` and source gutters does not leak into JSON mode

Fixes RUE-480.

## Validation

- ./fmt.sh
- ./buck2 test //:cli-tests
- ./clippy.sh
