### PR TITLE
RUE-520: correct stale frontend architecture/implementation guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,8 @@ rue main.rue -o program        # @imports resolved and loaded automatically
 - `--source-manifest <path>` restricts which files imports may read — for build
   systems (Buck) that need the compiler's input set to be explicit.
 - `main()` must exist in exactly one file.
-- Files are parsed in parallel, then merged for semantic analysis.
+- Files are parsed sequentially with a shared interner (so interned symbols
+  agree across files), then merged for semantic analysis.
 
 **Legacy flat mode is being removed (ADR-0046):** extra positional source files
 (`rue a.rue b.rue -o prog`) are still accepted as legacy inputs, but unqualified
@@ -116,7 +117,7 @@ tests or examples that rely on flat file lists.
 - **Index-based references**: Instructions stored in vectors, referenced by u32 indices (cache-friendly, no lifetimes)
 - **Direct code emission**: No LLVM dependency; machine code emitted directly
 - **Minimal linking**: Static executables with direct syscalls
-- **Built-in types as synthetic structs**: Types like `String` are defined in `rue-builtins` and injected as synthetic structs, not as hardcoded `Type` enum variants (see [ADR-0020](docs/designs/0020-builtin-types-as-structs.md))
+- **Built-in types as synthetic structs**: Types like `String` are defined in `rue-builtins` and injected as synthetic structs, not as hardcoded special-cased built-in types (see [ADR-0020](docs/designs/0020-builtin-types-as-structs.md))
 
 ### Built-in Types Architecture
 
@@ -128,7 +129,7 @@ imported via `@import("std")` (see ADR-0043). To add a new builtin: define a
 `BuiltinTypeDef` in `rue-builtins/src/lib.rs`, add it to `BUILTIN_TYPES`,
 implement runtime functions in `rue-runtime`. The module docs in `rue-builtins`
 walk through a full worked example. Injection point: `inject_builtin_types()`
-in `rue-air/src/sema.rs`.
+in `rue-air/src/sema/builtins.rs`.
 
 ## Testing
 
@@ -219,7 +220,7 @@ Use preview gating when adding new syntax (keywords, operators, constructs), new
 
 1. **Add to PreviewFeature enum** in `rue-error/src/lib.rs`; also update `name()`, `adr()`, `all()`, and the `FromStr` impl.
 
-2. **Add the gate check in Sema** (`rue-air/src/sema.rs`):
+2. **Add the gate check in Sema** (`rue-air/src/sema/analysis.rs`):
    ```rust
    self.require_preview(PreviewFeature::YourNewFeature, "your feature description", span)?;
    ```

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -1,6 +1,11 @@
 //! Type system for Rue.
 //!
-//! Currently very minimal - just i32. Will be extended as the language grows.
+//! A [`Type`] is a compact `u32` newtype: an index into a `TypeInternPool`
+//! (ADR-0024), so type equality and lookup are cheap and free of
+//! self-referential lifetimes. The system covers the integer and boolean
+//! primitives, user structs and enums, references and raw pointers, and generic
+//! instantiations — well beyond the original i32-only prototype this comment
+//! once described.
 
 /// A unique identifier for a struct definition.
 ///

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -1,8 +1,13 @@
 //! Unified compilation unit that owns all compilation artifacts.
 //!
-//! The [`CompilationUnit`] provides a single source of truth for all compilation state,
-//! from source files through to machine code. It enforces phase ordering through the
-//! type system - you can't access AIR without first running semantic analysis.
+//! The [`CompilationUnit`] provides a single source of truth for all compilation
+//! state, from source files through to machine code. Phase artifacts are held in
+//! `Option` fields and phase ordering is enforced *at runtime*: each phase method
+//! panics if a prerequisite phase has not run yet. The order is
+//! [`parse()`](CompilationUnit::parse) → [`lower()`](CompilationUnit::lower) →
+//! [`analyze()`](CompilationUnit::analyze) →
+//! [`compile()`](CompilationUnit::compile);
+//! [`run_all()`](CompilationUnit::run_all) runs them in sequence for you.
 //!
 //! # Example
 //!
@@ -15,11 +20,14 @@
 //!     SourceFile::new("main.rue", "fn main() -> i32 { 42 }", FileId::new(1)),
 //! ];
 //!
-//! // Create compilation unit and run phases
-//! let mut unit = CompilationUnit::new(sources, CompileOptions::default())?;
+//! // Run the phases IN ORDER — skipping one (e.g. analyze() before lower())
+//! // panics. `new` is infallible; the phase methods return results.
+//! let mut unit = CompilationUnit::new(sources, CompileOptions::default());
 //! unit.parse()?;
+//! unit.lower()?;
 //! unit.analyze()?;
 //! let output = unit.compile()?;
