### PR TITLE
RUE-488: remove :: path syntax entirely — . is the only member-access spelling

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1706,6 +1706,57 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Field access
             InstData::FieldGet { base, field } => {
+                // `Enum.Variant` (RUE-488): a field access on a bare enum type
+                // name is an enum-variant value. Yield the concrete enum type so
+                // a mismatch — e.g. returning `Shape.Circle` from a function
+                // declared `-> Color` — is caught here instead of a fresh
+                // variable silently unifying with the expected type. A comptime
+                // type-variable local (typed `COMPTIME_TYPE`) is a type
+                // reference, not a runtime value shadow.
+                if let InstData::VarRef { name } = self.rir.get(*base).data
+                    && !ctx.params.contains_key(&name)
+                    && ctx.locals.get(&name).is_none_or(
+                        |l| matches!(l.ty, InferType::Concrete(t) if t == Type::COMPTIME_TYPE),
+                    )
+                    && let Some(enum_ty) = self.enum_type_for(&name, span.file_id)
+                    && let Some(enum_id) = enum_ty.as_enum()
+                    && self
+                        .type_pool
+                        .enum_def(enum_id)
+                        .find_variant(self.interner.resolve(field))
+                        .is_some()
+                {
+                    return {
+                        let ty = InferType::Concrete(enum_ty);
+                        self.record_type(inst_ref, ty.clone());
+                        ExprInfo::new(ty, span)
+                    };
+                }
+
+                // Module-qualified `module.Enum.Variant` (RUE-488): the base is
+                // `module.Enum`, whose module member is an enum. Yield the
+                // concrete enum type so same-named enums from sibling modules stay
+                // distinct nominal types (a wrong one flowing into a call argument
+                // or return is caught here, not silently unified). RUE-501.
+                if let InstData::FieldGet {
+                    base: module_ref,
+                    field: type_name,
+                } = self.rir.get(*base).data
+                    && let Some(enum_ty) = self.enum_type_for_module(module_ref, &type_name)
+                    && let Some(enum_id) = enum_ty.as_enum()
+                    && self
+                        .type_pool
+                        .enum_def(enum_id)
+                        .find_variant(self.interner.resolve(field))
+                        .is_some()
+                {
+                    return {
+                        let ty = InferType::Concrete(enum_ty);
+                        self.record_type(inst_ref, ty.clone());
+                        ExprInfo::new(ty, span)
+                    };
+                }
+
                 let base_info = self.generate(*base, ctx);
                 // When the base's struct type is already concrete, the field's
                 // declared type is known RIGHT NOW — yield it so downstream
@@ -1887,6 +1938,44 @@ impl<'a> ConstraintGenerator<'a> {
                 args_start,
                 args_len,
             } => {
+                // `Type.method(args)` where the receiver names a type is an
+                // associated-function call / enum tuple-variant construction
+                // (RUE-488): forward to the type-qualified path so arguments are
+                // constrained to the callee signature (a bare `MethodCall` arm
+                // would leave a literal like the `8` in `String.with_capacity(8)`
+                // unconstrained, defaulting it to `i32` and later clashing with a
+                // `u64` parameter). Skip when a runtime value (a parameter, or a
+                // local that is not itself a comptime type value) shadows the type
+                // name — that is an ordinary value-method call. A comptime
+                // type-variable local (`let O = Option(i32)`, typed
+                // `COMPTIME_TYPE`) IS a type reference, so `O.Some(true)` resolves
+                // to its concrete enum and a wrong payload type is caught here.
+                if let InstData::VarRef { name } = self.rir.get(*receiver).data
+                    && !ctx.params.contains_key(&name)
+                    && ctx.locals.get(&name).is_none_or(
+                        |l| matches!(l.ty, InferType::Concrete(t) if t == Type::COMPTIME_TYPE),
+                    )
+                    && (self
+                        .structs
+                        .get(&name)
+                        .and_then(|t| t.as_struct())
+                        .is_some()
+                        || self.enum_type_for(&name, span.file_id).is_some())
+                {
+                    return {
+                        let ty = self.generate_type_qualified_call(
+                            name,
+                            *method,
+                            *args_start,
+                            *args_len,
+                            span,
+                            ctx,
+                        );
+                        self.record_type(inst_ref, ty.clone());
+                        ExprInfo::new(ty, span)
+                    };
+                }
+
                 // Generate type for receiver
                 let receiver_info = self.generate(*receiver, ctx);
                 let args = self.rir.get_call_args(*args_start, *args_len);
@@ -2002,86 +2091,23 @@ impl<'a> ConstraintGenerator<'a> {
                 result_type
             }
 
-            // Associated function call: Type::function(args)
+            // Associated function call: `Type.function(args)` lowers to an
+            // `AssocFnCall` only through legacy AST nodes; `.`-spelled calls
+            // reach the `MethodCall` arm above, which forwards a type-name
+            // receiver here (RUE-488).
             InstData::AssocFnCall {
                 type_name,
                 function,
                 args_start,
                 args_len,
-            } => {
-                let args = self.rir.get_call_args(*args_start, *args_len);
-
-                // Enum tuple-variant construction: `Shape::Circle(5)` parses as
-                // an associated-function call. If `type_name` is an enum and
-                // `function` names one of its variants, constrain each payload
-                // argument to the declared payload type and yield the enum type
-                // (RUE-221). Checked here first so it takes precedence over the
-                // struct-method path below.
-                let enum_variant = self
-                    .enum_type_for(type_name, span.file_id)
-                    .and_then(|ty| ty.as_enum().map(|id| (ty, id)))
-                    .and_then(|(ty, id)| {
-                        let def = self.type_pool.enum_def(id);
-                        def.find_variant(self.interner.resolve(function))
-                            .map(|vidx| (ty, def.variant_payload(vidx).to_vec()))
-                    });
-                if let Some((enum_ty, payload)) = enum_variant {
-                    for (i, arg) in args.iter().enumerate() {
-                        let arg_info = self.generate(arg.value, ctx);
-                        if let Some(&pty) = payload.get(i) {
-                            // Convert the declared payload type structurally so
-                            // an array payload (`[i32; 2]`) unifies with an
-                            // array-literal argument (`[1, 2]`) and propagates
-                            // the expected element type into its literal
-                            // elements — exactly as struct-field init does.
-                            // Using `InferType::Concrete` here left the literal
-                            // element type unconstrained, so `[{integer}; 2]`
-                            // failed to unify with `[i32; 2]` (RUE-260).
-                            let expected = self.type_to_infer(pty);
-                            self.add_constraint(Constraint::equal(
-                                arg_info.ty,
-                                expected,
-                                arg_info.span,
-                            ));
-                        }
-                    }
-                    let ty = InferType::Concrete(enum_ty);
-                    self.record_type(inst_ref, ty.clone());
-                    return ExprInfo::new(ty, span);
-                }
-
-                // Get struct ID from type name for method lookup
-                let struct_id = self.structs.get(type_name).and_then(|ty| ty.as_struct());
-                let result_type = if let Some(struct_id) = struct_id {
-                    let method_key = (struct_id, *function);
-                    if let Some(method_sig) = self.methods.get(&method_key) {
-                        // Generate constraints for arguments
-                        for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
-                            let arg_info = self.generate(arg.value, ctx);
-                            self.add_constraint(Constraint::equal(
-                                arg_info.ty,
-                                param_type.clone(),
-                                arg_info.span,
-                            ));
-                        }
-                        method_sig.return_type.clone()
-                    } else {
-                        // Method not found - sema will report the error
-                        // Still generate arg types to catch errors in arguments
-                        for arg in args.iter() {
-                            self.generate(arg.value, ctx);
-                        }
-                        InferType::Concrete(Type::ERROR)
-                    }
-                } else {
-                    // Type not found - sema will report the error
-                    for arg in args.iter() {
-                        self.generate(arg.value, ctx);
-                    }
-                    InferType::Concrete(Type::ERROR)
-                };
-                result_type
-            }
+            } => self.generate_type_qualified_call(
+                *type_name,
+                *function,
+                *args_start,
+                *args_len,
+                span,
+                ctx,
+            ),
 
             // Comptime block: the type depends on whether evaluation succeeds at compile time.
             // For type inference, we use a fresh type variable that can unify with
@@ -2257,8 +2283,85 @@ impl<'a> ConstraintGenerator<'a> {
         false
     }
 
+    /// Generate constraints for a type-qualified call — an associated-function
+    /// call or an enum tuple-variant construction — resolving the callee by type
+    /// name and constraining each argument to the declared parameter/payload
+    /// type. Shared by the `AssocFnCall` arm and the `MethodCall` arm's
+    /// type-name-receiver forwarding (`Type.function(args)`, RUE-488). Getting
+    /// the argument constraints here — not just in sema — is what pins a literal
+    /// like the `8` in `String.with_capacity(8)` to the declared `u64` parameter
+    /// instead of letting it default to `i32`.
+    fn generate_type_qualified_call(
+        &mut self,
+        type_name: Spur,
+        function: Spur,
+        args_start: u32,
+        args_len: u32,
+        span: Span,
+        ctx: &mut ConstraintContext,
+    ) -> InferType {
+        let args = self.rir.get_call_args(args_start, args_len);
+
+        // Enum tuple-variant construction: `Shape.Circle(5)`. If `type_name` is
+        // an enum and `function` names one of its variants, constrain each
+        // payload argument to the declared payload type and yield the enum type
+        // (RUE-221). Checked first so it takes precedence over the struct-method
+        // path below.
+        let enum_variant = self
+            .enum_type_for(&type_name, span.file_id)
+            .and_then(|ty| ty.as_enum().map(|id| (ty, id)))
+            .and_then(|(ty, id)| {
+                let def = self.type_pool.enum_def(id);
+                def.find_variant(self.interner.resolve(&function))
+                    .map(|vidx| (ty, def.variant_payload(vidx).to_vec()))
+            });
+        if let Some((enum_ty, payload)) = enum_variant {
+            for (i, arg) in args.iter().enumerate() {
+                let arg_info = self.generate(arg.value, ctx);
+                if let Some(&pty) = payload.get(i) {
+                    // Convert the declared payload type structurally so an array
+                    // payload (`[i32; 2]`) unifies with an array-literal argument
+                    // and propagates the expected element type into its literal
+                    // elements — exactly as struct-field init does (RUE-260).
+                    let expected = self.type_to_infer(pty);
+                    self.add_constraint(Constraint::equal(arg_info.ty, expected, arg_info.span));
+                }
+            }
+            return InferType::Concrete(enum_ty);
+        }
+
+        // Struct associated function: constrain each argument to the declared
+        // parameter type and yield the return type.
+        let struct_id = self.structs.get(&type_name).and_then(|ty| ty.as_struct());
+        if let Some(struct_id) = struct_id {
+            let method_key = (struct_id, function);
+            if let Some(method_sig) = self.methods.get(&method_key) {
+                for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
+                    let arg_info = self.generate(arg.value, ctx);
+                    self.add_constraint(Constraint::equal(
+                        arg_info.ty,
+                        param_type.clone(),
+                        arg_info.span,
+                    ));
+                }
+                return method_sig.return_type.clone();
+            }
+            // Method not found - sema reports the error; still process args.
+            for arg in args.iter() {
+                self.generate(arg.value, ctx);
+            }
+            return InferType::Concrete(Type::ERROR);
+        }
+
+        // Type not found - sema reports the error; still process args.
+        for arg in args.iter() {
+            self.generate(arg.value, ctx);
+        }
+        InferType::Concrete(Type::ERROR)
+    }
+
     /// Resolve an enum type name that may be a comptime type-variable binding
-    /// (`let O = Option(i32); O::Some(..)`), falling back to the named-enum
+    /// (`let O = Option(i32); O.Some(..)`), falling back to the named-enum
     /// table. Mirrors sema's `resolve_enum_type_name`; without the
     /// comptime-alias lookup, generic-enum construction/matching inferred
     /// `<error>` and poisoned the surrounding constraints (RUE-6 phase 2).

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -21,17 +21,41 @@ impl<'a> Sema<'a> {
         let receiver_var = self.extract_root_variable(receiver);
         let method_name_str = self.interner.resolve(&method).to_string();
 
-        // RUE-196: `Type.function(args)` is an additive dotted alias for the
-        // existing `Type::function(args)` form. Preserve ordinary value-method
-        // dispatch when a runtime local/parameter shadows the type name; only
-        // reinterpret an unbound identifier receiver as a type namespace.
+        // `Type.function(args)` is an associated-function call / enum
+        // tuple-variant construction (RUE-196, RUE-488): `.` is the sole
+        // member-access spelling. Preserve ordinary value-method dispatch when a
+        // runtime local/parameter shadows the type name; reinterpret an unbound
+        // identifier receiver as a type namespace when it names a struct/enum or
+        // a comptime type-variable bound to one (`let O = Option(i32);
+        // O.Some(1)`). The struct/enum lookups mirror what `analyze_assoc_fn_call`
+        // itself resolves — the global by-name tables, so a cross-directory
+        // imported type is recognized and its privacy enforced there (E0460),
+        // rather than decaying to an "undefined variable" method call.
         if let InstData::VarRef { name } = self.rir.get(receiver).data
             && !self.is_runtime_value_binding(name, ctx)
-            && self
-                .resolve_type(name, span)
-                .is_ok_and(|ty| matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Enum(_)))
+            && (ctx.comptime_type_vars.contains_key(&name)
+                || self.structs.contains_key(&name)
+                || self.resolve_enum_type_name(name, ctx).is_some())
         {
             return self.analyze_assoc_fn_call(air, name, method, args_start, args_len, span, ctx);
+        }
+
+        // Module-qualified associated-function call / tuple-variant construction:
+        // `module.Type.function(args)` (RUE-488). The receiver is `module.Type`
+        // (a field access) whose module member is a struct or enum type. In the
+        // transitional flat namespace the type name resolves globally — the same
+        // resolution the removed `module.Type::function(args)` form used — so
+        // dispatch on the type name once the receiver is confirmed to be a
+        // module-qualified type reference.
+        if let InstData::FieldGet {
+            base: module_ref,
+            field: type_name,
+        } = self.rir.get(receiver).data
+            && let Some(result) = self.try_analyze_module_qualified_type_call(
+                air, module_ref, type_name, method, args_start, args_len, span, ctx,
+            )?
+        {
+            return Ok(result);
         }
 
         // Slice methods (ADR-0043, RUE-322): `s.len()` reads the fat pointer's

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -338,7 +338,32 @@ impl<'a> Sema<'a> {
 
         // For nested field access (e.g., a.b.c), recursively use projection mode
         if let InstData::FieldGet { base, field } = &inst.data {
-            let base_result = self.analyze_inst_for_projection(air, *base, ctx)?;
+            let (base, field, field_span) = (*base, *field, inst.span);
+
+            // `Enum.Variant` (RUE-488): a field access on a bare enum type name
+            // is an enum-variant value, even in a projection/read position such
+            // as a comparison operand (`Color.Red == Color.Red`). Mirror the
+            // reroute in `analyze_field_get`, including the module-qualified
+            // form `module.Enum.Variant`.
+            if let InstData::VarRef { name } = self.rir.get(base).data
+                && !self.is_runtime_value_binding(name, ctx)
+                && let Some(result) =
+                    self.try_analyze_dotted_enum_variant(air, name, field, field_span, ctx)?
+            {
+                return Ok(result);
+            }
+            if let InstData::FieldGet {
+                base: module_ref,
+                field: type_name,
+            } = self.rir.get(base).data
+                && let Some(result) = self.try_analyze_module_dotted_enum_variant(
+                    air, module_ref, type_name, field, field_span, ctx,
+                )?
+            {
+                return Ok(result);
+            }
+
+            let base_result = self.analyze_inst_for_projection(air, base, ctx)?;
             let base_type = base_result.ty;
 
             let struct_id = match base_type.kind() {
@@ -348,13 +373,13 @@ impl<'a> Sema<'a> {
                         ErrorKind::FieldAccessOnNonStruct {
                             found: base_type.safe_name_with_pool(Some(&self.type_pool)),
                         },
-                        inst.span,
+                        field_span,
                     ));
                 }
             };
 
             let struct_def = self.type_pool.struct_def(struct_id);
-            let field_name_str = self.interner.resolve(&*field).to_string();
+            let field_name_str = self.interner.resolve(&field).to_string();
 
             let (field_index, struct_field) =
                 struct_def.find_field(&field_name_str).ok_or_compile_error(
@@ -362,7 +387,7 @@ impl<'a> Sema<'a> {
                         struct_name: struct_def.name.clone(),
                         field_name: field_name_str.clone(),
                     },
-                    inst.span,
+                    field_span,
                 )?;
 
             let field_type = struct_field.ty;
@@ -374,7 +399,7 @@ impl<'a> Sema<'a> {
                     field_index: field_index as u32,
                 },
                 ty: field_type,
