### PR TITLE
RUE-589: run generated differential smoke in CI

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -123,6 +123,23 @@ sh_test(
     },
 )
 
+# A fixed generated differential corpus in every full test run. The generator
+# unit contract pins that seeds 0..63 retain every required fragile source
+# shape; this target then compiles and runs those programs through both the
+# reference oracle and native codegen. It lives at the root so full/no-argument
+# `test.sh` and CI include it while `quick-test.sh` remains unit-only.
+sh_test(
+    name = "oracle-diff-generated-smoke",
+    test = "scripts/oracle-diff-generated-smoke.sh",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_ORACLE_DIFF_BINARY": "$(exe_target //crates/rue-oracle-diff:rue-oracle-diff)",
+    },
+    # Preserve enough outer margin for the harness to print all structured
+    # findings even if every compiler and native phase consumes its 2s budget.
+    test_rule_timeout_ms = 600000,
+)
+
 sh_test(
     name = "tutorial-snippet-tests",
     test = "scripts/check-tutorial-snippets.py",

--- a/scripts/oracle-diff-generated-smoke.sh
+++ b/scripts/oracle-diff-generated-smoke.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RUE_BINARY:?RUE_BINARY must point to the Rue compiler}"
+: "${RUE_ORACLE_DIFF_BINARY:?RUE_ORACLE_DIFF_BINARY must point to the differential harness}"
+
+scratch="$(mktemp -d)"
+# Buck retains the harness log, which includes every failing seed and its full
+# source. Scratch repro files are intentionally ephemeral here; the nightly
+# fuzz workflow owns durable artifact upload.
+cleanup() {
+    rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+mkdir -p "$scratch/tmp" "$scratch/crashes"
+TMPDIR="$scratch/tmp" "$RUE_ORACLE_DIFF_BINARY" fuzz \
+    --start 0 \
+    --seeds 64 \
+    --timeout 2 \
+    --crash-dir "$scratch/crashes"


### PR DESCRIPTION
## Summary

- add a root Buck smoke target that runs generated seeds 0–63 through the oracle, compiler, and native binaries in every full debug/release CI suite
- keep quick unit tests unchanged by placing the target outside `//crates/...`
- isolate temporary and crash paths, apply two-second per-phase timeouts, and retain structured failing seeds/sources in Buck logs
- leave ten minutes of outer timeout margin so pathological per-program timeouts can finish reporting

## Verification

- generated smoke — 64 agree, 0 generator-contract failures, 0 disagreements
- `scripts/rue test` — Pass 33, Fail 0
- shell syntax and executable mode verified

Part of RUE-589.