### PR TITLE
RUE-567: cleanup scripts fail closed on incomplete Git/GitHub inventory

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -162,3 +162,23 @@ sh_test(
         "RUE_BENCHMARK_TEST_ROOT": "$(location :benchmark-tool-inputs)",
     },
 )
+
+# The destructive maintenance scripts under test (jj-tidy, worktree-gc). Their
+# fail-closed contract is pinned by scripts/test-cleanup-scripts.sh (RUE-567),
+# which runs copies of them against fake gh/git/df on PATH — no real repo,
+# remote, or disk touched.
+filegroup(
+    name = "cleanup-script-inputs",
+    srcs = [
+        "scripts/jj-tidy",
+        "scripts/worktree-gc",
+    ],
+)
+
+sh_test(
+    name = "cleanup-script-tests",
+    test = "scripts/test-cleanup-scripts.sh",
+    env = {
+        "RUE_CLEANUP_SCRIPTS_ROOT": "$(location :cleanup-script-inputs)",
+    },
+)

--- a/scripts/jj-tidy
+++ b/scripts/jj-tidy
@@ -10,6 +10,9 @@
 #     so running workers' branches are protected automatically.
 #   * we only abandon unbookmarked orphan heads — never @, never a bookmarked
 #     (i.e. live-worker or open-PR) change.
+#   * remote branch deletion is FAIL CLOSED (RUE-567): it removes only branches
+#     proven merged/closed by a successful query, never branches merely absent
+#     from an open-PR list, and does nothing at all if the query fails.
 set -uo pipefail
 cd "$(dirname "$0")/.."
 REPO=rue-language/rue
@@ -33,14 +36,37 @@ for br in $(gh pr list --repo "$REPO" --author "$ME" --state merged --json headR
 done
 echo "jj-tidy: deleted $b merged/closed push bookmarks"
 
-# 3. Delete stale origin branches for merged/closed PRs (keeps open ones).
-open="$(gh pr list --repo "$REPO" --author "$ME" --state open --json headRefName --jq '.[].headRefName' 2>/dev/null | tr '\n' ' ')"
-stale=""
-for br in $(git branch -r --format='%(refname:short)' 2>/dev/null | sed -n 's|^origin/||p' | grep -E '(^|/)push-'); do
-  case " $open " in *" $br "*) continue ;; esac
-  stale="$stale $br"
-done
-[ -n "$stale" ] && git push origin --delete $stale >/dev/null 2>&1 || true
+# 3. Delete stale origin push-* branches — FAIL CLOSED (RUE-567).
+#
+# The old logic deleted every origin push-* branch ABSENT from our own open-PR
+# list. Absence is not proof of staleness: a failed `gh` query (empty open
+# list) would delete ALL of them, another maintainer's still-open branch would
+# be deleted, and an unpublished in-progress branch with no PR would be deleted.
+#
+# Instead require POSITIVE evidence: only remove a branch that matches the head
+# ref of one of OUR merged-or-closed PRs, and only when BOTH queries succeed. If
+# we cannot get that evidence, delete nothing. The `if` gates on the queries'
+# real exit status (stderr is muted, but that does not mask failure).
+if merged_closed="$(
+      gh pr list --repo "$REPO" --author "$ME" --state merged --json headRefName --limit 500 --jq '.[].headRefName' 2>/dev/null &&
+      gh pr list --repo "$REPO" --author "$ME" --state closed --json headRefName --limit 500 --jq '.[].headRefName' 2>/dev/null
+    )"; then
+  del=""
+  for br in $(git branch -r --format='%(refname:short)' 2>/dev/null | sed -n 's|^origin/||p' | grep -E '(^|/)push-'); do
+    # Newline-delimited exact match, so `push-ab` never matches `push-abc`.
+    case $'\n'"$merged_closed"$'\n' in
+      *$'\n'"$br"$'\n'*) del="$del $br" ;;
+    esac
+  done
+  if [ -n "$del" ]; then
+    git push origin --delete $del >/dev/null 2>&1 || true
+    echo "jj-tidy: deleted$del stale origin push branches"
+  else
+    echo "jj-tidy: no stale origin push branches to delete"
+  fi
+else
+  echo "jj-tidy: could not query merged/closed PR state — skipping remote branch cleanup (fail-closed)"
+fi
 
 # 4. Abandon orphaned mutable heads with no bookmark (never @, never a live/open change).
 jj abandon -r 'heads(mutable()) ~ @ ~ bookmarks() ~ remote_bookmarks()' >/dev/null 2>&1 || true

