### PR TITLE
RUE-531: zero-count array repeat evaluates its value expression (spec 7.1:39)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -4564,6 +4564,28 @@ impl<'a> Sema<'a> {
             ty: array_type,
             span,
         });
+
+        // The value expression is evaluated exactly once even when the length
+        // is 0 (spec 7.1:39). With no element referencing it the evaluation
+        // would be orphaned — CFG lowering is demand-driven and only follows
+        // the ArrayInit's element refs — so `[produce(); 0]` never called
+        // produce and `[return 42; 0]` fell through (RUE-531). Anchor the
+        // evaluation as a Block statement ahead of the empty array value;
+        // Block lowering also handles a diverging value (`return`/`break`)
+        // correctly, marking the array construction unreachable.
+        if length == 0 {
+            let stmts_start = air.add_extra(&[value_result.air_ref.as_u32()]);
+            let block_ref = air.add_inst(AirInst {
+                data: AirInstData::Block {
+                    stmts_start,
+                    stmts_len: 1,
+                    value: air_ref,
+                },
+                ty: array_type,
+                span,
+            });
+            return Ok(AnalysisResult::new(block_ref, array_type));
+        }
         Ok(AnalysisResult::new(air_ref, array_type))
     }
 

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -1033,6 +1033,33 @@ fn main() -> i32 {
 exit_code = 12
 
 [[case]]
+name = "array_repeat_zero_count_evaluates_value_side_effect"
+spec = ["7.1:39"]
+description = "The repeat value expression is evaluated exactly once even when the count is 0 (RUE-531: it was dropped entirely)"
+source = """
+fn produce() -> i32 { @dbg(42); 7 }
+fn main() -> i32 {
+    let a: [i32; 0] = [produce(); 0];
+    0
+}
+"""
+expected_stdout = """42
+"""
+exit_code = 0
+
+[[case]]
+name = "array_repeat_zero_count_evaluates_value_control_flow"
+spec = ["7.1:39"]
+description = "A diverging repeat value expression diverges even when the count is 0 (RUE-531)"
+source = """
+fn main() -> i32 {
+    let a: [i32; 0] = [return 42; 0];
+    0
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "array_repeat_non_copy_element_error"
 spec = ["7.1:38"]
 source = """


### PR DESCRIPTION
## Summary
Sema analyzed the repeat value exactly once, but with length 0 no `ArrayInit` element referenced it and CFG lowering is demand-driven — the evaluation was orphaned: `[produce(); 0]` never called produce and `[return 42; 0]` fell through to 0 at every opt level (both verified by execution). Fix: when the length is 0, anchor the evaluation as an AIR `Block` statement ahead of the empty-array value — Block lowering evaluates statements in order and already handles a diverging statement with the standard unreachable-code machinery.

## Validation
Both repros verified before/after at -O0 and -O2: control-flow form now exits 42, side-effect form prints 42. Two new spec cases against 7.1:39 (side-effect pinning stdout, control-flow pinning exit). ./test.sh Pass 28 / Fail 0.

Fixes RUE-531

🤖 Generated with [Claude Code](https://claude.com/claude-code)