### PR TITLE
[codex] Reject unqualified sibling function calls

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -171,7 +171,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
             }
 
             let function_key = sema
-                .resolve_function_name_in_file(*name, inst.span.file_id)
+                .resolve_function_name_local(*name, inst.span.file_id)
                 .unwrap_or(*name);
 
             // Skip FnDecls that are not in the functions table.
@@ -587,16 +587,20 @@ fn collect_static_function_references(sema: &Sema<'_>) -> HashSet<Spur> {
         };
 
         let mut target = *name;
+        let mut resolved_alias = false;
         if let Some(const_info) = sema.resolve_const_info_in_file(target, inst.span.file_id)
             && let Some(callee) = const_info.value.as_function()
         {
             target = callee;
+            resolved_alias = true;
         }
 
-        if let Some(function_key) = sema.resolve_function_name_in_file(target, inst.span.file_id) {
-            referenced.insert(function_key);
-        } else if sema.functions.contains_key(&target) {
+        if resolved_alias && sema.functions.contains_key(&target) {
             referenced.insert(target);
+        } else if let Some(function_key) =
+            sema.resolve_function_name_local(target, inst.span.file_id)
+        {
+            referenced.insert(function_key);
         }
     }
 
@@ -689,7 +693,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 } = &inst.data
                 {
                     let function_key = sema
-                        .resolve_function_name_in_file(*name, inst.span.file_id)
+                        .resolve_function_name_local(*name, inst.span.file_id)
                         .unwrap_or(*name);
                     if function_key == fn_name && !method_refs.contains(&inst_ref) {
                         found = true;

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5153,7 +5153,9 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        let source_name = name;
         let mut name = name;
+        let mut resolved_alias = false;
         if let Some(const_info) = self.resolve_const_info_in_file(name, span.file_id)
             && let Some(callee) = const_info.value.as_function()
         {
@@ -5166,20 +5168,47 @@ impl<'a> Sema<'a> {
                 span,
             )?;
             name = callee;
+            resolved_alias = true;
         }
-        name = self
-            .resolve_function_name_in_file(name, span.file_id)
-            .unwrap_or(name);
+
+        let local_name = (!resolved_alias)
+            .then(|| self.resolve_function_name_local(name, span.file_id))
+            .flatten();
+        if let Some(local_name) = local_name {
+            name = local_name;
+        }
 
         // `print(s)` / `println(s)` are builtin free functions (RUE-1), not
         // user-defined ones: intercept them here before the function lookup,
         // but only when the program hasn't shadowed the name with its own
         // `fn print`/`fn println` (a user definition wins, keeping these names
         // unreserved).
-        if (name == self.known.print || name == self.known.println)
-            && !self.functions.contains_key(&name)
+        if !resolved_alias
+            && local_name.is_none()
+            && (source_name == self.known.print || source_name == self.known.println)
         {
-            return self.analyze_print_builtin(air, name, args_start, args_len, span, ctx);
+            return self.analyze_print_builtin(air, source_name, args_start, args_len, span, ctx);
+        }
+
+        if !resolved_alias && local_name.is_none() {
+            // RUE-491 removes graph-global fallback for source-level value
+            // calls. Comptime type-function calls (`Option(T)`, `ArrayBuf(T)`)
+            // are intentionally left on the compatibility path for RUE-497,
+            // which removes that separate type/comptime fallback with its own
+            // std/library fixture updates.
+            if self
+                .functions
+                .get(&source_name)
+                .is_some_and(|info| info.return_type == Type::COMPTIME_TYPE)
+            {
+                name = source_name;
+            } else {
+                let fn_name_str = self.interner.resolve(&source_name).to_string();
+                return Err(CompileError::new(
+                    ErrorKind::UndefinedFunction(fn_name_str),
+                    span,
+                ));
+            }
         }
 
         // Look up the function

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1791,9 +1791,11 @@ impl<'a> Sema<'a> {
                     )?;
                     return Ok(ConstInit::Value(info.value));
                 }
-                if let Some((fn_file_id, is_pub)) = self.find_free_function_decl(name, None) {
+                if let Some((fn_file_id, is_pub)) =
+                    self.ensure_free_function_signature(name, Some(file_id))?
+                {
                     let function_key = self
-                        .resolve_function_name_in_file(name, span.file_id)
+                        .resolve_function_name_local(name, file_id)
                         .unwrap_or_else(|| self.internal_function_name(name, fn_file_id));
                     let fn_name = self.interner.resolve(&name).to_string();
                     self.check_unqualified_visibility(

--- a/crates/rue-cli-tests/cases/basics.toml
+++ b/crates/rue-cli-tests/cases/basics.toml
@@ -88,18 +88,20 @@ compile_stdout_contains = ["=== Tokens (main.rue) ===", "FN", "RBRACE"]
 name = "multi_file_compilation_with_dash_o"
 files = [
     { path = "main.rue", source = """
+const utils = @import("utils.rue");
+
 fn main() -> i32 {
-    @dbg(triple(14));
+    @dbg(utils.triple(14));
     0
 }
 """ },
     { path = "utils.rue", source = """
-fn triple(x: i32) -> i32 {
+pub fn triple(x: i32) -> i32 {
     x * 3
 }
 """ },
 ]
-args = ["main.rue", "utils.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 stdout = "42\n"
 
 # CLAUDE.md documents `rue a.rue b.rue` as an error, but the CLI currently

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1002,7 +1002,7 @@ error_contains = ["E0706", "function `secret` is private"]
 
 [[case]]
 name = "private_fn_cross_dir_unqualified_rejected"
-description = "Dropping the module qualifier must not bypass privacy: unqualified call to the same private function is E0460 (RUE-37)."
+description = "Dropping the module qualifier does not see functions from the imported module; use explicit module access."
 files = [
     { path = "main.rue", source = """
 const lib = @import("sub/lib.rue");
@@ -1018,7 +1018,7 @@ fn secret() -> i32 {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "function `secret` is private (defined in `sub/lib.rue`)"]
+error_contains = ["E0202", "undefined function 'secret'"]
 
 [[case]]
 name = "private_fn_cross_dir_unqualified_rejected_when_also_listed"
@@ -1061,14 +1061,14 @@ fn secret() -> i32 {
 exit_code = 99
 
 [[case]]
-name = "pub_fn_cross_dir_both_forms_allowed"
-description = "Control: a pub function in another directory is callable qualified and (transitionally) unqualified."
+name = "pub_fn_cross_dir_qualified_allowed_unqualified_rejected"
+description = "Control: a pub function in another directory is callable qualified, but not injected into the caller's unqualified namespace."
 files = [
     { path = "main.rue", source = """
 const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
-    lib.open() + open()
+    open()
 }
 """ },
     { path = "sub/lib.rue", source = """
@@ -1077,11 +1077,12 @@ pub fn open() -> i32 {
 }
 """ },
 ]
-exit_code = 14
+compile_fail = true
+error_contains = ["E0202", "undefined function 'open'"]
 
 [[case]]
 name = "flat_multifile_private_fn_cross_dir_rejected"
-description = "Uniform privacy (RUE-180): a never-imported file listed explicitly is still private cross-directory — E0460, and the diagnostic names the defining file (no import exists, so no module relationship is claimed)."
+description = "A never-imported listed file does not inject private functions into another file's unqualified namespace."
 args = ["main.rue", "sub/util.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1096,11 +1097,11 @@ fn secret() -> i32 {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "function `secret` is private (defined in `sub/util.rue`)"]
+error_contains = ["E0202", "undefined function 'secret'"]
 
 [[case]]
-name = "flat_multifile_pub_fn_cross_dir_allowed"
-description = "Positive control for uniform privacy (RUE-180): a pub function in another never-imported file is callable unqualified with no import — the flat namespace still resolves names (spec 10.3:8)."
+name = "flat_multifile_pub_fn_cross_dir_rejected"
+description = "A never-imported listed file does not inject pub functions into another file's unqualified namespace."
 args = ["main.rue", "sub/util.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1114,11 +1115,12 @@ pub fn open() -> i32 {
 }
 """ },
 ]
-exit_code = 42
+compile_fail = true
+error_contains = ["E0202", "undefined function 'open'"]
 
 [[case]]
-name = "flat_multifile_private_fn_same_dir_allowed"
-description = "Control: intra-directory visibility (ADR-0026) is unchanged by RUE-180 — a private function in another listed file in the SAME directory is still callable."
+name = "flat_multifile_private_fn_same_dir_rejected"
+description = "Another listed file in the same directory does not inject private functions into the unqualified namespace."
 args = ["main.rue", "util.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -1132,7 +1134,8 @@ fn secret() -> i32 {
 }
 """ },
 ]
-exit_code = 42
+compile_fail = true
+error_contains = ["E0202", "undefined function 'secret'"]
 
 # Structs and constants obey the same uniform rule (RUE-183): naming a
 # private struct (annotation or literal) or reading a private constant from
@@ -1330,11 +1333,13 @@ error_contains = ["E0421", "unknown enum type 'Color'"]
 [[case]]
 name = "flat_multifile_private_enum_match_pattern_rejected"
 description = "Match patterns do not see private enum names from another listed file unqualified."
-args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
 fn main() -> i32 {
-    match make() {
+    match lib.make() {
         Color::Red => 1,
         Color::Green => 2,
         Color::Blue => 3,
@@ -1916,11 +1921,13 @@ error_contains = ["E0707", "NOPE"]
 [[case]]
 name = "private_type_ctor_annotation_cross_dir_rejected"
 description = "Applying a private comptime type constructor in type-annotation position from another directory is E0460 (RUE-283) — the annotation path must gate privacy like the call path."
-args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
 fn main() -> i32 {
-    let s: Secret(i32) = mk();
+    let s: Secret(i32) = lib.mk();
     s.v
 }
 """ },
@@ -1935,11 +1942,13 @@ error_contains = ["E0460", "function `Secret` is private (defined in `sub/lib.ru
 [[case]]
 name = "pub_type_ctor_annotation_cross_dir_allowed"
 description = "Positive control for RUE-283: a pub comptime type constructor applied as an annotation from another directory is allowed."
-args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
 fn main() -> i32 {
-    let s: Secret(i32) = mk();
+    let s: Secret(i32) = lib.mk();
     s.v
 }
 """ },
@@ -1953,11 +1962,13 @@ exit_code = 7
 [[case]]
 name = "private_type_ctor_annotation_same_dir_allowed"
 description = "Control for RUE-283: a private comptime type constructor applied as an annotation from the SAME directory is still allowed (intra-directory visibility, ADR-0026)."
-args = ["main.rue", "lib.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
+const lib = @import("lib.rue");
+
 fn main() -> i32 {
-    let s: Secret(i32) = mk();
+    let s: Secret(i32) = lib.mk();
     s.v
 }
 """ },

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2184,10 +2184,15 @@ mod tests {
 
     #[test]
     fn test_cross_file_function_call() {
-        // Function in main.rue calls function in utils.rue
+        // Function in main.rue calls function in utils.rue through its module.
         let sources = vec![
-            SourceFile::new("main.rue", "fn main() -> i32 { helper() }", FileId::new(1)),
-            SourceFile::new("utils.rue", "fn helper() -> i32 { 42 }", FileId::new(2)),
+            SourceFile::new(
+                "main.rue",
+                r#"const utils = @import("utils.rue");
+                fn main() -> i32 { utils.helper() }"#,
+                FileId::new(1),
+            ),
+            SourceFile::new("utils.rue", "pub fn helper() -> i32 { 42 }", FileId::new(2)),
         ];
         let result = compile_multi_file_with_options(&sources, &CompileOptions::default());
         assert!(
@@ -2200,15 +2205,17 @@ mod tests {
     #[test]
     fn test_cross_file_function_call_with_args() {
         // Function in main.rue calls function in utils.rue with arguments
+        // through its module.
         let sources = vec![
             SourceFile::new(
                 "main.rue",
-                "fn main() -> i32 { add(10, 32) }",
+                r#"const utils = @import("utils.rue");
+                fn main() -> i32 { utils.add(10, 32) }"#,
                 FileId::new(1),
             ),
             SourceFile::new(
                 "utils.rue",
-                "fn add(a: i32, b: i32) -> i32 { a + b }",
+                "pub fn add(a: i32, b: i32) -> i32 { a + b }",
                 FileId::new(2),
             ),
         ];
@@ -2403,21 +2410,23 @@ mod tests {
 
     #[test]
     fn test_cross_file_three_files_chain() {
-        // main.rue -> utils.rue -> math.rue chain of calls
+        // main.rue -> utils.rue -> math.rue chain of module-qualified calls
         let sources = vec![
             SourceFile::new(
                 "main.rue",
-                "fn main() -> i32 { compute(6, 7) }",
+                r#"const utils = @import("utils.rue");
+                fn main() -> i32 { utils.compute(6, 7) }"#,
                 FileId::new(1),
             ),
             SourceFile::new(
                 "utils.rue",
-                "fn compute(a: i32, b: i32) -> i32 { multiply(a, b) }",
+                r#"const math = @import("math.rue");
+                pub fn compute(a: i32, b: i32) -> i32 { math.multiply(a, b) }"#,
                 FileId::new(2),
             ),
             SourceFile::new(
                 "math.rue",
-                "fn multiply(x: i32, y: i32) -> i32 { x * y }",
+                "pub fn multiply(x: i32, y: i32) -> i32 { x * y }",
                 FileId::new(3),
             ),
         ];
@@ -2431,17 +2440,24 @@ mod tests {
 
     #[test]
     fn test_cross_file_mutual_calls() {
-        // Two files calling each other (mutual recursion possible)
+        // Two files calling each other through explicit module bindings
+        // (mutual recursion remains possible).
         let sources = vec![
             SourceFile::new(
                 "main.rue",
-                r#"fn main() -> i32 { is_even(4) }
-                fn is_even(n: i32) -> i32 { if n == 0 { 1 } else { is_odd(n - 1) } }"#,
+                r#"const utils = @import("utils.rue");
+                fn main() -> i32 { is_even(4) }
+                pub fn is_even(n: i32) -> i32 {
+                    if n == 0 { 1 } else { utils.is_odd(n - 1) }
+                }"#,
                 FileId::new(1),
             ),
             SourceFile::new(
                 "utils.rue",
-                "fn is_odd(n: i32) -> i32 { if n == 0 { 0 } else { is_even(n - 1) } }",
+                r#"const mainmod = @import("main.rue");
+                pub fn is_odd(n: i32) -> i32 {
+                    if n == 0 { 0 } else { mainmod.is_even(n - 1) }
+                }"#,
                 FileId::new(2),
             ),
         ];

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -247,12 +247,12 @@ fn internal_fn() -> i32 {
 }
 """ }
 compile_fail = true
-error_contains = "is private (defined in"
+error_contains = "undefined function 'internal_fn'"
 
 [[case]]
-name = "cross_dir_unqualified_pub_fn_allowed"
-spec = ["10.3:7", "10.3:8", "10.5:2"]
-description = "Unqualified call to a pub function of an imported module still resolves (transitional flat namespace)"
+name = "cross_dir_unqualified_pub_fn_rejected"
+spec = ["10.3:7", "10.3:8"]
+description = "Unqualified call to a pub function of an imported module is rejected; use module-qualified access"
 source = """
 const utils = @import("subdir/utils");
 
@@ -265,12 +265,13 @@ pub fn public_fn() -> i32 {
     42
 }
 """ }
-exit_code = 42
+compile_fail = true
+error_contains = "undefined function 'public_fn'"
 
 [[case]]
-name = "same_dir_unqualified_private_fn_allowed"
+name = "same_dir_unqualified_private_fn_rejected"
 spec = ["10.3:2", "10.3:7"]
-description = "Unqualified call to a private function of an imported file in the SAME directory is allowed (intra-directory visibility)"
+description = "Unqualified call to a private function of an imported file in the SAME directory is rejected; use module-qualified access"
 source = """
 const utils = @import("utils");
 
@@ -283,7 +284,8 @@ fn internal_fn() -> i32 {
     42
 }
 """ }
-exit_code = 42
+compile_fail = true
+error_contains = "undefined function 'internal_fn'"
 
 # =============================================================================
 # Unqualified Cross-Directory Access: Structs and Constants (RUE-183)


### PR DESCRIPTION
## Summary

- resolve source-level unqualified value calls only through the caller file's local function table
- preserve local function aliases, builtins, and temporary type-constructor compatibility for RUE-497
- update compiler/CLI/spec fixtures away from flat unqualified function calls and toward explicit module-qualified calls

Fixes RUE-491.

## Validation

- `./fmt.sh`
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test //:cli-tests //:spec-tests`
