### PR TITLE
RUE-588: @intCast with an uninferrable target reports a cast error, not 'empty array'

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -648,8 +648,15 @@ impl<'a> Sema<'a> {
         let target_ty = match ctx.resolved_types.get(&inst_ref).copied() {
             Some(ty) if ty.is_integer() => ty,
             Some(Type::ERROR) => {
-                // Error already reported during type inference
-                return Err(CompileError::new(ErrorKind::TypeAnnotationRequired, span));
+                // The target type variable decayed to `<error>` with no
+                // constraint to fix it (e.g. the result flows only into a
+                // type-polymorphic sink like `@dbg`). Report the actual problem
+                // — the cast target can't be inferred — not the array-specific
+                // "empty array" message this used to borrow (RUE-588).
+                return Err(CompileError::new(
+                    ErrorKind::CannotInferCastTarget(intrinsic_name.to_string()),
+                    span,
+                ));
             }
             Some(ty) => {
                 return Err(CompileError::new(
@@ -662,8 +669,11 @@ impl<'a> Sema<'a> {
                 ));
             }
             None => {
-                // Type inference couldn't determine the target type
-                return Err(CompileError::new(ErrorKind::TypeAnnotationRequired, span));
+                // Type inference couldn't determine the target type (RUE-588).
+                return Err(CompileError::new(
+                    ErrorKind::CannotInferCastTarget(intrinsic_name.to_string()),
+                    span,
+                ));
             }
         };
 

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -328,6 +328,7 @@ impl ErrorCode {
     pub const PRIVATE_MEMBER_ACCESS: Self = Self(706);
     pub const UNKNOWN_MODULE_MEMBER: Self = Self(707);
     pub const AMBIGUOUS_MODULE: Self = Self(708);
+    pub const CANNOT_INFER_CAST_TARGET: Self = Self(709);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -1383,6 +1384,12 @@ pub enum ErrorKind {
     },
     #[error("intrinsic '@{name}' expects {expected}, found {found}", name = .0.name, expected = .0.expected, found = .0.found)]
     IntrinsicTypeMismatch(Box<IntrinsicTypeMismatchError>),
+    #[error(
+        "cannot infer the target type of '@{0}'; add a type annotation \
+         (e.g. `let n: i32 = @{0}(...)`) or use it where a specific integer \
+         type is expected"
+    )]
+    CannotInferCastTarget(String),
 
     // Module errors
     #[error("@import requires a string literal argument")]
@@ -1640,6 +1647,7 @@ impl ErrorKind {
             ErrorKind::UnknownIntrinsic(_) => ErrorCode::UNKNOWN_INTRINSIC,
             ErrorKind::IntrinsicWrongArgCount { .. } => ErrorCode::INTRINSIC_WRONG_ARG_COUNT,
             ErrorKind::IntrinsicTypeMismatch(_) => ErrorCode::INTRINSIC_TYPE_MISMATCH,
+            ErrorKind::CannotInferCastTarget(_) => ErrorCode::CANNOT_INFER_CAST_TARGET,
             ErrorKind::ImportRequiresStringLiteral => ErrorCode::IMPORT_REQUIRES_STRING_LITERAL,
             ErrorKind::ModuleNotFound { .. } => ErrorCode::MODULE_NOT_FOUND,
             ErrorKind::AmbiguousModule { .. } => ErrorCode::AMBIGUOUS_MODULE,

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -615,7 +615,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "type annotation required"
+error_contains = "cannot infer the target type of '@intCast'"
 
 [[case]]
 name = "intcast_non_integer_argument"

--- a/crates/rue-ui-tests/cases/diagnostics/intcast_infer_target.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/intcast_infer_target.toml
@@ -1,0 +1,41 @@
+[section]
+id = "diagnostics.intcast-infer-target"
+name = "@intCast uninferrable target reports a cast error, not an array error (RUE-588)"
+description = """
+`@intCast`'s target type comes from context. When the result is unconstrained —
+e.g. it flows only into the type-polymorphic `@dbg` — the target genuinely can't
+be inferred. This used to borrow the array-specific E0903 "type annotation
+required for empty array" message even though no array is involved (a baffling
+diagnostic found by dogfooding). It now reports a targeted E0709 naming the cast
+and suggesting an annotation. A real empty array must still get its own E0903.
+"""
+
+[[case]]
+name = "intcast_into_dbg_is_cast_error"
+description = "@intCast whose result only feeds @dbg cannot infer its target: E0709, not the empty-array message."
+source = """
+fn main() -> i32 {
+    let x: u64 = 5;
+    let n = @intCast(x);
+    @dbg(n);
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0709",
+    "cannot infer the target type of '@intCast'",
+    "add a type annotation",
+]
+
+[[case]]
+name = "real_empty_array_still_says_empty_array"
+description = "A genuine empty array literal keeps the array-specific E0903 message."
+source = """
+fn main() -> i32 {
+    let a = [];
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0903", "empty array"]


### PR DESCRIPTION
Found by dogfooding (RUE-586, a heap over `ArrayBuf`): `let n = @intCast(v.len())`
whose result fed only `@dbg` produced

```
error: [E0903]: type annotation required for empty array
```

— a baffling message naming an array that isn't there.

## Cause

`@intCast`'s target type comes from context. When it's unconstrained (the result
flows only into a type-polymorphic sink like `@dbg`), the two branches in
`analyze_int_cast` that handle it — resolved type is `<error>`, or no resolved
type — reused `ErrorKind::TypeAnnotationRequired`, whose message is hardcoded
"type annotation required for empty array".

## Fix

Add a targeted error: **E0709** (in the intrinsic band E0700-E0799, where a
cast-inference failure belongs — not the array band E0900) /
`ErrorKind::CannotInferCastTarget`:

```
error: [E0709]: cannot infer the target type of '@intCast'; add a type
annotation (e.g. `let n: i32 = @intCast(...)`) or use it where a specific
integer type is expected
```

A genuine empty array literal (`let a = []`) still gets its own E0903. Same
misattributed-fallback class as RUE-576 (fixed) — this is the `@intCast`/`@cast`
path.

## Tests

UI cases (the new `@intCast` message + a real empty array keeping E0903) and the
spec case for 4.13:27 updated to the new wording. Full suite green
(Pass 32 / Fail 0); clippy + fmt clean. Frontend/diagnostic only — no codegen.

Fixes RUE-588

🤖 Generated with [Claude Code](https://claude.com/claude-code)