### PR TITLE
RUE-575: comptime let-bound type aliases resolve in field and payload type position

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -104,6 +104,29 @@ pub(crate) struct ComptimeEnv<'a> {
 }
 
 impl<'a> ComptimeEnv<'a> {
+    /// The substitution maps augmented with this environment's comptime
+    /// `let` locals (RUE-575): a type-valued local (`let Inner = Mk(T);`)
+    /// participates in type resolution exactly like a `comptime T: type`
+    /// parameter, and an integer/bool-valued local like a comptime value
+    /// parameter, wherever the anonymous-type arms resolve field, payload,
+    /// and method-signature types. Locals are inserted last, so an alias
+    /// shadows a same-named enclosing parameter (lexical scoping).
+    fn substs_with_locals(&self) -> (HashMap<Spur, Type>, HashMap<Spur, ConstValue>) {
+        let mut type_subst = self.type_subst.clone();
+        let mut value_subst = self.value_subst.clone();
+        for (name, val) in &self.locals {
+            match val {
+                ConstValue::Type(t) => {
+                    type_subst.insert(*name, *t);
+                }
+                other => {
+                    value_subst.insert(*name, *other);
+                }
+            }
+        }
+        (type_subst, value_subst)
+    }
+
     /// An environment with no substitutions and no type information.
     pub(crate) fn new() -> Self {
         Self {
@@ -850,6 +873,11 @@ impl Sema<'_> {
             } => {
                 let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
 
+                // Comptime `let` locals in scope participate in field-type
+                // resolution (`let Inner = Mk(T); struct { x: Inner }`,
+                // RUE-575), alongside the enclosing parameters.
+                let (local_type_subst, local_value_subst) = env.substs_with_locals();
+
                 let mut struct_fields = Vec::with_capacity(field_decls.len());
                 for (name_sym, type_sym) in field_decls {
                     let name_str = self.interner.resolve(&name_sym).to_string();
@@ -860,8 +888,8 @@ impl Sema<'_> {
                     let Some(field_ty) = self
                         .resolve_type_for_comptime_with_subst_and_values_at_span(
                             type_sym,
-                            env.type_subst,
-                            env.value_subst,
+                            &local_type_subst,
+                            &local_value_subst,
                             span,
                         )
                     else {
@@ -876,8 +904,11 @@ impl Sema<'_> {
                 // Extract method signatures for structural equality comparison
                 let method_sigs = self.extract_anon_method_sigs(*methods_start, *methods_len);
 
-                let (struct_ty, _is_new) =
-                    self.find_or_create_anon_struct(&struct_fields, &method_sigs, env.value_subst);
+                let (struct_ty, _is_new) = self.find_or_create_anon_struct(
+                    &struct_fields,
+                    &method_sigs,
+                    &local_value_subst,
+                );
 
                 // Register methods if present and not yet registered for this
                 // struct (it may have been created earlier without methods).
@@ -932,8 +963,8 @@ impl Sema<'_> {
                                     *methods_start,
                                     *methods_len,
                                     span,
-                                    env.type_subst,
-                                    env.value_subst,
+                                    &local_type_subst,
+                                    &local_value_subst,
                                 )
                                 .is_none()
                         {
@@ -949,9 +980,9 @@ impl Sema<'_> {
                         // above (RUE-313). Method bodies are analyzed later, in
                         // a separate pass that has no other way to recover the
                         // constructor's type parameters.
-                        if needs_registration && !env.type_subst.is_empty() {
+                        if needs_registration && !local_type_subst.is_empty() {
                             self.anon_struct_type_subst
-                                .insert(struct_id, env.type_subst.clone());
+                                .insert(struct_id, local_type_subst.clone());
                         }
                     }
                 }
@@ -979,6 +1010,10 @@ impl Sema<'_> {
                 // Decode the self-describing payload region into per-variant
                 // type-symbol lists (parallel to `variant_syms`), then resolve
                 // each payload type through the substitutions.
+                // Comptime `let` locals participate in payload-type
+                // resolution, matching the struct arm (RUE-575).
+                let (enum_type_subst, enum_value_subst) = env.substs_with_locals();
+
                 let mut variant_names: Vec<String> = Vec::with_capacity(variant_syms.len());
                 let mut variant_payloads: Vec<Vec<Type>> = Vec::with_capacity(variant_syms.len());
                 let mut pi = 0usize;
@@ -1001,8 +1036,8 @@ impl Sema<'_> {
                         let Some(ty) = self
                             .resolve_type_for_comptime_with_subst_and_values_at_span(
                                 ty_sym,
-                                env.type_subst,
-                                env.value_subst,
+                                &enum_type_subst,
+                                &enum_value_subst,
                                 span,
                             )
                         else {

--- a/crates/rue-cli-tests/cases/comptime_cross_module.toml
+++ b/crates/rue-cli-tests/cases/comptime_cross_module.toml
@@ -243,3 +243,32 @@ fn main() -> i32 {
 """ },
 ]
 exit_code = 40
+
+[[case]]
+# RUE-575: a comptime let-bound alias of a CROSS-MODULE type constructor is
+# usable as a field type inside a -> type body.
+name = "cross_module_let_alias_in_field_type_position"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "b.rue", source = """
+pub fn Mk(comptime T: type) -> type {
+    struct { value: T }
+}
+""" },
+  { path = "main.rue", source = """
+const b = @import("b.rue");
+
+fn Wrap(comptime T: type) -> type {
+    let Inner = b.Mk(T);
+    struct { x: Inner }
+}
+
+fn main() -> i32 {
+    let W = Wrap(i32);
+    let I = b.Mk(i32);
+    let w: W = W { x: I { value: 42 } };
+    w.x.value
+}
+""" },
+]
+exit_code = 42

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2072,6 +2072,66 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "let_bound_type_alias_in_field_type_position"
+spec = ["4.14:22"]
+description = "A comptime let-bound type alias is usable as a struct field type inside a -> type body (RUE-575)"
+source = """
+fn Mk(comptime T: type) -> type { struct { value: T } }
+fn Wrap(comptime T: type) -> type {
+    let Inner = Mk(T);
+    struct { x: Inner }
+}
+fn main() -> i32 {
+    let W = Wrap(i32);
+    let I = Mk(i32);
+    let w: W = W { x: I { value: 42 } };
+    w.x.value
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "let_bound_type_alias_in_enum_payload_position"
+spec = ["4.14:22"]
+description = "A comptime let-bound type alias is usable as an enum payload type inside a -> type body (RUE-575)"
+source = """
+fn Payload(comptime T: type) -> type { struct { v: T } }
+fn Choice(comptime T: type) -> type {
+    let P = Payload(T);
+    enum { Got(P), Nothing }
+}
+fn main() -> i32 {
+    let C = Choice(i32);
+    let P = Payload(i32);
+    let c: C = C.Got(P { v: 42 });
+    match c {
+        C.Got(p) => p.v,
+        C.Nothing => 0,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "let_bound_type_alias_shadows_type_parameter"
+spec = ["4.14:22"]
+description = "A let-bound alias shadows a same-named enclosing comptime type parameter in field-type position (lexical scoping, RUE-575)"
+source = """
+fn Mk(comptime T: type) -> type { struct { value: T } }
+fn Wrap(comptime T: type) -> type {
+    let T = Mk(bool);
+    struct { x: T }
+}
+fn main() -> i32 {
+    let W = Wrap(i32);
+    let B = Mk(bool);
+    let w: W = W { x: B { value: true } };
+    if w.x.value { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "type_constructor_in_annotation_position"
 spec = ["4.14:23"]
 description = "F(i32) used directly as a let type annotation (RUE-289, RUE-241)"


### PR DESCRIPTION
A let-bound type alias inside a `-> type` body (`let Inner = Mk(T); struct { x: Inner }`) failed E1200: the anonymous struct/enum arms resolved field and payload types through the enclosing parameter substitutions only, so the evaluator env's **locals** were invisible in type position (only the delegating tail form `let X = Mk(T); X` worked).

`ComptimeEnv::substs_with_locals` folds type-valued locals into the type substitution and integer/bool-valued locals into the value substitution, inserted last so an alias **shadows** a same-named enclosing parameter (lexical scoping). Both anon-type arms use the augmented maps for field/payload resolution, method-signature registration, and the RUE-313 method-body substitution memo — methods of the constructed type see the alias too.

**Verified by execution:** struct field alias (42); enum payload alias (42); cross-module alias via `b.Mk(T)` (42); alias shadowing the enclosing `T` (42). Not covered (unchanged): an integer local as an array-length field (`[i32; n]` with `let n = 3`) is separately rejected by the array-length rule's own clear E0481.

3 spec cases under 4.14:22 + 1 cross-module CLI case. `buck2 test //...` **Pass 30 / Fail 0** (tally checked directly — see RUE-579).

Fixes RUE-575

🤖 Generated with [Claude Code](https://claude.com/claude-code)