### PR TITLE
RUE-610: speak the user's language in droppable-gate diagnostics

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6054,8 +6054,9 @@ impl<'a> Sema<'a> {
             // limit, RUE-261) must surface as its real diagnostic (E1200)
             // rather than being swallowed into a downstream link error, so use
             // the propagating reduction entry point.
-            if let Some(ConstValue::Type(ty)) =
-                self.eval_type_constructor_body(fn_body, &type_subst, &value_subst)?
+            if let Some(ConstValue::Type(ty)) = self
+                .eval_type_constructor_body(fn_body, &type_subst, &value_subst)
+                .map_err(|e| Self::label_ctor_instantiation_site(e, span))?
             {
                 // Success! Return a TypeConst instruction instead of a runtime call
                 let air_ref = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1184,6 +1184,7 @@ impl Sema<'_> {
             } => {
                 let (name, args_start, args_len) = (*name, *args_start, *args_len);
                 self.eval_comptime_type_call(name, args_start, args_len, env)
+                    .map_err(|e| Self::label_ctor_instantiation_site(e, span))
             }
 
             // Module-member access (`m.CONST`) as an operand of a larger const
@@ -1364,6 +1365,7 @@ impl Sema<'_> {
         // Reduce through the shared path; arguments are evaluated in the current
         // environment so `T` (an enclosing comptime parameter) still resolves.
         self.eval_comptime_type_call(function_key, args_start, args_len, env)
+            .map_err(|e| Self::label_ctor_instantiation_site(e, span))
     }
 
     /// The `@require_droppable(T)` well-formedness gate for owning growable
@@ -1604,7 +1606,64 @@ impl Sema<'_> {
         }
         let result = self.eval_const_expr(fn_body, &mut callee_env);
         self.comptime_type_call_depth -= 1;
+        // Record the human-readable instantiation spelling for a
+        // constructor-produced anonymous type, so diagnostics print
+        // `ArrayBuf(i64)` instead of `__anon_struct_4` (RUE-610).
+        if let Ok(Some(ConstValue::Type(t))) = &result {
+            self.record_ctor_type_display(name, *t, callee_types, callee_values);
+        }
         result
+    }
+
+    /// Record `Ctor(args...)` as the display name for an anonymous type just
+    /// produced by reducing `ctor`'s body (RUE-610; see
+    /// `Sema::ctor_type_displays`). Named types keep their declared names;
+    /// a partial substitution records nothing rather than a wrong spelling.
+    fn record_ctor_type_display(
+        &mut self,
+        ctor: Spur,
+        ty: Type,
+        callee_types: &HashMap<Spur, Type>,
+        callee_values: &HashMap<Spur, ConstValue>,
+    ) {
+        let is_anon = match ty.kind() {
+            TypeKind::Struct(id) => self
+                .type_pool
+                .struct_def(id)
+                .name
+                .starts_with("__anon_struct_"),
+            TypeKind::Enum(id) => self.type_pool.enum_def(id).name.starts_with("enum {"),
+            _ => false,
+        };
+        if !is_anon || self.ctor_type_displays.contains_key(&ty) {
+            return;
+        }
+        let Some(fn_info) = self.functions.get(&ctor) else {
+            return;
+        };
+        let param_names = self.param_arena.names(fn_info.params).to_vec();
+        let mut args: Vec<String> = Vec::with_capacity(param_names.len());
+        for param in &param_names {
+            if let Some(arg_ty) = callee_types.get(param) {
+                args.push(self.format_type_name(*arg_ty));
+            } else if let Some(value) = callee_values.get(param) {
+                match value {
+                    ConstValue::Integer(i) => args.push(i.to_string()),
+                    ConstValue::Bool(b) => args.push(b.to_string()),
+                    ConstValue::Type(t) => args.push(self.format_type_name(*t)),
+                    _ => return,
+                }
+            } else {
+                return;
+            }
+        }
+        let source_name = self.source_function_name(ctor);
+        let display = format!(
+            "{}({})",
+            self.interner.resolve(&source_name),
+            args.join(", ")
+        );
+        self.ctor_type_displays.insert(ty, display);
     }
 
     /// Pre-resolve `let`-bound compile-time type aliases in a function body,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -2587,7 +2587,10 @@ impl<'a> Sema<'a> {
             }
         }
 
