### PR TITLE
[codex] Keep same-named module enums nominal

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -173,6 +173,8 @@ pub struct ConstraintGenerator<'a> {
     structs_by_file_name: Option<&'a HashMap<(FileId, Spur), Type>>,
     /// Enum types (name -> Type::new_enum(id)).
     enums: &'a HashMap<Spur, Type>,
+    /// Module-local enum types ((defining file, source name) -> Type::new_enum(id)).
+    enums_by_file_name: Option<&'a HashMap<(FileId, Spur), Type>>,
     /// Method signatures: (struct_id, method_name) -> MethodSig
     methods: &'a HashMap<(StructId, Spur), MethodSig>,
     /// Type variables allocated for integer literals.
@@ -196,7 +198,8 @@ pub struct ConstraintGenerator<'a> {
     /// `None` only in unit tests; production passes the map via
     /// [`Self::with_module_binding_types`].
     module_binding_types: Option<&'a HashMap<(FileId, Spur), Type>>,
-    /// Module registry file identity for inference-time `module.Type` lookup.
+    /// Module registry file identity for inference-time `module.Type` and
+    /// `module.Enum` lookup.
     /// `None` only in unit tests; production passes the map via
     /// [`Self::with_module_file_ids`].
     module_file_ids: Option<&'a HashMap<crate::types::ModuleId, FileId>>,
