### PR TITLE
RUE-603: collect type-constructor signatures on demand in type positions

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -179,9 +179,17 @@ impl<'a> ComptimeEnv<'a> {
     /// results) the `comptime { }` block path gets from HM inference, instead
     /// of the raw-`i64` fallback that only range-checked the final value
     /// against the declared type (RUE-230).
+    ///
+    /// `defining_file` is the const's declaring file, so a type-constructor
+    /// call in the initializer can collect the same-file callee's signature on
+    /// demand (`const V = Vec(i32);` evaluated during struct-field resolution,
+    /// before the main declaration sweep collected `Vec`; RUE-603), and a
+    /// module-qualified comptime call nested in the initializer resolves its
+    /// receiver against that file's imports (RUE-511).
     pub(crate) fn for_const_init(
         resolved_types: &'a HashMap<InstRef, Type>,
         const_module_members: &'a HashMap<InstRef, ConstValue>,
+        defining_file: FileId,
     ) -> Self {
         Self {
             type_subst: &EMPTY_TYPE_SUBST,
@@ -190,7 +198,7 @@ impl<'a> ComptimeEnv<'a> {
             runtime_locals: None,
             locals: HashMap::new(),
             const_module_members,
-            defining_file: None,
+            defining_file: Some(defining_file),
         }
     }
 }
@@ -1435,8 +1443,26 @@ impl Sema<'_> {
         args_len: u32,
         env: &mut ComptimeEnv,
     ) -> CompileResult<Option<ConstValue>> {
-        let Some(fn_info) = self.functions.get(&name) else {
-            return Ok(None);
+        let (name_key, fn_info) = if let Some(info) = self.functions.get(&name).copied() {
+            (name, info)
+        } else {
+            // The callee may simply not be collected yet: const initializers
+            // (`const V = Vec(i32);`) and struct-field / enum-payload types
+            // evaluate before the main declaration sweep reaches the callee's
+            // `FnDecl` (RUE-603). Collect the evaluating expression's own
+            // file's declaration on demand; a genuinely unknown name stays
+            // non-evaluable.
+            let Some(file_id) = env.defining_file else {
+                return Ok(None);
+            };
+            self.ensure_free_function_signature(name, Some(file_id))?;
+            let Some((key, info)) = self
+                .resolve_function_name_local(name, file_id)
+                .and_then(|key| self.functions.get(&key).copied().map(|info| (key, info)))
+            else {
+                return Ok(None);
+            };
+            (key, info)
         };
         let is_type_fn = fn_info.return_type == Type::COMPTIME_TYPE;
         let params = fn_info.params;
@@ -1486,7 +1512,7 @@ impl Sema<'_> {
         }
         // The callee body sees only its own parameters. Reduce it with the
         // freshly-built substitution maps.
-        self.reduce_type_ctor_body(name, &callee_types, &callee_values)
+        self.reduce_type_ctor_body(name_key, &callee_types, &callee_values)
     }
 
     /// Reduce a comptime-evaluable function's body to a [`ConstValue`] under

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1989,6 +1989,7 @@ impl<'a> Sema<'a> {
         let mut env = super::comptime_eval::ComptimeEnv::for_const_init(
             &resolved_types,
             &const_module_members,
+            file_id,
         );
         match self.eval_const_expr(init, &mut env)? {
             Some(value) => Ok(ConstInit::Value(value)),
@@ -2566,6 +2567,7 @@ impl<'a> Sema<'a> {
             let mut env = super::comptime_eval::ComptimeEnv::for_const_init(
                 &resolved_types,
                 &const_module_members,
+                accessing_file,
             );
             let Some(value) = self.eval_const_expr(arg.value, &mut env)? else {
                 return Err(CompileError::new(
@@ -2600,6 +2602,36 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// Every `FnDecl` inst that is type-scoped — a method or associated
+    /// function declared inside a named struct or an anonymous struct type —
+    /// as opposed to a free function. These are namespaced under their
+    /// enclosing type (spec 10.5) and must not be found by free-function
+    /// lookups or collected as free functions (a `Self` signature type would
+    /// be rejected outside its struct context, RUE-123).
+    pub(crate) fn type_scoped_method_refs(&self) -> HashSet<InstRef> {
+        let mut refs = HashSet::new();
+        for (_, inst) in self.rir.iter() {
+            match &inst.data {
+                InstData::AnonStructType {
+                    methods_start,
+                    methods_len,
+                    ..
+                }
+                | InstData::StructDecl {
+                    methods_start,
+                    methods_len,
+                    ..
+                } => {
+                    for r in self.rir.get_inst_refs(*methods_start, *methods_len) {
+                        refs.insert(r);
+                    }
+                }
+                _ => {}
+            }
+        }
+        refs
+    }
+
     /// Find a free function declaration in RIR, optionally restricted to one
     /// source file. This is used during const collection, which is
     /// dependency-ordered and can run before the main function-signature pass
@@ -2609,7 +2641,8 @@ impl<'a> Sema<'a> {
         target: Spur,
         file_id: Option<FileId>,
     ) -> Option<(FileId, bool)> {
-        self.rir.iter().find_map(|(_, inst)| {
+        let method_refs = self.type_scoped_method_refs();
+        self.rir.iter().find_map(|(inst_ref, inst)| {
             let InstData::FnDecl {
                 is_pub,
                 name,
@@ -2619,7 +2652,7 @@ impl<'a> Sema<'a> {
             else {
                 return None;
             };
-            if *has_self || *name != target {
+            if *has_self || *name != target || method_refs.contains(&inst_ref) {
                 return None;
             }
             if file_id.is_some_and(|wanted| inst.span.file_id != wanted) {
@@ -2630,13 +2663,15 @@ impl<'a> Sema<'a> {
     }
 
     /// Ensure a free function's signature is available during const
-    /// collection, which can run before the main declaration walk reaches the
-    /// callee's `FnDecl`.
+    /// collection, struct-field/enum-payload type resolution, and
+    /// signature-type resolution — all of which can run before the main
+    /// declaration walk reaches the callee's `FnDecl` (RUE-603).
     pub(crate) fn ensure_free_function_signature(
         &mut self,
         target: Spur,
         file_id: Option<FileId>,
     ) -> CompileResult<Option<(FileId, bool)>> {
+        let method_refs = self.type_scoped_method_refs();
         let Some((
             span,
             is_pub,
@@ -2647,7 +2682,7 @@ impl<'a> Sema<'a> {
             is_unchecked,
             directives_start,
             directives_len,
-        )) = self.rir.iter().find_map(|(_, inst)| {
+        )) = self.rir.iter().find_map(|(inst_ref, inst)| {
             let InstData::FnDecl {
                 is_pub,
                 name,
@@ -2664,7 +2699,7 @@ impl<'a> Sema<'a> {
             else {
                 return None;
             };
-            if *has_self || *name != target {
+            if *has_self || *name != target || method_refs.contains(&inst_ref) {
                 return None;
             }
             if file_id.is_some_and(|wanted| inst.span.file_id != wanted) {
@@ -2688,7 +2723,15 @@ impl<'a> Sema<'a> {
 
         let internal_target = self.internal_function_name(target, span.file_id);
         if !self.functions.contains_key(&internal_target) {
-            self.collect_function_signature(
+            // Cycle guard (see `fn_signatures_in_flight`): collecting this
+            // signature resolves its parameter/return types, which may collect
+            // other signatures on demand; a signature cycle must terminate as
+            // "not found" (the referencing site reports E0204) instead of
+            // recursing forever.
+            if !self.fn_signatures_in_flight.insert(internal_target) {
+                return Ok(None);
+            }
+            let collected = self.collect_function_signature(
                 target,
                 params_start,
                 params_len,
@@ -2699,7 +2742,9 @@ impl<'a> Sema<'a> {
                 is_unchecked,
                 directives_start,
                 directives_len,
-            )?;
+            );
+            self.fn_signatures_in_flight.remove(&internal_target);
+            collected?;
         }
         Ok(Some((span.file_id, is_pub)))
     }

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -125,6 +125,7 @@ impl<'a> GatherOutput<'a> {
             destructor_spans: HashMap::new(),
             infectious_linear: HashMap::new(),
             comptime_type_call_depth: 0,
+            fn_signatures_in_flight: std::collections::HashSet::new(),
         }
     }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -52,7 +52,7 @@ pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
 pub use output::{AnalyzedFunction, ParamSlotModes, SemaOutput};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
@@ -156,6 +156,13 @@ pub struct Sema<'a> {
     /// overflow that stack (SIGABRT) without this guard. Bounded at
     /// `MAX_SPECIALIZATION_ROUNDS`, emitting the same E1200 (RUE-261).
     pub(crate) comptime_type_call_depth: usize,
+    /// Internal names of free functions whose signatures are mid-collection in
+    /// [`Self::ensure_free_function_signature`]. Collecting a signature
+    /// resolves its parameter/return types, which may name other type
+    /// constructors and collect *them* on demand (RUE-603); a signature cycle
+    /// (`fn A(x: B(i32))` / `fn B(x: A(i32))`) must not re-enter a
+    /// mid-collection signature, or the reduction would recurse forever.
+    pub(crate) fn_signatures_in_flight: HashSet<Spur>,
 }
 
 impl<'a> Sema<'a> {
@@ -211,6 +218,7 @@ impl<'a> Sema<'a> {
             destructor_spans: HashMap::new(),
             infectious_linear: HashMap::new(),
             comptime_type_call_depth: 0,
+            fn_signatures_in_flight: HashSet::new(),
         }
     }
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1345,7 +1345,20 @@ impl<'a> Sema<'a> {
         ctx: Option<&AnalysisContext>,
     ) -> CompileResult<Type> {
         let name_sym = self.interner.get_or_intern(call_name);
-        let Some(name_key) = self.resolve_function_name_local(name_sym, span.file_id) else {
+        // The constructor may not be collected yet: struct-field and
+        // enum-payload types, const initializers, and earlier function
+        // signatures all resolve before the main declaration sweep reaches
+        // the callee's `FnDecl`, so `struct S { v: Vec(i32) }` — or a
+        // signature naming `Vec(i32)` declared above `fn Vec` — used to
+        // E0204 while the same application resolved fine later (RUE-603).
+        // Collect the same-file declaration on demand, mirroring the
+        // const-alias path (`try_collect_const_on_demand`).
+        let mut name_key = self.resolve_function_name_local(name_sym, span.file_id);
+        if name_key.is_none() {
+            self.ensure_free_function_signature(name_sym, Some(span.file_id))?;
+            name_key = self.resolve_function_name_local(name_sym, span.file_id);
+        }
+        let Some(name_key) = name_key else {
             return Err(CompileError::new(
                 ErrorKind::UnknownType(format!("{}(...)", call_name)),
                 span,

--- a/crates/rue-cli-tests/cases/const_type_alias_member.toml
+++ b/crates/rue-cli-tests/cases/const_type_alias_member.toml
@@ -1,14 +1,16 @@
-# A comptime-type alias (`const P = Mod.Gen(T);`) is usable as a struct-field
-# and enum-payload type (RUE-603). Struct-field / enum-payload types are resolved
-# in the declaration pass, before the constant-collection pass; the alias is now
-# collected on demand there, so it resolves the same as in a function signature
-# (where it already worked). Driven through the real binary with a two-file
-# import so a data structure can actually hold a generic value.
+# A comptime-type alias (`const P = Mod.Gen(T);` or `const V = Vec(i32);`) and
+# an inline unqualified type-constructor application (`Vec(i32)`) are usable as
+# struct-field and enum-payload types (RUE-603). Member types are resolved in
+# the declaration pass, before the constant-collection and function-signature
+# passes; the alias's constant and the constructor's signature are now
+# collected on demand there, so they resolve the same as in a function
+# signature. Driven through the real binary with a two-file import so a data
+# structure can actually hold a generic value.
 
 [section]
 id = "cli.const_type_alias_member"
 name = "Const type alias as a member type"
-description = "`const P = mod.Pair(i32)` works as a struct field and enum payload type (RUE-603)."
+description = "`const P = mod.Pair(i32)`, `const V = Vec(i32)`, and inline `Vec(i32)` work as struct-field and enum-payload types (RUE-603)."
 
 [[case]]
 name = "alias_as_struct_field_and_enum_payload"
@@ -33,3 +35,73 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 42
+
+[[case]]
+name = "same_file_user_generic_alias_as_member"
+description = "A const alias to a same-file user generic (`const V = Vec(i32)`) is a valid struct-field and enum-payload type."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn Vec(comptime T: type) -> type { struct { x: T } }
+const V = Vec(i32);
+struct Holder { v: V }
+enum Maybe { Has(V), No }
+fn main() -> i32 {
+    let h = Holder { v: V { x: 20 } };
+    let extra = match Maybe.Has(V { x: 22 }) {
+        Maybe.Has(q) => q.x,
+        Maybe.No => 0,
+    };
+    h.v.x + extra
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inline_user_generic_as_member"
+description = "An inline unqualified user-generic application (`Vec(i32)`) is a valid struct-field and enum-payload type."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn Vec(comptime T: type) -> type { struct { x: T } }
+struct Holder { v: Vec(i32) }
+enum Maybe { Has(Vec(i32)), No }
+fn main() -> i32 {
+    let V = Vec(i32);
+    let h = Holder { v: V { x: 20 } };
+    let extra = match Maybe.Has(V { x: 22 }) {
+        Maybe.Has(q) => q.x,
+        Maybe.No => 0,
+    };
+    h.v.x + extra
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "signature_use_before_ctor_declaration"
+description = "A signature naming `Vec(i32)` declared above `fn Vec` resolves (declaration order must not matter)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn get(v: Vec(i32)) -> i32 { v.x }
+fn Vec(comptime T: type) -> type { struct { x: T } }
+fn main() -> i32 {
+    let V = Vec(i32);
+    get(V { x: 42 })
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "signature_cycle_terminates_with_diagnostic"
+description = "Mutually recursive signature type applications (`fn A(x: B(i32))` / `fn B(x: A(i32))`) terminate with a diagnostic instead of recursing forever."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """
+fn A(x: B(i32)) -> i32 { 0 }
+fn B(x: A(i32)) -> i32 { 0 }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0204"]


### PR DESCRIPTION
## Summary

Completes the RUE-603 matrix (the qualified/module-alias half landed in #1409). Member types (struct fields, enum payloads) and function-signature types resolve before the main declaration sweep collects function signatures, so a user type-constructor application there failed E0204 unless the callee happened to be collected already:

- `const V = Vec(i32); struct S { v: V }` — same-file user-generic alias as a member type
- `struct S { v: Vec(i32) }` / `enum E { Full(Vec(i32)) }` — inline unqualified application as a member type
- `fn get(v: Vec(i32))` declared above `fn Vec` — declaration-order sensitivity in signatures (new finding while fixing)

## Fix

The existing `ensure_free_function_signature` on-demand collector (already used by the qualified/module path) is now also consulted by:

- `resolve_type_function_call` — unqualified type-constructor applications in any type position collect the same-file callee on demand, mirroring `try_collect_const_on_demand`;
- `eval_comptime_type_call` — const initializers (`const V = Vec(i32);`) evaluated during the declaration pass, via the initializer's defining file now threaded into `ComptimeEnv::for_const_init` (which also lets module-qualified comptime calls nested in const initializers resolve their receiver, RUE-511).

Hardening while touching it: `ensure_free_function_signature` now skips type-scoped `FnDecl`s (a struct's associated functions must not be collectable as free functions — the RUE-123 hazard) and carries a cycle guard so mutually recursive signature applications (`fn A(x: B(i32))` / `fn B(x: A(i32))`) terminate with E0204 instead of recursing forever.

## Testing

Five CLI cases in `const_type_alias_member.toml` (the three matrix rows above, plus order-insensitivity and cycle termination). Full suite: Tests finished: Pass 33. Fail 0.

Fixes RUE-603

🤖 Generated with [Claude Code](https://claude.com/claude-code)
