### PR TITLE
RUE-589: bound oracle output capture

### DIFF
--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -22,7 +22,7 @@
 //! `test.sh`, and Buck test targets set from `scripts/rue-bin`.
 
 use crate::generator;
-use rue_oracle::{RunSourceError, run_source};
+use rue_oracle::{MAX_STDOUT_BYTES, RunSourceError, run_source};
 use std::io::Read;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
@@ -43,7 +43,7 @@ enum Compiled {
     Ran {
         exit: i32,
         stdout: String,
-        /// More stdout existed beyond [`STDOUT_CAP`]; `stdout` is only a prefix.
+        /// More stdout existed beyond [`MAX_STDOUT_BYTES`]; `stdout` is only a prefix.
         stdout_truncated: bool,
         stderr: String,
     },
@@ -399,7 +399,7 @@ fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
             // prefix so truncation can never manufacture agreement.
             if *stdout_truncated {
                 return Verdict::Disagree(format!(
-                    "compiled stdout exceeded the {STDOUT_CAP}-byte capture limit; \
+                    "compiled stdout exceeded the {MAX_STDOUT_BYTES}-byte capture limit; \
                      retained prefix cannot prove agreement"
                 ));
             }
@@ -496,11 +496,6 @@ fn compile_and_run(
     run_with_timeout(cmd, timeout)
 }
 
-/// Maximum stdout bytes retained from a generated binary. Output past this
-/// bound is still drained, and the explicit truncation bit makes the run a
-/// disagreement rather than comparing an incomplete prefix as if it were exact.
-const STDOUT_CAP: usize = 256 * 1024;
-
 /// Maximum stderr bytes retained from a run. Trap messages are short; the cap
 /// only bounds how much we *keep* — the pipe is still drained to EOF (see
 /// [`read_capped`]) so a chatty process can never deadlock the wait loop.
@@ -544,7 +539,9 @@ fn wait_for_process(mut child: Child, timeout: Duration) -> std::io::Result<Proc
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();
     let stdout_reader = std::thread::spawn(move || {
-        stdout_pipe.map_or_else(CappedRead::default, |out| read_capped(out, STDOUT_CAP))
+        stdout_pipe.map_or_else(CappedRead::default, |out| {
+            read_capped(out, MAX_STDOUT_BYTES)
+        })
     });
     let stderr_reader = std::thread::spawn(move || {
         stderr_pipe.map_or_else(CappedRead::default, |err| read_capped(err, STDERR_CAP))
@@ -1118,7 +1115,7 @@ mod tests {
         // (~64KB) must be drained concurrently while it runs. Before the fix the
         // pipe filled, the writer blocked on `write()`, `try_wait` never saw an
         // exit, and the 10s timeout fabricated a `Compiled::Timeout` (→ a false
-        // Disagree). Emit ~200KB (below STDOUT_CAP), capture every byte, and
+        // Disagree). Emit ~200KB (below MAX_STDOUT_BYTES), capture every byte, and
         // prove the complete output still participates in exact agreement.
         let n = 200_000usize;
         let mut cmd = Command::new("sh");
@@ -1146,7 +1143,7 @@ mod tests {
 
     #[test]
     fn stdout_above_cap_is_drained_capped_and_cannot_agree_on_its_prefix() {
-        let n = STDOUT_CAP + 100_000;
+        let n = MAX_STDOUT_BYTES + 100_000;
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg(format!("yes y | head -c {n}"));
         let result = run_with_timeout(cmd, Duration::from_secs(30)).expect("spawn");
@@ -1159,7 +1156,11 @@ mod tests {
                 ..
             } => {
                 assert_eq!(*exit, 0);
-                assert_eq!(stdout.len(), STDOUT_CAP, "retained stdout must be capped");
+                assert_eq!(
+                    stdout.len(),
+                    MAX_STDOUT_BYTES,
+                    "retained stdout must be capped"
+                );
                 assert!(*stdout_truncated, "overflow must remain explicit");
 
                 // Even an oracle outcome equal to the retained prefix cannot
@@ -1179,7 +1180,7 @@ mod tests {
         // Run the writer directly so killing the timed child closes the only
         // pipe write end. This is the adversarial always-on-smoke case: a
         // miscompiled binary can print forever, but retained memory stays at
-        // STDOUT_CAP and kill/reap/join still returns promptly.
+        // MAX_STDOUT_BYTES and kill/reap/join still returns promptly.
         let mut cmd = Command::new("yes");
         cmd.arg("y");
         let start = Instant::now();
@@ -1230,6 +1231,10 @@ mod tests {
         // Fewer bytes than the cap: keep them all.
         let kept = read_capped(std::io::Cursor::new(vec![b'q'; 10]), STDERR_CAP);
         assert_eq!(kept.bytes.len(), 10);
+        assert!(!kept.truncated);
+        // Exactly the cap is still complete, not truncated.
+        let kept = read_capped(std::io::Cursor::new(vec![b'x'; STDERR_CAP]), STDERR_CAP);
+        assert_eq!(kept.bytes.len(), STDERR_CAP);
         assert!(!kept.truncated);
     }
 

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -67,6 +67,7 @@ use rue_compiler::{
     CompileErrors, CompileState, PreviewFeatures, compile_to_cfg,
     compile_to_cfg_with_preview_features,
 };
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -81,6 +82,15 @@ pub struct Outcome {
     /// `None` on normal completion. The reason mirrors the runtime's category.
     pub panic: Option<String>,
 }
+
+/// Maximum number of raw bytes accepted from a program's `@dbg` output.
+///
+/// Both the interpreter and the native differential runner use this shared
+/// limit so neither side can exhaust harness memory through retained stdout or
+/// reject output that the other side accepts. Output at or below the limit
+/// remains exact; crossing it is surfaced explicitly and never accepted by
+/// comparing a truncated prefix.
+pub const MAX_STDOUT_BYTES: usize = 256 * 1024;
 
 /// A construct the interpreter does not yet model (see the coverage note). This
 /// is *not* a program error — it means the oracle cannot judge this program yet.
@@ -161,6 +171,14 @@ fn run_state(state: CompileState) -> Result<Outcome, Unsupported> {
 }
 
 fn run_state_with_budget(state: CompileState, budget: u64) -> Result<Outcome, Unsupported> {
+    run_state_with_limits(state, budget, MAX_STDOUT_BYTES)
+}
+
+fn run_state_with_limits(
+    state: CompileState,
+    budget: u64,
+    stdout_cap: usize,
+) -> Result<Outcome, Unsupported> {
     // Interpret on a dedicated large-stack worker thread. The tree-walking
     // interpreter recurses per expression *and* per call, so deep-but-valid
     // programs need far more stack than a default thread provides. Running on
@@ -175,6 +193,8 @@ fn run_state_with_budget(state: CompileState, budget: u64) -> Result<Outcome, Un
                 Interp {
                     state: &state,
                     stdout: String::new(),
+                    stdout_bytes: 0,
+                    stdout_cap,
                     budget,
                     depth: 0,
                 }
@@ -300,6 +320,10 @@ impl From<Unsupported> for Flow {
 struct Interp<'a> {
     state: &'a CompileState,
     stdout: String,
+    /// Raw emitted byte count. `stdout.len()` can be larger because invalid
+    /// UTF-8 bytes render as the three-byte replacement character.
+    stdout_bytes: usize,
+    stdout_cap: usize,
     /// Remaining total step budget (see [`STEP_BUDGET`]). Shared across every
     /// activation and decremented per instruction, so it bounds total work
     /// including recursion, not just per-frame loops.
@@ -355,6 +379,41 @@ impl<'a> Interp<'a> {
         } else {
             false
         }
+    }
+
+    fn write_dbg(&mut self, val: &Value, ty: Type) -> Step<()> {
+        let remaining = self.stdout_cap.saturating_sub(self.stdout_bytes);
+
+        // Formatting a String normally clones its complete contents. Reject an
+        // oversized value before formatting so the output limit also bounds
+        // that temporary allocation.
+        if let Value::Str { bytes, .. } = val
+            && bytes.len() >= remaining
+        {
+            return Err(Flow::Unsupported(Unsupported(format!(
+                "stdout byte limit exceeded ({}-byte limit)",
+                self.stdout_cap
+            ))));
+        }
+
+        let formatted = format_dbg(val, ty)?;
+        let emitted_len = match val {
+            Value::Str { bytes, .. } => bytes.len(),
+            _ => formatted.len(),
+        };
+        // Reserve one byte for the newline emitted by this `@dbg` call. Using
+        // the comparison form avoids overflowing while computing `len + 1`.
+        if emitted_len >= remaining {
+            return Err(Flow::Unsupported(Unsupported(format!(
+                "stdout byte limit exceeded ({}-byte limit)",
+                self.stdout_cap
+            ))));
+        }
+
+        self.stdout.push_str(&formatted);
+        self.stdout.push('\n');
+        self.stdout_bytes += emitted_len + 1;
+        Ok(())
     }
 
     fn run(mut self) -> Result<Outcome, Unsupported> {
@@ -1071,8 +1130,7 @@ impl<'a> Interp<'a> {
                     .ok_or_else(|| Flow::Unsupported(Unsupported("@dbg arity".into())))?;
                 let arg_ty = cfg.get_inst(arg).ty;
                 let val = self.eval(cfg, frame, arg)?;
-                self.stdout.push_str(&format_dbg(&val, arg_ty)?);
-                self.stdout.push('\n');
+                self.write_dbg(&val, arg_ty)?;
                 Value::Unit
             }
 
@@ -1549,19 +1607,19 @@ fn from_bits(bits_val: u128, bits: u32, signed: bool) -> i128 {
 
 /// Format a value exactly as the `@dbg` runtime intrinsic prints it (decimal for
 /// integers respecting signedness, `true`/`false` for bool), sans the newline.
-fn format_dbg(val: &Value, ty: Type) -> Result<String, Flow> {
+fn format_dbg(val: &Value, ty: Type) -> Result<Cow<'_, str>, Flow> {
     // `@dbg` of a String prints its content (matches __rue_dbg_str).
     if let Value::Str { bytes, .. } = val {
-        return Ok(String::from_utf8_lossy(bytes).into_owned());
+        return Ok(String::from_utf8_lossy(bytes));
     }
     Ok(match ty.kind() {
-        TypeKind::Bool => val.as_bool().to_string(),
-        k if kind_signed(k) => val.as_int().to_string(),
+        TypeKind::Bool => Cow::Owned(val.as_bool().to_string()),
+        k if kind_signed(k) => Cow::Owned(val.as_int().to_string()),
         TypeKind::U8 | TypeKind::U16 | TypeKind::U32 | TypeKind::U64 => {
             let (lo, hi) = int_bounds(ty).unwrap();
             let n = val.as_int();
             let _ = (lo, hi);
-            (n as u128).to_string()
+            Cow::Owned((n as u128).to_string())
         }
         other => {
             return Err(Flow::Unsupported(Unsupported(format!(

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -16,6 +16,11 @@ fn run_with_budget(src: &str, budget: u64) -> Result<Outcome, Unsupported> {
     run_state_with_budget(state, budget)
 }
 
+fn run_with_stdout_cap(src: &str, stdout_cap: usize) -> Result<Outcome, Unsupported> {
+    let state = compile_to_cfg(src).unwrap_or_else(|e| panic!("compile error: {e:#?}"));
+    run_state_with_limits(state, STEP_BUDGET, stdout_cap)
+}
+
 fn run_string_trio(src: &str) -> Outcome {
     let mut preview_features = PreviewFeatures::new();
     preview_features.insert(rue_compiler::PreviewFeature::StringTrio);
@@ -154,6 +159,44 @@ fn dbg_output() {
     let out = run("fn main() -> i32 { @dbg(7); @dbg(true); 0 }");
     assert_eq!(out.stdout, "7\ntrue\n");
     assert_eq!(out.exit_code, 0);
+}
+
+#[test]
+fn stdout_at_cap_remains_exact() {
+    let out = run_with_stdout_cap("fn main() -> i32 { @dbg(7); @dbg(true); 0 }", 7)
+        .unwrap_or_else(|unsupported| panic!("exactly capped output failed: {unsupported}"));
+    assert_eq!(out.stdout, "7\ntrue\n");
+}
+
+#[test]
+fn repeated_dbg_over_stdout_cap_is_unsupported() {
+    let unsupported = run_with_stdout_cap("fn main() -> i32 { @dbg(7); @dbg(8); 0 }", 3)
+        .expect_err("the second complete output line must exceed the cap");
+    assert_eq!(unsupported.0, "stdout byte limit exceeded (3-byte limit)");
+}
+
+#[test]
+fn oversized_string_dbg_is_unsupported() {
+    let unsupported = run_with_stdout_cap("fn main() -> i32 { let s = \"hello\"; @dbg(s); 0 }", 5)
+        .expect_err("the String plus its newline must exceed the cap");
+    assert_eq!(unsupported.0, "stdout byte limit exceeded (5-byte limit)");
+}
+
+#[test]
+fn stdout_cap_counts_raw_bytes_before_lossy_rendering() {
+    let src = "fn main() -> i32 {
+        let mut s = String.new();
+        s.push(195);
+        @dbg(s);
+        0
+    }";
+    let out = run_with_stdout_cap(src, 2)
+        .unwrap_or_else(|unsupported| panic!("two raw output bytes failed: {unsupported}"));
+    assert_eq!(out.stdout, "\u{fffd}\n");
+
+    let unsupported = run_with_stdout_cap(src, 1)
+        .expect_err("one content byte plus newline must exceed a one-byte cap");
+    assert_eq!(unsupported.0, "stdout byte limit exceeded (1-byte limit)");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- cap interpreted @dbg output at the same shared 256 KiB raw-byte limit as native execution
- reject overflow before formatting or appending a complete line, while avoiding valid-String clones with Cow
- keep raw-byte accounting aligned across lossy UTF-8 rendering and pin exact-limit behavior on both sides

## Verification

- `scripts/rue test` — Pass 32, Fail 0
- focused oracle and oracle-diff Clippy diagnostics are empty
- boundary regressions cover exact output, cumulative overflow, oversized Strings, and raw invalid UTF-8

Part of RUE-589.