### PR TITLE
RUE-599: type inline-ctor-head construction arguments in inference

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -219,6 +219,16 @@ pub struct ConstraintGenerator<'a> {
     /// scope-aware). `None` only in unit tests; production passes the map via
     /// [`Self::with_comptime_local_types`].
     comptime_local_types: Option<&'a HashMap<Spur, Type>>,
+    /// Inline type-constructor heads (`F(args).Variant(..)`, `F(args) { .. }`;
+    /// RUE-596, preview `inline_type_ctor_paths`) pre-reduced by sema to their
+    /// concrete struct/enum types, keyed by the head's own `InstRef` — the
+    /// per-instruction analogue of `comptime_local_types` for heads that have
+    /// no `let`-bound name. Consulted so construction arguments get their
+    /// declared payload/parameter constraints; without it an integer payload
+    /// literal defaulted to `i32` and could not satisfy a wider declared type
+    /// (RUE-599). `None` only in unit tests; production passes the map via
+    /// [`Self::with_inline_ctor_head_types`].
+    inline_ctor_head_types: Option<&'a HashMap<InstRef, Type>>,
     /// Method signatures registered after the shared `InferenceContext` was
     /// built: anonymous-struct methods are registered lazily during comptime
     /// evaluation, so they're absent from `methods`. Consulted when a method
