### PR TITLE
RUE-516: regenerate rust-project.json from Buck (incl third-party) + add validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,19 @@ jobs:
         # shellchecks all run: blocks.
         run: docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color
 
+  rust-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate rust-project.json
+        # Rue has no Cargo workspace, so rust-project.json is THE rust-analyzer
+        # model. It drifted silently before (referenced a deleted crate, omitted
+        # live ones), misdirecting anyone opening the repo in an IDE (RUE-516).
+        # Pure-filesystem check, no Buck needed; regenerate with
+        # ./gen-rust-project.sh when it complains.
+        run: python3 scripts/validate-rust-project.py
+
   test:
     strategy:
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,10 @@ scripts/rue test
 The wrappers bootstrap Buck2 and a hermetic Rust toolchain. macOS also requires
 Xcode Command Line Tools for linking Rue executables.
 
+For IDE support, rust-analyzer reads the checked-in `rust-project.json` (Rue has
+no Cargo workspace). Regenerate it with `./gen-rust-project.sh` when crates or
+dependencies change — see [docs/development.md](docs/development.md#editor--ide-support).
+
 ## Before submitting a change
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -153,9 +153,27 @@ scripts/rue fmt
 scripts/rue test
 ```
 
-CI additionally runs Clippy, workflow linting, debug tests on Linux x86-64,
-Linux AArch64, and macOS, plus a release-mode Linux suite. Fuzz, sanitizer,
-website, and benchmark workflows run separately.
+CI additionally runs Clippy, workflow linting, rust-project.json validation,
+debug tests on Linux x86-64, Linux AArch64, and macOS, plus a release-mode Linux
+suite. Fuzz, sanitizer, website, and benchmark workflows run separately.
+
+## Editor / IDE support
+
+Rue builds with Buck2, not Cargo, so rust-analyzer is driven by a checked-in
+`rust-project.json` rather than `Cargo.toml`. Point your editor's rust-analyzer
+at the repository root and it will use that file directly.
+
+Regenerate it from the Buck target graph whenever crates or dependencies change:
+
+```bash
+./gen-rust-project.sh                      # rewrites rust-project.json
+python3 scripts/validate-rust-project.py   # checks it (also a CI gate)
+```
+
+The generator models every first-party crate plus the third-party crates they
+depend on (following Buck alias/proc-macro indirection). The validator — run in
+CI — fails if the checked-in file references a missing `root_module` or omits a
+live first-party crate, so the model cannot silently drift out of date.
 
 ## Language and design changes
 

--- a/gen-rust-project.sh
+++ b/gen-rust-project.sh
@@ -1,108 +1,242 @@
 #!/usr/bin/env bash
-# Generate rust-project.json from Buck2 targets for rust-analyzer support
+# Generate rust-project.json from Buck2 targets for rust-analyzer support.
 #
 # Usage: ./gen-rust-project.sh
 #
-# This queries Buck2 for all Rust targets and generates a rust-project.json
-# file that rust-analyzer can use for IDE support.
+# Rue has no Cargo workspace, so rust-project.json IS the IDE project model, not
+# an optional fallback (RUE-516). This queries Buck2 for the first-party crates
+# AND every third-party crate they actually depend on (following Buck `alias` /
+# `transition_alias` / `rust_proc_macro_alias` indirection), so rust-analyzer
+# resolves both `crates/**` and vendored dependencies like `lasso`.
+#
+# Modeled: first-party + used third-party rust_library/rust_binary crates, their
+# dep edges, editions, feature cfgs, and proc-macro flags. Deliberately NOT
+# modeled yet (rust-analyzer degrades gracefully): the sysroot source
+# (`sysroot_src` is null; rust-analyzer falls back to `rustc --print sysroot`)
+# and proc-macro dylib paths (macros resolve as crates but are not expanded).
+# The model targets the default host platform. After regenerating, run
+# `python3 scripts/validate-rust-project.py` (also a CI gate).
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-echo "Querying Buck2 for Rust targets..."
-# Guard the query status and preserve its stderr on failure: the old
-# `2>/dev/null` left a Buck error silent, then Python failed downstream on an
-# empty/partial JSON file with an unrelated traceback (RUE-550).
+targets_json="$(mktemp)"
 gen_err="$(mktemp)"
-trap 'rm -f "$gen_err"' EXIT
+trap 'rm -f "$targets_json" "$gen_err"' EXIT
+
+echo "Querying Buck2 for Rust targets (first-party + third-party)..."
+# Guard the query status and preserve its stderr on failure: a swallowed Buck
+# error used to surface downstream as an unrelated Python traceback on an
+# empty/partial JSON file (RUE-550).
 gen_status=0
-./buck2 targets //crates/... --json 2>"$gen_err" > /tmp/buck_targets.json \
+./buck2 targets //crates/... //third-party/... --json 2>"$gen_err" > "$targets_json" \
     || gen_status=$?
 if [ "$gen_status" -ne 0 ]; then
-    echo "gen-rust-project.sh: 'buck2 targets //crates/...' failed (exit $gen_status):" >&2
+    echo "gen-rust-project.sh: 'buck2 targets //crates/... //third-party/...' failed (exit $gen_status):" >&2
     cat "$gen_err" >&2
     exit "$gen_status"
 fi
 
 echo "Generating rust-project.json..."
-python3 << 'EOF'
+python3 - "$targets_json" << 'EOF'
 import json
 import os
+import sys
 
-with open('/tmp/buck_targets.json') as f:
+with open(sys.argv[1]) as f:
     targets = json.load(f)
 
-root = os.getcwd()
+# Index every target by its full label so we can resolve dep/alias references.
+by_label = {}
+for t in targets:
+    label = f"{t.get('buck.package', '')}:{t.get('name', '')}"
+    by_label[label] = t
 
-# Build crate index
+
+def kind(t):
+    # buck.type looks like "prelude//rules.bzl:rust_library".
+    return t.get("buck.type", "").split(":")[-1]
+
+
+ALIAS_KINDS = {"alias", "transition_alias", "configured_alias"}
+
+
+def is_build_script(name):
+    return "build-script" in name
+
+
+def to_repo_path(t, p):
+    """Resolve a target src/crate_root to a repo-root-relative path. Buck gives
+    these either as full `root//...` labels or relative to the target's package
+    (third-party `crate_root`), so handle both."""
+    if p.startswith("root//"):
+        return p[len("root//"):]
+    pkg = t.get("buck.package", "").replace("root//", "")
+    return f"{pkg}/{p}" if pkg else p
+
+
+def resolve_concrete(label, seen=None):
+    """Follow alias chains to the concrete target label, or None.
+
+    Proc-macro deps go through a `rust_proc_macro_alias` (which points at the
+    real library via `actual_plugin`, not `actual`), usually behind a plain
+    `alias` first: e.g. `:logos-derive` (alias) -> `:logos-derive-0.14.4`
+    (proc_macro_alias) -> `:_logos-derive-0.14.4` (the real rust_library)."""
+    seen = seen or set()
+    if label in seen:
+        return None
+    seen.add(label)
+    t = by_label.get(label)
+    if t is None:
+        return None
+    k = kind(t)
+    if k == "rust_proc_macro_alias":
+        nxt = t.get("actual_plugin") or t.get("actual_exec")
+        return resolve_concrete(nxt, seen) if nxt else None
+    if k in ALIAS_KINDS:
+        actual = t.get("actual")
+        return resolve_concrete(actual, seen) if actual else None
+    return label
+
+
+def is_crate(t):
+    if kind(t) not in ("rust_library", "rust_binary"):
+        return False
+    return not is_build_script(t.get("name", ""))
+
+
+def is_first_party(label):
+    return label.startswith("root//crates/")
+
+
+# Closure: start from first-party crates, walk deps (resolving aliases), and
+# collect every concrete crate reached. This naturally pulls in the third-party
+# crates actually used and skips unused vendored packages and build scripts.
+wanted = {}
+queue = [lbl for lbl, t in by_label.items() if is_first_party(lbl) and is_crate(t)]
+while queue:
+    concrete = resolve_concrete(queue.pop())
+    if concrete is None:
+        continue
+    t = by_label.get(concrete)
+    if t is None or not is_crate(t) or concrete in wanted:
+        continue
+    wanted[concrete] = t
+    queue.extend(t.get("deps", []))
+
+
+def crate_name(t):
+    # The name used in `use <crate>` — the `crate` attribute (e.g. lasso-0.7.3 →
+    # "lasso"), falling back to the sanitized target name.
+    return t.get("crate") or t.get("name", "").replace("-", "_")
+
+
+def root_module(t):
+    cr = t.get("crate_root")
+    if cr:
+        return to_repo_path(t, cr)
+    lib = main = first = None
+    for s in t.get("srcs", []):
+        sp = to_repo_path(t, s)
+        if sp.endswith("lib.rs") and lib is None:
+            lib = sp
+        elif sp.endswith("main.rs") and main is None:
+            main = sp
+        elif first is None:
+            first = sp
+    return lib or main or first
+
+
+# Deterministic ordering so the checked-in file is stable across runs.
+labels = sorted(wanted)
+index = {lbl: i for i, lbl in enumerate(labels)}
+
 crates = []
-crate_name_to_idx = {}
-
-for target in targets:
-    ttype = target.get('buck.type', '')
-    name = target.get('name', '')
-
-    if 'rust_library' in ttype or 'rust_binary' in ttype:
-        if not name.endswith('-test'):
-            crate_name_to_idx[name] = len(crates)
-            crates.append(target)
-
-rust_project = {
-    "sysroot_src": None,
-    "crates": []
-}
-
-for idx, target in enumerate(crates):
-    name = target.get('name', '')
-    srcs = target.get('srcs', [])
-    deps = target.get('deps', [])
-
-    # Find crate root
-    root_file = None
-    for src in srcs:
-        src_path = src.replace('root//', '')
-        if src_path.endswith('lib.rs') or src_path.endswith('main.rs'):
-            root_file = src_path
-            break
-
-    if not root_file and srcs:
-        root_file = srcs[0].replace('root//', '')
-
-    if not root_file:
+for lbl in labels:
+    t = wanted[lbl]
+    rm = root_module(t)
+    if not rm:
         continue
 
-    # Convert deps to indices
-    dep_indices = []
-    for dep in deps:
-        if dep.startswith('root//'):
-            dep_name = dep.split(':')[-1]
-            if dep_name in crate_name_to_idx:
-                dep_indices.append({"crate": crate_name_to_idx[dep_name], "name": dep_name.replace('-', '_')})
+    dep_entries = []
+    seen = set()
+    for d in t.get("deps", []):
+        c = resolve_concrete(d)
+        if c is None or c == lbl or c not in index or c in seen:
+            continue
+        seen.add(c)
+        dep_entries.append({"crate": index[c], "name": crate_name(wanted[c])})
 
-    # Use relative paths - rust-analyzer resolves them relative to rust-project.json
-    rust_project["crates"].append({
-        "display_name": name,
-        "root_module": root_file,
-        "edition": "2024",
-        "deps": dep_indices,
+    cfg = ["test", "debug_assertions"]
+    cfg += [f'feature="{feat}"' for feat in t.get("features", [])]
+
+    crates.append({
+        "display_name": t.get("name", ""),
+        "root_module": rm,
+        "edition": t.get("edition") or "2024",
+        "deps": sorted(dep_entries, key=lambda d: d["crate"]),
+        "is_workspace_member": is_first_party(lbl),
+        "source": {"include_dirs": [os.path.dirname(rm)], "exclude_dirs": []},
+        "cfg": cfg,
+        "env": {},
+        "is_proc_macro": bool(t.get("proc_macro")),
+    })
+
+# Some first-party crates live outside the Buck graph as standalone Cargo crates
+# (e.g. rue-runtime-asan, the sanitizer harness — RUE-560). Buck cannot see them,
+# but a contributor still edits them, so add a minimal entry for any crates/<dir>
+# with a lib.rs/main.rs that the Buck closure did not already cover. They carry no
+# resolved dep edges, but their source is at least indexed.
+covered_dirs = set()
+for c in crates:
+    parts = c["root_module"].split("/")
+    if len(parts) >= 2 and parts[0] == "crates":
+        covered_dirs.add(parts[1])
+
+for entry in sorted(os.listdir("crates")):
+    directory = os.path.join("crates", entry)
+    if not os.path.isdir(directory) or entry in covered_dirs:
+        continue
+    rm = next(
+        (f"crates/{entry}/{cand}" for cand in ("src/lib.rs", "src/main.rs")
+         if os.path.exists(os.path.join(directory, cand))),
+        None,
+    )
+    if rm is None:
+        continue
+    edition = "2024"
+    cargo = os.path.join(directory, "Cargo.toml")
+    if os.path.exists(cargo):
+        for line in open(cargo):
+            stripped = line.strip()
+            if stripped.startswith("edition"):
+                edition = stripped.split("=", 1)[1].strip().strip('"') or edition
+                break
+    crates.append({
+        "display_name": entry,
+        "root_module": rm,
+        "edition": edition,
+        "deps": [],
         "is_workspace_member": True,
-        "source": {
-            "include_dirs": [os.path.dirname(root_file)],
-            "exclude_dirs": []
-        },
-        "cfg": [],
+        "source": {"include_dirs": [os.path.dirname(rm)], "exclude_dirs": []},
+        "cfg": ["test", "debug_assertions"],
         "env": {},
         "is_proc_macro": False,
     })
 
-with open(os.path.join(root, 'rust-project.json'), 'w') as f:
+rust_project = {"sysroot_src": None, "crates": crates}
+with open("rust-project.json", "w") as f:
     json.dump(rust_project, f, indent=2)
-    f.write('\n')
+    f.write("\n")
 
-print(f"Generated rust-project.json with {len(rust_project['crates'])} crates")
+first_party = sum(1 for c in crates if c["is_workspace_member"])
+print(
+    f"Generated rust-project.json: {len(crates)} crates "
+    f"({first_party} first-party, {len(crates) - first_party} third-party)"
+)
 EOF
 
-echo "Done! rust-analyzer should now work with this project."
+echo "Done. Validate with: python3 scripts/validate-rust-project.py"
 echo "You may need to restart rust-analyzer or reload your IDE."

--- a/rust-project.json
+++ b/rust-project.json
@@ -2,62 +2,45 @@
   "sysroot_src": null,
   "crates": [
     {
-      "display_name": "rue",
-      "root_module": "crates/rue/src/main.rs",
-      "edition": "2024",
-      "deps": [
-        {
-          "crate": 4,
-          "name": "rue_compiler"
-        },
-        {
-          "crate": 10,
-          "name": "rue_rir"
-        },
-        {
-          "crate": 14,
-          "name": "rue_target"
-        }
-      ],
-      "is_workspace_member": true,
-      "source": {
-        "include_dirs": [
-          "crates/rue/src"
-        ],
-        "exclude_dirs": []
-      },
-      "cfg": [],
-      "env": {},
-      "is_proc_macro": false
-    },
-    {
       "display_name": "rue-air",
       "root_module": "crates/rue-air/src/lib.rs",
       "edition": "2024",
       "deps": [
         {
-          "crate": 5,
-          "name": "rue_error"
+          "crate": 1,
+          "name": "rue_builtins"
         },
         {
           "crate": 6,
-          "name": "rue_intern"
+          "name": "rue_error"
         },
         {
-          "crate": 7,
+          "crate": 8,
           "name": "rue_lexer"
         },
         {
-          "crate": 9,
+          "crate": 12,
           "name": "rue_parser"
         },
         {
-          "crate": 10,
+          "crate": 13,
           "name": "rue_rir"
         },
         {
-          "crate": 12,
+          "crate": 15,
           "name": "rue_span"
+        },
+        {
+          "crate": 17,
+          "name": "rue_target"
+        },
+        {
+          "crate": 54,
+          "name": "lasso"
+        },
+        {
+          "crate": 84,
+          "name": "rayon"
         }
       ],
       "is_workspace_member": true,
@@ -67,7 +50,29 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-builtins",
+      "root_module": "crates/rue-builtins/src/lib.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-builtins/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -77,16 +82,20 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 1,
+          "crate": 0,
           "name": "rue_air"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_error"
         },
         {
-          "crate": 12,
+          "crate": 15,
           "name": "rue_span"
+        },
+        {
+          "crate": 54,
+          "name": "lasso"
         }
       ],
       "is_workspace_member": true,
@@ -96,7 +105,50 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-cli-tests",
+      "root_module": "crates/rue-cli-tests/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 18,
+          "name": "rue_test_runner"
+        },
+        {
+          "crate": 63,
+          "name": "libtest2_mimic"
+        },
+        {
+          "crate": 90,
+          "name": "serde"
+        },
+        {
+          "crate": 98,
+          "name": "tempfile"
+        },
+        {
+          "crate": 101,
+          "name": "toml"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-cli-tests/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -106,24 +158,36 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 1,
+          "crate": 0,
           "name": "rue_air"
+        },
+        {
+          "crate": 1,
+          "name": "rue_builtins"
         },
         {
           "crate": 2,
           "name": "rue_cfg"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_error"
         },
         {
-          "crate": 12,
+          "crate": 15,
           "name": "rue_span"
         },
         {
-          "crate": 14,
+          "crate": 17,
           "name": "rue_target"
+        },
+        {
+          "crate": 44,
+          "name": "fixedbitset"
+        },
+        {
+          "crate": 54,
+          "name": "lasso"
         }
       ],
       "is_workspace_member": true,
@@ -133,7 +197,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -143,7 +210,7 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 1,
+          "crate": 0,
           "name": "rue_air"
         },
         {
@@ -151,40 +218,56 @@
           "name": "rue_cfg"
         },
         {
-          "crate": 3,
+          "crate": 4,
           "name": "rue_codegen"
         },
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_error"
         },
         {
-          "crate": 6,
-          "name": "rue_intern"
-        },
-        {
-          "crate": 7,
+          "crate": 8,
           "name": "rue_lexer"
         },
         {
-          "crate": 8,
+          "crate": 9,
           "name": "rue_linker"
         },
         {
-          "crate": 9,
+          "crate": 12,
           "name": "rue_parser"
         },
         {
-          "crate": 10,
+          "crate": 13,
           "name": "rue_rir"
         },
         {
-          "crate": 12,
+          "crate": 15,
           "name": "rue_span"
         },
         {
-          "crate": 14,
+          "crate": 17,
           "name": "rue_target"
+        },
+        {
+          "crate": 28,
+          "name": "annotate_snippets"
+        },
+        {
+          "crate": 54,
+          "name": "lasso"
+        },
+        {
+          "crate": 84,
+          "name": "rayon"
+        },
+        {
+          "crate": 92,
+          "name": "serde_json"
+        },
+        {
+          "crate": 105,
+          "name": "tracing"
         }
       ],
       "is_workspace_member": true,
@@ -194,7 +277,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -204,8 +290,12 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 12,
+          "crate": 15,
           "name": "rue_span"
+        },
+        {
+          "crate": 99,
+          "name": "thiserror"
         }
       ],
       "is_workspace_member": true,
@@ -215,23 +305,58 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
     {
-      "display_name": "rue-intern",
-      "root_module": "crates/rue-intern/src/lib.rs",
+      "display_name": "rue-fuzz",
+      "root_module": "crates/rue-fuzz/src/main.rs",
       "edition": "2024",
-      "deps": [],
+      "deps": [
+        {
+          "crate": 4,
+          "name": "rue_codegen"
+        },
+        {
+          "crate": 5,
+          "name": "rue_compiler"
+        },
+        {
+          "crate": 8,
+          "name": "rue_lexer"
+        },
+        {
+          "crate": 12,
+          "name": "rue_parser"
+        },
+        {
+          "crate": 31,
+          "name": "anyhow"
+        },
+        {
+          "crate": 59,
+          "name": "libc"
+        },
+        {
+          "crate": 77,
+          "name": "proptest"
+        }
+      ],
       "is_workspace_member": true,
       "source": {
         "include_dirs": [
-          "crates/rue-intern/src"
+          "crates/rue-fuzz/src"
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -241,12 +366,20 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_error"
         },
         {
-          "crate": 12,
+          "crate": 15,
           "name": "rue_span"
+        },
+        {
+          "crate": 54,
+          "name": "lasso"
+        },
+        {
+          "crate": 66,
+          "name": "logos"
         }
       ],
       "is_workspace_member": true,
@@ -256,7 +389,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -266,8 +402,12 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 14,
+          "crate": 17,
           "name": "rue_target"
+        },
+        {
+          "crate": 105,
+          "name": "tracing"
         }
       ],
       "is_workspace_member": true,
@@ -277,7 +417,86 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-oracle-diff",
+      "root_module": "crates/rue-oracle-diff/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 6,
+          "name": "rue_error"
+        },
+        {
+          "crate": 11,
+          "name": "rue_oracle"
+        },
+        {
+          "crate": 18,
+          "name": "rue_test_runner"
+        },
+        {
+          "crate": 90,
+          "name": "serde"
+        },
+        {
+          "crate": 101,
+          "name": "toml"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-oracle-diff/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-oracle",
+      "root_module": "crates/rue-oracle/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 0,
+          "name": "rue_air"
+        },
+        {
+          "crate": 2,
+          "name": "rue_cfg"
+        },
+        {
+          "crate": 5,
+          "name": "rue_compiler"
+        },
+        {
+          "crate": 54,
+          "name": "lasso"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-oracle/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -287,16 +506,28 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 5,
+          "crate": 6,
           "name": "rue_error"
         },
         {
-          "crate": 7,
+          "crate": 8,
           "name": "rue_lexer"
         },
         {
-          "crate": 12,
+          "crate": 15,
           "name": "rue_span"
+        },
+        {
+          "crate": 37,
+          "name": "chumsky"
+        },
+        {
+          "crate": 54,
+          "name": "lasso"
+        },
+        {
+          "crate": 95,
+          "name": "smallvec"
         }
       ],
       "is_workspace_member": true,
@@ -306,7 +537,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -316,20 +550,20 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 6,
-          "name": "rue_intern"
-        },
-        {
-          "crate": 7,
+          "crate": 8,
           "name": "rue_lexer"
         },
         {
-          "crate": 9,
+          "crate": 12,
           "name": "rue_parser"
         },
         {
-          "crate": 12,
+          "crate": 15,
           "name": "rue_span"
+        },
+        {
+          "crate": 54,
+          "name": "lasso"
         }
       ],
       "is_workspace_member": true,
@@ -339,7 +573,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -355,7 +592,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -371,7 +611,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -381,8 +624,20 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 15,
+          "crate": 18,
           "name": "rue_test_runner"
+        },
+        {
+          "crate": 63,
+          "name": "libtest2_mimic"
+        },
+        {
+          "crate": 98,
+          "name": "tempfile"
+        },
+        {
+          "crate": 101,
+          "name": "toml"
         }
       ],
       "is_workspace_member": true,
@@ -392,7 +647,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -408,7 +666,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -416,7 +677,32 @@
       "display_name": "rue-test-runner",
       "root_module": "crates/rue-test-runner/src/lib.rs",
       "edition": "2024",
-      "deps": [],
+      "deps": [
+        {
+          "crate": 6,
+          "name": "rue_error"
+        },
+        {
+          "crate": 17,
+          "name": "rue_target"
+        },
+        {
+          "crate": 59,
+          "name": "libc"
+        },
+        {
+          "crate": 90,
+          "name": "serde"
+        },
+        {
+          "crate": 98,
+          "name": "tempfile"
+        },
+        {
+          "crate": 101,
+          "name": "toml"
+        }
+      ],
       "is_workspace_member": true,
       "source": {
         "include_dirs": [
@@ -424,7 +710,10 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     },
@@ -434,8 +723,12 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 15,
+          "crate": 18,
           "name": "rue_test_runner"
+        },
+        {
+          "crate": 63,
+          "name": "libtest2_mimic"
         }
       ],
       "is_workspace_member": true,
@@ -445,7 +738,2740 @@
         ],
         "exclude_dirs": []
       },
-      "cfg": [],
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue",
+      "root_module": "crates/rue/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 5,
+          "name": "rue_compiler"
+        },
+        {
+          "crate": 13,
+          "name": "rue_rir"
+        },
+        {
+          "crate": 17,
+          "name": "rue_target"
+        },
+        {
+          "crate": 59,
+          "name": "libc"
+        },
+        {
+          "crate": 90,
+          "name": "serde"
+        },
+        {
+          "crate": 92,
+          "name": "serde_json"
+        },
+        {
+          "crate": 105,
+          "name": "tracing"
+        },
+        {
+          "crate": 109,
+          "name": "tracing_subscriber"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "_logos-derive-0.14.4",
+      "root_module": "third-party/vendor/logos-derive-0.14.4/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 67,
+          "name": "logos_codegen"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/logos-derive-0.14.4/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": true
+    },
+    {
+      "display_name": "_serde_derive-1.0.228",
+      "root_module": "third-party/vendor/serde_derive-1.0.228/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 76,
+          "name": "proc_macro2"
+        },
+        {
+          "crate": 79,
+          "name": "quote"
+        },
+        {
+          "crate": 97,
+          "name": "syn"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/serde_derive-1.0.228/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\""
+      ],
+      "env": {},
+      "is_proc_macro": true
+    },
+    {
+      "display_name": "_thiserror-impl-2.0.17",
+      "root_module": "third-party/vendor/thiserror-impl-2.0.17/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 76,
+          "name": "proc_macro2"
+        },
+        {
+          "crate": 79,
+          "name": "quote"
+        },
+        {
+          "crate": 97,
+          "name": "syn"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/thiserror-impl-2.0.17/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": true
+    },
+    {
+      "display_name": "_tracing-attributes-0.1.31",
+      "root_module": "third-party/vendor/tracing-attributes-0.1.31/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 76,
+          "name": "proc_macro2"
+        },
+        {
+          "crate": 79,
+          "name": "quote"
+        },
+        {
+          "crate": 97,
+          "name": "syn"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/tracing-attributes-0.1.31/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": true
+    },
+    {
+      "display_name": "ahash-0.8.12",
+      "root_module": "third-party/vendor/ahash-0.8.12/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 36,
+          "name": "cfg_if"
+        },
+        {
+          "crate": 72,
+          "name": "once_cell"
+        },
+        {
+          "crate": 116,
+          "name": "zerocopy"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/ahash-0.8.12/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "aho-corasick-1.1.4",
+      "root_module": "third-party/vendor/aho-corasick-1.1.4/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 69,
+          "name": "memchr"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/aho-corasick-1.1.4/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"perf-literal\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "allocator-api2-0.2.21",
+      "root_module": "third-party/vendor/allocator-api2-0.2.21/src/lib.rs",
+      "edition": "2018",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/allocator-api2-0.2.21/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "annotate-snippets-0.11.5",
+      "root_module": "third-party/vendor/annotate-snippets-0.11.5/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 30,
+          "name": "anstyle"
+        },
+        {
+          "crate": 113,
+          "name": "unicode_width"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/annotate-snippets-0.11.5/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "anstream-0.6.21",
+      "root_module": "third-party/vendor/anstream-0.6.21/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/anstream-0.6.21/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"auto\"",
+        "feature=\"default\"",
+        "feature=\"wincon\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "anstyle-1.0.13",
+      "root_module": "third-party/vendor/anstyle-1.0.13/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/anstyle-1.0.13/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "anyhow-1.0.100",
+      "root_module": "third-party/vendor/anyhow-1.0.100/src/lib.rs",
+      "edition": "2018",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/anyhow-1.0.100/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "beef-0.5.2",
+      "root_module": "third-party/vendor/beef-0.5.2/src/lib.rs",
+      "edition": "2018",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/beef-0.5.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "bit-set-0.8.0",
+      "root_module": "third-party/vendor/bit-set-0.8.0/src/lib.rs",
+      "edition": "2015",
+      "deps": [
+        {
+          "crate": 34,
+          "name": "bit_vec"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/bit-set-0.8.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "bit-vec-0.8.0",
+      "root_module": "third-party/vendor/bit-vec-0.8.0/src/lib.rs",
+      "edition": "2015",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/bit-vec-0.8.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "bitflags-2.10.0",
+      "root_module": "third-party/vendor/bitflags-2.10.0/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/bitflags-2.10.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"__type\"",
+        "feature=\"entries\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "cfg-if-1.0.4",
+      "root_module": "third-party/vendor/cfg-if-1.0.4/src/lib.rs",
+      "edition": "2018",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/cfg-if-1.0.4/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "chumsky-1.0.0-alpha.8",
+      "root_module": "third-party/vendor/chumsky-1.0.0-alpha.8/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 49,
+          "name": "hashbrown"
+        },
+        {
+          "crate": 96,
+          "name": "stacker"
+        },
+        {
+          "crate": 111,
+          "name": "unicode_ident"
+        },
+        {
+          "crate": 112,
+          "name": "unicode_segmentation"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/chumsky-1.0.0-alpha.8/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"pratt\"",
+        "feature=\"stacker\"",
+        "feature=\"std\"",
+        "feature=\"unstable\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "crossbeam-deque-0.8.6",
+      "root_module": "third-party/vendor/crossbeam-deque-0.8.6/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 39,
+          "name": "crossbeam_epoch"
+        },
+        {
+          "crate": 40,
+          "name": "crossbeam_utils"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/crossbeam-deque-0.8.6/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "crossbeam-epoch-0.9.18",
+      "root_module": "third-party/vendor/crossbeam-epoch-0.9.18/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 40,
+          "name": "crossbeam_utils"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/crossbeam-epoch-0.9.18/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "crossbeam-utils-0.8.21",
+      "root_module": "third-party/vendor/crossbeam-utils-0.8.21/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/crossbeam-utils-0.8.21/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "dashmap-6.1.0",
+      "root_module": "third-party/vendor/dashmap-6.1.0/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 36,
+          "name": "cfg_if"
+        },
+        {
+          "crate": 40,
+          "name": "crossbeam_utils"
+        },
+        {
+          "crate": 48,
+          "name": "hashbrown"
+        },
+        {
+          "crate": 64,
+          "name": "lock_api"
+        },
+        {
+          "crate": 72,
+          "name": "once_cell"
+        },
+        {
+          "crate": 73,
+          "name": "parking_lot_core"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/dashmap-6.1.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"raw-api\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "either-1.15.0",
+      "root_module": "third-party/vendor/either-1.15.0/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/either-1.15.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "equivalent-1.0.2",
+      "root_module": "third-party/vendor/equivalent-1.0.2/src/lib.rs",
+      "edition": "2015",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/equivalent-1.0.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "fixedbitset-0.5.7",
+      "root_module": "third-party/vendor/fixedbitset-0.5.7/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/fixedbitset-0.5.7/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "fnv-1.0.7",
+      "root_module": "third-party/vendor/fnv-1.0.7/lib.rs",
+      "edition": "2015",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/fnv-1.0.7"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "foldhash-0.1.5",
+      "root_module": "third-party/vendor/foldhash-0.1.5/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/foldhash-0.1.5/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "getrandom-0.3.4",
+      "root_module": "third-party/vendor/getrandom-0.3.4/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/getrandom-0.3.4/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "hashbrown-0.14.5",
+      "root_module": "third-party/vendor/hashbrown-0.14.5/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 25,
+          "name": "ahash"
+        },
+        {
+          "crate": 27,
+          "name": "allocator_api2"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/hashbrown-0.14.5/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"ahash\"",
+        "feature=\"allocator-api2\"",
+        "feature=\"default\"",
+        "feature=\"inline-more\"",
+        "feature=\"raw\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "hashbrown-0.15.5",
+      "root_module": "third-party/vendor/hashbrown-0.15.5/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 27,
+          "name": "allocator_api2"
+        },
+        {
+          "crate": 43,
+          "name": "equivalent"
+        },
+        {
+          "crate": 46,
+          "name": "foldhash"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/hashbrown-0.15.5/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"allocator-api2\"",
+        "feature=\"default\"",
+        "feature=\"default-hasher\"",
+        "feature=\"equivalent\"",
+        "feature=\"inline-more\"",
+        "feature=\"raw-entry\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "hashbrown-0.16.1",
+      "root_module": "third-party/vendor/hashbrown-0.16.1/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/hashbrown-0.16.1/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "indexmap-2.12.1",
+      "root_module": "third-party/vendor/indexmap-2.12.1/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 43,
+          "name": "equivalent"
+        },
+        {
+          "crate": 50,
+          "name": "hashbrown"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/indexmap-2.12.1/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "itoa-1.0.16",
+      "root_module": "third-party/vendor/itoa-1.0.16/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/itoa-1.0.16/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "json-write-0.0.2",
+      "root_module": "third-party/vendor/json-write-0.0.2/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/json-write-0.0.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\"",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "lasso-0.7.3",
+      "root_module": "third-party/vendor/lasso-0.7.3/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 41,
+          "name": "dashmap"
+        },
+        {
+          "crate": 48,
+          "name": "hashbrown"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/lasso-0.7.3/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"dashmap\"",
+        "feature=\"default\"",
+        "feature=\"multi-threaded\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "lazy_static-1.5.0",
+      "root_module": "third-party/vendor/lazy_static-1.5.0/src/lib.rs",
+      "edition": "2015",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/lazy_static-1.5.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "lexarg-0.0.2",
+      "root_module": "third-party/vendor/lexarg-0.0.2/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 57,
+          "name": "lexarg_error"
+        },
+        {
+          "crate": 58,
+          "name": "lexarg_parser"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/lexarg-0.0.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "lexarg-error-0.0.2",
+      "root_module": "third-party/vendor/lexarg-error-0.0.2/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 58,
+          "name": "lexarg_parser"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/lexarg-error-0.0.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "lexarg-parser-0.0.2",
+      "root_module": "third-party/vendor/lexarg-parser-0.0.2/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/lexarg-parser-0.0.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "libc-0.2.178",
+      "root_module": "third-party/vendor/libc-0.2.178/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/libc-0.2.178/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "libtest-json-0.0.2",
+      "root_module": "third-party/vendor/libtest-json-0.0.2/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 53,
+          "name": "json_write"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/libtest-json-0.0.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"json\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "libtest-lexarg-0.0.3",
+      "root_module": "third-party/vendor/libtest-lexarg-0.0.3/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 56,
+          "name": "lexarg"
+        },
+        {
+          "crate": 57,
+          "name": "lexarg_error"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/libtest-lexarg-0.0.3/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "libtest2-harness-0.0.3",
+      "root_module": "third-party/vendor/libtest2-harness-0.0.3/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 29,
+          "name": "anstream"
+        },
+        {
+          "crate": 30,
+          "name": "anstyle"
+        },
+        {
+          "crate": 57,
+          "name": "lexarg_error"
+        },
+        {
+          "crate": 58,
+          "name": "lexarg_parser"
+        },
+        {
+          "crate": 60,
+          "name": "libtest_json"
+        },
+        {
+          "crate": 61,
+          "name": "libtest_lexarg"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/libtest2-harness-0.0.3/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"color\"",
+        "feature=\"default\"",
+        "feature=\"threads\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "libtest2-mimic-0.0.4",
+      "root_module": "third-party/vendor/libtest2-mimic-0.0.4/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 60,
+          "name": "libtest_json"
+        },
+        {
+          "crate": 62,
+          "name": "libtest2_harness"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/libtest2-mimic-0.0.4/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"color\"",
+        "feature=\"default\"",
+        "feature=\"threads\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "lock_api-0.4.14",
+      "root_module": "third-party/vendor/lock_api-0.4.14/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 89,
+          "name": "scopeguard"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/lock_api-0.4.14/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"atomic_usize\"",
+        "feature=\"default\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "log-0.4.29",
+      "root_module": "third-party/vendor/log-0.4.29/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/log-0.4.29/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "logos-0.14.4",
+      "root_module": "third-party/vendor/logos-0.14.4/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 21,
+          "name": "logos_derive"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/logos-0.14.4/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"export_derive\"",
+        "feature=\"logos-derive\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "logos-codegen-0.14.4",
+      "root_module": "third-party/vendor/logos-codegen-0.14.4/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 32,
+          "name": "beef"
+        },
+        {
+          "crate": 45,
+          "name": "fnv"
+        },
+        {
+          "crate": 55,
+          "name": "lazy_static"
+        },
+        {
+          "crate": 76,
+          "name": "proc_macro2"
+        },
+        {
+          "crate": 79,
+          "name": "quote"
+        },
+        {
+          "crate": 87,
+          "name": "regex_syntax"
+        },
+        {
+          "crate": 97,
+          "name": "syn"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/logos-codegen-0.14.4/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "matchers-0.2.0",
+      "root_module": "third-party/vendor/matchers-0.2.0/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 86,
+          "name": "regex_automata"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/matchers-0.2.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "memchr-2.7.6",
+      "root_module": "third-party/vendor/memchr-2.7.6/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/memchr-2.7.6/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "nu-ansi-term-0.50.3",
+      "root_module": "third-party/vendor/nu-ansi-term-0.50.3/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/nu-ansi-term-0.50.3/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "num-traits-0.2.19",
+      "root_module": "third-party/vendor/num-traits-0.2.19/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/num-traits-0.2.19/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "once_cell-1.21.3",
+      "root_module": "third-party/vendor/once_cell-1.21.3/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/once_cell-1.21.3/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\"",
+        "feature=\"default\"",
+        "feature=\"race\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "parking_lot_core-0.9.12",
+      "root_module": "third-party/vendor/parking_lot_core-0.9.12/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/parking_lot_core-0.9.12/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "pin-project-lite-0.2.16",
+      "root_module": "third-party/vendor/pin-project-lite-0.2.16/src/lib.rs",
+      "edition": "2018",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/pin-project-lite-0.2.16/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "ppv-lite86-0.2.21",
+      "root_module": "third-party/vendor/ppv-lite86-0.2.21/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 116,
+          "name": "zerocopy"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/ppv-lite86-0.2.21/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"simd\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "proc-macro2-1.0.103",
+      "root_module": "third-party/vendor/proc-macro2-1.0.103/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 111,
+          "name": "unicode_ident"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/proc-macro2-1.0.103/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"proc-macro\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "proptest-1.9.0",
+      "root_module": "third-party/vendor/proptest-1.9.0/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 33,
+          "name": "bit_set"
+        },
+        {
+          "crate": 34,
+          "name": "bit_vec"
+        },
+        {
+          "crate": 35,
+          "name": "bitflags"
+        },
+        {
+          "crate": 71,
+          "name": "num_traits"
+        },
+        {
+          "crate": 80,
+          "name": "rand"
+        },
+        {
+          "crate": 81,
+          "name": "rand_chacha"
+        },
+        {
+          "crate": 83,
+          "name": "rand_xorshift"
+        },
+        {
+          "crate": 87,
+          "name": "regex_syntax"
+        },
+        {
+          "crate": 88,
+          "name": "rusty_fork"
+        },
+        {
+          "crate": 98,
+          "name": "tempfile"
+        },
+        {
+          "crate": 110,
+          "name": "unarray"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/proptest-1.9.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"bit-set\"",
+        "feature=\"default\"",
+        "feature=\"fork\"",
+        "feature=\"regex-syntax\"",
+        "feature=\"rusty-fork\"",
+        "feature=\"std\"",
+        "feature=\"tempfile\"",
+        "feature=\"timeout\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "quick-error-1.2.3",
+      "root_module": "third-party/vendor/quick-error-1.2.3/src/lib.rs",
+      "edition": "2015",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/quick-error-1.2.3/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "quote-1.0.42",
+      "root_module": "third-party/vendor/quote-1.0.42/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 76,
+          "name": "proc_macro2"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/quote-1.0.42/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"proc-macro\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rand-0.9.2",
+      "root_module": "third-party/vendor/rand-0.9.2/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 82,
+          "name": "rand_core"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/rand-0.9.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\"",
+        "feature=\"os_rng\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rand_chacha-0.9.0",
+      "root_module": "third-party/vendor/rand_chacha-0.9.0/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 75,
+          "name": "ppv_lite86"
+        },
+        {
+          "crate": 82,
+          "name": "rand_core"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/rand_chacha-0.9.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rand_core-0.9.3",
+      "root_module": "third-party/vendor/rand_core-0.9.3/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 47,
+          "name": "getrandom"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/rand_core-0.9.3/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"os_rng\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rand_xorshift-0.4.0",
+      "root_module": "third-party/vendor/rand_xorshift-0.4.0/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 82,
+          "name": "rand_core"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/rand_xorshift-0.4.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rayon-1.11.0",
+      "root_module": "third-party/vendor/rayon-1.11.0/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 42,
+          "name": "either"
+        },
+        {
+          "crate": 85,
+          "name": "rayon_core"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/rayon-1.11.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rayon-core-1.13.0",
+      "root_module": "third-party/vendor/rayon-core-1.13.0/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 38,
+          "name": "crossbeam_deque"
+        },
+        {
+          "crate": 40,
+          "name": "crossbeam_utils"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/rayon-core-1.13.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "regex-automata-0.4.13",
+      "root_module": "third-party/vendor/regex-automata-0.4.13/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 26,
+          "name": "aho_corasick"
+        },
+        {
+          "crate": 69,
+          "name": "memchr"
+        },
+        {
+          "crate": 87,
+          "name": "regex_syntax"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/regex-automata-0.4.13/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\"",
+        "feature=\"dfa-build\"",
+        "feature=\"dfa-onepass\"",
+        "feature=\"dfa-search\"",
+        "feature=\"hybrid\"",
+        "feature=\"meta\"",
+        "feature=\"nfa-backtrack\"",
+        "feature=\"nfa-pikevm\"",
+        "feature=\"nfa-thompson\"",
+        "feature=\"perf-inline\"",
+        "feature=\"perf-literal\"",
+        "feature=\"perf-literal-multisubstring\"",
+        "feature=\"perf-literal-substring\"",
+        "feature=\"std\"",
+        "feature=\"syntax\"",
+        "feature=\"unicode\"",
+        "feature=\"unicode-age\"",
+        "feature=\"unicode-bool\"",
+        "feature=\"unicode-case\"",
+        "feature=\"unicode-gencat\"",
+        "feature=\"unicode-perl\"",
+        "feature=\"unicode-script\"",
+        "feature=\"unicode-segment\"",
+        "feature=\"unicode-word-boundary\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "regex-syntax-0.8.8",
+      "root_module": "third-party/vendor/regex-syntax-0.8.8/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/regex-syntax-0.8.8/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\"",
+        "feature=\"unicode\"",
+        "feature=\"unicode-age\"",
+        "feature=\"unicode-bool\"",
+        "feature=\"unicode-case\"",
+        "feature=\"unicode-gencat\"",
+        "feature=\"unicode-perl\"",
+        "feature=\"unicode-script\"",
+        "feature=\"unicode-segment\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rusty-fork-0.3.1",
+      "root_module": "third-party/vendor/rusty-fork-0.3.1/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 45,
+          "name": "fnv"
+        },
+        {
+          "crate": 78,
+          "name": "quick_error"
+        },
+        {
+          "crate": 98,
+          "name": "tempfile"
+        },
+        {
+          "crate": 114,
+          "name": "wait_timeout"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/rusty-fork-0.3.1/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"timeout\"",
+        "feature=\"wait-timeout\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "scopeguard-1.2.0",
+      "root_module": "third-party/vendor/scopeguard-1.2.0/src/lib.rs",
+      "edition": "2015",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/scopeguard-1.2.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "serde-1.0.228",
+      "root_module": "third-party/vendor/serde-1.0.228/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 22,
+          "name": "serde_derive"
+        },
+        {
+          "crate": 91,
+          "name": "serde_core"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/serde-1.0.228/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"derive\"",
+        "feature=\"serde_derive\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "serde_core-1.0.228",
+      "root_module": "third-party/vendor/serde_core-1.0.228/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/serde_core-1.0.228/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"result\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "serde_json-1.0.147",
+      "root_module": "third-party/vendor/serde_json-1.0.147/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 52,
+          "name": "itoa"
+        },
+        {
+          "crate": 69,
+          "name": "memchr"
+        },
+        {
+          "crate": 91,
+          "name": "serde_core"
+        },
+        {
+          "crate": 117,
+          "name": "zmij"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/serde_json-1.0.147/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "serde_spanned-0.6.9",
+      "root_module": "third-party/vendor/serde_spanned-0.6.9/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 90,
+          "name": "serde"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/serde_spanned-0.6.9/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"serde\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "sharded-slab-0.1.7",
+      "root_module": "third-party/vendor/sharded-slab-0.1.7/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 55,
+          "name": "lazy_static"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/sharded-slab-0.1.7/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "smallvec-1.15.1",
+      "root_module": "third-party/vendor/smallvec-1.15.1/src/lib.rs",
+      "edition": "2018",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/smallvec-1.15.1/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "stacker-0.1.22",
+      "root_module": "third-party/vendor/stacker-0.1.22/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/stacker-0.1.22/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "syn-2.0.111",
+      "root_module": "third-party/vendor/syn-2.0.111/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 76,
+          "name": "proc_macro2"
+        },
+        {
+          "crate": 79,
+          "name": "quote"
+        },
+        {
+          "crate": 111,
+          "name": "unicode_ident"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/syn-2.0.111/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"clone-impls\"",
+        "feature=\"default\"",
+        "feature=\"derive\"",
+        "feature=\"extra-traits\"",
+        "feature=\"full\"",
+        "feature=\"parsing\"",
+        "feature=\"printing\"",
+        "feature=\"proc-macro\"",
+        "feature=\"visit-mut\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "tempfile-3.24.0",
+      "root_module": "third-party/vendor/tempfile-3.24.0/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/tempfile-3.24.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"getrandom\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "thiserror-2.0.17",
+      "root_module": "third-party/vendor/thiserror-2.0.17/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 23,
+          "name": "thiserror_impl"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/thiserror-2.0.17/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "thread_local-1.1.9",
+      "root_module": "third-party/vendor/thread_local-1.1.9/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 36,
+          "name": "cfg_if"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/thread_local-1.1.9/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "toml-0.8.23",
+      "root_module": "third-party/vendor/toml-0.8.23/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 90,
+          "name": "serde"
+        },
+        {
+          "crate": 93,
+          "name": "serde_spanned"
+        },
+        {
+          "crate": 102,
+          "name": "toml_datetime"
+        },
+        {
+          "crate": 103,
+          "name": "toml_edit"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/toml-0.8.23/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"display\"",
+        "feature=\"parse\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "toml_datetime-0.6.11",
+      "root_module": "third-party/vendor/toml_datetime-0.6.11/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 90,
+          "name": "serde"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/toml_datetime-0.6.11/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"serde\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "toml_edit-0.22.27",
+      "root_module": "third-party/vendor/toml_edit-0.22.27/src/lib.rs",
+      "edition": "2021",
+      "deps": [
+        {
+          "crate": 51,
+          "name": "indexmap"
+        },
+        {
+          "crate": 90,
+          "name": "serde"
+        },
+        {
+          "crate": 93,
+          "name": "serde_spanned"
+        },
+        {
+          "crate": 102,
+          "name": "toml_datetime"
+        },
+        {
+          "crate": 104,
+          "name": "toml_write"
+        },
+        {
+          "crate": 115,
+          "name": "winnow"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/toml_edit-0.22.27/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"display\"",
+        "feature=\"parse\"",
+        "feature=\"serde\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "toml_write-0.1.2",
+      "root_module": "third-party/vendor/toml_write-0.1.2/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/toml_write-0.1.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\"",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "tracing-0.1.44",
+      "root_module": "third-party/vendor/tracing-0.1.44/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 24,
+          "name": "tracing_attributes"
+        },
+        {
+          "crate": 74,
+          "name": "pin_project_lite"
+        },
+        {
+          "crate": 106,
+          "name": "tracing_core"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/tracing-0.1.44/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"attributes\"",
+        "feature=\"default\"",
+        "feature=\"std\"",
+        "feature=\"tracing-attributes\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "tracing-core-0.1.36",
+      "root_module": "third-party/vendor/tracing-core-0.1.36/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 72,
+          "name": "once_cell"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/tracing-core-0.1.36/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"default\"",
+        "feature=\"once_cell\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "tracing-log-0.2.0",
+      "root_module": "third-party/vendor/tracing-log-0.2.0/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 65,
+          "name": "log"
+        },
+        {
+          "crate": 72,
+          "name": "once_cell"
+        },
+        {
+          "crate": 106,
+          "name": "tracing_core"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/tracing-log-0.2.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"log-tracer\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "tracing-serde-0.2.0",
+      "root_module": "third-party/vendor/tracing-serde-0.2.0/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 90,
+          "name": "serde"
+        },
+        {
+          "crate": 106,
+          "name": "tracing_core"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/tracing-serde-0.2.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "tracing-subscriber-0.3.22",
+      "root_module": "third-party/vendor/tracing-subscriber-0.3.22/src/lib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 68,
+          "name": "matchers"
+        },
+        {
+          "crate": 70,
+          "name": "nu_ansi_term"
+        },
+        {
+          "crate": 72,
+          "name": "once_cell"
+        },
+        {
+          "crate": 86,
+          "name": "regex_automata"
+        },
+        {
+          "crate": 90,
+          "name": "serde"
+        },
+        {
+          "crate": 92,
+          "name": "serde_json"
+        },
+        {
+          "crate": 94,
+          "name": "sharded_slab"
+        },
+        {
+          "crate": 95,
+          "name": "smallvec"
+        },
+        {
+          "crate": 100,
+          "name": "thread_local"
+        },
+        {
+          "crate": 105,
+          "name": "tracing"
+        },
+        {
+          "crate": 106,
+          "name": "tracing_core"
+        },
+        {
+          "crate": 107,
+          "name": "tracing_log"
+        },
+        {
+          "crate": 108,
+          "name": "tracing_serde"
+        }
+      ],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/tracing-subscriber-0.3.22/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\"",
+        "feature=\"ansi\"",
+        "feature=\"default\"",
+        "feature=\"env-filter\"",
+        "feature=\"fmt\"",
+        "feature=\"json\"",
+        "feature=\"matchers\"",
+        "feature=\"nu-ansi-term\"",
+        "feature=\"once_cell\"",
+        "feature=\"registry\"",
+        "feature=\"serde\"",
+        "feature=\"serde_json\"",
+        "feature=\"sharded-slab\"",
+        "feature=\"smallvec\"",
+        "feature=\"std\"",
+        "feature=\"thread_local\"",
+        "feature=\"tracing\"",
+        "feature=\"tracing-log\"",
+        "feature=\"tracing-serde\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "unarray-0.1.4",
+      "root_module": "third-party/vendor/unarray-0.1.4/src/lib.rs",
+      "edition": "2018",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/unarray-0.1.4/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "unicode-ident-1.0.22",
+      "root_module": "third-party/vendor/unicode-ident-1.0.22/src/lib.rs",
+      "edition": "2018",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/unicode-ident-1.0.22/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "unicode-segmentation-1.12.0",
+      "root_module": "third-party/vendor/unicode-segmentation-1.12.0/src/lib.rs",
+      "edition": "2018",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/unicode-segmentation-1.12.0/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "unicode-width-0.2.2",
+      "root_module": "third-party/vendor/unicode-width-0.2.2/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/unicode-width-0.2.2/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"cjk\"",
+        "feature=\"default\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "wait-timeout-0.2.1",
+      "root_module": "third-party/vendor/wait-timeout-0.2.1/src/lib.rs",
+      "edition": "2015",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/wait-timeout-0.2.1/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "winnow-0.7.14",
+      "root_module": "third-party/vendor/winnow-0.7.14/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/winnow-0.7.14/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"alloc\"",
+        "feature=\"default\"",
+        "feature=\"std\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "zerocopy-0.8.31",
+      "root_module": "third-party/vendor/zerocopy-0.8.31/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/zerocopy-0.8.31/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions",
+        "feature=\"simd\""
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "zmij-0.1.7",
+      "root_module": "third-party/vendor/zmij-0.1.7/src/lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": false,
+      "source": {
+        "include_dirs": [
+          "third-party/vendor/zmij-0.1.7/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-runtime-asan",
+      "root_module": "crates/rue-runtime-asan/src/main.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-runtime-asan/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
       "env": {},
       "is_proc_macro": false
     }

--- a/scripts/validate-rust-project.py
+++ b/scripts/validate-rust-project.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Validate the checked-in rust-project.json against the repository (RUE-516).
+
+Rue has no Cargo workspace, so rust-project.json IS the rust-analyzer project
+model. It used to drift silently — referencing a deleted crate (`rue-intern`)
+and omitting live ones — misdirecting anyone who opened the repo in an IDE. This
+is a pure-filesystem check (no Buck needed) that fails when the model:
+
+  * references a `root_module` that does not exist (e.g. a deleted crate),
+  * omits a live first-party crate under `crates/`, or
+  * is structurally malformed (bad dep index, unknown edition, etc.).
+
+Regenerate with `./gen-rust-project.sh` when it complains. Run from the repo
+root; exits non-zero with an explanation on any problem.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+VALID_EDITIONS = {"2015", "2018", "2021", "2024"}
+
+
+def fail(errors: list[str]) -> None:
+    print("rust-project.json validation FAILED:", file=sys.stderr)
+    for e in errors:
+        print(f"  - {e}", file=sys.stderr)
+    print(
+        "\nRegenerate with ./gen-rust-project.sh (and commit the result).",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def main() -> None:
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    os.chdir(repo_root)
+
+    path = "rust-project.json"
+    if not os.path.exists(path):
+        fail([f"{path} does not exist"])
+
+    try:
+        with open(path) as f:
+            model = json.load(f)
+    except json.JSONDecodeError as e:
+        fail([f"{path} is not valid JSON: {e}"])
+
+    errors: list[str] = []
+    crates = model.get("crates")
+    if not isinstance(crates, list) or not crates:
+        fail([f"{path} has no 'crates' array"])
+
+    n = len(crates)
+    for i, c in enumerate(crates):
+        who = c.get("display_name", f"crate #{i}")
+        root_module = c.get("root_module")
+        if not isinstance(root_module, str) or not root_module:
+            errors.append(f"{who}: missing root_module")
+        elif not os.path.exists(root_module):
+            errors.append(f"{who}: root_module does not exist: {root_module}")
+
+        edition = c.get("edition")
+        if edition not in VALID_EDITIONS:
+            errors.append(f"{who}: invalid edition {edition!r}")
+
+        for dep in c.get("deps", []):
+            idx = dep.get("crate")
+            if not isinstance(idx, int) or not (0 <= idx < n):
+                errors.append(f"{who}: dep index out of range: {idx}")
+
+    # First-party coverage: every crates/<dir> with a lib.rs/main.rs must be
+    # represented by some crate rooted under it. This is the exact class of bug
+    # that motivated RUE-516 (six live crates were silently absent).
+    represented_dirs = set()
+    for c in crates:
+        rm = c.get("root_module", "")
+        parts = rm.split("/")
+        if len(parts) >= 2 and parts[0] == "crates":
+            represented_dirs.add(parts[1])
+
+    for entry in sorted(os.listdir("crates")):
+        directory = os.path.join("crates", entry)
+        if not os.path.isdir(directory):
+            continue
+        has_root = any(
+            os.path.exists(os.path.join(directory, cand))
+            for cand in ("src/lib.rs", "src/main.rs")
+        )
+        if has_root and entry not in represented_dirs:
+            errors.append(
+                f"first-party crate 'crates/{entry}' is missing from rust-project.json"
+            )
+
+    if errors:
+        fail(errors)
+
+    first_party = sum(
+        1 for c in crates if c.get("root_module", "").startswith("crates/")
+    )
+    print(
+        f"rust-project.json OK: {n} crates "
+        f"({first_party} first-party), all root_modules exist."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The checked-in rust-analyzer model (`rust-project.json`) had drifted badly — and
Rue has **no Cargo workspace**, so this file *is* the IDE project model, not an
optional fallback:

- referenced the **deleted** `rue-intern` crate,
- **omitted six live** first-party crates (`rue-builtins`, `rue-cli-tests`,
  `rue-fuzz`, `rue-oracle`, `rue-oracle-diff`, `rue-runtime-asan`),
- modeled **zero** third-party dependencies, so rust-analyzer couldn't resolve
  `lasso`, `logos`, `thiserror`, …

The old generator only queried `//crates/...` and matched deps by bare name.

## Approach

I scouted Buck2's native rust-analyzer path first: the bundled prelude here
doesn't expose the `rust_analyzer` bxl (`resolve_deps.bxl` → *File not found*),
so "native" would mean depending on the external `rust-project` binary and its
fbcode-ish assumptions. Third-party crates, meanwhile, are already ordinary Buck
`rust_library` targets — so a correct, self-contained generator is the better
fit. (Full reasoning on the issue.)

Rewrote `gen-rust-project.sh` to build the model from the Buck graph properly:

- Query `//crates/...` **and** `//third-party/...`, then compute the **dependency
  closure** from the first-party crates, following Buck `alias` /
  `transition_alias` / `rust_proc_macro_alias` indirection (proc-macro aliases
  point via `actual_plugin`, behind a plain `alias`). This pulls in exactly the
  third-party crates actually used and skips build-script binaries and unused
  vendored packages.
- Resolve dep edges to crate indices, flag proc-macros (`is_proc_macro`), carry
  editions + feature cfgs, and fix package-relative `crate_root` paths.
- Cover standalone first-party **Cargo** crates outside the Buck graph
  (`rue-runtime-asan`) by scanning `crates/` for any dir with a `lib.rs`/`main.rs`
  the closure missed.
- Emit deterministically (sorted) so the checked-in file is stable/idempotent.

**Result: 17 → 119 crates** (22 first-party + used third-party); every
`root_module` exists; `rue-air` now resolves `lasso`/`rayon`, `rue-lexer`
resolves `logos`/`logos_derive`, `rue-error` resolves `thiserror`.

## Guardrail + docs

- `scripts/validate-rust-project.py` (pure filesystem, no Buck) fails if the
  model references a missing `root_module` or omits a live first-party crate —
  the exact bug class here — wired as a lightweight **CI job** (`rust-project`).
  Negative-control verified it catches a removed crate.
- Regeneration documented in `docs/development.md` (new "Editor / IDE support"
  section) and `CONTRIBUTING.md`.

## Deferred (noted in the generator header; rust-analyzer degrades gracefully)

`sysroot_src` (rust-analyzer falls back to `rustc --print sysroot`) and
proc-macro dylib paths (macros resolve as crates but aren't expanded). The model
targets the host platform.

## Verification

Generator is idempotent (two runs byte-identical); validator passes (119 crates,
all roots exist); `actionlint` clean on the CI change.

Fixes RUE-516

🤖 Generated with [Claude Code](https://claude.com/claude-code)