### PR TITLE
RUE-561: checked layout arithmetic — oversized types get E0906 instead of ICE or zero-sized truncation

### DIFF
--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -354,7 +354,9 @@ impl<'a> Sema<'a> {
                 // By-ref parameters are always 1 slot (pointer)
                 1
             } else {
-                self.abi_slot_count(*ptype)
+                // A by-value parameter materializes the whole object in the
+                // frame: reject an oversized type (E0906, RUE-561).
+                self.require_layout_slots(*ptype, self.rir.get(body).span)?
             };
             for _ in 0..slot_count {
                 param_modes.push(is_by_ref);

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2059,7 +2059,7 @@ impl<'a> Sema<'a> {
 
             // Allocate a local slot and register the binding.
             let slot = ctx.next_slot;
-            let num_slots = self.abi_slot_count(field_ty);
+            let num_slots = self.require_layout_slots(field_ty, pattern_span)?;
             ctx.next_slot += num_slots;
             ctx.insert_local(
                 *binding_name,
@@ -2437,7 +2437,7 @@ impl<'a> Sema<'a> {
 
         // Allocate slots
         let slot = ctx.next_slot;
-        let num_slots = self.abi_slot_count(var_type);
+        let num_slots = self.require_layout_slots(var_type, span)?;
         ctx.next_slot += num_slots;
 
         // A `for`-loop element binder over a NON-Copy collection aliases an
@@ -3754,7 +3754,7 @@ impl<'a> Sema<'a> {
 
         // Allocate a temporary slot for the computed struct value
         let temp_slot = ctx.next_slot;
-        let num_slots = self.abi_slot_count(base_type);
+        let num_slots = self.require_layout_slots(base_type, span)?;
         ctx.next_slot += num_slots;
 
         // Emit StorageLive for the temporary
@@ -4852,7 +4852,7 @@ impl<'a> Sema<'a> {
 
         // Allocate a temporary slot for the computed array value
         let temp_slot = ctx.next_slot;
-        let num_slots = self.abi_slot_count(base_type);
+        let num_slots = self.require_layout_slots(base_type, span)?;
         ctx.next_slot += num_slots;
 
         // Emit StorageLive for the temporary
@@ -6226,16 +6226,19 @@ impl<'a> Sema<'a> {
             return Ok(AnalysisResult::new(air_ref, Type::UNIT));
         }
 
-        // Calculate the value based on which intrinsic
+        // Calculate the value based on which intrinsic. Checked layout query
+        // (E0906 on oversized types, RUE-561): the old unchecked u32 math
+        // ICEd on a 2 GiB array in debug builds and truncated a 32 GiB one to
+        // size 0 / alignment 1.
         let value: u64 = match intrinsic_name.as_str() {
             "size_of" => {
                 // Calculate size in bytes (slot count * 8)
-                let slot_count = self.abi_slot_count(ty);
-                (slot_count * 8) as u64
+                let slot_count = self.require_layout_slots(ty, span)?;
+                u64::from(slot_count) * 8
             }
             "align_of" => {
                 // Zero-sized types have 1-byte alignment, others have 8-byte
-                let slot_count = self.abi_slot_count(ty);
+                let slot_count = self.require_layout_slots(ty, span)?;
                 if slot_count == 0 { 1u64 } else { 8u64 }
             }
             _ => {

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -15,6 +15,13 @@ use rue_span::{FileId, Span};
 
 use super::Sema;
 use super::context::AnalysisContext;
+
+/// Maximum size of a single object in bytes: `i32::MAX`, matching the
+/// codegen frame-offset (disp32) addressing range (Appendix C practical
+/// limit, RUE-561). Types larger than this are rejected with E0906.
+pub(crate) const MAX_TYPE_SIZE_BYTES: u64 = i32::MAX as u64;
+/// [`MAX_TYPE_SIZE_BYTES`] expressed in 8-byte ABI slots.
+pub(crate) const MAX_TYPE_SLOTS: u64 = MAX_TYPE_SIZE_BYTES / 8;
 use super::info::ConstInfo;
 use crate::inference::InferType;
 use crate::sema::ConstValue;
@@ -1728,10 +1735,73 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// Reject a type whose layout exceeds the implementation's maximum object
+    /// size (Appendix C practical limit, RUE-561), returning the slot count on
+    /// success. Call this wherever a value of `ty` is MATERIALIZED — a local
+    /// or temporary slot allocation, a by-value parameter, `@size_of` /
+    /// `@align_of` — so the saturating fallback in [`Self::abi_slot_count`]
+    /// is never observable.
+    pub(crate) fn require_layout_slots(&self, ty: Type, span: Span) -> CompileResult<u32> {
+        match self.checked_abi_slot_count(ty) {
+            Some(slots) => Ok(slots as u32),
+            None => Err(CompileError::new(
+                ErrorKind::TypeTooLarge {
+                    type_name: ty.safe_name_with_pool(Some(&self.type_pool)),
+                    max_bytes: MAX_TYPE_SIZE_BYTES,
+                },
+                span,
+            )),
+        }
+    }
+
+    /// Checked companion to [`Self::abi_slot_count`]: `None` when the type's
+    /// layout overflows or exceeds [`MAX_TYPE_SLOTS`] (RUE-561). Computed in
+    /// u64 with checked arithmetic, so a `[i32; 4294967296]` no longer
+    /// truncates to zero slots and a `[i32; 536870912]` no longer overflows
+    /// the debug-build multiply.
+    pub(crate) fn checked_abi_slot_count(&self, ty: Type) -> Option<u64> {
+        let slots = match ty.kind() {
+            TypeKind::Array(array_type_id) => {
+                let (element_type, length) = self.type_pool.array_def(array_type_id);
+                let element_slots = self.checked_abi_slot_count(element_type)?;
+                element_slots.checked_mul(length)?
+            }
+            TypeKind::Struct(struct_id) => {
+                let struct_def = self.type_pool.struct_def(struct_id);
+                let mut total = 0u64;
+                for f in &struct_def.fields {
+                    total = total.checked_add(self.checked_abi_slot_count(f.ty)?)?;
+                }
+                total
+            }
+            TypeKind::Enum(enum_id) => {
+                let enum_def = self.type_pool.enum_def(enum_id);
+                let mut max_payload = 0u64;
+                for i in 0..enum_def.variant_count() {
+                    let mut variant_slots = 0u64;
+                    for &vty in enum_def.variant_payload(i) {
+                        variant_slots =
+                            variant_slots.checked_add(self.checked_abi_slot_count(vty)?)?;
+                    }
+                    max_payload = max_payload.max(variant_slots);
+                }
+                1 + max_payload
+            }
+            // Every other kind is 0 or 1 slots; delegate.
+            _ => u64::from(self.abi_slot_count(ty)),
+        };
+        (slots <= MAX_TYPE_SLOTS).then_some(slots)
+    }
+
     /// Get the number of ABI slots required for a type.
     /// Scalar types (i8, i16, i32, i64, u8, u16, u32, u64, bool) use 1 slot,
     /// structs use 1 slot per field, arrays use 1 slot per element.
     /// Zero-sized types (unit, never, empty structs, zero-length arrays) use 0 slots.
+    ///
+    /// Layout arithmetic SATURATES (no overflow panic, no silent u32
+    /// truncation — RUE-561); an oversized type is rejected with E0906 at
+    /// every materialization site via [`Self::require_layout_slots`], so the
+    /// saturated value is never used for real allocation.
     pub(crate) fn abi_slot_count(&self, ty: Type) -> u32 {
         match ty.kind() {
             TypeKind::I8
@@ -1759,11 +1829,10 @@ impl<'a> Sema<'a> {
                     let variant_slots: u32 = enum_def
                         .variant_payload(i)
                         .iter()
-                        .map(|&ty| self.abi_slot_count(ty))
-                        .sum();
+                        .fold(0u32, |acc, &ty| acc.saturating_add(self.abi_slot_count(ty)));
                     max_payload = max_payload.max(variant_slots);
                 }
-                1 + max_payload
+                1u32.saturating_add(max_payload)
             }
             // Struct uses sum of all field slots (includes builtin String with 3 fields)
             TypeKind::Struct(struct_id) => {
@@ -1773,14 +1842,13 @@ impl<'a> Sema<'a> {
                 struct_def
                     .fields
                     .iter()
-                    .map(|f| self.abi_slot_count(f.ty))
-                    .sum()
+                    .fold(0u32, |acc, f| acc.saturating_add(self.abi_slot_count(f.ty)))
             }
             TypeKind::Array(array_type_id) => {
                 // Zero-length arrays naturally get 0 slots (0 * element_slots)
                 let (element_type, length) = self.type_pool.array_def(array_type_id);
-                let element_slots = self.abi_slot_count(element_type);
-                element_slots * length as u32
+                let element_slots = u64::from(self.abi_slot_count(element_type));
+                u32::try_from(element_slots.saturating_mul(length)).unwrap_or(u32::MAX)
             }
             // Module types don't take ABI slots (they're compile-time only)
             TypeKind::Module(_) => 0,

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -67,10 +67,14 @@ pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
         // Zero-sized types
         TypeKind::Unit | TypeKind::Never => 0,
         TypeKind::Array(array_type_id) => {
-            // Zero-length arrays naturally get 0 slots (0 * element_slots)
+            // Zero-length arrays naturally get 0 slots (0 * element_slots).
+            // SATURATING, not truncating-u32: sema rejects oversized types
+            // with E0906 before lowering (RUE-561), so this value is never
+            // used for real allocation, but it must not silently wrap
+            // (`[i32; 4294967296]` truncated to 0 slots) or panic in debug.
             let (element_type, length) = type_pool.array_def(array_type_id);
-            let elem_slots = type_slot_count(type_pool, element_type);
-            (length as u32) * elem_slots
+            let elem_slots = u64::from(type_slot_count(type_pool, element_type));
+            u32::try_from(elem_slots.saturating_mul(length)).unwrap_or(u32::MAX)
         }
         TypeKind::Struct(struct_id) => {
             // Sum the slot counts of all fields
@@ -78,7 +82,7 @@ pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
             let struct_def = type_pool.struct_def(struct_id);
             let mut total = 0u32;
             for field in &struct_def.fields {
-                total += type_slot_count(type_pool, field.ty);
+                total = total.saturating_add(type_slot_count(type_pool, field.ty));
             }
             total
         }
@@ -93,11 +97,11 @@ pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
             for i in 0..enum_def.variant_count() {
                 let mut variant_slots = 0u32;
                 for &ty in enum_def.variant_payload(i) {
-                    variant_slots += type_slot_count(type_pool, ty);
+                    variant_slots = variant_slots.saturating_add(type_slot_count(type_pool, ty));
                 }
                 max_payload = max_payload.max(variant_slots);
             }
-            1 + max_payload
+            1u32.saturating_add(max_payload)
         }
         // Scalars and other types use 1 slot
         _ => 1,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -345,6 +345,7 @@ impl ErrorCode {
     pub const TYPE_ANNOTATION_REQUIRED: Self = Self(903);
     pub const MOVE_OUT_OF_INDEX: Self = Self(904);
     pub const ARRAY_REPEAT_NON_COPY: Self = Self(905);
+    pub const TYPE_TOO_LARGE: Self = Self(906);
 
     // ========================================================================
     // Linker/target errors (E1000-E1099)
@@ -1441,6 +1442,12 @@ pub enum ErrorKind {
     /// RUE-235).
     #[error("array-repeat literal requires a Copy element type, but '{element_type}' is not Copy")]
     ArrayRepeatNonCopy { element_type: String },
+    /// A type's layout exceeds the implementation's maximum object size
+    /// (Appendix C practical limit; RUE-561 — unchecked u32 slot arithmetic
+    /// previously ICEd on 2 GiB arrays and silently truncated 32 GiB ones to
+    /// zero-sized).
+    #[error("type '{type_name}' exceeds the maximum supported object size ({max_bytes} bytes)")]
+    TypeTooLarge { type_name: String, max_bytes: u64 },
     /// Assignment into an array (element write, or a write through an element)
     /// while one or more of its elements are moved out (RUE-186). Reinstating
     /// per-element ownership through writes is not supported; the whole array
@@ -1653,6 +1660,7 @@ impl ErrorKind {
             ErrorKind::TypeAnnotationRequired => ErrorCode::TYPE_ANNOTATION_REQUIRED,
             ErrorKind::MoveOutOfIndex { .. } => ErrorCode::MOVE_OUT_OF_INDEX,
             ErrorKind::ArrayRepeatNonCopy { .. } => ErrorCode::ARRAY_REPEAT_NON_COPY,
+            ErrorKind::TypeTooLarge { .. } => ErrorCode::TYPE_TOO_LARGE,
             ErrorKind::AssignToPartiallyMovedArray { .. } => {
                 ErrorCode::ASSIGN_TO_PARTIALLY_MOVED_ARRAY
             }

--- a/crates/rue-ui-tests/cases/diagnostics/type_too_large.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/type_too_large.toml
@@ -1,0 +1,48 @@
+[section]
+id = "diagnostics.type_too_large"
+name = "Oversized type layouts (E0906)"
+description = "Types exceeding the maximum object size (Appendix C.4:3, RUE-561) are rejected with E0906 instead of ICEing (debug multiply overflow) or silently truncating the slot count to zero."
+
+[[case]]
+name = "size_of_2gib_array_rejected"
+source = """
+fn main() -> i32 { @size_of([i32; 536870912]) }
+"""
+compile_fail = true
+error_contains = ["[E0906]", "[i32; 536870912]", "2147483647"]
+
+[[case]]
+name = "size_of_32gib_array_rejected_not_zero"
+source = """
+fn main() -> i32 { @size_of([i32; 4294967296]) }
+"""
+compile_fail = true
+error_contains = ["[E0906]", "[i32; 4294967296]"]
+
+[[case]]
+name = "align_of_oversized_array_rejected"
+source = """
+fn main() -> i32 { @align_of([i32; 4294967296]) }
+"""
+compile_fail = true
+error_contains = ["[E0906]"]
+
+[[case]]
+name = "oversized_local_rejected"
+source = """
+fn main() -> i32 {
+    let a = [0; 536870912];
+    a[0]
+}
+"""
+compile_fail = true
+error_contains = ["[E0906]"]
+
+[[case]]
+name = "large_but_legal_array_size_of_ok"
+source = """
+fn main() -> i32 {
+    if @size_of([i32; 1000]) == 8000 { 0 } else { 1 }
+}
+"""
+exit_code = 0

--- a/docs/spec/src/appendices/C-implementation-limits.md
+++ b/docs/spec/src/appendices/C-implementation-limits.md
@@ -55,6 +55,10 @@ Array length **MUST** be representable as an unsigned 64-bit integer. This limit
 
 Practical limits on array size are determined by available memory and platform constraints rather than the type system.
 
+{{ rule(id="C.4:3", cat="informative") }}
+
+The current implementation limits any single object (including an array type) to 2,147,483,647 bytes (`i32::MAX`), matching the code generator's frame-offset addressing range. A type whose layout exceeds this limit is rejected with a diagnostic (E0906) wherever a value of the type would be materialized — a variable, a parameter, or a `@size_of`/`@align_of` query.
+
 ## Identifier Limits
 
 {{ rule(id="C.5:1", cat="informative") }}


### PR DESCRIPTION
## Summary
Both verified on trunk: `@size_of([i32; 536870912])` aborted the compiler (debug multiply overflow in u32 slot arithmetic) and `@size_of([i32; 4294967296])` compiled and returned 0 with alignment 1 (slot count truncated through `length as u32`). The limit is now explicit — one object ≤ `i32::MAX` bytes, the codegen disp32 frame-offset range, documented as informative Appendix C.4:3 — enforced by a new checked u64 slot-count query behind `require_layout_slots`, which rejects with the new **E0906** (`type '[i32; 4294967296]' exceeds the maximum supported object size (2147483647 bytes)`) at every materialization site: all four local/temporary slot-allocation sites, by-value parameters, and `@size_of`/`@align_of`. The unchecked `abi_slot_count` and codegen's duplicate `type_slot_count` now saturate instead of wrapping/panicking — unobservable behind the sema rejection, but panic-free by construction.

## Validation
Both repro shapes plus `@align_of` and an oversized local verified rejected with E0906 naming the exact type; `@size_of([i32; 1000]) == 8000` control verified running. 5 new UI cases. ./test.sh Pass 30 / Fail 0.

Fixes RUE-561

🤖 Generated with [Claude Code](https://claude.com/claude-code)