### PR TITLE
RUE-571: file-qualified symbols for methods, assoc fns, destructors, and drop glue

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -742,6 +742,72 @@ impl TypeInternPool {
         }
     }
 
+    /// The symbol-name component for functions derived from a struct —
+    /// methods (`P.get`), associated functions (`P::make`), destructors
+    /// (`P.__drop`), and drop glue (`__rue_drop_P`) — RUE-571.
+    ///
+    /// Same-named structs across files are legal (RUE-558), but these symbols
+    /// are program-wide identities: when this struct's source name is
+    /// registered by more than one file, the name is qualified with the
+    /// defining file (`P$2`). `$` cannot appear in a source identifier, so a
+    /// qualified name can never collide with a real type; unambiguous names
+    /// (the common case) are returned bare, keeping symbols and `--emit`
+    /// output unchanged. Builtins are never qualified (their symbols pair
+    /// with runtime-provided definitions).
+    ///
+    /// Every layer that names a function after a type — sema (definition and
+    /// call sites), the drop-glue generator in `rue-compiler`, and both
+    /// codegen backends — must derive the name through this ONE helper so
+    /// definitions and calls meet at link time.
+    pub fn struct_symbol_name(&self, struct_id: StructId) -> String {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        let pool_index = struct_id.0 as usize;
+        let data = match &inner.types[pool_index] {
+            TypeData::Struct(data) => data,
+            other => panic!(
+                "Expected struct at pool index {}, got {:?}",
+                pool_index, other
+            ),
+        };
+        if !data.def.is_builtin {
+            let defining_files = inner
+                .struct_by_file_name
+                .keys()
+                .filter(|(_, n)| *n == data.name)
+                .take(2)
+                .count();
+            if defining_files > 1 {
+                return format!("{}${}", data.def.name, data.def.file_id.0);
+            }
+        }
+        data.def.name.clone()
+    }
+
+    /// The symbol-name component for an enum's drop glue (`__rue_drop_E`),
+    /// file-qualified when the enum name is registered by more than one file.
+    /// See [`Self::struct_symbol_name`] (RUE-571) — same rule, same reason.
+    pub fn enum_symbol_name(&self, enum_id: EnumId) -> String {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        let pool_index = enum_id.0 as usize;
+        let data = match &inner.types[pool_index] {
+            TypeData::Enum(data) => data,
+            other => panic!(
+                "Expected enum at pool index {}, got {:?}",
+                pool_index, other
+            ),
+        };
+        let defining_files = inner
+            .enum_by_file_name
+            .keys()
+            .filter(|(_, n)| *n == data.name)
+            .take(2)
+            .count();
+        if defining_files > 1 {
+            return format!("{}${}", data.def.name, data.def.file_id.0);
+        }
+        data.def.name.clone()
+    }
+
     /// Update a struct definition in the pool.
     ///
     /// This is used during semantic analysis when struct fields are resolved