-                span: inst.span,
+                span: field_span,
             });
             return Ok(AnalysisResult::new(air_ref, field_type));
         }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1358,7 +1358,7 @@ impl<'a> Sema<'a> {
                         type_name, variant, ..
                     } => {
                         format!(
-                            "{}::{}",
+                            "{}.{}",
                             self.interner.resolve(&*type_name),
                             self.interner.resolve(&*variant)
                         )
@@ -1553,7 +1553,7 @@ impl<'a> Sema<'a> {
                     if let Some(first_span) = covered_variants.get(&(variant_index as u32)) {
                         if wildcard_span.is_none() {
                             let pat_str = format!(
-                                "{}::{}",
+                                "{}.{}",
                                 self.interner.resolve(&*type_name),
                                 self.interner.resolve(&*variant)
                             );
@@ -3424,6 +3424,21 @@ impl<'a> Sema<'a> {
             }
         }
 
+        // Module-qualified enum-variant path: `module.Enum.Variant` (RUE-488).
+        // The base is `module.Enum` (a field access), whose module member is an
+        // enum type; `.Variant` selects the variant.
+        if let InstData::FieldGet {
+            base: module_ref,
+            field: type_name,
+        } = base_inst.data
+        {
+            if let Some(result) = self.try_analyze_module_dotted_enum_variant(
+                air, module_ref, type_name, field, span, ctx,
+            )? {
+                return Ok(result);
+            }
+        }
+
         // Try to trace this expression to a place (lvalue)
         if let Some(trace) = self.try_trace_place(inst_ref, air, ctx)? {
             let field_type = trace.result_type();
@@ -4023,17 +4038,220 @@ impl<'a> Sema<'a> {
 
     /// Return true when `name` is a runtime local or parameter in this function.
     ///
-    /// Dotted type-member compatibility for RUE-196 (`Type.member`) must not
-    /// steal ordinary value field/method access when a binding shadows a type
-    /// name. Comptime type variables are intentionally not runtime bindings:
-    /// `let O = Option(i32); O.Some(1)` should behave like `O::Some(1)`.
+    /// Dotted type-member access (`Type.member`, RUE-196/RUE-488) must not steal
+    /// ordinary value field/method access when a binding shadows a type name.
+    /// Comptime type variables are intentionally not runtime bindings:
+    /// `let O = Option(i32); O.Some(1)` names the type, not a runtime value.
     pub(crate) fn is_runtime_value_binding(&self, name: Spur, ctx: &AnalysisContext) -> bool {
         ctx.locals.contains_key(&name) || ctx.params.iter().any(|param| param.name == name)
     }
 
-    /// Try to resolve `Enum.Variant` as an additive dotted alias for
-    /// `Enum::Variant` (RUE-196).
-    fn try_analyze_dotted_enum_variant(
+    /// Resolve the module a reference denotes, if any, without emitting AIR.
+    ///
+    /// Used to recognize module-qualified dotted member access
+    /// (`module.Enum.Variant`, `module.Type.function()`; RUE-488). Handles a
+    /// direct module binding — a `let`/`const`-bound `@import` (a local of module
+    /// type or a per-file module binding) — and a nested submodule chain
+    /// (`std.geo.Sign.Pos`), resolving `std.geo` by looking `geo` up as a module
+    /// binding re-exported from `std`'s file.
+    pub(crate) fn try_module_id_of(
+        &self,
+        inst_ref: rue_rir::InstRef,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> Option<crate::types::ModuleId> {
+        match self.rir.get(inst_ref).data {
+            InstData::VarRef { name } => {
+                if let Some(local) = ctx.locals.get(&name) {
+                    if let Some(module_id) = local.ty.as_module() {
+                        return Some(module_id);
+                    }
+                }
+                self.module_bindings
+                    .get(&(span.file_id, name))
+                    .and_then(|binding| binding.ty.as_module())
+            }
+            // Nested submodule: `parent.sub` where `parent` is a module and `sub`
+            // is a module re-exported from `parent`'s file (`pub const sub =
+            // @import(...)`).
+            InstData::FieldGet { base, field } => {
+                let parent_id = self.try_module_id_of(base, span, ctx)?;
+                let parent_def = self.module_registry.get_def(parent_id);
+                let parent_file = self.canonical_file_id(&parent_def.file_path)?;
+                self.module_bindings
+                    .get(&(parent_file, field))
+                    .and_then(|binding| binding.ty.as_module())
+            }
+            _ => None,
+        }
+    }
+
+    /// Try to analyze a module-qualified type-member call:
+    /// `module.Type.function(args)` (RUE-488) — an associated-function call on a
+    /// struct, or a tuple-variant construction on an enum. `.` is the sole
+    /// member-access spelling; this replaces the removed
+    /// `module.Type::function(args)` form.
+    ///
+    /// Returns `Ok(None)` — falling through to ordinary value-method dispatch —
+    /// unless `module_ref` names a module and `type_name` is a struct or enum
+    /// defined by that module's file.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_analyze_module_qualified_type_call(
+        &mut self,
+        air: &mut Air,
+        module_ref: rue_rir::InstRef,
+        type_name: Spur,
+        method: Spur,
+        args_start: u32,
+        args_len: u32,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<Option<AnalysisResult>> {
+        let Some(module_id) = self.try_module_id_of(module_ref, span, ctx) else {
+            return Ok(None);
+        };
+        let module_def = self.module_registry.get_def(module_id);
+        let Some(file_id) = self.canonical_file_id(&module_def.file_path) else {
+            return Ok(None);
+        };
+
+        // Enum member: `module.Enum.Variant(payload)` is tuple-variant
+        // construction. Resolve the enum through the module (the enum is not in
+        // the caller's file, so the global name resolvers cannot find it) and
+        // apply module-qualified visibility (E0706).
+        if let Some(enum_id) = self.enums_by_file_name.get(&(file_id, type_name)).copied() {
+            let enum_def = self.type_pool.enum_def(enum_id);
+            if !self.is_accessible(span.file_id, enum_def.file_id, enum_def.is_pub) {
+                return Err(CompileError::new(
+                    ErrorKind::PrivateMemberAccess {
+                        item_kind: "enum".to_string(),
+                        name: self.interner.resolve(&type_name).to_string(),
+                    },
+                    span,
+                ));
+            }
+            let variant_name = self.interner.resolve(&method);
+            let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
+                ErrorKind::UnknownVariant {
+                    enum_name: enum_def.name.clone(),
+                    variant_name: variant_name.to_string(),
+                },
+                span,
+            )?;
+            // Visibility was checked above (E0706), so skip the internal
+            // unqualified (E0460) check.
+            return self
+                .analyze_enum_variant_construction(
+                    air,
+                    enum_id,
+                    variant_index as u32,
+                    type_name,
+                    /* privacy_exempt = */ true,
+                    args_start,
+                    args_len,
+                    span,
+                    ctx,
+                )
+                .map(Some);
+        }
+
+        // Struct member: `module.Struct.function(args)` is an associated-function
+        // call. In the transitional flat namespace struct names resolve globally
+        // — the same resolution the removed `::` form used — so dispatch on the
+        // name.
+        if self
+            .structs_by_file_name
+            .contains_key(&(file_id, type_name))
+        {
+            return self
+                .analyze_assoc_fn_call(air, type_name, method, args_start, args_len, span, ctx)
+                .map(Some);
+        }
+
+        Ok(None)
+    }
+
+    /// Try to resolve `module.Enum.Variant` as a module-qualified enum-variant
+    /// path (RUE-488). `.` is the sole member-access spelling; this mirrors what
+    /// the old `module.Enum::Variant` path did, including E0706 module-visibility
+    /// enforcement.
+    ///
+    /// Returns `Ok(None)` — falling through to ordinary field access — unless
+    /// `module_ref` names a module **and** `type_name` is an enum defined by that
+    /// module's file. Once both hold the access is unambiguously a variant path
+    /// (an enum type has no instance fields), so a bad `variant` is a real error.
+    pub(crate) fn try_analyze_module_dotted_enum_variant(
+        &mut self,
+        air: &mut Air,
+        module_ref: rue_rir::InstRef,
+        type_name: Spur,
+        variant: Spur,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<Option<AnalysisResult>> {
+        let Some(module_id) = self.try_module_id_of(module_ref, span, ctx) else {
+            return Ok(None);
+        };
+        let module_def = self.module_registry.get_def(module_id);
+        let module_file_id = self.canonical_file_id(&module_def.file_path);
+        let Some(enum_id) = module_file_id
+            .and_then(|file_id| self.enums_by_file_name.get(&(file_id, type_name)).copied())
+        else {
+            // `type_name` is not an enum in this module: this is const/field
+            // access through the module, not a variant path. Fall through.
+            return Ok(None);
+        };
+
+        let enum_def = self.type_pool.enum_def(enum_id);
+        let type_name_str = self.interner.resolve(&type_name).to_string();
+
+        // Module-qualified visibility (E0706): a private enum is reachable only
+        // from its defining directory.
+        if !self.is_accessible(span.file_id, enum_def.file_id, enum_def.is_pub) {
+            return Err(CompileError::new(
+                ErrorKind::PrivateMemberAccess {
+                    item_kind: "enum".to_string(),
+                    name: type_name_str,
+                },
+                span,
+            ));
+        }
+
+        let variant_name = self.interner.resolve(&variant);
+        let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
+            ErrorKind::UnknownVariant {
+                enum_name: enum_def.name.clone(),
+                variant_name: variant_name.to_string(),
+            },
+            span,
+        )?;
+
+        // A tuple variant used as a bare path (no payload) is missing its data.
+        let expected = enum_def.variant_payload(variant_index).len();
+        if expected > 0 {
+            return Err(CompileError::new(
+                ErrorKind::WrongArgumentCount { expected, found: 0 },
+                span,
+            ));
+        }
+
+        let ty = Type::new_enum(enum_id);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::EnumVariant {
+                enum_id,
+                variant_index: variant_index as u32,
+                payload_start: 0,
+                payload_len: 0,
+            },
+            ty,
+            span,
+        });
+        Ok(Some(AnalysisResult::new(air_ref, ty)))
+    }
+
+    /// Try to resolve `Enum.Variant` as a dotted enum-variant path (RUE-196,
+    /// RUE-488). `.` is the sole member-access spelling.
+    pub(crate) fn try_analyze_dotted_enum_variant(
         &mut self,
         air: &mut Air,
         type_name: Spur,
@@ -4045,21 +4263,30 @@ impl<'a> Sema<'a> {
             return Ok(None);
         };
 
-        let enum_def = self.type_pool.enum_def(enum_id);
-        let variant_name = self.interner.resolve(&variant);
-        let Some(variant_index) = enum_def.find_variant(variant_name) else {
-            return Ok(None);
-        };
-
+        // `type_name` names an enum type, so `type_name.variant` is unambiguously
+        // a variant path (an enum type has no instance fields): a `variant` that
+        // is not one of its variants is a real error, not a fall-through to
+        // ordinary field access (which would report the opaque "field access on
+        // non-struct type 'type'"). RUE-488.
         if !via_comptime {
             self.check_unqualified_visibility(
                 "enum",
                 self.interner.resolve(&type_name),
-                enum_def.file_id,
-                enum_def.is_pub,
+                self.type_pool.enum_def(enum_id).file_id,
+                self.type_pool.enum_def(enum_id).is_pub,
                 span,
             )?;
         }
+
+        let enum_def = self.type_pool.enum_def(enum_id);
+        let variant_name = self.interner.resolve(&variant);
+        let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
+            ErrorKind::UnknownVariant {
+                enum_name: enum_def.name.clone(),
+                variant_name: variant_name.to_string(),
+            },
+            span,
+        )?;
 
         let expected = enum_def.variant_payload(variant_index).len();
         if expected > 0 {
@@ -5748,9 +5975,9 @@ impl<'a> Sema<'a> {
     }
 
     /// Analyze construction of an enum tuple variant with a payload
-    /// (`Shape::Circle(5)`), producing an `EnumVariant` AIR value (RUE-221).
+    /// (`Shape.Circle(5)`), producing an `EnumVariant` AIR value (RUE-221).
     #[allow(clippy::too_many_arguments)]
-    fn analyze_enum_variant_construction(
+    pub(crate) fn analyze_enum_variant_construction(
         &mut self,
         air: &mut Air,
         enum_id: crate::types::EnumId,

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -3402,9 +3402,9 @@ mod tests {
         // local (s and t) is dropped exactly once.
         let cfg = build_cfg(
             "fn main() -> i32 {\n\
-                 let mut s = String::with_capacity(8);\n\
+                 let mut s = String.with_capacity(8);\n\
                  loop {\n\
-                     let mut t = String::with_capacity(8);\n\
+                     let mut t = String.with_capacity(8);\n\
                      break;\n\
                      let unreachable_tail = 0;\n\
                  }\n\
@@ -3425,7 +3425,7 @@ mod tests {
         // scope exit; s's drop is suppressed by the MarkMoved marker.
         let cfg = build_cfg(
             "fn main() -> i32 {\n\
-                 let s = String::with_capacity(8);\n\
+                 let s = String.with_capacity(8);\n\
                  let t = s;\n\
                  0\n\
              }",
@@ -3466,7 +3466,7 @@ mod tests {
         // flag plumbing: a conditional branch on the flag around s's drop.
         let cfg = build_cfg(
             "fn main() -> i32 {\n\
-                 let s = String::with_capacity(8);\n\
+                 let s = String.with_capacity(8);\n\
                  let c = true;\n\
                  if c {\n\
                      let t = s;\n\
@@ -3496,7 +3496,7 @@ mod tests {
         // Moved in BOTH branches => moved on all paths => exit drop suppressed.
         let source = "fn consume(s: String) -> i32 { 0 }\n\
              fn main() -> i32 {\n\
-                 let s = String::with_capacity(8);\n\
+                 let s = String.with_capacity(8);\n\
                  let c = true;\n\
                  if c {\n\
                      consume(s);\n\
@@ -3528,7 +3528,7 @@ mod tests {
         let source = "fn eat(s: String) -> i32 { 0 }\n\
              struct H { a: String, b: String }\n\
              fn main() -> i32 {\n\
-                 let h = H { a: String::with_capacity(8), b: String::with_capacity(8) };\n\
+                 let h = H { a: String.with_capacity(8), b: String.with_capacity(8) };\n\
                  eat(h.a);\n\
                  0\n\
              }";
@@ -3584,9 +3584,9 @@ mod tests {
         let source = "fn eat(s: String) -> i32 { 0 }\n\
              struct H { a: String, b: String }\n\
              fn main() -> i32 {\n\
-                 let mut h = H { a: String::with_capacity(8), b: String::with_capacity(8) };\n\
+                 let mut h = H { a: String.with_capacity(8), b: String.with_capacity(8) };\n\
                  eat(h.a);\n\
-                 h.a = String::with_capacity(4);\n\
+                 h.a = String.with_capacity(4);\n\
                  0\n\
              }";
         let main_cfg = build_cfg_named(source, "main");

--- a/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
+++ b/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
@@ -503,15 +503,15 @@ files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
     match s {
-        Shape::Circle(r) => r,
-        Shape::Rect(w, h) => w + h,
-        Shape::Empty => 0,
+        Shape.Circle(r) => r,
+        Shape.Rect(w, h) => w + h,
+        Shape.Empty => 0,
     }
 }
 fn main() -> i32 {
-    @dbg(area(Shape::Circle(5)));
-    @dbg(area(Shape::Rect(3, 4)));
-    @dbg(area(Shape::Empty));
+    @dbg(area(Shape.Circle(5)));
+    @dbg(area(Shape.Rect(3, 4)));
+    @dbg(area(Shape.Empty));
     0
 }
 """ }]
@@ -524,9 +524,9 @@ name = "enum_return_join"
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
-fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
+fn sum(e: E) -> i32 { match e { E.V(x, y) => x + y, E.Empty => 0 } }
 fn choose(cond: bool) -> E {
-    if cond { E::V(3, 4) } else { E::V(30, 40) }
+    if cond { E.V(3, 4) } else { E.V(30, 40) }
 }
 fn main() -> i32 {
     @dbg(sum(choose(true)));
@@ -543,11 +543,11 @@ name = "enum_field_write_read"
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
-fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
+fn sum(e: E) -> i32 { match e { E.V(x, y) => x + y, E.Empty => 0 } }
 struct Wrap { e: E, tag: i32 }
 fn main() -> i32 {
-    let mut w = Wrap { e: E::Empty, tag: 9 };
-    w.e = E::V(7, 8);
+    let mut w = Wrap { e: E.Empty, tag: 9 };
+    w.e = E.V(7, 8);
     @dbg(sum(w.e)); @dbg(w.tag);
     0
 }
@@ -560,10 +560,10 @@ name = "enum_array_elem_rw"
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
-fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
+fn sum(e: E) -> i32 { match e { E.V(x, y) => x + y, E.Empty => 0 } }
 fn main() -> i32 {
-    let mut arr: [E; 2] = [E::Empty, E::Empty];
-    arr[1] = E::V(5, 6);
+    let mut arr: [E; 2] = [E.Empty, E.Empty];
+    arr[1] = E.V(5, 6);
     @dbg(sum(arr[1]));
     0
 }
@@ -576,10 +576,10 @@ name = "enum_mut_reassign"
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
-fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
+fn sum(e: E) -> i32 { match e { E.V(x, y) => x + y, E.Empty => 0 } }
 fn main() -> i32 {
-    let mut e = E::V(1, 1);
-    e = E::V(20, 30);
+    let mut e = E.V(1, 1);
+    e = E.V(20, 30);
     @dbg(sum(e));
     0
 }
@@ -593,10 +593,10 @@ name = "enum_inout_reassign"
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
-fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
-fn replace(inout e: E) { e = E::V(100, 23); }
+fn sum(e: E) -> i32 { match e { E.V(x, y) => x + y, E.Empty => 0 } }
+fn replace(inout e: E) { e = E.V(100, 23); }
 fn main() -> i32 {
-    let mut e = E::V(1, 2);
+    let mut e = E.V(1, 2);
     replace(inout e);
     @dbg(sum(e));
     0
@@ -610,12 +610,12 @@ name = "enum_ptr_rw"
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
-fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
+fn sum(e: E) -> i32 { match e { E.V(x, y) => x + y, E.Empty => 0 } }
 fn main() -> i32 {
-    let mut arr: [E; 1] = [E::Empty];
+    let mut arr: [E; 1] = [E.Empty];
     checked {
         let wp: ptr mut E = @raw_mut(arr[0]);
-        @ptr_write(wp, E::V(9, 8));
+        @ptr_write(wp, E.V(9, 8));
         let rp: ptr const E = @raw(arr[0]);
         let v = @ptr_read(rp);
         @dbg(sum(v));

--- a/crates/rue-cli-tests/cases/aggregate_equality.toml
+++ b/crates/rue-cli-tests/cases/aggregate_equality.toml
@@ -38,8 +38,8 @@ fn main() -> i32 {
     @dbg(if arr1 == arr2 { 1 } else { 0 });
     @dbg(if arr1 != arr3 { 1 } else { 0 });
 
-    @dbg(if Color::Red == Color::Red { 1 } else { 0 });
-    @dbg(if Color::Red != Color::Green { 1 } else { 0 });
+    @dbg(if Color.Red == Color.Red { 1 } else { 0 });
+    @dbg(if Color.Red != Color.Green { 1 } else { 0 });
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/anon_struct_destructor.toml
+++ b/crates/rue-cli-tests/cases/anon_struct_destructor.toml
@@ -30,7 +30,7 @@ fn Box(comptime T: type) -> type {
 
 fn main() -> i32 {
     let B = Box(i32);
-    let b = B::make(7);
+    let b = B.make(7);
     @dbg(100);
     0
 }
@@ -54,9 +54,9 @@ fn Tag(comptime T: type) -> type {
 
 fn main() -> i32 {
     let G = Tag(i32);
-    let a = G::make(1);
-    let b = G::make(2);
-    let c = G::make(3);
+    let a = G.make(1);
+    let b = G.make(2);
+    let c = G.make(3);
     @dbg(100);
     0
 }
@@ -86,7 +86,7 @@ fn eat(g: Tag(i32)) -> i32 {
 
 fn main() -> i32 {
     let G = Tag(i32);
-    let a = G::make(5);
+    let a = G.make(5);
     @dbg(eat(a));   // a moved into eat: dropped there (5), then eat returns 5
     @dbg(100);
     0
@@ -134,7 +134,7 @@ fn Buf(comptime T: type) -> type {
 
 fn main() -> i32 {
     let B = Buf(i32);
-    let b = B::with(4, 42);
+    let b = B.with(4, 42);
     @dbg(b.head());   // 42 (live)
     0                 // buffer freed here by the destructor: prints 999
 }
@@ -161,8 +161,8 @@ fn Cell(comptime T: type) -> type {
 fn main() -> i32 {
     let Ci = Cell(i32);
     let Cu = Cell(u32);
-    let a = Ci::of(11);
-    let b = Cu::of(22);
+    let a = Ci.of(11);
+    let b = Cu.of(22);
     @dbg(100);
     0
 }

--- a/crates/rue-cli-tests/cases/array_literal_string.toml
+++ b/crates/rue-cli-tests/cases/array_literal_string.toml
@@ -9,7 +9,7 @@ E9000 "Array literal inferred as non-array type: <error>".
 Two flavors:
   1. Valid String array literals must compile and run — elements are usable
      (indexing, .len(), .capacity()), and each fat pointer materializes fully.
-  2. Ill-typed elements (e.g. a nonexistent `String::from`, an undefined
+  2. Ill-typed elements (e.g. a nonexistent `String.from`, an undefined
      function) must surface the element's REAL diagnostic (E0412 / E0202),
      never an internal-compiler-error about a non-array type. HM inference
      collapses an array with an error-typed element to `<error>`; the array
@@ -19,12 +19,12 @@ Two flavors:
 
 # --- Flavor 1: valid String array literals compile and run ----------------
 
-# Two String::new() elements; array indexes usable, .len() is 0.
+# Two String.new() elements; array indexes usable, .len() is 0.
 [[case]]
 name = "array_of_string_new_len"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr = [String::new(), String::new()];
+    let arr = [String.new(), String.new()];
     let n: u64 = arr[0].len();
     if n == 0 { 0 } else { 1 }
 }
@@ -49,7 +49,7 @@ exit_code = 0
 name = "array_of_string_with_capacity"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr = [String::with_capacity(16), String::with_capacity(16)];
+    let arr = [String.with_capacity(16), String.with_capacity(16)];
     let a: u64 = arr[0].capacity();
     let b: u64 = arr[1].capacity();
     if a >= 16 { if b >= 16 { 0 } else { 2 } } else { 1 }
@@ -62,7 +62,7 @@ exit_code = 0
 name = "array_of_string_var_single"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let a = String::new();
+    let a = String.new();
     let arr = [a];
     let n: u64 = arr[0].len();
     if n == 0 { 0 } else { 1 }
@@ -72,13 +72,13 @@ exit_code = 0
 
 # --- Flavor 2: ill-typed elements surface the real error, not an ICE ------
 
-# The reported RUE-190 shape: `String::from` does not exist. Must report
+# The reported RUE-190 shape: `String.from` does not exist. Must report
 # E0412 (unknown associated function), never E9000 about a non-array type.
 [[case]]
 name = "array_of_bad_assoc_fn_reports_real_error"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr = [String::from(\"a\"), String::from(\"b\")];
+    let arr = [String.from(\"a\"), String.from(\"b\")];
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -31,20 +31,20 @@ fn main() -> i32 {
     let V = arraybuf.ArrayBuf(i32);
     let O = arraybuf.Option(i32);
 
-    let mut v = V::new();
+    let mut v = V.new();
     v.push(10);
     v.push(20);
     v.push(30);
     @dbg(v.len());          // 3
 
-    @dbg(match v.get(1) { O::Some(x) => x, O::None => -1 });   // 20
+    @dbg(match v.get(1) { O.Some(x) => x, O.None => -1 });   // 20
     v.set(0, 99);
-    @dbg(match v.get(0) { O::Some(x) => x, O::None => -1 });   // 99
+    @dbg(match v.get(0) { O.Some(x) => x, O.None => -1 });   // 99
 
-    @dbg(match v.pop() { O::Some(x) => x, O::None => -1 });    // 30 (removed)
+    @dbg(match v.pop() { O.Some(x) => x, O.None => -1 });    // 30 (removed)
     @dbg(v.len());          // 2
 
-    @dbg(match v.get(99) { O::Some(x) => x, O::None => -1 });  // -1 (out of bounds)
+    @dbg(match v.get(99) { O.Some(x) => x, O.None => -1 });  // -1 (out of bounds)
 
     let mut i: u64 = 0;
     let mut sum: i32 = 0;
@@ -103,9 +103,9 @@ pub fn ArrayBuf(comptime T: type) -> type {
         fn get(borrow self, i: u64) -> Option(T) {
             let O = Option(T);
             if i < self.len {
-                O::Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
+                O.Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
             } else {
-                O::None
+                O.None
             }
         }
         fn get_or(borrow self, i: u64, default: T) -> T {
@@ -126,10 +126,10 @@ pub fn ArrayBuf(comptime T: type) -> type {
         fn pop(inout self) -> Option(T) {
             let O = Option(T);
             if self.len == 0 {
-                O::None
+                O.None
             } else {
                 self.len = self.len - 1;
-                O::Some(checked { @ptr_read(@ptr_offset(self.buf, self.len)) })
+                O.Some(checked { @ptr_read(@ptr_offset(self.buf, self.len)) })
             }
         }
         fn clear(inout self) { self.len = 0; }
@@ -162,7 +162,7 @@ fn main() -> i32 {
     let m = @import(\"arraybuf.rue\");
     let V = m.ArrayBuf(Point);
 
-    let mut v = V::new();
+    let mut v = V.new();
     v.push(Point { x: 1, y: 2 });
     v.push(Point { x: 3, y: 4 });
     v.push(Point { x: 5, y: 6 });
@@ -264,7 +264,7 @@ fn main() -> i32 {
     let m = @import(\"arraybuf.rue\");
     let V = m.ArrayBuf(i32);
 
-    let mut v = V::new();
+    let mut v = V.new();
     v.push(10);
     v.push(20);
     v.push(30);
@@ -355,14 +355,14 @@ const arraybuf = @import("arraybuf.rue");
 fn main() -> i32 {
     let V = arraybuf.ArrayBuf(i32);
     let O = option.Option(i32);   // the caller's binding, via option.rue
-    let mut v = V::new();
+    let mut v = V.new();
     v.push(10);
     v.push(20);
     // The Option returned by ArrayBuf.get is option.Option(i32) — the SAME
     // nominal type the caller names here, so these match arms type-check.
-    let a = match v.get(1) { O::Some(x) => x, O::None => -1 };
+    let a = match v.get(1) { O.Some(x) => x, O.None => -1 };
     @dbg(a);   // 20
-    let b = match v.get(9) { O::Some(x) => x, O::None => -1 };
+    let b = match v.get(9) { O.Some(x) => x, O.None => -1 };
     @dbg(b);   // -1
     v.free();
     a
@@ -408,9 +408,9 @@ pub fn ArrayBuf(comptime T: type) -> type {
         fn get(borrow self, i: u64) -> option.Option(T) {
             let O = option.Option(T);
             if i < self.len {
-                O::Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
+                O.Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
             } else {
-                O::None
+                O.None
             }
         }
         fn free(inout self) {

--- a/crates/rue-cli-tests/cases/assoc_fn_privacy.toml
+++ b/crates/rue-cli-tests/cases/assoc_fn_privacy.toml
@@ -2,10 +2,10 @@
 # directory boundary (RUE-330). Calling an associated function of a private
 # struct from a source file in a different directory is E0460 — the same rule
 # that already governs naming that struct in a struct literal or type
-# annotation. This holds for both the unqualified (`Secret::make()`) and the
-# module-qualified (`lib.Secret::make()`) forms, since both resolve the
+# annotation. This holds for both the unqualified (`Secret.make()`) and the
+# module-qualified (`lib.Secret.make()`) forms, since both resolve the
 # receiver type through the transitional flat namespace. A receiver reached
-# through a comptime binding (`let P = lib.Point; P::origin()`) is exempt, and
+# through a comptime binding (`let P = lib.Point; P.origin()`) is exempt, and
 # intra-directory access is unchanged.
 
 [section]
@@ -21,7 +21,7 @@ files = [
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
-    let s = Secret::make();
+    let s = Secret.make();
     s.n
 }
 """ },
@@ -44,7 +44,7 @@ files = [
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
-    let s = lib.Secret::make();
+    let s = lib.Secret.make();
     s.n
 }
 """ },
@@ -66,7 +66,7 @@ files = [
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
-    let p = Point::origin();
+    let p = Point.origin();
     p.x + p.y
 }
 """ },
@@ -87,7 +87,7 @@ name = "same_dir_private_assoc_fn_allowed"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let s = Secret::make();
+    let s = Secret.make();
     s.n
 }
 """ },
@@ -111,7 +111,7 @@ const lib = @import("sub/lib");
 
 fn main() -> i32 {
     let P = lib.Point;
-    let p = P::origin();
+    let p = P.origin();
     p.x + p.y
 }
 """ },

--- a/crates/rue-cli-tests/cases/builtin_assocfn_infer.toml
+++ b/crates/rue-cli-tests/cases/builtin_assocfn_infer.toml
@@ -1,7 +1,7 @@
 # Builtin associated-function signatures must reach type inference (RUE-117).
 #
-# Sibling of RUE-95 (methods): builtin associated fns (`String::new`,
-# `String::with_capacity`) live only in the rue-builtins registry and weren't
+# Sibling of RUE-95 (methods): builtin associated fns (`String.new`,
+# `String.with_capacity`) live only in the rue-builtins registry and weren't
 # registered in the HM inference method map, so an untyped literal argument
 # wasn't constrained to the param type (`with_capacity(8)` -> E0206 expected u64
 # found i32) and a result feeding a literal resolved to `<error>`.
@@ -15,7 +15,7 @@ description = "Builtin associated functions must constrain literal args and anch
 name = "with_capacity_literal_arg_is_u64"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String::with_capacity(8);
+    let s = String.with_capacity(8);
     0
 }
 """ }]
@@ -25,7 +25,7 @@ exit_code = 0
 name = "string_new_result_is_empty"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String::new();
+    let s = String.new();
     if s.is_empty() { 0 } else { 1 }
 }
 """ }]
@@ -35,7 +35,7 @@ exit_code = 0
 name = "string_new_len_eq_literal"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String::new();
+    let s = String.new();
     if s.len() == 0 { 0 } else { 1 }
 }
 """ }]

--- a/crates/rue-cli-tests/cases/builtin_method_infer.toml
+++ b/crates/rue-cli-tests/cases/builtin_method_infer.toml
@@ -1,6 +1,6 @@
 # Builtin method-call return types must anchor integer-literal inference (RUE-95).
 #
-# `String::len`/`capacity` return u64, but builtin methods were registered only for
+# `String.len`/`capacity` return u64, but builtin methods were registered only for
 # sema/airgen — NOT for the HM inference `method_sigs` map — so a builtin method-call
 # result used in a binop with an untyped literal (`s.len() + 1`, `s.len() == 2`) left
 # the literal's type unconstrained, resolving to `<error>` and tripping the E0800

--- a/crates/rue-cli-tests/cases/comptime_enclosing_type_in_method.toml
+++ b/crates/rue-cli-tests/cases/comptime_enclosing_type_in_method.toml
@@ -48,7 +48,7 @@ fn Box(comptime T: type) -> type {
         v: T,
         fn wrap(borrow self) -> Option(T) {
             let O = Option(T);
-            O::Some(self.v)
+            O.Some(self.v)
         }
     }
 }
@@ -57,8 +57,8 @@ fn main() -> i32 {
     let O = Option(i32);
     let b = B { v: 42 };
     match b.wrap() {
-        O::Some(x) => x,
-        O::None => 0,
+        O.Some(x) => x,
+        O.None => 0,
     }
 }
 """ }]

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -150,7 +150,7 @@ exit_code = 98
 
 # Enum structural equality with payloads: the same variant with a DIFFERENT
 # payload must not compare equal. Regression for RUE-348 — const-folding compared
-# only the variant tag, so `Opt::Some(5) == Opt::Some(6)` folded to `true` at
+# only the variant tag, so `Opt.Some(5) == Opt.Some(6)` folded to `true` at
 # -O1+ while -O0 (deferring to codegen's structural compare) was correct.
 [[case]]
 name = "enum_payload_equality_across_opt_levels"
@@ -159,9 +159,9 @@ files = [{ path = "main.rue", source = """
 enum Opt { None, Some(i32) }
 
 fn main() -> i32 {
-    let ne: bool = Opt::Some(5) == Opt::Some(6);   // false: same variant, diff payload
-    let eq: bool = Opt::Some(5) == Opt::Some(5);   // true
-    let tag: bool = Opt::None == Opt::Some(0);     // false: different variant
+    let ne: bool = Opt.Some(5) == Opt.Some(6);   // false: same variant, diff payload
+    let eq: bool = Opt.Some(5) == Opt.Some(5);   // true
+    let tag: bool = Opt.None == Opt.Some(0);     // false: different variant
     if ne { @dbg(1); } else { @dbg(0); }
     if eq { @dbg(1); } else { @dbg(0); }
     if tag { @dbg(1); } else { @dbg(0); }

--- a/crates/rue-cli-tests/cases/divergence.toml
+++ b/crates/rue-cli-tests/cases/divergence.toml
@@ -168,10 +168,10 @@ name = "break_mid_block_no_double_drop"
 description = "Diverged statement mid-block must not re-drop the inner local on the exit path."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::with_capacity(8);
+    let mut s = String.with_capacity(8);
     s.push_str("outer");
     loop {
-        let mut t = String::with_capacity(8);
+        let mut t = String.with_capacity(8);
         t.push_str("inner");
         break;
         let unreachable_tail = 0;
@@ -193,7 +193,7 @@ description = "Mid-block return in an untaken branch: fall-through path must not
 files = [{ path = "main.rue", source = """
 fn check(flag: bool) -> i32 {
     if flag {
-        let mut t = String::with_capacity(8);
+        let mut t = String.with_capacity(8);
         t.push_str("taken");
         return 1;
         let unreachable_tail = 0;

--- a/crates/rue-cli-tests/cases/drop_intrinsic.toml
+++ b/crates/rue-cli-tests/cases/drop_intrinsic.toml
@@ -139,7 +139,7 @@ files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 
 fn main() -> i32 {
-    let s = Shape::Circle(5);
+    let s = Shape.Circle(5);
     @drop(s);
     @dbg(7);
     0

--- a/crates/rue-cli-tests/cases/drop_moves.toml
+++ b/crates/rue-cli-tests/cases/drop_moves.toml
@@ -393,7 +393,7 @@ fn eat(s: String) -> i32 {
 }
 
 fn main() -> i32 {
-    let h = Holder { name: String::with_capacity(8), tag: String::with_capacity(8) };
+    let h = Holder { name: String.with_capacity(8), tag: String.with_capacity(8) };
     eat(h.name);
     @dbg(777);
     0
@@ -413,7 +413,7 @@ fn eat(s: String) -> i32 {
 }
 
 fn main() -> i32 {
-    let h = Holder { name: String::with_capacity(8), tag: String::with_capacity(8) };
+    let h = Holder { name: String.with_capacity(8), tag: String.with_capacity(8) };
     let c = true;
     if c {
         eat(h.name);

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -138,8 +138,8 @@ description = "@target_arch() in --emit uses --target, not the compiler host (RU
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     match @target_arch() {
-        Arch::X86_64 => 86,
-        Arch::Aarch64 => 64,
+        Arch.X86_64 => 86,
+        Arch.Aarch64 => 64,
     }
 }
 """ }]
@@ -153,8 +153,8 @@ description = "@target_os() in --emit uses --target, not the compiler host (RUE-
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     match @target_os() {
-        Os::Linux => 1,
-        Os::Macos => 2,
+        Os.Linux => 1,
+        Os.Macos => 2,
     }
 }
 """ }]

--- a/crates/rue-cli-tests/cases/enum_array_payload.toml
+++ b/crates/rue-cli-tests/cases/enum_array_payload.toml
@@ -18,15 +18,15 @@ description = "Enum tuple variants may carry array payloads; array literals unif
 
 [[case]]
 name = "int_array_payload_constructs_and_round_trips"
-description = "RUE-260: `Wrapper::Has([1, 2])` compiles and the payload round-trips through a match: 10 + 20 = 30."
+description = "RUE-260: `Wrapper.Has([1, 2])` compiles and the payload round-trips through a match: 10 + 20 = 30."
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Wrapper { Has([i32; 2]), None }
 fn main() -> i32 {
-    let w = Wrapper::Has([10, 20]);
+    let w = Wrapper.Has([10, 20]);
     match w {
-        Wrapper::Has(a) => a[0] + a[1],
-        Wrapper::None => 0,
+        Wrapper.Has(a) => a[0] + a[1],
+        Wrapper.None => 0,
     }
 }
 """ }]
@@ -40,10 +40,10 @@ files = [{ path = "main.rue", source = """
 struct Guard { v: i32 }
 enum Wrapper { Has([Guard; 2]), None }
 fn main() -> i32 {
-    let w = Wrapper::Has([Guard{v:1}, Guard{v:2}]);
+    let w = Wrapper.Has([Guard{v:1}, Guard{v:2}]);
     match w {
-        Wrapper::Has(a) => a[0].v + a[1].v,
-        Wrapper::None => 0,
+        Wrapper.Has(a) => a[0].v + a[1].v,
+        Wrapper.None => 0,
     }
 }
 """ }]
@@ -56,7 +56,7 @@ args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Wrapper { Has([i32; 2]), None }
 fn main() -> i32 {
-    let w = Wrapper::Has([true, false]);
+    let w = Wrapper.Has([true, false]);
     0
 }
 """ }]
@@ -70,7 +70,7 @@ args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Wrapper { Has([i32; 2]), None }
 fn main() -> i32 {
-    let w = Wrapper::Has([1, 2, 3]);
+    let w = Wrapper.Has([1, 2, 3]);
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/enum_payloads.toml
+++ b/crates/rue-cli-tests/cases/enum_payloads.toml
@@ -18,13 +18,13 @@ files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
     match s {
-        Shape::Circle(r) => r,
-        Shape::Rect(w, h) => w + h,
-        Shape::Empty => 0,
+        Shape.Circle(r) => r,
+        Shape.Rect(w, h) => w + h,
+        Shape.Empty => 0,
     }
 }
 fn main() -> i32 {
-    area(Shape::Circle(5)) + area(Shape::Rect(3, 4)) + area(Shape::Empty)
+    area(Shape.Circle(5)) + area(Shape.Rect(3, 4)) + area(Shape.Empty)
 }
 """ }]
 exit_code = 12
@@ -40,10 +40,10 @@ struct Res { id: i32 }
 drop fn Res(self) { @dbg(self.id); }
 enum Holder { Full(Res), Nothing }
 fn main() -> i32 {
-    let h = Holder::Full(Res { id: 7 });
+    let h = Holder.Full(Res { id: 7 });
     match h {
-        Holder::Full(r) => r.id,
-        Holder::Nothing => 0,
+        Holder.Full(r) => r.id,
+        Holder.Nothing => 0,
     }
 }
 """ }]
@@ -63,7 +63,7 @@ struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 fn main() -> i32 {
-    let e = E::Has(D { v: 9 });
+    let e = E.Has(D { v: 9 });
     @dbg(-1);
     0
 }
@@ -84,7 +84,7 @@ drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 struct Box { e: E }
 fn main() -> i32 {
-    let b = Box { e: E::Has(D { v: 11 }) };
+    let b = Box { e: E.Has(D { v: 11 }) };
     @dbg(-1);
     0
 }
@@ -104,7 +104,7 @@ struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 fn main() -> i32 {
-    let a = [E::Has(D { v: 21 }), E::Has(D { v: 22 })];
+    let a = [E.Has(D { v: 21 }), E.Has(D { v: 22 })];
     @dbg(-1);
     0
 }
@@ -122,7 +122,7 @@ struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 fn main() -> i32 {
-    let e = E::None;
+    let e = E.None;
     @dbg(-1);
     0
 }
@@ -141,10 +141,10 @@ struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 fn main() -> i32 {
-    let e = E::Has(D { v: 7 });
+    let e = E.Has(D { v: 7 });
     match e {
-        E::Has(d) => d.v,
-        E::None => 0,
+        E.Has(d) => d.v,
+        E.None => 0,
     }
 }
 """ }]
@@ -162,7 +162,7 @@ files = [{ path = "main.rue", source = """
 linear struct L { v: i32 }
 enum E { Has(L), None }
 fn main() -> i32 {
-    let e = E::Has(L { v: 1 });
+    let e = E.Has(L { v: 1 });
     0
 }
 """ }]
@@ -180,10 +180,10 @@ linear struct L { v: i32 }
 enum E { Has(L), None }
 fn sink(l: L) -> i32 { l.v }
 fn main() -> i32 {
-    let e = E::Has(L { v: 5 });
+    let e = E.Has(L { v: 5 });
     match e {
-        E::Has(l) => sink(l),
-        E::None => 0,
+        E.Has(l) => sink(l),
+        E.None => 0,
     }
 }
 """ }]
@@ -197,9 +197,9 @@ description = "An enum whose only payloads are Copy stays Copy — usable twice 
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum C { A(i32), B }
-fn val(c: C) -> i32 { match c { C::A(x) => x, C::B => 0 } }
+fn val(c: C) -> i32 { match c { C.A(x) => x, C.B => 0 } }
 fn main() -> i32 {
-    let c = C::A(3);
+    let c = C.A(3);
     val(c) + val(c)
 }
 """ }]
@@ -215,11 +215,11 @@ description = "A function returning a payload enum by value carries the payload 
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
-fn make() -> Opt { Opt::Some(42) }
+fn make() -> Opt { Opt.Some(42) }
 fn main() -> i32 {
     match make() {
-        Opt::Some(v) => v,
-        Opt::None => 0,
+        Opt.Some(v) => v,
+        Opt.None => 0,
     }
 }
 """ }]
@@ -235,9 +235,9 @@ files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Square(i32) }
 fn passthru(s: Shape) -> Shape { s }
 fn main() -> i32 {
-    match passthru(Shape::Circle(9)) {
-        Shape::Circle(r) => r,
-        Shape::Square(x) => x,
+    match passthru(Shape.Circle(9)) {
+        Shape.Circle(r) => r,
+        Shape.Square(x) => x,
     }
 }
 """ }]
@@ -255,10 +255,10 @@ files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
 struct Wrapper { o: Opt }
 fn main() -> i32 {
-    let w = Wrapper { o: Opt::Some(42) };
+    let w = Wrapper { o: Opt.Some(42) };
     match w.o {
-        Opt::Some(v) => v,
-        Opt::None => 0,
+        Opt.Some(v) => v,
+        Opt.None => 0,
     }
 }
 """ }]
@@ -273,10 +273,10 @@ args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
 fn main() -> i32 {
-    let a = [Opt::Some(10), Opt::Some(32)];
+    let a = [Opt.Some(10), Opt.Some(32)];
     match a[0] {
-        Opt::Some(x) => match a[1] { Opt::Some(y) => x + y, Opt::None => 0 },
-        Opt::None => 0,
+        Opt.Some(x) => match a[1] { Opt.Some(y) => x + y, Opt.None => 0 },
+        Opt.None => 0,
     }
 }
 """ }]
@@ -294,7 +294,7 @@ struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 fn main() -> i32 {
-    let e = E::Has(D { v: 7 });
+    let e = E.Has(D { v: 7 });
     match e { _ => 0 }
 }
 """ }]
