### PR TITLE
RUE-584: borrow builtin queries through by-ref roots

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -121,18 +121,29 @@ impl<'a> Sema<'a> {
         // `self`, or through an inout/borrow parameter), mirroring the by-ref
         // *argument* path (spec 6.4:25/6.4:29). For a builtin String mutation
         // method the receiver is always by-ref, so its root is the by-ref root
-        // (RUE-256). For a user-struct method, resolution needs the receiver
-        // type — peeked WITHOUT emitting AIR or recording a move, since a
-        // move-based analysis would hard-reject the read of any non-local
-        // place (E0437/E0429/E0904) before the by-ref intent is known — and the
-        // root is by-ref only when the method takes `self` by reference
-        // (RUE-254). Module receivers keep their existing post-analysis handling.
+        // (RUE-256). Registry-declared builtin ByRef queries need the same
+        // pre-analysis classification (RUE-584). For a user-struct method,
+        // resolution needs the receiver type — peeked WITHOUT emitting AIR or
+        // recording a move, since a move-based analysis would hard-reject the
+        // read of any non-local place (E0437/E0429/E0904) before the by-ref
+        // intent is known — and the root is by-ref only when the method takes
+        // `self` by reference (RUE-254). Module receivers keep their existing
+        // post-analysis handling.
         let receiver_byref_root = if is_builtin_mutation_method {
             receiver_var
         } else {
             receiver_var.and_then(|root| {
                 let ty = self.peek_place_type(receiver, ctx)?;
                 let struct_id = ty.as_struct()?;
+
+                let builtin_borrow_receiver = self
+                    .get_builtin_type_def(struct_id)
+                    .and_then(|def| def.find_method(&method_name_str))
+                    .is_some_and(|info| info.receiver_mode == rue_builtins::ReceiverMode::ByRef);
+                if builtin_borrow_receiver {
+                    return Some(root);
+                }
+
                 let info = self.methods.get(&(struct_id, method))?;
                 matches!(info.self_mode, RirParamMode::Inout | RirParamMode::Borrow).then_some(root)
             })

--- a/crates/rue-spec/cases/types/mutable-strings.toml
+++ b/crates/rue-spec/cases/types/mutable-strings.toml
@@ -192,6 +192,32 @@ fn main() -> i32 {
 """
 exit_code = 0
 
+[[case]]
+name = "string_query_borrows_borrow_and_inout_rooted_places"
+spec = ["3.10:10", "3.10:13", "6.4:25", "6.4:29"]
+description = "A ByRef StrBuf query autoref-borrows borrow/inout-rooted places without consuming them (RUE-584)"
+source = """
+struct Parser { input: StrBuf }
+
+fn borrowed_length(borrow input: StrBuf) -> u64 {
+    input.len()
+}
+
+fn parser_length(inout parser: Parser) -> u64 {
+    parser.input.len()
+}
+
+fn main() -> i32 {
+    let input = "abc";
+    let first = borrowed_length(borrow input);
+    let mut parser = Parser { input: input };
+    let second = parser_length(inout parser);
+    let third = parser_length(inout parser);
+    @intCast(first + second + third)
+}
+"""
+exit_code = 9
+
 # =============================================================================
 # Mutation Methods (3.10:15 - 3.10:20)
 # =============================================================================


### PR DESCRIPTION
## Summary

- classify registry-declared builtin `ByRef` methods before receiver analysis
- let StrBuf queries autoref borrow parameters and fields rooted in inout parameters
- pin both facets in one conformance case, including a later move and a repeated query

Previously the receiver was analyzed as an ordinary value before builtin query metadata was consulted, so valid `input.len()` and `parser.input.len()` calls failed with E0429/E0437 before the existing borrow/unmove handling could run.

## Validation

- focused `types.mutable_strings::string_query_borrows_borrow_and_inout_rooted_places` regression
- `cli.method_receiver_byref_places` (8 passed)
- `cli.string_mutation_receivers` (7 passed)
- `cli.byref_params` (35 passed)
- `./test.sh` (Pass 32, Fail 0; zero oracle disagreements; passed sentinel)
- `./fmt.sh check`
- `./clippy.sh` (41 targets)
