### PR TITLE
Fix clippy manual_split_once regression in diagnostic.rs (RUE-548 follow-up)

### DIFF
--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -2151,7 +2151,7 @@ mod tests {
         // counts, since the only wide-in-bytes char here is the 1-column ESC
         // glyph) — byte offsets would differ by the glyph's extra bytes.
         let after_gutter =
-            |l: &str| -> String { l.splitn(2, "| ").nth(1).unwrap_or(l).to_string() };
+            |l: &str| -> String { l.split_once("| ").map_or(l, |(_, rest)| rest).to_string() };
         let src_body = after_gutter(src_line);
         let caret_body = after_gutter(caret_line);
         let nope_col = src_body[..src_body.find("nope").unwrap()].chars().count();


### PR DESCRIPTION
Trunk clippy went red: the caret-alignment test helper added in RUE-548 (`l.splitn(2, "| ").nth(1)`) trips `clippy::manual_split_once`, which `-D warnings` promotes to an error. It surfaced now because the CI toolchain bumped to rust-1.92.0, whose clippy flags this pattern. Because clippy is a required check, this blocks **every** open PR in the merge queue, not just the one I noticed it on (#1368).

One-line fix to the clippy-suggested form:

    l.split_once("| ").map_or(l, |(_, rest)| rest)

Verified: `./clippy.sh` exits 0, and `rue-compiler` tests still pass (218). No behavior change — same substring split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)