@@ -312,7 +312,7 @@ struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 fn main() -> i32 {
-    let e = E::None;
+    let e = E.None;
     match e { _ => 0 }
 }
 """ }]
@@ -322,16 +322,16 @@ exit_code = 0
 # still drops the payload of a value the wildcard catches, exactly once.
 [[case]]
 name = "wildcard_catchall_drops_caught_payload"
-description = "A `_` catch-all that catches a droppable variant drops its payload once: E::Has caught by `_`, prints 7."
+description = "A `_` catch-all that catches a droppable variant drops its payload once: E.Has caught by `_`, prints 7."
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 fn main() -> i32 {
-    let e = E::Has(D { v: 7 });
+    let e = E.Has(D { v: 7 });
     match e {
-        E::None => 1,
+        E.None => 1,
         _ => 0,
     }
 }
@@ -355,10 +355,10 @@ files = [{ path = "main.rue", source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let O = Option(i32);
-    let x: O = O::Some(5);
-    let y: O = O::None;
-    let a = match x { O::Some(n) => n, O::None => 0 };
-    let b = match y { O::Some(n) => n, O::None => 0 };
+    let x: O = O.Some(5);
+    let y: O = O.None;
+    let a = match x { O.Some(n) => n, O.None => 0 };
+    let b = match y { O.Some(n) => n, O.None => 0 };
     a + b
 }
 """ }]
@@ -373,8 +373,8 @@ files = [{ path = "main.rue", source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let O = Option(bool);
-    let x: O = O::Some(true);
-    match x { O::Some(b) => if b { 7 } else { 8 }, O::None => 0 }
+    let x: O = O.Some(true);
+    match x { O.Some(b) => if b { 7 } else { 8 }, O.None => 0 }
 }
 """ }]
 exit_code = 7
@@ -388,10 +388,10 @@ files = [{ path = "main.rue", source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn main() -> i32 {
     let R = Result(i32, bool);
-    let ok: R = R::Ok(100);
-    let er: R = R::Err(true);
-    let a = match ok { R::Ok(v) => v, R::Err(e) => if e { 1 } else { 2 } };
-    let b = match er { R::Ok(v) => v, R::Err(e) => if e { 42 } else { 43 } };
+    let ok: R = R.Ok(100);
+    let er: R = R.Err(true);
+    let a = match ok { R.Ok(v) => v, R.Err(e) => if e { 1 } else { 2 } };
+    let b = match er { R.Ok(v) => v, R.Err(e) => if e { 42 } else { 43 } };
     a + b
 }
 """ }]
@@ -408,7 +408,7 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Oi = Option(i32);
     let Ob = Option(bool);
-    let x: Oi = Ob::Some(true);
+    let x: Oi = Ob.Some(true);
     0
 }
 """ }]
@@ -427,10 +427,10 @@ drop fn Noisy(self) { @dbg(self.code); }
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let O = Option(Noisy);
-    let x: O = O::Some(Noisy { code: 33 });
+    let x: O = O.Some(Noisy { code: 33 });
     match x {
-        O::Some(v) => v.code,
-        O::None => 0,
+        O.Some(v) => v.code,
+        O.None => 0,
     }
 }
 """ }]
@@ -449,7 +449,7 @@ linear struct Token { v: i32 }
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn main() -> i32 {
     let R = Result(i32, Token);
-    let x: R = R::Ok(5);
+    let x: R = R.Ok(5);
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/for_loops.toml
+++ b/crates/rue-cli-tests/cases/for_loops.toml
@@ -109,7 +109,7 @@ description = "Lossy decode over a String holding a raw invalid byte (0xFF): the
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push(97);
     s.push(255);
     s.push(98);

--- a/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
+++ b/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
@@ -22,12 +22,12 @@ description = "fn divide(...) -> Result(i32, i32) compiles, is called, and its r
 files = [{ path = "main.rue", source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn divide(a: i32, b: i32) -> Result(i32, i32) {
-    if b == 0 { let R = Result(i32, i32); R::Err(1) }
-    else { let R = Result(i32, i32); R::Ok(a / b) }
+    if b == 0 { let R = Result(i32, i32); R.Err(1) }
+    else { let R = Result(i32, i32); R.Ok(a / b) }
 }
 fn main() -> i32 {
     let R = Result(i32, i32);
-    match divide(84, 2) { R::Ok(v) => v, R::Err(e) => 0 - e }
+    match divide(84, 2) { R.Ok(v) => v, R.Err(e) => 0 - e }
 }
 """ }]
 args = ["main.rue", "-o", "prog"]
@@ -42,11 +42,11 @@ files = [{ path = "main.rue", source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn unwrap_or(r: Result(i32, i32), d: i32) -> i32 {
     let R = Result(i32, i32);
-    match r { R::Ok(v) => v, R::Err(e) => d }
+    match r { R.Ok(v) => v, R.Err(e) => d }
 }
 fn divide(a: i32, b: i32) -> Result(i32, i32) {
     let R = Result(i32, i32);
-    if b == 0 { R::Err(1) } else { R::Ok(a / b) }
+    if b == 0 { R.Err(1) } else { R.Ok(a / b) }
 }
 fn main() -> i32 { unwrap_or(divide(84, 2), 0) }
 """ }]
@@ -64,14 +64,14 @@ fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn make() -> Result(Option(i32), i32) {
     let O = Option(i32);
     let R = Result(Option(i32), i32);
-    R::Ok(O::Some(42))
+    R.Ok(O.Some(42))
 }
 fn main() -> i32 {
     let O = Option(i32);
     let R = Result(Option(i32), i32);
     match make() {
-        R::Ok(o) => match o { O::Some(v) => v, O::None => 0 },
-        R::Err(e) => 0 - e
+        R.Ok(o) => match o { O.Some(v) => v, O.None => 0 },
+        R.Err(e) => 0 - e
     }
 }
 """ }]
@@ -87,12 +87,12 @@ files = [{ path = "main.rue", source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn divide(a: i32, b: i32) -> Result(i32, i32) {
     let R = Result(i32, i32);
-    if b == 0 { R::Err(1) } else { R::Ok(a / b) }
+    if b == 0 { R.Err(1) } else { R.Ok(a / b) }
 }
 fn main() -> i32 {
     let x: Result(i32, i32) = divide(84, 2);
     let R = Result(i32, i32);
-    match x { R::Ok(v) => v, R::Err(e) => 0 - e }
+    match x { R.Ok(v) => v, R.Err(e) => 0 - e }
 }
 """ }]
 args = ["main.rue", "-o", "prog"]
@@ -143,11 +143,11 @@ files = [{ path = "main.rue", source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn wrap(comptime T: type, v: T) -> Option(T) {
     let O = Option(T);
-    O::Some(v)
+    O.Some(v)
 }
 fn main() -> i32 {
     let O = Option(i32);
-    match wrap(i32, 42) { O::Some(x) => x, O::None => 0 }
+    match wrap(i32, 42) { O.Some(x) => x, O.None => 0 }
 }
 """ }]
 args = ["main.rue", "-o", "prog"]
@@ -160,13 +160,13 @@ files = [{ path = "main.rue", source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn wrap(comptime T: type, v: T) -> Option(T) {
     let O = Option(T);
-    O::Some(v)
+    O.Some(v)
 }
 fn main() -> i32 {
     let Oi = Option(i32);
-    let a = match wrap(i32, 40) { Oi::Some(x) => x, Oi::None => 0 };
+    let a = match wrap(i32, 40) { Oi.Some(x) => x, Oi.None => 0 };
     let Ob = Option(bool);
-    let b = match wrap(bool, true) { Ob::Some(x) => 2, Ob::None => 0 };
+    let b = match wrap(bool, true) { Ob.Some(x) => 2, Ob.None => 0 };
     a + b
 }
 """ }]
@@ -180,12 +180,12 @@ files = [{ path = "main.rue", source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn first(comptime T: type, xs: [T; 2]) -> Option(T) {
     let O = Option(T);
-    O::Some(xs[0])
+    O.Some(xs[0])
 }
 fn main() -> i32 {
     let arr = [7, 9];
     let O = Option(i32);
-    match first(i32, arr) { O::Some(x) => x, O::None => 0 }
+    match first(i32, arr) { O.Some(x) => x, O.None => 0 }
 }
 """ }]
 args = ["main.rue", "-o", "prog"]
@@ -200,14 +200,14 @@ fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn wrap_ok(comptime T: type, v: T) -> Result(Option(T), i32) {
     let O = Option(T);
     let R = Result(Option(T), i32);
-    R::Ok(O::Some(v))
+    R.Ok(O.Some(v))
 }
 fn main() -> i32 {
     let O = Option(i32);
     let R = Result(Option(i32), i32);
     match wrap_ok(i32, 42) {
-        R::Ok(o) => match o { O::Some(v) => v, O::None => 0 },
-        R::Err(e) => 0 - e,
+        R.Ok(o) => match o { O.Some(v) => v, O.None => 0 },
+        R.Err(e) => 0 - e,
     }
 }
 """ }]
@@ -221,12 +221,12 @@ files = [{ path = "main.rue", source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn wrap(comptime T: type, v: T) -> Option(T) {
     let O = Option(T);
-    let x: Option(T) = O::Some(v);
+    let x: Option(T) = O.Some(v);
     x
 }
 fn main() -> i32 {
     let O = Option(i32);
-    match wrap(i32, 42) { O::Some(x) => x, O::None => 0 }
+    match wrap(i32, 42) { O.Some(x) => x, O.None => 0 }
 }
 """ }]
 args = ["main.rue", "-o", "prog"]

--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -81,7 +81,7 @@ drop fn Buf(self) {
 }
 
 fn main() -> i32 {
-    let b = Buf::init();
+    let b = Buf.init();
     @dbg(b.first());
     0
 }

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -120,7 +120,7 @@ name = "array_literal_string_element_rue96"
 description = "RUE-96: array literal with a String element inferred the element as <error> -> E9000 ICE."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let a = String::new();
+    let a = String.new();
     let arr = [a];
     0
 }
@@ -132,7 +132,7 @@ name = "array_literal_string_exprs_rue190"
 description = "RUE-190: array literal of String-producing expressions used to ICE (E9000)."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr = [String::new(), String::new()];
+    let arr = [String.new(), String.new()];
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/intcast.toml
+++ b/crates/rue-cli-tests/cases/intcast.toml
@@ -139,7 +139,7 @@ runtime_error_contains = ["integer cast overflow"]
 [[case]]
 name = "u64_above_i64_max_traps"
 files = [{ path = "main.rue", source = """
-fn g() -> u64 { let a: u64 = 9223372036854775807; a + 1 }   // 2^63 > i64::MAX
+fn g() -> u64 { let a: u64 = 9223372036854775807; a + 1 }   // 2^63 > i64.MAX
 fn main() -> i32 {
     let x: u64 = g();
     let y: i64 = @intCast(x);       // out of i64 range -> must trap
@@ -154,7 +154,7 @@ runtime_error_contains = ["integer cast overflow"]
 [[case]]
 name = "i64_in_range_to_i32_ok"
 files = [{ path = "main.rue", source = """
-fn g() -> i64 { 0 - 2147483647 - 1 }    // i32::MIN, exactly in range
+fn g() -> i64 { 0 - 2147483647 - 1 }    // i32.MIN, exactly in range
 fn main() -> i32 {
     let x: i64 = g();
     let y: i32 = @intCast(x);           // boundary value -> must NOT trap

--- a/crates/rue-cli-tests/cases/match_inference_fixes.toml
+++ b/crates/rue-cli-tests/cases/match_inference_fixes.toml
@@ -87,7 +87,7 @@ description = "RUE-269: `Rect(w, w)` binds `w` twice — rejected with E0484 ins
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Shape { Rect(i32, i32) }
-fn main() -> i32 { match Shape::Rect(3, 4) { Shape::Rect(w, w) => w } }
+fn main() -> i32 { match Shape.Rect(3, 4) { Shape.Rect(w, w) => w } }
 """ }]
 compile_fail = true
 error_contains = ["E0484", "bound more than once"]
@@ -99,7 +99,7 @@ args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Shape { Rect(i32, i32) }
 fn main() -> i32 {
-    @dbg(match Shape::Rect(3, 4) { Shape::Rect(w, h) => w + h });
+    @dbg(match Shape.Rect(3, 4) { Shape.Rect(w, h) => w + h });
     0
 }
 """ }]
@@ -111,7 +111,7 @@ description = "RUE-269: a reused name anywhere in a longer payload (`Tri(a, b, a
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Tri { T(i32, i32, i32) }
-fn main() -> i32 { match Tri::T(1, 2, 3) { Tri::T(a, b, a) => a + b } }
+fn main() -> i32 { match Tri.T(1, 2, 3) { Tri.T(a, b, a) => a + b } }
 """ }]
 compile_fail = true
 error_contains = ["E0484"]

--- a/crates/rue-cli-tests/cases/module_consts.toml
+++ b/crates/rue-cli-tests/cases/module_consts.toml
@@ -152,7 +152,7 @@ const OptI = std.option.Option(i64);
 
 fn read_num() -> OptI {
     let n: i64 = 42;
-    OptI::Some(n)
+    OptI.Some(n)
 }
 
 fn main() -> i32 {

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -431,7 +431,7 @@ compile_fail = true
 error_contains = ["E0704", "does_not_exist"]
 
 # Multi-file compile where a NON-FIRST file matches on a module-qualified
-# enum path (`m.Color::Green`). The Path match-arm pattern embeds a module
+# enum path (`m.Color.Green`). The Path match-arm pattern embeds a module
 # InstRef that Rir::merge must renumber along with everything else; it used
 # to be left pointing into the first file's instruction space (RUE-130
 # item 9 — latent today because Sema resolves the enum globally, but this
@@ -447,7 +447,7 @@ pub enum Color {
 }
 
 pub fn pick() -> Color {
-    Color::Green
+    Color.Green
 }
 """ },
     { path = "main.rue", source = """
@@ -455,9 +455,9 @@ fn main() -> i32 {
     let m = @import("color.rue");
     let c = m.pick();
     match c {
-        m.Color::Red => 1,
-        m.Color::Green => 2,
-        m.Color::Blue => 3,
+        m.Color.Red => 1,
+        m.Color.Green => 2,
+        m.Color.Blue => 3,
     }
 }
 """ },
@@ -1377,7 +1377,7 @@ files = [
 const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
-    let c: Color = Color::Blue;
+    let c: Color = Color.Blue;
     0
 }
 """ },
@@ -1479,13 +1479,13 @@ const right = @import("right.rue");
 
 fn take_left(x: left.E) -> i32 {
     match x {
-        left.E::A => 1,
-        left.E::B => 2,
+        left.E.A => 1,
+        left.E.B => 2,
     }
 }
 
 fn main() -> i32 {
-    let r = right.E::B;
+    let r = right.E.B;
     take_left(r)
 }
 """ },
@@ -1515,13 +1515,13 @@ const right = @import("right.rue");
 
 fn take_left(x: left.E) -> i32 {
     match x {
-        left.E::A => 1,
-        left.E::B => 2,
+        left.E.A => 1,
+        left.E.B => 2,
     }
 }
 
 fn main() -> i32 {
-    let r = right.E::C;
+    let r = right.E.C;
     take_left(r)
 }
 """ },
@@ -1547,7 +1547,7 @@ args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let c = Color::Blue;
+    let c = Color.Blue;
     0
 }
 """ },
@@ -1560,7 +1560,11 @@ enum Color {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0421", "unknown enum type 'Color'"]
+# With `.` as the sole member-access spelling (RUE-488), `Color.Blue` where
+# `Color` is not in this file's unqualified namespace is an undefined-name
+# reference (E0201) rather than an unknown-enum-type path (E0421). The private
+# enum is still correctly not injected into another file's namespace.
+error_contains = ["E0201", "undefined variable 'Color'"]
 
 [[case]]
 name = "flat_multifile_private_enum_match_pattern_rejected"
@@ -1572,9 +1576,9 @@ const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     match lib.make() {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 """ },
@@ -1585,7 +1589,7 @@ enum Color {
     Blue,
 }
 pub fn make() -> Color {
-    Color::Green
+    Color.Green
 }
 """ },
 ]
@@ -1594,14 +1598,14 @@ error_contains = ["E0421", "unknown enum type 'Color'", "main.rue"]
 
 [[case]]
 name = "private_enum_module_qualified_pattern_rejected"
-description = "Through a module object the private enum stays E0706 (non-regression, RUE-185): `lib.Color::Red` in a match pattern."
+description = "Through a module object the private enum stays E0706 (non-regression, RUE-185): `lib.Color.Red` in a match pattern."
 files = [
     { path = "main.rue", source = """
 const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     match lib.make() {
-        lib.Color::Red => 1,
+        lib.Color.Red => 1,
         _ => 0,
     }
 }
@@ -1613,7 +1617,7 @@ enum Color {
     Blue,
 }
 pub fn make() -> Color {
-    Color::Green
+    Color.Green
 }
 """ },
 ]
@@ -1627,11 +1631,11 @@ args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let c: Color = Color::Blue;
+    let c: Color = Color.Blue;
     match c {
-        Color::Red => 10,
-        Color::Green => 20,
-        Color::Blue => 42,
+        Color.Red => 10,
+        Color.Green => 20,
+        Color.Blue => 42,
     }
 }
 """ },
@@ -1655,9 +1659,9 @@ const lib = @import("sub/lib.rue");
 
 fn main() -> i32 {
     match lib.make() {
-        lib.Color::Red => 1,
-        lib.Color::Green => 42,
-        lib.Color::Blue => 3,
+        lib.Color.Red => 1,
+        lib.Color.Green => 42,
+        lib.Color.Blue => 3,
     }
 }
 """ },
@@ -1668,7 +1672,7 @@ pub enum Color {
     Blue,
 }
 pub fn make() -> Color {
-    Color::Green
+    Color.Green
 }
 """ },
 ]
@@ -1681,11 +1685,11 @@ args = ["main.rue", "lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
-    let c: Color = Color::Green;
+    let c: Color = Color.Green;
     match c {
-        Color::Red => 1,
-        Color::Green => 42,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 42,
+        Color.Blue => 3,
     }
 }
 """ },
@@ -1808,9 +1812,9 @@ const std = @import("std");
 
 fn main() -> i32 {
     let p = std.geo.Point { x: 3, y: 4 };
-    let s = std.geo.Sign::Pos;
+    let s = std.geo.Sign.Pos;
     match s {
-        std.geo.Sign::Pos => p.x + p.y,
+        std.geo.Sign.Pos => p.x + p.y,
         _ => 0,
     }
 }

--- a/crates/rue-cli-tests/cases/multifile_errors.toml
+++ b/crates/rue-cli-tests/cases/multifile_errors.toml
@@ -112,7 +112,7 @@ error_contains = [
 [[case]]
 name = "binary_expr_span_in_second_file"
 description = """
-RUE-175: make_binary built the merged span with Span::new, dropping the
+RUE-175: make_binary built the merged span with Span.new, dropping the
 FileId. The E0206 on the `if 1 + 2` condition in main.rue (passed second)
 alternated between main.rue:2:8 and a misaligned caret in lib.rue depending on
 hash-map iteration order. It must always point at main.rue:2:8.
