### PR TITLE
RUE-522: scope stack saves/restores per-binding move state — shadowing no longer corrupts the move checker

### DIFF
--- a/crates/rue-air/src/scope.rs
+++ b/crates/rue-air/src/scope.rs
@@ -68,9 +68,15 @@ pub trait ScopedContext {
     /// When a scope is popped:
     /// - Variables that were introduced in this scope are removed
     /// - Variables that were shadowed are restored to their previous values
+    ///
+    /// Entries unwind in REVERSE declaration order: a name (re)declared
+    /// several times in one scope (`{ let d = 5; let d = 6; }`) has one entry
+    /// per declaration, and only reverse iteration lands on the state from
+    /// BEFORE the scope — forward iteration ended on the first inner binding,
+    /// leaking it past its block (RUE-522).
     fn pop_scope(&mut self) {
         if let Some(scope_entries) = self.scope_stack_mut().pop() {
-            for (symbol, old_value) in scope_entries {
+            for (symbol, old_value) in scope_entries.into_iter().rev() {
                 match old_value {
                     Some(old_var) => {
                         // Restore the shadowed variable

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -405,6 +405,7 @@ impl<'a> Sema<'a> {
             used_locals: HashSet::new(),
             return_type,
             scope_stack: Vec::new(),
+            moved_scope_stack: Vec::new(),
             resolved_types: &resolved_types,
             moved_vars: HashMap::new(),
             warnings: Vec::new(),

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -647,7 +647,7 @@ impl<'a> Sema<'a> {
 
     /// Reject recording a MOVE of `root` while an enclosing call's argument
     /// list holds an `inout`/`borrow` loan of the same root (law of
-    /// exclusivity, spec 6.1:31, RUE-523).
+    /// exclusivity, spec 6.1:36, RUE-523).
     ///
     /// The loan spans the entire call, so a by-value use of the loaned
     /// variable in the same argument list — in either order, directly

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -359,6 +359,15 @@ pub(crate) struct AnalysisContext<'a> {
     /// Each entry is a list of (symbol, old_value) pairs for variables added/shadowed in that scope.
     /// When a scope is popped, we restore old values (for shadowed vars) or remove new vars.
     pub scope_stack: Vec<Vec<(Spur, Option<LocalVar>)>>,
+    /// Per-scope saved MOVE states, parallel to `scope_stack`: each frame
+    /// holds one (symbol, shadowed binding's move state) entry per
+    /// `insert_local` in that scope. `moved_vars` is keyed by NAME, so a
+    /// shadowing declaration must save the outer binding's state here and
+    /// `pop_scope` must restore it — otherwise a moved outer binding is
+    /// resurrected by a same-named inner `let`/match binding (double
+    /// destruction) or a move of the inner shadow outlives its block and
+    /// poisons the outer binding with a false E0205 (RUE-522).
+    pub moved_scope_stack: Vec<Vec<(Spur, Option<VariableMoveState>)>>,
     /// Resolved types from HM inference.
     /// Maps RIR instruction refs to their resolved concrete types.
     /// This is populated by running constraint generation and unification
@@ -468,17 +477,60 @@ impl ScopedContext for AnalysisContext<'_> {
 
     /// Insert a local variable, tracking it in the current scope for later cleanup.
     ///
-    /// This override also clears any moved state for the variable, which handles
-    /// shadowing: `let x = moved_val; let x = new_val;`
-    /// The new `x` is a fresh binding and shouldn't carry the old moved state.
+    /// This override also handles the variable's MOVE state. A (re)declaration
+    /// is a fresh binding, so it starts with no moves — but the shadowed
+    /// binding's move state is SAVED in the current scope's move frame and
+    /// restored by `pop_scope`, because `moved_vars` is keyed by name, not
+    /// binding identity (RUE-522). Clearing it outright resurrected an
+    /// already-moved outer binding once the shadow's block ended (double
+    /// destruction); conversely, without the restore, a move of the inner
+    /// shadow outlived its block and poisoned the live outer binding (false
+    /// E0205). Applies to every scoped binding form that reaches
+    /// `insert_local`: nested `let`, `match` payload bindings, loop binders.
     fn insert_local(&mut self, symbol: Spur, var: LocalVar) {
         let old_value = self.locals.insert(symbol, var);
         // Track in the current scope (if any) for cleanup on pop
         if let Some(current_scope) = self.scope_stack.last_mut() {
             current_scope.push((symbol, old_value));
         }
-        // When a variable is (re)declared, clear any moved state for it.
-        self.moved_vars.remove(&symbol);
+        let old_moves = self.moved_vars.remove(&symbol);
+        if let Some(move_frame) = self.moved_scope_stack.last_mut() {
+            move_frame.push((symbol, old_moves));
+        }
+    }
+
+    fn push_scope(&mut self) {
+        self.scope_stack.push(Vec::with_capacity(2));
+        self.moved_scope_stack.push(Vec::new());
+    }
+
+    fn pop_scope(&mut self) {
+        // Mirrors the trait default for locals (reverse order — see the trait
+        // doc), plus the RUE-522 move-state restore from the parallel frame.
+        if let Some(scope_entries) = self.scope_stack.pop() {
+            for (symbol, old_value) in scope_entries.into_iter().rev() {
+                match old_value {
+                    Some(old_var) => {
+                        self.locals.insert(symbol, old_var);
+                    }
+                    None => {
+                        self.locals.remove(&symbol);
+                    }
+                }
+            }
+        }
+        if let Some(move_frame) = self.moved_scope_stack.pop() {
+            for (symbol, old_moves) in move_frame.into_iter().rev() {
+                match old_moves {
+                    Some(state) => {
+                        self.moved_vars.insert(symbol, state);
+                    }
+                    None => {
+                        self.moved_vars.remove(&symbol);
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -509,6 +561,7 @@ impl<'a> AnalysisContext<'a> {
             used_locals: self.used_locals.clone(),
             return_type: self.return_type,
             scope_stack: self.scope_stack.clone(),
+            moved_scope_stack: self.moved_scope_stack.clone(),
             resolved_types: self.resolved_types,
             moved_vars: self.moved_vars.clone(),
             warnings: Vec::new(),

--- a/crates/rue-cli-tests/cases/drop_moves.toml
+++ b/crates/rue-cli-tests/cases/drop_moves.toml
@@ -694,3 +694,28 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0456", "cannot move field `leaf` out of a value of type 'Mid'"]
+
+[[case]]
+# RUE-522: block shadowing must not corrupt name-keyed move state. This is the
+# legal-shadowing control with pinned drop output: the inner shadow drops once
+# at its block's end, the outer binding once at function exit — a scope-state
+# regression that double-drops (or leaks) either binding changes this stdout.
+name = "block_shadow_drops_each_binding_exactly_once"
+files = [{ path = "main.rue", source = """
+struct D { value: i32 }
+drop fn D(self) { @dbg(self.value); }
+
+fn main() -> i32 {
+    let d = D { value: 1 };
+    {
+        let d = D { value: 2 };
+        d.value;
+    }
+    d.value;
+    0
+}
+""" }]
+stdout = """2
+1
+"""
+exit_code = 0

--- a/crates/rue-spec/cases/expressions/blocks.toml
+++ b/crates/rue-spec/cases/expressions/blocks.toml
@@ -96,3 +96,20 @@ fn main() -> i32 {
 }
 """
 exit_code = 6
+
+[[case]]
+name = "block_local_binding_not_visible_after_block"
+spec = ["4.5:4"]
+description = "A block-local binding — even one redeclared several times in the block — is gone after the block ends (RUE-522: forward scope unwinding leaked the first inner binding)"
+source = """
+fn main() -> i32 {
+    {
+        let d = 5;
+        let d = 6;
+        d;
+    }
+    d
+}
+"""
+compile_fail = true
+error_contains = ["[E0201]", "undefined variable"]

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -401,6 +401,94 @@ fn main() -> i32 {
 """
 exit_code = 1
 
+[[case]]
+name = "block_shadow_does_not_resurrect_moved_outer"
+spec = ["3.8:5", "3.8:12"]
+description = "A same-named binding in an inner block does not restore the moved outer binding once the block ends (RUE-522 double destruction)"
+source = """
+struct D { value: i32 }
+drop fn D(self) { @dbg(self.value); }
+fn take(d: D) { }
+
+fn main() -> i32 {
+    let d = D { value: 1 };
+    take(d);
+    {
+        let d = D { value: 2 };
+        d.value;
+    }
+    take(d);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0205]", "moved"]
+
+[[case]]
+name = "inner_shadow_move_does_not_poison_outer"
+spec = ["3.8:12", "4.5:4"]
+description = "Moving an inner same-named binding does not mark the distinct outer binding moved once the block ends (RUE-522 false E0205)"
+source = """
+struct Data { value: i32 }
+fn take(d: Data) -> i32 { d.value }
+
+fn main() -> i32 {
+    let d = Data { value: 1 };
+    {
+        let d = Data { value: 2 };
+        take(d);
+    }
+    d.value
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "match_binding_does_not_resurrect_moved_outer"
+spec = ["3.8:5", "3.8:12"]
+description = "A match payload binding is a scoped shadow: it does not restore a moved same-named outer binding (RUE-522)"
+source = """
+struct D { value: i32 }
+drop fn D(self) { @dbg(self.value); }
+fn take(d: D) {}
+enum E { V(i32) }
+
+fn main() -> i32 {
+    let d = D { value: 1 };
+    take(d);
+    match E.V(2) {
+        E.V(d) => d,
+    };
+    take(d);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0205]", "moved"]
+
+[[case]]
+name = "for_binder_does_not_resurrect_moved_outer"
+spec = ["3.8:5", "3.8:12"]
+description = "A for-loop element binder is a scoped shadow: it does not restore a moved same-named outer binding (RUE-522)"
+source = """
+struct D { value: i32 }
+drop fn D(self) { @dbg(self.value); }
+fn take(d: D) {}
+
+fn main() -> i32 {
+    let d = D { value: 1 };
+    take(d);
+    let a: [i32; 2] = [5, 6];
+    for d in a {
+        d;
+    }
+    take(d);
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0205]", "moved"]
+
 # =============================================================================
 # Return Moves
 # =============================================================================


### PR DESCRIPTION
## Summary
`moved_vars` is keyed by source name, and scoped shadowing corrupted it in both directions (all verified by execution): a moved outer binding was resurrected by an inner same-named `let` (destructor ran twice — 1/2/1), by a match payload binding (Codex's follow-up, 1/1), and by a for-loop binder; and a move of the inner shadow outlived its block, poisoning the live outer binding with a false E0205. Fix: `AnalysisContext` keeps a per-scope move frame parallel to `scope_stack` — `insert_local` saves the shadowed binding's move state, `pop_scope` restores it. Scope frames also now unwind in reverse declaration order: forward unwinding leaked the first binding of a name redeclared twice in one block past the block (`{ let d = 5; let d = 6; } d` compiled and ran; now E0201) — fixed in the shared `ScopedContext` default so inference's scope handling gets it too.

Also fixes a stale 6.1:31→6.1:36 spec reference in a RUE-523 doc comment.

## Validation
Six behavior probes verified before/after (three accept-invalid double-drops now E0205, false-E0205 program now compiles and returns 1, same-scope re-let after move stays legal at exit 42, stale-binding leak now E0201). 5 new spec cases (3.8:5, 3.8:12, 4.5:4) + CLI case pinning exact drop stdout for legal shadowing. ./test.sh Pass 28 / Fail 0.

Fixes RUE-522

🤖 Generated with [Claude Code](https://claude.com/claude-code)