### PR TITLE
[codex] Move tutorial ending after modules

### DIFF
--- a/website/content/tutorial/10-putting-it-together.md
+++ b/website/content/tutorial/10-putting-it-together.md
@@ -112,8 +112,5 @@ in the `examples/` directory:
 
 ## Next Steps
 
-You've learned the current core of Rue. For the complete language reference,
-read the [Language Specification](/spec/).
-
-Rue is still in early development. If you find bugs or have ideas, please
-[file an issue](https://github.com/rue-language/rue/issues).
+This program imports `std` as a module. The next chapter shows the same module
+system with your own files, including public and private declarations.

--- a/website/content/tutorial/11-modules.md
+++ b/website/content/tutorial/11-modules.md
@@ -96,3 +96,11 @@ directory.
 
 The important habit is still the same: use explicit module imports and
 namespace-qualified access rather than hidden global names.
+
+## Next Steps
+
+You've learned the current core of Rue. For the complete language reference,
+read the [Language Specification](/spec/).
+
+Rue is still in early development. If you find bugs or have ideas, please
+[file an issue](https://github.com/rue-language/rue/issues).


### PR DESCRIPTION
## Summary
- make the “Putting It Together” next step point forward to the modules chapter
- move the final tutorial/spec/issues next-step text to the modules chapter

Linear: RUE-471

## Validation
- `./buck2 test //:tutorial-snippet-tests`