### PR TITLE
RUE-542+544+551: harden tutorial snippet test gate

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -52,6 +52,14 @@ filegroup(
 )
 
 filegroup(
+    name = "tutorial-snippet-tool-inputs",
+    srcs = [
+        "scripts/check-tutorial-snippets.py",
+        "test.sh",
+    ],
+)
+
+filegroup(
     name = "spec-docs",
     srcs = glob(["docs/spec/src/**"]),
 )
@@ -124,6 +132,16 @@ sh_test(
     ],
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_STD_PATH": "$(location :std)/std",
+    },
+)
+
+sh_test(
+    name = "tutorial-snippet-tool-tests",
+    test = "scripts/test-tutorial-snippets.py",
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "RUE_TUTORIAL_TEST_ROOT": "$(location :tutorial-snippet-tool-inputs)",
     },
 )
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -117,9 +117,10 @@ Tutorial Rue fences are checked when their info string opts in:
   ```
   ```` compiles successfully.
 - ````markdown
-  ```rue compile-fail
+  ```rue compile-fail E0203
   ```
-  ```` must fail compilation, for intentionally invalid examples.
+  ```` must fail compilation with the named diagnostic code, for intentionally
+  invalid examples.
 - ````markdown
   ```rue skip
   ```

--- a/docs/process/tutorial.md
+++ b/docs/process/tutorial.md
@@ -52,7 +52,7 @@ Snippet verification is tracked by RUE-399. Once that infrastructure is present,
 tutorial code fences use explicit metadata for automated checks:
 
 - ` ```rue check` must compile successfully.
-- ` ```rue compile-fail` must fail compilation.
+- ` ```rue compile-fail Edddd` must fail compilation with the named diagnostic.
 - ` ```rue skip` is an intentional prose-only or context-dependent fragment.
 - Plain ` ```rue` remains prose-only until a chapter refresh opts it in.
 
@@ -64,8 +64,9 @@ scripts/check-tutorial-snippets.py
 ```
 
 New or rewritten chapter-level complete programs should be marked `check`.
-Intentionally-invalid snippets should be marked `compile-fail` when they are
-self-contained, or `skip` when they depend on context from adjacent prose.
+Intentionally-invalid snippets should be marked `compile-fail Edddd` when they
+are self-contained, using the diagnostic code the prose intends to demonstrate,
+or `skip` when they depend on context from adjacent prose.
 
 ## Dogfood and preview stance
 

--- a/scripts/check-tutorial-snippets.py
+++ b/scripts/check-tutorial-snippets.py
@@ -4,7 +4,7 @@
 Tutorial fences are prose first, so the checker is intentionally marker-driven:
 
 * ```rue check        compiles successfully
-* ```rue compile-fail must fail compilation
+* ```rue compile-fail Edddd must fail with the named diagnostic code
 * ```rue skip         ignored with an explicit reason in prose nearby
 
 Unmarked ```rue fences are left alone. This lets chapter-refresh work opt
@@ -14,8 +14,11 @@ snippets in as they become complete, self-contained examples.
 from __future__ import annotations
 
 import argparse
+import json
+import math
 import os
 import re
+import signal
 import subprocess
 import sys
 import tempfile
@@ -24,7 +27,10 @@ from pathlib import Path
 
 
 FENCE_RE = re.compile(r"^```(?P<info>.*)$")
+DIAGNOSTIC_CODE_RE = re.compile(r"^E\d{4}$")
 CHECK_ATTRS = {"check", "compile-fail", "skip"}
+DEFAULT_TIMEOUT_SECONDS = 10.0
+ICE_MARKERS = ("panicked at", "internal compiler error")
 
 
 @dataclass(frozen=True)
@@ -33,6 +39,7 @@ class Snippet:
     line: int
     action: str
     source: str
+    expected_codes: frozenset[str] = frozenset()
 
     @property
     def label(self) -> str:
@@ -73,12 +80,39 @@ def collect_snippets(root: Path) -> tuple[list[Snippet], int]:
 
             if language == "rue":
                 actions = attrs & CHECK_ATTRS
+                expected_codes = frozenset(
+                    attr for attr in attrs if DIAGNOSTIC_CODE_RE.fullmatch(attr)
+                )
+                unknown_attrs = attrs - CHECK_ATTRS - expected_codes
+                if unknown_attrs:
+                    raise ValueError(
+                        f"{path}:{fence_line}: unknown rue fence attribute(s): "
+                        f"{', '.join(sorted(unknown_attrs))}"
+                    )
                 if len(actions) > 1:
                     raise ValueError(
                         f"{path}:{fence_line}: use only one of {sorted(CHECK_ATTRS)}"
                     )
                 if actions:
                     action = next(iter(actions))
