### PR TITLE
[codex] Count static call sites for unused function warnings

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -514,7 +514,9 @@ fn finalize_function_body_analysis(
         functions.push(analyzed);
     }
 
-    add_unused_function_warnings(sema, unused_function_roots, &mut all_warnings);
+    let mut referenced_for_unused_warnings = collect_static_function_references(sema);
+    referenced_for_unused_warnings.extend(unused_function_roots.iter().copied());
+    add_unused_function_warnings(sema, &referenced_for_unused_warnings, &mut all_warnings);
     all_warnings.sort_by_key(|w| w.span().map(|s| s.start));
 
     let mut output = SemaOutput {
@@ -574,6 +576,31 @@ fn add_unused_function_warnings(
                 )),
         );
     }
+}
+
+fn collect_static_function_references(sema: &Sema<'_>) -> HashSet<Spur> {
+    let mut referenced = HashSet::new();
+
+    for (_, inst) in sema.rir.iter() {
+        let InstData::Call { name, .. } = &inst.data else {
+            continue;
+        };
+
+        let mut target = *name;
+        if let Some(const_info) = sema.resolve_const_info_in_file(target, inst.span.file_id)
+            && let Some(callee) = const_info.value.as_function()
+        {
+            target = callee;
+        }
+
+        if let Some(function_key) = sema.resolve_function_name_in_file(target, inst.span.file_id) {
+            referenced.insert(function_key);
+        } else if sema.functions.contains_key(&target) {
+            referenced.insert(target);
+        }
+    }
+
+    referenced
 }
 
 /// Lazy analysis path (Phase 3 of module system, ADR-0026).

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2512,6 +2512,39 @@ mod tests {
     }
 
     #[test]
+    fn test_imported_private_helper_called_by_public_api_is_not_unused() {
+        let sources = vec![
+            SourceFile::new(
+                "main.rue",
+                r#"const lib = @import("lib.rue");
+
+                fn main() -> i32 { 0 }"#,
+                FileId::new(1),
+            ),
+            SourceFile::new(
+                "lib.rue",
+                r#"pub fn api() -> i32 { helper() }
+
+                fn helper() -> i32 { 1 }"#,
+                FileId::new(2),
+            ),
+        ];
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        unit.run_frontend().expect("frontend should compile");
+
+        let warnings = unit
+            .warnings()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !warnings.contains("helper"),
+            "a private helper with a static call site should not be reported as unused:\n{warnings}"
+        );
+    }
+
+    #[test]
     fn test_module_member_access_multiple_functions() {
         // Test accessing multiple functions from an imported module
         let sources = vec![


### PR DESCRIPTION
## Summary
- include static direct call sites when deciding whether a private function is unused
- handle function-valued const aliases in that static reference scan
- add a regression for imported modules where an unused public API calls a private helper

## Validation
- ./fmt.sh
- ./buck2 test //crates/rue-compiler:rue-compiler-test
- ./buck2 test //:cli-tests
- ./clippy.sh

Linear: RUE-467