### PR TITLE
Feed specialization references into lazy sema

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -485,9 +485,20 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         }
     }
 
-    finalize_function_body_analysis(
+    let mut specializer = crate::specialize::Specializer::default();
+    match specializer.run_to_fixpoint(
+        &mut functions_with_strings,
+        &mut all_warnings,
         sema,
         &infer_ctx,
+        sema.interner,
+    ) {
+        Ok(discovered) => referenced_functions.extend(discovered.functions),
+        Err(error) => errors.push(error),
+    }
+
+    finalize_function_body_analysis(
+        sema,
         functions_with_strings,
         all_warnings,
         &referenced_functions,
@@ -497,11 +508,10 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
 
 fn finalize_function_body_analysis(
     sema: &mut Sema<'_>,
-    infer_ctx: &InferenceContext,
     functions_with_strings: Vec<(AnalyzedFunction, Vec<String>)>,
     mut all_warnings: Vec<CompileWarning>,
     unused_function_roots: &HashSet<Spur>,
-    mut errors: CompileErrors,
+    errors: CompileErrors,
 ) -> MultiErrorResult<SemaOutput> {
     // Merge strings from all functions into a global table with deduplication.
     let mut global_string_table: HashMap<String, u32> = HashMap::new();
@@ -533,29 +543,14 @@ fn finalize_function_body_analysis(
     add_unused_function_warnings(sema, &referenced_for_unused_warnings, &mut all_warnings);
     all_warnings.sort_by_key(|w| w.span().map(|s| s.start));
 
-    let mut output = SemaOutput {
+    let output = SemaOutput {
         functions,
         strings: global_strings,
         warnings: all_warnings,
-        // Provisional: refreshed after specialization below. Specialized
-        // bodies can intern *new* composite types (e.g. `[i32; N]` from a
-        // `let y: [T; 2]` once `T := i32`) into `sema.type_pool`, so the pool
-        // handed to CFG/codegen must be cloned *after* the specialize pass.
+        // Specialization can intern new composite types, so snapshot only
+        // after its fixed point has completed.
         type_pool: sema.type_pool.clone(),
     };
-
-    // Run specialization pass to rewrite CallGeneric instructions to Call
-    // and create specialized function bodies
-    if let Err(e) = crate::specialize::specialize(&mut output, sema, infer_ctx, sema.interner) {
-        errors.push(e);
-    }
-
-    // Specialization interns new composite types into `sema.type_pool` (see the
-    // provisional-clone note above); re-snapshot so every array/pointer type a
-    // specialized body references exists in the pool CFG and codegen consult.
-    // Without this, a specialization-only `[i32; N]` decayed to an out-of-bounds
-    // ArrayTypeId and ICE'd in drop analysis (RUE-282).
-    output.type_pool = sema.type_pool.clone();
 
     errors.into_result_with(output)
 }
@@ -656,6 +651,35 @@ fn enqueue_references_sorted(
     pending_methods.extend(meths);
 }
 
+/// Enqueue anonymous destructors registered by comptime evaluation.
+///
+/// Drop glue, rather than user-written AIR, is their caller, so these implicit
+/// roots need an explicit deterministic scan whenever the ordinary reference
+/// frontier drains.
+fn enqueue_anonymous_destructors(
+    sema: &Sema<'_>,
+    drop_marker_sym: Spur,
+    analyzed_methods: &HashSet<(StructId, Spur)>,
+    pending_methods: &mut Vec<(StructId, Spur)>,
+) {
+    let mut destructors: Vec<(StructId, Spur)> = sema
+        .methods
+        .keys()
+        .copied()
+        .filter(|&method_key @ (struct_id, method_name)| {
+            method_name == drop_marker_sym
+                && !analyzed_methods.contains(&method_key)
+                && sema
+                    .type_pool
+                    .struct_def(struct_id)
+                    .name
+                    .starts_with("__anon_struct_")
+        })
+        .collect();
+    destructors.sort_by_key(|&(sid, name)| (sid.0, sema.interner.resolve(&name)));
+    pending_methods.extend(destructors);
+}
+
 /// Lazy analysis path (Phase 3 of module system, ADR-0026).
 ///
 /// This implements "lazy semantic analysis" where only functions reachable from
@@ -686,6 +710,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
     let mut analyzed_methods: HashSet<(StructId, Spur)> = HashSet::new();
     let drop_marker_sym = sema.interner.get_or_intern("__drop");
     let mut named_destructors_analyzed = false;
+    let mut specializer = crate::specialize::Specializer::default();
 
     // Collect results
     let mut functions_with_strings: Vec<(AnalyzedFunction, Vec<String>)> = Vec::new();
@@ -1024,24 +1049,12 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
         // so lazy analysis emits `__anon_struct_N.__drop` before the backend
         // links drop glue.
         if pending_functions.is_empty() && pending_methods.is_empty() {
-            // sema.methods is a HashMap: sort the enqueued keys so the
-            // destructor analysis order is deterministic too (RUE-513).
-            let mut anon_dtors: Vec<(StructId, Spur)> = sema
-                .methods
-                .keys()
-                .copied()
-                .filter(|&method_key @ (struct_id, method_name)| {
-                    method_name == drop_marker_sym
-                        && !analyzed_methods.contains(&method_key)
-                        && sema
-                            .type_pool
-                            .struct_def(struct_id)
-                            .name
-                            .starts_with("__anon_struct_")
-                })
-                .collect();
-            anon_dtors.sort_by_key(|&(sid, name)| (sid.0, sema.interner.resolve(&name)));
-            pending_methods.extend(anon_dtors);
+            enqueue_anonymous_destructors(
+                sema,
+                drop_marker_sym,
+                &analyzed_methods,
+                &mut pending_methods,
+            );
         }
 
         if !pending_functions.is_empty() || !pending_methods.is_empty() {
@@ -1100,12 +1113,54 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
             continue;
         }
 
+        // Specialized generic bodies are part of the same reachability fixed
+        // point as source-level bodies. Feed every ordinary function or method
+        // they call back through the deterministic analysis queues, then scan
+        // any later source bodies for further specialization requests.
+        match specializer.run_to_fixpoint(
+            &mut functions_with_strings,
+            &mut all_warnings,
+            sema,
+            &infer_ctx,
+            sema.interner,
+        ) {
+            Ok(discovered) => enqueue_references_sorted(
+                sema.interner,
+                discovered.functions,
+                discovered.methods,
+                &analyzed_functions,
+                &analyzed_methods,
+                &mut pending_functions,
+                &mut pending_methods,
+            ),
+            Err(error) => {
+                errors.push(error);
+                break;
+            }
+        }
+
+        // Comptime evaluation inside a specialization may register a new
+        // anonymous destructor without an explicit call in its AIR. Keep it as
+        // an implicit root, just like anonymous destructors registered by an
+        // ordinary source body above.
+        if pending_functions.is_empty() && pending_methods.is_empty() {
+            enqueue_anonymous_destructors(
+                sema,
+                drop_marker_sym,
+                &analyzed_methods,
+                &mut pending_methods,
+            );
+        }
+
+        if !pending_functions.is_empty() || !pending_methods.is_empty() {
+            continue;
+        }
+
         break;
     }
 
     finalize_function_body_analysis(
         sema,
-        &infer_ctx,
         functions_with_strings,
         all_warnings,
         &analyzed_functions,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -21,8 +21,10 @@
 //!
 //! # Architecture
 //!
-//! The specialization pass runs after semantic analysis but before CFG building.
-//! It transforms the AIR in-place and adds new specialized functions to the output.
+//! Specialization participates in semantic analysis's reachability fixed point:
+//! it transforms generic calls in-place, appends specialized bodies, and returns
+//! any ordinary calls those bodies discover to the source-body worklist. String
+//! tables and the type pool are finalized only after that joint fixed point.
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -34,8 +36,8 @@ use rue_rir::RirParamMode;
 use rue_span::Span;
 
 use crate::inst::{Air, AirInstData};
-use crate::sema::{AnalyzedFunction, ConstValue, FunctionInfo, InferenceContext, Sema, SemaOutput};
-use crate::types::Type;
+use crate::sema::{AnalyzedFunction, ConstValue, FunctionInfo, InferenceContext, Sema};
+use crate::types::{StructId, Type};
 
 /// A key for a specialized function:
 /// (base_function_name, type_arguments, value_arguments).
@@ -148,141 +150,153 @@ struct SpecializationInfo {
     call_site_span: Span,
 }
 
+/// Source-level references discovered while analyzing specialized bodies.
+#[derive(Default)]
+pub(crate) struct DiscoveredReferences {
+    pub(crate) functions: HashSet<Spur>,
+    pub(crate) methods: HashSet<(StructId, Spur)>,
+}
+
+/// Persistent specialization state shared with the demand-driven sema worklist.
+///
+/// Source bodies discovered after an earlier specialization wave may request
+/// either new or already-created specializations. Retaining both the request
+/// map and scan frontier makes those later waves incremental and deduplicated.
+#[derive(Default)]
+pub(crate) struct Specializer {
+    specializations: HashMap<SpecializationKey, SpecializationInfo>,
+    next_unscanned: usize,
+    seen_unreachable_spans: HashSet<Span>,
+    /// Expansion waves consumed across the entire joint sema fixed point.
+    rounds: usize,
+}
+
+struct SpecializedBody {
+    function: AnalyzedFunction,
+    warnings: Vec<CompileWarning>,
+    local_strings: Vec<String>,
+    referenced_functions: HashSet<Spur>,
+    referenced_methods: HashSet<(StructId, Spur)>,
+}
+
 /// Maximum number of specialization rounds before giving up.
 ///
 /// Each round creates the bodies for the specializations discovered in the
-/// previous round, so this bounds the nesting depth of generic-to-generic
-/// calls — including comptime-value recursion (`fact(comptime n)` calling
-/// `fact(n - 1)` adds one round per distinct value, RUE-166). Unbounded
-/// growth is possible when a generic function instantiates itself with an
-/// ever-growing type (e.g. `f(Pair(T), ...)` inside `f`) or a
-/// comptime-recursive function never reaches a comptime-known base case,
-/// so this cap turns a would-be-infinite loop into a clean E1200.
+/// previous round. The budget persists when specialization temporarily yields
+/// to sema's ordinary function/method worklists: otherwise a chain that
+/// alternates between a specialization and a newly registered method can reset
+/// the counter forever (RUE-580).
+///
+/// This is deliberately a conservative, program-wide expansion budget rather
+/// than exact causal-depth tracking. Independent branches can share the budget,
+/// but that tradeoff keeps every form of generic/comptime expansion bounded —
+/// including comptime-value recursion (`fact(comptime n)` calling
+/// `fact(n - 1)`, RUE-166) and ever-growing type instantiation such as
+/// `f(Pair(T), ...)` inside `f` — without threading provenance through every
+/// sema work queue.
 pub(crate) const MAX_SPECIALIZATION_ROUNDS: usize = 64;
 
-/// Perform the specialization pass on the sema output.
-///
-/// This collects all `CallGeneric` instructions, creates specialized functions,
-/// and rewrites calls to point to the specialized versions.
-///
-/// Specialized function bodies can themselves contain `CallGeneric` instructions
-/// (a generic function forwarding its type parameter to another generic call),
-/// so the pass iterates to a fixpoint: each round scans the functions created in
-/// the previous round for new specialization requests (RUE-102).
-pub fn specialize(
-    output: &mut SemaOutput,
-    sema: &mut Sema<'_>,
-    infer_ctx: &InferenceContext,
-    interner: &ThreadedRodeo,
-) -> CompileResult<()> {
-    let mut global_string_table: Option<HashMap<String, u32>> = None;
-    // All specializations ever requested, used to deduplicate across rounds.
-    let mut specializations: HashMap<SpecializationKey, SpecializationInfo> = HashMap::new();
-    // Index of the first function not yet scanned for CallGeneric instructions.
-    let mut next_unscanned = 0;
-    let mut rounds = 0;
-    // Spans of unreachable-pattern warnings already surfaced from specialized
-    // bodies (RUE-555). A generic function's pattern set is a static property
-    // of its single source location, so every specialization of it would emit
-    // the *same* warning at the *same* span; deduplicating by span collapses
-    // those to one, matching the single warning an ordinary function produces.
-    let mut seen_unreachable_spans: HashSet<Span> = HashSet::new();
-
-    loop {
-        // Phase 1: Collect specialization requests from not-yet-scanned functions
-        let mut pending: Vec<SpecializationKey> = Vec::new();
-        for func in &output.functions[next_unscanned..] {
-            collect_specializations(&func.air, interner, &mut specializations, &mut pending);
-        }
-
-        // Phase 2: Rewrite CallGeneric to Call in the newly scanned functions
-        // (previously scanned functions have no CallGeneric left)
-        for func in &mut output.functions[next_unscanned..] {
-            rewrite_call_generic(&mut func.air, &specializations);
-        }
-        next_unscanned = output.functions.len();
-
-        if pending.is_empty() {
-            // Unreachable-pattern warnings appended above land after the
-            // main-pass warnings sorted in `finalize_function_body_analysis`;
-            // restore span order so diagnostics read top-to-bottom (RUE-555).
-            output.warnings.sort_by_key(|w| w.span().map(|s| s.start));
-            return Ok(());
-        }
-
-        rounds += 1;
-        if rounds > MAX_SPECIALIZATION_ROUNDS {
-            let key = &pending[0];
-            return Err(CompileError::new(
-                ErrorKind::ComptimeEvaluationFailed {
-                    reason: format!(
-                        "specialization of '{}' exceeded the maximum nesting depth ({}); \
-                         is a comptime-recursive function missing a compile-time-known \
-                         base case, or a generic function recursively instantiating \
-                         itself with new types?",
-                        interner.resolve(&key.base_name),
-                        MAX_SPECIALIZATION_ROUNDS
-                    ),
-                },
-                specializations[key].call_site_span,
-            ));
-        }
-
-        let global_string_table = global_string_table.get_or_insert_with(|| {
-            output
-                .strings
-                .iter()
-                .cloned()
-                .enumerate()
-                .map(|(id, string)| (string, id as u32))
-                .collect()
-        });
-
-        // Phase 3: Create specialized function bodies by re-analyzing with type
-        // substitution. These new functions are scanned in the next round.
-        for key in &pending {
-            let info = &specializations[key];
-            let base_info = match sema.functions.get(&key.base_name) {
-                Some(info) => info.clone(),
-                None => {
-                    let func_name = interner.resolve(&key.base_name);
-                    return Err(CompileError::new(
-                        ErrorKind::UndefinedFunction(func_name.to_string()),
-                        info.call_site_span,
-                    ));
-                }
-            };
-            let (mut specialized_func, warnings, local_strings) = create_specialized_function(
-                sema,
-                infer_ctx,
-                key,
-                info.mangled_name,
-                &base_info,
-                interner,
-            )?;
-            remap_specialized_strings(
-                &mut specialized_func,
-                local_strings,
-                &mut output.strings,
-                global_string_table,
-            );
-            // Surface unreachable-pattern warnings from the specialized body
-            // (spec 4.7:20, RUE-555). A comptime-pruned match returns its
-            // selected arm before the normal warning loop, so these are emitted
-            // by `warn_unreachable_pruned_arms`; a non-pruned match in a
-            // specialized body warns via the normal loop. Both are structural
-            // (independent of the comptime value), so we keep only one per
-            // span across all specializations. Other specialized-body warnings
-            // stay suppressed, preserving existing behavior.
-            for w in warnings {
-                if matches!(w.kind, WarningKind::UnreachablePattern(_))
-                    && let Some(span) = w.span()
-                    && seen_unreachable_spans.insert(span)
-                {
-                    output.warnings.push(w);
-                }
+impl Specializer {
+    /// Analyze and rewrite every specialization reachable from newly appended
+    /// bodies, returning ordinary references that must re-enter sema's worklist.
+    ///
+    /// Generic-to-generic calls reach an internal fixed point here. The
+    /// `Specializer` itself persists across outer sema waves so an ordinary
+    /// helper analyzed later can request a specialization without duplicating
+    /// one created by an earlier wave.
+    pub(crate) fn run_to_fixpoint(
+        &mut self,
+        functions_with_strings: &mut Vec<(AnalyzedFunction, Vec<String>)>,
+        all_warnings: &mut Vec<CompileWarning>,
+        sema: &mut Sema<'_>,
+        infer_ctx: &InferenceContext,
+        interner: &ThreadedRodeo,
+    ) -> CompileResult<DiscoveredReferences> {
+        let mut discovered = DiscoveredReferences::default();
+        loop {
+            // Only scan bodies appended since the previous internal or outer
+            // wave. `scan_end` excludes specializations created below; they are
+            // picked up on the next internal round.
+            let scan_end = functions_with_strings.len();
+            let mut pending: Vec<SpecializationKey> = Vec::new();
+            for (function, _) in &functions_with_strings[self.next_unscanned..scan_end] {
+                collect_specializations(
+                    &function.air,
+                    interner,
+                    &mut self.specializations,
+                    &mut pending,
+                );
             }
-            output.functions.push(specialized_func);
+
+            // Previously scanned bodies have no CallGeneric instructions left.
+            for (function, _) in &mut functions_with_strings[self.next_unscanned..scan_end] {
+                rewrite_call_generic(&mut function.air, &self.specializations);
+            }
+            self.next_unscanned = scan_end;
+
+            if pending.is_empty() {
+                return Ok(discovered);
+            }
+
+            self.rounds += 1;
+            if self.rounds > MAX_SPECIALIZATION_ROUNDS {
+                let key = &pending[0];
+                return Err(CompileError::new(
+                    ErrorKind::ComptimeEvaluationFailed {
+                        reason: format!(
+                            "specialization of '{}' exceeded the maximum nesting depth ({}); \
+                             is a comptime-recursive function missing a compile-time-known \
+                             base case, or a generic function recursively instantiating \
+                             itself with new types?",
+                            interner.resolve(&key.base_name),
+                            MAX_SPECIALIZATION_ROUNDS
+                        ),
+                    },
+                    self.specializations[key].call_site_span,
+                ));
+            }
+
+            // Create specialized function bodies by re-analyzing with type
+            // substitution. Newly created bodies are scanned next round.
+            for key in &pending {
+                let info = &self.specializations[key];
+                let base_info = match sema.functions.get(&key.base_name) {
+                    Some(info) => info.clone(),
+                    None => {
+                        let func_name = interner.resolve(&key.base_name);
+                        return Err(CompileError::new(
+                            ErrorKind::UndefinedFunction(func_name.to_string()),
+                            info.call_site_span,
+                        ));
+                    }
+                };
+                let specialized = create_specialized_function(
+                    sema,
+                    infer_ctx,
+                    key,
+                    info.mangled_name,
+                    &base_info,
+                    interner,
+                )?;
+
+                discovered
+                    .functions
+                    .extend(specialized.referenced_functions);
+                discovered.methods.extend(specialized.referenced_methods);
+
+                // Surface unreachable-pattern warnings from the specialized
+                // body (spec 4.7:20, RUE-555), once per source span. Other
+                // specialized-body warnings stay suppressed as before.
+                for warning in specialized.warnings {
+                    if matches!(warning.kind, WarningKind::UnreachablePattern(_))
+                        && let Some(span) = warning.span()
+                        && self.seen_unreachable_spans.insert(span)
+                    {
+                        all_warnings.push(warning);
+                    }
+                }
+                functions_with_strings.push((specialized.function, specialized.local_strings));
+            }
         }
     }
 }
@@ -470,7 +484,7 @@ fn create_specialized_function(
     specialized_name: Spur,
     base_info: &FunctionInfo,
     interner: &ThreadedRodeo,
-) -> CompileResult<(AnalyzedFunction, Vec<CompileWarning>, Vec<String>)> {
+) -> CompileResult<SpecializedBody> {
     let specialized_name_str = interner.resolve(&specialized_name).to_string();
 
     // Pair each comptime parameter with its argument: type parameters
@@ -555,8 +569,8 @@ fn create_specialized_function(
         param_modes,
         warnings,
         local_strings,
-        _ref_fns,
-        _ref_meths,
+        referenced_functions,
+        referenced_methods,
     ) = sema.analyze_specialized_function(
         infer_ctx,
         return_type,
@@ -566,8 +580,8 @@ fn create_specialized_function(
         &value_subst,
     )?;
 
-    Ok((
-        AnalyzedFunction {
+    Ok(SpecializedBody {
+        function: AnalyzedFunction {
             name: specialized_name_str,
             air,
             num_locals,
@@ -577,36 +591,9 @@ fn create_specialized_function(
         },
         warnings,
         local_strings,
-    ))
-}
-
-/// Merge a specialized body's function-local strings into the program table
-/// and rewrite its AIR indices to the resulting global ids.
-fn remap_specialized_strings(
-    function: &mut AnalyzedFunction,
-    local_strings: Vec<String>,
-    global_strings: &mut Vec<String>,
-    global_string_table: &mut HashMap<String, u32>,
-) {
-    if local_strings.is_empty() {
-        return;
-    }
-
-    let local_to_global: Vec<u32> = local_strings
-        .into_iter()
-        .map(|string| {
-            *global_string_table
-                .entry(string.clone())
-                .or_insert_with(|| {
-                    let id = global_strings.len() as u32;
-                    global_strings.push(string);
-                    id
-                })
-        })
-        .collect();
-    function
-        .air
-        .remap_string_ids(|local_id| local_to_global[local_id as usize]);
+        referenced_functions,
+        referenced_methods,
+    })
 }
 
 /// Resolve a parameter's concrete type by substituting type parameters into

--- a/crates/rue-cli-tests/cases/lazy_specialization_references.toml
+++ b/crates/rue-cli-tests/cases/lazy_specialization_references.toml
@@ -1,0 +1,115 @@
+# References discovered while creating a comptime specialization must rejoin
+# the demand-driven body-analysis frontier (RUE-580). Each case uses a real
+# import so it exercises the production lazy path before that path is universal.
+
+[section]
+id = "cli.lazy_specialization_references"
+name = "Specialization reference discovery"
+description = "Functions, methods, and destructors reached only from specialized bodies are emitted exactly once."
+
+[[case]]
+name = "specialization_enqueues_function_and_method"
+description = "A specialized body directly references both an ordinary helper and a named method; both must be emitted."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 { lib.run(21) }
+""" },
+    { path = "lib.rue", source = """
+fn helper(x: i32) -> i32 { @dbg(x); x }
+
+struct Wrap {
+    value: i32,
+    fn get(self) -> i32 { @dbg(self.value); self.value }
+}
+
+pub fn run(comptime n: i32) -> i32 {
+    let w = Wrap { value: n };
+    helper(n) + w.get()
+}
+""" },
+]
+stdout = "21\n21\n"
+exit_code = 42
+
+[[case]]
+name = "late_body_reuses_existing_specialization"
+description = "A late-enqueued ordinary body requests id(i32) after that specialization already exists; it must reuse the symbol, not emit a duplicate."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 { lib.run() }
+""" },
+    { path = "lib.rue", source = """
+fn id(comptime T: type, x: T) -> T { x }
+
+fn late() -> i32 {
+    let x = id(i32, 40);
+    @dbg(x);
+    x
+}
+
+fn outer(comptime n: i32) -> i32 { late() + n }
+
+pub fn run() -> i32 {
+    id(i32, 0) + outer(2)
+}
+""" },
+]
+stdout = "40\n"
+exit_code = 42
+
+[[case]]
+name = "specialization_registers_anonymous_destructor"
+description = "A type created only while specializing run registers an anonymous destructor; the scheduler must discover and emit it before linking."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 { lib.run(i32, 7) }
+""" },
+    { path = "lib.rue", source = """
+fn Box(comptime T: type) -> type {
+    struct {
+        value: T,
+        drop fn(self) { @dbg(self.value); }
+    }
+}
+
+pub fn run(comptime T: type, x: T) -> i32 {
+    let B = Box(T);
+    let _value = B { value: x };
+    @dbg(100);
+    0
+}
+""" },
+]
+stdout = "100\n7\n"
+exit_code = 0
+
+[[case]]
+name = "alternating_specialization_method_recursion_is_bounded"
+description = "Specialization and a newly registered anonymous method cannot evade the specialization-depth guard by alternating outer scheduler waves."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 { lib.start() }
+""" },
+    { path = "lib.rue", source = """
+fn Wrapper(comptime N: i32) -> type {
+    struct {
+        value: i32,
+        fn go(self) -> i32 { runaway(N + 1) }
+    }
+}
+
+fn runaway(comptime n: i32) -> i32 {
+    let W = Wrapper(n);
+    let w = W { value: n };
+    w.go()
+}
+
+pub fn start() -> i32 { runaway(0) }
+""" },
+]
+compile_fail = true
+error_contains = ["E1200", "exceeded the maximum nesting depth"]


### PR DESCRIPTION
## What changed

- keep specialization state alive across lazy-sema worklist waves
- feed ordinary function and method references discovered in specialized bodies back into the deterministic analysis queues
- rescan anonymous destructors registered during specialization
- preserve one program-wide specialization budget, warning deduplication, and deferred string remapping across the joint fixed point

## Why

The lazy body-analysis frontier previously drained before specialization. A reachable generic body could therefore call an otherwise-unreferenced function or method that was never analyzed or emitted, producing an undefined-symbol link failure. Alternating specialization/method discovery could also reset the depth guard between waves.

## Scope

This fixes the import-triggered demand-driven path described by RUE-580. The pre-existing eager-only anonymous-destructor gap is intentionally unchanged here; RUE-578 follows by routing every program through this demand-driven driver.

## Verification

- `scripts/rue cli lazy_specialization_references` — 4 passed
- `./test.sh` — explicit `Pass 31 / Fail 0`
- `./clippy.sh` — all 41 targets clean
- `./fmt.sh check`
- CLI and spec differential oracles — zero disagreements

Fixes RUE-580
