### PR TITLE
RUE-511+509: cross-module comptime type functions resolve; ArrayBuf imports the official Option (+ RUE-565 array type args)

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -51,13 +51,13 @@ use std::sync::LazyLock;
 
 use lasso::{Key, Spur};
 use rue_error::{CompileError, CompileResult, ErrorKind};
-use rue_rir::{InstData, InstRef, RirPattern};
-use rue_span::Span;
+use rue_rir::{InstData, InstRef, RepeatCount, RirPattern};
+use rue_span::{FileId, Span};
 
 use super::Sema;
 use super::context::{AnalysisContext, ConstValue, LocalVar};
 use crate::specialize::MAX_SPECIALIZATION_ROUNDS;
-use crate::types::{StructField, Type, TypeKind};
+use crate::types::{ArrayLen, StructField, Type, TypeKind};
 
 /// Empty type substitution map for evaluation contexts without one.
 static EMPTY_TYPE_SUBST: LazyLock<HashMap<Spur, Type>> = LazyLock::new(HashMap::new);
@@ -91,6 +91,16 @@ pub(crate) struct ComptimeEnv<'a> {
     /// operand (`1 + m.CONST`) by looking its value up here (RUE-267). Keyed by
     /// the `FieldGet` instruction. Empty outside const-initializer evaluation.
     const_module_members: &'a HashMap<InstRef, ConstValue>,
+    /// The file whose code is currently being reduced (RUE-511). A
+    /// module-qualified comptime call written in a `-> type` constructor body
+    /// (`let O = b.Mk(T)`) names an import (`b`) of *this* file's import graph,
+    /// not of the file that triggered the instantiation — so resolving the
+    /// receiver as a module binding must key `module_bindings` by this file, not
+    /// the instantiation site. Set from `ctx.current_file_id` when analyzing a
+    /// body, and to the callee's `FunctionInfo.file_id` when reducing a
+    /// type-constructor body. `None` where no file context is available (the
+    /// receiver is then non-evaluable and the call is a runtime call).
+    defining_file: Option<FileId>,
 }
 
 impl<'a> ComptimeEnv<'a> {
@@ -103,6 +113,7 @@ impl<'a> ComptimeEnv<'a> {
             runtime_locals: None,
             locals: HashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
+            defining_file: None,
         }
     }
 
@@ -119,6 +130,7 @@ impl<'a> ComptimeEnv<'a> {
             runtime_locals: None,
             locals: HashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
+            defining_file: None,
         }
     }
 
@@ -132,6 +144,7 @@ impl<'a> ComptimeEnv<'a> {
             runtime_locals: Some(&ctx.locals),
             locals: HashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
+            defining_file: Some(ctx.current_file_id),
         }
     }
 
@@ -154,6 +167,7 @@ impl<'a> ComptimeEnv<'a> {
             runtime_locals: None,
             locals: HashMap::new(),
             const_module_members,
+            defining_file: None,
         }
     }
 }
@@ -256,6 +270,9 @@ impl Sema<'_> {
         value_subst: &HashMap<Spur, ConstValue>,
     ) -> Option<ConstValue> {
         let mut env = ComptimeEnv::with_subst(type_subst, value_subst);
+        // A module-qualified comptime call in the evaluated expression resolves
+        // its receiver against the expression's own file's imports (RUE-511).
+        env.defining_file = Some(self.rir.get(inst_ref).span.file_id);
         self.eval_const_expr(inst_ref, &mut env).ok().flatten()
     }
 
@@ -278,6 +295,10 @@ impl Sema<'_> {
         value_subst: &HashMap<Spur, ConstValue>,
     ) -> CompileResult<Option<ConstValue>> {
         let mut env = ComptimeEnv::with_subst(type_subst, value_subst);
+        // The body is code from the constructor's file, so a module-qualified
+        // comptime call inside it (`let O = b.Mk(T)`) resolves its receiver
+        // against that file's imports (RUE-511).
+        env.defining_file = Some(self.rir.get(inst_ref).span.file_id);
         self.eval_const_expr(inst_ref, &mut env)
     }
 
