### PR TITLE
RUE-546+547: harden expected failures and case environments

### DIFF
--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -50,9 +50,9 @@
 //! - `runtime_error_contains`: assert on the program's stderr
 //! - `exit_code`: expected program exit code (default 0)
 //! - `timeout_ms`: wall-clock limit for running the program (default 10s)
-//! - `known_bug = "RUE-NN"`: expected failure (xfail). The case runs; if it
-//!   fails, it is reported as ignored with the bug reference. If it PASSES,
-//!   the suite fails loudly so the marker gets removed when the bug is fixed.
+//! - `known_bug = "RUE-NN"`: expected failure (xfail). An ordinary assertion
+//!   failure is ignored with the bug reference. A fatal subprocess failure or
+//!   unexpected pass fails loudly.
 //! - `only_on = ["x86-64-linux", ...]`: run the case only on these hosts
 //!   (ignored elsewhere). For behavior that depends on the host platform,
 //!   e.g. whether `--target X` is a cross-compile or a native compile.
@@ -66,8 +66,7 @@
 //!
 //! Any compiler invocation that dies by signal or whose stderr contains a
 //! Rust panic is reported as an INTERNAL COMPILER ERROR — a distinct, loud
-//! failure class, regardless of what the case expected (it still counts as
-//! "failure" for `known_bug` purposes).
+//! failure class that a `known_bug` marker cannot turn into an expected pass.
 //!
 //! # Timeouts
 //!
@@ -87,8 +86,9 @@ use std::time::Duration;
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_test_runner::{
-    DEFAULT_TIMEOUT_MS, KNOWN_TARGETS, find_dir, find_rue_binary, ice_message, run_with_timeout,
-    validate_nonempty_case_corpus,
+    DEFAULT_TIMEOUT_MS, ExpectedFailureOutcome, KNOWN_TARGETS, TestFailure, TestResult,
+    classify_expected_failure, compiler_command, find_dir, find_rue_binary, ice_message,
+    run_with_timeout, validate_nonempty_case_corpus,
 };
 use serde::Deserialize;
 
@@ -373,8 +373,6 @@ struct Case {
     differential_opt: bool,
 }
 
-type TestResult = Result<(), String>;
-
 /// What running one case produced: the compiled program's exit code and
 /// stdout. For cases that don't run a program (`compile_fail`/`compile_only`),
 /// `ran` is false and the other fields are empty. Used by the opt-level
@@ -389,6 +387,29 @@ struct RunOutcome {
 /// Expand `${REAL_STD}` in env values to the absolute path of the repo's std/.
 fn expand_env_value(value: &str, real_std: &Path) -> String {
     value.replace("${REAL_STD}", &real_std.to_string_lossy())
+}
+
+fn apply_case_environment(
+    command: &mut Command,
+    environment: &HashMap<String, String>,
+    real_std: &Path,
+) {
+    for (key, value) in environment {
+        command.env(key, expand_env_value(value, real_std));
+    }
+}
+
+fn case_compiler_command(
+    binary: &Path,
+    args: &[String],
+    directory: &Path,
+    environment: &HashMap<String, String>,
+    real_std: &Path,
+) -> Command {
+    let mut command = compiler_command(binary);
+    command.args(args).current_dir(directory);
+    apply_case_environment(&mut command, environment, real_std);
+    command
 }
 
 fn find_repo_root(cases_dir: &Path, real_std: &Path) -> PathBuf {
@@ -446,8 +467,9 @@ fn run_case(
     real_std: &Path,
     repo_root: &Path,
     opt_level: Option<&str>,
-) -> Result<RunOutcome, String> {
-    let temp_dir = tempfile::tempdir().map_err(|e| format!("failed to create temp dir: {}", e))?;
+) -> TestResult<RunOutcome> {
+    let temp_dir = tempfile::tempdir()
+        .map_err(|e| TestFailure::fatal(format!("failed to create temp dir: {}", e)))?;
     let dir = temp_dir.path();
     let source_path = case
         .source_path
@@ -458,11 +480,12 @@ fn run_case(
     for file in &case.files {
         let path = dir.join(&file.path);
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("failed to create dir for {}: {}", file.path, e))?;
+            std::fs::create_dir_all(parent).map_err(|e| {
+                TestFailure::fatal(format!("failed to create dir for {}: {}", file.path, e))
+            })?;
         }
         std::fs::write(&path, &file.source)
-            .map_err(|e| format!("failed to write {}: {}", file.path, e))?;
+            .map_err(|e| TestFailure::fatal(format!("failed to write {}: {}", file.path, e)))?;
     }
 
     let output_name = case.output.clone().unwrap_or_else(|| "prog".to_string());
@@ -474,7 +497,12 @@ fn run_case(
         None => {
             let first = match &source_path {
                 Some(path) => path.display().to_string(),
-                None => case.files.first().ok_or("case has no files")?.path.clone(),
+                None => case
+                    .files
+                    .first()
+                    .ok_or_else(|| TestFailure::assertion("case has no files"))?
+                    .path
+                    .clone(),
             };
             vec![first, "-o".to_string(), output_name.clone()]
         }
@@ -487,11 +515,7 @@ fn run_case(
         args.push(level.to_string());
     }
 
-    let mut cmd = Command::new(rue_binary);
-    cmd.args(&args).current_dir(dir);
-    for (key, value) in &case.env {
-        cmd.env(key, expand_env_value(value, real_std));
-    }
+    let cmd = case_compiler_command(rue_binary, &args, dir, &case.env, real_std);
     // The COMPILE step runs under the same per-case timeout as execution: a
     // compile-time hang (comptime/parser loop) must fail this one case as a
     // TIMEOUT, not wedge the suite. Mirrors the spec runner's compile step.
@@ -510,37 +534,37 @@ fn run_case(
     // Debug-spew / leaked-diagnostics guard runs regardless of compile outcome.
     for expected in &case.compile_stderr_contains {
         if !compile_stderr.contains(expected) {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "compiler stderr missing expected substring: {}\n--- actual stderr ---\n{}",
                 expected, compile_stderr
-            ));
+            )));
         }
     }
 
     for forbidden in &case.compile_stderr_not_contains {
         if compile_stderr.contains(forbidden) {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "compiler stderr contained forbidden substring: {}\n--- actual stderr ---\n{}",
                 forbidden, compile_stderr
-            ));
+            )));
         }
     }
 
     for expected in &case.compile_stdout_contains {
         if !compile_stdout.contains(expected) {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "compiler stdout mismatch:\n  expected to contain: {}\n--- actual stdout ---\n{}",
                 expected, compile_stdout
-            ));
+            )));
         }
     }
 
     for forbidden in &case.compile_stdout_not_contains {
         if compile_stdout.contains(forbidden) {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "compiler stdout contained forbidden substring: {}\n--- actual stdout ---\n{}",
                 forbidden, compile_stdout
-            ));
+            )));
         }
     }
 
