### PR TITLE
RUE-565+577: unit as a comptime type argument; ZST fields lay out, read, and write correctly

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5828,6 +5828,16 @@ impl<'a> Sema<'a> {
                     Some(ConstValue::Type(t)) if param_types[i] == Type::COMPTIME_TYPE => {
                         type_subst.insert(param_names[i], t);
                     }
+                    // A unit argument to a `comptime T: type` parameter is the
+                    // unit TYPE (RUE-565): `()` is ambiguous between the unit
+                    // value and the unit type, and the parameter's declared
+                    // `type` kind is exactly the context that disambiguates
+                    // (spec Appendix A treats `()` as an unambiguous type
+                    // argument). Only this position converts; a unit value
+                    // elsewhere stays a value.
+                    Some(ConstValue::Unit) if param_types[i] == Type::COMPTIME_TYPE => {
+                        type_subst.insert(param_names[i], Type::UNIT);
+                    }
                     Some(const_val) if param_types[i] != Type::COMPTIME_TYPE => {
                         value_subst.insert(param_names[i], const_val);
                     }
@@ -5918,6 +5928,13 @@ impl<'a> Sema<'a> {
                             type_args.push(*ty);
                             // Record the substitution: param_name -> concrete_type
                             type_subst.insert(param_names[i], *ty);
+                        } else if matches!(inst.data, AirInstData::UnitConst) {
+                            // `()` in a `comptime T: type` position is the unit
+                            // TYPE (RUE-565); the declared parameter kind
+                            // disambiguates it from the unit value. Mirrors the
+                            // ConstValue::Unit arm in the reduction path above.
+                            type_args.push(Type::UNIT);
+                            type_subst.insert(param_names[i], Type::UNIT);
                         } else {
                             // Not a type - this is an error for type parameters
                             return Err(CompileError::new(

--- a/crates/rue-cli-tests/cases/unit_fields.toml
+++ b/crates/rue-cli-tests/cases/unit_fields.toml
@@ -1,0 +1,109 @@
+# Unit (zero-sized) struct fields and enum payloads (RUE-577, RUE-565).
+#
+# A zero-sized field occupies no slots (spec: zero-sized types), but codegen's
+# aggregate flattening pushed one dummy vreg per FIELD — an interior unit
+# field shifted every later field's slot at construction (silent miscompile),
+# a unit enum payload overfilled the payload area (frame clobber), and
+# reading a ZST place underflowed the origin shift (ICE). The `()` type is
+# also a valid `comptime T: type` argument (RUE-565), which makes unit fields
+# reachable through every generic container.
+
+[section]
+id = "cli.unit_fields"
+name = "Unit struct fields and payloads"
+description = "Zero-sized fields lay out, read, write, and compare correctly (RUE-577); () is a valid comptime type argument (RUE-565)."
+
+[[case]]
+name = "interior_unit_fields_do_not_shift_layout"
+description = "An i32 between two unit fields keeps its value through construction, ZST writes, and reads (RUE-577 facet 1)."
+files = [{ path = "main.rue", source = """
+struct Mixed { a: (), b: i32, c: () }
+fn main() -> i32 {
+    let mut m = Mixed { a: (), b: 42, c: () };
+    m.a = ();                      // ZST field write: must not clobber b
+    let x = m.a;                   // ZST field read
+    if m.a == m.c && x == () { m.b } else { 0 }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "interior_unit_fields_optimized"
+description = "The same layout survives the optimizer (constprop/DCE see consistent slot lists)."
+files = [{ path = "main.rue", source = """
+struct Mixed { a: (), b: i32, c: () }
+fn main() -> i32 {
+    let mut m = Mixed { a: (), b: 42, c: () };
+    m.a = ();
+    if m.a == m.c { m.b } else { 0 }
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "unit_only_struct_field_read_and_compare"
+description = "Reading and comparing a field of an all-ZST struct (RUE-577 facet 2: this ICE'd with a subtract-overflow panic)."
+files = [{ path = "main.rue", source = """
+struct U { value: () }
+fn main() -> i32 {
+    let c = U { value: () };
+    if c.value == () { 42 } else { 0 }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "unit_as_comptime_type_argument"
+description = "() is a valid comptime type argument; the constructed type's unit field reads back (RUE-565)."
+files = [{ path = "main.rue", source = """
+fn Box(comptime T: type) -> type { struct { value: T } }
+fn main() -> i32 {
+    let C = Box(());
+    let c: C = C { value: () };
+    if c.value == () { 42 } else { 0 }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "std_option_and_arraybuf_accept_unit"
+description = "std generic containers instantiate at (): Option(()) matches; ArrayBuf(()) pushes and pops (RUE-565, the issue's std repro)."
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let O = std.option.Option(());
+    let some = O.Some(());
+    let a = match some {
+        O.Some(u) => 21,
+        O.None => 0,
+    };
+    let B = std.arraybuf.ArrayBuf(());
+    let mut buf = B.new();
+    buf.push(());
+    let b = @intCast(buf.len()) * 21;
+    a + b
+}
+""" }]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+exit_code = 42
+
+[[case]]
+name = "unit_enum_payload_does_not_clobber_frame"
+description = "A unit payload occupies no payload slots; neighboring locals stay intact across construction and match (RUE-577, enum face)."
+files = [{ path = "main.rue", source = """
+enum E { Tag(()), Empty }
+
+fn main() -> i32 {
+    let guard1 = 40;
+    let v = E.Tag(());
+    let guard2 = 2;
+    let m = match v {
+        E.Tag(u) => 0,
+        E.Empty => 100,
+    };
+    guard1 + guard2 + m
+}
+""" }]
+exit_code = 42

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2998,6 +2998,13 @@ impl<'a> CfgLower<'a> {
                 // source, fall back to the old single-slot behavior. (RUE-118,
                 // RUE-23)
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
+                // A zero-sized value has no bytes to store (RUE-577): writing
+                // the dummy vreg CFG carries for unit would clobber a
+                // neighboring slot, and a ZST destination's origin shift
+                // underflows. Nothing to do.
+                if self.ctx.type_slot_count(val_type) == 0 {
+                    return;
+                }
                 let vals = if self.ctx.is_multislot_aggregate(val_type) {
                     self.get_or_compute_field_vregs(*val)
                         .unwrap_or_else(|| vec![self.get_vreg(*val)])
@@ -4175,7 +4182,19 @@ impl<'a> CfgLower<'a> {
     ///
     /// This loads a value from the memory location described by the place,
     /// walking through any projections (field accesses, array indices).
-    fn lower_place_read(&mut self, dst: VReg, place: &Place, _ty: Type) {
+    fn lower_place_read(&mut self, dst: VReg, place: &Place, ty: Type) {
+        // A zero-sized read has no bytes to load (RUE-577): define dst as the
+        // canonical 0 — matching UnitConst's lowering, so unit equality
+        // compares 0 == 0 — and skip address formation entirely (a ZST root's
+        // `root_count - 1` origin shift would underflow, and a full-width
+        // load would read a neighbor's slot or out of frame).
+        if self.ctx.type_slot_count(ty) == 0 {
+            self.mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(dst),
+                imm: 0,
+            });
+            return;
+        }
         let projections = self.ctx.cfg.get_place_projections(place);
 
         // Simple case: no projections, just load from the base slot

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -133,7 +133,17 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
             ..
         } => {
             let fields = b.ctx().cfg.get_extra(fields_start, fields_len).to_vec();
-            Some(fields.iter().map(|f| b.get_vreg(*f)).collect())
+            // Zero-sized fields (unit, [T; 0]) occupy no slots (RUE-577):
+            // including their dummy vregs would shift every later field.
+            let mut vregs = Vec::with_capacity(fields.len());
+            for f in &fields {
+                let field_ty = b.ctx().cfg.get_inst(*f).ty;
+                if b.ctx().type_slot_count(field_ty) == 0 {
+                    continue;
+                }
+                vregs.push(b.get_vreg(*f));
+            }
+            Some(vregs)
         }
         CfgInstData::Load { slot } => {
             let slot_count = b.ctx().type_slot_count(ty);
@@ -290,6 +300,13 @@ pub fn lower_struct_init<B: SlotBackend>(
     let mut slot_vregs = Vec::new();
     for field in &fields {
         let field_ty = b.ctx().cfg.get_inst(*field).ty;
+        // A zero-sized field (unit, [T; 0], empty struct) occupies no slots
+        // (RUE-577): pushing the dummy vreg CFG carries for it would shift
+        // every later field one slot over — `Mixed { a: (), b: 42 }` stored
+        // 42 into the wrong slot.
+        if b.ctx().type_slot_count(field_ty) == 0 {
+            continue;
+        }
         match field_ty.kind() {
             TypeKind::Struct(_) | TypeKind::Enum(_) => {
                 // Struct/payload-enum field: contribute every slot. A
@@ -365,6 +382,13 @@ pub fn lower_enum_variant<B: SlotBackend>(
     let payload = b.ctx().cfg.get_extra(payload_start, payload_len).to_vec();
     for field in &payload {
         let field_ty = b.ctx().cfg.get_inst(*field).ty;
+        // Zero-sized payload fields occupy no slots (RUE-577): pushing their
+        // dummy vreg would overfill the payload area before padding —
+        // `Some(())` cached one slot too many and stores clobbered the
+        // neighboring frame slot.
+        if b.ctx().type_slot_count(field_ty) == 0 {
+            continue;
+        }
         match field_ty.kind() {
             TypeKind::Struct(_) | TypeKind::Enum(_) => {
                 if let Some(nested) = get_or_compute_field_vregs(b, *field) {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3410,6 +3410,13 @@ impl<'a> CfgLower<'a> {
                 // materializes lazily-sourced values; if it can't model the source,
                 // fall back to the old single-slot behavior. (RUE-118, RUE-23)
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
+                // A zero-sized value has no bytes to store (RUE-577): writing
+                // the dummy vreg CFG carries for unit would clobber a
+                // neighboring slot, and a ZST destination's origin shift
+                // underflows. Nothing to do.
+                if self.ctx.type_slot_count(val_type) == 0 {
+                    return;
+                }
                 let vals = if self.ctx.is_multislot_aggregate(val_type) {
                     self.get_or_compute_field_vregs(*val)
                         .unwrap_or_else(|| vec![self.get_vreg(*val)])
@@ -4184,7 +4191,19 @@ impl<'a> CfgLower<'a> {
     /// A place consists of a base (local slot or param slot) and zero or more
     /// projections (field accesses and array indices). This function computes
     /// the final memory address and loads from it.
-    fn lower_place_read(&mut self, dst: VReg, place: &Place, _ty: Type) {
+    fn lower_place_read(&mut self, dst: VReg, place: &Place, ty: Type) {
+        // A zero-sized read has no bytes to load (RUE-577): define dst as the
+        // canonical 0 — matching UnitConst's lowering, so unit equality
+        // compares 0 == 0 — and skip address formation entirely (a ZST root's
+        // `root_count - 1` origin shift would underflow, and an 8-byte MovRM
+        // would read a neighbor's slot or out of frame).
+        if self.ctx.type_slot_count(ty) == 0 {
+            self.mir.push(X86Inst::MovRI64 {
+                dst: Operand::Virtual(dst),
+                imm: 0,
+            });
+            return;
+        }
         let projections = self.ctx.cfg.get_place_projections(place);
 
         // Simple case: no projections, just load from the base slot

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2009,6 +2009,20 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "type_constructor_accepts_unit_type_argument"
+spec = ["4.14:22"]
+description = "The unit type () is a valid comptime type argument; the parameter's declared `type` kind disambiguates it from the unit value (RUE-565)"
+source = """
+fn Box(comptime T: type) -> type { struct { value: T } }
+fn main() -> i32 {
+    let C = Box(());
+    let c: C = C { value: () };
+    if c.value == () { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "type_constructor_in_annotation_position"
 spec = ["4.14:23"]
 description = "F(i32) used directly as a let type annotation (RUE-289, RUE-241)"


### PR DESCRIPTION
**RUE-565, remaining unit sub-case** — `()` in a `comptime T: type` position is the unit **type**: the parameter's declared kind is exactly the context that disambiguates it from the unit value (spec Appendix A treats `()` as an unambiguous type argument). Both extraction sites convert — the reduction path's `ConstValue::Unit` arm and the generic path's `AirInstData::UnitConst` arm. Only this position converts; unit values elsewhere are untouched. `std.option.Option(())` and `std.arraybuf.ArrayBuf(())` now instantiate and run end-to-end (the issue's std repro, exit 42).

**RUE-577 (pre-existing, found the moment unit fields became constructible)** — zero-sized fields miscompiled:
- `agg_slots` flattening pushed one dummy vreg per **field**, including 0-slot ones: an interior unit field shifted every later field's slot (`Mixed { a: (), b: 42, c: () }` returned 0 for `m.b` — silent wrong answer), and a unit **enum payload** overfilled the payload area before padding, clobbering a neighboring frame slot. `lower_struct_init`, `lower_enum_variant`, and the accessor's `StructInit` arm now skip 0-slot fields.
- Reading a ZST place **ICE'd** (`root_count - 1` origin-shift underflow). `lower_place_read` now defines dst as the canonical 0 for a 0-slot type — matching `UnitConst`'s lowering, so unit equality compares 0 == 0 — and skips address formation entirely; `PlaceWrite` of a 0-slot value is a no-op (storing the dummy vreg would clobber a neighbor).

Both backends changed in parallel; aarch64 verified via `--emit asm`.

**Coverage grows with the surface** (new codegen path): `cli/unit_fields.toml` with 6 cases — interior-field layout at -O0 **and** -O2, all-ZST struct read/compare (the ICE), unit type argument, the std containers repro, and a unit enum payload with frame-guard locals — plus a 4.14:22 spec case. Full `./test.sh` exit 0 on current trunk.

Fixes RUE-565
Fixes RUE-577

🤖 Generated with [Claude Code](https://claude.com/claude-code)