### PR TITLE
[codex] Describe function bodies as expressions

### DIFF
--- a/website/content/tutorial/04-functions.md
+++ b/website/content/tutorial/04-functions.md
@@ -30,13 +30,14 @@ fn main() -> i32 {
 }
 ```
 
-## Implicit Returns
+## Function Body Values
 
-The last expression in a function is its return value—no `return` keyword needed:
+Rue is expression-oriented: a function body evaluates to the value of its final
+expression. That value is the function call's result:
 
 ```rue skip
 fn double(x: i32) -> i32 {
-    x * 2  // this value is returned
+    x * 2  // this is the body expression's value
 }
 ```
 


### PR DESCRIPTION
## Summary
- replace the tutorial “Implicit Returns” framing with expression-oriented function-body wording
- clarify that a function body evaluates to its final expression
- keep the explicit `return` section focused on early exits

Linear: RUE-468

## Validation
- `./buck2 test //:tutorial-snippet-tests`