### PR TITLE
RUE-589: reserve complete CFG temporary storage

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -306,6 +306,53 @@ impl TypeInternPool {
         }
     }
 
+    /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
+    ///
+    /// This is the canonical layout query shared by sema, CFG temporary
+    /// allocation, and code generation. Aggregate arithmetic saturates; sema
+    /// rejects layouts that exceed the representable slot range before they
+    /// can be materialized.
+    pub fn abi_slot_count(&self, ty: Type) -> u32 {
+        match ty.kind() {
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Error
+            | TypeKind::PtrConst(_)
+            | TypeKind::PtrMut(_) => 1,
+            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => 0,
+            TypeKind::Struct(struct_id) => self
+                .struct_def(struct_id)
+                .fields
+                .iter()
+                .fold(0u32, |total, field| {
+                    total.saturating_add(self.abi_slot_count(field.ty))
+                }),
+            TypeKind::Array(array_id) => {
+                let (element_type, length) = self.array_def(array_id);
+                let element_slots = u64::from(self.abi_slot_count(element_type));
+                u32::try_from(element_slots.saturating_mul(length)).unwrap_or(u32::MAX)
+            }
+            TypeKind::Enum(enum_id) => {
+                let def = self.enum_def(enum_id);
+                let mut max_payload = 0u32;
+                for index in 0..def.variant_count() {
+                    let payload = def.variant_payload(index).iter().fold(0u32, |total, &ty| {
+                        total.saturating_add(self.abi_slot_count(ty))
+                    });
+                    max_payload = max_payload.max(payload);
+                }
+                1u32.saturating_add(max_payload)
+            }
+        }
+    }
+
     /// Register a new struct (nominal - no deduplication).
     ///
     /// Returns the `StructId` (containing the pool index) and whether it was newly inserted.

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -2197,57 +2197,6 @@ impl<'a> Sema<'a> {
     /// every materialization site via [`Self::require_layout_slots`], so the
     /// saturated value is never used for real allocation.
     pub(crate) fn abi_slot_count(&self, ty: Type) -> u32 {
-        match ty.kind() {
-            TypeKind::I8
-            | TypeKind::I16
-            | TypeKind::I32
-            | TypeKind::I64
-            | TypeKind::U8
-            | TypeKind::U16
-            | TypeKind::U32
-            | TypeKind::U64
-            | TypeKind::Bool
-            | TypeKind::Error => 1,
-            // Zero-sized types use 0 slots
-            // ComptimeType is comptime-only and uses 0 runtime slots
-            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType => 0,
-            // Tagged-union layout (RUE-221, ADR-0038): slot 0 is the
-            // discriminant, followed by payload space sized to the largest
-            // variant. A discriminant-only (C-like) enum has no payload and so
-            // occupies exactly one slot. This MUST match the codegen layout in
-            // `rue_codegen::types::type_slot_count`.
-            TypeKind::Enum(enum_id) => {
-                let enum_def = self.type_pool.enum_def(enum_id);
-                let mut max_payload = 0u32;
-                for i in 0..enum_def.variant_count() {
-                    let variant_slots: u32 = enum_def
-                        .variant_payload(i)
-                        .iter()
-                        .fold(0u32, |acc, &ty| acc.saturating_add(self.abi_slot_count(ty)));
-                    max_payload = max_payload.max(variant_slots);
-                }
-                1u32.saturating_add(max_payload)
-            }
-            // Struct uses sum of all field slots (includes builtin String with 3 fields)
-            TypeKind::Struct(struct_id) => {
-                // Sum the slot counts of all fields (handles arrays, nested structs, and builtins)
-                // Empty structs naturally get 0 slots here
-                let struct_def = self.type_pool.struct_def(struct_id);
-                struct_def
-                    .fields
-                    .iter()
-                    .fold(0u32, |acc, f| acc.saturating_add(self.abi_slot_count(f.ty)))
-            }
-            TypeKind::Array(array_type_id) => {
-                // Zero-length arrays naturally get 0 slots (0 * element_slots)
-                let (element_type, length) = self.type_pool.array_def(array_type_id);
-                let element_slots = u64::from(self.abi_slot_count(element_type));
-                u32::try_from(element_slots.saturating_mul(length)).unwrap_or(u32::MAX)
-            }
-            // Module types don't take ABI slots (they're compile-time only)
-            TypeKind::Module(_) => 0,
-            // Pointer types take 1 slot (64-bit address)
-            TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => 1,
-        }
+        self.type_pool.abi_slot_count(ty)
     }
 }

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -986,8 +986,13 @@ impl<'a> CfgBuilder<'a> {
                     return Self::diverged();
                 };
 