@@ -167,7 +167,7 @@ compile_stderr_not_contains = ["lib.rue"]
 name = "unary_expr_span_in_second_file"
 description = """
 RUE-175: make_unary also built its merged span (operator start .. operand end)
-with Span::new. The E0206 on the `if -1` condition must point at main.rue:2:8,
+with Span.new. The E0206 on the `if -1` condition must point at main.rue:2:8,
 never at lib.rue.
 """
 files = [

--- a/crates/rue-cli-tests/cases/print_output.toml
+++ b/crates/rue-cli-tests/cases/print_output.toml
@@ -59,7 +59,7 @@ stdout = "\nend"
 name = "print_borrows_string_reusable_after_call"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("built ");
     s.push_str("string");
     print(s);

--- a/crates/rue-cli-tests/cases/programs.toml
+++ b/crates/rue-cli-tests/cases/programs.toml
@@ -44,16 +44,16 @@ enum Direction {
 
 fn steps(d: Direction) -> i32 {
     match d {
-        Direction::North => 1,
-        Direction::South => 2,
-        Direction::East => 3,
-        Direction::West => 4,
+        Direction.North => 1,
+        Direction.South => 2,
+        Direction.East => 3,
+        Direction.West => 4,
     }
 }
 
 fn main() -> i32 {
-    @dbg(steps(Direction::East));
-    @dbg(steps(Direction::North));
+    @dbg(steps(Direction.East));
+    @dbg(steps(Direction.North));
     0
 }
 """ }]
@@ -94,7 +94,7 @@ stdout = """
 name = "string_builder_push_str"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("Hello");
     s.push_str(", ");
     s.push_str("Rue!");
@@ -113,7 +113,7 @@ Hello, Rue!
 name = "dbg_string_then_use"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("Hello");
     @dbg(s);
     @dbg(s.len());
@@ -132,14 +132,14 @@ files = [
 fn main() -> i32 {
     let OptStr = @import("opt.rue").Option(String);
     match @read_line() {
-        OptStr::Some(answer) => {
+        OptStr.Some(answer) => {
             if answer == "yes" {
                 @dbg("affirmative");
             } else {
                 @dbg("negative");
             }
         },
-        OptStr::None => {},
+        OptStr.None => {},
     }
     0
 }

--- a/crates/rue-cli-tests/cases/raw_ptr_and_method_name.toml
+++ b/crates/rue-cli-tests/cases/raw_ptr_and_method_name.toml
@@ -120,7 +120,7 @@ stdout = "5\n9\n"
 name = "string_push_str_still_requires_mut"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String::new();
+    let s = String.new();
     s.push_str("x");
     0
 }
@@ -133,7 +133,7 @@ error_contains = ["E0203"]
 name = "string_push_str_on_mut_ok"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("hi");
     @dbg(s.len());
     0

--- a/crates/rue-cli-tests/cases/reserved_names.toml
+++ b/crates/rue-cli-tests/cases/reserved_names.toml
@@ -24,7 +24,7 @@ name = "builtin_method_name_allowed"
 files = [{ path = "main.rue", source = """
 fn String__len() -> i32 { 7 }
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("hello");
     let builtin: i32 = @intCast(s.len());
     builtin * 10 + String__len()

--- a/crates/rue-cli-tests/cases/self_type_methods.toml
+++ b/crates/rue-cli-tests/cases/self_type_methods.toml
@@ -24,7 +24,7 @@ struct P {
 }
 
 fn main() -> i32 {
-    let p = P::make();
+    let p = P.make();
     @dbg(p.get());
     0
 }
@@ -43,7 +43,7 @@ struct P {
 }
 
 fn main() -> i32 {
-    let a = P::make(30);
+    let a = P.make(30);
     let b = P { x: 12 };
     @dbg(a.combine(b).get());
     0

--- a/crates/rue-cli-tests/cases/std_type_paths.toml
+++ b/crates/rue-cli-tests/cases/std_type_paths.toml
@@ -13,14 +13,14 @@ const std = @import("std");
 
 fn read_num() -> std.option.Option(i64) {
     let O = std.option.Option(i64);
-    O::None
+    O.None
 }
 
 fn main() -> i32 {
     let O = std.option.Option(i64);
     match read_num() {
-        O::None => 0,
-        O::Some(n) => @intCast(n),
+        O.None => 0,
+        O.Some(n) => @intCast(n),
     }
 }
 """ }]
@@ -36,10 +36,10 @@ const std = @import("std");
 fn main() -> i32 {
     let O = std.option.Option(i64);
     let n: i64 = 42;
-    let x: std.option.Option(i64) = O::Some(n);
+    let x: std.option.Option(i64) = O.Some(n);
     match x {
-        O::None => 0,
-        O::Some(n) => @intCast(n),
+        O.None => 0,
+        O.Some(n) => @intCast(n),
     }
 }
 """ }]

--- a/crates/rue-cli-tests/cases/stdin.toml
+++ b/crates/rue-cli-tests/cases/stdin.toml
@@ -20,13 +20,13 @@ fn main() -> i32 {
     let OptInt = @import("opt.rue").Option(i32);
     let line: OptStr = @read_line();
     match line {
-        OptStr::Some(text) => {
+        OptStr.Some(text) => {
             match @parse_i32(text) {
-                OptInt::Some(n) => { @dbg(n); },
-                OptInt::None => {},
+                OptInt.Some(n) => { @dbg(n); },
+                OptInt.None => {},
             }
         },
-        OptStr::None => {},
+        OptStr.None => {},
     }
     0
 }
@@ -49,10 +49,10 @@ fn main() -> i32 {
     loop {
         let line: OptStr = @read_line();
         match line {
-            OptStr::None => break,
-            OptStr::Some(text) => {
+            OptStr.None => break,
+            OptStr.Some(text) => {
                 match @parse_i32(text) {
-                    OptInt::Some(guess) => {
+                    OptInt.Some(guess) => {
                         if guess < secret {
                             @dbg("Too low!");
                         } else if guess > secret {
@@ -62,7 +62,7 @@ fn main() -> i32 {
                             break;
                         }
                     },
-                    OptInt::None => {},
+                    OptInt.None => {},
                 }
             },
         }
@@ -94,13 +94,13 @@ fn main() -> i32 {
     let OptInt = @import("opt.rue").Option(i32);
     let line: OptStr = @read_line();
     match line {
-        OptStr::Some(text) => {
+        OptStr.Some(text) => {
             match @parse_i32(text) {
-                OptInt::Some(n) => n,
-                OptInt::None => 7,
+                OptInt.Some(n) => n,
+                OptInt.None => 7,
             }
         },
-        OptStr::None => 0,
+        OptStr.None => 0,
     }
 }
 """ },
@@ -119,8 +119,8 @@ fn main() -> i32 {
     let OptStr = @import("opt.rue").Option(String);
     let line: OptStr = @read_line();
     match line {
-        OptStr::Some(_text) => 1,
-        OptStr::None => 0,
+        OptStr.Some(_text) => 1,
+        OptStr.None => 0,
     }
 }
 """ },

--- a/crates/rue-cli-tests/cases/strbuf_library.toml
+++ b/crates/rue-cli-tests/cases/strbuf_library.toml
@@ -14,10 +14,10 @@ description = "The StrBuf canonical name (ADR-0043) builds, mutates, concatenate
 
 [[case]]
 name = "strbuf_new_push_str_len_print"
-description = "StrBuf::new(), push_str, len, and println on the canonical name."
+description = "StrBuf.new(), push_str, len, and println on the canonical name."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = StrBuf::new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     s.push_str(", world");
     println(s);
@@ -30,11 +30,11 @@ exit_code = 0
 
 [[case]]
 name = "strbuf_with_capacity_concat"
-description = "StrBuf::with_capacity plus @to_string concatenation build a StrBuf value."
+description = "StrBuf.with_capacity plus @to_string concatenation build a StrBuf value."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let cap: u64 = 8;
-    let mut s = StrBuf::with_capacity(cap);
+    let mut s = StrBuf.with_capacity(cap);
     s.push_str("n=");
     let combined = s + @to_string(42);
     println(combined);
@@ -49,9 +49,9 @@ name = "string_alias_parity"
 description = "The deprecated `String` alias resolves to the same StrBuf type: annotation, assoc fn, and equality against a StrBuf all work."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut a: String = String::new();
+    let mut a: String = String.new();
     a.push_str("abc");
-    let mut b = StrBuf::new();
+    let mut b = StrBuf.new();
     b.push_str("abc");
     if a == b { 0 } else { 1 }
 }

--- a/crates/rue-cli-tests/cases/string_alloc_failure.toml
+++ b/crates/rue-cli-tests/cases/string_alloc_failure.toml
@@ -1,4 +1,4 @@
-# String::with_capacity allocation-failure safety (RUE-255).
+# String.with_capacity allocation-failure safety (RUE-255).
 #
 # A huge requested capacity makes the heap allocation fail and return null.
 # with_capacity used to store ptr=null / cap=<huge> unconditionally, so a
@@ -10,14 +10,14 @@
 [section]
 id = "cli.string_alloc_failure"
 name = "String allocation-failure safety"
-description = "String::with_capacity must not poison capacity when allocation fails."
+description = "String.with_capacity must not poison capacity when allocation fails."
 
 [[case]]
 name = "with_capacity_huge_no_segfault"
 description = "with_capacity(u64::MAX) fails the alloc: capacity reports 0 and a subsequent push grows fresh instead of writing through null (no SIGSEGV)."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::with_capacity(18446744073709551615);
+    let mut s = String.with_capacity(18446744073709551615);
     @dbg(s.capacity());
     s.push(65);
     @dbg(s.len());
@@ -32,7 +32,7 @@ name = "with_capacity_normal_reserves"
 description = "A satisfiable with_capacity still reserves the requested capacity and appends normally."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::with_capacity(16);
+    let mut s = String.with_capacity(16);
     @dbg(s.capacity());
     s.push(65);
     @dbg(s.len());

--- a/crates/rue-cli-tests/cases/string_growth.toml
+++ b/crates/rue-cli-tests/cases/string_growth.toml
@@ -16,9 +16,9 @@ description = "Two interleaved strings: growing one then appending in-place must
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let cap: u64 = 16;
-    let mut s = String::with_capacity(cap);
+    let mut s = String.with_capacity(cap);
     s.push_str("AAAAAAAAAAAAAAAAA");
-    let mut s2 = String::with_capacity(cap);
+    let mut s2 = String.with_capacity(cap);
     s2.push_str("ZZZZZZZZ");
     s.push_str("XXXXXXXXXXXXXXX");
     if s2 == "ZZZZZZZZ" { 0 } else { 1 }
@@ -31,8 +31,8 @@ name = "interleaved_repeated_growth_stress"
 description = "Two strings growing in lockstep through many cap*2 doublings stay independent and reach the right lengths."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut a = String::new();
-    let mut b = String::new();
+    let mut a = String.new();
+    let mut b = String.new();
     let mut i = 0;
     while i < 50 {
         a.push_str("aaaaaaaaaa");

--- a/crates/rue-cli-tests/cases/string_mutation_receivers.toml
+++ b/crates/rue-cli-tests/cases/string_mutation_receivers.toml
@@ -19,7 +19,7 @@ description = "push_str through a struct field mutates the field (observed via i
 files = [{ path = "main.rue", source = """
 struct Buf { data: String }
 fn main() -> i32 {
-    let mut b = Buf { data: String::new() };
+    let mut b = Buf { data: String.new() };
     b.data.push_str("hi");
     b.data.push_str("!!!");
     @dbg(b.data.len());
@@ -35,7 +35,7 @@ name = "array_element_const_index_push"
 description = "arr[0].push(65) mutates element 0 and leaves element 1 untouched."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut arr = [String::new(), String::new()];
+    let mut arr = [String.new(), String.new()];
     arr[0].push(65);
     @dbg(arr[0].len());
     @dbg(arr[1].len());
@@ -51,7 +51,7 @@ name = "array_element_dynamic_index_push"
 description = "arr[i].push(66) with a runtime index mutates exactly the selected element."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut arr = [String::new(), String::new()];
+    let mut arr = [String.new(), String.new()];
     let i: u64 = 1;
     arr[i].push(66);
     @dbg(arr[1].len());
@@ -71,7 +71,7 @@ fn appendit(inout s: String) {
     s.push_str("more");
 }
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     appendit(inout s);
     appendit(inout s);
     @dbg(s.len());
@@ -92,7 +92,7 @@ struct Buf {
     fn append(inout self) { self.data.push_str("ab"); }
 }
 fn main() -> i32 {
-    let mut b = Buf { data: String::new() };
+    let mut b = Buf { data: String.new() };
     b.append();
     b.append();
     b.append();
@@ -109,7 +109,7 @@ name = "immutable_local_receiver_rejected"
 description = "A String mutation method on an immutable binding is still E0203."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String::new();
+    let s = String.new();
     s.push_str("x");
     0
 }
@@ -123,7 +123,7 @@ name = "moved_string_receiver_rejected"
 description = "Mutating a String after it was moved is still a use-after-move error."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     let s2 = s;
     s.push_str("x");
     @dbg(s2.len());

--- a/crates/rue-cli-tests/cases/string_mutation_value_position.toml
+++ b/crates/rue-cli-tests/cases/string_mutation_value_position.toml
@@ -25,7 +25,7 @@ description = "RUE-224 repro: `take(s.clear())` used to ICE at cfg_lower ('block
 files = [{ path = "main.rue", source = """
 fn take(s: String) -> i32 { 0 }
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     take(s.clear())
 }
 """ }]
@@ -37,7 +37,7 @@ name = "statement_position_mutation_still_runs"
 description = "Statement-position String mutation (`push_str`/`clear`) compiles and runs (control)."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("hi");
     s.clear();
     s.push_str("done");

--- a/crates/rue-cli-tests/cases/try_intrinsic.toml
+++ b/crates/rue-cli-tests/cases/try_intrinsic.toml
@@ -32,11 +32,11 @@ fn main() -> i32 {
     let mut sum: i64 = 0;
     loop {
         match read_num() {
-            O::Some(x) => {
+            O.Some(x) => {
                 count = count + 1;
                 sum = sum + x;
             },
-            O::None => break,
+            O.None => break,
         }
     }
     println("sum: " + @to_string(sum));
@@ -67,8 +67,8 @@ fn main() -> i32 {
     let mut count: i64 = 0;
     loop {
         match read_num() {
-            O::Some(_x) => { count = count + 1; },
-            O::None => break,
+            O.Some(_x) => { count = count + 1; },
+            O.None => break,
         }
     }
     println("done");
@@ -93,13 +93,13 @@ fn Option(comptime T: type) -> type {
 fn add_one(s: String) -> Option(i64) {
     let O = Option(i64);
     let n = @parse_i64(s)?;
-    O::Some(n + 1)
+    O.Some(n + 1)
 }
 fn main() -> i32 {
     let O = Option(i64);
     match add_one("40") {
-        O::Some(n) => @intCast(n),
-        O::None => 0,
+        O.Some(n) => @intCast(n),
+        O.None => 0,
     }
 }
 """ },
@@ -120,13 +120,13 @@ fn Option(comptime T: type) -> type {
 fn add_one(s: String) -> Option(i64) {
     let O = Option(i64);
     let n = @parse_i64(s)?;
-    O::Some(n + 1)
+    O.Some(n + 1)
 }
 fn main() -> i32 {
     let O = Option(i64);
     match add_one("not-a-number") {
-        O::Some(n) => @intCast(n),
-        O::None => 5,
+        O.Some(n) => @intCast(n),
+        O.None => 5,
     }
 }
 """ },

--- a/crates/rue-cli-tests/cases/try_operator.toml
+++ b/crates/rue-cli-tests/cases/try_operator.toml
@@ -15,18 +15,18 @@ fn Option(comptime T: type) -> type {
 }
 fn parse_positive(n: i64) -> Option(i64) {
     let O = Option(i64);
-    if n > 0 { O::Some(n) } else { O::None }
+    if n > 0 { O.Some(n) } else { O.None }
 }
 fn triple(n: i64) -> Option(i64) {
     let O = Option(i64);
     let v = parse_positive(n)?;
-    O::Some(v * 3)
+    O.Some(v * 3)
 }
 fn report(n: i64) {
     let O = Option(i64);
     match triple(n) {
-        O::Some(m) => println("triple: " + @to_string(m)),
-        O::None => println("triple: none"),
+        O.Some(m) => println("triple: " + @to_string(m)),
+        O.None => println("triple: none"),
     }
 }
 fn main() -> i32 {
@@ -56,18 +56,18 @@ fn Option(comptime T: type) -> type {
 }
 fn lookup(found: bool) -> Option(String) {
     let O = Option(String);
-    if found { O::Some("world") } else { O::None }
+    if found { O.Some("world") } else { O.None }
 }
 fn greet(found: bool) -> Option(String) {
     let O = Option(String);
     let name = lookup(found)?;
-    O::Some("hello " + name)
+    O.Some("hello " + name)
 }
 fn show(found: bool) {
     let O = Option(String);
     match greet(found) {
-        O::Some(s) => println(s),
-        O::None => println("(nothing)"),
+        O.Some(s) => println(s),
+        O.None => println("(nothing)"),
     }
 }
 fn main() -> i32 {
@@ -94,7 +94,7 @@ fn Option(comptime T: type) -> type {
 }
 fn some_val() -> Option(i64) {
     let O = Option(i64);
-    O::Some(1)
+    O.Some(1)
 }
 fn main() -> i32 {
     let v = some_val()?;
@@ -118,7 +118,7 @@ fn f() -> Option(i64) {
     let x = 5;
     let y = x?;
     let O = Option(i64);
-    O::Some(y)
+    O.Some(y)
 }
 fn main() -> i32 { 0 }
 """ },

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2322,11 +2322,11 @@ mod tests {
                 "main.rue",
                 r#"const types = @import("types.rue");
                 fn main() -> i32 {
-                    let c = types.Color::Red;
+                    let c = types.Color.Red;
                     match c {
-                        types.Color::Red => 1,
-                        types.Color::Green => 2,
-                        types.Color::Blue => 3,
+                        types.Color.Red => 1,
+                        types.Color.Green => 2,
+                        types.Color.Blue => 3,
                     }
                 }"#,
                 FileId::new(1),
@@ -2745,10 +2745,10 @@ mod tests {
                     let std = @import("std.rue");
                     let OptI = std.option.Option(i64);
                     let n: i64 = 42;
-                    let value = OptI::Some(n);
+                    let value = OptI.Some(n);
                     match value {
-                        OptI::Some(n) => 1,
-                        OptI::None => 0,
+                        OptI.Some(n) => 1,
+                        OptI.None => 0,
                     }
                 }"#,
                 FileId::new(1),
@@ -3528,7 +3528,7 @@ mod integration_tests {
             let src = r#"
                 enum Color { Red, Green, Blue }
                 fn main() -> i32 {
-                    let _c = Color::Red;
+                    let _c = Color.Red;
                     0
                 }
             "#;
@@ -3540,11 +3540,11 @@ mod integration_tests {
             let src = r#"
                 enum Color { Red, Green, Blue }
                 fn main() -> i32 {
-                    let c = Color::Green;
+                    let c = Color.Green;
                     match c {
-                        Color::Red => 1,
-                        Color::Green => 2,
-                        Color::Blue => 3,
+                        Color.Red => 1,
+                        Color.Green => 2,
+                        Color.Blue => 3,
                     }
                 }
             "#;
@@ -3559,12 +3559,12 @@ mod integration_tests {
                 enum Color { Red, Green, Blue }
                 fn eq(a: Color, b: Color) -> bool {
                     match a {
-                        Color::Red => match b { Color::Red => true, _ => false },
-                        Color::Green => match b { Color::Green => true, _ => false },
-                        Color::Blue => match b { Color::Blue => true, _ => false },
+                        Color.Red => match b { Color.Red => true, _ => false },
+                        Color.Green => match b { Color.Green => true, _ => false },
+                        Color.Blue => match b { Color.Blue => true, _ => false },
                     }
                 }
-                fn main() -> i32 { if eq(Color::Red, Color::Red) { 1 } else { 0 } }
+                fn main() -> i32 { if eq(Color.Red, Color.Red) { 1 } else { 0 } }
             "#;
             assert!(compile_to_cfg(src).is_ok());
         }
@@ -3574,7 +3574,7 @@ mod integration_tests {
             let src = r#"
                 enum Color { Red, Green, Blue }
                 fn main() -> i32 {
-                    let _c = Color::Yellow;
+                    let _c = Color.Yellow;
                     0
                 }
             "#;

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1110,7 +1110,7 @@ pub enum ErrorKind {
     MethodCallOnNonStruct { found: String, method_name: String },
     /// Calling a method (with self) as an associated function
     #[error(
-        "'{type_name}::{method_name}' is a method, not an associated function; use receiver.{method_name}() syntax"
+        "'{type_name}.{method_name}' is a method, not an associated function; call it on a receiver, e.g. `receiver.{method_name}()`"
     )]
     MethodCalledAsAssocFn {
         type_name: String,
@@ -1118,7 +1118,7 @@ pub enum ErrorKind {
     },
     /// Calling an associated function (without self) as a method
     #[error(
-        "'{function_name}' is an associated function, not a method; use {type_name}::{function_name}() syntax"
+        "'{function_name}' is an associated function, not a method; call it on the type, e.g. `{type_name}.{function_name}()`"
     )]
     AssocFnCalledAsMethod {
         type_name: String,

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -99,10 +99,12 @@ pub enum TokenKind {
     RParen,
     LBrace,
     RBrace,
-    LBracket,   // [
-    RBracket,   // ]
-    Arrow,      // ->
-    FatArrow,   // =>
+    LBracket, // [
+    RBracket, // ]
+    Arrow,    // ->
+    FatArrow, // =>
+    // `::` is no longer an operator (RUE-488); retained only so the parser can
+    // emit a precise "use `.`" diagnostic for a stray `::`.
     ColonColon, // ::
     Colon,
     Semi,

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -368,6 +368,10 @@ pub enum LogosTokenKind {
     Arrow,
     #[token("=>")]
     FatArrow,
+    // `::` is no longer a Rue operator (RUE-488): `.` is the sole member-access
+    // spelling. The token is still recognized so a stray `::` reaches the parser
+    // as one unit and yields a precise "use `.`" diagnostic, rather than lexing
+    // as two `:` tokens that would produce an opaque error.
     #[token("::")]
     ColonColon,
 

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -436,9 +436,9 @@ fn min_mod_neg_one_traps() {
 #[test]
 fn string_equality_by_content() {
     let src = "fn main() -> i32 {
-        let mut a = String::new();
+        let mut a = String.new();
         a.push_str(\"hi\");
-        let mut b = String::new();
+        let mut b = String.new();
         b.push_str(\"hi\");
         if a == b { 7 } else { 0 }
     }";
@@ -448,7 +448,7 @@ fn string_equality_by_content() {
 #[test]
 fn string_build_and_len() {
     let src = "fn main() -> i32 {
-        let mut s = String::new();
+        let mut s = String.new();
         s.push_str(\"hi\");
         let n: u64 = s.len();
         if n == 2 { 0 } else { 1 }
@@ -459,7 +459,7 @@ fn string_build_and_len() {
 #[test]
 fn string_dbg_and_concat() {
     let src = "fn main() -> i32 {
-        let mut s = String::new();
+        let mut s = String.new();
         s.push_str(\"foo\");
         s.push_str(\"bar\");
         @dbg(s);
@@ -486,8 +486,8 @@ fn target_arch_and_os_fold_to_host() {
     // in sema against `Target::host()`. The oracle runs on that same host, so the
     // folded discriminant must agree with this test binary's own host `cfg`.
     let src = "fn main() -> i32 {
-        let a = match @target_arch() { Arch::X86_64 => 1, Arch::Aarch64 => 2 };
-        let o = match @target_os() { Os::Linux => 10, Os::Macos => 20 };
+        let a = match @target_arch() { Arch.X86_64 => 1, Arch.Aarch64 => 2 };
+        let o = match @target_os() { Os.Linux => 10, Os.Macos => 20 };
         a + o
     }";
     let expected_arch = if cfg!(target_arch = "x86_64") { 1 } else { 2 };
@@ -540,11 +540,11 @@ fn string_byte_iteration_counts_bytes() {
 
 #[test]
 fn string_push_models_raw_non_utf8_byte() {
-    // `String::push` appends one byte, not one Unicode scalar. 0xC3 alone is
+    // `String.push` appends one byte, not one Unicode scalar. 0xC3 alone is
     // not valid UTF-8, but the byte-string model permits storing it; byte
     // operations must still see the raw byte.
     let src = "fn main() -> i32 {
-        let mut s = String::new();
+        let mut s = String.new();
         s.push(195);
         @dbg(s.len());
         @dbg(s[0]);
@@ -557,7 +557,7 @@ fn string_push_models_raw_non_utf8_byte() {
 fn string_chars_traps_on_raw_invalid_utf8_byte() {
     // Strict `.chars()` is the UTF-8 validation boundary for byte strings.
     let src = "fn main() -> i32 {
-        let mut s = String::new();
+        let mut s = String.new();
         s.push(195);
         for c in s.chars() {
             @dbg(c);
@@ -574,7 +574,7 @@ fn string_chars_lossy_replaces_raw_invalid_utf8_byte() {
     // The lossy view mirrors the runtime's replacement behavior: a lone invalid
     // lead byte becomes U+FFFD and advances by one byte.
     let src = "fn main() -> i32 {
-        let mut s = String::new();
+        let mut s = String.new();
         s.push(195);
         let mut count = 0;
         for c in s.chars_lossy() {
@@ -629,7 +629,7 @@ fn string_chars_lossy_matches_strict_over_valid_utf8() {
 #[test]
 fn string_is_empty_and_clear() {
     let src = "fn main() -> i32 {
-        let mut s = String::new();
+        let mut s = String.new();
         s.push_str(\"x\");
         let a: bool = s.is_empty();
         s.clear();

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -4,15 +4,15 @@
 //! with Pratt parsing for expression precedence.
 
 use crate::ast::{
-    AnonStructField, ArgMode, ArrayLength, ArrayLitExpr, AssignStatement, AssignTarget,
-    AssocFnCallExpr, Ast, BinaryExpr, BinaryOp, BlockExpr, BoolLit, BreakExpr, CallArg, CallExpr,
-    CheckedBlockExpr, ComptimeBlockExpr, ConstDecl, ContinueExpr, Directive, DirectiveArg,
-    Directives, DropFn, EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit, ForExpr,
-    Function, Ident, IfExpr, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern,
-    LetStatement, LoopExpr, MatchArm, MatchExpr, Method, MethodCallExpr, NegIntLit, Param,
-    ParamMode, ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, SelfExpr, SelfParam,
-    Statement, StringLit, StructDecl, StructLitExpr, TryExpr, TypeExpr, TypeLitExpr, UnaryExpr,
-    UnaryOp, UnitLit, Visibility, WhileExpr,
+    AnonStructField, ArgMode, ArrayLength, ArrayLitExpr, AssignStatement, AssignTarget, Ast,
+    BinaryExpr, BinaryOp, BlockExpr, BoolLit, BreakExpr, CallArg, CallExpr, CheckedBlockExpr,
+    ComptimeBlockExpr, ConstDecl, ContinueExpr, Directive, DirectiveArg, Directives, DropFn,
+    EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit, ForExpr, Function, Ident, IfExpr,
+    IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr,
+    MatchArm, MatchExpr, Method, MethodCallExpr, NegIntLit, Param, ParamMode, ParenExpr,
+    PathPattern, Pattern, ReturnExpr, SelfExpr, SelfParam, Statement, StringLit, StructDecl,
+    StructLitExpr, TryExpr, TypeExpr, TypeLitExpr, UnaryExpr, UnaryOp, UnitLit, Visibility,
+    WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, MapExtra, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -954,26 +954,8 @@ where
         .or_not()
         .map(|opt| opt.unwrap_or_default());
 
-    // Simple path pattern: Enum::Variant (no module prefix), optionally with
-    // payload bindings `Enum::Variant(a, b)`.
-    let simple_colon_path_pat = ident_parser()
-        .then_ignore(just(TokenKind::ColonColon))
-        .then(ident_parser())
-        .then(pattern_bindings.clone())
-        // Negative lookahead to ensure we're not at the start of a qualified path
-        // (i.e., ensure there's no `.` before this pattern that would make it
-        // part of a module.Enum::Variant pattern)
-        .map_with(|((type_name, variant), bindings), e| {
-            Pattern::Path(PathPattern {
-                base: None,
-                type_name,
-                variant,
-                bindings,
-                span: span_from_extra(e),
-            })
-        });
-
-    // Dotted alias for a simple enum path pattern: Enum.Variant (RUE-196).
+    // Simple enum path pattern: Enum.Variant (RUE-488). `.` is the sole
+    // member-access spelling; `::` was removed.
     let simple_dot_path_pat = ident_parser()
         .then_ignore(just(TokenKind::Dot))
         .then(ident_parser())
@@ -988,55 +970,8 @@ where
             })
         });
 
-    // Qualified path pattern: module.Enum::Variant or module.sub.Enum::Variant
-    // Parses: ident ("." ident)+ "::" ident
-    // where the part before "::" is module.Type and after is Variant
-    let qualified_colon_path_pat = ident_parser()
-        .then(
-            just(TokenKind::Dot)
-                .ignore_then(ident_parser())
-                .repeated()
-                .at_least(1)
-                .collect::<Vec<_>>(),
-        )
-        .then_ignore(just(TokenKind::ColonColon))
-        .then(ident_parser())
-        .then(pattern_bindings.clone())
-        .map_with(|(((first, mut rest), variant), bindings), e| {
-            // first is the first module identifier
-            // rest contains all subsequent identifiers up to and including type_name
-            // The last element of rest is the type_name
-            let type_name = rest.pop().expect("at_least(1) guarantees non-empty");
-
-            // Build the base expression: first.rest[0].rest[1]...
-            let base_expr = if rest.is_empty() {
-                // Just `module.Type::Variant` - base is single ident
-                Expr::Ident(first.clone())
-            } else {
-                // `a.b.c.Type::Variant` - build field access chain
-                let mut base = Expr::Ident(first.clone());
-                for field in rest {
-                    let span = base.span().extend_to(field.span.end);
-                    base = Expr::Field(FieldExpr {
-                        base: Box::new(base),
-                        field,
-                        span,
-                    });
-                }
-                base
-            };
-
-            Pattern::Path(PathPattern {
-                base: Some(Box::new(base_expr)),
-                type_name,
-                variant,
-                bindings,
-                span: span_from_extra(e),
-            })
-        });
-
-    // Dotted alias for qualified enum path patterns:
-    // module.Enum.Variant or module.sub.Enum.Variant (RUE-196). The final two
+    // Qualified enum path pattern:
+    // module.Enum.Variant or module.sub.Enum.Variant (RUE-488). The final two
     // identifiers are the enum type and variant; any earlier identifiers form
     // the module/member base expression.
     let qualified_dot_path_pat = ident_parser()
@@ -1082,13 +1017,12 @@ where
         int_pat,
         bool_true,
         bool_false,
-        // Keep the existing `::` precedence, then accept the simple dotted
-        // alias. The qualified dotted parser is last so `Type.Variant` does
-        // not report a spurious "expected '.'" from the longer form.
-        qualified_colon_path_pat,
-        simple_colon_path_pat,
-        simple_dot_path_pat,
+        // The qualified form (`module.Enum.Variant`, ≥2 dots) must be tried
+        // before the simple one (`Enum.Variant`, exactly 1 dot); otherwise the
+        // simple parser would greedily match the first two identifiers of a
+        // qualified pattern and leave the rest unconsumed.
         qualified_dot_path_pat,
+        simple_dot_path_pat,
     ))
 }
 
@@ -1472,13 +1406,16 @@ where
     ))
 }
 
-/// What can follow an identifier: call args, struct fields, path (::variant), path call (::fn()), or nothing
+/// What can follow an identifier: call args, struct fields, or nothing.
+///
+/// Enum-variant paths (`Enum.Variant`) and associated-function calls
+/// (`Type.function()`) are spelled with `.` (RUE-488) and parse as ordinary
+/// field-access / method-call suffixes in `with_suffix_parser`; sema
+/// reinterprets them when the base names a type. So no path suffix appears here.
 #[derive(Clone)]
 enum IdentSuffix {
     Call(Vec<CallArg>),
     StructLit(Vec<FieldInit>),
-    Path(Ident),                   // ::Variant (for enum variants)
-    PathCall(Ident, Vec<CallArg>), // ::function() (for associated functions)
     None,
 }
 
@@ -1500,18 +1437,6 @@ where
                 field_inits_parser(expr.clone())
                     .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace))
                     .map(IdentSuffix::StructLit),
-                // Associated function call: ::function(args)
-                just(TokenKind::ColonColon)
-                    .ignore_then(ident_parser())
-                    .then(
-                        call_args_parser(expr.clone())
-                            .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
-                    )
-                    .map(|(func, args)| IdentSuffix::PathCall(func, args)),
-                // Path: ::Variant (for enum variants)
-                just(TokenKind::ColonColon)
-                    .ignore_then(ident_parser())
-                    .map(IdentSuffix::Path),
             ))
             .or_not()
             .map(|opt| opt.unwrap_or(IdentSuffix::None)),
@@ -1526,19 +1451,6 @@ where
                 base: None, // No module prefix for simple `StructName { ... }`
                 name,
                 fields,
-                span: span_from_extra(e),
-            }),
-            IdentSuffix::PathCall(function, args) => Expr::AssocFnCall(AssocFnCallExpr {
-                base: None, // No module prefix for simple `Type::function()`
-                type_name: name,
-                function,
-                args,
-                span: span_from_extra(e),
-            }),
-            IdentSuffix::Path(variant) => Expr::Path(PathExpr {
-                base: None, // No module prefix for simple `Enum::Variant`
-                type_name: name,
-                variant,
                 span: span_from_extra(e),
             }),
             IdentSuffix::None => Expr::Ident(name),
@@ -1559,10 +1471,6 @@ enum Suffix {
     /// (Disambiguated from field access + block by the `{ }` / `{ ident :`
     /// lookahead in `with_suffix_parser`.)
     QualifiedStructLit(Ident, Vec<FieldInit>, u32),
-    /// Qualified path (enum variant): .EnumName::Variant
-    QualifiedPath(Ident, Ident, u32),
-    /// Qualified associated function call: .TypeName::function(args)
-    QualifiedAssocFnCall(Ident, Ident, Vec<CallArg>, u32),
     /// Try/`?` propagation: the `?` postfix operator, carrying the position
     /// just past the `?` token so the resulting span covers `operand?`.
     Try(u32),
@@ -1628,38 +1536,16 @@ where
         })
         .boxed();
 
-    // Qualified associated function call: .TypeName::function(args)
-    let qualified_assoc_fn_suffix = just(TokenKind::Dot)
-        .ignore_then(ident_parser())
-        .then_ignore(just(TokenKind::ColonColon))
-        .then(ident_parser())
-        .then(
-            call_args_parser(expr.clone())
-                .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
-        )
-        .map_with(|((type_name, function), args), e| {
-            Suffix::QualifiedAssocFnCall(type_name, function, args, offset_to_u32(e.span().end))
-        });
-
-    // Qualified path (enum variant): .EnumName::Variant
-    // We capture the end position from the variant ident before the negative lookahead
-    let qualified_path_suffix = just(TokenKind::Dot)
-        .ignore_then(ident_parser())
-        .then_ignore(just(TokenKind::ColonColon))
-        .then(ident_parser())
-        .map(|(type_name, variant)| {
-            let end = variant.span.end;
-            (type_name, variant, end)
-        })
-        .then_ignore(none_of([TokenKind::LParen]).rewind())
-        .map(|(type_name, variant, end)| Suffix::QualifiedPath(type_name, variant, end));
-
-    // Field access: .ident (but NOT followed by '(', '::', or struct literal pattern)
+    // Field access: .ident (but NOT followed by '(' or a struct-literal
+    // pattern). Enum-variant paths (`base.Enum.Variant`) and associated-function
+    // calls (`base.Type.func()`) are also spelled with `.` (RUE-488); they parse
+    // as field-access / method-call chains here and sema reinterprets them when
+    // the base names a type.
     // The qualified_struct_lit_suffix is tried first and uses lookahead, so field_suffix
     // only matches when we're certain it's field access, not a qualified struct literal.
     let field_suffix = just(TokenKind::Dot)
         .ignore_then(ident_parser())
-        .then_ignore(none_of([TokenKind::LParen, TokenKind::ColonColon]).rewind())
+        .then_ignore(none_of([TokenKind::LParen]).rewind())
         .map(Suffix::Field);
 
     let index_suffix = expr
@@ -1667,20 +1553,16 @@ where
         .map_with(|index, e| Suffix::Index(index, offset_to_u32(e.span().end)));
 
     // Order matters: more specific patterns must come before less specific ones
-    // - qualified_assoc_fn_suffix before qualified_path_suffix (both have ::)
     // - method_call_suffix before field_suffix (both start with .ident)
     // - qualified_struct_lit_suffix before field_suffix (uses lookahead for { ident: } pattern)
-    // - qualified_path_suffix before field_suffix (both start with .ident)
     //
     // NOTE: .boxed() is required here to shorten the monomorphized type name.
     // Without it, macOS's ld64 linker fails with "symbol name too long" because
-    // the 6-way choice creates extremely long generic type names.
+    // the choice creates extremely long generic type names.
     primary.foldl(
         choice((
             method_call_suffix,
-            qualified_assoc_fn_suffix,
             qualified_struct_lit_suffix,
-            qualified_path_suffix,
             field_suffix,
             index_suffix,
             question_suffix_parser(),
@@ -1731,27 +1613,6 @@ where
                     base: Some(Box::new(base)),
                     name,
                     fields,
-                    span,
-                })
-            }
-            Suffix::QualifiedPath(type_name, variant, end) => {
-                // module.EnumName::Variant → PathExpr with base
-                let span = base.span().extend_to(end);
-                Expr::Path(PathExpr {
-                    base: Some(Box::new(base)),
-                    type_name,
-                    variant,
-                    span,
-                })
-            }
-            Suffix::QualifiedAssocFnCall(type_name, function, args, end) => {
-                // module.TypeName::function(args) → AssocFnCallExpr with base
-                let span = base.span().extend_to(end);
-                Expr::AssocFnCall(AssocFnCallExpr {
-                    base: Some(Box::new(base)),
-                    type_name,
-                    function,
-                    args,
                     span,
                 })
             }
@@ -3154,6 +3015,14 @@ fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId, impl_spur: Spur) -> 
                 found.as_ref().map(|m| &**m),
                 Some(TokenKind::Ident(s)) if *s == impl_spur
             );
+            // `::` was removed as a path/member-access operator (RUE-488): `.`
+            // is the sole spelling for enum variants (`Enum.Variant`),
+            // associated-function calls (`Type.function()`), and module-member
+            // access. The token still lexes, so a stray `::` reaches the parser
+            // and dies here; point the user at `.` rather than leaving an
+            // opaque "unexpected '::'".
+            let found_is_coloncolon =
+                matches!(found.as_ref(), Some(t) if matches!(**t, TokenKind::ColonColon));
             let mut err = CompileError::new(
                 ErrorKind::UnexpectedToken {
                     expected: expected_str,
@@ -3168,6 +3037,8 @@ fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId, impl_spur: Spur) -> 
                     "Rue has no `impl` blocks; define methods inside the struct body, \
                      e.g. `struct S { x: i32, fn m(self) -> i32 { self.x } }`",
                 );
+            } else if found_is_coloncolon {
+                err = err.with_help("`::` is not a Rue operator; use `.` for member access, e.g. `Enum.Variant` or `Type.function()`");
             }
             err
         }
@@ -4265,16 +4136,37 @@ mod tests {
 
     #[test]
     fn test_associated_function_call() {
-        // Type::function(args) syntax
-        let result = parse_expr("Point::new(1, 2)").unwrap();
+        // Associated functions are called with `.` (RUE-488): `Type.function(args)`
+        // parses as a method call whose receiver is the type name; sema
+        // reinterprets it as an associated-function call.
+        let result = parse_expr("Point.new(1, 2)").unwrap();
         match &result.expr {
-            Expr::AssocFnCall(call) => {
-                assert_eq!(result.get(call.type_name.name), "Point");
-                assert_eq!(result.get(call.function.name), "new");
+            Expr::MethodCall(call) => {
+                match call.receiver.as_ref() {
+                    Expr::Ident(ident) => assert_eq!(result.get(ident.name), "Point"),
+                    other => panic!("expected Ident receiver, got {other:?}"),
+                }
+                assert_eq!(result.get(call.method.name), "new");
                 assert_eq!(call.args.len(), 2);
             }
-            _ => panic!("expected AssocFnCall, got {:?}", result.expr),
+            _ => panic!("expected MethodCall, got {:?}", result.expr),
         }
+    }
+
+    #[test]
+    fn test_path_separator_removed() {
+        // `::` is no longer a path/member-access operator (RUE-488); it is a
+        // hard parse error whose help points at `.`.
+        let err = parse("enum E { A } fn main() -> i32 { let x = E::A; 0 }").unwrap_err();
+        assert!(
+            err.iter().any(|e| {
+                e.diagnostic()
+                    .helps
+                    .iter()
+                    .any(|h| h.0.contains("use `.` for member access"))
+            }),
+            "expected a `::`-removed help pointing at `.`, got {err:?}"
+        );
     }
 
     // ==================== Borrow Parameter Parsing Tests ====================
@@ -4537,14 +4429,15 @@ mod tests {
 
     #[test]
     fn test_borrow_arg_in_associated_function() {
-        // Borrow argument in associated function call
-        let result = parse_expr("Foo::bar(borrow x)").unwrap();
+        // Borrow argument in an associated-function call, spelled with `.`
+        // (RUE-488): `Foo.bar(borrow x)` parses as a method call.
+        let result = parse_expr("Foo.bar(borrow x)").unwrap();
         match &result.expr {
-            Expr::AssocFnCall(call) => {
+            Expr::MethodCall(call) => {
                 assert_eq!(call.args.len(), 1);
                 assert_eq!(call.args[0].mode, ArgMode::Borrow);
             }
-            _ => panic!("expected AssocFnCall"),
+            _ => panic!("expected MethodCall"),
         }
     }
 

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -1960,6 +1960,9 @@ mod tests {
 
     #[test]
     fn test_gen_assoc_fn_call() {
+        // Associated functions are called with `.` (RUE-488). At the RIR level
+        // `Point.origin()` is a `MethodCall` whose receiver is the type name;
+        // sema reinterprets it as an associated-function call.
         let source = r#"
             struct Point {
                 x: i32,
@@ -1967,32 +1970,35 @@ mod tests {
                 fn origin() -> Point { Point { x: 0, y: 0 } }
             }
             fn main() -> i32 {
-                let p = Point::origin();
+                let p = Point.origin();
                 0
             }
         "#;
         let (rir, interner) = gen_rir(source);
 
-        // Find the AssocFnCall instruction
-        let assoc_fn_call = rir
+        // Find the MethodCall instruction
+        let method_call = rir
             .iter()
-            .find(|(_, inst)| matches!(inst.data, InstData::AssocFnCall { .. }));
-        assert!(assoc_fn_call.is_some(), "Expected AssocFnCall instruction");
+            .find(|(_, inst)| matches!(inst.data, InstData::MethodCall { .. }));
+        assert!(method_call.is_some(), "Expected MethodCall instruction");
 
-        let (_, inst) = assoc_fn_call.unwrap();
+        let (_, inst) = method_call.unwrap();
         match &inst.data {
-            InstData::AssocFnCall {
-                type_name,
-                function,
+            InstData::MethodCall {
+                receiver,
+                method,
                 args_start,
                 args_len,
             } => {
-                assert_eq!(interner.resolve(&*type_name), "Point");
-                assert_eq!(interner.resolve(&*function), "origin");
+                match &rir.get(*receiver).data {
+                    InstData::VarRef { name } => assert_eq!(interner.resolve(name), "Point"),
+                    other => panic!("expected VarRef receiver, got {other:?}"),
+                }
+                assert_eq!(interner.resolve(&*method), "origin");
                 let args = rir.get_call_args(*args_start, *args_len);
                 assert!(args.is_empty());
             }
-            _ => panic!("expected AssocFnCall"),
+            _ => panic!("expected MethodCall"),
         }
     }
 
@@ -2169,11 +2175,11 @@ mod tests {
         let source = r#"
             enum Color { Red, Green, Blue }
             fn main() -> i32 {
-                let c = Color::Red;
+                let c = Color.Red;
                 match c {
-                    Color::Red => 1,
-                    Color::Green => 2,
-                    Color::Blue => 3,
+                    Color.Red => 1,
+                    Color.Green => 2,
+                    Color.Blue => 3,
                 }
             }
         "#;
@@ -2194,7 +2200,7 @@ mod tests {
                 let arms = rir.get_match_arms(*arms_start, *arms_len);
                 assert_eq!(arms.len(), 3);
 
-                // Check first arm is Color::Red
+                // Check first arm is Color.Red
                 match &arms[0].0 {
                     RirPattern::Path {
                         type_name, variant, ..
@@ -2205,7 +2211,7 @@ mod tests {
                     _ => panic!("expected Path pattern"),
                 }
 
-                // Check second arm is Color::Green
+                // Check second arm is Color.Green
                 match &arms[1].0 {
                     RirPattern::Path {
                         type_name, variant, ..
@@ -2216,7 +2222,7 @@ mod tests {
                     _ => panic!("expected Path pattern"),
                 }
 
-                // Check third arm is Color::Blue
+                // Check third arm is Color.Blue
                 match &arms[2].0 {
                     RirPattern::Path {
                         type_name, variant, ..
@@ -2276,30 +2282,34 @@ mod tests {
 
     #[test]
     fn test_gen_enum_variant() {
+        // Enum variants are spelled with `.` (RUE-488). At the RIR level
+        // `Color.Red` is a `FieldGet` on the type name; sema reinterprets it as
+        // an enum-variant value.
         let source = r#"
             enum Color { Red, Green, Blue }
             fn main() -> i32 {
-                let c = Color::Red;
+                let c = Color.Red;
                 0
             }
         "#;
         let (rir, interner) = gen_rir(source);
 
-        // Find the EnumVariant instruction
-        let enum_variant = rir
+        // Find the FieldGet instruction
+        let field_get = rir
             .iter()
-            .find(|(_, inst)| matches!(inst.data, InstData::EnumVariant { .. }));
-        assert!(enum_variant.is_some(), "Expected EnumVariant instruction");
+            .find(|(_, inst)| matches!(inst.data, InstData::FieldGet { .. }));
+        assert!(field_get.is_some(), "Expected FieldGet instruction");
 
-        let (_, inst) = enum_variant.unwrap();
+        let (_, inst) = field_get.unwrap();
         match &inst.data {
-            InstData::EnumVariant {
-                type_name, variant, ..
-            } => {
-                assert_eq!(interner.resolve(&*type_name), "Color");
-                assert_eq!(interner.resolve(&*variant), "Red");
+            InstData::FieldGet { base, field } => {
+                match &rir.get(*base).data {
+                    InstData::VarRef { name } => assert_eq!(interner.resolve(name), "Color"),
+                    other => panic!("expected VarRef base, got {other:?}"),
+                }
+                assert_eq!(interner.resolve(&*field), "Red");
             }
-            _ => panic!("expected EnumVariant"),
+            _ => panic!("expected FieldGet"),
         }
     }
 
@@ -2361,7 +2371,7 @@ mod tests {
                 fn origin() -> Point { Point { x: 0, y: 0 } }
             }
             fn main() -> i32 {
-                let p = Point::origin();
+                let p = Point.origin();
                 p.x
             }
         "#;
@@ -2370,13 +2380,15 @@ mod tests {
         let printer = RirPrinter::new(&rir, &interner);
         let output = printer.to_string();
 
-        // Check key elements are present in the output
+        // Check key elements are present in the output. `Point.origin()` lowers
+        // to a `method_call` at the RIR level (RUE-488); sema reinterprets the
+        // type-name receiver as an associated-function call.
         assert!(output.contains("struct Point"));
         assert!(output.contains("methods: ["));
         assert!(output.contains("fn origin"));
         assert!(output.contains("fn main"));
         assert!(output.contains("struct_init Point"));
-        assert!(output.contains("assoc_fn_call Point::origin"));
+        assert!(output.contains("method_call"));
         assert!(output.contains("field_get"));
     }
 

--- a/crates/rue-spec/cases/appendices/implementation-limits.toml
+++ b/crates/rue-spec/cases/appendices/implementation-limits.toml
@@ -146,18 +146,18 @@ enum Color {
 }
 
 fn main() -> i32 {
-    let c = Color::Violet;
+    let c = Color.Violet;
     match c {
-        Color::Red => 0,
-        Color::Orange => 1,
-        Color::Yellow => 2,
-        Color::Green => 3,
-        Color::Blue => 4,
-        Color::Indigo => 5,
-        Color::Violet => 6,
-        Color::Black => 7,
-        Color::White => 8,
-        Color::Gray => 9,
+        Color.Red => 0,
+        Color.Orange => 1,
+        Color.Yellow => 2,
+        Color.Green => 3,
+        Color.Blue => 4,
+        Color.Indigo => 5,
+        Color.Violet => 6,
+        Color.Black => 7,
+        Color.White => 8,
+        Color.Gray => 9,
     }
 }
 """

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -406,8 +406,8 @@ source = """
 enum Color { Red, Green, Blue }
 
 fn main() -> i32 {
-    let a = Color::{a};
-    let b = Color::{b};
+    let a = Color.{a};
+    let b = Color.{b};
     if a {op} b { 1 } else { 0 }
 }
 """
@@ -425,8 +425,8 @@ source = """
 enum Color { Red, Green }
 
 fn main() -> i32 {
-    let a = Color::Red;
-    let b = Color::Green;
+    let a = Color.Red;
+    let b = Color.Green;
     if a < b { 1 } else { 0 }
 }
 """
@@ -441,8 +441,8 @@ source = """
 enum Shape { Circle(i32), Square(i32) }
 
 fn main() -> i32 {
-    let a = Shape::{a};
-    let b = Shape::{b};
+    let a = Shape.{a};
+    let b = Shape.{b};
     if a {op} b { 1 } else { 0 }
 }
 """

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -904,7 +904,7 @@ fn Box(comptime T: type) -> type {
 
         fn wrap(self) -> Option(T) {
             let O = Option(T);
-            O::Some(self.v)
+            O.Some(self.v)
         }
     }
 }
@@ -913,8 +913,8 @@ fn main() -> i32 {
     let O = Option(i32);
     let b: B = B { v: 42 };
     match b.wrap() {
-        O::Some(x) => x,
-        O::None => 0,
+        O.Some(x) => x,
+        O.None => 0,
     }
 }
 """
@@ -937,7 +937,7 @@ fn Point() -> type {
 }
 fn main() -> i32 {
     let P = Point();
-    let p = P::origin();
+    let p = P.origin();
     p.x + p.y
 }
 """
@@ -960,7 +960,7 @@ fn Point() -> type {
 }
 fn main() -> i32 {
     let P = Point();
-    let p = P::new(20, 22);
+    let p = P.new(20, 22);
     p.x + p.y
 }
 """
@@ -1006,7 +1006,7 @@ fn StaticUtils() -> type {
 }
 fn main() -> i32 {
     let U = StaticUtils();
-    U::constant()
+    U.constant()
 }
 """
 exit_code = 42
@@ -1815,8 +1815,8 @@ fn Option(comptime T: type) -> type {
 }
 fn main() -> i32 {
     let O = Option(i32);
-    let x: O = O::Some(42);
-    match x { O::Some(n) => n, O::None => 0 }
+    let x: O = O.Some(42);
+    match x { O.Some(n) => n, O.None => 0 }
 }
 """
 exit_code = 42
@@ -1831,8 +1831,8 @@ fn Option(comptime T: type) -> type {
 }
 fn main() -> i32 {
     let O = Option(i32);
-    let x: O = O::None;
-    match x { O::Some(n) => n, O::None => 42 }
+    let x: O = O.None;
+    match x { O.Some(n) => n, O.None => 42 }
 }
 """
 exit_code = 42
@@ -1847,10 +1847,10 @@ fn Result(comptime T: type, comptime E: type) -> type {
 }
 fn main() -> i32 {
     let R = Result(i32, bool);
-    let ok: R = R::Ok(40);
-    let er: R = R::Err(true);
-    let a = match ok { R::Ok(v) => v, R::Err(e) => if e { 1 } else { 2 } };
-    let b = match er { R::Ok(v) => v, R::Err(e) => if e { 2 } else { 3 } };
+    let ok: R = R.Ok(40);
+    let er: R = R.Err(true);
+    let a = match ok { R.Ok(v) => v, R.Err(e) => if e { 1 } else { 2 } };
+    let b = match er { R.Ok(v) => v, R.Err(e) => if e { 2 } else { 3 } };
     a + b
 }
 """
@@ -1867,7 +1867,7 @@ fn Option(comptime T: type) -> type {
 fn main() -> i32 {
     let Oi = Option(i32);
     let Ob = Option(bool);
-    let x: Oi = Ob::Some(true);
+    let x: Oi = Ob.Some(true);
     0
 }
 """
@@ -1885,9 +1885,9 @@ fn Option(comptime T: type) -> type {
 fn main() -> i32 {
     let A = Option(i32);
     let B = Option(i32);
-    let x: A = A::Some(42);
+    let x: A = A.Some(42);
     let y: B = x;
-    match y { B::Some(n) => n, B::None => 0 }
+    match y { B.Some(n) => n, B.None => 0 }
 }
 """
 exit_code = 42
@@ -1900,11 +1900,11 @@ source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn wrap(comptime T: type, v: T) -> Option(T) {
     let O = Option(T);
-    O::Some(v)
+    O.Some(v)
 }
 fn main() -> i32 {
     let O = Option(i32);
-    match wrap(i32, 42) { O::Some(x) => x, O::None => 0 }
+    match wrap(i32, 42) { O.Some(x) => x, O.None => 0 }
 }
 """
 exit_code = 42
@@ -1917,13 +1917,13 @@ source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn wrap(comptime T: type, v: T) -> Option(T) {
     let O = Option(T);
-    O::Some(v)
+    O.Some(v)
 }
 fn main() -> i32 {
     let Oi = Option(i32);
-    let a = match wrap(i32, 40) { Oi::Some(x) => x, Oi::None => 0 };
+    let a = match wrap(i32, 40) { Oi.Some(x) => x, Oi.None => 0 };
     let Ob = Option(bool);
-    let b = match wrap(bool, true) { Ob::Some(x) => 2, Ob::None => 0 };
+    let b = match wrap(bool, true) { Ob.Some(x) => 2, Ob.None => 0 };
     a + b
 }
 """
@@ -1945,8 +1945,8 @@ source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let O = Option(i32);
-    let x: O = O::Some(42);
-    match x { O::Some(n) => n, O::None => 0 }
+    let x: O = O.Some(42);
+    match x { O.Some(n) => n, O.None => 0 }
 }
 """
 exit_code = 42
@@ -2022,14 +2022,14 @@ fn Wrap(comptime T: type) -> type {
         inner: Option(T),
         fn get_or(self, d: T) -> T {
             let O = Option(T);
-            match self.inner { O::Some(v) => v, O::None => d }
+            match self.inner { O.Some(v) => v, O.None => d }
         }
     }
 }
 fn main() -> i32 {
     let W = Wrap(i32);
     let O = Option(i32);
-    let w: W = W { inner: O::Some(42) };
+    let w: W = W { inner: O.Some(42) };
     w.get_or(0)
 }
 """

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -204,7 +204,7 @@ spec = ["4.13:6", "4.13:7"]
 description = "@dbg borrows a String; the value stays usable after the call (RUE-21)"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("hello");
     @dbg(s);
     let n: u64 = s.len();
@@ -228,7 +228,7 @@ drop fn Holder(self) {
     @dbg(self.s);
 }
 fn main() -> i32 {
-    let mut tmp = String::new();
+    let mut tmp = String.new();
     tmp.push_str("world");
     let h = Holder { s: tmp };
     @dbg(h.s);
@@ -772,7 +772,7 @@ name = "intcast_unsigned_to_signed_overflow"
 spec = ["4.13:28"]
 source = """
 fn main() -> i32 {
-    let x: u32 = 2147483648;  // i32::MAX + 1
+    let x: u32 = 2147483648;  // i32.MAX + 1
     let y: i32 = @intCast(x);
     y
 }
@@ -799,8 +799,8 @@ fn main() -> i32 {
     let Opt = Option(String);
     let line: Opt = @read_line();
     match line {
-        Opt::Some(s) => @dbg(s),
-        Opt::None => {},
+        Opt.Some(s) => @dbg(s),
+        Opt.None => {},
     }
     0
 }
@@ -819,8 +819,8 @@ fn main() -> i32 {
     let Opt = Option(String);
     let line: Opt = @read_line();
     match line {
-        Opt::Some(s) => @dbg(s),
-        Opt::None => {},
+        Opt.Some(s) => @dbg(s),
+        Opt.None => {},
     }
     0
 }
@@ -863,8 +863,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(String);
     match @read_line() {
-        Opt::Some(line) => @dbg(line),
-        Opt::None => {},
+        Opt.Some(line) => @dbg(line),
+        Opt.None => {},
     }
     0
 }
@@ -881,8 +881,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(String);
     match @read_line() {
-        Opt::Some(line) => @dbg(line),
-        Opt::None => {},
+        Opt.Some(line) => @dbg(line),
+        Opt.None => {},
     }
     0
 }
@@ -899,12 +899,12 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(String);
     match @read_line() {
-        Opt::Some(line) => @dbg(line),
-        Opt::None => {},
+        Opt.Some(line) => @dbg(line),
+        Opt.None => {},
     }
     match @read_line() {
-        Opt::Some(line) => @dbg(line),
-        Opt::None => {},
+        Opt.Some(line) => @dbg(line),
+        Opt.None => {},
     }
     0
 }
@@ -924,8 +924,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(String);
     match @read_line() {
-        Opt::Some(line) => @dbg(line),
-        Opt::None => {},
+        Opt.Some(line) => @dbg(line),
+        Opt.None => {},
     }
     0
 }
@@ -943,8 +943,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(String);
     match @read_line() {
-        Opt::Some(line) => @dbg(line),
-        Opt::None => {},
+        Opt.Some(line) => @dbg(line),
+        Opt.None => {},
     }
     0
 }
@@ -964,8 +964,8 @@ fn main() -> i32 {
     let line: Opt = @read_line();
     // EOF with no data is None, not a trap: this returns 0, exit success.
     match line {
-        Opt::Some(_s) => 1,
-        Opt::None => 0,
+        Opt.Some(_s) => 1,
+        Opt.None => 0,
     }
 }
 """
@@ -988,8 +988,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i32);
     match @parse_i32("42") {
-        Opt::Some(n) => n,
-        Opt::None => 0,
+        Opt.Some(n) => n,
+        Opt.None => 0,
     }
 }
 """
@@ -1003,8 +1003,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i32);
     match @parse_i32("-17") {
-        Opt::Some(n) => n,
-        Opt::None => 0,
+        Opt.Some(n) => n,
+        Opt.None => 0,
     }
 }
 """
@@ -1018,8 +1018,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i32);
     match @parse_i32("0") {
-        Opt::Some(n) => n,
-        Opt::None => 1,
+        Opt.Some(n) => n,
+        Opt.None => 1,
     }
 }
 """
@@ -1033,8 +1033,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i32);
     match @parse_i32("007") {
-        Opt::Some(n) => n,
-        Opt::None => 0,
+        Opt.Some(n) => n,
+        Opt.None => 0,
     }
 }
 """
@@ -1051,8 +1051,8 @@ fn main() -> i32 {
     let n: Opt = @parse_i32(s);
     @dbg(s);
     match n {
-        Opt::Some(v) => v,
-        Opt::None => 0,
+        Opt.Some(v) => v,
+        Opt.None => 0,
     }
 }
 """
