### PR TITLE
RUE-587: resolve named `const` array lengths in struct fields and enum payloads

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1679,6 +1679,34 @@ impl<'a> Sema<'a> {
     /// Pre-scan the RIR for every `const` declaration, building the
     /// [`ConstCollector`] worklist. Two declarations of the same name in the
     /// same file are always a duplicate (E0418), whatever their kinds.
+    /// Best-effort collect the single value constant `name` (referenced from
+    /// `file_id`) on demand, returning its value if it resolves.
+    ///
+    /// Struct field and enum payload array lengths are resolved during
+    /// declaration gathering, *before* the main const-collection pass in
+    /// `resolve_remaining_declarations`. So `struct S { xs: [i32; N] }` used to
+    /// reject `N` (E0481) even though the same `const` resolves fine in `let`
+    /// and signature positions, which run after collection (RUE-587). This
+    /// collects just the named const (and its dependencies) into
+    /// `constants_by_file_name` so the field length can resolve it.
+    ///
+    /// A fresh collector is fine: `collect_const_by_key` writes results into
+    /// `constants_by_file_name`, and the main pass skips consts already present
+    /// there. Any collection error (e.g. the const's initializer names a
+    /// comptime function not declared until the later pass) is swallowed — the
+    /// caller then falls back to E0481, and the same const is collected and its
+    /// error reported deterministically by the main pass.
+    pub(crate) fn try_collect_const_on_demand(
+        &mut self,
+        name: Spur,
+        file_id: FileId,
+    ) -> Option<ConstValue> {
+        let mut collector = self.prescan_const_declarations().ok()?;
+        let _ = self.ensure_const_collected(name, file_id, &mut collector);
+        self.resolve_const_info_in_file(name, file_id)
+            .map(|info| info.value)
+    }
+
     fn prescan_const_declarations(&mut self) -> CompileResult<ConstCollector> {
         let mut st = ConstCollector {
             pending: HashMap::new(),

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1674,6 +1674,12 @@ impl<'a> Sema<'a> {
                     // 2. A file-level constant, evaluated during declaration
                     //    gathering.
                     info.value
+                } else if let Some(v) = self.try_collect_const_on_demand(sym, span.file_id) {
+                    // 3. A file-level constant not yet collected because this
+                    //    array length sits in a struct field / enum payload,
+                    //    resolved before the main const pass (RUE-587). Collect
+                    //    it on demand.
+                    v
                 } else {
                     return Err(CompileError::new(
                         ErrorKind::InvalidArrayLength {

--- a/crates/rue-cli-tests/cases/const_array_length_in_aggregate.toml
+++ b/crates/rue-cli-tests/cases/const_array_length_in_aggregate.toml
@@ -1,0 +1,64 @@
+[section]
+id = "cli.const_array_length_in_aggregate"
+name = "const as array length in struct fields and enum payloads"
+description = """
+Regression coverage for RUE-587: a top-level `const` used as an array length in
+a struct field or enum payload type was rejected (E0481) even though the same
+const resolves fine in `let`, parameter, and local positions. Struct fields and
+enum payloads are resolved before the main const-collection pass, so the array
+length now collects the named const on demand. A genuinely undefined length name
+must still be rejected.
+"""
+
+[[case]]
+name = "const_struct_field_1d"
+files = [{ path = "main.rue", source = """
+const N: i32 = 3;
+struct S { xs: [i32; N] }
+fn main() -> i32 {
+    let mut s = S { xs: [0; N] };
+    s.xs[0] = 4;
+    s.xs[2] = 5;
+    s.xs[0] + s.xs[2]
+}
+""" }]
+exit_code = 9
+
+[[case]]
+name = "const_struct_field_2d_with_methods"
+files = [{ path = "main.rue", source = """
+const N: i32 = 3;
+struct Grid {
+    cells: [[i32; N]; N],
+    fn get(borrow self, y: i32, x: i32) -> i32 { self.cells[y][x] }
+    fn set(inout self, y: i32, x: i32, v: i32) { self.cells[y][x] = v; }
+}
+fn main() -> i32 {
+    let mut g = Grid { cells: [[0; N]; N] };
+    g.set(2, 2, 7);
+    g.set(0, 1, 3);
+    g.get(2, 2) + g.get(0, 1)
+}
+""" }]
+exit_code = 10
+
+[[case]]
+name = "const_enum_payload"
+files = [{ path = "main.rue", source = """
+const N: i32 = 2;
+enum E { Pair([i32; N]) }
+fn main() -> i32 {
+    let e = E.Pair([3, 4]);
+    match e { E.Pair(a) => a[0] + a[1] }
+}
+""" }]
+exit_code = 7
+
+[[case]]
+name = "undefined_length_name_still_rejected"
+files = [{ path = "main.rue", source = """
+struct S { xs: [i32; NOPE] }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0481", "not a compile-time constant"]


### PR DESCRIPTION
Found by dogfooding the grid program (RUE-586): a top-level `const` used as an
array length is accepted in `let`, parameter, and local positions but was
**rejected (E0481) in a struct field or enum payload type** — e.g.
`struct S { xs: [i32; N] }` — with a self-contradictory message (it listed
`const` as an allowed length while rejecting one). I hit it on line one, trying
the idiomatic thing: wrap the grid in a struct.

## Root cause

Ordering. Struct fields and enum payloads are resolved during declaration
gathering, **before** the main value-constant collection pass in
`resolve_remaining_declarations`, so `resolve_array_length`'s file-level const
lookup found nothing. `let`/param/local lengths resolve later (during body
analysis, after collection), which is why they worked.

## Fix

When the array-length const lookup misses, collect just that named const (and
its dependencies) **on demand** via `try_collect_const_on_demand`, then retry.

I first tried hoisting the whole const-collection pass earlier — the full suite
caught that consts can name **comptime functions** declared later
(`const F6 = fact(6)` → E0434), and eager key-iteration perturbed the
deterministic cycle-error order. On-demand avoids both: it's best-effort, so a
length naming a const whose initializer needs a not-yet-declared function still
falls back to E0481 (reported by the main pass), and a genuinely undefined name
is still rejected. Target-independent (sema only) — no codegen change.

## Tests

`const_array_length_in_aggregate.toml`: 1D/2D struct fields, a struct with
methods + `inout` mutation, an enum payload, and the undefined-name rejection.
Full suite green (Pass 32, Fail 0); clippy + fmt clean.

Fixes RUE-587

🤖 Generated with [Claude Code](https://claude.com/claude-code)