### PR TITLE
[codex] Remove unqualified comptime sibling fallback

### DIFF
--- a/crates/rue-air/src/sema/analysis/anon_methods.rs
+++ b/crates/rue-air/src/sema/analysis/anon_methods.rs
@@ -295,10 +295,11 @@ impl<'a> Sema<'a> {
                     let resolved_ty = if type_str == "Self" {
                         struct_type
                     } else {
-                        self.resolve_type_for_comptime_with_subst_and_values(
+                        self.resolve_type_for_comptime_with_subst_and_values_at_span(
                             p.ty,
                             type_subst,
                             value_subst,
+                            method_inst.span,
                         )?
                     };
                     param_types.push(resolved_ty);
@@ -309,10 +310,11 @@ impl<'a> Sema<'a> {
                 let ret_type = if ret_type_str == "Self" {
                     struct_type
                 } else {
-                    self.resolve_type_for_comptime_with_subst_and_values(
+                    self.resolve_type_for_comptime_with_subst_and_values_at_span(
                         *return_type,
                         type_subst,
                         value_subst,
+                        method_inst.span,
                     )?
                 };
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5191,24 +5191,11 @@ impl<'a> Sema<'a> {
         }
 
         if !resolved_alias && local_name.is_none() {
-            // RUE-491 removes graph-global fallback for source-level value
-            // calls. Comptime type-function calls (`Option(T)`, `ArrayBuf(T)`)
-            // are intentionally left on the compatibility path for RUE-497,
-            // which removes that separate type/comptime fallback with its own
-            // std/library fixture updates.
-            if self
-                .functions
-                .get(&source_name)
-                .is_some_and(|info| info.return_type == Type::COMPTIME_TYPE)
-            {
-                name = source_name;
-            } else {
-                let fn_name_str = self.interner.resolve(&source_name).to_string();
-                return Err(CompileError::new(
-                    ErrorKind::UndefinedFunction(fn_name_str),
-                    span,
-                ));
-            }
+            let fn_name_str = self.interner.resolve(&source_name).to_string();
+            return Err(CompileError::new(
+                ErrorKind::UndefinedFunction(fn_name_str),
+                span,
+            ));
         }
 
         // Look up the function

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -831,11 +831,14 @@ impl Sema<'_> {
                     // (`comptime T: type`) and the value substitution
                     // (`comptime N: i32`, so an `[i32; N]` field gets a concrete
                     // length at each specialization; RUE-16).
-                    let Some(field_ty) = self.resolve_type_for_comptime_with_subst_and_values(
-                        type_sym,
-                        env.type_subst,
-                        env.value_subst,
-                    ) else {
+                    let Some(field_ty) = self
+                        .resolve_type_for_comptime_with_subst_and_values_at_span(
+                            type_sym,
+                            env.type_subst,
+                            env.value_subst,
+                            span,
+                        )
+                    else {
                         return Ok(None);
                     };
                     struct_fields.push(StructField {
@@ -969,11 +972,14 @@ impl Sema<'_> {
                         let ty_sym = lasso::Spur::try_from_usize(payload_words[pi] as usize)
                             .expect("valid payload type symbol");
                         pi += 1;
-                        let Some(ty) = self.resolve_type_for_comptime_with_subst_and_values(
-                            ty_sym,
-                            env.type_subst,
-                            env.value_subst,
-                        ) else {
+                        let Some(ty) = self
+                            .resolve_type_for_comptime_with_subst_and_values_at_span(
+                                ty_sym,
+                                env.type_subst,
+                                env.value_subst,
+                                span,
+                            )
+                        else {
                             return Ok(None);
                         };
                         tys.push(ty);

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -771,10 +771,13 @@ impl<'a> Sema<'a> {
         if let Some(module_file_id) = module_file_id {
             self.ensure_free_function_signature(member_sym, Some(module_file_id))?;
         }
+        let function_key = module_file_id
+            .and_then(|file_id| self.resolve_function_name_local(member_sym, file_id))
+            .unwrap_or(member_sym);
 
         let Some(fn_info) = self
             .functions
-            .get(&member_sym)
+            .get(&function_key)
             .copied()
             .filter(|info| module_file_id == Some(info.file_id))
         else {
@@ -833,7 +836,7 @@ impl<'a> Sema<'a> {
             callee_types.insert(param_names[i], arg_ty);
         }
         let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
-        match self.reduce_type_ctor_body(member_sym, &callee_types, &empty_values)? {
+        match self.reduce_type_ctor_body(function_key, &callee_types, &empty_values)? {
             Some(ConstValue::Type(t)) => Ok(t),
             _ => Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
@@ -1021,9 +1024,12 @@ impl<'a> Sema<'a> {
         ctx: Option<&AnalysisContext>,
     ) -> CompileResult<Type> {
         let name_sym = self.interner.get_or_intern(call_name);
-        let name_key = self
-            .resolve_function_name_in_file(name_sym, span.file_id)
-            .unwrap_or(name_sym);
+        let Some(name_key) = self.resolve_function_name_local(name_sym, span.file_id) else {
+            return Err(CompileError::new(
+                ErrorKind::UnknownType(format!("{}(...)", call_name)),
+                span,
+            ));
+        };
 
         // The callee must be a known `-> type` constructor.
         let Some(fn_info) = self.functions.get(&name_key) else {
@@ -1145,6 +1151,21 @@ impl<'a> Sema<'a> {
         type_subst: &std::collections::HashMap<Spur, Type>,
         value_subst: &HashMap<Spur, ConstValue>,
     ) -> Option<Type> {
+        self.resolve_type_for_comptime_with_subst_and_values_at_span(
+            type_sym,
+            type_subst,
+            value_subst,
+            Span::default(),
+        )
+    }
+
+    pub(crate) fn resolve_type_for_comptime_with_subst_and_values_at_span(
+        &mut self,
+        type_sym: Spur,
+        type_subst: &std::collections::HashMap<Spur, Type>,
+        value_subst: &HashMap<Spur, ConstValue>,
+        span: Span,
+    ) -> Option<Type> {
         // First check the substitution map for type parameters
         if let Some(&ty) = type_subst.get(&type_sym) {
             return Some(ty);
@@ -1169,17 +1190,18 @@ impl<'a> Sema<'a> {
         } else if let Some((element_type, len)) = parse_array_type_syntax(type_name) {
             // Resolve the element type first
             let element_sym = self.interner.get_or_intern(&element_type);
-            let element_ty = self.resolve_type_for_comptime_with_subst_and_values(
+            let element_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
                 element_sym,
                 type_subst,
                 value_subst,
+                span,
             )?;
             // Resolve the length via comptime value substitution (a `comptime`
             // value parameter) or file-level constants. In comptime evaluation
             // we can't emit a diagnostic, so an unresolvable length just makes
             // the type non-evaluable (None); the caller reports it (RUE-16).
             let length = self
-                .resolve_array_length(&len, Span::default(), Some(value_subst))
+                .resolve_array_length(&len, span, Some(value_subst))
                 .ok()?;
             // Get or create the array type
             let array_type_id = self.get_or_create_array_type(element_ty, length);
@@ -1187,20 +1209,22 @@ impl<'a> Sema<'a> {
         } else if let Some(pointee_type_str) = type_name.strip_prefix("ptr const ") {
             // Pointer type syntax: ptr const T
             let pointee_sym = self.interner.get_or_intern(pointee_type_str);
-            let pointee_ty = self.resolve_type_for_comptime_with_subst_and_values(
+            let pointee_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
                 pointee_sym,
                 type_subst,
                 value_subst,
+                span,
             )?;
             let ptr_type_id = self.type_pool.intern_ptr_const_from_type(pointee_ty);
             Some(Type::new_ptr_const(ptr_type_id))
         } else if let Some(pointee_type_str) = type_name.strip_prefix("ptr mut ") {
             // Pointer type syntax: ptr mut T
             let pointee_sym = self.interner.get_or_intern(pointee_type_str);
-            let pointee_ty = self.resolve_type_for_comptime_with_subst_and_values(
+            let pointee_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
                 pointee_sym,
                 type_subst,
                 value_subst,
+                span,
             )?;
             let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
             Some(Type::new_ptr_mut(ptr_type_id))
@@ -1219,7 +1243,12 @@ impl<'a> Sema<'a> {
             // guard) just makes the type non-evaluable (`None`); the caller
             // reports it.
             let name_sym = self.interner.get_or_intern(&call_name);
-            let fn_info = self.functions.get(&name_sym)?;
+            let function_key = if span == Span::default() {
+                name_sym
+            } else {
+                self.resolve_function_name_local(name_sym, span.file_id)?
+            };
+            let fn_info = self.functions.get(&function_key)?;
             if fn_info.return_type != Type::COMPTIME_TYPE {
                 return None;
             }
@@ -1234,16 +1263,17 @@ impl<'a> Sema<'a> {
             let mut callee_types: HashMap<Spur, Type> = HashMap::new();
             for (i, arg) in arg_strs.iter().enumerate() {
                 let arg_sym = self.interner.get_or_intern(arg);
-                let arg_ty = self.resolve_type_for_comptime_with_subst_and_values(
+                let arg_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
                     arg_sym,
                     type_subst,
                     value_subst,
+                    span,
                 )?;
                 callee_types.insert(param_names[i], arg_ty);
             }
             let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
             match self
-                .reduce_type_ctor_body(name_sym, &callee_types, &empty_values)
+                .reduce_type_ctor_body(function_key, &callee_types, &empty_values)
                 .ok()?
             {
                 Some(ConstValue::Type(t)) => Some(t),
@@ -1400,9 +1430,12 @@ impl<'a> Sema<'a> {
             |reason: String| CompileError::new(ErrorKind::InvalidArrayLength { reason }, span);
 
         let callee_sym = self.interner.get_or_intern(callee);
-        let callee_key = self
-            .resolve_function_name_in_file(callee_sym, span.file_id)
-            .unwrap_or(callee_sym);
+        let Some(callee_key) = self.resolve_function_name_local(callee_sym, span.file_id) else {
+            return Err(invalid(format!(
+                "'{callee}' is not a function; array lengths must be an integer literal, a \
+                 `const`, a `comptime` value parameter, or a call to a comptime function"
+            )));
+        };
         let Some(fn_info) = self.functions.get(&callee_key) else {
             return Err(invalid(format!(
                 "'{callee}' is not a function; array lengths must be an integer literal, a \

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -22,11 +22,14 @@ description = "A Rue-source ArrayBuf(T) on @alloc/@free with a full push/pop/get
 [[case]]
 name = "arraybuf_i32_dogfood"
 description = "push/len/get/set/pop/while-sum/out-of-bounds on ArrayBuf(i32), Option(T) accessors, flat multi-file."
+args = ["main.rue", "-o", "prog"]
 files = [
   { path = "main.rue", source = """
+const arraybuf = @import("arraybuf.rue");
+
 fn main() -> i32 {
-    let V = ArrayBuf(i32);
-    let O = Option(i32);
+    let V = arraybuf.ArrayBuf(i32);
+    let O = arraybuf.Option(i32);
 
     let mut v = V::new();
     v.push(10);
@@ -61,6 +64,10 @@ pub fn Option(comptime T: type) -> type {
 }
 """ },
   { path = "arraybuf.rue", source = """
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+
 pub fn ArrayBuf(comptime T: type) -> type {
     struct {
         buf: ptr mut T,
@@ -137,7 +144,6 @@ pub fn ArrayBuf(comptime T: type) -> type {
 }
 """ },
 ]
-args = ["main.rue", "arraybuf.rue", "option.rue", "-o", "prog"]
 stdout = "3\n20\n99\n30\n2\n-1\n119\n"
 exit_code = 119
 

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1304,6 +1304,83 @@ compile_fail = true
 error_contains = ["E0204", "unknown type 'Color'"]
 
 [[case]]
+name = "unqualified_sibling_comptime_type_function_rejected"
+description = "RUE-497: an unqualified comptime type-constructor call must not resolve to a sibling module function."
+files = [
+    { path = "main.rue", source = """
+const right = @import("right.rue");
+
+fn main() -> i32 {
+    let BoxI = Box(i32);
+    let b = BoxI { value: 7 };
+    b.value
+}
+""" },
+    { path = "right.rue", source = """
+pub fn Box(comptime T: type) -> type {
+    struct { value: T }
+}
+""" },
+]
+compile_fail = true
+error_contains = ["undefined function 'Box'"]
+
+[[case]]
+name = "module_qualified_comptime_type_function_still_allowed"
+description = "RUE-497 control: explicit module-qualified comptime type-constructor calls still work."
+files = [
+    { path = "main.rue", source = """
+const right = @import("right.rue");
+
+fn main() -> i32 {
+    let BoxI = right.Box(i32);
+    let b = BoxI { value: 7 };
+    b.value
+}
+""" },
+    { path = "right.rue", source = """
+pub fn Box(comptime T: type) -> type {
+    struct { value: T }
+}
+""" },
+]
+exit_code = 7
+
+[[case]]
+name = "unqualified_sibling_array_length_call_rejected"
+description = "RUE-497: an unqualified array-length comptime call must not resolve to a sibling module function."
+files = [
+    { path = "main.rue", source = """
+const right = @import("right.rue");
+
+fn main() -> i32 {
+    let xs: [i32; len(3)] = [1, 2, 3];
+    xs[2]
+}
+""" },
+    { path = "right.rue", source = """
+pub fn len(comptime n: i32) -> i32 { n }
+""" },
+]
+compile_fail = true
+error_contains = ["invalid array length", "'len' is not a function"]
+
+[[case]]
+name = "local_array_length_call_still_allowed"
+description = "RUE-497 control: unqualified array-length calls still work for functions local to the referencing file."
+files = [
+    { path = "main.rue", source = """
+fn len(comptime n: i32) -> i32 { n }
+
+fn main() -> i32 {
+    let xs: [i32; len(3)] = [1, 2, 3];
+    xs[2]
+}
+""" },
+]
+exit_code = 3
+
+[[case]]
 name = "flat_multifile_private_enum_construction_rejected"
 description = "Flat listed files do not inject private enum names into another file's unqualified namespace."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
@@ -1907,11 +1984,11 @@ compile_fail = true
 error_contains = ["E0707", "NOPE"]
 
 # A private comptime type constructor (`fn Secret(comptime T) -> type`) applied
-# in type-annotation position (`let s: Secret(i32)`, a param/return type) is a
-# reference to that function and obeys the same uniform-privacy rule the
-# value/call path enforces (RUE-283). Before the fix the annotation path
-# skipped the E0460 check, so a private type constructor leaked across
-# directories via an annotation — a privacy-soundness hole (accept-invalid).
+# in type-annotation position (`let s: lib.Secret(i32)`, a param/return type)
+# is a reference to that function and obeys the same uniform-privacy rule the
+# value/call path enforces (RUE-283). Before the fix the annotation path skipped
+# the E0460 check, so a private type constructor leaked across directories via
+# an annotation — a privacy-soundness hole (accept-invalid).
 
 [[case]]
 name = "private_type_ctor_annotation_cross_dir_rejected"
@@ -1922,7 +1999,7 @@ files = [
 const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
-    let s: Secret(i32) = lib.mk();
+    let s: lib.Secret(i32) = lib.mk();
     s.v
 }
 """ },
@@ -1943,7 +2020,7 @@ files = [
 const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
-    let s: Secret(i32) = lib.mk();
+    let s: lib.Secret(i32) = lib.mk();
     s.v
 }
 """ },
@@ -1963,7 +2040,7 @@ files = [
 const lib = @import("lib.rue");
 
 fn main() -> i32 {
-    let s: Secret(i32) = lib.mk();
+    let s: lib.Secret(i32) = lib.mk();
     s.v
 }
 """ },

--- a/examples/std/arraybuf_demo.rue
+++ b/examples/std/arraybuf_demo.rue
@@ -13,7 +13,7 @@ const std = @import("std");
 
 fn main() -> i32 {
     let V = std.arraybuf.ArrayBuf(i32);
-    let O = std.option.Option(i32);
+    let O = std.arraybuf.Option(i32);
 
     let mut v = V::new();
     v.push(10);

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -51,6 +51,10 @@
 // The enclosing element type `T` is usable throughout the method bodies below —
 // e.g. to name `Option(T)` and bind `let O = Option(T)` (RUE-313).
 
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+
 pub fn ArrayBuf(comptime T: type) -> type {
     struct {
         buf: ptr mut T,
@@ -94,7 +98,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
 
         // Element `i` by copy, wrapped in `Option(T)`: `Some(x)` when in
         // bounds, `None` otherwise (ADR-0041). The enclosing element type `T`
-        // is in scope here, so the method can name `Option(T)` directly
+        // is in scope here, so the method can pass it to `Option(T)`
         // (RUE-313).
         fn get(borrow self, i: u64) -> Option(T) {
             let O = Option(T);


### PR DESCRIPTION
## Summary

Removes the remaining graph-global fallback for unqualified comptime/type-position function resolution.

This makes unqualified calls like `Box(i32)` or array lengths like `len(3)` resolve only against the current file's local scope instead of accidentally finding a sibling module's function. Explicit module-qualified calls such as `right.Box(i32)` continue to work.

The ArrayBuf dogfood fixture now imports `arraybuf.rue` explicitly rather than relying on positional multi-file namespace injection.

## Validation

- `./fmt.sh`
- `./buck2 test //:cli-tests //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test //:spec-tests`
