### PR TITLE
examples: add stack-VM and arena-BST dogfood programs

### DIFF
--- a/examples/bst.rue
+++ b/examples/bst.rue
@@ -1,0 +1,94 @@
+// An arena-backed binary search tree — dogfood program for the milestone
+// (RUE-226).
+//
+// Recursive structures in Rue are spelled with indices into an arena rather
+// than owning pointers, so this deliberately stresses: multi-slot aggregate
+// elements in an ArrayBuf (the node struct), a user struct named through a
+// const alias as a member type (RUE-603 surface), sentinel-index linking,
+// borrow methods that allocate their own scratch collection (an explicit
+// traversal stack), and the get/set copy-out/copy-in mutation pattern.
+//
+// The deterministic, checkable output is the in-order sum of the inserted
+// keys (42).
+const std = @import("std");
+
+struct Node {
+    val: i64,
+    left: u64,   // 0 = none (slot 0 is a sentinel)
+    right: u64,
+}
+const Nodes = std.arraybuf.ArrayBuf(Node);
+const Stack = std.arraybuf.ArrayBuf(u64);
+
+struct Tree {
+    nodes: Nodes,
+
+    fn new() -> Self {
+        let mut nodes = Nodes.new();
+        nodes.push(Node { val: 0, left: 0, right: 0 });  // sentinel slot 0
+        Self { nodes: nodes }
+    }
+
+    fn insert(inout self, v: i64) {
+        let idx = self.nodes.len();
+        self.nodes.push(Node { val: v, left: 0, right: 0 });
+        if idx == 1 {
+            return;  // first real node is the root
+        }
+        let mut cur: u64 = 1;
+        loop {
+            let node = self.nodes.get_or(cur, Node { val: 0, left: 0, right: 0 });
+            if v < node.val {
+                if node.left == 0 {
+                    self.nodes.set(cur, Node { val: node.val, left: idx, right: node.right });
+                    return;
+                }
+                cur = node.left;
+            } else {
+                if node.right == 0 {
+                    self.nodes.set(cur, Node { val: node.val, left: node.left, right: idx });
+                    return;
+                }
+                cur = node.right;
+            }
+        }
+    }
+
+    // Iterative in-order traversal with an explicit index stack; returns the
+    // sum of all keys.
+    fn sum(borrow self) -> i64 {
+        let mut stack = Stack.new();
+        let mut total: i64 = 0;
+        let mut cur: u64 = 1;
+        if self.nodes.len() < 2 {
+            return 0;
+        }
+        loop {
+            loop {
+                if cur == 0 { break; }
+                stack.push(cur);
+                let node = self.nodes.get_or(cur, Node { val: 0, left: 0, right: 0 });
+                cur = node.left;
+            }
+            let top = stack.pop_or(0);
+            if top == 0 { break; }
+            let node = self.nodes.get_or(top, Node { val: 0, left: 0, right: 0 });
+            total = total + node.val;
+            cur = node.right;
+        }
+        total
+    }
+}
+
+fn main() -> i32 {
+    let mut t = Tree.new();
+    t.insert(8);
+    t.insert(3);
+    t.insert(10);
+    t.insert(1);
+    t.insert(6);
+    t.insert(14);
+    let s = t.sum();
+    println(@to_string(s));
+    if s == 42 { 0 } else { 1 }
+}

