### PR TITLE
RUE-589: classify oracle failures and save repros

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -115,8 +115,9 @@ jobs:
       # Differential fuzzing: generate valid programs and cross-check the
       # rue-oracle reference interpreter against the compiled native binary
       # (RUE-247). Any exit-code / stdout disagreement is an automatically-found
-      # miscompile; the step exits non-zero and a self-contained repro (named by
-      # its seed) lands in crates/rue-fuzz/crashes/ for the upload step below.
+      # miscompile. A compiler rejection or oracle Unsupported result is a
+      # generator-contract failure. Either class exits non-zero and writes a
+      # self-contained seed/source repro to crates/rue-fuzz/crashes/.
       - name: Differential fuzz (oracle vs compiled, 500 seeds)
         id: fuzz-differential
         continue-on-error: true

--- a/crates/rue-fuzz/README.md
+++ b/crates/rue-fuzz/README.md
@@ -112,9 +112,11 @@ random **valid, well-typed** programs (in the subset the `rue-oracle` reference
 interpreter models) and runs each through *both* the oracle and the real
 compiler + native binary, comparing exit code and `@dbg` stdout. A disagreement
 is an automatically-discovered **miscompile** with a deterministic, seed-based
-repro (not a crash — a *wrong answer*). Its repros land in this crate's
-`crashes/` directory as `oracle-diff-seed-<seed>.rue` and are uploaded by the
-same CI artifact step.
+repro (not a crash — a *wrong answer*). Because the generator promises valid
+programs inside the oracle's modeled subset, compiler rejection and
+`Unsupported` are also fail-closed generator-contract findings with the same
+seed/source repro format. Repros land in this crate's `crashes/` directory as
+`oracle-diff-seed-<seed>.rue` and are uploaded by the same CI artifact step.
 
 ```bash
 RUE_BINARY="$(scripts/rue-bin)" ./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- \

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -6,9 +6,9 @@ load("//crates:defs.bzl", "rue_binary")
 #    code / stdout (a mismatch localizes to codegen; wired as the sh_test below).
 #  * `fuzz`: the differential *fuzzer* (RUE-247) — generates random valid
 #    programs and cross-checks the oracle against the real compiler + native
-#    binary, reporting any exit/stdout disagreement as a miscompile with a
-#    seed-based repro. Driven by `.github/workflows/fuzz.yml` nightly; needs the
-#    `rue` binary via RUE_BINARY.
+#    binary, reporting exit/stdout disagreements as miscompiles and generated
+#    compile/Unsupported results as contract failures, all with seed-based
+#    repros. Driven by `.github/workflows/fuzz.yml` nightly; needs `RUE_BINARY`.
 # The harness driver itself has no #[test] functions — it IS the harness — but
 # the `generator` module carries unit tests (determinism + always-emits-main),
 # so the rust_test target (`:rue-oracle-diff-test`) is kept enabled.
@@ -26,7 +26,8 @@ rue_binary(
     test_deps = [
         # The generator promises valid, well-typed Rue. Compile a fixed corpus
         # through the shared front end so language-dialect drift fails in unit
-        # tests instead of becoming a clean Unsupported skip in fuzz mode.
+        # tests; fuzz mode also treats compile and Unsupported results as
+        # generator-contract failures.
         "//crates/rue-compiler:rue-compiler",
     ],
 )
@@ -37,9 +38,10 @@ rue_binary(
 # that diverges from the semantics fails CI here (RUE-205). Mirrors the
 # examples smoke test wiring (RUE-48): filegroup input + env var + sh_test.
 # Multi-file / unsupported custom-arg / compile-fail cases are skipped by the
-# harness (Unsupported or non-runnable shape), not counted as disagreements, so
-# they cannot cause spurious failures. Preview-gated cases are run when their
-# declared preview flags can be mapped onto the single-source oracle.
+# harness when their shape is intentionally non-runnable. For runnable cases,
+# oracle compile failures fail the harness while unsupported semantics remain a
+# coverage skip. Preview-gated cases run when their declared preview flags can
+# be mapped onto the single-source oracle.
 sh_test(
     name = "oracle-diff-test",
     test = ":rue-oracle-diff",

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -7,10 +7,11 @@
 //! 2. the real compiler + the produced native binary.
 //!
 //! Then compare the observable behavior — process exit code and `@dbg` stdout.
-//! A disagreement is an **automatically-discovered miscompile** with a concrete,
-//! deterministic repro: the seed regenerates the exact program. This is the
-//! RUE-50 payoff wired to RUE-205's harness — "Fable runs a hunt and files bugs"
-//! becomes "CI files the bugs."
+//! A disagreement is an **automatically-discovered miscompile**. A generated
+//! compile failure or oracle `Unsupported` result is a generator-contract
+//! failure. Both are findings with concrete, deterministic repros: the seed
+//! regenerates the exact program. This is the RUE-50 payoff wired to RUE-205's
+//! harness — "Fable runs a hunt and files bugs" becomes "CI files the bugs."
 //!
 //! Determinism: programs are a pure function of their `u64` seed, so the fuzzer
 //! is fully reproducible (`fuzz --start S --seeds 1` re-runs exactly seed `S`).
@@ -19,7 +20,7 @@
 //! `test.sh`, and Buck test targets set from `scripts/rue-bin`.
 
 use crate::generator;
-use rue_oracle::run_source;
+use rue_oracle::{RunSourceError, run_source};
 use std::io::Read;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
@@ -44,6 +45,59 @@ enum Compiled {
     Crash(i32),
     /// The binary did not terminate within the per-program timeout.
     Timeout,
+}
+
+/// A generated program violated the generator's contract before native
+/// compilation could be compared with the oracle. Generated programs promise
+/// both to compile and to stay inside the oracle's modeled subset, so neither
+/// failure is an ordinary differential-harness skip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GeneratorContractFailure {
+    /// The shared Rue frontend rejected generated source.
+    Compile(String),
+    /// The source compiled, but evaluation reached an unmodeled construct.
+    Unsupported(String),
+}
+
+impl GeneratorContractFailure {
+    fn from_run_source(error: RunSourceError) -> Self {
+        match error {
+            RunSourceError::Compile(errors) => Self::Compile(format!("{errors:#?}")),
+            RunSourceError::Unsupported(unsupported) => Self::Unsupported(unsupported.0),
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Compile(_) => "compile",
+            Self::Unsupported(_) => "unsupported",
+        }
+    }
+
+    fn detail(&self) -> &str {
+        match self {
+            Self::Compile(detail) | Self::Unsupported(detail) => detail,
+        }
+    }
+}
+
+struct GeneratorContractFinding {
+    seed: u64,
+    source: String,
+    failure: GeneratorContractFailure,
+}
+
+impl GeneratorContractFinding {
+    fn render(&self) -> String {
+        format!(
+            "\n\u{2717} GENERATOR CONTRACT FAILURE (seed {seed})\n  {kind}: {detail}\n  \
+             --- source (regenerate with `fuzz --start {seed} --seeds 1`) ---\n{source}",
+            seed = self.seed,
+            kind = self.failure.kind(),
+            detail = self.failure.detail(),
+            source = self.source,
+        )
+    }
 }
 
 struct Config {
@@ -95,6 +149,14 @@ fn parse_args(args: &[String]) -> Result<Config, String> {
             other => return Err(format!("unknown argument: {other}")),
         }
     }
+
+    if cfg.seeds == 0 {
+        return Err("--seeds must be greater than zero".to_string());
+    }
+    cfg.start
+        .checked_add(cfg.seeds)
+        .ok_or_else(|| "--start + --seeds exceeds the u64 seed range".to_string())?;
+
     Ok(cfg)
 }
 
@@ -138,28 +200,42 @@ pub fn run(args: &[String]) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
+    let seed_end = cfg
+        .start
+        .checked_add(cfg.seeds)
+        .expect("parse_args validates the seed range");
+
     println!(
         "=== rue-oracle-diff fuzz: seeds {}..{} (compiler: {}) ===",
         cfg.start,
-        cfg.start + cfg.seeds,
+        seed_end,
         rue.display()
     );
 
     let mut agree = 0u32;
-    let mut skip_unsupported = 0u32;
+    let mut generator_contract_failures: Vec<GeneratorContractFinding> = Vec::new();
     let mut disagreements: Vec<Disagreement> = Vec::new();
 
-    for seed in cfg.start..cfg.start + cfg.seeds {
+    for seed in cfg.start..seed_end {
         let source = generator::generate(seed);
 
         let oracle = match run_source(&source) {
-            // Outside the modeled subset (or a front-end compile error): a clean
-            // skip, exactly as intended — never a false disagreement.
-            Err(unsupported) => {
-                skip_unsupported += 1;
-                if cfg.verbose {
-                    println!("  seed {seed}: skip ({})", unsupported.0);
+            Err(error) => {
+                // Unlike corpus mode, generated mode has a strong input
+                // contract: every program must compile and remain within the
+                // oracle's supported subset. Record either typed failure as a
+                // finding, save its exact deterministic source, and continue so
+                // one bad seed cannot hide the rest of the batch.
+                let finding = GeneratorContractFinding {
+                    seed,
+                    source: source.clone(),
+                    failure: GeneratorContractFailure::from_run_source(error),
+                };
+                eprintln!("{}", finding.render());
+                if let Err(error) = save_generator_contract_repro(&cfg.crash_dir, &finding) {
+                    report_repro_write_error(&cfg.crash_dir, seed, &error);
                 }
+                generator_contract_failures.push(finding);
                 continue;
             }
             Ok(o) => o,
@@ -193,30 +269,40 @@ pub fn run(args: &[String]) -> ExitCode {
                     reason,
                 };
                 eprintln!("{}", d.render());
-                let _ = save_repro(&cfg.crash_dir, &d);
+                if let Err(error) = save_repro(&cfg.crash_dir, &d) {
+                    report_repro_write_error(&cfg.crash_dir, seed, &error);
+                }
                 disagreements.push(d);
             }
         }
     }
 
-    let total = agree + skip_unsupported + disagreements.len() as u32;
+    let total = agree + generator_contract_failures.len() as u32 + disagreements.len() as u32;
     println!("\n=== summary over {total} generated programs ===");
     println!("  agree:            {agree}");
-    println!("  skip (unmodeled): {skip_unsupported}");
+    println!(
+        "  GENERATOR CONTRACT FAILURES: {}",
+        generator_contract_failures.len()
+    );
     println!("  DISAGREEMENTS:    {}", disagreements.len());
 
-    if disagreements.is_empty() {
+    if generated_batch_passes(generator_contract_failures.len(), disagreements.len()) {
         println!("\noracle and compiler agree on every generated program.");
         ExitCode::SUCCESS
     } else {
         println!(
-            "\n{} disagreement(s) — each is an automatically-found miscompile. \
-             Repros saved to {}.",
+            "\n{} generator contract failure(s), {} disagreement(s). \
+             Repros targeted at {}; any write failures are reported above.",
+            generator_contract_failures.len(),
             disagreements.len(),
             cfg.crash_dir.display()
         );
         ExitCode::FAILURE
     }
+}
+
+fn generated_batch_passes(contract_failures: usize, disagreements: usize) -> bool {
+    contract_failures == 0 && disagreements == 0
 }
 
 /// The comparison verdict.
@@ -514,25 +600,94 @@ fn first_line(s: &str) -> String {
         .collect()
 }
 
+fn repro_path(dir: &Path, seed: u64) -> PathBuf {
+    dir.join(format!("oracle-diff-seed-{seed}.rue"))
+}
+
+/// Escape dynamic diagnostic text onto one physical `//` line. Diagnostics may
+/// contain newlines, carriage returns, or other controls; writing them verbatim
+/// could end the comment and turn metadata into active Rue source, making a
+/// saved repro non-reproducible (or even syntactically invalid).
+fn comment_safe(text: &str) -> String {
+    text.chars().flat_map(char::escape_debug).collect()
+}
+
+fn push_repro_comment(contents: &mut String, label: &str, value: &str) {
+    contents.push_str("// ");
+    contents.push_str(label);
+    contents.push_str(": ");
+    contents.push_str(&comment_safe(value));
+    contents.push('\n');
+}
+
+fn disagreement_repro_contents(d: &Disagreement) -> String {
+    let mut contents = format!(
+        "// rue-oracle-diff differential miscompile (seed {})\n",
+        d.seed
+    );
+    push_repro_comment(&mut contents, "reason", &d.reason);
+    push_repro_comment(
+        &mut contents,
+        "oracle",
+        &format!(
+            "exit={} panic={:?} stdout={:?}",
+            d.oracle_exit, d.oracle_panic, d.oracle_stdout
+        ),
+    );
+    push_repro_comment(&mut contents, "compiled", &d.compiled);
+    push_repro_comment(
+        &mut contents,
+        "regenerate",
+        &format!("rue-oracle-diff fuzz --start {} --seeds 1", d.seed),
+    );
+    contents.push('\n');
+    contents.push_str(&d.source);
+    contents
+}
+
+fn generator_contract_repro_contents(finding: &GeneratorContractFinding) -> String {
+    let mut contents = format!(
+        "// rue-oracle-diff generator contract failure (seed {})\n",
+        finding.seed
+    );
+    push_repro_comment(&mut contents, "failure kind", finding.failure.kind());
+    push_repro_comment(&mut contents, "detail", finding.failure.detail());
+    push_repro_comment(
+        &mut contents,
+        "regenerate",
+        &format!("rue-oracle-diff fuzz --start {} --seeds 1", finding.seed),
+    );
+    contents.push('\n');
+    contents.push_str(&finding.source);
+    contents
+}
+
+fn write_repro(dir: &Path, seed: u64, contents: &str) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(repro_path(dir, seed), contents)
+}
+
+fn report_repro_write_error(dir: &Path, seed: u64, error: &std::io::Error) {
+    eprintln!(
+        "seed {seed}: failed to save repro at {}: {error}",
+        repro_path(dir, seed).display()
+    );
+}
+
 /// Persist a repro so a CI failure uploads a concrete, self-contained program.
 fn save_repro(dir: &Path, d: &Disagreement) -> std::io::Result<()> {
-    std::fs::create_dir_all(dir)?;
-    let path = dir.join(format!("oracle-diff-seed-{}.rue", d.seed));
-    let contents = format!(
-        "// rue-oracle-diff differential miscompile (seed {seed})\n\
-         // reason: {reason}\n\
-         // oracle:   exit={exit} panic={panic:?} stdout={stdout:?}\n\
-         // compiled: {compiled}\n\
-         // regenerate: rue-oracle-diff fuzz --start {seed} --seeds 1\n\n{source}",
-        seed = d.seed,
-        reason = d.reason,
-        exit = d.oracle_exit,
-        panic = d.oracle_panic,
-        stdout = d.oracle_stdout,
-        compiled = d.compiled,
-        source = d.source,
-    );
-    std::fs::write(path, contents)
+    write_repro(dir, d.seed, &disagreement_repro_contents(d))
+}
+
+fn save_generator_contract_repro(
+    dir: &Path,
+    finding: &GeneratorContractFinding,
+) -> std::io::Result<()> {
+    write_repro(
+        dir,
+        finding.seed,
+        &generator_contract_repro_contents(finding),
+    )
 }
 
 #[cfg(test)]
