### PR TITLE
[codex] Share import candidate groups

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -36,7 +36,8 @@ pub use intern_pool::{
 pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};
 pub use sema::{
-    AnalyzedFunction, ConstValue, FunctionInfo, GatherOutput, MethodInfo, Sema, SemaOutput,
+    AnalyzedFunction, ConstValue, DirResolution, FunctionInfo, GatherOutput, MethodInfo,
+    ModulePath, Sema, SemaOutput, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -1228,8 +1228,6 @@ impl<'a> Sema<'a> {
 }
 
 fn import_candidates(import_path: &str, base_dirs: &[String]) -> Vec<String> {
-    use std::path::Path;
-
     let mut candidates = Vec::new();
     let push_unique = |candidates: &mut Vec<String>, candidate: String| {
         if !candidates.contains(&candidate) {
@@ -1237,34 +1235,9 @@ fn import_candidates(import_path: &str, base_dirs: &[String]) -> Vec<String> {
         }
     };
 
-    for base in base_dirs {
-        let base_path = Path::new(base);
-        if import_path.ends_with(".rue") {
-            push_unique(
-                &mut candidates,
-                base_path.join(import_path).to_string_lossy().into_owned(),
-            );
-        } else {
-            let rel = Path::new(import_path);
-            let basename = rel
-                .file_name()
-                .and_then(|s| s.to_str())
-                .unwrap_or(import_path);
-            push_unique(
-                &mut candidates,
-                base_path
-                    .join(format!("{import_path}.rue"))
-                    .to_string_lossy()
-                    .into_owned(),
-            );
-            push_unique(
-                &mut candidates,
-                base_path
-                    .join(import_path)
-                    .join(format!("_{basename}.rue"))
-                    .to_string_lossy()
-                    .into_owned(),
-            );
+    for group in super::super::module_path::import_candidate_groups(import_path, base_dirs, None) {
+        for candidate in group {
+            push_unique(&mut candidates, candidate);
         }
     }
 

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -49,6 +49,7 @@ pub use gather::GatherOutput;
 pub use inference_ctx::InferenceContext;
 pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
+pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
 pub use output::{AnalyzedFunction, SemaOutput};
 
 use std::collections::HashMap;

--- a/crates/rue-air/src/sema/module_path.rs
+++ b/crates/rue-air/src/sema/module_path.rs
@@ -119,6 +119,55 @@ impl ModulePath {
         }
     }
 
+    /// Build ordered filesystem candidate groups for this import path.
+    ///
+    /// Each inner group contains candidates that should be considered
+    /// together within one precedence level. If any candidate in a group
+    /// exists, later groups must not be probed. This lets the CLI load both
+    /// `foo.rue` and `foo/_foo.rue` from the same base directory so sema can
+    /// report the ambiguity, while still preserving importer-dir-before-root
+    /// precedence.
+    ///
+    /// `std_dir`, when present, is the `$RUE_STD_PATH` directory and is probed
+    /// before importer/root-relative stdlib facades.
+    pub fn candidate_groups(
+        &self,
+        base_dirs: &[String],
+        std_dir: Option<&str>,
+    ) -> Vec<Vec<String>> {
+        let mut groups = Vec::new();
+
+        match self {
+            ModulePath::Std => {
+                if let Some(std_dir) = std_dir {
+                    groups.push(vec![join_base(std_dir, "_std.rue")]);
+                }
+                for base in base_dirs {
+                    groups.push(vec![join_base(base, "std/_std.rue")]);
+                }
+            }
+            ModulePath::ExplicitRue { path } => {
+                for base in base_dirs {
+                    groups.push(vec![join_base(base, path)]);
+                }
+            }
+            ModulePath::Simple { path } => {
+                let basename = Path::new(path)
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(path);
+                for base in base_dirs {
+                    groups.push(vec![
+                        join_base(base, &format!("{path}.rue")),
+                        join_base(base, &format!("{path}/_{basename}.rue")),
+                    ]);
+                }
+            }
+        }
+
+        groups
+    }
+
     /// Resolve this import path against the loaded files, anchored to
     /// `base_dirs` (searched in order — importer's directory first, then the
     /// root file's directory; see spec 10.2:2).
@@ -176,23 +225,27 @@ impl ModulePath {
                 }
                 DirResolution::NotFound
             }
-            ModulePath::ExplicitRue { path } => {
-                for base in base_dirs {
-                    if let Some(hit) = find_exact(&join_base(base, path)) {
+            ModulePath::ExplicitRue { .. } => {
+                let base_dirs = base_dirs
+                    .iter()
+                    .map(|base| (*base).to_string())
+                    .collect::<Vec<_>>();
+                for group in self.candidate_groups(&base_dirs, None) {
+                    let candidate = &group[0];
+                    if let Some(hit) = find_exact(candidate) {
                         return DirResolution::Resolved(hit);
                     }
                 }
                 DirResolution::NotFound
             }
-            ModulePath::Simple { path } => {
-                let basename = Path::new(path)
-                    .file_name()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or(path);
-                for base in base_dirs {
-                    let file_module = find_exact(&join_base(base, &format!("{path}.rue")));
-                    let dir_module =
-                        find_exact(&join_base(base, &format!("{path}/_{basename}.rue")));
+            ModulePath::Simple { .. } => {
+                let base_dirs = base_dirs
+                    .iter()
+                    .map(|base| (*base).to_string())
+                    .collect::<Vec<_>>();
+                for group in self.candidate_groups(&base_dirs, None) {
+                    let file_module = find_exact(&group[0]);
+                    let dir_module = find_exact(&group[1]);
                     match (file_module, dir_module) {
                         (Some(file_module), Some(dir_module)) => {
                             // Both forms present in the SAME base directory:
@@ -212,6 +265,18 @@ impl ModulePath {
             }
         }
     }
+}
+
+/// Build ordered filesystem candidate groups for an import path string.
+///
+/// This is the public driver-facing entry point for the same candidate order
+/// used by [`ModulePath::resolve_in_dirs`].
+pub fn import_candidate_groups(
+    import_path: &str,
+    base_dirs: &[String],
+    std_dir: Option<&str>,
+) -> Vec<Vec<String>> {
+    ModulePath::parse(import_path).candidate_groups(base_dirs, std_dir)
 }
 
 /// Whether `candidate` ends with `suffix` at a path boundary (start of string
@@ -277,6 +342,52 @@ mod tests {
             ModulePath::Simple {
                 path: "utils/strings".to_string()
             }
+        );
+    }
+
+    // =========================================================================
+    // Candidate group tests
+    // =========================================================================
+
+    #[test]
+    fn test_candidate_groups_explicit_rue() {
+        assert_eq!(
+            import_candidate_groups("foo.rue", &owned(&["a", ""]), None),
+            vec![vec!["a/foo.rue".to_string()], vec!["foo.rue".to_string()]]
+        );
+    }
+
+    #[test]
+    fn test_candidate_groups_simple_groups_file_and_facade_per_base() {
+        assert_eq!(
+            import_candidate_groups("foo", &owned(&["a", ""]), None),
+            vec![
+                vec!["a/foo.rue".to_string(), "a/foo/_foo.rue".to_string()],
+                vec!["foo.rue".to_string(), "foo/_foo.rue".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn test_candidate_groups_nested_simple_uses_leaf_facade_name() {
+        assert_eq!(
+            import_candidate_groups("utils/strings", &owned(&["src"]), None),
+            vec![vec![
+                "src/utils/strings.rue".to_string(),
+                "src/utils/strings/_strings.rue".to_string(),
+            ]]
+        );
+    }
+
+    #[test]
+    fn test_candidate_groups_std_prefers_installed_facade() {
+        assert_eq!(
+            import_candidate_groups("std", &owned(&["a", ""]), Some("/opt/rue/std")),
+            vec![
+                vec!["/opt/rue/std/_std.rue".to_string()],
+                vec!["a/std/_std.rue".to_string()],
+                vec!["std/_std.rue".to_string()],
+            ]
         );
     }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -218,7 +218,10 @@ fn parse_runtime_archive(runtime_bytes: &[u8]) -> Result<Archive, String> {
 
 // Re-export commonly used types
 pub use lasso::{Spur, ThreadedRodeo};
-pub use rue_air::{Air, AnalyzedFunction, Sema, SemaOutput, StructDef, Type, TypeInternPool};
+pub use rue_air::{
+    Air, AnalyzedFunction, DirResolution, ModulePath, Sema, SemaOutput, StructDef, Type,
+    TypeInternPool, import_candidate_groups,
+};
 pub use rue_cfg::{Cfg, CfgBuilder, CfgOutput, OptLevel};
 pub use rue_codegen::{
     LoweringDebugInfo, RegAllocDebugInfo, RelocationKind, StackFrameInfo, X86Mir,

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -17,8 +17,8 @@ use rue_compiler::{
     MultiFileFormatter, MultiFileJsonFormatter, OptLevel, ParsedProgram, PreviewFeature,
     PreviewFeatures, SourceFile, SourceInfo, TokenKind, compile_multi_file_with_options,
     configure_thread_pool, generate_emitted_asm, generate_liveness_info, generate_lowering_info,
-    generate_mir, generate_regalloc_info, generate_stack_frame_info, merge_symbols,
-    parse_all_files,
+    generate_mir, generate_regalloc_info, generate_stack_frame_info, import_candidate_groups,
+    merge_symbols, parse_all_files,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -1228,38 +1228,24 @@ fn discover_and_load_imports(
                 .map(PathBuf::from)
                 .unwrap_or_default();
 
-            // Candidate GROUPS, nearest base directory first. Within a
-            // group, EVERY existing candidate is loaded — if both `foo.rue`
-            // and `foo/_foo.rue` exist, loading both lets sema report the
+            // Candidate GROUPS, nearest base directory first. Within a group,
+            // EVERY existing candidate is loaded — if both `foo.rue` and
+            // `foo/_foo.rue` exist, loading both lets sema report the
             // dual-entity ambiguity (E0708) instead of the driver silently
-            // picking one. Later groups are only probed when the nearer
-            // group had nothing.
-            let mut groups: Vec<Vec<PathBuf>> = Vec::new();
-            // "std" is the general directory-module rule (std/_std.rue) plus
-            // one extra candidate group: an installed stdlib via $RUE_STD_PATH.
-            if import_str == "std"
-                && let Ok(std_path) = env::var("RUE_STD_PATH")
-            {
-                groups.push(vec![Path::new(&std_path).join("_std.rue")]);
-            }
-            if import_str.ends_with(".rue") {
-                groups.push(vec![importer_dir.join(import_str)]);
-                groups.push(vec![root_dir.join(import_str)]);
-            } else {
-                // Directory-module facade: foo/_foo.rue (inside the
-                // directory, mirroring std/_std.rue — RUE-137).
-                let rel = Path::new(import_str);
-                let basename = rel.file_name().unwrap_or_default().to_string_lossy();
-                let facade = rel.join(format!("_{basename}.rue"));
-                groups.push(vec![
-                    importer_dir.join(format!("{import_str}.rue")),
-                    importer_dir.join(&facade),
-                ]);
-                groups.push(vec![
-                    root_dir.join(format!("{import_str}.rue")),
-                    root_dir.join(&facade),
-                ]);
-            }
+            // picking one. Later groups are only probed when the nearer group
+            // had nothing.
+            let base_dirs = vec![
+                importer_dir.to_string_lossy().into_owned(),
+                root_dir.to_string_lossy().into_owned(),
+            ];
+            let std_dir = (import_str == "std")
+                .then(|| env::var("RUE_STD_PATH").ok())
+                .flatten();
+            let groups: Vec<Vec<PathBuf>> =
+                import_candidate_groups(import_str, &base_dirs, std_dir.as_deref())
+                    .into_iter()
+                    .map(|group| group.into_iter().map(PathBuf::from).collect())
+                    .collect();
 
             'groups: for group in groups {
                 let mut group_hit = false;


### PR DESCRIPTION
## Summary

- move import candidate group construction into `rue-air` module-path logic
- have CLI discovery consume the shared groups while keeping filesystem probing, manifest checks, dedupe, and dependency graph recording in the driver
- have sema diagnostic candidate reporting flatten the same shared groups
- add module-path tests for explicit `.rue`, simple file/facade groups, nested facade names, and installed stdlib precedence

## Behavior note

`@import("std")` now follows sema’s std model for discovery candidates: `$RUE_STD_PATH/_std.rue`, then `std/_std.rue` relative to importer/root. It no longer probes `std.rue`, which sema never resolved as `ModulePath::Std` anyway.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue-air:rue-air-test //:cli-tests`
- `./buck2 test //crates/rue:rue-test`
- `./clippy.sh`

Linear: RUE-479