### PR TITLE
RUE-429: clarify the maintained stats example std model

### DIFF
--- a/examples/first/stats.rue
+++ b/examples/first/stats.rue
@@ -19,10 +19,10 @@
 // is what the dogfooding milestone was reaching for: the first real program can
 // read a stream cleanly, with the postfix `?` doing the early-exit plumbing.
 //
-// The one rough edge that remains (RUE-287): no prelude yet, so `Option` is not
-// in scope automatically. Import `std` explicitly, name the optional type as
-// `std.option.Option(i64)` in the helper signature, and use a local `OptInt`
-// alias for matching on `Some` and `None` in the loop below.
+// Rue intentionally has no implicit prelude (RUE-287). Following the public
+// standard-library model (RUE-315, ADR-0042), this program imports `std`
+// explicitly, names the helper's optional type as `std.option.Option(i64)`, and
+// uses a local `OptInt` alias to match on `Some` and `None` in the loop below.
 //
 // Exercises the dogfooding set end to end: @read_line, @parse_i64, the `?`
 // operator, std.option.Option, StrBuf concatenation + @to_string, println, a


### PR DESCRIPTION
## Summary

- describe the stats example's explicit `std` import as Rue's intentional public model
- replace the stale claim that RUE-287 tracks a remaining prelude rough edge
- keep the maintained program and its exact behavior unchanged

## Verification

- `./scripts/rue cli first_program` (3 passed, 0 failed)
- `./scripts/rue cli 'cli.examples::first::stats'` (1 passed, 0 failed)
- public `scripts/rue exec examples/first/stats.rue` path: documented output, exit 3
- `./test.sh` (Pass 32, Fail 0; passed sentinel)