+//! // Or, equivalently: let output = unit.run_all()?;
 //! ```
 
 use std::collections::HashMap;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,8 +29,8 @@ can be repeated to request several views.
 - **`rue-lexer`** tokenizes source and records byte spans and interned names.
 - **`rue-parser`** constructs a syntax tree without resolving names or types.
 - **`rue-rir`** lowers syntax into a dense, index-addressed, untyped IR. Each
-  source file initially has its own RIR; the compiler merges program inputs
-  before semantic analysis.
+  source file is parsed to its own AST; the compiler merges those ASTs and then
+  generates a single RIR from the merged AST before semantic analysis.
 - **`rue-air`** performs declaration collection, name resolution, inference,
   type checking, ownership/exclusivity analysis, comptime evaluation, and
   production of typed AIR.
@@ -79,7 +79,7 @@ run the resulting executable.
 
 `rue-compiler` orchestrates compilation and exposes intermediate states used by
 the CLI and tests. The `rue` crate implements source discovery, module loading,
-parallel file processing, target and optimization selection, emit modes,
+file processing, target and optimization selection, emit modes,
 linking, timing, and diagnostic rendering.
 
 `rue-error` defines stable error categories, suggestions, warnings, preview

--- a/docs/process/implementation.md
+++ b/docs/process/implementation.md
@@ -109,10 +109,11 @@ Run the full test suite:
 ./test.sh
 ```
 
-This runs:
-- Unit tests (`./buck2 test //...`)
-- Spec tests (`./buck2 run //crates/rue-spec:rue-spec`)
-- Traceability check
+This runs (via `buck2 test //...` plus the repository quality gates):
+- Unit tests for all crates
+- Spec tests and the spec-traceability gate
+- UI tests (diagnostics) and CLI integration tests
+- Tutorial snippet checks and ADR registry validation
 
 **For stable work**: All tests must pass.
 
@@ -154,12 +155,14 @@ When all phases are complete:
 2. Parser: Add parsing in `rue-parser`
 3. RIR: Add IR node in `rue-rir`
 4. AIR: Add typed node in `rue-air`
-5. Sema: Add type checking in `rue-air/src/sema.rs`
+5. Sema: Add type checking in the `rue-air/src/sema/` module
 6. Codegen: Add code generation in both backends
 
 ### Adding a New Type
 
-1. Add to `Type` enum in `rue-air/src/types.rs`
+1. Add its representation in `rue-air/src/types.rs` (`Type` is a `u32` interned
+   into `TypeInternPool`, not an enum); built-in types are synthetic structs
+   defined in `rue-builtins` (ADR-0020), not hardcoded variants
 2. Update type checking in sema
 3. Update code generation for the type's operations
 4. Add spec chapter and tests


### PR DESCRIPTION
Six high-authority, newcomer-facing statements described deleted files or
behavior the compiler no longer has. I verified each against live code and
corrected them (plus two extra instances found while sweeping).

| # | Was | Now (verified) |
|---|-----|----------------|
| 1 | `architecture.md`: each file has its own RIR, merged before sema | Each file → its own AST; ASTs are merged, then a **single RIR** is generated from the merged AST (`unit.rs` `parse()`/`lower()`) |
| 2 | `CLAUDE.md` + `architecture.md`: files parsed **in parallel** | Parsed **sequentially** with a shared interner (`parse_all_files`, `unit.rs`) — a remaining RUE-423 instance |
| 3 | `CLAUDE.md` + `implementation.md`: edit `rue-air/src/sema.rs`; add a `Type` **enum** variant | `sema.rs` doesn't exist (`mod sema;` tree — `inject_builtin_types`→`sema/builtins.rs`, preview gate→`sema/analysis.rs`); `Type` is a `u32` newtype interned into `TypeInternPool` (ADR-0024), built-ins are synthetic structs (ADR-0020) |
| 4 | `unit.rs`: phase ordering enforced "through the type system"; example skips `lower()` | Enforced **at runtime** (Option fields + `expect` panics); documented real `parse → lower → analyze → compile` order + `run_all()`, fixed the panicking example (`new()` is infallible) |
| 5 | `types.rs`: "very minimal — just i32" | The real interned type system (structs, enums, refs/pointers, generics) |
| 6 | `implementation.md`: `test.sh` runs unit/spec/traceability only | Also UI, CLI, tutorial snippets, and ADR validation |

## Scope notes

- `docs/designs/**` ADRs that mention `sema.rs` are **point-in-time decision
  records** and left as-is (updating them would rewrite history).
- The report's *"validate literal doc paths"* sub-suggestion is **deferred**:
  guidance docs legitimately contain illustrative non-existent paths
  (`main.rue`, `app/_app.rue`, `util.rue`), so a robust linter is its own design
  task rather than a lightweight add. Noted on the issue.

Verified on current trunk (after the lazy-sema driver merge): `sema.rs` still
absent, `Type(u32)` newtype intact, parsing still sequential, phase API
unchanged; `rue-air` and `rue-compiler` build; fmt clean.

Fixes RUE-520

🤖 Generated with [Claude Code](https://claude.com/claude-code)