+                    if action == "compile-fail" and not expected_codes:
+                        raise ValueError(
+                            f"{path}:{fence_line}: compile-fail requires at least "
+                            "one expected diagnostic code (for example E0203)"
+                        )
+                    internal_codes = sorted(
+                        code for code in expected_codes if code.startswith("E9")
+                    )
+                    if internal_codes:
+                        raise ValueError(
+                            f"{path}:{fence_line}: compile-fail cannot expect internal "
+                            f"compiler diagnostic code(s): {', '.join(internal_codes)}"
+                        )
+                    if action != "compile-fail" and expected_codes:
+                        raise ValueError(
+                            f"{path}:{fence_line}: diagnostic codes are only valid "
+                            "with compile-fail"
+                        )
                     if action != "skip":
                         snippets.append(
                             Snippet(
@@ -86,9 +120,15 @@ def collect_snippets(root: Path) -> tuple[list[Snippet], int]:
                                 line=fence_line,
                                 action=action,
                                 source="".join(body),
+                                expected_codes=expected_codes,
                             )
                         )
                 else:
+                    if attrs:
+                        raise ValueError(
+                            f"{path}:{fence_line}: rue fence attributes require one of "
+                            f"{sorted(CHECK_ATTRS)}"
+                        )
                     unmarked_rue_fences += 1
 
             # Skip the closing fence if present.
@@ -100,6 +140,10 @@ def collect_snippets(root: Path) -> tuple[list[Snippet], int]:
 
 def snippet_env() -> dict[str, str]:
     env = os.environ.copy()
+    # Structured diagnostics must remain a single JSON document. Inherited
+    # tracing output would prefix the document and make valid failures look
+    # like malformed infrastructure output.
+    env.pop("RUST_LOG", None)
     std_path = Path("std")
     if std_path.is_dir():
         env.setdefault("RUE_STD_PATH", str(std_path.resolve()))
@@ -111,19 +155,119 @@ def compile_snippet(
     snippet: Snippet,
     tempdir: Path,
     env: dict[str, str],
+    timeout_seconds: float,
 ) -> subprocess.CompletedProcess[str]:
     source_path = tempdir / f"{snippet.path.stem}-{snippet.line}.rue"
     output_path = tempdir / f"{snippet.path.stem}-{snippet.line}"
     source_path.write_text(snippet.source, encoding="utf-8")
 
-    return subprocess.run(
-        [rue_binary, str(source_path), "-o", str(output_path)],
+    command = [
+        rue_binary,
+        "--error-format",
+        "json",
+        str(source_path),
+        "-o",
+        str(output_path),
+    ]
+    process = subprocess.Popen(
+        command,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,
-        check=False,
+        start_new_session=True,
     )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as error:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        stdout, stderr = process.communicate()
+        raise subprocess.TimeoutExpired(
+            command,
+            timeout_seconds,
+            output=stdout,
+            stderr=stderr,
+        ) from error
+
+    return subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+
+
+def diagnostic_codes(stderr: str) -> frozenset[str]:
+    """Parse error codes from Rue's structured diagnostic output."""
+    try:
+        diagnostics = json.loads(stderr)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"compiler stderr was not valid JSON: {error.msg}") from error
+
+    if not isinstance(diagnostics, list):
+        raise ValueError("compiler diagnostics must be a JSON array")
+    if not diagnostics:
+        raise ValueError("compiler emitted an empty diagnostic array")
+
+    codes = set()
+    for diagnostic in diagnostics:
+        if not isinstance(diagnostic, dict):
+            raise ValueError("compiler diagnostic entries must be JSON objects")
+        code = diagnostic.get("code")
+        if diagnostic.get("severity") == "error" and isinstance(code, str):
+            codes.add(code)
+    if not codes:
+        raise ValueError("compiler emitted no error diagnostics")
+    return frozenset(codes)
+
+
+def snippet_failure(
+    snippet: Snippet, result: subprocess.CompletedProcess[str]
+) -> str | None:
+    """Return a failure reason, or None when the compiler outcome is expected."""
+    stderr = result.stderr or ""
+    if result.returncode < 0:
+        return f"compiler terminated by signal {-result.returncode}"
+    if result.returncode == 101 or any(marker in stderr for marker in ICE_MARKERS):
+        return "compiler reported an internal compiler error"
+
+    actual_codes = None
+    diagnostic_error = None
+    if result.returncode == 1:
+        try:
+            actual_codes = diagnostic_codes(stderr)
+        except ValueError as error:
+            diagnostic_error = error
+        else:
+            internal_codes = sorted(
+                code for code in actual_codes if code.startswith("E9")
+            )
+            if internal_codes:
+                return (
+                    "compiler reported internal compiler diagnostic code(s): "
+                    + ", ".join(internal_codes)
+                )
+
+    if snippet.action == "check":
+        if result.returncode == 0:
+            return None
+        return f"expected snippet to compile, but compiler exited {result.returncode}"
+
+    if result.returncode == 0:
+        return "expected snippet to fail compilation, but it compiled successfully"
+    if result.returncode != 1:
+        return f"compiler returned unexpected failure status {result.returncode}"
+
+    if diagnostic_error is not None:
+        return str(diagnostic_error)
+    assert actual_codes is not None
+
+    missing = sorted(snippet.expected_codes - actual_codes)
+    if missing:
+        actual = ", ".join(sorted(actual_codes)) or "none"
+        return (
+            f"missing expected diagnostic code(s) {', '.join(missing)}; "
+            f"compiler emitted: {actual}"
+        )
+    return None
 
 
 def find_rue_binary() -> str:
