### PR TITLE
RUE-432+RUE-513: deterministic multi-file diagnostics + transitive-import tests

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -607,6 +607,41 @@ fn collect_static_function_references(sema: &Sema<'_>) -> HashSet<Spur> {
     referenced
 }
 
+/// Move newly referenced functions/methods onto the lazy-analysis work queues
+/// in a deterministic order.
+///
+/// `analyze_single_function` (and its method/destructor siblings) collect
+/// references as `HashSet`s, whose iteration order is randomized per process.
+/// Pushing them unsorted made the whole lazy-analysis order — and with it the
+/// order diagnostics are emitted in AND the function order handed to codegen —
+/// differ between identical runs (RUE-513: two files with independent sema
+/// errors reported them in a random relative order). Sorting by resolved name
+/// (and struct id) restores run-to-run determinism at the only place the
+/// nondeterminism enters.
+fn enqueue_references_sorted(
+    interner: &ThreadedRodeo,
+    referenced_fns: HashSet<Spur>,
+    referenced_meths: HashSet<(StructId, Spur)>,
+    analyzed_functions: &HashSet<Spur>,
+    analyzed_methods: &HashSet<(StructId, Spur)>,
+    pending_functions: &mut Vec<Spur>,
+    pending_methods: &mut Vec<(StructId, Spur)>,
+) {
+    let mut fns: Vec<Spur> = referenced_fns
+        .into_iter()
+        .filter(|f| !analyzed_functions.contains(f))
+        .collect();
+    fns.sort_by_key(|f| interner.resolve(f));
+    pending_functions.extend(fns);
+
+    let mut meths: Vec<(StructId, Spur)> = referenced_meths
+        .into_iter()
+        .filter(|m| !analyzed_methods.contains(m))
+        .collect();
+    meths.sort_by_key(|&(sid, name)| (sid.0, interner.resolve(&name)));
+    pending_methods.extend(meths);
+}
+
 /// Lazy analysis path (Phase 3 of module system, ADR-0026).
 ///
 /// This implements "lazy semantic analysis" where only functions reachable from
@@ -720,16 +755,15 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                                 all_warnings.extend(warnings);
 
                                 // Add newly referenced functions to the work queue
-                                for ref_fn in referenced_fns {
-                                    if !analyzed_functions.contains(&ref_fn) {
-                                        pending_functions.push(ref_fn);
-                                    }
-                                }
-                                for ref_meth in referenced_meths {
-                                    if !analyzed_methods.contains(&ref_meth) {
-                                        pending_methods.push(ref_meth);
-                                    }
-                                }
+                                enqueue_references_sorted(
+                                    sema.interner,
+                                    referenced_fns,
+                                    referenced_meths,
+                                    &analyzed_functions,
+                                    &analyzed_methods,
+                                    &mut pending_functions,
+                                    &mut pending_methods,
+                                );
                             }
                             Err(e) => errors.push(e),
                         }
@@ -868,16 +902,15 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                         functions_with_strings.push((analyzed, local_strings));
                         all_warnings.extend(warnings);
 
-                        for ref_fn in referenced_fns {
-                            if !analyzed_functions.contains(&ref_fn) {
-                                pending_functions.push(ref_fn);
-                            }
-                        }
-                        for ref_meth in referenced_meths {
-                            if !analyzed_methods.contains(&ref_meth) {
-                                pending_methods.push(ref_meth);
-                            }
-                        }
+                        enqueue_references_sorted(
+                            sema.interner,
+                            referenced_fns,
+                            referenced_meths,
+                            &analyzed_functions,
+                            &analyzed_methods,
+                            &mut pending_functions,
+                            &mut pending_methods,
+                        );
                     }
                     Err(e) => errors.push(e),
                 }
@@ -943,16 +976,15 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                                     functions_with_strings.push((analyzed, local_strings));
                                     all_warnings.extend(warnings);
 
-                                    for ref_fn in referenced_fns {
-                                        if !analyzed_functions.contains(&ref_fn) {
-                                            pending_functions.push(ref_fn);
-                                        }
-                                    }
-                                    for ref_meth in referenced_meths {
-                                        if !analyzed_methods.contains(&ref_meth) {
-                                            pending_methods.push(ref_meth);
-                                        }
-                                    }
+                                    enqueue_references_sorted(
+                                        sema.interner,
+                                        referenced_fns,
+                                        referenced_meths,
+                                        &analyzed_functions,
+                                        &analyzed_methods,
+                                        &mut pending_functions,
+                                        &mut pending_methods,
+                                    );
                                 }
                                 Err(e) => errors.push(e),
                             }