@@ -1852,6 +1918,43 @@ mod tests {
         // Can retrieve the struct definition
         let retrieved = pool.struct_def(struct_id);
         assert_eq!(retrieved.name, name_str);
+    }
+
+    /// RUE-571: a struct name registered by two files yields file-qualified
+    /// symbol names; a unique name stays bare; builtins are never qualified.
+    #[test]
+    fn test_struct_symbol_name_qualifies_only_colliding_names() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let mk = |name: &str, file: u32, is_builtin: bool| StructDef {
+            name: name.to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin,
+            is_pub: true,
+            file_id: rue_span::FileId::new(file),
+        };
+
+        let p_sym = interner.get_or_intern("P");
+        let (p1, _) = pool.register_struct(p_sym, mk("P", 1, false));
+        let (p2, _) = pool.register_struct(p_sym, mk("P", 2, false));
+        let q_sym = interner.get_or_intern("Q");
+        let (q, _) = pool.register_struct(q_sym, mk("Q", 1, false));
+        let b_sym = interner.get_or_intern("StrBufTest");
+        let (b1, _) = pool.register_struct(b_sym, mk("StrBufTest", 0, true));
+        let (b2, _) = pool.register_struct(b_sym, mk("StrBufTest", 3, false));
+
+        // Colliding user structs are qualified with their defining file.
+        assert_eq!(pool.struct_symbol_name(p1), "P$1");
+        assert_eq!(pool.struct_symbol_name(p2), "P$2");
+        // A unique name stays bare.
+        assert_eq!(pool.struct_symbol_name(q), "Q");
+        // A builtin is never qualified, even when its name collides; the
+        // colliding user struct still is, so the pair stays distinct.
+        assert_eq!(pool.struct_symbol_name(b1), "StrBufTest");
+        assert_eq!(pool.struct_symbol_name(b2), "StrBufTest$3");
     }
 
     #[test]

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -42,6 +42,12 @@ use crate::types::{ModuleId, StructField, StructId, Type, TypeKind};
 /// Uses the lazy driver for import graphs and the eager driver for single-file
 /// compilations.
 pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResult<SemaOutput> {
+    // Declarations are complete: re-point destructor symbols of struct
+    // names that span multiple files at their file-qualified form (RUE-571).
+    // Must precede any body analysis — destructor definitions build their
+    // symbol from the same helper.
+    sema.requalify_colliding_destructor_symbols();
+
     // Use lazy analysis when imports are present (multi-file compilation)
     // This ensures only reachable code is analyzed, per ADR-0026
     let result = if sema.has_imports() {
@@ -265,11 +271,8 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                     let method_name_str = sema.interner.resolve(&*method_name).to_string();
                     let params = sema.rir.get_params(*params_start, *params_len);
 
-                    let full_name = if *has_self {
-                        format!("{}.{}", type_name_str, method_name_str)
-                    } else {
-                        format!("{}::{}", type_name_str, method_name_str)
-                    };
+                    // File-qualified when the type name spans files (RUE-571).
+                    let full_name = sema.method_symbol(struct_id, &method_name_str, *has_self);
 
                     match sema.analyze_method_function(
                         &infer_ctx,
@@ -318,7 +321,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 }
             };
             let struct_type = Type::new_struct(struct_id);
-            let full_name = format!("{}.__drop", type_name_str);
+            let full_name = sema.destructor_symbol(struct_id);
 
             match sema.analyze_destructor_function(
                 &infer_ctx,
@@ -370,15 +373,9 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         for (struct_id, method_name, method_info) in pending_anon_methods {
             analyzed_anon_methods.insert((struct_id, method_name));
 
-            let struct_def = sema.type_pool.struct_def(struct_id);
-            let type_name_str = struct_def.name.clone();
             let method_name_str = sema.interner.resolve(&method_name).to_string();
 
-            let full_name = if method_info.has_self {
-                format!("{}.{}", type_name_str, method_name_str)
-            } else {
-                format!("{}::{}", type_name_str, method_name_str)
-            };
+            let full_name = sema.method_symbol(struct_id, &method_name_str, method_info.has_self);
 
             // Build param_info from MethodInfo's ParamRange
             let param_names = sema.param_arena.names(method_info.params);
@@ -816,11 +813,8 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
 
             // For anonymous structs, use the MethodInfo directly since there's no named StructDecl
             if type_name_str.starts_with("__anon_struct_") {
-                let full_name = if method_info.has_self {
-                    format!("{}.{}", type_name_str, method_name_str)
-                } else {
-                    format!("{}::{}", type_name_str, method_name_str)
-                };
+                let full_name =
+                    sema.method_symbol(struct_id, &method_name_str, method_info.has_self);
 
                 // Build param_info from MethodInfo's ParamRange
                 let param_names = sema.param_arena.names(method_info.params);
@@ -947,6 +941,20 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                         continue;
                     }
 
+                    // Several files may declare a struct with this name
+                    // (RUE-558); only the declaration that resolves to THIS
+                    // struct_id owns the method bodies being analyzed —
+                    // matching by name alone would analyze the other file\'s
+                    // same-named method under this struct\'s symbol (RUE-571).
+                    let declared_id = sema
+                        .structs_by_file_name
+                        .get(&(inst.span.file_id, *struct_name))
+                        .or_else(|| sema.structs.get(struct_name))
+                        .copied();
+                    if declared_id != Some(struct_id) {
+                        continue;
+                    }
+
                     let methods = sema.rir.get_inst_refs(*methods_start, *methods_len);
                     for method_ref in methods {
                         let method_inst = sema.rir.get(method_ref);
@@ -966,11 +974,8 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                             }
 
                             let params = sema.rir.get_params(*params_start, *params_len);
-                            let full_name = if *has_self {
-                                format!("{}.{}", type_name_str, method_name_str)
-                            } else {
-                                format!("{}::{}", type_name_str, method_name_str)
-                            };
+                            let full_name =
+                                sema.method_symbol(struct_id, &method_name_str, *has_self);
 
                             match sema.analyze_method_function(
                                 &infer_ctx,
@@ -1042,7 +1047,6 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
     // (This is necessary because drop is implicitly called)
     for (_, inst) in sema.rir.iter() {
         if let InstData::DropFnDecl { type_name, body } = &inst.data {
-            let type_name_str = sema.interner.resolve(&*type_name).to_string();
             // File-aware first (RUE-558), matching the sites above.
             let struct_id = match sema
                 .structs_by_file_name
@@ -1053,7 +1057,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 None => continue,
             };
             let struct_type = Type::new_struct(struct_id);
-            let full_name = format!("{}.__drop", type_name_str);
+            let full_name = sema.destructor_symbol(struct_id);
 
             match sema.analyze_destructor_function(
                 &infer_ctx,
@@ -1107,6 +1111,8 @@ fn reject_self_move_in_destructor(air: &Air, full_name: &str) -> CompileResult<(
         } = inst.data
         {
             let type_name = full_name.strip_suffix(".__drop").unwrap_or(full_name);
+            // Strip the RUE-571 file qualifier (`P$2` -> `P`) for display.
+            let type_name = type_name.split('$').next().unwrap_or(type_name);
             return Err(CompileError::new(
                 ErrorKind::MoveSelfOutOfDestructor {
                     type_name: type_name.to_string(),

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -353,8 +353,10 @@ impl<'a> Sema<'a> {
         }
         air_args.extend(args_result?);
 
-        // Generate a method call name: Type.method
-        let call_name = format!("{}.{}", struct_name_str, method_name_str);
+        // Generate the method call symbol: `Type.method`, file-qualified when
+        // the type name spans files (RUE-571) — must match the definition
+        // side, which builds its name through the same helper.
+        let call_name = self.method_symbol(struct_id, &method_name_str, true);
         let call_name_sym = self.interner.get_or_intern(&call_name);
 
         // Encode call args into extra array
@@ -591,12 +593,12 @@ impl<'a> Sema<'a> {
         // Analyze arguments
         let air_args = self.analyze_call_args(air, &args, ctx)?;
 
-        // Generate a function call name: Type::function
-        // Use the internal struct name (e.g., "__anon_struct_0") for anonymous structs,
-        // not the user-visible type variable name (e.g., "P")
-        let struct_def = self.type_pool.struct_def(struct_id);
-        let internal_type_name = &struct_def.name;
-        let call_name = format!("{}::{}", internal_type_name, function_name_str);
+        // Generate the associated-function call symbol: `Type::function`.
+        // Uses the internal struct name (e.g. "__anon_struct_0") for anonymous
+        // structs — not the user-visible type variable name — and the
+        // file-qualified name when the type name spans files (RUE-571),
+        // matching the definition side.
+        let call_name = self.method_symbol(struct_id, &function_name_str, false);
         let call_name_sym = self.interner.get_or_intern(&call_name);
 
         // Encode call args into extra array

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -26,7 +26,8 @@ use super::info::ConstInfo;
 use crate::inference::InferType;
 use crate::sema::ConstValue;
 use crate::types::{
-    ArrayLen, ArrayTypeId, Type, TypeKind, parse_array_type_syntax, parse_type_call_syntax,
+    ArrayLen, ArrayTypeId, StructId, Type, TypeKind, parse_array_type_syntax,
+    parse_type_call_syntax,
 };
 
 impl<'a> Sema<'a> {
@@ -312,6 +313,68 @@ impl<'a> Sema<'a> {
             .insert((file_id, type_sym), struct_id);
         let _ = span;
         Ok(Type::new_struct(struct_id))
+    }
+
+    /// Requalify destructor symbols for struct names that span files
+    /// (RUE-571). Registration (`register_destructor`) runs per-file before
+    /// ambiguity is knowable, so it records the bare `Type.__drop`; once
+    /// declarations are complete this re-points colliding entries at their
+    /// file-qualified form, so every consumer of `StructDef::destructor`
+    /// (drop glue in CFG build and both codegen backends) agrees with the
+    /// definition side, which builds its name via [`Self::destructor_symbol`].
+    pub(crate) fn requalify_colliding_destructor_symbols(&mut self) {
+        let ids: Vec<StructId> = self
+            .structs_by_file_name
+            .values()
+            .copied()
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        for struct_id in ids {
+            if self.type_pool.struct_def(struct_id).destructor.is_none() {
+                continue;
+            }
+            let qualified = self.destructor_symbol(struct_id);
+            let def = self.type_pool.struct_def(struct_id);
+            if def.destructor.as_deref() != Some(qualified.as_str()) {
+                let mut def = def.clone();
+                def.destructor = Some(qualified);
+                self.type_pool.update_struct_def(struct_id, def);
+            }
+        }
+    }
+
+    /// The type-name component of function symbols for `struct_id` (RUE-571):
+    /// delegates to [`TypeInternPool::struct_symbol_name`], the single
+    /// definition shared with the drop-glue generator and both codegen
+    /// backends.
+    pub(crate) fn symbol_type_name(&self, struct_id: StructId) -> String {
+        self.type_pool.struct_symbol_name(struct_id)
+    }
+
+    /// Symbol for a method (`Type.method`) or associated function
+    /// (`Type::method`) of `struct_id`, file-qualified when the type name is
+    /// ambiguous (RUE-571). Definition sites (function-body analysis) and
+    /// call sites (method / assoc-fn call analysis) must both build the name
+    /// through this helper so they meet in AIR/codegen.
+    pub(crate) fn method_symbol(
+        &self,
+        struct_id: StructId,
+        method: &str,
+        has_self: bool,
+    ) -> String {
+        let type_name = self.symbol_type_name(struct_id);
+        if has_self {
+            format!("{}.{}", type_name, method)
+        } else {
+            format!("{}::{}", type_name, method)
+        }
+    }
+
+    /// Symbol for the destructor of `struct_id` (`Type.__drop`),
+    /// file-qualified when the type name is ambiguous (RUE-571).
+    pub(crate) fn destructor_symbol(&self, struct_id: StructId) -> String {
+        format!("{}.__drop", self.symbol_type_name(struct_id))
     }
 
     /// Is `ty` the synthetic `str` struct (ADR-0043 Phase 3, RUE-324)? Detected

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -2577,3 +2577,149 @@ fn main() -> i32 { 0 }
 ]
 args = ["a.rue", "b.rue", "-o", "prog"]
 exit_code = 0
+
+[[case]]
+# RUE-571: same-named structs in two modules each defining a same-named
+# method used to fail at link with "duplicate symbol: P.get" — method
+# symbols were built from the bare type name. Colliding names now get
+# file-qualified symbols; each call dispatches to its own file's body.
+name = "same_named_struct_methods_across_modules_link_and_dispatch"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "a.rue", source = """
+pub struct P {
+    x: i32,
+
+    fn get(self) -> i32 { self.x + 1 }
+}
+
+pub fn make(v: i32) -> P { P { x: v } }
+""" },
+  { path = "b.rue", source = """
+pub struct P {
+    x: i32,
+
+    fn get(self) -> i32 { self.x + 2 }
+}
+
+pub fn make(v: i32) -> P { P { x: v } }
+""" },
+  { path = "main.rue", source = """
+const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 {
+    let pa = a.make(10);
+    let pb = b.make(20);
+    pa.get() + pb.get()  // 11 + 22
+}
+""" },
+]
+exit_code = 33
+
+[[case]]
+# RUE-571, destructor + drop-glue face: same-named structs with `drop fn`
+# in two modules collided on both the user destructor symbol (`R.__drop`)
+# and the synthesized drop glue (`__rue_drop_R`). Each value must run ITS
+# file's destructor; drop order is reverse declaration order, so b's runs
+# first. Exact stdout pins which destructor body ran, not just the count.
+name = "same_named_struct_destructors_across_modules_run_own_body"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "a.rue", source = """
+pub struct R {
+    id: i32,
+
+    fn tag(self) -> i32 { self.id + 100 }
+}
+
+drop fn R(self) {
+    @dbg(1);
+}
+
+pub fn make(v: i32) -> R { R { id: v } }
+""" },
+  { path = "b.rue", source = """
+pub struct R {
+    id: i32,
+
+    fn tag(self) -> i32 { self.id + 200 }
+}
+
+drop fn R(self) {
+    @dbg(2);
+}
+
+pub fn make(v: i32) -> R { R { id: v } }
+""" },
+  { path = "main.rue", source = """
+const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 {
+    let ra = a.make(1);
+    let rb = b.make(2);
+    rb.tag() - ra.tag()  // 202 - 101
+}
+""" },
+]
+exit_code = 101
+stdout = "2\n1\n"
+
+[[case]]
+# RUE-571, enum drop-glue face: same-named payload enums in two modules
+# collided on `__rue_drop_E`. The payload's destructor output pins that
+# each enum value ran its own file's glue chain (reverse declaration order:
+# b's payload prints 12, then a's prints 1).
+name = "same_named_payload_enums_across_modules_drop_own_payload"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "ea.rue", source = """
+pub struct Payload {
+    v: i32,
+}
+
+drop fn Payload(self) {
+    @dbg(self.v);
+}
+
+pub enum E {
+    Keep(Payload),
+    Empty,
+}
+
+pub fn make(v: i32) -> E {
+    E.Keep(Payload { v: v })
+}
+""" },
+  { path = "eb.rue", source = """
+pub struct Payload {
+    v: i32,
+}
+
+drop fn Payload(self) {
+    @dbg(self.v + 10);
+}
+
+pub enum E {
+    Keep(Payload),
+    Empty,
+}
+
+pub fn make(v: i32) -> E {
+    E.Keep(Payload { v: v })
+}
+""" },
+  { path = "main.rue", source = """
+const a = @import("ea.rue");
+const b = @import("eb.rue");
+
+fn main() -> i32 {
+    let _ea = a.make(1);
+    let _eb = b.make(2);
+    0
+}
+""" },
+]
+exit_code = 0
+stdout = "12\n1\n"

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2907,7 +2907,13 @@ impl<'a> CfgLower<'a> {
                         }
                         off += fc;
                     }
-                    let drop_fn_name = format!("__rue_drop_{}", struct_def.name);
+                    // File-qualified when the struct name spans files
+                    // (RUE-571) — must match the glue definition in
+                    // rue_compiler::drop_glue.
+                    let drop_fn_name = format!(
+                        "__rue_drop_{}",
+                        self.ctx.type_pool.struct_symbol_name(struct_id)
+                    );
                     self.emit_call_with_slot_args(&glue_vregs, &drop_fn_name);
                     return;
                 }
@@ -2947,8 +2953,11 @@ impl<'a> CfgLower<'a> {
                     let field_vregs = self
                         .get_or_compute_field_vregs(*dropped_value)
                         .expect("payload enum value should have field vregs");
-                    let enum_def = self.ctx.type_pool.enum_def(enum_id);
-                    let drop_fn_name = format!("__rue_drop_{}", enum_def.name);
+                    // File-qualified when the enum name spans files (RUE-571).
+                    let drop_fn_name = format!(
+                        "__rue_drop_{}",
+                        self.ctx.type_pool.enum_symbol_name(enum_id)
+                    );
                     self.emit_call_with_slot_args(&field_vregs, &drop_fn_name);
                     return;
                 }

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -380,7 +380,9 @@ fn type_name(ty: Type, type_pool: &TypeInternPool) -> String {
         TypeKind::ComptimeType => "comptime_type".to_string(),
         TypeKind::Enum(enum_id) => format!("enum{}", enum_id.0),
         // Struct types include builtin types like String
-        TypeKind::Struct(struct_id) => type_pool.struct_def(struct_id).name.clone(),
+        // File-qualified when the struct name spans files (RUE-571); must
+        // match rue_compiler::drop_glue::type_name.
+        TypeKind::Struct(struct_id) => type_pool.struct_symbol_name(struct_id),
         TypeKind::Array(array_id) => {
             let (element_type, length) = type_pool.array_def(array_id);
             let elem_name = type_name(element_type, type_pool);

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3322,7 +3322,13 @@ impl<'a> CfgLower<'a> {
                         }
                         off += fc;
                     }
-                    let drop_fn_name = format!("__rue_drop_{}", struct_def.name);
+                    // File-qualified when the struct name spans files
+                    // (RUE-571) — must match the glue definition in
+                    // rue_compiler::drop_glue.
+                    let drop_fn_name = format!(
+                        "__rue_drop_{}",
+                        self.ctx.type_pool.struct_symbol_name(struct_id)
+                    );
                     self.emit_call_with_slot_args(&glue_vregs, &drop_fn_name);
                     return;
                 }
@@ -3362,8 +3368,11 @@ impl<'a> CfgLower<'a> {
                     let field_vregs = self
                         .get_or_compute_field_vregs(*dropped_value)
                         .expect("payload enum value should have field vregs");
-                    let enum_def = self.ctx.type_pool.enum_def(enum_id);
-                    let drop_fn_name = format!("__rue_drop_{}", enum_def.name);
+                    // File-qualified when the enum name spans files (RUE-571).
+                    let drop_fn_name = format!(
+                        "__rue_drop_{}",
+                        self.ctx.type_pool.enum_symbol_name(enum_id)
+                    );
                     self.emit_call_with_slot_args(&field_vregs, &drop_fn_name);
                     return;
                 }

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -208,10 +208,12 @@ pub fn synthesize_drop_glue(type_pool: &TypeInternPool) -> Vec<AnalyzedFunction>
 /// Create a drop glue function for a single struct.
 fn create_struct_drop_glue_function(
     struct_def: &StructDef,
-    _struct_id: rue_air::StructId,
+    struct_id: rue_air::StructId,
     type_pool: &TypeInternPool,
 ) -> AnalyzedFunction {
-    let fn_name = format!("__rue_drop_{}", struct_def.name);
+    // File-qualified when the struct name spans files (RUE-571) — must match
+    // the call side in both codegen backends' cfg_lower.
+    let fn_name = format!("__rue_drop_{}", type_pool.struct_symbol_name(struct_id));
     let span = Span::new(0, 0); // Synthetic span
 
     // Create AIR for the drop glue function
@@ -612,7 +614,8 @@ fn create_enum_drop_glue_function(enum_id: EnumId, type_pool: &TypeInternPool) -
 /// Types share a namespace, so the enum's own name cannot collide with a
 /// struct's `__rue_drop_<name>` glue.
 pub fn enum_drop_glue_name(enum_id: EnumId, type_pool: &TypeInternPool) -> String {
-    format!("__rue_drop_{}", type_pool.enum_def(enum_id).name)
+    // File-qualified when the enum name spans files (RUE-571).
+    format!("__rue_drop_{}", type_pool.enum_symbol_name(enum_id))
 }
 
 /// Generate the drop glue function name for an array type.
@@ -642,8 +645,10 @@ fn type_name(ty: Type, type_pool: &TypeInternPool) -> String {
         // ComptimeType only exists at compile time
         TypeKind::ComptimeType => "comptime_type".to_string(),
         TypeKind::Enum(enum_id) => format!("enum{}", enum_id.0),
-        // Struct types include builtin types like String
-        TypeKind::Struct(struct_id) => type_pool.struct_def(struct_id).name.clone(),
+        // Struct types include builtin types like String. File-qualified
+        // when the struct name spans files (RUE-571), so arrays of two
+        // same-named element types get distinct glue.
+        TypeKind::Struct(struct_id) => type_pool.struct_symbol_name(struct_id),
         TypeKind::Array(array_id) => {
             let (element_type, length) = type_pool.array_def(array_id);
             let elem_name = type_name(element_type, type_pool);


### PR DESCRIPTION
Same-named structs across files are legal since RUE-558, but every function symbol derived from a type name was still built from the **bare** name: methods (`P.get`), associated functions (`P::make`), user destructors (`P.__drop`), and synthesized drop glue (`__rue_drop_P`, `__rue_drop_E`, array-element glue). Two modules each defining `struct P { fn get }` failed at link with `duplicate symbol: P.get`; destructor pairs collided on both `R.__drop` and `__rue_drop_R`; same-named payload enums on `__rue_drop_E`.

**One rule, one place:** `TypeInternPool::struct_symbol_name` / `enum_symbol_name` qualify a type's symbol component with its defining file (`P$2`) exactly when the source name is registered by more than one file. `$` cannot appear in a source identifier, so qualified names never collide with real types; unambiguous programs keep bare symbols (zero `--emit` churn); builtins are never qualified (their symbols pair with runtime-provided definitions). Sema definition sites, call sites, the drop-glue generator in `rue-compiler`, and **both** codegen backends derive names through these helpers. Destructor symbols registered per-file before ambiguity is knowable are re-pointed once declarations complete.

Also fixes the lazy referenced-method path matching `StructDecl`s **by name only** — it would analyze the *other* file's same-named method body under this struct's symbol (wrong code, not just a link error).

**Verified by execution:** cross-module method dispatch (11+22=33); per-file destructors with drop order pinned by exact stdout (`2\n1\n`); per-file enum payload glue (`12\n1\n`); aarch64 `--emit asm` clean. Pool unit test + 3 CLI cases with exact-stdout assertions. Full `./test.sh` exit 0.

Found along the way, filed separately: RUE-576 (array literal of module-qualified call results fails E0903 even with an annotation).

Fixes RUE-571

🤖 Generated with [Claude Code](https://claude.com/claude-code)