### PR TITLE
[codex] Use stable module paths in duplicate function symbols

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -19,6 +19,7 @@ use rue_span::{FileId, Span};
 
 use super::{ConstInfo, ConstValue, FunctionInfo, InferenceContext, MethodInfo, Sema};
 use crate::inference::{FunctionSig, MethodSig};
+use crate::path_norm::normalize_module_path;
 use crate::types::{EnumDef, EnumId, StructDef, StructField, StructId, Type, TypeKind};
 
 /// A node in the "contains by value" type graph, used by
@@ -57,8 +58,13 @@ impl<'a> Sema<'a> {
             }
         }
         if count > 1 {
+            let module_component = self
+                .get_file_path(file_id)
+                .map(normalize_module_path)
+                .unwrap_or_else(|| format!("file{}", file_id.index()));
+            let module_component = mangle_symbol_component(&module_component);
             self.interner
-                .get_or_intern(&format!("__rue_fn_f{}_{}", file_id.index(), source))
+                .get_or_intern(&format!("__rue_fn_{}__{}", module_component, source))
         } else {
             source_name
         }
@@ -2719,6 +2725,20 @@ impl<'a> Sema<'a> {
             span,
         ))
     }
+}
+
+fn mangle_symbol_component(component: &str) -> String {
+    let mut mangled = String::new();
+    for byte in component.bytes() {
+        match byte {
+            b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z' => mangled.push(byte as char),
+            _ => {
+                use std::fmt::Write as _;
+                write!(&mut mangled, "_{byte:02x}").expect("writing to String cannot fail");
+            }
+        }
+    }
+    mangled
 }
 
 /// A constant declaration captured by the pre-scan, waiting to be collected.

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2461,6 +2461,54 @@ mod tests {
     }
 
     #[test]
+    fn test_module_duplicate_function_symbols_use_stable_paths_not_file_ids() {
+        fn duplicate_value_function_names(
+            main_id: FileId,
+            left_id: FileId,
+            right_id: FileId,
+        ) -> Vec<String> {
+            let sources = vec![
+                SourceFile::new(
+                    "main.rue",
+                    r#"fn main() -> i32 {
+                        let left = @import("left.rue");
+                        let right = @import("right.rue");
+                        left.value() + right.value()
+                    }"#,
+                    main_id,
+                ),
+                SourceFile::new("left.rue", "fn value() -> i32 { 10 }", left_id),
+                SourceFile::new("right.rue", "fn value() -> i32 { 20 }", right_id),
+            ];
+            let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+            unit.run_frontend().expect("frontend should compile");
+            let mut names: Vec<_> = unit
+                .functions()
+                .iter()
+                .map(|func| func.analyzed.name.clone())
+                .filter(|name| name.ends_with("__value"))
+                .collect();
+            names.sort();
+            names
+        }
+
+        let names = duplicate_value_function_names(FileId::new(1), FileId::new(2), FileId::new(3));
+        assert_eq!(
+            names,
+            vec![
+                "__rue_fn_left_2erue__value".to_string(),
+                "__rue_fn_right_2erue__value".to_string(),
+            ]
+        );
+
+        assert_eq!(
+            names,
+            duplicate_value_function_names(FileId::new(100), FileId::new(42), FileId::new(7)),
+            "generated symbols should be stable for the same source paths even when FileIds differ"
+        );
+    }
+
+    #[test]
     fn test_module_member_access_multiple_functions() {
         // Test accessing multiple functions from an imported module
         let sources = vec![


### PR DESCRIPTION
## Summary
- replace FileId-based duplicate function symbol suffixes with normalized source-path-based symbol components
- keep user-facing source names separate from generated internal symbols
- add a regression that verifies duplicate module-local functions keep stable symbols when FileIds change

## Validation
- ./fmt.sh
- ./buck2 test //crates/rue-compiler:rue-compiler-test
- ./buck2 test //:cli-tests
- ./buck2 test //crates/rue-air:rue-air-test
- ./clippy.sh

Linear: RUE-444