### PR TITLE
RUE-525+524: retire the last flat-namespace lookup; chapter 10 + 6.5 describe module-scoped reality

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1986,8 +1986,7 @@ impl<'a> ConstraintGenerator<'a> {
                         |l| matches!(l.ty, InferType::Concrete(t) if t == Type::COMPTIME_TYPE),
                     )
                     && (self
-                        .structs
-                        .get(&name)
+                        .struct_type_for(&name, span.file_id)
                         .and_then(|t| t.as_struct())
                         .is_some()
                         || self.enum_type_for(&name, span.file_id).is_some())
@@ -2420,6 +2419,22 @@ impl<'a> ConstraintGenerator<'a> {
     /// table. Mirrors sema's `resolve_enum_type_name`; without the
     /// comptime-alias lookup, generic-enum construction/matching inferred
     /// `<error>` and poisoned the surrounding constraints (RUE-6 phase 2).
+    /// Struct type for an unqualified name, module-local first (RUE-525).
+    /// The trailing global lookup covers builtins and stays as inference-side
+    /// permissiveness only — sema's module-local resolution is authoritative
+    /// and rejects cross-file unqualified references (E0204).
+    fn struct_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
+        self.comptime_local_types
+            .and_then(|aliases| aliases.get(type_name).copied())
+            .filter(|ty| ty.as_struct().is_some())
+            .or_else(|| {
+                self.structs_by_file_name
+                    .and_then(|structs| structs.get(&(file_id, *type_name)))
+                    .copied()
+            })
+            .or_else(|| self.structs.get(type_name).copied())
+    }
+
     fn enum_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
         self.comptime_local_types
             .and_then(|aliases| aliases.get(type_name).copied())

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -28,13 +28,18 @@ impl<'a> Sema<'a> {
         // identifier receiver as a type namespace when it names a struct/enum or
         // a comptime type-variable bound to one (`let O = Option(i32);
         // O.Some(1)`). The struct/enum lookups mirror what `analyze_assoc_fn_call`
-        // itself resolves — the global by-name tables, so a cross-directory
-        // imported type is recognized and its privacy enforced there (E0460),
-        // rather than decaying to an "undefined variable" method call.
+        // itself resolves — MODULE-LOCAL names plus builtins (RUE-525): an
+        // unqualified `Type.assoc()` naming another file's type is
+        // name-not-found, exactly like a struct literal, type annotation, or
+        // plain function reference; the module-qualified spelling
+        // (`m.Type.assoc()`) is the supported form (ADR-0046).
         if let InstData::VarRef { name } = self.rir.get(receiver).data
             && !self.is_runtime_value_binding(name, ctx)
             && (ctx.comptime_type_vars.contains_key(&name)
-                || self.structs.contains_key(&name)
+                || self
+                    .structs_by_file_name
+                    .contains_key(&(ctx.current_file_id, name))
+                || self.resolve_builtin_struct_name(name).is_some()
                 || self.resolve_enum_type_name(name, ctx).is_some())
         {
             return self.analyze_assoc_fn_call(air, name, method, args_start, args_len, span, ctx);
@@ -477,6 +482,12 @@ impl<'a> Sema<'a> {
     }
 
     /// Implementation for AssocFnCall.
+    ///
+    /// `resolved` carries a struct already resolved (and visibility-checked,
+    /// E0706) by the module-qualified path (`m.Type.assoc()`, RUE-525): the
+    /// type lives in the RECEIVER MODULE's file, so re-resolving the bare
+    /// name in the caller's file would miss it.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn analyze_assoc_fn_call_impl(
         &mut self,
         air: &mut Air,
@@ -486,6 +497,7 @@ impl<'a> Sema<'a> {
         args_len: u32,
         span: Span,
         ctx: &mut AnalysisContext,
+        resolved: Option<StructId>,
     ) -> CompileResult<AnalysisResult> {
         let args = self.rir.get_call_args(args_start, args_len);
         let type_name_str = self.interner.resolve(&type_name).to_string();
@@ -501,7 +513,12 @@ impl<'a> Sema<'a> {
         // and must obey the same uniform-privacy rule (spec 10.3:7) as a struct
         // literal or type annotation would.
         let mut privacy_exempt = false;
-        let struct_id = if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
+        let struct_id = if let Some(struct_id) = resolved {
+            // Module-qualified path: visibility (E0706) was already checked
+            // against the receiver module by the caller.
+            privacy_exempt = true;
+            struct_id
+        } else if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
             privacy_exempt = true;
             // Extract struct ID from the comptime type
             match ty.kind() {
@@ -517,9 +534,13 @@ impl<'a> Sema<'a> {
                 }
             }
         } else {
-            *self
-                .structs
-                .get(&type_name)
+            // Module-local first, then builtins (RUE-525) — never the global
+            // by-name table: an unqualified reference to another file's type
+            // is name-not-found, matching every other unqualified form.
+            self.structs_by_file_name
+                .get(&(ctx.current_file_id, type_name))
+                .copied()
+                .or_else(|| self.resolve_builtin_struct_name(type_name))
                 .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.clone()), span)?
         };
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3241,14 +3241,19 @@ impl<'a> Sema<'a> {
                         .copied()
                 })
                 .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
