### PR TITLE
RUE-603: resolve comptime-type aliases in struct-field and enum-payload positions (partial)

### DIFF
--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -533,6 +533,41 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
+    /// Resolve a type-name symbol that may be a comptime-type alias
+    /// (`const A = Pair(i32);` used as a type). Returns the aliased type, or
+    /// `None` if the name is not a `type`-valued constant.
+    ///
+    /// The fast path reads an already-collected constant; the slow path collects
+    /// it on demand. The latter is needed because struct-field and enum-payload
+    /// types are resolved in the declaration/collection pass — before the
+    /// constant-collection pass runs — so a const alias would otherwise be
+    /// `unknown type` there while resolving fine in a later-analyzed function
+    /// signature (RUE-603). This mirrors the on-demand collection already used
+    /// for array-length constants.
+    pub(crate) fn resolve_const_type_alias(
+        &mut self,
+        type_sym: Spur,
+        span: Span,
+    ) -> CompileResult<Option<Type>> {
+        let mut value = self
+            .resolve_const_info_in_file(type_sym, span.file_id)
+            .map(|info| info.value);
+        if value.is_none() {
+            value = self.try_collect_const_on_demand(type_sym, span.file_id);
+        }
+        let Some(ConstValue::Type(alias_ty)) = value else {
+            return Ok(None);
+        };
+        // Privacy (E0460): an unqualified alias must not reach a private constant
+        // in another directory. Re-read the (now-collected) info for its origin.
+        if let Some(info) = self.resolve_const_info_in_file(type_sym, span.file_id) {
+            let (file_id, is_pub) = (info.span.file_id, info.is_pub);
+            let type_name = self.interner.resolve(&type_sym).to_string();
+            self.check_unqualified_visibility("constant", &type_name, file_id, is_pub, span)?;
+        }
+        Ok(Some(alias_ty))
+    }
+
     pub(crate) fn resolve_type(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
         // Own the name so the read-only branches below borrow this local rather
         // than `self.interner`, leaving `self` free for the `&mut self` slice
@@ -593,16 +628,7 @@ impl<'a> Sema<'a> {
                 span,
             )?;
             Ok(Type::new_enum(enum_id))
-        } else if let Some(info) = self.resolve_const_info_in_file(type_sym, span.file_id)
-            && let ConstValue::Type(alias_ty) = info.value
-        {
-            self.check_unqualified_visibility(
-                "constant",
-                type_name,
-                info.span.file_id,
-                info.is_pub,
-                span,
-            )?;
+        } else if let Some(alias_ty) = self.resolve_const_type_alias(type_sym, span)? {
             Ok(alias_ty)
         } else {
             // Check for array type syntax: [T; N]

--- a/crates/rue-cli-tests/cases/const_type_alias_member.toml
+++ b/crates/rue-cli-tests/cases/const_type_alias_member.toml
@@ -1,0 +1,35 @@
+# A comptime-type alias (`const P = Mod.Gen(T);`) is usable as a struct-field
+# and enum-payload type (RUE-603). Struct-field / enum-payload types are resolved
+# in the declaration pass, before the constant-collection pass; the alias is now
+# collected on demand there, so it resolves the same as in a function signature
+# (where it already worked). Driven through the real binary with a two-file
+# import so a data structure can actually hold a generic value.
+
+[section]
+id = "cli.const_type_alias_member"
+name = "Const type alias as a member type"
+description = "`const P = mod.Pair(i32)` works as a struct field and enum payload type (RUE-603)."
+
+[[case]]
+name = "alias_as_struct_field_and_enum_payload"
+description = "A const alias to an imported generic specialization is a valid struct-field AND enum-payload type."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "lib.rue", source = """
+pub fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+""" },
+  { path = "main.rue", source = """
+const lib = @import("lib.rue");
+const P = lib.Pair(i32);
+struct Holder { p: P }
+enum Maybe { Has(P), No }
+fn main() -> i32 {
+    let h = Holder { p: P { a: 20, b: 1 } };
+    let extra = match Maybe.Has(P { a: 20, b: 1 }) {
+        Maybe.Has(q) => q.a + q.b,
+        Maybe.No => 0,
+    };
+    h.p.a + h.p.b + extra
+}
+""" }]
+exit_code = 42


### PR DESCRIPTION
RUE-603: resolve comptime-type aliases in struct-field and enum-payload positions

A `const` alias to a comptime-type specialization (`const P = mod.Pair(i32);`)
now resolves as a struct-field and enum-payload type, not only in function
signatures. Before, `struct Holder { p: P }` / `enum Maybe { Has(P) }` failed
with `E0204 unknown type 'P'` even though `fn f(p: P)` worked — blocking data
structures that hold a named generic specialization (`struct Parser { toks: AB }`
where `const AB = std.arraybuf.ArrayBuf(i32)`).

Cause: struct-field and enum-payload types are resolved in the declaration pass,
before the constant-collection pass runs, so `resolve_type`'s existing const-alias
branch read an empty `constants_by_file_name` and fell through to unknown-type.
Function signatures are analyzed later, after constants are collected, so they
resolved fine.

Fix: `resolve_type` now goes through `resolve_const_type_alias`, which reads an
already-collected constant on the fast path and otherwise collects it on demand
(`try_collect_const_on_demand`) — the same on-demand mechanism already used for
array-length constants. Privacy (E0460) is preserved by re-reading the collected
constant's origin.

Scope: this fixes aliases whose specialization is evaluable during the
declaration pass — i.e. module/qualified generics like
`const AB = std.arraybuf.ArrayBuf(i32)`. An alias to an *unqualified user*
generic (`const V = Vec(i32)` where `Vec` is a same-file `fn`) and the inline
unqualified form (`struct S { v: Vec(i32) }`) still fail, because the user
comptime function is not yet evaluable that early in the pass — a separate,
deeper ordering issue that remains under RUE-603.

Full suite green (Pass 33/Fail 0); added a two-file CLI case exercising a const
alias as both a struct field and an enum payload.

Part of RUE-603

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
