### PR TITLE
RUE-579: test.sh prints a greppable PASS/FAIL sentinel so piped runs are self-describing

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -14,8 +14,35 @@ set -euo pipefail
 #
 # With a pattern argument, the spec/UI/CLI suites are instead run directly
 # with the filter (unit tests still run in full, as before).
+#
+# READING THE RESULT (RUE-579). This script's EXIT CODE is authoritative:
+# `buck2 test` returns non-zero when any target fails and `set -e` propagates
+# it, so plain `./test.sh` (as CI runs it) and `./test.sh && ...` are correct.
+# BUT a shell PIPE discards the exit code — `./test.sh 2>&1 | tail` reports the
+# pipe's status (usually 0), not the suite's, so the `Tests finished: ... Fail
+# N` tally can scroll past while `$?` reads 0. To guard against that, the last
+# line this script prints is an unambiguous, greppable sentinel:
+#
+#     === TEST SUITE: PASSED ===
+#     === TEST SUITE: FAILED (exit N) ===
+#
+# When you pipe or capture this script's output, grep for that line instead of
+# trusting `$?`. (The tally text alone is not a verdict: a partial run can print
+# a green-looking count and still have failed a later gate.)
 
 cd "$(dirname "$0")"
+
+# Always print the result sentinel, even on an early `set -e` exit, so a piped
+# or captured run is self-describing (RUE-579).
+print_test_suite_result() {
+    local rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "=== TEST SUITE: PASSED ==="
+    else
+        echo "=== TEST SUITE: FAILED (exit $rc) ==="
+    fi
+}
+trap print_test_suite_result EXIT
 
 REPOSITORY_QUALITY_GATES=(
     //:benchmark-tool-tests


### PR DESCRIPTION
**The gate was never broken — I misdiagnosed it.** Verified: `buck2 test` returns non-zero on failure (exit 32 for a failing target), `test.sh` runs it under `set -euo pipefail`, and CI runs `test.sh` unpiped — so CI correctly fails (its run history has real `failure` conclusions, so the gate demonstrably *can* fail). My earlier "test.sh exited 0 despite failures" reads were a **measurement artifact**: `./test.sh 2>&1 | tail` reports the *pipe's* exit status (tail's 0), not the suite's, so the `Tests finished: … Fail N` tally scrolled past while `$?` read 0.

The real hazard is that **piping footgun**: anyone who pipes or captures the output loses the pass/fail signal and can misread a red run as green (it cost me time during RUE-525).

**Fix.** `test.sh` now prints an unmistakable sentinel as its last line via an `EXIT` trap:

    === TEST SUITE: PASSED ===
    === TEST SUITE: FAILED (exit N) ===

It survives piping (plain stdout text), so a captured run is self-describing even when the exit code is lost. The exit code stays authoritative for unpiped runs (CI, `test.sh && …`); the header documents both and says to grep the sentinel when piping.

Verified: pass path prints PASSED + exits 0; a failing sub-step fires the trap, prints `FAILED (exit N)`, and exits N; the sentinel is visible through `| tail`; full `./test.sh` → Pass 30 / Fail 0 ending in PASSED.

Downgraded the issue Urgent → Medium and corrected its description in a comment (CI is fine; this is a footgun guard, not an emergency). Scoped out the "sandbox failing-target self-test" from the original ask — buck2's non-zero propagation is empirically confirmed and a permanent failing target can't live in `//...`; the sentinel is the proportionate mitigation.

Fixes RUE-579

🤖 Generated with [Claude Code](https://claude.com/claude-code)