+            // Module-qualified visibility is E0706 (RUE-525), uniform with
+            // enum members and associated-function calls through a module;
+            // E0460 is the diagnostic for unqualified naming forms.
             let def = self.type_pool.struct_def(struct_id);
-            self.check_unqualified_visibility(
-                "struct",
-                type_name_str,
-                def.file_id,
-                def.is_pub,
-                span,
-            )?;
+            if !self.is_accessible(span.file_id, def.file_id, def.is_pub) {
+                return Err(CompileError::new(
+                    ErrorKind::PrivateMemberAccess {
+                        item_kind: "struct".to_string(),
+                        name: type_name_str.to_string(),
+                    },
+                    span,
+                ));
+            }
             struct_id
         } else if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
             // Extract struct ID from the comptime type
@@ -4378,16 +4383,37 @@ impl<'a> Sema<'a> {
                 .map(Some);
         }
 
-        // Struct member: `module.Struct.function(args)` is an associated-function
-        // call. In the transitional flat namespace struct names resolve globally
-        // — the same resolution the removed `::` form used — so dispatch on the
-        // name.
-        if self
+        // Struct member: `module.Struct.function(args)` is an associated-
+        // function call. Resolve the struct in the RECEIVER MODULE's file and
+        // pass it through (RUE-525): dispatching on the bare name would
+        // re-resolve in the caller's file (module-local rules) and miss.
+        // Module-qualified visibility is E0706, mirroring the enum branch.
+        if let Some(struct_id) = self
             .structs_by_file_name
-            .contains_key(&(file_id, type_name))
+            .get(&(file_id, type_name))
+            .copied()
         {
+            let struct_def = self.type_pool.struct_def(struct_id);
+            if !self.is_accessible(span.file_id, struct_def.file_id, struct_def.is_pub) {
+                return Err(CompileError::new(
+                    ErrorKind::PrivateMemberAccess {
+                        item_kind: "struct".to_string(),
+                        name: self.interner.resolve(&type_name).to_string(),
+                    },
+                    span,
+                ));
+            }
             return self
-                .analyze_assoc_fn_call(air, type_name, method, args_start, args_len, span, ctx)
+                .analyze_assoc_fn_call_impl(
+                    air,
+                    type_name,
+                    method,
+                    args_start,
+                    args_len,
+                    span,
+                    ctx,
+                    Some(struct_id),
+                )
                 .map(Some);
         }
 
@@ -6235,7 +6261,9 @@ impl<'a> Sema<'a> {
         }
 
         // Delegate to the main implementation in analysis.rs
-        self.analyze_assoc_fn_call_impl(air, type_name, function, args_start, args_len, span, ctx)
+        self.analyze_assoc_fn_call_impl(
+            air, type_name, function, args_start, args_len, span, ctx, None,
+        )
     }
 
     /// Analyze construction of an enum tuple variant with a payload

--- a/crates/rue-cli-tests/cases/assoc_fn_privacy.toml
+++ b/crates/rue-cli-tests/cases/assoc_fn_privacy.toml
@@ -1,19 +1,19 @@
 # Associated-function calls respect the enclosing type's privacy across a
-# directory boundary (RUE-330). Calling an associated function of a private
-# struct from a source file in a different directory is E0460 — the same rule
-# that already governs naming that struct in a struct literal or type
-# annotation. This holds for both the unqualified (`Secret.make()`) and the
-# module-qualified (`lib.Secret.make()`) forms, since both resolve the
-# receiver type through the transitional flat namespace. A receiver reached
-# through a comptime binding (`let P = lib.Point; P.origin()`) is exempt, and
-# intra-directory access is unchanged.
+# directory boundary (RUE-330, RUE-525). Module-qualified access to a private
+# type's associated function (`lib.Secret.make()`) is E0706, uniform with
+# every module-member privacy violation. The unqualified spelling
+# (`Secret.make()`) never resolves another file's type at all (spec 10.3:8):
+# it fails name resolution before privacy is considered. A receiver reached
+# through a comptime binding of a PUB type (`let P = lib.Point; P.origin()`)
+# works; binding a private type errors E0706 at the binding itself.
+# Intra-directory access is unchanged.
 
 [section]
 id = "cli.assoc_fn_privacy"
 name = "Associated-function privacy across directories"
 description = "Cross-directory associated-function calls on a private struct are rejected (RUE-330)."
 
