### PR TITLE
RUE-540+541: enforce complete benchmark data and aggregate dashboard metrics

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -61,6 +61,17 @@ filegroup(
     srcs = glob(["docs/designs/**"]),
 )
 
+filegroup(
+    name = "benchmark-tool-inputs",
+    srcs = [
+        "benchmarks/manifest.toml",
+        "scripts/append-benchmark.py",
+        "scripts/benchmark_validation.py",
+        "scripts/generate-charts.py",
+        "scripts/validate-benchmark.py",
+    ],
+)
+
 sh_test(
     name = "spec-tests",
     test = "//crates/rue-spec:rue-spec",
@@ -123,4 +134,13 @@ sh_test(
         "--adr-dir",
         "$(location :adr-designs)/docs/designs",
     ],
+)
+
+sh_test(
+    name = "benchmark-tool-tests",
+    test = "scripts/test-benchmark-tools.py",
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "RUE_BENCHMARK_TEST_ROOT": "$(location :benchmark-tool-inputs)",
+    },
 )

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -146,12 +146,12 @@ measurement (plain `{ … }` blocks nested N deep, DEFAULT build, this host):
 | 20 | > 30 s (killed) |
 
 Each added level roughly **doubles** parse time — i.e. **O(2^depth)**. That
-means `deep_nesting.rue` (nests ~40 levels) cannot be parsed, and `bench.sh`
-has almost certainly been silently skipping it (a failed benchmark iteration is
-logged and dropped, and `validate-benchmark.py` only fails when *all*
-benchmarks fail). This is a real parser bug, filed separately; it is out of
-scope for this measurement-only change. Once fixed, add `deep_nesting` back to
-`default_corpus()` in `scripts/perf-baseline.py`.
+means `deep_nesting.rue` (nests ~40 levels) cannot be parsed. `bench.sh` logs
+and drops failed benchmark iterations, but result validation now rejects any
+run that does not contain the manifest's exact benchmark set, so this failure
+cannot silently enter benchmark history. This is a real parser bug, filed
+separately; it is out of scope for this measurement-only change. Once fixed,
+add `deep_nesting` back to `default_corpus()` in `scripts/perf-baseline.py`.
 
 ## Build profile (release vs. DEFAULT)
 

--- a/scripts/append-benchmark.py
+++ b/scripts/append-benchmark.py
@@ -7,7 +7,7 @@ It handles:
 - Appending new results to existing history
 - Creating the history file if it doesn't exist
 - Limiting history to the most recent 100 entries
-- Validating JSON structure
+- Validating JSON structure and exact benchmark-manifest membership
 - Supporting both version 1 and version 2 result schemas
 
 Usage:
@@ -59,6 +59,12 @@ import json
 import sys
 from pathlib import Path
 
+from benchmark_validation import (
+    DEFAULT_MANIFEST,
+    load_manifest_names,
+    validate_results,
+)
+
 # Maximum number of runs to keep in history
 MAX_HISTORY_SIZE = 100
 
@@ -86,33 +92,22 @@ def save_json(path: Path, data: dict) -> None:
         f.write("\n")
 
 
-def validate_result(result: dict) -> bool:
-    """Validate that a result has the required fields and non-empty data."""
+def validate_result(result: object, expected_names: list[str]) -> bool:
+    """Validate required history fields and exact manifest membership."""
+    if not isinstance(result, dict):
+        print("Error: benchmark result must be a JSON object", file=sys.stderr)
+        return False
+
     required_fields = ["timestamp", "benchmarks"]
     for field in required_fields:
         if field not in result:
             print(f"Error: Result missing required field: {field}", file=sys.stderr)
             return False
 
-    if not isinstance(result["benchmarks"], list):
-        print("Error: benchmarks field must be an array", file=sys.stderr)
-        return False
-
-    if len(result["benchmarks"]) == 0:
-        print("Error: benchmarks array is empty - no data to record", file=sys.stderr)
-        print("This usually means all benchmark iterations failed.", file=sys.stderr)
-        return False
-
-    # Validate each benchmark has required fields
-    for i, bench in enumerate(result["benchmarks"]):
-        if "name" not in bench:
-            print(f"Error: benchmark[{i}] missing 'name' field", file=sys.stderr)
-            return False
-        if "mean_ms" not in bench:
-            print(f"Error: benchmark[{i}] ({bench.get('name', '?')}) missing 'mean_ms' field", file=sys.stderr)
-            return False
-
-    return True
+    errors = validate_results(result, expected_names)
+    for error in errors:
+        print(f"Error: {error}", file=sys.stderr)
+    return not errors
 
 
 def append_result(history: dict, result: dict) -> dict:
