### PR TITLE
RUE-549 + RUE-550: developer wrappers resolve caller-relative paths and surface Buck failures

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -182,3 +182,26 @@ sh_test(
         "RUE_CLEANUP_SCRIPTS_ROOT": "$(location :cleanup-script-inputs)",
     },
 )
+
+# The developer wrapper scripts. scripts/test-wrapper-scripts.sh (RUE-549,
+# RUE-550) runs copies of them against a fake ./buck2 and a fake compiler — no
+# real build — to pin that resolver failures are surfaced (not swallowed) and
+# that run/exec resolve relative paths from the caller's cwd. The filegroup
+# materializes these at package-relative paths (scripts/rue, fmt.sh), matching
+# the layout the harness expects under RUE_WRAPPER_ROOT.
+filegroup(
+    name = "wrapper-script-inputs",
+    srcs = [
+        "fmt.sh",
+        "scripts/rue",
+        "scripts/rue-bin",
+    ],
+)
+
+sh_test(
+    name = "wrapper-script-tests",
+    test = "scripts/test-wrapper-scripts.sh",
+    env = {
+        "RUE_WRAPPER_ROOT": "$(location :wrapper-script-inputs)",
+    },
+)

--- a/clippy.sh
+++ b/clippy.sh
@@ -34,9 +34,21 @@ for t in "${TARGETS[@]}"; do
 done
 
 echo "Running clippy on ${#CLIPPY_TARGETS[@]} targets..."
-# A real compile error (not a lint) makes this buck2 build fail non-zero, which
-# `set -e` propagates -- that is correct, the tree is broken.
-SHOW_OUTPUT="$(./buck2 build "${CLIPPY_TARGETS[@]}" --show-output 2>/dev/null)"
+# A real compile error (not a lint) makes this buck2 build fail non-zero -- that
+# is correct, the tree is broken -- but the old `2>/dev/null` swallowed the
+# compiler's diagnostics, so the gate failed with no explanation (RUE-550).
+# Capture stderr and surface it on failure while keeping the success path quiet.
+clippy_err="$(mktemp)"
+trap 'rm -f "$clippy_err"' EXIT
+clippy_status=0
+SHOW_OUTPUT="$(./buck2 build "${CLIPPY_TARGETS[@]}" --show-output 2>"$clippy_err")" \
+    || clippy_status=$?
+if [ "$clippy_status" -ne 0 ]; then
+    echo "clippy.sh: 'buck2 build' failed (exit $clippy_status) -- a real compile" >&2
+    echo "error, not a lint. The tree is broken; diagnostics follow:" >&2
+    cat "$clippy_err" >&2
+    exit "$clippy_status"
+fi
 
 FAILED=0
 # Each --show-output line is: "<target>[clippy.txt] <repo-root-relative-path>".

--- a/fmt.sh
+++ b/fmt.sh
@@ -19,11 +19,24 @@ MODE="${1:-format}"
 # `xargs ./buck2 run toolchains//rust:rustfmt` form paid a buck2 CLI
 # round-trip per xargs chunk; one `--show-output` resolve avoids that.
 # --show-output prints a repo-root-relative path, so make it absolute.
-RUSTFMT="$(./buck2 build toolchains//rust:rustfmt --show-output 2>/dev/null \
-    | awk '/rust:rustfmt /{print $2}' | tail -1)"
+# Capture Buck's stdout and stderr separately and guard the status: a bare
+# `RUSTFMT="$(./buck2 ... 2>/dev/null | awk ...)"` under `set -euo pipefail`
+# exits at the assignment on build failure, making the "re-running for
+# diagnosis" fallback unreachable and losing all diagnostics (RUE-550).
+fmt_err="$(mktemp)"
+trap 'rm -f "$fmt_err"' EXIT
+fmt_status=0
+rustfmt_show="$(./buck2 build toolchains//rust:rustfmt --show-output 2>"$fmt_err")" \
+    || fmt_status=$?
+if [ "$fmt_status" -ne 0 ]; then
+    echo "fmt.sh: 'buck2 build toolchains//rust:rustfmt' failed (exit $fmt_status):" >&2
+    cat "$fmt_err" >&2
+    exit "$fmt_status"
+fi
+RUSTFMT="$(printf '%s\n' "$rustfmt_show" | awk '/rust:rustfmt /{print $2}' | tail -1)"
 if [ -z "$RUSTFMT" ]; then
