### PR TITLE
[codex] Remove flat type and const lookup fallback

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3060,9 +3060,11 @@ impl<'a> Sema<'a> {
                 }
             }
         } else {
-            let struct_id = *self
-                .structs
-                .get(&type_name)
+            let struct_id = self
+                .structs_by_file_name
+                .get(&(span.file_id, type_name))
+                .copied()
+                .or_else(|| self.resolve_builtin_struct_name(type_name))
                 .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
             // Privacy (E0460, RUE-183): a struct literal names the type
             // unqualified, so a private struct from another directory is not
@@ -5674,15 +5676,18 @@ impl<'a> Sema<'a> {
         if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
             return ty.as_enum().map(|id| (id, true));
         }
-        if let Some(info) = self.constants.get(&type_name)
+        if let Some(info) = self
+            .constants_by_file_name
+            .get(&(ctx.current_file_id, type_name))
             && let ConstValue::Type(ty) = info.value
         {
             return ty.as_enum().map(|id| (id, true));
         }
         self.enums_by_file_name
             .get(&(ctx.current_file_id, type_name))
-            .or_else(|| self.enums.get(&type_name))
-            .map(|&id| (id, false))
+            .copied()
+            .or_else(|| self.resolve_builtin_enum_name(type_name))
+            .map(|id| (id, false))
     }
 
     /// Analyze an associated function call.

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1033,7 +1033,7 @@ impl Sema<'_> {
                 //    VarRef's own span locates the referencing file;
                 //    speculative callers (`try_evaluate_const*`) swallow the
                 //    error and defer to runtime analysis, which re-checks.
