### PR TITLE
RUE-523: reject by-value move of a call-loaned root — the f(inout x, x) double free (E0208, spec 6.1:36)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -23,8 +23,8 @@ use rue_span::{FileId, Span};
 use rue_target::{Arch, Os};
 
 use super::context::{
-    AnalysisContext, AnalysisResult, BuiltinMethodContext, ConstValue, ParamInfo, ReceiverInfo,
-    StringReceiverStorage,
+    AnalysisContext, AnalysisResult, BuiltinMethodContext, CallLoanKind, ConstValue, ParamInfo,
+    ReceiverInfo, StringReceiverStorage,
 };
 use super::{AnalyzedFunction, InferenceContext, MethodInfo, Sema, SemaOutput};
 use crate::inference::{

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -522,35 +522,56 @@ impl<'a> Sema<'a> {
         // Add receiver as first argument
         air_args.push((receiver.result.air_ref, AirArgMode::Normal));
 
-        // Analyze and add other arguments
-        for (i, arg) in args.iter().enumerate() {
-            let arg_result = self.analyze_inst(air, arg.value, ctx)?;
-
-            // Get expected type from param
-            let expected_ty = match method.params[i].ty {
-                BuiltinParamType::U64 => Type::U64,
-                BuiltinParamType::U8 => Type::U8,
-                BuiltinParamType::Bool => Type::BOOL,
-                BuiltinParamType::SelfType => Type::new_struct(method_ctx.struct_id),
-            };
-
-            // Type check
-            if arg_result.ty != expected_ty
-                && !arg_result.ty.is_error()
-                && !(self.is_builtin_string(arg_result.ty)
-                    && matches!(method.params[i].ty, BuiltinParamType::SelfType))
-            {
-                return Err(CompileError::new(
-                    ErrorKind::TypeMismatch {
-                        expected: expected_ty.safe_name_with_pool(Some(&self.type_pool)),
-                        found: arg_result.ty.safe_name_with_pool(Some(&self.type_pool)),
-                    },
-                    method_ctx.span,
-                ));
-            }
-
-            air_args.push((arg_result.air_ref, AirArgMode::Normal));
+        // A by-ref receiver's loan spans the whole call, so a by-value move of
+        // the receiver's root in an argument (`s.contains(s)` — the needle is
+        // a String, moved) must conflict exactly like `f(borrow s, s)` does
+        // (RUE-523). Push the receiver's loan frame while the arguments are
+        // analyzed; move-record sites consult it.
+        let receiver_loan = match (method.receiver_mode, receiver.var) {
+            (ReceiverMode::ByMutRef, Some(root)) => Some(vec![(root, CallLoanKind::Inout)]),
+            (ReceiverMode::ByRef, Some(root)) => Some(vec![(root, CallLoanKind::Borrow)]),
+            _ => None,
+        };
+        let receiver_loan_pushed = receiver_loan.is_some();
+        if let Some(frame) = receiver_loan {
+            ctx.call_loaned_roots.push(frame);
         }
+        let args_result = (|| -> CompileResult<()> {
+            // Analyze and add other arguments
+            for (i, arg) in args.iter().enumerate() {
+                let arg_result = self.analyze_inst(air, arg.value, ctx)?;
+
+                // Get expected type from param
+                let expected_ty = match method.params[i].ty {
+                    BuiltinParamType::U64 => Type::U64,
+                    BuiltinParamType::U8 => Type::U8,
+                    BuiltinParamType::Bool => Type::BOOL,
+                    BuiltinParamType::SelfType => Type::new_struct(method_ctx.struct_id),
+                };
+
+                // Type check
+                if arg_result.ty != expected_ty
+                    && !arg_result.ty.is_error()
+                    && !(self.is_builtin_string(arg_result.ty)
+                        && matches!(method.params[i].ty, BuiltinParamType::SelfType))
+                {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: expected_ty.safe_name_with_pool(Some(&self.type_pool)),
+                            found: arg_result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        method_ctx.span,
+                    ));
+                }
+
+                air_args.push((arg_result.air_ref, AirArgMode::Normal));
+            }
+            Ok(())
+        })();
+        if receiver_loan_pushed {
+            ctx.call_loaned_roots.pop();
+        }
+        args_result?;
 
         // Determine return type
         // Use builtin_air_type for SelfType to get correct AIR output type

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -328,12 +328,30 @@ impl<'a> Sema<'a> {
             self.check_exclusive_access(&args, span)?;
         }
 
-        // Analyze arguments - receiver first, then remaining args
+        // Analyze arguments - receiver first, then remaining args.
+        //
+        // A by-ref receiver's loan spans the whole call: while the remaining
+        // arguments are analyzed, a by-value move of the receiver's root
+        // (`s.absorb(s)`) must conflict exactly like `f(inout s, s)` does
+        // (RUE-523), so the receiver contributes a loan frame of its own.
         let mut air_args = vec![AirCallArg {
             value: receiver_result.air_ref,
             mode: receiver_mode,
         }];
-        air_args.extend(self.analyze_call_args(air, &args, ctx)?);
+        let receiver_frame = match (receiver_mode, receiver_var) {
+            (AirArgMode::Inout, Some(root)) => Some(vec![(root, CallLoanKind::Inout)]),
+            (AirArgMode::Borrow, Some(root)) => Some(vec![(root, CallLoanKind::Borrow)]),
+            _ => None,
+        };
+        let receiver_frame_pushed = receiver_frame.is_some();
+        if let Some(frame) = receiver_frame {
+            ctx.call_loaned_roots.push(frame);
+        }
+        let args_result = self.analyze_call_args(air, &args, ctx);
+        if receiver_frame_pushed {
+            ctx.call_loaned_roots.pop();
+        }
+        air_args.extend(args_result?);
 
         // Generate a method call name: Type.method
         let call_name = format!("{}.{}", struct_name_str, method_name_str);

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -416,6 +416,7 @@ impl<'a> Sema<'a> {
             referenced_functions: HashSet::new(),
             referenced_methods: HashSet::new(),
             byref_arg_root: None,
+            call_loaned_roots: Vec::new(),
             in_loop_move_recheck: false,
             iter_borrows: Vec::new(),
             expected_type: None,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -421,6 +421,7 @@ impl<'a> Sema<'a> {
                 ));
             }
         }