--- a/scripts/test-cleanup-scripts.sh
+++ b/scripts/test-cleanup-scripts.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# test-cleanup-scripts.sh — fail-closed regression tests for the destructive
+# maintenance scripts jj-tidy and worktree-gc (RUE-567).
+#
+# Both scripts perform irreversible operations (remote branch deletion,
+# `rm -rf`) driven by Git/GitHub inventory. The bug these tests pin: treating a
+# FAILED or incomplete inventory query as proof that a resource is stale, so a
+# `gh`/`git` failure — or a branch merely absent from one user's open-PR list —
+# caused live resources to be destroyed.
+#
+# Each test runs a COPY of the real script in a throwaway sandbox with fake
+# `gh`/`git`/`jj`/`df`/`buck2` on PATH, so no real repo, remote, or disk is
+# touched. The fakes log every invocation; we assert that destructive commands
+# (`git push --delete`, `rm -rf`) are or are not issued as the fail-closed
+# contract requires.
+set -uo pipefail
+
+# Directory holding the scripts under test. Under buck2 sh_test this is the
+# materialized `:cleanup-script-inputs` filegroup (RUE_CLEANUP_SCRIPTS_ROOT);
+# run directly from a checkout it defaults to the repo's scripts/ dir.
+if [ -n "${RUE_CLEANUP_SCRIPTS_ROOT:-}" ]; then
+  SCRIPTS_DIR="$RUE_CLEANUP_SCRIPTS_ROOT/scripts"
+else
+  SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+FAILURES=0
+TESTS=0
+
+# --- tiny assertion helpers -------------------------------------------------
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  printf 'ok: %s\n' "$1"
+}
+
+check() { # check <description> <condition-already-evaluated:0|1>
+  TESTS=$((TESTS + 1))
+  if [ "$2" -eq 0 ]; then pass "$1"; else fail "$1"; fi
+}
+
+# Build a sandbox: a fake repo root containing a copy of `scripts/<name>` plus a
+# `fakebin/` we prepend to PATH. Echoes the sandbox path.
+make_sandbox() {
+  local name="$1"
+  local sb
+  sb="$(mktemp -d)"
+  mkdir -p "$sb/scripts" "$sb/fakebin"
+  cp "$SCRIPTS_DIR/$name" "$sb/scripts/$name"
+  chmod +x "$sb/scripts/$name"
+  printf '%s\n' "$sb"
+}
+
+# Write a fake executable that logs its argv to $CALLS and runs the given body.
+# Usage: fake <sandbox> <name> <body...>
+fake() {
+  local sb="$1" name="$2"
+  shift 2
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'printf "%%s " "%s" >>"$CALLS"; printf "%%s\\n" "$*" >>"$CALLS"\n' "$name"
+    printf '%s\n' "$*"
+  } >"$sb/fakebin/$name"
+  chmod +x "$sb/fakebin/$name"
+}
+
+run_script() { # run_script <sandbox> <name> [args...]
+  local sb="$1" name="$2"
+  shift 2
+  ( cd "$sb" && CALLS="$sb/calls.log" PATH="$sb/fakebin:$PATH" \
+      bash "$sb/scripts/$name" "$@" ) >"$sb/out.log" 2>&1
+}
+
+calls() { cat "$1/calls.log" 2>/dev/null; }
+
+# ===========================================================================
+# jj-tidy — remote branch deletion must be fail-closed
+# ===========================================================================
+
+# A branch is deletable ONLY when it matches a head ref of one of OUR
+# merged/closed PRs, proven by a successful query. These fakes never let step 4
+# (jj abandon) touch anything real: `jj` is faked to a no-op.
+setup_jjtidy_common() {
+  local sb="$1"
+  fake "$sb" jj 'true'
+  # git: only the invocations jj-tidy makes. `branch -r` lists remote push
+  # branches; everything else is a harmless no-op that still gets logged.
+  cat >"$sb/fakebin/git" <<'EOF'
+#!/usr/bin/env bash
+printf 'git ' >>"$CALLS"; printf '%s\n' "$*" >>"$CALLS"
+case "$1 $2" in
+  "branch -r")
+    # Two remote push branches exist on origin.
+    printf 'origin/steveklabnik/push-aaa\n'
+    printf 'origin/otheruser/push-bbb\n'
+    ;;
+  "branch --format="*|"branch --format")
+    : ;;  # no local worker branches
+  *) : ;;
+esac
+exit 0
+EOF
+  chmod +x "$sb/fakebin/git"
+}
+
+# Test 1: gh PR-state query FAILS -> no remote deletion at all.
+test_jjtidy_gh_failure_deletes_nothing() {
+  local sb; sb="$(make_sandbox jj-tidy)"
+  setup_jjtidy_common "$sb"
+  # gh: `api user` succeeds (login), but every `pr list` fails (network/auth).
+  cat >"$sb/fakebin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh ' >>"$CALLS"; printf '%s\n' "$*" >>"$CALLS"
+case "$1 $2" in
+  "api user") printf 'steveklabnik\n'; exit 0 ;;
+  "pr list") exit 1 ;;   # query failure
+esac
+exit 0
+EOF
+  chmod +x "$sb/fakebin/gh"
+
+  run_script "$sb" jj-tidy
+  if calls "$sb" | grep -q 'git push .*--delete'; then
+    check "jj-tidy: gh failure issues NO remote deletion" 1
+  else
+    check "jj-tidy: gh failure issues NO remote deletion" 0
+  fi
+  grep -q 'fail-closed' "$sb/out.log" || fail "jj-tidy: expected fail-closed notice on gh failure"
+  rm -rf "$sb"
+}
+
+# Test 2: another author's open branch (no closed/merged PR of ours) is kept;
+# only OUR merged branch is deleted.
+test_jjtidy_only_deletes_proven_merged() {
+  local sb; sb="$(make_sandbox jj-tidy)"
+  setup_jjtidy_common "$sb"
+  # gh: our merged PRs include push-aaa; closed empty; open lists nothing
+  # relevant. push-bbb belongs to otheruser and is NOT in our merged/closed set.
+  cat >"$sb/fakebin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh ' >>"$CALLS"; printf '%s\n' "$*" >>"$CALLS"
+if [ "$1 $2" = "api user" ]; then printf 'steveklabnik\n'; exit 0; fi
+if [ "$1 $2" = "pr list" ]; then
+  case "$*" in
+    *"--state merged"*) printf 'steveklabnik/push-aaa\n'; exit 0 ;;
+    *"--state closed"*) exit 0 ;;   # none
+    *"--state open"*)   exit 0 ;;
+  esac
+fi
+exit 0
+EOF
+  chmod +x "$sb/fakebin/gh"
+
+  run_script "$sb" jj-tidy
+  local del
+  del="$(calls "$sb" | grep 'git push .*--delete' || true)"
+  # push-aaa (ours, merged) must be deleted.
+  if printf '%s' "$del" | grep -q 'steveklabnik/push-aaa'; then
+    check "jj-tidy: OUR merged branch is deleted" 0
+  else
+    check "jj-tidy: OUR merged branch is deleted" 1
+  fi
+  # push-bbb (other author, no merged/closed PR of ours) must NOT be deleted.
+  if printf '%s' "$del" | grep -q 'push-bbb'; then
+    check "jj-tidy: another author's branch is preserved" 1
+  else
+    check "jj-tidy: another author's branch is preserved" 0
+  fi
+  rm -rf "$sb"
+}
+
+# ===========================================================================
+# worktree-gc — worktree removal must be fail-closed
+# ===========================================================================
+
+# Common fakes: df reports high usage (past threshold) so step 2 runs; buck2 and
+# jj no-op. Real `rm`/`git` behavior is per-test.
+setup_gc_common() {
+  local sb="$1"
+  fake "$sb" df 'echo "Use% "; echo "99%"'
+  fake "$sb" buck2 'true'
+  mkdir -p "$sb/.claude/worktrees/live-1" "$sb/.claude/worktrees/live-2"
+}
+
+# Test 3: `git worktree list` FAILS (exit 128) -> no worktree dir removed.
+test_gc_git_failure_preserves_worktrees() {
+  local sb; sb="$(make_sandbox worktree-gc)"
+  setup_gc_common "$sb"
+  cat >"$sb/fakebin/git" <<'EOF'
+#!/usr/bin/env bash
+printf 'git ' >>"$CALLS"; printf '%s\n' "$*" >>"$CALLS"
+case "$1 $2" in
+  "worktree prune") exit 0 ;;
+  "worktree list") exit 128 ;;   # jj workspace w/o local .git
+esac
+exit 0
+EOF
+  chmod +x "$sb/fakebin/git"
+
+  run_script "$sb" worktree-gc
+  if [ -d "$sb/.claude/worktrees/live-1" ] && [ -d "$sb/.claude/worktrees/live-2" ]; then
+    check "worktree-gc: git-list failure preserves ALL worktrees" 0
+  else
+    check "worktree-gc: git-list failure preserves ALL worktrees" 1
+  fi
+  grep -q 'fail-closed' "$sb/out.log" || fail "worktree-gc: expected fail-closed notice on git failure"
+  rm -rf "$sb"
+}
+
+# Test 4 (positive control): git succeeds and lists live-1 as active; live-2 is
+# absent -> only the genuinely-orphaned live-2 is removed.
+test_gc_removes_only_orphans_when_git_ok() {
+  local sb; sb="$(make_sandbox worktree-gc)"
+  setup_gc_common "$sb"
+  # Emit live-1's absolute path as an active worktree; omit live-2.
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+printf 'git ' >>"\$CALLS"; printf '%s\n' "\$*" >>"\$CALLS"
+case "\$1 \$2" in
+  "worktree prune") exit 0 ;;
+  "worktree list") printf 'worktree %s/.claude/worktrees/live-1\n' "$sb"; exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$sb/fakebin/git"
+
+  run_script "$sb" worktree-gc
+  if [ -d "$sb/.claude/worktrees/live-1" ]; then
+    check "worktree-gc: active worktree kept when git succeeds" 0
+  else
+    check "worktree-gc: active worktree kept when git succeeds" 1
+  fi
+  if [ -d "$sb/.claude/worktrees/live-2" ]; then
+    check "worktree-gc: genuinely-orphaned worktree removed" 1
+  else
+    check "worktree-gc: genuinely-orphaned worktree removed" 0
+  fi
+  rm -rf "$sb"
+}
+
+# Test 5: disk below threshold -> step 2 never runs, nothing removed.
+test_gc_below_threshold_is_noop() {
+  local sb; sb="$(make_sandbox worktree-gc)"
+  fake "$sb" df 'echo "Use% "; echo "10%"'
+  fake "$sb" buck2 'true'
+  fake "$sb" git 'true'
+  mkdir -p "$sb/.claude/worktrees/live-1"
+  run_script "$sb" worktree-gc
+  if [ -d "$sb/.claude/worktrees/live-1" ]; then
+    check "worktree-gc: below threshold removes nothing" 0
+  else
+    check "worktree-gc: below threshold removes nothing" 1
+  fi
+  rm -rf "$sb"
+}
+
+# --- run everything ---------------------------------------------------------
+
+test_jjtidy_gh_failure_deletes_nothing
+test_jjtidy_only_deletes_proven_merged
+test_gc_git_failure_preserves_worktrees
+test_gc_removes_only_orphans_when_git_ok
+test_gc_below_threshold_is_noop
+
+echo "--------------------------------------------------"
+if [ "$FAILURES" -eq 0 ]; then
+  echo "cleanup-script tests: all $TESTS checks passed"
+  exit 0
+else
+  echo "cleanup-script tests: $FAILURES of $TESTS checks FAILED"
+  exit 1
+fi

