### PR TITLE
RUE-388: gate ArrayBuf element types — reject linear/destructor-bearing T (E0498/E0499)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6181,11 +6181,27 @@ impl<'a> Sema<'a> {
         type_arg: Spur,
         span: Span,
     ) -> CompileResult<AnalysisResult> {
-        let intrinsic_name = self.interner.resolve(&name);
+        let intrinsic_name = self.interner.resolve(&name).to_string();
         let ty = self.resolve_type(type_arg, span)?;
 
+        // `@require_droppable(T)` is the owning-container well-formedness gate
+        // (RUE-388): it has no runtime value and evaluates to unit. It is
+        // normally consumed at comptime while reducing a `-> type` constructor
+        // body (see `Sema::check_require_droppable`), but handle it here too so
+        // that if it ever reaches runtime analysis it performs the same
+        // linear/destructor rejection instead of falling to E0700.
+        if intrinsic_name == "require_droppable" {
+            self.check_require_droppable(ty, span)?;
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::Const(0),
+                ty: Type::UNIT,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
+        }
+
         // Calculate the value based on which intrinsic
-        let value: u64 = match intrinsic_name {
+        let value: u64 = match intrinsic_name.as_str() {
             "size_of" => {
                 // Calculate size in bytes (slot count * 8)
                 let slot_count = self.abi_slot_count(ty);

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -57,7 +57,7 @@ use rue_span::Span;
 use super::Sema;
 use super::context::{AnalysisContext, ConstValue, LocalVar};
 use crate::specialize::MAX_SPECIALIZATION_ROUNDS;
-use crate::types::{StructField, Type};
+use crate::types::{StructField, Type, TypeKind};
 
 /// Empty type substitution map for evaluation contexts without one.
 static EMPTY_TYPE_SUBST: LazyLock<HashMap<Spur, Type>> = LazyLock::new(HashMap::new);
@@ -1078,8 +1078,114 @@ impl Sema<'_> {
             // is not evaluable, so the caller reports it (RUE-267).
             InstData::FieldGet { .. } => Ok(env.const_module_members.get(&inst_ref).copied()),
 
+            // Type intrinsic in comptime position. `@require_droppable(T)` is the
+            // owning-container well-formedness gate (RUE-388): std's `ArrayBuf(T)`
+            // calls it in its `-> type` constructor body so that instantiating
+            // the container with an element type it cannot yet correctly own —
+            // one that is `linear` or carries a destructor — is rejected at
+            // instantiation time (E0499 / E0498) rather than silently leaking the
+            // element's `drop fn`. It reduces to unit so the surrounding block
+            // body still yields the `struct { .. }` tail. `@size_of`/`@align_of`
+            // are not comptime-foldable here and stay non-evaluable.
+            InstData::TypeIntrinsic { name, type_arg } => {
+                let (name, type_arg) = (*name, *type_arg);
+                if self.interner.resolve(&name) != "require_droppable" {
+                    return Ok(None);
+                }
+                // Resolve the element type through the enclosing comptime
+                // substitutions (`T -> Inner` for `ArrayBuf(Inner)`); a
+                // still-unresolved type parameter makes the gate non-evaluable
+                // (it will be re-checked at a concrete instantiation).
+                let Some(elem_ty) = self.resolve_type_for_comptime_with_subst_and_values_at_span(
+                    type_arg,
+                    env.type_subst,
+                    env.value_subst,
+                    span,
+                ) else {
+                    return Ok(None);
+                };
+                self.check_require_droppable(elem_ty, span)?;
+                Ok(Some(ConstValue::Unit))
+            }
+
             // Everything else requires runtime evaluation
             _ => Ok(None),
+        }
+    }
+
+    /// The `@require_droppable(T)` well-formedness gate for owning growable
+    /// containers (RUE-388, Steve's 2026-07-09 ruling).
+    ///
+    /// A source-level owning container such as `std/arraybuf.rue`'s `ArrayBuf(T)`
+    /// owns a heap buffer of `T` and drops it wholesale in its `drop fn` at scope
+    /// exit; it does **not** yet run per-element drop glue, nor track element
+    /// linearity. So an element type that is `linear` (must be consumed) or that
+    /// carries a destructor / drop glue would be silently leaked when the buffer
+    /// is freed. Until container/element multiplicity propagation is designed
+    /// (its own future ADR — deliberately out of scope here), the container gates
+    /// its element type through this check and rejects those two classes:
+    ///
+    /// - `linear` (transitively — infectious linearity, spec 3.8:57): E0499.
+    /// - carries a destructor / drop glue (transitively): E0498.
+    ///
+    /// Linearity takes precedence in the message: a linear type is the stronger
+    /// "must be consumed" property. A trivially-droppable element (primitives,
+    /// pointers, `Copy` structs of them) passes.
+    pub(crate) fn check_require_droppable(&self, ty: Type, span: Span) -> CompileResult<()> {
+        if self.type_carries_linear(ty) {
+            return Err(CompileError::new(
+                ErrorKind::ContainerElementIsLinear {
+                    ty: self.format_type_name(ty),
+                },
+                span,
+            ));
+        }
+        if self.type_needs_drop_gate(ty) {
+            return Err(CompileError::new(
+                ErrorKind::ContainerElementHasDestructor {
+                    ty: self.format_type_name(ty),
+                },
+                span,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Whether dropping `ty` requires running any drop glue — a destructor
+    /// (`drop fn`) on the type itself or, transitively, on a field / array
+    /// element / enum-variant payload. Mirrors `rue-cfg`'s `type_needs_drop`
+    /// (the drop-glue authority at CFG-build time), replicated here because that
+    /// method lives in a different crate; the two must agree so the
+    /// `@require_droppable` gate rejects exactly the element types whose drop
+    /// glue the container would otherwise silently skip (RUE-388). Linearity is
+    /// checked separately by [`Sema::type_carries_linear`].
+    fn type_needs_drop_gate(&self, ty: Type) -> bool {
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
+                let struct_def = self.type_pool.struct_def(struct_id);
+                if struct_def.destructor.is_some() {
+                    return true;
+                }
+                let field_types: Vec<Type> = struct_def.fields.iter().map(|f| f.ty).collect();
+                field_types
+                    .iter()
+                    .any(|&fty| self.type_needs_drop_gate(fty))
+            }
+            TypeKind::Enum(enum_id) => {
+                let enum_def = self.type_pool.enum_def(enum_id);
+                let payloads: Vec<Type> = enum_def
+                    .variant_payloads
+                    .iter()
+                    .flatten()
+                    .copied()
+                    .collect();
+                payloads.iter().any(|&pty| self.type_needs_drop_gate(pty))
+            }
+            TypeKind::Array(array_id) => {
+                let (element_type, _length) = self.type_pool.array_def(array_id);
+                self.type_needs_drop_gate(element_type)
+            }
+            _ => false,
         }
     }
 

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -426,3 +426,175 @@ pub fn ArrayBuf(comptime T: type) -> type {
 ]
 stdout = "20\n-1\n"
 exit_code = 20
+
+# RUE-388 well-formedness gate: an owning growable container (`ArrayBuf(T)`)
+# owns a heap buffer and frees it wholesale in its `drop fn` — it does NOT run
+# per-element drop glue, nor track element linearity. Before the gate, an
+# element type carrying a destructor was accepted and its `drop fn` was silently
+# skipped when the buffer dropped (a leaked destructor effect); a `linear`
+# element would likewise leak. The `@require_droppable(T)` gate in the ArrayBuf
+# constructor rejects both classes at INSTANTIATION time. These cases use an
+# inline ArrayBuf carrying that gate (mirroring std/arraybuf.rue) so the reject
+# is exercised end-to-end through the real binary.
+[[case]]
+name = "arraybuf_rejects_destructor_element"
+description = "ArrayBuf(T) with a destructor-bearing element type is rejected at instantiation (E0498), not silently leaked (RUE-388)."
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0498", "Inner", "drop fn"]
+files = [
+  { path = "main.rue", source = """
+const arraybuf = @import("arraybuf.rue");
+
+struct Inner { v: i32 }
+drop fn Inner(self) { @panic("dropped element"); }
+
+fn main() -> i32 {
+    let V = arraybuf.ArrayBuf(Inner);
+    let mut v = V.new();
+    v.push(Inner { v: 7 });
+    0
+}
+""" },
+  { path = "arraybuf.rue", source = """
+pub fn ArrayBuf(comptime T: type) -> type {
+    @require_droppable(T);
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+        fn reserve(inout self) {
+            if self.len == self.cap {
+                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    self.buf = grown;
+                };
+                self.cap = new_cap;
+            }
+        }
+        fn push(inout self, x: T) {
+            self.reserve();
+            checked {
+                let slot = @ptr_offset(self.buf, self.len);
+                @ptr_write(slot, x);
+            };
+            self.len = self.len + 1;
+        }
+    }
+}
+""" },
+]
+
+[[case]]
+name = "arraybuf_rejects_linear_element"
+description = "ArrayBuf(T) with a `linear` element type is rejected at instantiation (E0499), so the linear element cannot be leaked (RUE-388)."
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0499", "Token", "linear"]
+files = [
+  { path = "main.rue", source = """
+const arraybuf = @import("arraybuf.rue");
+
+linear struct Token { v: i32 }
+
+fn main() -> i32 {
+    let V = arraybuf.ArrayBuf(Token);
+    let mut v = V.new();
+    0
+}
+""" },
+  { path = "arraybuf.rue", source = """
+pub fn ArrayBuf(comptime T: type) -> type {
+    @require_droppable(T);
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+    }
+}
+""" },
+]
+
+# Positive control for the RUE-388 gate: a trivially-droppable `Copy` struct
+# element type passes the `@require_droppable(T)` gate and round-trips through
+# push/pop. This pins that the gate rejects ONLY non-droppable/linear elements
+# and does not regress ordinary aggregate element support (ADR-0040 / RUE-311).
+[[case]]
+name = "arraybuf_gate_allows_copy_struct_element"
+description = "ArrayBuf(T) with a trivially-droppable Copy struct element passes the @require_droppable gate and works (RUE-388)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+const arraybuf = @import("arraybuf.rue");
+
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let V = arraybuf.ArrayBuf(Point);
+    let O = arraybuf.Option(Point);
+    let mut v = V.new();
+    v.push(Point { x: 3, y: 4 });
+    v.push(Point { x: 10, y: 20 });
+    match v.pop() { O.Some(p) => p.x + p.y, O.None => -1 }   // 30
+}
+""" },
+  { path = "arraybuf.rue", source = """
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+
+pub fn ArrayBuf(comptime T: type) -> type {
+    @require_droppable(T);
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+        fn reserve(inout self) {
+            if self.len == self.cap {
+                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    self.buf = grown;
+                };
+                self.cap = new_cap;
+            }
+        }
+        fn push(inout self, x: T) {
+            self.reserve();
+            checked {
+                let slot = @ptr_offset(self.buf, self.len);
+                @ptr_write(slot, x);
+            };
+            self.len = self.len + 1;
+        }
+        fn pop(inout self) -> Option(T) {
+            let O = Option(T);
+            if self.len == 0 {
+                O.None
+            } else {
+                self.len = self.len - 1;
+                O.Some(checked { @ptr_read(@ptr_offset(self.buf, self.len)) })
+            }
+        }
+    }
+}
+""" },
+]
+stdout = ""
+exit_code = 30

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -280,6 +280,19 @@ impl ErrorCode {
     /// is second-class: it may only be read (`.len()`, byte indexing) or
     /// re-borrowed, never escape the call as a first-class value.
     pub const STR_VIEW_NOT_FIRST_CLASS: Self = Self(497);
+    /// An owning growable container (e.g. `ArrayBuf(T)`) was instantiated with
+    /// an element type that has a destructor (a `drop fn`), via the
+    /// `@require_droppable(T)` gate. Until container/element multiplicity
+    /// propagation is designed (RUE-388), such containers cannot yet run
+    /// per-element destructors, so a destructor-bearing element would silently
+    /// leak its `drop fn`; the instantiation is rejected instead.
+    pub const CONTAINER_ELEMENT_HAS_DESTRUCTOR: Self = Self(498);
+    /// An owning growable container (e.g. `ArrayBuf(T)`) was instantiated with a
+    /// `linear` element type, via the `@require_droppable(T)` gate. Until
+    /// container/element multiplicity propagation is designed (RUE-388), such
+    /// containers cannot yet track element linearity, so a linear element would
+    /// be leaked (never consumed); the instantiation is rejected instead.
+    pub const CONTAINER_ELEMENT_IS_LINEAR: Self = Self(499);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1253,6 +1266,22 @@ pub enum ErrorKind {
     /// names the position, as in [`Self::BufferNotFirstClassStr`].
     #[error("a borrowed `str` view cannot be used as a first-class `str` {site}")]
     StrViewNotFirstClass { site: String },
+    /// An owning growable container (`ArrayBuf(T)`) was instantiated with an
+    /// element type that has a destructor (`drop fn`), via `@require_droppable`
+    /// (RUE-388). The container cannot yet run per-element destructors, so the
+    /// element's `drop fn` would silently leak; the instantiation is rejected.
+    #[error(
+        "`@require_droppable` requires a trivially-droppable type, but `{ty}` carries a destructor (a `drop fn`, on the type itself or one of its fields) — an owning growable container (e.g. `ArrayBuf`) cannot yet run per-element destructors, so that `drop fn` would silently leak (RUE-388)"
+    )]
+    ContainerElementHasDestructor { ty: String },
+    /// An owning growable container (`ArrayBuf(T)`) was instantiated with a
+    /// `linear` element type, via `@require_droppable` (RUE-388). The container
+    /// cannot yet track element linearity, so a linear element would be leaked
+    /// (never consumed); the instantiation is rejected.
+    #[error(
+        "`@require_droppable` requires a trivially-droppable type, but `{ty}` is `linear` — an owning growable container (e.g. `ArrayBuf`) cannot yet track element linearity, so the element would be leaked (RUE-388)"
+    )]
+    ContainerElementIsLinear { ty: String },
     /// Inout argument is not an lvalue (variable, field, or array element)
     #[error("inout argument must be an lvalue (variable, field, or array element)")]
     InoutNonLvalue,
@@ -1558,6 +1587,10 @@ impl ErrorKind {
             ErrorKind::BufferNotFirstClassStr { .. } => ErrorCode::BUFFER_NOT_FIRST_CLASS_STR,
             ErrorKind::InoutStrRequiresLocalBuffer => ErrorCode::INOUT_STR_REQUIRES_LOCAL_BUFFER,
             ErrorKind::StrViewNotFirstClass { .. } => ErrorCode::STR_VIEW_NOT_FIRST_CLASS,
+            ErrorKind::ContainerElementHasDestructor { .. } => {
+                ErrorCode::CONTAINER_ELEMENT_HAS_DESTRUCTOR
+            }
+            ErrorKind::ContainerElementIsLinear { .. } => ErrorCode::CONTAINER_ELEMENT_IS_LINEAR,
             ErrorKind::InoutNonLvalue => ErrorCode::INOUT_NON_LVALUE,
             ErrorKind::InoutExclusiveAccess { .. } => ErrorCode::INOUT_EXCLUSIVE_ACCESS,
             ErrorKind::BorrowNonLvalue => ErrorCode::BORROW_NON_LVALUE,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -7,7 +7,14 @@ use lasso::{Key, Spur, ThreadedRodeo};
 
 /// Known type intrinsics that take a type argument rather than an expression.
 /// These intrinsics operate on types at compile time (e.g., @size_of(i32)).
-const TYPE_INTRINSICS: &[&str] = &["size_of", "align_of"];
+///
+/// `require_droppable` is the compile-time well-formedness gate an owning
+/// growable container (`std/arraybuf.rue`'s `ArrayBuf(T)`) uses to reject an
+/// element type it cannot yet correctly own — one with a destructor or a
+/// `linear` element (RUE-388). It takes the element type as its sole argument
+/// and evaluates to unit during comptime type-constructor reduction, so it must
+/// be lowered as a `TypeIntrinsic` (like `@size_of`), not an expression call.
+const TYPE_INTRINSICS: &[&str] = &["size_of", "align_of", "require_droppable"];
 use rue_parser::ast::{ConstDecl, DropFn};
 use rue_parser::{
     ArgMode, ArrayLength, AssignTarget, Ast, BinaryOp, CallArg, Directive, DirectiveArg, EnumDecl,

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -38,15 +38,20 @@
 // SCOPE / KNOWN LIMITATIONS (tracked separately — this file deliberately does
 // not work around them):
 //
-//   * Copy element types only. `get`/`pop` return an element *by copy* wrapped
-//     in `Option(T)` (`@ptr_read`, RUE-313). Move-out of a non-Copy element is
-//     not yet supported. (The destructor drops only the backing buffer, not
-//     per-element glue — for a Copy `T` there is none.)
-//   * Multi-slot aggregate element types (e.g. a two-field struct) now work:
-//     every aggregate is laid out ascending-in-address and `@ptr_read`/
-//     `@ptr_write` walk slots upward from the element base, matching the
-//     ascending heap layout (ADR-0040 / RUE-311). The Copy restriction above
-//     still applies (elements are transferred by copy).
+//   * Trivially-droppable element types only. `get`/`pop` return an element
+//     *by copy* wrapped in `Option(T)` (`@ptr_read`, RUE-313). Move-out of a
+//     non-Copy element is not yet supported, and the destructor drops only the
+//     backing buffer, not per-element glue. An element type that is `linear` or
+//     carries a destructor is therefore REJECTED at instantiation by the
+//     `@require_droppable(T)` gate in the constructor below (E0498 / E0499,
+//     RUE-388) — otherwise its `drop fn` would silently leak / a linear value
+//     would never be consumed. Lifting this to true per-element ownership needs
+//     container/element multiplicity propagation (a future ADR).
+//   * Multi-slot aggregate element types (e.g. a two-field struct) work as long
+//     as they are trivially droppable: every aggregate is laid out
+//     ascending-in-address and `@ptr_read`/`@ptr_write` walk slots upward from
+//     the element base, matching the ascending heap layout (ADR-0040 / RUE-311).
+//     Elements are transferred by copy.
 //
 // The enclosing element type `T` is usable throughout the method bodies below —
 // e.g. to name `Option(T)` and bind `let O = Option(T)` (RUE-313).
@@ -56,6 +61,17 @@ pub fn Option(comptime T: type) -> type {
 }
 
 pub fn ArrayBuf(comptime T: type) -> type {
+    // Well-formedness gate (RUE-388): ArrayBuf owns a heap buffer of `T` and
+    // frees it wholesale in its `drop fn` at scope exit — it does NOT yet run
+    // per-element drop glue, nor track element linearity. Instantiating it with
+    // an element type that is `linear` or carries a destructor would silently
+    // leak that element (its `drop fn` would never run / a linear value would
+    // never be consumed). Until container/element multiplicity propagation is
+    // designed (a future ADR — out of scope), reject such element types at
+    // instantiation with a clear compile error (E0498 / E0499) rather than
+    // miscompiling. Trivially-droppable elements (primitives, pointers, `Copy`
+    // structs of them) pass.
+    @require_droppable(T);
     struct {
         buf: ptr mut T,
         len: u64,


### PR DESCRIPTION
## Summary
Per the 2026-07-09 ruling: the safe gate ships now (multiplicity propagation = future ADR). New comptime type intrinsic `@require_droppable(T)` evaluated during `-> type` constructor reduction; std/arraybuf.rue calls it. Destructor-bearing → E0498, linear → E0499, transitively, naming the element type and reason. Closes the verified leaked-destructor hole (ArrayBuf(Inner) with a drop fn silently skipped the element's destructor). Stacked on the RUE-386 PR.
## Validation
Repro → E0498 naming Inner; linear Token → E0499; transitive wrapper → E0498; ArrayBuf(i32)/ArrayBuf(Point) + demo (exit 119) verified running. ./test.sh Pass 28 / Fail 0.

Fixes RUE-388
🤖 Generated with [Claude Code](https://claude.com/claude-code)