### PR TITLE
RUE-386: implement the two-types str model (E0495/E0496/E0497)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1592,6 +1592,7 @@ mod functions;
 mod instructions;
 mod intrinsics;
 mod ownership;
+pub(crate) use ownership::FirstClassStrSite;
 mod pointers;
 mod type_inference;
 

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -481,6 +481,21 @@ impl<'a> Sema<'a> {
 
         // Add implicit return only if body doesn't already diverge (e.g., explicit return)
         if body_result.ty != Type::NEVER {
+            // Two-types model (ADR-0043, RUE-386): a `str`-returning function's
+            // implicit-return (tail) value must be a first-class `str`. A buffer
+            // (`StrBuf`/`Str(N)`) or a borrowed `str` view escaping here dangles
+            // once its backing storage is dropped. (Explicit `return x;` is
+            // checked in `analyze_return`.)
+            if self.is_str_struct(return_type) {
+                let tail = self.rir_block_tail_expr(body);
+                self.reject_non_first_class_str(
+                    tail,
+                    body_result.ty,
+                    FirstClassStrSite::Return,
+                    self.rir.get(tail).span,
+                    &ctx,
+                )?;
+            }
             air.add_inst(AirInst {
                 data: AirInstData::Ret(Some(body_result.air_ref)),
                 ty: return_type,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -5,6 +5,33 @@
 
 use super::*;
 
+/// The position into which a value is being placed when the ADR-0043 two-types
+/// string model (RUE-386) requires a *first-class* `str`: a bare `str`
+/// parameter, a `str` binding, a `str` return, or a `str` struct field. Only a
+/// string literal or another first-class `str` may land in one of these; a
+/// string *buffer* (`StrBuf`/`Str(N)`) or a borrowed `str` *view* is rejected
+/// because it would escape its backing storage. The variant tailors the
+/// diagnostic (only the parameter case gets the `borrow str` did-you-mean).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FirstClassStrSite {
+    Param,
+    Binding,
+    Return,
+    Field,
+}
+
+impl FirstClassStrSite {
+    /// Human-readable position phrase for the diagnostic message.
+    fn describe(self) -> &'static str {
+        match self {
+            FirstClassStrSite::Param => "as a parameter argument",
+            FirstClassStrSite::Binding => "in a binding",
+            FirstClassStrSite::Return => "as a return value",
+            FirstClassStrSite::Field => "in a struct field",
+        }
+    }
+}
+
 impl<'a> Sema<'a> {
     /// Check if directives contain @allow for a specific warning name.
     pub(crate) fn has_allow_directive(
@@ -672,6 +699,120 @@ impl<'a> Sema<'a> {
         Ok(air_args)
     }
 
+    /// Is `operand` a *direct* reference to a `borrow str` / `inout str`
+    /// parameter — i.e. a borrowed `str` *view* value (ADR-0043 two-types
+    /// model, RUE-386)?
+    ///
+    /// Only a whole-value `VarRef` to such a parameter is a view value:
+    /// reading *through* the view (`s.len()`, `s[i]`) never yields a `str`, and
+    /// a `let`-rebind of the view is itself blocked at its binding site, so
+    /// there is never a second first-class root to chase. This keeps the check
+    /// structural (one instruction shape), never a dataflow — exactly what the
+    /// no-lifetimes spine requires.
+    pub(crate) fn is_str_view_operand(&self, operand: InstRef, ctx: &AnalysisContext) -> bool {
+        if let InstData::VarRef { name } = self.rir.get(operand).data {
+            return ctx.params.iter().any(|p| {
+                p.name == name
+                    && matches!(p.mode, RirParamMode::Borrow | RirParamMode::Inout)
+                    && self.is_str_struct(p.ty)
+            });
+        }
+        false
+    }
+
+    /// Enforce the ADR-0043 two-types string model at a *first-class* `str`
+    /// destination (RUE-386): reject a string *buffer* (`StrBuf`/`Str(N)`, the
+    /// growable/fixed rungs) or a borrowed `str` *view* being stored as a
+    /// first-class `str`. `found` is the operand's analyzed type; `operand` is
+    /// its source instruction (used to recognise a view). Callers invoke this
+    /// only when the destination type is the bare `str` (not `Str(N)`).
+    ///
+    /// A buffer's bytes live in caller-owned local/heap storage and a view
+    /// aliases a borrow's scope; either escaping as a first-class `str` (which
+    /// is `Copy`, storable, and returnable) dangles once the storage is freed —
+    /// the verified RUE-386 segfault. Buffers coerce only to `borrow str` /
+    /// `inout str`; views may only be read or re-borrowed.
+    pub(crate) fn reject_non_first_class_str(
+        &self,
+        operand: InstRef,
+        found: Type,
+        site: FirstClassStrSite,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<()> {
+        if self.is_builtin_string(found) || self.is_str_fixed_struct(found) {
+            let found_name = found.safe_name_with_pool(Some(&self.type_pool));
+            let mut err = CompileError::new(
+                ErrorKind::BufferNotFirstClassStr {
+                    found: found_name,
+                    site: site.describe().to_string(),
+                },
+                span,
+            );
+            err = if site == FirstClassStrSite::Param {
+                err.with_help(
+                    "parameter type `str` accepts only string literals; did you mean `borrow str`?",
+                )
+            } else {
+                err.with_help(
+                    "a string buffer can be viewed with `borrow str` / `inout str`, \
+                     but not stored as a first-class `str`",
+                )
+            };
+            return Err(err);
+        }
+        if self.is_str_view_operand(operand, ctx) {
+            return Err(CompileError::new(
+                ErrorKind::StrViewNotFirstClass {
+                    site: site.describe().to_string(),
+                },
+                span,
+            )
+            .with_help(
+                "a `borrow str` / `inout str` view is second-class and cannot escape the call; \
+                 it can only be read (`.len()`, byte indexing) or re-borrowed",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Enforce inout-`str`-requires-local-provenance (ADR-0043 two-types model,
+    /// RUE-386): the operand of an `inout str` parameter must be a *local*
+    /// string buffer (`StrBuf`/`Str(N)`), never a first-class / static-backed
+    /// `str`. A static `str` lives in read-only `.rodata`, so an exclusive view
+    /// would enable a write-to-`.rodata` fault once byte mutation lands; and
+    /// since `str` is `Copy`, two roots can alias one static buffer in a way
+    /// per-root exclusivity cannot see. `found` is the operand's analyzed type.
+    pub(crate) fn reject_static_str_inout(&self, found: Type, span: Span) -> CompileResult<()> {
+        if self.is_str_struct(found) {
+            return Err(
+                CompileError::new(ErrorKind::InoutStrRequiresLocalBuffer, span).with_help(
+                    "`inout str` requires a local `StrBuf` or `Str(N)`; \
+                     a first-class `str` cannot be exclusively viewed",
+                ),
+            );
+        }
+        Ok(())
+    }
+
+    /// The tail (value) expression of a RIR block, descending through nested
+    /// blocks. Used to locate the *implicit-return* operand of a `str`-typed
+    /// function body so the two-types model (RUE-386) can reject a buffer or a
+    /// borrowed view escaping via the tail value. A non-block body is its own
+    /// tail; an empty block returns itself (its value is unit, harmless here).
+    pub(crate) fn rir_block_tail_expr(&self, inst: InstRef) -> InstRef {
+        let mut current = inst;
+        loop {
+            match self.rir.get(current).data {
+                InstData::Block { extra_start, len } if len > 0 => {
+                    let refs = self.rir.get_extra(extra_start, len);
+                    current = InstRef::from_raw(refs[len as usize - 1]);
+                }
+                _ => return current,
+            }
+        }
+    }
+
     /// Analyze call arguments, materializing a fat-pointer slice value for any
     /// argument whose parameter is a slice type (ADR-0043, RUE-322).
     ///
@@ -685,6 +826,7 @@ impl<'a> Sema<'a> {
         air: &mut Air,
         args: &[RirCallArg],
         param_types: &[Type],
+        param_modes: &[RirParamMode],
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Vec<AirCallArg>> {
         let mut air_args = Vec::with_capacity(args.len());
@@ -709,6 +851,20 @@ impl<'a> Sema<'a> {
                 let arg_result = self.analyze_inst(air, arg.value, ctx);
                 ctx.expected_type = prev_expected;
                 let arg_result = arg_result?;
+                // Two-types model (ADR-0043, RUE-386): a bare `str` parameter
+                // (Normal mode) requires a first-class `str`; a buffer or a
+                // borrowed view passed here would escape and dangle. A
+                // `borrow str` parameter (Borrow mode) is the sanctioned view
+                // and accepts a buffer, so it is exempt.
+                if param_modes.get(i) == Some(&RirParamMode::Normal) && self.is_str_struct(str_ty) {
+                    self.reject_non_first_class_str(
+                        arg.value,
+                        arg_result.ty,
+                        FirstClassStrSite::Param,
+                        self.rir.get(arg.value).span,
+                        ctx,
+                    )?;
+                }
                 air_args.push(AirCallArg {
                     value: arg_result.air_ref,
                     mode: AirArgMode::Normal,
@@ -753,6 +909,13 @@ impl<'a> Sema<'a> {
             let arg_result = self.analyze_inst(air, arg.value, ctx);
             ctx.byref_arg_root = prev_byref_root;
             let arg_result = arg_result?;
+            // Two-types model (ADR-0043, RUE-386): an `inout str` parameter is
+            // an *exclusive* view and requires local provenance — a first-class
+            // / static `str` value is never a legal exclusive operand (closes
+            // the write-to-`.rodata` and Copy-two-roots aliasing holes).
+            if is_inout_str_param {
+                self.reject_static_str_inout(arg_result.ty, self.rir.get(arg.value).span)?;
+            }
             air_args.push(AirCallArg {
                 value: arg_result.air_ref,
                 mode: Self::convert_arg_mode(arg.mode),

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -32,7 +32,7 @@ use rue_rir::{InstData, InstRef, RirArgMode, RirParamMode, RirPattern};
 use crate::sema::context::ConstValue;
 use rue_span::Span;
 
-use super::analysis::move_out_of_inout_error;
+use super::analysis::{FirstClassStrSite, move_out_of_inout_error};
 use super::context::{AnalysisContext, AnalysisResult, LocalVar, VariableMoveState};
 use super::{FunctionInfo, Sema};
 use crate::inst::{
@@ -2116,6 +2116,21 @@ impl<'a> Sema<'a> {
             };
             let inner_ty = inner_result.ty;
 
+            // Two-types model (ADR-0043, RUE-386): an explicit `return <expr>;`
+            // in a `str`-returning function must return a first-class `str`,
+            // not a buffer or a borrowed view (which would dangle after its
+            // storage is dropped). Checked before the generic type-mismatch so
+            // the targeted E0495/E0497 wins over E0206.
+            if self.is_str_struct(ctx.return_type) {
+                self.reject_non_first_class_str(
+                    inner,
+                    inner_ty,
+                    FirstClassStrSite::Return,
+                    span,
+                    ctx,
+                )?;
+            }
+
             // Type check: returned value must match function's return type.
             if !ctx.return_type.is_error()
                 && !inner_ty.is_error()
@@ -2360,6 +2375,17 @@ impl<'a> Sema<'a> {
         ctx.expected_type = prev_expected;
         let init_result = init_outcome?;
         let var_type = init_result.ty;
+
+        // Two-types model (ADR-0043, RUE-386): a `str`-annotated binding, or one
+        // whose initializer is itself a first-class `str` slot, must not bind a
+        // buffer (`StrBuf`/`Str(N)`) or a borrowed `str` view — either would let
+        // the value escape past its backing storage as a first-class `str`. The
+        // check covers both an explicit `let s: str = <buffer>` (annotation is
+        // `str`; the annotation is otherwise unenforced here since `var_type`
+        // comes from the initializer) and `let s = <view>` (no annotation).
+        if annotation_type.is_some_and(|a| self.is_str_struct(a)) || self.is_str_struct(var_type) {
+            self.reject_non_first_class_str(init, var_type, FirstClassStrSite::Binding, span, ctx)?;
+        }
 
         // If name is None, this is a wildcard pattern `_` that discards the value.
         // `let _ = <expr>;` (and `let _: T = <expr>;`) is a discard site (spec
@@ -2940,6 +2966,19 @@ impl<'a> Sema<'a> {
         // on the post-RHS move state so `x = f(x)` counts as a discharge.
         let discharged = self.place_linear_discharged(local_ty, name, &[], span, ctx);
         self.check_linear_overwrite(local_ty, discharged, false, span)?;
+        // Two-types model (ADR-0043, RUE-386): reassigning a first-class `str`
+        // local must store a first-class `str`, not a buffer or a borrowed view
+        // (`s = <buffer>` used to silently truncate a 3-word `StrBuf` into the
+        // 2-word `str` slot, leaving a dangling pointer).
+        if self.is_str_struct(local_ty) {
+            self.reject_non_first_class_str(
+                value,
+                value_result.ty,
+                FirstClassStrSite::Binding,
+                span,
+                ctx,
+            )?;
+        }
 
         // Assignment to a mutable variable resets its move state.
         ctx.moved_vars.remove(&name);
@@ -3199,6 +3238,22 @@ impl<'a> Sema<'a> {
                 // Not an integer literal - analyze normally
                 self.analyze_inst(air, *field_value, ctx)?
             };
+
+            // Two-types model (ADR-0043, RUE-386): storing into a first-class
+            // `str` field must not smuggle a borrowed `str` view (a
+            // `borrow`/`inout str` parameter) into the aggregate — the view
+            // would outlive its borrow and dangle. A buffer field value is
+            // caught by the type-mismatch below (a `StrBuf`/`Str(N)` is not
+            // `str`); only the same-typed view needs this dedicated check.
+            if self.is_str_struct(expected_field_type) {
+                self.reject_non_first_class_str(
+                    *field_value,
+                    field_result.ty,
+                    FirstClassStrSite::Field,
+                    span,
+                    ctx,
+                )?;
+            }
 
             // Type check the field value against the expected type
             if field_result.ty != expected_field_type {
@@ -5563,6 +5618,7 @@ impl<'a> Sema<'a> {
         let param_types = param_types.to_vec();
         let param_comptime = param_comptime.to_vec();
         let param_names = param_names.to_vec();
+        let param_modes = param_modes.to_vec();
         let return_type_sym = fn_info.return_type_sym;
         let base_return_type = fn_info.return_type;
         let fn_body = fn_info.body;
@@ -5656,7 +5712,8 @@ impl<'a> Sema<'a> {
 
         // Analyze all arguments. Slice parameters (ADR-0043, RUE-322) coerce a
         // `borrow arr` argument into a by-value fat pointer here.
-        let air_args = self.analyze_call_args_coerced(air, &args, &param_types, ctx)?;
+        let air_args =
+            self.analyze_call_args_coerced(air, &args, &param_types, &param_modes, ctx)?;
 
         // Handle generic function calls differently
         if is_generic {

--- a/crates/rue-cli-tests/cases/str_fixed_type.toml
+++ b/crates/rue-cli-tests/cases/str_fixed_type.toml
@@ -93,26 +93,44 @@ args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0492"]
 
-# A `Str(N)` value coerces to a `str` parameter and is read through the str
-# interface — both a materialized literal and a forwarded Str(N) variable.
+# Two-types model (ADR-0043, RUE-386): a `Str(N)` buffer is read through a
+# `borrow str` view — NOT a first-class `str` parameter (that would let the
+# buffer escape). Read via `.len()` and byte index through the shared view.
 [[case]]
-name = "str_fixed_coerces_to_str_param"
+name = "str_fixed_read_through_borrow_str_view"
 files = [{ path = "main.rue", source = """
-fn len_of(s: str) -> u64 {
+fn len_of(borrow s: str) -> u64 {
     s.len()
 }
-fn first(s: str) -> u8 {
+fn first(borrow s: str) -> u8 {
     s[0]
 }
 fn main() -> i32 {
     let s: Str(8) = "hello";
-    let n: u64 = len_of(s);
-    let b: u8 = first(s);
+    let n: u64 = len_of(borrow s);
+    let b: u8 = first(borrow s);
     if n == 5 && b == 104 { 42 } else { 0 }
 }
 """ }]
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 42
+
+# The bare `str` parameter form of the above is rejected: a `Str(N)` buffer is
+# not a first-class `str` (E0495, RUE-386).
+[[case]]
+name = "str_fixed_to_first_class_str_param_rejected"
+files = [{ path = "main.rue", source = """
+fn len_of(s: str) -> u64 {
+    s.len()
+}
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    @intCast(len_of(s))
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0495", "did you mean `borrow str`?"]
 
 # A Str(N) is a value type: passing it to a Str(N) parameter and reading .len()
 # there round-trips.

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -110,12 +110,14 @@ fn main() -> i32 {
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 8
 
-# `inout str` rebinds the caller's first-class `{ptr, len}` value. This used to
-# ICE in both backends when the callee assigned to the parameter: sema emitted a
-# ParamStore, but function ABI lowering had treated `inout str` like a by-value
-# slice view (RUE-385).
+# Two-types model (ADR-0043, RUE-386): a first-class / static `str` value is NOT
+# a legal `inout str` operand — an exclusive view requires *local* buffer
+# provenance. (This supersedes the earlier RUE-385 behaviour, where `inout str`
+# rebound the caller's static `{ptr, len}`; under the ruling that static-operand
+# case is rejected outright, closing the write-to-`.rodata` and Copy-two-roots
+# holes.) The callee/assignment never runs; sema rejects the call.
 [[case]]
-name = "str_inout_rebinds_caller_fat_pointer"
+name = "str_inout_static_operand_rejected"
 files = [{ path = "main.rue", source = """
 fn set_hi(inout s: str) {
     s = "hi";
@@ -127,7 +129,24 @@ fn main() -> i32 {
 }
 """ }]
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
-exit_code = 2
+compile_fail = true
+error_contains = ["E0496"]
+
+# `inout str` DOES accept a local buffer operand (`StrBuf`/`Str(N)`): the
+# exclusive view reads the buffer's bytes through the `str` interface.
+[[case]]
+name = "str_inout_accepts_local_buffer"
+files = [{ path = "main.rue", source = """
+fn take(inout s: str) -> u64 {
+    s.len()
+}
+fn main() -> i32 {
+    let mut b: Str(8) = "hello";
+    @intCast(take(inout b))
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 5
 
 # Without the preview flag, `str` is gated with a clear diagnostic (not an ICE).
 [[case]]
@@ -155,3 +174,87 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 5
+
+# ============================================================================
+# RUE-386 two-types model: reject buffer/view -> first-class `str` escapes.
+# Both of these were VERIFIED SEGFAULTS (exit 139) on the pre-fix compiler: a
+# heap `StrBuf` coerced to a first-class `str` that escaped its scope, leaving a
+# dangling `{ptr, len}`. They are now compile errors (E0495), and each legal
+# alternative (`borrow str`) is exercised alongside.
+# ============================================================================
+
+# The original RUE-386 repro #1: a `StrBuf` passed to a bare `str` parameter,
+# stored in a struct field, and escaping its scope. SEGFAULT -> E0495.
+[[case]]
+name = "strbuf_to_first_class_str_param_field_escape_rejected"
+files = [{ path = "main.rue", source = """
+struct Keep { s: str }
+fn cap(s: str) -> Keep { Keep { s: s } }
+fn main() -> i32 {
+    let k = {
+        let b = "xx" + "yy";
+        cap(b)
+    };
+    @dbg(k.s.len());
+    @dbg(k.s[0]);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0495", "did you mean `borrow str`?"]
+
+# The original RUE-386 repro #2: the return-position variant. SEGFAULT -> E0495.
+[[case]]
+name = "strbuf_to_first_class_str_return_escape_rejected"
+files = [{ path = "main.rue", source = """
+fn take(s: str) -> str { s }
+fn main() -> i32 {
+    let r = {
+        let b = "xx" + "yy";
+        take(b)
+    };
+    @dbg(r.len());
+    @dbg(r[0]);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0495"]
+
+# A borrowed `str` view escaping via a returned struct field was ALSO a verified
+# segfault (the `borrow`-keyword variant of repro #1): E0497.
+[[case]]
+name = "borrow_str_view_field_escape_rejected"
+files = [{ path = "main.rue", source = """
+struct Keep { s: str }
+fn cap(borrow s: str) -> Keep { Keep { s: s } }
+fn main() -> i32 {
+    let k = {
+        let b = "xx" + "yy";
+        cap(borrow b)
+    };
+    @dbg(k.s.len());
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0497"]
+
+# The legal alternative to the repros: read the buffer through a `borrow str`
+# view within the call. A `Str(N)` buffer (static-backed like `str`) is read
+# correctly through the view — `.len()` and the first byte.
+[[case]]
+name = "buffer_read_through_borrow_str_view_ok"
+files = [{ path = "main.rue", source = """
+fn len_of(borrow s: str) -> u64 { s.len() }
+fn first(borrow s: str) -> u8 { s[0] }
+fn main() -> i32 {
+    let buf: Str(8) = "hello";
+    if len_of(borrow buf) == 5 && first(borrow buf) == 104 { 7 } else { 0 }
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 7

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -257,6 +257,29 @@ impl ErrorCode {
     /// never be proven moved-out (moving out of a by-ref binding is itself
     /// rejected), so a linear `inout` assignment is always ill-formed.
     pub const LINEAR_VALUE_OVERWRITTEN_THROUGH_INOUT: Self = Self(494);
+    /// A string *buffer* — `StrBuf` (growable) or `Str(N)` (fixed) — was used
+    /// where a *first-class* `str` value is required: a bare `str` parameter,
+    /// a `str` binding, a `str` return, or a `str` struct field (ADR-0043
+    /// two-types model, RUE-386). A first-class `str` is static-backed and may
+    /// escape; a buffer's bytes live in caller-owned local/heap storage, so
+    /// letting it become a first-class `str` produces a dangling view once the
+    /// buffer is dropped (the verified RUE-386 segfault). A buffer coerces only
+    /// to a second-class `borrow str` / `inout str` view.
+    pub const BUFFER_NOT_FIRST_CLASS_STR: Self = Self(495);
+    /// A first-class / static-backed `str` value was supplied as the operand
+    /// of an `inout str` parameter (ADR-0043 two-types model, RUE-386). An
+    /// exclusive `str` view requires *local* provenance — a `StrBuf`/`Str(N)`
+    /// buffer the caller owns — because a static `str` lives in read-only
+    /// `.rodata` (exclusive mutation would fault) and, being `Copy`, can have
+    /// two roots over one static buffer that per-root exclusivity cannot see.
+    pub const INOUT_STR_REQUIRES_LOCAL_BUFFER: Self = Self(496);
+    /// A borrowed `str` *view* — the binding of a `borrow str` / `inout str`
+    /// parameter — was used where a first-class `str` value is required
+    /// (returned, stored in a struct field, bound to a `str` local, or passed
+    /// to a bare `str` parameter) (ADR-0043 two-types model, RUE-386). A view
+    /// is second-class: it may only be read (`.len()`, byte indexing) or
+    /// re-borrowed, never escape the call as a first-class value.
+    pub const STR_VIEW_NOT_FIRST_CLASS: Self = Self(497);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1215,6 +1238,21 @@ pub enum ErrorKind {
         "string literal of {byte_len} bytes does not fit in `Str({capacity})` (capacity {capacity} bytes)"
     )]
     StrFixedCapacityExceeded { capacity: u64, byte_len: u64 },
+    /// A string buffer (`StrBuf`/`Str(N)`) flowed into a first-class `str`
+    /// slot (ADR-0043 two-types model, RUE-386). `site` names the position
+    /// ("as a parameter argument", "in a binding", "as a return value", "in a
+    /// struct field").
+    #[error("a string buffer (`{found}`) cannot be used as a first-class `str` {site}")]
+    BufferNotFirstClassStr { found: String, site: String },
+    /// A first-class / static `str` value was passed as an `inout str` operand
+    /// (ADR-0043 two-types model, RUE-386).
+    #[error("a first-class `str` value cannot be passed as `inout str`")]
+    InoutStrRequiresLocalBuffer,
+    /// A borrowed `str` view (a `borrow`/`inout str` parameter) escaped into a
+    /// first-class `str` slot (ADR-0043 two-types model, RUE-386). `site`
+    /// names the position, as in [`Self::BufferNotFirstClassStr`].
+    #[error("a borrowed `str` view cannot be used as a first-class `str` {site}")]
+    StrViewNotFirstClass { site: String },
     /// Inout argument is not an lvalue (variable, field, or array element)
     #[error("inout argument must be an lvalue (variable, field, or array element)")]
     InoutNonLvalue,
@@ -1517,6 +1555,9 @@ impl ErrorKind {
             ErrorKind::RawRequiresPlace => ErrorCode::RAW_REQUIRES_PLACE,
             ErrorKind::FieldPtrRequiresField => ErrorCode::FIELD_PTR_REQUIRES_FIELD,
             ErrorKind::StrFixedCapacityExceeded { .. } => ErrorCode::STR_FIXED_CAPACITY_EXCEEDED,
+            ErrorKind::BufferNotFirstClassStr { .. } => ErrorCode::BUFFER_NOT_FIRST_CLASS_STR,
+            ErrorKind::InoutStrRequiresLocalBuffer => ErrorCode::INOUT_STR_REQUIRES_LOCAL_BUFFER,
+            ErrorKind::StrViewNotFirstClass { .. } => ErrorCode::STR_VIEW_NOT_FIRST_CLASS,
             ErrorKind::InoutNonLvalue => ErrorCode::INOUT_NON_LVALUE,
             ErrorKind::InoutExclusiveAccess { .. } => ErrorCode::INOUT_EXCLUSIVE_ACCESS,
             ErrorKind::BorrowNonLvalue => ErrorCode::BORROW_NON_LVALUE,
@@ -2432,6 +2473,33 @@ mod tests {
         assert_eq!(ErrorCode::SLICE_RETURN_NOT_ALLOWED.0, 487);
         assert_eq!(ErrorCode::SLICE_IN_AGGREGATE_FIELD.0, 488);
         assert_eq!(ErrorCode::SLICE_ESCAPES_SCOPE.0, 489);
+    }
+
+    #[test]
+    fn test_two_types_string_model_codes() {
+        // ADR-0043 two-types model (RUE-386): first-class `str` vs. views.
+        assert_eq!(
+            ErrorKind::BufferNotFirstClassStr {
+                found: "StrBuf".to_string(),
+                site: "as a parameter argument".to_string(),
+            }
+            .code(),
+            ErrorCode::BUFFER_NOT_FIRST_CLASS_STR
+        );
+        assert_eq!(
+            ErrorKind::InoutStrRequiresLocalBuffer.code(),
+            ErrorCode::INOUT_STR_REQUIRES_LOCAL_BUFFER
+        );
+        assert_eq!(
+            ErrorKind::StrViewNotFirstClass {
+                site: "as a return value".to_string(),
+            }
+            .code(),
+            ErrorCode::STR_VIEW_NOT_FIRST_CLASS
+        );
+        assert_eq!(ErrorCode::BUFFER_NOT_FIRST_CLASS_STR.0, 495);
+        assert_eq!(ErrorCode::INOUT_STR_REQUIRES_LOCAL_BUFFER.0, 496);
+        assert_eq!(ErrorCode::STR_VIEW_NOT_FIRST_CLASS.0, 497);
     }
 
     #[test]

--- a/crates/rue-spec/cases/types/str-fixed-type.toml
+++ b/crates/rue-spec/cases/types/str-fixed-type.toml
@@ -164,25 +164,46 @@ fn main() -> i32 {
 """
 exit_code = 101
 
-# 3.7:55 — a `Str(N)` coerces to a `str` parameter and is read through it.
+# 3.7:55 — a `Str(N)` coerces to a `borrow str` view and is read through it
+# (ADR-0043 two-types model, RUE-386). It does NOT coerce to a first-class `str`
+# (that would let the buffer's bytes escape); the read interface is `borrow str`.
 [[case]]
-name = "str_fixed_coerces_to_str_param"
+name = "str_fixed_coerces_to_borrow_str_param"
 spec = ["3.7:55"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn len_of(borrow s: str) -> u64 {
+    s.len()
+}
+fn first(borrow s: str) -> u8 {
+    s[0]
+}
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    if len_of(borrow s) == 5 && first(borrow s) == 104 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# 3.7:59 — a `Str(N)` buffer passed to a bare first-class `str` parameter is
+# rejected (E0495): the buffer's bytes would escape. Use `borrow str` instead.
+[[case]]
+name = "str_fixed_to_first_class_str_param_rejected"
+spec = ["3.7:59"]
 preview = "string_trio"
 preview_should_pass = true
 source = """
 fn len_of(s: str) -> u64 {
     s.len()
 }
-fn first(s: str) -> u8 {
-    s[0]
-}
 fn main() -> i32 {
     let s: Str(8) = "hello";
-    if len_of(s) == 5 && first(s) == 104 { 0 } else { 1 }
+    @intCast(len_of(s))
 }
 """
-exit_code = 0
+compile_fail = true
+error_contains = "first-class `str`"
 
 # 3.7:10 / 4.3:3 — fixed string equality is byte-content equality, not
 # structural equality over the compiler's representation.

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -219,3 +219,103 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
+
+# ============================================================================
+# Two-types string model (ADR-0043, RUE-386): first-class `str` vs. views.
+# ============================================================================
+
+# 3.7:58 — a `borrow str` view reads a buffer's bytes through the `str`
+# interface (`.len()`, indexing) and may be re-borrowed. A `Str(N)` source is
+# used because it shares the static-backed 2-word representation of `str`.
+[[case]]
+name = "borrow_str_view_reads_and_reborrows"
+spec = ["3.7:58"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn inner(borrow s: str) -> u64 {
+    s.len()
+}
+fn outer(borrow s: str) -> u64 {
+    inner(borrow s)          // re-borrow is allowed
+}
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    @intCast(outer(borrow s))
+}
+"""
+exit_code = 5
+
+# 3.7:59 — a borrowed `str` view laundered into a first-class `str` (returned)
+# is rejected (E0497): the view is second-class and cannot escape the call.
+[[case]]
+name = "borrow_str_view_return_rejected"
+spec = ["3.7:59"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn bad(borrow s: str) -> str {
+    s
+}
+fn main() -> i32 {
+    0
+}
+"""
+compile_fail = true
+error_contains = "E0497"
+
+# 3.7:59 — a borrowed `str` view stored in a struct field is rejected (E0497).
+[[case]]
+name = "borrow_str_view_struct_field_rejected"
+spec = ["3.7:59"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+struct Keep { s: str }
+fn bad(borrow s: str) -> Keep {
+    Keep { s: s }
+}
+fn main() -> i32 {
+    0
+}
+"""
+compile_fail = true
+error_contains = "E0497"
+
+# 3.7:60 — a `StrBuf` buffer coerces to an `inout str` view (exclusive) when the
+# operand is a local buffer; the view reads through the `str` interface.
+[[case]]
+name = "inout_str_accepts_local_buffer"
+spec = ["3.7:60"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn take(inout s: str) -> u64 {
+    s.len()
+}
+fn main() -> i32 {
+    let mut b: Str(8) = "hello";
+    @intCast(take(inout b))
+}
+"""
+exit_code = 5
+
+# 3.7:60 — a first-class / static `str` value is NOT a legal `inout str` operand
+# (E0496): an exclusive view requires local buffer provenance.
+[[case]]
+name = "inout_str_static_operand_rejected"
+spec = ["3.7:60"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn take(inout s: str) {
+    s = "hi";
+}
+fn main() -> i32 {
+    let mut s: str = "hello";
+    take(inout s);
+    0
+}
+"""
+compile_fail = true
+error_contains = "E0496"

--- a/crates/rue-ui-tests/cases/diagnostics/str_two_types.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/str_two_types.toml
@@ -1,0 +1,104 @@
+[section]
+id = "diagnostics.str-two-types"
+name = "Two-types string model diagnostics (ADR-0043, RUE-386)"
+description = """
+The ADR-0043 two-types string model (RUE-386) distinguishes a first-class,
+static-backed `str` value from a second-class `borrow str` / `inout str` view.
+A string buffer (`StrBuf`/`Str(N)`) or a borrowed view used where a first-class
+`str` is required would escape its backing storage (a verified segfault), so it
+is a compile error. These cases pin the diagnostic wording — most importantly
+the targeted did-you-mean on a bare `str` parameter, which authors with a Rust
+prior will hit constantly. The end-to-end runtime behaviour and the segfault
+regressions are pinned in the CLI suite (str_type.toml).
+"""
+
+# The star diagnostic Steve asked for: passing a non-literal (a buffer) where a
+# bare `str` parameter is expected suggests `borrow str` by name.
+[[case]]
+name = "buffer_to_str_param_suggests_borrow_str"
+description = "A `StrBuf` argument to a bare `str` parameter is E0495 with the `borrow str` did-you-mean."
+preview = "string_trio"
+source = """
+fn cap(s: str) -> u64 { s.len() }
+fn main() -> i32 {
+    let b = "xx" + "yy";
+    @intCast(cap(b))
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0495",
+    "parameter type `str` accepts only string literals; did you mean `borrow str`?",
+]
+
+# A fixed `Str(N)` buffer gets the same did-you-mean at a bare `str` parameter.
+[[case]]
+name = "str_fixed_to_str_param_suggests_borrow_str"
+description = "A `Str(N)` argument to a bare `str` parameter is E0495 with the `borrow str` did-you-mean."
+preview = "string_trio"
+source = """
+fn cap(s: str) -> u64 { s.len() }
+fn main() -> i32 {
+    let x: Str(8) = "hello";
+    @intCast(cap(x))
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0495",
+    "did you mean `borrow str`?",
+]
+
+# A buffer bound to a `str` local is E0495 (binding site, no did-you-mean —
+# the fix is to keep the buffer's own type, so a different help fires).
+[[case]]
+name = "buffer_to_str_binding_rejected"
+description = "A `StrBuf` bound to a `str` local is E0495 (buffer is not a first-class str)."
+preview = "string_trio"
+source = """
+fn main() -> i32 {
+    let b = "xx" + "yy";
+    let s: str = b;
+    @intCast(s.len())
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0495",
+    "a string buffer can be viewed with `borrow str` / `inout str`",
+]
+
+# A borrowed `str` view returned as a first-class `str` is E0497.
+[[case]]
+name = "borrow_str_view_return_is_e0497"
+description = "Returning a `borrow str` parameter as a first-class `str` is E0497 (view cannot escape)."
+preview = "string_trio"
+source = """
+fn bad(borrow s: str) -> str { s }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E0497",
+    "cannot escape the call",
+]
+
+# A first-class / static `str` passed as `inout str` is E0496 (needs a local
+# buffer for the exclusive view).
+[[case]]
+name = "static_str_as_inout_is_e0496"
+description = "A static `str` value as an `inout str` operand is E0496 (requires a local buffer)."
+preview = "string_trio"
+source = """
+fn take(inout s: str) { s = "hi"; }
+fn main() -> i32 {
+    let mut s: str = "hello";
+    take(inout s);
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0496",
+    "`inout str` requires a local `StrBuf` or `Str(N)`",
+]

--- a/docs/designs/0043-collection-string-type-trio.md
+++ b/docs/designs/0043-collection-string-type-trio.md
@@ -109,11 +109,42 @@ system beyond this refinement plus literal syntax.
   languages, not an inconsistency.
 - **`"hello" : str`, a static-backed first-class value.** It is storable, `Copy`,
   and reassignable (`let s = "hello"; s = "hi";` compiles) — the ergonomic
-  default. The cost is that `str` has two provenances: **static** (literals →
-  first-class) and **local** (a `borrow` of a `StrBuf`/`Str(N)` → second-class,
-  argument-only). The compiler tracks this as a single bit, not a lifetime
-  system — the one place Rue's no-lifetime purity gets a smudge, taken
-  deliberately for `&str`-grade ergonomics.
+  default.
+
+  > **Amended 2026-07-09 (RUE-386): the two-types model, not a provenance bit.**
+  > This ADR originally said `str` "has two provenances — static (literals →
+  > first-class) and local (a `borrow` of a `StrBuf`/`Str(N)` → second-class) —
+  > tracked as a single bit." That bit was never sound: it requires a dataflow
+  > that follows the distinction through branches, calls, struct fields, arrays,
+  > and enum payloads — exactly the shadow lifetime analysis the no-lifetimes
+  > spine refuses — and without it a `StrBuf` coerced to a first-class `str` that
+  > escaped its scope (a **verified segfault**, RUE-386). Steve's ruling
+  > (2026-07-09) replaces the bit with a **two-types model** decided
+  > structurally at the coercion, needing zero flow analysis:
+  >
+  > - **`str`** is the *first-class* value: static-backed, `Copy`, storable,
+  >   returnable. It originates only from a string literal or another first-class
+  >   `str`.
+  > - **`borrow str` / `inout str`** are *second-class views* (the ordinary
+  >   slice/access-model machinery of ADR-0037), valid only in argument position.
+  > - **The only coercions:** literal/`str` → `borrow str`; and
+  >   `Str(N)`/`StrBuf` → `borrow str` **or** `inout str`. There is **no**
+  >   coercion from a view to a first-class `str`, and **no** buffer → first-class
+  >   `str` (E0495 for a buffer, E0497 for a view; §3.7:59).
+  > - **`inout str` requires local provenance:** its operand must be a
+  >   caller-owned `StrBuf`/`Str(N)` buffer; a static `str` is never a legal
+  >   exclusive-view operand (E0496) — closing the write-to-`.rodata` path and the
+  >   `Copy`-two-roots aliasing hole (`let s2 = s1` over one static buffer, which
+  >   per-root exclusivity cannot see). "A single bit, not a lifetime system"
+  >   becomes literally "which of two types," and every laundering channel
+  >   (return, struct field, binding, argument) closes at type-check.
+  >
+  > The recognized cost is two `str`-family spellings in signatures (`fn f(s:
+  > str)` vs `fn f(borrow s: str)`): `borrow str` is almost always what a
+  > parameter wants, and a Rust prior reaches for bare `str`. This is mitigated by
+  > a targeted diagnostic on a buffer/non-literal at a bare `str` parameter —
+  > *"parameter type `str` accepts only string literals; did you mean `borrow
+  > str`?"*
 - **Array literals land on the *fixed* rung** (`[1,2,3] : [T; N]`) while string
   literals land on the *slice* rung (`"hello" : str`). This asymmetry is
   principled: **string-literal data is always compile-time-static** (→ a natural
@@ -188,13 +219,16 @@ not an owned copy. This revises ADR-0035, which specified `s[a..b] -> String`
 ## Consequences
 
 - **New surface to build:** the slice type (`borrow [T]` / `inout [T]`), range
-  slicing syntax (`x[a..b]`), and the static-vs-local provenance bit on `str`.
-  This is foundational and should be built as *one* piece so arrays, strings, and
-  buffers share it rather than each inventing a view.
+  slicing syntax (`x[a..b]`), and the first-class-`str`-vs-view split (§3, as
+  amended by RUE-386). This is foundational and should be built as *one* piece so
+  arrays, strings, and buffers share it rather than each inventing a view.
 - **`str`/`String`-grade ergonomics without the tax:** no lifetimes, no `Cow`, no
   "take `&str` return `String`" puzzles, because views cannot escape.
-- **The one smudge:** `str` carries a static/local provenance distinction — a
-  single-bit, two-point echo of a lifetime. Accepted for literal ergonomics.
+- **No smudge, after all:** §3 originally kept a static/local provenance *bit* on
+  `str` — a single-point echo of a lifetime. RUE-386 replaced it with the
+  two-types model (`str` vs `borrow str`/`inout str`), decided structurally at
+  the coercion with no flow analysis, so the no-lifetimes purity holds exactly.
+  The cost moves from a hidden bit to a visible second spelling in signatures.
 - **Renames land as breaking changes** (`Vec` → `ArrayBuf`, `String` → `StrBuf`)
   while the surface is still small — cheapest to do now.
 - **Sequencing:** the slice/trio design is the irreversible part and is the same

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -391,7 +391,10 @@ value is a two-word view `{ptr, len}`: a pointer to the bytes and a byte length.
 Where a `str` is expected, a string literal has type `str` and is *static-backed*
 and *first-class*: its bytes reside in read-only data that cannot dangle, so the
 `str` value is `@copy`, storable in a binding or a struct field, reassignable,
-returnable from a function, and passable as an argument.
+returnable from a function, and passable as an argument. A first-class `str`
+value originates only from a string literal or from another first-class `str`;
+in particular a string *buffer* (`StrBuf` or `Str(N)`, §3.7:49) and a borrowed
+`str` *view* (§3.7:59) are never themselves first-class `str` values.
 
 {{ rule(id="3.7:45", cat="normative") }}
 
@@ -426,6 +429,38 @@ fn main() -> i32 {
     0
 }
 ```
+
+### First-class `str` versus borrowed views
+
+{{ rule(id="3.7:58", cat="normative") }}
+
+Rue distinguishes two string capabilities structurally, with no provenance
+tracking (ADR-0043): a *first-class* `str` (§3.7:44) — a static-backed value that
+may be copied, stored, returned, and rebound — and a second-class *view* spelled
+`borrow str` (shared) or `inout str` (exclusive). A view is a fat pointer over a
+buffer's bytes that is valid only in argument position; it may be read (`.len()`,
+byte indexing) or re-borrowed, but it cannot escape the call by being returned,
+stored in a struct field, or bound past its argument scope.
+
+{{ rule(id="3.7:59", cat="legality-rule") }}
+
+A string *buffer* — `StrBuf` or `Str(N)` — or a borrowed `str` view used where a
+*first-class* `str` value is required (a bare `str` parameter argument, a `str`
+binding, a `str` return value, or a `str` struct field) is a compile-time error:
+a buffer's bytes live in caller-owned local or heap storage and a view aliases a
+borrow's scope, so either escaping as a first-class `str` would dangle once the
+storage is released. Passing a buffer is reported as E0495 (a bare `str`
+parameter suggests `borrow str`); laundering a view is reported as E0497.
+
+{{ rule(id="3.7:60", cat="normative") }}
+
+A `StrBuf` or `Str(N)` value coerces only to a `borrow str` or `inout str` view,
+never to a first-class `str`. An `inout str` view — an *exclusive* view — further
+requires *local* provenance: its operand must be a `StrBuf`/`Str(N)` buffer the
+caller owns. A first-class or static-backed `str` value is not a legal `inout
+str` operand (E0496), because its bytes are immutable read-only data and, being
+`@copy`, one static buffer could be reached through two roots that per-root
+exclusivity cannot see.
 
 ## The `Str(N)` Type
 
@@ -475,25 +510,28 @@ array, `String`, or `str` index does.
 
 {{ rule(id="3.7:55", cat="normative") }}
 
-A `Str(N)` value is usable where a `str` (§3.7:43) is expected: it coerces to a
-`str` view over its bytes, so a `Str(N)` may be passed to a `str` parameter and
-read through the `str` interface (`.len()`, byte indexing). This makes `str` the
-universal read interface over both the fixed (`Str(N)`) and static-literal
-string rungs.
+A `Str(N)` value is readable through a borrowed `str` view (§3.7:60): it coerces
+to a `borrow str` (or `inout str`) over its bytes, so `borrow s` may be passed to
+a `borrow str` parameter and read through the `str` interface (`.len()`, byte
+indexing). This makes `borrow str` the universal read interface over the fixed
+(`Str(N)`), growable (`StrBuf`), and static-literal string rungs. A `Str(N)` does
+*not* coerce to a first-class `str` (§3.7:59): a bare `str` parameter would let
+the buffer's bytes escape, so `borrow str` is used instead.
 
 {{ rule(id="3.7:56") }}
 
 ```rue
-fn len_of(s: str) -> u64 {
-    s.len()               // read a Str(N) through the str view
+fn len_of(borrow s: str) -> u64 {
+    s.len()               // read a Str(N) through the borrowed str view
 }
 
 fn main() -> i32 {
     let s: Str(8) = "hello";   // fits in 8 bytes
     @dbg(s.len());             // 5
     @dbg(s[0]);                // 104 ('h')
-    @dbg(len_of(s));           // 5   (coerced to str)
+    @dbg(len_of(borrow s));    // 5   (borrowed as `borrow str`)
     // let bad: Str(3) = "hello";  // ERROR (E0492): 5 bytes exceed capacity 3
+    // let x: str = s;             // ERROR (E0495): a buffer is not a first-class str
     0
 }
 ```


### PR DESCRIPTION
## Summary
Per the 2026-07-09 ruling (ADR-0043 §3 amended): `str` is first-class and static-backed; StrBuf/Str(N) coerce only to second-class `borrow str`/`inout str` views; no buffer or view becomes first-class; `inout str` requires local provenance. E0495 includes the requested did-you-mean ("parameter type `str` accepts only string literals; did you mean `borrow str`?", UI-pinned). Both verified segfault repros are now compile errors + regression tests; the RUE-385/#1206 cross-check is pinned (E0496). Spec rules 3.7:58-60. All behind --preview string_trio. Stacked on the RUE-387 PR.
Pre-existing bug discovered and filed separately: borrow-str-of-StrBuf fat-pointer materialization reads cap as len / segfaults on index (no codegen touched here).
## Validation
Segfault repros → E0495/E0497 by execution; legal view patterns verified; ./test.sh Pass 28 / Fail 0; traceability 100%.

Fixes RUE-386
🤖 Generated with [Claude Code](https://claude.com/claude-code)