### PR TITLE
RUE-331: reserve impl and type as keywords (spec 2.4:2/2.4:3)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6181,11 +6181,27 @@ impl<'a> Sema<'a> {
         type_arg: Spur,
         span: Span,
     ) -> CompileResult<AnalysisResult> {
-        let intrinsic_name = self.interner.resolve(&name);
+        let intrinsic_name = self.interner.resolve(&name).to_string();
         let ty = self.resolve_type(type_arg, span)?;
 
+        // `@require_droppable(T)` is the owning-container well-formedness gate
+        // (RUE-388): it has no runtime value and evaluates to unit. It is
+        // normally consumed at comptime while reducing a `-> type` constructor
+        // body (see `Sema::check_require_droppable`), but handle it here too so
+        // that if it ever reaches runtime analysis it performs the same
+        // linear/destructor rejection instead of falling to E0700.
+        if intrinsic_name == "require_droppable" {
+            self.check_require_droppable(ty, span)?;
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::Const(0),
+                ty: Type::UNIT,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
+        }
+
         // Calculate the value based on which intrinsic
-        let value: u64 = match intrinsic_name {
+        let value: u64 = match intrinsic_name.as_str() {
             "size_of" => {
                 // Calculate size in bytes (slot count * 8)
                 let slot_count = self.abi_slot_count(ty);

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -57,7 +57,7 @@ use rue_span::Span;
 use super::Sema;
 use super::context::{AnalysisContext, ConstValue, LocalVar};
 use crate::specialize::MAX_SPECIALIZATION_ROUNDS;
-use crate::types::{StructField, Type};
+use crate::types::{StructField, Type, TypeKind};
 
 /// Empty type substitution map for evaluation contexts without one.
 static EMPTY_TYPE_SUBST: LazyLock<HashMap<Spur, Type>> = LazyLock::new(HashMap::new);
@@ -1078,8 +1078,114 @@ impl Sema<'_> {
             // is not evaluable, so the caller reports it (RUE-267).
             InstData::FieldGet { .. } => Ok(env.const_module_members.get(&inst_ref).copied()),
 
+            // Type intrinsic in comptime position. `@require_droppable(T)` is the
+            // owning-container well-formedness gate (RUE-388): std's `ArrayBuf(T)`
+            // calls it in its `-> type` constructor body so that instantiating
+            // the container with an element type it cannot yet correctly own —
+            // one that is `linear` or carries a destructor — is rejected at
+            // instantiation time (E0499 / E0498) rather than silently leaking the
+            // element's `drop fn`. It reduces to unit so the surrounding block
+            // body still yields the `struct { .. }` tail. `@size_of`/`@align_of`
+            // are not comptime-foldable here and stay non-evaluable.
+            InstData::TypeIntrinsic { name, type_arg } => {
+                let (name, type_arg) = (*name, *type_arg);
+                if self.interner.resolve(&name) != "require_droppable" {
+                    return Ok(None);
+                }
+                // Resolve the element type through the enclosing comptime
+                // substitutions (`T -> Inner` for `ArrayBuf(Inner)`); a
+                // still-unresolved type parameter makes the gate non-evaluable
+                // (it will be re-checked at a concrete instantiation).
+                let Some(elem_ty) = self.resolve_type_for_comptime_with_subst_and_values_at_span(
+                    type_arg,
+                    env.type_subst,
+                    env.value_subst,
+                    span,
+                ) else {
+                    return Ok(None);
+                };
+                self.check_require_droppable(elem_ty, span)?;
+                Ok(Some(ConstValue::Unit))
+            }
+
             // Everything else requires runtime evaluation
             _ => Ok(None),
+        }
+    }
+
+    /// The `@require_droppable(T)` well-formedness gate for owning growable
+    /// containers (RUE-388, Steve's 2026-07-09 ruling).
+    ///
+    /// A source-level owning container such as `std/arraybuf.rue`'s `ArrayBuf(T)`
+    /// owns a heap buffer of `T` and drops it wholesale in its `drop fn` at scope
+    /// exit; it does **not** yet run per-element drop glue, nor track element
+    /// linearity. So an element type that is `linear` (must be consumed) or that
+    /// carries a destructor / drop glue would be silently leaked when the buffer
+    /// is freed. Until container/element multiplicity propagation is designed
+    /// (its own future ADR — deliberately out of scope here), the container gates
+    /// its element type through this check and rejects those two classes:
+    ///
+    /// - `linear` (transitively — infectious linearity, spec 3.8:57): E0499.
+    /// - carries a destructor / drop glue (transitively): E0498.
+    ///
+    /// Linearity takes precedence in the message: a linear type is the stronger
+    /// "must be consumed" property. A trivially-droppable element (primitives,
+    /// pointers, `Copy` structs of them) passes.
+    pub(crate) fn check_require_droppable(&self, ty: Type, span: Span) -> CompileResult<()> {
+        if self.type_carries_linear(ty) {
+            return Err(CompileError::new(
+                ErrorKind::ContainerElementIsLinear {
+                    ty: self.format_type_name(ty),
+                },
+                span,
+            ));
+        }
+        if self.type_needs_drop_gate(ty) {
+            return Err(CompileError::new(
+                ErrorKind::ContainerElementHasDestructor {
+                    ty: self.format_type_name(ty),
+                },
+                span,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Whether dropping `ty` requires running any drop glue — a destructor
+    /// (`drop fn`) on the type itself or, transitively, on a field / array
+    /// element / enum-variant payload. Mirrors `rue-cfg`'s `type_needs_drop`
+    /// (the drop-glue authority at CFG-build time), replicated here because that
+    /// method lives in a different crate; the two must agree so the
+    /// `@require_droppable` gate rejects exactly the element types whose drop
+    /// glue the container would otherwise silently skip (RUE-388). Linearity is
+    /// checked separately by [`Sema::type_carries_linear`].
+    fn type_needs_drop_gate(&self, ty: Type) -> bool {
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
+                let struct_def = self.type_pool.struct_def(struct_id);
+                if struct_def.destructor.is_some() {
+                    return true;
+                }
+                let field_types: Vec<Type> = struct_def.fields.iter().map(|f| f.ty).collect();
+                field_types
+                    .iter()
+                    .any(|&fty| self.type_needs_drop_gate(fty))
+            }
+            TypeKind::Enum(enum_id) => {
+                let enum_def = self.type_pool.enum_def(enum_id);
+                let payloads: Vec<Type> = enum_def
+                    .variant_payloads
+                    .iter()
+                    .flatten()
+                    .copied()
+                    .collect();
+                payloads.iter().any(|&pty| self.type_needs_drop_gate(pty))
+            }
+            TypeKind::Array(array_id) => {
+                let (element_type, _length) = self.type_pool.array_def(array_id);
+                self.type_needs_drop_gate(element_type)
+            }
+            _ => false,
         }
     }
 

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -426,3 +426,175 @@ pub fn ArrayBuf(comptime T: type) -> type {
 ]
 stdout = "20\n-1\n"
 exit_code = 20
+
+# RUE-388 well-formedness gate: an owning growable container (`ArrayBuf(T)`)
+# owns a heap buffer and frees it wholesale in its `drop fn` — it does NOT run
+# per-element drop glue, nor track element linearity. Before the gate, an
+# element type carrying a destructor was accepted and its `drop fn` was silently
+# skipped when the buffer dropped (a leaked destructor effect); a `linear`
+# element would likewise leak. The `@require_droppable(T)` gate in the ArrayBuf
+# constructor rejects both classes at INSTANTIATION time. These cases use an
+# inline ArrayBuf carrying that gate (mirroring std/arraybuf.rue) so the reject
+# is exercised end-to-end through the real binary.
+[[case]]
+name = "arraybuf_rejects_destructor_element"
+description = "ArrayBuf(T) with a destructor-bearing element type is rejected at instantiation (E0498), not silently leaked (RUE-388)."
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0498", "Inner", "drop fn"]
+files = [
+  { path = "main.rue", source = """
+const arraybuf = @import("arraybuf.rue");
+
+struct Inner { v: i32 }
+drop fn Inner(self) { @panic("dropped element"); }
+
+fn main() -> i32 {
+    let V = arraybuf.ArrayBuf(Inner);
+    let mut v = V.new();
+    v.push(Inner { v: 7 });
+    0
+}
+""" },
+  { path = "arraybuf.rue", source = """
+pub fn ArrayBuf(comptime T: type) -> type {
+    @require_droppable(T);
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+        fn reserve(inout self) {
+            if self.len == self.cap {
+                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    self.buf = grown;
+                };
+                self.cap = new_cap;
+            }
+        }
+        fn push(inout self, x: T) {
+            self.reserve();
+            checked {
+                let slot = @ptr_offset(self.buf, self.len);
+                @ptr_write(slot, x);
+            };
+            self.len = self.len + 1;
+        }
+    }
+}
+""" },
+]
+
+[[case]]
+name = "arraybuf_rejects_linear_element"
+description = "ArrayBuf(T) with a `linear` element type is rejected at instantiation (E0499), so the linear element cannot be leaked (RUE-388)."
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0499", "Token", "linear"]
+files = [
+  { path = "main.rue", source = """
+const arraybuf = @import("arraybuf.rue");
+
+linear struct Token { v: i32 }
+
+fn main() -> i32 {
+    let V = arraybuf.ArrayBuf(Token);
+    let mut v = V.new();
+    0
+}
+""" },
+  { path = "arraybuf.rue", source = """
+pub fn ArrayBuf(comptime T: type) -> type {
+    @require_droppable(T);
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+    }
+}
+""" },
+]
+
+# Positive control for the RUE-388 gate: a trivially-droppable `Copy` struct
+# element type passes the `@require_droppable(T)` gate and round-trips through
+# push/pop. This pins that the gate rejects ONLY non-droppable/linear elements
+# and does not regress ordinary aggregate element support (ADR-0040 / RUE-311).
+[[case]]
+name = "arraybuf_gate_allows_copy_struct_element"
+description = "ArrayBuf(T) with a trivially-droppable Copy struct element passes the @require_droppable gate and works (RUE-388)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+const arraybuf = @import("arraybuf.rue");
+
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let V = arraybuf.ArrayBuf(Point);
+    let O = arraybuf.Option(Point);
+    let mut v = V.new();
+    v.push(Point { x: 3, y: 4 });
+    v.push(Point { x: 10, y: 20 });
+    match v.pop() { O.Some(p) => p.x + p.y, O.None => -1 }   // 30
+}
+""" },
+  { path = "arraybuf.rue", source = """
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+
+pub fn ArrayBuf(comptime T: type) -> type {
+    @require_droppable(T);
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+        fn reserve(inout self) {
+            if self.len == self.cap {
+                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    self.buf = grown;
+                };
+                self.cap = new_cap;
+            }
+        }
+        fn push(inout self, x: T) {
+            self.reserve();
+            checked {
+                let slot = @ptr_offset(self.buf, self.len);
+                @ptr_write(slot, x);
+            };
+            self.len = self.len + 1;
+        }
+        fn pop(inout self) -> Option(T) {
+            let O = Option(T);
+            if self.len == 0 {
+                O.None
+            } else {
+                self.len = self.len - 1;
+                O.Some(checked { @ptr_read(@ptr_offset(self.buf, self.len)) })
+            }
+        }
+    }
+}
+""" },
+]
+stdout = ""
+exit_code = 30

--- a/crates/rue-cli-tests/cases/reserved_keywords.toml
+++ b/crates/rue-cli-tests/cases/reserved_keywords.toml
@@ -1,0 +1,60 @@
+# `impl` and `type` are reserved keywords (spec 2.4:2 / 2.4:3), not identifiers
+# (RUE-331). Driver-visible checks: the real binary must reject them as binding
+# names, while `type` in type position (the type-of-types) keeps compiling and
+# running a generic program end to end.
+
+[section]
+id = "cli.reserved_keywords"
+name = "Reserved keywords impl and type"
+description = "impl/type cannot be identifiers; type still works as the compile-time type of types."
+
+[[case]]
+name = "let_impl_rejected"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let impl = 2;
+    impl
+}
+""" }]
+compile_fail = true
+error_contains = ["impl"]
+
+[[case]]
+name = "let_type_rejected"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let type = 1;
+    type
+}
+""" }]
+compile_fail = true
+error_contains = ["type"]
+
+[[case]]
+name = "impl_hint_points_at_struct_bodies"
+files = [{ path = "main.rue", source = """
+impl Foo {
+    fn bar(self) -> i32 { 0 }
+}
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["Rue has no `impl` blocks"]
+
+[[case]]
+name = "type_keyword_generic_runs"
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T {
+    return x;
+}
+fn max(comptime T: type, a: T, b: T) -> T {
+    if a > b { a } else { b }
+}
+fn main() -> i32 {
+    let a = identity(i32, 40);
+    let b = max(i32, 2, 1);
+    @dbg(a + b);
+    0
+}
+""" }]
+stdout = "42\n"

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -280,6 +280,19 @@ impl ErrorCode {
     /// is second-class: it may only be read (`.len()`, byte indexing) or
     /// re-borrowed, never escape the call as a first-class value.
     pub const STR_VIEW_NOT_FIRST_CLASS: Self = Self(497);
+    /// An owning growable container (e.g. `ArrayBuf(T)`) was instantiated with
+    /// an element type that has a destructor (a `drop fn`), via the
+    /// `@require_droppable(T)` gate. Until container/element multiplicity
+    /// propagation is designed (RUE-388), such containers cannot yet run
+    /// per-element destructors, so a destructor-bearing element would silently
+    /// leak its `drop fn`; the instantiation is rejected instead.
+    pub const CONTAINER_ELEMENT_HAS_DESTRUCTOR: Self = Self(498);
+    /// An owning growable container (e.g. `ArrayBuf(T)`) was instantiated with a
+    /// `linear` element type, via the `@require_droppable(T)` gate. Until
+    /// container/element multiplicity propagation is designed (RUE-388), such
+    /// containers cannot yet track element linearity, so a linear element would
+    /// be leaked (never consumed); the instantiation is rejected instead.
+    pub const CONTAINER_ELEMENT_IS_LINEAR: Self = Self(499);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1253,6 +1266,22 @@ pub enum ErrorKind {
     /// names the position, as in [`Self::BufferNotFirstClassStr`].
     #[error("a borrowed `str` view cannot be used as a first-class `str` {site}")]
     StrViewNotFirstClass { site: String },
+    /// An owning growable container (`ArrayBuf(T)`) was instantiated with an
+    /// element type that has a destructor (`drop fn`), via `@require_droppable`
+    /// (RUE-388). The container cannot yet run per-element destructors, so the
+    /// element's `drop fn` would silently leak; the instantiation is rejected.
+    #[error(
+        "`@require_droppable` requires a trivially-droppable type, but `{ty}` carries a destructor (a `drop fn`, on the type itself or one of its fields) — an owning growable container (e.g. `ArrayBuf`) cannot yet run per-element destructors, so that `drop fn` would silently leak (RUE-388)"
+    )]
+    ContainerElementHasDestructor { ty: String },
+    /// An owning growable container (`ArrayBuf(T)`) was instantiated with a
+    /// `linear` element type, via `@require_droppable` (RUE-388). The container
+    /// cannot yet track element linearity, so a linear element would be leaked
+    /// (never consumed); the instantiation is rejected.
+    #[error(
+        "`@require_droppable` requires a trivially-droppable type, but `{ty}` is `linear` — an owning growable container (e.g. `ArrayBuf`) cannot yet track element linearity, so the element would be leaked (RUE-388)"
+    )]
+    ContainerElementIsLinear { ty: String },
     /// Inout argument is not an lvalue (variable, field, or array element)
     #[error("inout argument must be an lvalue (variable, field, or array element)")]
     InoutNonLvalue,
@@ -1558,6 +1587,10 @@ impl ErrorKind {
             ErrorKind::BufferNotFirstClassStr { .. } => ErrorCode::BUFFER_NOT_FIRST_CLASS_STR,
             ErrorKind::InoutStrRequiresLocalBuffer => ErrorCode::INOUT_STR_REQUIRES_LOCAL_BUFFER,
             ErrorKind::StrViewNotFirstClass { .. } => ErrorCode::STR_VIEW_NOT_FIRST_CLASS,
+            ErrorKind::ContainerElementHasDestructor { .. } => {
+                ErrorCode::CONTAINER_ELEMENT_HAS_DESTRUCTOR
+            }
+            ErrorKind::ContainerElementIsLinear { .. } => ErrorCode::CONTAINER_ELEMENT_IS_LINEAR,
             ErrorKind::InoutNonLvalue => ErrorCode::INOUT_NON_LVALUE,
             ErrorKind::InoutExclusiveAccess { .. } => ErrorCode::INOUT_EXCLUSIVE_ACCESS,
             ErrorKind::BorrowNonLvalue => ErrorCode::BORROW_NON_LVALUE,

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -39,6 +39,7 @@ pub enum TokenKind {
     False,
     Struct,
     Enum,
+    Impl, // impl (reserved; no impl blocks in Rue — methods live in struct bodies)
     Drop,
     Linear,    // linear struct modifier
     SelfValue, // self (value, not type)
@@ -60,6 +61,7 @@ pub enum TokenKind {
     U32,
     U64,
     Bool,
+    Type, // type (the compile-time type of types, spec 2.4:3)
 
     // Patterns
     Underscore, // _ (wildcard pattern)
@@ -143,6 +145,7 @@ impl TokenKind {
             TokenKind::False => "'false'",
             TokenKind::Struct => "'struct'",
             TokenKind::Enum => "'enum'",
+            TokenKind::Impl => "'impl'",
             TokenKind::Drop => "'drop'",
             TokenKind::Linear => "'linear'",
             TokenKind::SelfValue => "'self'",
@@ -162,6 +165,7 @@ impl TokenKind {
             TokenKind::U32 => "type 'u32'",
             TokenKind::U64 => "type 'u64'",
             TokenKind::Bool => "type 'bool'",
+            TokenKind::Type => "type 'type'",
             TokenKind::Underscore => "'_'",
             TokenKind::Int(_) => "integer",
             TokenKind::String(_) => "string",
@@ -247,6 +251,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::False => write!(f, "FALSE"),
             TokenKind::Struct => write!(f, "STRUCT"),
             TokenKind::Enum => write!(f, "ENUM"),
+            TokenKind::Impl => write!(f, "IMPL"),
             TokenKind::Drop => write!(f, "DROP"),
             TokenKind::Linear => write!(f, "LINEAR"),
             TokenKind::SelfValue => write!(f, "SELF"),
@@ -266,6 +271,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::U32 => write!(f, "TYPE(u32)"),
             TokenKind::U64 => write!(f, "TYPE(u64)"),
             TokenKind::Bool => write!(f, "TYPE(bool)"),
+            TokenKind::Type => write!(f, "TYPE(type)"),
             TokenKind::Underscore => write!(f, "UNDERSCORE"),
             TokenKind::Int(v) => write!(f, "INT({})", v),
             TokenKind::String(s) => write!(f, "STRING(sym:{})", s.into_usize()),

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -278,6 +278,8 @@ pub enum LogosTokenKind {
     Struct,
     #[token("enum")]
     Enum,
+    #[token("impl")]
+    Impl,
     #[token("drop")]
     Drop,
     #[token("linear")]
@@ -318,6 +320,12 @@ pub enum LogosTokenKind {
     U64,
     #[token("bool")]
     Bool,
+    // `type` — the compile-time type of types (spec 2.4:3). A reserved keyword,
+    // not an identifier: it appears only in type position (`comptime T: type`,
+    // `-> type`), where the parser maps it back to the interned "type" name so
+    // sema's `Type::from_primitive_name("type")` resolution is unchanged.
+    #[token("type")]
+    Type,
 
     // Patterns
     #[token("_")]
@@ -469,6 +477,7 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::False => TokenKind::False,
             LogosTokenKind::Struct => TokenKind::Struct,
             LogosTokenKind::Enum => TokenKind::Enum,
+            LogosTokenKind::Impl => TokenKind::Impl,
             LogosTokenKind::Drop => TokenKind::Drop,
             LogosTokenKind::Linear => TokenKind::Linear,
             LogosTokenKind::SelfValue => TokenKind::SelfValue,
@@ -488,6 +497,7 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::U32 => TokenKind::U32,
             LogosTokenKind::U64 => TokenKind::U64,
             LogosTokenKind::Bool => TokenKind::Bool,
+            LogosTokenKind::Type => TokenKind::Type,
             LogosTokenKind::Underscore => TokenKind::Underscore,
             LogosTokenKind::Int(n) => TokenKind::Int(n),
             LogosTokenKind::String(s) => TokenKind::String(s),
@@ -1294,6 +1304,25 @@ mod tests {
         assert_eq!(get_ident_str(&tokens[1].kind, &interner), Some("i64ptr"));
         assert_eq!(get_ident_str(&tokens[2].kind, &interner), Some("boolish"));
         assert_eq!(get_ident_str(&tokens[3].kind, &interner), Some("u8_data"));
+    }
+
+    #[test]
+    fn test_logos_impl_and_type_are_keywords() {
+        // `impl` and `type` are reserved keywords (spec 2.4:2, 2.4:3), not
+        // identifiers (RUE-331). Each lexes to its dedicated keyword token.
+        let lexer = LogosLexer::new("impl type");
+        let (tokens, _) = lexer.tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::Impl));
+        assert!(matches!(tokens[1].kind, TokenKind::Type));
+        assert!(matches!(tokens[2].kind, TokenKind::Eof));
+
+        // Identifiers that merely START with a keyword stay identifiers.
+        let lexer = LogosLexer::new("impls typex typeof implement");
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        assert_eq!(get_ident_str(&tokens[0].kind, &interner), Some("impls"));
+        assert_eq!(get_ident_str(&tokens[1].kind, &interner), Some("typex"));
+        assert_eq!(get_ident_str(&tokens[2].kind, &interner), Some("typeof"));
+        assert_eq!(get_ident_str(&tokens[3].kind, &interner), Some("implement"));
     }
 
     #[test]

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -41,6 +41,12 @@ pub struct PrimitiveTypeSpurs {
     pub bool: Spur,
     /// Self type keyword - used in methods to refer to the containing struct type
     pub self_type: Spur,
+    /// The keyword `type` — the compile-time type of types (spec 2.4:3). The
+    /// lexer emits a dedicated `Type` token (not an `Ident`), so the type-position
+    /// parser maps that token back to this interned "type" symbol, keeping sema's
+    /// `Type::from_primitive_name("type")` / `comptime T: type` resolution
+    /// unchanged. (RUE-331)
+    pub type_kw: Spur,
     /// The identifier `as` — not a Rue keyword, but recognized after an
     /// expression to give Rust users a targeted "no 'as' operator" error
     /// instead of a generic parse error. (RUE-133)
@@ -79,6 +85,7 @@ impl PrimitiveTypeSpurs {
             u64: interner.get_or_intern("u64"),
             bool: interner.get_or_intern("bool"),
             self_type: interner.get_or_intern("Self"),
+            type_kw: interner.get_or_intern("type"),
             as_kw: interner.get_or_intern("as"),
             drop_kw: interner.get_or_intern("drop"),
             drop_marker: interner.get_or_intern("__drop"),
@@ -463,6 +470,19 @@ where
             })
         });
 
+        // `type` keyword: the compile-time type of types (spec 2.4:3), used in
+        // type position as `comptime T: type` and `-> type`. The lexer now emits
+        // a reserved `Type` token rather than an identifier (RUE-331), so map it
+        // back to the interned "type" name — downstream sema resolves it via
+        // `Type::from_primitive_name("type")` exactly as when it was an ident.
+        let comptime_type = just(TokenKind::Type).map_with(|_, e| {
+            let span = span_from_extra(e);
+            TypeExpr::Named(Ident {
+                name: e.state().syms.type_kw,
+                span,
+            })
+        });
+
         choice((
             unit_type,
             never_type,
@@ -473,6 +493,7 @@ where
             ptr_mut_type,
             primitive_type_parser(),
             self_type,
+            comptime_type,
             qualified_type_call,
             type_call,
             str_fixed_type,
@@ -2953,7 +2974,7 @@ fn format_pattern(pattern: &chumsky::error::RichPattern<'_, TokenKind>) -> Strin
 /// The `file_id` is threaded in from the parser so that error spans point at
 /// the file being parsed; without it, spans would default to `FileId::DEFAULT`
 /// and multi-file compilations would attribute errors to the wrong file.
-fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId, impl_spur: Spur) -> CompileError {
+fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId) -> CompileError {
     let span = to_rue_span_with_file(*err.span(), file_id);
 
     // Build the base error from the reason
@@ -3007,14 +3028,12 @@ fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId, impl_spur: Spur) -> 
             // opaque, so point the user at the rule. (RUE-19)
             let found_is_self =
                 matches!(found.as_ref(), Some(t) if t.name() == TokenKind::SelfValue.name());
-            // `impl` is Rust muscle memory: Rue has no `impl` blocks, so it
-            // lexes as a plain identifier and dies at item position with an
-            // opaque "expected item, found identifier". Point the user at where
-            // methods actually go. (RUE-19 item 4)
-            let found_is_impl = matches!(
-                found.as_ref().map(|m| &**m),
-                Some(TokenKind::Ident(s)) if *s == impl_spur
-            );
+            // `impl` is Rust muscle memory: Rue has no `impl` blocks. It is a
+            // reserved keyword (spec 2.4:2, RUE-331), so it reaches the parser as
+            // a dedicated `Impl` token and dies at item position with an opaque
+            // "expected item, found 'impl'". Point the user at where methods
+            // actually go. (RUE-19 item 4)
+            let found_is_impl = matches!(found.as_ref(), Some(t) if matches!(**t, TokenKind::Impl));
             // `::` was removed as a path/member-access operator (RUE-488): `.`
             // is the sole spelling for enum variants (`Enum.Variant`),
             // associated-function calls (`Type.function()`), and module-member
@@ -3279,12 +3298,6 @@ impl ChumskyParser {
         // (tens of KB per nesting level), so a 256-deep parse would blow the
         // default thread stack. The nesting pre-scan above caps the depth; the
         // roomy stack here ensures the capped depth parses cleanly.
-        // Pre-intern `impl` so `convert_error` (which runs on the parse thread
-        // without the interner) can recognize the Rust-muscle-memory `impl`
-        // identifier and offer a targeted hint (RUE-19 item 4). Interning here
-        // shares the lexer's interner, so the returned spur matches any lexed
-        // `impl` token.
-        let impl_spur = self.interner.get_or_intern("impl");
         let tokens = std::mem::take(&mut self.tokens);
         let source_len = self.source_len;
         let file_id = self.file_id;
@@ -3308,7 +3321,7 @@ impl ChumskyParser {
                     .map_err(|errs| {
                         let mut errors: Vec<CompileError> = errs
                             .into_iter()
-                            .map(|err| convert_error(err, file_id, impl_spur))
+                            .map(|err| convert_error(err, file_id))
                             .collect();
                         dedupe_parse_errors(&mut errors);
                         CompileErrors::from(errors)

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -7,7 +7,14 @@ use lasso::{Key, Spur, ThreadedRodeo};
 
 /// Known type intrinsics that take a type argument rather than an expression.
 /// These intrinsics operate on types at compile time (e.g., @size_of(i32)).
-const TYPE_INTRINSICS: &[&str] = &["size_of", "align_of"];
+///
+/// `require_droppable` is the compile-time well-formedness gate an owning
+/// growable container (`std/arraybuf.rue`'s `ArrayBuf(T)`) uses to reject an
+/// element type it cannot yet correctly own — one with a destructor or a
+/// `linear` element (RUE-388). It takes the element type as its sole argument
+/// and evaluates to unit during comptime type-constructor reduction, so it must
+/// be lowered as a `TypeIntrinsic` (like `@size_of`), not an expression call.
+const TYPE_INTRINSICS: &[&str] = &["size_of", "align_of", "require_droppable"];
 use rue_parser::ast::{ConstDecl, DropFn};
 use rue_parser::{
     ArgMode, ArrayLength, AssignTarget, Ast, BinaryOp, CallArg, Directive, DirectiveArg, EnumDecl,

--- a/crates/rue-spec/cases/lexical/keywords.toml
+++ b/crates/rue-spec/cases/lexical/keywords.toml
@@ -155,6 +155,25 @@ spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let ptr = 1; 0 }"
 compile_fail = true
 
+# `impl` is a reserved keyword (Rue has no impl blocks; it's held for future
+# trait support). Rejected as a binding name and as a parameter name. (RUE-331)
+[[case]]
+name = "keyword_impl_reserved"
+error_contains = "[E0100]"
+spec = ["2.4:1", "2.4:2"]
+source = "fn main() -> i32 { let impl = 1; 0 }"
+compile_fail = true
+
+[[case]]
+name = "keyword_impl_as_parameter"
+error_contains = "[E0100]"
+spec = ["2.4:1", "2.4:2"]
+source = """
+fn foo(impl: i32) -> i32 { 0 }
+fn main() -> i32 { foo(42) }
+"""
+compile_fail = true
+
 # =============================================================================
 # Type Names Are Reserved
 # =============================================================================
@@ -282,3 +301,43 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
+
+# `type` (the compile-time type of types) is a reserved type name: it cannot be
+# a binding name or a parameter name. (RUE-331)
+[[case]]
+name = "type_type_as_variable"
+error_contains = "[E0100]"
+spec = ["2.4:3"]
+source = """
+fn main() -> i32 {
+    let type = 42;
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "type_type_as_parameter"
+error_contains = "[E0100]"
+spec = ["2.4:3"]
+source = """
+fn foo(type: i32) -> i32 { 0 }
+fn main() -> i32 { foo(42) }
+"""
+compile_fail = true
+
+# But `type` remains usable IN TYPE POSITION as the type-of-types: a comptime
+# type parameter `comptime T: type` with a `-> type` return keeps working
+# exactly as before reservation. (RUE-331)
+[[case]]
+name = "type_keyword_in_type_position"
+spec = ["2.4:3"]
+source = """
+fn identity(comptime T: type, x: T) -> T {
+    return x;
+}
+fn main() -> i32 {
+    return identity(i32, 42);
+}
+"""
+exit_code = 42

--- a/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
@@ -54,10 +54,10 @@ exit_code = 42
 [[case]]
 name = "impl_block_hint"
 description = """
-RUE-19 item 4: `impl` is Rust muscle memory. Rue has no `impl` blocks, so it
-lexes as a plain identifier and dies at item position with an opaque
-"expected item, found identifier". The error must point the user at where
-methods actually go (inside the struct body).
+RUE-19 item 4: `impl` is Rust muscle memory. Rue has no `impl` blocks. `impl` is
+a reserved keyword (spec 2.4:2, RUE-331), so it reaches the parser as a dedicated
+token and dies at item position with an opaque "expected item, found 'impl'". The
+error must point the user at where methods actually go (inside the struct body).
 """
 source = """
 struct Block { x: i32 }
@@ -70,12 +70,18 @@ compile_fail = true
 error_contains = ["Rue has no `impl` blocks", "inside the struct body"]
 
 [[case]]
-name = "impl_still_valid_as_identifier"
-description = "`impl` is NOT reserved; only an `impl` at item position gets the hint."
+name = "impl_reserved_as_identifier"
+description = """
+`impl` is a reserved keyword (spec 2.4:2, RUE-331): it can no longer be used as a
+binding name. Even away from item position it is rejected, and the diagnostic
+still offers the `impl`-block hint. (Reservation was chosen over unreserving so
+that `impl` stays available for future trait support.)
+"""
 source = """
 fn main() -> i32 {
     let impl = 42;
     impl
 }
 """
-exit_code = 42
+compile_fail = true
+error_contains = ["Rue has no `impl` blocks"]

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -76,7 +76,7 @@ place_expr     = ( IDENT | "self" ) { "." IDENT | "[" expression "]" } ;
 type           = "i8" | "i16" | "i32" | "i64"
                | "u8" | "u16" | "u32" | "u64"
                | "usize" | "isize"
-               | "bool" | "()" | "!"
+               | "bool" | "type" | "()" | "!"
                | "[" type ";" array_length "]"
                | "ptr" "const" type
                | "ptr" "mut" type

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -38,15 +38,20 @@
 // SCOPE / KNOWN LIMITATIONS (tracked separately — this file deliberately does
 // not work around them):
 //
-//   * Copy element types only. `get`/`pop` return an element *by copy* wrapped
-//     in `Option(T)` (`@ptr_read`, RUE-313). Move-out of a non-Copy element is
-//     not yet supported. (The destructor drops only the backing buffer, not
-//     per-element glue — for a Copy `T` there is none.)
-//   * Multi-slot aggregate element types (e.g. a two-field struct) now work:
-//     every aggregate is laid out ascending-in-address and `@ptr_read`/
-//     `@ptr_write` walk slots upward from the element base, matching the
-//     ascending heap layout (ADR-0040 / RUE-311). The Copy restriction above
-//     still applies (elements are transferred by copy).
+//   * Trivially-droppable element types only. `get`/`pop` return an element
+//     *by copy* wrapped in `Option(T)` (`@ptr_read`, RUE-313). Move-out of a
+//     non-Copy element is not yet supported, and the destructor drops only the
+//     backing buffer, not per-element glue. An element type that is `linear` or
+//     carries a destructor is therefore REJECTED at instantiation by the
+//     `@require_droppable(T)` gate in the constructor below (E0498 / E0499,
+//     RUE-388) — otherwise its `drop fn` would silently leak / a linear value
+//     would never be consumed. Lifting this to true per-element ownership needs
+//     container/element multiplicity propagation (a future ADR).
+//   * Multi-slot aggregate element types (e.g. a two-field struct) work as long
+//     as they are trivially droppable: every aggregate is laid out
+//     ascending-in-address and `@ptr_read`/`@ptr_write` walk slots upward from
+//     the element base, matching the ascending heap layout (ADR-0040 / RUE-311).
+//     Elements are transferred by copy.
 //
 // The enclosing element type `T` is usable throughout the method bodies below —
 // e.g. to name `Option(T)` and bind `let O = Option(T)` (RUE-313).
@@ -56,6 +61,17 @@ pub fn Option(comptime T: type) -> type {
 }
 
 pub fn ArrayBuf(comptime T: type) -> type {
+    // Well-formedness gate (RUE-388): ArrayBuf owns a heap buffer of `T` and
+    // frees it wholesale in its `drop fn` at scope exit — it does NOT yet run
+    // per-element drop glue, nor track element linearity. Instantiating it with
+    // an element type that is `linear` or carries a destructor would silently
+    // leak that element (its `drop fn` would never run / a linear value would
+    // never be consumed). Until container/element multiplicity propagation is
+    // designed (a future ADR — out of scope), reject such element types at
+    // instantiation with a clear compile error (E0498 / E0499) rather than
+    // miscompiling. Trivially-droppable elements (primitives, pointers, `Copy`
+    // structs of them) pass.
+    @require_droppable(T);
     struct {
         buf: ptr mut T,
         len: u64,


### PR DESCRIPTION
## Summary
Per the 2026-07-09 ruling: dedicated `Impl`/`Type` lexer tokens; `type` accepted in type position (mapped to the interned name so `comptime T: type` / from_primitive_name is unchanged); `impl` rejected everywhere with the existing no-impl-blocks hint. Grammar appendix + keywords spec cases updated. Stacked on the RUE-388 PR.
## Validation
`let type = 1` / `let impl = 2` → parse errors; `fn identity(comptime T: type, x: T) -> T` runs exit 42; std demo (comptime type fns + @require_droppable) runs exit 119. ./test.sh Pass 28 / Fail 0; traceability 100%.

Fixes RUE-331
🤖 Generated with [Claude Code](https://claude.com/claude-code)