### PR TITLE
RUE-521: pin address-taken slots — constprop must keep @raw/@raw_mut/@field_ptr operands as places

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -882,6 +882,25 @@ impl<'a> CfgBuilder<'a> {
                     };
                     arg_vals.push(val);
                 }
+                // @raw/@raw_mut/@field_ptr take the ADDRESS of their place
+                // operand (arg 0): codegen requires that operand to still be a
+                // `Load`/`PlaceRead` when it lowers the intrinsic. Pin the
+                // operand's base slot so optimization passes (constprop) never
+                // rewrite its loads into constants — a `Const` operand would be
+                // dereferenced as an address (RUE-521 O1+ segfault).
+                if matches!(self.interner.resolve(name), "raw" | "raw_mut" | "field_ptr")
+                    && let Some(&place_val) = arg_vals.first()
+                {
+                    match &self.cfg.get_inst(place_val).data {
+                        CfgInstData::Load { slot } => self.cfg.mark_address_taken(*slot),
+                        CfgInstData::PlaceRead { place } => {
+                            if let PlaceBase::Local(slot) = place.base {
+                                self.cfg.mark_address_taken(slot);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
                 // Store args in extra array
                 let (args_start, args_len) = self.cfg.push_extra(arg_vals);
                 let value = self.emit(

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -588,6 +588,16 @@ pub struct Cfg {
     fn_name: String,
     /// Whether each parameter slot is inout (passed by reference)
     param_modes: Vec<bool>,
+    /// Local slots whose ADDRESS escapes through an address-taking intrinsic
+    /// (`@raw` / `@raw_mut` / `@field_ptr`), recorded at construction by
+    /// CfgBuilder (which has the interner to recognize the names — opt passes
+    /// don't). Codegen lowers those intrinsics by taking the operand place's
+    /// address, so its `Load`/`PlaceRead` must survive optimization: constprop
+    /// consults this to disqualify the slot, otherwise the Load becomes a
+    /// `Const` and the constant is dereferenced as an address — the verified
+    /// RUE-521 O1+ segfault. By-ref call arguments are the analogous
+    /// per-instruction escape, handled directly in constprop's scan.
+    address_taken_slots: std::collections::HashSet<u32>,
 }
 
 impl Cfg {
@@ -612,7 +622,23 @@ impl Cfg {
             num_params,
             fn_name,
             param_modes,
+            address_taken_slots: std::collections::HashSet::new(),
         }
+    }
+
+    /// Record that `slot`'s address escapes through an address-taking
+    /// intrinsic (`@raw` / `@raw_mut` / `@field_ptr`), pinning its loads as
+    /// places for the optimizer (RUE-521).
+    #[inline]
+    pub fn mark_address_taken(&mut self, slot: u32) {
+        self.address_taken_slots.insert(slot);
+    }
+
+    /// Whether `slot`'s address escapes through an address-taking intrinsic
+    /// (see [`Cfg::mark_address_taken`]).
+    #[inline]
+    pub fn is_address_taken(&self, slot: u32) -> bool {
+        self.address_taken_slots.contains(&slot)
     }
 
     /// Get the return type.

--- a/crates/rue-cfg/src/opt/constprop.rs
+++ b/crates/rue-cfg/src/opt/constprop.rs
@@ -53,6 +53,18 @@ enum ConstPayload {
 pub fn run(cfg: &mut Cfg) -> bool {
     let mut slots = vec![SlotState::NoWrite; cfg.num_locals() as usize];
 
+    // Slots whose address escapes through an address-taking intrinsic
+    // (`@raw`/`@raw_mut`/`@field_ptr`, recorded by CfgBuilder) must keep
+    // their Loads as places: codegen lowers those intrinsics by taking the
+    // operand's address, so rewriting the Load into a Const would make the
+    // constant be dereferenced as an address (RUE-521 O1+ segfault). Same
+    // reasoning as the by-ref call-argument disqualification below.
+    for (slot, state) in slots.iter_mut().enumerate() {
+        if cfg.is_address_taken(slot as u32) {
+            *state = SlotState::Disqualified;
+        }
+    }
+
     // Zero-sized locals (`[T; 0]`, `()`, empty structs) occupy 0 slots, so a
     // zero-sized local at the end of the frame is assigned a slot index equal
     // to `num_locals` — out of range for `slots`. Its Alloc/Load move no
@@ -230,6 +242,41 @@ mod tests {
         );
         let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
+
+        assert!(!run(&mut cfg));
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_address_taken_slot_not_propagated() {
+        // let x = 42; @raw(x) — CfgBuilder marks x's slot address-taken, so
+        // its Load must survive as a place even though the slot has exactly
+        // one constant write. Rewriting it to Const(42) makes codegen
+        // dereference 42 as an address (RUE-521 O1+ segfault).
+        let mut cfg = make_cfg(1);
+        let c = push(&mut cfg, CfgInstData::Const(42), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        let (args_start, args_len) = cfg.push_extra(vec![load]);
+        let raw_sym = Spur::try_from_usize(0).unwrap();
+        let ptr = push(
+            &mut cfg,
+            CfgInstData::Intrinsic {
+                name: raw_sym,
+                args_start,
+                args_len,
+            },
+            Type::I32,
+        );
+        cfg.mark_address_taken(0);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(ptr) });
 
         assert!(!run(&mut cfg));
         assert!(matches!(

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -173,3 +173,36 @@ stdout = """0
 0
 """
 exit_code = 0
+
+# Address-taking intrinsics keep their place operands (RUE-521): constprop
+# rewrote the `Load` feeding `@raw` into its constant value, so codegen
+# dereferenced the integer 42 as an address — a segfault at -O1+ while -O0 was
+# correct. Covers all three address-taking intrinsics (@raw, @raw_mut,
+# @field_ptr) with pointer round-trips pinned at every level.
+[[case]]
+name = "raw_pointer_place_operands_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct P { a: i32, b: i32 }
+
+fn main() -> i32 {
+    let x: i32 = 42;
+    let mut y: i32 = 7;
+    let s = P { a: 30, b: 12 };
+    checked {
+        let p: ptr const i32 = @raw(x);
+        let v: i32 = @ptr_read(p);
+        @dbg(v);
+        let q: ptr mut i32 = @raw_mut(y);
+        @ptr_write(q, 35);
+        let f: ptr const i32 = @field_ptr(s.a);
+        let w: i32 = @ptr_read(f);
+        @dbg(w);
+    };
+    y
+}
+""" }]
+stdout = """42
+30
+"""
+exit_code = 35


### PR DESCRIPTION
## Summary
Constprop rewrote a single-const-write slot's `Load` everywhere, including the place operand of an address-taking intrinsic, so codegen dereferenced the integer 42 as an address — segfault at -O1+ while -O0 was correct (verified by execution; the corrupted CFG is target-independent). Fix: CfgBuilder — which has the interner the opt passes lack — records the base slot of `@raw`/`@raw_mut`/`@field_ptr` place operands (whole-local `Load` and projected `PlaceRead` alike) as address-taken on the Cfg; constprop disqualifies those slots up front, mirroring its existing by-ref call-argument escape rule. Covers `@field_ptr` as well — the third address-taking intrinsic in the codegen lowering, which the issue's report didn't name.

## Validation
Repro segfaulted at -O1/-O2/-O3 before, prints 42/exit 0 at all levels after; `@raw_mut` write-through and `@field_ptr` projection variants verified at -O0/-O2. New constprop unit test (marked slot's Load survives) + `differential_opt` CLI case pinning stdout/exit for all three intrinsics across -O0..-O3. ./test.sh Pass 28 / Fail 0.

Fixes RUE-521

🤖 Generated with [Claude Code](https://claude.com/claude-code)