### PR TITLE
RUE-609: evaluate re-export-chain qualified type-ctor calls in comptime value positions

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -857,6 +857,20 @@ impl<'a> ConstraintGenerator<'a> {
                         // field types match the definition.
                         init_info.ty
                     }
+                } else if name.is_some_and(|n| {
+                    self.comptime_local_types
+                        .is_some_and(|aliases| aliases.contains_key(&n))
+                }) {
+                    // Sema pre-resolved this binding as a comptime type alias
+                    // (`let O = std.option.Option(i64);`). A module-qualified
+                    // constructor init infers as a fresh variable (the module
+                    // member-call arm can't reduce a `-> type` body), which
+                    // blocked the type-name-receiver forwarding for `O.Some(..)`
+                    // and left payload literals unconstrained (RUE-609, the
+                    // RUE-599 failure mode through a bound alias). The binding
+                    // holds a type value, so type it as one; downstream paths
+                    // read the concrete aliased type from `comptime_local_types`.
+                    InferType::Concrete(Type::COMPTIME_TYPE)
                 } else {
                     // No annotation - use the init expression's type
                     init_info.ty

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1274,9 +1274,22 @@ impl Sema<'_> {
         span: Span,
         env: &mut ComptimeEnv,
     ) -> CompileResult<Option<ConstValue>> {
-        // Receiver must be a bare name.
-        let InstData::VarRef { name: recv_name } = self.rir.get(receiver).data else {
-            return Ok(None);
+        // The receiver may be a bare import binding (`ab.Mk(..)`) or a
+        // re-export chain through module facades (`std.arraybuf.ArrayBuf(..)`,
+        // RUE-609); collect the dotted spine down to its root name. Any other
+        // receiver shape (a runtime value's method) is a genuine runtime call
+        // and stays non-evaluable.
+        let mut chain_rev: Vec<Spur> = Vec::new();
+        let mut cursor = receiver;
+        let recv_name = loop {
+            match self.rir.get(cursor).data {
+                InstData::VarRef { name } => break name,
+                InstData::FieldGet { base, field } => {
+                    chain_rev.push(field);
+                    cursor = base;
+                }
+                _ => return Ok(None),
+            }
         };
         // A `let`-binding, runtime local, or comptime parameter of the same name
         // shadows the module import (spec 4.14:6) — then this is not a module
@@ -1292,19 +1305,37 @@ impl Sema<'_> {
         if env.type_subst.contains_key(&recv_name) || env.value_subst.contains_key(&recv_name) {
             return Ok(None);
         }
-        // The receiver names an import of the file whose body is being reduced.
+        // The receiver's root names an import of the file whose body is being
+        // reduced; any further segments walk re-export bindings in the
+        // imported files (the same walk qualified type annotations use).
         let Some(file_id) = env.defining_file else {
             return Ok(None);
         };
-        let Some(binding) = self.module_bindings.get(&(file_id, recv_name)).cloned() else {
-            return Ok(None);
-        };
-        let Some(module_id) = binding.ty.as_module() else {
-            return Ok(None);
-        };
-        let module_def = self.module_registry.get_def(module_id);
-        let Some(module_file_id) = self.canonical_file_id(&module_def.file_path) else {
-            return Ok(None);
+        let module_file_id = if chain_rev.is_empty() {
+            let Some(binding) = self.module_bindings.get(&(file_id, recv_name)).cloned() else {
+                return Ok(None);
+            };
+            let Some(module_id) = binding.ty.as_module() else {
+                return Ok(None);
+            };
+            let module_def = self.module_registry.get_def(module_id);
+            let Some(module_file_id) = self.canonical_file_id(&module_def.file_path) else {
+                return Ok(None);
+            };
+            module_file_id
+        } else {
+            let mut segments: Vec<&str> = vec![self.interner.resolve(&recv_name)];
+            segments.extend(chain_rev.iter().rev().map(|s| self.interner.resolve(s)));
+            // Walk failures (unknown member, non-module segment, privacy) make
+            // the call non-evaluable here; the caller reports the comptime
+            // failure and sema's other paths carry the precise diagnostics.
+            let Some((_, Some(module_file_id), _)) = self
+                .resolve_type_module_prefix_in_file(file_id, &segments, span)
+                .ok()
+            else {
+                return Ok(None);
+            };
+            module_file_id
         };
         // Ensure the member's signature is collected, then require membership:
         // the resolved function must actually be declared in the module's file.

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1083,6 +1083,20 @@ impl<'a> Sema<'a> {
         segments: &[&str],
         span: Span,
     ) -> CompileResult<(crate::types::ModuleId, Option<FileId>, String)> {
+        self.resolve_type_module_prefix_in_file(span.file_id, segments, span)
+    }
+
+    /// Like [`Self::resolve_type_module_prefix`], but with the file whose
+    /// imports anchor the walk's first segment made explicit. The comptime
+    /// engine resolves against its environment's `defining_file` (RUE-511),
+    /// which is authoritative even when the expression's span is a default
+    /// span with no file context (RUE-609).
+    pub(crate) fn resolve_type_module_prefix_in_file(
+        &mut self,
+        root_file: FileId,
+        segments: &[&str],
+        span: Span,
+    ) -> CompileResult<(crate::types::ModuleId, Option<FileId>, String)> {
         let Some((first, rest)) = segments.split_first() else {
             return Err(CompileError::new(
                 ErrorKind::UnknownType(String::new()),
@@ -1092,9 +1106,9 @@ impl<'a> Sema<'a> {
         let first_sym = self.interner.get_or_intern(first);
         let Some(binding) = self
             .module_bindings
-            .get(&(span.file_id, first_sym))
+            .get(&(root_file, first_sym))
             .cloned()
-            .or_else(|| self.resolve_direct_import_module_binding(span.file_id, first_sym, span))
+            .or_else(|| self.resolve_direct_import_module_binding(root_file, first_sym, span))
         else {
             return Err(CompileError::new(
                 ErrorKind::UnknownType((*first).to_string()),

--- a/crates/rue-cli-tests/cases/reexport_qualified_ctor.toml
+++ b/crates/rue-cli-tests/cases/reexport_qualified_ctor.toml
@@ -1,0 +1,58 @@
+# A type-constructor application whose head is qualified through a module
+# RE-EXPORT chain (`std.arraybuf.ArrayBuf(...)`, or `m.inner.Pair(...)` through
+# `pub const inner = @import(...)`) evaluates in comptime value positions
+# (RUE-609): as a nested argument to another constructor in a const
+# initializer, and as a `let`-bound alias whose enum constructions then type
+# their payload literals at the declared width (the RUE-599 failure mode
+# through a bound alias).
+
+[section]
+id = "cli.reexport_qualified_ctor"
+name = "Re-export-qualified type-constructor calls in comptime value positions"
+description = "`m.inner.G(...)` chains evaluate as const-initializer arguments and as let-bound aliases (RUE-609)."
+
+[[case]]
+name = "nested_reexport_chain_ctor_arg_in_const"
+description = "A re-export-chain application nests as a const-initializer argument: `const N = m.inner.Pair(m.inner.Pair(i64));`"
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "inner.rue", source = """
+pub fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+""" },
+  { path = "outer.rue", source = """
+pub const inner = @import("inner.rue");
+""" },
+  { path = "main.rue", source = """
+const m = @import("outer.rue");
+const Nested = m.inner.Pair(m.inner.Pair(i64));
+const Inner = m.inner.Pair(i64);
+fn main() -> i32 {
+    let n = Nested {
+        a: Inner { a: 10, b: 11 },
+        b: Inner { a: 10, b: 11 },
+    };
+    if n.a.a + n.a.b + n.b.a + n.b.b == 42 { 42 } else { 1 }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "std_chain_alias_types_wide_payload_literal"
+description = "A let-bound alias of a std re-export-chain enum ctor types payload literals at the declared width: `let O = std.option.Option(i64); O.Some(40)`"
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+  { path = "main.rue", source = """
+const std = @import("std");
+const Longs = std.arraybuf.ArrayBuf(std.option.Option(i64));
+fn main() -> i32 {
+    let mut xs = Longs.new();
+    let O = std.option.Option(i64);
+    xs.push(O.Some(40));
+    xs.push(O.None);
+    let a = match xs.get_or(0, O.None) { O.Some(v) => v, O.None => 0 };
+    let b = match xs.get_or(1, O.Some(2)) { O.Some(v) => v, O.None => 2 };
+    if a + b == 42 { 42 } else { 1 }
+}
+""" }]
+exit_code = 42


### PR DESCRIPTION
## Summary

A type-constructor application whose head is qualified through a module **re-export chain** (`std.arraybuf.ArrayBuf(...)`, where `std.arraybuf` is `pub const arraybuf = @import(...)` in the std facade) was non-evaluable in the comptime engine: `eval_module_qualified_comptime_call` only accepted a bare `VarRef` receiver naming a direct import. Consequences:

- `const Nested = std.arraybuf.ArrayBuf(std.arraybuf.ArrayBuf(i64));` failed with a misleading E0434 ("argument to `ArrayBuf` is not supported in const context") instead of reducing — and, for `ArrayBuf` specifically, reaching the intended E0498 droppable-gate rejection.
- The idiomatic bind-first form `let O = std.option.Option(i64); O.Some(40)` mistyped the payload literal (E0206, the RUE-599 failure mode through a bound alias), because the alias never resolved as a comptime type.

## Fix

- The receiver walk now collects the `FieldGet` spine down to its root name and resolves multi-segment chains through the same re-export walk qualified type annotations use (`resolve_type_module_prefix`, refactored to take the anchoring file explicitly — the engine's `defining_file` is authoritative even for default spans). Walk failures stay non-evaluable, so runtime chained method calls are untouched.
- In inference, a `let` binding that sema's alias precompute resolved as a comptime type alias is typed `COMPTIME_TYPE` even when its initializer inferred as a fresh variable (the module member-call arm can't reduce a `-> type` body). This unblocks the type-name-receiver forwarding for `O.Some(..)` so payload literals get their declared-width constraints.

## Testing

Two CLI cases (`reexport_qualified_ctor.toml`): a local two-file re-export chain with a nested ctor argument in a const initializer, and a std-chain `ArrayBuf(Option(i64))` container exercising the bind-first alias with a wide payload literal end-to-end. Verified the misleading E0434 now reaches the correct E0498 for nested `ArrayBuf`. Full suite: Tests finished: Pass 33. Fail 0.

Fixes RUE-609

🤖 Generated with [Claude Code](https://claude.com/claude-code)