@@ -548,26 +572,28 @@ fn run_case(
 
     if case.compile_fail {
         if compile_succeeded {
-            return Err("expected compilation to fail, but it succeeded".to_string());
+            return Err(TestFailure::assertion(
+                "expected compilation to fail, but it succeeded",
+            ));
         }
         for expected in &case.error_contains {
             if !compile_stderr.contains(expected) {
-                return Err(format!(
+                return Err(TestFailure::assertion(format!(
                     "compiler error mismatch:\n  expected stderr to contain: {}\n--- actual stderr ---\n{}",
                     expected, compile_stderr
-                ));
+                )));
             }
         }
         return Ok(RunOutcome::default());
     }
 
     if !compile_succeeded {
-        return Err(format!(
+        return Err(TestFailure::assertion(format!(
             "compilation failed (exit: {:?}):\n--- compiler stdout ---\n{}\n--- compiler stderr ---\n{}",
             compile_output.status.code(),
             compile_stdout,
             compile_stderr
-        ));
+        )));
     }
 
     if case.compile_only {
@@ -577,10 +603,10 @@ fn run_case(
     // Run the produced binary from the temp dir.
     let program = dir.join(&output_name);
     if !program.exists() {
-        return Err(format!(
+        return Err(TestFailure::assertion(format!(
             "compiler reported success but did not produce '{}'",
             output_name
-        ));
+        )));
     }
 
     // Run the produced binary under a per-case wall-clock timeout. An infinite
@@ -595,39 +621,46 @@ fn run_case(
     let run_stdout = String::from_utf8_lossy(&run_output.stdout).to_string();
     let run_stderr = String::from_utf8_lossy(&run_output.stderr).to_string();
 
+    if run_output.status.code().is_none() {
+        return Err(TestFailure::fatal(format!(
+            "TEST PROGRAM CRASH: process killed by signal ({:?})\n--- program stderr ---\n{}",
+            run_output.status, run_stderr
+        )));
+    }
+
     let expected_exit = case.exit_code.unwrap_or(0);
     let actual_exit = run_output.status.code();
     if actual_exit != Some(expected_exit) {
-        return Err(format!(
+        return Err(TestFailure::assertion(format!(
             "program exit code mismatch:\n  expected: {}\n  actual: {:?}\n--- program stdout ---\n{}\n--- program stderr ---\n{}",
             expected_exit, actual_exit, run_stdout, run_stderr
-        ));
+        )));
     }
 
     if let Some(expected) = &case.stdout {
         if &run_stdout != expected {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "program stdout mismatch:\n--- expected ---\n{}\n--- actual ---\n{}",
                 expected, run_stdout
-            ));
+            )));
         }
     }
 
     for expected in &case.stdout_contains {
         if !run_stdout.contains(expected) {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "program stdout mismatch:\n  expected to contain: {}\n--- actual stdout ---\n{}",
                 expected, run_stdout
-            ));
+            )));
         }
     }
 
     for expected in &case.runtime_error_contains {
         if !run_stderr.contains(expected) {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "program stderr mismatch:\n  expected to contain: {}\n--- actual stderr ---\n{}",
                 expected, run_stderr
-            ));
+            )));
         }
     }
 
@@ -660,29 +693,27 @@ fn run_case_differential(
     // Guard against misuse: the runner drives the opt level, so these would be
     // ambiguous or meaningless.
     if case.compile_fail || case.compile_only {
-        return Err(
-            "differential_opt case must be a compile-and-run case (not compile_fail/compile_only)"
-                .to_string(),
-        );
+        return Err(TestFailure::assertion(
+            "differential_opt case must be a compile-and-run case (not compile_fail/compile_only)",
+        ));
     }
     if let Some(args) = &case.args {
         if args.iter().any(|a| a.starts_with("-O")) {
-            return Err(
-                "differential_opt case must not set its own -O flag in args (the runner drives it)"
-                    .to_string(),
-            );
+            return Err(TestFailure::assertion(
+                "differential_opt case must not set its own -O flag in args (the runner drives it)",
+            ));
         }
     }
 
     let mut baseline: Option<(&str, RunOutcome)> = None;
     for level in OPT_LEVELS {
         let outcome = run_case(case, rue_binary, real_std, repo_root, Some(level))
-            .map_err(|e| format!("at {}: {}", level, e))?;
+            .map_err(|error| error.with_context(format!("at {level}")))?;
         match &baseline {
             None => baseline = Some((level, outcome)),
             Some((base_level, base)) => {
                 if &outcome != base {
-                    return Err(format!(
+                    return Err(TestFailure::assertion(format!(
                         "opt-level divergence: {} produced (exit={:?}, stdout={:?}) but {} produced (exit={:?}, stdout={:?})",
                         base_level,
                         base.exit_code,
@@ -690,12 +721,36 @@ fn run_case_differential(
                         level,
                         outcome.exit_code,
                         outcome.stdout
-                    ));
+                    )));
                 }
             }
         }
     }
     Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum KnownBugDisposition {
+    Ignore(String),
+    Fail(String),
+}
+
+fn known_bug_disposition(bug: &str, result: TestResult) -> KnownBugDisposition {
+    match classify_expected_failure(result) {
+        ExpectedFailureOutcome::ExpectedFailure(error) => {
+            let first_line = error.lines().next().unwrap_or("");
+            KnownBugDisposition::Ignore(format!(
+                "known bug {} (expected failure): {}",
+                bug, first_line
+            ))
+        }
+        ExpectedFailureOutcome::FatalFailure(error) => KnownBugDisposition::Fail(error.to_string()),
+        ExpectedFailureOutcome::UnexpectedPass => KnownBugDisposition::Fail(format!(
+            "test PASSED but is marked known_bug = \"{}\". If the bug is fixed, \
+             remove the known_bug marker so this becomes a regression test.",
+            bug
+        )),
+    }
 }
 
 /// Wrapper handling skip and known_bug (xfail) semantics.
@@ -746,21 +801,11 @@ fn run_case_wrapper(
     match (known_bug, result) {
         // Normal case.
         (None, Ok(())) => Ok(()),
-        (None, Err(e)) => Err(RunError::fail(e)),
-        // Expected failure: report as ignored with the bug reference.
-        (Some(bug), Err(e)) => {
-            let first_line = e.lines().next().unwrap_or("");
-            ctx.ignore_for(format!(
-                "known bug {} (expected failure): {}",
-                bug, first_line
-            ))
-        }
-        // Unexpected pass: the bug may be fixed — demand marker removal.
-        (Some(bug), Ok(())) => Err(RunError::fail(format!(
-            "test PASSED but is marked known_bug = \"{}\". If the bug is fixed, \
-             remove the known_bug marker so this becomes a regression test.",
-            bug
-        ))),
+        (None, Err(error)) => Err(RunError::fail(error.to_string())),
+        (Some(bug), result) => match known_bug_disposition(bug, result) {
+            KnownBugDisposition::Ignore(reason) => ctx.ignore_for(reason),
+            KnownBugDisposition::Fail(reason) => Err(RunError::fail(reason)),
+        },
     }
 }
 
@@ -891,10 +936,11 @@ fn run_example(
     rue_binary: &Path,
     real_std: &Path,
 ) -> TestResult {
-    let temp_dir = tempfile::tempdir().map_err(|e| format!("failed to create temp dir: {}", e))?;
+    let temp_dir = tempfile::tempdir()
+        .map_err(|e| TestFailure::fatal(format!("failed to create temp dir: {}", e)))?;
     let dir = temp_dir.path();
 
-    let mut cmd = Command::new(rue_binary);
+    let mut cmd = compiler_command(rue_binary);
     cmd.arg(path).args(["-o", "prog"]).current_dir(dir);
     cmd.env("RUE_STD_PATH", real_std);
     // Compile under the default timeout too (see run_case): an example that
@@ -907,17 +953,19 @@ fn run_example(
         return Err(ice);
     }
     if !compile_output.status.success() {
-        return Err(format!(
+        return Err(TestFailure::assertion(format!(
             "example failed to compile (exit: {:?}):\n--- compiler stdout ---\n{}\n--- compiler stderr ---\n{}",
             compile_output.status.code(),
             compile_stdout,
             compile_stderr
-        ));
+        )));
     }
 
     let program = dir.join("prog");
     if !program.exists() {
-        return Err("compiler reported success but produced no 'prog' binary".to_string());
+        return Err(TestFailure::assertion(
+            "compiler reported success but produced no 'prog' binary",
+        ));
     }
 
     let mut run_cmd = Command::new(&program);
@@ -935,25 +983,25 @@ fn run_example(
     let actual_exit = match run_output.status.code() {
         Some(code) => code,
         None => {
-            return Err(format!(
+            return Err(TestFailure::fatal(format!(
                 "example crashed (killed by signal, status {:?})\n--- program stdout ---\n{}\n--- program stderr ---\n{}",
                 run_output.status, run_stdout, run_stderr
-            ));
+            )));
         }
     };
 
     if let Some(exp) = expectation {
         if actual_exit != exp.exit_code {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "example exit code mismatch:\n  expected: {}\n  actual: {}\n--- program stdout ---\n{}\n--- program stderr ---\n{}",
                 exp.exit_code, actual_exit, run_stdout, run_stderr
-            ));
+            )));
         }
         if run_stdout != exp.stdout {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "example stdout mismatch:\n--- expected ---\n{}\n--- actual ---\n{}",
                 exp.stdout, run_stdout
-            ));
+            )));
         }
     }
 