@@ -998,13 +1019,61 @@ impl Sema<'_> {
 
             // TypeConst: a type used as a value (e.g., `i32` in `identity(i32, 42)`)
             InstData::TypeConst { type_name } => {
+                let type_name = *type_name;
                 // Type parameters in scope substitute first.
-                if let Some(&ty) = env.type_subst.get(type_name) {
+                if let Some(&ty) = env.type_subst.get(&type_name) {
                     return Ok(Some(ConstValue::Type(ty)));
                 }
+                // A named type (primitive / struct / enum) resolves directly.
+                if let Some(ty) = self.resolve_named_type_value(&type_name) {
+                    return Ok(Some(ConstValue::Type(ty)));
+                }
+                // A *composite* or *unit* type value — `[i32; 2]`, `()`,
+                // `ptr const T` — is an equally-valid type argument (Appendix A
+                // treats them as unambiguous type spellings; RUE-565). Its
+                // TypeConst carries the composite spelling as the interned
+                // `type_name`, so decode it through the full comptime type
+                // resolver under the current substitutions (an inner element /
+                // pointee naming an enclosing `comptime T` still resolves). An
+                // unresolvable spelling stays non-evaluable (`None`).
                 Ok(self
-                    .resolve_named_type_value(type_name)
+                    .resolve_type_for_comptime_with_subst_and_values_at_span(
+                        type_name,
+                        env.type_subst,
+                        env.value_subst,
+                        span,
+                    )
                     .map(ConstValue::Type))
+            }
+
+            // An array-repeat expression `[T; N]` used as a comptime *type* value
+            // (RUE-565). The surface form `[i32; 2]` in expression position parses
+            // as an array-repeat literal whose element is a type value; when that
+            // element reduces to a `ConstValue::Type`, the whole expression is the
+            // array TYPE `[T; N]` — a legal type-constructor argument
+            // (`Option([i32; 2])`). A repeat over a *runtime* element is a genuine
+            // array value literal and is not comptime-foldable here (`None`).
+            InstData::ArrayRepeat { value, count } => {
+                let (value, count) = (*value, count.clone());
+                let Some(ConstValue::Type(elem_ty)) = self.eval_const_expr(value, env)? else {
+                    return Ok(None);
+                };
+                let len = match count {
+                    RepeatCount::Literal(n) => n,
+                    RepeatCount::Named(sym) => {
+                        let name = self.interner.resolve(&sym).to_string();
+                        match self.resolve_array_length(
+                            &ArrayLen::Named(name),
+                            span,
+                            Some(env.value_subst),
+                        ) {
+                            Ok(n) => n,
+                            Err(_) => return Ok(None),
+                        }
+                    }
+                };
+                let array_type_id = self.get_or_create_array_type(elem_ty, len);
+                Ok(Some(ConstValue::Type(Type::new_array(array_type_id))))
             }
 
             // VarRef: comptime let-bindings, comptime parameters, file-level
@@ -1113,9 +1182,114 @@ impl Sema<'_> {
                 Ok(Some(ConstValue::Unit))
             }
 
+            // Module-qualified comptime type-constructor call in value position,
+            // e.g. `let O = b.Mk(T)` inside a `-> type` constructor body that is
+            // being reduced (RUE-511). The receiver must be an unshadowed
+            // `VarRef` naming a module binding of the *defining* file; membership
+            // and visibility are validated before the call is reduced through the
+            // same path unqualified calls take. Any other receiver (a runtime
+            // value's method, a shadowed name) is a genuine runtime call and
+            // stays non-evaluable.
+            InstData::MethodCall {
+                receiver,
+                method,
+                args_start,
+                args_len,
+            } => {
+                let (receiver, method, args_start, args_len) =
+                    (*receiver, *method, *args_start, *args_len);
+                self.eval_module_qualified_comptime_call(
+                    receiver, method, args_start, args_len, span, env,
+                )
+            }
+
             // Everything else requires runtime evaluation
             _ => Ok(None),
         }