--- a/scripts/worktree-gc
+++ b/scripts/worktree-gc
@@ -4,7 +4,10 @@
 # Replaces the old blanket `rm -rf .claude/worktrees`, which raced running
 # workers (they reported "worktree deleted mid-run"). This only acts when disk
 # is actually low, and only removes worktrees git no longer lists as live — so
-# in-flight workers are never touched.
+# in-flight workers are never touched. Removal is FAIL CLOSED (RUE-567): if the
+# `git worktree list` inventory command fails (e.g. a jj workspace with no local
+# .git, where it exits 128), nothing is removed — a failed query is never read
+# as "zero active worktrees".
 #
 # Usage: scripts/worktree-gc [THRESHOLD_PERCENT]   (default 85)
 set -uo pipefail
@@ -25,16 +28,27 @@ git worktree prune 2>/dev/null || true
 # 2. Remove ORPHANED worktree dirs — present on disk but no longer in git's live
 #    list (i.e. a finished worker's leftover, holding a stale buck-out). Anything
 #    git still lists is live and left alone. This is where the disk actually is.
+#
+#    FAIL CLOSED (RUE-567): a FAILED `git worktree list` is not the same as an
+#    empty one. In a linked jj workspace with no local `.git`, `git worktree
+#    list` exits 128; if that failure were read as "zero active worktrees",
+#    every live worker's dir would be classified orphaned and rm -rf'd. So gate
+#    on the command's real exit status — proceed only when it SUCCEEDS, and skip
+#    removal entirely otherwise.
 if [ -d .claude/worktrees ]; then
