### PR TITLE
RUE-517: onboarding examples exit 0 so successful setup isn't mistaken for failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ the repository wrappers:
 
 ```bash
 scripts/rue build
-scripts/rue exec examples/fibonacci.rue
+scripts/rue exec examples/welcome.rue   # prints 1, 2, 3, 42 and exits 0
 scripts/rue quick
 scripts/rue test
 ```

--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ bootstrapped hermetically by the repository.
 
 ```bash
 scripts/rue build
-scripts/rue exec examples/fibonacci.rue
+scripts/rue exec examples/welcome.rue   # prints 1, 2, 3, 42 and exits 0
 scripts/rue test
 ```
+
+`examples/welcome.rue` is the setup health check: it prints recognizable output
+and exits 0, so a successful run is not mistaken for a failure under `set -e` or
+CI. (Programs like `examples/fibonacci.rue` return a value from `main`, which
+becomes the process exit code — informative, but a nonzero status.)
 
 Use `scripts/rue-bin` when you need the compiler path, or run the real CLI
 through the wrapper:
@@ -55,8 +60,8 @@ through the wrapper:
 ```bash
 RUE="$(scripts/rue-bin)"
 "$RUE" --help
-"$RUE" examples/fibonacci.rue -o fibonacci
-./fibonacci
+"$RUE" examples/welcome.rue -o welcome
+./welcome
 ```
 
 Supported targets are `x86-64-linux`, `aarch64-linux`, and `aarch64-macos`.

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -239,6 +239,17 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         stdout: "25\n50\n30\ntrue\n",
         stdin: None,
     },
+    // The onboarding smoke test. README, CONTRIBUTING, and the tutorial's
+    // installation page point new users at `scripts/rue exec examples/welcome.rue`
+    // to verify their setup, so it MUST print recognizable output and exit 0 —
+    // otherwise `set -e`, `&&` chains, and CI steps read a successful run as a
+    // failure (RUE-517). Guarded further by test_welcome_example_is_zero_exit.
+    ExampleExpectation {
+        path: "welcome.rue",
+        exit_code: 0,
+        stdout: "1\n2\n3\n42\n",
+        stdin: None,
+    },
 ];
 
 #[derive(Debug, Deserialize)]
@@ -1155,6 +1166,29 @@ mod tests {
         permissions.set_mode(0o755);
         std::fs::set_permissions(&binary, permissions).expect("make fake compiler executable");
         (directory, binary)
+    }
+
+    #[test]
+    fn test_welcome_example_is_zero_exit() {
+        // RUE-517: the onboarding docs (README, CONTRIBUTING, and the tutorial's
+        // installation page) use `scripts/rue exec examples/welcome.rue` as the
+        // "did my setup work?" health check. Because `exec` propagates the
+        // program's exit code, welcome MUST exit 0 and print recognizable output
+        // — otherwise a successful setup looks like a failure under `set -e`,
+        // `&&` chains, or CI. Pin the invariant so the canonical onboarding
+        // example can't silently regress to a nonzero exit.
+        let welcome = EXAMPLE_EXPECTATIONS
+            .iter()
+            .find(|e| e.path == "welcome.rue")
+            .expect("welcome.rue must be a pinned example expectation");
+        assert_eq!(
+            welcome.exit_code, 0,
+            "the onboarding example must exit 0 (RUE-517)"
+        );
+        assert!(
+            !welcome.stdout.is_empty(),
+            "the onboarding example must print recognizable output (RUE-517)"
+        );
     }
 
     #[test]

--- a/examples/welcome.rue
+++ b/examples/welcome.rue
@@ -1,0 +1,19 @@
+// welcome.rue — the canonical "did my setup work?" smoke test.
+//
+// Rue has no string printing yet (@dbg prints integers and booleans), so this
+// greets you with a small, recognizable sequence — 1, 2, 3, then 42 — and,
+// crucially, returns 0. Because `scripts/rue exec` propagates the program's
+// exit code, a health-check program must exit 0 so `set -e`, `&&` chains, CI
+// steps, and automated agents see success rather than a phantom failure
+// (RUE-517).
+//
+// Contrast hello.rue, which deliberately RETURNS 42 to show how `main`'s value
+// becomes the process exit code — great for teaching, poor as a setup probe.
+
+fn main() -> i32 {
+    @dbg(1);
+    @dbg(2);
+    @dbg(3);
+    @dbg(42);
+    0
+}

--- a/website/content/tutorial/01-installation.md
+++ b/website/content/tutorial/01-installation.md
@@ -30,14 +30,17 @@ The first build may take a minute. Subsequent builds are fast.
 
 ## Running an Example
 
-Try one of the checked-in examples:
+Try the checked-in setup smoke test:
 
 ```bash
-scripts/rue exec examples/hello.rue
+scripts/rue exec examples/welcome.rue
 ```
 
-`scripts/rue exec` builds the compiler if needed, compiles the Rue source to a
-temporary executable, and runs it.
+You should see `1`, `2`, `3`, and `42` printed, and the command exits 0 — so
+you know your toolchain works even inside a script or CI step. `scripts/rue exec`
+builds the compiler if needed, compiles the Rue source to a temporary
+executable, and runs it, propagating the program's exit code. (In the next
+chapter you'll see how a program's `main` return value *becomes* that exit code.)
 
 ## Compiling Manually
 
@@ -46,8 +49,8 @@ run the compiler directly:
 
 ```bash
 RUE="$(scripts/rue-bin)"
-"$RUE" examples/hello.rue -o hello
-./hello
+"$RUE" examples/welcome.rue -o welcome
+./welcome
 ```
 
 Rue currently supports native code generation for `x86-64-linux`,


### PR DESCRIPTION
## Problem

The documented first-run smoke commands ran examples whose `main()` return value
becomes the process exit code:

- README / CONTRIBUTING: `scripts/rue exec examples/fibonacci.rue` → exit **55**
- Tutorial installation: `scripts/rue exec examples/hello.rue` → exit **42**

Both compile and run correctly, but any enclosing `set -e`, `&&` chain, CI step,
installer, or automated agent reads the nonzero status as a **failed setup** —
a successful run is indistinguishable from a broken toolchain.

## Fix

Add `examples/welcome.rue`: it prints a recognizable sequence (`1, 2, 3, 42`) via
`@dbg` and returns **0**. (Rue has no string printing yet — `@dbg` handles
integers/booleans — so a numeric greeting is the clearest deterministic output.)

Point README, CONTRIBUTING, and the tutorial's installation page at it as the
canonical health check. `hello.rue` keeps returning 42 — the hello-world
tutorial chapter uses it precisely to teach how `main`'s value becomes the exit
code.

## Guardrails

- Pin `welcome.rue` in the examples smoke table (`exit 0`, stdout
  `1\n2\n3\n42\n`), so the RUE-48 harness runs it every build.
- Add `test_welcome_example_is_zero_exit` asserting the onboarding example stays
  zero-exit with non-empty output, so a future edit can't silently regress the
  documented command back to a nonzero status.

## Verification

`scripts/rue exec examples/welcome.rue` prints `1 2 3 42` and exits 0. CLI unit
tests (11) and the full CLI suite (1251, including the new welcome smoke) pass;
tutorial-snippet tests and the clippy gate pass.

Fixes RUE-517

🤖 Generated with [Claude Code](https://claude.com/claude-code)