### PR TITLE
[codex] Track constant-index subfield moves for drops

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -1110,14 +1110,11 @@ pub enum AirInstData {
         is_param: bool,
         /// `None`: the slot's whole value moved out. `Some(place)`: only
         /// the path named by the place's projections moved out — a pure
-        /// `Field` projection chain of any depth (`o.a`, `o.a.b`), or a
-        /// single CONSTANT-index projection (`xs[K]`, RUE-186, whose index
-        /// operand is a dedicated `Const` instruction); drop elaboration
-        /// then drops the struct/array path-granularly, skipping the moved
-        /// path. Paths THROUGH an array index (`arr[i].a`) are NOT exported
-        /// (no marker), keeping the whole-slot drop — which re-drops the
-        /// moved element (a known gap: index-interior paths aren't tracked
-        /// by drop elaboration).
+        /// `Field`/constant-`Index` projection chain of any depth (`o.a`,
+        /// `o.a.b`, `xs[K]`, `xs[K].a`); every index operand in the marker is a
+        /// dedicated `Const` instruction so drop elaboration can decode the
+        /// path. Drop elaboration then drops the struct/array path-granularly,
+        /// skipping the moved path.
         place: Option<AirPlaceRef>,
     },
 }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -135,6 +135,14 @@ impl PlaceTrace {
         }
         path
     }