@@ -147,6 +291,13 @@ def find_rue_binary() -> str:
     raise SystemExit("RUE_BINARY is not set and scripts/rue-bin was not found")
 
 
+def positive_seconds(value: str) -> float:
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise argparse.ArgumentTypeError("timeout must be a finite value greater than zero")
+    return seconds
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -157,9 +308,26 @@ def main() -> int:
         help="tutorial markdown directory to scan",
     )
     parser.add_argument("--quiet", action="store_true", help="only print failures")
+    parser.add_argument(
+        "--timeout",
+        type=positive_seconds,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"per-snippet compiler timeout in seconds (default: {DEFAULT_TIMEOUT_SECONDS:g})",
+    )
     args = parser.parse_args()
 
-    snippets, unmarked = collect_snippets(args.root)
+    try:
+        snippets, unmarked = collect_snippets(args.root)
+    except (OSError, UnicodeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    if not snippets:
+        print(
+            f"error: no checked tutorial snippets found in {args.root}",
+            file=sys.stderr,
+        )
+        return 1
+
     rue_binary = find_rue_binary()
 
     failures = 0
@@ -167,18 +335,37 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="rue-tutorial-snippets-") as temp:
         tempdir = Path(temp)
         for snippet in snippets:
-            result = compile_snippet(rue_binary, snippet, tempdir, env)
-            compiled = result.returncode == 0
-            expected_success = snippet.action == "check"
+            try:
+                result = compile_snippet(
+                    rue_binary, snippet, tempdir, env, args.timeout
+                )
+            except subprocess.TimeoutExpired as error:
+                failures += 1
+                print(
+                    f"FAIL {snippet.label}: compiler timed out after {args.timeout:g}s",
+                    file=sys.stderr,
+                )
+                if error.stdout:
+                    print(error.stdout, file=sys.stderr)
+                if error.stderr:
+                    print(error.stderr, file=sys.stderr)
+                continue
+            except OSError as error:
+                failures += 1
+                print(
+                    f"FAIL {snippet.label}: could not start compiler: {error}",
+                    file=sys.stderr,
+                )
+                continue
 
-            if compiled == expected_success:
+            failure = snippet_failure(snippet, result)
+            if failure is None:
                 if not args.quiet:
                     print(f"ok {snippet.label} ({snippet.action})")
                 continue
 
             failures += 1
-            expectation = "compile" if expected_success else "fail compilation"
-            print(f"FAIL {snippet.label}: expected snippet to {expectation}", file=sys.stderr)
+            print(f"FAIL {snippet.label}: {failure}", file=sys.stderr)
             if result.stdout:
                 print(result.stdout, file=sys.stderr)
             if result.stderr:

