### PR TITLE
[codex] Route module member generics through resolved calls

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -395,10 +395,20 @@ impl<'a> Sema<'a> {
         // Functions with comptime parameters need specialization: a plain
         // Call to the base name would reference a body that is never
         // analyzed (generic bodies are only materialized per specialization,
-        // RUE-166). Delegate to the unqualified call path, which emits
-        // CallGeneric; module membership and accessibility were checked above.
+        // RUE-166). Use the already-resolved call path so module-qualified
+        // type constructors do not re-enter unqualified-call fallback lookup;
+        // module membership and accessibility were checked above.
         if fn_info.is_generic {
-            return self.analyze_call(air, function_key, args_start, args_len, span, ctx);
+            return self.analyze_resolved_function_call(
+                air,
+                function_key,
+                fn_info,
+                args_start,
+                args_len,
+                span,
+                ctx,
+                false,
+            );
         }
 
         // Check for exclusive access violation. (The old, pre-deduplication

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -32,9 +32,9 @@ use rue_rir::{InstData, InstRef, RirArgMode, RirParamMode, RirPattern};
 use crate::sema::context::ConstValue;
 use rue_span::Span;
 
-use super::Sema;
 use super::analysis::move_out_of_inout_error;
 use super::context::{AnalysisContext, AnalysisResult, LocalVar, VariableMoveState};
+use super::{FunctionInfo, Sema};
 use crate::inst::{
     Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef,
     AirProjection, AirRef,
@@ -5138,19 +5138,52 @@ impl<'a> Sema<'a> {
             .functions
             .get(&name)
             .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
+        let fn_info = fn_info.clone();
+
+        self.analyze_resolved_function_call(
+            air, name, fn_info, args_start, args_len, span, ctx, true,
+        )
+    }
+
+    /// Analyze a call after the source-level callee has already been resolved
+    /// to an internal function key.
+    ///
+    /// Unqualified source calls enter through [`Self::analyze_call`], which
+    /// performs local alias resolution, module-local name canonicalization, and
+    /// builtin interception before reaching this helper. Module-member calls
+    /// such as `std.option.Option(i64)` resolve and validate their member in
+    /// `analyze_module_member_call_impl`; generic members use this helper
+    /// directly so module-qualified type constructors do not re-enter
+    /// unqualified-call fallback lookup.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn analyze_resolved_function_call(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        fn_info: FunctionInfo,
+        args_start: u32,
+        args_len: u32,
+        span: Span,
+        ctx: &mut AnalysisContext,
+        check_unqualified_visibility: bool,
+    ) -> CompileResult<AnalysisResult> {
+        let source_name = self.source_function_name(name);
+        let fn_name_str = self.interner.resolve(&source_name).to_string();
 
         // Visibility (E0460, RUE-37/RUE-180): an unqualified call must not
         // reach a private function defined in another directory — privacy is
         // uniform in every multi-file compilation, imports or not (spec
         // 10.3:7), so the flat namespace resolves the name but the callee
         // must be `pub` (or in the caller's directory).
-        self.check_unqualified_visibility(
-            "function",
-            &fn_name_str,
-            fn_info.file_id,
-            fn_info.is_pub,
-            span,
-        )?;
+        if check_unqualified_visibility {
+            self.check_unqualified_visibility(
+                "function",
+                &fn_name_str,
+                fn_info.file_id,
+                fn_info.is_pub,
+                span,
+            )?;
+        }
 
         // An `unchecked fn` may only be called inside a `checked` block
         // (spec 9.1:1). The callee's body is analyzed like any other function;

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2577,6 +2577,47 @@ mod tests {
     }
 
     #[test]
+    fn test_module_qualified_std_option_type_constructor_uses_resolved_member() {
+        let sources = vec![
+            SourceFile::new(
+                "main.rue",
+                r#"fn main() -> i32 {
+                    let std = @import("std.rue");
+                    let OptI = std.option.Option(i64);
+                    let n: i64 = 42;
+                    let value = OptI::Some(n);
+                    match value {
+                        OptI::Some(n) => 1,
+                        OptI::None => 0,
+                    }
+                }"#,
+                FileId::new(1),
+            ),
+            SourceFile::new(
+                "std.rue",
+                r#"pub const option = @import("option.rue");"#,
+                FileId::new(2),
+            ),
+            SourceFile::new(
+                "option.rue",
+                r#"pub fn Option(comptime T: type) -> type {
+                    enum {
+                        Some(T),
+                        None,
+                    }
+                }"#,
+                FileId::new(3),
+            ),
+        ];
+        let result = compile_multi_file_with_options(&sources, &CompileOptions::default());
+        assert!(
+            result.is_ok(),
+            "std.option.Option should resolve through the module member path: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
     fn test_module_undefined_function_error() {
         // Test that accessing an undefined function in a module produces an error
         let sources = vec![


### PR DESCRIPTION
## Summary
- split function-call lowering so already-resolved callees can bypass unqualified lookup
- route generic module-member calls through the resolved-callee helper
- add a regression for `std.option.Option(i64)` through a facade module

Linear: RUE-489

## Validation
- ./fmt.sh
- ./buck2 test //crates/rue-compiler:rue-compiler-test
- ./buck2 test //:cli-tests
- ./buck2 test //crates/rue-air:rue-air-test
- ./clippy.sh