### PR TITLE
RUE-556: diagnostic origin column reports original-source coordinate, not tab-expanded

### DIFF
--- a/crates/rue-cli-tests/cases/diagnostic_tab_origin.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_tab_origin.toml
@@ -1,0 +1,52 @@
+[section]
+id = "cli.diagnostic_tab_origin"
+name = "Tab-indented diagnostic origin column"
+description = """
+Regression coverage for RUE-556: a hard tab before the primary span used to
+inflate the reported `path:line:col` origin column in human text (the caret is
+aligned against a 4-space-expanded excerpt), while --error-format json reported
+the original-source column. The two disagreed — column 12 vs 9 — so editors and
+scripts parsing the conventional text origin jumped three characters past the
+token. Both formats must now name the SAME original-source column, and the
+human caret must still sit under the token.
+"""
+
+# The leading `\t` on line 2 is a real tab (TOML multi-line basic strings decode
+# escapes). "return " is 7 characters, so `nope` is at original column 9.
+
+[[case]]
+name = "tab_indent_text_origin_is_original_column"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+\treturn nope;
+}
+""" }]
+compile_fail = true
+error_contains = [
+  # Origin coordinate uses the original-source column, matching JSON below.
+  "main.rue:2:9",
+  # Excerpt still expands the tab, and the caret stays under `nope`.
+  "2 |     return nope;",
+  "|            ^^^^",
+]
+compile_stderr_not_contains = [
+  # The old tab-expanded origin column must not reappear.
+  "main.rue:2:12",
+]
+
+[[case]]
+name = "tab_indent_json_origin_is_original_column"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+\treturn nope;
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+  '"line":2',
+  '"column":9',
+]
+compile_stderr_not_contains = [
+  '"column":12',
+]

--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -176,6 +176,114 @@ impl<'a> RenderSource<'a> {
     }
 }
 
+/// Return the slice of `source` that becomes rendered line `line_no` (1-based).
+///
+/// Splits on LF, CR, and CRLF — each one line terminator (spec 2.3:1 / RUE-534)
+/// — mirroring how [`RenderSource`] builds the buffer whose lines annotate-
+/// snippets counts, so a rendered origin line maps back to the right original
+/// line even in CR/CRLF files. Returns `None` if `line_no` is out of range.
+fn nth_rendered_line(source: &str, line_no: usize) -> Option<&str> {
+    let bytes = source.as_bytes();
+    let mut start = 0;
+    let mut current = 1;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\n' | b'\r' => {
+                if current == line_no {
+                    return Some(&source[start..i]);
+                }
+                // CRLF is a single terminator: consume the trailing LF too.
+                if bytes[i] == b'\r' && bytes.get(i + 1) == Some(&b'\n') {
+                    i += 1;
+                }
+                i += 1;
+                start = i;
+                current += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    (current == line_no).then(|| &source[start..])
+}
+
+/// Map a tab-expanded display column back to the original-source character
+/// column on rendered line `line_no` (both 1-based).
+///
+/// [`RenderSource`] expands each `\t` to four spaces so the human caret aligns
+/// (RUE-362); as a side effect annotate-snippets derives the `--> path:line:col`
+/// origin coordinate from that widened buffer, pushing the reported column past
+/// the token (RUE-556). Only tabs change width (control chars map one glyph to
+/// one column), so walking the original line and charging four columns per tab
+/// recovers the coordinate JSON diagnostics and editors expect.
+fn original_col_for_expanded(source: &str, line_no: usize, expanded_col: usize) -> usize {
+    let Some(line) = nth_rendered_line(source, line_no) else {
+        return expanded_col;
+    };
+    let mut rendered_col = 1usize;
+    let mut orig_col = 1usize;
+    for ch in line.chars() {
+        if rendered_col >= expanded_col {
+            break;
+        }
+        rendered_col += if ch == '\t' { 4 } else { 1 };
+        orig_col += 1;
+    }
+    // If the caret sat exactly on a char start, `orig_col` names it. If it fell
+    // past the line's end (e.g. an EOF span), `orig_col` is the char after the
+    // last, which is the correct one-past-end column.
+    orig_col
+}
+
+/// Rewrite each `--> path:line:col` origin coordinate in `rendered` so its
+/// column is the ORIGINAL-source column rather than the tab-expanded one
+/// annotate-snippets derives (RUE-556). The caret/excerpt geometry — which
+/// legitimately uses the expanded buffer — is untouched.
+///
+/// `files` supplies the original source for each rendered path. Because only a
+/// tab widens the column, this is a no-op (and cheap early-out) for tab-free
+/// input. The path/line/col text is plain even under color, so the rewrite is
+/// a byte-exact `replacen` that preserves any surrounding ANSI styling.
+fn correct_origin_columns(rendered: String, files: &[(&str, &str)]) -> String {
+    if !files.iter().any(|(_, src)| src.contains('\t')) {
+        return rendered;
+    }
+    let mut out = String::with_capacity(rendered.len());
+    for line in rendered.split_inclusive('\n') {
+        out.push_str(&fix_origin_line(line, files).unwrap_or_else(|| line.to_string()));
+    }
+    out
+}
+
+/// Correct a single rendered line if it is a `--> path:line:col` origin whose
+/// column was inflated by tab expansion; otherwise return `None`.
+fn fix_origin_line(line: &str, files: &[(&str, &str)]) -> Option<String> {
+    for (path, source) in files {
+        let needle = format!("{path}:");
+        let Some(pos) = line.find(&needle) else {
+            continue;
+        };
+        // After "<path>:" the origin line is exactly "<line>:<col>" plus any
+        // line terminators. A stray path mention elsewhere fails to parse here
+        // (trailing text makes the column non-numeric), so it is left alone.
+        let after = line[pos + needle.len()..].trim_end_matches(['\n', '\r']);
+        let Some((line_str, col_str)) = after.split_once(':') else {
+            continue;
+        };
+        let (Ok(line_no), Ok(col)) = (line_str.parse::<usize>(), col_str.parse::<usize>()) else {
+            continue;
+        };
+        let new_col = original_col_for_expanded(source, line_no, col);
+        if new_col == col {
+            return None;
+        }
+        let old = format!("{path}:{line_no}:{col}");
+        let new = format!("{path}:{line_no}:{new_col}");
+        return Some(line.replacen(&old, &new, 1));
+    }
+    None
+}
+
 /// Source code information for diagnostic rendering.
 ///
 /// Contains the source text and file path needed for rendering annotated
@@ -456,7 +564,11 @@ impl<'a> DiagnosticFormatter<'a> {
             report = report.footer(Level::Help.title(help.as_ref()));
         }
 
-        format!("{}", self.renderer.render(report))
+        let rendered = format!("{}", self.renderer.render(report));
+        correct_origin_columns(
+            rendered,
+            &[(self.source_info.path, self.source_info.source)],
+        )
     }
 }
 
@@ -801,7 +913,12 @@ impl<'a> MultiFileFormatter<'a> {
             report = report.footer(Level::Help.title(help.as_ref()));
         }
 
-        format!("{}", self.renderer.render(report))
+        let rendered = format!("{}", self.renderer.render(report));
+        let files: Vec<(&str, &str)> = render_sources
+            .iter()
+            .map(|(_, source_info, _)| (source_info.path, source_info.source))
+            .collect();
+        correct_origin_columns(rendered, &files)
     }
 }
 
@@ -1396,6 +1513,83 @@ mod tests {
             "caret should stay under `nope` after expanding the leading tab:\n{}",
             output
         );
+    }
+
+    #[test]
+    fn test_tab_origin_column_matches_original_source_not_expanded() {
+        // RUE-556: the `--> path:line:col` origin must name the ORIGINAL-source
+        // column (the tab is one character), matching JSON diagnostics and what
+        // editors expect — even though the caret uses the tab-expanded excerpt.
+        let source = "fn main() -> i32 {\n\treturn nope;\n}";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::with_color_choice(&source_info, ColorChoice::Never);
+
+        let start = source.find("nope").unwrap() as u32;
+        let error = CompileError::new(
+            ErrorKind::UndefinedVariable("nope".to_string()),
+            Span::new(start, start + 4),
+        );
+        let output = formatter.format_error(&error);
+
+        // `\t` + "return " = 7 chars before `nope` -> column 9 in the original.
+        assert_eq!(
+            crate::Span::new(start, start + 4).line_number(source),
+            2,
+            "sanity: span is on line 2"
+        );
+        assert!(
+            output.contains("--> test.rue:2:9"),
+            "origin should report the original-source column 9, not the \
+             tab-expanded 12:\n{}",
+            output
+        );
+        assert!(
+            !output.contains("--> test.rue:2:12"),
+            "origin must not report the tab-expanded column:\n{}",
+            output
+        );
+        // Caret alignment is still driven by the expanded excerpt.
+        assert!(
+            output.contains("  |            ^^^^"),
+            "caret must remain under `nope`:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_space_indent_origin_column_is_unchanged() {
+        // The correction must be a no-op when there are no tabs: spaces are real
+        // characters, so the origin column already equals the original column.
+        let source = "fn main() -> i32 {\n    return nope;\n}";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::with_color_choice(&source_info, ColorChoice::Never);
+
+        let start = source.find("nope").unwrap() as u32;
+        let error = CompileError::new(
+            ErrorKind::UndefinedVariable("nope".to_string()),
+            Span::new(start, start + 4),
+        );
+        let output = formatter.format_error(&error);
+
+        // Four spaces + "return " = 11 chars before `nope` -> column 12.
+        assert!(
+            output.contains("--> test.rue:2:12"),
+            "space-indented origin column should be untouched:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_original_col_for_expanded_maps_tab_columns() {
+        // Unit-level check of the inverse mapping: `\treturn nope;`, the token
+        // `nope` sits at expanded column 12 but original column 9.
+        let source = "fn main() {\n\treturn nope;\n}";
+        assert_eq!(original_col_for_expanded(source, 2, 12), 9);
+        // Two leading tabs: expanded column 16 -> original column 10.
+        let two = "fn main() {\n\t\treturn nope;\n}";
+        assert_eq!(original_col_for_expanded(two, 2, 16), 10);
+        // A column before the first tab is unchanged.
+        assert_eq!(original_col_for_expanded(source, 1, 4), 4);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A hard tab before the primary span inflated the reported `path:line:col` origin
column in **human text**, disagreeing with `--error-format json`:

```
fn main() -> i32 {
	return nope;
}
```

For the same E0201 span, human text reported `main.rue:2:12` while JSON reported
`line 2, column 9`. Column 9 is the original-source coordinate (the tab is one
character); column 12 is the coordinate in the renderer's 4-space-expanded copy.
Editors and scripts parsing the conventional text origin jumped three characters
past the token.

Root cause: `RenderSource` expands each tab to four spaces so the human caret
aligns (RUE-362), and annotate-snippets derives **both** the caret geometry and
the displayed `-->` origin coordinate from that transformed buffer.

## Fix

After rendering, rewrite each `--> path:line:col` origin so its column is the
**original-source** character column (matching JSON and the compiler's own
spans), while leaving the visually-aligned caret/excerpt geometry — which
legitimately uses the expanded buffer — untouched.

- Only a tab changes rendered width (control chars map one glyph to one column),
  so `correct_origin_columns` is a cheap no-op for tab-free input.
- The `path:line:col` text is plain even under color (only `-->` is styled), so
  the rewrite is a byte-exact `replacen` that preserves surrounding ANSI.
- Applied in both `DiagnosticFormatter` (single-file) and `MultiFileFormatter`
  (the driver's text path).
- `nth_rendered_line` splits on CR/LF/CRLF to stay consistent with
  `RenderSource` line counting (RUE-534).

## Result

```
 --> main.rue:2:9          # was 2:12
2 |     return nope;       # excerpt still expands the tab
  |            ^^^^         # caret still under `nope`
```

Text and JSON now agree on column 9.

## Tests

- Three `rue-compiler` unit tests: original-column origin, space-indent no-op,
  and the inverse-mapping helper.
- Paired text/JSON CLI regression (`diagnostic_tab_origin`) asserting both
  formats name column 9 and the caret stays under the token.

Verified: `rue-compiler` unit (221), UI (154), full CLI (1250) all green; clippy
gate passes.

Fixes RUE-556

🤖 Generated with [Claude Code](https://claude.com/claude-code)