### PR TITLE
RUE-589: make generated trap comparison fail closed

### DIFF
--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -21,8 +21,8 @@
 //! The compiler binary is located via `RUE_BINARY`, which `scripts/rue`,
 //! `test.sh`, and Buck test targets set from `scripts/rue-bin`.
 
-use crate::generator;
-use rue_oracle::{MAX_STDOUT_BYTES, RunSourceError, run_source};
+use crate::{generator, trap::native_runtime_trap_kind};
+use rue_oracle::{MAX_STDOUT_BYTES, RunSourceError, TrapKind, run_source};
 use std::io::Read;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
@@ -335,57 +335,6 @@ enum Verdict {
     Disagree(String),
 }
 
-/// A category of runtime trap, shared vocabulary between the oracle's panic
-/// reason ([`rue_oracle::Outcome::panic`]) and the compiled runtime's stderr
-/// message (`rue-runtime/src/error.rs`). Every defined Rue trap exits 101, so
-/// the exit code alone cannot tell two traps apart; this is what lets
-/// [`classify`] catch a miscompile that traps for the *wrong reason* (RUE-339).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TrapCategory {
-    DivideByZero,
-    Overflow,
-    IntCastOverflow,
-    Bounds,
-}
-
-/// Classify the oracle's panic reason (the exact strings raised in
-/// `rue-oracle/src/lib.rs`) into a [`TrapCategory`]. Reasons we don't map (e.g.
-/// `"reached unreachable"`, which has no distinct runtime message class) return
-/// `None`, so the caller falls back to plain exit-code agreement rather than
-/// inventing a disagreement.
-fn oracle_trap_category(reason: &str) -> Option<TrapCategory> {
-    match reason {
-        // The runtime routes both `x / 0` and `x % 0` to the single
-        // `error: division by zero` handler, so both oracle reasons map here.
-        "divide by zero" | "remainder by zero" => Some(TrapCategory::DivideByZero),
-        "arithmetic overflow" => Some(TrapCategory::Overflow),
-        "integer cast overflow" => Some(TrapCategory::IntCastOverflow),
-        "index out of bounds" => Some(TrapCategory::Bounds),
-        _ => None,
-    }
-}
-
-/// Classify the compiled runtime's stderr message into a [`TrapCategory`] by its
-/// distinguishing class substring (the messages are defined in
-/// `rue-runtime/src/error.rs`). We match on the class rather than the exact
-/// bytes so wording tweaks don't cause false-disagrees, and check the more
-/// specific `integer cast overflow` before `integer overflow`. An unrecognized
-/// message (a `@panic`/`@assert`/UTF-8/unreachable trap, or future wording)
-/// returns `None`, falling back to exit-code agreement.
-fn runtime_trap_category(stderr: &str) -> Option<TrapCategory> {
-    if stderr.contains("integer cast overflow") {
-        Some(TrapCategory::IntCastOverflow)
-    } else if stderr.contains("integer overflow") {
-        Some(TrapCategory::Overflow)
-    } else if stderr.contains("division by zero") {
-        Some(TrapCategory::DivideByZero)
-    } else if stderr.contains("index out of bounds") {
-        Some(TrapCategory::Bounds)
-    } else {
-        None
-    }
-}
-
 fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
     match compiled {
         Compiled::Ran {
@@ -418,23 +367,49 @@ fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
                 }
                 return Verdict::Disagree(r);
             }