-    echo "fmt.sh: failed to resolve rustfmt via buck2 --show-output; re-running for diagnosis..." >&2
-    ./buck2 build toolchains//rust:rustfmt --show-output >&2
+    echo "fmt.sh: build succeeded but --show-output did not name rustfmt:" >&2
+    cat "$fmt_err" >&2
     exit 1
 fi
 RUSTFMT="$(pwd)/$RUSTFMT"

--- a/gen-rust-project.sh
+++ b/gen-rust-project.sh
@@ -12,7 +12,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 echo "Querying Buck2 for Rust targets..."
-./buck2 targets //crates/... --json 2>/dev/null > /tmp/buck_targets.json
+# Guard the query status and preserve its stderr on failure: the old
+# `2>/dev/null` left a Buck error silent, then Python failed downstream on an
+# empty/partial JSON file with an unrelated traceback (RUE-550).
+gen_err="$(mktemp)"
+trap 'rm -f "$gen_err"' EXIT
+gen_status=0
+./buck2 targets //crates/... --json 2>"$gen_err" > /tmp/buck_targets.json \
+    || gen_status=$?
+if [ "$gen_status" -ne 0 ]; then
+    echo "gen-rust-project.sh: 'buck2 targets //crates/...' failed (exit $gen_status):" >&2
+    cat "$gen_err" >&2
+    exit "$gen_status"
+fi
 
 echo "Generating rust-project.json..."
 python3 << 'EOF'

--- a/scripts/rue
+++ b/scripts/rue
@@ -18,6 +18,12 @@
 #
 set -euo pipefail
 
+# Remember the caller's working directory BEFORE we cd to the repo root, so that
+# subcommands forwarding relative source/output paths to the compiler (run,
+# exec) can resolve them against where the user actually stands — matching a
+# direct compiler invocation (RUE-549). Buck targets are still built from the
+# root; only the final compiler/program invocation runs from the caller's cwd.
+caller_pwd="$PWD"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
@@ -34,8 +40,10 @@ case "$cmd" in
         ;;
     run)
         # Compile via the real driver (so module resolution, -o, etc. behave
-        # exactly as a user would see).
+        # exactly as a user would see). Build from the root, then invoke from the
+        # caller's cwd so relative source and `-o` paths resolve there (RUE-549).
         bin="$(scripts/rue-bin)"
+        cd "$caller_pwd"
         RUE_STD_PATH="${RUE_STD_PATH:-$repo_root/std}" "$bin" "$@"
         ;;
     exec)
@@ -52,6 +60,11 @@ case "$cmd" in
         # skips a trailing `rm`, leaking the temp file (RUE-212). The trap
         # fires regardless of exit code, so cleanup always happens.
         trap 'rm -f "$out"' EXIT
+        # Invoke from the caller's cwd so a relative <source.rue> resolves there,
+        # exactly as a direct compiler call would (RUE-549). `out` is an absolute
+        # mktemp path and RUE_STD_PATH defaults to an absolute path, so both stay
+        # valid after the cd.
+        cd "$caller_pwd"
         RUE_STD_PATH="${RUE_STD_PATH:-$repo_root/std}" "$bin" "$src" "$out"
         # Run the program, capturing its exit code without letting `set -e`
         # abort first (`|| rc=$?`), then propagate it as our own exit code.

