### PR TITLE
RUE-576: module-member calls resolve (file, name) in inference (+ RUE-570 regression pins)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -198,6 +198,13 @@ pub struct ConstraintGenerator<'a> {
     /// `None` only in unit tests; production passes the map via
     /// [`Self::with_module_binding_types`].
     module_binding_types: Option<&'a HashMap<(FileId, Spur), Type>>,
+    /// Source-level function lookup: (defining file, source name) -> internal
+    /// function key. Same-named functions across files get module-qualified
+    /// internal keys in `functions`, so module-member calls resolve through
+    /// this map first — the bare source name misses for them (RUE-576).
+    /// `None` only in unit tests; production passes the map via
+    /// [`Self::with_functions_by_file_name`].
+    functions_by_file_name: Option<&'a HashMap<(FileId, Spur), Spur>>,
     /// Module registry file identity for inference-time `module.Type` and
     /// `module.Enum` lookup.
     /// `None` only in unit tests; production passes the map via
@@ -290,6 +297,7 @@ impl<'a> ConstraintGenerator<'a> {
             const_types: None,
             const_type_aliases: None,
             module_binding_types: None,
+            functions_by_file_name: None,
             module_file_ids: None,
             comptime_local_types: None,
             extra_method_sigs: None,
@@ -352,6 +360,16 @@ impl<'a> ConstraintGenerator<'a> {
         structs_by_file_name: &'a HashMap<(FileId, Spur), Type>,
     ) -> Self {
         self.structs_by_file_name = Some(structs_by_file_name);
+        self
+    }
+
+    /// Provide the (defining file, source name) -> internal function key map
+    /// for module-member call resolution (RUE-576).
+    pub fn with_functions_by_file_name(
+        mut self,
+        functions_by_file_name: &'a HashMap<(FileId, Spur), Spur>,
+    ) -> Self {
+        self.functions_by_file_name = Some(functions_by_file_name);
         self
     }
 
@@ -2001,14 +2019,31 @@ impl<'a> ConstraintGenerator<'a> {
                 // treats FieldGet the same way).
                 let result_type = match &receiver_info.ty {
                     // Module receiver: `m.go(...)` is a module member call.
-                    // Mirror sema's `check_module_member_call`: the lookup is
-                    // global by name, never verifying the function belongs to
-                    // the receiver module's file (known looseness, RUE-140 —
-                    // when that is ratified, narrow this lookup too). Yielding
-                    // the callee's return type anchors uses like `m.go() + 1`
-                    // that previously decayed to `<error>` (RUE-142).
+                    // Resolve the member in the receiver module's file first
+                    // (RUE-576): same-named functions across files carry
+                    // module-qualified internal keys in `functions`, so the
+                    // bare source name misses for exactly those and the call
+                    // decayed to `<error>` — which surfaced as a bogus E0903
+                    // when the result seeded an array literal's element type.
+                    // The bare-name fallback keeps unique names (and unit
+                    // tests without the map) working. Yielding the callee's
+                    // return type anchors uses like `m.go() + 1` that
+                    // previously decayed to `<error>` (RUE-142).
                     InferType::Concrete(ty) if ty.is_module() => {
-                        if let Some(func) = self.functions.get(method) {
+                        let function_key = ty
+                            .as_module()
+                            .and_then(|module_id| {
+                                self.module_file_ids
+                                    .and_then(|ids| ids.get(&module_id))
+                                    .copied()
+                            })
+                            .and_then(|file_id| {
+                                self.functions_by_file_name
+                                    .and_then(|m| m.get(&(file_id, *method)))
+                                    .copied()
+                            })
+                            .unwrap_or(*method);
+                        if let Some(func) = self.functions.get(&function_key) {
                             if !func.is_generic && args.len() == func.param_types.len() {
                                 // Constrain each argument against its declared
                                 // parameter type (same as a direct Call).

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -83,6 +83,7 @@ impl<'a> Sema<'a> {
         .with_enums_by_file_name(&infer_ctx.enum_types_by_file_name)
         .with_module_binding_types(&infer_ctx.module_binding_types)
         .with_module_file_ids(&infer_ctx.module_file_ids)
+        .with_functions_by_file_name(&infer_ctx.functions_by_file_name)
         .with_comptime_local_types(&comptime_local_types)
         .with_comptime_values(value_subst)
         .with_extra_method_sigs(&extra_method_sigs);

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -297,6 +297,7 @@ impl<'a> Sema<'a> {
             const_function_aliases,
             module_binding_types,
             module_file_ids,
+            functions_by_file_name: self.functions_by_file_name.clone(),
         }
     }
     /// Check if a directive list contains the @copy directive

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -64,4 +64,9 @@ pub struct InferenceContext {
     pub module_binding_types: HashMap<(FileId, Spur), Type>,
     /// Module registry file identity for inference-time member type lookup.
     pub module_file_ids: HashMap<crate::types::ModuleId, FileId>,
+    /// Source-level function lookup: (defining file, source name) -> internal
+    /// function key. Same-named functions across files get module-qualified
+    /// internal keys, so a module-member call must resolve through this map
+    /// before consulting `func_sigs` — the bare source name misses (RUE-576).
+    pub functions_by_file_name: HashMap<(FileId, Spur), Spur>,
 }

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -2723,3 +2723,134 @@ fn main() -> i32 {
 ]
 exit_code = 0
 stdout = "12\n1\n"
+
+[[case]]
+# RUE-576: an array literal of module-qualified call results decayed to
+# <error> during inference when the callee's SOURCE NAME is defined by more
+# than one file — such functions carry module-qualified internal keys, so
+# the module-member call arm's bare-name signature lookup missed and the
+# misfired fallback was E0903 "type annotation required for empty array"
+# (on a non-empty literal). Module calls now resolve (file, name) first.
+# The destructor output additionally pins per-file ARRAY drop glue
+# (RUE-571): each array's elements run their own file's destructor.
+name = "array_literal_of_module_calls_with_duplicate_fn_names"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "da.rue", source = """
+pub struct R {
+    id: i32,
+}
+
+drop fn R(self) {
+    @dbg(1);
+}
+
+pub fn make(v: i32) -> R { R { id: v } }
+""" },
+  { path = "db.rue", source = """
+pub struct R {
+    id: i32,
+}
+
+drop fn R(self) {
+    @dbg(2);
+}
+
+pub fn make(v: i32) -> R { R { id: v } }
+""" },
+  { path = "main.rue", source = """
+const a = @import("da.rue");
+const b = @import("db.rue");
+
+fn main() -> i32 {
+    let _ra: [a.R; 2] = [a.make(1), a.make(2)];
+    let _rb: [b.R; 2] = [b.make(3), b.make(4)];
+    0
+}
+""" },
+]
+exit_code = 0
+stdout = "2\n2\n1\n1\n"
+
+[[case]]
+# RUE-570: a module's own code must resolve its same-named struct to ITS
+# definition. Struct literal, method body field access, and dispatch all
+# stay within the defining file; m1's P is x-shaped, m2's is y-shaped.
+# (Root cause was shared with RUE-571's symbol/lazy-pairing fix; this pins
+# the user-visible resolution behavior.)
+name = "same_named_struct_literals_resolve_own_module"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "m1.rue", source = """
+pub struct P {
+    x: i32,
+
+    fn get(self) -> i32 { self.x }
+}
+
+pub fn mk() -> i32 {
+    let p = P { x: 5 };
+    p.get()
+}
+""" },
+  { path = "m2.rue", source = """
+pub struct P {
+    y: i32,
+
+    fn get(self) -> i32 { self.y * 2 }
+}
+
+pub fn mk() -> i32 {
+    let p: P = P { y: 10 };   // annotated form pins the annotation path too
+    p.get()
+}
+""" },
+  { path = "main.rue", source = """
+const m1 = @import("m1.rue");
+const m2 = @import("m2.rue");
+
+fn main() -> i32 {
+    m1.mk() + m2.mk()  // 5 + 20
+}
+""" },
+]
+exit_code = 25
+
+[[case]]
+# RUE-570, enum face: same-named enums with different variant sets construct
+# and match within their own modules.
+name = "same_named_enums_resolve_own_module"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "e1.rue", source = """
+pub enum Col { Red(i32), Blue }
+
+pub fn mk() -> i32 {
+    let c = Col.Red(5);
+    match c {
+        Col.Red(v) => v,
+        Col.Blue => 0,
+    }
+}
+""" },
+  { path = "e2.rue", source = """
+pub enum Col { Green(i32), Red(i32) }
+
+pub fn mk() -> i32 {
+    let c = Col.Green(10);
+    match c {
+        Col.Green(v) => v * 2,
+        Col.Red(v) => v,
+    }
+}
+""" },
+  { path = "main.rue", source = """
+const e1 = @import("e1.rue");
+const e2 = @import("e2.rue");
+
+fn main() -> i32 {
+    e1.mk() + e2.mk()  // 5 + 20
+}
+""" },
+]
+exit_code = 25


### PR DESCRIPTION
**RUE-576** — same-named functions across files carry module-qualified internal keys in the `functions` table, so the module-receiver `MethodCall` arm's bare-name signature lookup missed for exactly those and the call's inferred type decayed to `<error>`. Where the result seeded an array literal's element type, the misfired fallback was a bogus E0903 "type annotation required for **empty** array" on a non-empty literal. The constraint generator now receives `functions_by_file_name` (`(defining file, source name) → internal key`) and resolves module members through it, bare name as fallback for unique names (and unit tests without the map).

**RUE-570** — the struct-literal wrong-file resolution turned out to be fixed by #1346's symbol/lazy-pairing change (the crossed analysis was the name-only `StructDecl` matching); sema's and inference's literal paths were already file-aware. Verified by execution on trunk+#1346 and **pinned here** with CLI cases covering struct literals, type annotations, method dispatch, and same-named enums across modules (`m1.mk()+m2.mk()=25` both faces).

The duplicate-name array case additionally pins per-file **array drop glue** from #1346 (exact stdout `2\n2\n1\n1\n`: each array's elements run their own file's destructor, reverse declaration order) — the one glue family #1346 couldn't runtime-test because this very E0903 blocked the repro.

Full `./test.sh` exit 0 (run on trunk+#1346 content).

Fixes RUE-576
Fixes RUE-570

🤖 Generated with [Claude Code](https://claude.com/claude-code)