@@ -134,6 +129,12 @@ def main():
     parser.add_argument("results", type=Path, help="results.json from bench.sh")
     parser.add_argument("history", type=Path, help="history file to append to")
     parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="benchmark manifest (default: benchmarks/manifest.toml)",
+    )
+    parser.add_argument(
         "--reason",
         choices=["push", "manual", "scheduled"],
         help="what triggered this run; upgrades the result to the v2 schema",
@@ -151,18 +152,25 @@ def main():
     with open(results_path, "r") as f:
         result = json.load(f)
 
-    # Upgrade to the version 2 schema (commit range tracking)
+    try:
+        expected_names = load_manifest_names(args.manifest)
+    except (OSError, ValueError) as error:
+        print(f"Error: Cannot load benchmark manifest: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate the result at the final history-publication boundary.
+    if not validate_result(result, expected_names):
+        print("Error: Invalid result format", file=sys.stderr)
+        sys.exit(1)
+
+    # Upgrade to the version 2 schema (commit range tracking) only after the
+    # input has been established as an object with a complete corpus.
     if args.reason is not None:
         result["version"] = 2
         result["benchmark_reason"] = args.reason
         if not result.get("commit_range"):
             commit = result.get("commit")
             result["commit_range"] = [commit] if commit else []
-
-    # Validate the result
-    if not validate_result(result):
-        print("Error: Invalid result format", file=sys.stderr)
-        sys.exit(1)
 
     # Load existing history
     history = load_json(history_path)

--- a/scripts/benchmark_validation.py
+++ b/scripts/benchmark_validation.py
@@ -1,0 +1,81 @@
+"""Shared schema and corpus validation for benchmark result publication."""
+
+from collections import Counter
+from pathlib import Path
+import tomllib
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks" / "manifest.toml"
+
+
+def load_manifest_names(path: Path) -> list[str]:
+    """Load and validate the benchmark names declared by the manifest."""
+    with path.open("rb") as f:
+        manifest = tomllib.load(f)
+
+    entries = manifest.get("benchmark")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("manifest must contain at least one [[benchmark]] entry")
+
+    names = []
+    for index, entry in enumerate(entries):
+        name = entry.get("name") if isinstance(entry, dict) else None
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"manifest benchmark #{index + 1} has no valid name")
+        names.append(name)
+
+    duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+    if duplicates:
+        raise ValueError(
+            "manifest contains duplicate benchmark name(s): " + ", ".join(duplicates)
+        )
+
+    return names
+
+
+def validate_results(data: object, expected_names: list[str]) -> list[str]:
+    """Return every schema or corpus-membership error in a benchmark result."""
+    if not isinstance(data, dict):
+        return ["benchmark result must be a JSON object"]
+
+    benchmarks = data.get("benchmarks")
+    if not isinstance(benchmarks, list):
+        return ["benchmarks must be an array"]
+    if not benchmarks:
+        return ["no benchmark results collected; all benchmarks failed"]
+
+    errors = []
+    result_names = []
+    for index, bench in enumerate(benchmarks):
+        if not isinstance(bench, dict):
+            errors.append(f"benchmark #{index + 1} must be an object")
+            continue
+
+        name = bench.get("name")
+        if not isinstance(name, str) or not name:
+            errors.append(f"benchmark #{index + 1} has no valid name")
+        else:
+            result_names.append(name)
+
+        mean = bench.get("mean_ms")
+        if not isinstance(mean, (int, float)) or isinstance(mean, bool):
+            display_name = name if isinstance(name, str) and name else f"#{index + 1}"
+            errors.append(f"benchmark '{display_name}' has no numeric mean_ms")
+
+    duplicates = sorted(
+        name for name, count in Counter(result_names).items() if count > 1
+    )
+    if duplicates:
+        errors.append("duplicate benchmark result name(s): " + ", ".join(duplicates))
+
+    expected = set(expected_names)
+    actual = set(result_names)
+    missing = sorted(expected - actual)
+    unknown = sorted(actual - expected)
+    if missing:
+        errors.append("missing benchmark result(s): " + ", ".join(missing))
+    if unknown:
+        errors.append("unknown benchmark result name(s): " + ", ".join(unknown))
+
+    return errors

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -6,7 +6,7 @@ This script reads benchmark history from JSON and generates SVG charts:
 1. timeline.svg - Time-series chart showing total compilation time over commits
 2. breakdown.svg - Stacked bar chart showing time per compiler pass
 3. memory.svg - Memory usage over time
-4. binary_size.svg - Binary size over time
+4. binary_size.svg - Total binary size over time
 
 Usage:
     # Generate charts for a single platform
@@ -46,17 +46,42 @@ COMPARISON_HEIGHT = 400
 
 # Colors for passes (consistent with website theme)
 PASS_COLORS = {
+    "parse_file": "#5c6b34",            # olive
+    "merge_symbols": "#71813f",         # moss
+    "parallel_astgen": "#5c6b34",       # historical olive
+    "merge_rirs": "#71813f",            # historical moss
+    "validate_and_generate_rir": "#8f984d",  # dry grass
     "lexer": "#5c6b34",     # olive
     "parser": "#7d8f4a",    # moss
     "astgen": "#a3a25b",    # dry grass
     "sema": "#c9970e",      # rue yellow
     "cfg": "#8a6d2f",       # ochre
+    "cfg_construction": "#8a6d2f",  # ochre
     "codegen": "#a14e24",   # sienna
     "linker": "#6b4788",    # plum
 }
 
-# Order of passes in the stack
-PASS_ORDER = ["lexer", "parser", "astgen", "sema", "cfg", "codegen", "linker"]
+# Nested aggregate spans would double-count their leaf timings in a breakdown.
+AGGREGATE_PASSES = {"parse", "compile"}
+
+# Current leaf order followed by historical names still present in old data.
+# A chart only renders names present in the selected run, then appends unknown
+# future leaves alphabetically so new instrumentation cannot disappear.
+PASS_ORDER = [
+    "parse_file",
+    "merge_symbols",
+    "parallel_astgen",
+    "merge_rirs",
+    "validate_and_generate_rir",
+    "astgen",
+    "sema",
+    "cfg_construction",
+    "codegen",
+    "linker",
+    "lexer",
+    "parser",
+    "cfg",
+]
 
 # Platform display names and colors
 PLATFORM_INFO = {
@@ -82,46 +107,52 @@ def load_history(path: Path) -> dict:
 
 
 def get_pass_times(run: dict) -> dict[str, float]:
-    """Extract pass timing from a benchmark run."""
-    # Look for pass timing data in the benchmarks
+    """Sum each compiler pass across every benchmark in a run."""
+    totals: dict[str, float] = {}
     for bench in run.get("benchmarks", []):
-        if "passes" in bench:
-            # New format with per-pass timing
-            passes = bench["passes"]
-            return {
-                name: passes.get(name, {}).get("mean_ms", 0)
-                for name in PASS_ORDER
-            }
-    return {}
+        for name, timing in bench.get("passes", {}).items():
+            if name in AGGREGATE_PASSES:
+                continue
+            mean = timing.get("mean_ms", 0) if isinstance(timing, dict) else 0
+            totals[name] = totals.get(name, 0) + mean
+    return order_pass_times(totals)
+
+
+def order_pass_times(passes: dict[str, float]) -> dict[str, float]:
+    """Return pass timings in a stable known-first order."""
+    names = [name for name in PASS_ORDER if name in passes]
+    names.extend(sorted(set(passes) - set(PASS_ORDER)))
+    return {name: passes[name] for name in names}
+
+
+def benchmark_time(bench: dict) -> float:
+    """Read one benchmark's mean time across current and legacy schemas."""
+    if "mean_ms" in bench:
+        return bench["mean_ms"]
+    total = bench.get("total_ms", 0)
+    return total.get("mean", 0) if isinstance(total, dict) else total
 
 
 def get_total_time(run: dict) -> float:
-    """Get total compilation time from a run."""
-    for bench in run.get("benchmarks", []):
-        if "mean_ms" in bench:
-            return bench["mean_ms"]
-        if "total_ms" in bench:
-            total = bench["total_ms"]
-            if isinstance(total, dict):
-                return total.get("mean", 0)
-            return total
-    return 0
+    """Sum compilation time across every benchmark in a run."""
+    return sum(benchmark_time(bench) for bench in run.get("benchmarks", []))
 
 
 def get_peak_memory(run: dict) -> float:
-    """Get peak memory usage (in MB) from a run."""
-    for bench in run.get("benchmarks", []):
-        if "peak_memory_bytes" in bench:
-            return bench["peak_memory_bytes"] / (1024 * 1024)  # Convert to MB
-    return 0
+    """Get the highest per-compile peak memory usage (in MB) in a run."""
+    peak_bytes = max(
+        (bench.get("peak_memory_bytes", 0) for bench in run.get("benchmarks", [])),
+        default=0,
+    )
+    return peak_bytes / (1024 * 1024)
 
 
 def get_binary_size(run: dict) -> float:
-    """Get binary size (in KB) from a run."""
-    for bench in run.get("benchmarks", []):
-        if "binary_size_bytes" in bench:
-            return bench["binary_size_bytes"] / 1024  # Convert to KB
-    return 0
+    """Get the combined size (in KB) of all benchmark output binaries."""
+    total_bytes = sum(
+        bench.get("binary_size_bytes", 0) for bench in run.get("benchmarks", [])
+    )
+    return total_bytes / 1024
 
 
 def format_bytes(size_bytes: float) -> str:
@@ -306,13 +337,7 @@ def get_benchmark_time(run: dict, benchmark_name: str) -> float:
     """Get timing for a specific benchmark from a run."""
     for bench in run.get("benchmarks", []):
         if bench.get("name") == benchmark_name:
-            if "mean_ms" in bench:
-                return bench["mean_ms"]
-            if "total_ms" in bench:
-                total = bench["total_ms"]
-                if isinstance(total, dict):
-                    return total.get("mean", 0)
-                return total
+            return benchmark_time(bench)
     return 0
 
 
@@ -447,11 +472,12 @@ def get_pass_times_for_benchmark(run: dict, benchmark_name: str) -> dict[str, fl
     """Extract pass timing for a specific benchmark from a run."""
     for bench in run.get("benchmarks", []):
         if bench.get("name") == benchmark_name and "passes" in bench:
-            passes = bench["passes"]
-            return {
-                name: passes.get(name, {}).get("mean_ms", 0)
-                for name in PASS_ORDER
+            passes = {
+                name: timing.get("mean_ms", 0)
+                for name, timing in bench["passes"].items()
+                if isinstance(timing, dict) and name not in AGGREGATE_PASSES
             }
+            return order_pass_times(passes)
     return {}
 
 
@@ -525,7 +551,7 @@ def generate_breakdown_chart(runs: list[dict], benchmark_name: Optional[str] = N
     bar_y = margin["top"] + (chart_height - bar_height) / 2
     x_offset = margin["left"]
 
-    for pass_name in PASS_ORDER:
+    for pass_name in pass_times:
         time = pass_times.get(pass_name, 0)
         width = (time / total) * chart_width if time > 0 else 0
         color = PASS_COLORS.get(pass_name, "#888888")
@@ -545,7 +571,7 @@ def generate_breakdown_chart(runs: list[dict], benchmark_name: Optional[str] = N
     legend_x = BREAKDOWN_WIDTH - margin["right"] + 20
     legend_y = margin["top"] + 20
 
-    for i, pass_name in enumerate(PASS_ORDER):
+    for i, pass_name in enumerate(pass_times):
         y = legend_y + i * 22
         color = PASS_COLORS.get(pass_name, "#888888")
         time = pass_times.get(pass_name, 0)
@@ -707,7 +733,7 @@ def generate_binary_size_chart(runs: list[dict], platform: Optional[str] = None)
         return margin["top"] + chart_height - (v / max_size) * chart_height
 
     # Title with optional platform
-    title = "Binary Size Over Recent Commits"
+    title = "Total Binary Size Over Recent Commits"
     if platform:
         platform_name = PLATFORM_INFO.get(platform, {}).get("name", platform)
         title = f"{title} ({platform_name})"

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Regression tests for benchmark validation and dashboard aggregation."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+INPUT_ROOT = Path(
+    os.environ.get("RUE_BENCHMARK_TEST_ROOT", Path(__file__).resolve().parent.parent)
+)
+sys.path.insert(0, str(INPUT_ROOT / "scripts"))
+
+
+def load_module(name: str, relative_path: str):
+    path = INPUT_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = load_module("validate_benchmark", "scripts/validate-benchmark.py")
+charts = load_module("generate_charts", "scripts/generate-charts.py")
+
+
+class BenchmarkValidationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.expected_names = validator.load_manifest_names(
+            INPUT_ROOT / "benchmarks" / "manifest.toml"
+        )
+
+    def valid_result(self):
+        return {
+            "version": 1,
+            "timestamp": "2026-07-09T00:00:00Z",
+            "commit": "probe",
+            "benchmarks": [
+                {"name": name, "mean_ms": index + 0.5}
+                for index, name in enumerate(self.expected_names)
+            ],
+        }
+
+    def test_exact_manifest_corpus_is_accepted(self):
+        result = self.valid_result()
+        self.assertEqual(validator.validate_results(result, self.expected_names), [])
+        result["benchmarks"].reverse()
+        self.assertEqual(validator.validate_results(result, self.expected_names), [])
+
+    def test_missing_unknown_and_duplicate_names_are_rejected(self):
+        missing = self.valid_result()
+        removed = missing["benchmarks"].pop()["name"]
+        self.assertIn(
+            f"missing benchmark result(s): {removed}",
+            validator.validate_results(missing, self.expected_names),
+        )
+
+        unknown = self.valid_result()
+        unknown["benchmarks"][-1]["name"] = "not_in_manifest"
+        errors = validator.validate_results(unknown, self.expected_names)
+        self.assertTrue(any("missing benchmark result" in error for error in errors))
+        self.assertIn("unknown benchmark result name(s): not_in_manifest", errors)
+
+        duplicate = self.valid_result()
+        duplicate["benchmarks"].append(duplicate["benchmarks"][0].copy())
+        self.assertIn(
+            f"duplicate benchmark result name(s): {self.expected_names[0]}",
+            validator.validate_results(duplicate, self.expected_names),
+        )
+
+    def test_non_numeric_mean_is_rejected(self):
+        result = self.valid_result()
+        result["benchmarks"][0]["mean_ms"] = "fast"
+        errors = validator.validate_results(result, self.expected_names)
+        self.assertIn(
+            f"benchmark '{self.expected_names[0]}' has no numeric mean_ms", errors
+        )
+
+    def test_empty_and_malformed_corpora_are_rejected(self):
+        self.assertEqual(
+            validator.validate_results({"benchmarks": []}, self.expected_names),
+            ["no benchmark results collected; all benchmarks failed"],
+        )
+        errors = validator.validate_results(
+            {"benchmarks": ["not an object"]}, self.expected_names
+        )
+        self.assertIn("benchmark #1 must be an object", errors)
+        self.assertTrue(any("missing benchmark result" in error for error in errors))
+
+    def test_duplicate_and_malformed_manifest_entries_are_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest_path = Path(temp_dir) / "manifest.toml"
+            manifest_path.write_text(
+                '[[benchmark]]\nname = "same"\npath = "a.rue"\n'
+                '[[benchmark]]\nname = "same"\npath = "b.rue"\n'
+            )
+            with self.assertRaisesRegex(ValueError, "duplicate benchmark name"):
+                validator.load_manifest_names(manifest_path)
+
+            manifest_path.write_text('[[benchmark]]\npath = "missing-name.rue"\n')
+            with self.assertRaisesRegex(ValueError, "has no valid name"):
+                validator.load_manifest_names(manifest_path)
+
+    def test_ci_validator_and_history_append_both_reject_partial_corpus(self):
+        result = self.valid_result()
+        removed = result["benchmarks"].pop()["name"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result_path = Path(temp_dir) / "partial.json"
+            history_path = Path(temp_dir) / "history.json"
+            result_path.write_text(json.dumps(result))
+            validator_process = subprocess.run(
+                [
+                    sys.executable,
+                    str(INPUT_ROOT / "scripts" / "validate-benchmark.py"),
+                    str(result_path),
+                    "--manifest",
+                    str(INPUT_ROOT / "benchmarks" / "manifest.toml"),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            appender_process = subprocess.run(
+                [
+                    sys.executable,
+                    str(INPUT_ROOT / "scripts" / "append-benchmark.py"),
+                    str(result_path),
+                    str(history_path),
+                    "--manifest",
+                    str(INPUT_ROOT / "benchmarks" / "manifest.toml"),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(validator_process.returncode, 0)
+            self.assertIn(
+                f"missing benchmark result(s): {removed}", validator_process.stdout
+            )
+            self.assertNotEqual(appender_process.returncode, 0)
+            self.assertIn(
+                f"missing benchmark result(s): {removed}", appender_process.stderr
+            )
+            self.assertFalse(history_path.exists())
+
+            result_path.write_text(json.dumps(self.valid_result()))
+            valid_process = subprocess.run(
+                [
+                    sys.executable,
+                    str(INPUT_ROOT / "scripts" / "append-benchmark.py"),
+                    str(result_path),
+                    str(history_path),
+                    "--manifest",
+                    str(INPUT_ROOT / "benchmarks" / "manifest.toml"),
+                    "--reason",
+                    "push",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(valid_process.returncode, 0, valid_process.stderr)
+            published = json.loads(history_path.read_text())["runs"]
+            self.assertEqual(len(published), 1)
+            self.assertEqual(published[0]["version"], 2)
+            self.assertEqual(published[0]["benchmark_reason"], "push")
+            self.assertEqual(published[0]["commit_range"], ["probe"])
+
+
+class ChartAggregationTests(unittest.TestCase):
+    def setUp(self):
+        self.run = {
+            "benchmarks": [
+                {
+                    "name": "first",
+                    "mean_ms": 10,
+                    "peak_memory_bytes": 2 * 1024 * 1024,
+                    "binary_size_bytes": 3 * 1024,
+                    "passes": {
+                        "parallel_astgen": {"mean_ms": 1},
+                        "sema": {"mean_ms": 2},
+                        "compile": {"mean_ms": 9},
+                    },
+                },
+                {
+                    "name": "second",
+                    "mean_ms": 20,
+                    "peak_memory_bytes": 5 * 1024 * 1024,
+                    "binary_size_bytes": 7 * 1024,
+                    "passes": {
+                        "parallel_astgen": {"mean_ms": 3},
+                        "sema": {"mean_ms": 4},
+                        "new_pass": {"mean_ms": 5},
+                        "parse": {"mean_ms": 8},
+                    },
+                },
+            ]
+        }
+
+    def test_suite_metrics_cover_every_benchmark(self):
+        self.assertEqual(charts.get_total_time(self.run), 30)
+        self.assertEqual(
+            charts.get_pass_times(self.run),
+            {"parallel_astgen": 4, "sema": 6, "new_pass": 5},
+        )
+        self.assertEqual(charts.get_peak_memory(self.run), 5)
+        self.assertEqual(charts.get_binary_size(self.run), 10)
+
+        summary = charts.generate_summary_data([self.run])
+        self.assertEqual(summary["latest_time_ms"], 30)
+        self.assertEqual(summary["latest_memory_mb"], 5)
+        self.assertEqual(summary["latest_binary_kb"], 10)
+
+    def test_suite_metrics_are_invariant_to_manifest_order(self):
+        reversed_run = {"benchmarks": list(reversed(self.run["benchmarks"]))}
+        self.assertEqual(
+            charts.get_total_time(reversed_run), charts.get_total_time(self.run)
+        )
+        self.assertEqual(
+            charts.get_pass_times(reversed_run), charts.get_pass_times(self.run)
+        )
+        self.assertEqual(
+            charts.get_peak_memory(reversed_run), charts.get_peak_memory(self.run)
+        )
+        self.assertEqual(
+            charts.get_binary_size(reversed_run), charts.get_binary_size(self.run)
+        )
+
+    def test_legacy_total_time_schema_is_summed(self):
+        run = {
+            "benchmarks": [
+                {"name": "a", "total_ms": {"mean": 1.5}},
+                {"name": "b", "total_ms": 2.5},
+            ]
+        }
+        self.assertEqual(charts.get_total_time(run), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-benchmark.py
+++ b/scripts/validate-benchmark.py
@@ -2,48 +2,65 @@
 """
 Validate a bench.sh results file before it enters the benchmark history.
 
-Run in CI after bench.sh so a platform whose benchmarks all failed turns
-into a failed job (a distinct, visible failure) instead of silently
-appending an empty run to the history. Prints a summary of what was
-collected.
+Run in CI after bench.sh so a platform with a missing, duplicate, or unknown
+benchmark result turns into a failed job instead of publishing an incomplete
+corpus. Prints a summary of what was collected.
 
 Usage:
     ./validate-benchmark.py <results.json>
 """
 
+import argparse
 import json
+from pathlib import Path
 import sys
+
+from benchmark_validation import (
+    DEFAULT_MANIFEST,
+    load_manifest_names,
+    validate_results,
+)
 
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <results.json>", file=sys.stderr)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("results", type=Path, help="results.json from bench.sh")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="benchmark manifest (default: benchmarks/manifest.toml)",
+    )
+    args = parser.parse_args()
+
+    try:
+        with args.results.open() as f:
+            data = json.load(f)
+        expected_names = load_manifest_names(args.manifest)
+    except (OSError, ValueError) as error:
+        print(f"::error::Cannot validate benchmark results: {error}")
         return 1
 
-    with open(sys.argv[1]) as f:
-        data = json.load(f)
-
-    benchmarks = data.get("benchmarks", [])
-    print(f"Commit: {data.get('commit', 'unknown')}")
+    benchmarks = data.get("benchmarks", []) if isinstance(data, dict) else []
+    commit = data.get("commit", "unknown") if isinstance(data, dict) else "unknown"
+    print(f"Commit: {commit}")
     print(f"Benchmarks collected: {len(benchmarks)}")
 
-    if not benchmarks:
-        print("::error::No benchmark results collected! All benchmarks failed.")
-        return 1
-
-    ok = True
     for bench in benchmarks:
+        if not isinstance(bench, dict):
+            continue
         name = bench.get("name", "unknown")
         mean = bench.get("mean_ms")
-        if mean is None:
-            print(f"::error::Benchmark '{name}' is missing mean_ms")
-            ok = False
-        else:
+        if isinstance(mean, (int, float)) and not isinstance(mean, bool):
             print(f"  - {name}: {mean:.2f}ms")
 
-    if ok:
+    errors = validate_results(data, expected_names)
+    for error in errors:
+        print(f"::error::{error}")
+
+    if not errors:
         print("Validation passed!")
-    return 0 if ok else 1
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -29,7 +29,7 @@
         <section id="summary-stats" class="mb-12">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="bg-surface border border-themed rounded-lg p-4">
-                    <div class="text-sm text-muted mb-1">Compilation Time</div>
+                    <div class="text-sm text-muted mb-1">Total Compilation Time</div>
                     <div id="stat-time-body"><span class="text-2xl font-semibold">--</span></div>
                 </div>
                 <div class="bg-surface border border-themed rounded-lg p-4">
@@ -37,7 +37,7 @@
                     <div id="stat-memory-body"><span class="text-2xl font-semibold">--</span></div>
                 </div>
                 <div class="bg-surface border border-themed rounded-lg p-4">
-                    <div class="text-sm text-muted mb-1">Binary Size</div>
+                    <div class="text-sm text-muted mb-1">Total Binary Size</div>
                     <div id="stat-binary-body"><span class="text-2xl font-semibold">--</span></div>
                 </div>
             </div>
@@ -89,7 +89,7 @@
         <section id="memory-section" class="mb-12">
             <h2 class="section-title">Peak Memory Usage</h2>
             <p class="text-muted mb-4">
-                Peak memory consumption during compilation. Lower is better.
+                Highest peak memory consumption among the benchmark compilations. Lower is better.
             </p>
             <div id="memory-chart-container" class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
                 <p class="text-muted text-center py-8">Loading chart...</p>
@@ -98,9 +98,9 @@
 
         <!-- Binary Size Chart -->
         <section id="binary-section" class="mb-12">
-            <h2 class="section-title">Output Binary Size</h2>
+            <h2 class="section-title">Total Output Binary Size</h2>
             <p class="text-muted mb-4">
-                Size of compiled binary. Smaller binaries are generally preferable.
+                Combined size of every compiled benchmark binary. Smaller is generally preferable.
             </p>
             <div id="binary-chart-container" class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
                 <p class="text-muted text-center py-8">Loading chart...</p>


### PR DESCRIPTION
## Summary

- require benchmark results to match the manifest's exact unique name set at both CI validation and history publication boundaries
- aggregate total time and pass timings across every program, use maximum per-compile peak memory, and sum output binary sizes
- exclude nested aggregate timing spans while retaining current, historical, and future leaf passes deterministically
- add a Buck-owned nine-test regression gate and clarify aggregate dashboard labels

## Verification

- `./fmt.sh check`
- `./clippy.sh` (41 targets)
- `./buck2 test //:benchmark-tool-tests` (9 tests)
- `./test.sh` (29/29 targets)
- real checked-in seven-program history accepted by validator and appender
- generated all dashboard charts from that history; corrected summary is 3,877.29ms total, 74.66MB peak, and 2,716KB combined output
- synthetic missing, unknown, duplicate, empty, malformed, and wrong-type corpora rejected

Linear: RUE-540, RUE-541