### PR TITLE
[codex] Report deferred lowering errors during emit

### DIFF
--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -81,6 +81,25 @@ compile_only = true
 compile_stdout_contains = ["=== Assembly", "main"]
 
 [[case]]
+name = "emit_lowering_reports_deferred_lowering_errors"
+description = "--emit lowering used to ignore deferred by-ref lowering diagnostics and exit successfully (RUE-482)."
+files = [{ path = "main.rue", source = """
+const X: i32 = 1;
+
+fn f(inout x: i32) {
+    x = 2;
+}
+
+fn main() -> i32 {
+    f(inout X);
+    X
+}
+""" }]
+args = ["--emit", "lowering", "main.rue"]
+compile_fail = true
+error_contains = ["E0425", "inout argument must be an lvalue"]
+
+[[case]]
 name = "emit_air_target_arch_uses_requested_target"
 description = "@target_arch() in --emit uses --target, not the compiler host (RUE-417)."
 files = [{ path = "main.rue", source = """

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -408,7 +408,7 @@ impl<'a> CfgLower<'a> {
     ///
     /// This is like `lower()` but also captures detailed information about
     /// how each CFG instruction maps to MIR instructions.
-    pub fn lower_with_debug(mut self) -> (Aarch64Mir, crate::LoweringDebugInfo) {
+    pub fn lower_with_debug(mut self) -> CompileResult<(Aarch64Mir, crate::LoweringDebugInfo)> {
         use crate::cfg_lower::{format_cfg_inst_data, format_terminator};
         use crate::{
             BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
@@ -503,7 +503,11 @@ impl<'a> CfgLower<'a> {
             debug_info.blocks.push(block_info);
         }
 
-        (self.mir, debug_info)
+        if let Some(err) = self.deferred_error.take() {
+            return Err(err);
+        }
+
+        Ok((self.mir, debug_info))
     }
 
     /// Generate rationale for instruction lowering decisions.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -581,7 +581,7 @@ impl<'a> CfgLower<'a> {
     ///
     /// This is like `lower()` but also captures detailed information about
     /// how each CFG instruction maps to MIR instructions.
-    pub fn lower_with_debug(mut self) -> (X86Mir, crate::LoweringDebugInfo) {
+    pub fn lower_with_debug(mut self) -> CompileResult<(X86Mir, crate::LoweringDebugInfo)> {
         use crate::cfg_lower::{format_cfg_inst_data, format_terminator};
         use crate::{
             BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
@@ -676,7 +676,11 @@ impl<'a> CfgLower<'a> {
             debug_info.blocks.push(block_info);
         }
 
-        (self.mir, debug_info)
+        if let Some(err) = self.deferred_error.take() {
+            return Err(err);
+        }
+
+        Ok((self.mir, debug_info))
     }
 
     /// Generate rationale for instruction lowering decisions.

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -1583,18 +1583,18 @@ pub fn generate_lowering_info(
     type_pool: &TypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
-) -> rue_codegen::LoweringDebugInfo {
+) -> CompileResult<rue_codegen::LoweringDebugInfo> {
     match target.arch() {
         Arch::X86_64 => {
             let (_mir, debug_info) =
-                rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower_with_debug();
-            debug_info
+                rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower_with_debug()?;
+            Ok(debug_info)
         }
         Arch::Aarch64 => {
             let (_mir, debug_info) =
                 rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target)
-                    .lower_with_debug();
-            debug_info
+                    .lower_with_debug()?;
+            Ok(debug_info)
         }
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1844,12 +1844,18 @@ fn handle_emit_multi_file(
             EmitStage::Lowering => {
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
-                        let lowering_info = generate_lowering_info(
+                        let lowering_info = match generate_lowering_info(
                             &func.cfg,
                             &state.type_pool,
                             &state.interner,
                             options.target,
-                        );
+                        ) {
+                            Ok(info) => info,
+                            Err(e) => {
+                                diagnostics.print_error(&e);
+                                return Err(());
+                            }
+                        };
                         print!("{}", lowering_info);
                     }
                 }


### PR DESCRIPTION
## Summary
- make lowering debug generation return a CompileResult
- propagate deferred lowering diagnostics from both x86_64 and aarch64 debug lowering
- add a CLI regression test for `--emit lowering` on invalid `inout` usage

Linear: RUE-482

## Validation
- `./fmt.sh`
- `./buck2 test //crates/rue-codegen:rue-codegen-test //crates/rue-compiler:rue-compiler-test //crates/rue:rue-test //:cli-tests`
- `./clippy.sh`