### PR TITLE
RUE-552: value-parameterized type constructors apply in type position

### DIFF
--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -896,17 +896,11 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        let mut callee_types: HashMap<Spur, Type> = HashMap::new();
-        for (i, arg) in arg_strs.iter().enumerate() {
-            let arg_sym = self.interner.get_or_intern(arg);
-            let arg_ty = match ctx {
-                Some(ctx) => self.resolve_type_with_ctx(arg_sym, span, ctx)?,
-                None => self.resolve_type(arg_sym, span)?,
-            };
-            callee_types.insert(param_names[i], arg_ty);
-        }
-        let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
-        match self.reduce_type_ctor_body(function_key, &callee_types, &empty_values)? {
+        // Kind-aware binding: type args resolve as types, value args as
+        // comptime constants (RUE-552).
+        let (callee_types, callee_values) =
+            self.bind_type_ctor_args(call_path, params, arg_strs, span, ctx)?;
+        match self.reduce_type_ctor_body(function_key, &callee_types, &callee_values)? {
             Some(ConstValue::Type(t)) => Ok(t),
             _ => Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
@@ -941,6 +935,41 @@ impl<'a> Sema<'a> {
     ///
     /// [`resolve_qualified_type_function_call`]:
     /// Sema::resolve_qualified_type_function_call
+    /// Comptime-path analogue of [`Self::resolve_type_ctor_value_arg`]
+    /// (RUE-552): resolve one comptime VALUE argument of a type-constructor
+    /// application under the current `value_subst` — an integer/bool literal,
+    /// an enclosing comptime value parameter (`Buffer(M)` inside another
+    /// constructor body), or a file-level constant. `None` (no diagnostics on
+    /// this path) makes the enclosing type non-evaluable; the caller reports
+    /// the comptime failure.
+    fn resolve_comptime_type_ctor_value_arg(
+        &mut self,
+        arg: &str,
+        value_subst: &HashMap<Spur, ConstValue>,
+        span: Span,
+    ) -> Option<ConstValue> {
+        let text = arg.trim();
+        if let Ok(n) = text.parse::<i128>() {
+            return Some(ConstValue::Integer(n));
+        }
+        if text == "true" {
+            return Some(ConstValue::Bool(true));
+        }
+        if text == "false" {
+            return Some(ConstValue::Bool(false));
+        }
+        let sym = self.interner.get_or_intern(text);
+        if let Some(v) = value_subst.get(&sym) {
+            return Some(*v);
+        }
+        if span != Span::default()
+            && let Some(info) = self.resolve_const_info_in_file(sym, span.file_id)
+        {
+            return Some(info.value);
+        }
+        self.constants.get(&sym).map(|info| info.value)
+    }
+
     fn resolve_qualified_type_call_for_comptime(
         &mut self,
         call_path: &str,
@@ -993,20 +1022,29 @@ impl<'a> Sema<'a> {
         {
             return None;
         }
+        // Kind-aware binding (RUE-552): type parameters take type arguments;
+        // comptime VALUE parameters take value arguments resolved under the
+        // enclosing value substitution.
+        let param_types = self.param_arena.types(params).to_vec();
         let mut callee_types: HashMap<Spur, Type> = HashMap::new();
+        let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
         for (i, arg) in arg_strs.iter().enumerate() {
-            let arg_sym = self.interner.get_or_intern(arg);
-            let arg_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
-                arg_sym,
-                type_subst,
-                value_subst,
-                span,
-            )?;
-            callee_types.insert(param_names[i], arg_ty);
+            if param_types[i] == Type::COMPTIME_TYPE {
+                let arg_sym = self.interner.get_or_intern(arg);
+                let arg_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
+                    arg_sym,
+                    type_subst,
+                    value_subst,
+                    span,
+                )?;
+                callee_types.insert(param_names[i], arg_ty);
+            } else {
+                let val = self.resolve_comptime_type_ctor_value_arg(arg, value_subst, span)?;
+                callee_values.insert(param_names[i], val);
+            }
         }
-        let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
         match self
-            .reduce_type_ctor_body(function_key, &callee_types, &empty_values)
+            .reduce_type_ctor_body(function_key, &callee_types, &callee_values)
             .ok()?
         {
             Some(ConstValue::Type(t)) => Some(t),
@@ -1179,6 +1217,100 @@ impl<'a> Sema<'a> {
     /// context-free, exactly as before.
     ///
     /// [`resolve_type_with_ctx`]: Sema::resolve_type_with_ctx
+    /// Bind a type-constructor application's canonical argument strings to
+    /// the callee's comptime parameters (RUE-552). A `comptime T: type`
+    /// parameter takes a TYPE argument, resolved as a type; a comptime VALUE
+    /// parameter (`comptime N: i32`) takes an integer/bool literal, an
+    /// in-scope comptime value parameter, or a file-level constant — so
+    /// `Buffer(2)`, `Buffer(K)`, and `Matrix(i32, 3)` all apply directly in
+    /// type position (spec 4.14:22-23).
+    fn bind_type_ctor_args(
+        &mut self,
+        call_display: &str,
+        params: crate::param_arena::ParamRange,
+        arg_strs: &[String],
+        span: Span,
+        ctx: Option<&AnalysisContext>,
+    ) -> CompileResult<(HashMap<Spur, Type>, HashMap<Spur, ConstValue>)> {
+        let param_names = self.param_arena.names(params).to_vec();
+        let param_types = self.param_arena.types(params).to_vec();
+        let mut callee_types: HashMap<Spur, Type> = HashMap::new();
+        let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
+        for (i, arg) in arg_strs.iter().enumerate() {
+            if param_types[i] == Type::COMPTIME_TYPE {
+                // A value where a type is expected gets a targeted message
+                // instead of decaying to "unknown type '2'".
+                if arg.trim().parse::<i128>().is_ok() {
+                    return Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: format!(
+                                "argument '{}' of type constructor '{}' must be a type (this parameter is `comptime {}: type`)",
+                                arg,
+                                call_display,
+                                self.interner.resolve(&param_names[i])
+                            ),
+                        },
+                        span,
+                    ));
+                }
+                let arg_sym = self.interner.get_or_intern(arg);
+                let arg_ty = match ctx {
+                    Some(ctx) => self.resolve_type_with_ctx(arg_sym, span, ctx)?,
+                    None => self.resolve_type(arg_sym, span)?,
+                };
+                callee_types.insert(param_names[i], arg_ty);
+            } else {
+                let val = self.resolve_type_ctor_value_arg(call_display, arg, span, ctx)?;
+                callee_values.insert(param_names[i], val);
+            }
+        }
+        Ok((callee_types, callee_values))
+    }
+
+    /// Resolve one comptime VALUE argument of a type-constructor application
+    /// in type position (RUE-552) from its canonical string: an integer
+    /// literal (`2`, `-3`), a bool literal, an in-scope comptime value
+    /// parameter (`Buffer(M)` inside another constructor body), or a
+    /// file-level constant name. The comptime evaluator range-checks the
+    /// value against the parameter's declared width during reduction, the
+    /// same as a value-position application.
+    fn resolve_type_ctor_value_arg(
+        &mut self,
+        call_display: &str,
+        arg: &str,
+        span: Span,
+        ctx: Option<&AnalysisContext>,
+    ) -> CompileResult<ConstValue> {
+        let text = arg.trim();
+        if let Ok(n) = text.parse::<i128>() {
+            return Ok(ConstValue::Integer(n));
+        }
+        if text == "true" {
+            return Ok(ConstValue::Bool(true));
+        }
+        if text == "false" {
+            return Ok(ConstValue::Bool(false));
+        }
+        let sym = self.interner.get_or_intern(text);
+        if let Some(ctx) = ctx
+            && let Some(v) = ctx.comptime_value_vars.get(&sym)
+        {
+            return Ok(*v);
+        }
+        if let Some(info) = self.resolve_const_info_in_file(sym, span.file_id) {
+            return Ok(info.value);
+        }
+        Err(CompileError::new(
+            ErrorKind::ComptimeEvaluationFailed {
+                reason: format!(
+                    "argument '{}' of type constructor '{}' must be a compile-time known value (an integer or bool literal, a comptime parameter, or a constant)",
+                    text, call_display
+                ),
+            },
+            span,
+        ))
+    }
+
     fn resolve_type_function_call(
         &mut self,
         call_name: &str,
@@ -1246,22 +1378,15 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // Resolve each argument as a type and bind it to the corresponding
-        // comptime type parameter.
-        let mut callee_types: HashMap<Spur, Type> = HashMap::new();
-        for (i, arg) in arg_strs.iter().enumerate() {
-            let arg_sym = self.interner.get_or_intern(arg);
-            let arg_ty = match ctx {
-                Some(ctx) => self.resolve_type_with_ctx(arg_sym, span, ctx)?,
-                None => self.resolve_type(arg_sym, span)?,
-            };
-            callee_types.insert(param_names[i], arg_ty);
-        }
+        // Bind each argument to its parameter by the parameter's declared
+        // kind: type arguments resolve as types, value arguments as comptime
+        // constants (RUE-552).
+        let (callee_types, callee_values) =
+            self.bind_type_ctor_args(call_name, params, arg_strs, span, ctx)?;
 
         // Reduce the constructor body under the substitution. Shares the exact
         // reduction path (and E1200 recursion guard) with value-position calls.
-        let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
-        match self.reduce_type_ctor_body(name_key, &callee_types, &empty_values)? {
+        match self.reduce_type_ctor_body(name_key, &callee_types, &callee_values)? {
             Some(ConstValue::Type(t)) => Ok(t),
             _ => Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
@@ -1441,20 +1566,27 @@ impl<'a> Sema<'a> {
             {
                 return None;
             }
+            // Kind-aware binding (RUE-552): see the qualified resolver above.
+            let param_types = self.param_arena.types(params).to_vec();
             let mut callee_types: HashMap<Spur, Type> = HashMap::new();
+            let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
             for (i, arg) in arg_strs.iter().enumerate() {
-                let arg_sym = self.interner.get_or_intern(arg);
-                let arg_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
-                    arg_sym,
-                    type_subst,
-                    value_subst,
-                    span,
-                )?;
-                callee_types.insert(param_names[i], arg_ty);
+                if param_types[i] == Type::COMPTIME_TYPE {
+                    let arg_sym = self.interner.get_or_intern(arg);
+                    let arg_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
+                        arg_sym,
+                        type_subst,
+                        value_subst,
+                        span,
+                    )?;
+                    callee_types.insert(param_names[i], arg_ty);
+                } else {
+                    let val = self.resolve_comptime_type_ctor_value_arg(arg, value_subst, span)?;
+                    callee_values.insert(param_names[i], val);
+                }
             }
-            let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
             match self
-                .reduce_type_ctor_body(function_key, &callee_types, &empty_values)
+                .reduce_type_ctor_body(function_key, &callee_types, &callee_values)
                 .ok()?
             {
                 Some(ConstValue::Type(t)) => Some(t),

--- a/crates/rue-cli-tests/cases/comptime_cross_module.toml
+++ b/crates/rue-cli-tests/cases/comptime_cross_module.toml
@@ -216,3 +216,30 @@ fn main() -> i32 {
 """ }]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 exit_code = 3
+
+[[case]]
+# RUE-552: a MODULE-QUALIFIED value-parameterized constructor applies in
+# type position (`lib.Buffer(2)` as a parameter type). This used to fail at
+# PARSE time (E0100 at the integer token).
+name = "qualified_value_parameterized_ctor_in_type_position"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "lib.rue", source = """
+pub fn Buffer(comptime N: i32) -> type {
+    struct { data: [i32; N] }
+}
+""" },
+  { path = "main.rue", source = """
+const lib = @import("lib.rue");
+
+fn first(b: lib.Buffer(2)) -> i32 {
+    b.data[0]
+}
+
+fn main() -> i32 {
+    let B = lib.Buffer(2);
+    first(B { data: [40, 2] })
+}
+""" },
+]
+exit_code = 40

--- a/crates/rue-cli-tests/cases/comptime_type_functions.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_functions.toml
@@ -234,3 +234,56 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E1200"]
+
+[[case]]
+# RUE-552: a type constructor with a comptime VALUE parameter used to fail
+# E0204 "unknown type '2'" in type position (the type-call grammar accepted
+# only type arguments, and the resolver bound every argument as a type).
+name = "value_parameterized_ctor_in_type_position"
+files = [{ path = "main.rue", source = """
+fn Buffer(comptime N: i32) -> type {
+    struct { data: [i32; N] }
+}
+
+fn first(b: Buffer(2)) -> i32 {
+    b.data[0]
+}
+
+fn main() -> i32 {
+    let B = Buffer(2);
+    first(B { data: [42, 0] })
+}
+""" }]
+exit_code = 42
+
+[[case]]
+# RUE-552: a type argument where a comptime VALUE parameter is declared gets
+# a targeted E1200, not a decayed unknown-type error.
+name = "value_param_rejects_type_argument"
+files = [{ path = "main.rue", source = """
+fn Buffer(comptime N: i32) -> type {
+    struct { data: [i32; N] }
+}
+
+fn bad(b: Buffer(i32)) -> i32 { 0 }
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "must be a compile-time known value"]
+
+[[case]]
+# RUE-552: an integer argument where a comptime TYPE parameter is declared
+# gets a targeted E1200 naming the parameter, not "unknown type '2'".
+name = "type_param_rejects_value_argument"
+files = [{ path = "main.rue", source = """
+fn Box(comptime T: type) -> type {
+    struct { value: T }
+}
+
+fn bad(b: Box(2)) -> i32 { 0 }
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "must be a type"]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -395,6 +395,14 @@ pub enum TypeExpr {
         length: u64,
         span: Span,
     },
+    /// An integer literal in type-call ARGUMENT position: `Buffer(2)`,
+    /// `Matrix(2, 3)`, `lib.Buffer(2)` (RUE-552). A type constructor may
+    /// declare comptime VALUE parameters (`comptime N: i32`), so its
+    /// application in type position takes value arguments alongside type
+    /// arguments. Only produced inside `TypeCall`/`QualifiedTypeCall`
+    /// argument lists; astgen canonicalizes it into the call's type string
+    /// (the same decimal spelling `TypeExpr::StrFixed` produces for `Str(8)`).
+    IntArg { value: i128, span: Span },
 }
 
 /// The length of an array type `[T; N]`.
@@ -467,6 +475,7 @@ impl TypeExpr {
             TypeExpr::TypeCall { span, .. } => *span,
             TypeExpr::QualifiedTypeCall { span, .. } => *span,
             TypeExpr::StrFixed { span, .. } => *span,
+            TypeExpr::IntArg { span, .. } => *span,
         }
     }
 }
@@ -559,6 +568,7 @@ impl fmt::Display for TypeExpr {
             TypeExpr::StrFixed { name, length, .. } => {
                 write!(f, "sym:{}({})", name.name.into_usize(), length)
             }
+            TypeExpr::IntArg { value, .. } => write!(f, "{}", value),
         }
     }
 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -394,9 +394,29 @@ where
         // (`Result(Option(i32), i32)`). Must precede `named_type` in the
         // choice so `Name(...)` is not mis-parsed as a bare `Name` leaving the
         // argument list dangling.
+        // A type-call ARGUMENT is a type, or an integer literal bound to a
+        // comptime VALUE parameter (`Buffer(2)`, `Matrix(2, -1)`; RUE-552).
+        // The literal is canonicalized into the call's type string by astgen,
+        // exactly like `Str(8)`'s dedicated rule below.
+        let type_call_arg = choice((
+            just(TokenKind::Minus)
+                .or_not()
+                .then(select! { TokenKind::Int(n) => n })
+                .map_with(|(neg, n), e| TypeExpr::IntArg {
+                    value: if neg.is_some() {
+                        -(n as i128)
+                    } else {
+                        n as i128
+                    },
+                    span: span_from_extra(e),
+                }),
+            ty.clone(),
+        ));
+
         let type_call = ident_parser()
             .then(
-                ty.clone()
+                type_call_arg
+                    .clone()
                     .separated_by(just(TokenKind::Comma))
                     .allow_trailing()
                     .collect::<Vec<_>>()
@@ -417,7 +437,7 @@ where
             .at_least(2)
             .collect::<Vec<_>>()
             .then(
-                ty.clone()
+                type_call_arg
                     .separated_by(just(TokenKind::Comma))
                     .allow_trailing()
                     .collect::<Vec<_>>()

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -350,6 +350,9 @@ impl Validator<'_> {
             // Fixed-capacity string `Str(N)`: a scalar literal capacity, no
             // nested type expressions to validate (ADR-0043 Phase 5, RUE-326).
             TypeExpr::StrFixed { .. } => {}
+            // Integer type-call argument (RUE-552): a scalar literal, nothing
+            // nested to validate.
+            TypeExpr::IntArg { .. } => {}
         }
     }
 }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -208,6 +208,12 @@ impl<'a> AstGen<'a> {
                 s.push(')');
                 self.interner.get_or_intern(&s)
             }
+            TypeExpr::IntArg { value, .. } => {
+                // Integer type-call argument (RUE-552): canonicalize to its
+                // decimal spelling inside the enclosing call's type string,
+                // the same form `Str(8)`'s dedicated node produces.
+                self.interner.get_or_intern(value.to_string())
+            }
             TypeExpr::StrFixed { name, length, .. } => {
                 // Fixed-capacity string `Str(N)` with a literal capacity
                 // (ADR-0043 Phase 5, RUE-326). Canonicalize to `Name(N)` — the
@@ -1055,6 +1061,11 @@ impl<'a> AstGen<'a> {
                                 // (ADR-0043 Phase 5, RUE-326). Intern its canonical
                                 // `Str(N)` string for completeness; sema resolves it.
                                 self.intern_type(&type_lit.type_expr)
+                            }
+                            TypeExpr::IntArg { .. } => {
+                                // Only produced inside type-call argument lists
+                                // (RUE-552); a bare integer is never a TypeLit.
+                                unreachable!("IntArg outside a type-call argument list")
                             }
                         };
                         self.rir.add_inst(Inst {

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2023,6 +2023,55 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "value_parameterized_type_constructor_in_type_position"
+spec = ["4.14:23"]
+description = "A type constructor with a comptime VALUE parameter applies directly in param/return type position: Buffer(2) (RUE-552)"
+source = """
+fn Buffer(comptime N: i32) -> type { struct { data: [i32; N] } }
+fn first(b: Buffer(2)) -> i32 {
+    b.data[0]
+}
+fn main() -> i32 {
+    let B = Buffer(2);
+    first(B { data: [42, 0] })
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "mixed_type_and_value_args_in_type_position"
+spec = ["4.14:23"]
+description = "Mixed comptime type + value parameters with a const-name value argument: Matrix(i32, K) (RUE-552)"
+source = """
+const K: i32 = 3;
+fn Matrix(comptime T: type, comptime N: i32) -> type { struct { row: [T; N] } }
+fn sum(m: Matrix(i32, K)) -> i32 {
+    m.row[0] + m.row[1] + m.row[2]
+}
+fn main() -> i32 {
+    let M = Matrix(i32, K);
+    sum(M { row: [40, 1, 1] })
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "value_parameterized_ctor_forwards_enclosing_comptime_value"
+spec = ["4.14:23"]
+description = "A field type applies a value-parameterized constructor to the enclosing comptime value parameter: Buffer(M) inside Wrap(M) (RUE-552)"
+source = """
+fn Buffer(comptime N: i32) -> type { struct { data: [i32; N] } }
+fn Wrap(comptime M: i32) -> type { struct { inner: Buffer(M) } }
+fn main() -> i32 {
+    let I = Buffer(2);
+    let W = Wrap(2);
+    let w: W = W { inner: I { data: [21, 21] } };
+    w.inner.data[0] + w.inner.data[1]
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "type_constructor_in_annotation_position"
 spec = ["4.14:23"]
 description = "F(i32) used directly as a let type annotation (RUE-289, RUE-241)"

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -84,7 +84,8 @@ type           = "i8" | "i16" | "i32" | "i64"
                | "Self"
                | type_call
                | IDENT ;
-type_call      = IDENT "(" [ type { "," type } [ "," ] ] ")" ;  (* type-function application, e.g. Pair(i32), Result(Option(i32), i32) *)
+type_call      = IDENT "(" [ type_call_arg { "," type_call_arg } [ "," ] ] ")" ;  (* type-function application, e.g. Pair(i32), Result(Option(i32), i32), Buffer(2) *)
+type_call_arg  = type | [ "-" ] INTEGER ;  (* a type argument for a `comptime T: type` parameter, or an integer value argument for a comptime value parameter such as `comptime N: i32` *)
 array_length   = INTEGER | IDENT | length_call ;
 length_call    = IDENT "(" [ array_length { "," array_length } [ "," ] ] ")" ;  (* comptime-evaluable call, e.g. fact(4) *)
 anon_struct_type = "struct" "{" [ anon_struct_fields ] { method } "}" ;
@@ -218,11 +219,15 @@ Notes:
   restriction. A non-place argument such as `inout a + 1` parses but is
   rejected with an lvalue error (E0425).
 - **Type-function application in type position** (`type_call`): a name or
-  module-qualified path applied to type arguments, e.g. `Pair(i32)`,
-  `Result(Option(i32), i32)`, or `std.option.Option(i64)`, denotes the type
-  produced by a comptime `-> type` constructor (RUE-241). Nested applications
-  compose. Its result cannot yet head a struct literal
-  (`Pair(i32) { … }` does not parse); bind it via a `let` of that type instead.
+  module-qualified path applied to arguments, e.g. `Pair(i32)`,
+  `Result(Option(i32), i32)`, `std.option.Option(i64)`, or `Buffer(2)`,
+  denotes the type produced by a comptime `-> type` constructor (RUE-241).
+  Each argument is bound by the corresponding parameter's declared kind: a
+  `comptime T: type` parameter takes a type argument, and a comptime value
+  parameter (`comptime N: i32`) takes an integer literal, a comptime
+  parameter name, or a constant name (RUE-552). Nested applications compose.
+  Its result cannot yet head a struct literal (`Pair(i32) { … }` does not
+  parse); bind it via a `let` of that type instead.
 - **Anonymous struct types** carry inline methods only when a `struct { … }`
   appears as a *value* (e.g. the body of a comptime `-> type` function); in
   pure type position (a type annotation) a `struct { … }` parses fields only.


### PR DESCRIPTION
The type-call grammar accepted only **type** arguments (integer-call syntax was special-cased solely for `Str(N)`), and every resolver bound each argument as a type — so `fn first(b: Buffer(2))` failed E0204 `unknown type '2'`, and module-qualified `lib.Buffer(2)` failed at **parse** (E0100 at the integer token), despite spec 4.14:22-23.

**Grammar** — type-call arguments are now a type OR an integer literal (optionally negated), as a new `TypeExpr::IntArg`, in both bare and module-qualified type calls; astgen canonicalizes the literal into the call's type string exactly like `Str(8)`'s dedicated node, so downstream string-based resolution is unchanged in shape. Grammar appendix updated (`type_call_arg`).

**Resolution** — all four type-call resolvers (signature-position bare + qualified, comptime-path bare + qualified) bind arguments by the callee's declared parameter kind: `comptime T: type` parameters take type arguments; comptime **value** parameters (`comptime N: i32`) take an integer/bool literal, an in-scope comptime value parameter (`Buffer(M)` inside another constructor body), or a file-level constant — passed to `reduce_type_ctor_body` as `value_subst`, the same reduction value-position calls use. Wrong-kind arguments get targeted E1200s in both directions instead of decayed unknown-type errors.

**Verified by execution:** the issue repro (42); module-qualified `lib.Buffer(2)` (40); mixed `Matrix(i32, K)` with a const-name arg (42); `Buffer(M)` forwarding an enclosing comptime value in **field-type position** (42); oversized count rejected cleanly via E0906; aarch64 `--emit asm` clean. 3 spec cases under 4.14:23, 3 CLI cases + 1 module-qualified CLI case. Full `./test.sh` exit 0 on current trunk (post RUE-565/577 rebase, spec-case conflict resolved keeping both sets).

Known residual (grammar-level): a bare `true`/`false` literal as a type-call argument still doesn't parse (bool-valued comptime params are reachable via const names); trivially extendable if wanted.

Fixes RUE-552

🤖 Generated with [Claude Code](https://claude.com/claude-code)