### PR TITLE
RUE-509 (part): pin intended arraybuf→std.option import as known_bug xfail

### DIFF
--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -321,3 +321,108 @@ pub fn ArrayBuf(comptime T: type) -> type {
 ]
 stdout = "3\n10\n30\n60\n"
 exit_code = 60
+
+# RUE-509 regression PIN (known_bug): ArrayBuf should import the OFFICIAL Option
+# from option.rue instead of defining its own duplicate, so that an Option value
+# returned by `ArrayBuf.get` matches against `option.Option(T)` variants named in
+# the caller (single source of truth; nominal identity across importers).
+#
+# This is currently BLOCKED by a comptime limitation, NOT a missing test:
+# a source-level generic type function (`ArrayBuf(T)`) whose method references a
+# comptime type function imported from ANOTHER module (`option.Option(T)`) cannot
+# be instantiated — `let V = arraybuf.ArrayBuf(i32)` fails with
+#   E1200: comptime evaluation failed: cannot store type value in variable 'V'
+#          at runtime; type values only exist at compile time
+# The same pattern with a SAME-FILE `Option(T)` compiles and runs (see the
+# `arraybuf_i32_dogfood` case above), which is exactly why std/arraybuf.rue still
+# carries its own `Option` copy. Aliasing (`const OptionT = option.Option;`) hits
+# the same E1200; re-exporting (`pub const Option = option.Option;`) collides with
+# option.rue's `Option` under the transitional flat namespace (E0436).
+#
+# When the comptime cross-module type-function path is fixed, this case PASSES and
+# the suite fails loudly asking for the marker to be removed — at which point
+# std/arraybuf.rue can drop the duplicate and import option.rue (finishing RUE-509).
+[[case]]
+name = "arraybuf_imports_official_option"
+description = "ArrayBuf.get returns the official option.Option(T); caller matches it against option.Option(i32) (RUE-509)."
+known_bug = "RUE-509"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+const option = @import("option.rue");
+const arraybuf = @import("arraybuf.rue");
+
+fn main() -> i32 {
+    let V = arraybuf.ArrayBuf(i32);
+    let O = option.Option(i32);   // the caller's binding, via option.rue
+    let mut v = V::new();
+    v.push(10);
+    v.push(20);
+    // The Option returned by ArrayBuf.get is option.Option(i32) — the SAME
+    // nominal type the caller names here, so these match arms type-check.
+    let a = match v.get(1) { O::Some(x) => x, O::None => -1 };
+    @dbg(a);   // 20
+    let b = match v.get(9) { O::Some(x) => x, O::None => -1 };
+    @dbg(b);   // -1
+    v.free();
+    a
+}
+""" },
+  { path = "option.rue", source = """
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+""" },
+  { path = "arraybuf.rue", source = """
+const option = @import("option.rue");
+
+pub fn ArrayBuf(comptime T: type) -> type {
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+        fn len(borrow self) -> u64 { self.len }
+        fn reserve(inout self) {
+            if self.len == self.cap {
+                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    self.buf = grown;
+                };
+                self.cap = new_cap;
+            }
+        }
+        fn push(inout self, x: T) {
+            self.reserve();
+            checked {
+                let slot = @ptr_offset(self.buf, self.len);
+                @ptr_write(slot, x);
+            };
+            self.len = self.len + 1;
+        }
+        fn get(borrow self, i: u64) -> option.Option(T) {
+            let O = option.Option(T);
+            if i < self.len {
+                O::Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
+            } else {
+                O::None
+            }
+        }
+        fn free(inout self) {
+            checked { @free(self.buf, self.cap); };
+            let zero: u64 = 0;
+            self.buf = checked { @int_to_ptr(zero) };
+            self.len = 0;
+            self.cap = 0;
+        }
+    }
+}
+""" },
+]
+stdout = "20\n-1\n"
+exit_code = 20


### PR DESCRIPTION
## Summary

The RUE-509 dedup (import std/option.rue's `Option` into arraybuf instead of duplicating it) turned out to be **blocked by a compiler bug**: a generic type function whose methods reference a comptime type function imported from another module fails to instantiate with `E1200: cannot store type value in variable at runtime`. Same-file references work; cross-module is the trigger — so arraybuf's local `Option` is currently load-bearing. The blocker is isolated with a minimal repro and filed as RUE-511, which blocks RUE-509.

This PR ships the honest artifact instead of forcing the change: one CLI case, `arraybuf_imports_official_option`, marked `known_bug = "RUE-509"`. It encodes the intended import+match end state and auto-flips into a regression test the moment RUE-511 is fixed (the suite fails until the marker is removed, per harness convention), at which point the actual std/arraybuf.rue dedup is a small follow-up.

Note: the case intentionally uses `::` syntax to match its neighbors; the in-flight `::`-removal change (RUE-488) sweeps all case TOMLs mechanically.

## Validation

- New case correctly reported as **ignored (xfail)** — fails with a clean E1200, not an ICE
- 3 existing `arraybuf_library` cases pass; `examples/std/arraybuf_demo.rue` baseline unchanged
- `./test.sh`: Pass 28 / Fail 0

Part of RUE-509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