--- a/scripts/rue-bin
+++ b/scripts/rue-bin
@@ -20,15 +20,33 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-# Build and capture the relative output path. Build output goes to stderr so
-# stdout stays clean for command substitution.
-rel_path="$(./buck2 build //crates/rue:rue --show-output "$@" 2>/dev/null \
-    | awk '/crates\/rue:rue / {print $2}' | tail -1)"
+# Build the compiler. Capture Buck's stdout (which carries the --show-output
+# line) and its stderr (build chatter/diagnostics) SEPARATELY, guarding the exit
+# status explicitly. A bare `rel="$(./buck2 ... 2>/dev/null | awk ...)"` under
+# `set -euo pipefail` exits AT THE ASSIGNMENT when the build fails — before any
+# fallback below can run — and, because stderr was sent to /dev/null, with zero
+# diagnostics (RUE-550). Capturing status via `|| build_status=$?` keeps `set -e`
+# from firing so we can surface Buck's real error.
+build_err="$(mktemp)"
+trap 'rm -f "$build_err"' EXIT
+build_status=0
+build_out="$(./buck2 build //crates/rue:rue --show-output "$@" 2>"$build_err")" \
+    || build_status=$?
+
+if [[ $build_status -ne 0 ]]; then
+    echo "rue-bin: 'buck2 build //crates/rue:rue' failed (exit $build_status):" >&2
+    cat "$build_err" >&2
+    exit "$build_status"
+fi
+
+# stdout stays clean for command substitution; the --show-output line names the
+# binary at a repo-root-relative path.
+rel_path="$(printf '%s\n' "$build_out" | awk '/crates\/rue:rue / {print $2}' | tail -1)"
 
 if [[ -z "${rel_path:-}" ]]; then
