### PR TITLE
RUE-563: align 3.5:2 and 4.7:12 with shipped comptime behavior

### DIFF
--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -1067,3 +1067,24 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "use of moved value 'e'"
+
+[[case]]
+# RUE-563: 4.7:12's same-type rule now carries its 4.14:19 exception in the
+# text — a comptime-known scrutinee analyzes only the selected arm, so a
+# differently-typed dead arm is legal (RUE-268 shipped this).
+name = "comptime_match_dead_arm_different_type_ok"
+spec = ["4.7:12", "4.14:19"]
+description = "Unselected arms of a comptime match are exempt from the same-type rule; the match's type is the selected arm's type"
+source = """
+fn pick(comptime n: i32) -> i32 {
+    match n {
+        0 => true,
+        _ => 42,
+    }
+}
+
+fn main() -> i32 {
+    pick(1)
+}
+"""
+exit_code = 42

--- a/crates/rue-spec/cases/types/arrays.toml
+++ b/crates/rue-spec/cases/types/arrays.toml
@@ -157,3 +157,24 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+[[case]]
+# RUE-563: 3.5:2 now names all the compile-time-known length forms, aligned
+# with 7.1:18-21 — a constant identifier and a comptime call are lengths too,
+# not just literals. This case ties the 3.5:2 wording to those forms so
+# traceability cannot re-certify the old literal-only text.
+name = "array_length_const_and_comptime_call"
+spec = ["3.5:2"]
+description = "Array length may be an integer constant or a fully-comptime call, not only a literal (aligned with 7.1:18-21)"
+source = """
+const N: usize = 3;
+
+fn len(comptime k: i32) -> i32 { k + 1 }
+
+fn main() -> i32 {
+    let a: [i32; N] = [1, 2, 3];
+    let b: [i32; len(2)] = [7, 7, 7];
+    a[2] + b[2]
+}
+"""
+exit_code = 10

--- a/docs/spec/src/03-types/05-array-types.md
+++ b/docs/spec/src/03-types/05-array-types.md
@@ -12,7 +12,7 @@ An array type, written `[T; N]`, represents a fixed-size sequence of `N` element
 
 {{ rule(id="3.5:2", cat="normative") }}
 
-The length `N` **MUST** be a non-negative integer literal known at compile time.
+The length `N` **MUST** be a non-negative integer value known at compile time: an integer literal, a reference to an integer constant or `comptime` parameter, or a call to a function whose value is compile-time evaluable (the accepted forms and their legality rules are given in 7.1:18–7.1:21; the grammar is Appendix A's `array_length`).
 
 {{ rule(id="3.5:3", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -79,7 +79,7 @@ fn main() -> i32 {
 
 {{ rule(id="4.7:12", cat="normative") }}
 
-All match arms **MUST** have the same type. The type of the match expression is the common type of its arms.
+All match arms **MUST** have the same type. The type of the match expression is the common type of its arms. Exception: in a `match` whose scrutinee is compile-time known, only the selected arm's body is analyzed (rule 4.14:19) — the unselected arms' bodies are not type-checked, so they are exempt from this rule; the match expression's type is the selected arm's type.
 
 {{ rule(id="4.7:13", cat="normative") }}
 


### PR DESCRIPTION
## Summary
Two normative rules contradicted later chapters and already-shipped behavior, while their traceability cases kept certifying the stale text: 3.5:2 said array length must be an integer *literal* (RUE-16/RUE-309 + normative 7.1:18–21 also permit constant/comptime identifiers and fully-comptime calls — the rule now names all compile-time-known forms and cross-references 7.1:18–21); and 4.7:12 required all match arms to share a type unconditionally, contradicting 4.14:19's comptime arm pruning (shipped as RUE-268) — it now carries the explicit exception and defines the comptime match's type as the selected arm's type. No behavior change; this is spec-text alignment plus cross-rule traceability cases so the old wordings can't be re-certified independently.

## Validation
Both new cases verified running (const + comptime-call length exits 10; differently-typed dead arm exits 42). ./test.sh Pass 30 / Fail 0, traceability 100%.

Fixes RUE-563

🤖 Generated with [Claude Code](https://claude.com/claude-code)