### PR TITLE
RUE-560: real per-allocation ASan redzones with a required, self-verifying negative control

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -67,24 +67,53 @@ jobs:
       - name: Run programs under valgrind memcheck
         run: scripts/run-sanitizer.sh
 
-  # AddressSanitizer over rue-runtime's arena allocator (RUE-211). Standalone
-  # cargo crate (crates/rue-runtime-asan) driven by nightly rustc — no buck2 —
-  # because -Zsanitizer=address needs nightly, an explicit --target, and the
-  # compiler-rt asan runtime linked in. detect_leaks=0: arenas are intentionally
-  # never freed (bump allocator), which LeakSanitizer would otherwise flag.
+  # AddressSanitizer over rue-runtime's arena allocator (RUE-211, RUE-560).
+  # Standalone cargo crate (crates/rue-runtime-asan) driven by nightly rustc —
+  # no buck2 — because -Zsanitizer=address needs nightly, an explicit --target,
+  # and the compiler-rt asan runtime linked in. detect_leaks=0: arenas are
+  # intentionally never freed (bump allocator), which LeakSanitizer would
+  # otherwise flag.
+  #
+  # The nightly is PINNED (RUE-560): an un-pinned `nightly` floats and a bad
+  # daily build can silently break the harness or its sanitizer wiring. Bump
+  # NIGHTLY deliberately, verifying the harness (and its negative controls)
+  # still pass on the new toolchain.
   asan:
     runs-on: ubuntu-latest
+    env:
+      NIGHTLY: nightly-2026-04-13
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install nightly Rust
-        run: rustup toolchain install nightly --profile minimal
+      # clippy + rust-src round out the minimal profile: clippy for the lint
+      # gate below, rust-src is needed by some nightly asan setups.
+      - name: Install pinned nightly Rust
+        run: >
+          rustup toolchain install "$NIGHTLY" --profile minimal
+          --component clippy rust-src
 
+      # This standalone crate has no buck2 target, so it sits outside the
+      # repository-wide `./clippy.sh` query. Gate it here so it does not rot
+      # (RUE-560). Same instrumentation flags as the run, so lints see the
+      # sanitizer cfg the harness compiles under.
+      - name: Clippy the ASan harness
+        env:
+          RUSTFLAGS: "-Zsanitizer=address"
+        run: >
+          cargo "+$NIGHTLY" clippy
+          --manifest-path crates/rue-runtime-asan/Cargo.toml
+          --target x86_64-unknown-linux-gnu
+          -- -D warnings
+
+      # Runs the in-bounds allocator exercises AND spawns the negative-control
+      # children, each of which MUST abort under ASan (RUE-560). If the redzone
+      # instrumentation ever regresses, a control exits clean and the harness
+      # fails the job — the coverage is load-bearing, not decorative.
       - name: Exercise the arena allocator under AddressSanitizer
         env:
           RUSTFLAGS: "-Zsanitizer=address"
           ASAN_OPTIONS: "detect_leaks=0"
         run: >
-          cargo +nightly run
+          cargo "+$NIGHTLY" run
           --manifest-path crates/rue-runtime-asan/Cargo.toml
           --target x86_64-unknown-linux-gnu

--- a/crates/rue-runtime-asan/src/main.rs
+++ b/crates/rue-runtime-asan/src/main.rs
@@ -1,4 +1,4 @@
-//! AddressSanitizer harness for `rue-runtime`'s arena allocator (RUE-211).
+//! AddressSanitizer harness for `rue-runtime`'s arena allocator (RUE-211, RUE-560).
 //!
 //! # Why this exists
 //!
@@ -15,21 +15,28 @@
 //!
 //! This binary compiles the REAL allocator (`crates/rue-runtime/src/heap.rs`,
 //! pulled in verbatim via `#[path]` so there is nothing to drift) against a
