### PR TITLE
RUE-586: add matrix and binary-heap dogfood programs as fixtures

### DIFF
--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -212,6 +212,15 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         stdout: "5\n",
         stdin: None,
     },
+    // Integer matrix library (RUE-586 dogfood): exercises a @copy struct with a
+    // const-sized 2D array field + methods (the RUE-587 pattern). a * identity
+    // == a, so trace(a*id) == 1+5+9 == 15; identity trace == 3.
+    ExampleExpectation {
+        path: "matrix.rue",
+        exit_code: 15,
+        stdout: "15\n3\n",
+        stdin: None,
+    },
     ExampleExpectation {
         path: "power.rue",
         exit_code: 9,
@@ -246,6 +255,16 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         path: "std/arraybuf_demo.rue",
         exit_code: 119,
         stdout: "3\n20\n99\n30\n2\n-1\n119\n",
+        stdin: None,
+    },
+    // Binary min-heap over ArrayBuf (RUE-586 dogfood): heapsort pops a scramble
+    // in ascending order 1..9. Under examples/std/ (like arraybuf_demo) because
+    // it @imports("std"); the sanitizer's top-level examples/*.rue glob does not
+    // provide a std path.
+    ExampleExpectation {
+        path: "std/heap.rue",
+        exit_code: 9,
+        stdout: "1\n2\n3\n4\n5\n6\n7\n8\n9\n",
         stdin: None,
     },
     ExampleExpectation {

--- a/examples/matrix.rue
+++ b/examples/matrix.rue
@@ -1,0 +1,58 @@
+// Small integer matrix library — grid-track dogfood (RUE-586), exercising the
+// RUE-587 fix directly: a struct with a const-sized 2D array field, plus methods
+// and by-value struct returns.
+const N: i32 = 3;
+
+@copy
+struct Matrix {
+    data: [[i32; N]; N],
+    fn get(borrow self, r: i32, c: i32) -> i32 { self.data[r][c] }
+    fn set(inout self, r: i32, c: i32, v: i32) { self.data[r][c] = v; }
+    fn trace(borrow self) -> i32 {
+        let mut t = 0;
+        let mut i = 0;
+        while i < N { t = t + self.data[i][i]; i = i + 1; }
+        t
+    }
+}
+
+fn identity() -> Matrix {
+    let mut m = Matrix { data: [[0; N]; N] };
+    let mut i = 0;
+    while i < N { m.set(i, i, 1); i = i + 1; }
+    m
+}
+
+fn multiply(a: Matrix, b: Matrix) -> Matrix {
+    let mut out = Matrix { data: [[0; N]; N] };
+    let mut r = 0;
+    while r < N {
+        let mut c = 0;
+        while c < N {
+            let mut acc = 0;
+            let mut k = 0;
+            while k < N { acc = acc + a.get(r, k) * b.get(k, c); k = k + 1; }
+            out.set(r, c, acc);
+            c = c + 1;
+        }
+        r = r + 1;
+    }
+    out
+}
+
+fn main() -> i32 {
+    let id = identity();
+    let mut a = Matrix { data: [[0; N]; N] };
+    let mut v = 1;
+    let mut r = 0;
+    while r < N {
+        let mut c = 0;
+        while c < N { a.set(r, c, v); v = v + 1; c = c + 1; }
+        r = r + 1;
+    }
+    // a * identity == a, so trace(a*id) == trace(a) == 1 + 5 + 9 == 15
+    let prod = multiply(a, id);
+    @dbg(prod.trace());
+    @dbg(id.trace());
+    prod.trace()
+}

--- a/examples/std/heap.rue
+++ b/examples/std/heap.rue
@@ -1,0 +1,86 @@
+// Binary min-heap over ArrayBuf — grid-track dogfood (RUE-586).
+//
+// Stresses a different cluster than the fixed-array programs: a struct that
+// owns a heap-backed ArrayBuf (RAII frees it at scope exit), `inout self`
+// methods that call other `inout self` methods (nested mutable self-borrows),
+// Option returns from pop, and `break`. Push a scramble and pop everything:
+// heapsort yields ascending order — a deterministic, checkable invariant.
+const std = @import("std");
+
+struct MinHeap {
+    data: std.arraybuf.ArrayBuf(i32),
+
+    fn len(borrow self) -> u64 { self.data.len() }
+
+    fn swap(inout self, a: u64, b: u64) {
+        let va = self.data.get_or(a, 0);
+        let vb = self.data.get_or(b, 0);
+        self.data.set(a, vb);
+        self.data.set(b, va);
+    }
+
+    fn push(inout self, x: i32) {
+        self.data.push(x);
+        let mut i = self.data.len() - 1;
+        while i > 0 {
+            let parent = (i - 1) / 2;
+            if self.data.get_or(i, 0) < self.data.get_or(parent, 0) {
+                self.swap(i, parent);
+                i = parent;
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn pop_min(inout self) -> std.option.Option(i32) {
+        let O = std.option.Option(i32);
+        let n = self.data.len();
+        if n == 0 {
+            return O.None;
+        }
+        let root = self.data.get_or(0, 0);
+        let last = self.data.get_or(n - 1, 0);
+        let _ = self.data.pop();
+        let m = self.data.len();
+        if m == 0 {
+            return O.Some(root);
+        }
+        // Move the old last element to the root and sift it down.
+        self.data.set(0, last);
+        let mut i: u64 = 0;
+        while true {
+            let l = 2 * i + 1;
+            let r = 2 * i + 2;
+            let mut smallest = i;
+            if l < m {
+                if self.data.get_or(l, 0) < self.data.get_or(smallest, 0) { smallest = l; }
+            }
+            if r < m {
+                if self.data.get_or(r, 0) < self.data.get_or(smallest, 0) { smallest = r; }
+            }
+            if smallest == i { break; }
+            self.swap(i, smallest);
+            i = smallest;
+        }
+        O.Some(root)
+    }
+}
+
+fn main() -> i32 {
+    let O = std.option.Option(i32);
+    let V = std.arraybuf.ArrayBuf(i32);
+    let mut h = MinHeap { data: V.new() };
+
+    h.push(5); h.push(3); h.push(8); h.push(1); h.push(9);
+    h.push(2); h.push(7); h.push(4); h.push(6);
+
+    // Pop everything — ascending 1..9.
+    let mut last = 0;
+    while h.len() > 0 {
+        let v = match h.pop_min() { O.Some(e) => e, O.None => -1 };
+        @dbg(v);
+        last = v;
+    }
+    last
+}


### PR DESCRIPTION
Two more grid-track dogfood programs (RUE-226 milestone), landed as maintained
examples smoke-tested by the CLI suite.

- **`examples/matrix.rue`** — an integer matrix library: a `@copy` struct with a
  const-sized 2D array field plus methods (the exact pattern **RUE-587**
  unblocked), matrix multiply, identity, trace, by-value struct returns.
  `a * identity == a`, so `trace(a*id) == 1+5+9 == 15`.

- **`examples/heap.rue`** — a binary min-heap over `ArrayBuf`: a struct that owns
  a heap-backed collection (**RAII** frees it at scope exit), `inout self`
  methods that call *other* `inout self` methods (nested mutable self-borrows),
  `Option` returns from `pop`, and `break`. Push a scramble, pop all: heapsort
  yields ascending 1..9.

Both compiled and ran correctly on the first real attempt, exercising
`ArrayBuf`/`Option`/RAII and struct methods — a positive dogfooding signal that
these subsystems handle real code. The only friction hit while writing them was
RUE-588 (fixed separately — the `@intCast` diagnostic). Pinned in
`EXAMPLE_EXPECTATIONS` (matrix exit 15; heap exit 9, stdout 1..9); full CLI suite
green (1269 pass).

Part of RUE-586

🤖 Generated with [Claude Code](https://claude.com/claude-code)