### PR TITLE
Reject duplicate main declarations

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -314,10 +314,9 @@ impl<'a> Sema<'a> {
     /// Phase 0: Order-independent name-collision check across the function and
     /// type (struct/enum) name spaces (spec 10.3:1, 10.5:1, RUE-239).
     ///
-    /// Functions, structs, enums, and constants are all top-level items sharing
-    /// **one** name space, so any two of them with the same name collide —
-    /// regardless of their kinds, their order within a file, or the
-    /// command-line order of the files they come from. This pass over the
+    /// Functions, structs, enums, and constants are module-local top-level
+    /// items, except that `main` remains the program-global executable entry
+    /// point until root-module identity reaches Sema. This pass over the
     /// merged RIR is the order-independent source of truth for collisions among
     /// **functions, structs, and enums**; the previously order-dependent gap
     /// was a function colliding with a struct/enum, which was never checked.
@@ -364,12 +363,14 @@ impl<'a> Sema<'a> {
         }
 
         // Free functions duplicate-conflict only within their defining file
-        // (RUE-441). Types duplicate-conflict only within their defining file
-        // (RUE-454). Function/type cross-kind collisions are per-file too
-        // (RUE-572, spec 10.5:1/10.5:2): top-level names are module-scoped,
-        // so a fn in one file and a struct in another may share a name.
+        // (RUE-441), except for the program-global `main` entry point (RUE-582).
+        // Types and function/type cross-kind collisions are per-file too
+        // (RUE-454, RUE-572, spec 10.5:1/10.5:2): top-level names are
+        // module-scoped, so non-entry items in separate files may share a name.
+        let mut seen_function_names: HashMap<Spur, Span> = HashMap::new();
         let mut seen_functions_by_file: HashMap<(FileId, Spur), Span> = HashMap::new();
         let mut seen_types_by_file: HashMap<(FileId, Spur), Span> = HashMap::new();
+        let main_sym = self.interner.get("main");
         for (inst_ref, inst) in self.rir.iter() {
             match &inst.data {
                 InstData::StructDecl { name, .. } | InstData::EnumDecl { name, .. } => {
@@ -412,6 +413,18 @@ impl<'a> Sema<'a> {
                         )
                         .with_label("first defined here".to_string(), first_span));
                     }
+                    if Some(*name) == main_sym
+                        && let Some(first_span) = seen_function_names.get(name).copied()
+                    {
+                        return Err(CompileError::new(
+                            ErrorKind::DuplicateFunctionDefinition {
+                                function_name: "main".to_string(),
+                            },
+                            inst.span,
+                        )
+                        .with_label("first defined here".to_string(), first_span));
+                    }
+                    seen_function_names.entry(*name).or_insert(inst.span);
                     if let Some(first_span) =
                         seen_functions_by_file.insert((inst.span.file_id, *name), inst.span)
                     {

--- a/crates/rue-cli-tests/cases/duplicate_main.toml
+++ b/crates/rue-cli-tests/cases/duplicate_main.toml
@@ -1,0 +1,24 @@
+# An executable import graph has one entry point. `main` is temporarily the one
+# free-function name that remains program-global while ordinary function names
+# become module-local (RUE-582; ADR-0047 tracks the root-module end state).
+
+[section]
+id = "cli.duplicate_main"
+name = "Duplicate entry points"
+description = "Loaded modules cannot define a second main function."
+
+[[case]]
+name = "import_graph_rejects_second_main"
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper.rue");
+
+fn main() -> i32 { helper.answer() }
+""" },
+    { path = "helper.rue", source = """
+pub fn main() -> i32 { 0 }
+pub fn answer() -> i32 { 42 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0436", "duplicate function definition", "main", "first defined here"]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -413,9 +413,9 @@ pub(crate) struct DuplicateSymbolCheck {
 /// Free functions and nominal types are scoped to their defining file/module
 /// for same-kind AND cross-kind duplicate detection (RUE-572, spec 10.5:1):
 /// top-level names are module-scoped, so a fn in one file and a type in
-/// another may share a name. Every duplicate
-/// produces one error pointing at the redefinition, with a label at the first
-/// definition.
+/// another may share a name. The executable entry point `main` is the temporary
+/// program-global exception (RUE-582). Every duplicate produces one error
+/// pointing at the redefinition, with a label at the first definition.
 ///
 /// This is the single source of truth for duplicate-symbol detection, shared
 /// by [`merge_symbols`] and `CompilationUnit::parse`.
@@ -426,6 +426,7 @@ pub(crate) fn detect_duplicate_symbols<'a>(
     use std::collections::HashMap;
 
     let mut functions: HashMap<(String, String), SymbolDef> = HashMap::new();
+    let mut program_main: Option<SymbolDef> = None;
     let mut function_names: HashMap<(String, String), SymbolDef> = HashMap::new();
     let mut type_names: HashMap<(String, String), SymbolDef> = HashMap::new();
     let mut structs: HashMap<(String, String), SymbolDef> = HashMap::new();
@@ -449,13 +450,27 @@ pub(crate) fn detect_duplicate_symbols<'a>(
                         .with_label(format!("first defined in {}", first.file_path), first.span);
                         errors.push(err);
                     } else {
-                        functions.insert(
-                            key.clone(),
-                            SymbolDef {
-                                span: func.span,
-                                file_path: file_path.to_string(),
-                            },
-                        );
+                        let definition = SymbolDef {
+                            span: func.span,
+                            file_path: file_path.to_string(),
+                        };
+                        if name == "main"
+                            && let Some(first) = &program_main
+                        {
+                            let err = CompileError::new(
+                                ErrorKind::DuplicateFunctionDefinition {
+                                    function_name: name.clone(),
+                                },
+                                func.span,
+                            )
+                            .with_label("first defined here", first.span);
+                            errors.push(err);
+                        } else {
+                            if name == "main" {
+                                program_main = Some(definition.clone());
+                            }
+                            functions.insert(key.clone(), definition);
+                        }
                     }
                     if let Some(first) = type_names.get(&key) {
                         // (cross-kind, same file)
@@ -2020,6 +2035,26 @@ mod tests {
             result.is_ok(),
             "module-local functions in different files may share a source name"
         );
+    }
+
+    #[test]
+    fn test_merge_symbols_duplicate_main_across_files_rejected() {
+        let sources = vec![
+            SourceFile::new("a.rue", "fn main() -> i32 { 1 }", FileId::new(1)),
+            SourceFile::new("b.rue", "fn main() -> i32 { 2 }", FileId::new(2)),
+        ];
+        let parsed = parse_all_files(&sources).unwrap();
+        let errors = merge_symbols(parsed).expect_err("main is program-global");
+
+        assert_eq!(errors.len(), 1, "should report one duplicate entry point");
+        let error = errors.first().unwrap();
+        assert!(matches!(
+            &error.kind,
+            ErrorKind::DuplicateFunctionDefinition { function_name } if function_name == "main"
+        ));
+        assert_eq!(error.diagnostic().labels.len(), 1);
+        assert_eq!(error.diagnostic().labels[0].message, "first defined here");
+        assert_eq!(error.diagnostic().labels[0].span.file_id, FileId::new(1));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- reject a second free function named `main` across the loaded program
- keep ordinary same-named and cross-kind items module-local
- enforce the exception in both shared parse/merge collision detection and the sema declaration backstop
- add import-graph and flat multi-file regressions with first-definition diagnostics

## Why

The demand-driven driver roots analysis through the interned `main` symbol. When more than one loaded file defined `main`, collection could overwrite metadata and analysis could silently select one declaration. The eager path previously caught this only accidentally by emitting duplicate symbols.

## Impact

`main` remains the one program-global function name during the transition to the ADR-0047 root-module-aware entry-point model. Duplicate entry points now fail deterministically with E0436 before body analysis.

## Verification

- `scripts/rue cli duplicate_main`
- `./buck2 test root//crates/rue-compiler:rue-compiler-test` (214 passed)
- `./test.sh` (all 30 targets)
- `./clippy.sh` (all 41 first-party Rust targets)
- CLI and spec differential oracles: zero disagreements

Fixes RUE-582