-  active="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')"
-  for d in .claude/worktrees/*/; do
-    [ -d "$d" ] || continue
-    d="${d%/}"
-    abs="$(cd "$d" 2>/dev/null && pwd)" || continue
-    if ! printf '%s\n' "$active" | grep -qxF "$abs"; then
-      rm -rf "${d:?}" && echo "  removed orphaned worktree ${d##*/}"
-    fi
-  done
+  if wt_porcelain="$(git worktree list --porcelain 2>/dev/null)"; then
+    active="$(printf '%s\n' "$wt_porcelain" | awk '/^worktree /{print $2}')"
+    for d in .claude/worktrees/*/; do
+      [ -d "$d" ] || continue
+      d="${d%/}"
+      abs="$(cd "$d" 2>/dev/null && pwd)" || continue
+      if ! printf '%s\n' "$active" | grep -qxF "$abs"; then
+        rm -rf "${d:?}" && echo "  removed orphaned worktree ${d##*/}"
+      fi
+    done
+  else
+    echo "worktree-gc: 'git worktree list' failed — skipping worktree removal (fail-closed)"
+  fi
 fi
 
 # 3. Stale main-repo buck artifacts (safe; rebuilds on demand).


### PR DESCRIPTION
Two maintenance scripts advertised as "SAFE" performed destructive cleanup by treating a **missing or failed** inventory query as proof a resource was stale.

