### PR TITLE
Keep compiler and CLI semantic fixtures reachable

### DIFF
--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -99,7 +99,7 @@ fn consume(s: String) -> i32 {
     let held = s;
     0
 }
-fn main() -> i32 { 0 }
+fn main() -> i32 { consume(String.new()) }
 """ }]
 exit_code = 0
 

--- a/crates/rue-cli-tests/cases/loop_break.toml
+++ b/crates/rue-cli-tests/cases/loop_break.toml
@@ -71,6 +71,7 @@ fn never_returns() -> ! {
 }
 
 fn main() -> i32 {
+    if false { never_returns(); }
     let mut x = 0;
     loop {
         x = x + 2;

--- a/crates/rue-cli-tests/cases/match_inference_fixes.toml
+++ b/crates/rue-cli-tests/cases/match_inference_fixes.toml
@@ -122,12 +122,12 @@ error_contains = ["E0484"]
 
 [[case]]
 name = "literal_plus_empty_match_compiles"
-description = "RUE-270: `1 + match n {}` — the empty match has type `!`, which coerces to the literal's type (spec 3.4:3-4). Compiles (the fn is uncallable — Never is uninhabited)."
+description = "RUE-270: `1 + match n {}` — the empty match has type `!`, which coerces to the literal's type (spec 3.4:3-4)."
 compile_only = true
 files = [{ path = "main.rue", source = """
 enum Never {}
 fn absurd(n: Never) -> i32 { 1 + match n {} }
-fn main() -> i32 { 0 }
+fn main() -> i32 { if false { absurd(loop {}); } 0 }
 """ }]
 
 [[case]]
@@ -137,7 +137,7 @@ compile_only = true
 files = [{ path = "main.rue", source = """
 enum Never {}
 fn absurd(n: Never) -> i32 { let x: i32 = match n {}; x }
-fn main() -> i32 { 0 }
+fn main() -> i32 { if false { absurd(loop {}); } 0 }
 """ }]
 
 [[case]]
@@ -165,6 +165,6 @@ compile_fail = true
 files = [{ path = "main.rue", source = """
 enum Never {}
 fn absurd(n: Never) -> i32 { let y: u8 = 300; let _ = match n {}; 0 }
-fn main() -> i32 { 0 }
+fn main() -> i32 { absurd(loop {}) }
 """ }]
 error_contains = ["E0800"]

--- a/crates/rue-cli-tests/cases/match_patterns.toml
+++ b/crates/rue-cli-tests/cases/match_patterns.toml
@@ -159,6 +159,7 @@ fn absurd(n: Never) -> i32 {
 }
 
 fn main() -> i32 {
+    if false { absurd(loop {}); }
     7
 }
 """ }]

--- a/crates/rue-cli-tests/cases/stmt_expr_boundary.toml
+++ b/crates/rue-cli-tests/cases/stmt_expr_boundary.toml
@@ -40,7 +40,7 @@ error_contains = ["E0206"]
 name = "while_return_condition_compiles"
 files = [{ path = "main.rue", source = """
 fn sink() { loop { while return {} } }
-fn main() -> i32 { 0 }
+fn main() -> i32 { sink(); 0 }
 """ }]
 compile_only = true
 

--- a/crates/rue-cli-tests/cases/try_operator.toml
+++ b/crates/rue-cli-tests/cases/try_operator.toml
@@ -120,7 +120,7 @@ fn f() -> Option(i64) {
     let O = Option(i64);
     O.Some(y)
 }
-fn main() -> i32 { 0 }
+fn main() -> i32 { f(); 0 }
 """ },
 ]
 args = ["main.rue", "-o", "prog"]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2925,7 +2925,7 @@ mod integration_tests {
 
         #[test]
         fn implicit_unit_return() {
-            assert!(compile_to_air("fn foo() -> () { } fn main() -> i32 { 0 }").is_ok());
+            assert!(compile_to_air("fn foo() -> () { } fn main() -> i32 { foo(); 0 }").is_ok());
         }
     }
 


### PR DESCRIPTION
## Summary

- make compiler and CLI fixtures reference the helper bodies they intend to exercise
- use runtime-dead branches for uninhabited inputs so behavior stays unchanged
- prevent demand-driven body analysis from turning these regressions into silent false positives

## Testing

- ./buck2 test root//crates/rue-compiler:rue-compiler-test root//:cli-tests
- 213 compiler tests and 1,234 CLI tests passed