-            // Exit code and stdout agree. When both engines ended in a runtime
-            // trap (exit 101), also compare *which* trap fired: since every Rue
-            // trap exits 101, a miscompile that traps for the wrong reason at
-            // the same point would otherwise be a false-AGREE (RUE-339). We
-            // compare category classes, not exact message bytes, to avoid
-            // false-disagrees; if either side's cause can't be classified (e.g.
-            // a `@panic`/unreachable trap, or an unmapped oracle reason) we fall
-            // back to the exit-code agreement above — a documented residual
-            // blind spot, never a manufactured disagreement.
-            if *exit == 101
-                && let Some(want) = oracle.panic.as_deref().and_then(oracle_trap_category)
-                && let Some(got) = runtime_trap_category(stderr)
-                && want != got
-            {
+            // Exit code and stdout agree. Exit 101 alone is not proof of the
+            // same semantics: every Rue trap shares it, and a normal `return
+            // 101` is legal. Compare the oracle's typed cause with the native
+            // runtime message, failing closed when either trapped cause cannot
+            // be classified.
+            if *exit == 101 {
+                let native_trap = native_runtime_trap_kind(stderr);
+                match (oracle.panic, native_trap) {
+                    (Some(want), Some(got)) if want == got => {}
+                    (Some(want), Some(got)) => {
+                        return Verdict::Disagree(format!(
+                            "trap category: oracle {want:?} vs compiled {got:?} \
+                             (both exit 101; compiled stderr {:?})",
+                            first_line(stderr)
+                        ));
+                    }
+                    (Some(want), None) => {
+                        return Verdict::Disagree(format!(
+                            "oracle trapped with {want:?}, but compiled exit 101 had no \
+                             recognized trap category (stderr {:?})",
+                            first_line(stderr)
+                        ));
+                    }
+                    (None, Some(got)) => {
+                        return Verdict::Disagree(format!(
+                            "oracle returned 101 normally, but compiled code trapped with {got:?}"
+                        ));
+                    }
+                    (None, None) if !stderr.is_empty() => {
+                        return Verdict::Disagree(format!(
+                            "oracle returned 101 normally, but compiled exit 101 wrote \
+                             unclassified stderr {:?}",
+                            first_line(stderr)
+                        ));
+                    }
+                    (None, None) => {}
+                }
+            } else if !stderr.is_empty() {
+                // Generated Rue has no modeled normal-stderr channel. Treat
+                // any such output as unexplained native behavior rather than
+                // allowing matching exit/stdout to manufacture agreement.
                 return Verdict::Disagree(format!(
-                    "panic category: oracle {want:?} vs compiled {got:?} \
-                     (both exit 101; compiled stderr {:?})",
+                    "compiled program wrote unexpected stderr {:?}",
                     first_line(stderr)
                 ));
             }
@@ -658,7 +633,7 @@ struct Disagreement {
     source: String,
     oracle_exit: i32,
     oracle_stdout: String,
-    oracle_panic: Option<String>,
+    oracle_panic: Option<TrapKind>,
     compiled: String,
     reason: String,
 }
@@ -832,12 +807,12 @@ mod tests {
         }
     }
 
