### PR TITLE
[codex] Keep same-named module structs nominal

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -169,6 +169,8 @@ pub struct ConstraintGenerator<'a> {
     functions: &'a HashMap<Spur, FunctionSig>,
     /// Struct types (name -> Type::new_struct(id)).
     structs: &'a HashMap<Spur, Type>,
+    /// Module-local struct types ((defining file, source name) -> Type::new_struct(id)).
+    structs_by_file_name: Option<&'a HashMap<(FileId, Spur), Type>>,
     /// Enum types (name -> Type::new_enum(id)).
     enums: &'a HashMap<Spur, Type>,
     /// Method signatures: (struct_id, method_name) -> MethodSig
@@ -194,6 +196,10 @@ pub struct ConstraintGenerator<'a> {
     /// `None` only in unit tests; production passes the map via
     /// [`Self::with_module_binding_types`].
     module_binding_types: Option<&'a HashMap<(FileId, Spur), Type>>,
+    /// Module registry file identity for inference-time `module.Type` lookup.
+    /// `None` only in unit tests; production passes the map via
+    /// [`Self::with_module_file_ids`].
+    module_file_ids: Option<&'a HashMap<crate::types::ModuleId, FileId>>,
     /// Compile-time type aliases bound by `let` in the current function body
     /// (`let P = F();` where `F` returns `type`), pre-resolved by sema before
     /// constraint generation. Consulted after `type_subst` when resolving
