### PR TITLE
RUE-589: declare spec overflow trap causes

### DIFF
--- a/crates/rue-spec/cases/runtime/overflow.toml
+++ b/crates/rue-spec/cases/runtime/overflow.toml
@@ -17,7 +17,7 @@ fn main() -> i32 {
     x + 1
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "overflow_sub_exit_101"
@@ -28,7 +28,7 @@ fn main() -> i32 {
     x - 1
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "overflow_mul_exit_101"
@@ -39,7 +39,7 @@ fn main() -> i32 {
     x * 2
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 # =============================================================================
 # Operations That Can Overflow
@@ -54,7 +54,7 @@ fn main() -> i32 {
     x + 1
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "overflow_subtraction"
@@ -65,7 +65,7 @@ fn main() -> i32 {
     x - 1
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "overflow_multiplication"
@@ -76,7 +76,7 @@ fn main() -> i32 {
     x * 10000
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "overflow_negation"
@@ -87,7 +87,7 @@ fn main() -> i32 {
     -x
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 # Division and remainder overflow exactly for MIN / -1 (RUE-30): the quotient
 # -MIN is unrepresentable. Hardware gives no clean trap (x86 IDIV raises
@@ -104,7 +104,7 @@ fn main() -> i32 {
     x / y
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "overflow_remainder_min_by_neg1"
@@ -116,7 +116,7 @@ fn main() -> i32 {
     x % y
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 # Near-miss controls: MIN / 1 and (MIN + 1) / -1 are representable and must
 # NOT trap.

--- a/crates/rue-spec/cases/types/integers.toml
+++ b/crates/rue-spec/cases/types/integers.toml
@@ -193,7 +193,7 @@ params = [
 [[case]]
 name = "{type}_overflow_addition"
 spec = ["3.1:6"]
-exit_code = 101
+runtime_error = "integer overflow"
 source = """
 fn main() -> {type} {
     let x: {type} = {max};
@@ -208,7 +208,7 @@ params = [
 [[case]]
 name = "{type}_overflow_subtraction"
 spec = ["3.1:6"]
-exit_code = 101
+runtime_error = "integer overflow"
 source = """
 fn main() -> {type} {
     let x: {type} = {min};
@@ -229,7 +229,7 @@ fn main() -> i8 {
     x * 16
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "i32_overflow_multiplication"
@@ -240,7 +240,7 @@ fn main() -> i32 {
     x * 2
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "i64_overflow_addition"
@@ -252,7 +252,7 @@ fn main() -> i64 {
     y + x
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "i64_overflow_subtraction"
@@ -264,7 +264,7 @@ fn main() -> i64 {
     y + x
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "i64_overflow_multiplication"
@@ -275,7 +275,7 @@ fn main() -> i64 {
     x * x
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 # =============================================================================
 # Unsigned Integer Overflow (Runtime Panic - Exit 101)
@@ -284,7 +284,7 @@ exit_code = 101
 [[case]]
 name = "{type}_overflow_addition"
 spec = ["3.1:13"]
-exit_code = 101
+runtime_error = "integer overflow"
 source = """
 fn main() -> {type} {
     let x: {type} = {max};
@@ -307,12 +307,12 @@ fn main() -> u8 {
     x + y
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 [[case]]
 name = "{type}_overflow_subtraction"
 spec = ["3.1:13"]
-exit_code = 101
+runtime_error = "integer overflow"
 source = """
 fn main() -> {type} {
     let x: {type} = 0;
@@ -329,7 +329,7 @@ params = [
 [[case]]
 name = "{type}_overflow_multiplication"
 spec = ["3.1:13"]
-exit_code = 101
+runtime_error = "integer overflow"
 source = """
 fn main() -> {type} {
     let x: {type} = {value};
@@ -351,7 +351,7 @@ fn main() -> u64 {
     y + x
 }
 """
-exit_code = 101
+runtime_error = "integer overflow"
 
 # =============================================================================
 # Valid Arithmetic (No Overflow)


### PR DESCRIPTION
## Summary

- replace generic `exit_code = 101` metadata with `runtime_error = "integer overflow"`
- cover 9 runtime-overflow cases and 12 integer-type declarations that expand to 20 cases
- make all 29 witnesses verify the exact runtime diagnostic and typed oracle trap cause

## Why

Exit 101 only proves that some Rue trap occurred. These cases specifically exercise arithmetic overflow—including `MIN / -1` and `MIN % -1`—so their metadata should name `ArithmeticOverflow` instead of permitting an unrelated trap to pass.

## Validation

- `./buck2 test //:spec-tests //crates/rue-oracle-diff:oracle-diff-spec-test //:oracle-diff-generated-smoke`
- spec suite: 1,989 passed, 14 ignored, 0 failed
- oracle audit: 1,315 agree / 107 unmodeled / 581 ineligible, zero failures or disagreements
- generated smoke: 64/64 agree

Part of RUE-589.