@@ -666,6 +821,74 @@ mod tests {
     }
 
     #[test]
+    fn generated_oracle_errors_remain_typed_contract_failures() {
+        // A frontend rejection is a generator compile-contract failure, not an
+        // oracle Unsupported skip and not a native `Compiled::CompileFail`.
+        let compile_error = run_source("fn main(").expect_err("invalid Rue must not compile");
+        let compile_failure = GeneratorContractFailure::from_run_source(compile_error);
+        assert!(matches!(
+            compile_failure,
+            GeneratorContractFailure::Compile(detail) if !detail.is_empty()
+        ));
+
+        // A compiled-but-unmodeled program is the other distinct contract
+        // failure class. Keep the variant typed so summaries/repros cannot
+        // collapse it back into the old generic skip path.
+        let unsupported = RunSourceError::Unsupported(rue_oracle::Unsupported(
+            "intrinsic @random_u32".to_string(),
+        ));
+        assert_eq!(
+            GeneratorContractFailure::from_run_source(unsupported),
+            GeneratorContractFailure::Unsupported("intrinsic @random_u32".to_string())
+        );
+    }
+
+    #[test]
+    fn generator_contract_repro_is_deterministic_and_comment_safe() {
+        let finding = GeneratorContractFinding {
+            seed: 17,
+            source: "fn main() -> i32 { 17 }\n".to_string(),
+            failure: GeneratorContractFailure::Compile(
+                "first diagnostic\nfn injected() -> i32 { 0 }\rsecond".to_string(),
+            ),
+        };
+
+        let contents = generator_contract_repro_contents(&finding);
+        assert_eq!(contents, generator_contract_repro_contents(&finding));
+        assert!(
+            contents
+                .contains("// detail: first diagnostic\\nfn injected() -> i32 { 0 }\\rsecond\n")
+        );
+        assert!(
+            !contents.contains("\nfn injected"),
+            "diagnostic text must never escape its metadata comment"
+        );
+        assert!(
+            contents.ends_with("\n\nfn main() -> i32 { 17 }\n"),
+            "the exact generated source follows the comment-only metadata"
+        );
+    }
+
+    #[test]
+    fn disagreement_repro_also_escapes_multiline_metadata() {
+        let disagreement = Disagreement {
+            seed: 23,
+            source: "fn main() -> i32 { 23 }\n".to_string(),
+            oracle_exit: 23,
+            oracle_stdout: String::new(),
+            oracle_panic: None,
+            compiled: "compile-fail: first\rsecond".to_string(),
+            reason: "wrong exit\nconst injected = 1;".to_string(),
+        };
+
+        let contents = disagreement_repro_contents(&disagreement);
+        assert!(contents.contains("// reason: wrong exit\\nconst injected = 1;\n"));
+        assert!(contents.contains("// compiled: compile-fail: first\\rsecond\n"));
+        assert!(!contents.contains("\nconst injected"));
+        assert!(contents.ends_with("\n\nfn main() -> i32 { 23 }\n"));
+    }
+
+    #[test]
     fn large_stdout_does_not_deadlock() {
         // RUE-338: a program that writes far more than the OS pipe capacity
         // (~64KB) must be drained concurrently while it runs. Before the fix the
@@ -753,5 +976,26 @@ mod tests {
         let cfg = parse_args(&["--start=5".into(), "--seeds".into(), "12".into()]).expect("parse");
         assert_eq!(cfg.start, 5);
         assert_eq!(cfg.seeds, 12);
+    }
+
+    #[test]
+    fn args_reject_vacuous_or_wrapped_seed_ranges() {
+        let zero = parse_args(&["--seeds=0".into()])
+            .err()
+            .expect("zero seeds must fail closed");
+        assert!(zero.contains("greater than zero"));
+
+        let wrapped = parse_args(&[format!("--start={}", u64::MAX), "--seeds=1".into()])
+            .err()
+            .expect("a seed range must not wrap around u64::MAX");
+        assert!(wrapped.contains("exceeds the u64 seed range"));
+    }
+
+    #[test]
+    fn generated_batch_fails_for_either_finding_class() {
+        assert!(generated_batch_passes(0, 0));
+        assert!(!generated_batch_passes(1, 0));
+        assert!(!generated_batch_passes(0, 1));
+        assert!(!generated_batch_passes(1, 1));
     }
 }

