### PR TITLE
RUE-387: reject overwrite-assignment of live linear values (E0493/E0494)

### DIFF
--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -527,6 +527,20 @@ impl<'a> Sema<'a> {
             // Analyze the value
             let value_result = self.analyze_inst(air, value, ctx)?;
 
+            // RUE-387: writing a live linear value's field would silently drop
+            // the old field value. Legal only when that exact field path was
+            // proven moved-out on every path (`consume(o.f); o.f = ...`); a
+            // dynamic index anywhere in the chain can never prove it.
+            let discharged = !trace.has_untrackable_index()
+                && self.place_linear_discharged(
+                    field_type,
+                    trace.root_var,
+                    &trace.field_path(),
+                    span,
+                    ctx,
+                );
+            self.check_linear_overwrite(field_type, discharged, false, span)?;
+
             // The write reinitializes its destination: the assigned path
             // (and any moved sub-paths under it) is no longer moved, so
             // `o.f = ...` after `consume(o.f)` makes `o.f` usable again.
@@ -705,6 +719,21 @@ impl<'a> Sema<'a> {
 
             // Analyze the value
             let value_result = self.analyze_inst(air, value, ctx)?;
+
+            // RUE-387: writing a live linear value into an array element would
+            // silently drop the old element. Legal only when that exact
+            // constant-index element was proven moved-out on every path
+            // (`arr[0] = f(arr[0])`); a runtime index can never prove which
+            // element is live, so it is always rejected (repro 3).
+            let discharged = !trace.has_untrackable_index()
+                && self.place_linear_discharged(
+                    elem_type,
+                    trace.root_var,
+                    &trace.field_path(),
+                    span,
+                    ctx,
+                );
+            self.check_linear_overwrite(elem_type, discharged, false, span)?;
 
             // The write reinitializes its destination element: the assigned
             // path is no longer moved, so `arr[0] = arr[0]` un-marks the

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -207,6 +207,92 @@ impl<'a> Sema<'a> {
         )
     }
 
+    /// RUE-387: reject an assignment `p = e` that would overwrite a place
+    /// still holding a live linear value.
+    ///
+    /// Steve's ruling (2026-07-09): assignment to an initialized place holding
+    /// a linear value is a compile error unless the old value has provably been
+    /// moved/consumed first — there is no implicit consume-on-overwrite. The
+    /// overwrite-drop machinery (#968, spec 3.9:18) would otherwise silently
+    /// drop the old linear value, a theorem-5 soundness hole (docs/formal
+    /// §5.2 D-Assign).
+    ///
+    /// The check is TYPE-based (`type_requires_consumption`), not state-based:
+    /// it fires whenever the destination's type carries a must-consume
+    /// obligation. The sole carve-out is the reinit-after-move idiom (spec
+    /// 3.8:55/56): a place proven moved-out on every path holds nothing to
+    /// destroy. `discharged` is that proof, computed by the caller via
+    /// [`Self::place_linear_discharged`]; a runtime-index element can never
+    /// prove it and passes `false`.
+    pub(crate) fn check_linear_overwrite(
+        &self,
+        dest_ty: Type,
+        discharged: bool,
+        through_inout: bool,
+        span: Span,
+    ) -> CompileResult<()> {
+        if !self.type_requires_consumption(dest_ty) || discharged {
+            return Ok(());
+        }
+        let type_name = dest_ty.safe_name_with_pool(Some(&self.type_pool));
+        let err = if through_inout {
+            CompileError::new(
+                ErrorKind::LinearValueOverwrittenThroughInout { type_name },
+                span,
+            )
+            .with_help(
+                "an `inout` binding names the caller's storage; move its linear \
+                 value out before the callee reassigns, or pass ownership instead",
+            )
+        } else {
+            CompileError::new(ErrorKind::LinearValueOverwritten { type_name }, span).with_help(
+                "consume the old value first (move it, or `@drop` it); a linear \
+                 value is never dropped implicitly by an assignment",
+            )
+        };
+        Err(self.attach_infectious_linear_note(err, dest_ty))
+    }
+
+    /// Whether the destination place of an assignment provably holds no live
+    /// linear value on the current path (RUE-387), so overwriting it destroys
+    /// nothing (the spec 3.8:55/56 reinit-after-move idiom).
+    ///
+    /// True when the exact place was moved out on every path, or — for a whole
+    /// linear array — every element was consumed element-wise on every path
+    /// (spec 3.8:71). The caller evaluates this on the POST-RHS move state so
+    /// that an RHS which itself consumes the old value (`x = f(x)`) counts as a
+    /// discharge, matching the RHS-first overwrite-drop order (#968). Only the
+    /// whole-variable array shape is tracked per element, so `assigned_path`
+    /// must be empty for the element-wise case to apply.
+    pub(crate) fn place_linear_discharged(
+        &self,
+        dest_ty: Type,
+        root_var: Spur,
+        assigned_path: &[Spur],
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> bool {
+        let Some(state) = ctx.moved_vars.get(&root_var) else {
+            return false;
+        };
+        // The exact destination place was moved out on every path.
+        if assigned_path.is_empty() {
+            if state.full_move_on_all_paths {
+                return true;
+            }
+        } else if state.partial_moves_on_all_paths.contains(assigned_path) {
+            return true;
+        }
+        // A whole linear array consumed element-wise on every path holds no
+        // live element to drop. Reuse the must-consume element check; `Err`
+        // (partial consumption) and `NotElementwise` are both "not discharged".
+        assigned_path.is_empty()
+            && matches!(
+                self.check_array_elementwise_consumption(dest_ty, Some(state), root_var, span),
+                Ok(ElementwiseConsumption::Complete)
+            )
+    }
+
     /// Reject a discarded expression value that carries a linear value
     /// (RUE-176): an expression statement (`make_linear();`) or a loop body
     /// result is dropped without being consumed, which linearity forbids.

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2871,9 +2871,17 @@ impl<'a> Sema<'a> {
                 }
 
                 let abi_slot = param_info.abi_slot;
+                let param_ty = param_info.ty;
 
                 // Analyze the value
                 let value_result = self.analyze_inst(air, value, ctx)?;
+
+                // RUE-387: reassigning an `inout` parameter whose type carries
+                // a linear value would silently drop the caller's live value.
+                // An `inout` binding can never be proven moved-out, so this is
+                // always ill-formed (E0494).
+                let discharged = self.place_linear_discharged(param_ty, name, &[], span, ctx);
+                self.check_linear_overwrite(param_ty, discharged, true, span)?;
 
                 // Assignment to a parameter resets its move state
                 ctx.moved_vars.remove(&name);
@@ -2925,6 +2933,13 @@ impl<'a> Sema<'a> {
         } else {
             self.analyze_inst(air, value, ctx)?
         };
+
+        // RUE-387: overwriting a local that still holds a live linear value
+        // would silently drop it. Legal only when the whole variable was
+        // proven moved-out on every path (reinit-after-move idiom) — evaluated
+        // on the post-RHS move state so `x = f(x)` counts as a discharge.
+        let discharged = self.place_linear_discharged(local_ty, name, &[], span, ctx);
+        self.check_linear_overwrite(local_ty, discharged, false, span)?;
 
         // Assignment to a mutable variable resets its move state.
         ctx.moved_vars.remove(&name);

--- a/crates/rue-cli-tests/cases/linear_overwrite_assignment.toml
+++ b/crates/rue-cli-tests/cases/linear_overwrite_assignment.toml
@@ -1,0 +1,113 @@
+# Overwrite-assignment must not silently destroy a live linear value (RUE-387).
+#
+# Steve's ruling (2026-07-09): assignment to an initialized place holding a
+# linear value is a COMPILE ERROR (E0493, or E0494 through `inout`) unless the
+# old value has provably been moved/consumed first. Before the fix all four
+# shapes below compiled and ran, silently dropping the old linear value via the
+# #968 overwrite-drop machinery — a theorem-5 linearity-soundness hole. The
+# positive cases pin that the reinit-after-move idiom (spec 3.8:55/56) stays
+# legal and runs.
+
+[section]
+id = "cli.linear_overwrite_assignment"
+name = "Linear overwrite-assignment rejection"
+description = "Overwriting a live linear value is rejected (E0493/E0494); reinit-after-move stays legal (RUE-387)."
+
+[[case]]
+name = "whole_var_overwrite_rejected"
+description = "Repro 1: `x = L{..}` over a live linear local is E0493."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+fn main() -> i32 {
+    let mut x = L { v: 1 };
+    x = L { v: 2 };
+    @drop(x);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["[E0493]", "overwrite a live linear value"]
+
+[[case]]
+name = "const_element_overwrite_rejected"
+description = "Repro 2: `a[0] = L{..}` over a live linear element is E0493."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+fn main() -> i32 {
+    let mut a = [L { v: 1 }, L { v: 2 }];
+    a[0] = L { v: 3 };
+    @drop(a[0]);
+    @drop(a[1]);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["[E0493]", "overwrite a live linear value"]
+
+[[case]]
+name = "runtime_element_overwrite_rejected"
+description = "Repro 3: a runtime-index element write can never prove moved-out, so it is always E0493."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+fn idx() -> i32 { 0 }
+fn main() -> i32 {
+    let mut a = [L { v: 1 }, L { v: 2 }];
+    a[idx()] = L { v: 3 };
+    @drop(a[0]);
+    @drop(a[1]);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["[E0493]", "overwrite a live linear value"]
+
+[[case]]
+name = "through_inout_overwrite_rejected"
+description = "Repro 4: reassigning an `inout` linear parameter is E0494 (clobbers the caller's live value)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+fn f(inout x: L) { x = L { v: 9 }; }
+fn main() -> i32 {
+    let mut x = L { v: 1 };
+    f(inout x);
+    @drop(x);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["[E0494]", "inout"]
+
+[[case]]
+name = "reinit_after_move_runs"
+description = "Positive: reinitializing a moved-out linear local is legal and runs. The destructor fires once per constructed value (1, then the reinitialized 2)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+drop fn L(self) { @dbg(self.v); }
+fn take(x: L) -> i32 { @drop(x); 0 }
+fn main() -> i32 {
+    let mut x = L { v: 1 };
+    let a = take(x);
+    x = L { v: 2 };
+    @drop(x);
+    a
+}
+""" }]
+stdout = "1\n2\n"
+exit_code = 0
+
+[[case]]
+name = "reinit_via_rhs_consume_runs"
+description = "Positive: `x = remake(x)` is legal because the RHS consumes the old value first (RHS-first drop order). Old 1 dropped inside remake, new 9 dropped at scope exit."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+drop fn L(self) { @dbg(self.v); }
+fn remake(x: L) -> L { @drop(x); L { v: 9 } }
+fn main() -> i32 {
+    let mut x = L { v: 1 };
+    x = remake(x);
+    @drop(x);
+    0
+}
+""" }]
+stdout = "1\n9\n"
+exit_code = 0

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -241,6 +241,22 @@ impl ErrorCode {
     /// heap, so an over-long literal cannot be stored — the fit is checked at
     /// compile time.
     pub const STR_FIXED_CAPACITY_EXCEEDED: Self = Self(492);
+    /// Assignment to an initialized place that holds a live linear value
+    /// (RUE-387). Overwriting the place would implicitly drop (silently
+    /// consume) the old linear value, which linearity forbids — a theorem-5
+    /// soundness hole (spec 3.9:18 overwrite-drop is carved out for linear
+    /// types). The value must be moved/consumed explicitly first; the sole
+    /// exception is reinitializing a place that was provably moved out on
+    /// every path (the spec 3.8:55/56 reinit idiom), which holds nothing to
+    /// destroy.
+    pub const LINEAR_VALUE_OVERWRITTEN: Self = Self(493);
+    /// Assignment to an `inout` parameter (or a place rooted at one) whose
+    /// type carries a linear value (RUE-387). The parameter names the
+    /// caller's storage, which holds a live linear value; reassigning it
+    /// would implicitly drop that value in the caller. An `inout` place can
+    /// never be proven moved-out (moving out of a by-ref binding is itself
+    /// rejected), so a linear `inout` assignment is always ill-formed.
+    pub const LINEAR_VALUE_OVERWRITTEN_THROUGH_INOUT: Self = Self(494);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1071,6 +1087,16 @@ pub enum ErrorKind {
     /// body result) carries a linear value, which would be implicitly dropped
     #[error("discarded value of type '{type_name}' carries a linear value and must be consumed")]
     LinearValueDiscarded { type_name: String },
+    /// Assignment to a place holding a live linear value (RUE-387): the
+    /// overwrite would implicitly drop the old linear value.
+    #[error("assignment would overwrite a live linear value of type '{type_name}'")]
+    LinearValueOverwritten { type_name: String },
+    /// Assignment to an `inout` parameter whose type carries a linear value
+    /// (RUE-387): reassigning it would implicitly drop the caller's value.
+    #[error(
+        "assignment to `inout` parameter would overwrite the caller's live linear value of type '{type_name}'"
+    )]
+    LinearValueOverwrittenThroughInout { type_name: String },
     /// Linear struct cannot be marked @copy
     #[error("linear struct '{0}' cannot be marked @copy")]
     LinearStructCopy(String),
@@ -1459,6 +1485,10 @@ impl ErrorKind {
                 ErrorCode::LINEAR_VALUE_NOT_CONSUMED_ON_ALL_PATHS
             }
             ErrorKind::LinearValueDiscarded { .. } => ErrorCode::LINEAR_VALUE_DISCARDED,
+            ErrorKind::LinearValueOverwritten { .. } => ErrorCode::LINEAR_VALUE_OVERWRITTEN,
+            ErrorKind::LinearValueOverwrittenThroughInout { .. } => {
+                ErrorCode::LINEAR_VALUE_OVERWRITTEN_THROUGH_INOUT
+            }
             ErrorKind::LinearStructCopy(_) => ErrorCode::LINEAR_STRUCT_COPY,
             ErrorKind::LinearFieldDroppedByDestructure(_) => {
                 ErrorCode::LINEAR_FIELD_DROPPED_BY_DESTRUCTURE

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1912,3 +1912,165 @@ fn main() -> i32 {
 """
 exit_code = 0
 expected_stdout = "1\n100\n2\n"
+
+# =============================================================================
+# Linear overwrite-assignment rejection (RUE-387, spec 3.8:77)
+#
+# Overwriting a place that still holds a live linear value would implicitly
+# drop it (spec 3.9:18 overwrite-drop), which linearity forbids — a theorem-5
+# soundness hole. The overwrite is a compile error (E0493, or E0494 through an
+# `inout` parameter) unless the destination was provably moved out first.
+# =============================================================================
+
+[[case]]
+name = "linear_overwrite_whole_var_rejected"
+spec = ["3.8:77"]
+description = "Assigning a new linear value to a live linear local is rejected (would silently drop the old value)"
+source = """
+linear struct L { v: i32 }
+
+fn main() -> i32 {
+    let mut x = L { v: 1 };
+    x = L { v: 2 };
+    @drop(x);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0493]", "overwrite a live linear value"]
+
+[[case]]
+name = "linear_overwrite_const_element_rejected"
+spec = ["3.8:77"]
+description = "Assigning a new linear value to a live constant-index array element is rejected"
+source = """
+linear struct L { v: i32 }
+
+fn main() -> i32 {
+    let mut a = [L { v: 1 }, L { v: 2 }];
+    a[0] = L { v: 3 };
+    @drop(a[0]);
+    @drop(a[1]);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0493]", "overwrite a live linear value"]
+
+[[case]]
+name = "linear_overwrite_runtime_element_rejected"
+spec = ["3.8:77"]
+description = "Assigning a linear value through a runtime index can never prove the element moved out, so it is always rejected"
+source = """
+linear struct L { v: i32 }
+
+fn idx() -> i32 { 0 }
+
+fn main() -> i32 {
+    let mut a = [L { v: 1 }, L { v: 2 }];
+    a[idx()] = L { v: 3 };
+    @drop(a[0]);
+    @drop(a[1]);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0493]", "overwrite a live linear value"]
+
+[[case]]
+name = "linear_overwrite_through_inout_rejected"
+spec = ["3.8:77"]
+description = "Reassigning an `inout` linear parameter would drop the caller's live value; always rejected (E0494)"
+source = """
+linear struct L { v: i32 }
+
+fn f(inout x: L) { x = L { v: 9 }; }
+
+fn main() -> i32 {
+    let mut x = L { v: 1 };
+    f(inout x);
+    @drop(x);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0494]", "inout"]
+
+[[case]]
+name = "linear_reinit_after_move_legal"
+spec = ["3.8:77", "3.8:55"]
+description = "Reinitializing a linear local that was moved out on every path is legal: the moved-out place holds nothing to destroy"
+source = """
+linear struct L { v: i32 }
+
+fn take(x: L) -> i32 { @drop(x); 3 }
+
+fn main() -> i32 {
+    let mut x = L { v: 1 };
+    let a = take(x);
+    x = L { v: 2 };
+    @drop(x);
+    a
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "linear_reinit_via_rhs_consume_legal"
+spec = ["3.8:77"]
+description = "`x = f(x)` is legal when the right-hand side consumes the old linear value before the store (RHS-first)"
+source = """
+linear struct L { v: i32 }
+
+fn remake(x: L) -> L { @drop(x); L { v: 9 } }
+
+fn main() -> i32 {
+    let mut x = L { v: 1 };
+    x = remake(x);
+    @drop(x);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "linear_array_whole_reinit_after_full_consume_legal"
+spec = ["3.8:77"]
+description = "Whole-array reassignment is legal once every element of a linear array has been consumed element-wise"
+source = """
+linear struct L { v: i32 }
+
+fn take(x: L) { @drop(x); }
+
+fn main() -> i32 {
+    let mut a = [L { v: 1 }, L { v: 2 }];
+    take(a[0]);
+    take(a[1]);
+    a = [L { v: 3 }, L { v: 4 }];
+    @drop(a[0]);
+    @drop(a[1]);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "linear_array_whole_reinit_partial_consume_rejected"
+spec = ["3.8:77"]
+description = "Whole-array reassignment is rejected while any element remains live: it would silently drop the live element(s)"
+source = """
+linear struct L { v: i32 }
+
+fn take(x: L) { @drop(x); }
+
+fn main() -> i32 {
+    let mut a = [L { v: 1 }, L { v: 2 }];
+    take(a[0]);
+    a = [L { v: 3 }, L { v: 4 }];
+    @drop(a[0]);
+    @drop(a[1]);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0493]", "overwrite a live linear value"]

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -326,15 +326,25 @@ ProjRead rule instead:
 
 ```
   Γ ; Σ ; Λ ⊢ e ⇒ T ⊣ Σ1       Γ ⊢ p : T       (mutability & loan side-conditions)
+  Σ1(p) = MovedOut  ∨  ¬carries_linear(T)                  -- 3.8:77: no implicit linear drop-on-overwrite
   p's prior value, if Owned and droppable, is dropped BEFORE the store (dynamic, §6)
   ─────────────────────────────────────────────────────────────────────────────── (Assign)
   Γ ; Σ ; Λ ⊢ (assign p = e) ⇒ unit ⊣ Σ1[ p ↦ Owned ]      -- reinitialization (3.8:55)
 ```
 
 Assigning to a `MovedOut` place makes it `Owned` again (`3.8:55/56`). Assigning to
-an already-`Owned` place drops the old value first (`3.8` overwrite-drop). Writing
-*into* an array while any element is moved out is rejected by a side condition
-(`3.8:72`).
+an already-`Owned` place whose type does **not** carry a linear value drops the old
+value first (`3.8` overwrite-drop). Overwriting an already-`Owned` place whose type
+*does* carry a linear value is **ill-formed** (`3.8:77`): the second premise, checked
+on the post-RHS state `Σ1`, admits the assignment only when `p` is `MovedOut` (the
+reinitialization idiom, where there is nothing to drop) or `T` carries no linear
+value. This closes the theorem-5 hole (RUE-387): without it, the overwrite-drop
+would implicitly consume a linear value that the program never explicitly consumed.
+The `Σ1` (rather than `Σ`) reading of the premise makes `p = e` legal when `e` itself
+consumes `p` (`x = f(x)`), matching the RHS-first drop order. Writing *into* an array
+while any element is moved out is rejected by a side condition (`3.8:72`); a runtime
+index can never establish `Σ1(p) = MovedOut`, so a linear element assignment through
+one is always rejected.
 
 ### 5.3 Sequencing, discard, and the linear leak check
 
@@ -1067,7 +1077,12 @@ The result is `⟨⟩` and the position becomes `Owned` (`place_write`, `lib.rs:
 
 (The compiler elaborates the overwrite-drop as an explicit `Drop` emitted before
 the store, so the oracle's `place_write` needs only to overwrite — the drop
-instruction ran first; consistent with `3.8` overwrite-drop.)
+instruction ran first; consistent with `3.8` overwrite-drop.) By the (Assign)
+premise (§5.2, `3.8:77`), whenever the dropped value `c ≠ ⊘` here has a type that
+carries a linear value the program was rejected statically — so this rule only ever
+drops non-linear (`Affine`/`Copy`) contents on overwrite, and a linear position it
+reaches is necessarily `⊘` (nothing to drop). No linear value is implicitly dropped
+at an assignment.
 
 ### 6.9 Calls, parameters, and return
 
@@ -1264,8 +1279,11 @@ rather than hopes. Stated now; proved in `03-metatheory.md`.
 
 - **Linear values are consumed exactly once.** No value whose type carries a
   linear value reaches end of scope `Owned` (§5.6 rejects it) or is discarded
-  (§5.3 rejects it) or is consumed on only some paths (§5.5 join rejects it);
-  and no value is used twice (`Use-Move` consumes it). Hence exactly once. This
+  (§5.3 rejects it) or is consumed on only some paths (§5.5 join rejects it) or is
+  **overwritten by an assignment while still live** (§5.2's (Assign) premise
+  rejects it, `3.8:77` — the RUE-387 hole: without this premise the overwrite-drop
+  of §6.8 would consume the old linear value implicitly); and no value is used
+  twice (`Use-Move` consumes it). Hence exactly once. This
   now covers **enums**: `class(E)` is the payload join (§3), so a `Linear`-payload
   enum is itself `Linear` and `carries_linear(E)` holds (§5.3); letting it reach
   end of scope unconsumed is rejected exactly as for a linear struct (`6.3:19`),
@@ -1319,7 +1337,7 @@ witness of the dynamic semantics (RUE-50), cited inline in each §6 rule group.
 | §5.8 leaf/operator/aggregate/call statics | 4.1:2/5/7, 4.2:1, 4.3:1/2, 3.6:5/6/15/16, 3.5:1/2, 4.10:3/4/5/7 |
 | §5.6 enum drop (active payload) | 6.3:20 |
 | §4.3 expression/return value | 4.5:3 (→ value, not just type), 6.1:4/5, 4.9:1/7 |
-| §5.2 assignment / reinit | 3.8:55/56, 3.8:72 |
+| §5.2 assignment / reinit | 3.8:55/56, 3.8:72, 3.8:77 |
 | §5.3 discard leak check / explicit `@drop` | 3.8:64/65, 3.9:31–33 |
 | §5.4 borrows / exclusivity | 6.1:14–35, 6.1:20, 6.1:30 |
 | §5.5 branch join | 3.8:50/51, 3.8:73 |

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -477,6 +477,26 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="3.8:77", cat="legality-rule") }}
+
+Assigning to a place whose type carries a linear value (3.8:57) is a compile-time error when the place currently holds a live value. A linear value **MUST** be consumed explicitly (3.8:32); an assignment that overwrote it would drop it implicitly (3.9:18), which linearity forbids. The assignment is legal only when the destination place has provably been moved out on every path reaching it — the reinitialization idiom (3.8:55): a moved-out place holds nothing to destroy. For an array whose element type carries a linear value, whole-array reassignment is legal only when every element has been consumed (as a whole or element-wise, 3.8:71); assignment to an individual element is legal only when that exact constant-index element was moved out. An element reached through a non-constant (runtime) index can never be proven moved out and its assignment is always rejected. This restriction applies regardless of the run-time move state: the diagnostic is determined by the destination's type together with the statically tracked move paths, never by a run-time drop flag.
+
+{{ rule(id="3.8:78", cat="example") }}
+
+```rue
+linear struct L { v: i32 }
+
+fn remake(x: L) -> L { @drop(x); L { v: 9 } }
+
+fn main() -> i32 {
+    let mut x = L { v: 1 };
+    x = L { v: 2 };   // ERROR: would overwrite a live linear value
+    x = remake(x);    // OK: the right-hand side consumed x first
+    @drop(x);
+    0
+}
+```
+
 ## Array Element Moves
 
 {{ rule(id="3.8:68", cat="normative") }}

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -130,7 +130,7 @@ Drops are inserted at the following points:
 - At the end of a block scope, for all live bindings declared in that scope
 - Before a `return` statement, for all live bindings in all enclosing scopes
 - Before a `break` statement, for all live bindings declared inside the loop
-- At an assignment, for the destination's previous value: when an assignment overwrites a place (a variable, struct field, array element, or `inout` parameter) whose current value is live (not moved out), the overwritten value is dropped after the right-hand side has been fully evaluated and before the new value is stored
+- At an assignment, for the destination's previous value: when an assignment overwrites a place (a variable, struct field, array element, or `inout` parameter) whose current value is live (not moved out), the overwritten value is dropped after the right-hand side has been fully evaluated and before the new value is stored. This implicit drop applies only to places whose type does **not** carry a linear value (3.8:57); overwriting a live *linear* place is instead a compile-time error (3.8:77), because a linear value may never be dropped implicitly.
 - At the end of an expression statement whose result is discarded (including a `let _ = ...` statement), for the discarded result value
 
 {{ rule(id="3.9:19", cat="dynamic-semantics") }}


### PR DESCRIPTION
## Summary
Per the 2026-07-09 ruling: assignment to an initialized place holding a Linear value is a compile error unless the old value is provably moved/consumed on every path (type-based rule; reinit-after-move stays legal, evaluated post-RHS so `x = remake(x)` works; runtime-index paths always rejected). Closes the theorem-5 counterexample in all three views: sema gate (E0493 direct / E0494 through-inout), spec legality rule 3.8:77 + linear carve-out in 3.9:18, formal-core (Assign) premise + theorem-5 case.
## Validation
All four issue repros (whole-var, array element, runtime index, through-inout) verified rejected by execution; positives (reinit-after-move, x=remake(x), element-wise consume) verified running. ./test.sh Pass 28 / Fail 0; traceability 728/728; oracle-diff clean.

Fixes RUE-387
🤖 Generated with [Claude Code](https://claude.com/claude-code)