### PR TITLE
RUE-589: declare spec bounds trap causes

### DIFF
--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -232,7 +232,7 @@ fn main() -> i32 {
     arr[i]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # =============================================================================
 # Mutable Array Element Assignment
@@ -502,7 +502,7 @@ fn main() -> i32 {
     matrix[i][0]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # Arrays in structs
 

--- a/crates/rue-spec/cases/expressions/index.toml
+++ b/crates/rue-spec/cases/expressions/index.toml
@@ -130,7 +130,7 @@ fn main() -> i32 {
     arr[i]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # =============================================================================
 # Mutable Array Element Assignment

--- a/crates/rue-spec/cases/runtime/bounds.toml
+++ b/crates/rue-spec/cases/runtime/bounds.toml
@@ -18,7 +18,7 @@ fn main() -> i32 {
     arr[i]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # =============================================================================
 # Exit Code 101 on Out-of-Bounds
@@ -34,7 +34,7 @@ fn main() -> i32 {
     arr[i]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # =============================================================================
 # Compile-Time Bounds Checking
@@ -154,7 +154,7 @@ fn main() -> i32 {
     arr[i]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # A negative signed index computed at runtime must trap: the bounds check is
 # an unsigned 64-bit comparison, so a negative value (all high bits set)
@@ -169,7 +169,7 @@ fn main() -> i32 {
     arr[i]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # An out-of-range signed index also traps at runtime.
 [[case]]
@@ -182,4 +182,4 @@ fn main() -> i32 {
     arr[i]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"

--- a/crates/rue-spec/cases/types/arrays.toml
+++ b/crates/rue-spec/cases/types/arrays.toml
@@ -105,7 +105,7 @@ fn main() -> i32 {
     arr[i]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # =============================================================================
 # Out-of-Bounds Panic
@@ -121,7 +121,7 @@ fn main() -> i32 {
     arr[i]
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # =============================================================================
 # Zero-Length Arrays (Zero-Sized Types)

--- a/crates/rue-spec/cases/types/str-fixed-type.toml
+++ b/crates/rue-spec/cases/types/str-fixed-type.toml
@@ -163,7 +163,7 @@ fn main() -> i32 {
     @intCast(b)
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # 3.7:55 — a `Str(N)` coerces to a `borrow str` view and is read through it
 # (ADR-0043 two-types model, RUE-386). It does NOT coerce to a first-class `str`

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -120,7 +120,7 @@ fn main() -> i32 {
     @intCast(b)
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 # 3.7:44 — a literal `str` is first-class: passable as a `str` argument.
 [[case]]

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -743,7 +743,7 @@ fn main() -> i32 {
     0
 }
 """
-exit_code = 101
+runtime_error = "index out of bounds"
 
 [[case]]
 name = "string_substring_len"


### PR DESCRIPTION
## Summary

- replace generic exit-101 metadata with `runtime_error = "index out of bounds"`
- cover 13 eligible array, signed-index, `Str(N)`, `str`, and `String` byte-index witnesses
- leave the separate substring case untouched because the oracle does not model that call yet

## Why

Exit 101 alone cannot distinguish bounds failure from another Rue trap. These declarations now strengthen the real spec runner and make #1411's differential comparison require typed `IndexOutOfBounds` parity.

## Validation

- `./buck2 test //:spec-tests //crates/rue-oracle-diff:oracle-diff-spec-test //:oracle-diff-generated-smoke`
- all 2,003 spec cases pass
- oracle audit remains 1,315 agree / 107 unmodeled / 581 ineligible with zero failures/disagreements
- generated smoke: 64/64 agree

Part of RUE-589.