-# Unqualified call on a private struct from another directory: rejected.
+# Unqualified reference to another file's struct: does not resolve (RUE-525).
 [[case]]
 name = "cross_dir_unqualified_private_assoc_fn_rejected"
 files = [
@@ -33,10 +33,10 @@ struct Secret {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "struct `Secret` is private"]
+error_contains = ["E0201", "undefined variable 'Secret'"]
 
-# Module-qualified call on a private struct from another directory: also
-# rejected (the type resolves through the flat namespace, so it is E0460 too).
+# Module-qualified call on a private struct from another directory: E0706,
+# like every module-member privacy violation.
 [[case]]
 name = "cross_dir_qualified_private_assoc_fn_rejected"
 files = [
@@ -56,7 +56,7 @@ struct Secret {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "struct `Secret` is private"]
+error_contains = ["E0706", "struct `Secret` is private"]
 
 # Pub struct: the associated-function call across directories is allowed.
 [[case]]
@@ -66,7 +66,7 @@ files = [
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
-    let p = Point.origin();
+    let p = lib.Point.origin();
     p.x + p.y
 }
 """ },
@@ -86,8 +86,10 @@ exit_code = 42
 name = "same_dir_private_assoc_fn_allowed"
 files = [
     { path = "main.rue", source = """
+const lib = @import("lib.rue");
+
 fn main() -> i32 {
-    let s = Secret.make();
+    let s = lib.Secret.make();
     s.n
 }
 """ },
@@ -98,7 +100,7 @@ struct Secret {
 }
 """ },
 ]
-args = ["main.rue", "lib.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 # Receiver type reached through a comptime binding, not by naming the struct:

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -409,7 +409,7 @@ exit_code = 42
 [[case]]
 name = "qualified_private_struct_literal_rejected"
 spec = ["10.4:18"]
-description = "A private struct named in a module-qualified struct literal from another directory is E0460 (resolves through the flat namespace)"
+description = "A private struct named in a module-qualified struct literal from another directory is E0706, uniform with every module-member privacy violation (RUE-525)"
 source = """
 const lib = @import("sub/lib");
 
@@ -423,7 +423,7 @@ struct Secret { n: i32, }
 pub fn touch() -> i32 { let s = Secret { n: 1 }; s.n }
 """ }
 compile_fail = true
-error_contains = ["E0460", "is private"]
+error_contains = ["E0706", "is private"]
 
 [[case]]
 name = "qualified_private_enum_variant_rejected"
@@ -445,15 +445,15 @@ compile_fail = true
 error_contains = ["E0706", "is private"]
 
 # =============================================================================
-# Associated-function privacy follows the enclosing type (10.4:19, RUE-330).
-# Calling an associated function of a private struct across a directory
-# boundary is E0460 — the same rule as naming that struct in a literal or
-# annotation — whether the call is unqualified or module-qualified.
+# Associated-function privacy follows the enclosing type (10.4:19, RUE-330,
+# RUE-525). Module-qualified access to a private type's associated function
+# is E0706; the unqualified spelling never resolves another file's type at
+# all (10.3:8), so it fails name resolution before privacy is considered.
 
 [[case]]
 name = "cross_dir_unqualified_private_assoc_fn_rejected"
-spec = ["10.4:19"]
-description = "An unqualified associated-function call on a private struct from another directory is E0460 (RUE-330)"
+spec = ["10.4:19", "10.3:8"]
+description = "An unqualified associated-function call on another file's struct does not resolve at all (RUE-525): name-resolution error, never a flat-namespace hit"
 source = """
 const lib = @import("sub/lib");
 
@@ -469,12 +469,12 @@ struct Secret {
 }
 """ }
 compile_fail = true
-error_contains = ["E0460", "struct `Secret` is private"]
+error_contains = ["E0201", "undefined variable 'Secret'"]
 
 [[case]]
 name = "cross_dir_qualified_private_assoc_fn_rejected"
-spec = ["10.4:19"]
-description = "A module-qualified associated-function call on a private struct from another directory is E0460 (resolves the type through the flat namespace, RUE-330)"
+spec = ["10.4:19", "10.4:18"]
+description = "A module-qualified associated-function call on a private struct from another directory is E0706, uniform with every module-member privacy violation (RUE-525)"
 source = """
 const lib = @import("sub/lib");
 
@@ -490,17 +490,17 @@ struct Secret {
 }
 """ }
 compile_fail = true