-        match self.reduce_type_ctor_body(function_key, &callee_types, &callee_values)? {
+        match self
+            .reduce_type_ctor_body(function_key, &callee_types, &callee_values)
+            .map_err(|e| Self::label_ctor_instantiation_site(e, span))?
+        {
             Some(ConstValue::Type(ty)) => Ok(ConstInit::Value(ConstValue::Type(ty))),
             _ => Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -126,6 +126,7 @@ impl<'a> GatherOutput<'a> {
             infectious_linear: HashMap::new(),
             comptime_type_call_depth: 0,
             fn_signatures_in_flight: std::collections::HashSet::new(),
+            ctor_type_displays: HashMap::new(),
         }
     }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -163,6 +163,14 @@ pub struct Sema<'a> {
     /// (`fn A(x: B(i32))` / `fn B(x: A(i32))`) must not re-enter a
     /// mid-collection signature, or the reduction would recurse forever.
     pub(crate) fn_signatures_in_flight: HashSet<Spur>,
+    /// Human-readable instantiation spellings for type-constructor-produced
+    /// anonymous types (`ArrayBuf(i64)` for the anon struct otherwise named
+    /// `__anon_struct_4`), recorded when [`Self::reduce_type_ctor_body`]
+    /// reduces a constructor application. Consulted by
+    /// [`Self::format_type_name`] so diagnostics print the spelling the user
+    /// wrote (RUE-610). First writer wins: structurally-deduped types keep
+    /// the spelling of their first instantiation.
+    pub(crate) ctor_type_displays: HashMap<Type, String>,
 }
 
 impl<'a> Sema<'a> {
@@ -219,6 +227,7 @@ impl<'a> Sema<'a> {
             infectious_linear: HashMap::new(),
             comptime_type_call_depth: 0,
             fn_signatures_in_flight: HashSet::new(),
+            ctor_type_displays: HashMap::new(),
         }
     }
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -33,6 +33,12 @@ use crate::types::{
 impl<'a> Sema<'a> {
     /// Get a human-readable name for a type.
     pub(crate) fn format_type_name(&self, ty: Type) -> String {
+        // A constructor-produced anonymous type prints its instantiation
+        // spelling (`ArrayBuf(i64)`), not its internal structural name
+        // (RUE-610; recorded by `reduce_type_ctor_body`).
+        if let Some(display) = self.ctor_type_displays.get(&ty) {
+            return display.clone();
+        }
         match ty.kind() {
             TypeKind::I8 => "i8".to_string(),
             TypeKind::I16 => "i16".to_string(),
@@ -63,6 +69,23 @@ impl<'a> Sema<'a> {
             }
             TypeKind::Module(_) => "<module>".to_string(),
             TypeKind::ComptimeType => "type".to_string(),
+        }
+    }
+
+    /// Point a container well-formedness rejection (E0498/E0499, RUE-388) at
+    /// the user's type-constructor application. The gate raises inside the
+    /// constructor's own body (`@require_droppable(T)` in std source), so
+    /// without this label the user's file never appears in the diagnostic
+    /// (RUE-610). Other reduction errors already carry their own spans.
+    pub(crate) fn label_ctor_instantiation_site(err: CompileError, span: Span) -> CompileError {
+        if matches!(
+            err.kind,
+            ErrorKind::ContainerElementHasDestructor { .. }
+                | ErrorKind::ContainerElementIsLinear { .. }
+        ) {
+            err.with_label("required by the type-constructor application here", span)
+        } else {
+            err
         }
     }
 
@@ -926,7 +949,10 @@ impl<'a> Sema<'a> {
         // comptime constants (RUE-552).
         let (callee_types, callee_values) =
             self.bind_type_ctor_args(call_path, params, arg_strs, span, ctx)?;
-        match self.reduce_type_ctor_body(function_key, &callee_types, &callee_values)? {
+        match self
+            .reduce_type_ctor_body(function_key, &callee_types, &callee_values)
+            .map_err(|e| Self::label_ctor_instantiation_site(e, span))?
+        {
             Some(ConstValue::Type(t)) => Ok(t),
             _ => Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
@@ -1439,7 +1465,10 @@ impl<'a> Sema<'a> {
 
         // Reduce the constructor body under the substitution. Shares the exact
         // reduction path (and E1200 recursion guard) with value-position calls.
-        match self.reduce_type_ctor_body(name_key, &callee_types, &callee_values)? {
+        match self
+            .reduce_type_ctor_body(name_key, &callee_types, &callee_values)
+            .map_err(|e| Self::label_ctor_instantiation_site(e, span))?
+        {
             Some(ConstValue::Type(t)) => Ok(t),
             _ => Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {

--- a/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
@@ -1,0 +1,66 @@
+[section]
+id = "diagnostics.droppable-gate"
+name = "Container droppable-gate diagnostics (E0498/E0499)"
+description = """
+The @require_droppable rejection is raised inside the CONSTRUCTOR's body, so
+the diagnostic must still speak the user's language (RUE-610): the offending
+type prints as its instantiation spelling (`Holder(Res)`, not the internal
+`__anon_struct_N`), and a label points at the user's type-constructor
+application, not just the constructor's own source.
+"""
+
+[[case]]
+name = "e0498_names_ctor_spelling_and_user_site"
+description = "A ctor-produced anonymous element type prints as Ctor(args) and the rejection labels the user's application site (RUE-610)"
+source = """
+struct Res { v: i64 }
+drop fn Res(self) { let _ = self.v; }
+fn Holder(comptime T: type) -> type { struct { x: T } }
+fn Gated(comptime T: type) -> type {
+    @require_droppable(T);
+    struct { y: T }
+}
+const H = Holder(Res);
+const G = Gated(H);
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E0498",
+    "Holder(Res)",
+    "required by the type-constructor application here",
+]
+
+[[case]]
+name = "e0498_value_position_labels_user_site"
+description = "The application-site label also appears for a let-bound instantiation inside a function body (RUE-610)"
+source = """
+struct Res { v: i64 }
+drop fn Res(self) { let _ = self.v; }
+fn Gated(comptime T: type) -> type {
+    @require_droppable(T);
+    struct { y: T }
+}
+fn main() -> i32 {
+    let G = Gated(Res);
+    let _ = G;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0498", "Res", "required by the type-constructor application here"]
+
+[[case]]
+name = "e0499_linear_names_and_labels"
+description = "The linear-element rejection (E0499) gets the same application-site label (RUE-610)"
+source = """
+linear struct Token { v: i32 }
+fn Gated(comptime T: type) -> type {
+    @require_droppable(T);
+    struct { y: T }
+}
+const G = Gated(Token);
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0499", "Token", "required by the type-constructor application here"]


### PR DESCRIPTION
## Summary

The `@require_droppable` rejection (E0498/E0499, RUE-388) is raised inside the constructor's own body, so the diagnostic named the offending type by its internal anonymous name and pointed only into std source — the user's file never appeared:

```
error: [E0498]: … but `__anon_struct_4` carries a destructor …
  --> std/arraybuf.rue:77:5
```

## Fix

- `reduce_type_ctor_body` now records the instantiation spelling (`Ctor(args…)`) for every constructor-produced anonymous type it reduces, and `format_type_name` prefers that spelling — diagnostics say `ArrayBuf(i64)` / `Holder(Res)` instead of `__anon_struct_N` (or the structural `enum { … }` dump). First writer wins for structurally-deduped types; partial substitutions record nothing rather than a wrong name.
- E0498/E0499 crossing a reduction entry point that knows the user's application span (type-position resolvers, the const-collection qualified path, the value-position analyze path, and the comptime engine's call arms) gain a `required by the type-constructor application here` label, so the user's own line is always shown alongside the `@require_droppable` site:

```
error: [E0498]: … but `ArrayBuf(i64)` carries a destructor …
 --> user.rue:3:16
  |
3 | const Nested = std.arraybuf.ArrayBuf(Inner);
  |                ---------------------------- info: required by the type-constructor application here
  |
 ::: std/arraybuf.rue:77:5
```

Named element types (`Inner`, `Token` in the existing CLI cases) print unchanged.

## Testing

Three UI cases (`diagnostics/droppable_gate.toml`): ctor-spelling + label in const position, label in value position, and the E0499 linear variant. Full suite: Tests finished: Pass 33. Fail 0.

Fixes RUE-610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