--- a/examples/vm.rue
+++ b/examples/vm.rue
@@ -1,0 +1,118 @@
+// A tiny bytecode stack machine — dogfood program for the milestone (RUE-226).
+//
+// Deliberately stresses: growable ArrayBuf state owned by a struct across a
+// whole run (code and operand stack), inout methods driving inout methods on
+// collection fields, an enum step result matched in the interpreter loop,
+// u64/i64 mixing with @intCast for jump targets, and hand-assembled control
+// flow (a countdown loop with a conditional jump).
+//
+// The assembled program computes sum(1..=10) via a countdown loop; the
+// deterministic, checkable output is the printed result (55).
+const std = @import("std");
+const Ints = std.arraybuf.ArrayBuf(i64);
+
+// opcodes: 0=push imm, 1=add, 2=sub, 3=dup, 4=halt, 5=jz, 6=jmp, 7=swap, 8=over
+enum Step {
+    Running,
+    Halted(i64),
+}
+
+struct VM {
+    code: Ints,
+    stack: Ints,
+    pc: u64,
+
+    fn new() -> Self {
+        Self { code: Ints.new(), stack: Ints.new(), pc: 0 }
+    }
+
+    fn emit(inout self, word: i64) {
+        self.code.push(word);
+    }
+
+    // Fetch the immediate operand following the current opcode.
+    fn imm(inout self) -> i64 {
+        let v = self.code.get_or(self.pc, 0);
+        self.pc = self.pc + 1;
+        v
+    }
+
+    fn step(inout self) -> Step {
+        let op = self.code.get_or(self.pc, 4);
+        self.pc = self.pc + 1;
+        if op == 0 {
+            let v = self.imm();
+            self.stack.push(v);
+            Step.Running
+        } else if op == 1 {
+            let b = self.stack.pop_or(0);
+            let a = self.stack.pop_or(0);
+            self.stack.push(a + b);
+            Step.Running
+        } else if op == 2 {
+            let b = self.stack.pop_or(0);
+            let a = self.stack.pop_or(0);
+            self.stack.push(a - b);
+            Step.Running
+        } else if op == 3 {
+            let n = self.stack.len();
+            let top = self.stack.get_or(n - 1, 0);
+            self.stack.push(top);
+            Step.Running
+        } else if op == 5 {
+            let target = self.imm();
+            let cond = self.stack.pop_or(1);
+            if cond == 0 {
+                self.pc = @intCast(target);
+            }
+            Step.Running
+        } else if op == 6 {
+            let target = self.imm();
+            self.pc = @intCast(target);
+            Step.Running
+        } else if op == 7 {
+            let b = self.stack.pop_or(0);
+            let a = self.stack.pop_or(0);
+            self.stack.push(b);
+            self.stack.push(a);
+            Step.Running
+        } else if op == 8 {
+            let n = self.stack.len();
+            let second = self.stack.get_or(n - 2, 0);
+            self.stack.push(second);
+            Step.Running
+        } else {
+            Step.Halted(self.stack.pop_or(0))
+        }
+    }
+
+    fn run(inout self) -> i64 {
+        loop {
+            match self.step() {
+                Step.Halted(v) => { return v; },
+                Step.Running => {},
+            }
+        }
+    }
+}
+
+fn main() -> i32 {
+    let mut vm = VM.new();
+    // sum(1..=10) = 55 via countdown; stack invariant at the loop head: [sum n]
+    vm.emit(0); vm.emit(0);    //  0: push 0        [0]
+    vm.emit(0); vm.emit(10);   //  2: push 10       [0 10]
+    vm.emit(3);                //  4: dup           [sum n n]
+    vm.emit(5); vm.emit(16);   //  5: jz 16         [sum n]
+    vm.emit(7);                //  7: swap          [n sum]
+    vm.emit(8);                //  8: over          [n sum n]
+    vm.emit(1);                //  9: add           [n sum+n]
+    vm.emit(7);                // 10: swap          [sum' n]
+    vm.emit(0); vm.emit(1);    // 11: push 1        [sum' n 1]
+    vm.emit(2);                // 13: sub           [sum' n-1]
+    vm.emit(6); vm.emit(4);    // 14: jmp 4
+    vm.emit(7);                // 16: swap          [0 sum]
+    vm.emit(4);                // 17: halt -> sum
+    let out = vm.run();
+    println(@to_string(out));
+    if out == 55 { 0 } else { 1 }
+}


### PR DESCRIPTION
## Summary

Two new maintained example fixtures exercising the generic-collections-as-members surface that landed this week (RUE-595/596/599/601/603/608/609), written fresh against current trunk:

- **`examples/vm.rue`** — a bytecode stack machine: growable `ArrayBuf` code/operand-stack owned by a struct across the whole run, `inout` methods driving `inout` methods on collection fields, an enum step result matched in the interpreter loop, u64/i64 mixing with `@intCast` jump targets, and a hand-assembled countdown-sum program. Prints `55`, exits 0.
- **`examples/bst.rue`** — an arena-backed binary search tree: multi-slot aggregate elements in an `ArrayBuf`, a user struct named through `const` aliases as member types, sentinel-index linking, and a `borrow` method that allocates its own scratch traversal stack. Prints the in-order key sum `42`, exits 0.

Both print a deterministic checkable value, and land in the `examples/*.rue` set the sanitizer CI job compiles and runs.

Part of the RUE-226 dogfooding milestone (fresh programs on this surface — the friction they hit earlier today became RUE-608/RUE-609/RUE-610/RUE-613).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
