### PR TITLE
RUE-589: type CLI panic and assertion traps

### DIFF
--- a/crates/rue-cli-tests/cases/panic_assert.toml
+++ b/crates/rue-cli-tests/cases/panic_assert.toml
@@ -135,7 +135,7 @@ fn main() -> i32 {
 """ }]
 exit_code = 101
 stdout = ""
-runtime_error_contains = ["one is not two"]
+runtime_error_contains = ["panic: one is not two"]
 
 # ── @cast rejection ──────────────────────────────────────────────────────────
 

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -938,10 +938,20 @@ mod tests {
             &ran_trap("error: integer overflow\n"),
         );
         assert!(is_disagree(v));
+        let v = classify(
+            &trap(TrapKind::UserPanic),
+            &ran_trap("panic: user message\n"),
+        );
+        assert!(matches!(v, Verdict::Agree));
+        let v = classify(
+            &trap(TrapKind::AssertionFailure),
+            &ran_trap("assertion failed\n"),
+        );
+        assert!(matches!(v, Verdict::Agree));
     }
 
     #[test]
-    fn unclassified_or_one_sided_trap_causes_fail_closed() {
+    fn wrong_or_one_sided_trap_causes_fail_closed() {
         let v = classify(
             &trap(TrapKind::ArithmeticOverflow),
             &ran_trap("panic: boom\n"),

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -760,7 +760,7 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
     };
     let source = &case.files[0].source;
     let expected_trap =
-        trap::trap_expectation(case.runtime_error_contains.iter().map(String::as_str));
+        trap::cli_trap_expectation(case.runtime_error_contains.iter().map(String::as_str));
 
     // A program that expects a runtime panic exits 101 by convention.
     let expected_exit = case
@@ -1811,7 +1811,7 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
     fn unknown_runtime_expectations_are_counted_as_unmodeled() {
         let mut case = corpus_case("fn main() -> i32 { let x: i32 = 2147483647; x + 1 }", false);
         case.exit_code = None;
-        case.runtime_error_contains = vec!["panic: integer overflow".to_string()];
+        case.runtime_error_contains = vec!["custom trap wording".to_string()];
 
         let mut report = Report::default();
         report.record(check_case(Path::new("trap.toml"), &case));
@@ -1896,7 +1896,7 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
         let mut trap_case =
             corpus_case("fn main() -> i32 { let x: i32 = 2147483647; x + 1 }", false);
         trap_case.exit_code = None;
-        trap_case.runtime_error_contains = vec!["panic: integer overflow".to_string()];
+        trap_case.runtime_error_contains = vec!["custom trap wording".to_string()];
         let trap_outcome = check_case(Path::new("trap.toml"), &trap_case);
 
         let stderr_case = rue_test_runner::Case {

--- a/crates/rue-oracle-diff/src/trap.rs
+++ b/crates/rue-oracle-diff/src/trap.rs
@@ -28,6 +28,11 @@ pub(crate) fn native_runtime_trap_kind(stderr: &str) -> Option<TrapKind> {
         "error: division by zero\n" => Some(TrapKind::DivisionByZero),
         "error: index out of bounds\n" => Some(TrapKind::IndexOutOfBounds),
         "error: invalid UTF-8\n" => Some(TrapKind::InvalidUtf8),
+        "panic\n" => Some(TrapKind::UserPanic),
+        "assertion failed\n" => Some(TrapKind::AssertionFailure),
+        stderr if stderr.starts_with("panic: ") && stderr.ends_with('\n') => {
+            Some(TrapKind::UserPanic)
+        }
         _ => None,
     }
 }
@@ -43,13 +48,26 @@ fn expected_trap_kind(fragment: &str) -> Option<TrapKind> {
     }
 }
 
-pub(crate) fn trap_expectation<'a>(
+/// CLI cases also pin the two abort intrinsics' exact runtime prefixes. Keep
+/// this vocabulary separate from rue-spec so adding the CLI registry does not
+/// silently reclassify that corpus's existing observation coverage.
+fn cli_expected_trap_kind(fragment: &str) -> Option<TrapKind> {
+    expected_trap_kind(fragment).or_else(|| match fragment {
+        "panic" => Some(TrapKind::UserPanic),
+        "assertion failed" => Some(TrapKind::AssertionFailure),
+        fragment if fragment.starts_with("panic: ") => Some(TrapKind::UserPanic),
+        _ => None,
+    })
+}
+
+fn classify_expectation<'a>(
     fragments: impl IntoIterator<Item = &'a str>,
+    classify: fn(&str) -> Option<TrapKind>,
 ) -> TrapExpectation {
     let mut expected = None;
 
     for fragment in fragments {
-        let Some(kind) = expected_trap_kind(fragment) else {
+        let Some(kind) = classify(fragment) else {
             return TrapExpectation::Unmodeled;
         };
         if expected.is_some_and(|prior| prior != kind) {
@@ -59,6 +77,18 @@ pub(crate) fn trap_expectation<'a>(
     }
 
     expected.map_or(TrapExpectation::Undeclared, TrapExpectation::Modeled)
+}
+
+pub(crate) fn trap_expectation<'a>(
+    fragments: impl IntoIterator<Item = &'a str>,
+) -> TrapExpectation {
+    classify_expectation(fragments, expected_trap_kind)
+}
+
+pub(crate) fn cli_trap_expectation<'a>(
+    fragments: impl IntoIterator<Item = &'a str>,
+) -> TrapExpectation {
+    classify_expectation(fragments, cli_expected_trap_kind)
 }
 
 #[cfg(test)]
@@ -87,15 +117,26 @@ mod tests {
             native_runtime_trap_kind("error: invalid UTF-8\n"),
             Some(TrapKind::InvalidUtf8)
         );
+        assert_eq!(
+            native_runtime_trap_kind("panic\n"),
+            Some(TrapKind::UserPanic)
+        );
+        assert_eq!(
+            native_runtime_trap_kind("panic: boom\n"),
+            Some(TrapKind::UserPanic)
+        );
+        assert_eq!(
+            native_runtime_trap_kind("assertion failed\n"),
+            Some(TrapKind::AssertionFailure)
+        );
     }
 
     #[test]
-    fn expectation_fragments_user_panics_and_extra_output_are_not_proof() {
+    fn user_panics_are_distinct_from_builtin_traps_and_extra_output_is_not_proof() {
         assert_eq!(native_runtime_trap_kind("integer overflow"), None);
-        assert_eq!(native_runtime_trap_kind("panic: integer overflow\n"), None);
         assert_eq!(
             native_runtime_trap_kind("panic: index out of bounds\n"),
-            None
+            Some(TrapKind::UserPanic)
         );
         assert_eq!(
             native_runtime_trap_kind("error: integer cast overflow\nerror: integer overflow\n"),
@@ -131,6 +172,22 @@ mod tests {
         assert_eq!(
             trap_expectation(["division by zero", "division by zero"]),
             TrapExpectation::Modeled(TrapKind::DivisionByZero)
+        );
+
+        for fragment in ["panic", "panic: boom", "panic: integer overflow"] {
+            assert_eq!(
+                cli_trap_expectation([fragment]),
+                TrapExpectation::Modeled(TrapKind::UserPanic)
+            );
+            assert_eq!(trap_expectation([fragment]), TrapExpectation::Unmodeled);
+        }
+        assert_eq!(
+            cli_trap_expectation(["assertion failed"]),
+            TrapExpectation::Modeled(TrapKind::AssertionFailure)
+        );
+        assert_eq!(
+            trap_expectation(["assertion failed"]),
+            TrapExpectation::Unmodeled
         );
     }
 

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -88,6 +88,8 @@ pub enum TrapKind {
     IntegerCastOverflow,
     IndexOutOfBounds,
     InvalidUtf8,
+    UserPanic,
+    AssertionFailure,
     Unreachable,
 }
 
@@ -99,6 +101,8 @@ impl fmt::Display for TrapKind {
             Self::IntegerCastOverflow => "integer cast overflow",
             Self::IndexOutOfBounds => "index out of bounds",
             Self::InvalidUtf8 => "invalid UTF-8",
+            Self::UserPanic => "user panic",
+            Self::AssertionFailure => "assertion failure",
             Self::Unreachable => "reached unreachable",
         })
     }

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -433,6 +433,8 @@ fn trap_kind_display_spellings_are_stable() {
         (TrapKind::IntegerCastOverflow, "integer cast overflow"),
         (TrapKind::IndexOutOfBounds, "index out of bounds"),
         (TrapKind::InvalidUtf8, "invalid UTF-8"),
+        (TrapKind::UserPanic, "user panic"),
+        (TrapKind::AssertionFailure, "assertion failure"),
         (TrapKind::Unreachable, "reached unreachable"),
     ];
 


### PR DESCRIPTION
## Summary

- add typed `UserPanic` and `AssertionFailure` trap categories at the oracle/native boundary
- give the CLI corpus its own exact `@panic`/`@assert` expectation vocabulary while preserving the stricter existing spec vocabulary
- distinguish user text such as `panic: integer overflow` from builtin arithmetic traps
- tighten the custom-message assertion case to require its actual `panic:` prefix

The CLI model-gap registry audit exposed this independent observation dimension: an oracle model gap must never hide an imprecise trap contract. This small prerequisite makes the live panic/assert declarations structurally modeled before the registry lands.

## Validation

- `./fmt.sh`
- `./clippy.sh` — 41 first-party Rust targets
- `./test.sh` — 33/33 targets
- rue-oracle-diff unit suite: 64/64
- live CLI corpus remains 619 agree / 107 unmodeled / 548 ineligible, zero failures
- live spec corpus remains 1318 / 107 / 582, zero failures

