### PR TITLE
[codex] Buffer fallible emit output

### DIFF
--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -100,6 +100,26 @@ compile_fail = true
 error_contains = ["E0425", "inout argument must be an lvalue"]
 
 [[case]]
+name = "emit_mir_suppresses_partial_stdout_on_late_lowering_error"
+description = "--emit mir buffers fallible per-function output so a later lowering error does not leave partial MIR on stdout (RUE-483)."
+files = [{ path = "main.rue", source = """
+const X: i32 = 1;
+
+fn f(inout x: i32) {
+    x = 2;
+}
+
+fn main() -> i32 {
+    f(inout X);
+    X
+}
+""" }]
+args = ["--emit", "mir", "main.rue"]
+compile_fail = true
+error_contains = ["E0425", "inout argument must be an lvalue"]
+compile_stdout_not_contains = ["=== MIR", "function f:"]
+
+[[case]]
 name = "emit_air_target_arch_uses_requested_target"
 description = "@target_arch() in --emit uses --target, not the compiler host (RUE-417)."
 files = [{ path = "main.rue", source = """

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1791,6 +1791,8 @@ fn handle_emit_multi_file(
         None
     };
 
+    use std::fmt::Write as _;
+
     // Now emit in order
     for stage in &options.emit_stages {
         match stage {
@@ -1842,6 +1844,7 @@ fn handle_emit_multi_file(
                 println!();
             }
             EmitStage::Lowering => {
+                let mut output = String::new();
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
                         let lowering_info = match generate_lowering_info(
@@ -1856,13 +1859,15 @@ fn handle_emit_multi_file(
                                 return Err(());
                             }
                         };
-                        print!("{}", lowering_info);
+                        write!(&mut output, "{}", lowering_info).expect("write to String");
                     }
                 }
-                println!();
+                output.push('\n');
+                print!("{}", output);
             }
             EmitStage::Mir => {
-                println!("=== MIR ({}) ===", options.target);
+                let mut output = String::new();
+                writeln!(&mut output, "=== MIR ({}) ===", options.target).expect("write to String");
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
                         let mir = match generate_mir(
@@ -1877,17 +1882,24 @@ fn handle_emit_multi_file(
                                 return Err(());
                             }
                         };
-                        println!("function {}:", func.analyzed.name);
-                        println!("{}", mir);
+                        writeln!(&mut output, "function {}:", func.analyzed.name)
+                            .expect("write to String");
+                        writeln!(&mut output, "{}", mir).expect("write to String");
                     }
                 }
-                println!();
+                output.push('\n');
+                print!("{}", output);
             }
             EmitStage::Liveness => {
-                println!("=== Liveness Analysis ({}) ===", options.target);
+                let mut output = String::new();
+                writeln!(
+                    &mut output,
+                    "=== Liveness Analysis ({}) ===",
+                    options.target
+                )
+                .expect("write to String");
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
-                        println!("function {}:", func.analyzed.name);
                         let liveness_info = match generate_liveness_info(
                             &func.cfg,
                             &state.type_pool,
@@ -1900,16 +1912,24 @@ fn handle_emit_multi_file(
                                 return Err(());
                             }
                         };
-                        println!("{}", liveness_info);
+                        writeln!(&mut output, "function {}:", func.analyzed.name)
+                            .expect("write to String");
+                        writeln!(&mut output, "{}", liveness_info).expect("write to String");
                     }
                 }
-                println!();
+                output.push('\n');
+                print!("{}", output);
             }
             EmitStage::RegAlloc => {
-                println!("=== Register Allocation ({}) ===", options.target);
+                let mut output = String::new();
+                writeln!(
+                    &mut output,
+                    "=== Register Allocation ({}) ===",
+                    options.target
+                )
+                .expect("write to String");
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
-                        println!("function {}:", func.analyzed.name);
                         let regalloc_info = match generate_regalloc_info(
                             &func.cfg,
                             &state.type_pool,
@@ -1922,17 +1942,20 @@ fn handle_emit_multi_file(
                                 return Err(());
                             }
                         };
-                        print!("{}", regalloc_info);
+                        writeln!(&mut output, "function {}:", func.analyzed.name)
+                            .expect("write to String");
+                        write!(&mut output, "{}", regalloc_info).expect("write to String");
                     }
                 }
-                println!();
+                output.push('\n');
+                print!("{}", output);
             }
             EmitStage::Asm => {
-                println!("=== Assembly ({}) ===", options.target);
+                let mut output = String::new();
+                writeln!(&mut output, "=== Assembly ({}) ===", options.target)
+                    .expect("write to String");
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
-                        println!(".globl {}", func.analyzed.name);
-                        println!("{}:", func.analyzed.name);
                         let asm = match generate_emitted_asm(
                             &func.cfg,
                             &state.type_pool,
@@ -1946,12 +1969,17 @@ fn handle_emit_multi_file(
                                 return Err(());
                             }
                         };
-                        print!("{}", asm);
+                        writeln!(&mut output, ".globl {}", func.analyzed.name)
+                            .expect("write to String");
+                        writeln!(&mut output, "{}:", func.analyzed.name).expect("write to String");
+                        write!(&mut output, "{}", asm).expect("write to String");
                     }
                 }
-                println!();
+                output.push('\n');
+                print!("{}", output);
             }
             EmitStage::StackFrame => {
+                let mut output = String::new();
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
                         let frame_info = match generate_stack_frame_info(
@@ -1967,9 +1995,10 @@ fn handle_emit_multi_file(
                                 return Err(());
                             }
                         };
-                        println!("{}", frame_info);
+                        writeln!(&mut output, "{}", frame_info).expect("write to String");
                     }
                 }
+                print!("{}", output);
             }
             EmitStage::Deps => unreachable!("--emit deps is handled before frontend emission"),
         }


### PR DESCRIPTION
## Summary

- buffer fallible `--emit` stage output before printing it
- avoid partial stdout when a later function fails during lowering/MIR/liveness/regalloc/asm/stackframe emission
- add a CLI regression for `--emit mir` with a late by-ref lowering error

## Root cause

Some emit stages printed headers or earlier function output before running fallible per-function lowering work for later functions. A later failure then exited non-zero while leaving misleading partial stage output on stdout.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue:rue-test //:cli-tests`
- `./clippy.sh`

Linear: RUE-483