@@ -1066,8 +1066,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i64);
     match @parse_i64("123") {
-        Opt::Some(n) => @intCast(n),
-        Opt::None => 0,
+        Opt.Some(n) => @intCast(n),
+        Opt.None => 0,
     }
 }
 """
@@ -1081,8 +1081,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i64);
     match @parse_i64("-5") {
-        Opt::Some(n) => @intCast(n),
-        Opt::None => 0,
+        Opt.Some(n) => @intCast(n),
+        Opt.None => 0,
     }
 }
 """
@@ -1096,8 +1096,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(u32);
     match @parse_u32("42") {
-        Opt::Some(n) => @intCast(n),
-        Opt::None => 0,
+        Opt.Some(n) => @intCast(n),
+        Opt.None => 0,
     }
 }
 """
@@ -1111,8 +1111,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(u64);
     match @parse_u64("99") {
-        Opt::Some(n) => @intCast(n),
-        Opt::None => 0,
+        Opt.Some(n) => @intCast(n),
+        Opt.None => 0,
     }
 }
 """
@@ -1160,8 +1160,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i32);
     match @parse_i32("") {
-        Opt::Some(n) => n,
-        Opt::None => 42,
+        Opt.Some(n) => n,
+        Opt.None => 42,
     }
 }
 """
@@ -1175,8 +1175,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i32);
     match @parse_i32("12abc") {
-        Opt::Some(n) => n,
-        Opt::None => 42,
+        Opt.Some(n) => n,
+        Opt.None => 42,
     }
 }
 """
@@ -1190,8 +1190,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i32);
     match @parse_i32("2147483648") {
-        Opt::Some(n) => n,
-        Opt::None => 42,
+        Opt.Some(n) => n,
+        Opt.None => 42,
     }
 }
 """
@@ -1205,8 +1205,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(u32);
     match @parse_u32("4294967296") {
-        Opt::Some(n) => @intCast(n),
-        Opt::None => 42,
+        Opt.Some(n) => @intCast(n),
+        Opt.None => 42,
     }
 }
 """
@@ -1220,8 +1220,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(u32);
     match @parse_u32("-1") {
-        Opt::Some(n) => @intCast(n),
-        Opt::None => 42,
+        Opt.Some(n) => @intCast(n),
+        Opt.None => 42,
     }
 }
 """
@@ -1235,8 +1235,8 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let Opt = Option(i32);
     match @parse_i32("127") {
-        Opt::Some(n) => n,
-        Opt::None => 0,
+        Opt.Some(n) => n,
+        Opt.None => 0,
     }
 }
 """
@@ -1248,11 +1248,11 @@ spec = ["4.13:43", "4.13:44"]
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    // Test parsing of i32::MAX (doesn't overflow)
+    // Test parsing of i32.MAX (doesn't overflow)
     let Opt = Option(i32);
     match @parse_i32("2147483647") {
-        Opt::Some(n) => if n == 2147483647 { 255 } else { 1 },
-        Opt::None => 1,
+        Opt.Some(n) => if n == 2147483647 { 255 } else { 1 },
+        Opt.None => 1,
     }
 }
 """
@@ -1264,11 +1264,11 @@ spec = ["4.13:43", "4.13:44", "4.13:47"]
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    // Test parsing of i32::MIN (doesn't overflow)
+    // Test parsing of i32.MIN (doesn't overflow)
     let Opt = Option(i32);
     match @parse_i32("-2147483648") {
-        Opt::Some(n) => if n == -2147483648 { 254 } else { 1 },
-        Opt::None => 1,
+        Opt.Some(n) => if n == -2147483648 { 254 } else { 1 },
+        Opt.None => 1,
     }
 }
 """
@@ -1450,8 +1450,8 @@ fn main() -> i32 {
     // @target_arch() returns an Arch enum value
     let arch = @target_arch();
     match arch {
-        Arch::X86_64 => 1,
-        Arch::Aarch64 => 2,
+        Arch.X86_64 => 1,
+        Arch.Aarch64 => 2,
     }
 }
 """
@@ -1466,8 +1466,8 @@ fn main() -> i32 {
     // @target_arch() returns an Arch enum value
     let arch = @target_arch();
     match arch {
-        Arch::X86_64 => 1,
-        Arch::Aarch64 => 2,
+        Arch.X86_64 => 1,
+        Arch.Aarch64 => 2,
     }
 }
 """
@@ -1505,8 +1505,8 @@ source = """
 // The branch is selected at compile time based on target arch
 fn main() -> i32 {
     match @target_arch() {
-        Arch::X86_64 => 42,
-        Arch::Aarch64 => 43,
+        Arch.X86_64 => 42,
+        Arch.Aarch64 => 43,
     }
 }
 """
@@ -1520,8 +1520,8 @@ source = """
 // The branch is selected at compile time based on target arch
 fn main() -> i32 {
     match @target_arch() {
-        Arch::X86_64 => 42,
-        Arch::Aarch64 => 43,
+        Arch.X86_64 => 42,
+        Arch.Aarch64 => 43,
     }
 }
 """
@@ -1534,8 +1534,8 @@ only_on = ["x86-64-linux", "x86-64-macos"]
 source = """
 fn main() -> i32 {
     match @target_arch() {
-        Arch::X86_64 => 100,
-        Arch::Aarch64 => 200,
+        Arch.X86_64 => 100,
+        Arch.Aarch64 => 200,
     }
 }
 """
@@ -1548,8 +1548,8 @@ only_on = ["aarch64-linux", "aarch64-macos"]
 source = """
 fn main() -> i32 {
     match @target_arch() {
-        Arch::X86_64 => 100,
-        Arch::Aarch64 => 200,
+        Arch.X86_64 => 100,
+        Arch.Aarch64 => 200,
     }
 }
 """
@@ -1568,8 +1568,8 @@ fn main() -> i32 {
     // @target_os() returns an Os enum value
     let os = @target_os();
     match os {
-        Os::Linux => 1,
-        Os::Macos => 2,
+        Os.Linux => 1,
+        Os.Macos => 2,
     }
 }
 """
@@ -1584,8 +1584,8 @@ fn main() -> i32 {
     // @target_os() returns an Os enum value
     let os = @target_os();
     match os {
-        Os::Linux => 1,
-        Os::Macos => 2,
+        Os.Linux => 1,
+        Os.Macos => 2,
     }
 }
 """
@@ -1622,8 +1622,8 @@ only_on = ["x86-64-linux", "aarch64-linux"]
 source = """
 fn main() -> i32 {
     match @target_os() {
-        Os::Linux => 10,
-        Os::Macos => 20,
+        Os.Linux => 10,
+        Os.Macos => 20,
     }
 }
 """
@@ -1636,8 +1636,8 @@ only_on = ["x86-64-macos", "aarch64-macos"]
 source = """
 fn main() -> i32 {
     match @target_os() {
-        Os::Linux => 10,
-        Os::Macos => 20,
+        Os.Linux => 10,
+        Os.Macos => 20,
     }
 }
 """