@@ -968,15 +1000,24 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
         // so lazy analysis emits `__anon_struct_N.__drop` before the backend
         // links drop glue.
         if pending_functions.is_empty() && pending_methods.is_empty() {
-            for (&method_key @ (struct_id, method_name), _) in sema.methods.iter() {
-                if method_name != drop_marker_sym || analyzed_methods.contains(&method_key) {
-                    continue;
-                }
-                let struct_def = sema.type_pool.struct_def(struct_id);
-                if struct_def.name.starts_with("__anon_struct_") {
-                    pending_methods.push(method_key);
-                }
-            }
+            // sema.methods is a HashMap: sort the enqueued keys so the
+            // destructor analysis order is deterministic too (RUE-513).
+            let mut anon_dtors: Vec<(StructId, Spur)> = sema
+                .methods
+                .keys()
+                .copied()
+                .filter(|&method_key @ (struct_id, method_name)| {
+                    method_name == drop_marker_sym
+                        && !analyzed_methods.contains(&method_key)
+                        && sema
+                            .type_pool
+                            .struct_def(struct_id)
+                            .name
+                            .starts_with("__anon_struct_")
+                })
+                .collect();
+            anon_dtors.sort_by_key(|&(sid, name)| (sid.0, sema.interner.resolve(&name)));
+            pending_methods.extend(anon_dtors);
         }
     }
 

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -2398,3 +2398,84 @@ pub fn double_max() -> i32 { MAX + MAX }
 """ },
 ]
 exit_code = 122
+
+# ---------------------------------------------------------------------------
+# Transitive-import diagnostics (RUE-432 / RUE-424).
+#
+# Errors in files discovered transitively from the root must be attributed to
+# the right file with exact line:col, and multi-file error output must be
+# deterministic across runs (the lazy-analysis work queue is sorted; RUE-513).
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "transitive_import_parse_error_attribution"
+description = "A parse error in a transitively discovered file names that file with exact line:col (RUE-432)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib/util.rue");
+
+fn main() -> i32 { lib.val() }
+""" },
+    { path = "lib/util.rue", source = """
+pub fn val() -> i32 { 5
+""" },
+]
+compile_fail = true
+error_contains = ["E0102", "lib/util.rue:1:23"]
+
+[[case]]
+name = "transitive_import_type_error_attribution"
+description = "A type error in a transitively discovered file names that file with exact line:col (RUE-432)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib/util.rue");
+
+fn main() -> i32 { lib.val() }
+""" },
+    { path = "lib/util.rue", source = """
+pub fn val() -> i32 { true }
+""" },
+]
+compile_fail = true
+error_contains = ["E0206", "lib/util.rue:1:23"]
+
+[[case]]
+name = "transitive_import_name_error_in_directory_module"
+description = "A name-resolution error inside a directory module's internal file is attributed to that file, not the facade or root (RUE-432)."
+files = [
+    { path = "main.rue", source = """
+const pkg = @import("pkg");
+
+fn main() -> i32 { pkg.api() }
+""" },
+    { path = "pkg/_pkg.rue", source = """
+const inner = @import("inner.rue");
+
+pub fn api() -> i32 { inner.broken() }
+""" },
+    { path = "pkg/inner.rue", source = """
+pub fn broken() -> i32 { missing_fn() }
+""" },
+]
+compile_fail = true
+error_contains = ["E0202", "missing_fn", "pkg/inner.rue:1:26"]
+
+[[case]]
+name = "transitive_import_independent_errors_both_reported"
+description = "Independent sema errors in two different transitive deps are BOTH reported with correct attribution, plus the count summary; emission order is deterministic across runs (RUE-513)."
+files = [
+    { path = "main.rue", source = """
+const a = @import("a/one.rue");
+const b = @import("b/two.rue");
+
+fn main() -> i32 { a.one() + b.two() }
+""" },
+    { path = "a/one.rue", source = """
+pub fn one() -> i32 { true }
+""" },
+    { path = "b/two.rue", source = """
+pub fn two() -> i32 { false }
+""" },
+]
+compile_fail = true
+error_contains = ["a/one.rue:1:23", "b/two.rue:1:23", "aborting due to 2 previous errors"]


### PR DESCRIPTION
## Summary

Writing RUE-432's diagnostics tests flushed out a real bug: **identical multi-file compiles emitted diagnostics in a random relative order** — two files with independent E0206s swapped their error blocks between runs (verified: 5 identical invocations, 2 distinct outputs).

**Root cause (RUE-513):** the lazy-analysis driver extended its work queue by iterating `HashSet<Spur>` / `HashSet<(StructId, Spur)>` returns directly (three call sites), and the anonymous-destructor sweep iterated `sema.methods` (a HashMap). Per-process randomized iteration made the whole analysis order vary — flipping diagnostic emission order *and* the function list order handed to codegen (a reproducible-builds hazard, not just cosmetics).

**Fix:** `enqueue_references_sorted` — referenced functions/methods are sorted by resolved name (and struct id) before entering the work queue, at all four sites. Verified: 12 identical invocations of the repro now produce byte-identical output.

**New CLI cases (RUE-432 scope):**
- parse error in a transitively discovered file → attributed with exact `file:line:col`
- type error in a transitive dep → exact attribution
- name-resolution error inside a directory-module facade's internal file → attributed to that file, not the facade or root
- independent sema errors in two different deps → both reported, with the `aborting due to 2 previous errors` summary, in a now-deterministic order

## Validation

- Determinism: 12/12 identical outputs on the repro (was 2 variants in 5 runs before the fix)
- `scripts/rue cli transitive_import`: 4 passed
- `./test.sh`: Pass 28 / Fail 0

Fixes RUE-432
Fixes RUE-513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
