### PR TITLE
RUE-586: add enum-shapes and generic-stack dogfood programs as fixtures

### DIFF
--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -185,6 +185,15 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         stdout: "6\n1\n36\n",
         stdin: None,
     },
+    // Generic fixed-capacity Stack(T, CAP) (RUE-586 dogfood): a user-defined
+    // comptime generic instantiated at two types (i32 and bool) in one program —
+    // specialization stress. Pops 7, true; sizes 1, 2; flag true -> 7+1+2 = 10.
+    ExampleExpectation {
+        path: "generic_stack.rue",
+        exit_code: 10,
+        stdout: "7\ntrue\n1\n2\n",
+        stdin: None,
+    },
     ExampleExpectation {
         path: "generics.rue",
         exit_code: 72,
@@ -252,6 +261,15 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         exit_code: 0,
         stdout: "result: 11\n",
         stdin: Some("2 + 3 * (4 - 1)\n"),
+    },
+    // Tagged-union geometry (RUE-586 dogfood): enum payloads (single + multi-
+    // field), match with tuple bindings, and an array of enum values. Areas
+    // 12, 12, 25, 3 sum to 52.
+    ExampleExpectation {
+        path: "shapes.rue",
+        exit_code: 52,
+        stdout: "12\n12\n25\n3\n",
+        stdin: None,
     },
     ExampleExpectation {
         path: "sqrt.rue",

--- a/examples/generic_stack.rue
+++ b/examples/generic_stack.rue
@@ -1,0 +1,29 @@
+fn Stack(comptime T: type, comptime CAP: i32) -> type {
+    struct {
+        items: [T; CAP],
+        top: i32,
+        fn push(inout self, x: T) { self.items[self.top] = x; self.top = self.top + 1; }
+        fn pop(inout self) -> T { self.top = self.top - 1; self.items[self.top] }
+        fn size(borrow self) -> i32 { self.top }
+    }
+}
+
+fn main() -> i32 {
+    // Two instantiations of the same generic (specialization stress).
+    let SI = Stack(i32, 8);
+    let SB = Stack(bool, 4);
+    let mut si = SI { items: [0; 8], top: 0 };
+    let mut sb = SB { items: [false; 4], top: 0 };
+    si.push(100);
+    si.push(7);
+    sb.push(true);
+    sb.push(false);
+    sb.push(true);
+    let x = si.pop();               // 7
+    let flag = sb.pop();            // true
+    @dbg(x);
+    @dbg(flag);
+    @dbg(si.size());               // 1
+    @dbg(sb.size());               // 2
+    if flag { x + si.size() + sb.size() } else { -1 }   // 7 + 1 + 2 = 10
+}

--- a/examples/shapes.rue
+++ b/examples/shapes.rue
@@ -1,0 +1,34 @@
+// Geometry shapes — grid-track dogfood (RUE-586), stressing tagged unions:
+// enum payloads (single and multi-field), match with tuple bindings, and an
+// array of enum values (a layout stress). Integer areas (pi ~ 3).
+enum Shape {
+    Circle(i32),        // radius
+    Rect(i32, i32),     // width, height
+    Square(i32),        // side
+}
+
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape.Circle(r) => 3 * r * r,
+        Shape.Rect(w, h) => w * h,
+        Shape.Square(side) => side * side,
+    }
+}
+
+fn main() -> i32 {
+    let shapes = [
+        Shape.Circle(2),      // 12
+        Shape.Rect(3, 4),     // 12
+        Shape.Square(5),      // 25
+        Shape.Circle(1)       // 3
+    ];
+    let mut total = 0;
+    let mut i = 0;
+    while i < 4 {
+        let a = area(shapes[i]);
+        @dbg(a);
+        total = total + a;
+        i = i + 1;
+    }
+    total
+}


### PR DESCRIPTION
Two more grid-track dogfood programs (RUE-226), landed as maintained examples.
Both are self-contained (no std, valgrind-safe) and cover subsystems no current
example exercised:

- **`examples/shapes.rue`** — tagged-union geometry: an `enum` with single- and
  multi-field payloads, `match` with tuple bindings, and an array of enum values
  (a layout stress). Areas 12, 12, 25, 3 sum to 52.

- **`examples/generic_stack.rue`** — a user-defined comptime generic
  `Stack(T, CAP)` instantiated at **two types** (`i32` and `bool`) in one program
  — specialization stress. Pops 7 and `true`; sizes 1 and 2; exit 10.

Both compiled and ran correctly on the first real attempt — a dogfooding signal
that the enum/tagged-union and user-generics subsystems handle real programs
today. The only friction writing `shapes` was trailing commas in array/arg
lists, a known design-open policy question (**RUE-536**, commented there with
data) — not a code change here.

Pinned in `EXAMPLE_EXPECTATIONS`; full CLI suite green (1269 pass), fmt clean.

Part of RUE-586

🤖 Generated with [Claude Code](https://claude.com/claude-code)