@@ -300,6 +310,7 @@ impl<'a> ConstraintGenerator<'a> {
             functions_by_file_name: None,
             module_file_ids: None,
             comptime_local_types: None,
+            inline_ctor_head_types: None,
             extra_method_sigs: None,
             const_values: None,
             const_function_aliases: None,
@@ -400,6 +411,17 @@ impl<'a> ConstraintGenerator<'a> {
         comptime_local_types: &'a HashMap<Spur, Type>,
     ) -> Self {
         self.comptime_local_types = Some(comptime_local_types);
+        self
+    }
+
+    /// Provide sema's pre-reduced inline type-constructor heads (head
+    /// `InstRef` -> concrete type). See the `inline_ctor_head_types` field
+    /// (RUE-599).
+    pub fn with_inline_ctor_head_types(
+        mut self,
+        inline_ctor_head_types: &'a HashMap<InstRef, Type>,
+    ) -> Self {
+        self.inline_ctor_head_types = Some(inline_ctor_head_types);
         self
     }
 
@@ -1655,18 +1677,27 @@ impl<'a> ConstraintGenerator<'a> {
             // Struct initialization
             InstData::StructInit {
                 module,
+                ctor_head,
                 type_name,
                 fields_start,
                 fields_len,
-                ..
             } => {
-                // Module-qualified literals (`m.Point { ... }`) resolve in
-                // the module's defining file, matching sema. Unqualified
-                // literals check type_subst first (for Self/type parameters),
-                // then comptime type aliases (`let P = F(); P { ... }`,
-                // RUE-170), then the current file's module-local type table,
-                // then the unique-name compatibility map.
-                let struct_ty = if let Some(module_ref) = module {
+                // Inline type-constructor literal heads (`F(args) { ... }`,
+                // RUE-596) resolve through sema's pre-reduced head map, the
+                // same way the call-head path does (RUE-599); a head sema
+                // could not reduce falls through to the error path below and
+                // sema diagnoses it. Module-qualified literals
+                // (`m.Point { ... }`) resolve in the module's defining file,
+                // matching sema. Unqualified literals check type_subst first
+                // (for Self/type parameters), then comptime type aliases
+                // (`let P = F(); P { ... }`, RUE-170), then the current
+                // file's module-local type table, then the unique-name
+                // compatibility map.
+                let struct_ty = if let Some(head) = ctor_head {
+                    self.inline_ctor_head_types
+                        .and_then(|heads| heads.get(head).copied())
+                        .filter(|ty| ty.as_struct().is_some())
+                } else if let Some(module_ref) = module {
                     let module_info = self.generate(*module_ref, ctx);
                     let module_id = match module_info.ty {
                         InferType::Concrete(ty) => ty.as_module(),
@@ -2091,11 +2122,34 @@ impl<'a> ConstraintGenerator<'a> {
                     // return type. Sema's comptime evaluation resolves the
                     // receiver and types the call during analysis; an ERROR
                     // here poisoned inference first (RUE-119 family).
+                    //
+                    // An inline type-constructor head (`Result(i64, i32)
+                    // .Ok(41)`, RUE-596) is the exception: sema pre-reduced it
+                    // in `inline_ctor_head_types`, so constrain the
+                    // construction's arguments against the variant payload /
+                    // assoc-fn signature exactly like the bound-alias form —
+                    // an unconstrained integer payload literal otherwise
+                    // defaulted to `i32` and could not satisfy a wider
+                    // declared payload type (RUE-599).
                     InferType::Concrete(ty) if *ty == Type::COMPTIME_TYPE => {
-                        for arg in args.iter() {
-                            self.generate(arg.value, ctx);
+                        if let Some(reduced) = self
+                            .inline_ctor_head_types
+                            .and_then(|heads| heads.get(receiver).copied())
+                            && let Some(result) = self.generate_call_on_reduced_type(
+                                reduced,
+                                *method,
+                                *args_start,
+                                *args_len,
+                                ctx,
+                            )
+                        {
+                            result
+                        } else {
+                            for arg in args.iter() {
+                                self.generate(arg.value, ctx);
+                            }
+                            InferType::Var(self.fresh_var())
                         }
-                        InferType::Var(self.fresh_var())
                     }
                     InferType::Concrete(ty) => {
                         if let Some(struct_id) = ty.as_struct() {
@@ -2355,22 +2409,67 @@ impl<'a> ConstraintGenerator<'a> {
         span: Span,
         ctx: &mut ConstraintContext,
     ) -> InferType {
-        let args = self.rir.get_call_args(args_start, args_len);
+        // Enum tuple-variant construction: `Shape.Circle(5)` (RUE-221).
+        // Checked first so it takes precedence over the struct-method path
+        // below.
+        if let Some(enum_ty) = self.enum_type_for(&type_name, span.file_id)
+            && let Some(result) =
+                self.generate_call_on_reduced_type(enum_ty, function, args_start, args_len, ctx)
+        {
+            return result;
+        }
 
-        // Enum tuple-variant construction: `Shape.Circle(5)`. If `type_name` is
-        // an enum and `function` names one of its variants, constrain each
-        // payload argument to the declared payload type and yield the enum type
-        // (RUE-221). Checked first so it takes precedence over the struct-method
-        // path below.
-        let enum_variant = self
-            .enum_type_for(&type_name, span.file_id)
-            .and_then(|ty| ty.as_enum().map(|id| (ty, id)))
-            .and_then(|(ty, id)| {
-                let def = self.type_pool.enum_def(id);
-                def.find_variant(self.interner.resolve(&function))
-                    .map(|vidx| (ty, def.variant_payload(vidx).to_vec()))
-            });
-        if let Some((enum_ty, payload)) = enum_variant {
+        // Struct associated function: constrain each argument to the declared
+        // parameter type and yield the return type.
+        if let Some(struct_ty) = self.structs.get(&type_name).copied()
+            && struct_ty.as_struct().is_some()
+        {
+            if let Some(result) =
+                self.generate_call_on_reduced_type(struct_ty, function, args_start, args_len, ctx)
+            {
+                return result;
+            }
+            // Method not found - sema reports the error; still process args.
+            let args = self.rir.get_call_args(args_start, args_len);
+            for arg in args.iter() {
+                self.generate(arg.value, ctx);
+            }
+            return InferType::Concrete(Type::ERROR);
+        }
+
+        // Type not found - sema reports the error; still process args.
+        let args = self.rir.get_call_args(args_start, args_len);
+        for arg in args.iter() {
+            self.generate(arg.value, ctx);
+        }
+        InferType::Concrete(Type::ERROR)
+    }
+
+    /// Constrain a `Type.function(args)` call against an already-concrete
+    /// type: enum tuple-variant construction (`Shape.Circle(5)`, RUE-221) or a
+    /// struct associated-function call. Imposing the declared payload/parameter
+    /// types on the arguments here — not just in sema — is what pins a literal
+    /// like the `8` in `String.with_capacity(8)` to the declared `u64` instead
+    /// of letting it default to `i32`. Shared by
+    /// [`Self::generate_type_qualified_call`] (name-resolved heads) and the
+    /// inline type-constructor head path (sema-reduced heads, RUE-599).
+    /// Returns `None` — with the arguments NOT yet visited — when `function`
+    /// is not a variant/associated function of `ty`; the caller processes the
+    /// arguments and lets sema diagnose.
+    fn generate_call_on_reduced_type(
+        &mut self,
+        ty: Type,
+        function: Spur,
+        args_start: u32,
+        args_len: u32,
+        ctx: &mut ConstraintContext,
+    ) -> Option<InferType> {
+        if let Some(enum_id) = ty.as_enum() {
+            let def = self.type_pool.enum_def(enum_id);
+            let payload = def
+                .find_variant(self.interner.resolve(&function))
+                .map(|vidx| def.variant_payload(vidx).to_vec())?;
+            let args = self.rir.get_call_args(args_start, args_len);
             for (i, arg) in args.iter().enumerate() {
                 let arg_info = self.generate(arg.value, ctx);
                 if let Some(&pty) = payload.get(i) {
@@ -2382,37 +2481,20 @@ impl<'a> ConstraintGenerator<'a> {
                     self.add_constraint(Constraint::equal(arg_info.ty, expected, arg_info.span));
                 }
             }
-            return InferType::Concrete(enum_ty);
+            return Some(InferType::Concrete(ty));
         }
-
-        // Struct associated function: constrain each argument to the declared
-        // parameter type and yield the return type.
-        let struct_id = self.structs.get(&type_name).and_then(|ty| ty.as_struct());
-        if let Some(struct_id) = struct_id {
-            let method_key = (struct_id, function);
-            if let Some(method_sig) = self.methods.get(&method_key) {
-                for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
-                    let arg_info = self.generate(arg.value, ctx);
-                    self.add_constraint(Constraint::equal(
-                        arg_info.ty,
-                        param_type.clone(),
-                        arg_info.span,
-                    ));
-                }
-                return method_sig.return_type.clone();
-            }
-            // Method not found - sema reports the error; still process args.
-            for arg in args.iter() {
-                self.generate(arg.value, ctx);
-            }
-            return InferType::Concrete(Type::ERROR);
+        let struct_id = ty.as_struct()?;
+        let method_sig = self.method_sig(&(struct_id, function))?;
+        let args = self.rir.get_call_args(args_start, args_len);
+        for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
+            let arg_info = self.generate(arg.value, ctx);
+            self.add_constraint(Constraint::equal(
+                arg_info.ty,
+                param_type.clone(),
+                arg_info.span,
+            ));
         }
-
-        // Type not found - sema reports the error; still process args.
-        for arg in args.iter() {
-            self.generate(arg.value, ctx);
-        }
-        InferType::Concrete(Type::ERROR)
+        Some(method_sig.return_type.clone())
     }
 
     /// Resolve an enum type name that may be a comptime type-variable binding

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -36,6 +36,16 @@ impl<'a> Sema<'a> {
         let comptime_local_types =
             self.precompute_comptime_type_locals(body, type_subst, value_subst);
 
+        // Pre-reduce inline type-constructor heads (`F(args).Variant(..)`,
+        // `F(args) { ... }`; RUE-596) to their concrete types, keyed by the
+        // head's `InstRef` — the nameless analogue of the alias map above.
+        // Without this, a construction argument on an inline head was never
+        // constrained and an integer payload literal defaulted to `i32`
+        // (RUE-599). Runs before the lazy-method collection below so methods
+        // registered while reducing a head are included in it.
+        let inline_ctor_head_types =
+            self.precompute_inline_ctor_head_types(type_subst, value_subst, &comptime_local_types);
+
         // Anonymous-struct methods are registered lazily (during comptime
         // evaluation, including the pre-pass above), after the shared
         // `InferenceContext` was built — so collect the signatures it doesn't
@@ -85,6 +95,7 @@ impl<'a> Sema<'a> {
         .with_module_file_ids(&infer_ctx.module_file_ids)
         .with_functions_by_file_name(&infer_ctx.functions_by_file_name)
         .with_comptime_local_types(&comptime_local_types)
+        .with_inline_ctor_head_types(&inline_ctor_head_types)
         .with_comptime_values(value_subst)
         .with_extra_method_sigs(&extra_method_sigs);
 

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -50,7 +50,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use lasso::{Key, Spur};
-use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
 use rue_rir::{InstData, InstRef, RepeatCount, RirPattern};
 use rue_span::{FileId, Span};
 
@@ -1668,5 +1668,82 @@ impl Sema<'_> {
             Some(ConstValue::Type(t)) => Some(t),
             _ => None,
         }
+    }
+
+    /// Pre-reduce inline type-constructor heads (`F(args).Variant(..)`,
+    /// `F(args) { .. }`; RUE-596, preview `inline_type_ctor_paths`) to their
+    /// concrete struct/enum types before HM inference runs (RUE-599).
+    ///
+    /// The constraint generator has no comptime interpreter, so an inline
+    /// head left the construction's arguments unconstrained — an integer
+    /// payload literal then defaulted to `i32` and could no longer satisfy a
+    /// wider declared payload type (`Result(i64, i32).Ok(41)` → E0206), even
+    /// though the bound-alias form (`let R = Result(i64, i32); R.Ok(41)`)
+    /// typed it correctly via `comptime_local_types`. This pass reduces each
+    /// candidate head opportunistically (like
+    /// [`precompute_comptime_type_locals`], non-evaluable heads are simply
+    /// skipped and sema diagnoses them later) and returns the reductions
+    /// keyed by the head's own `InstRef` for the generator to look up.
+    ///
+    /// The scan covers the whole RIR, not just the current body: heads
+    /// belonging to other functions evaluate under this function's
+    /// substitutions, but their keys are `InstRef`s this body's constraint
+    /// generation never visits, and reduction is idempotent (specializations
+    /// are cached, anonymous types dedup structurally), so stray entries are
+    /// inert. `comptime_local_types` carries the body's `let`-bound type
+    /// aliases so a head like `Result(T, i32)` with `let T = i64;` reduces.
+    ///
+    /// Gated on the preview feature so non-preview compiles pay nothing;
+    /// when `inline_type_ctor_paths` stabilizes (RUE-598), remove the gate
+    /// and cache the candidate scan if it shows up in `--time-passes`.
+    ///
+    /// [`precompute_comptime_type_locals`]: Sema::precompute_comptime_type_locals
+    pub(crate) fn precompute_inline_ctor_head_types(
+        &mut self,
+        type_subst: Option<&HashMap<Spur, Type>>,
+        value_subst: Option<&HashMap<Spur, ConstValue>>,
+        comptime_local_types: &HashMap<Spur, Type>,
+    ) -> HashMap<InstRef, Type> {
+        if !self
+            .preview_features
+            .contains(&PreviewFeature::InlineTypeCtorPath)
+        {
+            return HashMap::new();
+        }
+        // A head is the receiver of a `.NAME(..)` path whose receiver is
+        // itself a call (`F(args).Ok(x)`, or module-qualified
+        // `m.F(args).Ok(x)`, which RIR spells as a nested MethodCall), or a
+        // struct literal's explicit `ctor_head`. Runtime shapes like
+        // `foo(x).bar()` are collected too but fail the reduction cheaply
+        // (the comptime engine rejects callees with runtime parameters).
+        let candidates: Vec<InstRef> = self
+            .rir
+            .iter()
+            .filter_map(|(_, inst)| match inst.data {
+                InstData::MethodCall { receiver, .. } => matches!(
+                    self.rir.get(receiver).data,
+                    InstData::Call { .. } | InstData::MethodCall { .. }
+                )
+                .then_some(receiver),
+                InstData::StructInit {
+                    ctor_head: Some(head),
+                    ..
+                } => Some(head),
+                _ => None,
+            })
+            .collect();
+        let mut eval_types: HashMap<Spur, Type> = type_subst.cloned().unwrap_or_default();
+        eval_types.extend(comptime_local_types);
+        let eval_values: HashMap<Spur, ConstValue> = value_subst.cloned().unwrap_or_default();
+        let mut reduced = HashMap::new();
+        for head in candidates {
+            if let Some(ConstValue::Type(ty)) =
+                self.try_evaluate_const_with_subst(head, &eval_types, &eval_values)
+                && (ty.is_enum() || ty.as_struct().is_some())
+            {
+                reduced.insert(head, ty);
+            }
+        }
+        reduced
     }
 }

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2263,6 +2263,77 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "inline_type_ctor_enum_head_wide_payload_literal"
+spec = ["4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+description = "An integer payload literal on an inline enum-variant head is typed at the declared payload type, not defaulted to i32: Result(i64, i32).Ok(41) (RUE-599)"
+source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn main() -> i32 {
+    let r = Result(i64, i32).Ok(41);
+    let R = Result(i64, i32);
+    match r {
+        R.Ok(v) => if v == 41 { 42 } else { 1 },
+        R.Err(e) => e,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inline_type_ctor_enum_head_payload_literal_range_checked"
+spec = ["4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+description = "An integer payload literal on an inline enum-variant head is range-checked at the declared payload width: Wrap(u8).Some(300) is E0800 (RUE-599)"
+source = """
+fn Wrap(comptime T: type) -> type { enum { Some(T), None } }
+fn main() -> i32 {
+    let a = Wrap(u8).Some(300);
+    let _ = a;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0800", "u8"]
+
+[[case]]
+name = "inline_type_ctor_assoc_fn_head_wide_param_literal"
+spec = ["4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+description = "An integer argument literal on an inline assoc-fn head is typed at the declared parameter type, not defaulted to i32: Box(u64).make(8) (RUE-599)"
+source = """
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+        fn make(x: T) -> Self { Self { v: x } }
+    }
+}
+fn main() -> i32 {
+    let b = Box(u64).make(8);
+    if b.v == 8 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inline_type_ctor_struct_literal_head_wide_field_literal"
+spec = ["4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+description = "An integer field-initializer literal on an inline struct-literal head is typed at the declared field type: Pair(i64) { ... } (RUE-599)"
+source = """
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+fn main() -> i32 {
+    let p = Pair(i64) { first: 40, second: 2 };
+    if p.first + p.second == 42 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "type_param_scopes_into_method_body"
 spec = ["4.14:24"]
 description = "The enclosing type parameter T names types in a method body and nests into another constructor Option(T) (RUE-289, RUE-313)"


### PR DESCRIPTION
## Summary

An inline type-constructor head (RUE-596, preview `inline_type_ctor_paths`) cannot be reduced by the HM inference engine, so the construction's arguments were never constrained: an integer payload literal defaulted to `i32` and could no longer satisfy a wider declared payload type — `Result(i64, i32).Ok(41)` failed with E0206 while the bound-alias form (`let R = Result(i64, i32); R.Ok(41)`) worked.

## Fix

- Sema pre-reduces every inline head (`F(args).Variant(..)` call heads and `F(args) { .. }` struct-literal ctor heads) before inference runs, keyed by the head's own `InstRef` — the nameless analogue of the existing `comptime_local_types` alias map. The pre-pass is gated on the preview feature, so non-preview compiles pay nothing.
- The constraint generator consults the map in the `MethodCall` comptime-receiver arm and the `StructInit` arm, constraining variant-payload / assoc-fn-parameter / field types exactly like the bound-alias form.
- The reduced-type constraint core is extracted into `generate_call_on_reduced_type`, shared with the existing name-resolved `Type.function(args)` path.

Verified end-to-end: i64/u8 payloads carry the right value at runtime, out-of-range literals get E0800 at the declared width, wrong payload types still E0206, alias-dependent heads (`let T = i64; Result(T, i32)`) and heads inside generic bodies (`Wrap(T).Some(x)`) reduce, and the preview gate is intact. Full suite: Tests finished: Pass 33. Fail 0.

Unblocks RUE-598 (stabilization).

Fixes RUE-599

🤖 Generated with [Claude Code](https://claude.com/claude-code)
