### PR TITLE
RUE-589: declare spec division trap causes

### DIFF
--- a/crates/rue-spec/cases/runtime/division.toml
+++ b/crates/rue-spec/cases/runtime/division.toml
@@ -17,7 +17,7 @@ fn main() -> i32 {
     x / 0
 }
 """
-exit_code = 101
+runtime_error = "division by zero"
 
 [[case]]
 name = "mod_by_zero_exit_101"
@@ -28,7 +28,7 @@ fn main() -> i32 {
     x % 0
 }
 """
-exit_code = 101
+runtime_error = "division by zero"
 
 # =============================================================================
 # Both Division and Remainder Affected
@@ -42,7 +42,7 @@ fn main() -> i32 {
     10 / 0
 }
 """
-exit_code = 101
+runtime_error = "division by zero"
 
 [[case]]
 name = "remainder_by_zero"
@@ -52,7 +52,7 @@ fn main() -> i32 {
     10 % 0
 }
 """
-exit_code = 101
+runtime_error = "division by zero"
 
 [[case]]
 name = "computed_divisor_zero"
@@ -64,4 +64,4 @@ fn main() -> i32 {
     10 / (x - y)
 }
 """
-exit_code = 101
+runtime_error = "division by zero"


### PR DESCRIPTION
## Summary

- replace generic exit-101 metadata with `runtime_error = "division by zero"`
- cover five division and remainder witnesses, including a computed zero divisor
- make the real spec runner and typed oracle comparison require `DivisionByZero`

## Why

Division and remainder by zero intentionally share Rue's `DivisionByZero` trap category. Exit 101 alone cannot distinguish that cause from overflow, bounds, or a normal return of 101.

## Validation

- `./buck2 test //:spec-tests //crates/rue-oracle-diff:oracle-diff-spec-test //:oracle-diff-generated-smoke`
- all 2,003 spec cases pass
- oracle audit remains 1,315 agree / 107 unmodeled / 581 ineligible with zero failures/disagreements
- generated smoke: 64/64 agree

Part of RUE-589.