@@ -272,6 +278,7 @@ impl<'a> ConstraintGenerator<'a> {
             expr_types: HashMap::new(),
             functions,
             structs,
+            structs_by_file_name: None,
             enums,
             methods,
             int_literal_vars: Vec::new(),
@@ -279,6 +286,7 @@ impl<'a> ConstraintGenerator<'a> {
             const_types: None,
             const_type_aliases: None,
             module_binding_types: None,
+            module_file_ids: None,
             comptime_local_types: None,
             extra_method_sigs: None,
             const_values: None,
@@ -330,6 +338,25 @@ impl<'a> ConstraintGenerator<'a> {
         module_binding_types: &'a HashMap<(FileId, Spur), Type>,
     ) -> Self {
         self.module_binding_types = Some(module_binding_types);
+        self
+    }
+
+    /// Provide module-local struct types for file-scoped and module-qualified
+    /// struct literal resolution.
+    pub fn with_structs_by_file_name(
+        mut self,
+        structs_by_file_name: &'a HashMap<(FileId, Spur), Type>,
+    ) -> Self {
+        self.structs_by_file_name = Some(structs_by_file_name);
+        self
+    }
+
+    /// Provide module registry file identities for `module.Type` lookup.
+    pub fn with_module_file_ids(
+        mut self,
+        module_file_ids: &'a HashMap<crate::types::ModuleId, FileId>,
+    ) -> Self {
+        self.module_file_ids = Some(module_file_ids);
         self
     }
 
@@ -1578,24 +1605,49 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Struct initialization
             InstData::StructInit {
+                module,
                 type_name,
                 fields_start,
                 fields_len,
                 ..
             } => {
-                // Check type_subst first (for Self and type parameters in
-                // method bodies), then comptime type aliases (`let P = F();
-                // P { ... }`, RUE-170) — mirroring sema, which consults
-                // `comptime_type_vars` before the struct table — then named
-                // structs.
-                let struct_ty = self
-                    .type_subst
-                    .and_then(|subst| subst.get(type_name).copied())
-                    .or_else(|| {
-                        self.comptime_local_types
-                            .and_then(|aliases| aliases.get(type_name).copied())
-                    })
-                    .or_else(|| self.structs.get(type_name).copied());
+                // Module-qualified literals (`m.Point { ... }`) resolve in
+                // the module's defining file, matching sema. Unqualified
+                // literals check type_subst first (for Self/type parameters),
+                // then comptime type aliases (`let P = F(); P { ... }`,
+                // RUE-170), then the current file's module-local type table,
+                // then the unique-name compatibility map.
+                let struct_ty = if let Some(module_ref) = module {
+                    let module_info = self.generate(*module_ref, ctx);
+                    let module_id = match module_info.ty {
+                        InferType::Concrete(ty) => ty.as_module(),
+                        _ => None,
+                    };
+                    module_id
+                        .and_then(|module_id| {
+                            self.module_file_ids
+                                .and_then(|module_file_ids| module_file_ids.get(&module_id))
+                                .copied()
+                        })
+                        .and_then(|file_id| {
+                            self.structs_by_file_name
+                                .and_then(|structs| structs.get(&(file_id, *type_name)))
+                                .copied()
+                        })
+                } else {
+                    self.type_subst
+                        .and_then(|subst| subst.get(type_name).copied())
+                        .or_else(|| {
+                            self.comptime_local_types
+                                .and_then(|aliases| aliases.get(type_name).copied())
+                        })
+                        .or_else(|| {
+                            self.structs_by_file_name
+                                .and_then(|structs| structs.get(&(span.file_id, *type_name)))
+                                .copied()
+                                .or_else(|| self.structs.get(type_name).copied())
+                        })
+                };
 
                 let fields = self.rir.get_field_inits(*fields_start, *fields_len);
                 if let Some(struct_ty) = struct_ty {

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -79,7 +79,9 @@ impl<'a> Sema<'a> {
         .with_const_type_aliases(&infer_ctx.const_type_aliases)
         .with_const_values(&infer_ctx.const_values)
         .with_const_function_aliases(&infer_ctx.const_function_aliases)
+        .with_structs_by_file_name(&infer_ctx.struct_types_by_file_name)
         .with_module_binding_types(&infer_ctx.module_binding_types)
+        .with_module_file_ids(&infer_ctx.module_file_ids)
         .with_comptime_local_types(&comptime_local_types)
         .with_comptime_values(value_subst)
         .with_extra_method_sigs(&extra_method_sigs);

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -174,6 +174,12 @@ impl<'a> Sema<'a> {
             .map(|(name, id)| (*name, Type::new_struct(*id)))
             .collect();
 
+        let struct_types_by_file_name: HashMap<(FileId, Spur), Type> = self
+            .structs_by_file_name
+            .iter()
+            .map(|(key, id)| (*key, Type::new_struct(*id)))
+            .collect();
+
         // Build enum types map (name -> Type::new_enum(id))
         let enum_types: HashMap<Spur, Type> = self
             .enums
@@ -262,9 +268,20 @@ impl<'a> Sema<'a> {
             .map(|(key, info)| (*key, info.ty))
             .collect();
 
+        let module_file_ids: HashMap<crate::types::ModuleId, FileId> =
+            (0..self.module_registry.len())
+                .filter_map(|index| {
+                    let module_id = crate::types::ModuleId::new(index as u32);
+                    let module_def = self.module_registry.get_def(module_id);
+                    self.canonical_file_id(&module_def.file_path)
+                        .map(|file_id| (module_id, file_id))
+                })
+                .collect();
+
         InferenceContext {
             func_sigs,
             struct_types,
+            struct_types_by_file_name,
             enum_types,
             method_sigs,
             const_types,
@@ -272,6 +289,7 @@ impl<'a> Sema<'a> {
             const_values,
             const_function_aliases,
             module_binding_types,
+            module_file_ids,
         }
     }
     /// Check if a directive list contains the @copy directive

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -30,6 +30,8 @@ pub struct InferenceContext {
     pub func_sigs: HashMap<Spur, FunctionSig>,
     /// Struct types: name -> Type::new_struct(id).
     pub struct_types: HashMap<Spur, Type>,
+    /// Module-local struct types: (defining file, source name) -> Type::new_struct(id).
+    pub struct_types_by_file_name: HashMap<(FileId, Spur), Type>,
     /// Enum types: name -> Type::new_enum(id).
     pub enum_types: HashMap<Spur, Type>,
     /// Method signatures with InferType: (struct_id, method_name) -> MethodSig.
@@ -58,4 +60,6 @@ pub struct InferenceContext {
     /// name) -> module type. Module bindings are per-file scoped (RUE-113),
     /// so they're keyed by file rather than living in `const_types`.
     pub module_binding_types: HashMap<(FileId, Spur), Type>,
+    /// Module registry file identity for inference-time member type lookup.
+    pub module_file_ids: HashMap<crate::types::ModuleId, FileId>,
 }

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1161,6 +1161,68 @@ compile_fail = true
 error_contains = ["E0204", "unknown type 'Point'"]
 
 [[case]]
+name = "same_named_module_structs_are_nominal_different_layouts"
+description = "RUE-500: module-qualified same-named structs from different modules are distinct nominal types, even with different layouts."
+files = [
+    { path = "main.rue", source = """
+const left = @import("left.rue");
+const right = @import("right.rue");
+
+fn take_left(x: left.Box) -> i32 {
+    x.a
+}
+
+fn main() -> i32 {
+    let r = right.Box { b: 7 };
+    take_left(r)
+}
+""" },
+    { path = "left.rue", source = """
+pub struct Box {
+    a: i32,
+}
+""" },
+    { path = "right.rue", source = """
+pub struct Box {
+    b: i32,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+[[case]]
+name = "same_named_module_structs_are_nominal_same_layout"
+description = "RUE-500: module-qualified same-named structs remain distinct nominal types even when their fields match."
+files = [
+    { path = "main.rue", source = """
+const left = @import("left.rue");
+const right = @import("right.rue");
+
+fn take_left(x: left.Box) -> i32 {
+    x.value
+}
+
+fn main() -> i32 {
+    let r = right.Box { value: 7 };
+    take_left(r)
+}
+""" },
+    { path = "left.rue", source = """
+pub struct Box {
+    value: i32,
+}
+""" },
+    { path = "right.rue", source = """
+pub struct Box {
+    value: i32,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+[[case]]
 name = "private_const_cross_dir_unqualified_rejected"
 description = "Unqualified read does not see a constant from another module, even when that module is imported."
 files = [


### PR DESCRIPTION
## Summary

- pass module-local struct type maps and module file identities into inference
- resolve `module.Struct { ... }` literals against the module's defining file instead of the bare-name compatibility map
- add regressions proving same-named structs in sibling modules stay nominally distinct, including same-layout structs

Fixes RUE-500.

## Validation

- `./fmt.sh`
- `./buck2 test //:cli-tests //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test //:spec-tests`
- manual repro: `right.Box` passed to `fn take_left(x: left.Box)` now fails with a type mismatch
