### PR TITLE
RUE-589: preserve oracle SSA values across CFG edges

### DIFF
--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -111,6 +111,10 @@ pub fn run_source_with_preview_features(
 }
 
 fn run_state(state: CompileState) -> Result<Outcome, Unsupported> {
+    run_state_with_budget(state, STEP_BUDGET)
+}
+
+fn run_state_with_budget(state: CompileState, budget: u64) -> Result<Outcome, Unsupported> {
     // Interpret on a dedicated large-stack worker thread. The tree-walking
     // interpreter recurses per expression *and* per call, so deep-but-valid
     // programs need far more stack than a default thread provides. Running on
@@ -125,7 +129,7 @@ fn run_state(state: CompileState) -> Result<Outcome, Unsupported> {
                 Interp {
                     state: &state,
                     stdout: String::new(),
-                    budget: STEP_BUDGET,
+                    budget,
                     depth: 0,
                 }
                 .run()
@@ -259,10 +263,11 @@ struct Interp<'a> {
     depth: u32,
 }
 
-/// Per-call activation record. `cache` is scoped to a *single block execution*
-/// (cleared on entry to each block): the CFG is block-parameter SSA, so all
-/// cross-block dataflow flows through block parameters, and a persistent cache
-/// would return stale values on loop back-edges.
+/// Per-call activation record. `cache` preserves values produced along the
+/// executed CFG path: Rue SSA values may be used in dominated blocks without
+/// being repeated as block arguments. On block entry, that block's own values
+/// are invalidated so loop re-entry recomputes the current iteration while
+/// values from executed dominators retain their original evaluation snapshot.
 struct Frame {
     /// Parameters laid out by ABI **slot**, not by logical argument: an
     /// aggregate argument spans one slot per flattened scalar leaf (a `[i32; 3]`
@@ -384,7 +389,18 @@ impl<'a> Interp<'a> {
 
         loop {
             let block = cfg.get_block(current);
-            frame.cache.clear();
+            // Re-entering a block (a loop back-edge) must recompute that
+            // block's instructions and receive fresh block arguments. Keep
+            // every other cached value: CFG SSA permits dominated blocks to
+            // use values produced by executed dominators without threading
+            // them through every intervening block, and recomputing a Load
+            // after a mutation would change its evaluation-time value.
+            for &(param, _) in &block.params {
+                frame.cache.remove(&param.as_u32());
+            }
+            for &inst in &block.insts {
+                frame.cache.remove(&inst.as_u32());
+            }
             for (i, (pv, _)) in block.params.iter().enumerate() {
                 let val = incoming
                     .get(i)

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -11,6 +11,11 @@ fn run(src: &str) -> Outcome {
     run_source(src).unwrap_or_else(|u| panic!("unsupported: {}", u.0))
 }
 
+fn run_with_budget(src: &str, budget: u64) -> Result<Outcome, Unsupported> {
+    let state = compile_to_cfg(src).unwrap_or_else(|e| panic!("compile error: {e:#?}"));
+    run_state_with_budget(state, budget)
+}
+
 fn run_string_trio(src: &str) -> Outcome {
     let mut preview_features = PreviewFeatures::new();
     preview_features.insert(rue_compiler::PreviewFeature::StringTrio);
@@ -52,6 +57,60 @@ fn if_expression_value() {
         exit("fn main() -> i32 { let n = 5; if n > 3 { 100 } else { 0 } }"),
         100
     );
+}
+
+#[test]
+fn dominated_ssa_value_survives_nested_control_flow() {
+    // The first short-circuit expression produces a block parameter and `!`
+    // derives a value from it. That derived value dominates the second
+    // short-circuit expression and must remain available across its blocks.
+    let src = "fn main() -> i32 {
+        let f = false;
+        let t = true;
+        if (!(f && f)) != (!(t || t)) { 0 } else { 1 }
+    }";
+
+    assert_eq!(exit(src), 0);
+}
+
+#[test]
+fn pre_branch_load_remains_an_evaluation_snapshot() {
+    // Rue evaluates the left operand before the right-hand `if`. Its load of
+    // `x` is an SSA value: entering the branch must not discard and recompute
+    // it after the branch mutates the local.
+    let src = "fn main() -> i32 {
+        let mut x = 1;
+        let take = true;
+        let result: i32 = x + (if take {
+            x = 2;
+            10
+        } else {
+            20
+        });
+        result
+    }";
+
+    assert_eq!(exit(src), 11);
+}
+
+#[test]
+fn loop_reentry_recomputes_the_current_blocks() {
+    // A persistent cache must still invalidate a block's own values when that
+    // block is re-entered. Keep the test budget small so a stale loop condition
+    // fails promptly instead of consuming the production 50M-step budget.
+    let src = "fn main() -> i32 {
+        let mut i = 0;
+        let mut sum = 0;
+        while i < 3 {
+            sum = sum + i;
+            i = i + 1;
+        }
+        sum
+    }";
+
+    let out =
+        run_with_budget(src, 1_000).unwrap_or_else(|u| panic!("bounded loop unsupported: {}", u.0));
+    assert_eq!(out.exit_code, 3);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve SSA values produced by executed dominator blocks across CFG edges in the oracle
- invalidate only the destination block's parameters and instructions on entry, so loop iterations still recompute
- add minimized regressions for dominated block-parameter values, pre-branch load snapshots, and loop re-entry
- allow tests to run the interpreter with a small work budget so a stale loop condition fails promptly

## Root cause

The oracle cleared its entire value cache whenever execution entered a new basic block. Rue CFG is SSA, but valid dominated values do not have to be repeated as arguments through every intervening block. Clearing the cache therefore caused two correctness failures:

- recursively evaluating a dominated value could reach an unavailable ancestor block parameter and return `Unsupported("unbound block param")`
- recursively evaluating a pre-branch `Load` after the branch mutated its local observed the new value, changing Rue's evaluation order

The cache now retains values along the executed path. On every block entry, only that block's own parameter and instruction IDs are removed before fresh arguments are bound. This preserves immutable SSA evaluation snapshots while making loop back-edges recompute the current iteration.

## Impact

Before the fix, one minimized regression skipped as unbound and another returned 12 instead of the required 11. The repaired generator's 500-seed differential also had eight Unsupported skips. Afterward, all three minimized classes pass and the generated run reports exactly 500 agreements, zero skips, and zero disagreements.

Part of RUE-589

## Validation

- `./buck2 test //crates/rue-oracle:rue-oracle-test`
- `RUE_BINARY="$(scripts/rue-bin)" ./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- fuzz --start 0 --seeds 500`
- `scripts/rue fmt`
- `scripts/rue test` — Pass 32, Fail 0
- `./clippy.sh`
