### PR TITLE
RUE-553+554+555: evaluator-based comptime pruning in inference; pruned matches keep unreachable-pattern warnings

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1377,6 +1377,38 @@ impl<'a> ConstraintGenerator<'a> {
                     cond_info.span,
                 ));
 
+                // Comptime-known condition (spec 4.14:17): inside a
+                // specialization whose comptime value params make the condition
+                // compile-time evaluable, only the taken branch is analyzed —
+                // the untaken branch may be legal only for other
+                // specializations, exactly as sema's `analyze_branch` prunes it
+                // (RUE-554). This mirrors the `Match` arm's comptime selection;
+                // the `comptime_values.is_some()` gate (the analog of sema's
+                // non-empty `comptime_value_vars`) keeps ordinary `if`s fully
+                // constrained even when the condition is a literal, and the
+                // cond above is still constrained to `bool` on every path.
+                if self.comptime_values.is_some()
+                    && let Some(ConstValue::Bool(taken)) = self.eval_comptime_value(*cond)
+                {
+                    let selected = if taken {
+                        Some(*then_block)
+                    } else {
+                        *else_block
+                    };
+                    let result_ty = match selected {
+                        Some(block) => {
+                            ctx.push_scope();
+                            let info = self.generate(block, ctx);
+                            ctx.pop_scope();
+                            info.ty
+                        }
+                        // `if false { .. }` with no else: nothing runs, unit.
+                        None => InferType::Concrete(Type::UNIT),
+                    };
+                    self.record_type(inst_ref, result_ty.clone());
+                    return ExprInfo::new(result_ty, span);
+                }
+
                 let then_info = self.generate(*then_block, ctx);
 
                 if let Some(else_ref) = else_block {
@@ -2477,20 +2509,142 @@ impl<'a> ConstraintGenerator<'a> {
 
     /// Extract a comptime *value* argument as an integer constant, for
     /// resolving an array length parameterized by a comptime value param
-    /// (`fn f(comptime N: i32) -> [i32; N]`, RUE-252). Handles an integer
-    /// literal, its negation, and a reference to a file-level `const`; other
-    /// forms (checked fully in sema) yield `None`.
+    /// (`fn f(comptime N: i32) -> [i32; N]`, RUE-252/RUE-553). Evaluates any
+    /// compile-time-known integer expression — a literal, a `const`/comptime
+    /// value reference, and arithmetic over them (`make(1 + 2)`) — via
+    /// [`Self::eval_comptime_value`]; non-integer or non-comptime forms
+    /// (checked fully in sema) yield `None`.
     fn extract_int_argument(&self, arg: InstRef) -> Option<i128> {
-        match &self.rir.get(arg).data {
-            InstData::IntConst(v) => Some(*v as i128),
-            InstData::Neg { operand } => {
-                if let InstData::IntConst(v) = &self.rir.get(*operand).data {
-                    Some(-(*v as i128))
-                } else {
-                    None
-                }
-            }
-            InstData::VarRef { name } => self.const_values.and_then(|m| m.get(name).copied()),
+        match self.eval_comptime_value(arg)? {
+            ConstValue::Integer(n) => Some(n),
+            _ => None,
+        }
+    }
+
+    /// Evaluate a compile-time-known integer/boolean expression against the
+    /// comptime value parameters (`comptime_values`) and file-level integer
+    /// constants (`const_values`) currently in scope, returning its
+    /// [`ConstValue`]. Handles literals, `const`/comptime references, unary
+    /// `-`/`!`, integer arithmetic (`+ - * / %`), the comparison operators,
+    /// and boolean `&& ||`.
+    ///
+    /// Returns `None` for any form not statically decidable here — a runtime
+    /// value, a call, an operation that could trap (division or modulo by
+    /// zero) or overflow `i128`, or a kind mismatch (comparing an integer to a
+    /// bool). This mirrors the *values* sema's comptime evaluator produces for
+    /// the same expressions so inference and sema agree on which branch/arm is
+    /// live (RUE-553/RUE-554); when in doubt it returns `None`, keeping it a
+    /// strict subset of what sema evaluates, so the caller safely falls back
+    /// to its runtime path.
+    fn eval_comptime_value(&self, inst: InstRef) -> Option<ConstValue> {
+        use ConstValue::{Bool, Integer};
+        match &self.rir.get(inst).data {
+            InstData::IntConst(v) => Some(Integer(*v as i128)),
+            InstData::BoolConst(b) => Some(Bool(*b)),
+            InstData::VarRef { name } => self
+                .comptime_values
+                .and_then(|m| m.get(name).copied())
+                .or_else(|| {
+                    self.const_values
+                        .and_then(|m| m.get(name).copied())
+                        .map(Integer)
+                }),
+            InstData::Neg { operand } => match self.eval_comptime_value(*operand)? {
+                Integer(n) => Some(Integer(n.checked_neg()?)),
+                _ => None,
+            },
+            InstData::Not { operand } => match self.eval_comptime_value(*operand)? {
+                Bool(b) => Some(Bool(!b)),
+                _ => None,
+            },
+            InstData::Add { lhs, rhs } => self.eval_int_binop(*lhs, *rhs, i128::checked_add),
+            InstData::Sub { lhs, rhs } => self.eval_int_binop(*lhs, *rhs, i128::checked_sub),
+            InstData::Mul { lhs, rhs } => self.eval_int_binop(*lhs, *rhs, i128::checked_mul),
+            // `checked_div`/`checked_rem` return `None` on divide-by-zero, so a
+            // trapping operation falls back to the runtime path rather than
+            // diverging from sema (which reports the error).
+            InstData::Div { lhs, rhs } => self.eval_int_binop(*lhs, *rhs, i128::checked_div),
+            InstData::Mod { lhs, rhs } => self.eval_int_binop(*lhs, *rhs, i128::checked_rem),
+            InstData::Eq { lhs, rhs } => self.eval_eq(*lhs, *rhs, true),
+            InstData::Ne { lhs, rhs } => self.eval_eq(*lhs, *rhs, false),
+            InstData::Lt { lhs, rhs } => self.eval_int_cmp(*lhs, *rhs, |a, b| a < b),
+            InstData::Gt { lhs, rhs } => self.eval_int_cmp(*lhs, *rhs, |a, b| a > b),
+            InstData::Le { lhs, rhs } => self.eval_int_cmp(*lhs, *rhs, |a, b| a <= b),
+            InstData::Ge { lhs, rhs } => self.eval_int_cmp(*lhs, *rhs, |a, b| a >= b),
+            InstData::And { lhs, rhs } => self.eval_bool_binop(*lhs, *rhs, |a, b| a && b),
+            InstData::Or { lhs, rhs } => self.eval_bool_binop(*lhs, *rhs, |a, b| a || b),
+            _ => None,
+        }
+    }
+
+    /// Evaluate both operands as comptime integers and combine them with a
+    /// checked arithmetic op; `None` if either operand isn't a comptime
+    /// integer or the op traps/overflows. See [`Self::eval_comptime_value`].
+    fn eval_int_binop(
+        &self,
+        lhs: InstRef,
+        rhs: InstRef,
+        f: fn(i128, i128) -> Option<i128>,
+    ) -> Option<ConstValue> {
+        let a = self.eval_comptime_int(lhs)?;
+        let b = self.eval_comptime_int(rhs)?;
+        f(a, b).map(ConstValue::Integer)
+    }
+
+    /// Evaluate both operands as comptime integers and compare them, yielding a
+    /// boolean. See [`Self::eval_comptime_value`].
+    fn eval_int_cmp(
+        &self,
+        lhs: InstRef,
+        rhs: InstRef,
+        f: fn(i128, i128) -> bool,
+    ) -> Option<ConstValue> {
+        let a = self.eval_comptime_int(lhs)?;
+        let b = self.eval_comptime_int(rhs)?;
+        Some(ConstValue::Bool(f(a, b)))
+    }
+
+    /// Evaluate both operands as comptime booleans and combine them. `None` if
+    /// either operand isn't a comptime bool. See [`Self::eval_comptime_value`].
+    fn eval_bool_binop(
+        &self,
+        lhs: InstRef,
+        rhs: InstRef,
+        f: fn(bool, bool) -> bool,
+    ) -> Option<ConstValue> {
+        let a = self.eval_comptime_bool(lhs)?;
+        let b = self.eval_comptime_bool(rhs)?;
+        Some(ConstValue::Bool(f(a, b)))
+    }
+
+    /// `==`/`!=` over two comptime values of the *same* kind (both integers or
+    /// both booleans). A kind mismatch — comparing an integer to a bool — is
+    /// ill-typed and left to sema, so this returns `None` rather than a
+    /// defined-but-misleading answer. See [`Self::eval_comptime_value`].
+    fn eval_eq(&self, lhs: InstRef, rhs: InstRef, want_equal: bool) -> Option<ConstValue> {
+        use ConstValue::{Bool, Integer};
+        let a = self.eval_comptime_value(lhs)?;
+        let b = self.eval_comptime_value(rhs)?;
+        let equal = match (a, b) {
+            (Integer(x), Integer(y)) => x == y,
+            (Bool(x), Bool(y)) => x == y,
+            _ => return None,
+        };
+        Some(Bool(equal == want_equal))
+    }
+
+    /// Evaluate `inst` as a comptime integer, or `None` if it isn't one.
+    fn eval_comptime_int(&self, inst: InstRef) -> Option<i128> {
+        match self.eval_comptime_value(inst)? {
+            ConstValue::Integer(n) => Some(n),
+            _ => None,
+        }
+    }
+
+    /// Evaluate `inst` as a comptime boolean, or `None` if it isn't one.
+    fn eval_comptime_bool(&self, inst: InstRef) -> Option<bool> {
+        match self.eval_comptime_value(inst)? {
+            ConstValue::Bool(b) => Some(b),
             _ => None,
         }
     }
@@ -2504,11 +2658,13 @@ impl<'a> ConstraintGenerator<'a> {
     /// program whose statically-unselected arm has a different type (RUE-268).
     ///
     /// Returns `None` — meaning "constrain all arms as a runtime match" — for
-    /// any shape not understood (a non-comptime or compound scrutinee, an enum
-    /// pattern, a non-exhaustive set). The comptime cases handled here are a
-    /// strict subset of those sema prunes with the same value and patterns, so
-    /// whenever this prunes, sema also prunes to the *same* arm — the only arm
-    /// whose body inference generated a type for.
+    /// any shape not understood (a scrutinee that isn't comptime-evaluable, an
+    /// enum pattern, a non-exhaustive set). A compound comptime scrutinee
+    /// (`match n + 0`) is handled the same as a bare `match n`, since both go
+    /// through [`Self::eval_comptime_value`] (RUE-554). The comptime cases
+    /// handled here are a strict subset of those sema prunes with the same
+    /// value and patterns, so whenever this prunes, sema also prunes to the
+    /// *same* arm — the only arm whose body inference generated a type for.
     fn comptime_selected_arm(
         &self,
         scrutinee: InstRef,
@@ -2516,13 +2672,15 @@ impl<'a> ConstraintGenerator<'a> {
     ) -> Option<InstRef> {
         use rue_rir::RirPattern;
 
-        // Only a bare reference to a comptime value parameter is evaluated
-        // here; richer scrutinees are left to sema's own selection.
-        // `ConstValue` is `Copy`, so take an owned copy for the match below.
-        let value: ConstValue = match &self.rir.get(scrutinee).data {
-            InstData::VarRef { name } => *self.comptime_values?.get(name)?,
-            _ => return None,
-        };
+        // Only prune inside a specialization that has comptime value params in
+        // scope (mirrors sema's `!ctx.comptime_value_vars.is_empty()` gate in
+        // `analyze_match`); ordinary functions treat every match as runtime.
+        self.comptime_values?;
+        // Evaluate the scrutinee with the shared comptime evaluator, so a
+        // compound scrutinee (`match n + 0 { .. }`) prunes exactly like the
+        // bare `match n` form — matching sema's `try_evaluate_const_in_fn`
+        // rather than a syntax-specific extraction (RUE-554).
+        let value: ConstValue = self.eval_comptime_value(scrutinee)?;
 
         let mut selected: Option<InstRef> = None;
         let mut has_wildcard = false;

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1128,6 +1128,146 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// Emit unreachable-pattern warnings (spec 4.7:20) for a `match` that the
+    /// comptime-selection path is about to prune to its single selected arm.
+    /// Pruning returns that arm's body without running the normal per-arm loop
+    /// in [`Self::analyze_match`], which is where these warnings are otherwise
+    /// produced; without this a comptime-specialized match silently accepts
+    /// unreachable arms that a structurally identical ordinary match rejects
+    /// (RUE-555). Only the wildcard / integer / boolean pattern shapes a
+    /// prunable match can contain are inspected — an enum pattern makes the
+    /// match non-prunable, so it takes the normal path — and no arm *body* is
+    /// analyzed, honoring 4.14:19. `scrutinee_type` is the HM-resolved type,
+    /// used only to canonicalize integer patterns for duplicate detection;
+    /// every pattern was already range-checked by the caller, so the
+    /// `check_pattern_int` below never errors here.
+    ///
+    /// The warning shapes and messages mirror the normal per-arm loop exactly,
+    /// so a pruned match and an ordinary match report identical diagnostics.
+    fn warn_unreachable_pruned_arms(
+        &self,
+        arms: &[(RirPattern, InstRef)],
+        scrutinee_type: Type,
+        ctx: &mut AnalysisContext,
+    ) {
+        let mut wildcard_span: Option<Span> = None;
+        let mut bool_true_span: Option<Span> = None;
+        let mut bool_false_span: Option<Span> = None;
+        let mut seen_ints: HashMap<i64, Span> = HashMap::new();
+        for (pattern, _) in arms {
+            let pattern_span = pattern.span();
+
+            // Any arm after a wildcard is unreachable.
+            if let Some(first_wildcard_span) = wildcard_span {
+                let pat_str = match pattern {
+                    RirPattern::Wildcard(_) => "_".to_string(),
+                    RirPattern::Int {
+                        value, negative, ..
+                    } => {
+                        if *negative {
+                            format!("-{}", value)
+                        } else {
+                            value.to_string()
+                        }
+                    }
+                    RirPattern::Bool(b, _) => b.to_string(),
+                    RirPattern::Path {
+                        type_name, variant, ..
+                    } => format!(
+                        "{}.{}",
+                        self.interner.resolve(&*type_name),
+                        self.interner.resolve(&*variant)
+                    ),
+                };
+                ctx.warnings.push(
+                    CompileWarning::new(WarningKind::UnreachablePattern(pat_str), pattern_span)
+                        .with_label("previous wildcard pattern here", first_wildcard_span)
+                        .with_note(
+                            "this pattern will never be matched because the wildcard pattern above matches everything",
+                        ),
+                );
+                continue;
+            }
+
+            match pattern {
+                RirPattern::Wildcard(_) => {
+                    // A `_` after both booleans are already covered is
+                    // unreachable. An integer scrutinee is never fully covered
+                    // by literals, and enum patterns can't reach this path.
+                    if scrutinee_type == Type::BOOL
+                        && bool_true_span.is_some()
+                        && bool_false_span.is_some()
+                    {
+                        ctx.warnings.push(
+                            CompileWarning::new(
+                                WarningKind::UnreachablePattern("_".to_string()),
+                                pattern_span,
+                            )
+                            .with_note(
+                                "this pattern will never be matched because the arms above already cover every possible value",
+                            ),
+                        );
+                    }
+                    wildcard_span = Some(pattern_span);
+                }
+                RirPattern::Int {
+                    value, negative, ..
+                } => {
+                    // Every pattern already passed the caller's range check, so
+                    // this only recomputes the canonical value for dedup.
+                    let Ok(n) =
+                        self.check_pattern_int(*value, *negative, scrutinee_type, pattern_span)
+                    else {
+                        continue;
+                    };
+                    if let Some(first_span) = seen_ints.get(&n) {
+                        let pat_str = if *negative {
+                            format!("-{}", value)
+                        } else {
+                            value.to_string()
+                        };
+                        ctx.warnings.push(
+                            CompileWarning::new(
+                                WarningKind::UnreachablePattern(pat_str),
+                                pattern_span,
+                            )
+                            .with_label("first occurrence of this pattern", *first_span)
+                            .with_note(
+                                "this pattern will never be matched because an earlier arm already matches the same value",
+                            ),
+                        );
+                    } else {
+                        seen_ints.insert(n, pattern_span);
+                    }
+                }
+                RirPattern::Bool(b, _) => {
+                    let first_span_opt = if *b {
+                        &mut bool_true_span
+                    } else {
+                        &mut bool_false_span
+                    };
+                    if let Some(first_span) = *first_span_opt {
+                        ctx.warnings.push(
+                            CompileWarning::new(
+                                WarningKind::UnreachablePattern(b.to_string()),
+                                pattern_span,
+                            )
+                            .with_label("first occurrence of this pattern", first_span)
+                            .with_note(
+                                "this pattern will never be matched because an earlier arm already matches the same value",
+                            ),
+                        );
+                    } else {
+                        *first_span_opt = Some(pattern_span);
+                    }
+                }
+                // Enum patterns can't appear in a prunable match (they set
+                // `prunable = false` in the caller), so there's nothing to do.
+                RirPattern::Path { .. } => {}
+            }
+        }
+    }
+
     /// Analyze a match expression.
     fn analyze_match(
         &mut self,
@@ -1241,6 +1381,15 @@ impl<'a> Sema<'a> {
                             }
                         }
                     }
+                    // Unreachable-pattern diagnostics (spec 4.7:20) are a
+                    // property of the pattern *set*, not of which arm the
+                    // comptime value selects, so they must still fire even
+                    // though we prune to a single body below (RUE-555). The
+                    // normal per-arm loop that would otherwise emit them is
+                    // skipped by the early return, so run them here. Only
+                    // pattern shapes are inspected — no arm body is analyzed,
+                    // honoring 4.14:19.
+                    self.warn_unreachable_pruned_arms(&arms, scrutinee_type, ctx);
                     if let Some(body) = selected {
                         ctx.push_scope();
                         let result = self.analyze_inst(air, body, ctx)?;

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -25,10 +25,11 @@
 //! It transforms the AIR in-place and adds new specialized functions to the output.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 
 use lasso::{Key, Spur, ThreadedRodeo};
-use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind, WarningKind};
 use rue_rir::RirParamMode;
 use rue_span::Span;
 
@@ -179,6 +180,12 @@ pub fn specialize(
     // Index of the first function not yet scanned for CallGeneric instructions.
     let mut next_unscanned = 0;
     let mut rounds = 0;
+    // Spans of unreachable-pattern warnings already surfaced from specialized
+    // bodies (RUE-555). A generic function's pattern set is a static property
+    // of its single source location, so every specialization of it would emit
+    // the *same* warning at the *same* span; deduplicating by span collapses
+    // those to one, matching the single warning an ordinary function produces.
+    let mut seen_unreachable_spans: HashSet<Span> = HashSet::new();
 
     loop {
         // Phase 1: Collect specialization requests from not-yet-scanned functions
@@ -195,6 +202,10 @@ pub fn specialize(
         next_unscanned = output.functions.len();
 
         if pending.is_empty() {
+            // Unreachable-pattern warnings appended above land after the
+            // main-pass warnings sorted in `finalize_function_body_analysis`;
+            // restore span order so diagnostics read top-to-bottom (RUE-555).
+            output.warnings.sort_by_key(|w| w.span().map(|s| s.start));
             return Ok(());
         }
 
@@ -230,7 +241,7 @@ pub fn specialize(
                     ));
                 }
             };
-            let specialized_func = create_specialized_function(
+            let (specialized_func, warnings) = create_specialized_function(
                 sema,
                 infer_ctx,
                 key,
@@ -238,6 +249,22 @@ pub fn specialize(
                 &base_info,
                 interner,
             )?;
+            // Surface unreachable-pattern warnings from the specialized body
+            // (spec 4.7:20, RUE-555). A comptime-pruned match returns its
+            // selected arm before the normal warning loop, so these are emitted
+            // by `warn_unreachable_pruned_arms`; a non-pruned match in a
+            // specialized body warns via the normal loop. Both are structural
+            // (independent of the comptime value), so we keep only one per
+            // span across all specializations. Other specialized-body warnings
+            // stay suppressed, preserving existing behavior.
+            for w in warnings {
+                if matches!(w.kind, WarningKind::UnreachablePattern(_))
+                    && let Some(span) = w.span()
+                    && seen_unreachable_spans.insert(span)
+                {
+                    output.warnings.push(w);
+                }
+            }
             output.functions.push(specialized_func);
         }
     }
@@ -426,7 +453,7 @@ fn create_specialized_function(
     specialized_name: Spur,
     base_info: &FunctionInfo,
     interner: &ThreadedRodeo,
-) -> CompileResult<AnalyzedFunction> {
+) -> CompileResult<(AnalyzedFunction, Vec<CompileWarning>)> {
     let specialized_name_str = interner.resolve(&specialized_name).to_string();
 
     // Pair each comptime parameter with its argument: type parameters
@@ -509,7 +536,7 @@ fn create_specialized_function(
         num_locals,
         num_param_slots,
         param_modes,
-        _warnings,
+        warnings,
         _local_strings,
         _ref_fns,
         _ref_meths,
@@ -522,14 +549,17 @@ fn create_specialized_function(
         &value_subst,
     )?;
 
-    Ok(AnalyzedFunction {
-        name: specialized_name_str,
-        air,
-        num_locals,
-        num_param_slots,
-        param_modes,
-        allow_unreachable_code: base_info.allow_unreachable_code,
-    })
+    Ok((
+        AnalyzedFunction {
+            name: specialized_name_str,
+            air,
+            num_locals,
+            num_param_slots,
+            param_modes,
+            allow_unreachable_code: base_info.allow_unreachable_code,
+        },
+        warnings,
+    ))
 }
 
 /// Resolve a parameter's concrete type by substituting type parameters into

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -899,6 +899,24 @@ fn main() -> i32 {
 """
 exit_code = 19
 
+# RUE-553: a generic return type `[i32; N]` is sized by the comptime *argument*,
+# which need not be a bare literal — any comptime-evaluable expression (4.14:27),
+# e.g. `1 + 2`, resolves N at the call site so the return type specializes to
+# `[i32; 3]`, exactly like `make(3)`.
+[[case]]
+name = "array_return_length_from_comptime_arithmetic_arg"
+spec = ["7.1:34", "4.14:27"]
+source = """
+fn make(comptime N: i32) -> [i32; N] {
+    [7; N]
+}
+fn main() -> i32 {
+    let a: [i32; 3] = make(1 + 2);
+    a[0] + a[1] + a[2]
+}
+"""
+exit_code = 21
+
 [[case]]
 name = "array_length_runtime_variable_error"
 spec = ["7.1:33"]

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1648,6 +1648,42 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# RUE-554: only the *taken* branch of a comptime-known `if` is analyzed, so the
+# statically-dead branch may have an unrelated type. Here `choose(1)` takes the
+# `42` branch; the dead `else { false }` (a bool, incompatible with the `i32`
+# return) must not be type-checked. Inference must prune the branch too, not
+# just sema — a shape-independent condition (`n == 1`) is comptime-evaluable
+# under 4.14:27.
+[[case]]
+name = "comptime_if_dead_branch_different_type_ok"
+spec = ["4.14:17", "4.14:27"]
+description = "The untaken branch of a comptime if is exempt from the branch same-type rule; only the taken branch is analyzed"
+source = """
+fn choose(comptime n: i32) -> i32 {
+    if n == 1 { 42 } else { false }
+}
+fn main() -> i32 {
+    choose(1)
+}
+"""
+exit_code = 42
+
+# The reverse selection: `pick(0)` takes the `else` branch, so the dead
+# `then` branch (a bool) is exempt while the taken `99` branch is analyzed.
+[[case]]
+name = "comptime_if_dead_then_branch_different_type_ok"
+spec = ["4.14:17", "4.14:27"]
+description = "The untaken then-branch of a comptime if may have an unrelated type"
+source = """
+fn pick(comptime n: i32) -> i32 {
+    if n == 1 { false } else { 99 }
+}
+fn main() -> i32 {
+    pick(0) - 99
+}
+"""
+exit_code = 0
+
 [[case]]
 name = "comptime_recursion_depth_limit"
 spec = ["4.14:18"]
@@ -1795,6 +1831,27 @@ fn sign(comptime n: i32) -> i32 {
 }
 fn main() -> i32 {
     sign(7)
+}
+"""
+exit_code = 42
+
+# RUE-554: a compound scrutinee (`n + 0`), not just a bare `match n`, is
+# comptime-evaluable under 4.14:27, so its arm is selected at compile time and
+# the statically-dead arm's unrelated type is exempt. Inference must prune the
+# arm too, not only sema.
+[[case]]
+name = "comptime_match_compound_scrutinee_dead_arm_ok"
+spec = ["4.14:19", "4.14:27"]
+description = "A comptime match with a compound (arithmetic) scrutinee prunes to the selected arm; the dead arm may have a different type"
+source = """
+fn choose(comptime n: i32) -> i32 {
+    match n + 0 {
+        1 => 42,
+        _ => false,
+    }
+}
+fn main() -> i32 {
+    choose(1)
 }
 """
 exit_code = 42

--- a/crates/rue-ui-tests/cases/warnings/unreachable.toml
+++ b/crates/rue-ui-tests/cases/warnings/unreachable.toml
@@ -197,6 +197,94 @@ exit_code = 10
 warning_contains = ["unreachable pattern"]
 expected_warning_count = 2
 
+# =============================================================================
+# Unreachable patterns in comptime-specialized matches (RUE-555)
+#
+# A `match` on a comptime value parameter is pruned to its selected arm during
+# specialization, but unreachable-pattern warnings (spec 4.7:20) are a property
+# of the pattern set and must still fire — the same warning a structurally
+# identical ordinary match produces.
+# =============================================================================
+
+[[case]]
+name = "comptime_specialized_match_unreachable_pattern"
+source = """
+fn specialized(comptime n: i32) -> i32 {
+    match n {
+        _ => 42,
+        1 => 0,
+    }
+}
+fn main() -> i32 {
+    specialized(1)
+}
+"""
+exit_code = 42
+warning_contains = ["unreachable pattern", "'1'"]
+expected_warning_count = 1
+
+[[case]]
+name = "comptime_and_ordinary_match_both_warn"
+source = """
+fn specialized(comptime n: i32) -> i32 {
+    match n {
+        _ => 42,
+        1 => 0,
+    }
+}
+fn ordinary(n: i32) -> i32 {
+    match n {
+        _ => 42,
+        1 => 0,
+    }
+}
+fn main() -> i32 {
+    specialized(1) + ordinary(0) - 42
+}
+"""
+exit_code = 42
+warning_contains = ["unreachable pattern"]
+expected_warning_count = 2
+
+# Two specializations of the same generic fn share one source location, so the
+# structural warning is reported once, not once per specialization.
+[[case]]
+name = "comptime_specialized_match_warning_deduplicated"
+source = """
+fn specialized(comptime n: i32) -> i32 {
+    match n {
+        _ => 42,
+        1 => 0,
+    }
+}
+fn main() -> i32 {
+    specialized(1) + specialized(2) - 84
+}
+"""
+exit_code = 0
+warning_contains = ["unreachable pattern", "'1'"]
+expected_warning_count = 1
+
+# A duplicate integer literal (before any wildcard) in a specialized body is
+# unreachable too, exercising the non-wildcard warning path.
+[[case]]
+name = "comptime_specialized_match_duplicate_literal"
+source = """
+fn specialized(comptime n: i32) -> i32 {
+    match n {
+        1 => 10,
+        1 => 20,
+        _ => 30,
+    }
+}
+fn main() -> i32 {
+    specialized(1) - 10
+}
+"""
+exit_code = 0
+warning_contains = ["unreachable pattern", "'1'"]
+expected_warning_count = 1
+
 [[case]]
 name = "duplicate_wildcard"
 source = """


### PR DESCRIPTION
Integrates fix-cycle worker 1 (all three found by Codex's autonomous hunt; every repro re-verified by execution on trunk `978e5d26` at integration).

**RUE-553** — `extract_int_argument` only recognized an int literal / negated literal / const reference, so `make(1 + 2)` sizing `[i32; N]` failed E0206. Constraint generation now evaluates comptime arguments with a recursive RIR evaluator (`eval_comptime_value`) over the comptime/const maps. The evaluator is a deliberate **strict subset** of sema's (checked i128; `None` on overflow, div-by-zero, kind mismatch), preserving the invariant that inference and sema always prune to the same branch.

**RUE-554** — comptime `if` constrained BOTH arms (a dead branch of a different type errored), and match pruning only recognized a bare `VarRef` scrutinee (`match n + 0` cross-constrained arms). Both now prune via the evaluator; the TAKEN branch is still fully type-checked (verified: an ill-typed taken branch still errors E0206).

**RUE-555** — comptime-pruned matches emitted no unreachable-pattern warnings (spec 4.7:20). Two root causes: `analyze_match` returned the selected arm before the warning loop (new `warn_unreachable_pruned_arms` runs first, without analyzing dead arm bodies per 4.14:19), and `specialize.rs` **discarded all specialized-body warnings** — it now threads `UnreachablePattern` warnings through, deduplicated by span across specializations (3 specializations → 1 warning, verified).

Verified at integration: `make(1+2)` sum = 21; comptime-if = 42; compound-scrutinee match = 42; warning emitted and deduplicated; taken-branch type error intact. 4 new spec cases + 4 new UI cases; full `./test.sh` exit 0.

Known residual (worth its own issue, noted by the worker): specialized bodies still drop all non-unreachable warnings (e.g. unused variables in generic fns) — pre-existing, intentionally out of scope here.

Fixes RUE-553
Fixes RUE-554
Fixes RUE-555

🤖 Generated with [Claude Code](https://claude.com/claude-code)