+
+    /// Whether this place contains an index projection whose element cannot be
+    /// named statically in the move/drop path model.
+    pub fn has_untrackable_index(&self) -> bool {
+        self.projections
+            .iter()
+            .any(|p| matches!(p.proj, AirProjection::Index { .. }) && p.index_segment.is_none())
+    }
 }
 
 impl<'a> Sema<'a> {
@@ -337,6 +345,38 @@ impl<'a> Sema<'a> {
     /// Build an AirPlaceRef from a PlaceTrace, adding projections to the Air.
     pub(crate) fn build_place_ref(air: &mut Air, trace: &PlaceTrace) -> AirPlaceRef {
         let projs = trace.projections.iter().map(|p| p.proj);
+        air.make_place(trace.base, projs)
+    }
+
+    /// Build a `MarkMoved` place from a trace.
+    ///
+    /// Normal place reads keep the user's index expression, but move markers
+    /// must be statically decodable by drop elaboration. Re-emit constant index
+    /// projections with dedicated `Const` instructions so CFG lowering can turn
+    /// paths like `arr[0].field` into the moved path `[0, field]`.
+    pub(crate) fn build_move_marker_place_ref(
+        air: &mut Air,
+        trace: &PlaceTrace,
+        span: Span,
+    ) -> AirPlaceRef {
+        let mut projs = Vec::with_capacity(trace.projections.len());
+        for p in &trace.projections {
+            match p.proj {
+                AirProjection::Field { .. } => projs.push(p.proj),
+                AirProjection::Index { array_type, .. } => {
+                    let k = p
+                        .const_index
+                        .expect("move-marker index must be statically trackable");
+                    debug_assert!(k >= 0, "move-marker index must be non-negative");
+                    let index = air.add_inst(AirInst {
+                        data: AirInstData::Const(k as u64),
+                        ty: Type::U64,
+                        span,
+                    });
+                    projs.push(AirProjection::Index { array_type, index });
+                }
+            }
+        }
         air.make_place(trace.base, projs)
     }
 
@@ -3474,6 +3514,20 @@ impl<'a> Sema<'a> {
                 // For non-linear types, check if accessing a non-Copy field
                 self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
                 self.reject_field_move_out_of_destructor_type(&trace, span)?;
+
+                if trace.has_untrackable_index() {
+                    return Err(CompileError::new(
+                        ErrorKind::MoveOutOfIndex {
+                            element_type: field_type.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        span,
+                    )
+                    .with_help(
+                        "moving a field out through an array index requires a \
+                         compile-time constant index",
+                    ));
+                }
+
                 let field_path = trace.field_path();
 
                 // Check if this field path is already moved. Moving the field
@@ -3500,31 +3554,24 @@ impl<'a> Sema<'a> {
                     .or_default()
                     .mark_path_moved(&field_path, span);
 
-                // Export pure-field-path moves of any depth (`o.a`, `o.a.b`)
-                // to drop elaboration so the moved path's drop inside the
-                // struct's scope-exit drop is suppressed (RUE-62, RUE-157).
-                // Paths THROUGH an array index (`arr[i].a`) get no marker:
-                // drop elaboration keeps the whole-slot drop, which re-drops
-                // the moved element (a known gap; root-level element moves
-                // `arr[K]` ARE tracked — RUE-186 — but index-interior paths
-                // are not). Only Normal params occupy a real ABI slot that
-                // drop elaboration would drop.
-                let pure_field_path = trace
-                    .projections
-                    .iter()
-                    .all(|p| matches!(p.proj, AirProjection::Field { .. }));
-                if pure_field_path {
-                    let is_droppable_param_base = match trace.base {
-                        AirPlaceBase::Local(_) => true,
-                        AirPlaceBase::Param(_) => ctx
-                            .params
-                            .iter()
-                            .any(|p| p.name == trace.root_var && p.mode == RirParamMode::Normal),
-                    };
-                    if is_droppable_param_base {
-                        emit_move_marker = true;
-                        move_is_partial = true;
-                    }
+                // Export statically-trackable partial moves to drop elaboration
+                // so the moved path's drop inside the scope-exit drop is
+                // suppressed. This covers pure field paths (`o.a`, `o.a.b`,
+                // RUE-62/RUE-157) and constant-index array subfields
+                // (`arr[0].a`, RUE-494). Dynamic index paths were rejected
+                // above because drop elaboration cannot know which element was
+                // holed. Only Normal params occupy a real ABI slot that drop
+                // elaboration would drop.
+                let is_droppable_param_base = match trace.base {
+                    AirPlaceBase::Local(_) => true,
+                    AirPlaceBase::Param(_) => ctx
+                        .params
+                        .iter()
+                        .any(|p| p.name == trace.root_var && p.mode == RirParamMode::Normal),
+                };
+                if is_droppable_param_base {
+                    emit_move_marker = true;
+                    move_is_partial = true;
                 }
             } else {
                 // Copy fields are read, not moved — but reading one THROUGH
@@ -3561,12 +3608,14 @@ impl<'a> Sema<'a> {
                     AirPlaceBase::Local(slot) => (slot, false),
                     AirPlaceBase::Param(slot) => (slot, true),
                 };
+                let marker_place =
+                    move_is_partial.then(|| Self::build_move_marker_place_ref(air, &trace, span));
                 air_ref = air.add_inst(AirInst {
                     data: AirInstData::MarkMoved {
                         value: air_ref,
                         slot,
                         is_param,
-                        place: move_is_partial.then_some(place_ref),
+                        place: marker_place,
                     },
                     ty: field_type,
                     span,

--- a/crates/rue-cli-tests/cases/partial_move_depth.toml
+++ b/crates/rue-cli-tests/cases/partial_move_depth.toml
@@ -123,3 +123,58 @@ fn main() -> i32 {
 """ },
 ]
 exit_code = 2
+
+[[case]]
+name = "constant_index_subfield_move_drops_once"
+description = "RUE-494: moving arr[0].inner emits a drop-suppression marker so the moved field is not dropped again at array scope exit."
+files = [
+    { path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Wrap { inner: Inner, tag: i32 }
+
+fn take(i: Inner) -> i32 {
+    i.v
+}
+
+fn main() -> i32 {
+    let arr = [Wrap { inner: Inner { v: 5 }, tag: 0 }];
+    take(arr[0].inner);
+    0
+}
+""" },
+]
+stdout = "5\n"
+exit_code = 0
+
+[[case]]
+name = "dynamic_index_subfield_move_rejected"
+description = "RUE-494: moving a non-Copy field through arr[i] is rejected because the moved path cannot be tracked for drop suppression."
+files = [
+    { path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Wrap { inner: Inner, tag: i32 }
+
+fn take(i: Inner) -> i32 {
+    i.v
+}
+
+fn main() -> i32 {
+    let i = 0;
+    let arr = [Wrap { inner: Inner { v: 5 }, tag: 0 }];
+    take(arr[i].inner);
+    0
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0904", "moving a field out through an array index requires a compile-time constant index"]


### PR DESCRIPTION
## Summary

- track constant-index subfield moves like `arr[0].field` by emitting a statically-decodable `MarkMoved` path
- reject dynamic-index non-Copy subfield moves conservatively because drop elaboration cannot know which element was moved
- add CLI regressions for the double-drop case and the dynamic-index rejection

Fixes RUE-494.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-cfg:rue-cfg-test //:cli-tests`
