### PR TITLE
RUE-589: declare CLI bounds trap causes

### DIFF
--- a/crates/rue-cli-tests/cases/signed_array_index.toml
+++ b/crates/rue-cli-tests/cases/signed_array_index.toml
@@ -81,6 +81,7 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 101
+runtime_error_contains = ["index out of bounds"]
 
 [[case]]
 name = "out_of_range_signed_index_traps"
@@ -93,3 +94,4 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 101
+runtime_error_contains = ["index out of bounds"]

--- a/crates/rue-cli-tests/cases/str_fixed_type.toml
+++ b/crates/rue-cli-tests/cases/str_fixed_type.toml
@@ -78,6 +78,7 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 101
+runtime_error_contains = ["index out of bounds"]
 
 # A string literal exceeding the capacity N is a clean compile error (E0492),
 # never a silent truncation or a crash.

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -66,6 +66,7 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 101
+runtime_error_contains = ["index out of bounds"]
 
 # A `str` parameter receives a string literal (first-class argument) and a
 # forwarded `str` variable, both by value.

--- a/crates/rue-cli-tests/cases/string_byte_access.toml
+++ b/crates/rue-cli-tests/cases/string_byte_access.toml
@@ -42,6 +42,7 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 101
+runtime_error_contains = ["index out of bounds"]
 
 [[case]]
 name = "substring_byte_range"


### PR DESCRIPTION
## Summary

- declare `index out of bounds` for five CLI tests that previously asserted only exit code 101
- cover signed array indices, `Str(N)` indexing, first-class `str` indexing, and string byte indexing
- make those existing witnesses participate in the typed trap comparison landed in #1411

## Why

Exit code 101 identifies that some Rue trap occurred, but not which one. These cases already specify and exercise bounds failures; recording the cause makes the real CLI suite verify stderr and lets oracle-diff distinguish bounds failures from unrelated traps.

## Validation

- `./buck2 test //:cli-tests //crates/rue-oracle-diff:oracle-diff-test //:oracle-diff-generated-smoke`
- CLI suite: 1,289 passed, 2 ignored, 0 failed
- oracle audit: 613 agree / 107 unmodeled / 545 ineligible, zero failures or disagreements
- generated smoke: 64/64 agree

Part of RUE-589.
