### PR TITLE
RUE-585: define by-ref pointers before CFG branches

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -229,6 +229,17 @@ impl<'a> CfgLower<'a> {
         ptr_vreg
     }
 
+    /// Materialize every by-reference parameter pointer before CFG control
+    /// flow begins, so the function-wide cache only contains definitions that
+    /// dominate every block which may reuse them.
+    fn preload_inout_param_ptrs(&mut self) {
+        for param_slot in 0..self.ctx.num_params {
+            if self.ctx.cfg.is_param_inout(param_slot) {
+                self.ensure_inout_param_ptr(param_slot);
+            }
+        }
+    }
+
     /// Emit a bounds check for array indexing.
     ///
     /// Generates code to check that `index_vreg < length` and calls `__rue_bounds_check`
@@ -381,6 +392,8 @@ impl<'a> CfgLower<'a> {
 
     /// Lower CFG to Aarch64Mir.
     pub fn lower(mut self) -> CompileResult<Aarch64Mir> {
+        self.preload_inout_param_ptrs();
+
         // Pre-allocate vregs for block parameters
         for block in self.ctx.cfg.blocks() {
             for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
@@ -419,6 +432,8 @@ impl<'a> CfgLower<'a> {
             target_arch: "aarch64".to_string(),
             blocks: Vec::new(),
         };
+
+        self.preload_inout_param_ptrs();
 
         // Pre-allocate vregs for block parameters (same as lower())
         for block in self.ctx.cfg.blocks() {
@@ -685,20 +700,8 @@ impl<'a> CfgLower<'a> {
                 if is_inout {
                     // For inout params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.
-                    let ptr_vreg = self.mir.alloc_vreg();
+                    let ptr_vreg = self.ensure_inout_param_ptr(*index);
                     let val_vreg = self.mir.alloc_vreg();
-
-                    // Load the pointer from the param slot
-                    let slot = self.ctx.num_locals + *index;
-                    let offset = self.ctx.local_offset(slot);
-                    self.mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Virtual(ptr_vreg),
-                        base: Reg::Fp,
-                        offset,
-                    });
-
-                    // Store the pointer vreg for later use by Store
-                    self.inout_param_ptrs.insert(*index, ptr_vreg);
 
                     // Dereference the pointer to get the actual value
                     self.mir.push(Aarch64Inst::LdrIndexed {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -236,6 +236,17 @@ impl<'a> CfgLower<'a> {
         ptr_vreg
     }
 
+    /// Materialize every by-reference parameter pointer before CFG control
+    /// flow begins, so the function-wide cache only contains definitions that
+    /// dominate every block which may reuse them.
+    fn preload_inout_param_ptrs(&mut self) {
+        for param_slot in 0..self.ctx.num_params {
+            if self.ctx.cfg.is_param_inout(param_slot) {
+                self.ensure_inout_param_ptr(param_slot);
+            }
+        }
+    }
+
     /// Emit a bounds check for array indexing.
     ///
     /// Generates code to check that `index_vreg < length` and calls `__rue_bounds_check`
@@ -554,6 +565,8 @@ impl<'a> CfgLower<'a> {
 
     /// Lower CFG to X86Mir.
     pub fn lower(mut self) -> CompileResult<X86Mir> {
+        self.preload_inout_param_ptrs();
+
         // Pre-allocate vregs for block parameters
         for block in self.ctx.cfg.blocks() {
             for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
@@ -592,6 +605,8 @@ impl<'a> CfgLower<'a> {
             target_arch: "x86_64".to_string(),
             blocks: Vec::new(),
         };
+
+        self.preload_inout_param_ptrs();
 
         // Pre-allocate vregs for block parameters (same as lower())
         for block in self.ctx.cfg.blocks() {
@@ -905,20 +920,8 @@ impl<'a> CfgLower<'a> {
                 if is_inout {
                     // For inout params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.
-                    let ptr_vreg = self.mir.alloc_vreg();
+                    let ptr_vreg = self.ensure_inout_param_ptr(*index);
                     let val_vreg = self.mir.alloc_vreg();
-
-                    // Load the pointer from the param slot
-                    let slot = self.ctx.num_locals + *index;
-                    let offset = self.ctx.local_offset(slot);
-                    self.mir.push(X86Inst::MovRM {
-                        dst: Operand::Virtual(ptr_vreg),
-                        base: Reg::Rbp,
-                        offset,
-                    });
-
-                    // Store the pointer vreg for later use by Store
-                    self.inout_param_ptrs.insert(*index, ptr_vreg);
 
                     // Dereference the pointer to get the actual value
                     self.mir.push(X86Inst::MovRMIndexed {

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -504,6 +504,29 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+[[case]]
+name = "inout_forward_in_one_branch_then_write_in_sibling"
+spec = ["6.1:18", "6.1:35"]
+description = "Forwarding an inout parameter in one branch does not poison a sibling branch's direct write (RUE-585)"
+source = """
+fn noop(inout x: i32) {}
+
+fn choose(inout x: i32) {
+    if x == 0 {
+        noop(inout x);
+    } else {
+        x = 7;
+    }
+}
+
+fn main() -> i32 {
+    let mut x = 1;
+    choose(inout x);
+    if x == 7 { 0 } else { 42 }
+}
+"""
+exit_code = 0
+
 # =============================================================================
 # Inout parameter errors
 # =============================================================================


### PR DESCRIPTION
## Summary

- add a scalar regression for an inout parameter forwarded in one branch and written in its sibling
- materialize one canonical by-reference parameter pointer before CFG control flow begins
- reuse that dominating pointer in normal and debug lowering for both x86-64 and AArch64

Before this change, a branch-local `Param` could replace the function-wide pointer cache. A sibling `ParamStore` or `PlaceWrite` then reused a virtual register whose definition did not dominate the store, producing either a segfault or a silent write to unrelated memory.

## Validation

- focused spec regression passes
- minimal scalar repro: exit 0 at `-O0` through `-O3` (was 139)
- calculator parser-error repro: exit 3 at `-O0` through `-O3` (was 139)
- calculator division-by-zero repro: exit 0 at `-O0` through `-O3` (was 42)
- AArch64 MIR emission succeeds for the scalar repro
- `//crates/rue-codegen:rue-codegen-test` (482 passed, 0 failed)
- `./test.sh` (Pass 32, Fail 0; zero oracle disagreements; passed sentinel)
- `./fmt.sh check`
- `./clippy.sh` (41 targets)
