### PR TITLE
Fix sanitizer component installation

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install pinned nightly Rust
         run: >
           rustup toolchain install "$NIGHTLY" --profile minimal
-          --component clippy rust-src
+          --component clippy,rust-src
 
       # This standalone crate has no buck2 target, so it sits outside the
       # repository-wide `./clippy.sh` query. Gate it here so it does not rot


### PR DESCRIPTION
Follow-up to #1359.

The ASan workflow passed `rust-src` as a second positional toolchain name, so `rustup` rejected the install command before compilation. Pass the documented comma-separated component list instead, restoring the sanitizer gate on pull requests, merge groups, and trunk pushes.

Validation:

- installed `nightly-2026-04-13` with `--component clippy,rust-src`
- confirmed both `clippy` and `rust-src` are installed
- ran the workflow's sanitizer-instrumented clippy command
- ran the ASan harness, including both required negative controls
- linted `sanitizer.yml` with actionlint