@@ -1094,6 +1142,21 @@ fn main() {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn fake_compiler(script: &str) -> (tempfile::TempDir, PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("temporary fake compiler directory");
+        let binary = directory.path().join("rue");
+        std::fs::write(&binary, script).expect("write fake compiler");
+        let mut permissions = std::fs::metadata(&binary)
+            .expect("fake compiler metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&binary, permissions).expect("make fake compiler executable");
+        (directory, binary)
+    }
+
     #[test]
     fn differential_opt_requires_stdout_and_exit_code() {
         // Missing both -> rejected.
@@ -1196,5 +1259,77 @@ mod tests {
         };
 
         assert!(compile_fail_has_exit_code(&case));
+    }
+
+    #[test]
+    fn case_compiler_command_applies_explicit_environment_after_sanitizing() {
+        let real_std = Path::new("/repo/std");
+        let environment = HashMap::from([
+            ("RUE_STD_PATH".to_string(), "${REAL_STD}".to_string()),
+            ("RUST_LOG".to_string(), "trace".to_string()),
+        ]);
+        let command = case_compiler_command(
+            Path::new("rue"),
+            &["main.rue".to_string()],
+            Path::new("/case"),
+            &environment,
+            real_std,
+        );
+        let environments: HashMap<_, _> = command.get_envs().collect();
+
+        assert_eq!(
+            environments.get(std::ffi::OsStr::new("RUE_STD_PATH")),
+            Some(&Some(std::ffi::OsStr::new("/repo/std")))
+        );
+        assert_eq!(
+            environments.get(std::ffi::OsStr::new("RUST_LOG")),
+            Some(&Some(std::ffi::OsStr::new("trace")))
+        );
+        assert_eq!(command.get_args().collect::<Vec<_>>(), ["main.rue"]);
+        assert_eq!(command.get_current_dir(), Some(Path::new("/case")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn known_bug_cannot_absorb_fake_compiler_panic() {
+        let (_directory, binary) =
+            fake_compiler("#!/bin/sh\nprintf 'panicked at fake CLI compiler' >&2\nexit 101\n");
+        let case = Case {
+            name: "known_bug_panic".to_string(),
+            files: vec![SourceFile {
+                path: "main.rue".to_string(),
+                source: "fn main() -> i32 { 0 }".to_string(),
+            }],
+            known_bug: Some("RUE-PROBE".to_string()),
+            differential_opt: true,
+            stdout: Some(String::new()),
+            exit_code: Some(0),
+            ..Default::default()
+        };
+
+        let result = run_case_differential(&case, &binary, Path::new("std"), Path::new("."));
+        let error = result.expect_err("compiler panic must fail an xfail");
+        assert!(error.is_fatal());
+        assert!(error.contains("at -O0"));
+        assert!(matches!(
+            known_bug_disposition("RUE-PROBE", Err(error)),
+            KnownBugDisposition::Fail(message) if message.contains("INTERNAL COMPILER ERROR")
+        ));
+    }
+
+    #[test]
+    fn known_bug_disposition_ignores_only_ordinary_failures_and_rejects_xpass() {
+        assert!(matches!(
+            known_bug_disposition(
+                "RUE-PROBE",
+                Err(TestFailure::assertion("wrong output\nmore detail"))
+            ),
+            KnownBugDisposition::Ignore(message)
+                if message == "known bug RUE-PROBE (expected failure): wrong output"
+        ));
+        assert!(matches!(
+            known_bug_disposition("RUE-PROBE", Ok(())),
+            KnownBugDisposition::Fail(message) if message.contains("test PASSED")
+        ));
     }
 }

--- a/crates/rue-spec/README.md
+++ b/crates/rue-spec/README.md
@@ -65,7 +65,7 @@ air (return_type: i32) {
 # expected_mir, expected_lowering, expected_liveness, expected_regalloc,
 # expected_asm, and expected_stackframe.
 
-# Preview feature test (allowed to fail)
+# Preview feature test (expected to fail)
 [[case]]
 name = "some_preview_feature"
 spec = ["X.Y:Z"]
@@ -86,11 +86,11 @@ exit_code = 0
 #### Preview Feature Tests
 
 Tests for preview features use two fields:
-- `preview = "feature_name"` - Marks the test as requiring a preview feature. The test runs with `--preview feature_name` and is allowed to fail (shows as "ignored" in output).
+- `preview = "feature_name"` - Marks the test as requiring a preview feature. An ordinary assertion failure is expected and shows as "ignored". Fatal subprocess failures still fail the suite, and a passing assertion is an XPASS failure until its metadata is updated.
 - `preview_should_pass = true` - When combined with `preview`, makes the test required to pass. Use this for portions of preview features that are already implemented.
 
 **Workflow for preview features:**
-1. Initially, add tests with just `preview = "feature_name"` (allowed to fail)
+1. Initially, add failing tests with just `preview = "feature_name"` (xfail)
 2. As you implement parts of the feature, add `preview_should_pass = true` to tests that should now pass
 3. When stabilizing the feature, remove both `preview` and `preview_should_pass` fields
 

--- a/crates/rue-spec/cases/runtime/preview-features.toml
+++ b/crates/rue-spec/cases/runtime/preview-features.toml
@@ -27,6 +27,7 @@ error_contains = "requires preview feature"
 name = "test_preview_gate_with_feature"
 spec = ["8.4:1"]
 preview = "test_infra"
+preview_should_pass = true
 source = """
 fn main() -> i32 {
     @test_preview_gate();

--- a/crates/rue-spec/cases/types/str-fixed-type.toml
+++ b/crates/rue-spec/cases/types/str-fixed-type.toml
@@ -84,6 +84,7 @@ exit_code = 8
 name = "str_fixed_over_capacity_is_error"
 spec = ["3.7:51"]
 preview = "string_trio"
+preview_should_pass = true
 source = """
 fn main() -> i32 {
     let s: Str(3) = "hello";

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -36,8 +36,8 @@
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
 use rue_test_runner::{
-    Case, find_dir, find_rue_binary, load_test_files, run_test_case, should_skip_for_platform,
-    validate_nonempty_case_corpus,
+    Case, ExpectedFailureOutcome, TestResult, classify_expected_failure, find_dir, find_rue_binary,
+    load_test_files, run_test_case, should_skip_for_platform, validate_nonempty_case_corpus,
 };
 use std::path::Path;
 
@@ -101,7 +101,27 @@ fn run_case_wrapper(
     run_test_case(case, rue_binary).map_err(|e| RunError::fail(e.to_string()))
 }
 
-/// Wrapper for preview tests - reports failures but marks them as ignored to avoid failing the build.
+#[derive(Debug, PartialEq, Eq)]
+enum PreviewDisposition {
+    Ignore(String),
+    Fail(String),
+}
+
+fn preview_disposition(result: TestResult) -> PreviewDisposition {
+    match classify_expected_failure(result) {
+        ExpectedFailureOutcome::ExpectedFailure(error) => {
+            PreviewDisposition::Ignore(format!("preview test failed (allowed): {}", error))
+        }
+        ExpectedFailureOutcome::FatalFailure(error) => PreviewDisposition::Fail(error.to_string()),
+        ExpectedFailureOutcome::UnexpectedPass => PreviewDisposition::Fail(
+            "preview test PASSED without preview_should_pass = true. Add that marker so this \
+             assertion becomes required coverage."
+                .to_string(),
+        ),
+    }
+}
+
+/// Wrapper giving preview cases xfail semantics without hiding fatal failures.
 fn run_preview_case_wrapper(
     case: &Case,
     rue_binary: &Path,
@@ -114,12 +134,9 @@ fn run_preview_case_wrapper(
     if let Some(reason) = should_skip_for_platform(&case.only_on) {
         return ctx.ignore_for(reason);
     }
-    match run_test_case(case, rue_binary) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            // Report the failure but mark as ignored so it doesn't fail the suite
-            ctx.ignore_for(format!("preview test failed (allowed): {}", e))
-        }
+    match preview_disposition(run_test_case(case, rue_binary)) {
+        PreviewDisposition::Ignore(reason) => ctx.ignore_for(reason),
+        PreviewDisposition::Fail(reason) => Err(RunError::fail(reason)),
     }
 }
 
@@ -174,10 +191,11 @@ fn main() {
             let rue_binary = rue_binary.clone();
 
             // Preview tests that should pass use the normal wrapper (fail on error).
-            // Preview tests without preview_should_pass use the lenient wrapper (allow failure).
+            // Other preview tests use xfail semantics: an ordinary failure is
+            // ignored, while a fatal failure or unexpected pass fails.
             // Non-preview tests always use the normal wrapper.
             let trial = if is_preview && !preview_should_pass {
-                // Preview tests that are allowed to fail
+                // Preview tests expected to fail until their marker is updated.
                 Trial::test(test_name, move |ctx| {
                     run_preview_case_wrapper(&case, &rue_binary, skip, ctx)
                 })
@@ -194,10 +212,66 @@ fn main() {
 
     // Run all tests
     //
-    // Preview tests without `preview_should_pass` are allowed to fail -
-    // failures are marked as "ignored" so they don't break the build.
+    // Preview tests without `preview_should_pass` are expected to fail -
+    // ordinary failures are ignored, but fatal failures and XPASS fail.
     //
     // Preview tests with `preview_should_pass = true` fail normally,
     // providing real test output for implemented portions of preview features.
     Harness::with_env().discover(tests).main();
+}
+
+#[cfg(test)]
+mod runner_tests {
+    use super::*;
+    use rue_test_runner::TestFailure;
+
+    #[test]
+    fn preview_disposition_rejects_xpass_and_fatal_failure() {
+        let xpass = preview_disposition(Ok(()));
+        assert!(matches!(
+            xpass,
+            PreviewDisposition::Fail(message) if message.contains("preview_should_pass")
+        ));
+
+        let ordinary = preview_disposition(Err(TestFailure::assertion("not implemented")));
+        assert!(matches!(ordinary, PreviewDisposition::Ignore(_)));
+
+        let fatal = preview_disposition(Err(TestFailure::fatal("compiler timed out")));
+        assert_eq!(
+            fatal,
+            PreviewDisposition::Fail("compiler timed out".to_string())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preview_disposition_rejects_fake_compiler_panic() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("temporary fake compiler directory");
+        let binary = directory.path().join("rue");
+        std::fs::write(
+            &binary,
+            "#!/bin/sh\nprintf 'panicked at fake preview compiler' >&2\nexit 101\n",
+        )
+        .expect("write fake compiler");
+        let mut permissions = std::fs::metadata(&binary)
+            .expect("fake compiler metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&binary, permissions).expect("make fake compiler executable");
+
+        let case = Case {
+            name: "preview_panic".to_string(),
+            source: "fn main() -> i32 { 0 }".to_string(),
+            preview: Some("test_infra".to_string()),
+            ..Default::default()
+        };
+        let disposition = preview_disposition(run_test_case(&case, &binary));
+
+        assert!(matches!(
+            disposition,
+            PreviewDisposition::Fail(message) if message.contains("INTERNAL COMPILER ERROR")
+        ));
+    }
 }

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -127,7 +127,7 @@ impl<'de> Deserialize<'de> for ErrorContains {
 /// skipped when a golden assertion was present; see RUE-132.)
 /// `compile_fail` cannot be combined with golden-IR assertions, since a
 /// program that fails to compile has no IR to dump.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Case {
     pub name: String,
@@ -322,8 +322,77 @@ pub struct TestFile {
     pub case: Vec<Case>,
 }
 
-/// Result of running a test.
-pub type TestResult = Result<(), String>;
+/// A test failure with a class that expected-failure wrappers cannot erase.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestFailure {
+    message: String,
+    fatal: bool,
+}
+
+impl TestFailure {
+    /// A normal expectation mismatch that an explicit xfail may absorb.
+    pub fn assertion(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            fatal: false,
+        }
+    }
+
+    /// An infrastructure failure, timeout, signal, panic, or compiler ICE.
+    pub fn fatal(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            fatal: true,
+        }
+    }
+
+    /// Whether this failure must fail even an expected-failure test.
+    pub fn is_fatal(&self) -> bool {
+        self.fatal
+    }
+
+    /// Add context without losing the failure class.
+    pub fn with_context(mut self, context: impl std::fmt::Display) -> Self {
+        self.message = format!("{context}: {}", self.message);
+        self
+    }
+}
+
+impl std::fmt::Display for TestFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for TestFailure {}
+
+impl std::ops::Deref for TestFailure {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.message
+    }
+}
+
+/// Result of running a test or one of its subprocesses.
+pub type TestResult<T = ()> = Result<T, TestFailure>;
+
+/// The three possible outcomes of running a case marked as expected to fail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExpectedFailureOutcome {
+    UnexpectedPass,
+    ExpectedFailure(TestFailure),
+    FatalFailure(TestFailure),
+}
+
+/// Classify an expected-failure result without allowing fatal errors to hide.
+pub fn classify_expected_failure(result: TestResult) -> ExpectedFailureOutcome {
+    match result {
+        Ok(()) => ExpectedFailureOutcome::UnexpectedPass,
+        Err(error) if error.is_fatal() => ExpectedFailureOutcome::FatalFailure(error),
+        Err(error) => ExpectedFailureOutcome::ExpectedFailure(error),
+    }
+}
 
 /// Get the current host target triple in Rue's format.
 ///
@@ -1568,10 +1637,10 @@ pub fn check_golden(actual: &str, expected: &str, label: &str) -> TestResult {
     let expected_normalized = normalize_golden(expected);
 
     if actual_normalized != expected_normalized {
-        return Err(format!(
+        return Err(TestFailure::assertion(format!(
             "{} mismatch:\n--- expected ---\n{}\n--- actual ---\n{}\n",
             label, expected_normalized, actual_normalized
-        ));
+        )));
     }
     Ok(())
 }
@@ -1615,14 +1684,18 @@ fn run_golden_ir_test(
     let mut cmd = build_command(rue_binary);
     cmd.arg("--emit").arg(stage).arg(source_path);
     let output = run_with_timeout(cmd, timeout, None)
-        .map_err(|e| format!("Failed to run rue --emit {}: {}", stage, e))?;
+        .map_err(|error| error.with_context(format!("Failed to run rue --emit {stage}")))?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if let Some(error) = ice_message(&output.status, &stderr) {
+        return Err(error.with_context(format!("rue --emit {stage}")));
+    }
 
     if !output.status.success() {
-        return Err(format!(
+        return Err(TestFailure::assertion(format!(
             "rue --emit {} failed:\n{}",
-            stage,
-            String::from_utf8_lossy(&output.stderr)
-        ));
+            stage, stderr
+        )));
     }
 
     let actual = String::from_utf8_lossy(&output.stdout);
@@ -1699,6 +1772,18 @@ fn collect_drained_bytes(rx: mpsc::Receiver<DrainMessage>, timeout: Duration) ->
 /// in a test program is reported and skipped past, never hanging the suite.
 pub const TIMEOUT_PREFIX: &str = "TIMEOUT:";
 
+/// Build a compiler command without ambient settings that can change a case.
+///
+/// Harness-specific, explicit environment entries may be applied after this
+/// function returns. Removing these variables first keeps the default case
+/// environment deterministic while preserving intentional overrides.
+pub fn compiler_command(binary: &Path) -> Command {
+    let mut command = Command::new(binary);
+    command.env_remove("RUE_STD_PATH");
+    command.env_remove("RUST_LOG");
+    command
+}
+
 /// Put the spawned child in its own process group so a timeout can kill the
 /// whole group, not just the direct child. A compiled test program spawning
 /// nothing is the common case, but killing the group is the safe default: any
@@ -1758,14 +1843,14 @@ fn kill_process_group(child: &mut std::process::Child) {
 ///
 /// # Returns
 /// * `Ok(Output)` - The process output (stdout, stderr, exit status)
-/// * `Err(String)` - Error message if the process timed out or failed to start.
+/// * `Err(TestFailure)` - Fatal failure if the process timed out or could not run.
 ///   A timeout error is prefixed with [`TIMEOUT_PREFIX`] so callers can report
 ///   it as a distinct failure class.
 pub fn run_with_timeout(
     mut cmd: Command,
     timeout: Duration,
     stdin_input: Option<&str>,
-) -> Result<Output, String> {
+) -> TestResult<Output> {
     configure_process_group(&mut cmd);
     let mut child = cmd
         .stdin(if stdin_input.is_some() {
@@ -1776,7 +1861,7 @@ pub fn run_with_timeout(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| format!("Failed to spawn process: {}", e))?;
+        .map_err(|e| TestFailure::fatal(format!("Failed to spawn process: {}", e)))?;
 
     // Drain stdout and stderr on their own threads, started right after spawn so
     // neither pipe can fill and wedge the child (see the RUE-338 note above).
@@ -1823,17 +1908,20 @@ pub fn run_with_timeout(
                     let _stdout = collect_drained_bytes(stdout_rx, PIPE_DRAIN_FINISH_TIMEOUT);
                     let _stderr = collect_drained_bytes(stderr_rx, PIPE_DRAIN_FINISH_TIMEOUT);
                     drop(stdin_writer);
-                    return Err(format!(
+                    return Err(TestFailure::fatal(format!(
                         "{} test execution timed out after {} ms (process group killed)",
                         TIMEOUT_PREFIX,
                         timeout.as_millis()
-                    ));
+                    )));
                 }
                 // Sleep briefly before polling again
                 std::thread::sleep(Duration::from_millis(10));
             }
             Err(e) => {
-                return Err(format!("Failed to wait for process: {}", e));
+                return Err(TestFailure::fatal(format!(
+                    "Failed to wait for process: {}",
+                    e
+                )));
             }
         }
     }
@@ -1851,62 +1939,67 @@ pub fn run_with_timeout(
 /// This is the SINGLE shared implementation — rue-cli-tests imports it
 /// rather than keeping its own copy, so a new panic marker or abort
 /// signature added here covers every harness at once.
-pub fn ice_message(status: &std::process::ExitStatus, stderr: &str) -> Option<String> {
+pub fn ice_message(status: &std::process::ExitStatus, stderr: &str) -> Option<TestFailure> {
     if stderr.contains("panicked at") || stderr.contains("internal compiler error") {
-        return Some(format!(
+        return Some(TestFailure::fatal(format!(
             "INTERNAL COMPILER ERROR: compiler panicked\n--- compiler stderr ---\n{}",
             stderr
-        ));
+        )));
     }
     if status.code().is_none() {
-        return Some(format!(
+        return Some(TestFailure::fatal(format!(
             "INTERNAL COMPILER ERROR: compiler killed by signal ({:?})\n--- compiler stderr ---\n{}",
             status, stderr
-        ));
+        )));
     }
     None
+}
+
+fn test_case_compiler_command(case: &Case, binary: &Path) -> Command {
+    let mut command = compiler_command(binary);
+    if let Some(ref target) = case.target {
+        command.arg("--target").arg(target);
+    }
+    if let Some(ref feature) = case.preview {
+        command.arg("--preview").arg(feature);
+    }
+    if let Some(level) = case.opt_level {
+        command.arg(format!("-O{}", level));
+    }
+    command
 }
 
 /// Run a single test case.
 pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     // Create a temporary directory for this test
-    let temp_dir = tempfile::tempdir().map_err(|e| format!("Failed to create temp dir: {}", e))?;
+    let temp_dir = tempfile::tempdir()
+        .map_err(|e| TestFailure::fatal(format!("Failed to create temp dir: {}", e)))?;
     let source_path = temp_dir.path().join("test.rue");
     let output_path = temp_dir.path().join("test");
 
     // Write source to file
     let mut source_file = fs::File::create(&source_path)
-        .map_err(|e| format!("Failed to create source file: {}", e))?;
+        .map_err(|e| TestFailure::fatal(format!("Failed to create source file: {}", e)))?;
     source_file
         .write_all(case.source.as_bytes())
-        .map_err(|e| format!("Failed to write source: {}", e))?;
+        .map_err(|e| TestFailure::fatal(format!("Failed to write source: {}", e)))?;
 
     // Write auxiliary files for multi-file tests (module imports)
     for (filename, content) in &case.aux_files {
         // Create subdirectories if needed (e.g., "foo/bar.rue")
         let aux_path = temp_dir.path().join(filename);
         if let Some(parent) = aux_path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("Failed to create dir for {}: {}", filename, e))?;
+            fs::create_dir_all(parent).map_err(|e| {
+                TestFailure::fatal(format!("Failed to create dir for {}: {}", filename, e))
+            })?;
         }
-        fs::write(&aux_path, content)
-            .map_err(|e| format!("Failed to write aux file {}: {}", filename, e))?;
+        fs::write(&aux_path, content).map_err(|e| {
+            TestFailure::fatal(format!("Failed to write aux file {}: {}", filename, e))
+        })?;
     }
 
     // Build base command with target, preview, and optimization flags if needed
-    let build_command = |binary: &Path| -> Command {
-        let mut cmd = Command::new(binary);
-        if let Some(ref target) = case.target {
-            cmd.arg("--target").arg(target);
-        }
-        if let Some(ref feature) = case.preview {
-            cmd.arg("--preview").arg(feature);
-        }
-        if let Some(level) = case.opt_level {
-            cmd.arg(format!("-O{}", level));
-        }
-        cmd
-    };
+    let build_command = |binary: &Path| test_case_compiler_command(case, binary);
 
     // Timeout applied to every compiler invocation in this case (golden-IR
     // emits and the compile step), so a compiler hang fails the case instead of
@@ -1919,9 +2012,10 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         // combination can never be satisfied — reject it loudly rather than
         // letting one half of the case go unchecked.
         if case.compile_fail {
-            return Err("golden IR assertions cannot be combined with compile_fail \
-                 (use expected_error / error_contains for diagnostics instead)"
-                .to_string());
+            return Err(TestFailure::assertion(
+                "golden IR assertions cannot be combined with compile_fail \
+                 (use expected_error / error_contains for diagnostics instead)",
+            ));
         }
 
         // Run dump commands and check golden output
@@ -1981,9 +2075,10 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
 
         if case.has_target_specific_golden_ir_assertions() && case.target.is_none() {
-            return Err("target-specific golden IR tests require a 'target' field \
-                 (e.g., target = \"x86-64-linux\")"
-                .to_string());
+            return Err(TestFailure::assertion(
+                "target-specific golden IR tests require a 'target' field \
+                 (e.g., target = \"x86-64-linux\")",
+            ));
         }
 
         if let Some(ref expected) = case.expected_mir {
@@ -2071,7 +2166,7 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     // compiled program, so a compiler hang fails the case instead of wedging
     // the whole suite.
     let compile_output = run_with_timeout(compile_cmd, compile_timeout, None)
-        .map_err(|e| format!("Failed to run rue compiler: {}", e))?;
+        .map_err(|error| error.with_context("Failed to run rue compiler"))?;
 
     let compile_succeeded = compile_output.status.success();
     let stderr = String::from_utf8_lossy(&compile_output.stderr);
@@ -2080,16 +2175,16 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     // panic would otherwise be indistinguishable from the expected diagnostic
     // failure. Report it as a distinct ICE failure class instead.
     if let Some(ice) = ice_message(&compile_output.status, &stderr) {
-        return Err(format!("{}\n  source: {}", ice, case.source));
+        return Err(ice.with_context(format!("source: {}", case.source)));
     }
 
     if case.compile_fail {
         // Expected to fail compilation
         if compile_succeeded {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "Expected compilation to fail, but it succeeded\n  source: {}",
                 case.source
-            ));
+            )));
         }
 
         // Check exact error message (golden test)
@@ -2097,20 +2192,20 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
             let actual_normalized = normalize_error_output(&stderr, &source_path);
             let expected_normalized = normalize_golden(expected);
             if actual_normalized != expected_normalized {
-                return Err(format!(
+                return Err(TestFailure::assertion(format!(
                     "Error mismatch:\n--- expected ---\n{}\n--- actual ---\n{}\n",
                     expected_normalized, actual_normalized
-                ));
+                )));
             }
         }
 
         // Check error message contains all expected substrings
         for expected_error in case.error_contains.iter() {
             if !stderr.contains(expected_error) {
-                return Err(format!(
+                return Err(TestFailure::assertion(format!(
                     "Error message mismatch:\n  expected to contain: {}\n  actual stderr: {}\n  source: {}",
                     expected_error, stderr, case.source
-                ));
+                )));
             }
         }
 
@@ -2119,11 +2214,11 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
 
     // Expected to succeed
     if !compile_succeeded {
-        return Err(format!(
+        return Err(TestFailure::assertion(format!(
             "Compilation failed:\nstdout: {}\nstderr: {}",
             String::from_utf8_lossy(&compile_output.stdout),
             stderr
-        ));
+        )));
     }
 
     // Check warning-related assertions
@@ -2132,10 +2227,10 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     // Check if no warnings expected
     if case.no_warnings {
         if compile_stderr.contains("warning:") {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "Expected no warnings but got:\n{}\n  source: {}",
                 compile_stderr, case.source
-            ));
+            )));
         }
     }
 