--- a/crates/rue-oracle-diff/src/generator.rs
+++ b/crates/rue-oracle-diff/src/generator.rs
@@ -8,8 +8,9 @@
 //! required type, every literal is emitted inside a typed context (a `let`
 //! annotation, a struct-field position, or a same-typed sibling), and aggregate
 //! values are never used after a by-value move. A generated program therefore
-//! compiles cleanly (a compile failure is itself a finding, not noise) and stays
-//! inside the oracle's coverage, so `Unsupported` is a clean skip.
+//! compiles cleanly and stays inside the oracle's coverage. A compile failure or
+//! `Unsupported` result is therefore a generator-contract finding, not noise or
+//! a coverage skip.
 //!
 //! The generator biases toward the historically-fragile shapes that every
 //! 2026-07 miscompile lived in: aggregates crossing the call ABI (struct
@@ -846,7 +847,8 @@ mod tests {
     /// The generator is part of the compiler's correctness boundary: it
     /// promises valid, well-typed Rue programs. Compile a deterministic corpus
     /// through the shared front end so grammar, name-resolution, or typing
-    /// drift is a failing test rather than an `Unsupported` fuzz skip.
+    /// drift is a failing test; generated fuzz mode also fails closed if the
+    /// oracle reports `Unsupported`.
     #[test]
     fn generated_programs_compile() {
         let mut saw_string_associated_call = false;

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -34,14 +34,18 @@
 //!   against the real compiler + native binary. See [`fuzz`]. A `dump <seed>`
 //!   subcommand prints a generated program for inspection.
 //!
-//! Every mode exits non-zero if any disagreement is found.
+//! Every mode exits non-zero if a runnable program is rejected by the front end
+//! or if the oracle disagrees with the expected behavior. Generated fuzz mode
+//! also exits non-zero if the oracle reports `Unsupported`, because its
+//! generator promises to stay within the modeled subset.
 
 mod fuzz;
 mod generator;
 
 use rue_error::{PreviewFeature, PreviewFeatures};
-use rue_oracle::run_source_with_preview_features;
+use rue_oracle::{RunSourceError, run_source_with_preview_features};
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::str::FromStr;
@@ -64,6 +68,8 @@ struct Case {
     args: Option<Vec<String>>,
     #[serde(default)]
     stdin: Option<String>,
+    #[serde(default)]
+    env: HashMap<String, String>,
     #[serde(default)]
     compile_fail: bool,
     #[serde(default)]
@@ -94,6 +100,8 @@ struct Report {
     skip_unsupported: u32,
     /// case shape the harness cannot drive (multi-file, stdin, custom args, …)
     skip_nonrunnable: u32,
+    /// a runnable corpus case was rejected by the shared compiler front end
+    frontend_failures: Vec<String>,
     /// oracle ran but disagreed with the expected behavior — a bug
     disagreements: Vec<String>,
 }
@@ -197,17 +205,22 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
 
 /// Print the tallied report and turn it into a process exit code: success when
 /// the oracle agreed with the compiler on every runnable case, failure on any
-/// disagreement. Shared by [`corpus_mode`] and [`spec_mode`]; `corpus` names
-/// which corpus was differenced, for the header.
+/// front-end rejection or disagreement. Shared by [`corpus_mode`] and
+/// [`spec_mode`]; `corpus` names which corpus was differenced, for the header.
 fn finish_report(report: &Report, corpus: &str) -> ExitCode {
     let total = report.agree
         + report.skip_unsupported
         + report.skip_nonrunnable
+        + report.frontend_failures.len() as u32
         + report.disagreements.len() as u32;
     println!("\n=== rue-oracle-diff: differential agreement over {total} {corpus} cases ===");
     println!("  agree:            {}", report.agree);
     println!("  skip (unmodeled): {}", report.skip_unsupported);
     println!("  skip (non-runnable shape): {}", report.skip_nonrunnable);
+    println!("  FRONTEND FAILURES: {}", report.frontend_failures.len());
+    for failure in &report.frontend_failures {
+        println!("\n  ✗ {failure}");
+    }
     println!("  DISAGREEMENTS:    {}", report.disagreements.len());
     for d in &report.disagreements {
         println!("\n  ✗ {d}");
@@ -221,12 +234,14 @@ fn finish_report(report: &Report, corpus: &str) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    if report.disagreements.is_empty() {
+    if report.frontend_failures.is_empty() && report.disagreements.is_empty() {
         println!("\noracle agrees with the compiler on every runnable case.");
         ExitCode::SUCCESS
     } else {
         println!(
-            "\n{} disagreement(s) — each is a bug in the oracle or (more likely) codegen.",
+            "\n{} frontend failure(s), {} disagreement(s) — runnable corpus cases must \
+             compile before the oracle can check them.",
+            report.frontend_failures.len(),
             report.disagreements.len()
         );
         ExitCode::FAILURE
@@ -282,8 +297,9 @@ fn spec_mode(raw_args: Vec<String>) -> ExitCode {
 /// (no runtime output), `compile_only` (never executed), golden-IR-only (an IR
 /// dump, not a run), or a shape with no oracle model (stdin, multi-file
 /// `aux_files`). Preview-gated cases run with their declared preview feature.
-/// Cases the oracle simply can't model yet return [`Unsupported`] and count as
-/// unmodeled skips.
+/// Cases the oracle simply can't model yet return [`RunSourceError::Unsupported`]
+/// and count as unmodeled skips. [`RunSourceError::Compile`] for a case that
+/// survived these shape filters is a front-end failure and fails the harness.
 fn check_spec_case(ident: &str, case: &rue_test_runner::Case, report: &mut Report) {
     let golden_only = case.has_golden_ir_assertions() && !case.has_execution_assertions();
     // A `target`-pinned case's expected exit is target-specific (e.g. it matches
@@ -326,9 +342,13 @@ fn check_spec_case(ident: &str, case: &rue_test_runner::Case, report: &mut Repor
     let preview_features = spec_preview_features(case);
 
     match run_source_with_preview_features(&case.source, &preview_features) {
-        // Oracle bailed (unmodeled construct). For a tracked gap this is the
-        // "skip Unsupported cleanly" outcome; either way it's a skip, not a bug.
-        Err(_unsupported) => report.skip_unsupported += 1,
+        // Unsupported means the interpreter cannot model a valid program and is
+        // a clean skip. Compile means this runnable corpus case was rejected by
+        // the shared front end and must fail rather than disappear as unmodeled.
+        Err(error) => {
+            let context = format!("{ident} :: {}", case.name);
+            record_oracle_error(&context, error, report);
+        }
         Ok(outcome) => {
             let exit_ok = outcome.exit_code == expected_exit;
             // Compare stdout the way the spec runner itself does: byte-exact
@@ -395,13 +415,13 @@ fn spec_preview_features(case: &rue_test_runner::Case) -> PreviewFeatures {
 }
 
 /// Spec-corpus cases the oracle is known to model incorrectly (returning a
-/// wrong-but-`Ok` result rather than [`Unsupported`]), each paired with the
-/// tracking issue. These are **not** miscompiles — the compiler is correct; the
-/// oracle is. They are carried as xfails (see [`check_spec_case`]): each is
-/// asserted to *still* diverge, so when its tracked bug is fixed the harness
-/// fails and points at the entry to delete. Keep this list tiny — it exists
-/// only to keep CI green over a documented, tracked oracle limitation, never to
-/// paper over a real codegen disagreement.
+/// wrong-but-`Ok` result rather than [`RunSourceError::Unsupported`]), each
+/// paired with the tracking issue. These are **not** miscompiles — the compiler
+/// is correct; the oracle is. They are carried as xfails (see
+/// [`check_spec_case`]): each is asserted to *still* diverge, so when its
+/// tracked bug is fixed the harness fails and points at the entry to delete.
+/// Keep this list tiny — it exists only to keep CI green over a documented,
+/// tracked oracle limitation, never to paper over a real codegen disagreement.
 ///
 /// Entry: `(section-identifier, case-name, tracking-issue)`.
 const KNOWN_ORACLE_GAPS: &[(&str, &str, &str)] = &[
@@ -422,6 +442,10 @@ fn check_case(path: &Path, case: &Case, report: &mut Report) {
         || case.compile_only
         || case.known_bug.is_some()
         || case.stdin.is_some()
+        // The in-process oracle compiles one source string; it cannot reproduce
+        // CLI-only environment-dependent loading such as RUE_STD_PATH. Treat
+        // any declared environment as a shape limitation before compilation.
+        || !case.env.is_empty()
         || case.files.len() != 1
     {
         report.skip_nonrunnable += 1;
@@ -439,7 +463,10 @@ fn check_case(path: &Path, case: &Case, report: &mut Report) {
         });
 
     match run_source_with_preview_features(source, &preview_features) {
-        Err(_unsupported) => report.skip_unsupported += 1,
+        Err(error) => {
+            let context = format!("{} :: {}", rel(path), case.name);
+            record_oracle_error(&context, error, report);
+        }
         Ok(outcome) => {
             let exit_ok = outcome.exit_code == expected_exit;
             let stdout_ok = case.stdout.as_ref().is_none_or(|s| &outcome.stdout == s);
@@ -463,6 +490,19 @@ fn check_case(path: &Path, case: &Case, report: &mut Report) {
                 report.disagreements.push(msg);
             }
         }
+    }
+}
+
+/// Classify an oracle error without conflating a compiler rejection with an
+/// interpreter coverage gap. Corpus/spec callers prefilter intentional
+/// `compile_fail` cases, so any [`RunSourceError::Compile`] reaching this helper
+/// is an unexpected front-end failure in a supposedly runnable program.
+fn record_oracle_error(context: &str, error: RunSourceError, report: &mut Report) {
+    match error {
+        RunSourceError::Compile(errors) => report
+            .frontend_failures
+            .push(format!("{context}\n      {errors:#?}")),
+        RunSourceError::Unsupported(_) => report.skip_unsupported += 1,
     }
 }
 
@@ -527,5 +567,87 @@ fn collect_toml(dir: &Path, out: &mut Vec<PathBuf>) {
         } else if p.extension().is_some_and(|e| e == "toml") {
             out.push(p);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_oracle::Unsupported;
+
+    fn corpus_case(source: &str, compile_fail: bool) -> Case {
+        Case {
+            name: "classification probe".to_string(),
+            files: vec![SourceFile {
+                path: "probe.rue".to_string(),
+                source: source.to_string(),
+            }],
+            args: None,
+            stdin: None,
+            env: HashMap::new(),
+            compile_fail,
+            compile_only: false,
+            stdout: None,
+            runtime_error_contains: Vec::new(),
+            exit_code: Some(0),
+            known_bug: None,
+            skip: false,
+        }
+    }
+
+    #[test]
+    fn runnable_compile_rejection_is_a_frontend_failure() {
+        let case = corpus_case("fn main() -> i32 { missing_name }", false);
+        let mut report = Report::default();
+
+        check_case(Path::new("classification.toml"), &case, &mut report);
+
+        assert_eq!(report.frontend_failures.len(), 1);
+        assert!(report.frontend_failures[0].contains("classification.toml"));
+        assert_eq!(report.skip_unsupported, 0);
+        assert_eq!(finish_report(&report, "test"), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn unsupported_is_still_a_clean_skip() {
+        let mut report = Report::default();
+
+        record_oracle_error(
+            "unsupported probe",
+            RunSourceError::Unsupported(Unsupported("known coverage gap".to_string())),
+            &mut report,
+        );
+
+        assert_eq!(report.skip_unsupported, 1);
+        assert!(report.frontend_failures.is_empty());
+        assert_eq!(finish_report(&report, "test"), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn intentional_compile_fail_is_prefiltered() {
+        let case = corpus_case("this is intentionally not Rue", true);
+        let mut report = Report::default();
+
+        check_case(Path::new("compile_fail.toml"), &case, &mut report);
+
+        assert_eq!(report.skip_nonrunnable, 1);
+        assert_eq!(report.skip_unsupported, 0);
+        assert!(report.frontend_failures.is_empty());
+        assert_eq!(finish_report(&report, "test"), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn environment_dependent_case_is_prefiltered() {
+        let mut case = corpus_case("this would fail if the oracle compiled it", false);
+        case.env
+            .insert("RUE_STD_PATH".to_string(), "${REAL_STD}".to_string());
+        let mut report = Report::default();
+
+        check_case(Path::new("environment.toml"), &case, &mut report);
+
+        assert_eq!(report.skip_nonrunnable, 1);
+        assert_eq!(report.skip_unsupported, 0);
+        assert!(report.frontend_failures.is_empty());
+        assert_eq!(finish_report(&report, "test"), ExitCode::SUCCESS);
     }
 }

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -42,9 +42,11 @@
 //!
 //! ## What is *not* modeled (reported [`Unsupported`], never guessed)
 //!
-//! A program hitting any of these is **skipped** by the differential harness, so
-//! "compiles + runs under the oracle" is NOT the same as "differentially
-//! checked" — the gaps below are genuinely unvalidated:
+//! Corpus/spec programs hitting any of these are **skipped** by the differential
+//! harness, so "compiles + runs under the oracle" is NOT the same as
+//! "differentially checked" — the gaps below are genuinely unvalidated. The
+//! generated-program mode has a stronger contract and fails closed if its
+//! supposedly supported generator reaches one of these gaps.
 //!
 //! - **All CFG intrinsics except `@dbg`.** The `Intrinsic` arm models only
 //!   `@dbg`; every other intrinsic that survives to the CFG bails: the
@@ -62,9 +64,11 @@ use lasso::ThreadedRodeo;
 use rue_air::{Type, TypeKind};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
 use rue_compiler::{
-    CompileState, PreviewFeatures, compile_to_cfg, compile_to_cfg_with_preview_features,
+    CompileErrors, CompileState, PreviewFeatures, compile_to_cfg,
+    compile_to_cfg_with_preview_features,
 };
 use std::collections::HashMap;
+use std::fmt;
 
 /// Observable result of running a program under the oracle.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,20 +83,62 @@ pub struct Outcome {
 }
 
 /// A construct the interpreter does not yet model (see the coverage note). This
-/// is *not* a program error — it means the oracle cannot judge this program yet,
-/// so a differential harness should skip it rather than report a disagreement.
+/// is *not* a program error — it means the oracle cannot judge this program yet.
+/// Callers decide whether that is an expected coverage skip or a violation of a
+/// stronger contract, such as a generator that promises oracle-supported input.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Unsupported(pub String);
 
+impl fmt::Display for Unsupported {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for Unsupported {}
+
+/// Failure to compile or interpret a source program under the oracle.
+///
+/// These variants deliberately distinguish a front-end rejection from a
+/// well-typed program that reaches a construct outside the interpreter's
+/// coverage. Callers must choose an explicit policy for each case instead of
+/// inferring it from an error-message prefix.
+#[derive(Debug, Clone)]
+pub enum RunSourceError {
+    /// Rue's front end rejected the source before interpretation could begin.
+    Compile(CompileErrors),
+    /// The source compiled, but the interpreter cannot model part of it.
+    Unsupported(Unsupported),
+}
+
+impl fmt::Display for RunSourceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RunSourceError::Compile(errors) => write!(f, "source failed to compile: {errors}"),
+            RunSourceError::Unsupported(unsupported) => {
+                write!(f, "unsupported by the oracle: {unsupported}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RunSourceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RunSourceError::Compile(errors) => Some(errors),
+            RunSourceError::Unsupported(unsupported) => Some(unsupported),
+        }
+    }
+}
+
 /// Compile `source` to CFG and run it under the reference semantics.
 ///
-/// `Err(Unsupported)` means the program uses a construct outside the current
-/// slice. A compile error is surfaced as `Err(Unsupported("compile: .."))` so
-/// callers can distinguish it from a real interpreter result; a well-typed
-/// program in the supported subset always yields `Ok`.
-pub fn run_source(source: &str) -> Result<Outcome, Unsupported> {
-    let state = compile_to_cfg(source).map_err(|e| Unsupported(format!("compile: {e:?}")))?;
-    run_state(state)
+/// [`RunSourceError::Compile`] means the front end rejected the source;
+/// [`RunSourceError::Unsupported`] means compilation succeeded but execution
+/// reached a construct outside the interpreter's current coverage.
+pub fn run_source(source: &str) -> Result<Outcome, RunSourceError> {
+    let state = compile_to_cfg(source).map_err(RunSourceError::Compile)?;
+    run_state(state).map_err(RunSourceError::Unsupported)
 }
 
 /// Compile `source` with explicit preview features, then run it under the
@@ -104,10 +150,10 @@ pub fn run_source(source: &str) -> Result<Outcome, Unsupported> {
 pub fn run_source_with_preview_features(
     source: &str,
     preview_features: &PreviewFeatures,
-) -> Result<Outcome, Unsupported> {
+) -> Result<Outcome, RunSourceError> {
     let state = compile_to_cfg_with_preview_features(source, preview_features)
-        .map_err(|e| Unsupported(format!("compile: {e:?}")))?;
-    run_state(state)
+        .map_err(RunSourceError::Compile)?;
+    run_state(state).map_err(RunSourceError::Unsupported)
 }
 
 fn run_state(state: CompileState) -> Result<Outcome, Unsupported> {

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -8,7 +8,7 @@
 use super::*;
 
 fn run(src: &str) -> Outcome {
-    run_source(src).unwrap_or_else(|u| panic!("unsupported: {}", u.0))
+    run_source(src).unwrap_or_else(|error| panic!("oracle failed: {error}"))
 }
 
 fn run_with_budget(src: &str, budget: u64) -> Result<Outcome, Unsupported> {
@@ -20,7 +20,17 @@ fn run_string_trio(src: &str) -> Outcome {
     let mut preview_features = PreviewFeatures::new();
     preview_features.insert(rue_compiler::PreviewFeature::StringTrio);
     run_source_with_preview_features(src, &preview_features)
-        .unwrap_or_else(|u| panic!("unsupported: {}", u.0))
+        .unwrap_or_else(|error| panic!("oracle failed: {error}"))
+}
+
+fn expect_unsupported(src: &str) -> Unsupported {
+    match run_source(src) {
+        Err(RunSourceError::Unsupported(unsupported)) => unsupported,
+        Err(RunSourceError::Compile(errors)) => {
+            panic!("expected oracle-unsupported source, but it failed to compile: {errors:#?}")
+        }
+        Ok(outcome) => panic!("expected oracle-unsupported source, got {outcome:?}"),
+    }
 }
 
 fn exit(src: &str) -> i32 {
@@ -153,8 +163,37 @@ fn preview_features_reach_oracle_frontend() {
         0
     }"#;
 
-    assert!(run_source(src).is_err(), "str should stay gated by default");
+    assert!(
+        matches!(run_source(src), Err(RunSourceError::Compile(_))),
+        "str should stay gated by default with a compile error"
+    );
     assert_eq!(run_string_trio(src).exit_code, 0);
+}
+
+#[test]
+fn compile_errors_are_distinct_from_unsupported_programs() {
+    let error = run_source("fn main() -> i32 { missing }")
+        .expect_err("an undefined name must fail compilation");
+
+    match error {
+        RunSourceError::Compile(errors) => {
+            assert!(!errors.is_empty(), "compile failure must carry diagnostics");
+        }
+        RunSourceError::Unsupported(unsupported) => {
+            panic!("compile failure was misclassified as unsupported: {unsupported}");
+        }
+    }
+}
+
+#[test]
+fn valid_unmodeled_program_is_unsupported_not_a_compile_error() {
+    let src = "fn main() -> i32 {
+        let value: u32 = @random_u32();
+        if value == 0 { 0 } else { 1 }
+    }";
+
+    let unsupported = expect_unsupported(src);
+    assert_eq!(unsupported.0, "intrinsic @random_u32");
 }
 
 #[test]
@@ -224,7 +263,7 @@ fn unbounded_recursion_is_unsupported() {
     // (MAX_DEPTH) must turn it into a clean `Unsupported` skip instead (RUE-340).
     let src = "fn r(n: i32) -> i32 { r(n) }
     fn main() -> i32 { r(0) }";
-    let err = run_source(src).expect_err("unbounded recursion must not produce an Outcome");
+    let err = expect_unsupported(src);
     assert!(
         err.0.contains("depth budget"),
         "expected a depth-budget skip, got: {}",
@@ -238,7 +277,7 @@ fn deep_bounded_recursion_is_unsupported() {
     // cleanly (hitting the depth bound) rather than overflow the stack.
     let src = "fn r(n: i32) -> i32 { if n <= 0 { 0 } else { r(n - 1) } }
     fn main() -> i32 { r(100000) }";
-    let err = run_source(src).expect_err("deep recursion must not produce an Outcome");
+    let err = expect_unsupported(src);
     assert!(
         err.0.contains("depth budget"),
         "expected a depth-budget skip, got: {}",
@@ -270,7 +309,7 @@ fn runaway_loop_is_unsupported() {
     // reported `Unsupported`, never hang. Each iteration flips `b` (a `Not`
     // instruction), so the budget is decremented every turn of the loop.
     let src = "fn main() -> i32 { let mut b = true; loop { b = !b; } }";
-    let err = run_source(src).expect_err("a runaway loop must not produce an Outcome");
+    let err = expect_unsupported(src);
     assert!(
         err.0.contains("step budget"),
         "expected a step-budget skip, got: {}",


### PR DESCRIPTION
## Summary

- replace the oracle's stringly compile-error convention with `RunSourceError::{Compile, Unsupported}`
- make generated mode treat either variant as a generator-contract failure, continue the seed batch, and save a deterministic seed/source repro
- keep corpus/spec `Unsupported` as an explicit coverage skip while making unexpected frontend rejection fail the harness
- prefilter environment-dependent corpus cases as non-runnable metadata shapes instead of special-casing std imports
- reject zero-length and overflowing seed ranges so the differential gate cannot pass vacuously
- update the generator, Buck, workflow, and fuzzing docs to state the fail-closed contract

This is the next bounded unit of RUE-589. It keeps generated-program policy deliberately stricter than arbitrary corpus policy: the generator promises valid source inside oracle coverage, so compile rejection or `Unsupported` is drift, not noise.

## Verification

- `scripts/rue test` — Pass 32, Fail 0; trusted exit status
- `./clippy.sh` — 41 targets, no violations
- oracle tests — 57 passed, 1 intentionally ignored
- oracle-diff tests — 26 passed
- live CLI corpus — 603 agree, 106 unmodeled, 539 non-runnable, 0 frontend failures, 0 disagreements
- live spec corpus — 1310 agree, 107 unmodeled, 581 non-runnable, 0 frontend failures, 0 disagreements
- generated acceptance — 500/500 agree, 0 contract failures, 0 disagreements
- `fuzz --seeds 0` — exits 1 with a non-vacuity error

Part of RUE-589.