-    /// An oracle outcome that ended in a runtime trap (exit 101) with `reason`.
-    fn trap(reason: &str) -> Outcome {
+    /// An oracle outcome that ended in a runtime trap (exit 101).
+    fn trap(kind: TrapKind) -> Outcome {
         Outcome {
             exit_code: 101,
             stdout: String::new(),
-            panic: Some(reason.to_string()),
+            panic: Some(kind),
         }
     }
 
@@ -872,6 +847,17 @@ mod tests {
     }
 
     #[test]
+    fn unexpected_stderr_on_normal_exit_fails_closed() {
+        let compiled = Compiled::Ran {
+            exit: 42,
+            stdout: "7\n".to_string(),
+            stdout_truncated: false,
+            stderr: "unmodeled native diagnostic\n".to_string(),
+        };
+        assert!(is_disagree(classify(&oc(42, "7\n"), &compiled)));
+    }
+
+    #[test]
     fn detects_exit_mismatch() {
         // The planted-bug shape: same stdout, wrong exit code.
         let v = classify(&oc(42, ""), &ran(43, ""));
@@ -882,6 +868,18 @@ mod tests {
     fn detects_stdout_mismatch() {
         let v = classify(&oc(0, "7\n"), &ran(0, "8\n"));
         assert!(is_disagree(v));
+
+        // Trap-category agreement cannot hide an earlier stdout mismatch.
+        let compiled = Compiled::Ran {
+            exit: 101,
+            stdout: "unexpected\n".to_string(),
+            stdout_truncated: false,
+            stderr: "error: integer overflow\n".to_string(),
+        };
+        assert!(is_disagree(classify(
+            &trap(TrapKind::ArithmeticOverflow),
+            &compiled
+        )));
     }
 
     #[test]
@@ -891,7 +889,7 @@ mod tests {
         // overflow while the compiled binary trapped on a bounds check — a
         // miscompile that the old exit-code-only comparator scored as Agree.
         let v = classify(
-            &trap("arithmetic overflow"),
+            &trap(TrapKind::ArithmeticOverflow),
             &ran_trap("error: index out of bounds\n"),
         );
         assert!(is_disagree(v));
@@ -901,41 +899,50 @@ mod tests {
     fn agrees_when_trap_categories_match() {
         // Same cause on both sides -> genuine agreement, not a false-disagree.
         let v = classify(
-            &trap("divide by zero"),
+            &trap(TrapKind::DivisionByZero),
             &ran_trap("error: division by zero\n"),
         );
         assert!(matches!(v, Verdict::Agree));
-        // The oracle's `remainder by zero` maps to the runtime's single
-        // `division by zero` handler — must still agree (category, not bytes).
         let v = classify(
-            &trap("remainder by zero"),
-            &ran_trap("error: division by zero\n"),
+            &trap(TrapKind::InvalidUtf8),
+            &ran_trap("error: invalid UTF-8\n"),
         );
         assert!(matches!(v, Verdict::Agree));
         // `integer cast overflow` must not be confused with `integer overflow`.
         let v = classify(
-            &trap("integer cast overflow"),
+            &trap(TrapKind::IntegerCastOverflow),
             &ran_trap("error: integer cast overflow\n"),
         );
         assert!(matches!(v, Verdict::Agree));
         let v = classify(
-            &trap("integer cast overflow"),
+            &trap(TrapKind::IntegerCastOverflow),
             &ran_trap("error: integer overflow\n"),
         );
         assert!(is_disagree(v));
     }
 
     #[test]
-    fn falls_back_when_cause_unclassifiable() {
-        // An unmapped runtime message (e.g. a `@panic`/unreachable trap) must
-        // NOT manufacture a disagreement — we fall back to exit-code agreement.
-        let v = classify(&trap("arithmetic overflow"), &ran_trap("panic: boom\n"));
-        assert!(matches!(v, Verdict::Agree));
-        // Likewise an oracle reason we don't map (e.g. reached unreachable).
+    fn unclassified_or_one_sided_trap_causes_fail_closed() {
         let v = classify(
-            &trap("reached unreachable"),
+            &trap(TrapKind::ArithmeticOverflow),
+            &ran_trap("panic: boom\n"),
+        );
+        assert!(is_disagree(v));
+        let v = classify(
+            &trap(TrapKind::Unreachable),
             &ran_trap("error: integer overflow\n"),
         );
+        assert!(is_disagree(v));
+        let v = classify(&oc(101, ""), &ran_trap("error: index out of bounds\n"));
+        assert!(is_disagree(v));
+        let v = classify(&oc(101, ""), &ran_trap("panic: boom\n"));
+        assert!(is_disagree(v));
+        let v = classify(&trap(TrapKind::ArithmeticOverflow), &ran(101, ""));
+        assert!(is_disagree(v));
+
+        // A normal return of 101 with no trap evidence on either side remains
+        // an ordinary agreeing program.
+        let v = classify(&oc(101, ""), &ran(101, ""));
         assert!(matches!(v, Verdict::Agree));
     }
 
@@ -950,6 +957,17 @@ mod tests {
         assert!(is_disagree(classify(&oc(0, ""), &Compiled::CompileTimeout)));
         assert!(is_disagree(classify(&oc(0, ""), &Compiled::Crash(11))));
         assert!(is_disagree(classify(&oc(0, ""), &Compiled::Timeout)));
+
+        // A native crash or timeout is still a disagreement when the oracle
+        // expected a trap; neither is evidence for the same termination cause.
+        assert!(is_disagree(classify(
+            &trap(TrapKind::ArithmeticOverflow),
+            &Compiled::Crash(4)
+        )));
+        assert!(is_disagree(classify(
+            &trap(TrapKind::ArithmeticOverflow),
+            &Compiled::Timeout
+        )));
     }
 
     #[test]
@@ -1007,16 +1025,19 @@ mod tests {
             seed: 23,
             timeout_secs: 3,
             source: "fn main() -> i32 { 23 }\n".to_string(),
-            oracle_exit: 23,
+            oracle_exit: 101,
             oracle_stdout: String::new(),
-            oracle_panic: None,
+            oracle_panic: Some(TrapKind::IntegerCastOverflow),
             compiled: "compile-fail: first\rsecond".to_string(),
             reason: "wrong exit\nconst injected = 1;".to_string(),
         };
 
-        assert!(disagreement.render().contains("--timeout 3"));
+        let rendered = disagreement.render();
+        assert!(rendered.contains("--timeout 3"));
+        assert!(rendered.contains("panic=Some(IntegerCastOverflow)"));
         let contents = disagreement_repro_contents(&disagreement);
         assert!(contents.contains("// reason: wrong exit\\nconst injected = 1;\n"));
+        assert!(contents.contains("panic=Some(IntegerCastOverflow)"));
         assert!(contents.contains("// compiled: compile-fail: first\\rsecond\n"));
         assert!(
             contents

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -41,6 +41,7 @@
 
 mod fuzz;
 mod generator;
+mod trap;
 
 use rue_error::{PreviewFeature, PreviewFeatures};
 use rue_oracle::{RunSourceError, run_source_with_preview_features};

--- a/crates/rue-oracle-diff/src/trap.rs
+++ b/crates/rue-oracle-diff/src/trap.rs
@@ -1,0 +1,70 @@
+//! Native-runtime trap classification at the text boundary.
+//!
+//! The oracle emits [`TrapKind`] directly, while native executions expose the
+//! runtime's stderr. Only a complete, stable runtime diagnostic proves a native
+//! trap kind: loose substring matching could mistake `@panic("integer
+//! overflow")` or unrelated prose for the overflow handler.
+
+use rue_oracle::TrapKind;
+
+pub(crate) fn native_runtime_trap_kind(stderr: &str) -> Option<TrapKind> {
+    match stderr {
+        "error: integer cast overflow\n" => Some(TrapKind::IntegerCastOverflow),
+        "error: integer overflow\n" => Some(TrapKind::ArithmeticOverflow),
+        "error: division by zero\n" => Some(TrapKind::DivisionByZero),
+        "error: index out of bounds\n" => Some(TrapKind::IndexOutOfBounds),
+        "error: invalid UTF-8\n" => Some(TrapKind::InvalidUtf8),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_every_stable_runtime_trap_spelling() {
+        assert_eq!(
+            native_runtime_trap_kind("error: integer cast overflow\n"),
+            Some(TrapKind::IntegerCastOverflow)
+        );
+        assert_eq!(
+            native_runtime_trap_kind("error: integer overflow\n"),
+            Some(TrapKind::ArithmeticOverflow)
+        );
+        assert_eq!(
+            native_runtime_trap_kind("error: division by zero\n"),
+            Some(TrapKind::DivisionByZero)
+        );
+        assert_eq!(
+            native_runtime_trap_kind("error: index out of bounds\n"),
+            Some(TrapKind::IndexOutOfBounds)
+        );
+        assert_eq!(
+            native_runtime_trap_kind("error: invalid UTF-8\n"),
+            Some(TrapKind::InvalidUtf8)
+        );
+    }
+
+    #[test]
+    fn expectation_fragments_user_panics_and_extra_output_are_not_proof() {
+        assert_eq!(native_runtime_trap_kind("integer overflow"), None);
+        assert_eq!(native_runtime_trap_kind("panic: integer overflow\n"), None);
+        assert_eq!(
+            native_runtime_trap_kind("panic: index out of bounds\n"),
+            None
+        );
+        assert_eq!(
+            native_runtime_trap_kind("error: integer cast overflow\nerror: integer overflow\n"),
+            None
+        );
+        assert_eq!(
+            native_runtime_trap_kind("note\nerror: index out of bounds\n"),
+            None
+        );
+        assert_eq!(
+            native_runtime_trap_kind("error: invalid UTF-8\nnote\n"),
+            None
+        );
+    }
+}

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -71,6 +71,35 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 
+/// A modeled oracle trap category.
+///
+/// The runtime-handled variants exit with code 101. [`TrapKind::Unreachable`]
+/// instead records a defensive CFG condition whose native counterpart normally
+/// faults. Keeping the category typed lets differential callers distinguish
+/// programs that terminate alike but trap for different semantic reasons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TrapKind {
+    ArithmeticOverflow,
+    DivisionByZero,
+    IntegerCastOverflow,
+    IndexOutOfBounds,
+    InvalidUtf8,
+    Unreachable,
+}
+
+impl fmt::Display for TrapKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::ArithmeticOverflow => "arithmetic overflow",
+            Self::DivisionByZero => "division by zero",
+            Self::IntegerCastOverflow => "integer cast overflow",
+            Self::IndexOutOfBounds => "index out of bounds",
+            Self::InvalidUtf8 => "invalid UTF-8",
+            Self::Unreachable => "reached unreachable",
+        })
+    }
+}
+
 /// Observable result of running a program under the oracle.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Outcome {
@@ -78,9 +107,9 @@ pub struct Outcome {
     pub exit_code: i32,
     /// Everything `@dbg` wrote, in order, newline-terminated per call.
     pub stdout: String,
-    /// `Some(reason)` if execution ended in a runtime panic (exit code 101),
-    /// `None` on normal completion. The reason mirrors the runtime's category.
-    pub panic: Option<String>,
+    /// `Some(kind)` if execution ended in a modeled trap, `None` on normal
+    /// completion. Runtime-handled kinds mirror the runtime's trap categories.
+    pub panic: Option<TrapKind>,
 }
 
 /// Maximum number of raw bytes accepted from a program's `@dbg` output.
@@ -299,7 +328,7 @@ impl Value {
 }
 
 /// A runtime panic, carrying its category (mirrors the runtime's panic classes).
-struct Panic(String);
+struct Panic(TrapKind);
 
 type Step<T> = Result<T, Flow>;
 
@@ -579,7 +608,7 @@ impl<'a> Interp<'a> {
                     incoming = Vec::new();
                 }
                 Terminator::Unreachable => {
-                    return Err(Flow::Panic(Panic("reached unreachable".into())));
+                    return Err(Flow::Panic(Panic(TrapKind::Unreachable)));
                 }
                 Terminator::None => {
                     return Err(Flow::Unsupported(Unsupported("terminator None".into())));
@@ -674,7 +703,7 @@ impl<'a> Interp<'a> {
                 let bytes = s(&args[0])?;
                 let idx = args[1].as_int();
                 if idx < 0 || idx as u128 >= bytes.len() as u128 {
-                    return Err(Flow::Panic(Panic("index out of bounds".into())));
+                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
                 }
                 Value::Int(bytes[idx as usize] as i128)
             }
@@ -687,7 +716,7 @@ impl<'a> Interp<'a> {
                 let bytes = s(&args[0])?;
                 let idx = args[1].as_int();
                 if idx < 0 || idx as u128 >= bytes.len() as u128 {
-                    return Err(Flow::Panic(Panic("index out of bounds".into())));
+                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
                 }
                 Value::Int(bytes[idx as usize] as i128)
             }
@@ -697,7 +726,7 @@ impl<'a> Interp<'a> {
                 let bytes = s(&args[0])?;
                 match char_at(&bytes, args[1].as_int()) {
                     Some((scalar, _)) => Value::Int(scalar as i128),
-                    None => return Err(Flow::Panic(Panic("invalid UTF-8".into()))),
+                    None => return Err(Flow::Panic(Panic(TrapKind::InvalidUtf8))),
                 }
             }
             "__rue_String_char_next" => {
@@ -705,7 +734,7 @@ impl<'a> Interp<'a> {
                 let offset = args[1].as_int();
                 match char_at(&bytes, offset) {
                     Some((_, width)) => Value::Int(offset + width as i128),
-                    None => return Err(Flow::Panic(Panic("invalid UTF-8".into()))),
+                    None => return Err(Flow::Panic(Panic(TrapKind::InvalidUtf8))),
                 }
             }
             // The lossy character view never traps: invalid UTF-8 becomes U+FFFD
@@ -990,7 +1019,7 @@ impl<'a> Interp<'a> {
                 let idx = self.eval(cfg, frame, *index)?.as_int();
                 let val = self.eval(cfg, frame, *value)?;
                 if idx < 0 {
-                    return Err(Flow::Panic(Panic("index out of bounds".into())));
+                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
                 }
                 Self::set_agg_elem(frame, *slot, idx as usize, val)?;
                 Value::Unit
@@ -1065,7 +1094,7 @@ impl<'a> Interp<'a> {
                 let idx = self.eval(cfg, frame, *index)?.as_int();
                 let val = self.eval(cfg, frame, *value)?;
                 if idx < 0 {
-                    return Err(Flow::Panic(Panic("index out of bounds".into())));
+                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
                 }
                 Self::set_param_elem(frame, *param_slot, idx as usize, val)?;
                 Value::Unit
@@ -1140,7 +1169,7 @@ impl<'a> Interp<'a> {
                     Flow::Unsupported(Unsupported("intcast target not an int".into()))
                 })?;
                 if x < lo || x > hi {
-                    return Err(Flow::Panic(Panic("integer cast overflow".into())));
+                    return Err(Flow::Panic(Panic(TrapKind::IntegerCastOverflow)));
                 }
                 Value::Int(x)
             }
@@ -1183,19 +1212,14 @@ impl<'a> Interp<'a> {
         let x = self.eval(cfg, frame, a)?.as_int();
         let y = self.eval(cfg, frame, b)?.as_int();
         if y == 0 {
-            let reason = if is_mod {
-                "remainder by zero"
-            } else {
-                "divide by zero"
-            };
-            return Err(Flow::Panic(Panic(reason.into())));
+            return Err(Flow::Panic(Panic(TrapKind::DivisionByZero)));
         }
         // MIN / -1 (and MIN % -1) trap at the operand width: the hardware `idiv`
         // faults even though the mathematical remainder is 0. Our i128 model
         // wouldn't otherwise catch it (the value fits in i128).
         if let Some((lo, _)) = int_bounds(ty) {
             if ty.is_signed() && x == lo && y == -1 {
-                return Err(Flow::Panic(Panic("arithmetic overflow".into())));
+                return Err(Flow::Panic(Panic(TrapKind::ArithmeticOverflow)));
             }
         }
         let r = if is_mod {
@@ -1316,7 +1340,7 @@ impl<'a> Interp<'a> {
                 Projection::Index { index, .. } => {
                     let i = self.eval(cfg, frame, index)?.as_int();
                     if i < 0 {
-                        return Err(Flow::Panic(Panic("index out of bounds".into())));
+                        return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
                     }
                     path.push(i as usize);
                 }
@@ -1343,7 +1367,7 @@ impl<'a> Interp<'a> {
             cur = match cur {
                 Value::Aggregate(mut v) if idx < v.len() => v.swap_remove(idx),
                 Value::Aggregate(_) => {
-                    return Err(Flow::Panic(Panic("index out of bounds".into())));
+                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
                 }
                 _ => {
                     return Err(Flow::Unsupported(Unsupported(
@@ -1378,7 +1402,7 @@ impl<'a> Interp<'a> {
             cur = match cur {
                 Value::Aggregate(v) if *idx < v.len() => &mut v[*idx],
                 Value::Aggregate(_) => {
-                    return Err(Flow::Panic(Panic("index out of bounds".into())));
+                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
                 }
                 _ => {
                     return Err(Flow::Unsupported(Unsupported(
@@ -1399,7 +1423,7 @@ impl<'a> Interp<'a> {
                 v[idx] = val;
                 Ok(())
             }
-            Some(Value::Aggregate(_)) => Err(Flow::Panic(Panic("index out of bounds".into()))),
+            Some(Value::Aggregate(_)) => Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds))),
             _ => Err(Flow::Unsupported(Unsupported(
                 "field/index set on non-aggregate".into(),
             ))),
@@ -1432,7 +1456,7 @@ impl<'a> Interp<'a> {
                 v[idx] = val;
                 Ok(())
             }
-            Some(Value::Aggregate(_)) => Err(Flow::Panic(Panic("index out of bounds".into()))),
+            Some(Value::Aggregate(_)) => Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds))),
             _ => Err(Flow::Unsupported(Unsupported(
                 "field/index set on non-aggregate inout param".into(),
             ))),
@@ -1574,9 +1598,9 @@ fn int_bounds(ty: Type) -> Option<(i128, i128)> {
 /// `None` (a checked-arithmetic overflow) or an out-of-range result traps as a
 /// runtime overflow panic (spec 3.1:6/13); otherwise the value is returned.
 fn range_check(v: Option<i128>, ty: Type) -> Step<Value> {
-    let n = v.ok_or_else(|| Flow::Panic(Panic("arithmetic overflow".into())))?;
+    let n = v.ok_or(Flow::Panic(Panic(TrapKind::ArithmeticOverflow)))?;
     match int_bounds(ty) {
-        Some((lo, hi)) if n < lo || n > hi => Err(Flow::Panic(Panic("arithmetic overflow".into()))),
+        Some((lo, hi)) if n < lo || n > hi => Err(Flow::Panic(Panic(TrapKind::ArithmeticOverflow))),
         _ => Ok(Value::Int(n)),
     }
 }

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -265,14 +265,41 @@ fn overflow_traps() {
         b
     }");
     assert_eq!(out.exit_code, 101);
-    assert!(out.panic.as_deref() == Some("arithmetic overflow"));
+    assert_eq!(out.panic, Some(TrapKind::ArithmeticOverflow));
 }
 
 #[test]
-fn divide_by_zero_traps() {
+fn divide_and_remainder_by_zero_share_a_trap_kind() {
     let out = run("fn main() -> i32 { let z = 0; 10 / z }");
     assert_eq!(out.exit_code, 101);
-    assert_eq!(out.panic.as_deref(), Some("divide by zero"));
+    assert_eq!(out.panic, Some(TrapKind::DivisionByZero));
+
+    let out = run("fn main() -> i32 { let z = 0; 10 % z }");
+    assert_eq!(out.exit_code, 101);
+    assert_eq!(out.panic, Some(TrapKind::DivisionByZero));
+}
+
+#[test]
+fn trap_kind_display_spellings_are_stable() {
+    let cases = [
+        (TrapKind::ArithmeticOverflow, "arithmetic overflow"),
+        (TrapKind::DivisionByZero, "division by zero"),
+        (TrapKind::IntegerCastOverflow, "integer cast overflow"),
+        (TrapKind::IndexOutOfBounds, "index out of bounds"),
+        (TrapKind::InvalidUtf8, "invalid UTF-8"),
+        (TrapKind::Unreachable, "reached unreachable"),
+    ];
+
+    for (kind, expected) in cases {
+        assert_eq!(kind.to_string(), expected);
+    }
+}
+
+#[test]
+fn normal_return_101_is_not_a_trap() {
+    let out = run("fn main() -> i32 { 101 }");
+    assert_eq!(out.exit_code, 101);
+    assert_eq!(out.panic, None);
 }
 
 #[test]
@@ -296,7 +323,7 @@ fn intcast_in_range_and_overflow() {
         y
     }");
     assert_eq!(out.exit_code, 101);
-    assert_eq!(out.panic.as_deref(), Some("integer cast overflow"));
+    assert_eq!(out.panic, Some(TrapKind::IntegerCastOverflow));
 }
 
 #[test]
@@ -417,7 +444,7 @@ fn array_out_of_bounds_traps() {
     }";
     let out = run(src);
     assert_eq!(out.exit_code, 101);
-    assert_eq!(out.panic.as_deref(), Some("index out of bounds"));
+    assert_eq!(out.panic, Some(TrapKind::IndexOutOfBounds));
 }
 
 #[test]
@@ -661,7 +688,7 @@ fn string_byte_index_out_of_bounds_traps() {
     }";
     let out = run(src);
     assert_eq!(out.exit_code, 101);
-    assert_eq!(out.panic.as_deref(), Some("index out of bounds"));
+    assert_eq!(out.panic, Some(TrapKind::IndexOutOfBounds));
 }
 
 #[test]
@@ -707,7 +734,7 @@ fn string_chars_traps_on_raw_invalid_utf8_byte() {
     }";
     let out = run(src);
     assert_eq!(out.exit_code, 101);
-    assert_eq!(out.panic.as_deref(), Some("invalid UTF-8"));
+    assert_eq!(out.panic, Some(TrapKind::InvalidUtf8));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace the oracle's free-form panic strings with a typed `TrapKind`
- compare generated native traps using exact, complete runtime diagnostics
- fail closed for mismatched or unclassified traps, user-panic lookalikes, normal `return 101`, and unexpected stderr
- preserve the typed oracle trap in deterministic disagreement output and saved repro metadata

## Root cause

Generated differential runs compared only exit code and stdout. Every Rue runtime trap exits 101, and a program may also return 101 normally, so different termination causes could be reported as agreement. Loose diagnostic matching would introduce the same false-agreement class for panic messages containing trap-like text.

## Impact

The always-on generated oracle now requires evidence that both engines reached the same modeled trap category. Unknown or ambiguous native behavior becomes a finding instead of a false green. Corpus expectation matching remains a separate follow-up so its substring vocabulary cannot weaken the native boundary.

## Validation

- `scripts/rue fmt --check`
- `./buck2 test //crates/rue-oracle:rue-oracle-test //crates/rue-oracle-diff:rue-oracle-diff-test //:oracle-diff-generated-smoke`
- `./test.sh` — Pass 33, zero failures; CLI 613/107/544 and spec 1315/107/581 with zero frontend failures or disagreements
- `./clippy.sh` — 41 targets clean

Part of RUE-589.
