### PR TITLE
RUE-591: ship std.Result + `?` propagation for Result (ADR-0038 A+B)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1943,6 +1943,25 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// Recognize a `Result`-shaped enum (`Ok(T)` / `Err(E)`) by variant name and
+    /// payload arity, mirroring [`Self::option_enum_shape`] (ADR-0038). Returns
+    /// `(ok_idx, err_idx, ok_payload_ty, err_payload_ty)`.
+    fn result_enum_shape(&self, enum_id: crate::types::EnumId) -> Option<(u32, u32, Type, Type)> {
+        let def = self.type_pool.enum_def(enum_id);
+        if def.variant_count() != 2 {
+            return None;
+        }
+        let ok_idx = def.find_variant("Ok")?;
+        let err_idx = def.find_variant("Err")?;
+        let ok_payload = def.variant_payload(ok_idx);
+        let err_payload = def.variant_payload(err_idx);
+        if ok_payload.len() == 1 && err_payload.len() == 1 {
+            Some((ok_idx as u32, err_idx as u32, ok_payload[0], err_payload[0]))
+        } else {
+            None
+        }
+    }
+
     /// Analyze the `?` operator (RUE-6, ADR-0038).
     ///
     /// `operand?` requires `operand` to be an `Option(T)` and the enclosing
@@ -1958,43 +1977,17 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // The enclosing function must return an `Option`; `?` propagates its
-        // `None`. Resolve that shape first so a clear error fires even when the
-        // operand is fine (E0503).
         let return_type = ctx.return_type;
-        let ret_shape = return_type.as_enum().and_then(|rid| {
-            self.option_enum_shape(rid)
-                .map(|(_, none_idx, _)| (rid, none_idx))
-        });
-        let (ret_enum_id, ret_none_idx) = match ret_shape {
-            Some(s) => s,
-            None => {
-                // Still analyze the operand so unrelated errors inside it are
-                // reported, but the `?` itself is the diagnostic.
-                if return_type.is_error() {
-                    let r = self.analyze_inst(air, operand, ctx)?;
-                    return Ok(AnalysisResult::new(r.air_ref, Type::ERROR));
-                }
-                return Err(CompileError::new(
-                    ErrorKind::QuestionOutsideOptionFn {
-                        return_type: return_type.safe_name_with_pool(Some(&self.type_pool)),
-                    },
-                    span,
-                ));
-            }
-        };
 
-        // Analyze the operand.
+        // Analyze the operand first, then dispatch on ITS shape (Option vs
+        // Result); the enclosing return type must match (ADR-0038).
         //
-        // `?` works on any typed `Option` value (a function result, constructor,
-        // variable, etc.), whose type is already known. A BARE fallible-intrinsic
-        // operand — `@read_line()?` / `@parse_i64(s)?` — is special: the intrinsic
-        // needs its exact `Option` return type (e.g. `Option(String)`), and the
-        // `?` site cannot supply it as an `expected_type` — the enclosing fn's
-        // `Option(U)` has the wrong payload (RUE-318). So we clear `expected_type`
-        // and set `try_operand`, telling a fallible intrinsic to instantiate its
-        // OWN fixed `Option(payload)` (it knows its payload). A non-intrinsic
-        // operand ignores both flags — its type is resolved independently.
+        // A BARE fallible-intrinsic operand — `@read_line()?` / `@parse_i64(s)?`
+        // — is special: the intrinsic needs its exact `Option` return type and
+        // the `?` site cannot supply it as an `expected_type` (RUE-318), so we
+        // clear `expected_type` and set `try_operand` so the intrinsic
+        // instantiates its OWN fixed payload. A non-intrinsic operand ignores
+        // both flags — its type is resolved independently.
         let prev_expected = ctx.expected_type.take();
         let prev_try_operand = ctx.try_operand;
         ctx.try_operand = true;
