### PR TITLE
RUE-354: reserve the runtime's unmangled exports (memcpy family, _main)

### DIFF
--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -610,32 +610,48 @@ pub fn is_reserved_type_name(name: &str) -> bool {
     name == STRING_ALIAS_NAME || BUILTIN_TYPES.iter().any(|t| t.name == name)
 }
 
+/// Runtime symbols exported UNMANGLED outside the `__rue_` prefix, because
+/// their exact names are load-bearing (RUE-354):
+///
+/// - `memcpy`/`memmove`/`memset`/`memcmp`/`bcmp` (`rue-runtime/src/memory.rs`):
+///   rustc/LLVM lowers copies and comparisons to calls with exactly these
+///   compiler-builtin names, so they cannot be moved under `__rue_`.
+/// - `_start` / `_main` (`rue-runtime/src/entry.rs`): the program entry points
+///   the linker resolves on Linux and macOS respectively.
+///
+/// Keep this list in sync with the `#[unsafe(no_mangle)]` items in those two
+/// files — a missed name surfaces as a confusing duplicate-symbol link error
+/// (E1000) instead of the intended E0435 declaration-time diagnostic.
+const RUNTIME_EXPORTED_NAMES: &[&str] = &[
+    "memcpy", "memmove", "memset", "memcmp", "bcmp", "_start", "_main",
+];
+
 /// Check if a name is reserved for a runtime/codegen helper function, and thus
 /// may not be used as a user-defined function name.
 ///
 /// A user function with one of these names would collide with a symbol emitted
-/// by the runtime or codegen. Every such symbol lives under the reserved
+/// by the runtime or codegen. Almost every such symbol lives under the reserved
 /// `__rue_` prefix — built-in type methods and associated functions
 /// (`__rue_String_len`, `__rue_String_new`), allocation/exit/drop glue
 /// (`__rue_alloc`, `__rue_exit`, `__rue_drop_String`), and operator helpers
-/// (`__rue_str_eq`) — with the sole exception of the linker-emitted program
-/// entry point `_start`. Reserving exactly `__rue_*` and `_start` (rather than
-/// growing the set for every new builtin) means `<BuiltinType>__<method>`
-/// spellings like `String__len` are ordinary, legal user identifiers
-/// (RUE-125). Depending on link order a real collision either fails to link or
-/// silently binds calls to the wrong definition, so these names are rejected at
-/// declaration time with a clear diagnostic.
+/// (`__rue_str_eq`) — but the runtime also exports a handful of unmangled
+/// names whose spellings are fixed by the platform or by rustc/LLVM lowering:
+/// see [`RUNTIME_EXPORTED_NAMES`]. Reserving exactly `__rue_*` plus that short
+/// fixed list (rather than growing the set for every new builtin) means
+/// `<BuiltinType>__<method>` spellings like `String__len` are ordinary, legal
+/// user identifiers (RUE-125). Depending on link order a real collision either
+/// fails to link or silently binds calls to the wrong definition, so these
+/// names are rejected at declaration time with a clear diagnostic.
 pub fn is_reserved_function_name(name: &str) -> bool {
     // Runtime internal helpers, built-in methods, drop glue, operators — every
-    // compiler/runtime symbol is emitted under this prefix.
+    // compiler/runtime symbol not in RUNTIME_EXPORTED_NAMES is emitted under
+    // this prefix.
     if name.starts_with("__rue_") {
         return true;
     }
-    // The program entry point emitted by the linker.
-    if name == "_start" {
-        return true;
-    }
-    false
+    // Entry points and compiler-builtin memory routines the runtime exports
+    // under their fixed platform names (RUE-354).
+    RUNTIME_EXPORTED_NAMES.contains(&name)
 }
 
 // ============================================================================
@@ -782,6 +798,19 @@ mod tests {
         assert!(!is_reserved_function_name("Vec__push"));
         assert!(!is_reserved_function_name("_start_engine"));
         assert!(!is_reserved_function_name("rue_helper")); // no leading __
+
+        // Unmangled runtime exports outside the __rue_ prefix (RUE-354):
+        // compiler-builtin memory routines and the macOS entry point.
+        for name in ["memcpy", "memmove", "memset", "memcmp", "bcmp", "_main"] {
+            assert!(
+                is_reserved_function_name(name),
+                "runtime-exported symbol must be reserved: {}",
+                name
+            );
+        }
+        assert!(!is_reserved_function_name("memcpy2"));
+        assert!(!is_reserved_function_name("my_memcpy"));
+        assert!(!is_reserved_function_name("_main_loop"));
     }
 
     #[test]

