### PR TITLE
[codex] Preserve multi-error lexer diagnostics under emit tokens

### DIFF
--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -64,6 +64,19 @@ compile_fail = true
 compile_stderr_contains = ["bad.rue:", "let # = 3;"]
 compile_stderr_not_contains = ["main.rue:"]
 
+[[case]]
+name = "emit_tokens_reports_multiple_lexer_errors"
+description = "--emit tokens preserves accumulated lexer diagnostics instead of collapsing to the first error (RUE-496)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { $ # }
+""" }]
+args = ["--emit", "tokens", "main.rue"]
+compile_fail = true
+compile_stderr_contains = [
+    "unexpected character: $",
+    "unexpected character: #",
+]
+
 # RUE-352: `-j`/`--jobs` was silently ignored under --emit. The jobs setting was
 # only applied inside compile_multi_file_with_options, which the --emit path
 # never calls, so `--emit asm -j1` ran multi-threaded. The pool config is now

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1692,12 +1692,12 @@ fn handle_emit_multi_file(
             // Lex with the file's real FileId so a lex error in the Nth file
             // is attributed to that file, not to the first one (RUE-38).
             let lexer = Lexer::with_file_id(source.source, source.file_id);
-            match lexer.tokenize() {
+            match lexer.tokenize_preserving_interner() {
                 Ok((tokens, _interner)) => {
                     file_tokens.push((source.path.to_string(), tokens));
                 }
-                Err(e) => {
-                    diagnostics.print_error(&e);
+                Err((errors, _interner)) => {
+                    diagnostics.print_errors(&errors);
                     return Err(());
                 }
             }


### PR DESCRIPTION
## Summary

- preserve accumulated lexer diagnostics in the `--emit tokens` path
- add a CLI regression for two lexer errors under token emission
- correct RUE-496 repro to use `$ #`, since standalone `@` is lexically valid today

Fixes RUE-496.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue:rue-test //:cli-tests`