-error_contains = ["E0460", "struct `Secret` is private"]
+error_contains = ["E0706", "struct `Secret` is private"]
 
 [[case]]
 name = "cross_dir_pub_assoc_fn_allowed"
-spec = ["10.4:19"]
-description = "An associated-function call on a pub struct across directories is allowed"
+spec = ["10.4:19", "10.4:17"]
+description = "A module-qualified associated-function call on a pub struct across directories is allowed; the qualifier resolves the type in the named module"
 source = """
 const lib = @import("sub/lib");
 
 fn main() -> i32 {
-    let p = Point.origin();
+    let p = lib.Point.origin();
     p.x + p.y
 }
 """

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -2,11 +2,11 @@
 id = "modules.composition"
 spec_chapter = "10.5"
 name = "Program Composition"
-description = "Cross-file name collisions among modules loaded through the root import graph (spec chapter 10.5)."
+description = "Module-scoped top-level names and extent of analysis (spec chapter 10.5)."
 
 [[case]]
 name = "same_named_functions_across_imported_files_ok"
-spec = ["10.5:1"]
+spec = ["10.5:2"]
 description = "Two loaded files may define the same top-level function name when each is accessed through its own module"
 source = """
 fn main() -> i32 {
@@ -20,7 +20,7 @@ exit_code = 1
 
 [[case]]
 name = "same_named_consts_across_imported_files_ok"
-spec = ["10.5:1"]
+spec = ["10.5:2"]
 description = "Top-level value constants may share a source name across imported files when accessed through their modules"
 source = """
 fn main() -> i32 {
@@ -37,3 +37,57 @@ pub const LIMIT: i32 = 2;
 pub fn go2() -> i32 { LIMIT }
 """ }
 exit_code = 1
+
+[[case]]
+name = "same_file_duplicate_function_error"
+spec = ["10.5:1"]
+description = "Two top-level items with one name in ONE file are a duplicate-definition error; the check is per-file"
+source = """
+fn shared() -> i32 { 1 }
+fn shared() -> i32 { 2 }
+fn main() -> i32 { shared() }
+"""
+compile_fail = true
+error_contains = "E0436"
+
+[[case]]
+name = "same_file_cross_kind_collision_error"
+spec = ["10.5:1"]
+description = "A const and a fn sharing one name in ONE file collide across kinds (E0436)"
+source = """
+const X: i32 = 1;
+fn X() -> i32 { 2 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "E0436"
+
+[[case]]
+name = "same_named_functions_qualified_calls_sum"
+spec = ["10.5:3"]
+description = "The 10.5:3 example: same-named functions in two modules, each call resolving in its own module"
+source = """
+fn main() -> i32 {
+    let a = @import("a");
+    let b = @import("b");
+    a.shared() + b.shared()
+}
+"""
+aux_files = { "a.rue" = "pub fn shared() -> i32 { 1 }", "b.rue" = "pub fn shared() -> i32 { 2 }" }
+exit_code = 3
+
+[[case]]
+name = "reachable_broken_imported_item_always_errors"
+spec = ["10.5:4"]
+description = "The guaranteed half of demand-driven analysis: an error in imported code the program reaches is always reported (the lazy half — unreferenced items possibly unanalyzed — is exercised by the real driver in CLI tests)"
+source = """
+fn main() -> i32 {
+    let m = @import("m");
+    m.broken()
+}
+"""
+aux_files = { "m.rue" = """
+pub fn broken() -> i32 { true }
+""" }
+compile_fail = true
+error_contains = "E0206"

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -225,14 +225,14 @@ exit_code = 42
 # =============================================================================
 # Unqualified Cross-Directory Access (RUE-37, RUE-180)
 # =============================================================================
-# Privacy is uniform (10.3:7): a private function in a file in another
-# directory is rejected when called unqualified (E0460), whether that file
-# was imported. The flat namespace (10.5:2) only resolves names — pub items
-# remain callable without qualification (10.3:8).
+# Unqualified references resolve module-locally (10.3:8): a function of an
+# imported file — private OR pub, same directory or another — does not
+# resolve unqualified. Cross-module access is spelled through the module
+# binding; privacy through the binding is E0706 (10.3:7, 10.4:18).
 
 [[case]]
 name = "cross_dir_unqualified_private_fn_error"
-spec = ["10.3:7"]
+spec = ["10.3:8"]
 description = "Unqualified call to a private function of an imported module in another directory is rejected"
 source = """
 const utils = @import("subdir/utils");
@@ -251,7 +251,7 @@ error_contains = "undefined function 'internal_fn'"
 
 [[case]]
 name = "cross_dir_unqualified_pub_fn_rejected"
-spec = ["10.3:7", "10.3:8"]
+spec = ["10.3:8"]
 description = "Unqualified call to a pub function of an imported module is rejected; use module-qualified access"
 source = """
 const utils = @import("subdir/utils");
@@ -270,7 +270,7 @@ error_contains = "undefined function 'public_fn'"
 
 [[case]]
 name = "same_dir_unqualified_private_fn_rejected"
-spec = ["10.3:2", "10.3:7"]
+spec = ["10.3:2", "10.3:8"]
 description = "Unqualified call to a private function of an imported file in the SAME directory is rejected; use module-qualified access"
 source = """
 const utils = @import("utils");

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -88,9 +88,10 @@ full semantics):
 
 {{ rule(id="4.13:5b", cat="informative") }}
 
-The compiler frontend additionally reserves the names `@cast`, `@panic`, and
-`@assert`. Their surface syntax is not yet fully stabilized, so they are omitted
-from the normative inventory above, but they are no longer no-ops (RUE-319):
+The compiler frontend additionally reserves the names `@cast`, `@panic`,
+`@assert`, and `@test_preview_gate`. Their surface syntax is not yet fully
+stabilized, so they are omitted from the normative inventory above, but they
+are no longer no-ops (RUE-319):
 
 - `@panic(msg?)` aborts the process. It writes `panic: <msg>` (or just `panic`
   when called with no argument) to standard error and exits with status 101 —
@@ -103,6 +104,9 @@ from the normative inventory above, but they are no longer no-ops (RUE-319):
 - `@cast` is rejected at compile time with a diagnostic directing the programmer
   to `@intCast`; it never had a working inference rule and is fully redundant
   with `@intCast`. Use `@intCast` for integer conversions.
+- `@test_preview_gate()` is a zero-argument no-op that exists only to test the
+  preview-feature gating machinery itself (`--preview test_infra`); it is test
+  infrastructure, not a language feature.
 
 ## `@dbg`
 

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -124,8 +124,10 @@ of aggregate type may be revisited in a future revision.
 {{ rule(id="6.5:7", cat="normative") }}
 
 A constant initializer may reference constants declared later in the same
-file or in another file of the program; declaration and file order do not
-affect the result. Initializers are evaluated in dependency order.
+file, and constants of other modules through a module binding (`m.LIMIT`);
+declaration and file order do not affect the result. Initializers are
+evaluated in dependency order. An unqualified reference to a constant
+defined only in another file does not resolve (10.3:8).
 
 {{ rule(id="6.5:8", cat="legality-rule") }}
 

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -59,28 +59,27 @@ fn main() -> i32 {
 
 {{ rule(id="10.3:7", cat="legality-rule") }}
 
-Visibility is uniform across every multi-file compilation: an item is
-visible outside its defining directory if and only if it is `pub`,
-whether its defining file was loaded via `@import` or, while the legacy
-flat multi-file mode still exists, only listed explicitly in the
-compilation. It is a compile-time error to reference a private item by
-its unqualified name from a source file in a different directory than the
-item's defining file (error E0460). This covers every form of
-unqualified reference: calling a private function, naming a private
-struct (in a type annotation, a signature, or a struct literal), naming
-a private enum (in a type annotation, a signature, a variant
-construction, or a match pattern), and reading a private constant —
-including from another constant's initializer.
+Visibility is uniform across every multi-file compilation and every item
+kind: an item is usable outside its defining directory if and only if it
+is `pub`, whether its defining file was loaded via `@import` or listed
+explicitly in the compilation. Access to a private item through a module
+binding from another directory is error E0706 (10.4:18) — this is the
+diagnostic for privacy violations, since cross-module references are
+spelled through module bindings. Where an implementation still accepts an
+unqualified reference that names a cross-directory item directly (legacy
+forms scheduled for removal with flat mode, ADR-0046), referencing a
+private item that way is error E0460.
 
 {{ rule(id="10.3:8", cat="normative") }}
 
-The legacy flat namespace (10.5:2) affects only *name resolution*: an
-unqualified reference may currently resolve to an item in any explicitly
-loaded source file without an import, but the visibility rules of this
-section apply regardless of how the item's file was loaded. A `pub` item
-in another directory is therefore usable unqualified without any import
-only through this transitional mode; new code should use `@import`, and
-RUE-434 tracks removing the unqualified cross-file fallback.
+Unqualified references resolve module-locally: a top-level name refers to
+an item of the referencing file (or a compiler builtin). A name defined
+only in other loaded files — imported or explicitly listed, `pub` or not,
+any directory — does not resolve unqualified; the reference is a
+name-resolution error (E0201 for variables/constants and enum type names
+in expressions, E0202 for functions, E0204 for types), never a silent
+resolution into another file. Cross-module access is spelled through a
+module binding (10.4:1).
 
 {{ rule(id="10.3:9", cat="example") }}
 
@@ -90,21 +89,17 @@ fn secret() -> i32 { 99 }       // private to sub/
 pub fn open() -> i32 { 7 }
 struct Hidden { n: i32, }       // private to sub/
 pub struct Shared { n: i32, }
-enum Mode { Fast, Slow, }       // private to sub/
-pub enum Level { Low, High, }
-const LIMIT: i32 = 8;           // private to sub/
 pub const MAX: i32 = 16;
 
-// main.rue — a different directory, relying on legacy flat mode (10.5:2)
+// main.rue — a different directory
+const lib = @import("sub/lib");
+
 fn main() -> i32 {
-    // secret()                  // error E0460: private to sub/lib.rue
-    // let h = Hidden { n: 1 };  // error E0460: private to sub/lib.rue
-    // let m = Mode.Fast;       // error E0460: private to sub/lib.rue
-    // let l = LIMIT;            // error E0460: private to sub/lib.rue
-    let s = Shared { n: MAX };   // OK: `Shared` and `MAX` are pub
-    match Level.High {          // OK: `Level` is pub
-        Level.Low => 0,
-        Level.High => open() + s.n,
-    }
+    // secret()                    // error E0202: does not resolve here (10.3:8)
+    // Shared { n: 1 };            // error E0204: pub, but still module-scoped
+    // lib.secret()                // error E0706: private to sub/ (10.4:18)
+    // lib.Hidden { n: 1 };        // error E0706: private to sub/
+    let s = lib.Shared { n: lib.MAX };  // OK: pub members through the binding
+    lib.open() + s.n                    // 7 + 16 = 23
 }
 ```

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -34,13 +34,12 @@ fn main() -> i32 {
 
 {{ rule(id="10.4:8", cat="normative") }}
 
-A top-level `const` module binding is scoped to the file that declares it.
-Two files **MAY** bind the same name — whether to the same module or to
-different modules — without conflict; references in each file resolve to
-that file's own binding. This is an exception to the shared flat namespace
-of rule 10.5:1, because every file writes its own imports. Declaring two
-module bindings with the same name in one file remains a compile-time error
-(E0418).
+A top-level `const` module binding is scoped to the file that declares it,
+like every other top-level name (10.5:2). Two files **MAY** bind the same
+name — whether to the same module or to different modules — without
+conflict; references in each file resolve to that file's own binding.
+Declaring two module bindings with the same name in one file remains a
+compile-time error (E0418).
 
 {{ rule(id="10.4:9", cat="example") }}
 
@@ -164,40 +163,36 @@ annotation, a field type, or a parameter or return type. In those positions,
 `m.Type(T)` applies a module-qualified type constructor. This is the preferred
 form for referring to standard-library types such as `std.option.Option(i64)`.
 
-{{ rule(id="10.4:17") }}
+{{ rule(id="10.4:17", cat="normative") }}
 
-Resolution of the tail path in the forms of 10.4:15 currently proceeds through
-the transitional flat namespace (10.5:2): the type, variant, or associated
-function is looked up by name across the whole compilation, and the leading
-module qualifier does **not** restrict the lookup to members of the named
-module. A program must not rely on the qualifier naming the module that defines
-the item; unlike functions and value constants (10.4:3, 10.4:12), which resolve
-as genuine module members, the qualifier is not yet load-bearing for these item
-kinds. This is a transitional artifact that will change when top-level names
-become module-scoped (10.5:2).
+The module qualifier is load-bearing for every item kind. In the forms of
+10.4:15 the type, variant, or associated function resolves as a member of
+the named module's file — exactly as functions and value constants do
+(10.4:3, 10.4:12). If the named module's file does not define the item,
+the reference is an unknown-member error even when another loaded file
+defines an item of that name; same-named types in distinct modules are
+distinct nominal types (10.5:2).
 
 {{ rule(id="10.4:18", cat="legality-rule") }}
 
-Privacy of module-qualified type and enum-variant access is uniform (10.3:7).
-Naming a private struct in a module-qualified struct literal from a source file
-in another directory is a compile-time error (E0460, the same error as the
-unqualified form, because the type resolves through the flat namespace).
-Naming a private enum's variant through a module from another directory is a
-compile-time error (E0706, because a variant path routes through
-module-member resolution).
+Privacy of module-qualified access is uniform across item kinds (10.3:7)
+and reports one diagnostic: accessing a private member through a module
+binding from a source file in another directory is a compile-time error
+E0706 — for a struct named in a qualified struct literal or type
+annotation, for an enum's variant, for an associated function's enclosing
+type, and for functions and constants alike.
 
 {{ rule(id="10.4:19", cat="legality-rule") }}
 
-An associated function's visibility follows the visibility of its enclosing type
-(10.3:7): calling an associated function of a private struct from a source file
-in another directory is a compile-time error (E0460), exactly as naming that
-struct in a struct literal or type annotation would be. This holds whether the
-call is written unqualified (`Point.origin()`) or module-qualified
-(`lib.Point.origin()`) — both resolve the receiver type through the flat
-namespace (10.5:2), so both report E0460 (RUE-330). A call whose receiver type
-arrives through a comptime binding rather than by naming the struct
-(`let P = lib.Point; P.origin()`) is exempt, matching every other reference
-that reaches a type through a binding.
+An associated function's visibility follows the visibility of its enclosing
+type (10.3:7). A module-qualified call on a private type from another
+directory (`lib.Secret.make()`) is a compile-time error E0706 (10.4:18).
+An unqualified call (`Secret.make()`) never reaches the visibility check
+from another file: the bare type name does not resolve outside its
+defining module (10.3:8), so the reference is a name-resolution error.
+Binding the type value first does not launder privacy: the binding
+(`let P = lib.Secret;`) is itself a module-member access and reports
+E0706 at the binding site.
 
 {{ rule(id="10.4:20", cat="example") }}
 

--- a/docs/spec/src/10-modules/05-program-composition.md
+++ b/docs/spec/src/10-modules/05-program-composition.md
@@ -7,41 +7,42 @@ template = "spec/page.html"
 # Program Composition
 
 This section specifies how the root source file, imported modules, and
-legacy explicitly listed source files compose into one program.
+explicitly listed source files compose into one program.
 
-The intended driver contract is root-module based: a normal compiler
-invocation names one root source file, and that root's transitive
-`@import` graph determines the semantic module graph. Source files may
-also be declared to a build system as action inputs, but declaration as an
-available input is not a way to put names in scope. A source file affects
-name resolution only when the program reaches it through an explicit import
-or through the legacy flat multi-file mode described below.
+The driver contract is root-module based: a normal compiler invocation
+names one root source file, and that root's transitive `@import` graph
+determines the semantic module graph. Source files may also be declared to
+a build system as action inputs (a source manifest, ADR-0047), but
+declaration as an available input is not a way to put names in scope: a
+source file affects name resolution only when the program reaches it
+through an explicit import.
 
-The current implementation still contains that legacy flat mode for
-additional source files listed explicitly on the command line. ADR-0046
-and ADR-0047 define its removal; RUE-434 tracks the implementation work.
-Until that removal lands, this section distinguishes the intended root
-module/import-graph contract from the transitional loaded-file namespace.
+Extra source files listed positionally on the command line are a legacy
+input form (ADR-0046 defines its removal; RUE-434 tracks it). Listed files
+are loaded, but their names are **not** placed in any shared scope: an
+unqualified reference to another file's item is a name-resolution error
+exactly as it is between imported modules (rule 10.5:2).
 
-## Legacy Name Collisions
+## Top-Level Names Are Module-Scoped
 
 {{ rule(id="10.5:1", cat="legality-rule") }}
 
-In the legacy flat loaded-file namespace, it is a compile-time error for
-two loaded source files to define a top-level item with the same name
-(duplicate definition, E0436). This holds regardless of the items'
-visibility and regardless of whether the files are in the same directory.
-Module-binding constants (`const m = @import(...)`) are the exception:
-they are scoped per file (rule 10.4:8) and do not collide across files.
+It is a compile-time error for one source file to define two top-level
+items with the same name, whether of the same kind (duplicate definition,
+E0436) or of different kinds (a `const` and a `fn` sharing a name, also
+E0436). This check is per-file: it never considers items in other loaded
+files.
 
-{{ rule(id="10.5:2") }}
+{{ rule(id="10.5:2", cat="normative") }}
 
-Rule 10.5:1 is *transitional*: loaded files currently share one flat global
-namespace, so symbols collide program-wide even when each is only ever
-accessed through its own module. This is not the long-term module model.
-The root-module contract scopes program structure through explicit imports,
-and programs should not be designed to rely on cross-file collisions being
-errors outside a single module.
+Top-level names are scoped to their defining source file (their module).
+Two loaded files **MAY** define top-level items with the same name — of
+the same kind or of different kinds — regardless of visibility and
+regardless of directory. Each file's items are reachable from other files
+only through a module binding (`m.item`, rule 10.4:1); an unqualified
+reference to a name defined only in another loaded file is a
+name-resolution error (E0201/E0202/E0204, rule 10.3:8), never a silent
+resolution into the other file.
 
 {{ rule(id="10.5:3", cat="example") }}
 
@@ -50,27 +51,25 @@ errors outside a single module.
 pub fn shared() -> i32 { 1 }
 
 // b.rue
-pub fn shared() -> i32 { 2 }   // error: duplicate definition of `shared`
+pub fn shared() -> i32 { 2 }   // legal: names are module-scoped
 
 // main.rue
 fn main() -> i32 {
     let a = @import("a");
-    let b = @import("b");      // loading both files collides
-    a.shared()
+    let b = @import("b");
+    a.shared() + b.shared()    // 3: each call resolves in its own module
 }
 ```
 
 ## Root Module and Extent of Analysis
 
-{{ rule(id="10.5:4") }}
+{{ rule(id="10.5:4", cat="normative") }}
 
-In the current implementation, every loaded source file is fully analyzed:
-a compile-time error anywhere in an imported module is reported even if the
-offending item is never referenced by the importing program.
-
-This eager behavior is an implementation property, not the semantic
-definition of a Rue program. The semantic compilation unit is the root
-module and its transitive import graph; ADR-0045 allows future lazy,
-on-demand analysis of imported modules, and ADR-0047 allows future
-build-system source manifests that constrain which files may be imported
-without turning every declared input into a semantic root.
+The semantic compilation unit is the root module and its transitive import
+graph. An implementation **MAY** analyze imported modules on demand
+(ADR-0045): items of an imported module that the program never references
+are not guaranteed to be semantically analyzed, so a program **MUST NOT**
+rely on a compile-time error inside an unreferenced imported item being
+reported. Errors in code the program reaches — including declaration-level
+errors of any loaded file (parse errors, duplicate definitions, invalid
+signatures) — are always reported.


### PR DESCRIPTION
Lands the behavior change and the spec text together, per the sequencing note on RUE-525.

**Behavior (RUE-525)** — unqualified associated-function calls were the one form still resolving through the global by-name tables: `Type.assoc()` found another file's type while every sibling form (functions, annotations, struct literals, enum variants, constants) was already name-not-found. Now:
- The receiver gate and dispatch resolve **module-locally** (plus builtins). Unqualified references to another file's type fail name resolution — verified against a 10-probe matrix (same-dir × cross-dir × item kinds) before and after.
- The module-qualified path resolves the struct **in the receiver module's file** and passes it through dispatch — the old code gated on the module's file but re-resolved the bare name (the RUE-431 audit's gate/dispatch mismatch), which was also the wrong-file hazard for same-named types.
- Module-qualified privacy is **E0706 uniformly**: struct literals through a binding now report E0706 like enum variants and assoc-fns (was E0460); `let P = lib.Secret` errors E0706 at the binding, so type values can't launder privacy. Inference's type-namespace gate mirrors sema.
- Fallout sweep: nothing in std/examples relied on the flat form; 4 spec cases + 4 CLI cases asserted the old behavior and are converted (one was a legacy positional-file spelling, now module-scoped).

**Spec (RUE-524)** — the six false normative rules verified by the 2026-07-09 audit are rewritten to module-scoped reality (ADR-0045/0046, drift repair not new design): 10.5:1 (per-file duplicate check — was **inverted**), new 10.5:2 (module-scoped top-level names), 10.5:3 + 10.3:9 examples (now compile/fail as annotated), 10.5:4 (demand-driven analysis latitude with the guaranteed reachable-error half), 10.3:7/10.3:8 (E0706 through bindings; name-not-found for unqualified cross-file; E0460 scoped to residual legacy forms), 10.4:8/17/18/19 (qualifier is load-bearing; uniform E0706; no comptime-binding exemption), 6.5:7 (cross-file consts via `m.CONST` only), 4.13:5b (`@test_preview_gate` in the reserved-names note). Traceability re-pointed so every case cites a rule that states what it asserts, closing the audit's masking problem; composition.toml gains per-file collision and cross-kind cases.

**Verification**: `buck2 test //...` tally **Pass 30 / Fail 0**, checked directly — during this work I found `./test.sh` exits 0 even when buck reports failing targets (masked failures twice); filed **RUE-579 (Urgent)**.

Fixes RUE-525
Fixes RUE-524

🤖 Generated with [Claude Code](https://claude.com/claude-code)