### PR TITLE
RUE-592: resolve re-exported function members through the module object (ADR-0026)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1108,12 +1108,14 @@ fn check_module_member_call(
     param_modes: &[RirParamMode],
     args: &[RirCallArg],
     accessible: bool,
+    via_reexport: bool,
     span: Span,
 ) -> CompileResult<()> {
-    // Check membership: the function must be defined in the module's file.
-    // (Canonical FileId equality, mirroring the struct/enum/const member-access
-    // checks in analyze_module_type_member_access.)
-    if module_file_id != Some(member_file_id) {
+    // Check membership: the function must be defined in the module's file
+    // (canonical FileId equality) — UNLESS the call resolved through a
+    // re-export const in the facade, whose presence is the membership grant
+    // (`pub const f = @import("x").f;`, ADR-0026, RUE-592).
+    if !via_reexport && module_file_id != Some(member_file_id) {
         return Err(CompileError::new(
             ErrorKind::UnknownModuleMember {
                 module_name: module_name.to_string(),

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -417,8 +417,42 @@ impl<'a> Sema<'a> {
         let fn_name_str = self.interner.resolve(&function_name).to_string();
         let module_def = self.module_registry.get_def(module_id);
         let module_file_id = self.canonical_file_id(&module_def.file_path);
-        let function_key = module_file_id
+        let mut function_key = module_file_id
             .and_then(|file_id| self.resolve_function_name_local(function_name, file_id));
+
+        // Fallback: a re-exported function member — `pub const f = @import("x").f;`
+        // in the facade binds `f` to a function value (ADR-0026, RUE-592). It is
+        // not a free function *defined* in the facade, so resolve the call to the
+        // underlying function the const points at. The re-export const's own
+        // visibility gates access from here; its presence is the membership grant,
+        // so the "defined in this file" and underlying-visibility checks are
+        // bypassed below.
+        let mut via_reexport = false;
+        if function_key.is_none()
+            && let Some(mfile) = module_file_id
+        {
+            let reexport = self
+                .constants_by_file_name
+                .get(&(mfile, function_name))
+                .and_then(|info| match info.value {
+                    ConstValue::Function(fkey) => Some((fkey, info.is_pub)),
+                    _ => None,
+                });
+            if let Some((fkey, is_pub)) = reexport {
+                if !self.is_accessible(span.file_id, mfile, is_pub) {
+                    return Err(CompileError::new(
+                        ErrorKind::PrivateMemberAccess {
+                            item_kind: "const".to_string(),
+                            name: fn_name_str.clone(),
+                        },
+                        span,
+                    ));
+                }
+                function_key = Some(fkey);
+                via_reexport = true;
+            }
+        }
+
         let fn_info = self
             .functions
             .get(&function_key.unwrap_or(function_name))
@@ -438,7 +472,9 @@ impl<'a> Sema<'a> {
         let param_types = self.param_arena.types(fn_info.params).to_vec();
         let param_modes = self.param_arena.modes(fn_info.params).to_vec();
         let args = self.rir.get_call_args(args_start, args_len);
-        let accessible = self.is_accessible(span.file_id, fn_info.file_id, fn_info.is_pub);
+        // A re-export was already visibility-checked against its facade const.
+        let accessible =
+            via_reexport || self.is_accessible(span.file_id, fn_info.file_id, fn_info.is_pub);
         check_module_member_call(
             self.rir,
             &module_def.import_path,
@@ -449,6 +485,7 @@ impl<'a> Sema<'a> {
             &param_modes,
             &args,
             accessible,
+            via_reexport,
             span,
         )?;
 

--- a/crates/rue-cli-tests/cases/module_reexport_function.toml
+++ b/crates/rue-cli-tests/cases/module_reexport_function.toml
@@ -1,0 +1,63 @@
+[section]
+id = "cli.module_reexport_function"
+name = "Re-exported function member through a facade (ADR-0026, RUE-592)"
+description = """
+ADR-0026's directory-facade re-export idiom — `pub const f = @import("x").f;`
+accessed as `facade.f()` — was broken for FUNCTION members (E0707: no member),
+though whole-module and value-const re-exports worked. The module-member call
+resolver now falls back to a facade's function-valued constants and resolves the
+call to the underlying function. Privacy is preserved: a non-`pub` re-export is
+rejected across directories.
+"""
+
+[[case]]
+name = "reexported_function_member_is_callable"
+description = "`pub const value = @import(...).value;` is callable as `f.value()`."
+files = [
+    { path = "main.rue", source = """
+const f = @import("facade.rue");
+fn main() -> i32 { f.value() }
+""" },
+    { path = "facade.rue", source = """
+pub const value = @import("helper.rue").value;
+""" },
+    { path = "helper.rue", source = """
+pub fn value() -> i32 { 42 }
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "reexported_function_passes_arguments"
+description = "A re-exported function called through the facade forwards its arguments."
+files = [
+    { path = "main.rue", source = """
+const m = @import("facade.rue");
+fn main() -> i32 { m.add(30, 12) }
+""" },
+    { path = "facade.rue", source = """
+pub const add = @import("math.rue").add;
+""" },
+    { path = "math.rue", source = """
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "non_pub_reexport_is_private_across_dirs"
+description = "A non-`pub` re-export const is rejected (E0706) from another directory."
+compile_fail = true
+error_contains = ["E0706", "private"]
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib");
+fn main() -> i32 { lib.secret() }
+""" },
+    { path = "lib/_lib.rue", source = """
+const secret = @import("impl.rue").secret;
+""" },
+    { path = "lib/impl.rue", source = """
+pub fn secret() -> i32 { 99 }
+""" },
+]


### PR DESCRIPTION
Found by the ADR-implementation audit. ADR-0026 (status **stable**) documents the
directory-facade re-export idiom — `pub const helper = @import("internal.rue").helper;`
accessed as `facade.helper()` — and marks it complete, but it was **broken for
function members**: `facade.value()` → `E0707: module has no member`. Whole-module
re-exports (RUE-136) and local member bindings already worked; this was the
function-member hole.

## Cause
`analyze_module_member_call_impl` resolved the call target only as a free function
*defined in* the facade's file. A re-export binds the member to a function-valued
const (`ConstValue::Function`), not a defined function — so the lookup missed and
fell through to E0707.

## Fix
When the free-function lookup fails, fall back to the facade's function-valued
constants and resolve the call to the underlying function. Since that function
lives in another file, the re-export is the membership grant:
`check_module_member_call` gains a `via_reexport` flag that bypasses the
"defined in this file" membership check and the underlying-visibility check.
Access is instead gated by the **re-export const's own visibility** — so a
non-`pub` re-export is still rejected across directories (E0706). Sema-only; no
codegen change.

## Tests
`module_reexport_function.toml` — callable re-exported function, argument
forwarding, and the private-re-export E0706 rejection. Whole-module and
value-const re-exports still work; full suite green (Pass 32 / Fail 0); clippy +
fmt clean.

Fixes RUE-592

🤖 Generated with [Claude Code](https://claude.com/claude-code)