@@ -2004,16 +1997,12 @@ impl<'a> Sema<'a> {
         let operand_result = operand_outcome?;
         let operand_ty = operand_result.ty;
 
-        if operand_ty.is_error() {
+        if operand_ty.is_error() || return_type.is_error() {
             return Ok(AnalysisResult::new(operand_result.air_ref, Type::ERROR));
         }
 
-        // The operand must be an `Option`-shaped enum (E0504).
-        let (some_idx, none_idx, payload_ty) = match operand_ty
-            .as_enum()
-            .and_then(|oid| self.option_enum_shape(oid).map(|s| (oid, s)))
-        {
-            Some((_oid, shape)) => shape,
+        let operand_enum_id = match operand_ty.as_enum() {
+            Some(id) => id,
             None => {
                 return Err(CompileError::new(
                     ErrorKind::QuestionOnNonOption {
@@ -2023,53 +2012,185 @@ impl<'a> Sema<'a> {
                 ));
             }
         };
-        let operand_enum_id = operand_ty
-            .as_enum()
-            .expect("operand is an Option-shaped enum");
 
-        // Some(v) arm: read the payload out of the scrutinee; that value is the
-        // arm's (and the whole `?`-expression's) result. Mirrors the payload
-        // read that a `Some(v) => v` match arm performs (RUE-221).
-        let some_body = air.add_inst(AirInst {
+        // Option operand: `?` evaluates to `T` on `Some(v)` and early-returns
+        // the enclosing function's `None`.
+        if let Some((some_idx, none_idx, payload_ty)) = self.option_enum_shape(operand_enum_id) {
+            let ret_shape = return_type
+                .as_enum()
+                .and_then(|rid| self.option_enum_shape(rid).map(|(_, n, _)| (rid, n)));
+            let (ret_enum_id, ret_none_idx) = match ret_shape {
+                Some(s) => s,
+                None => {
+                    return Err(CompileError::new(
+                        ErrorKind::QuestionOutsideOptionFn {
+                            return_type: return_type.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        span,
+                    ));
+                }
+            };
+            return Ok(self.build_try_desugar(
+                air,
+                operand_result.air_ref,
+                operand_enum_id,
+                some_idx,
+                none_idx,
+                payload_ty,
+                return_type,
+                ret_enum_id,
+                ret_none_idx,
+                None,
+                span,
+            ));
+        }
+
+        // Result operand: `?` evaluates to `T` on `Ok(v)` and early-returns
+        // `Err(e)`. The error type must match exactly (ADR-0038, no conversion).
+        if let Some((ok_idx, err_idx, ok_ty, err_ty)) = self.result_enum_shape(operand_enum_id) {
+            let ret_shape = return_type.as_enum().and_then(|rid| {
+                self.result_enum_shape(rid)
+                    .map(|(_, e, _, et)| (rid, e, et))
+            });
+            let (ret_enum_id, ret_err_idx, ret_err_ty) = match ret_shape {
+                Some(s) => s,
+                None => {
+                    return Err(CompileError::new(
+                        ErrorKind::QuestionOutsideResultFn {
+                            return_type: return_type.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        span,
+                    ));
+                }
+            };
+            if err_ty != ret_err_ty {
+                return Err(CompileError::new(
+                    ErrorKind::QuestionErrTypeMismatch {
+                        operand_err: err_ty.safe_name_with_pool(Some(&self.type_pool)),
+                        fn_err: ret_err_ty.safe_name_with_pool(Some(&self.type_pool)),
+                    },
+                    span,
+                ));
+            }
+            return Ok(self.build_try_desugar(
+                air,
+                operand_result.air_ref,
+                operand_enum_id,
+                ok_idx,
+                err_idx,
+                ok_ty,
+                return_type,
+                ret_enum_id,
+                ret_err_idx,
+                Some(err_ty),
+                span,
+            ));
+        }
+
+        // The operand is a two-variant enum but neither Option- nor
+        // Result-shaped.
+        Err(CompileError::new(
+            ErrorKind::QuestionOnNonOption {
+                found: operand_ty.safe_name_with_pool(Some(&self.type_pool)),
+            },
+            span,
+        ))
+    }
+
+    /// Build the `match`-desugaring shared by the `?` operator's Option and
+    /// Result forms: a two-arm discriminant match whose success arm reads the
+    /// payload out and whose failure arm early-`return`s.
+    ///
+    /// `fail_err_ty` distinguishes the two: `None` is the Option case (the
+    /// failure arm drops the scrutinee and returns the nullary `None`);
+    /// `Some(err_ty)` is the Result case (the failure arm moves the error
+    /// payload out and returns `Err(e)`).
+    #[allow(clippy::too_many_arguments)]
+    fn build_try_desugar(
+        &mut self,
+        air: &mut Air,
+        scrutinee: AirRef,
+        operand_enum_id: crate::types::EnumId,
+        success_idx: u32,
+        fail_idx: u32,
+        success_payload_ty: Type,
+        return_type: Type,
+        ret_enum_id: crate::types::EnumId,
+        ret_fail_idx: u32,
+        fail_err_ty: Option<Type>,
+        span: Span,
+    ) -> AnalysisResult {
+        // Success arm (`Some(v)` / `Ok(v)`): read the payload out; it is the
+        // whole `?`-expression's value (RUE-221).
+        let success_body = air.add_inst(AirInst {
             data: AirInstData::EnumPayloadGet {
-                base: operand_result.air_ref,
+                base: scrutinee,
                 enum_id: operand_enum_id,
-                variant_index: some_idx,
+                variant_index: success_idx,
                 field_index: 0,
             },
-            ty: payload_ty,
+            ty: success_payload_ty,
             span,
         });
 
-        // None arm: drop the scrutinee (a non-binding arm consumes it; the
-        // active `None` variant carries nothing, so the drop glue is a no-op),
-        // then `return` the enclosing function's `None`.
-        let drop_scrutinee = air.add_inst(AirInst {
-            data: AirInstData::Drop {
-                value: operand_result.air_ref,
-            },
-            ty: Type::UNIT,
-            span,
-        });
-        let none_ctor = air.add_inst(AirInst {
-            data: AirInstData::EnumVariant {
-                enum_id: ret_enum_id,
-                variant_index: ret_none_idx,
-                payload_start: 0,
-                payload_len: 0,
-            },
-            ty: return_type,
-            span,
-        });
+        // Failure arm: build the early `return`.
+        let (fail_stmt, fail_ret_value) = match fail_err_ty {
+            None => {
+                // Option `None`: drop the scrutinee (nullary variant, no-op glue)
+                // and return the enclosing `None`.
+                let drop_scrutinee = air.add_inst(AirInst {
+                    data: AirInstData::Drop { value: scrutinee },
+                    ty: Type::UNIT,
+                    span,
+                });
+                let none_ctor = air.add_inst(AirInst {
+                    data: AirInstData::EnumVariant {
+                        enum_id: ret_enum_id,
+                        variant_index: ret_fail_idx,
+                        payload_start: 0,
+                        payload_len: 0,
+                    },
+                    ty: return_type,
+                    span,
+                });
+                (drop_scrutinee, none_ctor)
+            }
+            Some(err_ty) => {
+                // Result `Err(e)`: move the error payload out of the scrutinee
+                // and return `Err(e)` of the enclosing function's Result type.
+                let err_val = air.add_inst(AirInst {
+                    data: AirInstData::EnumPayloadGet {
+                        base: scrutinee,
+                        enum_id: operand_enum_id,
+                        variant_index: fail_idx,
+                        field_index: 0,
+                    },
+                    ty: err_ty,
+                    span,
+                });
+                let payload = air.add_extra(&[err_val.as_u32()]);
+                let err_ctor = air.add_inst(AirInst {
+                    data: AirInstData::EnumVariant {
+                        enum_id: ret_enum_id,
+                        variant_index: ret_fail_idx,
+                        payload_start: payload,
+                        payload_len: 1,
+                    },
+                    ty: return_type,
+                    span,
+                });
+                (err_val, err_ctor)
+            }
+        };
         let ret = air.add_inst(AirInst {
-            data: AirInstData::Ret(Some(none_ctor)),
+            data: AirInstData::Ret(Some(fail_ret_value)),
             ty: Type::NEVER,
             span,
         });
-        let none_stmts = air.add_extra(&[drop_scrutinee.as_u32()]);
-        let none_body = air.add_inst(AirInst {
+        let fail_stmts = air.add_extra(&[fail_stmt.as_u32()]);
+        let fail_body = air.add_inst(AirInst {
             data: AirInstData::Block {
-                stmts_start: none_stmts,
+                stmts_start: fail_stmts,
                 stmts_len: 1,
                 value: ret,
             },
@@ -2078,21 +2199,21 @@ impl<'a> Sema<'a> {
         });
 
         // Encode the two arms and emit the dispatching match. Its value type is
-        // the `Some` payload (the `None` arm diverges).
+        // the success payload (the failure arm diverges).
         let air_arms = [
             (
                 AirPattern::EnumVariant {
                     enum_id: operand_enum_id,
-                    variant_index: some_idx,
+                    variant_index: success_idx,
                 },
-                some_body,
+                success_body,
             ),
             (
                 AirPattern::EnumVariant {
                     enum_id: operand_enum_id,
-                    variant_index: none_idx,
+                    variant_index: fail_idx,
                 },
-                none_body,
+                fail_body,
             ),
         ];
         let mut extra_data = Vec::new();
@@ -2102,14 +2223,14 @@ impl<'a> Sema<'a> {
         let arms_start = air.add_extra(&extra_data);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Match {
-                scrutinee: operand_result.air_ref,
+                scrutinee,
                 arms_start,
                 arms_len: air_arms.len() as u32,
             },
-            ty: payload_ty,
+            ty: success_payload_ty,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, payload_ty))
+        AnalysisResult::new(air_ref, success_payload_ty)
     }
 
     /// Materialize the payload bindings of a tuple-variant match pattern

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -167,6 +167,14 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         stdout: "triple: 12\ntriple: none\n",
         stdin: None,
     },
+    // `?` propagation for Result (RUE-591, ADR-0038): Ok unwraps, Err
+    // short-circuits. add_one_over(10,2)=Ok(6); add_one_over(10,0)=Err(1).
+    ExampleExpectation {
+        path: "first/result_try.rue",
+        exit_code: 0,
+        stdout: "ok: 6\nerr: 1\n",
+        stdin: None,
+    },
     ExampleExpectation {
         path: "first/stats.rue",
         exit_code: 3,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -305,6 +305,8 @@ impl ErrorCode {
     /// `Option` (RUE-6, ADR-0038): `?` early-returns `None`, so the enclosing
     /// function must return an `Option`.
     pub const QUESTION_OUTSIDE_OPTION_FN: Self = Self(503);
+    pub const QUESTION_OUTSIDE_RESULT_FN: Self = Self(505);
+    pub const QUESTION_ERR_TYPE_MISMATCH: Self = Self(506);
     /// The `?` operator was applied to a value that is not an `Option`
     /// (RUE-6, ADR-0038).
     pub const QUESTION_ON_NON_OPTION: Self = Self(504);
@@ -1361,9 +1363,21 @@ pub enum ErrorKind {
         "the `?` operator can only be used in a function that returns an `Option` (found return type `{return_type}`)"
     )]
     QuestionOutsideOptionFn { return_type: String },
-    /// The `?` operator applied to a value that is not an `Option`.
-    #[error("the `?` operator can only be applied to an `Option` (found `{found}`)")]
+    /// The `?` operator applied to a value that is neither an `Option` nor a `Result`.
+    #[error("the `?` operator can only be applied to an `Option` or `Result` (found `{found}`)")]
     QuestionOnNonOption { found: String },
+    /// `?` on a `Result` in a function that does not return a `Result` (ADR-0038).
+    #[error(
+        "the `?` operator on a `Result` requires the enclosing function to return a `Result` (found return type `{return_type}`)"
+    )]
+    QuestionOutsideResultFn { return_type: String },
+    /// `?` on a `Result` whose error type differs from the function's error type.
+    /// Rue has no error conversion (no `From`/`Try`) until traits exist, so the
+    /// error types must match exactly (ADR-0038).
+    #[error(
+        "the `?` operator requires matching error types: the operand is `Err({operand_err})` but the function returns `Err({fn_err})` (no error conversion until traits exist)"
+    )]
+    QuestionErrTypeMismatch { operand_err: String, fn_err: String },
 
     // Match errors
     #[error("match is not exhaustive")]
@@ -1637,6 +1651,8 @@ impl ErrorKind {
             ErrorKind::BreakWithValue => ErrorCode::BREAK_WITH_VALUE,
             ErrorKind::QuestionOutsideOptionFn { .. } => ErrorCode::QUESTION_OUTSIDE_OPTION_FN,
             ErrorKind::QuestionOnNonOption { .. } => ErrorCode::QUESTION_ON_NON_OPTION,
+            ErrorKind::QuestionOutsideResultFn { .. } => ErrorCode::QUESTION_OUTSIDE_RESULT_FN,
+            ErrorKind::QuestionErrTypeMismatch { .. } => ErrorCode::QUESTION_ERR_TYPE_MISMATCH,
 
             // Match errors (E0600-E0699)
             ErrorKind::NonExhaustiveMatch => ErrorCode::NON_EXHAUSTIVE_MATCH,

--- a/crates/rue-ui-tests/cases/diagnostics/result_try_errors.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/result_try_errors.toml
@@ -1,0 +1,62 @@
+[section]
+id = "diagnostics.result-try-errors"
+name = "`?` on Result: targeted diagnostics (RUE-591, ADR-0038)"
+description = """
+`?` now propagates Result (Ok/Err), not just Option. These pin the two Result-
+specific error diagnostics: using `?` on a Result in a function that doesn't
+return a Result (E0505), and a Result whose error type doesn't match the
+function's error type (E0506) — Rue has no error conversion until traits exist.
+`?` recognizes Result by shape, so these use an inline `Result` (the UI harness
+provides no std). Functions are reached from main so the driver analyzes them.
+"""
+
+[[case]]
+name = "question_on_result_in_non_result_fn"
+description = "`?` on a Result inside an Option-returning fn is E0505, not the Option E0503."
+source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn div(a: i32, b: i32) -> Result(i32, i32) {
+    let R = Result(i32, i32);
+    if b == 0 { R.Err(1) } else { R.Ok(a / b) }
+}
+fn f() -> Option(i32) {
+    let O = Option(i32);
+    let q = div(4, 2)?;
+    O.Some(q)
+}
+fn main() -> i32 {
+    let O = Option(i32);
+    match f() { O.Some(v) => v, O.None => 0 }
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0505",
+    "on a `Result` requires the enclosing function to return a `Result`",
+]
+
+[[case]]
+name = "question_result_err_type_mismatch"
+description = "`?` on Err(i32) in a fn returning Err(bool) is E0506 (no error conversion yet)."
+source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn div(a: i32, b: i32) -> Result(i32, i32) {
+    let R = Result(i32, i32);
+    if b == 0 { R.Err(1) } else { R.Ok(a / b) }
+}
+fn f() -> Result(i32, bool) {
+    let R = Result(i32, bool);
+    let q = div(4, 2)?;
+    R.Ok(q)
+}
+fn main() -> i32 {
+    let R = Result(i32, bool);
+    match f() { R.Ok(v) => v, R.Err(e) => 0 }
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0506",
+    "matching error types",
+]

--- a/docs/designs/0038-error-handling-sum-types-result-must-check.md
+++ b/docs/designs/0038-error-handling-sum-types-result-must-check.md
@@ -28,6 +28,16 @@ enums take their multiplicity from the join of their variants' payloads
 (spec 6.3:19/6.3:20), and the pre-payload blanket ownership rules were narrowed
 to discriminant-only enums (RUE-294).
 
+**Implementation status (updated 2026-07-10, RUE-591):** the sum-type + `?`
+machinery is implemented, and `std.Option`, `std.Result` (the `Ok(T)`/`Err(E)`
+library enum), and `?` propagation for **both** now ship. **Not yet implemented:**
+the must-check-via-linearity property below (point 4) — a `Result` is not yet a
+`linear` type, so an unhandled `Result` is silently dropped rather than rejected
+at compile time. `?` currently propagates the **exact** error type (no
+`From`/`Try` conversion, as intended until traits exist). The remaining
+linear/must-check enforcement is tracked by **RUE-591**; this ADR is not fully
+realized until it lands.
+
 ## Summary
 
 Rue gets error handling with no new ownership machinery — it composes parts that

--- a/examples/first/result_try.rue
+++ b/examples/first/result_try.rue
@@ -1,0 +1,38 @@
+// The `?` operator: Result propagation (RUE-6, RUE-591, ADR-0038).
+//
+//   $ rue examples/first/result_try.rue -o try && ./try
+//   ok: 6
+//   err: 1
+//
+// `expr?` on a Result evaluates to the `Ok` payload and early-returns `Err(e)`
+// from the enclosing function (which must itself return a Result with the same
+// error type) when `expr` is `Err(e)`. Compare `add_one_over`, which unwraps
+// with a single `?`, against the `match` it desugars to.
+const std = @import("std");
+
+// checked_div: Ok(a / b), or Err(1) on divide-by-zero.
+fn checked_div(a: i32, b: i32) -> std.result.Result(i32, i32) {
+    let R = std.result.Result(i32, i32);
+    if b == 0 { R.Err(1) } else { R.Ok(a / b) }
+}
+
+// add_one_over: (a / b) + 1, propagating the division error with `?`.
+fn add_one_over(a: i32, b: i32) -> std.result.Result(i32, i32) {
+    let R = std.result.Result(i32, i32);
+    let q = checked_div(a, b)?;
+    R.Ok(q + 1)
+}
+
+fn report(a: i32, b: i32) {
+    let R = std.result.Result(i32, i32);
+    match add_one_over(a, b) {
+        R.Ok(v) => println("ok: " + @to_string(v)),
+        R.Err(e) => println("err: " + @to_string(e)),
+    }
+}
+
+fn main() -> i32 {
+    report(10, 2);        // checked_div = Ok(5) -> add_one_over = Ok(6)
+    report(10, 0);        // checked_div = Err(1) -> `?` short-circuits to Err(1)
+    0
+}

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -6,11 +6,13 @@
 // The standard library provides common utilities organized into submodules:
 // - std.math: Mathematical functions
 // - std.option.Option: Optional values
+// - std.result.Result: Fallible values (Ok/Err), propagated with `?`
 // - std.arraybuf.ArrayBuf: Growable heap-backed collections
 
 // Re-export library modules.
 pub const math = @import("math.rue");
 pub const option = @import("option.rue");
+pub const result = @import("result.rue");
 pub const arraybuf = @import("arraybuf.rue");
 
 fn _exit_syscall_number() -> u64 {

--- a/std/result.rue
+++ b/std/result.rue
@@ -1,0 +1,21 @@
+// Result(T, E) — a fallible value, written in Rue as a comptime-generic enum
+// (ADR-0038). `Ok(T)` carries a success value, `Err(E)` an error value.
+//
+//     const std = @import("std");
+//     let R = std.result.Result(i32, i32);
+//     let x: R = R.Ok(42);
+//     match x {
+//         R.Ok(v) => v,
+//         R.Err(e) => 0 - e,
+//     }
+//
+// The `?` operator propagates it: in a function returning `Result(U, E)`,
+// `expr?` evaluates to the `Ok` payload and early-returns `Err(e)` when `expr`
+// is `Err(e)` (the error type `E` must match — no conversion until traits
+// exist).
+pub fn Result(comptime T: type, comptime E: type) -> type {
+    enum {
+        Ok(T),
+        Err(E),
+    }
+}


### PR DESCRIPTION
ADR-0038 ("Error handling — sum types, Result/Option, must-check via linearity")
was marked *implemented*, but only the Option half shipped: there was **no
`std.Result`**, and `?` was hardcoded to `Option` (`E0503`). Found while
dogfooding an error-handling program (RUE-586).

## Part A — `std.Result`
`std/result.rue`: the ADR-0038 literal
`fn Result(comptime T, comptime E) -> type { enum { Ok(T), Err(E) } }`,
re-exported in the std facade so `std.result.Result(T, E)` works. Usable via
`match` immediately.

## Part B — `?` for Result
`analyze_try` now analyzes the operand first and dispatches on **its** shape.
Option operands are unchanged (propagate `None`). Result operands (recognized by
the new `result_enum_shape`) evaluate to the `Ok` payload on `Ok(v)` and
**early-return `Err(e)`** — moving the error payload out and re-wrapping it in
the enclosing function's `Err`. The enclosing fn must return a `Result` with a
**matching** error type (ADR-0038: no error conversion until traits exist). The
shared desugar is factored into `build_try_desugar`.

Purely a frontend change — `?` lowers to the same `Match`/`EnumPayloadGet`/
`EnumVariant`/`Ret` AIR both backends already handle, so **no codegen change**.

New diagnostics: **E0505** (`?` on a Result in a non-Result-returning fn) and
**E0506** (Result error type mismatch); E0504 now says "Option or Result".

## Not in scope — Part C (tracked by RUE-591)
The **linear must-check**: an unhandled `Result` is still silently dropped rather
than a compile error. ADR-0038's status note is updated to say this honestly
instead of claiming full implementation.

## Result in action
```rue
fn add_one_over(a: i32, b: i32) -> std.result.Result(i32, i32) {
    let R = std.result.Result(i32, i32);
    let q = checked_div(a, b)?;   // early-returns Err(e) on failure
    R.Ok(q + 1)
}
```

## Tests
`examples/first/result_try.rue` (a maintained `?`-propagation fixture mirroring
`option_try.rue`, pinned in the smoke table) + UI cases for E0505/E0506. Option
`?` regression unchanged. Full suite green (Pass 32 / Fail 0); clippy + fmt clean.

Part of RUE-591

🤖 Generated with [Claude Code](https://claude.com/claude-code)