@@ -280,6 +283,7 @@ impl<'a> ConstraintGenerator<'a> {
             structs,
             structs_by_file_name: None,
             enums,
+            enums_by_file_name: None,
             methods,
             int_literal_vars: Vec::new(),
             type_subst,
@@ -357,6 +361,16 @@ impl<'a> ConstraintGenerator<'a> {
         module_file_ids: &'a HashMap<crate::types::ModuleId, FileId>,
     ) -> Self {
         self.module_file_ids = Some(module_file_ids);
+        self
+    }
+
+    /// Provide module-local enum types for file-scoped and module-qualified
+    /// enum variant/pattern resolution.
+    pub fn with_enums_by_file_name(
+        mut self,
+        enums_by_file_name: &'a HashMap<(FileId, Spur), Type>,
+    ) -> Self {
+        self.enums_by_file_name = Some(enums_by_file_name);
         self
     }
 
@@ -1539,16 +1553,20 @@ impl<'a> ConstraintGenerator<'a> {
                     use crate::scope::ScopedContext;
                     ctx.push_scope();
                     if let rue_rir::RirPattern::Path {
+                        module,
                         type_name,
                         variant,
                         bindings,
                         span: pat_span,
-                        ..
                     } = pattern
                     {
                         if !bindings.is_empty() {
-                            if let Some(payload) = self
-                                .enum_type_for(type_name)
+                            let enum_ty = module
+                                .and_then(|module_ref| {
+                                    self.enum_type_for_module(module_ref, type_name)
+                                })
+                                .or_else(|| self.enum_type_for(type_name, pat_span.file_id));
+                            if let Some(payload) = enum_ty
                                 .and_then(|ty| ty.as_enum())
                                 .map(|id| self.type_pool.enum_def(id))
                                 .and_then(|def| {
@@ -1738,8 +1756,13 @@ impl<'a> ConstraintGenerator<'a> {
             }
 
             // Enum variant
-            InstData::EnumVariant { type_name, .. } => {
-                if let Some(enum_ty) = self.enum_type_for(type_name) {
+            InstData::EnumVariant {
+                module, type_name, ..
+            } => {
+                let enum_ty = module
+                    .and_then(|module_ref| self.enum_type_for_module(module_ref, type_name))
+                    .or_else(|| self.enum_type_for(type_name, span.file_id));
+                if let Some(enum_ty) = enum_ty {
                     InferType::Concrete(enum_ty)
                 } else {
                     InferType::Concrete(Type::ERROR)
@@ -1995,7 +2018,7 @@ impl<'a> ConstraintGenerator<'a> {
                 // (RUE-221). Checked here first so it takes precedence over the
                 // struct-method path below.
                 let enum_variant = self
-                    .enum_type_for(type_name)
+                    .enum_type_for(type_name, span.file_id)
                     .and_then(|ty| ty.as_enum().map(|id| (ty, id)))
                     .and_then(|(ty, id)| {
                         let def = self.type_pool.enum_def(id);
@@ -2239,11 +2262,35 @@ impl<'a> ConstraintGenerator<'a> {
     /// table. Mirrors sema's `resolve_enum_type_name`; without the
     /// comptime-alias lookup, generic-enum construction/matching inferred
     /// `<error>` and poisoned the surrounding constraints (RUE-6 phase 2).
-    fn enum_type_for(&self, type_name: &Spur) -> Option<Type> {
+    fn enum_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
         self.comptime_local_types
             .and_then(|aliases| aliases.get(type_name).copied())
             .filter(|ty| ty.is_enum())
+            .or_else(|| {
+                self.enums_by_file_name
+                    .and_then(|enums| enums.get(&(file_id, *type_name)))
+                    .copied()
+            })
             .or_else(|| self.enums.get(type_name).copied())
+    }
+
+    fn enum_type_for_module(&self, module: InstRef, type_name: &Spur) -> Option<Type> {
+        let inst = self.rir.get(module);
+        let InstData::VarRef { name } = &inst.data else {
+            return None;
+        };
+        let module_ty = self
+            .module_binding_types
+            .and_then(|bindings| bindings.get(&(inst.span.file_id, *name)))
+            .copied()?;
+        let module_id = module_ty.as_module()?;
+        let file_id = self
+            .module_file_ids
+            .and_then(|module_file_ids| module_file_ids.get(&module_id))
+            .copied()?;
+        self.enums_by_file_name
+            .and_then(|enums| enums.get(&(file_id, *type_name)))
+            .copied()
     }
 
     /// Get the inferred type for a pattern.
@@ -2256,8 +2303,13 @@ impl<'a> ConstraintGenerator<'a> {
             }
             rue_rir::RirPattern::Int { .. } => InferType::IntLiteral,
             rue_rir::RirPattern::Bool(_, _) => InferType::Concrete(Type::BOOL),
-            rue_rir::RirPattern::Path { type_name, .. } => {
-                if let Some(enum_ty) = self.enum_type_for(type_name) {
+            rue_rir::RirPattern::Path {
+                module, type_name, ..
+            } => {
+                let enum_ty = module
+                    .and_then(|module_ref| self.enum_type_for_module(module_ref, type_name))
+                    .or_else(|| self.enum_type_for(type_name, pattern.span().file_id));
+                if let Some(enum_ty) = enum_ty {
                     InferType::Concrete(enum_ty)
                 } else {
                     InferType::Concrete(Type::ERROR)

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -80,6 +80,7 @@ impl<'a> Sema<'a> {
         .with_const_values(&infer_ctx.const_values)
         .with_const_function_aliases(&infer_ctx.const_function_aliases)
         .with_structs_by_file_name(&infer_ctx.struct_types_by_file_name)
+        .with_enums_by_file_name(&infer_ctx.enum_types_by_file_name)
         .with_module_binding_types(&infer_ctx.module_binding_types)
         .with_module_file_ids(&infer_ctx.module_file_ids)
         .with_comptime_local_types(&comptime_local_types)

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -187,6 +187,12 @@ impl<'a> Sema<'a> {
             .map(|(name, id)| (*name, Type::new_enum(*id)))
             .collect();
 
+        let enum_types_by_file_name: HashMap<(FileId, Spur), Type> = self
+            .enums_by_file_name
+            .iter()
+            .map(|(key, id)| (*key, Type::new_enum(*id)))
+            .collect();
+
         // Build method signatures with InferType for constraint generation
         let mut method_sigs: HashMap<(StructId, Spur), MethodSig> = self
             .methods
@@ -283,6 +289,7 @@ impl<'a> Sema<'a> {
             struct_types,
             struct_types_by_file_name,
             enum_types,
+            enum_types_by_file_name,
             method_sigs,
             const_types,
             const_type_aliases,

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -34,6 +34,8 @@ pub struct InferenceContext {
     pub struct_types_by_file_name: HashMap<(FileId, Spur), Type>,
     /// Enum types: name -> Type::new_enum(id).
     pub enum_types: HashMap<Spur, Type>,
+    /// Module-local enum types: (defining file, source name) -> Type::new_enum(id).
+    pub enum_types_by_file_name: HashMap<(FileId, Spur), Type>,
     /// Method signatures with InferType: (struct_id, method_name) -> MethodSig.
     pub method_sigs: HashMap<(StructId, Spur), MethodSig>,
     /// File-level constant types: name -> declared type (e.g. `Type::I32` for

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1470,6 +1470,77 @@ fn main() -> i32 {
 exit_code = 3
 
 [[case]]
+name = "same_named_module_enums_are_nominal_same_variants"
+description = "RUE-501: module-qualified same-named enums from different modules are distinct nominal types, even when their variants match."
+files = [
+    { path = "main.rue", source = """
+const left = @import("left.rue");
+const right = @import("right.rue");
+
+fn take_left(x: left.E) -> i32 {
+    match x {
+        left.E::A => 1,
+        left.E::B => 2,
+    }
+}
+
+fn main() -> i32 {
+    let r = right.E::B;
+    take_left(r)
+}
+""" },
+    { path = "left.rue", source = """
+pub enum E {
+    A,
+    B,
+}
+""" },
+    { path = "right.rue", source = """
+pub enum E {
+    A,
+    B,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+[[case]]
+name = "same_named_module_enums_are_nominal_different_variants"
+description = "RUE-501: module-qualified same-named enums from different modules are distinct nominal types when variants differ too."
+files = [
+    { path = "main.rue", source = """
+const left = @import("left.rue");
+const right = @import("right.rue");
+
+fn take_left(x: left.E) -> i32 {
+    match x {
+        left.E::A => 1,
+        left.E::B => 2,
+    }
+}
+
+fn main() -> i32 {
+    let r = right.E::C;
+    take_left(r)
+}
+""" },
+    { path = "left.rue", source = """
+pub enum E {
+    A,
+    B,
+}
+""" },
+    { path = "right.rue", source = """
+pub enum E {
+    C,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+[[case]]
 name = "flat_multifile_private_enum_construction_rejected"
 description = "Flat listed files do not inject private enum names into another file's unqualified namespace."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]


### PR DESCRIPTION
## Summary

- pass module-local enum type maps and module file identities into inference
- resolve module-qualified enum variants and match patterns against the module's defining file
- add regressions proving same-named enums in sibling modules stay nominally distinct, including matching and differing variants

Fixes RUE-501.

## Validation

- `./fmt.sh`
- `./buck2 test //:cli-tests //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test //:spec-tests`
- manual repro: `right.E::B` passed to `fn take_left(x: left.E)` now fails with a type mismatch