@@ -2143,10 +2238,10 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     if let Some(expected_count) = case.expected_warning_count {
         let actual_count = compile_stderr.matches("warning:").count();
         if actual_count != expected_count {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "Warning count mismatch:\n  expected: {}\n  actual: {}\n  stderr: {}\n  source: {}",
                 expected_count, actual_count, compile_stderr, case.source
-            ));
+            )));
         }
     }
 
@@ -2154,10 +2249,10 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     if let Some(ref expected_warnings) = case.warning_contains {
         for expected in expected_warnings {
             if !compile_stderr.contains(expected) {
-                return Err(format!(
+                return Err(TestFailure::assertion(format!(
                     "Warning message mismatch:\n  expected to contain: {}\n  actual stderr: {}\n  source: {}",
                     expected, compile_stderr, case.source
-                ));
+                )));
             }
         }
     }
@@ -2171,7 +2266,15 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     let timeout = Duration::from_millis(case.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
     let run_output = run_with_timeout(Command::new(&output_path), timeout, case.stdin.as_deref())?;
 
-    let actual_exit_code = run_output.status.code().unwrap_or(-1);
+    if run_output.status.code().is_none() {
+        return Err(TestFailure::fatal(format!(
+            "TEST PROGRAM CRASH: process killed by signal ({:?})\n--- program stderr ---\n{}",
+            run_output.status,
+            String::from_utf8_lossy(&run_output.stderr)
+        )));
+    }
+
+    let actual_exit_code = run_output.status.code().expect("signal handled above");
     let stderr = String::from_utf8_lossy(&run_output.stderr);
 
     // Handle runtime error tests
@@ -2180,18 +2283,18 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
 
         // Check exit code
         if actual_exit_code != expected_exit {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "Runtime error exit code mismatch:\n  expected: {}\n  actual: {}\n  source: {}",
                 expected_exit, actual_exit_code, case.source
-            ));
+            )));
         }
 
         // Check that stderr contains the expected error message
         if !stderr.contains(expected_error.as_str()) {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "Runtime error message mismatch:\n  expected to contain: {}\n  actual stderr: {}\n  source: {}",
                 expected_error, stderr, case.source
-            ));
+            )));
         }
 
         return Ok(());
