### PR TITLE
RUE-428: add maintained arithmetic calculator

### DIFF
--- a/crates/rue-cli-tests/cases/second_program.toml
+++ b/crates/rue-cli-tests/cases/second_program.toml
@@ -1,0 +1,69 @@
+# The second real Rue program (RUE-428; RUE-226 dogfooding milestone):
+# examples/second/calculator.rue.
+#
+# These cases compile the checked-in example directly via `source_path` so the
+# regression suite stays pinned to the parser users actually see.
+
+[section]
+id = "cli.second_program"
+name = "Second dogfood program (calculator)"
+description = "tokenize and parse one-line integer arithmetic with precedence, parentheses, and byte-positioned errors"
+
+# Exercises both left-associative operator levels and every ASCII whitespace
+# byte that can occur inside a line. LF is the @read_line boundary.
+[[case]]
+name = "calculator_left_associative_with_ascii_whitespace"
+source_path = "examples/second/calculator.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdin = "\t20 - 8 - 3 + 48 / 6 / 2 \u000B\f\r\n"
+stdout = "result: 13\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "calculator_rejects_unexpected_byte"
+source_path = "examples/second/calculator.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdin = "12 + cat\n"
+stdout = "token error at byte 6: unexpected byte 99\n"
+exit_code = 2
+
+[[case]]
+name = "calculator_reports_missing_primary"
+source_path = "examples/second/calculator.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdin = "12 +\n"
+stdout = "parse error at byte 5: expected a number or '('\n"
+exit_code = 2
+
+[[case]]
+name = "calculator_reports_missing_right_parenthesis"
+source_path = "examples/second/calculator.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdin = "2 * (3 + 4\n"
+stdout = "parse error at byte 11: expected ')'\n"
+exit_code = 2
+
+[[case]]
+name = "calculator_reports_division_by_zero"
+source_path = "examples/second/calculator.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdin = "8 / (3 - 3)\n"
+stdout = "parse error at byte 3: division by zero\n"
+exit_code = 2
+
+[[case]]
+name = "calculator_rejects_oversized_integer_literal"
+source_path = "examples/second/calculator.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdin = "9223372036854775808\n"
+stdout = "token error at byte 1: integer literal is too large\n"
+exit_code = 2
+
+[[case]]
+name = "calculator_rejects_trailing_token"
+source_path = "examples/second/calculator.rue"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+stdin = "12 34\n"
+stdout = "parse error at byte 4: unexpected token\n"
+exit_code = 2

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -231,6 +231,12 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         stdin: None,
     },
     ExampleExpectation {
+        path: "second/calculator.rue",
+        exit_code: 0,
+        stdout: "result: 11\n",
+        stdin: Some("2 + 3 * (4 - 1)\n"),
+    },
+    ExampleExpectation {
         path: "sqrt.rue",
         exit_code: 12,
         stdout: "0\n1\n2\n2\n3\n3\n4\n10\n31\n",

--- a/examples/second/calculator.rue
+++ b/examples/second/calculator.rue
@@ -1,0 +1,288 @@
+// The second real Rue program: a one-line arithmetic calculator (RUE-428).
+// It exercises Rue's public APIs for the RUE-226 dogfooding milestone.
+//
+//   $ printf '2 + 3 * (4 - 1)\n' | scripts/rue exec examples/second/calculator.rue
+//   result: 11
+//
+// Grammar:
+//
+//   expression = product (("+" | "-") product)*
+//   product    = primary (("*" | "/") primary)*
+//   primary    = integer | "(" expression ")"
+
+const std = @import("std");
+
+enum Token {
+    Number(i64, u64),
+    Plus(u64),
+    Minus(u64),
+    Star(u64),
+    Slash(u64),
+    LParen(u64),
+    RParen(u64),
+    End(u64),
+}
+
+enum LexError {
+    None,
+    UnexpectedByte(u64, u8),
+    IntegerLiteralTooLarge(u64),
+}
+
+enum ParseError {
+    None,
+    ExpectedPrimary(u64),
+    ExpectedRParen(u64),
+    UnexpectedToken(u64),
+    DivisionByZero(u64),
+}
+
+fn is_ascii_whitespace(byte: u8) -> bool {
+    byte == 9 || byte == 10 || byte == 11 || byte == 12 || byte == 13 || byte == 32
+}
+
+fn is_ascii_digit(byte: u8) -> bool {
+    byte >= 48 && byte <= 57
+}
+
+fn tokenize(input: StrBuf, inout tokens: std.arraybuf.ArrayBuf(Token)) -> LexError {
+    let mut index: u64 = 0;
+
+    while index < input.len() {
+        let byte = input[index];
+
+        if is_ascii_whitespace(byte) {
+            index = index + 1;
+        } else if is_ascii_digit(byte) {
+            let start = index;
+            let mut value: i64 = 0;
+
+            while index < input.len() && is_ascii_digit(input[index]) {
+                let digit: i64 = @intCast(input[index] - 48);
+
+                // i64::MAX is 9223372036854775807. Check before performing
+                // either operation so an oversized literal is a token error,
+                // not the runtime's generic integer-overflow trap.
+                if value > 922337203685477580 ||
+                    (value == 922337203685477580 && digit > 7) {
+                    return LexError.IntegerLiteralTooLarge(start + 1);
+                }
+
+                value = value * 10 + digit;
+                index = index + 1;
+            }
+
+            tokens.push(Token.Number(value, start + 1));
+        } else if byte == 43 {
+            tokens.push(Token.Plus(index + 1));
+            index = index + 1;
+        } else if byte == 45 {
+            tokens.push(Token.Minus(index + 1));
+            index = index + 1;
+        } else if byte == 42 {
+            tokens.push(Token.Star(index + 1));
+            index = index + 1;
+        } else if byte == 47 {
+            tokens.push(Token.Slash(index + 1));
+            index = index + 1;
+        } else if byte == 40 {
+            tokens.push(Token.LParen(index + 1));
+            index = index + 1;
+        } else if byte == 41 {
+            tokens.push(Token.RParen(index + 1));
+            index = index + 1;
+        } else {
+            return LexError.UnexpectedByte(index + 1, byte);
+        }
+    }
+
+    tokens.push(Token.End(input.len() + 1));
+    LexError.None
+}
+
+fn token_position(token: Token) -> u64 {
+    match token {
+        Token.Number(_value, position) => position,
+        Token.Plus(position) => position,
+        Token.Minus(position) => position,
+        Token.Star(position) => position,
+        Token.Slash(position) => position,
+        Token.LParen(position) => position,
+        Token.RParen(position) => position,
+        Token.End(position) => position,
+    }
+}
+
+struct Parser {
+    tokens: std.arraybuf.ArrayBuf(Token),
+    index: u64,
+    error: ParseError,
+
+    fn new(tokens: std.arraybuf.ArrayBuf(Token)) -> Self {
+        Self {
+            tokens: tokens,
+            index: 0,
+            error: ParseError.None,
+        }
+    }
+
+    fn current(borrow self) -> Token {
+        let OptToken = std.option.Option(Token);
+        match self.tokens.get(self.index) {
+            OptToken.Some(token) => token,
+            // The tokenizer always appends End; retain a deterministic result
+            // if that invariant is accidentally broken.
+            OptToken.None => Token.End(1),
+        }
+    }
+
+    fn fail(inout self, error: ParseError) -> std.option.Option(i64) {
+        let OptInt = std.option.Option(i64);
+        self.error = error;
+        OptInt.None
+    }
+
+    fn parse_primary(inout self) -> std.option.Option(i64) {
+        let OptInt = std.option.Option(i64);
+        let token = self.current();
+
+        match token {
+            Token.Number(value, _position) => {
+                self.index = self.index + 1;
+                OptInt.Some(value)
+            },
+            Token.LParen(_position) => {
+                self.index = self.index + 1;
+                let value = self.parse_expression()?;
+                let close = self.current();
+
+                match close {
+                    Token.RParen(_close_position) => {
+                        self.index = self.index + 1;
+                        OptInt.Some(value)
+                    },
+                    _ => self.fail(ParseError.ExpectedRParen(token_position(close))),
+                }
+            },
+            _ => self.fail(ParseError.ExpectedPrimary(token_position(token))),
+        }
+    }
+
+    fn parse_product(inout self) -> std.option.Option(i64) {
+        let OptInt = std.option.Option(i64);
+        let mut value = self.parse_primary()?;
+
+        loop {
+            match self.current() {
+                Token.Star(_position) => {
+                    self.index = self.index + 1;
+                    let right = self.parse_primary()?;
+                    value = value * right;
+                },
+                Token.Slash(position) => {
+                    self.index = self.index + 1;
+                    let right = self.parse_primary()?;
+                    if right == 0 {
+                        return self.fail(ParseError.DivisionByZero(position));
+                    }
+                    value = value / right;
+                },
+                _ => break,
+            }
+        }
+
+        OptInt.Some(value)
+    }
+
+    fn parse_expression(inout self) -> std.option.Option(i64) {
+        let OptInt = std.option.Option(i64);
+        let mut value = self.parse_product()?;
+
+        loop {
+            match self.current() {
+                Token.Plus(_position) => {
+                    self.index = self.index + 1;
+                    let right = self.parse_product()?;
+                    value = value + right;
+                },
+                Token.Minus(_position) => {
+                    self.index = self.index + 1;
+                    let right = self.parse_product()?;
+                    value = value - right;
+                },
+                _ => break,
+            }
+        }
+
+        OptInt.Some(value)
+    }
+
+    fn parse(inout self) -> std.option.Option(i64) {
+        let OptInt = std.option.Option(i64);
+        let value = self.parse_expression()?;
+        let token = self.current();
+
+        match token {
+            Token.End(_position) => OptInt.Some(value),
+            _ => self.fail(ParseError.UnexpectedToken(token_position(token))),
+        }
+    }
+}
+
+fn report_lex_error(error: LexError) -> ! {
+    match error {
+        LexError.UnexpectedByte(position, byte) => {
+            println("token error at byte " + @to_string(position) + ": unexpected byte " + @to_string(byte));
+        },
+        LexError.IntegerLiteralTooLarge(position) => {
+            println("token error at byte " + @to_string(position) + ": integer literal is too large");
+        },
+        LexError.None => {},
+    }
+    std.exit(2)
+}
+
+fn report_parse_error(error: ParseError) -> ! {
+    match error {
+        ParseError.ExpectedPrimary(position) => {
+            println("parse error at byte " + @to_string(position) + ": expected a number or '('");
+        },
+        ParseError.ExpectedRParen(position) => {
+            println("parse error at byte " + @to_string(position) + ": expected ')'");
+        },
+        ParseError.UnexpectedToken(position) => {
+            println("parse error at byte " + @to_string(position) + ": unexpected token");
+        },
+        ParseError.DivisionByZero(position) => {
+            println("parse error at byte " + @to_string(position) + ": division by zero");
+        },
+        ParseError.None => {},
+    }
+    std.exit(2)
+}
+
+fn main() -> i32 {
+    let OptStrBuf = std.option.Option(StrBuf);
+    let OptInt = std.option.Option(i64);
+
+    let input = match @read_line() {
+        OptStrBuf.Some(line) => line,
+        OptStrBuf.None => StrBuf.new(),
+    };
+
+    let Tokens = std.arraybuf.ArrayBuf(Token);
+    let mut tokens = Tokens.new();
+    let lex_error = tokenize(input, inout tokens);
+    match lex_error {
+        LexError.None => {},
+        _ => report_lex_error(lex_error),
+    }
+
+    let mut parser = Parser.new(tokens);
+    match parser.parse() {
+        OptInt.Some(value) => println("result: " + @to_string(value)),
+        OptInt.None => report_parse_error(parser.error),
+    }
+
+    0
+}


### PR DESCRIPTION
## Summary

- add the second maintained real Rue program at `examples/second/calculator.rue`
- tokenize one-line integer arithmetic into payload enums and `ArrayBuf(Token)`, then evaluate it with an inout recursive-descent parser
- exercise explicit std paths, canonical `StrBuf`, `Option(i64)` plus `?`, byte indexing, deterministic one-based errors, and `std.exit(2)`
- pin one exact auto-discovered example and seven source-backed CLI cases, including left associativity, all in-line ASCII whitespace, parse failures, division by zero, and literal overflow

The checked-in grammar supports binary `+`, `-`, `*`, and `/` with precedence, left associativity, and parentheses. Computed arithmetic overflow retains the normal Rue checked-runtime behavior; oversized decimal literals receive a clean token error.

## Dogfood findings

This program exposed two compiler bugs, both fixed in separate regression-first PRs before this program was published:

- RUE-585 / #1382: branch-local by-ref pointer caching could segfault or silently lose parser error-state writes
- RUE-584 / #1383: builtin ByRef queries rejected receivers rooted in borrow/inout parameters

## Validation

- `./scripts/rue cli cli.second_program` — 7 passed, including one `-O0` through `-O3` differential case
- `./scripts/rue cli cli.examples::second::calculator` — exact stdout/exit expectation passed
- public `scripts/rue exec` — valid input exits 0; missing operand reports byte 5 and exits 2
- `./test.sh` — Pass 32 / Fail 0 with the final PASSED sentinel
- both oracle comparisons — 0 disagreements
- `./fmt.sh check`
- `./clippy.sh` — 41 targets
- AArch64 assembly emission