+    }
+
+    /// Reduce a module-qualified comptime type-constructor call written in
+    /// *value position* inside a reducing `-> type` constructor body — the
+    /// cross-module analogue of the `Call` arm's `eval_comptime_type_call`
+    /// (RUE-511). Returns `Ok(None)` (a runtime call, non-evaluable) unless the
+    /// receiver is an unshadowed `VarRef` that names a module binding of the
+    /// environment's `defining_file`, and the named member is a `-> type`
+    /// constructor that actually belongs to that module's file.
+    ///
+    /// The membership check (`fn_info.file_id == module_file_id`) closes the
+    /// RUE-564 cross-module hole: functions live in a flat global table keyed by
+    /// name, so a same-named constructor in a different file must not satisfy
+    /// `b.Mk`. Visibility is enforced the same way the qualified type-annotation
+    /// path enforces it (E0460/E0706 surface as the reduction's E1200 here since
+    /// the comptime engine cannot itself emit a diagnostic mid-reduction).
+    fn eval_module_qualified_comptime_call(
+        &mut self,
+        receiver: InstRef,
+        method: Spur,
+        args_start: u32,
+        args_len: u32,
+        span: Span,
+        env: &mut ComptimeEnv,
+    ) -> CompileResult<Option<ConstValue>> {
+        // Receiver must be a bare name.
+        let InstData::VarRef { name: recv_name } = self.rir.get(receiver).data else {
+            return Ok(None);
+        };
+        // A `let`-binding, runtime local, or comptime parameter of the same name
+        // shadows the module import (spec 4.14:6) — then this is not a module
+        // call and is non-evaluable.
+        if env.locals.contains_key(&recv_name) {
+            return Ok(None);
+        }
+        if let Some(locals) = env.runtime_locals {
+            if locals.contains_key(&recv_name) {
+                return Ok(None);
+            }
+        }
+        if env.type_subst.contains_key(&recv_name) || env.value_subst.contains_key(&recv_name) {
+            return Ok(None);
+        }
+        // The receiver names an import of the file whose body is being reduced.
+        let Some(file_id) = env.defining_file else {
+            return Ok(None);
+        };
+        let Some(binding) = self.module_bindings.get(&(file_id, recv_name)).cloned() else {
+            return Ok(None);
+        };
+        let Some(module_id) = binding.ty.as_module() else {
+            return Ok(None);
+        };
+        let module_def = self.module_registry.get_def(module_id);
+        let Some(module_file_id) = self.canonical_file_id(&module_def.file_path) else {
+            return Ok(None);
+        };
+        // Ensure the member's signature is collected, then require membership:
+        // the resolved function must actually be declared in the module's file.
+        self.ensure_free_function_signature(method, Some(module_file_id))?;
+        let function_key = self
+            .resolve_function_name_local(method, module_file_id)
+            .unwrap_or(method);
+        let Some(fn_info) = self
+            .functions
+            .get(&function_key)
+            .copied()
+            .filter(|info| info.file_id == module_file_id)
+        else {
+            return Ok(None);
+        };
+        // Visibility: a non-`pub` member accessed through a module object is not
+        // usable from another directory (spec 10.3:7).
+        let member_name = self.interner.resolve(&method).to_string();
+        self.check_unqualified_visibility(
+            "function",
+            &member_name,
+            fn_info.file_id,
+            fn_info.is_pub,
+            span,
+        )?;
+        // Reduce through the shared path; arguments are evaluated in the current
+        // environment so `T` (an enclosing comptime parameter) still resolves.
+        self.eval_comptime_type_call(function_key, args_start, args_len, env)
     }
 
     /// The `@require_droppable(T)` well-formedness gate for owning growable
@@ -1312,7 +1486,13 @@ impl Sema<'_> {
         };
         let fn_body = fn_info.body;
         let fn_span = fn_info.span;
+        let fn_file = fn_info.file_id;
         let mut callee_env = ComptimeEnv::with_subst(callee_types, callee_values);
