### PR TITLE
RUE-574: surface all warning kinds from specialized generic bodies

### DIFF
--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -166,7 +166,10 @@ pub(crate) struct DiscoveredReferences {
 pub(crate) struct Specializer {
     specializations: HashMap<SpecializationKey, SpecializationInfo>,
     next_unscanned: usize,
-    seen_unreachable_spans: HashSet<Span>,
+    /// Warnings already surfaced from specialized bodies, keyed by kind
+    /// discriminant + source span, so N specializations of one generic body
+    /// emit each warning once (RUE-555, RUE-574).
+    seen_warnings: HashSet<(std::mem::Discriminant<WarningKind>, Span)>,
     /// Expansion waves consumed across the entire joint sema fixed point.
     rounds: usize,
 }
@@ -284,13 +287,18 @@ impl Specializer {
                     .extend(specialized.referenced_functions);
                 discovered.methods.extend(specialized.referenced_methods);
 
-                // Surface unreachable-pattern warnings from the specialized
-                // body (spec 4.7:20, RUE-555), once per source span. Other
-                // specialized-body warnings stay suppressed as before.
+                // Surface warnings from the specialized body, once per (kind,
+                // source span) across all specializations (RUE-555 for
+                // unreachable patterns, RUE-574 for every other kind — a
+                // generic body's unused variable used to warn only when the
+                // function was non-generic). A warning that fires in ANY
+                // specialization is surfaced: with comptime-pruned branches
+                // the body that triggers it is really compiled.
                 for warning in specialized.warnings {
-                    if matches!(warning.kind, WarningKind::UnreachablePattern(_))
-                        && let Some(span) = warning.span()
-                        && self.seen_unreachable_spans.insert(span)
+                    if let Some(span) = warning.span()
+                        && self
+                            .seen_warnings
+                            .insert((std::mem::discriminant(&warning.kind), span))
                     {
                         all_warnings.push(warning);
                     }

--- a/crates/rue-ui-tests/cases/warnings/unused.toml
+++ b/crates/rue-ui-tests/cases/warnings/unused.toml
@@ -439,6 +439,40 @@ warning_contains = ["unused function", "'Unused'"]
 expected_warning_count = 1
 
 [[case]]
+name = "unused_variable_in_generic_body_warns"
+description = "A specialized generic body surfaces its warnings like any other body (RUE-574)"
+source = """
+fn gen(comptime n: i32) -> i32 {
+    let unused = 99;
+    n
+}
+
+fn main() -> i32 {
+    gen(42)
+}
+"""
+exit_code = 42
+warning_contains = ["unused variable", "'unused'"]
+expected_warning_count = 1
+
+[[case]]
+name = "generic_body_warning_deduped_across_specializations"
+description = "N specializations of one generic body emit each warning once (RUE-555 dedup, extended by RUE-574)"
+source = """
+fn gen(comptime n: i32) -> i32 {
+    let unused = 99;
+    n
+}
+
+fn main() -> i32 {
+    gen(20) + gen(22)
+}
+"""
+exit_code = 42
+warning_contains = ["unused variable", "'unused'"]
+expected_warning_count = 1
+
+[[case]]
 name = "multiple_unused_functions"
 source = """
 fn helper1() -> i32 { 1 }


### PR DESCRIPTION
## Summary

`specialize.rs` discarded every warning produced while analyzing a specialized generic body except `UnreachablePattern` (threaded through by the RUE-555 fix, which deliberately kept its blast radius small). So `fn gen(comptime n: i32) -> i32 { let unused = 99; n }` never warned about the unused variable, while the identical non-generic body did.

## Fix

The RUE-555 collection point now forwards every warning kind, deduplicated by (kind discriminant, source span) across specializations so N instantiations of one body emit each warning once. A warning that fires in any specialization is surfaced — with comptime-pruned branches, the body that triggers it is really compiled.

## Fallout audit

Full suite green unchanged (`Tests finished: Pass 33. Fail 0.`), and a warning sweep over every `examples/*.rue` (including the std-heavy, generic-heavy fixtures) surfaced nothing new — the only warning found (`collatz.rue`'s unused helper) is a pre-existing non-generic one.

Two UI cases added: a generic body's unused variable warns, and two specializations of one body emit exactly one warning.

Fixes RUE-574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
