### PR TITLE
RUE-589: preserve place base types in CFG

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -65,14 +65,20 @@ impl fmt::Display for AirPlaceRef {
 ///
 /// # Examples
 ///
-/// - `x` → `AirPlace { base: Local(0), projections_start: 0, projections_len: 0 }`
-/// - `arr[i]` → `AirPlace { base: Local(0), ... }` with `Index` projection
-/// - `point.x` → `AirPlace { base: Local(0), ... }` with `Field` projection
-/// - `arr[i].x` → `AirPlace { base: Local(0), ... }` with `Index` then `Field`
+/// - `x` → `AirPlace { base: Local(0), base_type: T, ... }`
+/// - `arr[i]` → `AirPlace { base: Local(0), base_type: Array, ... }` with `Index` projection
+/// - `point.x` → `AirPlace { base: Local(0), base_type: Point, ... }` with `Field` projection
+/// - `arr[i].x` → the same `Array` base type with `Index` then `Field`
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AirPlace {
     /// The base of the place - either a local slot or parameter slot
     pub base: AirPlaceBase,
+    /// The logical type stored at the base before applying projections.
+    ///
+    /// A physical slot index does not uniquely identify this type: aggregate
+    /// parameters are flattened and zero-sized parameters can share an ABI
+    /// index. Carrying it on the place keeps the first projection typed.
+    pub base_type: Type,
     /// Start index into Air's projections array
     pub projections_start: u32,
     /// Number of projections
@@ -82,9 +88,10 @@ pub struct AirPlace {
 impl AirPlace {
     /// Create a place for a local variable with no projections.
     #[inline]
-    pub const fn local(slot: u32) -> Self {
+    pub const fn local(slot: u32, base_type: Type) -> Self {
         Self {
             base: AirPlaceBase::Local(slot),
+            base_type,
             projections_start: 0,
             projections_len: 0,
         }
@@ -92,9 +99,10 @@ impl AirPlace {
 
     /// Create a place for a parameter with no projections.
     #[inline]
-    pub const fn param(slot: u32) -> Self {
+    pub const fn param(slot: u32, base_type: Type) -> Self {
         Self {
             base: AirPlaceBase::Param(slot),
+            base_type,
             projections_start: 0,
             projections_len: 0,
         }
@@ -652,11 +660,13 @@ impl Air {
     pub fn make_place(
         &mut self,
         base: AirPlaceBase,
+        base_type: Type,
         projs: impl IntoIterator<Item = AirProjection>,
     ) -> AirPlaceRef {
         let (projections_start, projections_len) = self.push_projections(projs);
         let place = AirPlace {
             base,
+            base_type,
             projections_start,
             projections_len,
         };
@@ -1559,5 +1569,24 @@ mod tests {
         let retrieved = air.get(inst_ref);
         assert!(matches!(retrieved.data, AirInstData::Const(42)));
         assert_eq!(retrieved.ty, Type::I32);
+    }
+
+    #[test]
+    fn place_preserves_logical_base_type() {
+        let mut air = Air::new(Type::I32);
+        let struct_id = StructId::from_pool_index(7);
+        let base_type = Type::new_struct(struct_id);
+        let place_ref = air.make_place(
+            AirPlaceBase::Param(3),
+            base_type,
+            [AirProjection::Field {
+                struct_id,
+                field_index: 0,
+            }],
+        );
+
+        let place = air.get_place(place_ref);
+        assert_eq!(place.base, AirPlaceBase::Param(3));
+        assert_eq!(place.base_type, base_type);
     }
 }

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -471,6 +471,7 @@ impl<'a> Sema<'a> {
         });
         let marker_place = air.make_place(
             trace.base,
+            trace.base_type,
             std::iter::once(AirProjection::Index {
                 array_type,
                 index: idx_const,
@@ -1098,7 +1099,7 @@ impl<'a> Sema<'a> {
         // and pass it through — no re-materialization.
         if arr_ty == slice_ty {
             let projs: Vec<AirProjection> = trace.projections.iter().map(|p| p.proj).collect();
-            let place_ref = air.make_place(trace.base, projs);
+            let place_ref = air.make_place(trace.base, trace.base_type, projs);
             let val = air.add_inst(AirInst {
                 data: AirInstData::PlaceRead { place: place_ref },
                 ty: slice_ty,
@@ -1147,7 +1148,7 @@ impl<'a> Sema<'a> {
                 array_type: arr_ty,
                 index: zero_ref,
             });
-            let place_ref = air.make_place(trace.base, projs);
+            let place_ref = air.make_place(trace.base, trace.base_type, projs);
             let elem0_read = air.add_inst(AirInst {
                 data: AirInstData::PlaceRead { place: place_ref },
                 ty: arr_elem,
@@ -1226,7 +1227,7 @@ impl<'a> Sema<'a> {
         // the fat pointer by value (it is `@copy`) and pass it through.
         if self.is_str_like(src_ty) {
             let projs: Vec<AirProjection> = trace.projections.iter().map(|p| p.proj).collect();
-            let place_ref = air.make_place(trace.base, projs);
+            let place_ref = air.make_place(trace.base, trace.base_type, projs);
             return Ok(air.add_inst(AirInst {
                 data: AirInstData::PlaceRead { place: place_ref },
                 ty: str_ty,
@@ -1247,7 +1248,7 @@ impl<'a> Sema<'a> {
                     struct_id: buf_struct_id,
                     field_index,
                 });
-                let place_ref = air.make_place(trace.base, projs);
+                let place_ref = air.make_place(trace.base, trace.base_type, projs);
                 let field_ty =
                     self.type_pool.struct_def(buf_struct_id).fields[field_index as usize].ty;
                 let word = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -345,7 +345,7 @@ impl<'a> Sema<'a> {
     /// Build an AirPlaceRef from a PlaceTrace, adding projections to the Air.
     pub(crate) fn build_place_ref(air: &mut Air, trace: &PlaceTrace) -> AirPlaceRef {
         let projs = trace.projections.iter().map(|p| p.proj);
-        air.make_place(trace.base, projs)
+        air.make_place(trace.base, trace.base_type, projs)
     }
 
     /// Build a `MarkMoved` place from a trace.
@@ -377,7 +377,7 @@ impl<'a> Sema<'a> {
                 }
             }
         }
-        air.make_place(trace.base, projs)
+        air.make_place(trace.base, trace.base_type, projs)
     }
 
     // ========================================================================
@@ -4107,6 +4107,7 @@ impl<'a> Sema<'a> {
         // Create PlaceRead with Field projection on the temp slot
         let place_ref = air.make_place(
             AirPlaceBase::Local(temp_slot),
+            base_type,
             std::iter::once(AirProjection::Field {
                 struct_id,
                 field_index: field_index as u32,
@@ -5226,6 +5227,7 @@ impl<'a> Sema<'a> {
         // Create PlaceRead with Index projection on the temp slot
         let place_ref = air.make_place(
             AirPlaceBase::Local(temp_slot),
+            base_type,
             std::iter::once(AirProjection::Index {
                 array_type: base_type,
                 index: index_result.air_ref,

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1007,6 +1007,7 @@ impl<'a> CfgBuilder<'a> {
                 // Create a PlaceRead from the temp slot with Field projection
                 let place = self.cfg.make_place(
                     PlaceBase::Local(temp_slot),
+                    self.air.get(*base).ty,
                     std::iter::once(Projection::Field {
                         struct_id: *struct_id,
                         field_index: *field_index,
@@ -1745,6 +1746,7 @@ impl<'a> CfgBuilder<'a> {
                 // Create a PlaceRead from the temp slot with Index projection
                 let place = self.cfg.make_place(
                     PlaceBase::Local(temp_slot),
+                    *array_type,
                     std::iter::once(Projection::Index {
                         array_type: *array_type,
                         index: index_val,
@@ -1784,6 +1786,7 @@ impl<'a> CfgBuilder<'a> {
                 let elem_ty = self.air.get(*value).ty;
                 let elem_place = self.cfg.make_place(
                     PlaceBase::Local(*slot),
+                    *array_type,
                     std::iter::once(Projection::Index {
                         array_type: *array_type,
                         index: index_val,
@@ -1830,6 +1833,7 @@ impl<'a> CfgBuilder<'a> {
                 let elem_ty = self.air.get(*value).ty;
                 let elem_place = self.cfg.make_place(
                     PlaceBase::Param(*param_slot),
+                    *array_type,
                     std::iter::once(Projection::Index {
                         array_type: *array_type,
                         index: index_val,
@@ -2834,6 +2838,7 @@ impl<'a> CfgBuilder<'a> {
             TypeKind::Struct(struct_id) => {
                 self.emit_partial_struct_drop_level(
                     key,
+                    ty,
                     struct_id,
                     ty,
                     &mut Vec::new(),
@@ -2847,6 +2852,7 @@ impl<'a> CfgBuilder<'a> {
             TypeKind::Array(_) => {
                 self.emit_partial_array_drop_level(
                     key,
+                    ty,
                     ty,
                     &mut Vec::new(),
                     &mut Vec::new(),
@@ -2872,6 +2878,7 @@ impl<'a> CfgBuilder<'a> {
     fn emit_partial_struct_drop_level(
         &mut self,
         key: MovedSlot,
+        root_type: Type,
         struct_id: StructId,
         ty: Type,
         path: &mut FieldPath,
@@ -2894,7 +2901,7 @@ impl<'a> CfgBuilder<'a> {
                     MovedSlot::Param(index) => self.emit(CfgInstData::Param { index }, ty, span),
                 }
             } else {
-                let place = self.cfg.make_place(base, projs.iter().copied());
+                let place = self.cfg.make_place(base, root_type, projs.iter().copied());
                 self.emit(CfgInstData::PlaceRead { place }, ty, span)
             };
             let name = self.interner.get_or_intern(destructor_name);
@@ -2953,6 +2960,7 @@ impl<'a> CfgBuilder<'a> {
                     TypeKind::Struct(field_struct_id) => {
                         self.emit_partial_struct_drop_level(
                             key,
+                            root_type,
                             field_struct_id,
                             field.ty,
                             path,
@@ -2965,7 +2973,7 @@ impl<'a> CfgBuilder<'a> {
                     }
                     TypeKind::Array(_) => {
                         self.emit_partial_array_drop_level(
-                            key, field.ty, path, projs, definite, maybe, span,
+                            key, root_type, field.ty, path, projs, definite, maybe, span,
                         );
                         true
                     }
@@ -2980,7 +2988,7 @@ impl<'a> CfgBuilder<'a> {
                 false
             };
             if !recursed {
-                let place = self.cfg.make_place(base, projs.iter().copied());
+                let place = self.cfg.make_place(base, root_type, projs.iter().copied());
                 let field_val = self.emit(CfgInstData::PlaceRead { place }, field.ty, span);
                 self.emit(CfgInstData::Drop { value: field_val }, Type::UNIT, span);
             }
@@ -3000,9 +3008,11 @@ impl<'a> CfgBuilder<'a> {
     /// skipped, possibly moved → guarded by the element path's runtime drop
     /// flag, deeper moved path → recursive path-granular drop, untouched →
     /// plain `Drop`. Arrays have no destructor of their own.
+    #[allow(clippy::too_many_arguments)]
     fn emit_partial_array_drop_level(
         &mut self,
         key: MovedSlot,
+        root_type: Type,
         array_ty: Type,
         path: &mut FieldPath,
         projs: &mut Vec<Projection>,
@@ -3050,6 +3060,7 @@ impl<'a> CfgBuilder<'a> {
                     TypeKind::Struct(elem_struct_id) => {
                         self.emit_partial_struct_drop_level(
                             key,
+                            root_type,
                             elem_struct_id,
                             elem_ty,
                             path,
@@ -3062,7 +3073,7 @@ impl<'a> CfgBuilder<'a> {
                     }
                     TypeKind::Array(_) => {
                         self.emit_partial_array_drop_level(
-                            key, elem_ty, path, projs, definite, maybe, span,
+                            key, root_type, elem_ty, path, projs, definite, maybe, span,
                         );
                         true
                     }
@@ -3072,7 +3083,7 @@ impl<'a> CfgBuilder<'a> {
                 false
             };
             if !recursed {
-                let place = self.cfg.make_place(base, projs.iter().copied());
+                let place = self.cfg.make_place(base, root_type, projs.iter().copied());
                 let elem_val = self.emit(CfgInstData::PlaceRead { place }, elem_ty, span);
                 self.emit(CfgInstData::Drop { value: elem_val }, Type::UNIT, span);
             }
@@ -3091,9 +3102,10 @@ impl<'a> CfgBuilder<'a> {
 
     /// Try to trace an AIR expression back to a Place.
     ///
-    /// Returns `Some((base, projections))` if the expression represents a place
-    /// (lvalue) that can be read from or written to. Returns `None` if the
-    /// expression is not a simple place (e.g., a function call result).
+    /// Returns `Some((base, base_type, projections))` if the expression
+    /// represents a place (lvalue) that can be read from or written to.
+    /// Returns `None` if the expression is not a simple place (e.g., a function
+    /// call result).
     ///
     /// This function traces chains like `arr[i][j].field` into a `PlaceBase` and
     /// a list of `Projection`s. The projections are returned in order from the
@@ -3104,15 +3116,15 @@ impl<'a> CfgBuilder<'a> {
     fn try_trace_place(
         &mut self,
         air_ref: AirRef,
-    ) -> Option<(PlaceBase, Vec<(Projection, Option<CfgValue>)>)> {
+    ) -> Option<(PlaceBase, Type, Vec<(Projection, Option<CfgValue>)>)> {
         let inst = self.air.get(air_ref);
 
         match &inst.data {
             // Base case: Load from a local variable
-            AirInstData::Load { slot } => Some((PlaceBase::Local(*slot), Vec::new())),
+            AirInstData::Load { slot } => Some((PlaceBase::Local(*slot), inst.ty, Vec::new())),
 
             // Base case: Parameter reference
-            AirInstData::Param { index } => Some((PlaceBase::Param(*index), Vec::new())),
+            AirInstData::Param { index } => Some((PlaceBase::Param(*index), inst.ty, Vec::new())),
 
             // Recursive case: Array index
             AirInstData::IndexGet {
@@ -3121,7 +3133,7 @@ impl<'a> CfgBuilder<'a> {
                 index,
             } => {
                 // Recursively trace the base
-                let (base_place, mut projections) = self.try_trace_place(*base)?;
+                let (base_place, base_type, mut projections) = self.try_trace_place(*base)?;
 
                 // Lower the index expression to get the CfgValue
                 let index_val = self.lower_value(*index)?;
@@ -3135,7 +3147,7 @@ impl<'a> CfgBuilder<'a> {
                     Some(index_val),
                 ));
 
-                Some((base_place, projections))
+                Some((base_place, base_type, projections))
             }
 
             // Recursive case: Field access
@@ -3145,7 +3157,7 @@ impl<'a> CfgBuilder<'a> {
                 field_index,
             } => {
                 // Recursively trace the base
-                let (base_place, mut projections) = self.try_trace_place(*base)?;
+                let (base_place, base_type, mut projections) = self.try_trace_place(*base)?;
 
                 // Add the Field projection
                 projections.push((
@@ -3156,7 +3168,7 @@ impl<'a> CfgBuilder<'a> {
                     None,
                 ));
 
-                Some((base_place, projections))
+                Some((base_place, base_type, projections))
             }
 
             // Not a simple place expression
@@ -3175,11 +3187,11 @@ impl<'a> CfgBuilder<'a> {
         span: rue_span::Span,
     ) -> Option<CfgValue> {
         // Try to trace the expression to a place
-        let (base, projections) = self.try_trace_place(air_ref)?;
+        let (base, base_type, projections) = self.try_trace_place(air_ref)?;
 
         // Build the Place with all projections
         let proj_iter = projections.into_iter().map(|(proj, _)| proj);
-        let place = self.cfg.make_place(base, proj_iter);
+        let place = self.cfg.make_place(base, base_type, proj_iter);
 
         // Emit the PlaceRead instruction
         let value = self.emit(CfgInstData::PlaceRead { place }, ty, span);
@@ -3217,7 +3229,9 @@ impl<'a> CfgBuilder<'a> {
     /// ADR-0030 Phase 8: This is the bridge between AIR's PlaceRead/PlaceWrite
     /// and CFG's PlaceRead/PlaceWrite.
     fn lower_air_place(&mut self, place_ref: AirPlaceRef) -> Option<Place> {
-        let air_place = self.air.get_place(place_ref);
+        // Copy the compact descriptor before lowering index operands mutably.
+        // In particular, `base_type` is still needed after that lowering.
+        let air_place = *self.air.get_place(place_ref);
 
         // Convert the base
         let base = match air_place.base {
@@ -3226,7 +3240,7 @@ impl<'a> CfgBuilder<'a> {
         };
 
         // Convert projections, lowering any index expressions
-        let air_projections = self.air.get_place_projections(air_place);
+        let air_projections = self.air.get_place_projections(&air_place);
         let mut cfg_projections = Vec::with_capacity(air_projections.len());
 
         for proj in air_projections {
@@ -3251,7 +3265,9 @@ impl<'a> CfgBuilder<'a> {
         }
 
         // Create the CFG place
-        let place = self.cfg.make_place(base, cfg_projections);
+        let place = self
+            .cfg
+            .make_place(base, air_place.base_type, cfg_projections);
 
         Some(place)
     }
@@ -3324,6 +3340,41 @@ mod tests {
             .flat_map(|b| b.insts.iter())
             .filter(|v| matches!(cfg.get_inst(**v).data, CfgInstData::Drop { .. }))
             .count()
+    }
+
+    #[test]
+    fn projected_only_parameter_preserves_logical_base_type() {
+        let cfg = build_cfg_named(
+            "struct Pair { a: i32, b: i32 }\n\
+             fn read(borrow p: Pair) -> i32 { p.a }\n\
+             fn main() -> i32 { let p = Pair { a: 1, b: 2 }; read(borrow p) }",
+            "read",
+        );
+        let (place, struct_id) = cfg
+            .blocks()
+            .iter()
+            .flat_map(|block| block.insts.iter().copied())
+            .find_map(|value| match &cfg.get_inst(value).data {
+                CfgInstData::PlaceRead { place } => {
+                    let Projection::Field { struct_id, .. } = cfg.get_place_projections(place)[0]
+                    else {
+                        return None;
+                    };
+                    Some((*place, struct_id))
+                }
+                _ => None,
+            })
+            .expect("projected parameter read");
+
+        assert_eq!(place.base, PlaceBase::Param(0));
+        assert_eq!(place.base_type, Type::new_struct(struct_id));
+        assert!(
+            cfg.blocks()
+                .iter()
+                .flat_map(|block| block.insts.iter())
+                .all(|value| !matches!(cfg.get_inst(*value).data, CfgInstData::Param { .. })),
+            "the base type must not depend on a separate Param instruction"
+        );
     }
 
     #[test]

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -40,14 +40,21 @@ use rue_span::Span;
 ///
 /// # Examples
 ///
-/// - `x` → `Place { base: Local(0), proj_start: 0, proj_len: 0 }`
-/// - `arr[i]` → `Place { base: Local(0), proj_start: 0, proj_len: 1 }` with `Index` projection
-/// - `point.x` → `Place { base: Local(0), proj_start: 0, proj_len: 1 }` with `Field` projection
-/// - `arr[i].x` → `Place { base: Local(0), proj_start: 0, proj_len: 2 }` with `Index` then `Field`
+/// - `x` → `Place { base: Local(0), base_type: T, ... }`
+/// - `arr[i]` → `Place { base: Local(0), base_type: Array, ... }` with `Index` projection
+/// - `point.x` → `Place { base: Local(0), base_type: Point, ... }` with `Field` projection
+/// - `arr[i].x` → the same `Array` base type with `Index` then `Field`
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Place {
     /// The base of the place - either a local slot or parameter slot
     pub base: PlaceBase,
+    /// The logical type stored at the base before applying projections.
+    ///
+    /// This is explicit because a physical ABI slot does not uniquely identify
+    /// its logical value type (aggregates are flattened and zero-sized values
+    /// can share an index). It also lets the verifier type-check the first
+    /// projection instead of trusting its self-described container.
+    pub base_type: Type,
     /// Start index into Cfg's projections array
     pub proj_start: u32,
     /// Number of projections
@@ -57,9 +64,10 @@ pub struct Place {
 impl Place {
     /// Create a place for a local variable with no projections.
     #[inline]
-    pub const fn local(slot: u32) -> Self {
+    pub const fn local(slot: u32, base_type: Type) -> Self {
         Self {
             base: PlaceBase::Local(slot),
+            base_type,
             proj_start: 0,
             proj_len: 0,
         }
@@ -67,9 +75,10 @@ impl Place {
 
     /// Create a place for a parameter with no projections.
     #[inline]
-    pub const fn param(slot: u32) -> Self {
+    pub const fn param(slot: u32, base_type: Type) -> Self {
         Self {
             base: PlaceBase::Param(slot),
+            base_type,
             proj_start: 0,
             proj_len: 0,
         }
@@ -834,11 +843,13 @@ impl Cfg {
     pub fn make_place(
         &mut self,
         base: PlaceBase,
+        base_type: Type,
         projs: impl IntoIterator<Item = Projection>,
     ) -> Place {
         let (proj_start, proj_len) = self.push_projections(projs);
         Place {
             base,
+            base_type,
             proj_start,
             proj_len,
         }

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -29,6 +29,10 @@
 //!    type invariant SSA passes and codegen rely on; a divergence-handling bug
 //!    in lowering (e.g. wiring a unit "result" of a `!`-typed arm into a join)
 //!    trips it here instead of miscompiling later.
+//! 5. **Place-root types** (RUE-589) — the first field/index projection consumes
+//!    the logical base type recorded on the place. Physical slot indices alone
+//!    cannot recover that type for flattened or zero-sized parameters, so a
+//!    projection that names a different root is malformed CFG.
 //!
 //! Unreachable blocks skip the termination check only: an orphan block created
 //! but never wired in (or one left behind before DCE) may legitimately carry a
@@ -40,6 +44,7 @@
 //! one into a real miscompile.
 
 use crate::inst::{Cfg, CfgInstData, CfgValue, Projection, Terminator};
+use rue_air::{Type, TypeKind};
 
 impl Cfg {
     /// Verify the CFG's structural invariants, panicking with a precise,
@@ -83,10 +88,17 @@ impl Cfg {
             }
             for &inst_val in &block.insts {
                 self.check_value_defined(inst_val, value_count, block.id, "instruction result");
+                let inst = self.get_inst(inst_val);
                 let mut operands = Vec::new();
-                self.collect_inst_operands(&self.get_inst(inst_val).data, &mut operands);
+                self.collect_inst_operands(&inst.data, &mut operands);
                 for op in operands {
                     self.check_value_defined(op, value_count, block.id, "instruction operand");
+                }
+                if matches!(
+                    &inst.data,
+                    CfgInstData::PlaceRead { .. } | CfgInstData::PlaceWrite { .. }
+                ) {
+                    self.verify_place_root_type(block.id, inst_val, inst);
                 }
             }
 
@@ -114,6 +126,52 @@ impl Cfg {
             value,
             block,
             value_count,
+        );
+    }
+
+    /// Verify that the first projection consumes the logical type carried by
+    /// the place base. Later projection links need the type pool to validate,
+    /// but this first link is fully described by the CFG itself and must not
+    /// be inferred from the projection under test.
+    fn verify_place_root_type(
+        &self,
+        block: crate::inst::BlockId,
+        value: CfgValue,
+        inst: &crate::inst::CfgInst,
+    ) {
+        let place = match &inst.data {
+            CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } => place,
+            _ => unreachable!("verify_place_root_type called on a non-place instruction"),
+        };
+        let Some(first) = self.get_place_projections(place).first() else {
+            return;
+        };
+        let required_base_type = match first {
+            Projection::Field { struct_id, .. } => Type::new_struct(*struct_id),
+            Projection::Index { array_type, .. } => {
+                assert!(
+                    matches!(array_type.kind(), TypeKind::Array(_)),
+                    "internal compiler error: CFG verification failed in function `{}`: place in \
+                     instruction {} in block {} has an Index projection whose declared \
+                     container type {:?} is not an array. This is a compiler bug (RUE-589).",
+                    self.fn_name(),
+                    value,
+                    block,
+                    array_type,
+                );
+                *array_type
+            }
+        };
+        assert!(
+            place.base_type == required_base_type,
+            "internal compiler error: CFG verification failed in function `{}`: place in \
+             instruction {} in block {} has logical base type {:?}, but its first \
+             projection requires base type {:?}. This is a compiler bug (RUE-589).",
+            self.fn_name(),
+            value,
+            block,
+            place.base_type,
+            required_base_type,
         );
     }
 
@@ -369,8 +427,8 @@ impl Cfg {
 
 #[cfg(test)]
 mod tests {
-    use crate::inst::{Cfg, CfgInst, CfgInstData, Terminator};
-    use rue_air::Type;
+    use crate::inst::{Cfg, CfgInst, CfgInstData, PlaceBase, Projection, Terminator};
+    use rue_air::{ArrayTypeId, StructId, Type};
     use rue_span::Span;
 
     fn unit_cfg() -> Cfg {
@@ -392,6 +450,119 @@ mod tests {
         );
         cfg.set_terminator(entry, Terminator::Return { value: Some(v) });
         cfg.verify(); // must not panic
+    }
+
+    fn cfg_with_field_place(base_type: Type) -> Cfg {
+        let mut cfg = Cfg::new(Type::I32, 1, 0, "field_place".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let struct_id = StructId::from_pool_index(9);
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            base_type,
+            [Projection::Field {
+                struct_id,
+                field_index: 0,
+            }],
+        );
+        let read = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty: Type::I32,
+                span: Span::new(0, 1),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(read) });
+        cfg
+    }
+
+    #[test]
+    fn verify_accepts_matching_place_base_type() {
+        let struct_type = Type::new_struct(StructId::from_pool_index(9));
+        cfg_with_field_place(struct_type).verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "first projection requires base type")]
+    fn verify_rejects_field_projection_with_wrong_base_type() {
+        cfg_with_field_place(Type::I32).verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "first projection requires base type")]
+    fn verify_rejects_index_projection_with_wrong_base_type_on_write() {
+        let mut cfg = Cfg::new(Type::UNIT, 1, 0, "index_place".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let index = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::U64,
+                span: Span::new(0, 1),
+            },
+        );
+        let value = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(1),
+                ty: Type::I32,
+                span: Span::new(0, 1),
+            },
+        );
+        let array_type = Type::new_array(ArrayTypeId::from_pool_index(10));
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            Type::I32,
+            [Projection::Index { array_type, index }],
+        );
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceWrite { place, value },
+                ty: Type::UNIT,
+                span: Span::new(0, 1),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: None });
+
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "declared container type Type::I32 is not an array")]
+    fn verify_rejects_non_array_index_projection_type() {
+        let mut cfg = Cfg::new(Type::I32, 1, 0, "index_type".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let index = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::U64,
+                span: Span::new(0, 1),
+            },
+        );
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            Type::I32,
+            [Projection::Index {
+                array_type: Type::I32,
+                index,
+            }],
+        );
+        let read = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty: Type::I32,
+                span: Span::new(0, 1),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(read) });
+
+        cfg.verify();
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/aggregate_slots.toml
+++ b/crates/rue-cli-tests/cases/aggregate_slots.toml
@@ -501,3 +501,63 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 0
+
+# RUE-589: every projected place carries its root type instead of reconstructing
+# the root width from its first projection. One deliberately deep root exercises
+# the three consumers of that fact: static aggregate reads, dynamic aggregate
+# writes, and projected inout address formation. Sentinels on both sides of each
+# aggregate make a wrong root-origin shift observable.
+[[case]]
+name = "deep_place_root_type_drives_all_codegen_paths"
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+struct Mid { lead: i32, pair: Pair, trail: i32 }
+struct Root { head: i32, mid: Mid, rows: [Mid; 2], tail: i32 }
+
+fn bump(inout pair: Pair) {
+    pair.a = pair.a + 20;
+    pair.b = pair.b + 30;
+}
+
+fn main() -> i32 {
+    let mut root = Root {
+        head: 1,
+        mid: Mid { lead: 2, pair: Pair { a: 3, b: 4 }, trail: 5 },
+        rows: [
+            Mid { lead: 6, pair: Pair { a: 7, b: 8 }, trail: 9 },
+            Mid { lead: 10, pair: Pair { a: 11, b: 12 }, trail: 13 }
+        ],
+        tail: 14,
+    };
+
+    let copy = root.mid.pair;
+    root.rows[1].pair = copy;
+    bump(inout root.rows[0].pair);
+
+    @dbg(root.head);
+    @dbg(root.mid.lead); @dbg(root.mid.trail);
+    @dbg(root.rows[0].lead); @dbg(root.rows[0].pair.a); @dbg(root.rows[0].pair.b); @dbg(root.rows[0].trail);
+    @dbg(root.rows[1].lead); @dbg(root.rows[1].pair.a); @dbg(root.rows[1].pair.b); @dbg(root.rows[1].trail);
+    @dbg(root.tail);
+    0
+}
+""" }]
+exit_code = 0
+stdout = "1\n2\n5\n6\n27\n38\n9\n10\n3\n4\n13\n14\n"
+
+# A zero-sized logical root still needs a concrete address for the physical
+# by-reference ABI. Its explicit type must not make the low-end origin shift
+# underflow (`slot_count == 0`).
+[[case]]
+name = "zero_sized_place_root_byref_address"
+files = [{ path = "main.rue", source = """
+struct Empty {}
+struct Holder { value: Empty }
+fn answer(borrow value: Empty) -> i32 { 42 }
+fn main() -> i32 {
+    let holder = Holder { value: Empty {} };
+    let values: [Empty; 1] = [Empty {}];
+    answer(borrow holder.value) + answer(borrow values[0])
+}
+""" }]
+exit_code = 84

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -4282,7 +4282,7 @@ impl<'a> CfgLower<'a> {
         }
 
         // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311).
-        let root_count = crate::agg_slots::root_slot_count(self, projections, 1);
+        let root_count = crate::agg_slots::root_slot_count(self, place);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4476,7 +4476,7 @@ impl<'a> CfgLower<'a> {
         }
 
         // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311).
-        let root_count = crate::agg_slots::root_slot_count(self, projections, vals.len() as u32);
+        let root_count = crate::agg_slots::root_slot_count(self, place);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4664,8 +4664,8 @@ impl<'a> CfgLower<'a> {
 
         // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311); the
         // resulting address is the accessed place's LOW end, from which slots
-        // ascend. With no projections the place is a scalar (root_count 1).
-        let root_count = crate::agg_slots::root_slot_count(self, projections, 1);
+        // ascend. The place's explicit logical base type supplies root_count.
+        let root_count = crate::agg_slots::root_slot_count(self, place);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -156,7 +156,7 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
                 // to the caller's storage, not the value — load the slots
                 // through it (emit_place_addr fetches the received pointer).
                 let addr_vreg = b.alloc_vreg();
-                b.emit_place_addr(addr_vreg, &Place::param(index));
+                b.emit_place_addr(addr_vreg, &Place::param(index, ty));
                 Some(load_through_ptr(b, addr_vreg, slot_count))
             } else {
                 let base_slot = b.ctx().num_locals + index;
@@ -203,7 +203,7 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
                     PlaceBase::Local(slot) => slot,
                     PlaceBase::Param(param_slot) => b.ctx().num_locals + param_slot,
                 };
-                let root_count = root_slot_count(b, &projections, slot_count);
+                let root_count = root_slot_count(b, &place);
                 let field_low_slot = root_base + (root_count - 1) - static_slot_offset;
                 return Some(load_slots_at_low(b, field_low_slot, slot_count));
             }
@@ -232,20 +232,17 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
     }
 }
 
-/// Total slot count of the ROOT object a projected place is rooted at — the
-/// container the first projection indexes into. Ascending place addressing
+/// Total slot count of the ROOT object a place is rooted at. Ascending place addressing
 /// (ADR-0040 / RUE-311) anchors every field/element at the root object's low
 /// end (`root_base + root_count - 1` in frame slots), so the root's own slot
 /// count is the one origin shift a projection chain needs; nested containers
-/// contribute only their byte offsets from that anchor. With no projections the
-/// place *is* the root, so `fallback` (the accessed value's own slot count) is
-/// used.
-pub fn root_slot_count<B: SlotBackend>(b: &B, projections: &[Projection], fallback: u32) -> u32 {
-    match projections.first() {
-        Some(Projection::Field { struct_id, .. }) => b.ctx().struct_total_slot_count(*struct_id),
-        Some(Projection::Index { array_type, .. }) => b.ctx().type_slot_count(*array_type),
-        None => fallback,
-    }
+/// contribute only their byte offsets from that anchor. The place carries this
+/// type explicitly so lowering does not have to trust the first projection's
+/// self-described container type. A zero-sized root still uses one conceptual
+/// address slot: by-ref/raw operations need a concrete frame address, and every
+/// consumer computes that address with `root_count - 1`.
+pub fn root_slot_count<B: SlotBackend>(b: &B, place: &Place) -> u32 {
+    b.ctx().type_slot_count(place.base_type).max(1)
 }
 
 /// Pre-allocate the per-slot vregs for an aggregate block parameter.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -4296,7 +4296,7 @@ impl<'a> CfgLower<'a> {
         // frame-resident aggregate's low-address end is its highest-numbered
         // slot, `root_base + root_count - 1`. Field offsets then move UP in
         // address (toward higher addresses = lower slot numbers).
-        let root_count = crate::agg_slots::root_slot_count(self, projections, 1);
+        let root_count = crate::agg_slots::root_slot_count(self, place);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4494,7 +4494,7 @@ impl<'a> CfgLower<'a> {
         }
 
         // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311).
-        let root_count = crate::agg_slots::root_slot_count(self, projections, vals.len() as u32);
+        let root_count = crate::agg_slots::root_slot_count(self, place);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4686,8 +4686,8 @@ impl<'a> CfgLower<'a> {
 
         // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311); the
         // resulting address is the accessed place's LOW end, from which slots
-        // ascend. With no projections the place is a scalar (root_count 1).
-        let root_count = crate::agg_slots::root_slot_count(self, projections, 1);
+        // ascend. The place's explicit logical base type supplies root_count.
+        let root_count = crate::agg_slots::root_slot_count(self, place);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1434,7 +1434,7 @@ impl<'a> Interp<'a> {
     /// mutated value can be copied back after the call.
     fn lvalue_of(cfg: &'a Cfg, v: CfgValue) -> Step<Place> {
         match &cfg.get_inst(v).data {
-            CfgInstData::Load { slot } => Ok(Place::local(*slot)),
+            CfgInstData::Load { slot } => Ok(Place::local(*slot, cfg.get_inst(v).ty)),
             CfgInstData::PlaceRead { place } => Ok(place.clone()),
             other => Err(Flow::Unsupported(Unsupported(format!(
                 "inout argument is not an lvalue: {other:?}"


### PR DESCRIPTION
A projected CFG place previously carried only a physical local/parameter slot plus self-described projections. That is not enough to recover its logical root type: aggregate params are flattened, ZST params can share ABI indices, and a projected-only parameter may have no separate `Param` instruction.

This prerequisite makes that invariant explicit:

- carries `base_type` from sema's `PlaceTrace` through AIR and every CFG construction path, including recursive partial-drop synthesis;
- verifies that the first Field/Index projection consumes that root type and rejects non-array Index metadata;
- makes both backends derive all seven root-origin shifts from `root_slot_count(&Place)`, so future callers cannot substitute a leaf/result width;
- gives zero-sized roots one conceptual address slot, fixing the projected Field/Index by-ref underflow class exposed while pinning the invariant;
- adds deep aggregate read/write/inout and projected-ZST witnesses across the CLI suite.

This is intentionally separate from the dependent typed-oracle-failure change so the compiler IR invariant can be reviewed and landed on its own.

Validation:

- `./fmt.sh`
- `./clippy.sh`
- `./test.sh` — 33 suites passed
- independent construction/codegen audit found no missed place constructors or root-width consumers

Linear: RUE-589