--- a/scripts/test-tutorial-snippets.py
+++ b/scripts/test-tutorial-snippets.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Regression tests for the tutorial snippet checker and wrapper wiring."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+
+INPUT_ROOT = Path(
+    os.environ.get("RUE_TUTORIAL_TEST_ROOT", Path(__file__).resolve().parent.parent)
+)
+CHECKER_PATH = INPUT_ROOT / "scripts" / "check-tutorial-snippets.py"
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location("tutorial_snippet_checker", CHECKER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {CHECKER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = load_checker()
+
+
+def snippet(action="compile-fail", expected_codes=frozenset({"E0203"})):
+    return checker.Snippet(
+        path=Path("chapter.md"),
+        line=1,
+        action=action,
+        source="fn main() -> i32 { 0 }\n",
+        expected_codes=expected_codes,
+    )
+
+
+def outcome(returncode, stderr="", stdout=""):
+    return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+
+def diagnostics(*codes):
+    return json.dumps(
+        [
+            {"code": code, "message": "probe", "severity": "error", "spans": []}
+            for code in codes
+        ]
+    )
+
+
+class SnippetMetadataTests(unittest.TestCase):
+    def test_compile_fail_requires_and_records_diagnostic_codes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            chapter = root / "chapter.md"
+            chapter.write_text(
+                "```rue compile-fail E0203 E0902\n"
+                "fn main() -> i32 { 0 }\n"
+                "```\n"
+            )
+            snippets, unmarked = checker.collect_snippets(root)
+            self.assertEqual(unmarked, 0)
+            self.assertEqual(len(snippets), 1)
+            self.assertEqual(snippets[0].expected_codes, {"E0203", "E0902"})
+
+            chapter.write_text(
+                "```rue compile-fail\nfn main() -> i32 { 0 }\n```\n"
+            )
+            with self.assertRaisesRegex(ValueError, "requires at least one"):
+                checker.collect_snippets(root)
+
+    def test_diagnostic_code_on_success_case_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chapter = Path(temp_dir) / "chapter.md"
+            chapter.write_text("```rue check E0203\nfn main() -> i32 { 0 }\n```\n")
+            with self.assertRaisesRegex(ValueError, "only valid with compile-fail"):
+                checker.collect_snippets(Path(temp_dir))
+
+    def test_unknown_attributes_and_internal_codes_are_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chapter = Path(temp_dir) / "chapter.md"
+            chapter.write_text(
+                "```rue compile-fail E0203 typo\nfn main() -> i32 { 0 }\n```\n"
+            )
+            with self.assertRaisesRegex(ValueError, "unknown rue fence attribute"):
+                checker.collect_snippets(Path(temp_dir))
+
+            chapter.write_text(
+                "```rue compile-fail E9000\nfn main() -> i32 { 0 }\n```\n"
+            )
+            with self.assertRaisesRegex(ValueError, "cannot expect internal"):
+                checker.collect_snippets(Path(temp_dir))
+
+            chapter.write_text(
+                "```rue check\nfn main() -> i32 { 0 }\n```\n"
+                "```rue compile-fial E0203\nfn main() -> i32 { 0 }\n```\n"
+            )
+            with self.assertRaisesRegex(ValueError, "compile-fial"):
+                checker.collect_snippets(Path(temp_dir))
+
+
+class CompilerOutcomeTests(unittest.TestCase):
+    def test_expected_success_and_compile_failure_are_accepted(self):
+        self.assertIsNone(checker.snippet_failure(snippet("check", frozenset()), outcome(0)))
+        self.assertIsNone(
+            checker.snippet_failure(snippet(), outcome(1, diagnostics("E0203")))
+        )
+
+    def test_wrong_or_malformed_diagnostic_is_rejected(self):
+        failure = checker.snippet_failure(snippet(), outcome(1, diagnostics("E0902")))
+        self.assertIn("missing expected diagnostic code(s) E0203", failure)
+
+        failure = checker.snippet_failure(snippet(), outcome(1, "not json"))
+        self.assertIn("not valid JSON", failure)
+
+        failure = checker.snippet_failure(snippet(), outcome(1, "[]"))
+        self.assertIn("empty diagnostic array", failure)
+
+    def test_signal_ice_and_infrastructure_status_are_distinct(self):
+        self.assertEqual(
+            checker.snippet_failure(snippet(), outcome(-11)),
+            "compiler terminated by signal 11",
+        )
+        self.assertEqual(
+            checker.snippet_failure(snippet(), outcome(101, "panicked at probe")),
+            "compiler reported an internal compiler error",
+        )
+        self.assertEqual(
+            checker.snippet_failure(snippet(), outcome(2)),
+            "compiler returned unexpected failure status 2",
+        )
+        self.assertEqual(
+            checker.snippet_failure(snippet(), outcome(1, diagnostics("E9001"))),
+            "compiler reported internal compiler diagnostic code(s): E9001",
+        )
+        self.assertEqual(
+            checker.snippet_failure(
+                snippet("check", frozenset()), outcome(1, diagnostics("E9001"))
+            ),
+            "compiler reported internal compiler diagnostic code(s): E9001",
+        )
+
+    def test_compile_timeout_kills_the_compiler_process_group(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            fake = root / "fake-rue"
+            fake.write_text("#!/bin/sh\nsleep 10 &\nwait\n")
+            fake.chmod(0o755)
+
+            started = time.monotonic()
+            with self.assertRaises(subprocess.TimeoutExpired):
+                checker.compile_snippet(
+                    str(fake), snippet("check", frozenset()), root, os.environ.copy(), 0.05
+                )
+            self.assertLess(time.monotonic() - started, 2)
+
+
+class GateWiringTests(unittest.TestCase):
+    def test_snippet_environment_removes_tracing_configuration(self):
+        with patch.dict(os.environ, {"RUST_LOG": "debug"}):
+            self.assertNotIn("RUST_LOG", checker.snippet_env())
+
+    def test_empty_discovery_fails_before_compiler_lookup(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env = os.environ.copy()
+            env["RUE_BINARY"] = "/does/not/exist"
+            process = subprocess.run(
+                [sys.executable, str(CHECKER_PATH), "--quiet", temp_dir],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+        self.assertEqual(process.returncode, 1)
+        self.assertIn("no checked tutorial snippets found", process.stderr)
+
+    def test_missing_compiler_reports_infrastructure_failure(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "chapter.md").write_text(
+                "```rue check\nfn main() -> i32 { 0 }\n```\n"
+            )
+            env = os.environ.copy()
+            env["RUE_BINARY"] = str(root / "missing-rue")
+            process = subprocess.run(
+                [sys.executable, str(CHECKER_PATH), "--quiet", str(root)],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+        self.assertEqual(process.returncode, 1)
+        self.assertIn("could not start compiler", process.stderr)
+
+    def test_filtered_wrapper_lists_repository_quality_gates(self):
+        wrapper = (INPUT_ROOT / "test.sh").read_text()
+        self.assertIn("//:benchmark-tool-tests", wrapper)
+        self.assertIn("//:tutorial-snippet-tool-tests", wrapper)
+        self.assertIn("//:tutorial-snippet-tests", wrapper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test.sh
+++ b/test.sh
@@ -17,6 +17,14 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+REPOSITORY_QUALITY_GATES=(
+    //:benchmark-tool-tests
+    //:tutorial-snippet-tool-tests
+    //:tutorial-snippet-tests
+    //:spec-traceability
+    //:adr-registry-validation
+)
+
 if [[ $# -eq 0 ]]; then
     echo "Running unit tests and spec/UI/CLI suites..."
     ./buck2 test //...
@@ -48,5 +56,5 @@ else
     ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- --quiet "$@"
 
     echo "Running repository quality gates..."
-    ./buck2 test //:spec-traceability //:adr-registry-validation
+    ./buck2 test "${REPOSITORY_QUALITY_GATES[@]}"
 fi

--- a/website/content/tutorial/03-variables-and-types.md
+++ b/website/content/tutorial/03-variables-and-types.md
@@ -93,7 +93,7 @@ fn main() -> i32 {
 
 Trying to assign to an immutable variable is a compile error:
 
-```rue compile-fail
+```rue compile-fail E0203
 fn main() -> i32 {
     let x = 42;
     x = 43;  // Error: cannot assign to immutable variable

--- a/website/content/tutorial/06-arrays.md
+++ b/website/content/tutorial/06-arrays.md
@@ -79,7 +79,7 @@ fn main() -> i32 {
 
 Rue checks array bounds. A constant out-of-bounds index is rejected at compile time:
 
-```rue compile-fail
+```rue compile-fail E0902
 fn main() -> i32 {
     let arr = [1, 2, 3];
     println(@to_string(arr[10]));  // Error: index out of bounds


### PR DESCRIPTION
## Summary

- require tutorial compile-fail snippets to pin expected diagnostics, and reject malformed diagnostics, ICEs, signals, and infrastructure statuses
- add finite process-group timeouts plus empty-corpus and checker regression coverage
- make the Buck tutorial target declare its standard-library input and keep repository quality gates active in filtered `test.sh` runs

Linear: RUE-542, RUE-544, RUE-551

## Verification

- `./fmt.sh check`
- `./clippy.sh` (41 targets)
- `./test.sh` (30 targets)
- `./test.sh __codex_no_matching_test__`
- `./buck2 test //:tutorial-snippet-tool-tests //:tutorial-snippet-tests //:benchmark-tool-tests`
- Buck query confirms `root//:std` is declared and `RUE_STD_PATH` is absolute