+        self.reject_move_of_call_loaned_root(trace.root_var, span, ctx)?;
         ctx.moved_vars
             .entry(trace.root_var)
             .or_default()
@@ -644,6 +645,46 @@ impl<'a> Sema<'a> {
         check_exclusive_access_in(self.rir, self.interner, args, call_span)
     }
 
+    /// Reject recording a MOVE of `root` while an enclosing call's argument
+    /// list holds an `inout`/`borrow` loan of the same root (law of
+    /// exclusivity, spec 6.1:31, RUE-523).
+    ///
+    /// The loan spans the entire call, so a by-value use of the loaned
+    /// variable in the same argument list — in either order, directly
+    /// (`f(inout x, x)`) or nested (`f(inout x, g(x))`) — would hand the
+    /// callee an `inout`/`borrow` view of moved-from storage: its destructor
+    /// runs in the callee (via the moved-into owner) AND through the loaned
+    /// alias — a double free in safe code. Called at every move-record site;
+    /// a no-op outside call-argument analysis (the frame stack is empty).
+    /// Root-granular, like the other exclusivity rules: even disjoint
+    /// projections of one root conflict.
+    pub(crate) fn reject_move_of_call_loaned_root(
+        &self,
+        root: Spur,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<()> {
+        for frame in ctx.call_loaned_roots.iter().rev() {
+            if let Some((_, kind)) = frame.iter().find(|(r, _)| *r == root) {
+                let variable = self.interner.resolve(&root).to_string();
+                let kw = kind.keyword();
+                return Err(CompileError::new(
+                    ErrorKind::MoveWhileCallLoaned {
+                        variable: variable.clone(),
+                        loan_mode: kw.to_string(),
+                    },
+                    span,
+                )
+                .with_help(format!(
+                    "the `{kw}` access to `{variable}` spans the whole call, so its value \
+                     cannot also be moved into it; copy or clone the value into a new \
+                     binding before the call"
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Analyze a list of call arguments, enforcing by-ref argument rules.
     ///
     /// Inout/borrow arguments are borrows, not moves: `ctx.byref_arg_root` is
@@ -657,6 +698,44 @@ impl<'a> Sema<'a> {
     /// An `inout` argument rooted at a `borrow` parameter is rejected here:
     /// it would hand the callee a mutable view of read-only memory.
     pub(crate) fn analyze_call_args(
+        &mut self,
+        air: &mut Air,
+        args: &[RirCallArg],
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<Vec<AirCallArg>> {
+        // Collect this call's loan frame up front — every by-ref argument's
+        // root — so a by-value move of a loaned root is caught in EITHER
+        // argument order (`f(inout x, x)` and `f(x, inout x)` alike, RUE-523).
+        // The frame stays pushed while every argument (and anything nested in
+        // one) is analyzed; move-record sites consult it via
+        // `reject_move_of_call_loaned_root`.
+        let frame: Vec<(Spur, CallLoanKind)> = args
+            .iter()
+            .filter_map(|arg| {
+                let kind = if arg.is_inout() {
+                    CallLoanKind::Inout
+                } else if arg.is_borrow() {
+                    CallLoanKind::Borrow
+                } else {
+                    return None;
+                };
+                root_variable_of(self.rir, arg.value).map(|root| (root, kind))
+            })
+            .collect();
+        let pushed = !frame.is_empty();
+        if pushed {
+            ctx.call_loaned_roots.push(frame);
+        }
+        let result = self.analyze_call_args_inner(air, args, ctx);
+        if pushed {
+            ctx.call_loaned_roots.pop();
+        }
+        result
+    }
+
+    /// The argument loop behind [`Sema::analyze_call_args`], factored out so
+    /// the loan frame is popped on every exit path (including `?` errors).
+    fn analyze_call_args_inner(
         &mut self,
         air: &mut Air,
         args: &[RirCallArg],
@@ -822,6 +901,43 @@ impl<'a> Sema<'a> {
     /// see [`crate::sema::Sema`] parameter setup). Non-slice parameters use the
     /// ordinary [`Self::analyze_call_args`] argument path unchanged.
     pub(crate) fn analyze_call_args_coerced(
+        &mut self,
+        air: &mut Air,
+        args: &[RirCallArg],
+        param_types: &[Type],
+        param_modes: &[RirParamMode],
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<Vec<AirCallArg>> {
+        // Same loan-frame discipline as `analyze_call_args` (RUE-523): a
+        // by-value move of a root this call passes `inout`/`borrow` conflicts
+        // in either argument order.
+        let frame: Vec<(Spur, CallLoanKind)> = args
+            .iter()
+            .filter_map(|arg| {
+                let kind = if arg.is_inout() {
+                    CallLoanKind::Inout
+                } else if arg.is_borrow() {
+                    CallLoanKind::Borrow
+                } else {
+                    return None;
+                };
+                root_variable_of(self.rir, arg.value).map(|root| (root, kind))
+            })
+            .collect();
+        let pushed = !frame.is_empty();
+        if pushed {
+            ctx.call_loaned_roots.push(frame);
+        }
+        let result = self.analyze_call_args_coerced_inner(air, args, param_types, param_modes, ctx);
+        if pushed {
+            ctx.call_loaned_roots.pop();
+        }
+        result
+    }
+
+    /// The argument loop behind [`Sema::analyze_call_args_coerced`], factored
+    /// out so the loan frame is popped on every exit path.
+    fn analyze_call_args_coerced_inner(
         &mut self,
         air: &mut Air,
         args: &[RirCallArg],

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2556,6 +2556,7 @@ impl<'a> Sema<'a> {
                         // (comptime params are substituted at compile time)
                         RirParamMode::Normal | RirParamMode::Comptime => {
                             if !is_byref_arg_use {
+                                self.reject_move_of_call_loaned_root(name, span, ctx)?;
                                 ctx.moved_vars
                                     .entry(name)
                                     .or_default()
@@ -2658,6 +2659,7 @@ impl<'a> Sema<'a> {
                 ));
             }
             if moves_out {
+                self.reject_move_of_call_loaned_root(name, span, ctx)?;
                 ctx.moved_vars
                     .entry(name)
                     .or_default()
@@ -3592,6 +3594,7 @@ impl<'a> Sema<'a> {
                 // For linear types, field access consumes the entire struct
                 self.reject_linear_destructure_dropping_linear_field(&trace, span)?;
                 self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
+                self.reject_move_of_call_loaned_root(trace.root_var, span, ctx)?;
                 ctx.moved_vars
                     .entry(trace.root_var)
                     .or_default()
@@ -3636,6 +3639,7 @@ impl<'a> Sema<'a> {
                 }
 
                 // Mark this field path as moved
+                self.reject_move_of_call_loaned_root(trace.root_var, span, ctx)?;
                 ctx.moved_vars
                     .entry(trace.root_var)
                     .or_default()

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -306,6 +306,26 @@ pub(crate) struct ParamInfo {
     pub is_comptime: bool,
 }
 
+/// How a call argument (or method receiver) loans its root variable for the
+/// duration of the call — the two by-ref modes tracked in
+/// [`AnalysisContext::call_loaned_roots`]. Carried in the loan frame so the
+/// E0208 diagnostic can name the conflicting keyword (RUE-523).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CallLoanKind {
+    Inout,
+    Borrow,
+}
+
+impl CallLoanKind {
+    /// The source keyword, for diagnostics.
+    pub(crate) fn keyword(self) -> &'static str {
+        match self {
+            CallLoanKind::Inout => "inout",
+            CallLoanKind::Borrow => "borrow",
+        }
+    }
+}
+
 /// Context for analyzing instructions within a function.
 ///
 /// Bundles together the mutable state that needs to be threaded through
@@ -385,6 +405,17 @@ pub(crate) struct AnalysisContext<'a> {
     /// reject forwarding a by-ref parameter to another function's by-ref
     /// parameter (RUE-143).
     pub byref_arg_root: Option<Spur>,
+    /// Stack of loan frames, one per call whose argument list is currently
+    /// being analyzed (outermost first): the ROOT variables that call passes
+    /// `inout`/`borrow`, plus a by-ref method receiver's root. A loan spans
+    /// the entire call, so recording a MOVE of any root on this stack while
+    /// evaluating another argument of the same call (directly, or nested —
+    /// `f(inout x, g(x))`) would leave the loan aliasing moved-from storage:
+    /// a double free in safe code. Move-record sites consult this via
+    /// `Sema::reject_move_of_call_loaned_root` (E0208, spec 6.1, RUE-523).
+    /// Completed nested LOANS (`f(inout x, g(borrow x))`) do not conflict:
+    /// the inner loan ends before the outer call begins.
+    pub call_loaned_roots: Vec<Vec<(Spur, CallLoanKind)>>,
     /// True while re-running a loop's condition/body to validate the loop's
     /// back edge (see [`AnalysisContext::fork_for_loop_recheck`]). The recheck
     /// pass starts from a move state that already includes every move the loop
@@ -495,6 +526,10 @@ impl<'a> AnalysisContext<'a> {
             // while this is set; the fork starts between whole-expression
             // analyses.
             byref_arg_root: None,
+            // The recheck re-analyzes the loop body's moves, and an argument
+            // value may contain a loop (`f(inout x, { while … })`), so the
+            // enclosing calls' loan frames must stay visible.
+            call_loaned_roots: self.call_loaned_roots.clone(),
             in_loop_move_recheck: true,
             iter_borrows: self.iter_borrows.clone(),
             expected_type: None,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -110,6 +110,7 @@ impl ErrorCode {
     pub const USE_AFTER_MOVE: Self = Self(205);
     pub const TYPE_MISMATCH: Self = Self(206);
     pub const WRONG_ARGUMENT_COUNT: Self = Self(207);
+    pub const MOVE_WHILE_CALL_LOANED: Self = Self(208);
 
     // ========================================================================
     // Struct/enum errors (E0400-E0499)
@@ -1300,6 +1301,12 @@ pub enum ErrorKind {
     /// Same variable passed to both borrow and inout parameters (law of exclusivity)
     #[error("cannot borrow '{variable}' while it is mutably borrowed (inout)")]
     BorrowInoutConflict { variable: String },
+    /// A moving (by-value) use of a variable inside an argument list that also
+    /// passes the same variable `inout`/`borrow`: the loan spans the whole
+    /// call, so the move would leave it aliasing moved-from storage — a double
+    /// free in safe code (law of exclusivity, RUE-523).
+    #[error("cannot move '{variable}' into a call that also passes it '{loan_mode}'")]
+    MoveWhileCallLoaned { variable: String, loan_mode: String },
     /// Argument to inout parameter is missing `inout` keyword at call site
     #[error("argument to inout parameter must use 'inout' keyword")]
     InoutKeywordMissing,
@@ -1597,6 +1604,7 @@ impl ErrorKind {
             ErrorKind::MutateBorrowedValue { .. } => ErrorCode::MUTATE_BORROWED_VALUE,
             ErrorKind::MoveOutOfBorrow { .. } => ErrorCode::MOVE_OUT_OF_BORROW,
             ErrorKind::BorrowInoutConflict { .. } => ErrorCode::BORROW_INOUT_CONFLICT,
+            ErrorKind::MoveWhileCallLoaned { .. } => ErrorCode::MOVE_WHILE_CALL_LOANED,
             ErrorKind::InoutKeywordMissing => ErrorCode::INOUT_KEYWORD_MISSING,
             ErrorKind::BorrowKeywordMissing => ErrorCode::BORROW_KEYWORD_MISSING,
             ErrorKind::MoveOutOfInout { .. } => ErrorCode::MOVE_OUT_OF_INOUT,

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -796,6 +796,183 @@ compile_fail = true
 error_contains = "borrow"
 
 [[case]]
+name = "move_while_inout_loaned"
+spec = ["6.1:36"]
+description = "Passing a variable by value while also passing it inout in the same call is rejected (RUE-523 double free)"
+source = """
+struct R { id: i32 }
+drop fn R(self) { @dbg(self.id); }
+fn f(inout a: R, b: R) -> i32 {
+    a = R { id: 99 };
+    b.id
+}
+fn main() -> i32 {
+    let mut x = R { id: 5 };
+    let r = f(inout x, x);
+    r
+}
+"""
+compile_fail = true
+error_contains = "into a call that also passes it"
+
+[[case]]
+name = "move_while_inout_loaned_reversed_order"
+spec = ["6.1:36"]
+description = "The by-value-first order is rejected by the same rule — argument order does not matter"
+source = """
+struct R { id: i32 }
+drop fn R(self) { @dbg(self.id); }
+fn f(a: R, inout b: R) -> i32 {
+    b = R { id: 99 };
+    a.id
+}
+fn main() -> i32 {
+    let mut x = R { id: 5 };
+    let r = f(x, inout x);
+    r
+}
+"""
+compile_fail = true
+error_contains = "into a call that also passes it"
+
+[[case]]
+name = "move_while_borrow_loaned"
+spec = ["6.1:36"]
+description = "Passing a variable by value while also passing it borrow in the same call is rejected"
+source = """
+struct R { id: i32 }
+drop fn R(self) { @dbg(self.id); }
+fn f(borrow a: R, b: R) -> i32 {
+    a.id + b.id
+}
+fn main() -> i32 {
+    let mut x = R { id: 5 };
+    let r = f(borrow x, x);
+    r
+}
+"""
+compile_fail = true
+error_contains = "into a call that also passes it"
+
+[[case]]
+name = "move_while_loaned_string_heap"
+spec = ["6.1:36"]
+description = "The heap shape: moving a String into a call that passes it inout would double-free the buffer"
+source = """
+fn f(inout a: String, b: String) -> u64 {
+    a.push(120);
+    b.len()
+}
+fn main() -> i32 {
+    let mut s = String.new();
+    s.push(104);
+    let r = f(inout s, s);
+    if r == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = "into a call that also passes it"
+
+[[case]]
+name = "move_while_loaned_nested_call"
+spec = ["6.1:36"]
+description = "A move that happens inside a nested call in another argument conflicts with the outer call's loan"
+source = """
+struct R { id: i32 }
+drop fn R(self) { @dbg(self.id); }
+fn g(r: R) -> i32 { r.id }
+fn f(inout a: R, b: i32) -> i32 {
+    a = R { id: 99 };
+    b
+}
+fn main() -> i32 {
+    let mut x = R { id: 5 };
+    let r = f(inout x, g(x));
+    r
+}
+"""
+compile_fail = true
+error_contains = "into a call that also passes it"
+
+[[case]]
+name = "move_field_while_root_loaned"
+spec = ["6.1:36"]
+description = "Moving one field by value while loaning the whole variable shares a root and is rejected"
+source = """
+struct Inner { s: String }
+struct Outer { inner: Inner, n: i32 }
+fn f(inout a: Outer, b: Inner) -> i32 {
+    a.n = 1;
+    if b.s.len() == 1 { 7 } else { 8 }
+}
+fn main() -> i32 {
+    let mut st = String.new();
+    st.push(120);
+    let mut o = Outer { inner: Inner { s: st }, n: 0 };
+    f(inout o, o.inner)
+}
+"""
+compile_fail = true
+error_contains = "into a call that also passes it"
+
+[[case]]
+name = "move_receiver_root_into_method_arg"
+spec = ["6.1:36"]
+description = "A by-reference method receiver is a loan: moving the receiver variable into an argument of the same call is rejected"
+source = """
+struct R {
+    id: i32,
+    fn absorb(inout self, other: R) {
+        self.id = self.id + other.id;
+    }
+}
+drop fn R(self) { @dbg(self.id); }
+fn main() -> i32 {
+    let mut x = R { id: 5 };
+    x.absorb(x);
+    0
+}
+"""
+compile_fail = true
+error_contains = "into a call that also passes it"
+
+[[case]]
+name = "copy_by_value_with_inout_same_var_ok"
+spec = ["6.1:36"]
+description = "A by-value argument of a Copy type is a completed read, not a move, so it may accompany an inout loan of the same variable"
+source = """
+fn f(inout a: i32, b: i32) -> i32 {
+    a = a + b;
+    b
+}
+fn main() -> i32 {
+    let mut n = 20;
+    let r = f(inout n, n);
+    n + r
+}
+"""
+exit_code = 60
+
+[[case]]
+name = "nested_completed_borrow_with_inout_ok"
+spec = ["6.1:36"]
+description = "A loan nested inside another argument completes before the outer call begins, so it does not conflict with the outer inout"
+source = """
+struct R { id: i32 }
+fn g(borrow r: R) -> i32 { r.id }
+fn f(inout a: R, b: i32) -> i32 {
+    a = R { id: 99 };
+    b
+}
+fn main() -> i32 {
+    let mut x = R { id: 5 };
+    let r = f(inout x, g(borrow x));
+    r + x.id - 104
+}
+"""
+exit_code = 0
+
+[[case]]
 name = "borrow_multiple_same_var_ok"
 spec = ["6.1:28"]
 description = "Multiple borrows of the same variable is allowed"

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -197,6 +197,28 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="6.1:36", cat="legality-rule") }}
+
+A single call **MUST NOT** both loan a variable — pass it `inout` or `borrow`, including as a by-reference method receiver — and move that variable's value by passing it, or any part of it, to a by-value parameter of a non-`Copy` type. The loan spans the entire call, so the move would leave the loaned place referring to moved-from storage (its destructor would run both through the moved-into owner and through the loaned alias). The rule applies in either argument order, and to a move that occurs anywhere within the call's argument expressions, including inside a nested call that consumes the variable. As with rules 6.1:20 and 6.1:30, it applies to the argument's root variable: moving one field while loaning another field of the same variable is likewise rejected. A by-value argument of a `Copy` type is a read that completes before the call begins and does not conflict; likewise a loan nested inside another argument (such as `f(inout x, g(borrow x))`) ends before the outer call begins and does not conflict.
+
+{{ rule(id="6.1:37", cat="example") }}
+
+```rue
+struct R { id: i32 }
+drop fn R(self) { @dbg(self.id); }
+
+fn f(inout a: R, b: R) -> i32 {
+    a = R { id: 99 };
+    b.id
+}
+
+fn main() -> i32 {
+    let mut x = R { id: 5 };
+    let r = f(inout x, x);  // error: cannot move 'x' into a call that also passes it 'inout'
+    r
+}
+```
+
 ## Parameter Immutability
 
 {{ rule(id="6.1:32", cat="legality-rule") }}


### PR DESCRIPTION
## Summary
Closes the P1 soundness hole: the exclusivity rules only enumerated inout+inout (6.1:20) and borrow+inout (6.1:30), so `f(inout x, x)` compiled clean and ran the destructor twice (verified: `5 5 1000`, heap String variant double-freed a real buffer). `f(borrow x, x)` likewise read moved-from storage. Fix: `AnalysisContext` carries a stack of per-call loan frames (inout/borrow roots of each argument list being analyzed, plus by-ref method and builtin-method receivers); every move-record site consults it. Catches both argument orders (the by-value-first order previously produced E0205), partial field/element moves, nested moves (`f(inout x, g(x))`), method receivers (`x.absorb(x)`), and builtin receivers (`s.contains(s)`). Copy types and completed nested loans (`f(inout x, g(borrow x))`) stay legal. New diagnostic E0208; spec rule 6.1:36 (+ example 6.1:37).

The formal core's Call rule (RUE-389) already forbade this — the model caught the compiler; no core amendment needed.

## Validation
All ten behavior probes verified by execution before/after (double free reproduced on trunk, rejected after; legal controls run with correct exits). 9 new spec cases with 6.1:36 traceability. ./test.sh Pass 28 / Fail 0; traceability 100%.

Fixes RUE-523

🤖 Generated with [Claude Code](https://claude.com/claude-code)