-                if let Some(info) = self.constants.get(name) {
+                if let Some(info) = self.constants_by_file_name.get(&(span.file_id, *name)) {
                     self.check_unqualified_visibility(
                         "constant",
                         self.interner.resolve(name),

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -106,9 +106,21 @@ impl<'a> Sema<'a> {
         name: Spur,
         file_id: FileId,
     ) -> Option<&ConstInfo> {
-        self.constants_by_file_name
-            .get(&(file_id, name))
-            .or_else(|| self.constants.get(&name))
+        self.constants_by_file_name.get(&(file_id, name))
+    }
+
+    pub(crate) fn resolve_builtin_struct_name(&self, name: Spur) -> Option<StructId> {
+        self.structs
+            .get(&name)
+            .copied()
+            .filter(|id| self.type_pool.struct_def(*id).is_builtin)
+    }
+
+    pub(crate) fn resolve_builtin_enum_name(&self, name: Spur) -> Option<EnumId> {
+        self.enums
+            .get(&name)
+            .copied()
+            .filter(|id| Some(*id) == self.builtin_arch_id || Some(*id) == self.builtin_os_id)
     }
 
     /// Build an `InferenceContext` from the collected type information.

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -484,10 +484,11 @@ impl<'a> Sema<'a> {
             return self.get_or_create_str_struct(span);
         }
 
-        if let Some(&struct_id) = self
+        if let Some(struct_id) = self
             .structs_by_file_name
             .get(&(span.file_id, type_sym))
-            .or_else(|| self.structs.get(&type_sym))
+            .copied()
+            .or_else(|| self.resolve_builtin_struct_name(type_sym))
         {
             // Privacy (E0460, RUE-183): an unqualified type reference must
             // not reach a private struct defined in another directory —
@@ -504,10 +505,11 @@ impl<'a> Sema<'a> {
                 span,
             )?;
             Ok(Type::new_struct(struct_id))
-        } else if let Some(&enum_id) = self
+        } else if let Some(enum_id) = self
             .enums_by_file_name
             .get(&(span.file_id, type_sym))
-            .or_else(|| self.enums.get(&type_sym))
+            .copied()
+            .or_else(|| self.resolve_builtin_enum_name(type_sym))
         {
             // Privacy (E0460, RUE-185): same rule for enums — an unqualified
             // type reference must not reach a private enum defined in another

--- a/crates/rue-cli-tests/cases/const_init.toml
+++ b/crates/rue-cli-tests/cases/const_init.toml
@@ -198,10 +198,11 @@ exit_code = 21
 # line, so collection must be dependency-ordered, not file-ordered.
 [[case]]
 name = "cross_file_chain_definer_second"
-args = ["main.rue", "config.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
-const FROM_CONFIG: i32 = LIMIT + 1;
+const config = @import("config.rue");
+const FROM_CONFIG: i32 = config.LIMIT + 1;
 
 fn main() -> i32 {
     FROM_CONFIG
@@ -216,13 +217,14 @@ exit_code = 42
 # Same chain with the defining file first (both orders must agree).
 [[case]]
 name = "cross_file_chain_definer_first"
-args = ["config.rue", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [
     { path = "config.rue", source = """
 pub const LIMIT: i32 = 41;
 """ },
     { path = "main.rue", source = """
-const FROM_CONFIG: i32 = LIMIT + 1;
+const config = @import("config.rue");
+const FROM_CONFIG: i32 = config.LIMIT + 1;
 
 fn main() -> i32 {
     FROM_CONFIG

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1140,7 +1140,7 @@ exit_code = 42
 
 [[case]]
 name = "private_struct_cross_dir_unqualified_rejected"
-description = "Unqualified struct literal/annotation naming a private struct in another directory is E0460 (RUE-183) — fn-only privacy is not enough."
+description = "Unqualified struct literal/annotation does not see a struct from another module, even when that module is imported."
 files = [
     { path = "main.rue", source = """
 const lib = @import("sub/lib.rue");
@@ -1158,11 +1158,11 @@ struct Point {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "struct `Point` is private (defined in `sub/lib.rue`)"]
+error_contains = ["E0204", "unknown type 'Point'"]
 
 [[case]]
 name = "private_const_cross_dir_unqualified_rejected"
-description = "Unqualified read of a private constant in another directory is E0460 (RUE-183)."
+description = "Unqualified read does not see a constant from another module, even when that module is imported."
 files = [
     { path = "main.rue", source = """
 const lib = @import("sub/lib.rue");
@@ -1176,11 +1176,11 @@ const LIMIT: i32 = 99;
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "constant `LIMIT` is private (defined in `sub/lib.rue`)"]
+error_contains = ["E0201", "undefined variable 'LIMIT'"]
 
 [[case]]
 name = "flat_multifile_private_struct_cross_dir_rejected"
-description = "Uniform privacy for structs (RUE-183): a private struct in a never-imported listed file is not nameable cross-directory."
+description = "Flat listed files do not inject private structs into another file's unqualified namespace."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1197,11 +1197,11 @@ struct Point {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "struct `Point` is private (defined in `sub/lib.rue`)"]
+error_contains = ["E0204", "unknown type 'Point'"]
 
 [[case]]
 name = "flat_multifile_private_const_cross_dir_rejected"
-description = "Uniform privacy for constants (RUE-183): a private constant in a never-imported listed file is not readable cross-directory."
+description = "Flat listed files do not inject private constants into another file's unqualified namespace."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1214,11 +1214,11 @@ const LIMIT: i32 = 99;
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "constant `LIMIT` is private (defined in `sub/lib.rue`)"]
+error_contains = ["E0201", "undefined variable 'LIMIT'"]
 
 [[case]]
 name = "flat_multifile_private_const_in_const_init_rejected"
-description = "A constant initializer is a reference site too (RUE-183): `const X = LIMIT;` reading a private cross-directory constant is E0460."
+description = "A constant initializer does not see a constant from a different listed file unqualified."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1233,11 +1233,11 @@ const LIMIT: i32 = 99;
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "constant `LIMIT` is private (defined in `sub/lib.rue`)"]
+error_contains = ["E0434", "not supported in const context"]
 
 [[case]]
-name = "flat_multifile_pub_struct_and_const_cross_dir_allowed"
-description = "Positive control (RUE-183): pub structs and constants in another never-imported directory remain usable unqualified (spec 10.3:8)."
+name = "flat_multifile_pub_struct_and_const_cross_dir_rejected"
+description = "Pub structs and constants in another listed directory are not usable unqualified; use explicit module-qualified access."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1254,11 +1254,12 @@ pub struct Point {
 pub const BONUS: i32 = 10;
 """ },
 ]
-exit_code = 42
+compile_fail = true
+error_contains = ["E0204", "unknown type 'Point'"]
 
 [[case]]
-name = "flat_multifile_private_struct_and_const_same_dir_allowed"
-description = "Control (RUE-183): intra-directory visibility is unchanged — private structs and constants in another listed file in the SAME directory are usable."
+name = "flat_multifile_private_struct_and_const_same_dir_rejected"
+description = "Another listed file in the same directory does not inject private structs/constants into the unqualified namespace."
 args = ["main.rue", "lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1275,14 +1276,15 @@ struct Point {
 const BONUS: i32 = 10;
 """ },
 ]
-exit_code = 42
+compile_fail = true
+error_contains = ["E0204", "unknown type 'Point'"]
 
 # Enums obey the same uniform rule (RUE-185): naming a private enum from
 # another directory — annotation, variant construction, or match pattern —
 # is E0460, whether the file was imported or merely listed.
 [[case]]
 name = "private_enum_cross_dir_unqualified_rejected"
-description = "Unqualified annotation/construction naming a private enum in another directory is E0460 (RUE-185), imported or not."
+description = "Unqualified annotation/construction does not see an enum from another module, even when that module is imported."
 files = [
     { path = "main.rue", source = """
 const lib = @import("sub/lib.rue");
@@ -1301,11 +1303,11 @@ enum Color {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)"]
+error_contains = ["E0204", "unknown type 'Color'"]
 
 [[case]]
 name = "flat_multifile_private_enum_construction_rejected"
-description = "Uniform privacy for enums (RUE-185): a variant of a private enum in a never-imported listed file is not constructible cross-directory."
+description = "Flat listed files do not inject private enum names into another file's unqualified namespace."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1323,11 +1325,11 @@ enum Color {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)"]
+error_contains = ["E0421", "unknown enum type 'Color'"]
 
 [[case]]
 name = "flat_multifile_private_enum_match_pattern_rejected"
-description = "A match pattern is a reference site too (RUE-185): matching on a private cross-directory enum is E0460 with the pattern's own file-attributed span, even when the scrutinee arrives via a pub fn."
+description = "Match patterns do not see private enum names from another listed file unqualified."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1351,7 +1353,7 @@ pub fn make() -> Color {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)", "main.rue"]
+error_contains = ["E0421", "unknown enum type 'Color'", "main.rue"]
 
 [[case]]
 name = "private_enum_module_qualified_pattern_rejected"
@@ -1382,8 +1384,8 @@ compile_fail = true
 error_contains = ["E0706", "enum `Color` is private"]
 
 [[case]]
-name = "flat_multifile_pub_enum_cross_dir_allowed"
-description = "Positive control (RUE-185): a pub enum in another never-imported directory remains usable unqualified — annotation, construction, and match (spec 10.3:8)."
+name = "flat_multifile_pub_enum_cross_dir_rejected"
+description = "A pub enum in another listed directory is not usable unqualified; use explicit module-qualified access."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1404,7 +1406,8 @@ pub enum Color {
 }
 """ },
 ]
-exit_code = 42
+compile_fail = true
+error_contains = ["E0204", "unknown type 'Color'"]
 
 [[case]]
 name = "pub_enum_module_qualified_pattern_allowed"
@@ -1435,8 +1438,8 @@ pub fn make() -> Color {
 exit_code = 42
 
 [[case]]
-name = "flat_multifile_private_enum_same_dir_allowed"
-description = "Control (RUE-185): intra-directory visibility is unchanged — a private enum in another listed file in the SAME directory is usable."
+name = "flat_multifile_private_enum_same_dir_rejected"
+description = "Another listed file in the same directory does not inject private enum names into the unqualified namespace."
 args = ["main.rue", "lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1457,7 +1460,8 @@ enum Color {
 }
 """ },
 ]
-exit_code = 42
+compile_fail = true
+error_contains = ["E0204", "unknown type 'Color'"]
 
 # ---------------------------------------------------------------------------
 # Nested module member access (RUE-122 regression coverage).

--- a/crates/rue-cli-tests/cases/recursive_value_type.toml
+++ b/crates/rue-cli-tests/cases/recursive_value_type.toml
@@ -28,17 +28,19 @@ fn main() -> i32 { 0 }
 
 [[case]]
 name = "mutually_recursive_structs_multifile_is_e0483"
-description = "Cross-file mutual recursion `struct A { b: B }` / `struct B { a: A }` → clean E0483 (was SIGABRT 134)."
-args = ["a.rue", "b.rue", "-o", "prog"]
+description = "Cross-file mutual recursion through explicit module-qualified types → clean E0483 (was SIGABRT 134)."
+args = ["a.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0483", "infinite size"]
 files = [
     { path = "a.rue", source = """
-struct A { b: B }
+const bmod = @import("b.rue");
+pub struct A { b: bmod.B }
 fn main() -> i32 { 0 }
 """ },
     { path = "b.rue", source = """
-struct B { a: A }
+const amod = @import("a.rue");
+pub struct B { a: amod.A }
 """ },
 ]
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2222,16 +2222,20 @@ mod tests {
 
     #[test]
     fn test_cross_file_struct_usage() {
-        // Struct defined in types.rue, used in main.rue
+        // Struct defined in types.rue, used explicitly through its module.
         let sources = vec![
             SourceFile::new(
                 "main.rue",
-                "fn main() -> i32 { let p = Point { x: 1, y: 2 }; p.x + p.y }",
+                r#"const types = @import("types.rue");
+                fn main() -> i32 {
+                    let p = types.Point { x: 1, y: 2 };
+                    p.x + p.y
+                }"#,
                 FileId::new(1),
             ),
             SourceFile::new(
                 "types.rue",
-                "struct Point { x: i32, y: i32 }",
+                "pub struct Point { x: i32, y: i32 }",
                 FileId::new(2),
             ),
         ];
@@ -2245,21 +2249,28 @@ mod tests {
 
     #[test]
     fn test_cross_file_struct_as_function_param() {
-        // Struct defined in types.rue, function in utils.rue takes it as param
+        // Struct defined in types.rue, function in utils.rue takes it as an
+        // explicitly module-qualified param type.
         let sources = vec![
             SourceFile::new(
                 "main.rue",
-                "fn main() -> i32 { let p = Point { x: 10, y: 5 }; get_sum(p) }",
+                r#"const types = @import("types.rue");
+                const utils = @import("utils.rue");
+                fn main() -> i32 {
+                    let p = types.Point { x: 10, y: 5 };
+                    utils.get_sum(p)
+                }"#,
                 FileId::new(1),
             ),
             SourceFile::new(
                 "types.rue",
-                "struct Point { x: i32, y: i32 }",
+                "pub struct Point { x: i32, y: i32 }",
                 FileId::new(2),
             ),
             SourceFile::new(
                 "utils.rue",
-                "fn get_sum(p: Point) -> i32 { p.x + p.y }",
+                r#"const types = @import("types.rue");
+                pub fn get_sum(p: types.Point) -> i32 { p.x + p.y }"#,
                 FileId::new(3),
             ),
         ];
@@ -2273,19 +2284,24 @@ mod tests {
 
     #[test]
     fn test_cross_file_enum_usage() {
-        // Enum defined in types.rue, used in main.rue
+        // Enum defined in types.rue, used explicitly through its module.
         let sources = vec![
             SourceFile::new(
                 "main.rue",
-                r#"fn main() -> i32 {
-                    let c = Color::Red;
-                    match c { Color::Red => 1, Color::Green => 2, Color::Blue => 3 }
+                r#"const types = @import("types.rue");
+                fn main() -> i32 {
+                    let c = types.Color::Red;
+                    match c {
+                        types.Color::Red => 1,
+                        types.Color::Green => 2,
+                        types.Color::Blue => 3,
+                    }
                 }"#,
                 FileId::new(1),
             ),
             SourceFile::new(
                 "types.rue",
-                "enum Color { Red, Green, Blue }",
+                "pub enum Color { Red, Green, Blue }",
                 FileId::new(2),
             ),
         ];
@@ -2294,6 +2310,33 @@ mod tests {
             result.is_ok(),
             "cross-file enum usage should compile: {:?}",
             result.err()
+        );
+    }
+
+    #[test]
+    fn test_unqualified_sibling_type_and_const_lookup_is_rejected() {
+        let sources = vec![
+            SourceFile::new(
+                "main.rue",
+                r#"const lib = @import("lib.rue");
+                fn main() -> i32 {
+                    let s = Shared { n: LIMIT };
+                    match Mode::Fast { Mode::Fast => s.n, Mode::Slow => 0 }
+                }"#,
+                FileId::new(1),
+            ),
+            SourceFile::new(
+                "lib.rue",
+                r#"pub struct Shared { n: i32 }
+                pub enum Mode { Fast, Slow }
+                pub const LIMIT: i32 = 11;"#,
+                FileId::new(2),
+            ),
+        ];
+        let result = compile_multi_file_with_options(&sources, &CompileOptions::default());
+        assert!(
+            result.is_err(),
+            "loaded sibling modules should not inject public types or constants into the caller's unqualified namespace"
         );
     }
 

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -288,9 +288,9 @@ exit_code = 42
 # =============================================================================
 # Unqualified Cross-Directory Access: Structs and Constants (RUE-183)
 # =============================================================================
-# The uniform privacy rule (10.3:7) covers every item kind, not just
-# functions: naming a private struct (annotation or literal) or reading a
-# private constant from another directory is E0460 through an imported module.
+# Unqualified lookup does not import another module's item names into the
+# current file. These references are rejected as unknown names before privacy
+# applies; module-qualified references exercise the privacy rule.
 
 [[case]]
 name = "cross_dir_unqualified_private_struct_error"
@@ -311,7 +311,7 @@ struct Point {
 }
 """ }
 compile_fail = true
-error_contains = "struct `Point` is private (defined in"
+error_contains = "unknown type 'Point'"
 
 [[case]]
 name = "cross_dir_unqualified_private_const_error"
@@ -328,14 +328,14 @@ aux_files = { "subdir/defs.rue" = """
 const LIMIT: i32 = 42;
 """ }
 compile_fail = true
-error_contains = "constant `LIMIT` is private (defined in"
+error_contains = "undefined variable 'LIMIT'"
 
 # =============================================================================
 # Unqualified Cross-Directory Access: Enums (RUE-185)
 # =============================================================================
-# The uniform privacy rule (10.3:7) covers enums too: naming a private enum
-# from another directory — in a type annotation, a variant construction, or a
-# match pattern — is E0460 through an imported module.
+# Unqualified lookup does not import enum names from another module into the
+# current file. These references are rejected as unknown names before privacy
+# applies; module-qualified references exercise the privacy rule.
 
 [[case]]
 name = "cross_dir_unqualified_private_enum_error"
@@ -357,4 +357,4 @@ enum Color {
 }
 """ }
 compile_fail = true
-error_contains = "enum `Color` is private (defined in"
+error_contains = "unknown type 'Color'"


### PR DESCRIPTION
## Summary

- resolve unqualified user types/constants only from the referencing source file
- keep globally visible builtin types/enums (`String`/`StrBuf`, `Arch`, `Os`) available through a narrow builtin lookup
- update compiler/CLI module fixtures away from flat non-function lookup and add a regression that imported siblings do not inject public types/constants unqualified

Fixes RUE-498.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test //:cli-tests`