-//! host `platform` shim, and runs it under `-Zsanitizer=address`. It then uses
-//! ASan's manual poisoning API (`__asan_poison_memory_region`) to lay a redzone
-//! immediately past an allocation's reserved end, so a write past that end —
-//! exactly the RUE-34 manifestation — is reported as `use-after-poison`, even
-//! though the bytes sit inside a live arena. That is coverage memcheck cannot
-//! provide.
+//! host `platform` shim, and runs it under `-Zsanitizer=address`. Every
+//! allocation the harness makes goes through [`guarded_alloc`], which reserves
+//! a redzone immediately past the usable block and poisons it with ASan's
+//! manual API (`__asan_poison_memory_region`). A write past an allocation's
+//! end — exactly the RUE-34 manifestation — then lands in poisoned shadow and
+//! is reported as `use-after-poison`, even though the bytes sit inside a live
+//! arena. That is coverage memcheck cannot provide.
 //!
-//! # Verifying detection actually works
+//! # The instrumentation is self-verifying (RUE-560)
 //!
-//! `demonstrate_intra_arena_redzone()` contains a commented-out deliberate
-//! overflow. Uncomment that single line and run the CI command
-//! (`RUSTFLAGS=-Zsanitizer=address cargo +nightly run --target
-//! x86_64-unknown-linux-gnu --manifest-path crates/rue-runtime-asan/Cargo.toml`)
-//! to confirm ASan aborts with a `use-after-poison` report, then re-comment it
-//! so the committed harness stays clean (CI green).
+//! Poisoning that silently stops working would leave the job green while
+//! covering nothing — the exact gap RUE-560 documented (the old harness
+//! poisoned one artificial final guard and left its detection write commented
+//! out, so nothing proved the redzones fire). This harness instead runs
+//! **negative controls in child processes** and *requires* each to abort under
+//! ASan (see [`require_negative_controls_fail`]). If the redzone instrumentation
+//! regresses, a control exits 0, the parent's assertion fails, and the whole
+//! job goes red. Coverage is therefore load-bearing, not decorative.
+//!
+//! A negative control is a deliberate one-byte out-of-bounds write into this
+//! harness's own poisoned redzone whose sole purpose is to make ASan fault; it
+//! exercises no external input and touches no memory outside the harness.
 
 // The real allocator source, included verbatim. It references `crate::platform`
 // and `core::*`; we satisfy the former with the module below and the latter is
@@ -37,13 +44,27 @@
 #[path = "../../rue-runtime/src/heap.rs"]
 mod heap;
 
+use std::process::Command;
+
+/// Environment variable that puts the harness into negative-control (self-test)
+/// mode. Set by [`require_negative_controls_fail`] when it re-execs this binary
+/// as a child; the child performs one deliberate poisoned-redzone overrun and
+/// is expected to abort under ASan.
+const SELFTEST_ENV: &str = "RUE_ASAN_SELFTEST";
+
+/// Bytes of poisoned redzone placed past every guarded allocation's usable end.
+/// A whole number of 8-byte ASan shadow granules so the poison covers complete
+/// granules (partial-granule poisoning cannot flag a write in a granule that
+/// also holds valid bytes).
+const REDZONE: usize = 32;
+
 /// Host stand-in for the runtime's platform layer.
 ///
 /// `heap.rs` only needs `mmap`/`munmap` with the same contract as the real
 /// syscall wrappers: `mmap` returns page-aligned, zero-initialized memory (or
 /// null), and `munmap` returns it. We back arenas with the global allocator so
