### PR TITLE
RUE-534: bare CR is a newline in comments, line numbers, and rendering

### DIFF
--- a/crates/rue-cli-tests/cases/bare_cr_newlines.toml
+++ b/crates/rue-cli-tests/cases/bare_cr_newlines.toml
@@ -1,0 +1,26 @@
+[section]
+id = "cli.bare_cr_newlines"
+name = "Bare CR newline handling"
+description = """
+RUE-534: the spec (2.3:1) treats a bare carriage return as a newline. A //
+comment must end at a CR (not swallow the code after it), and diagnostics must
+locate/render CR-separated lines correctly. The \\r below is a TOML escape,
+so the on-disk source contains a real CR byte.
+"""
+
+# A CR-terminated line comment must end at the CR; the code after it compiles
+# and runs (was E0200 "no main function found" when the comment ate the code).
+[[case]]
+name = "cr_comment_does_not_swallow_code"
+files = [{ path = "main.rue", source = "// comment\rfn main() -> i32 { 7 }\r" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 7
+
+# A lexical error on a CR-only second line is reported at line 2, and the
+# rendered source does not collapse the CR-separated lines onto one.
+[[case]]
+name = "cr_error_reported_on_correct_line"
+files = [{ path = "main.rue", source = "fn main() -> i32 {\r$\r0\r}\r" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0001", "main.rue:2:1"]

--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -129,7 +129,16 @@ impl<'a> RenderSource<'a> {
 
             match ch {
                 '\t' => rendered.push_str("    "),
-                '\r' => {}
+                '\r' => {
+                    // In a CRLF the CR is dropped and the following LF renders
+                    // the break (as before). A BARE CR is itself a newline
+                    // (spec 2.3:1), so render it as a line break instead of
+                    // dropping it — dropping collapsed CR-separated lines into
+                    // one, mislocating the diagnostic (RUE-534).
+                    if !source[next_idx..].starts_with('\n') {
+                        rendered.push('\n');
+                    }
+                }
                 '\n' => rendered.push('\n'),
                 // Any other control char is a terminal-injection hazard: render
                 // a visible one-column glyph instead (RUE-548). The byte_map

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -255,7 +255,11 @@ fn parse_based_literal(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<u64
 // (Pattern_White_Space), but Zig does not, and Rue follows Zig's strict,
 // explicit set here (RUE-333). A stray FF byte therefore lexes to an error.
 #[logos(skip r"[ \t\n\r]+")]
-#[logos(skip r"//[^\n]*")]
+// A line comment ends at end-of-line. The spec classes CR, LF, and CRLF all
+// as newlines (2.3:1), so the comment body must exclude BOTH `\n` and `\r` —
+// otherwise `// c<CR>code` on a CR-only file swallows the code as comment text
+// (RUE-534).
+#[logos(skip r"//[^\n\r]*")]
 pub enum LogosTokenKind {
     // Keywords - logos prefers longer/specific matches over shorter/generic ones
     #[token("fn")]
@@ -1023,6 +1027,24 @@ mod tests {
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
         assert_eq!(get_ident_str(&tokens[1].kind, &interner), Some("main"));
         assert!(matches!(tokens[2].kind, TokenKind::Eof));
+    }
+
+    #[test]
+    fn test_logos_line_comment_ends_at_bare_cr() {
+        // RUE-534: a `//` comment ends at end-of-line, and a bare CR is a
+        // newline (spec 2.3:1). The comment must NOT swallow the code after a
+        // CR-only line ending, so `main` is a real token, not comment text.
+        let lexer = LogosLexer::new("fn // comment\rmain");
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::Fn));
+        assert_eq!(get_ident_str(&tokens[1].kind, &interner), Some("main"));
+        assert!(matches!(tokens[2].kind, TokenKind::Eof));
+
+        // CRLF still terminates the comment too (regression guard).
+        let lexer = LogosLexer::new("fn // c\r\nmain");
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::Fn));
+        assert_eq!(get_ident_str(&tokens[1].kind, &interner), Some("main"));
     }
 
     #[test]

--- a/crates/rue-span/src/lib.rs
+++ b/crates/rue-span/src/lib.rs
@@ -134,12 +134,34 @@ impl Span {
             self.start,
             source.len()
         );
-        source[..(self.start as usize).min(source.len())]
-            .bytes()
-            .filter(|&b| b == b'\n')
-            .count()
-            + 1
+        count_newlines(&source[..(self.start as usize).min(source.len())]) + 1
     }
+}
+
+/// Count line terminators in `s`, per the spec's newline classification
+/// (2.3:1): LF (`\n`), CR (`\r`), and CRLF (`\r\n`) are each ONE newline. A
+/// bare CR — which older code ignored — begins a new line (RUE-534).
+#[inline]
+fn count_newlines(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    let mut count = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\n' => count += 1,
+            b'\r' => {
+                count += 1;
+                // CRLF is a single terminator: skip the LF so it is not
+                // counted again.
+                if bytes.get(i + 1) == Some(&b'\n') {
+                    i += 1;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    count
 }
 
 /// Convert a byte offset to 1-based line and character-column numbers.
@@ -153,16 +175,32 @@ pub fn offset_to_line_col(source: &str, offset: u32) -> (u32, u32) {
     let offset = offset as usize;
     let mut line = 1;
     let mut col = 1;
+    // Track whether the previous char was a CR so a following LF (CRLF) is not
+    // counted as a second line break (RUE-534).
+    let mut prev_cr = false;
     for (i, ch) in source.char_indices() {
         if i >= offset {
             break;
         }
-        if ch == '\n' {
-            line += 1;
-            col = 1;
-        } else {
-            col += 1;
+        match ch {
+            '\r' => {
+                // CR (and CR of a CRLF) begins a new line, per spec 2.3:1.
+                line += 1;
+                col = 1;
+                prev_cr = true;
+                continue;
+            }
+            '\n' if prev_cr => {
+                // The LF of a CRLF: the CR already advanced the line.
+                col = 1;
+            }
+            '\n' => {
+                line += 1;
+                col = 1;
+            }
+            _ => col += 1,
         }
+        prev_cr = false;
     }
     (line, col)
 }
@@ -296,5 +334,26 @@ mod tests {
         assert_eq!(offset_to_line_col(source, 3), (1, 3)); // after `x`
         assert_eq!(offset_to_line_col(source, 4), (2, 1)); // after newline
         assert_eq!(offset_to_line_col(source, 8), (2, 2)); // after `🙂`
+    }
+
+    #[test]
+    fn test_line_calc_treats_bare_cr_as_newline() {
+        // Spec 2.3:1: CR, LF, and CRLF are each one newline (RUE-534).
+        // Bare CR (`a\rb`): the `b` is on line 2.
+        let cr = "a\rb";
+        assert_eq!(offset_to_line_col(cr, 2), (2, 1));
+        assert_eq!(Span::new(2, 3).line_number(cr), 2);
+        // CRLF (`a\r\nb`): still ONE newline, `b` on line 2, not line 3.
+        let crlf = "a\r\nb";
+        assert_eq!(offset_to_line_col(crlf, 3), (2, 1));
+        assert_eq!(Span::new(3, 4).line_number(crlf), 2);
+        // LF unchanged.
+        let lf = "a\nb";
+        assert_eq!(offset_to_line_col(lf, 2), (2, 1));
+        assert_eq!(Span::new(2, 3).line_number(lf), 2);
+        // Mixed: two CR-only lines then the target on line 3.
+        let mixed = "l1\rl2\rx";
+        assert_eq!(offset_to_line_col(mixed, 6), (3, 1));
+        assert_eq!(Span::new(6, 7).line_number(mixed), 3);
     }
 }


### PR DESCRIPTION
Spec 2.3:1 classes CR, LF, and CRLF all as newlines, but three paths only recognized LF:

- **Comment termination** — the line-comment skip was `//[^\n]*`, so a bare CR did *not* end the comment: `// c<CR>fn main() ...` on a CR-only file swallowed the code as comment text and compilation reported E0200 `no main function found`. Now `//[^\n\r]*` — the comment ends at CR too.
- **Line/column** — `line_number` and `offset_to_line_col` (rue-span) counted only `\n`, so a lexical error on a CR-separated line was reported one line too early. Both now count CR as a line break, treating CRLF as a *single* terminator (a shared `count_newlines` helper + a `prev_cr` guard).
- **Rendering** — the diagnostic renderer (`RenderSource`) dropped every `\r`, collapsing CR-separated lines into one. It now drops the CR only in a CRLF (the LF renders the break) and renders a **bare** CR as a line break, keeping annotation offsets aligned via the existing `byte_map`.

**Verified:** the CR-comment program compiles and exits 7 (was E0200); a `$` on a CR-only line 2 is reported at `:2:1` and rendered on its own line; LF-only and CRLF inputs are unchanged. Tests: rue-span CR/CRLF/LF/mixed line-calc, rue-lexer CR- and CRLF-terminated comments, 2 CLI cases (CR comment exit 7; CR error at line 2). Full `buck2 test //...` Pass 31 / Fail 0.

Picked up from Codex's lexer/diagnostics territory; follows RUE-535 and complements RUE-362 (CRLF rendering).

Fixes RUE-534

🤖 Generated with [Claude Code](https://claude.com/claude-code)