### PR TITLE
RUE-566: zero-sized-element ArrayBuf works — ZST pointer ops and enum payload extraction handle 0 slots

### DIFF
--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -598,3 +598,35 @@ pub fn ArrayBuf(comptime T: type) -> type {
 ]
 stdout = ""
 exit_code = 30
+
+[[case]]
+# RUE-566: a zero-sized Copy element type is valid for ArrayBuf. The buffer is
+# never allocated (element size 0), so @ptr_write/@ptr_read must be zero-byte
+# no-ops (they dereferenced the null buffer: first a codegen abort, then a
+# runtime segfault) and a zero-slot Option payload extraction must not touch
+# the 1-slot discriminant-only enum's nonexistent payload slots (codegen
+# panic). Exercises push/pop/len/clear + Option(Z) match; score pins each leg.
+name = "arraybuf_zero_sized_element"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+struct Z {}
+
+fn main() -> i32 {
+    let V = std.arraybuf.ArrayBuf(Z);
+    let mut v = V.new();
+    v.push(Z {});
+    v.push(Z {});
+    v.push(Z {});
+    let O = std.option.Option(Z);
+    let popped = v.pop();
+    let mut score = 0;
+    match popped { O.Some(z) => { score = score + 1; }, O.None => {} }
+    if v.len() == 2 { score = score + 10; }
+    if v.is_empty() { score = score + 100; }
+    v.clear();
+    if v.is_empty() { score = score + 1000; }
+    score
+}
+""" }]
+exit_code = 243

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2174,7 +2174,16 @@ impl<'a> CfgLower<'a> {
                     // every field but the first (RUE-242).
                     let result_ty = self.ctx.cfg.get_inst(value).ty;
                     let slot_count = self.ctx.type_slot_count(result_ty);
-                    if slot_count > 1 {
+                    if slot_count == 0 {
+                        // Zero-sized pointee (`ptr const Z` where `Z {}` has no
+                        // fields): the read is a no-op carrying no bits — do
+                        // NOT dereference. ArrayBuf never allocates for a
+                        // zero-sized element type, so its buffer stays null
+                        // and a 1-slot load here segfaulted (RUE-566). The
+                        // value maps to a fresh (never-read) vreg, like unit.
+                        let result_vreg = self.mir.alloc_vreg();
+                        self.value_map.insert(value, result_vreg);
+                    } else if slot_count > 1 {
                         let slot_vregs =
                             crate::agg_slots::load_slots_through_ptr(self, ptr_vreg, slot_count);
                         let first = slot_vregs[0];
@@ -2202,7 +2211,13 @@ impl<'a> CfgLower<'a> {
                     // every field but the first (RUE-242).
                     let value_ty = self.ctx.cfg.get_inst(value_val).ty;
                     let slot_count = self.ctx.type_slot_count(value_ty);
-                    if slot_count > 1 {
+                    if slot_count == 0 {
+                        // Zero-sized value: a zero-byte store — emit nothing
+                        // and do NOT dereference the pointer (which is null
+                        // for a never-allocated zero-sized-element ArrayBuf,
+                        // RUE-566). Logical effects (`len` bookkeeping) live
+                        // in the caller.
+                    } else if slot_count > 1 {
                         let slot_vregs = self
                             .get_or_compute_field_vregs(value_val)
                             .unwrap_or_else(|| vec![self.get_vreg(value_val)]);
@@ -2744,23 +2759,33 @@ impl<'a> CfgLower<'a> {
                     variant_index,
                     field_index,
                 ) as usize;
-                let base_slots = self
-                    .get_or_compute_field_vregs(base)
-                    .expect("enum payload base must have slot vregs");
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-                if field_slots > 1 {
-                    let slots: Vec<VReg> = base_slots[offset..offset + field_slots].to_vec();
-                    self.struct_slot_vregs.insert(value, slots.clone());
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(slots[0]),
-                    });
+                // A zero-sized payload field (`Option(Z)` where `Z {}` has no
+                // fields) carries no bits and its enclosing enum may be a
+                // 1-slot discriminant-only value with NO tracked aggregate
+                // slots — reading a payload slot here panicked (RUE-566).
+                // Map to a fresh never-read vreg, like unit.
+                if field_slots == 0 {
+                    let vreg = self.mir.alloc_vreg();
+                    self.value_map.insert(value, vreg);
                 } else {
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(base_slots[offset]),
-                    });
+                    let base_slots = self
+                        .get_or_compute_field_vregs(base)
+                        .expect("enum payload base must have slot vregs");
+                    let vreg = self.mir.alloc_vreg();
+                    self.value_map.insert(value, vreg);
+                    if field_slots > 1 {
+                        let slots: Vec<VReg> = base_slots[offset..offset + field_slots].to_vec();
+                        self.struct_slot_vregs.insert(value, slots.clone());
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(slots[0]),
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(base_slots[offset]),
+                        });
+                    }
                 }
             }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2514,7 +2514,16 @@ impl<'a> CfgLower<'a> {
                     // every field but the first (RUE-242).
                     let result_ty = self.ctx.cfg.get_inst(value).ty;
                     let slot_count = self.ctx.type_slot_count(result_ty);
-                    if slot_count > 1 {
+                    if slot_count == 0 {
+                        // Zero-sized pointee (`ptr const Z` where `Z {}` has no
+                        // fields): the read is a no-op carrying no bits — do
+                        // NOT dereference. ArrayBuf never allocates for a
+                        // zero-sized element type, so its buffer stays null
+                        // and a 1-slot load here segfaulted (RUE-566). The
+                        // value maps to a fresh (never-read) vreg, like unit.
+                        let result_vreg = self.mir.alloc_vreg();
+                        self.value_map.insert(value, result_vreg);
+                    } else if slot_count > 1 {
                         let slot_vregs =
                             crate::agg_slots::load_slots_through_ptr(self, ptr_vreg, slot_count);
                         let first = slot_vregs[0];
@@ -2543,7 +2552,13 @@ impl<'a> CfgLower<'a> {
                     // every field but the first (RUE-242).
                     let value_ty = self.ctx.cfg.get_inst(value_val).ty;
                     let slot_count = self.ctx.type_slot_count(value_ty);
-                    if slot_count > 1 {
+                    if slot_count == 0 {
+                        // Zero-sized value: a zero-byte store — emit nothing
+                        // and do NOT dereference the pointer (which is null
+                        // for a never-allocated zero-sized-element ArrayBuf,
+                        // RUE-566). Logical effects (`len` bookkeeping) live
+                        // in the caller.
+                    } else if slot_count > 1 {
                         let slot_vregs = self
                             .get_or_compute_field_vregs(value_val)
                             .unwrap_or_else(|| vec![self.get_vreg(value_val)]);
@@ -3149,24 +3164,34 @@ impl<'a> CfgLower<'a> {
                     variant_index,
                     field_index,
                 ) as usize;
-                let base_slots = self
-                    .get_or_compute_field_vregs(base)
-                    .expect("enum payload base must have slot vregs");
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-                if field_slots > 1 {
-                    // Multi-slot payload (nested aggregate): expose all slots.
-                    let slots: Vec<VReg> = base_slots[offset..offset + field_slots].to_vec();
-                    self.struct_slot_vregs.insert(value, slots.clone());
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(slots[0]),
-                    });
+                // A zero-sized payload field (`Option(Z)` where `Z {}` has no
+                // fields) carries no bits and its enclosing enum may be a
+                // 1-slot discriminant-only value with NO tracked aggregate
+                // slots — reading a payload slot here panicked (RUE-566).
+                // Map to a fresh never-read vreg, like unit.
+                if field_slots == 0 {
+                    let vreg = self.mir.alloc_vreg();
+                    self.value_map.insert(value, vreg);
                 } else {
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(base_slots[offset]),
-                    });
+                    let base_slots = self
+                        .get_or_compute_field_vregs(base)
+                        .expect("enum payload base must have slot vregs");
+                    let vreg = self.mir.alloc_vreg();
+                    self.value_map.insert(value, vreg);
+                    if field_slots > 1 {
+                        // Multi-slot payload (nested aggregate): expose all slots.
+                        let slots: Vec<VReg> = base_slots[offset..offset + field_slots].to_vec();
+                        self.struct_slot_vregs.insert(value, slots.clone());
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(slots[0]),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(base_slots[offset]),
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
`ArrayBuf(Z)` with an empty Copy struct never allocates (element size 0), so its buffer stays null — and three zero-slot holes existed in BOTH backends. The reported compile-time abort had already shifted to a **runtime segfault** on current trunk (verified): `@ptr_write` treated `slot_count == 0` as the scalar case and stored 8 bytes through the null buffer; `@ptr_read` likewise loaded through it; and extracting a zero-sized `Option(Z)` payload panicked the compiler (`enum payload base must have slot vregs`) because a discriminant-only 1-slot enum has no tracked aggregate slots. Zero-sized reads/writes are now zero-byte no-ops that never dereference, and zero-slot payload extraction skips payload slots entirely — applied identically to x86_64 and aarch64 `cfg_lower` in this PR per the codegen parity checklist.

## Validation
Full push/pop/len/clear/`Option(Z)`-match exercise runs with the exact expected score (243) at -O0 and -O2 on x86-64; aarch64 `--emit asm` lowers cleanly (was abort 134). New CLI case pins the exercise and runs natively on both architectures in CI. ./test.sh Pass 30 / Fail 0.

Fixes RUE-566

🤖 Generated with [Claude Code](https://claude.com/claude-code)