@@ -2211,34 +2314,35 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         let expected_cmp = strip_block_boundary_newlines(expected);
         let actual_cmp = strip_block_boundary_newlines(&stdout);
         if actual_cmp != expected_cmp {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "Stdout mismatch:\n--- expected ---\n{:?}\n--- actual ---\n{:?}\n  source: {}",
                 expected_cmp, actual_cmp, case.source
-            ));
+            )));
         }
     }
 
     // Check stderr contains expected substring (for non-error cases)
     if let Some(ref expected) = case.stderr_contains {
         if !stderr.contains(expected.as_str()) {
-            return Err(format!(
+            return Err(TestFailure::assertion(format!(
                 "Stderr mismatch:\n  expected to contain: {}\n  actual stderr: {}\n  source: {}",
                 expected, stderr, case.source
-            ));
+            )));
         }
     }
 
     // Normal exit code test
     let expected_exit_code = case.exit_code.ok_or_else(|| {
-        "Test case should have exit_code when compile_fail is false and runtime_error is not set"
-            .to_string()
+        TestFailure::assertion(
+            "Test case should have exit_code when compile_fail is false and runtime_error is not set",
+        )
     })?;
 
     if actual_exit_code != expected_exit_code {
-        return Err(format!(
+        return Err(TestFailure::assertion(format!(
             "Exit code mismatch:\n  expected: {}\n  actual: {}\n  source: {}",
             expected_exit_code, actual_exit_code, case.source
-        ));
+        )));
     }
 
     Ok(())
