### PR TITLE
RUE-528: chained-comparison check moves to the parser — parenthesized boolean operands are not chains

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -540,22 +540,6 @@ impl<'a> ConstraintGenerator<'a> {
         var
     }
 
-    /// Check whether an instruction is a comparison operator.
-    ///
-    /// Mirrors `Sema::is_comparison`; used to recognize chained comparisons
-    /// (`a < b < c`) during constraint generation.
-    fn is_comparison(&self, inst_ref: InstRef) -> bool {
-        matches!(
-            self.rir.get(inst_ref).data,
-            InstData::Lt { .. }
-                | InstData::Gt { .. }
-                | InstData::Le { .. }
-                | InstData::Ge { .. }
-                | InstData::Eq { .. }
-                | InstData::Ne { .. }
-        )
-    }
-
     /// Add a constraint.
     pub fn add_constraint(&mut self, constraint: Constraint) {
         self.constraints.push(constraint);
@@ -680,15 +664,11 @@ impl<'a> ConstraintGenerator<'a> {
             | InstData::Ge { lhs, rhs } => {
                 let lhs_info = self.generate(*lhs, ctx);
                 let rhs_info = self.generate(*rhs, ctx);
-                // A chained comparison (`a < b < c`, left-associative, so the
-                // LHS is itself a comparison) is always rejected by sema with a
-                // dedicated error. Skip the operand-equality constraint in that
-                // case so inference doesn't mask it with a generic type
-                // mismatch (e.g. bool vs integer literal).
-                if !self.is_comparison(*lhs) {
-                    // Operands must have the same type
-                    self.add_constraint(Constraint::equal(lhs_info.ty, rhs_info.ty, span));
-                }
+                // Operands must have the same type. (Chained comparisons are
+                // rejected at parse time — validate.rs, RUE-528 — so a
+                // comparison LHS reaching here is a legitimately
+                // parenthesized boolean operand and gets normal typing.)
+                self.add_constraint(Constraint::equal(lhs_info.ty, rhs_info.ty, span));
                 InferType::Concrete(Type::BOOL)
             }
 

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -255,13 +255,11 @@ impl<'a> Sema<'a> {
     where
         F: FnOnce(AirRef, AirRef) -> AirInstData,
     {
-        // Check for chained comparisons (e.g., `a < b < c`)
-        // Since the parser is left-associative, `a < b < c` parses as `(a < b) < c`,
-        // so we only need to check if the LHS is a comparison.
-        if self.is_comparison(lhs) {
-            return Err(CompileError::new(ErrorKind::ChainedComparison, span)
-                .with_help("use `&&` to combine comparisons: `a < b && b < c`"));
-        }
+        // Chained comparisons (`a < b < c`) are rejected at PARSE time
+        // (`rue-parser/src/validate.rs`), where parentheses are still
+        // visible. RIR erases parens, so an RIR-level check here could not
+        // tell `1 < 2 == true` (a chain) from `(1 < 2) == true` (an ordinary
+        // boolean equality) and wrongly rejected the latter (RUE-528).
 
         // Comparisons read values without consuming them (like projections).
         // This matches Rust's PartialEq trait which takes references.
@@ -329,22 +327,6 @@ impl<'a> Sema<'a> {
         } else {
             false
         }
-    }
-
-    /// Check if an RIR instruction is a comparison operation.
-    ///
-    /// This is used to detect chained comparisons (e.g., `a < b < c`) which are
-    /// not allowed in Rue.
-    pub(super) fn is_comparison(&self, inst_ref: InstRef) -> bool {
-        matches!(
-            self.rir.get(inst_ref).data,
-            InstData::Lt { .. }
-                | InstData::Gt { .. }
-                | InstData::Le { .. }
-                | InstData::Ge { .. }
-                | InstData::Eq { .. }
-                | InstData::Ne { .. }
-        )
     }
 
     /// Analyze a builtin type associated function call.

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -193,6 +193,26 @@ impl Validator<'_> {
             | Expr::SelfExpr(_)
             | Expr::Error(_) => {}
             Expr::Binary(b) => {
+                // Chained comparison check (spec 4.3:12, RUE-528). Comparison
+                // operators are left-associative and share one precedence
+                // level, so `a < b == c` parses as `(a < b) == c` with the
+                // inner comparison DIRECTLY as the left operand. This is the
+                // only paren-aware place to check: RIR erases parentheses, so
+                // the old sema check also rejected the explicitly
+                // parenthesized `(a < b) == c` — an ordinary boolean
+                // equality, not a chain. An explicit `Expr::Paren` between
+                // the two comparisons breaks the chain (anything ill-typed
+                // inside is then diagnosed normally by sema).
+                if is_comparison_op(b.op)
+                    && matches!(&*b.left, Expr::Binary(inner) if is_comparison_op(inner.op))
+                {
+                    self.errors.push(
+                        CompileError::new(ErrorKind::ChainedComparison, b.span).with_help(
+                            "use `&&` to combine comparisons (`a < b && b < c`), or \
+                             parenthesize a boolean operand: `(a < b) == c`",
+                        ),
+                    );
+                }
                 self.check_expr(&b.left);
                 self.check_expr(&b.right);
             }
@@ -332,4 +352,14 @@ impl Validator<'_> {
             TypeExpr::StrFixed { .. } => {}
         }
     }
+}
+
+/// Whether `op` is one of the six comparison operators, which share a single
+/// non-chainable precedence level (spec 4.3:12).
+fn is_comparison_op(op: crate::ast::BinaryOp) -> bool {
+    use crate::ast::BinaryOp;
+    matches!(
+        op,
+        BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Gt | BinaryOp::Le | BinaryOp::Ge
+    )
 }

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -157,7 +157,39 @@ params = [
   { variant = "lt", expr = "1 < 2 < 3" },
   { variant = "eq", expr = "1 == 1 == true" },
   { variant = "mixed", expr = "1 < 2 == true" },
-  { variant = "parenthesized", expr = "(1 < 2) < 3" },
+]
+
+[[case]]
+# RUE-528: explicit parentheses BREAK a chain (the restriction is syntactic).
+# `(1 < 2) < 3` is not a chain — it is an ordered comparison with a bool left
+# operand, rejected by ordinary operand typing, not E0802.
+name = "parenthesized_comparison_operand_is_not_a_chain_typing_still_applies"
+spec = ["4.3:12"]
+source = """
+fn main() -> i32 {
+    if (1 < 2) < 3 { 1 } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = "[E0206]"
+
+[[case]]
+# RUE-528: a parenthesized comparison is a legal boolean operand of equality,
+# in either position. The old RIR-level chain check (parens erased) rejected
+# the left-operand form while accepting the right-operand form.
+name = "parenthesized_comparison_equality_{variant}"
+spec = ["4.3:12"]
+source = """
+fn main() -> i32 {
+    if {expr} { 7 } else { 9 }
+}
+"""
+exit_code = 7
+params = [
+  { variant = "left", expr = "(1 < 2) == true" },
+  { variant = "right", expr = "true == (1 < 2)" },
+  { variant = "both", expr = "(1 < 2) == (3 > 2)" },
+  { variant = "ne", expr = "(1 < 2) != false" },
 ]
 
 [[case]]

--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -182,7 +182,7 @@ When one operand has a known type, the other is inferred to have the same type.
 
 {{ rule(id="4.3:12", cat="legality-rule") }}
 
-Comparison operators cannot be chained. Expressions like `a < b < c` or `a == b == c` are compile-time errors.
+Comparison operators cannot be chained. Expressions like `a < b < c` or `a == b == c` are compile-time errors. The restriction is syntactic: it applies when a comparison expression is directly an operand of another comparison. Explicit parentheses break a chain — `(a < b) == c` is an ordinary equality whose left operand is a parenthesized boolean expression, and is legal whenever its operand types are (a parenthesized boolean operand of an ordered comparison such as `(a < b) < c` is instead rejected by the ordinary operand typing rules).
 
 {{ rule(id="4.3:13", cat="example") }}
 


### PR DESCRIPTION
## Summary
The chain check lived in sema on RIR, where parentheses are erased — so it couldn't tell `1 < 2 == true` (a chain) from `(1 < 2) == true` (ordinary boolean equality), and since it only looked left, `true == (1 < 2)` compiled while its mirror was rejected E0802 (both verified). The check now runs in the parser's post-parse validation walk, where `Expr::Paren` is visible: a comparison whose left operand is *directly* another comparison is a chain; parentheses break it. Sema's RIR check and inference's constraint suppression are removed, so `(1 < 2) < 3` becomes an honest E0206 bool-vs-int mismatch instead of E0802 — the one spec case pinning that artifact is updated, and 4.3:12's prose now states the restriction is syntactic.

## Validation
Five shapes verified by execution: both parenthesized-equality orders now run (exit 7); `1 < 2 < 3` and `1 < 2 == true` still E0802; `(1 < 2) < 3` now E0206. 5 new spec cases + 3 existing chained rejections unchanged. ./test.sh Pass 30 / Fail 0.

Fixes RUE-528

🤖 Generated with [Claude Code](https://claude.com/claude-code)