### PR TITLE
RUE-532: constant u64 indices above i64::MAX get the compile-time bounds check (spec 7.1:9)

### DIFF
--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -684,7 +684,7 @@ impl<'a> Sema<'a> {
             // index's resolved operand types so an overflowing index expression
             // is a compile-time error, not a folded runtime panic (RUE-234).
             if let Some(const_index) = self.try_get_const_index_checked(index, ctx)? {
-                if const_index < 0 || const_index as u64 >= array_len {
+                if const_index < 0 || const_index >= array_len as i128 {
                     return Err(CompileError::new(
                         ErrorKind::IndexOutOfBounds {
                             index: const_index,

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -446,7 +446,7 @@ impl<'a> Sema<'a> {
             // index's resolved operand types so an overflowing index expression
             // is a compile-time error, not a folded runtime panic (RUE-234).
             if let Some(const_index) = self.try_get_const_index_checked(*index, ctx)? {
-                if const_index < 0 || const_index as u64 >= array_length {
+                if const_index < 0 || const_index >= array_length as i128 {
                     return Err(CompileError::new(
                         ErrorKind::IndexOutOfBounds {
                             index: const_index,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -4642,7 +4642,7 @@ impl<'a> Sema<'a> {
             // integer type (`arr[X + 1]`, X: i8 = 127) is a compile-time error
             // rather than a folded-then-bounds-checked value (RUE-234).
             if let Some(const_idx) = self.try_get_const_index_checked(index, ctx)? {
-                if const_idx < 0 || const_idx as u64 >= array_len {
+                if const_idx < 0 || const_idx >= array_len as i128 {
                     return Err(CompileError::new(
                         ErrorKind::IndexOutOfBounds {
                             index: const_idx,
@@ -4806,7 +4806,7 @@ impl<'a> Sema<'a> {
         // operand types, so an overflowing index expression is a compile-time
         // error rather than a folded runtime panic — RUE-234).
         if let Some(const_idx) = self.try_get_const_index_checked(index, ctx)? {
-            if const_idx < 0 || const_idx as u64 >= array_len {
+            if const_idx < 0 || const_idx >= array_len as i128 {
                 return Err(CompileError::new(
                     ErrorKind::IndexOutOfBounds {
                         index: const_idx,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -310,11 +310,16 @@ impl Sema<'_> {
         &mut self,
         inst_ref: InstRef,
         ctx: &AnalysisContext,
-    ) -> CompileResult<Option<i64>> {
+    ) -> CompileResult<Option<i128>> {
         let mut env = ComptimeEnv::for_analysis(ctx);
+        // Full i128 backing value, NOT the i64 narrowing: `as_integer()`
+        // returns None for a u64 constant above i64::MAX, which made an
+        // exactly-known out-of-bounds index (`a[18446744073709551615]`)
+        // indistinguishable from a runtime index and skip the compile-time
+        // bounds check (RUE-532).
         Ok(self
             .eval_const_expr(inst_ref, &mut env)?
-            .and_then(|v| v.as_integer()))
+            .and_then(|v| v.as_int_value()))
     }
 
     /// Check if an RIR instruction is a direct reference to a `comptime`

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1421,8 +1421,11 @@ pub enum ErrorKind {
     IndexOnNonArray { found: String },
     #[error("{}", format_array_length_mismatch(*.expected, *.found))]
     ArrayLengthMismatch { expected: u64, found: u64 },
+    // `index` is i128 so a constant u64 index above i64::MAX is still
+    // reported exactly (RUE-532) — the old i64 narrowing made such an index
+    // look non-constant and skip the compile-time bounds check entirely.
     #[error("index out of bounds: the length is {length} but the index is {index}")]
-    IndexOutOfBounds { index: i64, length: u64 },
+    IndexOutOfBounds { index: i128, length: u64 },
     #[error("type annotation required for empty array")]
     TypeAnnotationRequired,
     /// Cannot move non-Copy element out of array index position.

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -177,6 +177,35 @@ fn main() -> i32 {
 """
 compile_fail = true
 
+[[case]]
+name = "constant_u64_index_above_i64_max_out_of_bounds"
+error_contains = ["[E0902]", "18446744073709551615"]
+spec = ["7.1:9"]
+description = "A constant u64 index above i64::MAX is still a compile-time bounds error naming the exact index (RUE-532: i64 narrowing made it look non-constant and defer to a runtime trap)"
+source = """
+const MAX: u64 = 18446744073709551615;
+
+fn main() -> i32 {
+    let a: [i32; 1] = [42];
+    a[MAX]
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "constant_u64_index_in_bounds_ok"
+spec = ["7.1:9"]
+description = "A constant u64 index within bounds still compiles and reads the element (control for RUE-532)"
+source = """
+const I: u64 = 2;
+
+fn main() -> i32 {
+    let a: [i32; 3] = [1, 2, 42];
+    a[I]
+}
+"""
+exit_code = 42
+
 # =============================================================================
 # Runtime Bounds Checking
 # =============================================================================


### PR DESCRIPTION
## Summary
`try_get_const_index_checked` narrowed the comptime evaluator's i128 through `ConstValue::as_integer() -> Option<i64>`, so a u64 constant above i64::MAX returned `None` — an exactly-known out-of-bounds index (`a[18446744073709551615]`) was indistinguishable from a runtime index and deferred to the runtime trap (verified: exit 101 instead of E0902). The query now returns the full `i128`, all four bounds-check call sites compare in i128, and `IndexOutOfBounds` carries i128 so the diagnostic reports the exact index rather than a clamp.

## Validation
Repro now rejected at compile time — `error: [E0902]: index out of bounds: the length is 1 but the index is 18446744073709551615` — and an in-bounds constant u64 index still compiles and runs (exit 42). Two new 7.1:9 spec cases (rejection pinning the exact index in the message + in-bounds control). ./test.sh Pass 29 / Fail 0.

Fixes RUE-532

🤖 Generated with [Claude Code](https://claude.com/claude-code)