### PR TITLE
RUE-590: give sanitizer examples the standard library

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -184,18 +184,20 @@ sh_test(
 )
 
 # The developer wrapper scripts. scripts/test-wrapper-scripts.sh (RUE-537,
-# RUE-549, RUE-550) runs copies of them against a fake ./buck2 and a fake
-# compiler — no real build — to pin that resolver failures are surfaced (not
-# swallowed), that run/exec resolve relative paths from the caller's cwd, and
-# that filtered CLI examples stay repository-anchored across per-case cwd
-# changes. The filegroup materializes these at package-relative paths
-# (scripts/rue, fmt.sh), matching the layout expected under RUE_WRAPPER_ROOT.
+# RUE-549, RUE-550, RUE-590) runs copies of them against fake tools — no real
+# build — to pin that resolver failures are surfaced (not swallowed), that
+# run/exec resolve relative paths from the caller's cwd, that filtered CLI
+# examples stay repository-anchored across per-case cwd changes, and that the
+# sanitizer gives examples the bundled standard library. The filegroup
+# materializes these at package-relative paths, matching the layout expected
+# under RUE_WRAPPER_ROOT.
 filegroup(
     name = "wrapper-script-inputs",
     srcs = [
         "fmt.sh",
         "scripts/rue",
         "scripts/rue-bin",
+        "scripts/run-sanitizer.sh",
         "test.sh",
     ],
 )

--- a/scripts/run-sanitizer.sh
+++ b/scripts/run-sanitizer.sh
@@ -50,6 +50,11 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+# Examples may import the bundled standard library. Match the developer
+# wrappers' default while preserving an explicit caller override; without this
+# the sanitizer fails during compilation and never reaches Valgrind (RUE-590).
+export RUE_STD_PATH="${RUE_STD_PATH:-$repo_root/std}"
+
 if ! command -v valgrind >/dev/null 2>&1; then
     echo "run-sanitizer: valgrind not found on PATH." >&2
     echo "run-sanitizer: install it (Debian/Ubuntu: apt-get install valgrind)." >&2

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -18,6 +18,10 @@
 #     directory. The harness later runs each compiler case from a temporary
 #     directory, where that repository-relative path no longer resolves.
 #
+#   * RUE-590: the Valgrind driver compiled repository examples without the
+#     bundled standard-library path, so a top-level example using @import("std")
+#     failed before Valgrind ever ran.
+#
 # Each test runs a COPY of the real script in a throwaway sandbox with a fake
 # `./buck2` (and, for scripts/rue, a fake scripts/rue-bin + fake compiler), so
 # no real build runs. The fakes log their cwd/argv; we assert on exit status,
@@ -247,6 +251,93 @@ test_testsh_cli_examples_survive_case_chdir() {
   rm -rf "$sb"
 }
 
