### PR TITLE
[codex] Make module-local function lookup explicit

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -358,7 +358,7 @@ impl<'a> Sema<'a> {
         let module_def = self.module_registry.get_def(module_id);
         let module_file_id = self.canonical_file_id(&module_def.file_path);
         let function_key = module_file_id
-            .and_then(|file_id| self.resolve_function_name_in_file(function_name, file_id));
+            .and_then(|file_id| self.resolve_function_name_local(function_name, file_id));
         let fn_info = self
             .functions
             .get(&function_key.unwrap_or(function_name))

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -70,7 +70,11 @@ impl<'a> Sema<'a> {
         }
     }
 
-    pub(crate) fn resolve_function_name_in_file(
+    /// Resolve a source-level function name only in the given source file.
+    ///
+    /// This is the module-local lookup path used for unqualified calls before
+    /// considering the legacy graph-global compatibility fallback.
+    pub(crate) fn resolve_function_name_local(
         &self,
         source_name: Spur,
         file_id: FileId,
@@ -78,6 +82,16 @@ impl<'a> Sema<'a> {
         self.functions_by_file_name
             .get(&(file_id, source_name))
             .copied()
+    }
+
+    /// Resolve a source-level function name from a given file, preserving the
+    /// legacy global fallback while the flat model is being removed.
+    pub(crate) fn resolve_function_name_in_file(
+        &self,
+        source_name: Spur,
+        file_id: FileId,
+    ) -> Option<Spur> {
+        self.resolve_function_name_local(source_name, file_id)
             .or_else(|| {
                 if self.functions.contains_key(&source_name) {
                     Some(source_name)

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2464,6 +2464,49 @@ mod tests {
     }
 
     #[test]
+    fn test_module_local_unqualified_calls_with_duplicate_names() {
+        let sources = vec![
+            SourceFile::new(
+                "main.rue",
+                r#"fn main() -> i32 {
+                    let left = @import("left.rue");
+                    let right = @import("right.rue");
+                    left.entry() + right.entry()
+                }"#,
+                FileId::new(1),
+            ),
+            SourceFile::new(
+                "left.rue",
+                r#"pub fn entry() -> i32 { value() + first() + recur(1) }
+                fn value() -> i32 { 10 }
+                fn first() -> i32 { second() }
+                fn second() -> i32 { 1 }
+                fn recur(n: i32) -> i32 {
+                    if n == 0 { 0 } else { recur(n - 1) }
+                }"#,
+                FileId::new(2),
+            ),
+            SourceFile::new(
+                "right.rue",
+                r#"pub fn entry() -> i32 { value() + first() + recur(1) }
+                fn value() -> i32 { 20 }
+                fn first() -> i32 { second() }
+                fn second() -> i32 { 2 }
+                fn recur(n: i32) -> i32 {
+                    if n == 0 { 0 } else { recur(n - 1) }
+                }"#,
+                FileId::new(3),
+            ),
+        ];
+        let result = compile_multi_file_with_options(&sources, &CompileOptions::default());
+        assert!(
+            result.is_ok(),
+            "unqualified calls should resolve within the caller's module even when sibling modules define the same names: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
     fn test_module_duplicate_function_symbols_use_stable_paths_not_file_ids() {
         fn duplicate_value_function_names(
             main_id: FileId,


### PR DESCRIPTION
## Summary

- add an explicit module-local function lookup helper keyed by `(file_id, source_name)`
- preserve the existing graph-global compatibility fallback behind the existing helper
- use local-only lookup for module-qualified member calls so missing members cannot resolve through the compatibility path
- add a compiler regression covering duplicate helper names, local calls, mutual calls, and recursion across sibling modules

Fixes RUE-490.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test`