-/// ASan tracks the underlying blocks; the manual poisoning in `main` adds the
-/// intra-arena redzones on top.
+/// ASan tracks the underlying blocks; the manual poisoning in the harness adds
+/// the intra-arena redzones on top.
 mod platform {
     use std::alloc::{Layout, alloc_zeroed, dealloc};
 
@@ -91,9 +112,89 @@ fn unpoison(addr: *const u8, size: usize) {
     unsafe { __asan_unpoison_memory_region(addr.cast(), size) };
 }
 
+/// Round `n` up to the next multiple of 8 (the ASan shadow granularity).
+fn align_up_8(n: usize) -> usize {
+    (n + 7) & !7
+}
+
+/// A guarded allocation: a real arena block whose usable end is followed by a
+/// poisoned redzone.
+struct Guarded {
+    /// Pointer to the usable region (`[ptr, ptr+size)`).
+    ptr: *mut u8,
+    /// Usable bytes the caller may touch.
+    size: usize,
+    /// Start of the poisoned redzone, kept so it can be cleared on drop.
+    redzone: *mut u8,
+}
+
+/// Allocate `size` usable bytes through the REAL allocator with a poisoned
+/// redzone immediately past the usable end (RUE-560).
+///
+/// The block reserved from the arena is `align_up_8(size) + REDZONE`; the
+/// caller sees only the first `size` bytes. The redzone begins at the
+/// 8-aligned boundary at or after `ptr+size` so it covers whole shadow
+/// granules. Because the bump allocator hands the *next* allocation an offset
+/// past the full reservation, poisoning the redzone can never collide with a
+/// later block.
+fn guarded_alloc(size: usize, align: usize) -> Guarded {
+    assert!(size > 0);
+    let usable = align_up_8(size);
+    let total = usable + REDZONE;
+    let ptr = heap::alloc(total as u64, align as u64);
+    assert!(!ptr.is_null(), "guarded_alloc({size}, {align}) OOM");
+    let redzone = unsafe { ptr.add(usable) };
+    poison(redzone, REDZONE);
+    Guarded { ptr, size, redzone }
+}
+
+impl Guarded {
+    /// Fill the usable region with `byte`, then read it back — strictly
+    /// in-bounds, so a correct harness run produces no ASan report.
+    fn write_and_verify(&self, byte: u8) {
+        unsafe {
+            for i in 0..self.size {
+                *self.ptr.add(i) = byte;
+            }
+            for i in 0..self.size {
+                assert_eq!(*self.ptr.add(i), byte, "byte {i} readback mismatch");
+            }
+        }
+    }
+}
+
+impl Drop for Guarded {
+    fn drop(&mut self) {
+        // Clear the shadow so a later (unrelated) allocation reusing nearby
+        // bytes is not falsely flagged. `free` is a no-op in the bump
+        // allocator, so nothing reclaims the block; this is purely shadow
+        // hygiene for the long-lived process.
+        unpoison(self.redzone, REDZONE);
+    }
+}
+
 fn main() {
+    // Negative-control mode (RUE-560): a child process re-execed by
+    // `require_negative_controls_fail` runs exactly one deliberate
+    // poisoned-redzone overrun and is expected to abort under ASan.
+    if let Ok(mode) = std::env::var(SELFTEST_ENV) {
+        run_negative_control(&mode);
+        // A working redzone aborts inside `run_negative_control` (nonzero
+        // exit). Reaching here means the poisoned write was NOT caught, so the
+        // overrun landed in valid arena bytes — the RUE-560 gap. Exit 0
+        // (success) on purpose: the parent requires this child to FAIL, so a
+        // clean exit trips its assertion and turns the whole job red.
+        eprintln!(
+            "negative control '{mode}' completed WITHOUT an ASan report — \
+             redzone instrumentation is not catching the overrun"
+        );
+        return;
+    }
+
     exercise_allocator();
-    demonstrate_intra_arena_redzone();
+    exercise_guarded_allocations();
+    exercise_container_growth();
+    require_negative_controls_fail();
     println!("rue-runtime ASan harness: OK");
 }
 
@@ -158,34 +259,139 @@ fn exercise_allocator() {
     }
 }
 
