### PR TITLE
RUE-595: resolve a module-const-bound comptime struct type as a type namespace

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -35,12 +35,9 @@ impl<'a> Sema<'a> {
         // (`m.Type.assoc()`) is the supported form (ADR-0046).
         if let InstData::VarRef { name } = self.rir.get(receiver).data
             && !self.is_runtime_value_binding(name, ctx)
-            && (ctx.comptime_type_vars.contains_key(&name)
-                || self
-                    .structs_by_file_name
-                    .contains_key(&(ctx.current_file_id, name))
-                || self.resolve_builtin_struct_name(name).is_some()
-                || self.resolve_enum_type_name(name, ctx).is_some())
+            && (self.resolve_struct_type_name(name, ctx).is_some()
+                || self.resolve_enum_type_name(name, ctx).is_some()
+                || ctx.comptime_type_vars.contains_key(&name))
         {
             return self.analyze_assoc_fn_call(air, name, method, args_start, args_len, span, ctx);
         }
@@ -569,6 +566,28 @@ impl<'a> Sema<'a> {
         } else if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
             privacy_exempt = true;
             // Extract struct ID from the comptime type
+            match ty.kind() {
+                TypeKind::Struct(id) => id,
+                _ => {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: "struct type".to_string(),
+                            found: ty.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        span,
+                    ));
+                }
+            }
+        } else if let Some(info) = self
+            .constants_by_file_name
+            .get(&(ctx.current_file_id, type_name))
+            && let ConstValue::Type(ty) = info.value
+        {
+            // Module-level `const C = Counter(i32); C.zero()` (RUE-595): the
+            // specialization arrived through a `const` binding, mirroring the
+            // comptime-type-variable branch above and the const arm of
+            // `resolve_enum_type_name` — so it is likewise privacy-exempt.
+            privacy_exempt = true;
             match ty.kind() {
                 TypeKind::Struct(id) => id,
                 _ => {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3390,6 +3390,27 @@ impl<'a> Sema<'a> {
                     ));
                 }
             }
+        } else if let Some(info) = self.constants_by_file_name.get(&(span.file_id, type_name))
+            && let ConstValue::Type(ty) = info.value
+        {
+            // Module-level `const P = Point(i32); P { .. }` (RUE-595): the
+            // specialization arrived through a `const` binding, mirroring the
+            // comptime-type-variable branch above — privacy-exempt for the same
+            // reason (the type value came from a binding, not by naming the
+            // struct). Without this arm the literal head was `UnknownType`
+            // (E0204) even though the annotation form (`fn f() -> P`) resolved.
+            match ty.kind() {
+                TypeKind::Struct(id) => id,
+                _ => {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: "struct type".to_string(),
+                            found: ty.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        span,
+                    ));
+                }
+            }
         } else {
             let struct_id = self
                 .structs_by_file_name
@@ -6341,6 +6362,40 @@ impl<'a> Sema<'a> {
             .get(&(ctx.current_file_id, type_name))
             .copied()
             .or_else(|| self.resolve_builtin_enum_name(type_name))
+            .map(|id| (id, false))
+    }
+
+    /// Resolve a `Type.assoc()` / `Type { .. }` struct type name that may be a
+    /// comptime type-variable binding (`let P = Point(i32)`) or a module-level
+    /// `const` binding (`const P = Point(i32)`), falling back to the named-struct
+    /// table and builtins. Returns `(struct_id, via_binding)`, or `None` if the
+    /// name is not a struct. `via_binding` is true when the struct arrived
+    /// through a `let`/`const` binding (an anonymous struct from a comptime type
+    /// function), so privacy does not apply — the exact mirror of
+    /// `resolve_enum_type_name` for the struct side (RUE-595). Without the
+    /// `constants_by_file_name` arm a module-`const`-bound struct type resolved
+    /// as a type namespace nowhere, so `const C = Counter(i32); C.zero()` failed
+    /// (E0413) and `const P = Point(i32); P { .. }` failed (E0204) while the
+    /// enum-bound and local-`let`-bound forms worked.
+    pub(crate) fn resolve_struct_type_name(
+        &self,
+        type_name: Spur,
+        ctx: &AnalysisContext,
+    ) -> Option<(crate::types::StructId, bool)> {
+        if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
+            return ty.as_struct().map(|id| (id, true));
+        }
+        if let Some(info) = self
+            .constants_by_file_name
+            .get(&(ctx.current_file_id, type_name))
+            && let ConstValue::Type(ty) = info.value
+        {
+            return ty.as_struct().map(|id| (id, true));
+        }
+        self.structs_by_file_name
+            .get(&(ctx.current_file_id, type_name))
+            .copied()
+            .or_else(|| self.resolve_builtin_struct_name(type_name))
             .map(|id| (id, false))
     }
 

