### PR TITLE
RUE-559: materialize the borrow str view — StrBuf sources narrow to {ptr,len} instead of passing the raw 3-word header

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1982,6 +1982,14 @@ impl<'a> ConstraintGenerator<'a> {
                                 // parameter type (same as a direct Call).
                                 for (arg, param_ty) in args.iter().zip(func.param_types.iter()) {
                                     let arg_info = self.generate(arg.value, ctx);
+                                    // Slice and `borrow str` parameters coerce
+                                    // from a `borrow` argument; skip strict
+                                    // equality and let sema materialize the
+                                    // fat-pointer view (ADR-0043, RUE-322,
+                                    // RUE-559) — same as the direct-Call path.
+                                    if self.is_slice_struct_type(param_ty.clone()) {
+                                        continue;
+                                    }
                                     self.add_constraint(Constraint::equal(
                                         arg_info.ty,
                                         param_ty.clone(),

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -457,8 +457,13 @@ impl<'a> Sema<'a> {
         // copy of this function skipped this check entirely.)
         self.check_exclusive_access(&args, span)?;
 
-        // Analyze arguments (the per-pipeline recursion seam)
-        let air_args = self.analyze_call_args(air, &args, ctx)?;
+        // Analyze arguments (the per-pipeline recursion seam). Module-qualified
+        // calls use the coercing path so slice and `borrow str` parameters
+        // materialize their by-value fat-pointer views exactly like direct
+        // calls do (RUE-559) — std functions taking `borrow s: str` are called
+        // this way.
+        let air_args =
+            self.analyze_call_args_coerced(air, &args, &param_types, &param_modes, ctx)?;
 
         Ok(emit_module_member_call(
             air,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -963,6 +963,24 @@ impl<'a> Sema<'a> {
                 arg.is_inout() && param_types.get(i).is_some_and(|pt| self.is_str_struct(*pt));
             if is_str_param && !is_inout_str_param {
                 let str_ty = param_types[i];
+                // A `borrow` argument to a `borrow s: str` parameter views an
+                // existing string place — a `StrBuf`, `Str(N)`, `str`, or a
+                // re-borrowed view (ADR-0043 two-types model). The source is
+                // borrowed (never moved) and a `StrBuf` source's 3-word header
+                // is narrowed to the 2-word `{ptr, len}` view here (RUE-559).
+                // The argument is always a place: `check_exclusive_access`
+                // rejected non-lvalue `borrow` arguments (E0427) before
+                // argument analysis began.
+                if arg.is_borrow() && self.is_str_struct(str_ty) {
+                    let value = self.coerce_borrow_str_place_to_view(air, arg, str_ty, ctx)?;
+                    air_args.push(AirCallArg {
+                        value,
+                        // The 2-word view is passed BY VALUE (multi-slot
+                        // aggregate), exactly like a slice fat pointer.
+                        mode: AirArgMode::Normal,
+                    });
+                    continue;
+                }
                 let prev_expected = ctx.expected_type.replace(str_ty);
                 let arg_result = self.analyze_inst(air, arg.value, ctx);
                 ctx.expected_type = prev_expected;
@@ -1168,5 +1186,91 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(slice_val)
+    }
+
+    /// Build a by-value `str` view `{ptr, len}` from a `borrow` argument whose
+    /// parameter is `borrow s: str` (ADR-0043 two-types model, RUE-559).
+    ///
+    /// The source place is *borrowed*: `ctx.byref_arg_root` is set while it is
+    /// traced, so no move is recorded and the buffer stays owned by (and is
+    /// dropped in) the caller — which also keeps the RUE-523 loan-frame check
+    /// from misreading the view construction as a move of its own loan.
+    ///
+    /// - A `str` / `Str(N)` source (including a re-borrowed `borrow str`
+    ///   parameter, spec 3.7:58) already has the 2-word view shape and is read
+    ///   by value.
+    /// - A `StrBuf` source is a 3-word `{ptr, len, cap}` buffer header; the
+    ///   view copies exactly the `{ptr, len}` prefix. Passing the raw 3-word
+    ///   value through the 2-slot by-value parameter ABI was the RUE-559
+    ///   miscompile: the callee read `cap` as the length and dereferenced the
+    ///   length as the data pointer (segfault on indexing).
+    fn coerce_borrow_str_place_to_view(
+        &mut self,
+        air: &mut Air,
+        arg: &RirCallArg,
+        str_ty: Type,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AirRef> {
+        use crate::inst::{AirInstData, AirProjection};
+
+        let span = self.rir.get(arg.value).span;
+        let root = require_byref_place_arg(self.rir, arg)?;
+        let prev_byref_root = ctx.byref_arg_root.replace(root);
+        let trace = self.try_trace_place(arg.value, air, ctx);
+        ctx.byref_arg_root = prev_byref_root;
+        let trace = trace?.ok_or_else(|| CompileError::new(ErrorKind::BorrowNonLvalue, span))?;
+
+        let src_ty = trace.result_type();
+
+        // `str` / `Str(N)` sources share the 2-word `{ptr, len}` shape: read
+        // the fat pointer by value (it is `@copy`) and pass it through.
+        if self.is_str_like(src_ty) {
+            let projs: Vec<AirProjection> = trace.projections.iter().map(|p| p.proj).collect();
+            let place_ref = air.make_place(trace.base, projs);
+            return Ok(air.add_inst(AirInst {
+                data: AirInstData::PlaceRead { place: place_ref },
+                ty: str_ty,
+                span,
+            }));
+        }
+
+        // `StrBuf` source: the view is the `{ptr, len}` prefix of the 3-word
+        // buffer header, read field-by-field from the borrowed place.
+        if self.is_builtin_string(src_ty) {
+            let buf_struct_id = src_ty.as_struct().expect("StrBuf is a synthetic struct");
+            let str_struct_id = str_ty.as_struct().expect("str is a synthetic struct");
+            let mut field_words = Vec::with_capacity(2);
+            for field_index in 0..2u32 {
+                let mut projs: Vec<AirProjection> =
+                    trace.projections.iter().map(|p| p.proj).collect();
+                projs.push(AirProjection::Field {
+                    struct_id: buf_struct_id,
+                    field_index,
+                });
+                let place_ref = air.make_place(trace.base, projs);
+                let field_ty =
+                    self.type_pool.struct_def(buf_struct_id).fields[field_index as usize].ty;
+                let word = air.add_inst(AirInst {
+                    data: AirInstData::PlaceRead { place: place_ref },
+                    ty: field_ty,
+                    span,
+                });
+                field_words.push(word.as_u32());
+            }
+            let fields = air.add_extra(&field_words);
+            let source_order = air.add_extra(&[0u32, 1u32]);
+            return Ok(air.add_inst(AirInst {
+                data: AirInstData::StructInit {
+                    struct_id: str_struct_id,
+                    fields_start: fields,
+                    fields_len: 2,
+                    source_order_start: source_order,
+                },
+                ty: str_ty,
+                span,
+            }));
+        }
+
+        Err(self.type_mismatch_error(str_ty, src_ty, span))
     }
 }

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -258,3 +258,83 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 7
+
+# RUE-559 facet 1: the SAME reads with a heap `StrBuf` source. Before the
+# call-site view materialization, the 3-word `{ptr, len, cap}` header was
+# passed raw through the 2-slot by-value ABI: `.len()` returned the CAPACITY
+# (16) and byte indexing dereferenced the length (segfault, exit 139). The
+# buffer is borrowed, not moved, so it stays usable (and is dropped exactly
+# once) in the caller.
+[[case]]
+name = "strbuf_read_through_borrow_str_view_values"
+files = [{ path = "main.rue", source = """
+fn len_of(borrow s: str) -> u64 { s.len() }
+fn first(borrow s: str) -> u8 { s[0] }
+fn main() -> i32 {
+    let b = "xx" + "yy";                 // heap StrBuf: len 4, cap != 4
+    let len_ok = len_of(borrow b) == 4;  // the length, NOT the capacity
+    let byte_ok = first(borrow b) == 120;    // 'x', no segfault
+    let reuse_ok = len_of(borrow b) == 4;    // borrow again: not moved
+    let own_ok = b.len() == 4;               // caller still owns b
+    if len_ok && byte_ok && reuse_ok && own_ok { 9 } else { 0 }
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 9
+
+# RUE-559 facet 2: an unannotated literal binding is a `StrBuf` too (see
+# str_preview_does_not_change_string_default) — its borrowed view used to
+# read length 0. Also pins the loan/move interaction (RUE-523): a single
+# `borrow` argument must NOT be misread as a move of its own loan (E0208).
+[[case]]
+name = "strbuf_literal_binding_borrow_str_len"
+files = [{ path = "main.rue", source = """
+fn rd(borrow s: str) -> u64 { s.len() }
+fn main() -> i32 {
+    let s = "hello";             // StrBuf (no `str` annotation)
+    @intCast(rd(borrow s))
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 5
+
+# RUE-559: module-qualified calls take a separate argument-analysis path
+# (analyze_module_member_call) that skipped the slice/str coercions entirely —
+# a `StrBuf` passed to a module function's `borrow s: str` parameter failed
+# E0206. Exercises the coercion through `m.f(borrow b)`.
+[[case]]
+name = "module_fn_borrow_str_view_of_strbuf"
+files = [
+    { path = "util.rue", source = """
+pub fn rd(borrow s: str) -> u64 {
+    s.len()
+}
+""" },
+    { path = "main.rue", source = """
+const util = @import("util.rue");
+
+fn main() -> i32 {
+    let b = "xx" + "yy";
+    @intCast(util.rd(borrow b))
+}
+""" },
+]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 4
+
+# RUE-559: a `StrBuf` struct FIELD as the borrowed view source — the coercion
+# traces the place projection, not just whole variables.
+[[case]]
+name = "strbuf_field_borrow_str_view"
+files = [{ path = "main.rue", source = """
+struct Holder { buf: StrBuf }
+
+fn rd(borrow s: str) -> u64 { s.len() }
+
+fn main() -> i32 {
+    let h = Holder { buf: "xyz" + "w" };
+    @intCast(rd(borrow h.buf))
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 4

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -246,6 +246,34 @@ fn main() -> i32 {
 """
 exit_code = 5
 
+# 3.7:58 — the same view semantics with a heap `StrBuf` source: the call-site
+# coercion narrows the 3-word `{ptr, len, cap}` buffer header to the 2-word
+# `{ptr, len}` view, so `.len()` reads the length (not the capacity) and byte
+# indexing reads the data (RUE-559: the raw header used to be passed through,
+# so `.len()` returned the capacity and indexing dereferenced the length).
+# The buffer is borrowed, not moved: it remains usable after the call.
+[[case]]
+name = "borrow_str_view_of_strbuf_reads_values"
+spec = ["3.7:58"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn view_len(borrow s: str) -> u64 {
+    s.len()
+}
+fn first_byte(borrow s: str) -> u8 {
+    s[0]
+}
+fn main() -> i32 {
+    let b = "xx" + "yy";                        // heap-backed StrBuf, len 4
+    let len_ok = view_len(borrow b) == 4;       // len, not cap
+    let byte_ok = first_byte(borrow b) == 120;  // 'x'
+    let still_usable = b.len() == 4;            // borrowed, not moved
+    if len_ok && byte_ok && still_usable { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
 # 3.7:59 — a borrowed `str` view laundered into a first-class `str` (returned)
 # is rejected (E0497): the view is second-class and cannot escape the call.
 [[case]]


### PR DESCRIPTION
The `is_str_param` branch of `analyze_call_args_coerced` passed a `borrow` argument by value with **no view construction**: a `StrBuf`'s 3-word `{ptr, len, cap}` header flowed straight into the 2-slot by-value `str` param ABI, so the callee read `cap` as the length and dereferenced the length as the data pointer — `s.len()` returned the capacity (16 for `"xx"+"yy"`), and `s[i]` segfaulted. The issue's facet 2 (literal-bound source reading len 0) is the same bug: an unannotated `let s = "hello"` binds a `StrBuf` too. Since RUE-523, the same path also recorded a spurious **move** of the borrowed buffer, so every `StrBuf → borrow str` call was rejected E0208 against its own loan.

**Fix (sema-level, so both backends are covered):**
- New `coerce_borrow_str_place_to_view` mirrors the slice coercion: trace the place under byref discipline (no move — the caller keeps ownership and drops exactly once), forward 2-word `str`/`Str(N)` sources by value, and read the `{ptr, len}` prefix field-by-field for `StrBuf` sources.
- Module-qualified calls (`analyze_module_member_call`) skipped the slice/str coercions entirely, and the inference constraint for module calls had no coercion carve-out — `m.rd(borrow b)` failed E0206. The module path now uses `analyze_call_args_coerced`, and the `MethodCall` module-receiver inference arm gets the same `is_slice_struct_type` skip the direct-call path has.

**Verified by running:** len=4 (was 16), literal-source len=5 (was 0), `s[0]`='x' (was SIGSEGV), module call =4 (was E0206), re-borrow chain + buffer reuse after borrow, repeated borrows with clean drop, E0497/E0495/E0208 guards still fire, aarch64 `--emit asm` clean. Full `./test.sh` exit 0.

**Tests:** spec case under 3.7:58 (StrBuf source asserts values); CLI cases for both facets, the module-qualified path, a struct-field source, and the RUE-523 loan interaction.

Found along the way, filed separately: RUE-573 (pattern-filtered CLI runs break on example cases — relative `RUE_EXAMPLES_DIR` + temp cwd).

Fixes RUE-559

🤖 Generated with [Claude Code](https://claude.com/claude-code)