--- a/crates/rue-spec/cases/items/general.toml
+++ b/crates/rue-spec/cases/items/general.toml
@@ -130,6 +130,28 @@ compile_fail = true
 error_contains = "cannot define function `_start`: name is reserved for a runtime helper"
 
 [[case]]
+name = "fn_reserved_memcpy"
+spec = ["6.0:5"]
+description = "User-defined function cannot use a compiler-builtin memory-routine name the runtime exports unmangled (RUE-354)"
+source = """
+fn memcpy(x: i32) -> i32 { x }
+fn main() -> i32 { memcpy(3) }
+"""
+compile_fail = true
+error_contains = "cannot define function `memcpy`: name is reserved for a runtime helper"
+
+[[case]]
+name = "fn_reserved_macos_entry_point"
+spec = ["6.0:5"]
+description = "User-defined function cannot use the macOS entry-point name _main (RUE-354)"
+source = """
+fn _main() -> i32 { 1 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "cannot define function `_main`: name is reserved for a runtime helper"
+
+[[case]]
 name = "fn_lookalike_name_allowed"
 spec = ["6.0:5"]
 description = "A name resembling but not matching a reserved name is allowed"

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -57,7 +57,7 @@ struct StrBuf { data: i32 }  // compile error
 
 {{ rule(id="6.0:5", cat="legality-rule") }}
 
-User-defined functions **MUST NOT** use names reserved for runtime and code-generation helpers. The reserved function names are exactly: any name beginning with `__rue_`, and the program entry point `_start`. Every compiler- and runtime-emitted symbol — including built-in type methods and associated functions (`__rue_String_len`, `__rue_String_new`) — lives under the `__rue_` prefix, so the reserved set does not grow as built-in types are added. Defining a function with a reserved name produces a compile-time error.
+User-defined functions **MUST NOT** use names reserved for runtime and code-generation helpers. The reserved function names are exactly: any name beginning with `__rue_`; the program entry points `_start` and `_main`; and the compiler-builtin memory routines `memcpy`, `memmove`, `memset`, `memcmp`, and `bcmp` (the runtime exports these under their fixed platform names, so a user definition would collide at link time). Every other compiler- and runtime-emitted symbol — including built-in type methods and associated functions (`__rue_String_len`, `__rue_String_new`) — lives under the `__rue_` prefix, so the reserved set does not grow as built-in types are added. Defining a function with a reserved name produces a compile-time error.
 
 {{ rule(id="6.0:6", cat="example") }}
 


### PR DESCRIPTION
## Summary

`is_reserved_function_name` reserved only `__rue_*` and `_start`, and its doc comment asserted every other runtime symbol lives under the prefix. That invariant is false: rue-runtime exports `memcpy`/`memmove`/`memset`/`memcmp`/`bcmp` unmangled (rustc/LLVM lowers copies and comparisons to exactly those compiler-builtin names, so they can't be moved under `__rue_`) plus `_main` (the macOS entry point). A user function with one of those names skipped the E0435 guard and died at link time with a confusing `E1000: duplicate symbol` — verified with `fn memcpy` plus any aggregate copy.

Fix:
- `RUNTIME_EXPORTED_NAMES` list in rue-builtins, consulted by the guard; the doc comment is corrected and instructs keeping the list in sync with the `#[unsafe(no_mangle)]` items in `memory.rs`/`entry.rs`.
- Spec rule **6.0:5** now enumerates the reserved set honestly (entry points + memory routines); website spec mirror updated.
- New spec cases pin `memcpy` and `_main` rejection; the rue-builtins unit test covers all six names and confirms lookalikes (`memcpy2`, `my_memcpy`, `_main_loop`) remain legal.

Per the issue: RUE-125's minimal-set policy was premised on the now-disproven "everything is `__rue_`" claim, and these six names cannot be prefixed, so expanding the fixed list is the only correct direction (Steve promoted this to Todo 2026-07-09).

## Validation

- Repro (`fn memcpy` + aggregate copy): was `E1000 duplicate symbol` at link → now `E0435` at declaration with a span on the definition
- Repo-wide check: no in-repo Rue code defines any of the six names
- `./test.sh`: Pass 28 / Fail 0 (spec traceability included)

Fixes RUE-354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