-    echo "rue-bin: failed to determine binary path from buck2 --show-output" >&2
-    echo "rue-bin: re-running build with output for diagnosis..." >&2
-    ./buck2 build //crates/rue:rue --show-output "$@" >&2
+    echo "rue-bin: build succeeded but --show-output did not name the binary." >&2
+    echo "rue-bin: captured build output follows:" >&2
+    cat "$build_err" >&2
     exit 1
 fi
 

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# test-wrapper-scripts.sh — regressions for the developer wrapper scripts.
+#
+# Two failure modes found during the autonomous bug hunt:
+#
+#   * RUE-550: Buck stderr was discarded inside `set -euo pipefail` assignments
+#     (`X="$(./buck2 ... 2>/dev/null | awk ...)"`). A build/toolchain failure
+#     therefore exited the resolver scripts (rue-bin, fmt.sh) AT THE ASSIGNMENT,
+#     before any diagnostic fallback could run — zero bytes on stdout AND
+#     stderr. Every higher-level wrapper obtains the compiler through
+#     `$(scripts/rue-bin)`, so the failure was invisible everywhere.
+#
+#   * RUE-549: `scripts/rue run|exec` cd'd to the repo root before forwarding
+#     relative <source.rue> / `-o` paths to the compiler, so they resolved from
+#     the wrong directory even though the script advertises "run from anywhere".
+#
+# Each test runs a COPY of the real script in a throwaway sandbox with a fake
+# `./buck2` (and, for scripts/rue, a fake scripts/rue-bin + fake compiler), so
+# no real build runs. The fakes log their cwd/argv; we assert on exit status,
+# surfaced stderr, and the directory the compiler was invoked from.
+set -uo pipefail
+
+# Root holding the real scripts. Under buck2 sh_test this is the materialized
+# `:wrapper-script-inputs` filegroup (RUE_WRAPPER_ROOT); run directly from a
+# checkout it defaults to the repo root (this script lives in scripts/).
+if [ -n "${RUE_WRAPPER_ROOT:-}" ]; then
+  SRC_ROOT="$RUE_WRAPPER_ROOT"
+else
+  SRC_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+FAILURES=0
+TESTS=0
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAILURES=$((FAILURES + 1)); }
+pass() { printf 'ok: %s\n' "$1"; }
+# check <description> <0-if-ok|1-if-failed>
+check() { TESTS=$((TESTS + 1)); if [ "$2" -eq 0 ]; then pass "$1"; else fail "$1"; fi; }
+
+# ===========================================================================
+# RUE-550 — resolver scripts must surface Buck failures, not swallow them
+# ===========================================================================
+
+# A failing `./buck2` must make rue-bin exit non-zero AND print Buck's stderr.
+test_ruebin_build_failure_is_loud() {
+  local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/scripts"
+  cp "$SRC_ROOT/scripts/rue-bin" "$sb/scripts/rue-bin"; chmod +x "$sb/scripts/rue-bin"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+echo "BUCK-DIAGNOSTIC: unknown target platform" >&2
+exit 3
+EOF
+  chmod +x "$sb/buck2"
+
+  local rc out
+  out="$( "$sb/scripts/rue-bin" 2>&1 )"; rc=$?
+  check "rue-bin: buck failure exits non-zero" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "rue-bin: buck stderr is surfaced" \
+    "$(printf '%s' "$out" | grep -q 'BUCK-DIAGNOSTIC' && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# A successful build still prints ONLY the absolute binary path on stdout.
+test_ruebin_success_prints_clean_path() {
+  local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/scripts" "$sb/fakebin"
+  cp "$SRC_ROOT/scripts/rue-bin" "$sb/scripts/rue-bin"; chmod +x "$sb/scripts/rue-bin"
+  printf '#!/bin/sh\ntrue\n' >"$sb/fakebin/compiler"; chmod +x "$sb/fakebin/compiler"
+  # --show-output line: "<target> <repo-root-relative-path>"; plus build chatter
+  # on stderr that must NOT leak into the captured stdout on success.
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+echo "build chatter that must stay on stderr" >&2
+echo "root//crates/rue:rue fakebin/compiler"
+EOF
+  chmod +x "$sb/buck2"
+
+  local rc out
+  out="$( "$sb/scripts/rue-bin" 2>/dev/null )"; rc=$?
+  check "rue-bin: success exits zero" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  check "rue-bin: prints the absolute binary path only" \
+    "$([ "$out" = "$sb/fakebin/compiler" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# fmt.sh resolves rustfmt the same way; a failing `./buck2` must be loud too.
+test_fmt_build_failure_is_loud() {
+  local sb; sb="$(mktemp -d)"
+  cp "$SRC_ROOT/fmt.sh" "$sb/fmt.sh"; chmod +x "$sb/fmt.sh"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+echo "BUCK-DIAGNOSTIC: rustfmt toolchain unavailable" >&2
+exit 3
+EOF
+  chmod +x "$sb/buck2"
+
+  local rc out
+  out="$( bash "$sb/fmt.sh" 2>&1 )"; rc=$?
+  check "fmt.sh: buck failure exits non-zero" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "fmt.sh: buck stderr is surfaced" \
+    "$(printf '%s' "$out" | grep -q 'BUCK-DIAGNOSTIC' && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# ===========================================================================
+# RUE-549 — scripts/rue run|exec resolve relative paths from the caller's cwd
+# ===========================================================================
+
+# Build a scripts/rue sandbox: a copy of the real script, a fake scripts/rue-bin
+# that prints $FAKE_COMPILER, and a fake compiler that logs the cwd it ran in
+# and fabricates its output binary (last argv) so `exec` can run it. Echoes the
+# sandbox path.
+make_rue_sandbox() {
+  local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/scripts" "$sb/work" "$sb/std"
+  cp "$SRC_ROOT/scripts/rue" "$sb/scripts/rue"; chmod +x "$sb/scripts/rue"
+  cat >"$sb/scripts/rue-bin" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$FAKE_COMPILER"
+EOF
+  chmod +x "$sb/scripts/rue-bin"
+  cat >"$sb/compiler" <<'EOF'
+#!/usr/bin/env bash
+printf 'cwd=%s\n' "$PWD" >>"$COMPILE_LOG"
+printf 'args=%s\n' "$*" >>"$COMPILE_LOG"
+# Fabricate the output binary (the last argument) so a following exec can run it.
+out="${!#}"
+printf '#!/bin/sh\nexit 0\n' >"$out" 2>/dev/null || true
+chmod +x "$out" 2>/dev/null || true
+EOF
+  chmod +x "$sb/compiler"
+  echo 'fn main() -> i32 { 0 }' >"$sb/work/hello.rue"
+  printf '%s\n' "$sb"
+}
+
+# `exec hello.rue` from a nested dir must invoke the compiler FROM that nested
+# dir, so the relative source resolves there.
+test_rue_exec_resolves_from_caller_cwd() {
+  local sb; sb="$(make_rue_sandbox)"
+  ( cd "$sb/work" && FAKE_COMPILER="$sb/compiler" COMPILE_LOG="$sb/compile.log" \
+      "$sb/scripts/rue" exec hello.rue ) >/dev/null 2>&1
+  local cwd_line
+  cwd_line="$(grep '^cwd=' "$sb/compile.log" 2>/dev/null | head -1)"
+  check "scripts/rue exec: compiler runs in the caller's cwd" \
+    "$([ "$cwd_line" = "cwd=$sb/work" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# `run hello.rue -o out` from a nested dir must write the relative `-o` target
+# into that nested dir (the caller's cwd), not the repo root.
+test_rue_run_resolves_relative_output() {
+  local sb; sb="$(make_rue_sandbox)"
+  ( cd "$sb/work" && FAKE_COMPILER="$sb/compiler" COMPILE_LOG="$sb/compile.log" \
+      "$sb/scripts/rue" run hello.rue -o out ) >/dev/null 2>&1
+  local cwd_line
+  cwd_line="$(grep '^cwd=' "$sb/compile.log" 2>/dev/null | head -1)"
+  check "scripts/rue run: compiler runs in the caller's cwd" \
+    "$([ "$cwd_line" = "cwd=$sb/work" ] && echo 0 || echo 1)"
+  check "scripts/rue run: relative -o is written in the caller's cwd" \
+    "$([ -f "$sb/work/out" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# --- run everything ---------------------------------------------------------
+
+test_ruebin_build_failure_is_loud
+test_ruebin_success_prints_clean_path
+test_fmt_build_failure_is_loud
+test_rue_exec_resolves_from_caller_cwd
+test_rue_run_resolves_relative_output
+
+echo "--------------------------------------------------"
+if [ "$FAILURES" -eq 0 ]; then
+  echo "wrapper-script tests: all $TESTS checks passed"
+  exit 0
+else
+  echo "wrapper-script tests: $FAILURES of $TESTS checks FAILED"
+  exit 1
+fi


### PR DESCRIPTION
Two developer-tooling bugs found during the autonomous hunt.

## RUE-550 — suppressed Buck stderr made build/toolchain failures silent

Several shell helpers discarded Buck stderr inside `set -euo pipefail`
assignments (`X="$(./buck2 ... 2>/dev/null | awk ...)"`). When the build itself
failed, `pipefail` tripped `set -e` **at the assignment** — before the intended
diagnostic fallback could run — and, with stderr sent to `/dev/null`, the script
exited with **zero bytes on stdout and stderr**. Because every higher-level
wrapper obtains the compiler through `$(scripts/rue-bin)`, the failure was
invisible everywhere.

Repro (before): `scripts/rue-bin --target-platforms //platforms:definitely-missing` → exit 3, no output.

Fixed in `scripts/rue-bin`, `fmt.sh`, `clippy.sh`, and `gen-rust-project.sh`:
capture Buck's status explicitly (`|| status=$?`), send its stderr to a temp
file, and on failure surface that file with the real exit code — while keeping
stdout clean on success.

## RUE-549 — `scripts/rue run|exec` resolved relative paths from the repo root

The wrapper advertises "run from anywhere", but `run`/`exec` `cd`'d to the repo
root before forwarding relative `<source.rue>` / `-o` paths to the compiler, so
they resolved from the wrong directory.

Repro (before), from `examples/`: `../scripts/rue exec hello.rue` → `Error reading hello.rue: No such file or directory`.

Now the caller's cwd is captured before the `cd`; Buck targets still build from
the root, but the final compiler/program invocation runs from the caller's cwd.
The output path (`mktemp`) and the `RUE_STD_PATH` default are already absolute,
so they survive the `cd`.

## Tests

New `scripts/test-wrapper-scripts.sh` (buck `//:wrapper-script-tests`) runs
copies of the scripts against a fake `./buck2` and a fake compiler — no real
build — and pins both behaviors (9 checks). Verified it **fails on the pre-fix
scripts** (5 of 9 checks) and passes after the fix.

Fixes RUE-549
Fixes RUE-550

🤖 Generated with [Claude Code](https://claude.com/claude-code)