### PR TITLE
Use demand-driven body analysis for every program

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -6,9 +6,9 @@
 //! - RIR to AIR instruction lowering (analyze_inst)
 //! - Helper functions for expression analysis
 //!
-//! Two drivers share these analysis functions: the eager path (single-file
-//! compilation analyzes every function) and the lazy path (multi-file
-//! compilation analyzes only reachable functions, per ADR-0026).
+//! The demand-driven driver analyzes ordinary function and method bodies only
+//! when they are reachable from `main`, per ADR-0045. Program shape does not
+//! change which bodies are checked.
 
 use std::collections::{HashMap, HashSet};
 
@@ -39,8 +39,7 @@ use crate::types::{ModuleId, StructField, StructId, Type, TypeKind};
 /// Main entry point for analyzing all function bodies.
 ///
 /// Called from Sema::analyze_all after declarations are collected.
-/// Uses the lazy driver for import graphs and the eager driver for single-file
-/// compilations.
+/// Uses the demand-driven driver for every program shape.
 pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResult<SemaOutput> {
     // Declarations are complete: re-point destructor symbols of struct
     // names that span multiple files at their file-qualified form (RUE-571).
@@ -48,14 +47,9 @@ pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResul
     // symbol from the same helper.
     sema.requalify_colliding_destructor_symbols();
 
-    // Use lazy analysis when imports are present (multi-file compilation)
-    // This ensures only reachable code is analyzed, per ADR-0026
-    let result = if sema.has_imports() {
-        analyze_function_bodies_lazy(&mut sema)
-    } else {
-        // Use eager analysis for single-file compilation (backwards compatibility)
-        analyze_all_function_bodies_sequential(&mut sema)
-    };
+    // ADR-0045 defines reachability from `main` as the function-body analysis
+    // frontier for every executable.
+    let result = analyze_function_bodies_lazy(&mut sema);
 
     // Sema→CFG boundary invariant (RUE-153): a value may only carry the
     // `<error>` type as part of error recovery, i.e. when at least one
@@ -112,6 +106,7 @@ fn find_undiagnosed_error_type(output: &SemaOutput) -> Option<CompileError> {
 }
 
 /// Sequential analysis path (current implementation).
+#[allow(dead_code)] // Removed in the follow-up that deletes the legacy driver.
 fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOutput> {
     // Build inference context once
     let infer_ctx = sema.build_inference_context();
@@ -680,18 +675,19 @@ fn enqueue_anonymous_destructors(
     pending_methods.extend(destructors);
 }
 
-/// Lazy analysis path (Phase 3 of module system, ADR-0026).
+/// Demand-driven body-analysis path (ADR-0045).
 ///
-/// This implements "lazy semantic analysis" where only functions reachable from
-/// the entry point (main) are analyzed. Unreferenced code is not analyzed,
-/// not codegen'd, and errors in unreferenced code are not reported.
+/// Ordinary function and method bodies are analyzed only when reachable from
+/// the entry point (`main`). Declaration gathering remains eager, and named
+/// destructors are currently implicit roots because drop glue is synthesized
+/// from the full type pool.
 ///
 /// This is the same trade-off Zig makes for faster builds and smaller binaries.
 fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOutput> {
     // Build inference context once
     let infer_ctx = sema.build_inference_context();
 
-    // Find main() function - this is the entry point for lazy analysis
+    // Find main() - the reference root for executable body analysis.
     let main_sym = match sema.interner.get("main") {
         Some(sym) if sema.functions.contains_key(&sym) => sym,
         _ => {

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -400,7 +400,7 @@ pub(crate) struct AnalysisContext<'a> {
     /// this map stores the captured values so method bodies can resolve them.
     pub comptime_value_vars: HashMap<Spur, ConstValue>,
     /// Functions referenced during analysis of this function.
-    /// Used for lazy semantic analysis (Phase 3 of module system) to track
+    /// Used for demand-driven semantic analysis (ADR-0045) to track
     /// which functions need to be analyzed. Each entry is a function name symbol.
     pub referenced_functions: HashSet<Spur>,
     /// Methods referenced during analysis of this function.

--- a/crates/rue-air/src/sema/file_paths.rs
+++ b/crates/rue-air/src/sema/file_paths.rs
@@ -67,11 +67,10 @@ impl<'a> Sema<'a> {
             .map(|(id, _)| *id)
     }
 
-    /// Check if the compilation involves imports (multi-file compilation).
-    ///
-    /// When imports are present, lazy analysis is used to only analyze
-    /// functions reachable from main(). For single-file compilation,
-    /// eager analysis is used for backwards compatibility.
+    /// Legacy import-presence selector retained only so the universal
+    /// demand-driven cutover and its eager-driver deletion remain separate
+    /// review units. The body-analysis entry point no longer calls it.
+    #[allow(dead_code)] // Removed with the legacy eager-driver selector.
     pub(crate) fn has_imports(&self) -> bool {
         !self.module_registry.is_empty()
     }

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -22,7 +22,7 @@ use super::{KnownSymbols, Sema};
 ///
 /// This contains the state built during declaration gathering that is needed
 /// for function body analysis. After gathering, this can be converted back
-/// into a `Sema` for the eager or lazy analysis drivers.
+/// into a `Sema` for demand-driven function-body analysis.
 ///
 /// # Architecture
 ///

--- a/crates/rue-cli-tests/cases/anon_struct_destructor.toml
+++ b/crates/rue-cli-tests/cases/anon_struct_destructor.toml
@@ -39,6 +39,31 @@ args = ["main.rue", "-o", "prog"]
 stdout = "100\n7\n"
 exit_code = 0
 
+# RUE-578: this direct literal has no method call to pull the anonymous type's
+# destructor into the old eager body's one-time method sweep. The universal
+# demand-driven driver must discover the destructor registered while analyzing
+# main and emit it before linking.
+[[case]]
+name = "direct_literal_destructor_runs_without_imports"
+description = "A destructor registered while analyzing a single-file main is emitted before linking."
+files = [{ path = "main.rue", source = """
+fn Box(comptime T: type) -> type {
+    struct {
+        value: T,
+        drop fn(self) { @dbg(self.value); }
+    }
+}
+
+fn main() -> i32 {
+    let B = Box(i32);
+    let _value = B { value: 7 };
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "7\n"
+exit_code = 0
+
 # Reverse declaration order (LIFO) across three values, like named structs.
 [[case]]
 name = "destructor_drop_order_lifo"

--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -391,7 +391,7 @@ exit_code = 7
 
 [[case]]
 name = "move_out_of_inout_rejected_in_imported_module"
-description = "The lazy (import-driven) analysis path enforces the same rule as the single-file path."
+description = "The imported-module call shape enforces the same rule as a local call."
 files = [
     { path = "main.rue", source = """
 const lib = @import("lib.rue");
@@ -412,9 +412,9 @@ error_contains = ["E0437", "cannot move out of inout parameter"]
 # ---------------------------------------------------------------------------
 # Exclusive-access checks are uniform across call shapes and pipelines
 # (RUE-141). Module member calls (`m.f(...)`) used to skip the exclusive-
-# access check entirely, and the lazy (import-driven) pipeline's check had
-# drifted to cover less than the single-file one (no borrow/inout conflict
-# detection, no lvalue check). Both now share one implementation.
+# access check entirely, and its check had drifted to cover less than the local
+# call shape (no borrow/inout conflict detection, no lvalue check). Both now
+# share one implementation.
 # ---------------------------------------------------------------------------
 
 [[case]]
@@ -462,7 +462,7 @@ error_contains = ["E0430", "cannot borrow 'x' while it is mutably borrowed"]
 
 [[case]]
 name = "regular_call_borrow_inout_conflict_rejected_with_import"
-description = "With an import present (lazy pipeline), a regular call mixing borrow and inout of the same variable is still rejected."
+description = "A regular call mixing borrow and inout is rejected even when the program also has an import."
 files = [
     { path = "main.rue", source = """
 fn observe(borrow a: i32, inout b: i32) -> i32 {

--- a/crates/rue-cli-tests/cases/lazy_specialization_references.toml
+++ b/crates/rue-cli-tests/cases/lazy_specialization_references.toml
@@ -1,6 +1,6 @@
 # References discovered while creating a comptime specialization must rejoin
 # the demand-driven body-analysis frontier (RUE-580). Each case uses a real
-# import so it exercises the production lazy path before that path is universal.
+# import so module-qualified calls participate in the same coverage.
 
 [section]
 id = "cli.lazy_specialization_references"

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -91,3 +91,46 @@ pub fn broken() -> i32 { true }
 """ }
 compile_fail = true
 error_contains = "E0206"
+
+[[case]]
+name = "single_file_skips_unreferenced_invalid_body"
+spec = ["10.5:4"]
+description = "An invalid ordinary function body is not analyzed when main does not reach it"
+source = """
+fn answer() -> i32 { 42 }
+
+fn broken() -> i32 { true }
+
+fn main() -> i32 { answer() }
+"""
+exit_code = 42
+
+[[case]]
+name = "import_graph_skips_unreferenced_invalid_body"
+spec = ["10.5:4"]
+description = "Adding a harmless import to the same root program does not change the body-analysis frontier"
+source = """
+const harmless = @import("helper.rue");
+
+fn answer() -> i32 { 42 }
+
+fn broken() -> i32 { true }
+
+fn main() -> i32 { answer() }
+"""
+aux_files = { "helper.rue" = "pub fn unused() -> i32 { 0 }" }
+exit_code = 42
+
+[[case]]
+name = "single_file_skips_unreferenced_invalid_method_body"
+spec = ["10.5:4"]
+description = "An invalid ordinary method body is not analyzed when main does not reach it"
+source = """
+struct Wrap {
+    value: i32,
+    fn broken(self) -> i32 { true }
+}
+
+fn main() -> i32 { 42 }
+"""
+exit_code = 42

--- a/docs/designs/0045-lazy-semantic-analysis.md
+++ b/docs/designs/0045-lazy-semantic-analysis.md
@@ -105,13 +105,15 @@ Analysis is a **reachability walk** over declarations, seeded from a set of
 
 ### 2. Eager → on-demand across the pipeline
 
-The compiler pipeline (Lexer → Parser → AstGen → Sema → CfgBuilder → Lower →
-RegAlloc → Emit → Link) is today driven eagerly: each pass processes *every*
-item before the next pass runs. Lazy analysis reorganizes the front half of the
-pipeline to be **demand-driven per declaration**, converging on the model
-comptime monomorphization already uses:
+The original compiler pipeline (Lexer → Parser → AstGen → Sema → CfgBuilder →
+Lower → RegAlloc → Emit → Link) was driven eagerly: each pass processed *every*
+item before the next pass ran. The first rollout now makes ordinary function
+and method bodies demand-driven from `main`; loaded files are still lexed,
+parsed, and gathered eagerly. The broader design reorganizes the front half of
+the pipeline **per declaration**, converging on the model comptime
+monomorphization already uses:
 
-| Stage | Today (eager) | Under lazy analysis |
+| Stage | Before rollout (eager) | Under lazy analysis |
 |-------|---------------|---------------------|
 | Lexer | whole file | whole file (unchanged — lexing is cheap, and a file is the unit of parse) |
 | Parser → AST | whole file | whole file, but a **module is not parsed until referenced** (§3) |

--- a/docs/spec/src/10-modules/05-program-composition.md
+++ b/docs/spec/src/10-modules/05-program-composition.md
@@ -66,10 +66,15 @@ fn main() -> i32 {
 {{ rule(id="10.5:4", cat="normative") }}
 
 The semantic compilation unit is the root module and its transitive import
-graph. An implementation **MAY** analyze imported modules on demand
-(ADR-0045): items of an imported module that the program never references
-are not guaranteed to be semantically analyzed, so a program **MUST NOT**
-rely on a compile-time error inside an unreferenced imported item being
-reported. Errors in code the program reaches — including declaration-level
-errors of any loaded file (parse errors, duplicate definitions, invalid
-signatures) — are always reported.
+graph. Ordinary function and method bodies are analyzed on demand from
+`main`. A compile-time error inside an unreferenced ordinary body is not
+reported, whether that body is in the root file or an imported module.
+
+This body-level frontier does not yet make the entire front end lazy. Loaded
+files are parsed and their declarations are gathered eagerly, so syntax,
+duplicate-definition, and signature errors are reported before body
+reachability is known. Named destructors are also currently implicit analysis
+roots because drop glue is synthesized from the full type pool. ADR-0045
+defines the broader on-demand model; ADR-0047 allows future build-system source
+manifests that constrain which files may be imported without turning every
+declared input into a semantic root.

--- a/website/content/std/_index.md
+++ b/website/content/std/_index.md
@@ -67,7 +67,7 @@ As Rue matures, the standard library will grow to include:
 The Rue standard library follows several design principles:
 
 1. **Explicit imports** - No implicit prelude; all dependencies are visible
-2. **Lazy analysis** - Only imported code is analyzed, enabling fast compilation
+2. **Lazy analysis** - Function bodies are analyzed on demand from `main`, enabling fast compilation
 3. **File = module** - Each `.rue` file is a module; the filesystem is the source of truth
 4. **Simple visibility** - Just `pub` (public) or nothing (private)
 


### PR DESCRIPTION
## Summary

- route every executable through the demand-driven function-body driver, independent of whether the program imports another file
- preserve eager declaration gathering and the current named-destructor roots
- pin import invariance, unreferenced invalid function/method bodies, and single-file anonymous-destructor discovery
- align ADR-0045, the program-composition specification, and user-facing documentation with the universal path

This is the behavior cutover after #1371. The now-unused eager driver and import selector are intentionally retained here so their deletion can be a separate, deletion-only review.

## Validation

- `./test.sh`: Pass 31, Fail 0; 1,235 CLI and 1,996 spec cases with zero oracle disagreements
- `./clippy.sh`: all 41 first-party targets clean
- `./fmt.sh check`
- focused composition, specialization-reference, and anonymous-destructor regressions

Fixes RUE-578
