### PR TITLE
RUE-601: accept _ as a discarding tuple-variant payload binding

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1601,6 +1601,11 @@ impl<'a> ConstraintGenerator<'a> {
                                 })
                             {
                                 for (i, bname) in bindings.iter().enumerate() {
+                                    // A `_` payload (RUE-601) binds nothing —
+                                    // skip registering a local for it.
+                                    if self.interner.resolve(bname) == "_" {
+                                        continue;
+                                    }
                                     if let Some(&pty) = payload.get(i) {
                                         ctx.insert_local(
                                             *bname,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2285,9 +2285,12 @@ impl<'a> Sema<'a> {
         // Every payload binding must be a fresh name (spec 4.7:30). Reusing an
         // identifier — `Rect(w, w)` — silently shadows the earlier binding and
         // discards its value, so reject it (E0484, analogous to Rust E0416)
-        // rather than losing a field (RUE-269). Wildcards never reach here:
-        // `_` in payload position isn't a binding.
+        // rather than losing a field (RUE-269). The `_` discard (RUE-601) is
+        // exempt: it binds nothing, so any number may repeat (`Rect(_, _)`).
         for (i, name) in bindings.iter().enumerate() {
+            if self.interner.resolve(name) == "_" {
+                continue;
+            }
             if bindings[..i].contains(name) {
                 return Err(CompileError::new(
                     ErrorKind::DuplicatePatternBinding {
@@ -2300,6 +2303,15 @@ impl<'a> Sema<'a> {
 
         let mut stmts: Vec<u32> = Vec::with_capacity(bindings.len() * 2);
         for (i, binding_name) in bindings.iter().enumerate() {
+            // A `_` payload (RUE-601) discards its field: bind nothing and emit
+            // no read. The field is not moved out of the scrutinee, so it is
+            // dropped together with the scrutinee — exactly like a
+            // discriminant-only match on a payload-carrying variant. The
+            // enumerate index `i` still tracks the real field position for the
+            // other bindings.
+            if self.interner.resolve(binding_name) == "_" {
+                continue;
+            }
             let field_ty = payload[i];
 
             // Read the payload field out of the scrutinee.

--- a/crates/rue-cli-tests/cases/wildcard_payload_binding.toml
+++ b/crates/rue-cli-tests/cases/wildcard_payload_binding.toml
@@ -1,0 +1,51 @@
+# `_` as a tuple-variant payload binding (RUE-601): matches and discards a
+# payload field without binding it. Driven through the real binary, including
+# the drop-semantics guarantee — a discarded non-Copy payload is not moved out
+# of the scrutinee, so its destructor runs exactly once (via the scrutinee's
+# drop), same as a bound-but-unused binding.
+
+[section]
+id = "cli.wildcard_payload_binding"
+name = "Wildcard payload binding"
+description = "`Err(_)` / `Rect(_, _)` discard payload fields; a discarded non-Copy field is dropped exactly once (RUE-601)."
+
+[[case]]
+name = "discard_partial_and_multiple"
+description = "`_` in one, the other, and both payload positions; discards compile and select correctly."
+files = [{ path = "main.rue", source = """
+enum Shape { Rect(i32, i32), Circle(i32), Empty }
+fn main() -> i32 {
+    let a = match Shape.Rect(40, 2) { Shape.Rect(w, _) => w, Shape.Circle(r) => r, Shape.Empty => 0 };
+    let b = match Shape.Rect(40, 2) { Shape.Rect(_, h) => h, Shape.Circle(r) => r, Shape.Empty => 0 };
+    let c = match Shape.Rect(9, 9)  { Shape.Rect(_, _) => 0, Shape.Circle(r) => r, Shape.Empty => 1 };
+    a + b + c
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "discarded_non_copy_payload_drops_once"
+description = "A discarded non-Copy payload's destructor runs exactly once — printed once, not zero (leak-semantics) or twice (double-drop)."
+files = [{ path = "main.rue", source = """
+struct Res { id: i32 }
+drop fn Res(self) { println(@to_string(self.id)); }
+enum Box { Full(Res), Empty }
+fn make() -> Box { Box.Full(Res { id: 5 }) }
+fn main() -> i32 {
+    match make() { Box.Full(_) => 7, Box.Empty => 0 }
+}
+""" }]
+stdout = "5\n"
+exit_code = 7
+
+[[case]]
+name = "err_underscore_common_idiom"
+description = "The common `Err(_) => default` idiom now parses (was E0100 before RUE-601)."
+files = [{ path = "main.rue", source = """
+enum Res { Ok(i32), Err(i32) }
+fn div(a: i32, b: i32) -> Res { if b == 0 { Res.Err(1) } else { Res.Ok(a / b) } }
+fn main() -> i32 {
+    match div(84, 2) { Res.Ok(v) => v, Res.Err(_) => -1 }
+}
+""" }]
+exit_code = 42

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -69,6 +69,11 @@ pub struct PrimitiveTypeSpurs {
     /// Known directive name `copy`. Pre-interned so expression-position
     /// `@copy(...)` can be rejected as a misplaced directive (RUE-403).
     pub copy_directive: Spur,
+    /// The wildcard `_` used as a discarding tuple-variant payload binding
+    /// (`Ok(_)`, `Rect(w, _)`, RUE-601). The lexer emits a dedicated
+    /// `Underscore` token; the payload-binding parser maps it back to this
+    /// symbol, and sema skips extracting/binding any payload named `_`.
+    pub underscore: Spur,
 }
 
 impl PrimitiveTypeSpurs {
@@ -91,6 +96,7 @@ impl PrimitiveTypeSpurs {
             drop_marker: interner.get_or_intern("__drop"),
             allow_directive: interner.get_or_intern("allow"),
             copy_directive: interner.get_or_intern("copy"),
+            underscore: interner.get_or_intern("_"),
         }
     }
 }
@@ -987,8 +993,18 @@ where
     };
 
     // Optional payload bindings for a tuple-variant pattern: `(a, b, ...)`
-    // (RUE-221). At least one binding required inside the parens.
-    let pattern_bindings = ident_parser()
+    // (RUE-221). At least one binding required inside the parens. Each binding
+    // is an identifier or `_` (a discard, RUE-601) — the latter is mapped to the
+    // interned `_` symbol, which sema skips extracting/binding.
+    let wildcard_binding = just(TokenKind::Underscore).map_with(|_, e| {
+        let span = span_from_extra(e);
+        Ident {
+            name: e.state().syms.underscore,
+            span,
+        }
+    });
+    let payload_binding = choice((wildcard_binding, ident_parser()));
+    let pattern_bindings = payload_binding
         .separated_by(just(TokenKind::Comma))
         .at_least(1)
         .allow_trailing()

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -958,6 +958,22 @@ fn main() -> i32 {
 """
 exit_code = 7
 
+# A `_` binding position discards a payload field without binding it, and may
+# repeat (`Rect(_, _)`) since it introduces no name (4.7:30, RUE-601).
+[[case]]
+name = "match_payload_wildcard_discard"
+spec = ["4.7:30"]
+source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn main() -> i32 {
+    let a = match Shape.Rect(40, 2) { Shape.Rect(w, _) => w, Shape.Circle(r) => r, Shape.Empty => 0 };
+    let b = match Shape.Rect(40, 2) { Shape.Rect(_, h) => h, Shape.Circle(r) => r, Shape.Empty => 0 };
+    let c = match Shape.Rect(1, 1)  { Shape.Rect(_, _) => 0, Shape.Circle(r) => r, Shape.Empty => 9 };
+    a + b + c
+}
+"""
+exit_code = 42
+
 # Bindings move the payload out in value context and are usable in the arm
 # body (4.7:31).
 [[case]]

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -229,8 +229,11 @@ fn absurd(n: Never) -> i32 {
 
 A tuple-variant pattern binds the variant's payload into fresh names:
 `EnumName.Variant(a, b)` matches a value of that variant and binds `a`, `b`
-to its payload fields in order. The number of bindings **MUST** equal the
-variant's payload arity (see spec 6.3).
+to its payload fields in order. A binding position may instead be the wildcard
+`_`, which matches and discards that field without binding it; unlike a name it
+introduces nothing and so may repeat (`Rect(_, _)`). A discarded field is not
+moved out of the scrutinee and is dropped together with it. The number of
+binding positions **MUST** equal the variant's payload arity (see spec 6.3).
 
 {{ rule(id="4.7:31", cat="normative") }}
 


### PR DESCRIPTION
RUE-601: accept `_` as a discarding tuple-variant payload binding

`Err(_)` / `Rect(_, _)` are now legal: a payload binding position may be the
wildcard `_`, which matches and discards that field without binding it (and,
unlike a name, may repeat). Before, every payload required a named identifier —
`Err(_) => default`, an extremely common idiom, was a parse error (E0100).

- Parser: `pattern_bindings` accepts `_` (mapped to the interned `_` symbol)
  in addition to an identifier; added the `underscore` symbol to the parser's
  pre-interned symbol set.
- Sema (`materialize_match_bindings`): a `_` binding is exempt from the
  fresh-name/duplicate check and is skipped in the extraction loop — no
  `EnumPayloadGet`, no local, no slot. The field is not moved out of the
  scrutinee, so it is dropped together with the scrutinee, exactly like a
  discriminant-only match on a payload-carrying variant. The enumerate index
  still tracks real field positions for the other bindings.
- Inference: skip registering a local for `_` payload bindings.
- Spec 4.7:30 updated to describe the `_` discard and its drop behavior.

The design was already intended: the sema comment at the dedup check read
"Wildcards never reach here: `_` in payload position isn't a binding" — the
parser simply never allowed it.

Verified: Copy payloads (partial `Rect(w, _)`, `Rect(_, h)`, and multiple
`Rect(_, _)`); a discarded non-Copy payload's user destructor runs EXACTLY once
(observed via a `drop fn` that prints — one line, not zero or two), matching the
bound-but-unused path; a 200k-iteration discard loop over a heap-owning payload
does not crash (no double-free). Full suite green (Pass 33/Fail 0), traceability
maintained; spec + CLI fixtures added.

Fixes RUE-601

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
