### PR TITLE
Use split_once in diagnostic rendering test

### DIFF
--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -2151,7 +2151,7 @@ mod tests {
         // counts, since the only wide-in-bytes char here is the 1-column ESC
         // glyph) — byte offsets would differ by the glyph's extra bytes.
         let after_gutter =
-            |l: &str| -> String { l.splitn(2, "| ").nth(1).unwrap_or(l).to_string() };
+            |l: &str| -> String { l.split_once("| ").map_or(l, |(_, body)| body).to_string() };
         let src_body = after_gutter(src_line);
         let caret_body = after_gutter(caret_line);
         let nope_col = src_body[..src_body.find("nope").unwrap()].chars().count();


### PR DESCRIPTION
Current trunk fails the clippy gate on `clippy::manual_split_once` in a diagnostic-rendering test helper.

Replace the manual `splitn(...).nth(1)` with `split_once`. This is a test-only mechanical cleanup; diagnostic behavior is unchanged.

Validation:

- `./buck2 test root//crates/rue-compiler:rue-compiler-test` — 218 passed
- `./clippy.sh` — all 41 targets clean
- `./fmt.sh check`
