### PR TITLE
RUE-589: preserve logical parameter writability in CFG

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -37,7 +37,7 @@ pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};
 pub use sema::{
     AnalyzedFunction, ConstValue, DirResolution, FunctionInfo, GatherOutput, MethodInfo,
-    ModulePath, Sema, SemaOutput, import_candidate_groups,
+    ModulePath, ParamSlotModes, Sema, SemaOutput, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -26,7 +26,7 @@ use super::context::{
     AnalysisContext, AnalysisResult, BuiltinMethodContext, CallLoanKind, ConstValue, ParamInfo,
     ReceiverInfo, StringReceiverStorage,
 };
-use super::{AnalyzedFunction, InferenceContext, MethodInfo, Sema, SemaOutput};
+use super::{AnalyzedFunction, InferenceContext, MethodInfo, ParamSlotModes, Sema, SemaOutput};
 use crate::inference::{
     Constraint, ConstraintContext, ConstraintGenerator, InferType, ParamVarInfo, Unifier,
     UnifyResult,
@@ -1331,7 +1331,7 @@ mod error_invariant_tests {
             air,
             num_locals: 0,
             num_param_slots: 0,
-            param_modes: Vec::new(),
+            param_modes: ParamSlotModes::default(),
             allow_unreachable_code: false,
         }
     }

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -246,7 +246,7 @@ impl<'a> Sema<'a> {
         Air,
         u32,
         u32,
-        Vec<bool>,
+        ParamSlotModes,
         Vec<CompileWarning>,
         Vec<String>,
         HashSet<Spur>,
@@ -290,7 +290,7 @@ impl<'a> Sema<'a> {
         Air,
         u32,
         u32,
-        Vec<bool>,
+        ParamSlotModes,
         Vec<CompileWarning>,
         Vec<String>,
         HashSet<Spur>,
@@ -314,7 +314,8 @@ impl<'a> Sema<'a> {
         }
 
         let mut param_vec: Vec<ParamInfo> = Vec::new();
-        let mut param_modes: Vec<bool> = Vec::new();
+        let mut param_by_ref: Vec<bool> = Vec::new();
+        let mut param_writable: Vec<bool> = Vec::new();
 
         // Add parameters to the param vec, tracking ABI slot offsets.
         // Each parameter starts at the next available ABI slot.
@@ -359,11 +360,13 @@ impl<'a> Sema<'a> {
                 self.require_layout_slots(*ptype, self.rir.get(body).span)?
             };
             for _ in 0..slot_count {
-                param_modes.push(is_by_ref);
+                param_by_ref.push(is_by_ref);
+                param_writable.push(*mode == RirParamMode::Inout);
             }
             next_abi_slot += slot_count;
         }
         let num_param_slots = next_abi_slot;
+        let param_modes = ParamSlotModes::new(param_by_ref, param_writable);
 
         // The callee owns its pass-by-value (Normal) parameters and must drop
         // them at exit unless they are moved out (RUE-61). Inout/borrow params
@@ -540,7 +543,7 @@ impl<'a> Sema<'a> {
         Air,
         u32,
         u32,
-        Vec<bool>,
+        ParamSlotModes,
         Vec<CompileWarning>,
         Vec<String>,
         HashSet<Spur>,
@@ -582,7 +585,7 @@ impl<'a> Sema<'a> {
         Air,
         u32,
         u32,
-        Vec<bool>,
+        ParamSlotModes,
         Vec<CompileWarning>,
         Vec<String>,
         HashSet<Spur>,
@@ -635,7 +638,7 @@ impl<'a> Sema<'a> {
         Air,
         u32,
         u32,
-        Vec<bool>,
+        ParamSlotModes,
         Vec<CompileWarning>,
         Vec<String>,
         HashSet<Spur>,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -50,7 +50,7 @@ pub use inference_ctx::InferenceContext;
 pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
-pub use output::{AnalyzedFunction, SemaOutput};
+pub use output::{AnalyzedFunction, ParamSlotModes, SemaOutput};
 
 use std::collections::HashMap;
 

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -8,6 +8,47 @@ use crate::inst::Air;
 use crate::intern_pool::TypeInternPool;
 use rue_error::CompileWarning;
 
+/// Per-ABI-slot parameter access metadata preserved into CFG.
+///
+/// `by_ref` describes the physical calling convention: both `borrow` and
+/// `inout` parameters may be passed indirectly. `writable` preserves the
+/// distinct source-level permission needed by consumers such as the oracle;
+/// only logical `inout` slots are writable. Keeping the two facts separate
+/// prevents a shared borrow from being mistaken for mutable caller storage.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParamSlotModes {
+    by_ref: Vec<bool>,
+    writable: Vec<bool>,
+}
+
+impl ParamSlotModes {
+    pub fn new(by_ref: Vec<bool>, writable: Vec<bool>) -> Self {
+        assert_eq!(
+            by_ref.len(),
+            writable.len(),
+            "parameter slot mode vectors must have equal length"
+        );
+        Self { by_ref, writable }
+    }
+
+    pub fn by_ref(&self) -> &[bool] {
+        &self.by_ref
+    }
+
+    pub fn writable(&self) -> &[bool] {
+        &self.writable
+    }
+}
+
+/// Compatibility for synthetic/test CFGs that only describe the physical
+/// convention. Such parameters are conservatively not writable.
+impl From<Vec<bool>> for ParamSlotModes {
+    fn from(by_ref: Vec<bool>) -> Self {
+        let writable = vec![false; by_ref.len()];
+        Self { by_ref, writable }
+    }
+}
+
 /// Result of analyzing a function.
 #[derive(Debug)]
 pub struct AnalyzedFunction {
@@ -19,10 +60,10 @@ pub struct AnalyzedFunction {
     /// For scalar types (i32, bool), each parameter uses 1 slot.
     /// For struct types, each field uses 1 slot (flattened ABI).
     pub num_param_slots: u32,
-    /// Whether each parameter slot is passed as inout (by reference).
-    /// Length matches num_param_slots - for struct params, all slots share
-    /// the same mode as the original parameter.
-    pub param_modes: Vec<bool>,
+    /// Physical by-reference and logical writability modes for every ABI slot.
+    /// Length matches `num_param_slots`; flattened parameters repeat their
+    /// source parameter's mode for each occupied slot.
+    pub param_modes: ParamSlotModes,
     /// Whether function-level `@allow(unreachable_code)` suppresses CFG
     /// unreachable-code warnings while lowering this function.
     pub allow_unreachable_code: bool,

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -6,7 +6,7 @@
 use lasso::ThreadedRodeo;
 use rue_air::{
     Air, AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
-    StructId, Type, TypeInternPool, TypeKind,
+    ParamSlotModes, StructId, Type, TypeInternPool, TypeKind,
 };
 use rue_error::{CompileError, CompileWarning, ErrorKind, WarningKind};
 
@@ -251,7 +251,7 @@ impl<'a> CfgBuilder<'a> {
         num_params: u32,
         fn_name: &str,
         type_pool: &'a TypeInternPool,
-        param_modes: Vec<bool>,
+        param_modes: impl Into<ParamSlotModes>,
         interner: &'a ThreadedRodeo,
         allow_unreachable_code: bool,
     ) -> CfgOutput {
@@ -3686,6 +3686,31 @@ mod tests {
             "field a's exit drop must be guarded by a flag test"
         );
         assert_all_blocks_terminated(&main_cfg);
+    }
+
+    #[test]
+    fn cfg_preserves_logical_writability_separately_from_by_ref_abi() {
+        let source = "struct Pair { a: i32, b: i32 }\n\
+             fn borrowed(borrow p: Pair) -> i32 { p.a }\n\
+             fn writable(inout p: Pair) -> i32 { p.a }\n\
+             fn main() -> i32 {\n\
+                 let mut p = Pair { a: 1, b: 2 };\n\
+                 borrowed(borrow p) + writable(inout p)\n\
+             }";
+
+        let borrow_cfg = build_cfg_named(source, "borrowed");
+        assert!(borrow_cfg.is_param_inout(0), "borrow uses the by-ref ABI");
+        assert!(
+            !borrow_cfg.is_param_writable(0),
+            "borrow must not carry logical write permission"
+        );
+
+        let inout_cfg = build_cfg_named(source, "writable");
+        assert!(inout_cfg.is_param_inout(0), "inout uses the by-ref ABI");
+        assert!(
+            inout_cfg.is_param_writable(0),
+            "inout must preserve logical write permission"
+        );
     }
 
     #[test]

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -25,7 +25,7 @@ const _: () = assert!(std::mem::size_of::<CfgInst>() <= 48);
 const _: () = assert!(std::mem::size_of::<CfgInstData>() <= 32);
 
 use lasso::{Key, Spur};
-use rue_air::{EnumId, StructId, Type};
+use rue_air::{EnumId, ParamSlotModes, StructId, Type};
 use rue_span::Span;
 
 // ============================================================================
@@ -586,8 +586,9 @@ pub struct Cfg {
     num_params: u32,
     /// Function name
     fn_name: String,
-    /// Whether each parameter slot is inout (passed by reference)
-    param_modes: Vec<bool>,
+    /// Physical by-reference and logical writability facts for every
+    /// parameter ABI slot.
+    param_modes: ParamSlotModes,
     /// Local slots whose ADDRESS escapes through an address-taking intrinsic
     /// (`@raw` / `@raw_mut` / `@field_ptr`), recorded at construction by
     /// CfgBuilder (which has the interner to recognize the names — opt passes
@@ -607,7 +608,7 @@ impl Cfg {
         num_locals: u32,
         num_params: u32,
         fn_name: String,
-        param_modes: Vec<bool>,
+        param_modes: impl Into<ParamSlotModes>,
     ) -> Self {
         Self {
             blocks: Vec::new(),
@@ -621,7 +622,7 @@ impl Cfg {
             num_locals,
             num_params,
             fn_name,
-            param_modes,
+            param_modes: param_modes.into(),
             address_taken_slots: std::collections::HashSet::new(),
         }
     }
@@ -679,10 +680,25 @@ impl Cfg {
         &self.fn_name
     }
 
-    /// Get whether a parameter slot is inout.
+    /// Get whether a parameter slot uses the physical by-reference ABI.
+    ///
+    /// This legacy name is retained for codegen callers. It is true for both
+    /// logical `borrow` and logical `inout`; use [`Cfg::is_param_writable`] for
+    /// mutation permission.
     #[inline]
     pub fn is_param_inout(&self, slot: u32) -> bool {
         self.param_modes
+            .by_ref()
+            .get(slot as usize)
+            .copied()
+            .unwrap_or(false)
+    }
+
+    /// Get whether a parameter ABI slot is logically writable (`inout`).
+    #[inline]
+    pub fn is_param_writable(&self, slot: u32) -> bool {
+        self.param_modes
+            .writable()
             .get(slot as usize)
             .copied()
             .unwrap_or(false)
@@ -691,7 +707,7 @@ impl Cfg {
     /// Get the parameter modes slice.
     #[inline]
     pub fn param_modes(&self) -> &[bool] {
-        &self.param_modes
+        self.param_modes.by_ref()
     }
 
     /// Create a new basic block and return its ID.

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -341,7 +341,7 @@ fn create_struct_drop_glue_function(
         air,
         num_locals: 0,
         num_param_slots,
-        param_modes,
+        param_modes: param_modes.into(),
         allow_unreachable_code: false,
     }
 }
@@ -474,7 +474,7 @@ fn create_array_drop_glue_function(
         air,
         num_locals: 0,
         num_param_slots,
-        param_modes,
+        param_modes: param_modes.into(),
         allow_unreachable_code: false,
     }
 }
@@ -604,7 +604,7 @@ fn create_enum_drop_glue_function(enum_id: EnumId, type_pool: &TypeInternPool) -
         air,
         num_locals: 0,
         num_param_slots,
-        param_modes,
+        param_modes: param_modes.into(),
         allow_unreachable_code: false,
     }
 }


### PR DESCRIPTION
## Summary

- preserve source-level `inout` writability separately from the physical by-reference ABI
- carry both facts from semantic analysis into CFG parameter-slot metadata
- keep existing codegen behavior unchanged while exposing an exact `is_param_writable` query
- pin borrow-vs-inout propagation with a sema-to-CFG regression test

## Why

The existing CFG bit is true for both `borrow` and `inout` because both may use the by-reference ABI. Consumers that need mutation permission cannot safely infer it from that physical representation. This closes that metadata ambiguity before the differential oracle starts using the distinction.

## Tests

- `./buck2 test //crates/rue-cfg:rue-cfg-test`
- affected crate tests (`rue-air`, `rue-cfg`, `rue-compiler`)
- `./clippy.sh`