**`jj-tidy` could delete live remote branches.** Step 3 deleted every origin `push-*` branch *absent from our own open-PR list*. Absence is not proof of staleness: a failed `gh` query (empty open list) deleted **all** push branches; another maintainer's still-open branch was deleted; an unpublished no-PR branch was deleted. It now requires **positive evidence** — a branch is removed only when it matches the head ref of one of *our* merged-or-closed PRs, and only when *both* the merged and closed lookups **succeed**. If the query fails, nothing is deleted (a fail-closed notice is printed instead).

**`worktree-gc` could `rm -rf` active worktrees.** Step 2 suppressed `git worktree list` failure into an empty `active` set, so in a linked jj workspace with no local `.git` (where the command exits 128) every worker's directory was classified orphaned and deleted. It now gates on the command's real exit status: it proceeds only when the inventory **succeeds**, and skips removal otherwise. A genuine zero-active result (successful empty) still cleans up.

**Tests (`scripts/test-cleanup-scripts.sh`, wired as the `cleanup-script-tests` buck `sh_test`).** Runs *copies* of both scripts in a throwaway sandbox with fake `gh`/`git`/`df` on PATH — no real repo, remote, or disk touched — and asserts: a failed `gh` query issues **no** `git push --delete`; another author's branch is preserved; a failed `git worktree list` preserves **all** worktrees; and the positive controls still delete only proven-stale resources (our merged branch; a genuinely-orphaned worktree). I verified the tests **fail against the pre-fix scripts** and pass against the fix. Full `buck2 test //...` **Pass 31 / Fail 0** (tally checked directly, RUE-579).

Picked up from Codex, which had mapped both bugs but its execution platform kept interrupting on the destructive-operation surface. For reviewers: this change only *adds* refusal-to-delete guards and a hermetic test — it removes no safety and touches nothing outside the two scripts, their test, and the BUCK wiring.

Fixes RUE-567

🤖 Generated with [Claude Code](https://claude.com/claude-code)