### PR TITLE
RUE-589: declare spec intcast trap causes

### DIFF
--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -665,8 +665,7 @@ fn main() -> i32 {
     0
 }
 """
-exit_code = 101
-stderr_contains = "integer cast overflow"
+runtime_error = "integer cast overflow"
 
 [[case]]
 name = "intcast_overflow_negative_to_unsigned"
@@ -678,8 +677,7 @@ fn main() -> i32 {
     0
 }
 """
-exit_code = 101
-stderr_contains = "integer cast overflow"
+runtime_error = "integer cast overflow"
 
 [[case]]
 name = "intcast_overflow_i8_max"
@@ -691,8 +689,7 @@ fn main() -> i32 {
     0
 }
 """
-exit_code = 101
-stderr_contains = "integer cast overflow"
+runtime_error = "integer cast overflow"
 
 [[case]]
 name = "intcast_overflow_i8_min"
@@ -704,8 +701,7 @@ fn main() -> i32 {
     0
 }
 """
-exit_code = 101
-stderr_contains = "integer cast overflow"
+runtime_error = "integer cast overflow"
 
 [[case]]
 name = "intcast_boundary_i8_max"
@@ -777,8 +773,7 @@ fn main() -> i32 {
     y
 }
 """
-exit_code = 101
-stderr_contains = "integer cast overflow"
+runtime_error = "integer cast overflow"
 
 # =============================================================================
 # @read_line Intrinsic


### PR DESCRIPTION
## Summary

- replace five redundant `exit_code` + `stderr_contains` pairs with `runtime_error = "integer cast overflow"`
- make the spec schema describe these as runtime traps rather than successful-run stderr assertions
- require typed `IntegerCastOverflow` agreement in oracle-diff

## Why

The runtime-error field already implies exit 101 and checks stderr. It also supplies #1411's typed trap expectation, preventing an unrelated exit-101 trap from satisfying an int-cast overflow witness.

## Validation

- `./buck2 test //:spec-tests //crates/rue-oracle-diff:oracle-diff-spec-test //:oracle-diff-generated-smoke`
- all 2,003 spec cases pass
- oracle audit remains 1,315 agree / 107 unmodeled / 581 ineligible with zero failures/disagreements
- generated smoke: 64/64 agree

Part of RUE-589.
