### PR TITLE
RUE-593: ADR documentation-accuracy sweep — remove dead inference arms, fix stale syntax

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1178,12 +1178,6 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Concrete(Type::UNIT)
-                } else if intrinsic_name == "is_null" {
-                    // @is_null: takes a pointer, returns bool
-                    for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
-                    }
-                    InferType::Concrete(Type::BOOL)
                 } else if intrinsic_name == "ptr_read" {
                     // @ptr_read: takes ptr const T or ptr mut T, returns T
                     // The return type depends on the pointee type of the argument.
@@ -1271,19 +1265,13 @@ impl<'a> ConstraintGenerator<'a> {
                         }
                     }
                     InferType::Concrete(Type::UNIT)
-                } else if intrinsic_name == "int_to_ptr" || intrinsic_name == "null_ptr" {
-                    // @int_to_ptr / @null_ptr: returns a pointer type inferred from context
+                } else if intrinsic_name == "int_to_ptr" {
+                    // @int_to_ptr: returns a pointer type inferred from context
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
-                } else if intrinsic_name == "ptr_copy" {
-                    // @ptr_copy: (dst: ptr mut T, src: ptr const T, count: u64) -> ()
-                    for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
-                    }
-                    InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "target_arch" {
                     // @target_arch: returns Arch enum
                     if let Some(arch_spur) = self.interner.get("Arch") {

--- a/docs/designs/0002-single-pass-bidirectional-types.md
+++ b/docs/designs/0002-single-pass-bidirectional-types.md
@@ -1,14 +1,14 @@
 ---
 id: 0002
 title: Single-Pass Bidirectional Type Checking
-status: implemented
+status: superseded
 tags: [compiler]
 feature-flag: bidirectional-types
 created: 2025-01-01
 accepted: 2025-01-01
 implemented: 2025-01-01
 spec-sections: []
-superseded-by:
+superseded-by: 0007
 ---
 
 <!-- Note: This ADR predates the preview feature system (ADR-0005). The feature-flag

--- a/docs/designs/0004-enum-types.md
+++ b/docs/designs/0004-enum-types.md
@@ -54,11 +54,11 @@ enum Color {
 }
 
 fn main() -> i32 {
-    let c = Color::Green;
+    let c = Color.Green;
     match c {
-        Color::Red => 1,
-        Color::Green => 2,
-        Color::Blue => 3,
+        Color.Red => 1,
+        Color.Green => 2,
+        Color.Blue => 3,
     }
 }
 ```
@@ -128,7 +128,7 @@ The discriminant type is chosen to be the smallest unsigned integer that can rep
 Variants are constructed using path syntax `EnumName::VariantName`:
 
 ```rue
-let color = Color::Red;
+let color = Color.Red;
 ```
 
 #### Pattern Matching
@@ -137,9 +137,9 @@ Enum variants are matched using the same path syntax:
 
 ```rue
 match color {
-    Color::Red => 0,
-    Color::Green => 1,
-    Color::Blue => 2,
+    Color.Red => 0,
+    Color.Green => 1,
+    Color.Blue => 2,
 }
 ```
 

--- a/docs/designs/0007-hindley-milner-inference.md
+++ b/docs/designs/0007-hindley-milner-inference.md
@@ -8,6 +8,7 @@ created: 2025-12-24
 accepted: 2025-12-24
 implemented: 2025-12-24
 spec-sections: []
+supersedes: 0002
 superseded-by:
 ---
 

--- a/docs/designs/0008-affine-types-mvs.md
+++ b/docs/designs/0008-affine-types-mvs.md
@@ -23,6 +23,11 @@ needs no `@handle`; if explicit duplication of an Affine type is wanted later it
 is just such a function, requiring no directive. References to `Handle` below are
 retained as historical design context.
 
+Two surface spellings in the examples below are also dated: mutable bindings are
+`let mut x`, not `var x` (Rue has no `var` keyword), and the `inout` mode marker
+precedes the parameter name — `fn f(inout x: i32)`, not `fn f(x: inout i32)`.
+The semantics are as described; read the syntax accordingly.
+
 ## Summary
 
 Introduce an affine type system with mutable value semantics (MVS) to provide memory safety without garbage collection and without a borrow checker. Types are affine by default (can be dropped, cannot be implicitly copied), with opt-in `linear` types that must be consumed, opt-in `Copy` for implicit bitwise copying, and opt-in `Handle` for explicit logical duplication. Mutation is handled via `inout` parameters with projection semantics for collections.

--- a/docs/designs/0009-struct-methods.md
+++ b/docs/designs/0009-struct-methods.md
@@ -15,11 +15,29 @@ superseded-by:
 
 ## Status
 
-Implemented
+Implemented — **but the syntax below is stale.** The *capability* (struct
+methods, associated functions, `self` receivers, `obj.method(args)` call syntax)
+ships and works. The **mechanism changed**: Rue has **no `impl` blocks**. Methods
+are declared **inside the struct body** (Zig-style, aligned with ADR-0029's
+anonymous-struct methods), and associated functions are called `Type.method()`
+(`.`, never `::`). The compiler rejects `impl` outright: "Rue has no 'impl'
+blocks; define methods inside the struct body." Read the `impl`-block examples
+below as historical intent; the shipped form is:
+
+```rue
+struct Point {
+    x: i32,
+    y: i32,
+    fn dist2(self) -> i32 { self.x * self.x + self.y * self.y }
+    fn origin() -> Point { Point { x: 0, y: 0 } }
+}
+```
 
 ## Summary
 
-Add the ability to define methods on structs using `impl` blocks, allowing method call syntax (`obj.method(args)`) as an ergonomic alternative to free functions.
+Add the ability to define methods on structs, allowing method call syntax
+(`obj.method(args)`) as an ergonomic alternative to free functions. (Originally
+proposed as `impl` blocks; shipped as in-struct-body methods — see Status.)
 
 ## Context
 

--- a/docs/designs/0014-mutable-strings.md
+++ b/docs/designs/0014-mutable-strings.md
@@ -13,6 +13,15 @@ superseded-by:
 
 # ADR-0014: Mutable Strings
 
+> **Surface syntax below is dated.** The *capability* (a heap-owning, affine,
+> growable string) ships, but two spellings changed after this ADR was written:
+> the type is now **`StrBuf`**, not `String` (renamed by
+> [ADR-0043](0043-collection-string-type-trio.md) — it is the growable rung of
+> the collection trio, not a blessed builtin), and associated functions are
+> called with `.` on a bound name (`StrBuf.new()`), never `::`. Mutable bindings
+> are `let mut x`, not `var x` (Rue has no `var` keyword). Read the `String::` /
+> `var` examples below as historical; substitute `StrBuf.` / `let mut`.
+
 ## Status
 
 Implemented

--- a/docs/designs/0025-comptime.md
+++ b/docs/designs/0025-comptime.md
@@ -100,7 +100,8 @@ Attempting to store these in a runtime variable is a compile error:
 
 ```rue
 fn main() -> i32 {
-    let t: type = i32;  // ERROR: type 'type' cannot exist at runtime
+    let t: type = i32;  // binding is accepted; a `type` value cannot exist at
+                        // runtime, so it errors only when USED at runtime
     0
 }
 ```
@@ -286,7 +287,11 @@ fn Pair(comptime T: type, comptime U: type) -> type {
 }
 
 fn main() -> i32 {
-    let p: Pair(i32, bool) = Pair(i32, bool) { first: 42, second: true };
+    // A comptime type constructor must be bound to a name before it can be used
+    // in a type position or a struct literal (`Pair(i32, bool) { ... }` directly
+    // does not parse).
+    let P = Pair(i32, bool);
+    let p: P = P { first: 42, second: true };
     p.first
 }
 ```
@@ -474,7 +479,8 @@ fn Array(comptime T: type, comptime N: i32) -> type {
 }
 
 fn main() -> i32 {
-    let arr: Array(i32, 10) = Array(i32, 10) {
+    let A = Array(i32, 10);
+    let arr: A = A {
         data: [0; 10],
         len: 10,
     };

--- a/docs/designs/0028-unsafe-and-raw-pointers.md
+++ b/docs/designs/0028-unsafe-and-raw-pointers.md
@@ -147,12 +147,6 @@ checked {
 
     // Convert pointer to integer
     let addr: u64 = @ptr_to_int(p);
-
-    // Null pointer
-    let null: ptr const i32 = @null_ptr();
-
-    // Check for null
-    let is_null: bool = @is_null(p);
 }
 ```
 
@@ -165,9 +159,6 @@ checked {
 | `@ptr_offset(p, n)` | `(ptr T, i64) -> ptr T` | Offset by n elements (not bytes) |
 | `@ptr_to_int(p)` | `(ptr T) -> u64` | Convert pointer to integer |
 | `@int_to_ptr(n)` | `(u64) -> ptr mut T` | Convert integer to pointer |
-| `@null_ptr()` | `() -> ptr const T` | Create null pointer |
-| `@is_null(p)` | `(ptr T) -> bool` | Check if pointer is null |
-| `@ptr_copy(dst, src, n)` | `(ptr mut T, ptr const T, u64) -> ()` | Copy n elements |
 
 ### Raw Pointer Intrinsics
 

--- a/docs/designs/0029-anonymous-struct-methods.md
+++ b/docs/designs/0029-anonymous-struct-methods.md
@@ -95,9 +95,10 @@ fn Vec(comptime T: type) -> type {
 }
 
 fn main() -> i32 {
-    let v = Vec(i32)::new();
+    let V = Vec(i32);
+    let v = V.new();
     let v2 = v.push(42);
-    v2.len() as i32
+    @intCast(v2.len())
 }
 ```
 
@@ -154,13 +155,15 @@ fn B() -> type {
 }
 
 fn C() -> type {
-    struct { x: i32, fn get(self) -> i64 { self.x as i64 } }  // DIFFERENT type (i64 vs i32)
+    struct { x: i32, fn get(self) -> i64 { @intCast(self.x) } }  // DIFFERENT type (i64 vs i32)
 }
 ```
 
 ### Associated Functions
 
-Functions without `self` are associated functions, called with `Type::function()` syntax:
+Functions without `self` are associated functions, called with `Type.function()`
+syntax on a type bound to a variable (`.` is the sole member-access spelling;
+`::` is not accepted):
 
 ```rue
 fn Point(comptime T: type) -> type {
@@ -175,7 +178,8 @@ fn Point(comptime T: type) -> type {
 }
 
 fn main() -> i32 {
-    let p = Point(i32)::origin();
+    let P = Point(i32);
+    let p = P.origin();
     p.x
 }
 ```
@@ -227,13 +231,13 @@ Epic: rue-nj40 (historical bd ID, pre-Linear; the `.N` suffixes below are its su
 - [x] Change method lookup key from `(Spur, Spur)` to `(StructId, Spur)`
 - [x] Register methods when creating anonymous struct types
 - [x] Resolve `Self` to the anonymous struct's `StructId` (in signatures only)
-- [x] Handle `Type::function()` call syntax for comptime type variables (historical bd ID rue-ybbz, pre-Linear)
+- [x] Handle `Type.function()` call syntax for comptime type variables (historical bd ID rue-ybbz, pre-Linear)
 - [ ] Update structural equality to include method signatures
 - [ ] Handle comptime parameter capture in method bodies
 - [x] Analyze method bodies with `self` in scope
 - [x] Resolve `Self` in method body expressions (historical bd ID rue-h6zn, pre-Linear)
 
-**Status**: Most items complete. Method registration, `self` in method bodies, associated function calls on comptime type variables (`P::constant()`), and `Self` type resolution all work. Remaining: structural equality with methods, comptime parameter capture.
+**Status**: Most items complete. Method registration, `self` in method bodies, associated function calls on comptime type variables (`P.constant()`), and `Self` type resolution all work. Remaining: structural equality with methods, comptime parameter capture.
 
 **Deliverable**: `v.push(42)` compiles when `v` is an anonymous struct type with a `push` method.
 

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -164,7 +164,7 @@ The table is generated from ADR frontmatter. Run
 | --- | --- | --- | --- |
 | [0000](0000-template.md) | ADR Title | Proposal | — |
 | [0001](0001-never-type.md) | The Never Type | Implemented | types |
-| [0002](0002-single-pass-bidirectional-types.md) | Single-Pass Bidirectional Type Checking | Implemented | compiler |
+| [0002](0002-single-pass-bidirectional-types.md) | Single-Pass Bidirectional Type Checking | Superseded | compiler |
 | [0003](0003-constant-evaluation.md) | Constant Expression Evaluation | Implemented | compiler |
 | [0004](0004-enum-types.md) | Enum Types | Implemented | types, syntax |
 | [0005](0005-preview-features.md) | Preview Features | Implemented | process |


### PR DESCRIPTION
RUE-593: ADR documentation-accuracy sweep — remove dead inference arms, fix stale surface syntax

The ADR-implementation audit (RUE-593's parent sweep) found the language and
ADR text had drifted in two ways. This fixes the honest gaps:

- rue-air/inference/generate.rs: drop three dead intrinsic arms (`is_null`,
  `null_ptr`, `ptr_copy`) — these intrinsics no longer exist (ADR-0028), the
  arms were unreachable.

- 0028: remove the @null_ptr / @is_null / @ptr_copy example lines and table
  rows for the same removed intrinsics.

- 0002 → superseded-by 0007; 0007 gains supersedes: 0002 (the bidirectional
  type checker was replaced by HM inference, but the frontmatter never said so).

- 0004, 0029: `Type::member` → `Type.member` (`.` is the sole member-access
  spelling; `::` is not accepted). 0029 also fixes `as` casts to @intCast and
  the `Type(args)::fn()` → bind-then-`.` call form.

- 0009: add a status banner — the *capability* (struct methods) ships, but Rue
  has no `impl` blocks; methods are declared inside the struct body.

- 0014: banner — `String` is now `StrBuf` (ADR-0043), `var` is `let mut`,
  associated fns use `.` not `::`.

- 0008: extend the status note — `var` → `let mut`, `inout` marker precedes the
  param name (`fn f(inout x: i32)`).

- 0025: `let t: type` is accepted at the binding (errors only on runtime use);
  a comptime type constructor must be bound to a name before use in a type
  position or struct literal.

- README.md: regenerated ADR index (frontmatter status changes).

No behavior change beyond deleting unreachable code; full suite green.

Fixes RUE-593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
