### PR TITLE
RUE-586: add Game of Life as the third dogfood program

### DIFF
--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -197,6 +197,15 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         stdout: "",
         stdin: None,
     },
+    // Conway's Game of Life (RUE-586 dogfood): a glider's population is 5 and
+    // holds across all eight generations we print, so this pins both the
+    // per-generation output and the final population (exit code).
+    ExampleExpectation {
+        path: "life.rue",
+        exit_code: 5,
+        stdout: "5\n5\n5\n5\n5\n5\n5\n5\n",
+        stdin: None,
+    },
     ExampleExpectation {
         path: "match.rue",
         exit_code: 5,

--- a/examples/life.rue
+++ b/examples/life.rue
@@ -1,0 +1,92 @@
+// Conway's Game of Life on a bounded grid — third dogfood program (RUE-586).
+//
+// A glider has a stable population of 5 and translates by (1, 1) every four
+// generations. We print the live-cell count each generation, which stays 5 for
+// a glider on an open interior — a deterministic, checkable invariant.
+
+const W: i32 = 12;
+const H: i32 = 12;
+
+// Read a cell, treating out-of-bounds as dead so edge cells count correctly.
+fn alive_at(g: [[i32; W]; H], y: i32, x: i32) -> i32 {
+    if y < 0 { return 0; }
+    if x < 0 { return 0; }
+    if y >= H { return 0; }
+    if x >= W { return 0; }
+    g[y][x]
+}
+
+// Count the eight neighbors of (y, x).
+fn count_neighbors(g: [[i32; W]; H], y: i32, x: i32) -> i32 {
+    let mut total = 0;
+    let mut dy = -1;
+    while dy <= 1 {
+        let mut dx = -1;
+        while dx <= 1 {
+            if dy != 0 || dx != 0 {
+                total = total + alive_at(g, y + dy, x + dx);
+            }
+            dx = dx + 1;
+        }
+        dy = dy + 1;
+    }
+    total
+}
+
+// Compute the next generation as a fresh grid.
+fn step(g: [[i32; W]; H]) -> [[i32; W]; H] {
+    let mut next = [[0; W]; H];
+    let mut y = 0;
+    while y < H {
+        let mut x = 0;
+        while x < W {
+            let n = count_neighbors(g, y, x);
+            let live = g[y][x];
+            // Alive stays alive on 2 or 3 neighbors; dead is born on exactly 3.
+            if live == 1 {
+                if n == 2 || n == 3 { next[y][x] = 1; }
+            } else {
+                if n == 3 { next[y][x] = 1; }
+            }
+            x = x + 1;
+        }
+        y = y + 1;
+    }
+    next
+}
+
+fn population(g: [[i32; W]; H]) -> i32 {
+    let mut total = 0;
+    let mut y = 0;
+    while y < H {
+        let mut x = 0;
+        while x < W {
+            total = total + g[y][x];
+            x = x + 1;
+        }
+        y = y + 1;
+    }
+    total
+}
+
+fn main() -> i32 {
+    // A glider near the top-left, room to travel down-right.
+    //   . X .
+    //   . . X
+    //   X X X
+    let mut g = [[0; W]; H];
+    g[1][2] = 1;
+    g[2][3] = 1;
+    g[3][1] = 1;
+    g[3][2] = 1;
+    g[3][3] = 1;
+
+    let mut gen = 0;
+    while gen < 8 {
+        @dbg(population(g));
+        g = step(g);
+        gen = gen + 1;
+    }
+
+    population(g)
+}


### PR DESCRIPTION
Third maintained real Rue program for the dogfooding milestone (RUE-226),
deliberately **complementing** RUE-428's parser track (Codex) by stressing a
different feature cluster: nested 2D fixed arrays as grid state, const-sized
arrays, `Copy` arrays passed by value, nested `while` loops, and integer
neighbor arithmetic — with no string handling.

Conway's Game of Life with a glider: a glider's population is a stable **5** and
it translates by (1,1) every four generations, so printing the live-cell count
each generation is a deterministic, checkable invariant. Pinned in the examples
smoke table (`exit 5`, eight `5` lines) so it's compiled and run through the real
CLI on every build.

## Dogfooding notes (the point of the exercise)

The grid program **compiled and ran correctly on the first real attempt** —
nested arrays, const-as-size, `Copy`-by-value arrays, early returns, and `||` all
work. Friction it surfaced:

- **No range type**: `for i in 0..n` is a parse error (E0100); `for` only
  iterates arrays, so every counting loop is a manual `while` (RUE-219 territory).
- **Struct field array length by named `const` is rejected (E0481)** even though
  the same `const` works as an array length in let/param/local positions — filed
  as **RUE-587**.

Part of RUE-586

🤖 Generated with [Claude Code](https://claude.com/claude-code)