@@ -1655,16 +1655,16 @@ source = """
 fn main() -> i32 {
     // Combined arch + os detection using nested match
     match @target_arch() {
-        Arch::X86_64 => {
+        Arch.X86_64 => {
             match @target_os() {
-                Os::Linux => 99,
-                Os::Macos => 88,
+                Os.Linux => 99,
+                Os.Macos => 88,
             }
         },
-        Arch::Aarch64 => {
+        Arch.Aarch64 => {
             match @target_os() {
-                Os::Linux => 77,
-                Os::Macos => 66,
+                Os.Linux => 77,
+                Os.Macos => 66,
             }
         },
     }
@@ -1680,16 +1680,16 @@ source = """
 fn main() -> i32 {
     // Combined arch + os detection using nested match
     match @target_arch() {
-        Arch::X86_64 => {
+        Arch.X86_64 => {
             match @target_os() {
-                Os::Linux => 99,
-                Os::Macos => 88,
+                Os.Linux => 99,
+                Os.Macos => 88,
             }
         },
-        Arch::Aarch64 => {
+        Arch.Aarch64 => {
             match @target_os() {
-                Os::Linux => 77,
-                Os::Macos => 66,
+                Os.Linux => 77,
+                Os.Macos => 66,
             }
         },
     }
@@ -1705,16 +1705,16 @@ source = """
 fn main() -> i32 {
     // Combined arch + os detection using nested match
     match @target_arch() {
-        Arch::X86_64 => {
+        Arch.X86_64 => {
             match @target_os() {
-                Os::Linux => 99,
-                Os::Macos => 88,
+                Os.Linux => 99,
+                Os.Macos => 88,
             }
         },
-        Arch::Aarch64 => {
+        Arch.Aarch64 => {
             match @target_os() {
-                Os::Linux => 77,
-                Os::Macos => 66,
+                Os.Linux => 77,
+                Os.Macos => 66,
             }
         },
     }
@@ -1730,16 +1730,16 @@ source = """
 fn main() -> i32 {
     // Combined arch + os detection using nested match
     match @target_arch() {
-        Arch::X86_64 => {
+        Arch.X86_64 => {
             match @target_os() {
-                Os::Linux => 99,
-                Os::Macos => 88,
+                Os.Linux => 99,
+                Os.Macos => 88,
             }
         },
-        Arch::Aarch64 => {
+        Arch.Aarch64 => {
             match @target_os() {
-                Os::Linux => 77,
-                Os::Macos => 66,
+                Os.Linux => 77,
+                Os.Macos => 66,
             }
         },
     }
@@ -1755,8 +1755,8 @@ source = """
 fn main() -> i32 {
     // Test that Arch enum has X86_64 and Aarch64 variants
     match @target_arch() {
-        Arch::X86_64 => 1,
-        Arch::Aarch64 => 2,
+        Arch.X86_64 => 1,
+        Arch.Aarch64 => 2,
     }
 }
 """
@@ -1770,8 +1770,8 @@ source = """
 fn main() -> i32 {
     // Test that Arch enum has X86_64 and Aarch64 variants
     match @target_arch() {
-        Arch::X86_64 => 1,
-        Arch::Aarch64 => 2,
+        Arch.X86_64 => 1,
+        Arch.Aarch64 => 2,
     }
 }
 """
@@ -1785,8 +1785,8 @@ source = """
 fn main() -> i32 {
     // Test that Os enum has Linux and Macos variants
     match @target_os() {
-        Os::Linux => 1,
-        Os::Macos => 2,
+        Os.Linux => 1,
+        Os.Macos => 2,
     }
 }
 """
@@ -1800,8 +1800,8 @@ source = """
 fn main() -> i32 {
     // Test that Os enum has Linux and Macos variants
     match @target_os() {
-        Os::Linux => 1,
-        Os::Macos => 2,
+        Os.Linux => 1,
+        Os.Macos => 2,
     }
 }
 """
@@ -1816,8 +1816,8 @@ fn main() -> i32 {
     // The value is determined at compile time
     let os = @target_os();
     match os {
-        Os::Linux => 10,
-        Os::Macos => 20,
+        Os.Linux => 10,
+        Os.Macos => 20,
     }
 }
 """
@@ -1832,8 +1832,8 @@ fn main() -> i32 {
     // The value is determined at compile time
     let os = @target_os();
     match os {
-        Os::Linux => 10,
-        Os::Macos => 20,
+        Os.Linux => 10,
+        Os.Macos => 20,
     }
 }
 """

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -912,7 +912,7 @@ enum Color {
 }
 
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     match c {}
 }
 """
@@ -947,10 +947,10 @@ spec = ["4.7:30"]
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 {
-    match Shape::Rect(3, 4) {
-        Shape::Circle(r) => r,
-        Shape::Rect(w, h) => w + h,
-        Shape::Empty => 0,
+    match Shape.Rect(3, 4) {
+        Shape.Circle(r) => r,
+        Shape.Rect(w, h) => w + h,
+        Shape.Empty => 0,
     }
 }
 """
@@ -964,9 +964,9 @@ spec = ["4.7:31"]
 source = """
 enum Wrap { One(i32) }
 fn main() -> i32 {
-    let w = Wrap::One(10);
+    let w = Wrap.One(10);
     match w {
-        Wrap::One(x) => x + x,
+        Wrap.One(x) => x + x,
     }
 }
 """
@@ -980,8 +980,8 @@ spec = ["4.7:30"]
 source = """
 enum Shape { Rect(i32, i32) }
 fn main() -> i32 {
-    match Shape::Rect(3, 4) {
-        Shape::Rect(w) => w,
+    match Shape.Rect(3, 4) {
+        Shape.Rect(w) => w,
     }
 }
 """
@@ -996,8 +996,8 @@ spec = ["4.7:30"]
 source = """
 enum Shape { Rect(i32, i32) }
 fn main() -> i32 {
-    match Shape::Rect(3, 4) {
-        Shape::Rect(w, w) => w,
+    match Shape.Rect(3, 4) {
+        Shape.Rect(w, w) => w,
     }
 }
 """
@@ -1016,10 +1016,10 @@ source = """
 enum E { A(i32), B }
 fn use_again(e: E) -> i32 { 2 }
 fn main() -> i32 {
-    let e = E::A(40);
+    let e = E.A(40);
     let r = match e {
-        E::A(x) => x,
-        E::B => 0,
+        E.A(x) => x,
+        E.B => 0,
     };
     r + use_again(e)
 }
@@ -1036,10 +1036,10 @@ struct Big { value: i32 }
 enum E { A(Big), B }
 fn use_again(e: E) -> i32 { 0 }
 fn main() -> i32 {
-    let e = E::A(Big { value: 7 });
+    let e = E.A(Big { value: 7 });
     let r = match e {
-        E::A(s) => s.value,
-        E::B => 0,
+        E.A(s) => s.value,
+        E.B => 0,
     };
     r + use_again(e)
 }
@@ -1057,10 +1057,10 @@ struct Big { value: i32 }
 enum E { A(Big), B }
 fn use_again(e: E) -> i32 { 0 }
 fn main() -> i32 {
-    let e = E::A(Big { value: 7 });
+    let e = E.A(Big { value: 7 });
     let r = match e {
-        E::A => 1,
-        E::B => 2,
+        E.A => 1,
+        E.B => 2,
     };
     r + use_again(e)
 }

--- a/crates/rue-spec/cases/expressions/try.toml
+++ b/crates/rue-spec/cases/expressions/try.toml
@@ -19,18 +19,18 @@ fn Option(comptime T: type) -> type {
 }
 fn some_val() -> Option(i64) {
     let O = Option(i64);
-    O::Some(20)
+    O.Some(20)
 }
 fn use_it() -> Option(i64) {
     let O = Option(i64);
     let v = some_val()?;
-    O::Some(v + 1)
+    O.Some(v + 1)
 }
 fn main() -> i32 {
     let O = Option(i64);
     match use_it() {
-        O::Some(n) => @intCast(n),
-        O::None => 0,
+        O.Some(n) => @intCast(n),
+        O.None => 0,
     }
 }
 """
@@ -50,18 +50,18 @@ fn Option(comptime T: type) -> type {
 }
 fn none_val() -> Option(i64) {
     let O = Option(i64);
-    O::None
+    O.None
 }
 fn use_it() -> Option(i64) {
     let O = Option(i64);
     let v = none_val()?;
-    O::Some(v + 1)
+    O.Some(v + 1)
 }
 fn main() -> i32 {
     let O = Option(i64);
     match use_it() {
-        O::Some(n) => @intCast(n),
-        O::None => 7,
+        O.Some(n) => @intCast(n),
+        O.None => 7,
     }
 }
 """
@@ -81,17 +81,17 @@ fn Option(comptime T: type) -> type {
 }
 fn wrap(x: i64) -> Option(i64) {
     let O = Option(i64);
-    O::Some(x)
+    O.Some(x)
 }
 fn add_two(x: i64) -> Option(i64) {
     let O = Option(i64);
-    O::Some(wrap(x)? + 2)
+    O.Some(wrap(x)? + 2)
 }
 fn main() -> i32 {
     let O = Option(i64);
     match add_two(40) {
-        O::Some(n) => @intCast(n),
-        O::None => 0,
+        O.Some(n) => @intCast(n),
+        O.None => 0,
     }
 }
 """
@@ -115,7 +115,7 @@ fn f() -> Option(i64) {
     let x = 5;
     let y = x?;
     let O = Option(i64);
-    O::Some(y)
+    O.Some(y)
 }
 fn main() -> i32 { 0 }
 """
@@ -137,7 +137,7 @@ fn Option(comptime T: type) -> type {
 }
 fn some_val() -> Option(i64) {
     let O = Option(i64);
-    O::Some(1)
+    O.Some(1)
 }
 fn main() -> i32 {
     let v = some_val()?;
@@ -165,8 +165,8 @@ fn read_num() -> Option(i64) {
 fn main() -> i32 {
     let O = Option(i64);
     match read_num() {
-        O::Some(n) => @intCast(n),
-        O::None => 0,
+        O.Some(n) => @intCast(n),
+        O.None => 0,
     }
 }
 """
@@ -188,8 +188,8 @@ fn read_num() -> Option(i64) {
 fn main() -> i32 {
     let O = Option(i64);
     match read_num() {
-        O::Some(n) => @intCast(n),
-        O::None => 7,
+        O.Some(n) => @intCast(n),
+        O.None => 7,
     }
 }
 """
@@ -207,13 +207,13 @@ fn Option(comptime T: type) -> type {
 fn add_one(s: String) -> Option(i64) {
     let O = Option(i64);
     let n = @parse_i64(s)?;
-    O::Some(n + 1)
+    O.Some(n + 1)
 }
 fn main() -> i32 {
     let O = Option(i64);
     match add_one("41") {
-        O::Some(n) => @intCast(n),
-        O::None => 0,
+        O.Some(n) => @intCast(n),
+        O.None => 0,
     }
 }
 """
@@ -230,13 +230,13 @@ fn Option(comptime T: type) -> type {
 fn add_one(s: String) -> Option(i64) {
     let O = Option(i64);
     let n = @parse_i64(s)?;
-    O::Some(n + 1)
+    O.Some(n + 1)
 }
 fn main() -> i32 {
     let O = Option(i64);
     match add_one("nope") {
-        O::Some(n) => @intCast(n),
-        O::None => 9,
+        O.Some(n) => @intCast(n),
+        O.None => 9,
     }
 }
 """

--- a/crates/rue-spec/cases/items/enums.toml
+++ b/crates/rue-spec/cases/items/enums.toml
@@ -14,7 +14,7 @@ spec = ["6.3:1", "6.3:2"]
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     0
 }
 """
@@ -26,7 +26,7 @@ spec = ["6.3:1"]
 source = """
 enum Single { Only }
 fn main() -> i32 {
-    let s = Single::Only;
+    let s = Single.Only;
     0
 }
 """
@@ -38,7 +38,7 @@ spec = ["6.3:1"]
 source = """
 enum Direction { North, East, South, West }
 fn main() -> i32 {
-    let d = Direction::South;
+    let d = Direction.South;
     0
 }
 """
@@ -92,12 +92,15 @@ name = "unknown_enum_type_error"
 spec = ["6.3:4"]
 source = """
 fn main() -> i32 {
-    let c = Unknown::Red;
+    let c = Unknown.Red;
     0
 }
 """
 compile_fail = true
-error_contains = "unknown"
+# With `.` as the sole member-access spelling (RUE-488), `Unknown.Red` where
+# `Unknown` names nothing is an undefined-name reference — the parser cannot
+# distinguish it from ordinary field access on a variable.
+error_contains = "undefined variable"
 
 # =============================================================================
 # Unknown Variant Error
@@ -109,7 +112,7 @@ spec = ["6.3:5"]
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    let c = Color::Yellow;
+    let c = Color.Yellow;
     0
 }
 """
@@ -126,11 +129,11 @@ spec = ["4.7:7", "4.7:10", "6.3:7", "6.3:8"]
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    let c = Color::Green;
+    let c = Color.Green;
     match c {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 """
@@ -142,9 +145,9 @@ spec = ["4.7:4", "4.7:7", "4.7:10", "6.3:7", "6.3:8"]
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    let c = Color::Blue;
+    let c = Color.Blue;
     match c {
-        Color::Red => 1,
+        Color.Red => 1,
         _ => 99,
     }
 }
@@ -157,10 +160,10 @@ spec = ["4.7:9", "4.7:10", "6.3:8"]
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     match c {
-        Color::Red => 1,
-        Color::Green => 2,
+        Color.Red => 1,
+        Color.Green => 2,
     }
 }
 """
@@ -173,11 +176,11 @@ spec = ["4.7:7", "4.7:10", "6.3:7"]
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     match c {
-        Color::Red => 42,
-        Color::Green => 0,
-        Color::Blue => 0,
+        Color.Red => 42,
+        Color.Green => 0,
+        Color.Blue => 0,
     }
 }
 """
@@ -189,11 +192,11 @@ spec = ["4.7:7", "4.7:10", "6.3:7"]
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    let c = Color::Blue;
+    let c = Color.Blue;
     match c {
-        Color::Red => 0,
-        Color::Green => 0,
-        Color::Blue => 42,
+        Color.Red => 0,
+        Color.Green => 0,
+        Color.Blue => 42,
     }
 }
 """
@@ -210,13 +213,13 @@ source = """
 enum Color { Red, Green, Blue }
 fn color_value(c: Color) -> i32 {
     match c {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 fn main() -> i32 {
-    color_value(Color::Green)
+    color_value(Color.Green)
 }
 """
 exit_code = 2
@@ -227,13 +230,13 @@ spec = ["6.3:10"]
 source = """
 enum Color { Red, Green, Blue }
 fn get_color() -> Color {
-    Color::Blue
+    Color.Blue
 }
 fn main() -> i32 {
     match get_color() {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 42,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 42,
     }
 }
 """
@@ -250,7 +253,7 @@ source = """
 enum Color { Red, Green, Blue }
 struct Pixel { color: Color, x: i32 }
 fn main() -> i32 {
-    let p = Pixel { color: Color::Red, x: 42 };
+    let p = Pixel { color: Color.Red, x: 42 };
     p.x
 }
 """
@@ -278,9 +281,9 @@ spec = ["6.3:2", "6.3:13"]
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 {
-    let a = Shape::Circle(5);
-    let b = Shape::Rect(3, 4);
-    let c = Shape::Empty;
+    let a = Shape.Circle(5);
+    let b = Shape.Rect(3, 4);
+    let c = Shape.Empty;
     0
 }
 """
@@ -294,12 +297,12 @@ source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
     match s {
-        Shape::Circle(r) => r,
-        Shape::Rect(w, h) => w + h,
-        Shape::Empty => 0,
+        Shape.Circle(r) => r,
+        Shape.Rect(w, h) => w + h,
+        Shape.Empty => 0,
     }
 }
-fn main() -> i32 { area(Shape::Circle(5)) }
+fn main() -> i32 { area(Shape.Circle(5)) }
 """
 exit_code = 5
 
@@ -311,12 +314,12 @@ source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
     match s {
-        Shape::Circle(r) => r,
-        Shape::Rect(w, h) => w + h,
-        Shape::Empty => 0,
+        Shape.Circle(r) => r,
+        Shape.Rect(w, h) => w + h,
+        Shape.Empty => 0,
     }
 }
-fn main() -> i32 { area(Shape::Rect(3, 4)) }
+fn main() -> i32 { area(Shape.Rect(3, 4)) }
 """
 exit_code = 7
 
@@ -328,12 +331,12 @@ source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
     match s {
-        Shape::Circle(r) => r,
-        Shape::Rect(w, h) => w + h,
-        Shape::Empty => 0,
+        Shape.Circle(r) => r,
+        Shape.Rect(w, h) => w + h,
+        Shape.Empty => 0,
     }
 }
-fn main() -> i32 { area(Shape::Empty) }
+fn main() -> i32 { area(Shape.Empty) }
 """
 exit_code = 0
 
@@ -344,7 +347,7 @@ error_contains = "[E0207]"
 spec = ["6.3:16"]
 source = """
 enum Shape { Rect(i32, i32) }
-fn main() -> i32 { let r = Shape::Rect(3); 0 }
+fn main() -> i32 { let r = Shape.Rect(3); 0 }
 """
 compile_fail = true
 
@@ -355,7 +358,7 @@ error_contains = "[E0207]"
 spec = ["6.3:16"]
 source = """
 enum Shape { Circle(i32) }
-fn main() -> i32 { let c = Shape::Circle; 0 }
+fn main() -> i32 { let c = Shape.Circle; 0 }
 """
 compile_fail = true
 
@@ -369,10 +372,10 @@ struct Res { id: i32 }
 drop fn Res(self) { @dbg(self.id); }
 enum Holder { Full(Res), Nothing }
 fn main() -> i32 {
-    let h = Holder::Full(Res { id: 7 });
+    let h = Holder.Full(Res { id: 7 });
     match h {
-        Holder::Full(r) => r.id,
-        Holder::Nothing => 0,
+        Holder.Full(r) => r.id,
+        Holder.Nothing => 0,
     }
 }
 """
@@ -387,7 +390,7 @@ source = """
 linear struct L { v: i32 }
 enum E { Has(L), None }
 fn main() -> i32 {
-    let e = E::Has(L { v: 1 });
+    let e = E.Has(L { v: 1 });
     0
 }
 """
@@ -404,10 +407,10 @@ linear struct L { v: i32 }
 enum E { Has(L), None }
 fn sink(l: L) -> i32 { l.v }
 fn main() -> i32 {
-    let e = E::Has(L { v: 5 });
+    let e = E.Has(L { v: 5 });
     match e {
-        E::Has(l) => sink(l),
-        E::None => 0,
+        E.Has(l) => sink(l),
+        E.None => 0,
     }
 }
 """
@@ -420,9 +423,9 @@ name = "enum_copy_payload_stays_copy"
 spec = ["6.3:19"]
 source = """
 enum C { A(i32), B }
-fn val(c: C) -> i32 { match c { C::A(x) => x, C::B => 0 } }
+fn val(c: C) -> i32 { match c { C.A(x) => x, C.B => 0 } }
 fn main() -> i32 {
-    let c = C::A(3);
+    let c = C.A(3);
     val(c) + val(c)
 }
 """
@@ -439,7 +442,7 @@ struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 fn main() -> i32 {
-    let e = E::Has(D { v: 9 });
+    let e = E.Has(D { v: 9 });
     @dbg(-1);
     0
 }
@@ -456,7 +459,7 @@ struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
 enum E { Has(D), None }
 fn main() -> i32 {
-    let e = E::None;
+    let e = E.None;
     @dbg(-1);
     0
 }

--- a/crates/rue-spec/cases/items/general.toml
+++ b/crates/rue-spec/cases/items/general.toml
@@ -99,7 +99,7 @@ description = "A `Type__method` name is an ordinary identifier: runtime symbols 
 source = """
 fn String__len() -> i32 { 7 }
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("hello");
     let builtin: i32 = @intCast(s.len());
     builtin * 10 + String__len()

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -94,7 +94,7 @@ struct Point {
 }
 
 fn main() -> i32 {
-    let p = Point::origin();
+    let p = Point.origin();
     p.x
 }
 """
@@ -114,7 +114,7 @@ struct Point {
 }
 
 fn main() -> i32 {
-    let p = Point::new(42, 10);
+    let p = Point.new(42, 10);
     p.x
 }
 """
@@ -194,7 +194,7 @@ struct Counter {
 }
 
 fn main() -> i32 {
-    let c = Counter::new(42);
+    let c = Counter.new(42);
     c.get()
 }
 """
@@ -290,7 +290,7 @@ struct Point {
 }
 
 fn main() -> i32 {
-    Point::get_x()
+    Point.get_x()
 }
 """
 compile_fail = true
@@ -334,7 +334,7 @@ struct P {
 }
 
 fn main() -> i32 {
-    let p = P::make();
+    let p = P.make();
     p.get()
 }
 """
@@ -354,7 +354,7 @@ struct P {
 }
 
 fn main() -> i32 {
-    let a = P::make(30);
+    let a = P.make(30);
     let b = P { x: 12 };
     a.combine(b).get()
 }
@@ -529,7 +529,7 @@ struct P {
 }
 
 fn main() -> i32 {
-    P::make(5).get()
+    P.make(5).get()
 }
 """
 

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -548,10 +548,10 @@ spec = ["2.0:2"]
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    match Color::Red {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+    match Color.Red {
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 """

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -317,13 +317,13 @@ const lib = @import("sub/lib");
 
 fn main() -> i32 {
     let p = lib.Point { x: 40, y: 2 };
-    let q = lib.Point::origin();
-    let c = lib.Color::Green;
+    let q = lib.Point.origin();
+    let c = lib.Color.Green;
     let base = p.x + p.y + q.x + q.y;
     match c {
-        lib.Color::Red => 0,
-        lib.Color::Green => base,
-        lib.Color::Blue => 0,
+        lib.Color.Red => 0,
+        lib.Color.Green => base,
+        lib.Color.Blue => 0,
     }
 }
 """
@@ -387,22 +387,22 @@ fn main() -> i32 {
     let left = a.pick_a();
     let right = b.pick_b();
     let x = match left {
-        a.Color::Red => 10,
-        a.Color::Green => 0,
+        a.Color.Red => 10,
+        a.Color.Green => 0,
     };
     let y = match right {
-        b.Color::Red => 0,
-        b.Color::Green => 32,
+        b.Color.Red => 0,
+        b.Color.Green => 32,
     };
     x + y
 }
 """
 aux_files = { "a.rue" = """
 pub enum Color { Red, Green, }
-pub fn pick_a() -> Color { Color::Red }
+pub fn pick_a() -> Color { Color.Red }
 """, "b.rue" = """
 pub enum Color { Red, Green, }
-pub fn pick_b() -> Color { Color::Green }
+pub fn pick_b() -> Color { Color.Green }
 """ }
 exit_code = 42
 
@@ -433,13 +433,13 @@ source = """
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
-    let h = lib.Hidden::A;
+    let h = lib.Hidden.A;
     0
 }
 """
 aux_files = { "sub/lib.rue" = """
 enum Hidden { A, B, }
-pub fn touch() -> i32 { let h = Hidden::A; match h { Hidden::A => 1, Hidden::B => 2, } }
+pub fn touch() -> i32 { let h = Hidden.A; match h { Hidden.A => 1, Hidden.B => 2, } }
 """ }
 compile_fail = true
 error_contains = ["E0706", "is private"]
@@ -458,7 +458,7 @@ source = """
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
-    let s = Secret::make();
+    let s = Secret.make();
     s.n
 }
 """
@@ -479,7 +479,7 @@ source = """
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
-    let s = lib.Secret::make();
+    let s = lib.Secret.make();
     s.n
 }
 """
@@ -500,7 +500,7 @@ source = """
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
-    let p = Point::origin();
+    let p = Point.origin();
     p.x + p.y
 }
 """
@@ -521,7 +521,7 @@ source = """
 const lib = @import("lib");
 
 fn main() -> i32 {
-    let s = lib.Secret::make();
+    let s = lib.Secret.make();
     s.n
 }
 """
@@ -536,13 +536,13 @@ exit_code = 42
 [[case]]
 name = "cross_dir_comptime_bound_assoc_fn_allowed"
 spec = ["10.4:19"]
-description = "A receiver type reached through a comptime binding (not by naming the struct) is exempt: `let P = lib.Point; P::origin()` is allowed"
+description = "A receiver type reached through a comptime binding (not by naming the struct) is exempt: `let P = lib.Point; P.origin()` is allowed"
 source = """
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
     let P = lib.Point;
-    let p = P::origin();
+    let p = P.origin();
     p.x + p.y
 }
 """

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -68,10 +68,10 @@ description = "Files in same directory can access private enums"
 source = """
 fn main() -> i32 {
     let utils = @import("utils");
-    let s = utils.InternalStatus::Active;
+    let s = utils.InternalStatus.Active;
     match s {
-        utils.InternalStatus::Active => 42,
-        utils.InternalStatus::Inactive => 0,
+        utils.InternalStatus.Active => 42,
+        utils.InternalStatus.Inactive => 0,
     }
 }
 """
@@ -163,10 +163,10 @@ description = "Files in different directories can access public enums"
 source = """
 fn main() -> i32 {
     let utils = @import("subdir/utils");
-    let s = utils.PublicStatus::On;
+    let s = utils.PublicStatus.On;
     match s {
-        utils.PublicStatus::On => 42,
-        utils.PublicStatus::Off => 0,
+        utils.PublicStatus.On => 42,
+        utils.PublicStatus.Off => 0,
     }
 }
 """
@@ -182,7 +182,7 @@ description = "Files in different directories cannot access private enums"
 source = """
 fn main() -> i32 {
     let utils = @import("subdir/utils");
-    let s = utils.PrivateStatus::On;
+    let s = utils.PrivateStatus.On;
     0
 }
 """
@@ -347,7 +347,7 @@ source = """
 const defs = @import("subdir/defs");
 
 fn main() -> i32 {
-    let c: Color = Color::Blue;
+    let c: Color = Color.Blue;
     0
 }
 """

--- a/crates/rue-spec/cases/modules/stdlib.toml
+++ b/crates/rue-spec/cases/modules/stdlib.toml
@@ -75,10 +75,10 @@ source = """
 fn main() -> i32 {
     let std = @import("std");
     let O = std.option.Option(i32);
-    let x = O::Some(7);
+    let x = O.Some(7);
     match x {
-        O::Some(n) => n,
-        O::None => 1,
+        O.Some(n) => n,
+        O.None => 1,
     }
 }
 """

--- a/crates/rue-spec/cases/modules/visibility.toml
+++ b/crates/rue-spec/cases/modules/visibility.toml
@@ -54,11 +54,11 @@ description = "Basic pub enum declaration"
 source = """
 pub enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     match c {
-        Color::Red => 42,
-        Color::Green => 0,
-        Color::Blue => 0,
+        Color.Red => 42,
+        Color.Green => 0,
+        Color.Blue => 0,
     }
 }
 """
@@ -85,11 +85,11 @@ enum PrivStatus { Active, Inactive }
 fn main() -> i32 {
     let p1 = PubPoint { x: public_fn() };
     let p2 = PrivPoint { y: private_fn() };
-    let s1 = PubStatus::On;
-    let s2 = PrivStatus::Active;
+    let s1 = PubStatus.On;
+    let s2 = PrivStatus.Active;
     match s1 {
-        PubStatus::On => p1.x + p2.y + 12,
-        PubStatus::Off => 0,
+        PubStatus.On => p1.x + p2.y + 12,
+        PubStatus.Off => 0,
     }
 }
 """

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -199,11 +199,11 @@ source = """
 enum Color { Red, Green, Blue }
 
 fn main() -> i32 {
-    let c = Color::Green;
+    let c = Color.Green;
     match c {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 """
@@ -374,7 +374,7 @@ spec = ["3.9:11", "3.10:29"]
 description = "A type has a destructor if dropping requires cleanup (String drops heap buffer)"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("hello");
     // s has heap allocation
     0
@@ -420,7 +420,7 @@ struct Container {
 }
 
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("test");
     let c = Container { name: s, value: 42 };
     c.value
