### PR TITLE
[codex] Restrict std import resolution to std candidates

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -6,6 +6,36 @@
 use super::*;
 
 impl<'a> Sema<'a> {
+    fn import_base_dirs(&self, span: Span) -> Vec<String> {
+        use std::path::Path;
+
+        let dir_of = |p: &str| {
+            Path::new(p)
+                .parent()
+                .map(|d| d.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        };
+        let importer_dir = self.get_source_path(span).map(&dir_of);
+        let root_dir = self
+            .file_paths
+            .iter()
+            .min_by_key(|(id, _)| id.index())
+            .map(|(_, p)| dir_of(p));
+        let mut base_dirs: Vec<String> = Vec::new();
+        if let Some(d) = importer_dir {
+            base_dirs.push(d);
+        }
+        if let Some(d) = root_dir
+            && !base_dirs.contains(&d)
+        {
+            base_dirs.push(d);
+        }
+        if base_dirs.is_empty() {
+            base_dirs.push(String::new());
+        }
+        base_dirs
+    }
+
     /// Implementation for Intrinsic calls.
     pub(crate) fn analyze_intrinsic_impl(
         &mut self,
@@ -1127,8 +1157,6 @@ impl<'a> Sema<'a> {
         import_path: &str,
         span: Span,
     ) -> CompileResult<String> {
-        use std::path::Path;
-
         // Standard library imports resolve only when the driver/test harness
         // has already loaded the std facade into `file_paths`.
         if import_path == "std" {
@@ -1148,30 +1176,7 @@ impl<'a> Sema<'a> {
         // `@import("foo")` sites in different directories each resolve to their
         // own `foo` with no false cross-directory collision.
         let module_path = super::super::module_path::ModulePath::parse(import_path);
-        let dir_of = |p: &str| {
-            Path::new(p)
-                .parent()
-                .map(|d| d.to_string_lossy().into_owned())
-                .unwrap_or_default()
-        };
-        let importer_dir = self.get_source_path(span).map(&dir_of);
-        let root_dir = self
-            .file_paths
-            .iter()
-            .min_by_key(|(id, _)| id.index())
-            .map(|(_, p)| dir_of(p));
-        let mut base_dirs: Vec<String> = Vec::new();
-        if let Some(d) = importer_dir {
-            base_dirs.push(d);
-        }
-        if let Some(d) = root_dir
-            && !base_dirs.contains(&d)
-        {
-            base_dirs.push(d);
-        }
-        if base_dirs.is_empty() {
-            base_dirs.push(String::new());
-        }
+        let base_dirs = self.import_base_dirs(span);
         let base_refs: Vec<&str> = base_dirs.iter().map(|s| s.as_str()).collect();
         match module_path.resolve_in_dirs(&base_refs, self.file_paths.values()) {
             super::super::module_path::DirResolution::Ambiguous {
@@ -1206,11 +1211,17 @@ impl<'a> Sema<'a> {
     /// Resolve the standard library import.
     ///
     /// The driver is responsible for locating and loading the standard library
-    /// facade. Sema only verifies that a loaded `_std.rue` is present.
+    /// facade. Sema verifies that a loaded file matches the same std candidates
+    /// the driver would have probed.
     pub(super) fn resolve_std_import(&self, span: Span) -> CompileResult<String> {
-        match super::super::module_path::ModulePath::Std
-            .resolve_in_dirs(&[], self.file_paths.values())
-        {
+        let base_dirs = self.import_base_dirs(span);
+        let base_refs: Vec<&str> = base_dirs.iter().map(|s| s.as_str()).collect();
+        let std_dir = std::env::var("RUE_STD_PATH").ok();
+        match super::super::module_path::ModulePath::Std.resolve_in_dirs_with_std_dir(
+            &base_refs,
+            self.file_paths.values(),
+            std_dir.as_deref(),
+        ) {
             super::super::module_path::DirResolution::Resolved(path) => Ok(path),
             super::super::module_path::DirResolution::Ambiguous { .. }
             | super::super::module_path::DirResolution::NotFound => {

--- a/crates/rue-air/src/sema/module_path.rs
+++ b/crates/rue-air/src/sema/module_path.rs
@@ -187,6 +187,21 @@ impl ModulePath {
     where
         I: Iterator<Item = &'a String>,
     {
+        self.resolve_in_dirs_with_std_dir(base_dirs, loaded_paths, None)
+    }
+
+    /// Like [`Self::resolve_in_dirs`], but lets callers provide the
+    /// `$RUE_STD_PATH` directory used by the driver when resolving
+    /// `@import("std")`.
+    pub fn resolve_in_dirs_with_std_dir<'a, I>(
+        &self,
+        base_dirs: &[&str],
+        loaded_paths: I,
+        std_dir: Option<&str>,
+    ) -> DirResolution
+    where
+        I: Iterator<Item = &'a String>,
+    {
         // Pair each loaded path with its normalized form once. When the path
         // exists on disk, also keep its filesystem-canonical identity so
         // relative/absolute aliases and symlinks still resolve to the one
@@ -213,14 +228,18 @@ impl ModulePath {
 
         match self {
             ModulePath::Std => {
-                // The standard library's entry point is `_std.rue`. The driver
-                // loads it from $RUE_STD_PATH or an adjacent std/ directory
-                // (see discover_and_load_imports in the rue crate); here we
-                // just match it among the loaded files. Std is not
-                // importer-relative, so base_dirs are ignored.
-                for (_, _, orig) in &normalized {
-                    if boundary_ends(orig, "_std.rue") {
-                        return DirResolution::Resolved((*orig).clone());
+                // Match only the standard-library candidates the driver would
+                // have loaded, not any unrelated loaded file named `_std.rue`
+                // (RUE-493).
+                let base_dirs = base_dirs
+                    .iter()
+                    .map(|base| (*base).to_string())
+                    .collect::<Vec<_>>();
+                for group in self.candidate_groups(&base_dirs, std_dir) {
+                    for candidate in group {
+                        if let Some(hit) = find_exact(&candidate) {
+                            return DirResolution::Resolved(hit);
+                        }
                     }
                 }
                 DirResolution::NotFound
@@ -277,15 +296,6 @@ pub fn import_candidate_groups(
     std_dir: Option<&str>,
 ) -> Vec<Vec<String>> {
     ModulePath::parse(import_path).candidate_groups(base_dirs, std_dir)
-}
-
-/// Whether `candidate` ends with `suffix` at a path boundary (start of string
-/// or immediately after a `/`).
-fn boundary_ends(candidate: &str, suffix: &str) -> bool {
-    candidate.ends_with(suffix) && {
-        let prefix_len = candidate.len() - suffix.len();
-        prefix_len == 0 || candidate.as_bytes()[prefix_len - 1] == b'/'
-    }
 }
 
 fn canonical_key(path: &str) -> Option<String> {
@@ -412,6 +422,26 @@ mod tests {
         assert_eq!(
             module.resolve_in_dirs(&[""], paths.iter()),
             DirResolution::Resolved("std/_std.rue".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_std_ignores_unrelated_loaded_std_facade_name() {
+        let paths = owned(&["main.rue", "helper/_std.rue"]);
+        let module = ModulePath::Std;
+        assert_eq!(
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::NotFound
+        );
+    }
+
+    #[test]
+    fn test_resolve_std_accepts_explicit_std_dir_candidate() {
+        let paths = owned(&["main.rue", "/opt/rue/lib/_std.rue"]);
+        let module = ModulePath::Std;
+        assert_eq!(
+            module.resolve_in_dirs_with_std_dir(&[""], paths.iter(), Some("/opt/rue/lib")),
+            DirResolution::Resolved("/opt/rue/lib/_std.rue".to_string())
         );
     }
 

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -374,6 +374,28 @@ env = { RUE_STD_PATH = "${REAL_STD}" }
 compile_stderr_not_contains = ["unused function", "exit_syscall_number"]
 stdout = "5\n"
 
+[[case]]
+name = "import_std_ignores_unrelated_loaded_std_facade_name"
+description = "@import(\"std\") must not bind to an unrelated loaded helper/_std.rue just because its filename is _std.rue (RUE-493)."
+files = [
+    { path = "main.rue", source = """
+const fake = @import("helper/_std.rue");
+const std = @import("std");
+
+fn main() -> i32 {
+    std.answer()
+}
+""" },
+    { path = "helper/_std.rue", source = """
+pub fn answer() -> i32 {
+    7
+}
+""" },
+]
+env = { RUE_STD_PATH = "" }
+compile_fail = true
+error_contains = ["E0705", "standard library not found"]
+
 # A genuinely missing module should be a clean error (works today).
 [[case]]
 name = "import_missing_module_is_clean_error"


### PR DESCRIPTION
## Summary

- resolve `@import("std")` only against the std candidates the driver would load
- preserve explicit `RUE_STD_PATH` std directories while rejecting unrelated loaded `_std.rue` files
- add unit and CLI regressions for RUE-493

Fixes RUE-493.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue-air:rue-air-test //:cli-tests`