+        // The callee body is code from the callee's file: a module-qualified
+        // comptime call inside it (`let O = b.Mk(T)`) names an import of *that*
+        // file, so the receiver must resolve against the callee's module
+        // bindings, not the instantiation site's (RUE-511).
+        callee_env.defining_file = Some(fn_file);
         self.comptime_type_call_depth += 1;
         if self.comptime_type_call_depth > MAX_SPECIALIZATION_ROUNDS {
             self.comptime_type_call_depth -= 1;

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -858,6 +858,99 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// Resolve a module-qualified type-constructor call (`m.Mk(T)`,
+    /// `std.option.Option(T)`) appearing in a *comptime type position* during
+    /// body reduction, under the current comptime substitutions (RUE-511).
+    ///
+    /// This is the comptime-evaluation analogue of
+    /// [`resolve_qualified_type_function_call`]: same module-prefix walk,
+    /// membership check, and visibility rule, but arguments resolve through the
+    /// enclosing `type_subst`/`value_subst` (so `T` inside the constructor binds
+    /// to the concrete element type) and every failure yields `None` rather than
+    /// a diagnostic — the caller reports the comptime failure (E1200).
+    ///
+    /// The membership check (`fn_info.file_id == module_file_id`) is essential:
+    /// functions live in a flat global table keyed by name, so a same-named
+    /// constructor in a *different* file must not satisfy `m.Mk` (that would
+    /// reintroduce the RUE-564 cross-module-membership hole inside comptime
+    /// evaluation). A default span carries no file context for the prefix walk,
+    /// so it is treated as non-evaluable.
+    ///
+    /// [`resolve_qualified_type_function_call`]:
+    /// Sema::resolve_qualified_type_function_call
+    fn resolve_qualified_type_call_for_comptime(
+        &mut self,
+        call_path: &str,
+        arg_strs: &[String],
+        type_subst: &HashMap<Spur, Type>,
+        value_subst: &HashMap<Spur, ConstValue>,
+        span: Span,
+    ) -> Option<Type> {
+        if span == Span::default() {
+            return None;
+        }
+        let segments: Vec<&str> = call_path.split('.').collect();
+        if segments.len() < 2 || segments.iter().any(|s| s.is_empty()) {
+            return None;
+        }
+        let (_module_id, module_file_id, _module_file_path) = self
+            .resolve_type_module_prefix(&segments[..segments.len() - 1], span)
+            .ok()?;
+        let module_file_id = module_file_id?;
+        let member = segments[segments.len() - 1];
+        let member_sym = self.interner.get_or_intern(member);
+        self.ensure_free_function_signature(member_sym, Some(module_file_id))
+            .ok()?;
+        let function_key = self
+            .resolve_function_name_local(member_sym, module_file_id)
+            .unwrap_or(member_sym);
+        // Membership (RUE-564 hole guard) + `-> type` + visibility.
+        let fn_info = self
+            .functions
+            .get(&function_key)
+            .copied()
+            .filter(|info| info.file_id == module_file_id)?;
+        if fn_info.return_type != Type::COMPTIME_TYPE {
+            return None;
+        }
+        self.check_unqualified_visibility(
+            "function",
+            member,
+            fn_info.file_id,
+            fn_info.is_pub,
+            span,
+        )
+        .ok()?;
+
+        let params = fn_info.params;
+        let param_names = self.param_arena.names(params).to_vec();
+        let param_comptime = self.param_arena.comptime(params).to_vec();
+        if arg_strs.len() != param_names.len()
+            || !(param_names.is_empty() || param_comptime.iter().all(|&c| c))
+        {
+            return None;
+        }
+        let mut callee_types: HashMap<Spur, Type> = HashMap::new();
+        for (i, arg) in arg_strs.iter().enumerate() {
+            let arg_sym = self.interner.get_or_intern(arg);
+            let arg_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
+                arg_sym,
+                type_subst,
+                value_subst,
+                span,
+            )?;
+            callee_types.insert(param_names[i], arg_ty);
+        }
+        let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
+        match self
+            .reduce_type_ctor_body(function_key, &callee_types, &empty_values)
+            .ok()?
+        {
+            Some(ConstValue::Type(t)) => Some(t),
+            _ => None,
+        }
+    }
+
     fn resolve_type_module_prefix(
         &mut self,
         segments: &[&str],
@@ -1236,6 +1329,24 @@ impl<'a> Sema<'a> {
             let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
             Some(Type::new_ptr_mut(ptr_type_id))
         } else if let Some((call_name, arg_strs)) = parse_type_call_syntax(type_name) {
+            // A *module-qualified* type-function application (`m.Mk(T)`,
+            // `std.option.Option(T)`) appearing in a comptime type position
+            // during body reduction — a field type, an enum-variant payload, or
+            // a method's parameter/return type inside a `-> type` constructor
+            // whose method references a constructor imported from another module
+            // (RUE-511). The unqualified path below can't resolve `m.Mk` as a
+            // function name, so dispatch to the qualified resolver, which walks
+            // the module prefix (keyed by `span.file_id`, the defining file),
+            // enforces membership + visibility, and reduces the callee body.
+            if call_name.contains('.') {
+                return self.resolve_qualified_type_call_for_comptime(
+                    &call_name,
+                    &arg_strs,
+                    type_subst,
+                    value_subst,
+                    span,
+                );
+            }
             // A type-function application whose arguments may name enclosing
             // comptime type parameters (`Option(T)` with `T` in `type_subst`).
             // Resolve each argument under the current substitution, then reduce

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -322,30 +322,24 @@ pub fn ArrayBuf(comptime T: type) -> type {
 stdout = "3\n10\n30\n60\n"
 exit_code = 60
 
-# RUE-509 regression PIN (known_bug): ArrayBuf should import the OFFICIAL Option
-# from option.rue instead of defining its own duplicate, so that an Option value
-# returned by `ArrayBuf.get` matches against `option.Option(T)` variants named in
-# the caller (single source of truth; nominal identity across importers).
+# RUE-509 regression: ArrayBuf imports the OFFICIAL Option from option.rue
+# instead of defining its own duplicate, so that an Option value returned by
+# `ArrayBuf.get` matches against `option.Option(T)` variants named in the caller
+# (single source of truth; nominal identity across importers).
 #
-# This is currently BLOCKED by a comptime limitation, NOT a missing test:
-# a source-level generic type function (`ArrayBuf(T)`) whose method references a
-# comptime type function imported from ANOTHER module (`option.Option(T)`) cannot
-# be instantiated — `let V = arraybuf.ArrayBuf(i32)` fails with
+# This used to be BLOCKED by a comptime limitation (RUE-511): a source-level
+# generic type function (`ArrayBuf(T)`) whose method references a comptime type
+# function imported from ANOTHER module (`option.Option(T)`) could not be
+# instantiated — `let V = arraybuf.ArrayBuf(i32)` failed with
 #   E1200: comptime evaluation failed: cannot store type value in variable 'V'
 #          at runtime; type values only exist at compile time
-# The same pattern with a SAME-FILE `Option(T)` compiles and runs (see the
-# `arraybuf_i32_dogfood` case above), which is exactly why std/arraybuf.rue still
-# carries its own `Option` copy. Aliasing (`const OptionT = option.Option;`) hits
-# the same E1200; re-exporting (`pub const Option = option.Option;`) collides with
-# option.rue's `Option` under the transitional flat namespace (E0436).
-#
-# When the comptime cross-module type-function path is fixed, this case PASSES and
-# the suite fails loudly asking for the marker to be removed — at which point
-# std/arraybuf.rue can drop the duplicate and import option.rue (finishing RUE-509).
+# RUE-511 fixed cross-module comptime type-function references in field/return/
+# value positions, so `ArrayBuf.get() -> option.Option(T)` with a method-body
+# `let O = option.Option(T)` now instantiates. This case (and std/arraybuf.rue's
+# real import of option.rue) pins that fix end-to-end.
 [[case]]
 name = "arraybuf_imports_official_option"
 description = "ArrayBuf.get returns the official option.Option(T); caller matches it against option.Option(i32) (RUE-509)."
-known_bug = "RUE-509"
 args = ["main.rue", "-o", "prog"]
 files = [
   { path = "main.rue", source = """

--- a/crates/rue-cli-tests/cases/comptime_cross_module.toml
+++ b/crates/rue-cli-tests/cases/comptime_cross_module.toml
@@ -1,0 +1,218 @@
+# Cross-module comptime type-function references (RUE-511) and composite type
+# values as type-constructor arguments (RUE-565), driven end-to-end through the
+# real binary with @imports resolved from disk.
+#
+# RUE-511: a source-level generic type function (`Wrap(T)`) whose method bodies /
+# field types / return types reference a comptime type function imported from
+# ANOTHER module (`b.Mk(T)`) used to fail with
+#   E1200: cannot store type value in variable 'W' at runtime
+# because the comptime evaluator only recognized SAME-file constructor calls.
+# The fix resolves module-qualified comptime type calls in field position,
+# method-signature position, and value position (`let O = b.Mk(T)`), with a
+# membership + visibility check so a same-named constructor in a different file
+# cannot satisfy the call (the RUE-564 hole). These cases pin every position AND
+# the runtime result of matching the cross-module enum.
+#
+# RUE-565: composite type VALUES (`[i32; 2]`, nested arrays) are legal
+# type-constructor arguments; they used to be rejected with E1201.
+
+[section]
+id = "cli.comptime_cross_module"
+name = "Cross-module comptime type functions"
+description = "Module-qualified comptime type-function references (RUE-511) and composite type arguments (RUE-565)."
+
+# --- RUE-511: field-type position ---
+[[case]]
+name = "cross_module_ctor_field_type"
+description = "A generic type function's struct field type references an imported constructor `b.Mk(T)` (RUE-511)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "b.rue", source = """
+pub fn Mk(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+""" },
+  { path = "a.rue", source = """
+const b = @import("b.rue");
+
+pub fn Wrap(comptime T: type) -> type {
+    struct {
+        inner: b.Mk(T),
+        fn make(v: T) -> Self {
+            let O = b.Mk(T);
+            Self { inner: O.Some(v) }
+        }
+    }
+}
+""" },
+  { path = "main.rue", source = """
+const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 {
+    let W = a.Wrap(i32);
+    let O = b.Mk(i32);
+    let w = W.make(42);
+    match w.inner {
+        O.Some(x) => x,
+        O.None => -1,
+    }
+}
+""" },
+]
+exit_code = 42
+
+# --- RUE-511: method return-type + value (let) position ---
+[[case]]
+name = "cross_module_ctor_return_and_let"
+description = "A method returns `b.Mk(T)` and binds `let O = b.Mk(T)` in its body, both cross-module (RUE-511)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "b.rue", source = """
+pub fn Mk(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+""" },
+  { path = "a.rue", source = """
+const b = @import("b.rue");
+
+pub fn Wrap(comptime T: type) -> type {
+    struct {
+        v: T,
+        fn get(borrow self) -> b.Mk(T) {
+            let O = b.Mk(T);
+            O.Some(self.v)
+        }
+    }
+}
+""" },
+  { path = "main.rue", source = """
+const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 {
+    let W = a.Wrap(i32);
+    let O = b.Mk(i32);
+    let w = W { v: 30 };
+    match w.get() {
+        O.Some(x) => x,
+        O.None => -1,
+    }
+}
+""" },
+]
+exit_code = 30
+
+# --- RUE-511: value position inside the -> type constructor body (delegating) ---
+[[case]]
+name = "cross_module_ctor_body_let_binding"
+description = "A `-> type` constructor binds `let X = b.Mk(T)` in its body and returns X, cross-module (RUE-511)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "b.rue", source = """
+pub fn Mk(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+""" },
+  { path = "a.rue", source = """
+const b = @import("b.rue");
+
+pub fn Alias(comptime T: type) -> type {
+    let X = b.Mk(T);
+    X
+}
+""" },
+  { path = "main.rue", source = """
+const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 {
+    let A = a.Alias(i32);
+    let O = b.Mk(i32);
+    let x = A.Some(7);
+    match x {
+        O.Some(v) => v,
+        O.None => -1,
+    }
+}
+""" },
+]
+exit_code = 7
+
+# --- RUE-511: privacy — a non-pub imported constructor is NOT usable across
+# directories (the visibility guard must reject it, not silently leak). ---
+[[case]]
+name = "cross_module_ctor_private_rejected"
+description = "A non-pub constructor imported from another DIRECTORY is rejected in a cross-module comptime reference (RUE-511)."
+compile_fail = true
+args = ["main.rue", "-o", "prog"]
+# The visibility guard makes the private constructor non-evaluable, so the
+# instantiation cannot reduce to a type — reported as the reduction's E1200
+# rather than silently leaking the private type across directories.
+error_contains = ["E1200"]
+files = [
+  { path = "sub/b.rue", source = """
+fn Mk(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+""" },
+  { path = "a.rue", source = """
+const b = @import("sub/b.rue");
+
+pub fn Wrap(comptime T: type) -> type {
+    struct { inner: b.Mk(T) }
+}
+""" },
+  { path = "main.rue", source = """
+const a = @import("a.rue");
+
+fn main() -> i32 {
+    let W = a.Wrap(i32);
+    0
+}
+""" },
+]
+
+# --- RUE-565: composite (array) type value as a type-constructor argument ---
+[[case]]
+name = "array_type_arg_local_ctor"
+description = "`[i32; 2]` is accepted as a comptime type argument to a local `-> type` constructor (RUE-565)."
+files = [{ path = "main.rue", source = """
+fn Box(comptime T: type) -> type {
+    struct { value: T }
+}
+
+fn main() -> i32 {
+    let B = Box([i32; 2]);
+    let arr: [i32; 2] = [21, 21];
+    let b = B { value: arr };
+    b.value[0] + b.value[1]
+}
+""" }]
+exit_code = 42
+
+# --- RUE-565: array type value through the std bundle + nested arrays ---
+[[case]]
+name = "array_type_arg_std_and_nested"
+description = "`[i32; 2]` and nested `[[i32; 3]; 2]` are accepted as type arguments to std.option.Option / std.arraybuf.ArrayBuf (RUE-565)."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn Box(comptime T: type) -> type {
+    struct { value: T }
+}
+
+fn main() -> i32 {
+    let A = std.option.Option([i32; 2]);
+    let V = std.arraybuf.ArrayBuf([i32; 2]);
+    let N = Box([[i32; 3]; 2]);
+    let arr: [i32; 2] = [1, 2];
+    let x = A.Some(arr);
+    match x {
+        A.Some(a) => a[0] + a[1],
+        A.None => -1,
+    }
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 3

--- a/examples/std/arraybuf_demo.rue
+++ b/examples/std/arraybuf_demo.rue
@@ -13,7 +13,7 @@ const std = @import("std");
 
 fn main() -> i32 {
     let V = std.arraybuf.ArrayBuf(i32);
-    let O = std.arraybuf.Option(i32);
+    let O = std.option.Option(i32);
 
     let mut v = V.new();
     v.push(10);

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -9,7 +9,7 @@
 // mutation, and the raw-pointer intrinsics all at once — exactly the "stdlib on
 // unchecked code" framing of RUE-1.
 //
-// `get`/`pop` return `Option(T)` from the std bundle:
+// `get`/`pop` return the official `option.Option(T)` from the std bundle:
 //
 //     const std = @import("std");
 //     let V = std.arraybuf.ArrayBuf(i32);
@@ -54,11 +54,14 @@
 //     Elements are transferred by copy.
 //
 // The enclosing element type `T` is usable throughout the method bodies below —
-// e.g. to name `Option(T)` and bind `let O = Option(T)` (RUE-313).
-
-pub fn Option(comptime T: type) -> type {
-    enum { Some(T), None }
-}
+// e.g. to name `option.Option(T)` and bind `let O = option.Option(T)` (RUE-313).
+//
+// `get`/`pop` return the OFFICIAL `option.Option(T)` from the std bundle (a
+// single source of truth, not a duplicate copy). Cross-module comptime
+// type-function references inside a generic type function's methods were the
+// blocker (RUE-511); now that they resolve, ArrayBuf imports option.rue directly
+// (RUE-509).
+const option = @import("option.rue");
 
 pub fn ArrayBuf(comptime T: type) -> type {
     // Well-formedness gate (RUE-388): ArrayBuf owns a heap buffer of `T` and
@@ -112,12 +115,12 @@ pub fn ArrayBuf(comptime T: type) -> type {
         fn capacity(borrow self) -> u64 { self.cap }
         fn is_empty(borrow self) -> bool { self.len == 0 }
 
-        // Element `i` by copy, wrapped in `Option(T)`: `Some(x)` when in
+        // Element `i` by copy, wrapped in `option.Option(T)`: `Some(x)` when in
         // bounds, `None` otherwise (ADR-0041). The enclosing element type `T`
-        // is in scope here, so the method can pass it to `Option(T)`
+        // is in scope here, so the method can pass it to `option.Option(T)`
         // (RUE-313).
-        fn get(borrow self, i: u64) -> Option(T) {
-            let O = Option(T);
+        fn get(borrow self, i: u64) -> option.Option(T) {
+            let O = option.Option(T);
             if i < self.len {
                 O.Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
             } else {
@@ -163,8 +166,8 @@ pub fn ArrayBuf(comptime T: type) -> type {
 
         // Remove and return the last element as `Some(x)`, or `None` when the
         // buffer is empty (ADR-0041).
-        fn pop(inout self) -> Option(T) {
-            let O = Option(T);
+        fn pop(inout self) -> option.Option(T) {
+            let O = option.Option(T);
             if self.len == 0 {
                 O.None
             } else {


### PR DESCRIPTION
Integrates fix-cycle worker 2; every repro re-verified by execution on trunk `978e5d26` at integration.

**RUE-511** — a module-qualified comptime type-function reference (`b.Mk(T)`) failed E1200 in every position. Empirical tracing showed the failure funnels through **two** evaluation paths, both fixed:
1. *Type position* (field types, enum payloads, method signatures): new `resolve_qualified_type_call_for_comptime` in `typeck.rs` — walks the module prefix keyed by `span.file_id`, enforces **membership** (`fn_info.file_id == module file`, keeping the RUE-564 hole closed) and **visibility**, then reduces the constructor body.
2. *Value position* (`let O = b.Mk(T)` inside a `-> type` body): new `MethodCall` arm in `eval_const_expr`, gated on an unshadowed module binding of the env's new `defining_file`. `defining_file` is set at every reduction entry point — including `eval_type_constructor_body`/`try_evaluate_const_with_subst`, the `with_subst` paths module-member reduction actually uses (the subtle miss in the original plan).

**RUE-509** (was blocked solely by 511) — `std/arraybuf.rue` now imports the official `std.option.Option` and drops its duplicate. The `known_bug` xfail on `arraybuf_imports_official_option` is un-marked into a regression test; `examples/std/arraybuf_demo.rue` updated off the removed alias.

**RUE-565, array part** — `[i32; 2]` in type-argument position parses as `ArrayRepeat` over a `TypeConst`, so `eval_const_expr` gains an `ArrayRepeat` arm producing the array **type**: `std.option.Option([i32; 2])` works, nested arrays too. The unit `()` sub-case needs an `analyze_ops.rs` change (precise pointer in the issue) and stays open.

Verified at integration: cross-module enum constructor program exit 42; `Option([i32; 2])` match exit 42; all 9 arraybuf CLI cases including the un-marked regression; 6 new `comptime_cross_module` cases (incl. cross-directory privacy still rejected). Full `./test.sh` exit 0.

Follow-ups filed: RUE-575 (let-bound type alias in field-type position, pre-existing), RUE-574 (specialized-body warnings, from worker 1).

Fixes RUE-511
Fixes RUE-509
Part of RUE-565

🤖 Generated with [Claude Code](https://claude.com/claude-code)