### PR TITLE
RUE-558: method and destructor analysis resolve structs file-aware — same-named types across files no longer ICE

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -222,7 +222,18 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         } = &inst.data
         {
             let type_name_str = sema.interner.resolve(&*type_name).to_string();
-            let struct_id = match sema.structs.get(type_name) {
+            // Resolve the struct FILE-AWARE first: same-named types in
+            // different files are distinct after RUE-454, and the global
+            // by-name map drops ambiguous names entirely — so a name-only
+            // lookup ICEd for flat positional files ("not found in struct
+            // map") and, worse, analyzed a module file's methods against the
+            // OTHER file's same-named struct (RUE-558). The declaration's own
+            // span carries its file.
+            let struct_id = match sema
+                .structs_by_file_name
+                .get(&(inst.span.file_id, *type_name))
+                .or_else(|| sema.structs.get(type_name))
+            {
                 Some(id) => *id,
                 None => {
                     errors.push(CompileError::new(
@@ -287,7 +298,13 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
     for (_, inst) in sema.rir.iter() {
         if let InstData::DropFnDecl { type_name, body } = &inst.data {
             let type_name_str = sema.interner.resolve(&*type_name).to_string();
-            let struct_id = match sema.structs.get(type_name) {
+            // File-aware first, like method analysis above (RUE-558): the
+            // global by-name map drops names duplicated across files.
+            let struct_id = match sema
+                .structs_by_file_name
+                .get(&(inst.span.file_id, *type_name))
+                .or_else(|| sema.structs.get(type_name))
+            {
                 Some(id) => *id,
                 None => {
                     errors.push(CompileError::new(
@@ -1026,7 +1043,12 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
     for (_, inst) in sema.rir.iter() {
         if let InstData::DropFnDecl { type_name, body } = &inst.data {
             let type_name_str = sema.interner.resolve(&*type_name).to_string();
-            let struct_id = match sema.structs.get(type_name) {
+            // File-aware first (RUE-558), matching the sites above.
+            let struct_id = match sema
+                .structs_by_file_name
+                .get(&(inst.span.file_id, *type_name))
+                .or_else(|| sema.structs.get(type_name))
+            {
                 Some(id) => *id,
                 None => continue,
             };

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -2561,3 +2561,19 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 42
+
+[[case]]
+# RUE-558: same-named structs in two flat positional files must not ICE.
+# Types are file-scoped (RUE-454); the global by-name struct map drops
+# duplicated names, and method/destructor analysis looked up name-only,
+# producing E9000 "struct 'P' not found in struct map".
+name = "flat_positional_same_named_structs_no_ice"
+files = [
+  { path = "a.rue", source = """
+struct P { x: i32 }
+fn main() -> i32 { 0 }
+""" },
+  { path = "b.rue", source = "struct P { y: i32 }\n" },
+]
+args = ["a.rue", "b.rue", "-o", "prog"]
+exit_code = 0


### PR DESCRIPTION
## Summary
Types are file-scoped (RUE-454), and the global by-name struct map **drops** a name duplicated across files — but method analysis and both destructor-analysis loops still looked structs up name-only. Two flat positional files declaring the same struct name hit E9000 `struct 'P' not found in struct map` (verified), and a module file's methods could analyze against the *other* file's same-named struct. All three sites now resolve through `structs_by_file_name` keyed by the declaration's own file (global fallback), matching how method registration already resolves.

While verifying, I found the remaining module-mode face — struct **literals** resolving a same-named type to the wrong file's definition (E0401 against the wrong struct) — which is a distinct type-use-path gap, filed as RUE-570 with a verified repro.

## Validation
Flat repro compiles and runs (was double E9000); destructor sites get the same fix. New CLI case pins the flat two-file shape at exit 0. ./test.sh Pass 30 / Fail 0.

Fixes RUE-558

🤖 Generated with [Claude Code](https://claude.com/claude-code)