-                // Allocate a temporary slot for the struct
-                let temp_slot = self.cfg.alloc_temp_local();
+                // Reserve the computed value's complete frame region. Codegen
+                // stores every flattened slot before reading the projection;
+                // a one-slot reservation would overlap the next local/param.
+                let base_type = self.air.get(*base).ty;
+                let temp_slot = self
+                    .cfg
+                    .alloc_temp_local_slots(self.type_pool.abi_slot_count(base_type).max(1));
 
                 // Emit StorageLive, Alloc to store the computed struct
                 self.emit(
@@ -1007,7 +1012,7 @@ impl<'a> CfgBuilder<'a> {
                 // Create a PlaceRead from the temp slot with Field projection
                 let place = self.cfg.make_place(
                     PlaceBase::Local(temp_slot),
-                    self.air.get(*base).ty,
+                    base_type,
                     std::iter::once(Projection::Field {
                         struct_id: *struct_id,
                         field_index: *field_index,
@@ -1725,8 +1730,11 @@ impl<'a> CfgBuilder<'a> {
                     return Self::diverged();
                 };
 
-                // Allocate a temporary slot for the array
-                let temp_slot = self.cfg.alloc_temp_local();
+                // Reserve every flattened array slot (or one concrete slot
+                // for a zero-sized root whose address may still be formed).
+                let temp_slot = self
+                    .cfg
+                    .alloc_temp_local_slots(self.type_pool.abi_slot_count(*array_type).max(1));
 
                 // Emit StorageLive, Alloc to store the computed array
                 self.emit(
@@ -3375,6 +3383,39 @@ mod tests {
                 .all(|value| !matches!(cfg.get_inst(*value).data, CfgInstData::Param { .. })),
             "the base type must not depend on a separate Param instruction"
         );
+    }
+
+    #[test]
+    fn computed_aggregate_projection_reserves_the_complete_temp_width() {
+        let cfg = build_cfg_named(
+            "struct Pair { left: i32, right: i32 }\n\
+             fn make() -> Pair { Pair { left: 10, right: 20 } }\n\
+             fn use(n: i32) -> i32 { make().right + n }\n\
+             fn main() -> i32 { use(5) }",
+            "use",
+        );
+
+        assert_eq!(cfg.num_params(), 1);
+        assert_eq!(
+            cfg.num_locals(),
+            2,
+            "the two-slot Pair spill must end before the parameter area"
+        );
+        let place = cfg
+            .blocks()
+            .iter()
+            .flat_map(|block| block.insts.iter().copied())
+            .find_map(|value| match cfg.get_inst(value).data {
+                CfgInstData::PlaceRead { place } if matches!(place.base, PlaceBase::Local(0)) => {
+                    Some(place)
+                }
+                _ => None,
+            })
+            .expect("computed Pair projection");
+        assert!(matches!(
+            cfg.get_place_projections(&place),
+            [Projection::Field { field_index: 1, .. }]
+        ));
     }
 
     #[test]

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -672,8 +672,26 @@ impl Cfg {
     /// Returns the slot number for the new local.
     #[inline]
     pub fn alloc_temp_local(&mut self) -> u32 {
+        self.alloc_temp_local_slots(1)
+    }
+
+    /// Allocate a contiguous temporary frame region and return its base slot.
+    ///
+    /// Multi-slot aggregate spills must reserve their complete ABI width;
+    /// reserving only the first slot lets codegen overwrite the following
+    /// local or parameter area. Callers use at least one slot for zero-sized
+    /// roots that still need a concrete address.
+    #[inline]
+    pub fn alloc_temp_local_slots(&mut self, slots: u32) -> u32 {
+        assert!(
+            slots > 0,
+            "temporary frame regions must reserve at least one slot"
+        );
         let slot = self.num_locals;
-        self.num_locals += 1;
+        self.num_locals = self
+            .num_locals
+            .checked_add(slots)
+            .expect("temporary frame slot count overflow");
         slot
     }
 

--- a/crates/rue-cli-tests/cases/aggregate_slots.toml
+++ b/crates/rue-cli-tests/cases/aggregate_slots.toml
@@ -561,3 +561,17 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 84
+
+# CFG lowering spills a computed aggregate before projecting it. The temporary
+# must reserve the aggregate's full flattened width: with only one slot, the
+# Pair's first word overwrites `n` in the adjacent parameter area and this
+# returns 30 instead of 25.
+[[case]]
+name = "computed_aggregate_projection_temp_does_not_overlap_parameter"
+files = [{ path = "main.rue", source = """
+struct Pair { left: i32, right: i32 }
+fn make() -> Pair { Pair { left: 10, right: 20 } }
+fn use(n: i32) -> i32 { make().right + n }
+fn main() -> i32 { use(5) }
+""" }]
+exit_code = 25

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -63,49 +63,7 @@ pub fn array_element_slot_count_from_type(type_pool: &TypeInternPool, ty: Type) 
 /// For nested types, this recursively calculates.
 /// Zero-sized types (unit, never, empty structs, zero-length arrays) return 0.
 pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
-    match ty.kind() {
-        // Zero-sized types
-        TypeKind::Unit | TypeKind::Never => 0,
-        TypeKind::Array(array_type_id) => {
-            // Zero-length arrays naturally get 0 slots (0 * element_slots).
-            // SATURATING, not truncating-u32: sema rejects oversized types
-            // with E0906 before lowering (RUE-561), so this value is never
-            // used for real allocation, but it must not silently wrap
-            // (`[i32; 4294967296]` truncated to 0 slots) or panic in debug.
-            let (element_type, length) = type_pool.array_def(array_type_id);
-            let elem_slots = u64::from(type_slot_count(type_pool, element_type));
-            u32::try_from(elem_slots.saturating_mul(length)).unwrap_or(u32::MAX)
-        }
-        TypeKind::Struct(struct_id) => {
-            // Sum the slot counts of all fields
-            // Empty structs naturally get 0 slots here
-            let struct_def = type_pool.struct_def(struct_id);
-            let mut total = 0u32;
-            for field in &struct_def.fields {
-                total = total.saturating_add(type_slot_count(type_pool, field.ty));
-            }
-            total
-        }
-        TypeKind::Enum(enum_id) => {
-            // Tagged-union layout (RUE-221, ADR-0038): slot 0 holds the
-            // discriminant; the payload area that follows is sized to the
-            // largest variant. A discriminant-only (C-like) enum has no
-            // payload and therefore occupies exactly one slot, unchanged from
-            // before payloads existed.
-            let enum_def = type_pool.enum_def(enum_id);
-            let mut max_payload = 0u32;
-            for i in 0..enum_def.variant_count() {
-                let mut variant_slots = 0u32;
-                for &ty in enum_def.variant_payload(i) {
-                    variant_slots = variant_slots.saturating_add(type_slot_count(type_pool, ty));
-                }
-                max_payload = max_payload.max(variant_slots);
-            }
-            1u32.saturating_add(max_payload)
-        }
-        // Scalars and other types use 1 slot
-        _ => 1,
-    }
+    type_pool.abi_slot_count(ty)
 }
 
 /// Return the `(Some, None)` discriminant values for an `Option`-shaped enum


### PR DESCRIPTION
## Summary

- make `TypeInternPool::abi_slot_count` the canonical flattened ABI-width query used by sema and codegen
- reserve the complete width of computed struct/array CFG spill temporaries, while retaining one concrete slot for zero-sized addressable roots
- add CFG and executable witnesses proving a two-slot spill cannot overlap the adjacent parameter area

## Why

The typed differential gate exposed that `FieldGet`/`IndexGet` fallback lowering called the one-slot temporary allocator even when codegen subsequently stored a multi-slot aggregate. In a padded frame this could appear to work by accident; with a following parameter, the spill overwrote the parameter slot. This fixes the allocation class at the shared layout boundary rather than special-casing the observed string cases.

## Validation

- `./fmt.sh`
- `./clippy.sh` (41 first-party targets)
- `./test.sh` (33/33 Buck targets)
- CFG unit witness: full two-slot temporary reservation
- CLI witness: computed `Pair` projection plus adjacent parameter returns 25, not the corrupted 30

Independent read-only audit: clear.