-/// Model the RUE-34 class and prove ASan catches it.
-///
-/// The allocator RESERVES `RESERVED` bytes. A buggy caller (e.g. a String that
-/// recorded a larger capacity than was actually allocated) would write past
-/// that end, into other arena bytes — invisible to memcheck. We poison a guard
-/// immediately past the reservation so that overflow is reported.
-fn demonstrate_intra_arena_redzone() {
-    const RESERVED: usize = 64;
-    const GUARD: usize = 256;
+/// Exercise per-allocation redzones on the real allocator with strictly
+/// in-bounds writes (RUE-560). Every block carries a poisoned redzone; because
+/// all accesses stay within the usable region, a working harness produces no
+/// ASan report. The negative controls prove the redzones would fire on an
+/// overrun.
+fn exercise_guarded_allocations() {
+    // A spread of usable sizes, including non-8-multiples (redzone still lands
+    // on an 8-aligned boundary), across several alignments.
+    for &(size, align) in &[(1usize, 1usize), (7, 8), (64, 8), (100, 16), (4096, 8)] {
+        let g = guarded_alloc(size, align);
+        assert_eq!(g.ptr as usize % align, 0, "bad alignment for align={align}");
+        g.write_and_verify(0xAB);
+    }
 
-    let p = heap::alloc(RESERVED as u64, 8);
-    assert!(!p.is_null());
+    // Many live guarded allocations at once: each keeps its own redzone, and
+    // the next bump-allocated block starts past the previous redzone, so the
+    // poison of one never overlaps the usable region of another.
+    let blocks: Vec<Guarded> = (0..48).map(|i| guarded_alloc(24 + i, 8)).collect();
+    for g in &blocks {
+        g.write_and_verify(0xCD);
+    }
+    drop(blocks);
+}
 
-    // This is the last allocation the harness makes, so nothing reclaims the
-    // guard bytes; poisoning them cannot collide with a later reservation.
-    poison(unsafe { p.add(RESERVED) }, GUARD);
+/// A minimal growable byte buffer over the real allocator, modeling the
+/// container grow path RUE-34 named — with a poisoned redzone tracking the
+/// *real* reservation, so a write past the truly-allocated end is caught even
+/// if a length/capacity bookkeeping bug lets it through (RUE-560).
+struct GuardedVec {
+    buf: Guarded,
+    len: usize,
+    cap: usize,
+}
 
-    // Correct, in-bounds writes: entirely within the reserved region.
-    unsafe {
-        for i in 0..RESERVED {
-            *p.add(i) = 0xAB;
+impl GuardedVec {
+    fn with_capacity(cap: usize) -> Self {
+        Self {
+            buf: guarded_alloc(cap, 8),
+            len: 0,
+            cap,
         }
     }
 
-    // VERIFICATION HOOK: uncomment to confirm ASan flags an intra-arena
-    // overflow (`use-after-poison`), then re-comment so CI stays green.
-    // unsafe { *p.add(RESERVED) = 0xFF; }
+    /// Push one byte, growing (fresh guarded alloc + copy, mirroring
+    /// `heap::realloc`'s grow path) when full.
+    fn push(&mut self, byte: u8) {
+        if self.len == self.cap {
+            let new_cap = self.cap * 2;
+            let new_buf = guarded_alloc(new_cap, 8);
+            unsafe {
+                core::ptr::copy_nonoverlapping(self.buf.ptr, new_buf.ptr, self.len);
+            }
+            self.buf = new_buf;
+            self.cap = new_cap;
+        }
+        unsafe { *self.buf.ptr.add(self.len) = byte };
+        self.len += 1;
+    }
 
-    // Restore shadow state (belt-and-suspenders; the process is exiting).
-    unpoison(unsafe { p.add(RESERVED) }, GUARD);
+    fn get(&self, i: usize) -> u8 {
+        assert!(i < self.len);
+        unsafe { *self.buf.ptr.add(i) }
+    }
+}
+
+/// Exercise a container-like grow loop end to end, strictly in-bounds
+/// (RUE-560). Pushes enough bytes to force several reallocations and verifies
+/// every byte survives each grow — the real-world path (String/ArrayBuf push)
+/// the RUE-34 overflow class lives on.
+fn exercise_container_growth() {
+    let mut v = GuardedVec::with_capacity(8);
+    for i in 0..1000usize {
+        v.push((i & 0xFF) as u8);
+    }
+    for i in 0..1000usize {
+        assert_eq!(v.get(i), (i & 0xFF) as u8, "grow lost byte {i}");
+    }
+}
+
+/// Re-exec this binary once per negative control and REQUIRE each child to fail
+/// under ASan (RUE-560). This is what makes the redzone coverage load-bearing:
+/// if the poisoning ever silently stops working, a control exits 0, the
+/// assertion here fires, and the whole harness (and CI job) goes red.
+///
+/// The child inherits `RUSTFLAGS`-baked ASan instrumentation and `ASAN_OPTIONS`
+/// from the environment; it runs [`run_negative_control`] and is expected to
+/// abort with a `use-after-poison` report (nonzero exit).
+fn require_negative_controls_fail() {
+    let exe = std::env::current_exe().expect("current_exe");
+    for mode in ["raw-overflow", "growth-overflow"] {
+        let status = Command::new(&exe)
+            .env(SELFTEST_ENV, mode)
+            .status()
+            .expect("spawn negative-control child");
+        assert!(
+            !status.success(),
+            "NEGATIVE CONTROL '{mode}' DID NOT FAIL under AddressSanitizer: the \
+             redzone instrumentation is not catching intra-arena overruns — the \
+             RUE-560 coverage gap has regressed (child exited {status})"
+        );
+    }
+}
+
+/// Perform exactly one deliberate poisoned-redzone overrun for the named
+/// control. Under a working harness ASan reports `use-after-poison` and aborts
+/// the process here; this function does not return on success.
+fn run_negative_control(mode: &str) {
+    match mode {
+        // A raw allocation overrun: write one byte past the usable end, into
+        // the poisoned redzone. This is the `*p.add(64) = 0xFF` in the issue's
+        // repro, but against the guarded allocator every allocation carries.
+        "raw-overflow" => {
+            let g = guarded_alloc(64, 8);
+            g.write_and_verify(0xAB); // in-bounds, fine
+            // One byte past the usable end -> poisoned -> ASan aborts.
+            unsafe { *g.ptr.add(g.size) = 0xFF };
+        }
+        // The RUE-34 class directly: a container whose bookkeeping thinks it
+        // has one more byte of capacity than was really reserved writes at the
+        // recorded end, past the real allocation, into the redzone.
+        "growth-overflow" => {
+            let mut v = GuardedVec::with_capacity(8);
+            for i in 0..8usize {
+                v.push(i as u8);
+            }
+            // `v` is full (len == cap == 8). Simulate a grow-path bug that
+            // recorded capacity without reserving it: write at the real end
+            // WITHOUT growing. That byte lands in the poisoned redzone.
+            unsafe { *v.buf.ptr.add(v.cap) = 0xFF };
+        }
+        other => {
+            eprintln!("unknown negative-control mode: {other}");
+            std::process::exit(3);
+        }
+    }
 }


### PR DESCRIPTION
The ASan harness for the arena allocator poisoned only **one artificial final guard** and left its detection write **commented out**, so nothing proved the instrumentation fired — ordinary intra-arena overruns (the RUE-34 class it names) stayed invisible while the `asan` CI job reported coverage.

**Real per-allocation redzones.** Every allocation the harness makes now goes through `guarded_alloc`: it reserves `align_up_8(size) + REDZONE` from the *real* allocator and poisons the trailing redzone, so a write past an allocation's usable end lands in poisoned shadow and ASan reports `use-after-poison` — even though the bytes sit inside a live arena (coverage memcheck can't provide). In-bounds exercises cover raw allocations across sizes/alignments, many simultaneously-live guarded blocks, and a container-like grow loop (`GuardedVec` push + realloc — the String/ArrayBuf path the RUE-34 overflow lives on).

**Coverage is load-bearing, not decorative.** `require_negative_controls_fail` re-execs the binary once per control (a raw overrun and a RUE-34-style recorded-capacity overrun) and **requires each child to abort under ASan**. If the poisoning ever regresses, a control exits clean, the parent's assertion fires, and the whole job goes red.

Verified both directions locally on the pinned nightly:
- clean harness → exits 0, both controls abort with `use-after-poison` on the redzone;
- poison disabled (regression sim) → harness panics `NEGATIVE CONTROL ... DID NOT FAIL ... the RUE-560 coverage gap has regressed` (exit 101).

The meta-test also caught a bug in my first cut — a nonzero fallback exit masked a dead redzone, so a broken harness would still have looked green; the fallback now exits 0 so a non-firing redzone reads as success and trips the parent's assertion.

**Related hardening (from the issue):** pin the workflow's floating `nightly` to `nightly-2026-04-13` (confirmed it resolves on the servers and the harness + controls pass on it) and add a `clippy -D warnings` gate for this standalone crate, which has no buck target and sat outside the repo-wide clippy query.

Picked up from Codex (which had mapped the allocator/CI gap but its execution platform kept interrupting on the deliberate-overrun pattern). For reviewers: the overrun is a one-byte write into a redzone *inside our own sanitizer harness* whose only purpose is to make ASan fault — standard allocator-test practice, no external input, no memory touched outside the harness.

This crate is outside buck2, so `./test.sh` does not exercise it; it is verified only by the `asan` CI job (and the local runs above).

Fixes RUE-560

🤖 Generated with [Claude Code](https://claude.com/claude-code)