### PR TITLE
RUE-596: inline type-constructor call heads (preview inline_type_ctor_paths)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1576,9 +1576,17 @@ impl<'a> ConstraintGenerator<'a> {
                         variant,
                         bindings,
                         span: pat_span,
+                        ..
                     } = pattern
                     {
                         if !bindings.is_empty() {
+                            // NOTE: an inline type-constructor pattern head
+                            // (`Result(i32,i32).Ok(v)`, RUE-596) cannot be
+                            // reduced by the inference engine (it has no comptime
+                            // interpreter), so `enum_type_for` is `None` for it
+                            // and the payload bindings are not pre-typed here.
+                            // Sema's `materialize_match_bindings` resolves them
+                            // authoritatively via `try_evaluate_const`.
                             let enum_ty = module
                                 .and_then(|module_ref| {
                                     self.enum_type_for_module(module_ref, type_name)

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -173,6 +173,71 @@ impl<'a> Sema<'a> {
             );
         }
 
+        // Inline type-constructor call head (RUE-596, preview
+        // `inline_type_ctor_paths`, relaxing spec 4.14:23): `F(args).NAME(..)`
+        // where `F(args)` reduced to a concrete type at comptime. Resolve
+        // `.NAME` as an enum-variant construction or associated-function call on
+        // the reduced type — exactly as if it had been bound with
+        // `let P = F(args); P.NAME(..)`. The receiver's stray `TypeConst` is a
+        // comptime-only no-op (CFG build drops it). Only a struct/enum reduced
+        // type takes this path; any other kind (e.g. `const X = i32; X.foo()`)
+        // falls through to the ordinary `MethodCallOnNonStruct` diagnostic, and
+        // the bound-name form (`let P = F(args); P.NAME`) never reaches here.
+        // Elided args (`Option(_)`) stay out of scope (RUE-401).
+        if receiver_type == Type::COMPTIME_TYPE
+            && let AirInstData::TypeConst(reduced_ty) = air.get(receiver_result.air_ref).data
+        {
+            match reduced_ty.kind() {
+                TypeKind::Enum(enum_id) => {
+                    self.require_preview(
+                        PreviewFeature::InlineTypeCtorPath,
+                        "an inline type-constructor call as a path head",
+                        span,
+                    )?;
+                    let variant_name = self.interner.resolve(&method).to_string();
+                    let def = self.type_pool.enum_def(enum_id);
+                    if let Some(vidx) = def.find_variant(&variant_name) {
+                        return self.analyze_enum_variant_construction(
+                            air,
+                            enum_id,
+                            vidx as u32,
+                            method,
+                            true,
+                            args_start,
+                            args_len,
+                            span,
+                            ctx,
+                        );
+                    }
+                    return Err(CompileError::new(
+                        ErrorKind::UndefinedAssocFn {
+                            type_name: reduced_ty.safe_name_with_pool(Some(&self.type_pool)),
+                            function_name: variant_name,
+                        },
+                        span,
+                    ));
+                }
+                TypeKind::Struct(struct_id) => {
+                    self.require_preview(
+                        PreviewFeature::InlineTypeCtorPath,
+                        "an inline type-constructor call as a path head",
+                        span,
+                    )?;
+                    return self.analyze_assoc_fn_call_impl(
+                        air,
+                        method,
+                        method,
+                        args_start,
+                        args_len,
+                        span,
+                        ctx,
+                        Some(struct_id),
+                    );
+                }
+                _ => {}
+            }
+        }
+
         // Check that receiver is a struct type
         let struct_id = match receiver_type.kind() {
             TypeKind::Struct(id) => id,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use lasso::Spur;
 use rue_error::{
     CompileError, CompileResult, CompileWarning, ErrorKind, MissingFieldsError, OptionExt,
-    WarningKind,
+    PreviewFeature, WarningKind,
 };
 use rue_rir::{InstData, InstRef, RirArgMode, RirParamMode, RirPattern};
 
@@ -1631,14 +1631,16 @@ impl<'a> Sema<'a> {
                 }
                 RirPattern::Path {
                     module,
+                    ctor_head,
                     type_name,
                     variant,
                     ..
                 } => {
-                    // Look up the enum type — through a module or unqualified /
-                    // comptime-bound — via the shared pattern-enum chokepoint.
+                    // Look up the enum type — through a module, unqualified /
+                    // comptime-bound, or an inline type-constructor head — via
+                    // the shared pattern-enum chokepoint.
                     let (enum_id, privacy_handled) = self
-                        .resolve_pattern_enum(*module, *type_name, ctx, pattern_span)?
+                        .resolve_pattern_enum(*module, *ctor_head, *type_name, ctx, pattern_span)?
                         .ok_or_compile_error(
                             ErrorKind::UnknownEnumType(
                                 self.interner.resolve(&*type_name).to_string(),
@@ -1793,13 +1795,14 @@ impl<'a> Sema<'a> {
                 RirPattern::Bool(b, _) => AirPattern::Bool(*b),
                 RirPattern::Path {
                     module,
+                    ctor_head,
                     type_name,
                     variant,
                     ..
                 } => {
                     let type_name_str = self.interner.resolve(&*type_name).to_string();
                     let enum_id = self
-                        .resolve_pattern_enum(*module, *type_name, ctx, pattern_span)?
+                        .resolve_pattern_enum(*module, *ctor_head, *type_name, ctx, pattern_span)?
                         .map(|(id, _)| id)
                         .ok_or_else(|| {
                             CompileError::new(
@@ -2236,6 +2239,7 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<Vec<u32>> {
         let RirPattern::Path {
             module,
+            ctor_head,
             type_name,
             variant,
             bindings,
@@ -2250,7 +2254,7 @@ impl<'a> Sema<'a> {
         let pattern_span = *span;
 
         let enum_id = self
-            .resolve_pattern_enum(*module, *type_name, ctx, pattern_span)?
+            .resolve_pattern_enum(*module, *ctor_head, *type_name, ctx, pattern_span)?
             .map(|(id, _)| id)
             .ok_or_compile_error(
                 ErrorKind::UnknownEnumType(self.interner.resolve(&*type_name).to_string()),
@@ -3278,13 +3282,14 @@ impl<'a> Sema<'a> {
 
             InstData::StructInit {
                 module,
+                ctor_head,
                 type_name,
                 fields_start,
                 fields_len,
-                ..
             } => self.analyze_struct_init(
                 air,
                 *module,
+                *ctor_head,
                 *type_name,
                 *fields_start,
                 *fields_len,
@@ -3311,10 +3316,12 @@ impl<'a> Sema<'a> {
     }
 
     /// Analyze a struct initialization.
+    #[allow(clippy::too_many_arguments)]
     fn analyze_struct_init(
         &mut self,
         air: &mut Air,
         module: Option<InstRef>,
+        ctor_head: Option<InstRef>,
         type_name: Spur,
         fields_start: u32,
         fields_len: u32,
@@ -3325,7 +3332,39 @@ impl<'a> Sema<'a> {
         // Look up the struct type
         // First check if it's a comptime type variable (e.g., `let Point = make_point(); Point { ... }`)
         let type_name_str = self.interner.resolve(&type_name);
-        let struct_id = if let Some(module_ref) = module {
+        let struct_id = if let Some(head_ref) = ctor_head {
+            // Inline type-constructor struct-literal head `F(args) { ... }`
+            // (RUE-596, preview `inline_type_ctor_paths`, relaxing spec 4.14:23):
+            // the head call reduces to a concrete type at comptime; construct as
+            // if the type had been bound to a name first (`let P = F(args); P { .. }`).
+            self.require_preview(
+                PreviewFeature::InlineTypeCtorPath,
+                "an inline type-constructor call as a struct-literal head",
+                span,
+            )?;
+            let head_result = self.analyze_inst(air, head_ref, ctx)?;
+            let AirInstData::TypeConst(reduced_ty) = air.get(head_result.air_ref).data else {
+                return Err(CompileError::new(
+                    ErrorKind::TypeMismatch {
+                        expected: "a type".to_string(),
+                        found: head_result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                    },
+                    span,
+                ));
+            };
+            match reduced_ty.kind() {
+                TypeKind::Struct(id) => id,
+                _ => {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: "struct type".to_string(),
+                            found: reduced_ty.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        span,
+                    ));
+                }
+            }
+        } else if let Some(module_ref) = module {
             let module_result = self.analyze_inst(air, module_ref, ctx)?;
             let Some(module_id) = module_result.ty.as_module() else {
                 return Err(CompileError::new(
@@ -6401,12 +6440,29 @@ impl<'a> Sema<'a> {
     /// (`Result(i32, i32).Ok(v)`, RUE-596) a localized follow-up: it need only
     /// teach this one method to comptime-evaluate a constructor-call head.
     pub(crate) fn resolve_pattern_enum(
-        &self,
+        &mut self,
         module: Option<InstRef>,
+        ctor_head: Option<InstRef>,
         type_name: Spur,
         ctx: &AnalysisContext,
         span: Span,
     ) -> CompileResult<Option<(crate::types::EnumId, bool)>> {
+        // Inline type-constructor pattern head `F(args).Variant(..)` (RUE-596,
+        // preview `inline_type_ctor_paths`): comptime-evaluate the constructor
+        // call to a concrete type (no AIR emitted) and take its enum. The head
+        // arrived through a call, not by naming the enum, so it is privacy-exempt
+        // — reported as `privacy_handled = true`, exactly like a comptime binding.
+        if let Some(head_ref) = ctor_head {
+            self.require_preview(
+                PreviewFeature::InlineTypeCtorPath,
+                "an inline type-constructor call as a pattern head",
+                span,
+            )?;
+            return Ok(match self.try_evaluate_const(head_ref) {
+                Some(ConstValue::Type(ty)) => ty.as_enum().map(|id| (id, true)),
+                _ => None,
+            });
+        }
         if let Some(module_ref) = module {
             let enum_id = self.resolve_enum_through_module(module_ref, type_name, span)?;
             Ok(Some((enum_id, true)))

--- a/crates/rue-cli-tests/cases/inline_type_ctor_expr_head.toml
+++ b/crates/rue-cli-tests/cases/inline_type_ctor_expr_head.toml
@@ -1,0 +1,98 @@
+# Inline type-constructor call as an EXPRESSION head (RUE-596, preview
+# `inline_type_ctor_paths`, relaxing spec 4.14:23): `F(args).NAME(..)` where
+# `F(args)` reduces to a concrete type at comptime, used directly as an
+# enum-variant construction (`Result(i32,i32).Ok(42)`) or an associated-function
+# call (`Counter(i32).zero()`) without binding the specialization to a name
+# first. Gated: absent `--preview` it is E1100. This is the expression-head
+# slice of the feature; the struct-literal head and pattern head land separately.
+
+[section]
+id = "cli.inline_type_ctor_expr_head"
+name = "Inline type-constructor expression head"
+description = "`F(args).Variant(..)` / `F(args).assoc(..)` as an expression head, preview-gated (RUE-596)."
+
+[[case]]
+name = "enum_variant_head_runs"
+description = "`Result(i32,i32).Ok(42)` constructs an enum variant inline; `?`-free round-trip through a match."
+args = ["main.rue", "--preview", "inline_type_ctor_paths", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn main() -> i32 {
+    let r = Result(i32, i32).Ok(42);        // inline variant head
+    let R = Result(i32, i32);
+    match r { R.Ok(v) => v, R.Err(e) => e } // 42
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "struct_assoc_fn_head_runs"
+description = "`Counter(i32).zero()` calls an associated function on an inline type-constructor head."
+args = ["main.rue", "--preview", "inline_type_ctor_paths", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Counter(comptime T: type) -> type {
+    struct {
+        n: T,
+        fn zero() -> Self { Self { n: 0 } }
+        fn bump(self) -> Self { Self { n: self.n + 1 } }
+        fn get(borrow self) -> T { self.n }
+    }
+}
+fn main() -> i32 {
+    let c = Counter(i32).zero().bump().bump();   // inline head, then by-value chain
+    c.get()                                       // 2
+}
+""" }]
+exit_code = 2
+
+[[case]]
+name = "gated_without_preview"
+description = "Without --preview the inline head is rejected with the E1100 preview-required diagnostic."
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn main() -> i32 {
+    let r = Result(i32, i32).Ok(42);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E1100", "inline_type_ctor_paths"]
+
+[[case]]
+name = "bound_name_form_needs_no_preview"
+description = "The bind-first form stays legal without the flag — the gate is scoped to the inline head only."
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn main() -> i32 {
+    let R = Result(i32, i32);
+    let r = R.Ok(42);
+    match r { R.Ok(v) => v, R.Err(e) => e }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "all_three_heads_one_program"
+description = "Struct-literal head, enum-variant head, and pattern head together, driven through the real binary (RUE-596)."
+args = ["main.rue", "--preview", "inline_type_ctor_paths", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+
+fn classify(p_a: i32, p_b: i32) -> Result(i32, i32) {
+    let p = Pair(i32) { a: p_a, b: p_b };   // struct-literal head
+    if p.a > p.b {
+        Result(i32, i32).Err(p.a)           // enum-variant head
+    } else {
+        Result(i32, i32).Ok(p.a + p.b)      // enum-variant head
+    }
+}
+
+fn main() -> i32 {
+    match classify(20, 22) {                // pattern heads below
+        Result(i32, i32).Ok(v) => v,        // 42
+        Result(i32, i32).Err(e) => e,
+    }
+}
+""" }]
+exit_code = 42

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -499,6 +499,14 @@ pub enum PreviewFeature {
     /// representation; string literals live in `.rodata` and produce a 2-word
     /// `str` value where a `str` is expected.
     StringTrio,
+    /// Inline type-constructor call heads (RUE-596, relaxing spec 4.14:23): a
+    /// type-constructor call with explicit comptime args used directly as a
+    /// struct-literal head (`Pair(i32) { .. }`), an associated-function / enum-
+    /// variant head (`Result(i32, i32).Ok(v)`), or a pattern head
+    /// (`match r { Result(i32, i32).Ok(v) => .. }`). Reduces to today's
+    /// bind-first form (`let P = F(args); P.NAME`). Elided args (`Option(_)`)
+    /// remain out of scope (RUE-401).
+    InlineTypeCtorPath,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -521,6 +529,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::Slices => "slices",
             PreviewFeature::StringTrio => "string_trio",
+            PreviewFeature::InlineTypeCtorPath => "inline_type_ctor_paths",
         }
     }
 
@@ -531,6 +540,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::Slices => "ADR-0043",
             PreviewFeature::StringTrio => "ADR-0043",
+            PreviewFeature::InlineTypeCtorPath => "ADR-0025",
         }
     }
 
@@ -540,6 +550,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra,
             PreviewFeature::Slices,
             PreviewFeature::StringTrio,
+            PreviewFeature::InlineTypeCtorPath,
         ]
     }
 
@@ -565,6 +576,7 @@ impl std::str::FromStr for PreviewFeature {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "slices" => Ok(PreviewFeature::Slices),
             "string_trio" => Ok(PreviewFeature::StringTrio),
+            "inline_type_ctor_paths" => Ok(PreviewFeature::InlineTypeCtorPath),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -2506,7 +2518,10 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, slices, string_trio");
+        assert_eq!(
+            names,
+            "test_infra, slices, string_trio, inline_type_ctor_paths"
+        );
     }
 
     #[test]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -813,6 +813,13 @@ pub struct PathPattern {
     pub base: Option<Box<Expr>>,
     /// The type name (e.g., `Color`)
     pub type_name: Ident,
+    /// Inline type-constructor arguments when the pattern head is a
+    /// type-constructor call, e.g. `Result(i32, i32).Ok(v)` (RUE-596, preview
+    /// `inline_type_ctor_paths`, relaxing spec 4.14:23). When `Some`, `type_name`
+    /// is the constructor function and these are its comptime arguments; the
+    /// pattern's enum type is the reduction of `type_name(ctor_args)`. `None`
+    /// for an ordinary `Enum.Variant` pattern.
+    pub ctor_args: Option<Vec<CallArg>>,
     /// The variant name (e.g., `Red`)
     pub variant: Ident,
     /// Payload binding names (empty = no payload pattern).
@@ -905,6 +912,12 @@ pub struct StructLitExpr {
     pub base: Option<Box<Expr>>,
     /// Struct type name
     pub name: Ident,
+    /// Inline type-constructor arguments when the head is a type-constructor
+    /// call, e.g. `Pair(i32) { ... }` (RUE-596, preview `inline_type_ctor_paths`,
+    /// relaxing spec 4.14:23). When `Some`, `name` is the constructor function
+    /// and these are its comptime arguments; the literal's struct type is the
+    /// reduction of `name(ctor_args)`. `None` for an ordinary `Name { ... }`.
+    pub ctor_args: Option<Vec<CallArg>>,
     /// Field initializers
     pub fields: Vec<FieldInit>,
     pub span: Span,

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -943,7 +943,9 @@ where
 }
 
 /// Parser for patterns in match arms
-fn pattern_parser<'src, I>() -> impl Parser<'src, I, Pattern, ParserExtras<'src>> + Clone
+fn pattern_parser<'src, I>(
+    expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
+) -> impl Parser<'src, I, Pattern, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
@@ -995,6 +997,34 @@ where
         .or_not()
         .map(|opt| opt.unwrap_or_default());
 
+    // Inline type-constructor pattern head: `F(args).Variant(bindings)`
+    // (RUE-596, preview `inline_type_ctor_paths`, relaxing spec 4.14:23). The
+    // head `F(args)` is a type-constructor call whose comptime reduction is the
+    // enum; `.Variant` selects the variant. Unambiguous: a bare `ident(` never
+    // begins any other pattern (there is no bare `Variant(binds)` form — every
+    // variant pattern carries at least one dot), so the parens-before-dot shape
+    // is distinct from the `ident . ident` paths below. The head arguments are
+    // full expressions (comptime type/value arguments), so this needs the
+    // expression parser threaded in.
+    let ctor_head_pat = ident_parser()
+        .then(
+            call_args_parser(expr.clone())
+                .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+        )
+        .then_ignore(just(TokenKind::Dot))
+        .then(ident_parser())
+        .then(pattern_bindings.clone())
+        .map_with(|(((type_name, ctor_args), variant), bindings), e| {
+            Pattern::Path(PathPattern {
+                base: None,
+                type_name,
+                ctor_args: Some(ctor_args),
+                variant,
+                bindings,
+                span: span_from_extra(e),
+            })
+        });
+
     // Simple enum path pattern: Enum.Variant (RUE-488). `.` is the sole
     // member-access spelling; `::` was removed.
     let simple_dot_path_pat = ident_parser()
@@ -1005,6 +1035,7 @@ where
             Pattern::Path(PathPattern {
                 base: None,
                 type_name,
+                ctor_args: None,
                 variant,
                 bindings,
                 span: span_from_extra(e),
@@ -1046,6 +1077,7 @@ where
             Pattern::Path(PathPattern {
                 base: Some(Box::new(base_expr)),
                 type_name,
+                ctor_args: None,
                 variant,
                 bindings,
                 span: span_from_extra(e),
@@ -1058,6 +1090,11 @@ where
         int_pat,
         bool_true,
         bool_false,
+        // The inline type-constructor head (`F(args).Variant`) is tried first:
+        // it is the only pattern that begins `ident (`, so it cannot conflict
+        // with the dot-paths, but ordering it ahead keeps the parens-before-dot
+        // shape unambiguous.
+        ctor_head_pat,
         // The qualified form (`module.Enum.Variant`, ≥2 dots) must be tried
         // before the simple one (`Enum.Variant`, exactly 1 dot); otherwise the
         // simple parser would greedily match the first two identifiers of a
@@ -1069,12 +1106,12 @@ where
 
 /// Parser for a single match arm: pattern => expr
 fn match_arm_parser<'src, I>(
-    expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone,
+    expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
 ) -> impl Parser<'src, I, MatchArm, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    pattern_parser()
+    pattern_parser(expr.clone())
         .then_ignore(just(TokenKind::FatArrow))
         .then(expr)
         .map_with(|(pattern, body), e| MatchArm {
@@ -1146,9 +1183,20 @@ fn reclaim_empty_struct_lit_head(lit: StructLitExpr) -> Option<Expr> {
         return None;
     }
 
-    Some(match lit.base {
-        None => Expr::Ident(lit.name),
-        Some(base) => {
+    Some(match (lit.base, lit.ctor_args) {
+        // `F(args) {}` used as a restricted-position head (`if`/`while`/`for`)
+        // reclaims to the constructor call `F(args)`; the empty braces are the
+        // block body, exactly as `if F(args) {}` parsed before the inline
+        // type-constructor struct-literal head existed (RUE-596). Only the
+        // unqualified form is reclaimable here.
+        (None, Some(args)) => Expr::Call(CallExpr {
+            name: lit.name,
+            args,
+            span: lit.span,
+        }),
+        (Some(_), Some(_)) => return None,
+        (None, None) => Expr::Ident(lit.name),
+        (Some(base), None) => {
             let span = base.span().extend_to(lit.name.span.end);
             Expr::Field(FieldExpr {
                 base,
@@ -1409,13 +1457,23 @@ where
             };
             match (scrutinee, arms) {
                 // `match v {}`: reclaim the struct literal's braces as the
-                // match's empty arm list; the scrutinee is the bare identifier.
-                (Expr::StructLit(lit), None) if lit.base.is_none() && lit.fields.is_empty() => {
-                    Ok(Expr::Match(MatchExpr {
-                        scrutinee: Box::new(Expr::Ident(lit.name)),
-                        arms: Vec::new(),
-                        span,
-                    }))
+                // match's empty arm list; the scrutinee is the reclaimed head (a
+                // bare identifier, or a constructor call `F(args)` for an inline
+                // type-constructor head, RUE-596). A qualified head (`mod.Type`)
+                // is not reclaimable and falls to the error arm below.
+                (Expr::StructLit(lit), None) if lit.fields.is_empty() => {
+                    match reclaim_empty_struct_lit_head(lit) {
+                        Some(scrutinee) => Ok(Expr::Match(MatchExpr {
+                            scrutinee: Box::new(scrutinee),
+                            arms: Vec::new(),
+                            span,
+                        })),
+                        None => Err(Rich::custom(
+                            e.span(),
+                            "struct literals are not allowed as a bare match scrutinee; \
+                             wrap the scrutinee in parentheses",
+                        )),
+                    }
                 }
                 (Expr::StructLit(_), _) => Err(Rich::custom(
                     e.span(),
@@ -1455,7 +1513,9 @@ where
 /// reinterprets them when the base names a type. So no path suffix appears here.
 #[derive(Clone)]
 enum IdentSuffix {
-    Call(Vec<CallArg>),
+    /// `F(args)`, optionally with a trailing `{ fields }` inline
+    /// type-constructor struct-literal head `F(args) { fields }` (RUE-596).
+    Call(Vec<CallArg>, Option<Vec<FieldInit>>),
     StructLit(Vec<FieldInit>),
     None,
 }
@@ -1470,10 +1530,21 @@ where
     ident_parser()
         .then(
             choice((
-                // Function call: (args)
+                // Function call `(args)`, optionally followed by an inline
+                // type-constructor struct-literal body `{ fields }`
+                // (`F(args) { ... }`, RUE-596). The trailing body is `.or_not()`
+                // so a plain call `F(args)` is unaffected, and a following block
+                // that is not valid field inits (`{ stmt }`) is left for the
+                // enclosing block/`if`/`while` body — the same `{ ident: }`-vs-
+                // `{ expr }` rule the bare-ident struct-literal head relies on.
                 call_args_parser(expr.clone())
                     .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen))
-                    .map(IdentSuffix::Call),
+                    .then(
+                        field_inits_parser(expr.clone())
+                            .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace))
+                            .or_not(),
+                    )
+                    .map(|(args, body)| IdentSuffix::Call(args, body)),
                 // Struct literal: { field: value, ... }
                 field_inits_parser(expr.clone())
                     .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace))
@@ -1483,14 +1554,23 @@ where
             .map(|opt| opt.unwrap_or(IdentSuffix::None)),
         )
         .map_with(|(name, suffix), e| match suffix {
-            IdentSuffix::Call(args) => Expr::Call(CallExpr {
+            IdentSuffix::Call(args, None) => Expr::Call(CallExpr {
                 name,
                 args,
+                span: span_from_extra(e),
+            }),
+            // `F(args) { fields }` — inline type-constructor struct-literal head.
+            IdentSuffix::Call(args, Some(fields)) => Expr::StructLit(StructLitExpr {
+                base: None,
+                name,
+                ctor_args: Some(args),
+                fields,
                 span: span_from_extra(e),
             }),
             IdentSuffix::StructLit(fields) => Expr::StructLit(StructLitExpr {
                 base: None, // No module prefix for simple `StructName { ... }`
                 name,
+                ctor_args: None,
                 fields,
                 span: span_from_extra(e),
             }),
@@ -1653,6 +1733,7 @@ where
                 Expr::StructLit(StructLitExpr {
                     base: Some(Box::new(base)),
                     name,
+                    ctor_args: None,
                     fields,
                     span,
                 })
@@ -1978,6 +2059,7 @@ where
                     name: e.state().syms.self_type,
                     span,
                 },
+                ctor_args: None,
                 fields,
                 span,
             })

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -706,6 +706,22 @@ impl<'a> AstGen<'a> {
                     .as_ref()
                     .map(|base_expr| self.gen_expr(base_expr));
 
+                // Inline type-constructor struct-literal head `F(args) { ... }`
+                // (RUE-596): generate the constructor call `F(args)` as its own
+                // instruction; sema reduces it to the struct type at comptime.
+                let ctor_head = struct_lit.ctor_args.as_ref().map(|args| {
+                    let arg_refs: Vec<_> = args.iter().map(|a| self.convert_call_arg(a)).collect();
+                    let (args_start, args_len) = self.rir.add_call_args(&arg_refs);
+                    self.rir.add_inst(Inst {
+                        data: InstData::Call {
+                            name: struct_lit.name.name,
+                            args_start,
+                            args_len,
+                        },
+                        span: struct_lit.span,
+                    })
+                });
+
                 let fields: Vec<_> = struct_lit
                     .fields
                     .iter()
@@ -719,6 +735,7 @@ impl<'a> AstGen<'a> {
                 self.rir.add_inst(Inst {
                     data: InstData::StructInit {
                         module,
+                        ctor_head,
                         type_name: struct_lit.name.name, // Already a Spur
                         fields_start,
                         fields_len,
@@ -1105,10 +1122,26 @@ impl<'a> AstGen<'a> {
             Pattern::Path(path) => {
                 // If there's a base expression (module reference), generate it first
                 let module = path.base.as_ref().map(|base| self.gen_expr(base));
+                // Inline type-constructor pattern head `F(args).Variant(..)`
+                // (RUE-596): generate the constructor call `F(args)` as its own
+                // instruction; sema reduces it to the enum type at comptime.
+                let ctor_head = path.ctor_args.as_ref().map(|args| {
+                    let arg_refs: Vec<_> = args.iter().map(|a| self.convert_call_arg(a)).collect();
+                    let (args_start, args_len) = self.rir.add_call_args(&arg_refs);
+                    self.rir.add_inst(Inst {
+                        data: InstData::Call {
+                            name: path.type_name.name,
+                            args_start,
+                            args_len,
+                        },
+                        span: path.span,
+                    })
+                });
                 // Payload binding names for a tuple-variant pattern (RUE-221).
                 let bindings: Vec<Spur> = path.bindings.iter().map(|b| b.name).collect();
                 RirPattern::Path {
                     module,
+                    ctor_head,
                     type_name: path.type_name.name, // Already a Spur
                     variant: path.variant.name,     // Already a Spur
                     bindings,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -155,6 +155,12 @@ pub enum RirPattern {
     Path {
         /// Optional module reference for qualified paths (e.g., the `module` in `module.Color::Red`)
         module: Option<InstRef>,
+        /// Optional inline type-constructor call head — the instruction that
+        /// reduces to the enum type at comptime for `F(args).Variant(..)`
+        /// (RUE-596, preview `inline_type_ctor_paths`). When `Some`, the enum is
+        /// the reduction of this head and `type_name` is only the constructor
+        /// function's name; `None` for an ordinary `Enum.Variant` pattern.
+        ctor_head: Option<InstRef>,
         /// The enum type name
         type_name: Spur,
         /// The variant name
@@ -464,6 +470,7 @@ impl Rir {
                 }
                 RirPattern::Path {
                     module,
+                    ctor_head,
                     type_name,
                     variant,
                     bindings,
@@ -475,6 +482,9 @@ impl Rir {
                     self.extra.push(span.file_id.index());
                     // Store module as u32::MAX for None, otherwise the InstRef
                     self.extra.push(module.map_or(u32::MAX, |r| r.as_u32()));
+                    // Store ctor_head (inline type-constructor pattern head,
+                    // RUE-596) the same way — u32::MAX for None.
+                    self.extra.push(ctor_head.map_or(u32::MAX, |r| r.as_u32()));
                     self.extra.push(type_name.into_usize() as u32);
                     self.extra.push(variant.into_usize() as u32);
                     // Variable-length payload bindings (RUE-221): a count
@@ -547,19 +557,28 @@ impl Rir {
                     } else {
                         Some(InstRef::from_raw(module_raw))
                     };
-                    let type_name = Spur::try_from_usize(self.extra[pos + 5] as usize).unwrap();
-                    let variant = Spur::try_from_usize(self.extra[pos + 6] as usize).unwrap();
+                    // Decode ctor_head (inline type-constructor pattern head,
+                    // RUE-596): u32::MAX means None.
+                    let ctor_head_raw = self.extra[pos + 5];
+                    let ctor_head = if ctor_head_raw == u32::MAX {
+                        None
+                    } else {
+                        Some(InstRef::from_raw(ctor_head_raw))
+                    };
+                    let type_name = Spur::try_from_usize(self.extra[pos + 6] as usize).unwrap();
+                    let variant = Spur::try_from_usize(self.extra[pos + 7] as usize).unwrap();
                     // Variable-length payload bindings (RUE-221).
-                    let n_bindings = self.extra[pos + 7] as usize;
+                    let n_bindings = self.extra[pos + 8] as usize;
                     let mut bindings = Vec::with_capacity(n_bindings);
                     for i in 0..n_bindings {
                         bindings
-                            .push(Spur::try_from_usize(self.extra[pos + 8 + i] as usize).unwrap());
+                            .push(Spur::try_from_usize(self.extra[pos + 9 + i] as usize).unwrap());
                     }
-                    let body = InstRef::from_raw(self.extra[pos + 8 + n_bindings]);
+                    let body = InstRef::from_raw(self.extra[pos + 9 + n_bindings]);
                     arms.push((
                         RirPattern::Path {
                             module,
+                            ctor_head,
                             type_name,
                             variant,
                             bindings,
@@ -567,7 +586,7 @@ impl Rir {
                         },
                         body,
                     ));
-                    pos += 9 + n_bindings;
+                    pos += 10 + n_bindings;
                 }
                 _ => panic!("Unknown pattern kind: {}", kind),
             }
@@ -1007,11 +1026,13 @@ impl Rir {
             },
             InstData::StructInit {
                 module,
+                ctor_head,
                 type_name,
                 fields_start,
                 fields_len,
             } => InstData::StructInit {
                 module: module.map(renumber),
+                ctor_head: ctor_head.map(renumber),
                 type_name: *type_name,
                 fields_start: *fields_start + extra_offset,
                 fields_len: *fields_len,
@@ -1268,19 +1289,25 @@ impl Rir {
                             k if k == PatternKind::Int as u32 => PATTERN_INT_SIZE as usize,
                             k if k == PatternKind::Bool as u32 => PATTERN_BOOL_SIZE as usize,
                             // Path is variable-length (RUE-221): the payload
-                            // binding count sits at offset 7, so the record is
-                            // 9 + n_bindings words (kind, span×3, module,
-                            // type_name, variant, n, bindings…, body).
-                            k if k == PatternKind::Path as u32 => 9 + extra[pos + 7] as usize,
+                            // binding count sits at offset 8, so the record is
+                            // 10 + n_bindings words (kind, span×3, module,
+                            // ctor_head, type_name, variant, n, bindings…, body).
+                            k if k == PatternKind::Path as u32 => 10 + extra[pos + 8] as usize,
                             _ => panic!("Unknown pattern kind during merge: {}", kind),
                         };
-                        // Path patterns also embed a module InstRef at offset 4
-                        // (after kind + the 3-word span; u32::MAX encodes
-                        // None); it must be renumbered like every other
-                        // InstRef or it would point into the wrong file's
-                        // instruction space after merging.
-                        if kind == PatternKind::Path as u32 && extra[pos + 4] != u32::MAX {
-                            extra[pos + 4] += inst_offset;
+                        // Path patterns embed two InstRefs that must be
+                        // renumbered like every other InstRef, or they would
+                        // point into the wrong file's instruction space after
+                        // merging: the module reference at offset 4 and the
+                        // inline type-constructor pattern head at offset 5
+                        // (RUE-596); u32::MAX encodes None for each.
+                        if kind == PatternKind::Path as u32 {
+                            if extra[pos + 4] != u32::MAX {
+                                extra[pos + 4] += inst_offset;
+                            }
+                            if extra[pos + 5] != u32::MAX {
+                                extra[pos + 5] += inst_offset;
+                            }
                         }
                         // The body InstRef is always the last element of each pattern
                         extra[pos + pattern_size - 1] += inst_offset;
@@ -1657,6 +1684,12 @@ pub enum InstData {
         /// Optional module reference (for qualified struct literals like `module.Point { ... }`)
         /// If Some, the struct is looked up in the module's exports.
         module: Option<InstRef>,
+        /// Optional inline type-constructor call head — the instruction that
+        /// reduces to the struct type at comptime for `F(args) { ... }` (RUE-596,
+        /// preview `inline_type_ctor_paths`). When `Some`, the struct type is
+        /// the reduction of this head and `type_name` is only the constructor
+        /// function's name (kept for diagnostics); `None` for `Name { ... }`.
+        ctor_head: Option<InstRef>,
         /// Struct type name
         type_name: Spur,
         /// Index into extra data where fields start
@@ -2223,11 +2256,15 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 }
                 InstData::StructInit {
                     module,
+                    ctor_head,
                     type_name,
                     fields_start,
                     fields_len,
                 } => {
-                    let module_str = module.map(|m| format!("{}.", m)).unwrap_or_default();
+                    let module_str = match ctor_head {
+                        Some(head) => format!("<{}>.", head),
+                        None => module.map(|m| format!("{}.", m)).unwrap_or_default(),
+                    };
                     let type_str = self.interner.resolve(&*type_name);
                     let fields = self.rir.get_field_inits(*fields_start, *fields_len);
                     let fields_str: Vec<String> = fields
@@ -2592,6 +2629,7 @@ mod tests {
 
         let pattern = RirPattern::Path {
             module: None,
+            ctor_head: None,
             type_name,
             variant,
             bindings: Vec::new(),
@@ -3484,6 +3522,7 @@ mod tests {
         rir.add_inst(Inst {
             data: InstData::StructInit {
                 module: None,
+                ctor_head: None,
                 type_name,
                 fields_start,
                 fields_len,
@@ -4036,6 +4075,7 @@ mod tests {
             (
                 RirPattern::Path {
                     module: None,
+                    ctor_head: None,
                     type_name: color,
                     variant: red,
                     bindings: Vec::new(),
@@ -4046,6 +4086,7 @@ mod tests {
             (
                 RirPattern::Path {
                     module: None,
+                    ctor_head: None,
                     type_name: color,
                     variant: green,
                     bindings: Vec::new(),
@@ -4351,6 +4392,7 @@ mod tests {
             (
                 RirPattern::Path {
                     module: Some(module),
+                    ctor_head: None,
                     type_name,
                     variant,
                     bindings: Vec::new(),
@@ -4425,6 +4467,7 @@ mod tests {
         let (arms_start, arms_len) = rir2.add_match_arms(&[(
             RirPattern::Path {
                 module: None,
+                ctor_head: None,
                 type_name,
                 variant,
                 bindings: Vec::new(),

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2179,9 +2179,9 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "type_constructor_call_not_a_struct_literal_path"
+name = "type_constructor_struct_literal_head_requires_preview"
 spec = ["4.14:23"]
-description = "A type-constructor call is not a struct-literal path: F(args) { ... } does not parse; bind an alias first (RUE-289)"
+description = "An inline type-constructor struct-literal head F(args) { ... } is gated behind the inline_type_ctor_paths preview feature; without it, E1100 (RUE-596)"
 source = """
 fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
 fn main() -> i32 {
@@ -2190,7 +2190,77 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "found '{'"
+error_contains = ["E1100", "inline_type_ctor_paths"]
+
+[[case]]
+name = "inline_type_ctor_struct_literal_head"
+spec = ["4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+description = "Under the preview, a type-constructor call heads a struct literal: Pair(i32) { ... } (RUE-596)"
+source = """
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+fn main() -> i32 {
+    let p = Pair(i32) { first: 40, second: 2 };
+    p.first + p.second
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inline_type_ctor_enum_variant_head"
+spec = ["4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+description = "Under the preview, a type-constructor call heads an enum-variant construction: Result(i32, i32).Ok(v) (RUE-596)"
+source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn main() -> i32 {
+    let r = Result(i32, i32).Ok(42);
+    let R = Result(i32, i32);
+    match r { R.Ok(v) => v, R.Err(e) => e }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inline_type_ctor_assoc_fn_head"
+spec = ["4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+description = "Under the preview, a type-constructor call heads an associated-function call: Counter(i32).zero() (RUE-596)"
+source = """
+fn Counter(comptime T: type) -> type {
+    struct {
+        n: T,
+        fn start(v: T) -> Self { Self { n: v } }
+        fn get(borrow self) -> T { self.n }
+    }
+}
+fn main() -> i32 {
+    let c = Counter(i32).start(42);
+    c.get()
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inline_type_ctor_pattern_head"
+spec = ["4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+description = "Under the preview, a type-constructor call heads a match pattern: match r { Result(i32, i32).Ok(v) => .. } (RUE-596)"
+source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn main() -> i32 {
+    let r = Result(i32, i32).Ok(40);
+    match r {
+        Result(i32, i32).Ok(v) => v + 2,
+        Result(i32, i32).Err(e) => e,
+    }
+}
+"""
+exit_code = 42
 
 [[case]]
 name = "type_param_scopes_into_method_body"

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -472,12 +472,21 @@ fn main() -> i32 {
 }
 ```
 
-A type-constructor call is a type, not a path expression: the forms
+By default a type-constructor call is a type, not a path expression: the forms
 `F(args) { … }` (a struct literal) and `F(args).NAME` (an associated item or
 enum variant) are not accepted, because a call expression is not a permitted
 struct-literal or pattern path. Bind the resulting type to a name first — with
 `let P = F(args);` — and use that name as the path in expression and pattern
 position (`P { … }`, `P.NAME`).
+
+Under the `inline_type_ctor_paths` preview feature these inline forms are
+accepted with explicit (compile-time-known) arguments: a type-constructor call
+may head a struct literal (`Pair(i32) { first: 1, second: 2 }`), an
+associated-function or enum-variant call (`Result(i32, i32).Ok(v)`,
+`Vec(i32).new()`), and a match pattern (`match r { Result(i32, i32).Ok(v) => … }`).
+Each is evaluated exactly as if the call had been bound to a name first (as
+above); it is pure surface sugar and adds no new typing rule. Eliding the
+arguments (`Option(_).Some(5)`) is not part of this feature.
 
 {{ rule(id="4.14:24", cat="normative") }}
 


### PR DESCRIPTION
RUE-596: inline type-constructor call heads (preview inline_type_ctor_paths)

Relax spec 4.14:23 under a new preview feature so a type-constructor call with
explicit (comptime-known) arguments may head a struct literal, an associated-
function / enum-variant call, and a match pattern — instead of forcing a
`let P = F(args);` bind first. Motivated by dogfooding std.Result (RUE-591): the
bind-first rule taxed the language's headline error-handling ergonomic, and the
inline form now reads the same in construction and matching.

Behind `--preview inline_type_ctor_paths`:

    let r = Result(i32, i32).Ok(42);          // enum-variant head
    let v = Counter(i32).zero();              // associated-function head
    let p = Pair(i32) { first: 1, second: 2 } // struct-literal head
    match r {                                 // pattern head
        Result(i32, i32).Ok(v) => v,
        Result(i32, i32).Err(e) => e,
    }

Each form is pure surface sugar: the head call is comptime-evaluated to a
concrete type and resolved exactly as if it had been bound to a name first, so
no new typing rule is added. Without the flag the forms are rejected with the
E1100 preview-required diagnostic; eliding arguments (`Option(_)`) is out of
scope (tracked by RUE-401).

Implementation:
- Preview gate PreviewFeature::InlineTypeCtorPath in rue-error.
- Expression assoc-fn/variant head: sema-only — a method-call receiver that
  reduces to a comptime type value resolves `.NAME` as a variant/assoc call on
  the reduced type (analyze_method_call_impl).
- Struct-literal head `F(args) { .. }`: new AST/RIR field (ctor_args / ctor_head)
  threaded parser -> astgen -> sema; the parser's Call suffix optionally carries
  a trailing struct body, and the if/while/for/match empty-brace reclaim gains a
  constructor-call arm so `if F(args) {}` still parses as call-then-body.
- Pattern head `F(args).Variant(..)`: a new pattern grammar alternative (the
  expression parser is threaded into pattern_parser) plus a RirPattern::Path
  ctor_head field; sema resolves it through the RUE-597 resolve_pattern_enum
  chokepoint, which comptime-evaluates the head with try_evaluate_const (no AIR
  emitted). The inference engine cannot reduce the head, so payload-binding types
  are resolved authoritatively in sema's materialize_match_bindings.

Tests: spec cases (preview-gated positives for all three heads + the E1100 gate),
CLI cases (per-head + a combined program + the gate + the bind-first form still
needing no flag), and the 4.14:23 prose updated to describe the preview
relaxation. Full suite green (Pass 32/Fail 0), traceability maintained.

Fixes RUE-596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