+# ===========================================================================
+# RUE-590 — the sanitizer gives repository examples the bundled std library
+# ===========================================================================
+
+# Run a copy of the real sanitizer against a fake compiler and fake Valgrind.
+# The fake compiler refuses every source unless RUE_STD_PATH names the expected
+# std/ directory, then fabricates the output binary. This exercises
+# every compiler invocation without needing a real compiler or Valgrind.
+test_sanitizer_defaults_std_path() {
+  local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/scripts" "$sb/examples" "$sb/std" "$sb/fakebin" "$sb/tmp"
+  cp "$SRC_ROOT/scripts/run-sanitizer.sh" "$sb/scripts/run-sanitizer.sh"
+  chmod +x "$sb/scripts/run-sanitizer.sh"
+  printf 'const std = @import("std");\nfn main() -> i32 { 0 }\n' >"$sb/examples/std_probe.rue"
+  echo '// fake bundled standard library' >"$sb/std/_std.rue"
+
+  cat >"$sb/compiler" <<'EOF'
+#!/usr/bin/env bash
+if [ "${RUE_STD_PATH:-}" != "$EXPECTED_STD" ]; then
+  printf 'wrong RUE_STD_PATH: %s\n' "${RUE_STD_PATH:-<unset>}" >&2
+  exit 88
+fi
+printf 'src=%s std=%s\n' "$1" "$RUE_STD_PATH" >>"$COMPILE_LOG"
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    out="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[ -n "$out" ] || exit 89
+printf '#!/bin/sh\nexit 0\n' >"$out"
+chmod +x "$out"
+EOF
+  chmod +x "$sb/compiler"
+
+  cat >"$sb/fakebin/valgrind" <<'EOF'
+#!/usr/bin/env bash
+log=""
+for arg in "$@"; do
+  case "$arg" in
+    --log-file=*) log="${arg#--log-file=}" ;;
+  esac
+done
+[ -n "$log" ] || exit 90
+printf 'ERROR SUMMARY: 0 errors\n' >"$log"
+EOF
+  chmod +x "$sb/fakebin/valgrind"
+
+  # run-sanitizer is a Linux/Valgrind driver, but this wrapper contract test
+  # also runs on macOS, where GNU timeout is not installed by default.
+  cat >"$sb/fakebin/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+exec "$@"
+EOF
+  chmod +x "$sb/fakebin/timeout"
+
+  local rc=0
+  env -u RUE_STD_PATH \
+    PATH="$sb/fakebin:$PATH" \
+    RUE_BINARY="$sb/compiler" \
+    EXPECTED_STD="$sb/std" \
+    COMPILE_LOG="$sb/compile.log" \
+    TMPDIR="$sb/tmp" \
+    "$sb/scripts/run-sanitizer.sh" >/dev/null 2>&1 || rc=$?
+
+  check "run-sanitizer: std-importing examples receive repository std path" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq "src=$sb/examples/std_probe.rue std=$sb/std" "$sb/compile.log" 2>/dev/null && echo 0 || echo 1)"
+
+  mkdir -p "$sb/alternate-std"
+  echo '// explicit alternate standard library' >"$sb/alternate-std/_std.rue"
+  rc=0
+  PATH="$sb/fakebin:$PATH" \
+    RUE_BINARY="$sb/compiler" \
+    RUE_STD_PATH="$sb/alternate-std" \
+    EXPECTED_STD="$sb/alternate-std" \
+    COMPILE_LOG="$sb/override-compile.log" \
+    TMPDIR="$sb/tmp" \
+    "$sb/scripts/run-sanitizer.sh" >/dev/null 2>&1 || rc=$?
+  check "run-sanitizer: explicit std path override is preserved" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq "src=$sb/examples/std_probe.rue std=$sb/alternate-std" "$sb/override-compile.log" 2>/dev/null && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
 # --- run everything ---------------------------------------------------------
 
 test_ruebin_build_failure_is_loud
@@ -256,6 +347,7 @@ test_rue_exec_resolves_from_caller_cwd
 test_rue_run_resolves_relative_output
 test_rue_cli_examples_survive_case_chdir
 test_testsh_cli_examples_survive_case_chdir
+test_sanitizer_defaults_std_path
 
 echo "--------------------------------------------------"
 if [ "$FAILURES" -eq 0 ]; then


### PR DESCRIPTION
## Summary

- default `RUE_STD_PATH` to the repository's absolute `std/` directory in the Valgrind driver
- preserve an explicit caller-provided standard-library path, matching the other developer wrappers
- add a fake-compiler/fake-Valgrind regression that proves both the top-level std-importing example path and override behavior
- wire the sanitizer script into the existing wrapper-script test inputs

## Root cause

`scripts/run-sanitizer.sh` compiled every top-level example directly but did not provide the bundled standard-library path. Once `examples/heap.rue` became the first top-level example using `@import("std")`, the sanitizer stopped during compilation with E0204 and never reached Valgrind.

The driver now establishes the same repository-relative default as `scripts/rue`. The regression runs the real sanitizer script against fake tools, refuses compilation unless the expected `RUE_STD_PATH` reaches the compiler, and proves an explicit alternate path is not overwritten.

## Impact

The heap example is already in the sanitizer's `examples/*.rue` corpus. With this fix it compiles and exercises real ArrayBuf growth, get/set, pop, and RAII teardown under Valgrind instead of failing before instrumentation begins.

Fixes RUE-590

## Validation

- `bash -n scripts/run-sanitizer.sh scripts/test-wrapper-scripts.sh`
- `./buck2 test //:wrapper-script-tests` — 21 checks passed
- real `examples/heap.rue` compile/run with repository std — stdout 1 through 9, exit 9
- `scripts/rue fmt`
- `scripts/rue test` — Pass 32, Fail 0
- `./clippy.sh`

Real Valgrind is not installed in the local environment; the GitHub sanitizer job is the final end-to-end verification.