--- a/crates/rue-cli-tests/cases/module_const_type_namespace.toml
+++ b/crates/rue-cli-tests/cases/module_const_type_namespace.toml
@@ -1,0 +1,130 @@
+# A comptime type-constructor result bound to a module-level `const` must work
+# as a TYPE NAMESPACE — for associated-function calls (`C.zero()`) and struct
+# literals (`P { .. }`) — exactly like a local `let`-bound one and like a
+# module-`const`-bound ENUM (`R.Ok(..)`, which already worked). Before RUE-595
+# the struct side consulted only `comptime_type_vars` (local `let`) and the
+# named-struct tables, never `constants_by_file_name`, so a module-`const`
+# struct alias fell through: `C.zero()` was E0413 ("no method named 'zero' on
+# type 'type'") and `P { .. }` was E0204 ("unknown type 'P'"), even though the
+# TYPE-ANNOTATION form (`fn f() -> P`) resolved. `const AB = ArrayBuf(i32)` at
+# module scope — the natural way to alias a generic collection — was the real
+# casualty; the std docs only ever used `let`, so the suite never caught it.
+
+[section]
+id = "cli.module_const_type_namespace"
+name = "Module-const comptime type as a namespace"
+description = "`const C = Ctor(T)` resolves for assoc-fn calls and struct literals, matching local `let` and enum consts (RUE-595)."
+
+# --- Facet A: associated-function call through a module-level const ---
+
+[[case]]
+name = "module_const_assoc_fn"
+description = "`const C = Counter(i32); C.zero()` resolves the assoc fn (was E0413 before RUE-595)."
+files = [{ path = "main.rue", source = """
+fn Counter(comptime T: type) -> type {
+    struct {
+        n: T,
+        fn zero() -> Self { Self { n: 0 } }
+        fn bump(self) -> Self { Self { n: self.n + 1 } }
+    }
+}
+const C = Counter(i32);
+
+fn main() -> i32 {
+    let c = C.zero().bump().bump();
+    @dbg(c.n);   // 2
+    0
+}
+""" }]
+stdout = "2\n"
+
+# --- Facet B: struct literal through a module-level const ---
+
+[[case]]
+name = "module_const_struct_literal"
+description = "`const P = Point(i32); P { .. }` resolves the literal head (was E0204 before RUE-595)."
+files = [{ path = "main.rue", source = """
+fn Point(comptime T: type) -> type { struct { x: T, y: T } }
+const P = Point(i32);
+
+fn main() -> i32 {
+    let p: P = P { x: 3, y: 4 };
+    p.x + p.y   // 7
+}
+""" }]
+exit_code = 7
+
+# --- Both facets + the const type used in annotation position, one program ---
+
+[[case]]
+name = "module_const_annotation_and_construction"
+description = "The same module-const type drives a return annotation, a parameter type, an assoc fn, and a literal."
+files = [{ path = "main.rue", source = """
+fn Vec2(comptime T: type) -> type {
+    struct {
+        x: T,
+        y: T,
+        fn origin() -> Self { Self { x: 0, y: 0 } }
+        fn sum(borrow self) -> T { self.x + self.y }
+    }
+}
+const V = Vec2(i32);
+
+fn make() -> V { V { x: 20, y: 22 } }
+fn total(borrow v: V) -> i32 { v.sum() }
+
+fn main() -> i32 {
+    let o = V.origin();
+    @dbg(o.sum());       // 0
+    let m = make();
+    @dbg(total(borrow m));  // 42
+    0
+}
+""" }]
+stdout = "0\n42\n"
+
+# --- Cross-file: the realistic alias — const bound to an imported ctor ---
+
+[[case]]
+name = "module_const_alias_of_imported_ctor"
+description = "`const C = lib.Counter(i32)` aliasing an imported type constructor resolves for assoc-fn + literal."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "lib.rue", source = """
+pub fn Counter(comptime T: type) -> type {
+    struct {
+        n: T,
+        fn start(v: T) -> Self { Self { n: v } }
+        fn get(borrow self) -> T { self.n }
+    }
+}
+""" },
+  { path = "main.rue", source = """
+const lib = @import("lib.rue");
+const C = lib.Counter(i32);
+
+fn main() -> i32 {
+    let a = C.start(40);       // assoc fn through the const alias
+    let b: C = C { n: 2 };     // literal through the const alias
+    @dbg(a.get() + b.get());   // 42
+    0
+}
+""" }]
+stdout = "42\n"
+
+# --- Guard: enum consts (which always worked) still resolve, so the struct
+#     fix keeps struct and enum namespaces uniform ---
+
+[[case]]
+name = "module_const_enum_still_resolves"
+description = "A module-const enum alias constructs and matches — unchanged by the struct-side fix (RUE-595 guard)."
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+const R = Result(i32, i32);
+
+fn main() -> i32 {
+    let r = R.Ok(42);
+    match r { R.Ok(v) => v, R.Err(e) => e }
+}
+""" }]
+exit_code = 42


### PR DESCRIPTION
RUE-595: resolve a module-level `const`-bound comptime struct type as a type namespace

A comptime type-constructor result bound to a module-level `const` — the
natural way to write a type alias, e.g. `const AB = std.arraybuf.ArrayBuf(i32)`
— did not resolve as a TYPE NAMESPACE on the struct side. `C.zero()` failed with
E0413 ("no method named 'zero' on type 'type'") and `P { .. }` failed with E0204
("unknown type 'P'"), even though the *type-annotation* form (`fn f() -> P`)
resolved and the equivalent local `let` binding worked. Enum consts were
unaffected, so `std.Result`/`std.Option` were fine — but every generic struct
collection was awkward to alias at module scope.

Root cause: `resolve_enum_type_name` consulted `constants_by_file_name` (so a
module-`const` enum resolved), but the struct side had no equivalent. The
method-call dispatch, `analyze_assoc_fn_call_impl`, and struct-literal
construction each checked only `comptime_type_vars` (local `let`) plus the
named-struct tables. A `const`-bound struct type thus fell through: the receiver
was analyzed as a value of type `type`.

Fix: add `resolve_struct_type_name`, the exact mirror of `resolve_enum_type_name`
(comptime var → module const → named table → builtin, returning a
`via_binding` flag), and wire the module-`const` arm into all three struct
sites. A `const` binding is privacy-exempt, matching the comptime-var branch and
the const arm of the enum resolver (the type value arrived through a binding,
not by naming the struct).

The std docs only ever used local `let`, so the suite never exercised the
`const` alias — added crates/rue-cli-tests/cases/module_const_type_namespace.toml
(assoc-fn call, struct literal, annotation+construction, cross-file imported
constructor, and an enum-const guard). Also verified a non-struct const
(`const X = i32; X.foo()`) still errors cleanly (E0413), not an ICE.

Fixes RUE-595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