@@ -463,9 +463,9 @@ struct TwoStrings {
 }
 
 fn main() -> i32 {
-    let mut a = String::new();
+    let mut a = String.new();
     a.push_str("first");
-    let mut b = String::new();
+    let mut b = String.new();
     b.push_str("second");
     let ts = TwoStrings { first: a, second: b };
     0
@@ -677,7 +677,7 @@ spec = ["3.9:21", "3.10:29"]
 description = "Non-trivially droppable types generate destructor calls"
 source = """
 fn main() -> i32 {
-    let mut s = String::new();
+    let mut s = String.new();
     s.push_str("hello");
     0
 }
@@ -1191,7 +1191,7 @@ fn Box(comptime T: type) -> type {
 
 fn main() -> i32 {
     let B = Box(i32);
-    let b = B::make(7);
+    let b = B.make(7);
     @dbg(100);
     0
 }
@@ -1214,9 +1214,9 @@ fn Tag(comptime T: type) -> type {
 
 fn main() -> i32 {
     let G = Tag(i32);
-    let a = G::make(1);
-    let b = G::make(2);
-    let c = G::make(3);
+    let a = G.make(1);
+    let b = G.make(2);
+    let c = G.make(3);
     @dbg(100);
     0
 }
@@ -1244,7 +1244,7 @@ fn eat(g: Tag(i32)) -> i32 {
 
 fn main() -> i32 {
     let G = Tag(i32);
-    let a = G::make(5);
+    let a = G.make(5);
     @dbg(eat(a));   // a moved into eat: dropped there (prints 5), then eat returns 5
     @dbg(100);
     0

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -79,13 +79,13 @@ spec = ["3.8:2"]
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     let a = c;
     let b = c;
     match a {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 """
@@ -139,14 +139,14 @@ description = "Array of enum is Copy (enums are Copy)"
 source = """
 enum Status { On, Off }
 fn main() -> i32 {
-    let states: [Status; 2] = [Status::On, Status::Off];
+    let states: [Status; 2] = [Status.On, Status.Off];
     let s2 = states;
     match states[0] {
-        Status::On => match s2[1] {
-            Status::Off => 42,
-            Status::On => 0,
+        Status.On => match s2[1] {
+            Status.Off => 42,
+            Status.On => 0,
         },
-        Status::Off => 0,
+        Status.Off => 0,
     }
 }
 """
@@ -652,11 +652,11 @@ enum Status { Active, Inactive }
 struct Data { status: Status, value: i32 }
 
 fn main() -> i32 {
-    let d = Data { status: Status::Active, value: 10 };
+    let d = Data { status: Status.Active, value: 10 };
     let e = d;
     match d.status {
-        Status::Active => d.value + e.value,
-        Status::Inactive => 0,
+        Status.Active => d.value + e.value,
+        Status.Inactive => 0,
     }
 }
 """

--- a/crates/rue-spec/cases/types/mutable-strings.toml
+++ b/crates/rue-spec/cases/types/mutable-strings.toml
@@ -86,10 +86,10 @@ error_contains = "use of moved value"
 [[case]]
 name = "string_new_empty"
 spec = ["3.10:7", "3.10:9"]
-description = "StrBuf::new() creates an empty string"
+description = "StrBuf.new() creates an empty string"
 source = """
 fn main() -> i32 {
-    let s = StrBuf::new();
+    let s = StrBuf.new();
     if s.is_empty() { 0 } else { 1 }
 }
 """
@@ -98,11 +98,11 @@ exit_code = 0
 [[case]]
 name = "string_with_capacity"
 spec = ["3.10:8", "3.10:9"]
-description = "StrBuf::with_capacity() pre-allocates"
+description = "StrBuf.with_capacity() pre-allocates"
 source = """
 fn main() -> i32 {
     let cap: u64 = 100;
-    let s = StrBuf::with_capacity(cap);
+    let s = StrBuf.with_capacity(cap);
     if s.capacity() >= cap { 0 } else { 1 }
 }
 """
@@ -202,7 +202,7 @@ spec = ["3.10:15", "3.10:19", "3.10:20"]
 description = "push_str() appends string content"
 source = """
 fn main() -> i32 {
-    let mut s = StrBuf::new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     let five: u64 = 5;
     if s.len() == five { 0 } else { 1 }
@@ -216,7 +216,7 @@ spec = ["3.10:15", "3.10:20"]
 description = "Multiple push_str() calls accumulate"
 source = """
 fn main() -> i32 {
-    let mut s = StrBuf::new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     s.push_str(" world");
     let eleven: u64 = 11;
@@ -231,7 +231,7 @@ spec = ["3.10:16", "3.10:19"]
 description = "push() appends a single byte"
 source = """
 fn main() -> i32 {
-    let mut s = StrBuf::new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     let exclaim: u8 = 33;  // '!'
     s.push(exclaim);
@@ -248,7 +248,7 @@ description = "clear() removes content but retains capacity"
 source = """
 fn main() -> i32 {
     let cap: u64 = 100;
-    let mut s = StrBuf::with_capacity(cap);
+    let mut s = StrBuf.with_capacity(cap);
     s.push_str("hello");
     let cap_before = s.capacity();
     s.clear();
@@ -263,7 +263,7 @@ spec = ["3.10:18", "3.10:19"]
 description = "reserve() ensures additional capacity"
 source = """
 fn main() -> i32 {
-    let mut s = StrBuf::new();
+    let mut s = StrBuf.new();
     s.push_str("hi");
     let additional: u64 = 100;
     s.reserve(additional);
@@ -279,7 +279,7 @@ spec = ["3.10:19"]
 description = "Mutation methods require let mut binding"
 source = """
 fn main() -> i32 {
-    let s = StrBuf::new();
+    let s = StrBuf.new();
     s.push_str("hello");
     0
 }
@@ -329,7 +329,7 @@ spec = ["3.10:24", "3.10:25"]
 description = "StrBuf grows capacity when needed"
 source = """
 fn main() -> i32 {
-    let mut s = StrBuf::new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     let cap1 = s.capacity();
     // Append enough to exceed initial capacity
@@ -449,7 +449,7 @@ spec = ["3.10:32"]
 description = "Strings are byte sequences"
 source = """
 fn main() -> i32 {
-    let mut s = StrBuf::new();
+    let mut s = StrBuf.new();
     // Push some bytes
     let h: u8 = 72;   // 'H'
     let i: u8 = 105;  // 'i'
@@ -471,7 +471,7 @@ spec = ["3.10:15", "3.10:16", "3.10:20"]
 description = "Build a complete message through appending"
 source = """
 fn main() -> i32 {
-    let mut msg = StrBuf::new();
+    let mut msg = StrBuf.new();
     msg.push_str("Hello");
     msg.push_str(", ");
     msg.push_str("world");
@@ -490,7 +490,7 @@ spec = ["3.10:15", "3.7:9", "3.7:10"]
 description = "Mutated string can be compared"
 source = """
 fn main() -> i32 {
-    let mut s = StrBuf::new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     if s == "hello" { 0 } else { 1 }
 }

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -620,7 +620,7 @@ name = "string_new_basic"
 spec = ["3.10:7"]
 source = """
 fn main() -> i32 {
-    let s = String::new();
+    let s = String.new();
     0
 }
 """
@@ -631,7 +631,7 @@ name = "string_new_equality_with_empty"
 spec = ["3.10:7", "3.7:9"]
 source = """
 fn main() -> i32 {
-    let s = String::new();
+    let s = String.new();
     if s == "" { 1 } else { 0 }
 }
 """
@@ -643,7 +643,7 @@ spec = ["3.10:8"]
 source = """
 fn main() -> i32 {
     let cap: u64 = 1024;
-    let s = String::with_capacity(cap);
+    let s = String.with_capacity(cap);
     0
 }
 """
@@ -655,7 +655,7 @@ spec = ["3.10:8"]
 source = """
 fn main() -> i32 {
     let cap: u64 = 0;
-    let s = String::with_capacity(cap);
+    let s = String.with_capacity(cap);
     0
 }
 """
@@ -667,7 +667,7 @@ spec = ["3.10:8", "3.7:9"]
 source = """
 fn main() -> i32 {
     let cap: u64 = 64;
-    let s = String::with_capacity(cap);
+    let s = String.with_capacity(cap);
     if s == "" { 1 } else { 0 }
 }
 """
@@ -679,8 +679,8 @@ spec = ["3.10:7", "3.10:9"]
 source = """
 fn main() -> i32 {
     let cap: u64 = 1024;
-    let empty = String::new();
-    let prealloc = String::with_capacity(cap);
+    let empty = String.new();
+    let prealloc = String.with_capacity(cap);
     0
 }
 """

--- a/crates/rue-ui-tests/cases/diagnostics/anon-struct-methods.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/anon-struct-methods.toml
@@ -80,7 +80,7 @@ error_contains = "comptime evaluation failed"
 # }
 # fn main() -> i32 {
 #     let C = Counter();
-#     C::get()
+#     C.get()
 # }
 # """
 # compile_fail = true

--- a/crates/rue-ui-tests/cases/diagnostics/directives.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/directives.toml
@@ -173,7 +173,7 @@ exit_code = 8
 name = "duplicate_comptime_modifier_rejected"
 description = """
 RUE-133 item 8: `comptime comptime T: type` was silently accepted (the second
-`comptime` landed in a vestigial ParamMode::Comptime next to the is_comptime
+`comptime` landed in a vestigial ParamMode.Comptime next to the is_comptime
 flag; the duality is now collapsed and duplicates are parse errors).
 """
 source = """

--- a/crates/rue-ui-tests/cases/diagnostics/duplicate-parameters.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/duplicate-parameters.toml
@@ -64,7 +64,7 @@ struct S {
     v: i32,
     fn mk(a: i32, a: i32) -> i32 { a }
 }
-fn main() -> i32 { S::mk(1, 2) }
+fn main() -> i32 { S.mk(1, 2) }
 """
 compile_fail = true
 error_contains = ["E0491", "duplicate parameter name 'a'"]

--- a/crates/rue-ui-tests/cases/diagnostics/match_diagnostics.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/match_diagnostics.toml
@@ -19,34 +19,34 @@ quoted as the primary span (a multi-line span starting at the fn body renders
 source = """
 enum Color { Red, Blue }
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     match c {
-        Color::Red => 1,
-        Color::Blue => true,
+        Color.Red => 1,
+        Color.Blue => true,
     }
 }
 """
 exit_code = 1
 compile_fail = true
-error_contains = ["expected integer type, found bool", "6:24", "Color::Blue => true"]
+error_contains = ["expected integer type, found bool", "6:23", "Color.Blue => true"]
 
 [[case]]
 name = "arm_result_conflict_concrete_arms_points_at_arm"
 source = """
 enum Color { Red, Blue }
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     let n: i32 = 5;
     let r = match c {
-        Color::Red => n,
-        Color::Blue => true,
+        Color.Red => n,
+        Color.Blue => true,
     };
     0
 }
 """
 exit_code = 1
 compile_fail = true
-error_contains = ["expected i32, found bool", "7:24"]
+error_contains = ["expected i32, found bool", "7:23"]
 
 [[case]]
 name = "non_exhaustive_enum_lists_missing_variants"
@@ -54,9 +54,9 @@ description = "E0600 must name the uncovered variants, which are known at the er
 source = """
 enum Color { Red, Blue, Green }
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     match c {
-        Color::Red => 1,
+        Color.Red => 1,
     }
 }
 """
@@ -98,10 +98,10 @@ name = "exhaustive_enum_match_still_compiles"
 source = """
 enum Color { Red, Blue }
 fn main() -> i32 {
-    let c = Color::Blue;
+    let c = Color.Blue;
     match c {
-        Color::Red => 1,
-        Color::Blue => 42,
+        Color.Red => 1,
+        Color.Blue => 42,
     }
 }
 """

--- a/crates/rue-ui-tests/cases/diagnostics/type_names.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/type_names.toml
@@ -13,7 +13,7 @@ description = "Used to print 'expected <enum>, found <enum>'."
 source = """
 enum Color { Red, Blue }
 enum Shape { Circle, Square }
-fn f() -> Color { Shape::Circle }
+fn f() -> Color { Shape.Circle }
 fn main() -> i32 { 0 }
 """
 exit_code = 1

--- a/crates/rue-ui-tests/cases/warnings/unreachable.toml
+++ b/crates/rue-ui-tests/cases/warnings/unreachable.toml
@@ -264,15 +264,15 @@ name = "duplicate_enum_variant_pattern"
 source = """
 enum Dir { N, S }
 fn main() -> i32 {
-    match Dir::N {
-        Dir::N => 1,
-        Dir::N => 2,
-        Dir::S => 3,
+    match Dir.N {
+        Dir.N => 1,
+        Dir.N => 2,
+        Dir.S => 3,
     }
 }
 """
 exit_code = 1
-warning_contains = ["unreachable pattern", "'Dir::N'"]
+warning_contains = ["unreachable pattern", "'Dir.N'"]
 expected_warning_count = 1
 
 # Negative control: distinct variants must NOT warn.
@@ -281,9 +281,9 @@ name = "distinct_enum_variant_patterns_no_warning"
 source = """
 enum Dir { N, S }
 fn main() -> i32 {
-    match Dir::S {
-        Dir::N => 1,
-        Dir::S => 3,
+    match Dir.S {
+        Dir.N => 1,
+        Dir.S => 3,
     }
 }
 """
@@ -298,9 +298,9 @@ name = "wildcard_after_full_enum_coverage"
 source = """
 enum Color { Red, Green }
 fn main() -> i32 {
-    match Color::Red {
-        Color::Red => 1,
-        Color::Green => 2,
+    match Color.Red {
+        Color.Red => 1,
+        Color.Green => 2,
         _ => 3,
     }
 }
@@ -331,9 +331,9 @@ name = "wildcard_covering_missing_enum_variant_no_warning"
 source = """
 enum Color { Red, Green, Blue }
 fn main() -> i32 {
-    match Color::Blue {
-        Color::Red => 1,
-        Color::Green => 2,
+    match Color.Blue {
+        Color.Red => 1,
+        Color.Green => 2,
         _ => 3,
     }
 }

--- a/docs/process/tutorial.md
+++ b/docs/process/tutorial.md
@@ -35,8 +35,10 @@ Every chapter should:
 3. Add one positive example per new concept and, where it materially helps,
    one expected-error example.
 4. Prefer stable, user-facing APIs over compiler-internal or debugging-only
-   tools. Use `print`/`println` once the chapter has introduced strings and
-   standard-library access; keep `@dbg` framed as debugging output.
+   tools. Use `print`/`println` for user-facing output from the first chapter
+   that produces any output; example output should flow through `println`.
+   `@dbg` may be introduced once as a brief debugging aid, but it is not the
+   tutorial's output mechanism.
 5. Say when a feature is preview, incomplete, or dogfood-motivated. Do not
    silently teach unstable syntax as if it were settled.
 6. Avoid duplicating the specification. Link to the spec for exact normative

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -328,8 +328,8 @@ fn Tag(comptime T: type) -> type {
 
 fn main() -> i32 {
     let G = Tag(i32);
-    let a = G::make(1);
-    let b = G::make(2);
+    let a = G.make(1);
+    let b = G.make(2);
     @dbg(100);
     0
 }

--- a/docs/spec/src/03-types/10-mutable-strings.md
+++ b/docs/spec/src/03-types/10-mutable-strings.md
@@ -51,18 +51,18 @@ fn main() -> i32 {
 
 {{ rule(id="3.10:7", cat="normative") }}
 
-`StrBuf::new()` returns an empty string with no allocation.
+`StrBuf.new()` returns an empty string with no allocation.
 
 {{ rule(id="3.10:8", cat="normative") }}
 
-`StrBuf::with_capacity(cap: u64)` returns an empty string with pre-allocated capacity for `cap` bytes.
+`StrBuf.with_capacity(cap: u64)` returns an empty string with pre-allocated capacity for `cap` bytes.
 
 {{ rule(id="3.10:9", cat="example") }}
 
 ```rue
 fn main() -> i32 {
-    let empty = StrBuf::new();
-    let prealloc = StrBuf::with_capacity(1024);
+    let empty = StrBuf.new();
+    let prealloc = StrBuf.with_capacity(1024);
     0
 }
 ```
@@ -124,7 +124,7 @@ Mutation methods use `inout self` to modify the string in place. The variable mu
 
 ```rue
 fn main() -> i32 {
-    let mut s = StrBuf::new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     s.push_str(" world");
     s.push(33);  // '!' character

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -16,7 +16,7 @@ A match expression provides multi-way branching based on pattern matching.
 match_expr = "match" expression "{" { match_arm "," } [ match_arm ] "}" ;
 match_arm = pattern "=>" expression ;
 pattern = "_" | [ "-" ] INTEGER | BOOL | enum_variant_pattern ;
-enum_variant_pattern = IDENT "::" IDENT ;
+enum_variant_pattern = IDENT "." IDENT ;
 ```
 
 ## Patterns
@@ -228,7 +228,7 @@ fn absurd(n: Never) -> i32 {
 {{ rule(id="4.7:30", cat="normative") }}
 
 A tuple-variant pattern binds the variant's payload into fresh names:
-`EnumName::Variant(a, b)` matches a value of that variant and binds `a`, `b`
+`EnumName.Variant(a, b)` matches a value of that variant and binds `a`, `b`
 to its payload fields in order. The number of bindings **MUST** equal the
 variant's payload arity (see spec 6.3).
 
@@ -246,10 +246,10 @@ binding of the same name.
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 
 fn main() -> i32 {
-    match Shape::Rect(3, 4) {
-        Shape::Circle(r) => r,
-        Shape::Rect(w, h) => w + h,
-        Shape::Empty => 0,
+    match Shape.Rect(3, 4) {
+        Shape.Circle(r) => r,
+        Shape.Rect(w, h) => w + h,
+        Shape.Empty => 0,
     }
 }
 ```
@@ -283,10 +283,10 @@ enum E { A(i32), B }
 fn use_again(e: E) -> i32 { 2 }
 
 fn main() -> i32 {
-    let e = E::A(40);       // payload is Copy, so E is a Copy type
+    let e = E.A(40);       // payload is Copy, so E is a Copy type
     let r = match e {
-        E::A(x) => x,
-        E::B => 0,
+        E.A(x) => x,
+        E.B => 0,
     };
     r + use_again(e)        // OK: Copy scrutinee still valid -> 42
 }
@@ -301,10 +301,10 @@ enum E { A(Big), B }
 fn use_again(e: E) -> i32 { 0 }
 
 fn main() -> i32 {
-    let e = E::A(Big { value: 7 });   // move type: Big is not Copy
+    let e = E.A(Big { value: 7 });   // move type: Big is not Copy
     let r = match e {
-        E::A => 1,                    // binds nothing, yet consumes `e`
-        E::B => 2,
+        E.A => 1,                    // binds nothing, yet consumes `e`
+        E.B => 2,
     };
     r + use_again(e)                  // ERROR: use of moved value 'e'
 }

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -238,7 +238,7 @@ fn main() -> i32 {
 {{ rule(id="4.13:91", cat="normative") }}
 
 The `@offset_of` intrinsic returns the byte offset of a field within a struct
-type, mirroring Rust's `core::mem::offset_of!`.
+type, mirroring Rust's `core::mem.offset_of!`.
 
 {{ rule(id="4.13:92", cat="normative") }}
 
@@ -384,8 +384,8 @@ fn main() -> i32 {
     let Opt = @import("std/option.rue").Option(StrBuf);
     @dbg("What is your name?");
     match @read_line() {
-        Opt::Some(name) => @dbg(name),
-        Opt::None => @dbg("(no input)"),
+        Opt.Some(name) => @dbg(name),
+        Opt.None => @dbg("(no input)"),
     }
     0
 }
@@ -401,8 +401,8 @@ fn main() -> i32 {
     loop {
         let line: Opt = @read_line();
         match line {
-            Opt::None => break,
-            Opt::Some(text) => @dbg(text),
+            Opt.None => break,
+            Opt.Some(text) => @dbg(text),
         }
     }
     0
@@ -460,8 +460,8 @@ The result is `None` (a recoverable parse failure, not a panic) if:
 fn main() -> i32 {
     let Opt = @import("std/option.rue").Option(i32);
     match @parse_i32("42") {
-        Opt::Some(n) => n,   // returns 42
-        Opt::None => 0,
+        Opt.Some(n) => n,   // returns 42
+        Opt.None => 0,
     }
 }
 ```
@@ -472,8 +472,8 @@ fn main() -> i32 {
 fn main() -> i32 {
     let Opt = @import("std/option.rue").Option(i32);
     match @parse_i32("-17") {
-        Opt::Some(n) => n,   // returns -17
-        Opt::None => 0,
+        Opt.Some(n) => n,   // returns -17
+        Opt.None => 0,
     }
 }
 ```
@@ -488,8 +488,8 @@ fn main() -> i32 {
     let parsed: Opt = @parse_i32(s);
     @dbg(s);  // s is still valid
     match parsed {
-        Opt::Some(n) => n,
-        Opt::None => 0,
+        Opt.Some(n) => n,
+        Opt.None => 0,
     }
 }
 ```
@@ -501,8 +501,8 @@ fn main() -> i32 {
 fn main() -> i32 {
     let Opt = @import("std/option.rue").Option(i32);
     match @parse_i32("12abc") {
-        Opt::Some(n) => n,
-        Opt::None => -1,   // taken: "12abc" is not an integer
+        Opt.Some(n) => n,
+        Opt.None => -1,   // taken: "12abc" is not an integer
     }
 }
 ```
@@ -514,8 +514,8 @@ fn main() -> i32 {
 fn main() -> i32 {
     let Opt = @import("std/option.rue").Option(u32);
     match @parse_u32("-17") {
-        Opt::Some(n) => @intCast(n),
-        Opt::None => 0,   // taken: "-17" is negative
+        Opt.Some(n) => @intCast(n),
+        Opt.None => 0,   // taken: "-17" is negative
     }
 }
 ```
@@ -567,10 +567,10 @@ fn main() -> i32 {
     loop {
         let input: OptStr = @read_line();
         match input {
-            OptStr::None => break,          // end of input
-            OptStr::Some(text) => {
+            OptStr.None => break,          // end of input
+            OptStr.Some(text) => {
                 match @parse_u32(text) {
-                    OptU32::Some(guess) => {
+                    OptU32.Some(guess) => {
                         guesses = guesses + 1;
                         if guess < secret {
                             @dbg("Too low!");
@@ -581,7 +581,7 @@ fn main() -> i32 {
                             break;
                         }
                     },
-                    OptU32::None => @dbg("not a number, try again"),
+                    OptU32.None => @dbg("not a number, try again"),
                 }
             },
         }
@@ -632,8 +632,8 @@ The return type of `@target_arch` is `Arch`.
 {{ rule(id="4.13:69", cat="normative") }}
 
 The `Arch` enum is a built-in enum with the following variants:
-- `Arch::X86_64` - x86-64 architecture
-- `Arch::Aarch64` - ARM64/AArch64 architecture
+- `Arch.X86_64` - x86-64 architecture
+- `Arch.Aarch64` - ARM64/AArch64 architecture
 
 {{ rule(id="4.13:70", cat="normative") }}
 
@@ -644,8 +644,8 @@ The value returned by `@target_arch` is determined at compile time based on the 
 ```rue
 fn main() -> i32 {
     match @target_arch() {
-        Arch::X86_64 => 1,
-        Arch::Aarch64 => 2,
+        Arch.X86_64 => 1,
+        Arch.Aarch64 => 2,
     }
 }
 ```
@@ -667,8 +667,8 @@ The return type of `@target_os` is `Os`.
 {{ rule(id="4.13:75", cat="normative") }}
 
 The `Os` enum is a built-in enum with the following variants:
-- `Os::Linux` - Linux operating system
-- `Os::Macos` - macOS operating system
+- `Os.Linux` - Linux operating system
+- `Os.Macos` - macOS operating system
 
 {{ rule(id="4.13:76", cat="normative") }}
 
@@ -679,8 +679,8 @@ The value returned by `@target_os` is determined at compile time based on the co
 ```rue
 fn main() -> i32 {
     match @target_os() {
-        Os::Linux => 1,
-        Os::Macos => 2,
+        Os.Linux => 1,
+        Os.Macos => 2,
     }
 }
 ```
@@ -692,16 +692,16 @@ Combining `@target_arch` and `@target_os` for platform-specific code:
 ```rue
 fn main() -> i32 {
     match @target_arch() {
-        Arch::X86_64 => {
+        Arch.X86_64 => {
             match @target_os() {
-                Os::Linux => 99,
-                Os::Macos => 88,
+                Os.Linux => 99,
+                Os.Macos => 88,
             }
         },
-        Arch::Aarch64 => {
+        Arch.Aarch64 => {
             match @target_os() {
-                Os::Linux => 77,
-                Os::Macos => 66,
+                Os.Linux => 77,
+                Os.Macos => 66,
             }
         },
     }

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -321,7 +321,7 @@ fn Array(comptime T: type, comptime N: i32) -> type {
 
 {{ rule(id="4.14:13", cat="normative") }}
 
-Functions defined without a `self` parameter are associated functions, called using the `Type::function()` syntax:
+Functions defined without a `self` parameter are associated functions, called using the `Type.function()` syntax:
 
 ```rue
 fn Point() -> type {
@@ -337,7 +337,7 @@ fn Point() -> type {
 
 fn main() -> i32 {
     let P = Point();
-    let p = P::origin();
+    let p = P.origin();
     p.x
 }
 ```
@@ -388,8 +388,8 @@ fn Option(comptime T: type) -> type {
 
 fn main() -> i32 {
     let O = Option(i32);
-    let x: O = O::Some(5);
-    match x { O::Some(n) => n, O::None => 0 }
+    let x: O = O.Some(5);
+    match x { O.Some(n) => n, O.None => 0 }
 }
 ```
 
@@ -405,9 +405,9 @@ fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     let A = Option(i32);
     let B = Option(i32);
-    let x: A = A::Some(10);
+    let x: A = A.Some(10);
     let y: B = x;  // OK: A and B are structurally equal
-    match y { B::Some(n) => n, B::None => 0 }
+    match y { B.Some(n) => n, B.None => 0 }
 }
 ```
 
@@ -433,15 +433,15 @@ supplied by a `comptime` parameter or another type value.
 In *value position*, the reduced type is an ordinary compile-time type value:
 it may be bound with `let` and then used as the path of a struct-literal
 expression (`P { … }`), a method call, or an associated-function call
-(`P::origin()`), exactly as in rules 4.14:7 through 4.14:13.
+(`P.origin()`), exactly as in rules 4.14:7 through 4.14:13.
 
 ```rue
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 
 fn main() -> i32 {
     let O = Option(i32);        // type-function application in value position
-    let x: O = O::Some(42);
-    match x { O::Some(n) => n, O::None => 0 }
+    let x: O = O.Some(42);
+    match x { O.Some(n) => n, O.None => 0 }
 }
 ```
 
@@ -473,11 +473,11 @@ fn main() -> i32 {
 ```
 
 A type-constructor call is a type, not a path expression: the forms
-`F(args) { … }` (a struct literal) and `F(args)::NAME` (an associated item or
+`F(args) { … }` (a struct literal) and `F(args).NAME` (an associated item or
 enum variant) are not accepted, because a call expression is not a permitted
 struct-literal or pattern path. Bind the resulting type to a name first — with
 `let P = F(args);` — and use that name as the path in expression and pattern
-position (`P { … }`, `P::NAME`).
+position (`P { … }`, `P.NAME`).
 
 {{ rule(id="4.14:24", cat="normative") }}
 
@@ -499,7 +499,7 @@ fn Wrap(comptime T: type) -> type {
         inner: Option(T),               // T passed to another constructor
         fn get_or(self, d: T) -> T {    // T names the parameter/return type
             let O = Option(T);          // T in scope in the method body
-            match self.inner { O::Some(v) => v, O::None => d }
+            match self.inner { O.Some(v) => v, O.None => d }
         }
     }
 }
@@ -507,7 +507,7 @@ fn Wrap(comptime T: type) -> type {
 fn main() -> i32 {
     let W = Wrap(i32);
     let O = Option(i32);
-    let w: W = W { inner: O::Some(7) };
+    let w: W = W { inner: O.Some(7) };
     w.get_or(0)
 }
 ```

--- a/docs/spec/src/04-expressions/15-try-expressions.md
+++ b/docs/spec/src/04-expressions/15-try-expressions.md
@@ -69,21 +69,21 @@ fn Option(comptime T: type) -> type {
 
 fn checked_div(a: i64, b: i64) -> Option(i64) {
     let O = Option(i64);
-    if b == 0 { O::None } else { O::Some(a / b) }
+    if b == 0 { O.None } else { O.Some(a / b) }
 }
 
 fn halve_then_div(a: i64, b: i64) -> Option(i64) {
     let O = Option(i64);
     // `?` unwraps the quotient, or short-circuits to None when b == 0.
     let q = checked_div(a, b)?;
-    O::Some(q / 2)
+    O.Some(q / 2)
 }
 
 fn main() -> i32 {
     let O = Option(i64);
     match halve_then_div(40, 4) {
-        O::Some(n) => n,      // 40 / 4 / 2 == 5
-        O::None => 0 - 1,
+        O.Some(n) => n,      // 40 / 4 / 2 == 5
+        O.None => 0 - 1,
     }
 }
 ```
@@ -116,8 +116,8 @@ fn read_num() -> Option(i64) {
 fn main() -> i32 {
     let O = Option(i64);
     match read_num() {
-        O::Some(n) => @intCast(n),
-        O::None => 0,
+        O.Some(n) => @intCast(n),
+        O.None => 0,
     }
 }
 ```

--- a/docs/spec/src/06-items/03-enums.md
+++ b/docs/spec/src/06-items/03-enums.md
@@ -31,13 +31,14 @@ A zero-variant enum can never be constructed.
 
 {{ rule(id="6.3:4", cat="normative") }}
 
-Enum variants are referenced using path syntax: `EnumName::VariantName`.
-It is a compile-time error (E0421) if the named enum type does not exist.
+Enum variants are referenced using dot syntax: `EnumName.VariantName`. Because
+`.` is the sole member-access spelling, `Name.VariantName` where `Name` does not
+name a type is an ordinary undefined-name reference and is a compile-time error.
 
 {{ rule(id="6.3:5", cat="normative") }}
 
-It is a compile-time error (E0420) if the named variant does not exist within
-the enum.
+It is a compile-time error (E0420) if the named enum type exists but the named
+variant does not exist within it.
 
 {{ rule(id="6.3:6") }}
 
@@ -49,7 +50,7 @@ enum Color {
 }
 
 fn main() -> i32 {
-    let c = Color::Red;
+    let c = Color.Red;
     0
 }
 ```
@@ -72,11 +73,11 @@ either explicitly or via a wildcard pattern `_`.
 enum Color { Red, Green, Blue }
 
 fn main() -> i32 {
-    let c = Color::Green;
+    let c = Color.Green;
     match c {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 ```
@@ -94,9 +95,9 @@ enum Color { Red, Green, Blue }
 
 fn get_value(c: Color) -> i32 {
     match c {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 ```
@@ -129,10 +130,10 @@ specification.
 {{ rule(id="6.3:16", cat="normative") }}
 
 A tuple variant is constructed by applying the variant path to payload
-arguments: `EnumName::Variant(arg, ...)`. The number of arguments **MUST**
+arguments: `EnumName.Variant(arg, ...)`. The number of arguments **MUST**
 equal the variant's payload arity, and each argument's type **MUST** match the
 corresponding declared payload type. Using a payload-carrying variant as a
-bare path (`EnumName::Variant`, with no arguments) is an error.
+bare path (`EnumName.Variant`, with no arguments) is an error.
 
 {{ rule(id="6.3:17", cat="normative") }}
 
@@ -166,13 +167,13 @@ enum Shape { Circle(i32), Rect(i32, i32), Empty }
 
 fn area(s: Shape) -> i32 {
     match s {
-        Shape::Circle(r) => r,
-        Shape::Rect(w, h) => w + h,
-        Shape::Empty => 0,
+        Shape.Circle(r) => r,
+        Shape.Rect(w, h) => w + h,
+        Shape.Empty => 0,
     }
 }
 
 fn main() -> i32 {
-    area(Shape::Rect(3, 4))
+    area(Shape.Rect(3, 4))
 }
 ```

--- a/docs/spec/src/06-items/04-impl-blocks.md
+++ b/docs/spec/src/06-items/04-impl-blocks.md
@@ -114,7 +114,7 @@ A function in a struct block that does not take `self` as its first parameter is
 
 {{ rule(id="6.4:13", cat="normative") }}
 
-Associated functions are called using path notation: `Type::function(args)`.
+Associated functions are called using dot notation: `Type.function(args)`.
 
 {{ rule(id="6.4:14", cat="example") }}
 
@@ -129,7 +129,7 @@ struct Point {
 }
 
 fn main() -> i32 {
-    let p = Point::origin();
+    let p = Point.origin();
     p.x  // Returns 0
 }
 ```
@@ -160,7 +160,7 @@ struct Point {
 }
 
 fn main() -> i32 {
-    let p = Point::origin().translate(Point { x: 42, y: 0 });
+    let p = Point.origin().translate(Point { x: 42, y: 0 });
     p.x  // Returns 42
 }
 ```
@@ -236,7 +236,7 @@ Calling an associated function with method call syntax (receiver.function()) is 
 
 {{ rule(id="6.4:23", cat="legality-rule") }}
 
-Calling a method with associated function syntax (Type::method()) is a compile-time error.
+Calling a method with associated function syntax (Type.method()) is a compile-time error.
 
 ## Receiver Modes
 

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -66,6 +66,6 @@ User-defined functions **MUST NOT** use names reserved for runtime and code-gene
 fn __rue_alloc() -> i32 { 0 }  // compile error: `__rue_` prefix is reserved
 
 // OK: `String__len` is an ordinary identifier, distinct from the built-in
-// `String::len` method (whose runtime symbol is `__rue_String_len`).
+// `String.len` method (whose runtime symbol is `__rue_String_len`).
 fn String__len() -> i32 { 0 }  // allowed
 ```

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -99,12 +99,12 @@ pub const MAX: i32 = 16;
 fn main() -> i32 {
     // secret()                  // error E0460: private to sub/lib.rue
     // let h = Hidden { n: 1 };  // error E0460: private to sub/lib.rue
-    // let m = Mode::Fast;       // error E0460: private to sub/lib.rue
+    // let m = Mode.Fast;       // error E0460: private to sub/lib.rue
     // let l = LIMIT;            // error E0460: private to sub/lib.rue
     let s = Shared { n: MAX };   // OK: `Shared` and `MAX` are pub
-    match Level::High {          // OK: `Level` is pub
-        Level::Low => 0,
-        Level::High => open() + s.n,
+    match Level.High {          // OK: `Level` is pub
+        Level.Low => 0,
+        Level.High => open() + s.n,
     }
 }
 ```

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -151,9 +151,9 @@ A type, enum variant, or associated function of a module **MAY** be named
 through a module binding in an *expression* or *pattern* position by writing
 the binding, a `.`, and the item's path: a struct type in a struct-literal
 expression (`m.Point { .. }`), an enum variant in a variant expression or a
-match pattern (`m.Color::Red`), and an associated function in a call
-(`m.Point::origin()`). Each of these forms is accepted wherever the
-corresponding *bare* path — `Point { .. }`, `Color::Red`, `Point::origin()` —
+match pattern (`m.Color.Red`), and an associated function in a call
+(`m.Point.origin()`). Each of these forms is accepted wherever the
+corresponding *bare* path — `Point { .. }`, `Color.Red`, `Point.origin()` —
 is accepted, and has the same meaning.
 
 {{ rule(id="10.4:16", cat="normative") }}
@@ -192,11 +192,11 @@ An associated function's visibility follows the visibility of its enclosing type
 (10.3:7): calling an associated function of a private struct from a source file
 in another directory is a compile-time error (E0460), exactly as naming that
 struct in a struct literal or type annotation would be. This holds whether the
-call is written unqualified (`Point::origin()`) or module-qualified
-(`lib.Point::origin()`) — both resolve the receiver type through the flat
+call is written unqualified (`Point.origin()`) or module-qualified
+(`lib.Point.origin()`) — both resolve the receiver type through the flat
 namespace (10.5:2), so both report E0460 (RUE-330). A call whose receiver type
 arrives through a comptime binding rather than by naming the struct
-(`let P = lib.Point; P::origin()`) is exempt, matching every other reference
+(`let P = lib.Point; P.origin()`) is exempt, matching every other reference
 that reaches a type through a binding.
 
 {{ rule(id="10.4:20", cat="example") }}
@@ -215,15 +215,15 @@ enum Hidden { A, B, }               // private outside sub/
 const lib = @import("sub/lib");
 fn main() -> i32 {
     let p = lib.Point { x: 40, y: 2 };     // qualified struct literal
-    let q = lib.Point::origin();           // qualified associated fn
-    let c = lib.Color::Green;              // qualified variant expression
+    let q = lib.Point.origin();           // qualified associated fn
+    let c = lib.Color.Green;              // qualified variant expression
     let typed: lib.Point = p;           // qualified type annotation
-    // let h = lib.Hidden::A;            // error E0706: `Hidden` is private outside sub/
+    // let h = lib.Hidden.A;            // error E0706: `Hidden` is private outside sub/
     let base = typed.x + typed.y + q.x + q.y; // 40 + 2 + 30 + 12 = 84
     match c {
-        lib.Color::Red => 0,             // qualified variant pattern
-        lib.Color::Green => base,        // 84
-        lib.Color::Blue => 0,
+        lib.Color.Red => 0,             // qualified variant pattern
+        lib.Color.Green => base,        // 84
+        lib.Color.Blue => 0,
     }
 }
 ```

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -105,16 +105,17 @@ additive       = multiplicative { ( "+" | "-" ) multiplicative } ;
 multiplicative = unary { ( "*" | "/" | "%" ) unary } ;
 unary          = ( "-" | "!" | "~" ) unary | postfix ;
 
-(* Postfix suffixes: field access, method calls, indexing, and
-   module-qualified struct literals / enum paths / associated calls. *)
+(* Postfix suffixes: field access, method calls, indexing, and qualified
+   struct literals. `.` is the sole member-access spelling (RUE-488): an enum
+   variant `Enum.Variant`, an associated call `Type.function(args)`, and their
+   module-qualified forms are all chains of `.` field/method suffixes here,
+   disambiguated during semantic analysis by whether the base names a type. *)
 postfix        = primary { suffix } ;
-suffix         = "." IDENT                                     (* field access *)
-               | "." IDENT "(" [ call_args ] ")"               (* method call *)
+suffix         = "." IDENT                                     (* field access / Enum.Variant / assoc-fn path *)
+               | "." IDENT "(" [ call_args ] ")"               (* method call / Type.function(args) *)
                | "[" expression "]"                            (* indexing *)
                | "?"                                           (* try / Option propagation *)
-               | "." IDENT "{" [ field_inits ] "}"             (* qualified struct literal *)
-               | "." IDENT "::" IDENT                          (* qualified enum variant *)
-               | "." IDENT "::" IDENT "(" [ call_args ] ")" ;  (* qualified assoc fn call *)
+               | "." IDENT "{" [ field_inits ] "}" ;           (* qualified struct literal *)
 
 (* Call arguments: any argument may carry an `inout`/`borrow` mode. The
    argument itself is parsed as an arbitrary expression; the requirement that
@@ -141,9 +142,7 @@ primary        = INTEGER | STRING | BOOL | "()"
    body, or a path. *)
 ident_expr     = IDENT "(" [ call_args ] ")"           (* function call *)
                | IDENT "{" [ field_inits ] "}"         (* struct literal *)
-               | IDENT "::" IDENT "(" [ call_args ] ")" (* associated fn call *)
-               | IDENT "::" IDENT                      (* enum variant *)
-               | IDENT ;
+               | IDENT ;                               (* Enum.Variant / Type.function(args) parse via postfix `.` suffixes *)
 self_struct_literal = "Self" "{" [ field_inits ] "}" ;
 primitive_type_literal = "i8" | "i16" | "i32" | "i64"
                        | "u8" | "u16" | "u32" | "u64" | "bool" ;
@@ -162,8 +161,9 @@ match_arm      = pattern "=>" expression ;
 pattern        = "_"
                | [ "-" ] INTEGER
                | BOOL
-               | IDENT "::" IDENT                      (* Enum::Variant *)
-               | IDENT { "." IDENT } "::" IDENT ;      (* module.Enum::Variant *)
+               | IDENT "." IDENT [ "(" pattern_bindings ")" ]         (* Enum.Variant *)
+               | IDENT "." IDENT { "." IDENT } [ "(" pattern_bindings ")" ] ; (* module.Enum.Variant *)
+pattern_bindings = IDENT { "," IDENT } [ "," ] ;
 while_expr     = "while" expression "{" block "}" ;
 loop_expr      = "loop" "{" block "}" ;
 for_expr       = "for" ( IDENT | "_" ) "in" expression "{" block "}" ;

--- a/e1.rue
+++ b/e1.rue
@@ -1,3 +1,0 @@
-enum E{A,B
- fn f(self)->i32{1} }
-fn main()->i32{ E::A.f() }

--- a/examples/first/option_try.rue
+++ b/examples/first/option_try.rue
@@ -10,8 +10,8 @@
 //     fn triple(n: i64) -> std.option.Option(i64) {
 //         let O = std.option.Option(i64);
 //         match parse_positive(n) {           // the `?`-free equivalent
-//             O::Some(v) => O::Some(v * 3),
-//             O::None => O::None,
+//             O.Some(v) => O.Some(v * 3),
+//             O.None => O.None,
 //         }
 //     }
 //
@@ -23,7 +23,7 @@
 // No prelude yet: import `std` explicitly. `std.option.Option(i64)` names the
 // standard-library type directly in a return position. Constructing a variant
 // or matching still needs a bound type name (`let O = std.option.Option(i64);
-// O::Some(..)`), so functions that construct or match variants bind `O`
+// O.Some(..)`), so functions that construct or match variants bind `O`
 // locally.
 
 const std = @import("std");
@@ -31,7 +31,7 @@ const std = @import("std");
 // parse_positive: Some(n) when n is positive, else None.
 fn parse_positive(n: i64) -> std.option.Option(i64) {
     let O = std.option.Option(i64);
-    if n > 0 { O::Some(n) } else { O::None }
+    if n > 0 { O.Some(n) } else { O.None }
 }
 
 // triple: unwrap the positive value with `?`, then wrap n * 3. On a None input
@@ -39,14 +39,14 @@ fn parse_positive(n: i64) -> std.option.Option(i64) {
 fn triple(n: i64) -> std.option.Option(i64) {
     let O = std.option.Option(i64);
     let v = parse_positive(n)?;
-    O::Some(v * 3)
+    O.Some(v * 3)
 }
 
 fn report(n: i64) {
     let O = std.option.Option(i64);
     match triple(n) {
-        O::Some(m) => println("triple: " + @to_string(m)),
-        O::None => println("triple: none"),
+        O.Some(m) => println("triple: " + @to_string(m)),
+        O.None => println("triple: none"),
     }
 }
 

--- a/examples/first/stats.rue
+++ b/examples/first/stats.rue
@@ -42,27 +42,27 @@ fn main() -> i32 {
 
     let mut count: i64 = 0;
     let mut sum: i64 = 0;
-    let mut max: OptInt = OptInt::None;
+    let mut max: OptInt = OptInt.None;
 
     loop {
         match read_num() {
-            OptInt::Some(x) => {
+            OptInt.Some(x) => {
                 count = count + 1;
                 sum = sum + x;
                 max = match max {
-                    OptInt::None => OptInt::Some(x),
-                    OptInt::Some(m) => if x > m { OptInt::Some(x) } else { OptInt::Some(m) },
+                    OptInt.None => OptInt.Some(x),
+                    OptInt.Some(m) => if x > m { OptInt.Some(x) } else { OptInt.Some(m) },
                 };
             },
-            OptInt::None => break,
+            OptInt.None => break,
         }
     }
 
     println("count: " + @to_string(count));
     println("sum: " + @to_string(sum));
     match max {
-        OptInt::Some(m) => println("max: " + @to_string(m)),
-        OptInt::None => println("max: (no input)"),
+        OptInt.Some(m) => println("max: " + @to_string(m)),
+        OptInt.None => println("max: (no input)"),
     }
 
     @intCast(count)

--- a/examples/std/arraybuf_demo.rue
+++ b/examples/std/arraybuf_demo.rue
@@ -15,22 +15,22 @@ fn main() -> i32 {
     let V = std.arraybuf.ArrayBuf(i32);
     let O = std.arraybuf.Option(i32);
 
-    let mut v = V::new();
+    let mut v = V.new();
     v.push(10);
     v.push(20);
     v.push(30);
     @dbg(v.len());          // 3
 
     // `get` returns Option(i32): Some in bounds, None otherwise.
-    @dbg(match v.get(1) { O::Some(x) => x, O::None => -1 });   // 20
+    @dbg(match v.get(1) { O.Some(x) => x, O.None => -1 });   // 20
     v.set(0, 99);
-    @dbg(match v.get(0) { O::Some(x) => x, O::None => -1 });   // 99
+    @dbg(match v.get(0) { O.Some(x) => x, O.None => -1 });   // 99
 
     // `pop` returns Option(i32): Some(last) or None when empty.
-    @dbg(match v.pop() { O::Some(x) => x, O::None => -1 });    // 30 (removed)
+    @dbg(match v.pop() { O.Some(x) => x, O.None => -1 });    // 30 (removed)
     @dbg(v.len());          // 2
 
-    @dbg(match v.get(99) { O::Some(x) => x, O::None => -1 });  // -1 (out of bounds)
+    @dbg(match v.get(99) { O.Some(x) => x, O.None => -1 });  // -1 (out of bounds)
 
     // Sum the remaining elements with a manual while loop (no for/index sugar).
     // `get_or` is the ergonomic default-based read used inside the loop.

--- a/lc.rue
+++ b/lc.rue
@@ -1,1 +1,0 @@
-fn main()->i32{ const C: i32 = 5; C }

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -15,16 +15,16 @@ pub const arraybuf = @import("arraybuf.rue");
 
 fn _exit_syscall_number() -> u64 {
     match @target_arch() {
-        Arch::X86_64 => {
+        Arch.X86_64 => {
             match @target_os() {
-                Os::Linux => 60,
-                Os::Macos => 1,
+                Os.Linux => 60,
+                Os.Macos => 1,
             }
         },
-        Arch::Aarch64 => {
+        Arch.Aarch64 => {
             match @target_os() {
-                Os::Linux => 93,
-                Os::Macos => 1,
+                Os.Linux => 93,
+                Os.Macos => 1,
             }
         },
     }

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -19,13 +19,13 @@
 //
 //     let V = std.arraybuf.ArrayBuf(i32);
 //     let O = std.option.Option(i32);
-//     let mut v = V::new();
+//     let mut v = V.new();
 //     v.push(10);
 //     v.push(20);
 //     let n = v.len();                                 // 2
-//     let x = match v.get(0) { O::Some(e) => e, O::None => -1 };   // 10
+//     let x = match v.get(0) { O.Some(e) => e, O.None => -1 };   // 10
 //     v.set(0, 99);
-//     let last = match v.pop() { O::Some(e) => e, O::None => -1 }; // 20
+//     let last = match v.pop() { O.Some(e) => e, O.None => -1 }; // 20
 //     // the heap buffer is freed AUTOMATICALLY when `v` goes out of scope
 //     // (the `drop fn` below); call `v.free()` only for explicit early release.
 //
@@ -103,9 +103,9 @@ pub fn ArrayBuf(comptime T: type) -> type {
         fn get(borrow self, i: u64) -> Option(T) {
             let O = Option(T);
             if i < self.len {
-                O::Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
+                O.Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
             } else {
-                O::None
+                O.None
             }
         }
 
@@ -150,10 +150,10 @@ pub fn ArrayBuf(comptime T: type) -> type {
         fn pop(inout self) -> Option(T) {
             let O = Option(T);
             if self.len == 0 {
-                O::None
+                O.None
             } else {
                 self.len = self.len - 1;
-                O::Some(checked { @ptr_read(@ptr_offset(self.buf, self.len)) })
+                O.Some(checked { @ptr_read(@ptr_offset(self.buf, self.len)) })
             }
         }
 

--- a/std/option.rue
+++ b/std/option.rue
@@ -2,10 +2,10 @@
 //
 //     const std = @import("std");
 //     let OptI = std.option.Option(i32);
-//     let x: OptI = OptI::Some(42);
+//     let x: OptI = OptI.Some(42);
 //     match x {
-//         OptI::Some(v) => v,
-//         OptI::None => 0,
+//         OptI.Some(v) => v,
+//         OptI.None => 0,
 //     }
 //
 pub fn Option(comptime T: type) -> type {

--- a/website/content/tutorial/03-variables-and-types.md
+++ b/website/content/tutorial/03-variables-and-types.md
@@ -54,12 +54,28 @@ fn main() -> i32 {
     let flag: bool = true;
     let done = false;
 
-    @dbg(flag);   // prints: true
-    @dbg(done);   // prints: false
+    if flag {
+        println("flag is true");
+    }
+    if done {
+        println("done");
+    } else {
+        println("not done yet");
+    }
 
     0
 }
 ```
+
+This prints:
+
+```
+flag is true
+not done yet
+```
+
+`@to_string` turns integers into strings, but a boolean is easiest to report by
+branching on it, as above.
 
 ## Mutability
 

--- a/website/content/tutorial/04-functions.md
+++ b/website/content/tutorial/04-functions.md
@@ -23,11 +23,25 @@ fn main() -> i32 {
     let sum = add(3, 4);
     println("sum = " + @to_string(sum));
 
-    @dbg(is_positive(sum));   // prints: true
-    @dbg(is_positive(-5));    // prints: false
+    if is_positive(sum) {
+        println("sum is positive");
+    }
+    if is_positive(-5) {
+        println("-5 is positive");
+    } else {
+        println("-5 is not positive");
+    }
 
     sum
 }
+```
+
+This prints:
+
+```
+sum = 7
+sum is positive
+-5 is not positive
 ```
 
 ## Function Body Values

--- a/website/content/tutorial/05-control-flow.md
+++ b/website/content/tutorial/05-control-flow.md
@@ -19,7 +19,7 @@ fn max(a: i32, b: i32) -> i32 {
 
 fn main() -> i32 {
     let bigger = max(10, 20);
-    @dbg(bigger);  // prints: 20
+    println(@to_string(bigger));  // prints: 20
     bigger
 }
 ```
@@ -30,7 +30,7 @@ Because `if` is an expression, you can use it anywhere a value is expected:
 fn main() -> i32 {
     let x = 5;
     let description = if x > 0 { 1 } else { 0 };
-    @dbg(description);  // prints: 1
+    println(@to_string(description));  // prints: 1
     0
 }
 ```
@@ -49,7 +49,7 @@ fn main() -> i32 {
         i = i + 1;
     }
 
-    @dbg(sum);  // prints: 55 (1+2+...+10)
+    println(@to_string(sum));  // prints: 55 (1+2+...+10)
     sum
 }
 ```
@@ -69,8 +69,8 @@ fn day_type(day: i32) -> i32 {
 }
 
 fn main() -> i32 {
-    @dbg(day_type(0));  // prints: 0 (weekend)
-    @dbg(day_type(3));  // prints: 1 (weekday)
+    println(@to_string(day_type(0)));  // prints: 0 (weekend)
+    println(@to_string(day_type(3)));  // prints: 1 (weekday)
     0
 }
 ```
@@ -100,7 +100,7 @@ fn fizzbuzz(n: i32) -> i32 {
 fn main() -> i32 {
     let mut i = 1;
     while i <= 15 {
-        @dbg(fizzbuzz(i));
+        println(@to_string(fizzbuzz(i)));
         i = i + 1;
     }
     0

--- a/website/content/tutorial/06-arrays.md
+++ b/website/content/tutorial/06-arrays.md
@@ -15,8 +15,8 @@ fn main() -> i32 {
     let numbers = [10, 20, 30, 40, 50];
 
     // Access by index
-    @dbg(numbers[0]);  // prints: 10
-    @dbg(numbers[4]);  // prints: 50
+    println(@to_string(numbers[0]));  // prints: 10
+    println(@to_string(numbers[4]));  // prints: 50
 
     numbers[0]
 }
@@ -34,7 +34,7 @@ fn main() -> i32 {
     let a: [i32; 3] = [1, 2, 3];     // 3 elements
     let b: [bool; 2] = [true, false]; // 2 booleans
 
-    @dbg(a[0]);
+    println(@to_string(a[0]));  // prints: 1
     0
 }
 ```
@@ -53,7 +53,7 @@ fn main() -> i32 {
         sum = sum + numbers[i];
         i = i + 1;
     }
-    @dbg(sum);  // prints: 150
+    println(@to_string(sum));  // prints: 150
 
     sum
 }
@@ -70,7 +70,7 @@ fn main() -> i32 {
     scores[1] = 85;
     scores[2] = 92;
 
-    @dbg(scores[0] + scores[1] + scores[2]);  // prints: 277
+    println(@to_string(scores[0] + scores[1] + scores[2]));  // prints: 277
     0
 }
 ```
@@ -82,7 +82,7 @@ Rue checks array bounds. A constant out-of-bounds index is rejected at compile t
 ```rue compile-fail
 fn main() -> i32 {
     let arr = [1, 2, 3];
-    @dbg(arr[10]);  // Error: index out of bounds
+    println(@to_string(arr[10]));  // Error: index out of bounds
     0
 }
 ```
@@ -105,7 +105,7 @@ fn main() -> i32 {
         i = i + 1;
     }
 
-    @dbg(max);  // prints: 64
+    println(@to_string(max));  // prints: 64
     max
 }
 ```
@@ -126,7 +126,7 @@ fn main() -> i32 {
     let Buffer = std.arraybuf.ArrayBuf(i32);
     let MaybeI32 = std.option.Option(i32);
 
-    let mut values = Buffer::new();
+    let mut values = Buffer.new();
     values.push(10);
     values.push(20);
     values.push(30);
@@ -134,8 +134,8 @@ fn main() -> i32 {
     println("len = " + @to_string(values.len()));
 
     let second = match values.get(1) {
-        MaybeI32::Some(n) => n,
-        MaybeI32::None => -1,
+        MaybeI32.Some(n) => n,
+        MaybeI32.None => -1,
     };
     println("second = " + @to_string(second));
 
@@ -146,8 +146,8 @@ fn main() -> i32 {
 `ArrayBuf(i32)` owns heap storage and frees it automatically when the buffer is
 dropped. Its `get` method returns `Option(i32)` rather than trapping:
 
-- `Option::Some(value)` means the index was in bounds.
-- `Option::None` means there was no element at that index.
+- `Option.Some(value)` means the index was in bounds.
+- `Option.None` means there was no element at that index.
 
 Use fixed arrays for small, known-size data and `ArrayBuf(T)` when the program
 discovers the number of elements as it runs. The slice and growable string parts

--- a/website/content/tutorial/07-structs.md
+++ b/website/content/tutorial/07-structs.md
@@ -20,8 +20,8 @@ fn main() -> i32 {
     let origin = Point { x: 0, y: 0 };
     let target = Point { x: 3, y: 4 };
 
-    @dbg(origin.x);  // prints: 0
-    @dbg(target.y);  // prints: 4
+    println(@to_string(origin.x));  // prints: 0
+    println(@to_string(target.y));  // prints: 4
 
     0
 }
@@ -48,7 +48,7 @@ fn main() -> i32 {
     let target = Point { x: 3, y: 4 };
 
     let dist_sq = distance_squared(origin, target);
-    @dbg(dist_sq);  // prints: 25 (distance is 5)
+    println(@to_string(dist_sq));  // prints: 25 (distance is 5)
 
     dist_sq
 }
@@ -85,8 +85,8 @@ fn main() -> i32 {
         height: 50,
     };
 
-    @dbg(origin_x(borrow rect));  // prints: 10
-    @dbg(area(rect));             // prints: 5000
+    println(@to_string(origin_x(borrow rect)));  // prints: 10
+    println(@to_string(area(rect)));             // prints: 5000
 
     0
 }
@@ -106,7 +106,7 @@ fn main() -> i32 {
     c.value = c.value + 1;
     c.value = c.value + 1;
 
-    @dbg(c.value);  // prints: 2
+    println(@to_string(c.value));  // prints: 2
     c.value
 }
 ```
@@ -124,7 +124,7 @@ struct Point {
 }
 
 fn use_point(p: Point) {
-    @dbg(p.x);
+    println(@to_string(p.x));
 }
 
 fn main() -> i32 {
@@ -148,8 +148,8 @@ fn main() -> i32 {
     let p1 = Point { x: 1, y: 2 };
     let p2 = p1;      // p1 moves into p2
 
-    @dbg(p2.x);       // prints: 1
-    // @dbg(p1.x);    // ERROR: p1 was moved
+    println(@to_string(p2.x));       // prints: 1
+    // println(@to_string(p1.x));    // ERROR: p1 was moved
 
     0
 }
@@ -171,8 +171,8 @@ fn main() -> i32 {
 
     p2.x = 100;
 
-    @dbg(p1.x);  // prints: 1 (unchanged)
-    @dbg(p2.x);  // prints: 100
+    println(@to_string(p1.x));  // prints: 1 (unchanged)
+    println(@to_string(p2.x));  // prints: 100
 
     0
 }

--- a/website/content/tutorial/08-enums.md
+++ b/website/content/tutorial/08-enums.md
@@ -18,12 +18,12 @@ enum Color {
 }
 
 fn main() -> i32 {
-    let c = Color::Green;
+    let c = Color.Green;
     0
 }
 ```
 
-Variants are accessed with the `::` syntax: `EnumName::VariantName`.
+Variants are accessed with a `.`: `EnumName.VariantName`.
 
 ## Matching on Enums
 
@@ -38,16 +38,16 @@ enum Color {
 
 fn color_value(c: Color) -> i32 {
     match c {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 
 fn main() -> i32 {
-    @dbg(color_value(Color::Red));    // prints: 1
-    @dbg(color_value(Color::Green));  // prints: 2
-    @dbg(color_value(Color::Blue));   // prints: 3
+    println(@to_string(color_value(Color.Red)));    // prints: 1
+    println(@to_string(color_value(Color.Green)));  // prints: 2
+    println(@to_string(color_value(Color.Blue)));   // prints: 3
     0
 }
 ```
@@ -66,15 +66,15 @@ enum Direction {
 
 fn to_degrees(d: Direction) -> i32 {
     match d {
-        Direction::North => 0,
-        Direction::East => 90,
-        Direction::South => 180,
-        Direction::West => 270,
+        Direction.North => 0,
+        Direction.East => 90,
+        Direction.South => 180,
+        Direction.West => 270,
     }
 }
 
 fn main() -> i32 {
-    to_degrees(Direction::North)
+    to_degrees(Direction.North)
 }
 ```
 
@@ -83,8 +83,8 @@ If you forget a variant, the compiler will tell you:
 ```rue skip
 fn to_degrees(d: Direction) -> i32 {
     match d {
-        Direction::North => 0,
-        Direction::East => 90,
+        Direction.North => 0,
+        Direction.East => 90,
         // Error: non-exhaustive match, missing South and West
     }
 }
@@ -108,7 +108,7 @@ struct Task {
 
 fn is_done(task: Task) -> bool {
     match task.status {
-        Status::Completed => true,
+        Status.Completed => true,
         _ => false,
     }
 }
@@ -116,10 +116,14 @@ fn is_done(task: Task) -> bool {
 fn main() -> i32 {
     let task = Task {
         id: 1,
-        status: Status::Active,
+        status: Status.Active,
     };
 
-    @dbg(is_done(task));  // prints: 0 (false)
+    if is_done(task) {
+        println("task is done");
+    } else {
+        println("task is not done");  // this branch runs: status is Active
+    }
     0
 }
 ```
@@ -135,21 +139,21 @@ enum TrafficLight {
 
 fn next_light(current: TrafficLight) -> TrafficLight {
     match current {
-        TrafficLight::Red => TrafficLight::Green,
-        TrafficLight::Green => TrafficLight::Yellow,
-        TrafficLight::Yellow => TrafficLight::Red,
+        TrafficLight.Red => TrafficLight.Green,
+        TrafficLight.Green => TrafficLight.Yellow,
+        TrafficLight.Yellow => TrafficLight.Red,
     }
 }
 
 fn light_duration(light: TrafficLight) -> i32 {
     match light {
-        TrafficLight::Red => 30,
-        TrafficLight::Yellow => 5,
-        TrafficLight::Green => 25,
+        TrafficLight.Red => 30,
+        TrafficLight.Yellow => 5,
+        TrafficLight.Green => 25,
     }
 }
 
 fn main() -> i32 {
-    light_duration(next_light(TrafficLight::Red))
+    light_duration(next_light(TrafficLight.Red))
 }
 ```

--- a/website/content/tutorial/09-borrow-and-inout.md
+++ b/website/content/tutorial/09-borrow-and-inout.md
@@ -67,9 +67,9 @@ fn main() -> i32 {
     let mut values = [10, 20, 30];
     double_all(inout values);
 
-    @dbg(values[0]);  // prints: 20
-    @dbg(values[1]);  // prints: 40
-    @dbg(values[2]);  // prints: 60
+    println(@to_string(values[0]));  // prints: 20
+    println(@to_string(values[1]));  // prints: 40
+    println(@to_string(values[2]));  // prints: 60
 
     values[0]
 }
@@ -95,7 +95,7 @@ fn sum_array(borrow arr: [i32; 5]) -> i32 {
 fn main() -> i32 {
     let numbers = [1, 2, 3, 4, 5];
     let sum = sum_array(borrow numbers);
-    @dbg(sum);  // prints: 15
+    println(@to_string(sum));  // prints: 15
     sum
 }
 ```
@@ -118,8 +118,8 @@ fn main() -> i32 {
     let p = Point { x: 10, y: 20 };
     let sum = sum_point(borrow p);
 
-    @dbg(sum);  // prints: 30
-    @dbg(p.x);  // still valid: p was borrowed, not moved
+    println(@to_string(sum));  // prints: 30
+    println(@to_string(p.x));  // still valid: p was borrowed, not moved
 
     sum
 }
@@ -144,9 +144,9 @@ fn main() -> i32 {
 
     copy_into(borrow source, inout dest);
 
-    @dbg(dest[0]);  // prints: 1
-    @dbg(dest[1]);  // prints: 2
-    @dbg(dest[2]);  // prints: 3
+    println(@to_string(dest[0]));  // prints: 1
+    println(@to_string(dest[1]));  // prints: 2
+    println(@to_string(dest[2]));  // prints: 3
 
     0
 }
@@ -192,8 +192,8 @@ fn translate(inout p: Point, dx: i32, dy: i32) {
 }
 
 fn print_point(borrow p: Point) {
-    @dbg(p.x);
-    @dbg(p.y);
+    println(@to_string(p.x));
+    println(@to_string(p.y));
 }
 
 fn main() -> i32 {
@@ -218,12 +218,12 @@ struct Guard {
 }
 
 drop fn Guard(self) {
-    @dbg(self.value);
+    println(@to_string(self.value));
 }
 
 fn main() -> i32 {
     let _guard = Guard { value: 42 };
-    @dbg(1);
+    println(@to_string(1));
 
     0
 }  // prints: 42 when _guard is dropped
@@ -238,7 +238,7 @@ struct Guard {
 }
 
 drop fn Guard(self) {
-    @dbg(self.value);
+    println(@to_string(self.value));
 }
 
 fn main() -> i32 {

--- a/website/content/tutorial/10-putting-it-together.md
+++ b/website/content/tutorial/10-putting-it-together.md
@@ -29,27 +29,27 @@ fn main() -> i32 {
 
     let mut count: i64 = 0;
     let mut sum: i64 = 0;
-    let mut max: OptInt = OptInt::None;
+    let mut max: OptInt = OptInt.None;
 
     loop {
         match read_num() {
-            OptInt::Some(x) => {
+            OptInt.Some(x) => {
                 count = count + 1;
                 sum = sum + x;
                 max = match max {
-                    OptInt::None => OptInt::Some(x),
-                    OptInt::Some(m) => if x > m { OptInt::Some(x) } else { OptInt::Some(m) },
+                    OptInt.None => OptInt.Some(x),
+                    OptInt.Some(m) => if x > m { OptInt.Some(x) } else { OptInt.Some(m) },
                 };
             },
-            OptInt::None => break,
+            OptInt.None => break,
         }
     }
 
     println("count: " + @to_string(count));
     println("sum: " + @to_string(sum));
     match max {
-        OptInt::Some(m) => println("max: " + @to_string(m)),
-        OptInt::None => println("max: (no input)"),
+        OptInt.Some(m) => println("max: " + @to_string(m)),
+        OptInt.None => println("max: (no input)"),
     }
 
     @intCast(count)


### PR DESCRIPTION
## Summary

Per Steve's ruling on RUE-488 (clean break, no deprecation window): **`::` is deleted as a path/member-access operator** — `.` is the only spelling for enum variants, associated functions, and their module-qualified forms. A stray `::` is a hard parse error with a targeted help (*"`::` is not a Rue operator; use `.` for member access…"*), reusing the existing unexpected-token machinery — no new E-codes. The `ColonColon` token is deliberately kept in the lexer so the diagnostic sees `::` as one unit instead of two opaque `:`s.

Removing the `::` fallback forced finishing what RUE-196/#1219 left partial. Each of these was verified broken-before/works-after by running real programs:
- module-qualified enum variants / assoc-fns / tuple-variant construction (`lib.Color.Green`, `lib.Box.make(10)`, `lib.Opt.Some(7)`), incl. E0706 visibility
- nested submodule chains (`std.geo.Sign.Pos`)
- comptime type vars (`let O = Option(i32); O.Some(1)`)
- builtin assoc-fn argument constraints (`String.with_capacity(8)` constrains `8` to `u64`)
- projection operands (`Color.Red == Color.Red`)
- same-named sibling-module enums stay nominally distinct (RUE-501)
- `Enum.badVariant` → E0420 UnknownVariant instead of an opaque field-access error

Spec rules 6.3:4/6.3:5, 6.4:13 and the grammar appendix are rewritten for single-operator semantics; the 6.4:22/6.4:23 diagnostics survive reworded (the value-vs-type receiver distinction remains meaningful). Traceability stays 100%.

**Tutorial (RUE-469)** — bundled because the changes are mutually dependent: the tutorial-snippet test target compiles every snippet against the new parser (so the `::`-teaching tutorial would break this PR), and the rewritten tutorial's `Buffer.new()` / `OptInt.Some` snippets only compile with this PR's dotted-access support. `println` is now the primary output mechanism from hello-world on; `@dbg` is one brief aside in chapter 02; every touched sample was compiled and run.

**RUE-507**: stray `e1.rue` / `lc.rue` deleted from the repo root (zero references repo-wide).

Integrator sweep of worker-boundary files: `std/arraybuf.rue`, `examples/std/arraybuf_demo.rue`, `arraybuf_library.toml` converted to `.`; demo verified by execution (exit 119, exact stdout).

## Validation

- `E::A` / `Type::f()` → parse error + help; all dotted forms above compile and run with correct exit codes
- `examples/std/arraybuf_demo.rue` via real CLI: exact stdout, exit 119
- `./test.sh`: Pass 28 / Fail 0 (spec 1918/0 with 100% traceability, UI 140/0, tutorial-snippet-tests green)

Fixes RUE-488
Fixes RUE-507
Fixes RUE-469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