@@ -2295,6 +2399,21 @@ pub fn find_rue_binary() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    fn fake_compiler(script: &str) -> (tempfile::TempDir, PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("temporary fake compiler directory");
+        let binary = directory.path().join("rue");
+        fs::write(&binary, script).expect("write fake compiler");
+        let mut permissions = fs::metadata(&binary)
+            .expect("fake compiler metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&binary, permissions).expect("make fake compiler executable");
+        (directory, binary)
+    }
 
     fn case_with_param_override(override_entry: &str) -> Case {
         let toml = format!(
@@ -3006,6 +3125,148 @@ params = [
         assert!(check_golden(actual, expected, "Test").is_ok());
     }
 
+    #[test]
+    fn test_expected_failure_classification_preserves_fatal_errors_and_xpass() {
+        assert_eq!(
+            classify_expected_failure(Ok(())),
+            ExpectedFailureOutcome::UnexpectedPass
+        );
+
+        let assertion = TestFailure::assertion("wrong output");
+        assert_eq!(
+            classify_expected_failure(Err(assertion.clone())),
+            ExpectedFailureOutcome::ExpectedFailure(assertion)
+        );
+
+        let fatal = TestFailure::fatal("compiler timed out").with_context("at -O2");
+        assert!(fatal.is_fatal());
+        assert_eq!(
+            classify_expected_failure(Err(fatal.clone())),
+            ExpectedFailureOutcome::FatalFailure(fatal)
+        );
+    }
+
+    #[test]
+    fn test_case_compiler_command_removes_ambient_configuration() {
+        let case = Case {
+            target: Some("x86-64-linux".to_string()),
+            preview: Some("test_infra".to_string()),
+            opt_level: Some(2),
+            ..Default::default()
+        };
+        let command = test_case_compiler_command(&case, Path::new("rue"));
+        let environments: HashMap<_, _> = command.get_envs().collect();
+
+        assert_eq!(
+            environments.get(std::ffi::OsStr::new("RUE_STD_PATH")),
+            Some(&None)
+        );
+        assert_eq!(
+            environments.get(std::ffi::OsStr::new("RUST_LOG")),
+            Some(&None)
+        );
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["--target", "x86-64-linux", "--preview", "test_infra", "-O2"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_fake_compiler_panic_is_fatal() {
+        let (_directory, binary) =
+            fake_compiler("#!/bin/sh\nprintf 'panicked at fake compiler' >&2\nexit 101\n");
+        let case = Case {
+            name: "compiler_panic".to_string(),
+            source: "fn main() -> i32 { 0 }".to_string(),
+            ..Default::default()
+        };
+
+        let error = run_test_case(&case, &binary).expect_err("compiler panic must fail");
+        assert!(error.is_fatal());
+        assert!(error.contains("INTERNAL COMPILER ERROR"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_fake_compiler_signal_is_fatal() {
+        let (_directory, binary) = fake_compiler("#!/bin/sh\nkill -ABRT $$\n");
+        let case = Case {
+            name: "compiler_signal".to_string(),
+            source: "fn main() -> i32 { 0 }".to_string(),
+            ..Default::default()
+        };
+
+        let error = run_test_case(&case, &binary).expect_err("compiler signal must fail");
+        assert!(error.is_fatal());
+        assert!(error.contains("compiler killed by signal"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_fake_golden_compiler_panic_is_fatal() {
+        let (_directory, binary) =
+            fake_compiler("#!/bin/sh\nprintf 'panicked at fake emit' >&2\nexit 101\n");
+        let case = Case {
+            name: "golden_compiler_panic".to_string(),
+            source: "fn main() -> i32 { 0 }".to_string(),
+            expected_tokens: Some("token".to_string()),
+            ..Default::default()
+        };
+
+        let error = run_test_case(&case, &binary).expect_err("emit panic must fail");
+        assert!(error.is_fatal());
+        assert!(error.contains("rue --emit tokens"));
+        assert!(error.contains("INTERNAL COMPILER ERROR"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_fake_compiler_timeout_is_fatal() {
+        let (_directory, binary) = fake_compiler("#!/bin/sh\nsleep 5\n");
+        let case = Case {
+            name: "compiler_timeout".to_string(),
+            source: "fn main() -> i32 { 0 }".to_string(),
+            timeout_ms: Some(20),
+            ..Default::default()
+        };
+
+        let error = run_test_case(&case, &binary).expect_err("compiler timeout must fail");
+        assert!(error.is_fatal());
+        assert!(error.contains(TIMEOUT_PREFIX));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_generated_program_signal_is_fatal() {
+        let (_directory, binary) = fake_compiler(
+            r#"#!/bin/sh
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        output="$2"
+        break
+    fi
+    shift
+done
+cat > "$output" <<'EOF'
+#!/bin/sh
+kill -ABRT $$
+EOF
+chmod +x "$output"
+"#,
+        );
+        let case = Case {
+            name: "program_signal".to_string(),
+            source: "fn main() -> i32 { 0 }".to_string(),
+            exit_code: Some(0),
+            ..Default::default()
+        };
+
+        let error = run_test_case(&case, &binary).expect_err("program signal must fail");
+        assert!(error.is_fatal());
+        assert!(error.contains("TEST PROGRAM CRASH"));
+    }
+
     // Tests for run_with_timeout
     #[test]
     fn test_run_with_timeout_completes_normally() {
@@ -3037,6 +3298,7 @@ params = [
 
         assert!(result.is_err());
         let err = result.unwrap_err();
+        assert!(err.is_fatal());
         assert!(
             err.contains("timed out"),
             "Error should mention timeout: {}",

--- a/docs/designs/0005-preview-features.md
+++ b/docs/designs/0005-preview-features.md
@@ -153,8 +153,9 @@ exit_code = 42
 
 The test runner:
 1. **Always runs preview tests** (compiling with the appropriate `--preview` flag)
-2. **Allows preview tests to fail** without failing the overall suite
-3. **Reports progress** on each preview feature
+2. **Treats ordinary assertion failures as expected** until marked `preview_should_pass`
+3. **Fails on fatal subprocess errors and unexpected passes** so infrastructure failures and stale xfail metadata cannot hide
+4. **Reports progress** on each preview feature
 
 ### Stabilization
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,7 +104,8 @@ See [architecture.md](architecture.md) for the compiler pipeline.
   multiple files, linking, runtime I/O, or internal-compiler-error regressions.
 
 Known compiler defects use `known_bug = "RUE-NN"` in CLI cases. The harness
-treats an unexpected pass as a failure so obsolete markers cannot linger.
+treats an unexpected pass or fatal subprocess failure as a failure so obsolete
+markers and infrastructure failures cannot linger.
 Preview-language cases must enable their feature explicitly and do not count as
 stable normative coverage.
 

--- a/docs/process/implementation.md
+++ b/docs/process/implementation.md
@@ -98,7 +98,9 @@ if using_preview_syntax {
 }
 ```
 
-Preview tests run but are allowed to fail until the feature is complete.
+Preview tests use xfail semantics until the feature is complete: ordinary
+assertion failures are ignored, while fatal subprocess failures and unexpected
+passes fail the suite. Add `preview_should_pass = true` as each assertion works.
 
 ## Step 4: Verify
 


### PR DESCRIPTION
## Summary
- classify harness failures so expected-failure markers cannot hide compiler ICEs, signals, or timeouts
- make preview and `known_bug` cases fail on unexpected passes
- remove ambient `RUE_STD_PATH` and `RUST_LOG` from per-case compiler commands while preserving explicit case overrides
- cover real command-construction and wrapper paths with fake-compiler panic, signal, timeout, golden, and runtime-crash tests

## Verification
- `./fmt.sh check`
- `./clippy.sh` (41 first-party Rust targets)
- `./test.sh` (30 targets)
- focused harness tests: 83 rue-test-runner, 10 rue-cli-tests, 12 rue-spec
- poisoned-environment spec and explicit CLI override reproductions

Tracks RUE-546 and RUE-547.
