### PR TITLE
RUE-3: share target-independent codegen infrastructure

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -194,16 +194,6 @@ impl<'a> CfgLower<'a> {
         })
     }
 
-    /// Check if a slot corresponds to an inout parameter.
-    fn slot_to_inout_param_index(&self, slot: u32) -> Option<u32> {
-        if let Some(param_index) = self.ctx.slot_to_inout_param_index(slot) {
-            if self.ctx.cfg.is_param_inout(param_index) {
-                return Some(param_index);
-            }
-        }
-        None
-    }
-
     /// Ensure the inout parameter pointer vreg exists for the given param slot.
     fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
         if let Some(ptr_vreg) = self.inout_param_ptrs.get(&param_slot).copied() {
@@ -1345,214 +1335,22 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Alloc { slot, init } => {
-                let init_type = self.ctx.cfg.get_inst(*init).ty;
-                if init_type.is_array() {
-                    // Array: store all element slots. Try the accessor first —
-                    // it materializes lazily-sourced arrays (Load/Param/
-                    // PlaceRead, including array-typed struct fields `s.arr`
-                    // and indexed reads `m[i]`, RUE-188) and cache-hits eager
-                    // ones. Fall back to the recursive flattener for ArrayInit.
-                    let scalar_vregs = self
-                        .get_or_compute_field_vregs(*init)
-                        .unwrap_or_else(|| self.collect_array_scalar_vregs(*init));
-                    crate::agg_slots::store_slots(self, &scalar_vregs, *slot);
-                } else if self.ctx.is_multislot_aggregate(init_type)
-                    && !self.ctx.is_builtin_string(init_type)
-                {
-                    // Struct or payload enum (RUE-221): store all slots via the
-                    // single accessor. It materializes a struct read from a place
-                    // (`let q = a.p`) by loading its slot_count consecutive slots,
-                    // and cache-hits StructInit/EnumVariant/Load/Param/Call/
-                    // BlockParam — all of which carry fully-flattened slot lists.
-                    // Fall back to the flattener for any source the accessor
-                    // doesn't model. (RUE-118 / RUE-22)
-                    // (Builtin String is excluded above — it takes the fat-pointer branch.)
-                    let scalar_vregs = self
-                        .get_or_compute_field_vregs(*init)
-                        .unwrap_or_else(|| self.collect_struct_scalar_vregs(*init));
-                    crate::agg_slots::store_slots(self, &scalar_vregs, *slot);
-                } else if self.ctx.is_builtin_string(init_type) {
-                    // String: store ptr, len, and cap to consecutive slots
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*init)
-                        .expect("string should have fat pointer fields in Alloc");
-                    // Correctness guard (must run in release): storing the wrong
-                    // number of fat-pointer slots miscompiles the String, so this
-                    // is a plain `assert!` not `debug_assert!` (RUE-45).
-                    assert_eq!(
-                        field_vregs.len(),
-                        3,
-                        "string should have 3 fields (ptr, len, cap)"
-                    );
-                    crate::agg_slots::store_slots(self, &field_vregs, *slot);
-                } else {
-                    let init_vreg = self.get_vreg(*init);
-                    let offset = self.ctx.local_offset(*slot);
-                    self.mir.push(Aarch64Inst::Str {
-                        src: Operand::Virtual(init_vreg),
-                        base: Reg::Fp,
-                        offset,
-                    });
-                }
+                crate::storage_lower::lower_alloc(self, *slot, *init);
             }
 
             CfgInstData::Load { slot } => {
-                let load_type = self.ctx.cfg.get_inst(value).ty;
-
-                if self.ctx.is_builtin_string(load_type) {
-                    // String fat pointer (ptr, len, cap). Ascending layout
-                    // (ADR-0040 / RUE-311): logical slot 0 (ptr) is at the
-                    // region's low end (highest-numbered slot `slot + 2`),
-                    // slot k at `slot + 2 - k`.
-                    let slot_vregs = crate::agg_slots::load_slots_at_low(self, slot + 2, 3);
-                    let ptr_vreg = slot_vregs[0];
-                    // Register String fields (ptr, len, cap)
-                    self.struct_slot_vregs.insert(value, slot_vregs);
-                    self.value_map.insert(value, ptr_vreg);
-                } else if load_type.is_array() {
-                    // Array: load every logical slot (ascending, ADR-0040 /
-                    // RUE-311): slot 0 at the region's low end.
-                    let slot_count = self.ctx.type_slot_count(load_type);
-                    let slot_vregs = if slot_count > 0 {
-                        crate::agg_slots::load_slots_at_low(self, slot + slot_count - 1, slot_count)
-                    } else {
-                        Vec::new()
-                    };
-
-                    // Register array element vregs
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-
-                    // Use first element as the primary vreg
-                    if let Some(&first_vreg) = slot_vregs.first() {
-                        self.value_map.insert(value, first_vreg);
-                    } else {
-                        let vreg = self.mir.alloc_vreg();
-                        self.value_map.insert(value, vreg);
-                    }
-                } else if self.ctx.is_multislot_aggregate(load_type) {
-                    // Struct or payload enum (RUE-221): load all slots ascending
-                    // (ADR-0040 / RUE-311). For an enum, slot 0 is the
-                    // discriminant (what a `match` switches on).
-                    let slot_count = self.ctx.type_slot_count(load_type);
-                    let slot_vregs = if slot_count > 0 {
-                        crate::agg_slots::load_slots_at_low(self, slot + slot_count - 1, slot_count)
-                    } else {
-                        Vec::new()
-                    };
-
-                    // Register struct field vregs
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-
-                    // Use first field as the primary vreg
-                    if let Some(&first_vreg) = slot_vregs.first() {
-                        self.value_map.insert(value, first_vreg);
-                    } else {
-                        let vreg = self.mir.alloc_vreg();
-                        self.value_map.insert(value, vreg);
-                    }
-                } else {
-                    let vreg = self.mir.alloc_vreg();
-                    self.value_map.insert(value, vreg);
-
-                    let offset = self.ctx.local_offset(*slot);
-                    self.mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Virtual(vreg),
-                        base: Reg::Fp,
-                        offset,
-                    });
-                }
+                crate::storage_lower::lower_load(self, value, *slot);
             }
 
             CfgInstData::Store { slot, value: val } => {
-                let val_type = self.ctx.cfg.get_inst(*val).ty;
-                // Multi-slot aggregate (struct, builtin String fat pointer,
-                // array, or payload enum): store ALL slots, not just the first.
-                // Routed through the single is_multislot_aggregate predicate so
-                // enum payloads are covered by construction (RUE-248). The
-                // accessor materializes lazily-sourced values and cache-hits
-                // eager ones; if it can't model the source (e.g. a
-                // dynamically-indexed place-read) fall back to the old
-                // single-slot behavior rather than ICE. (RUE-118, RUE-80)
-                let aggregate_vregs = if self.ctx.is_multislot_aggregate(val_type) {
-                    self.get_or_compute_field_vregs(*val)
-                } else {
-                    None
-                };
-
-                if let Some(slot_vregs) = aggregate_vregs {
-                    // Check if this slot corresponds to an inout parameter
-                    if let Some(param_index) = self.slot_to_inout_param_index(*slot) {
-                        // Whole-aggregate store through the inout pointer. The
-                        // pointer denotes the value's low end, so logical slot i
-                        // lives at ptr + i*8 (ADR-0040 / RUE-311).
-                        let ptr_vreg = self.ensure_inout_param_ptr(param_index);
-                        crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
-                    } else {
-                        crate::agg_slots::store_slots(self, &slot_vregs, *slot);
-                    }
-                } else {
-                    let val_vreg = self.get_vreg(*val);
-
-                    // Check if this slot corresponds to an inout parameter
-                    if let Some(param_index) = self.slot_to_inout_param_index(*slot) {
-                        // For inout params, store through the pointer
-                        // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                        let ptr_vreg = self.ensure_inout_param_ptr(param_index);
-                        self.mir.push(Aarch64Inst::StrIndexed {
-                            src: Operand::Virtual(val_vreg),
-                            base: ptr_vreg,
-                        });
-                    } else {
-                        // Normal local variable: store to stack slot
-                        let offset = self.ctx.local_offset(*slot);
-                        self.mir.push(Aarch64Inst::Str {
-                            src: Operand::Virtual(val_vreg),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    }
-                }
+                crate::storage_lower::lower_store(self, *slot, *val);
             }
 
             CfgInstData::ParamStore {
                 param_slot,
                 value: val,
             } => {
-                // ParamStore is used for inout params - store through the pointer.
-                //
-                // For inout params, param_slot is the first ABI slot for that param.
-                // For scalar params, param_slot = param_index.
-                // For struct params, param_slot is the first slot (same as param_index for first param).
-                if !self.ctx.cfg.is_param_inout(*param_slot) {
-                    panic!("ParamStore used on non-inout param slot {}", param_slot);
-                }
-
-                // Whole-value reassignment of a multi-slot aggregate (struct,
-                // builtin String, array, or payload enum) through inout must
-                // write ALL slots through the pointer, not just the first —
-                // same shape as the aggregate branch of Store above. The
-                // pointer denotes the value's low end, so logical slot i lives
-                // at ptr + i*8 (ADR-0040 / RUE-311). Unmodeled sources fall
-                // back to single-slot. Single is_multislot_aggregate predicate
-                // (RUE-248, RUE-145).
-                let val_type = self.ctx.cfg.get_inst(*val).ty;
-                let aggregate_vregs = if self.ctx.is_multislot_aggregate(val_type) {
-                    self.get_or_compute_field_vregs(*val)
-                } else {
-                    None
-                };
-
-                // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
-                if let Some(slot_vregs) = aggregate_vregs {
-                    crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
-                } else {
-                    let val_vreg = self.get_vreg(*val);
-                    self.mir.push(Aarch64Inst::StrIndexed {
-                        src: Operand::Virtual(val_vreg),
-                        base: ptr_vreg,
-                    });
-                }
+                crate::storage_lower::lower_param_store(self, *param_slot, *val);
             }
 
             CfgInstData::Call {
@@ -4333,6 +4131,19 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
     }
 }
 
+impl crate::storage_lower::StorageLowerBackend for CfgLower<'_> {
+    fn collect_struct_scalars(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.collect_struct_scalar_vregs(value)
+    }
+
+    fn emit_store_ptr_base(&mut self, src: VReg, ptr: VReg) {
+        self.mir.push(Aarch64Inst::StrIndexed {
+            src: Operand::Virtual(src),
+            base: ptr,
+        });
+    }
+}
+
 impl crate::aggregate_eq::AggregateEqBackend for CfgLower<'_> {
     fn ctx(&self) -> &crate::cfg_lower::CfgLowerContext<'_> {
         &self.ctx
@@ -4401,7 +4212,7 @@ mod tests {
     use rue_parser::Parser;
     use rue_rir::AstGen;
 
-    fn lower_to_mir(source: &str) -> Aarch64Mir {
+    fn lower_function_to_mir(source: &str, function_name: &str) -> Aarch64Mir {
         let lexer = Lexer::new(source);
         let (tokens, interner) = lexer.tokenize().unwrap();
         let parser = Parser::new(tokens, interner);
@@ -4413,7 +4224,11 @@ mod tests {
         let sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
         let output = sema.analyze_all().unwrap();
 
-        let func = &output.functions[0];
+        let func = output
+            .functions
+            .iter()
+            .find(|func| func.name == function_name)
+            .expect("requested test function should exist");
         let type_pool = &output.type_pool;
         let cfg_output = CfgBuilder::build(
             &func.air,
@@ -4437,6 +4252,10 @@ mod tests {
         .expect("test lowering should succeed")
     }
 
+    fn lower_to_mir(source: &str) -> Aarch64Mir {
+        lower_function_to_mir(source, "main")
+    }
+
     #[test]
     fn test_simple_return() {
         let mir = lower_to_mir("fn main() -> i32 { 42 }");
@@ -4453,5 +4272,25 @@ mod tests {
     fn test_if_else() {
         let mir = lower_to_mir("fn main() -> i32 { if true { 1 } else { 2 } }");
         assert!(!mir.instructions().is_empty());
+    }
+
+    #[test]
+    fn scalar_param_store_keeps_base_only_indexed_mir() {
+        let mir = lower_function_to_mir(
+            "fn set(inout x: i32) { x = 42; } \
+             fn main() -> i32 { let mut x = 0; set(inout x); x }",
+            "set",
+        );
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::StrIndexed { .. }))
+        );
+        assert!(
+            !mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::StrIndexedOffset { offset: 0, .. })),
+            "scalar ParamStore must not drift to the offset-form pseudo"
+        );
     }
 }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -7,14 +7,12 @@ use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
 use rue_air::{TypeInternPool, TypeKind};
-use rue_cfg::{
-    BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, Type,
-};
+use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, Terminator, Type};
 use rue_error::{CompileError, CompileResult};
 use rue_target::Target;
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
-use crate::cfg_lower::{CfgLowerContext, IndexLevel};
+use crate::cfg_lower::CfgLowerContext;
 use crate::types;
 
 /// Argument passing registers per AAPCS64. ABI arg slots beyond these are
@@ -1484,9 +1482,9 @@ impl<'a> CfgLower<'a> {
                 if let Some(slot_vregs) = aggregate_vregs {
                     // Check if this slot corresponds to an inout parameter
                     if let Some(param_index) = self.slot_to_inout_param_index(*slot) {
-                        // Whole-aggregate store through the inout pointer. Caller
-                        // slots descend from the pointer (stack grows down), so
-                        // slot i lives at ptr - i*8 — matching the place-read path.
+                        // Whole-aggregate store through the inout pointer. The
+                        // pointer denotes the value's low end, so logical slot i
+                        // lives at ptr + i*8 (ADR-0040 / RUE-311).
                         let ptr_vreg = self.ensure_inout_param_ptr(param_index);
                         crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
                     } else {
@@ -1532,11 +1530,11 @@ impl<'a> CfgLower<'a> {
                 // Whole-value reassignment of a multi-slot aggregate (struct,
                 // builtin String, array, or payload enum) through inout must
                 // write ALL slots through the pointer, not just the first —
-                // same shape as the aggregate branch of Store above. Caller
-                // slots descend from the pointer (stack grows down), so slot i
-                // lives at ptr - i*8. Unmodeled sources fall back to
-                // single-slot. Single is_multislot_aggregate predicate (RUE-248,
-                // RUE-145).
+                // same shape as the aggregate branch of Store above. The
+                // pointer denotes the value's low end, so logical slot i lives
+                // at ptr + i*8 (ADR-0040 / RUE-311). Unmodeled sources fall
+                // back to single-slot. Single is_multislot_aggregate predicate
+                // (RUE-248, RUE-145).
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
                 let aggregate_vregs = if self.ctx.is_multislot_aggregate(val_type) {
                     self.get_or_compute_field_vregs(*val)
@@ -2171,9 +2169,9 @@ impl<'a> CfgLower<'a> {
 
                     // The result type is the pointee type. An aggregate pointee
                     // (struct/array/payload enum) occupies several 8-byte slots;
-                    // read EVERY slot at its descending byte offset (slot i at
-                    // ptr - i*8, matching how @raw addresses the place and the
-                    // by-ref aggregate load path). Reading only slot 0 dropped
+                    // read EVERY logical slot at its ascending byte offset
+                    // (slot i at ptr + i*8, matching @raw and the by-ref
+                    // aggregate load path). Reading only slot 0 dropped
                     // every field but the first (RUE-242).
                     let result_ty = self.ctx.cfg.get_inst(value).ty;
                     let slot_count = self.ctx.type_slot_count(result_ty);
@@ -2209,8 +2207,8 @@ impl<'a> CfgLower<'a> {
                     let ptr_vreg = self.get_vreg(ptr_val);
 
                     // An aggregate value spans several 8-byte slots; store EVERY
-                    // slot at its descending byte offset (slot i at ptr - i*8),
-                    // symmetric with @ptr_read. Storing only slot 0 dropped
+                    // logical slot at its ascending byte offset (slot i at
+                    // ptr + i*8), symmetric with @ptr_read. Storing only slot 0 dropped
                     // every field but the first (RUE-242).
                     let value_ty = self.ctx.cfg.get_inst(value_val).ty;
                     let slot_count = self.ctx.type_slot_count(value_ty);
@@ -2495,7 +2493,7 @@ impl<'a> CfgLower<'a> {
                         // Address of a place expression (array element, struct field, etc.)
                         // We compute the address without loading the value.
                         let result_vreg = self.mir.alloc_vreg();
-                        self.lower_place_addr(result_vreg, place);
+                        crate::place_lower::lower_place_addr(self, result_vreg, place);
                         self.value_map.insert(value, result_vreg);
                     } else if let CfgInstData::Param { index } = &lvalue_inst.data {
                         // @raw of a function parameter: take the ADDRESS of the
@@ -2989,7 +2987,7 @@ impl<'a> CfgLower<'a> {
             CfgInstData::PlaceRead { place } => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
-                self.lower_place_read(vreg, place, ty);
+                crate::place_lower::lower_place_read(self, vreg, place, ty);
             }
 
             CfgInstData::PlaceWrite { place, value: val } => {
@@ -3014,7 +3012,7 @@ impl<'a> CfgLower<'a> {
                 } else {
                     vec![self.get_vreg(*val)]
                 };
-                self.lower_place_write(place, &vals);
+                crate::place_lower::lower_place_write(self, place, &vals);
             }
         }
     }
@@ -4178,577 +4176,6 @@ impl<'a> CfgLower<'a> {
             }
         }
     }
-
-    // === Place operations (ADR-0030) ===
-
-    /// Lower a PlaceRead instruction.
-    ///
-    /// This loads a value from the memory location described by the place,
-    /// walking through any projections (field accesses, array indices).
-    fn lower_place_read(&mut self, dst: VReg, place: &Place, ty: Type) {
-        // A zero-sized read has no bytes to load (RUE-577): define dst as the
-        // canonical 0 — matching UnitConst's lowering, so unit equality
-        // compares 0 == 0 — and skip address formation entirely (a ZST root's
-        // `root_count - 1` origin shift would underflow, and a full-width
-        // load would read a neighbor's slot or out of frame).
-        if self.ctx.type_slot_count(ty) == 0 {
-            self.mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(dst),
-                imm: 0,
-            });
-            return;
-        }
-        let projections = self.ctx.cfg.get_place_projections(place);
-
-        // Simple case: no projections, just load from the base slot
-        if projections.is_empty() {
-            match place.base {
-                PlaceBase::Local(slot) => {
-                    let offset = self.ctx.local_offset(slot);
-                    self.mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Virtual(dst),
-                        base: Reg::Fp,
-                        offset,
-                    });
-                }
-                PlaceBase::Param(param_slot) => {
-                    // Check if this is an inout parameter
-                    if self.ctx.cfg.is_param_inout(param_slot) {
-                        // Inout param - load through the pointer
-                        let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                        self.mir.push(Aarch64Inst::LdrIndexed {
-                            dst: Operand::Virtual(dst),
-                            base: ptr_vreg,
-                        });
-                    } else {
-                        // Normal param - load from local slot
-                        let slot = self.ctx.num_locals + param_slot;
-                        let offset = self.ctx.local_offset(slot);
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(dst),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    }
-                }
-            }
-            return;
-        }
-
-        // Complex case: has projections - compute the address
-        self.lower_place_read_with_projections(dst, place, projections);
-    }
-
-    /// Lower a PlaceRead with projections (field accesses and/or array indices).
-    fn lower_place_read_with_projections(
-        &mut self,
-        dst: VReg,
-        place: &Place,
-        projections: &[Projection],
-    ) {
-        // Calculate the static field offset (sum of all Field projection offsets)
-        let mut static_slot_offset: u32 = 0;
-
-        // Collect index projections for dynamic offset calculation
-        let mut index_levels: Vec<IndexLevel> = Vec::new();
-
-        for proj in projections {
-            match proj {
-                Projection::Field {
-                    struct_id,
-                    field_index,
-                } => {
-                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                    static_slot_offset += field_offset;
-                }
-                Projection::Index { array_type, index } => {
-                    // Emit bounds check for this index
-                    let index_vreg = self.get_vreg(*index);
-                    let array_length = self.ctx.array_length(*array_type);
-                    self.emit_bounds_check(index_vreg, array_length);
-
-                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
-                    // offset from the low-end origin is `index*size`, added
-                    // below; the single root-object origin shift covers the
-                    // array's own origin (no per-array `(N-1)` shift).
-                    index_levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-                }
-            }
-        }
-
-        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311).
-        let root_count = crate::agg_slots::root_slot_count(self, place);
-
-        // Calculate dynamic offset from index projections
-        let dynamic_offset_vreg = if !index_levels.is_empty() {
-            Some(self.compute_index_offset(&index_levels))
-        } else {
-            None
-        };
-
-        // Compute final address based on base type
-        match place.base {
-            PlaceBase::Local(slot) => {
-                let base_slot = slot + (root_count - 1) - static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_slot);
-
-                if let Some(dyn_offset) = dynamic_offset_vreg {
-                    // Compute address: fp + base_offset + dynamic_offset (ascending, ADR-0040)
-                    let addr_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::AddImm {
-                        dst: Operand::Virtual(addr_vreg),
-                        src: Operand::Physical(Reg::Fp),
-                        imm: base_offset,
-                    });
-                    // Ascending layout: element i is at base + i*size, so ADD
-                    // the scaled index to the (lowest-address) origin (ADR-0040).
-                    self.mir.push(Aarch64Inst::AddRR {
-                        dst: Operand::Virtual(addr_vreg),
-                        src1: Operand::Virtual(addr_vreg),
-                        src2: Operand::Virtual(dyn_offset),
-                    });
-                    self.mir.push(Aarch64Inst::LdrIndexed {
-                        dst: Operand::Virtual(dst),
-                        base: addr_vreg,
-                    });
-                } else {
-                    // Static offset only
-                    self.mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Virtual(dst),
-                        base: Reg::Fp,
-                        offset: base_offset,
-                    });
-                }
-            }
-            PlaceBase::Param(param_slot) => {
-                if self.ctx.cfg.is_param_inout(param_slot) {
-                    // Inout param - use pointer. Received pointer is the caller
-                    // place's low end; field offset and scaled index both ADD
-                    // (ascending, ADR-0040 / RUE-311).
-                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                    let static_byte_offset = (static_slot_offset as i32) * 8;
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        // Compute address: ptr + static_offset + dynamic_offset (ascending)
-                        let addr_vreg = self.mir.alloc_vreg();
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Virtual(ptr_vreg),
-                        });
-                        if static_byte_offset != 0 {
-                            self.mir.push(Aarch64Inst::AddImm {
-                                dst: Operand::Virtual(addr_vreg),
-                                src: Operand::Virtual(addr_vreg),
-                                imm: static_byte_offset,
-                            });
-                        }
-                        self.mir.push(Aarch64Inst::AddRR {
-                            dst: Operand::Virtual(addr_vreg),
-                            src1: Operand::Virtual(addr_vreg),
-                            src2: Operand::Virtual(dyn_offset),
-                        });
-                        self.mir.push(Aarch64Inst::LdrIndexed {
-                            dst: Operand::Virtual(dst),
-                            base: addr_vreg,
-                        });
-                    } else {
-                        // Static offset only (ascending: field at ptr + off)
-                        self.mir.push(Aarch64Inst::LdrIndexedOffset {
-                            dst: Operand::Virtual(dst),
-                            base: ptr_vreg,
-                            offset: static_byte_offset,
-                        });
-                    }
-                } else {
-                    // Normal param - treat like local
-                    let base_slot =
-                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_slot);
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        let addr_vreg = self.mir.alloc_vreg();
-                        self.mir.push(Aarch64Inst::AddImm {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Physical(Reg::Fp),
-                            imm: base_offset,
-                        });
-                        self.mir.push(Aarch64Inst::AddRR {
-                            dst: Operand::Virtual(addr_vreg),
-                            src1: Operand::Virtual(addr_vreg),
-                            src2: Operand::Virtual(dyn_offset),
-                        });
-                        self.mir.push(Aarch64Inst::LdrIndexed {
-                            dst: Operand::Virtual(dst),
-                            base: addr_vreg,
-                        });
-                    } else {
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(dst),
-                            base: Reg::Fp,
-                            offset: base_offset,
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    /// Lower a PlaceWrite instruction.
-    ///
-    /// This stores a value to the memory location described by the place. `vals`
-    /// holds one vreg per slot of the value (a single element for scalars); all
-    /// slots are stored to consecutive locations. Slot i of an fp-relative place
-    /// lives at `local_offset(slot + i)`; through a pointer it lives at
-    /// `ptr_offset - i*8` (caller slots descend, stack grows down). (RUE-118)
-    fn lower_place_write(&mut self, place: &Place, vals: &[VReg]) {
-        let projections = self.ctx.cfg.get_place_projections(place);
-
-        // Simple case: no projections, just store to the base slot
-        if projections.is_empty() {
-            match place.base {
-                PlaceBase::Local(slot) => {
-                    crate::agg_slots::store_slots(self, vals, slot);
-                }
-                PlaceBase::Param(param_slot) => {
-                    if self.ctx.cfg.is_param_inout(param_slot) {
-                        // Inout param - store through the pointer
-                        let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                        crate::agg_slots::store_slots_through_ptr(self, vals, ptr_vreg, 0);
-                    } else {
-                        // Normal param - store to local slot
-                        let slot = self.ctx.num_locals + param_slot;
-                        crate::agg_slots::store_slots(self, vals, slot);
-                    }
-                }
-            }
-            return;
-        }
-
-        // Complex case: has projections - compute the address
-        self.lower_place_write_with_projections(place, projections, vals);
-    }
-
-    /// Lower a PlaceWrite with projections.
-    fn lower_place_write_with_projections(
-        &mut self,
-        place: &Place,
-        projections: &[Projection],
-        vals: &[VReg],
-    ) {
-        // Calculate the static field offset
-        let mut static_slot_offset: u32 = 0;
-
-        // Collect index projections for dynamic offset calculation
-        let mut index_levels: Vec<IndexLevel> = Vec::new();
-
-        for proj in projections {
-            match proj {
-                Projection::Field {
-                    struct_id,
-                    field_index,
-                } => {
-                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                    static_slot_offset += field_offset;
-                }
-                Projection::Index { array_type, index } => {
-                    // Emit bounds check for this index
-                    let index_vreg = self.get_vreg(*index);
-                    let array_length = self.ctx.array_length(*array_type);
-                    self.emit_bounds_check(index_vreg, array_length);
-
-                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
-                    // offset from the low-end origin is `index*size`, added
-                    // below; the single root-object origin shift covers the
-                    // array's own origin (no per-array `(N-1)` shift).
-                    index_levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-                }
-            }
-        }
-
-        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311).
-        let root_count = crate::agg_slots::root_slot_count(self, place);
-
-        // Calculate dynamic offset from index projections
-        let dynamic_offset_vreg = if !index_levels.is_empty() {
-            Some(self.compute_index_offset(&index_levels))
-        } else {
-            None
-        };
-
-        // Compute final address based on base type
-        match place.base {
-            PlaceBase::Local(slot) => {
-                let base_low_slot = slot + (root_count - 1) - static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_low_slot);
-
-                if let Some(dyn_offset) = dynamic_offset_vreg {
-                    let addr_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::AddImm {
-                        dst: Operand::Virtual(addr_vreg),
-                        src: Operand::Physical(Reg::Fp),
-                        imm: base_offset,
-                    });
-                    // Ascending layout: element i is at base + i*size, so ADD
-                    // the scaled index to the (lowest-address) origin (ADR-0040).
-                    self.mir.push(Aarch64Inst::AddRR {
-                        dst: Operand::Virtual(addr_vreg),
-                        src1: Operand::Virtual(addr_vreg),
-                        src2: Operand::Virtual(dyn_offset),
-                    });
-                    crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
-                } else {
-                    crate::agg_slots::store_slots_at_low(self, vals, base_low_slot);
-                }
-            }
-            PlaceBase::Param(param_slot) => {
-                if self.ctx.cfg.is_param_inout(param_slot) {
-                    // Received pointer is the caller place's low end; field
-                    // offsets and the scaled index both ADD (ascending).
-                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                    let static_byte_offset = (static_slot_offset as i32) * 8;
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        let addr_vreg = self.mir.alloc_vreg();
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Virtual(ptr_vreg),
-                        });
-                        if static_byte_offset != 0 {
-                            self.mir.push(Aarch64Inst::AddImm {
-                                dst: Operand::Virtual(addr_vreg),
-                                src: Operand::Virtual(addr_vreg),
-                                imm: static_byte_offset,
-                            });
-                        }
-                        self.mir.push(Aarch64Inst::AddRR {
-                            dst: Operand::Virtual(addr_vreg),
-                            src1: Operand::Virtual(addr_vreg),
-                            src2: Operand::Virtual(dyn_offset),
-                        });
-                        crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
-                    } else {
-                        crate::agg_slots::store_slots_through_ptr(
-                            self,
-                            vals,
-                            ptr_vreg,
-                            static_byte_offset,
-                        );
-                    }
-                } else {
-                    let base_low_slot =
-                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_low_slot);
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        let addr_vreg = self.mir.alloc_vreg();
-                        self.mir.push(Aarch64Inst::AddImm {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Physical(Reg::Fp),
-                            imm: base_offset,
-                        });
-                        self.mir.push(Aarch64Inst::AddRR {
-                            dst: Operand::Virtual(addr_vreg),
-                            src1: Operand::Virtual(addr_vreg),
-                            src2: Operand::Virtual(dyn_offset),
-                        });
-                        crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
-                    } else {
-                        crate::agg_slots::store_slots_at_low(self, vals, base_low_slot);
-                    }
-                }
-            }
-        }
-    }
-
-    /// Compute the byte offset for a series of index projections.
-    ///
-    /// Returns a vreg containing the total byte offset (index * stride for each level).
-    fn compute_index_offset(&mut self, levels: &[IndexLevel]) -> VReg {
-        let mut total_offset_vreg: Option<VReg> = None;
-
-        for level in levels {
-            let level_index_vreg = self.get_vreg(level.index);
-            let level_stride = level.elem_slot_count;
-
-            // Scale this level's index by its stride
-            let scaled = self.mir.alloc_vreg();
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Virtual(scaled),
-                src: Operand::Virtual(level_index_vreg),
-            });
-
-            if level_stride == 1 {
-                // Simple case: just shift by 3 (multiply by 8)
-                self.mir.push(Aarch64Inst::LslImm {
-                    dst: Operand::Virtual(scaled),
-                    src: Operand::Virtual(scaled),
-                    imm: 3,
-                });
-            } else {
-                // Multiply by stride * 8
-                let stride_vreg = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Virtual(stride_vreg),
-                    imm: (level_stride * 8) as i64,
-                });
-                self.mir.push(Aarch64Inst::MulRR {
-                    dst: Operand::Virtual(scaled),
-                    src1: Operand::Virtual(scaled),
-                    src2: Operand::Virtual(stride_vreg),
-                });
-            }
-
-            // Add to running total
-            if let Some(prev_total) = total_offset_vreg {
-                self.mir.push(Aarch64Inst::AddRR {
-                    dst: Operand::Virtual(prev_total),
-                    src1: Operand::Virtual(prev_total),
-                    src2: Operand::Virtual(scaled),
-                });
-                // prev_total is modified in place
-            } else {
-                total_offset_vreg = Some(scaled);
-            }
-        }
-
-        total_offset_vreg.expect("compute_index_offset called with empty levels")
-    }
-
-    /// Compute the address of a place (for the @raw intrinsic and for by-ref
-    /// call arguments via `crate::byref_args`, RUE-143).
-    ///
-    /// This is similar to lower_place_read but returns the address instead of
-    /// loading. Index projections are NOT bounds-checked here (@raw is
-    /// deliberately unchecked); by-ref arguments bounds-check first in
-    /// `byref_args::lower_byref_arg_addr`.
-    fn lower_place_addr(&mut self, dst: VReg, place: &Place) {
-        let projections = self.ctx.cfg.get_place_projections(place);
-
-        // Calculate static slot offset from field projections
-        let mut static_slot_offset: u32 = 0;
-        let mut index_levels: Vec<IndexLevel> = Vec::new();
-
-        for proj in projections {
-            match proj {
-                Projection::Field {
-                    struct_id,
-                    field_index,
-                } => {
-                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                    static_slot_offset += field_offset;
-                }
-                Projection::Index { array_type, index } => {
-                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
-                    // offset from the low-end origin is `index*size`, added
-                    // below; the single root-object origin shift covers the
-                    // array's own origin (no per-array `(N-1)` shift).
-                    index_levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-                }
-            }
-        }
-
-        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311); the
-        // resulting address is the accessed place's LOW end, from which slots
-        // ascend. The place's explicit logical base type supplies root_count.
-        let root_count = crate::agg_slots::root_slot_count(self, place);
-
-        // Calculate dynamic offset from index projections
-        let dynamic_offset_vreg = if !index_levels.is_empty() {
-            Some(self.compute_index_offset(&index_levels))
-        } else {
-            None
-        };
-
-        // Compute address based on base type
-        match place.base {
-            PlaceBase::Local(slot) => {
-                let base_low_slot = slot + (root_count - 1) - static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_low_slot);
-
-                // Start with fp + base_offset
-                self.mir.push(Aarch64Inst::AddImm {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::Fp),
-                    imm: base_offset,
-                });
-
-                // Add dynamic offset if any (ascending)
-                if let Some(dyn_offset) = dynamic_offset_vreg {
-                    self.mir.push(Aarch64Inst::AddRR {
-                        dst: Operand::Virtual(dst),
-                        src1: Operand::Virtual(dst),
-                        src2: Operand::Virtual(dyn_offset),
-                    });
-                }
-            }
-            PlaceBase::Param(param_slot) => {
-                if self.ctx.cfg.is_param_inout(param_slot) {
-                    // Received pointer is the caller place's low end; field
-                    // offset and scaled index both ADD (ascending).
-                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                    let static_byte_offset = (static_slot_offset as i32) * 8;
-
-                    // Start with the pointer value
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(dst),
-                        src: Operand::Virtual(ptr_vreg),
-                    });
-
-                    // Add static offset
-                    if static_byte_offset != 0 {
-                        self.mir.push(Aarch64Inst::AddImm {
-                            dst: Operand::Virtual(dst),
-                            src: Operand::Virtual(dst),
-                            imm: static_byte_offset,
-                        });
-                    }
-
-                    // Add dynamic offset
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        self.mir.push(Aarch64Inst::AddRR {
-                            dst: Operand::Virtual(dst),
-                            src1: Operand::Virtual(dst),
-                            src2: Operand::Virtual(dyn_offset),
-                        });
-                    }
-                } else {
-                    let base_low_slot =
-                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_low_slot);
-
-                    self.mir.push(Aarch64Inst::AddImm {
-                        dst: Operand::Virtual(dst),
-                        src: Operand::Physical(Reg::Fp),
-                        imm: base_offset,
-                    });
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        self.mir.push(Aarch64Inst::AddRR {
-                            dst: Operand::Virtual(dst),
-                            src1: Operand::Virtual(dst),
-                            src2: Operand::Virtual(dyn_offset),
-                        });
-                    }
-                }
-            }
-        }
-    }
-
     /// Get the vreg for a CFG value.
     fn get_vreg(&mut self, value: CfgValue) -> VReg {
         if let Some(&vreg) = self.value_map.get(&value) {
@@ -4836,7 +4263,73 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         CfgLower::emit_bounds_check(self, index_vreg, length)
     }
     fn emit_place_addr(&mut self, dst: VReg, place: &Place) {
-        CfgLower::lower_place_addr(self, dst, place)
+        crate::place_lower::lower_place_addr(self, dst, place)
+    }
+}
+
+impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
+    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
+        CfgLower::ensure_inout_param_ptr(self, param_slot)
+    }
+
+    fn emit_frame_addr(&mut self, dst: VReg, slot: u32) {
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Virtual(dst),
+            src: Operand::Physical(Reg::Fp),
+            imm: offset,
+        });
+    }
+
+    fn emit_addr_add(&mut self, dst: VReg, rhs: VReg) {
+        self.mir.push(Aarch64Inst::AddRR {
+            dst: Operand::Virtual(dst),
+            src1: Operand::Virtual(dst),
+            src2: Operand::Virtual(rhs),
+        });
+    }
+
+    fn emit_addr_add_imm(&mut self, dst: VReg, byte_offset: i32) {
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(dst),
+            imm: byte_offset,
+        });
+    }
+
+    fn emit_scale_index_bytes(&mut self, scaled: VReg, elem_slot_count: u32) {
+        if elem_slot_count == 1 {
+            self.mir.push(Aarch64Inst::LslImm {
+                dst: Operand::Virtual(scaled),
+                src: Operand::Virtual(scaled),
+                imm: 3,
+            });
+        } else {
+            let stride = self.mir.alloc_vreg();
+            self.mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(stride),
+                imm: (elem_slot_count * 8) as i64,
+            });
+            self.mir.push(Aarch64Inst::MulRR {
+                dst: Operand::Virtual(scaled),
+                src1: Operand::Virtual(scaled),
+                src2: Operand::Virtual(stride),
+            });
+        }
+    }
+
+    fn emit_zero_sized_place(&mut self, dst: VReg) {
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(dst),
+            imm: 0,
+        });
+    }
+
+    fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg) {
+        self.mir.push(Aarch64Inst::LdrIndexed {
+            dst: Operand::Virtual(dst),
+            base: ptr,
+        });
     }
 }
 
@@ -4893,17 +4386,6 @@ impl crate::aggregate_eq::AggregateEqBackend for CfgLower<'_> {
 }
 
 impl crate::byref_args::ByrefAddrBackend for CfgLower<'_> {
-    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
-        CfgLower::ensure_inout_param_ptr(self, param_slot)
-    }
-    fn emit_frame_addr(&mut self, dst: VReg, slot: u32) {
-        let offset = self.ctx.local_offset(slot);
-        self.mir.push(Aarch64Inst::AddImm {
-            dst: Operand::Virtual(dst),
-            src: Operand::Physical(Reg::Fp),
-            imm: offset,
-        });
-    }
     fn record_deferred_error(&mut self, err: CompileError) {
         self.deferred_error.get_or_insert(err);
     }

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -466,6 +466,7 @@ impl<'a> Emitter<'a> {
     pub fn emit_all(mut self) -> CompileResult<EmittedCode> {
         self.emit_asm = true;
         self.emit_internal()?;
+        crate::synchronize_emitted_bytes(&mut self.instructions, &self.code)?;
         Ok(EmittedCode {
             instructions: self.instructions,
             relocations: self.relocations,

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -38,6 +38,50 @@ use crate::regalloc::RegAllocDebugInfo;
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation};
 
+fn prepare_backend(
+    cfg: &Cfg,
+    type_pool: &TypeInternPool,
+    interner: &ThreadedRodeo,
+    target: Target,
+) -> CompileResult<crate::codegen_pipeline::PreparedMir<Aarch64Mir, Reg>> {
+    crate::codegen_pipeline::prepare_mir(
+        cfg,
+        type_pool,
+        cfg_lower::RET_REGS.len() as u32,
+        || CfgLower::new(cfg, type_pool, interner, target).lower(),
+        |mir, existing_slots| RegAlloc::new(mir, existing_slots).allocate_with_spills(),
+        |mir| {
+            peephole::optimize(mir.instructions_vec_mut());
+        },
+        schedule::schedule,
+        verify::verify_stack_alignment,
+    )
+}
+
+fn generate_inner<T, Emit>(
+    cfg: &Cfg,
+    type_pool: &TypeInternPool,
+    strings: &[String],
+    interner: &ThreadedRodeo,
+    target: Target,
+    emit: Emit,
+) -> CompileResult<T>
+where
+    Emit: for<'a> FnOnce(Emitter<'a>) -> CompileResult<T>,
+{
+    let prepared = prepare_backend(cfg, type_pool, interner, target)?;
+    let emitter = Emitter::new(
+        &prepared.mir,
+        prepared.total_locals,
+        prepared.num_locals_original,
+        prepared.num_params,
+        &prepared.used_callee_saved,
+        strings,
+    )
+    .with_sret(prepared.has_sret);
+    emit(emitter)
+}
+
 /// Generate machine code from CFG.
 ///
 /// This is the main entry point for AArch64 code generation.
@@ -48,51 +92,14 @@ pub fn generate(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<MachineCode> {
-    let num_locals = cfg.num_locals();
-    let num_params = cfg.num_params();
-    // sret returns reserve one extra frame slot (one past the param area)
-    // for the incoming buffer pointer; see crate::cfg_lower::type_uses_sret_return.
-    let has_sret =
-        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
-
-    // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner, target).lower()?;
-
-    // Allocate physical registers
-    // Spill slots go after locals, parameters AND the sret pointer slot to avoid conflicts
-    let existing_slots = num_locals + num_params + has_sret as u32;
-    let (mut mir, num_spills, used_callee_saved) =
-        RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
-
-    // Apply peephole optimizations after register allocation
-    peephole::optimize(mir.instructions_vec_mut());
-
-    // Schedule instructions for better performance
-    schedule::schedule(&mut mir);
-
-    // Verify stack alignment. This is a correctness check (a misaligned call
-    // violates the AAPCS64 ABI and can crash at runtime) and already returns a
-    // real ice_error, so it runs in release too — not gated on
-    // debug_assertions (RUE-45).
-    verify::verify_stack_alignment(&mir)?;
-
-    // Emit machine code bytes
-    let total_locals = num_locals + num_spills;
-    let (code, relocations) = Emitter::new(
-        &mir,
-        total_locals,
-        num_locals,
-        num_params,
-        &used_callee_saved,
-        strings,
-    )
-    .with_sret(has_sret)
-    .emit()?;
-
-    Ok(MachineCode {
-        code,
-        relocations,
-        strings: strings.to_vec(),
+    generate_inner(cfg, type_pool, strings, interner, target, |emitter| {
+        // Keep the normal path allocation-free with respect to assembly text.
+        let (code, relocations) = emitter.emit()?;
+        Ok(MachineCode {
+            code,
+            relocations,
+            strings: strings.to_vec(),
+        })
     })
 }
 
@@ -107,52 +114,16 @@ pub fn generate_with_asm(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<(MachineCode, String)> {
-    let num_locals = cfg.num_locals();
-    let num_params = cfg.num_params();
-    let has_sret =
-        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
-
-    // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner, target).lower()?;
-
-    // Allocate physical registers
-    let existing_slots = num_locals + num_params + has_sret as u32;
-    let (mut mir, num_spills, used_callee_saved) =
-        RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
-
-    // Apply peephole optimizations after register allocation
-    peephole::optimize(mir.instructions_vec_mut());
-
-    // Schedule instructions for better performance
-    schedule::schedule(&mut mir);
-
-    // Verify stack alignment. This is a correctness check (a misaligned call
-    // violates the AAPCS64 ABI and can crash at runtime) and already returns a
-    // real ice_error, so it runs in release too — not gated on
-    // debug_assertions (RUE-45).
-    verify::verify_stack_alignment(&mir)?;
-
-    // Emit machine code bytes with assembly text
-    let total_locals = num_locals + num_spills;
-    let emitted = Emitter::new(
-        &mir,
-        total_locals,
-        num_locals,
-        num_params,
-        &used_callee_saved,
-        strings,
-    )
-    .with_sret(has_sret)
-    .emit_all()?;
-
-    let asm = emitted.to_asm();
-    let machine_code = MachineCode {
-        code: emitted.to_bytes(),
-        relocations: emitted.relocations,
-        strings: strings.to_vec(),
-    };
-
-    Ok((machine_code, asm))
+    generate_inner(cfg, type_pool, strings, interner, target, |emitter| {
+        let emitted = emitter.emit_all()?;
+        let asm = emitted.to_asm();
+        let machine_code = MachineCode {
+            code: emitted.to_bytes(),
+            relocations: emitted.relocations,
+            strings: strings.to_vec(),
+        };
+        Ok((machine_code, asm))
+    })
 }
 
 /// Generate register allocation debug info from CFG.

--- a/crates/rue-codegen/src/byref_args.rs
+++ b/crates/rue-codegen/src/byref_args.rs
@@ -11,9 +11,10 @@
 //! Like [`crate::agg_slots`], the decision logic here is target-independent —
 //! which argument shapes are addressable, that every index projection is
 //! bounds-checked before the address is formed — so backends only provide
-//! the leaf operations: take a frame slot's address and fetch a received
-//! by-ref pointer (via [`ByrefAddrBackend`]), plus the bounds check and
-//! projected-place address formation that now live on [`SlotBackend`]
+//! the leaf operations in [`crate::place_lower::PlaceLowerBackend`], plus the
+//! deferred-diagnostic hook on [`ByrefAddrBackend`]. Bounds checks and
+//! projected-place address formation are shared through
+//! [`crate::agg_slots::SlotBackend`]
 //! (the indexed-place-read materialization in `agg_slots` needs them too,
 //! RUE-188). `emit_place_addr` is the same math the backend's
 //! `PlaceRead`/`PlaceWrite` lowering uses: it yields the place's LOW-end
@@ -23,21 +24,12 @@
 use rue_cfg::{CfgInstData, CfgValue, Place, Projection};
 use rue_error::{CompileError, ErrorKind};
 
-use crate::agg_slots::SlotBackend;
+use crate::place_lower::PlaceLowerBackend;
 use crate::vreg::VReg;
 
-/// The per-backend leaf operations by-ref address formation needs, on top of
-/// the [`SlotBackend`] basics (`ctx`, `alloc_vreg`, `get_vreg`,
-/// `emit_reg_move`, `emit_bounds_check`, `emit_place_addr`).
-pub trait ByrefAddrBackend: SlotBackend {
-    /// Get (or lazily materialize) the pointer vreg of a by-ref (inout or
-    /// borrow) parameter of the CURRENT function.
-    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg;
-
-    /// Emit `dst = address of frame slot` (`lea dst, [rbp+off]` /
-    /// `add dst, fp, #off`).
-    fn emit_frame_addr(&mut self, dst: VReg, slot: u32);
-
+/// The deferred-diagnostic hook by-ref argument lowering needs on top of the
+/// shared place-lowering operations.
+pub trait ByrefAddrBackend: PlaceLowerBackend {
     /// Record a user-facing diagnostic discovered during the (infallible)
     /// lowering pass, to be surfaced by `generate()` once lowering finishes.
     /// Only the FIRST recorded error is kept. See [`lower_byref_arg_addr`].

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -26,16 +26,6 @@ use rue_cfg::{BlockId, Cfg, CfgValue, Type};
 
 use crate::types;
 
-/// Represents an index operation: the index value and the stride (slots per element).
-/// Used for lowering Place projections that include array indexing.
-#[derive(Clone)]
-pub struct IndexLevel {
-    pub index: CfgValue,
-    pub elem_slot_count: u32,
-    /// The array type (Type::Array(...)) for bounds checking.
-    pub array_type: Type,
-}
-
 /// A single lowering decision: maps one CFG instruction to its MIR expansion.
 #[derive(Debug, Clone)]
 pub struct LoweringDecision {

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -1,0 +1,136 @@
+//! Shared backend pass sequencing and frame accounting (RUE-607).
+//!
+//! Concrete MIR, register allocation, instruction selection, scheduling facts,
+//! verification rules, and emission remain target-specific. The order in which
+//! those passes run — and the distinction between spill-placement slots and
+//! emitted-frame locals — is common to every machine-code emission entry point.
+
+use rue_air::TypeInternPool;
+use rue_cfg::Cfg;
+use rue_error::CompileResult;
+
+/// A target's MIR after allocation, peephole optimization, scheduling, and
+/// stack verification, together with the frame metadata its emitter needs.
+pub(crate) struct PreparedMir<M, R> {
+    pub(crate) mir: M,
+    pub(crate) total_locals: u32,
+    pub(crate) num_locals_original: u32,
+    pub(crate) num_params: u32,
+    pub(crate) has_sret: bool,
+    pub(crate) used_callee_saved: Vec<R>,
+}
+
+/// Run the target-independent backend pipeline around concrete pass hooks.
+///
+/// The closures monomorphize for each backend; there is no dynamic dispatch or
+/// universal backend trait. Keeping the two slot formulas here is deliberate:
+///
+/// - `existing_slots` includes locals, parameters, and the optional incoming
+///   sret pointer so register-allocation spills cannot overlap any of them.
+/// - `total_locals` includes only original locals and new spill slots because
+///   emitters account for parameters and sret separately.
+pub(crate) fn prepare_mir<M, R, Lower, Allocate, Peephole, Schedule, Verify>(
+    cfg: &Cfg,
+    type_pool: &TypeInternPool,
+    return_reg_count: u32,
+    lower: Lower,
+    allocate: Allocate,
+    peephole: Peephole,
+    schedule: Schedule,
+    verify: Verify,
+) -> CompileResult<PreparedMir<M, R>>
+where
+    Lower: FnOnce() -> CompileResult<M>,
+    Allocate: FnOnce(M, u32) -> CompileResult<(M, u32, Vec<R>)>,
+    Peephole: FnOnce(&mut M),
+    Schedule: FnOnce(&mut M),
+    Verify: FnOnce(&M) -> CompileResult<()>,
+{
+    let num_locals_original = cfg.num_locals();
+    let num_params = cfg.num_params();
+    let has_sret = crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, return_reg_count);
+
+    let mir = lower()?;
+    let existing_slots = num_locals_original + num_params + u32::from(has_sret);
+    let (mut mir, num_spills, used_callee_saved) = allocate(mir, existing_slots)?;
+
+    peephole(&mut mir);
+    schedule(&mut mir);
+    verify(&mir)?;
+
+    Ok(PreparedMir {
+        mir,
+        total_locals: num_locals_original + num_spills,
+        num_locals_original,
+        num_params,
+        has_sret,
+        used_callee_saved,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use rue_air::{Type, TypeInternPool};
+    use rue_cfg::Cfg;
+
+    use super::prepare_mir;
+
+    #[test]
+    fn pass_order_and_frame_slot_formulas_are_single_source() {
+        let type_pool = TypeInternPool::new();
+        let array_id = type_pool.intern_array_from_type(Type::I32, 7);
+        let cfg = Cfg::new(
+            Type::new_array(array_id),
+            3,
+            2,
+            "pipeline_test".to_owned(),
+            vec![false, false],
+        );
+        let events = RefCell::new(Vec::new());
+
+        // A seven-slot return exceeds the six-register budget, so spill
+        // placement sees 3 locals + 2 params + 1 sret-pointer slot. Four
+        // spills then produce 3 + 4 emitted locals (not 3 + 2 + 1 + 4).
+        let prepared = prepare_mir(
+            &cfg,
+            &type_pool,
+            6,
+            || {
+                events.borrow_mut().push("lower");
+                Ok(10_u32)
+            },
+            |mir, existing_slots| {
+                events.borrow_mut().push("allocate");
+                assert_eq!(existing_slots, 6);
+                Ok((mir + 1, 4, vec![5_u8]))
+            },
+            |mir| {
+                events.borrow_mut().push("peephole");
+                *mir += 2;
+            },
+            |mir| {
+                events.borrow_mut().push("schedule");
+                *mir += 3;
+            },
+            |mir| {
+                events.borrow_mut().push("verify");
+                assert_eq!(*mir, 16);
+                Ok(())
+            },
+        )
+        .expect("synthetic pipeline should succeed");
+
+        assert_eq!(
+            events.into_inner(),
+            ["lower", "allocate", "peephole", "schedule", "verify"]
+        );
+        assert_eq!(prepared.mir, 16);
+        assert_eq!(prepared.total_locals, 7);
+        assert_eq!(prepared.num_locals_original, 3);
+        assert_eq!(prepared.num_params, 2);
+        assert!(prepared.has_sret);
+        assert_eq!(prepared.used_callee_saved, [5]);
+    }
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -52,6 +52,7 @@ pub mod byref_args;
 pub mod cfg_lower;
 pub mod index_map;
 pub mod liveness;
+pub mod place_lower;
 pub mod regalloc;
 pub mod types;
 pub mod vreg;

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -41,6 +41,7 @@ macro_rules! end_inst {
     };
 }
 
+mod codegen_pipeline;
 mod schedule_core;
 mod stack_frame;
 mod stack_verify;
@@ -339,12 +340,11 @@ pub use x86_64::{Operand, Reg, X86Inst, X86Mir};
 mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
-    use rue_air::{Air, AirInst, AirInstData, Type};
-    use rue_cfg::CfgBuilder;
+    use rue_air::{Air, AirInst, AirInstData, Type, TypeInternPool};
+    use rue_cfg::{Cfg, CfgBuilder};
     use rue_span::Span;
 
-    #[test]
-    fn test_generate_x86_64() {
+    fn test_cfg() -> (Cfg, TypeInternPool, ThreadedRodeo) {
         let mut air = Air::new(Type::I32);
 
         let const_ref = air.add_inst(AirInst {
@@ -359,14 +359,70 @@ mod tests {
             span: Span::new(0, 2),
         });
 
-        // Build CFG from AIR (no struct/array types in this simple test)
         let interner = ThreadedRodeo::new();
-        let type_pool = rue_air::TypeInternPool::new();
+        let type_pool = TypeInternPool::new();
         let cfg_output =
             CfgBuilder::build(&air, 0, 0, "main", &type_pool, vec![], &interner, false);
+        (cfg_output.cfg, type_pool, interner)
+    }
+
+    fn syscall_cfg() -> (Cfg, TypeInternPool, ThreadedRodeo) {
+        let type_pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let mut air = Air::new(Type::I64);
+        let span = Span::new(0, 2);
+        let number = air.add_inst(AirInst {
+            data: AirInstData::Const(1),
+            ty: Type::I64,
+            span,
+        });
+        let args_start = air.add_extra(&[number.as_u32()]);
+        let result = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name: interner.get_or_intern("syscall"),
+                args_start,
+                args_len: 1,
+            },
+            ty: Type::I64,
+            span,
+        });
+        air.add_inst(AirInst {
+            data: AirInstData::Ret(Some(result)),
+            ty: Type::I64,
+            span,
+        });
+
+        let cfg_output = CfgBuilder::build(
+            &air,
+            0,
+            0,
+            "syscall_parity",
+            &type_pool,
+            vec![],
+            &interner,
+            false,
+        );
+        (cfg_output.cfg, type_pool, interner)
+    }
+
+    fn assert_same_machine_code(normal: &MachineCode, with_asm: &MachineCode) {
+        assert_eq!(normal.code, with_asm.code);
+        assert_eq!(normal.strings, with_asm.strings);
+        assert_eq!(normal.relocations.len(), with_asm.relocations.len());
+        for (normal, with_asm) in normal.relocations.iter().zip(&with_asm.relocations) {
+            assert_eq!(normal.offset, with_asm.offset);
+            assert_eq!(normal.symbol, with_asm.symbol);
+            assert_eq!(normal.kind, with_asm.kind);
+            assert_eq!(normal.addend, with_asm.addend);
+        }
+    }
+
+    #[test]
+    fn test_generate_x86_64() {
+        let (cfg, type_pool, interner) = test_cfg();
 
         // Test the generate function
-        let machine_code = generate(&cfg_output.cfg, &type_pool, &[], &interner).unwrap();
+        let machine_code = generate(&cfg, &type_pool, &[], &interner).unwrap();
 
         // Should generate working code
         assert!(!machine_code.code.is_empty());
@@ -383,5 +439,75 @@ mod tests {
 
         // Should have no strings
         assert!(machine_code.strings.is_empty());
+    }
+
+    #[test]
+    fn normal_and_assembly_entry_points_emit_identical_machine_code() {
+        let (cfg, type_pool, interner) = test_cfg();
+        let strings = vec!["pipeline parity sentinel".to_owned()];
+
+        let x86 = x86_64::generate(&cfg, &type_pool, &strings, &interner)
+            .expect("x86 normal generation should succeed");
+        let (x86_asm_code, x86_asm) =
+            x86_64::generate_with_asm(&cfg, &type_pool, &strings, &interner)
+                .expect("x86 assembly generation should succeed");
+        assert_same_machine_code(&x86, &x86_asm_code);
+        assert!(!x86_asm.is_empty());
+
+        for target in [
+            rue_target::Target::Aarch64Linux,
+            rue_target::Target::Aarch64Macos,
+        ] {
+            let arm = aarch64::generate(&cfg, &type_pool, &strings, &interner, target)
+                .expect("AArch64 normal generation should succeed");
+            let (arm_asm_code, arm_asm) =
+                aarch64::generate_with_asm(&cfg, &type_pool, &strings, &interner, target)
+                    .expect("AArch64 assembly generation should succeed");
+            assert_same_machine_code(&arm, &arm_asm_code);
+            assert!(!arm_asm.is_empty());
+        }
+    }
+
+    #[test]
+    fn aarch64_entry_points_preserve_target_specific_syscall_lowering() {
+        let (cfg, type_pool, interner) = syscall_cfg();
+        let linux = aarch64::generate(
+            &cfg,
+            &type_pool,
+            &[],
+            &interner,
+            rue_target::Target::Aarch64Linux,
+        )
+        .expect("AArch64 Linux normal generation should succeed");
+        let (linux_asm_code, linux_asm) = aarch64::generate_with_asm(
+            &cfg,
+            &type_pool,
+            &[],
+            &interner,
+            rue_target::Target::Aarch64Linux,
+        )
+        .expect("AArch64 Linux assembly generation should succeed");
+        assert_same_machine_code(&linux, &linux_asm_code);
+        assert!(linux_asm.contains("svc #0x0"));
+
+        let macos = aarch64::generate(
+            &cfg,
+            &type_pool,
+            &[],
+            &interner,
+            rue_target::Target::Aarch64Macos,
+        )
+        .expect("AArch64 macOS normal generation should succeed");
+        let (macos_asm_code, macos_asm) = aarch64::generate_with_asm(
+            &cfg,
+            &type_pool,
+            &[],
+            &interner,
+            rue_target::Target::Aarch64Macos,
+        )
+        .expect("AArch64 macOS assembly generation should succeed");
+        assert_same_machine_code(&macos, &macos_asm_code);
+        assert!(macos_asm.contains("svc #0x80"));
+        assert_ne!(linux.code, macos.code);
     }
 }

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -45,6 +45,7 @@ mod codegen_pipeline;
 mod schedule_core;
 mod stack_frame;
 mod stack_verify;
+mod storage_lower;
 
 pub mod aarch64;
 pub mod agg_slots;

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -231,6 +231,38 @@ impl EmittedInst {
     }
 }
 
+/// Replace assembly-mode instruction snapshots with the final bytes after
+/// label fixups have patched the emitter's contiguous code buffer.
+///
+/// Instruction sizes never change during fixup: x86-64 uses fixed-width rel32
+/// jumps and AArch64 branches are always four bytes. Labels and comments have
+/// zero-length snapshots, so walking the recorded lengths reconstructs the
+/// exact byte range belonging to every instruction without target knowledge.
+pub(crate) fn synchronize_emitted_bytes(
+    instructions: &mut [EmittedInst],
+    code: &[u8],
+) -> rue_error::CompileResult<()> {
+    let recorded_len: usize = instructions.iter().map(|inst| inst.bytes.len()).sum();
+    if recorded_len != code.len() {
+        return Err(rue_error::ice_error!(
+            "assembly instruction byte coverage mismatch",
+            phase: "codegen/emit",
+            details: {
+                "recorded_bytes" => recorded_len.to_string(),
+                "emitted_bytes" => code.len().to_string()
+            }
+        ));
+    }
+
+    let mut offset = 0;
+    for inst in instructions {
+        let end = offset + inst.bytes.len();
+        inst.bytes.copy_from_slice(&code[offset..end]);
+        offset = end;
+    }
+    Ok(())
+}
+
 /// Result of emitting a function's machine code.
 ///
 /// This holds all emitted instructions along with metadata needed for
@@ -366,6 +398,63 @@ mod tests {
         (cfg_output.cfg, type_pool, interner)
     }
 
+    fn aggregate_cfg(len: u64) -> (Cfg, TypeInternPool, ThreadedRodeo) {
+        let type_pool = TypeInternPool::new();
+        let array_id = type_pool.intern_array_from_type(Type::I64, len);
+        let array_ty = Type::new_array(array_id);
+        let mut air = Air::new(array_ty);
+        let span = Span::new(0, 2);
+
+        let seed = air.add_inst(AirInst {
+            data: AirInstData::Const(1),
+            ty: Type::I64,
+            span,
+        });
+        let mut elements = Vec::with_capacity(len as usize);
+        for value in 0..len {
+            let rhs = air.add_inst(AirInst {
+                data: AirInstData::Const(value),
+                ty: Type::I64,
+                span,
+            });
+            elements.push(
+                air.add_inst(AirInst {
+                    data: AirInstData::Add(seed, rhs),
+                    ty: Type::I64,
+                    span,
+                })
+                .as_u32(),
+            );
+        }
+        let elements_start = air.add_extra(&elements);
+        let array = air.add_inst(AirInst {
+            data: AirInstData::ArrayInit {
+                elems_start: elements_start,
+                elems_len: len as u32,
+            },
+            ty: array_ty,
+            span,
+        });
+        air.add_inst(AirInst {
+            data: AirInstData::Ret(Some(array)),
+            ty: array_ty,
+            span,
+        });
+
+        let interner = ThreadedRodeo::new();
+        let cfg_output = CfgBuilder::build(
+            &air,
+            3,
+            2,
+            "pipeline_parity",
+            &type_pool,
+            vec![false, false],
+            &interner,
+            false,
+        );
+        (cfg_output.cfg, type_pool, interner)
+    }
+
     fn syscall_cfg() -> (Cfg, TypeInternPool, ThreadedRodeo) {
         let type_pool = TypeInternPool::new();
         let interner = ThreadedRodeo::new();
@@ -418,6 +507,30 @@ mod tests {
     }
 
     #[test]
+    fn emitted_byte_synchronization_handles_labels_and_rejects_gaps() {
+        let mut instructions = vec![
+            EmittedInst::comment("before"),
+            EmittedInst::new([0, 0], "first"),
+            EmittedInst::label("target"),
+            EmittedInst::new([0], "second"),
+        ];
+        synchronize_emitted_bytes(&mut instructions, &[1, 2, 3])
+            .expect("recorded instruction lengths cover the final code");
+        assert_eq!(instructions[0].bytes, []);
+        assert_eq!(instructions[1].bytes, [1, 2]);
+        assert_eq!(instructions[2].bytes, []);
+        assert_eq!(instructions[3].bytes, [3]);
+
+        let error = synchronize_emitted_bytes(&mut instructions, &[1, 2, 3, 4])
+            .expect_err("a byte-coverage gap must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("assembly instruction byte coverage mismatch")
+        );
+    }
+
+    #[test]
     fn test_generate_x86_64() {
         let (cfg, type_pool, interner) = test_cfg();
 
@@ -442,8 +555,41 @@ mod tests {
     }
 
     #[test]
-    fn normal_and_assembly_entry_points_emit_identical_machine_code() {
-        let (cfg, type_pool, interner) = test_cfg();
+    fn normal_and_assembly_entry_points_match_with_sret_and_spills() {
+        let (threshold_cfg, threshold_types, _) = aggregate_cfg(7);
+        assert!(cfg_lower::fn_uses_sret_return(
+            &threshold_cfg,
+            &threshold_types,
+            6
+        ));
+        assert!(!cfg_lower::fn_uses_sret_return(
+            &threshold_cfg,
+            &threshold_types,
+            8
+        ));
+
+        let (cfg, type_pool, interner) = aggregate_cfg(40);
+        assert!(cfg_lower::fn_uses_sret_return(&cfg, &type_pool, 6));
+        assert!(cfg_lower::fn_uses_sret_return(&cfg, &type_pool, 8));
+        assert!(
+            !x86_64::generate_regalloc_info(&cfg, &type_pool, &interner)
+                .expect("x86 register allocation should succeed")
+                .spills
+                .is_empty(),
+            "fixture must exercise x86 spills"
+        );
+        assert!(
+            !aarch64::generate_regalloc_info(
+                &cfg,
+                &type_pool,
+                &interner,
+                rue_target::Target::Aarch64Linux,
+            )
+            .expect("AArch64 register allocation should succeed")
+            .spills
+            .is_empty(),
+            "fixture must exercise AArch64 spills"
+        );
         let strings = vec!["pipeline parity sentinel".to_owned()];
 
         let x86 = x86_64::generate(&cfg, &type_pool, &strings, &interner)
@@ -453,6 +599,7 @@ mod tests {
                 .expect("x86 assembly generation should succeed");
         assert_same_machine_code(&x86, &x86_asm_code);
         assert!(!x86_asm.is_empty());
+        assert!(x86_asm.contains("jno "), "fixture must retain rel32 fixups");
 
         for target in [
             rue_target::Target::Aarch64Linux,
@@ -465,6 +612,10 @@ mod tests {
                     .expect("AArch64 assembly generation should succeed");
             assert_same_machine_code(&arm, &arm_asm_code);
             assert!(!arm_asm.is_empty());
+            assert!(
+                arm_asm.contains("b.vc "),
+                "fixture must retain AArch64 branch fixups"
+            );
         }
     }
 

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -1,0 +1,511 @@
+//! Shared lowering for CFG places (RUE-604).
+//!
+//! A [`Place`] names storage rooted at a local or parameter and refined by a
+//! chain of field and array-index projections. The address arithmetic is
+//! target-independent: field offsets accumulate statically, every checked
+//! index is validated before address formation, and dynamic indices contribute
+//! `index * element_size` to the root object's low-end address. Historically
+//! x86-64 and AArch64 each carried a roughly 560-line copy of that algorithm.
+//!
+//! This module owns the algorithm once. Backends retain only the instruction
+//! leaves in [`PlaceLowerBackend`], including two intentionally narrow leaves
+//! that preserve the exact MIR forms emitted before this extraction.
+
+use rue_air::Type;
+use rue_cfg::{CfgValue, Place, PlaceBase, Projection};
+
+use crate::agg_slots::{self, SlotBackend};
+use crate::vreg::VReg;
+
+/// Per-target instruction leaves used by shared place lowering.
+pub trait PlaceLowerBackend: SlotBackend {
+    /// Get or lazily materialize a received inout/borrow parameter pointer.
+    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg;
+
+    /// Emit `dst = address of frame slot`.
+    fn emit_frame_addr(&mut self, dst: VReg, slot: u32);
+
+    /// Add an address held in `rhs` to `dst`, modifying `dst` in place.
+    fn emit_addr_add(&mut self, dst: VReg, rhs: VReg);
+
+    /// Add a nonzero byte displacement to an address in `dst`.
+    fn emit_addr_add_imm(&mut self, dst: VReg, byte_offset: i32);
+
+    /// Scale the copied index in `scaled` by `elem_slot_count * 8` bytes.
+    /// Implementations may allocate target-specific temporary vregs.
+    fn emit_scale_index_bytes(&mut self, scaled: VReg, elem_slot_count: u32);
+
+    /// Materialize the canonical value for a zero-sized place read.
+    ///
+    /// This stays distinct from [`SlotBackend::emit_load_zero`] because x86-64
+    /// historically used a 64-bit immediate here; retaining that exact MIR is
+    /// part of making this extraction mechanically output-neutral.
+    fn emit_zero_sized_place(&mut self, dst: VReg);
+
+    /// Load from the address in `ptr` with no encoded displacement.
+    ///
+    /// AArch64 has separate base-only and base-plus-zero MIR variants. Keeping
+    /// this leaf preserves the pre-extraction choice at simple and dynamically
+    /// addressed place reads.
+    fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg);
+}
+
+#[derive(Clone, Copy)]
+struct IndexLevel {
+    index: CfgValue,
+    elem_slot_count: u32,
+}
+
+struct ProjectionOffsets {
+    static_slot_offset: u32,
+    index_levels: Vec<IndexLevel>,
+}
+
+enum ProjectedAccess {
+    /// A statically known frame slot containing the accessed value's low end.
+    FrameSlot(u32),
+    /// A fully formed address. Reads use the backend's base-only load form.
+    PointerAddr(VReg),
+    /// A received by-ref pointer plus a statically encoded displacement.
+    PointerOffset { ptr: VReg, byte_offset: i32 },
+}
+
+/// Lower a scalar [`Place`] read, including projection bounds checks and
+/// address formation.
+pub fn lower_place_read<B: PlaceLowerBackend>(b: &mut B, dst: VReg, place: &Place, ty: Type) {
+    // This guard must precede root-origin arithmetic: a zero-slot root would
+    // underflow at `root_count - 1`, and there are no bytes to load (RUE-577).
+    if b.ctx().type_slot_count(ty) == 0 {
+        b.emit_zero_sized_place(dst);
+        return;
+    }
+
+    // Clone the compact projection slice so generic emission can mutably
+    // borrow the backend without retaining a borrow through its CFG context.
+    let projections = b.ctx().cfg.get_place_projections(place).to_vec();
+    if projections.is_empty() {
+        match place.base {
+            PlaceBase::Local(slot) => b.emit_load_slot(dst, slot),
+            PlaceBase::Param(param_slot) => {
+                if b.ctx().cfg.is_param_inout(param_slot) {
+                    let ptr = b.ensure_inout_param_ptr(param_slot);
+                    b.emit_load_ptr_base(dst, ptr);
+                } else {
+                    let slot = b.ctx().num_locals + param_slot;
+                    b.emit_load_slot(dst, slot);
+                }
+            }
+        }
+        return;
+    }
+
+    let offsets = analyze_projections(b, &projections, true);
+    match projected_access(b, place, offsets) {
+        ProjectedAccess::FrameSlot(slot) => b.emit_load_slot(dst, slot),
+        ProjectedAccess::PointerAddr(ptr) => b.emit_load_ptr_base(dst, ptr),
+        ProjectedAccess::PointerOffset { ptr, byte_offset } => {
+            b.emit_load_through_ptr(dst, ptr, byte_offset);
+        }
+    }
+}
+
+/// Lower a [`Place`] write. `vals` contains one vreg per logical value slot,
+/// with slot zero first.
+pub fn lower_place_write<B: PlaceLowerBackend>(b: &mut B, place: &Place, vals: &[VReg]) {
+    // A zero-sized value has no storage to update. Current CFG callers filter
+    // these writes before reaching codegen, but keeping the shared boundary
+    // total avoids forming an address for a value with no storage.
+    if vals.is_empty() {
+        return;
+    }
+
+    let projections = b.ctx().cfg.get_place_projections(place).to_vec();
+    if projections.is_empty() {
+        match place.base {
+            PlaceBase::Local(slot) => agg_slots::store_slots(b, vals, slot),
+            PlaceBase::Param(param_slot) => {
+                if b.ctx().cfg.is_param_inout(param_slot) {
+                    let ptr = b.ensure_inout_param_ptr(param_slot);
+                    agg_slots::store_slots_through_ptr(b, vals, ptr, 0);
+                } else {
+                    let slot = b.ctx().num_locals + param_slot;
+                    agg_slots::store_slots(b, vals, slot);
+                }
+            }
+        }
+        return;
+    }
+
+    let offsets = analyze_projections(b, &projections, true);
+    match projected_access(b, place, offsets) {
+        ProjectedAccess::FrameSlot(low_slot) => {
+            agg_slots::store_slots_at_low(b, vals, low_slot);
+        }
+        ProjectedAccess::PointerAddr(ptr) => {
+            agg_slots::store_slots_through_ptr(b, vals, ptr, 0);
+        }
+        ProjectedAccess::PointerOffset { ptr, byte_offset } => {
+            agg_slots::store_slots_through_ptr(b, vals, ptr, byte_offset);
+        }
+    }
+}
+
+/// Emit the low-end address of `place` into `dst`.
+///
+/// Index projections are intentionally unchecked here: `@raw` is unchecked,
+/// while by-ref argument lowering performs its bounds checks before calling
+/// through [`SlotBackend::emit_place_addr`].
+pub fn lower_place_addr<B: PlaceLowerBackend>(b: &mut B, dst: VReg, place: &Place) {
+    let projections = b.ctx().cfg.get_place_projections(place).to_vec();
+    let offsets = analyze_projections(b, &projections, false);
+    let root_count = agg_slots::root_slot_count(b, place);
+    let dynamic_offset = compute_index_offset(b, &offsets.index_levels);
+
+    match place.base {
+        PlaceBase::Local(slot) => {
+            let low_slot = slot + (root_count - 1) - offsets.static_slot_offset;
+            b.emit_frame_addr(dst, low_slot);
+            if let Some(dynamic_offset) = dynamic_offset {
+                b.emit_addr_add(dst, dynamic_offset);
+            }
+        }
+        PlaceBase::Param(param_slot) => {
+            if b.ctx().cfg.is_param_inout(param_slot) {
+                // A received by-ref pointer already denotes the caller place's
+                // low end. Both field and index offsets therefore add.
+                let ptr = b.ensure_inout_param_ptr(param_slot);
+                b.emit_reg_move(dst, ptr);
+                let static_byte_offset = offsets.static_slot_offset as i32 * 8;
+                if static_byte_offset != 0 {
+                    b.emit_addr_add_imm(dst, static_byte_offset);
+                }
+                if let Some(dynamic_offset) = dynamic_offset {
+                    b.emit_addr_add(dst, dynamic_offset);
+                }
+            } else {
+                let low_slot =
+                    b.ctx().num_locals + param_slot + (root_count - 1) - offsets.static_slot_offset;
+                b.emit_frame_addr(dst, low_slot);
+                if let Some(dynamic_offset) = dynamic_offset {
+                    b.emit_addr_add(dst, dynamic_offset);
+                }
+            }
+        }
+    }
+}
+
+fn analyze_projections<B: PlaceLowerBackend>(
+    b: &mut B,
+    projections: &[Projection],
+    check_bounds: bool,
+) -> ProjectionOffsets {
+    let mut static_slot_offset = 0;
+    let mut index_levels = Vec::new();
+
+    for projection in projections {
+        match projection {
+            Projection::Field {
+                struct_id,
+                field_index,
+            } => {
+                static_slot_offset += b.ctx().struct_field_slot_offset(*struct_id, *field_index);
+            }
+            Projection::Index { array_type, index } => {
+                if check_bounds {
+                    // Preserve the historical ordering: every bounds check is
+                    // emitted while walking the chain, before any address math.
+                    let index_vreg = b.get_vreg(*index);
+                    let length = b.ctx().array_length(*array_type);
+                    b.emit_bounds_check(index_vreg, length);
+                }
+                index_levels.push(IndexLevel {
+                    index: *index,
+                    elem_slot_count: b.ctx().array_element_slot_count(*array_type),
+                });
+            }
+        }
+    }
+
+    ProjectionOffsets {
+        static_slot_offset,
+        index_levels,
+    }
+}
+
+fn projected_access<B: PlaceLowerBackend>(
+    b: &mut B,
+    place: &Place,
+    offsets: ProjectionOffsets,
+) -> ProjectedAccess {
+    // Frame slots descend in address, so the root object's low-address end is
+    // its highest-numbered slot. Once anchored there, logical aggregate slots,
+    // field offsets, and scaled indices all ascend in address (ADR-0040).
+    let root_count = agg_slots::root_slot_count(b, place);
+    let dynamic_offset = compute_index_offset(b, &offsets.index_levels);
+
+    match place.base {
+        PlaceBase::Local(slot) => {
+            let low_slot = slot + (root_count - 1) - offsets.static_slot_offset;
+            frame_access(b, low_slot, dynamic_offset)
+        }
+        PlaceBase::Param(param_slot) => {
+            if b.ctx().cfg.is_param_inout(param_slot) {
+                let ptr = b.ensure_inout_param_ptr(param_slot);
+                let static_byte_offset = offsets.static_slot_offset as i32 * 8;
+                if let Some(dynamic_offset) = dynamic_offset {
+                    let addr = b.alloc_vreg();
+                    b.emit_reg_move(addr, ptr);
+                    if static_byte_offset != 0 {
+                        b.emit_addr_add_imm(addr, static_byte_offset);
+                    }
+                    b.emit_addr_add(addr, dynamic_offset);
+                    ProjectedAccess::PointerAddr(addr)
+                } else {
+                    ProjectedAccess::PointerOffset {
+                        ptr,
+                        byte_offset: static_byte_offset,
+                    }
+                }
+            } else {
+                let low_slot =
+                    b.ctx().num_locals + param_slot + (root_count - 1) - offsets.static_slot_offset;
+                frame_access(b, low_slot, dynamic_offset)
+            }
+        }
+    }
+}
+
+fn frame_access<B: PlaceLowerBackend>(
+    b: &mut B,
+    low_slot: u32,
+    dynamic_offset: Option<VReg>,
+) -> ProjectedAccess {
+    if let Some(dynamic_offset) = dynamic_offset {
+        let addr = b.alloc_vreg();
+        b.emit_frame_addr(addr, low_slot);
+        b.emit_addr_add(addr, dynamic_offset);
+        ProjectedAccess::PointerAddr(addr)
+    } else {
+        ProjectedAccess::FrameSlot(low_slot)
+    }
+}
+
+fn compute_index_offset<B: PlaceLowerBackend>(b: &mut B, levels: &[IndexLevel]) -> Option<VReg> {
+    let mut total = None;
+
+    for level in levels {
+        let index = b.get_vreg(level.index);
+        let scaled = b.alloc_vreg();
+        b.emit_reg_move(scaled, index);
+        b.emit_scale_index_bytes(scaled, level.elem_slot_count);
+
+        if let Some(previous) = total {
+            b.emit_addr_add(previous, scaled);
+        } else {
+            total = Some(scaled);
+        }
+    }
+
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use rue_air::Sema;
+    use rue_cfg::CfgBuilder;
+    use rue_error::PreviewFeatures;
+    use rue_lexer::Lexer;
+    use rue_parser::Parser;
+    use rue_rir::AstGen;
+    use rue_target::Target;
+
+    use crate::aarch64::{Aarch64Inst, CfgLower as Aarch64CfgLower};
+    use crate::x86_64::{CfgLower as X86CfgLower, X86Inst};
+
+    /// Exercise all three shared entry points with a field followed by two
+    /// index projections. The outer index has a two-slot stride (multiply),
+    /// while the inner scalar index has a one-slot stride (shift).
+    #[test]
+    fn nested_field_index_read_write_and_addr_lower_on_both_backends() {
+        let source = r#"
+            struct Grid { pad: i32, cells: [[i32; 2]; 2] }
+            struct Empty { unit: () }
+            fn read_inout(inout value: i32) -> i32 { value }
+            fn read_unit(value: Empty) -> () { value.unit }
+            fn main() -> i32 {
+                let mut scalar = 7;
+                let _scalar_read = read_inout(inout scalar);
+                let empty = Empty { unit: () };
+                read_unit(empty);
+                let mut grid = Grid { pad: 9, cells: [[10, 20], [30, 40]] };
+                let i: u64 = 1;
+                let j: u64 = 0;
+                grid.cells[i][j] = grid.cells[i][j] + 1;
+                let _address: ptr const i32 = checked { @raw(grid.cells[i][j]) };
+                grid.cells[i][j]
+            }
+        "#;
+
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().expect("fixture should lex");
+        let parser = Parser::new(tokens, interner);
+        let (ast, mut interner) = parser.parse().expect("fixture should parse");
+        let rir = AstGen::new(&ast, &mut interner).generate();
+        let output = Sema::new(&rir, &mut interner, PreviewFeatures::new())
+            .analyze_all()
+            .expect("fixture should analyze");
+        let build_cfg = |name: &str| {
+            let function = output
+                .functions
+                .iter()
+                .find(|function| function.name == name)
+                .expect("fixture function should exist");
+            CfgBuilder::build(
+                &function.air,
+                function.num_locals,
+                function.num_param_slots,
+                &function.name,
+                &output.type_pool,
+                function.param_modes.clone(),
+                &interner,
+                function.allow_unreachable_code,
+            )
+            .cfg
+        };
+        let cfg = build_cfg("main");
+
+        let x86 = X86CfgLower::new(&cfg, &output.type_pool, &interner)
+            .lower()
+            .expect("x86 fixture should lower");
+        let arm = Aarch64CfgLower::new(&cfg, &output.type_pool, &interner, Target::Aarch64Linux)
+            .lower()
+            .expect("AArch64 fixture should lower");
+
+        // RHS read, write destination, @raw's argument read/address pair, and
+        // final read each walk both indices. Only the write emits an indexed
+        // store; the three ordinary reads emit indexed loads. These counts
+        // make projection traversal regressions visible without snapshotting
+        // unrelated prologue/ABI details.
+        assert_eq!(
+            x86.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, X86Inst::ImulRR64 { .. }))
+                .count(),
+            5
+        );
+        assert_eq!(
+            x86.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, X86Inst::Shl { .. }))
+                .count(),
+            5
+        );
+        assert_eq!(
+            x86.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, X86Inst::MovRMIndexed { .. }))
+                .count(),
+            3
+        );
+        assert_eq!(
+            x86.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, X86Inst::MovMRIndexed { .. }))
+                .count(),
+            1
+        );
+
+        assert_eq!(
+            arm.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, Aarch64Inst::MulRR { .. }))
+                .count(),
+            5
+        );
+        assert_eq!(
+            arm.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, Aarch64Inst::LslImm { .. }))
+                .count(),
+            5
+        );
+        assert_eq!(
+            arm.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, Aarch64Inst::LdrIndexed { .. }))
+                .count(),
+            3
+        );
+        assert_eq!(
+            arm.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, Aarch64Inst::StrIndexedOffset { .. }))
+                .count(),
+            1
+        );
+
+        // Lock down the two deliberately distinct compatibility leaves. A
+        // simple by-ref read must retain AArch64's base-only LdrIndexed form,
+        // while a projected ZST read must materialize zero without attempting
+        // root-origin address arithmetic (and x86 keeps its 64-bit immediate).
+        let inout_cfg = build_cfg("read_inout");
+        let inout_x86 = X86CfgLower::new(&inout_cfg, &output.type_pool, &interner)
+            .lower()
+            .expect("x86 inout fixture should lower");
+        let inout_arm = Aarch64CfgLower::new(
+            &inout_cfg,
+            &output.type_pool,
+            &interner,
+            Target::Aarch64Linux,
+        )
+        .lower()
+        .expect("AArch64 inout fixture should lower");
+        assert!(matches!(
+            inout_x86.instructions(),
+            [
+                X86Inst::MovRM { .. },
+                X86Inst::MovRMIndexed { .. },
+                X86Inst::MovRR { .. },
+                X86Inst::Ret
+            ]
+        ));
+        assert!(matches!(
+            inout_arm.instructions(),
+            [
+                Aarch64Inst::Ldr { .. },
+                Aarch64Inst::LdrIndexed { .. },
+                Aarch64Inst::MovRR { .. },
+                Aarch64Inst::Ret
+            ]
+        ));
+
+        let unit_cfg = build_cfg("read_unit");
+        let unit_x86 = X86CfgLower::new(&unit_cfg, &output.type_pool, &interner)
+            .lower()
+            .expect("x86 ZST fixture should lower");
+        let unit_arm = Aarch64CfgLower::new(
+            &unit_cfg,
+            &output.type_pool,
+            &interner,
+            Target::Aarch64Linux,
+        )
+        .lower()
+        .expect("AArch64 ZST fixture should lower");
+        assert!(matches!(
+            unit_x86.instructions(),
+            [
+                X86Inst::MovRI64 { imm: 0, .. },
+                X86Inst::MovRR { .. },
+                X86Inst::Ret
+            ]
+        ));
+        assert!(matches!(
+            unit_arm.instructions(),
+            [
+                Aarch64Inst::MovImm { imm: 0, .. },
+                Aarch64Inst::MovRR { .. },
+                Aarch64Inst::Ret
+            ]
+        ));
+    }
+}

--- a/crates/rue-codegen/src/storage_lower.rs
+++ b/crates/rue-codegen/src/storage_lower.rs
@@ -1,0 +1,147 @@
+//! Shared local and parameter storage lowering (RUE-612).
+//!
+//! CFG storage operations choose between scalar and flattened aggregate values,
+//! frame slots and received inout pointers, and eager and lazy aggregate
+//! materialization. Those choices are target-independent. Backends retain only
+//! recursive struct flattening and the exact base-only pointer-store MIR leaf.
+
+use rue_cfg::CfgValue;
+
+use crate::agg_slots::{self, SlotBackend};
+use crate::place_lower::PlaceLowerBackend;
+use crate::vreg::VReg;
+
+/// Narrow target-specific leaves used by shared storage lowering.
+pub(crate) trait StorageLowerBackend: PlaceLowerBackend {
+    /// Recursively flatten a struct value not modeled by the slot accessor.
+    fn collect_struct_scalars(&mut self, value: CfgValue) -> Vec<VReg>;
+
+    /// Store through `ptr` using the backend's base-only MIR form.
+    ///
+    /// AArch64 intentionally distinguishes `StrIndexed` from
+    /// `StrIndexedOffset { offset: 0 }`; preserving that distinction keeps this
+    /// extraction byte-for-byte and MIR-for-MIR neutral.
+    fn emit_store_ptr_base(&mut self, src: VReg, ptr: VReg);
+}
+
+/// Lower a local allocation and its initializer.
+pub(crate) fn lower_alloc<B: StorageLowerBackend>(b: &mut B, slot: u32, init: CfgValue) {
+    let init_type = b.ctx().cfg.get_inst(init).ty;
+    if init_type.is_array() {
+        // Materialize lazily-sourced arrays through the accessor and fall back
+        // to recursively flattening ArrayInit values.
+        let scalar_vregs = agg_slots::get_or_compute_field_vregs(b, init)
+            .unwrap_or_else(|| b.collect_array_scalars(init));
+        agg_slots::store_slots(b, &scalar_vregs, slot);
+    } else if b.ctx().is_builtin_string(init_type) {
+        // StrBuf is always the ptr/len/cap three-slot fat pointer. Keep this
+        // before generic structs so a layout drift fails loudly.
+        let field_vregs = agg_slots::get_or_compute_field_vregs(b, init)
+            .expect("string should have fat pointer fields in Alloc");
+        assert_eq!(
+            field_vregs.len(),
+            3,
+            "string should have 3 fields (ptr, len, cap)"
+        );
+        agg_slots::store_slots(b, &field_vregs, slot);
+    } else if b.ctx().is_multislot_aggregate(init_type) {
+        // Struct or payload enum: the accessor handles cached and lazy values;
+        // retain the recursive fallback for sources it does not model.
+        let scalar_vregs = agg_slots::get_or_compute_field_vregs(b, init)
+            .unwrap_or_else(|| b.collect_struct_scalars(init));
+        agg_slots::store_slots(b, &scalar_vregs, slot);
+    } else {
+        let init_vreg = b.get_vreg(init);
+        b.emit_store_slot(init_vreg, slot);
+    }
+}
+
+/// Lower a local load, including flattened aggregate cache bookkeeping.
+pub(crate) fn lower_load<B: StorageLowerBackend>(b: &mut B, value: CfgValue, slot: u32) {
+    let load_type = b.ctx().cfg.get_inst(value).ty;
+
+    if b.ctx().is_builtin_string(load_type) {
+        let slot_vregs = agg_slots::load_slots_at_low(b, slot + 2, 3);
+        let ptr_vreg = slot_vregs[0];
+        b.slot_cache().insert(value, slot_vregs);
+        b.map_value(value, ptr_vreg);
+    } else if load_type.is_array() || b.ctx().is_multislot_aggregate(load_type) {
+        let slot_count = b.ctx().type_slot_count(load_type);
+        let slot_vregs = if slot_count > 0 {
+            agg_slots::load_slots_at_low(b, slot + slot_count - 1, slot_count)
+        } else {
+            Vec::new()
+        };
+
+        b.slot_cache().insert(value, slot_vregs.clone());
+        if let Some(&primary) = slot_vregs.first() {
+            b.map_value(value, primary);
+        } else {
+            let primary = b.alloc_vreg();
+            b.map_value(value, primary);
+        }
+    } else {
+        let vreg = b.alloc_vreg();
+        b.map_value(value, vreg);
+        b.emit_load_slot(vreg, slot);
+    }
+}
+
+/// Lower a store to either a local frame slot or an inout parameter's pointee.
+pub(crate) fn lower_store<B: StorageLowerBackend>(b: &mut B, slot: u32, value: CfgValue) {
+    let value_type = b.ctx().cfg.get_inst(value).ty;
+    let aggregate_vregs = if b.ctx().is_multislot_aggregate(value_type) {
+        agg_slots::get_or_compute_field_vregs(b, value)
+    } else {
+        None
+    };
+
+    if let Some(slot_vregs) = aggregate_vregs {
+        if let Some(param_slot) = inout_param_for_slot(b, slot) {
+            let ptr = b.ensure_inout_param_ptr(param_slot);
+            agg_slots::store_slots_through_ptr(b, &slot_vregs, ptr, 0);
+        } else {
+            agg_slots::store_slots(b, &slot_vregs, slot);
+        }
+    } else {
+        let value_vreg = b.get_vreg(value);
+        if let Some(param_slot) = inout_param_for_slot(b, slot) {
+            let ptr = b.ensure_inout_param_ptr(param_slot);
+            b.emit_store_ptr_base(value_vreg, ptr);
+        } else {
+            b.emit_store_slot(value_vreg, slot);
+        }
+    }
+}
+
+/// Lower a whole-value assignment through an inout parameter pointer.
+pub(crate) fn lower_param_store<B: StorageLowerBackend>(
+    b: &mut B,
+    param_slot: u32,
+    value: CfgValue,
+) {
+    if !b.ctx().cfg.is_param_inout(param_slot) {
+        panic!("ParamStore used on non-inout param slot {}", param_slot);
+    }
+
+    let value_type = b.ctx().cfg.get_inst(value).ty;
+    let aggregate_vregs = if b.ctx().is_multislot_aggregate(value_type) {
+        agg_slots::get_or_compute_field_vregs(b, value)
+    } else {
+        None
+    };
+
+    let ptr = b.ensure_inout_param_ptr(param_slot);
+    if let Some(slot_vregs) = aggregate_vregs {
+        agg_slots::store_slots_through_ptr(b, &slot_vregs, ptr, 0);
+    } else {
+        let value_vreg = b.get_vreg(value);
+        b.emit_store_ptr_base(value_vreg, ptr);
+    }
+}
+
+fn inout_param_for_slot<B: SlotBackend>(b: &B, slot: u32) -> Option<u32> {
+    b.ctx()
+        .slot_to_inout_param_index(slot)
+        .filter(|&param_slot| b.ctx().cfg.is_param_inout(param_slot))
+}

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -30,13 +30,11 @@ use std::collections::HashMap;
 use lasso::ThreadedRodeo;
 use rue_air::{TypeInternPool, TypeKind};
 use rue_builtins::BinOp;
-use rue_cfg::{
-    BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, Type,
-};
+use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, Terminator, Type};
 use rue_error::{CompileError, CompileResult};
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
-use crate::cfg_lower::{CfgLowerContext, IndexLevel};
+use crate::cfg_lower::CfgLowerContext;
 use crate::types;
 use crate::vreg::BLOCK_LABEL_BASE;
 
@@ -1833,9 +1831,9 @@ impl<'a> CfgLower<'a> {
                 if let Some(slot_vregs) = aggregate_vregs {
                     // Check if this slot corresponds to an inout parameter
                     if let Some(param_index) = self.slot_to_inout_param_index(*slot) {
-                        // Whole-aggregate store through the inout pointer. Caller
-                        // slots descend from the pointer (stack grows down), so
-                        // slot i lives at ptr - i*8 — matching the place-read path.
+                        // Whole-aggregate store through the inout pointer. The
+                        // pointer denotes the value's low end, so logical slot i
+                        // lives at ptr + i*8 (ADR-0040 / RUE-311).
                         let ptr_vreg = self.ensure_inout_param_ptr(param_index);
                         crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
                     } else {
@@ -1883,9 +1881,10 @@ impl<'a> CfgLower<'a> {
                 // Whole-value reassignment of a multi-slot aggregate (struct,
                 // builtin String, or array) through inout must write ALL slots
                 // through the pointer, not just the first — same shape as the
-                // aggregate branch of Store above. Caller slots descend from
-                // the pointer (stack grows down), so slot i lives at ptr - i*8.
-                // Unmodeled sources fall back to single-slot. (RUE-145)
+                // aggregate branch of Store above. The pointer denotes the
+                // value's low end, so logical slot i lives at ptr + i*8
+                // (ADR-0040 / RUE-311). Unmodeled sources fall back to
+                // single-slot. (RUE-145)
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
                 let aggregate_vregs = if self.ctx.is_multislot_aggregate(val_type) {
                     self.get_or_compute_field_vregs(*val)
@@ -2511,9 +2510,9 @@ impl<'a> CfgLower<'a> {
 
                     // The result type is the pointee type. An aggregate pointee
                     // (struct/array/payload enum) occupies several 8-byte slots;
-                    // read EVERY slot at its descending byte offset (slot i at
-                    // ptr - i*8, matching how @raw addresses the place and the
-                    // by-ref aggregate load path). Reading only slot 0 dropped
+                    // read EVERY logical slot at its ascending byte offset
+                    // (slot i at ptr + i*8, matching @raw and the by-ref
+                    // aggregate load path). Reading only slot 0 dropped
                     // every field but the first (RUE-242).
                     let result_ty = self.ctx.cfg.get_inst(value).ty;
                     let slot_count = self.ctx.type_slot_count(result_ty);
@@ -2550,8 +2549,8 @@ impl<'a> CfgLower<'a> {
                     let ptr_vreg = self.get_vreg(ptr_val);
 
                     // An aggregate value spans several 8-byte slots; store EVERY
-                    // slot at its descending byte offset (slot i at ptr - i*8),
-                    // symmetric with @ptr_read. Storing only slot 0 dropped
+                    // logical slot at its ascending byte offset (slot i at
+                    // ptr + i*8), symmetric with @ptr_read. Storing only slot 0 dropped
                     // every field but the first (RUE-242).
                     let value_ty = self.ctx.cfg.get_inst(value_val).ty;
                     let slot_count = self.ctx.type_slot_count(value_ty);
@@ -2846,7 +2845,7 @@ impl<'a> CfgLower<'a> {
                         // ADR-0030: Handle PlaceRead for @raw
                         // Compute the address of the place instead of reading from it
                         let result_vreg = self.mir.alloc_vreg();
-                        self.lower_place_addr(result_vreg, place);
+                        crate::place_lower::lower_place_addr(self, result_vreg, place);
                         self.value_map.insert(value, result_vreg);
                     } else if let CfgInstData::Param { index } = &lvalue_inst.data {
                         // @raw of a function parameter: take the ADDRESS of the
@@ -3404,7 +3403,7 @@ impl<'a> CfgLower<'a> {
             CfgInstData::PlaceRead { place } => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
-                self.lower_place_read(vreg, place, ty);
+                crate::place_lower::lower_place_read(self, vreg, place, ty);
             }
 
             CfgInstData::PlaceWrite { place, value: val } => {
@@ -3426,7 +3425,7 @@ impl<'a> CfgLower<'a> {
                 } else {
                     vec![self.get_vreg(*val)]
                 };
-                self.lower_place_write(place, &vals);
+                crate::place_lower::lower_place_write(self, place, &vals);
             }
         }
     }
@@ -4185,588 +4184,6 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    // ========================================================================
-    // Place operations (ADR-0030)
-    // ========================================================================
-
-    /// Lower a PlaceRead instruction.
-    ///
-    /// A place consists of a base (local slot or param slot) and zero or more
-    /// projections (field accesses and array indices). This function computes
-    /// the final memory address and loads from it.
-    fn lower_place_read(&mut self, dst: VReg, place: &Place, ty: Type) {
-        // A zero-sized read has no bytes to load (RUE-577): define dst as the
-        // canonical 0 — matching UnitConst's lowering, so unit equality
-        // compares 0 == 0 — and skip address formation entirely (a ZST root's
-        // `root_count - 1` origin shift would underflow, and an 8-byte MovRM
-        // would read a neighbor's slot or out of frame).
-        if self.ctx.type_slot_count(ty) == 0 {
-            self.mir.push(X86Inst::MovRI64 {
-                dst: Operand::Virtual(dst),
-                imm: 0,
-            });
-            return;
-        }
-        let projections = self.ctx.cfg.get_place_projections(place);
-
-        // Simple case: no projections, just load from the base slot
-        if projections.is_empty() {
-            match place.base {
-                PlaceBase::Local(slot) => {
-                    let offset = self.ctx.local_offset(slot);
-                    self.mir.push(X86Inst::MovRM {
-                        dst: Operand::Virtual(dst),
-                        base: Reg::Rbp,
-                        offset,
-                    });
-                }
-                PlaceBase::Param(param_slot) => {
-                    // Check if this is an inout parameter
-                    if self.ctx.cfg.is_param_inout(param_slot) {
-                        // Inout param - load through the pointer
-                        let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                        self.mir.push(X86Inst::MovRMIndexed {
-                            dst: Operand::Virtual(dst),
-                            base: ptr_vreg,
-                            offset: 0,
-                        });
-                    } else {
-                        // Normal param - load from local slot
-                        let slot = self.ctx.num_locals + param_slot;
-                        let offset = self.ctx.local_offset(slot);
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(dst),
-                            base: Reg::Rbp,
-                            offset,
-                        });
-                    }
-                }
-            }
-            return;
-        }
-
-        // Complex case: has projections - compute the address
-        self.lower_place_read_with_projections(dst, place, projections);
-    }
-
-    /// Lower a PlaceRead with projections (field accesses and/or array indices).
-    fn lower_place_read_with_projections(
-        &mut self,
-        dst: VReg,
-        place: &Place,
-        projections: &[Projection],
-    ) {
-        // Calculate the static field offset (sum of all Field projection offsets)
-        let mut static_slot_offset: u32 = 0;
-
-        // Collect index projections for dynamic offset calculation
-        let mut index_levels: Vec<IndexLevel> = Vec::new();
-
-        for proj in projections {
-            match proj {
-                Projection::Field {
-                    struct_id,
-                    field_index,
-                } => {
-                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                    static_slot_offset += field_offset;
-                }
-                Projection::Index { array_type, index } => {
-                    // Emit bounds check for this index
-                    let index_vreg = self.get_vreg(*index);
-                    let array_length = self.ctx.array_length(*array_type);
-                    self.emit_bounds_check(index_vreg, array_length);
-
-                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
-                    // offset from the array's low-end origin is `index*size`,
-                    // added below. The single root-object origin shift (applied
-                    // when forming the base address) already places us at the
-                    // low end, so no per-array `(N-1)` shift is needed.
-                    index_levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-                }
-            }
-        }
-
-        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311): a
-        // frame-resident aggregate's low-address end is its highest-numbered
-        // slot, `root_base + root_count - 1`. Field offsets then move UP in
-        // address (toward higher addresses = lower slot numbers).
-        let root_count = crate::agg_slots::root_slot_count(self, place);
-
-        // Calculate dynamic offset from index projections
-        let dynamic_offset_vreg = if !index_levels.is_empty() {
-            Some(self.compute_index_offset(&index_levels))
-        } else {
-            None
-        };
-
-        // Compute final address based on base type
-        match place.base {
-            PlaceBase::Local(slot) => {
-                let base_slot = slot + (root_count - 1) - static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_slot);
-
-                if let Some(dyn_offset) = dynamic_offset_vreg {
-                    // Compute address: rbp + base_offset + dynamic_offset (ascending, ADR-0040)
-                    let addr_vreg = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::Lea {
-                        dst: Operand::Virtual(addr_vreg),
-                        base: Reg::Rbp,
-                        disp: base_offset,
-                    });
-                    // Ascending layout: element i is at base + i*size, so ADD
-                    // the scaled index to the (lowest-address) origin (ADR-0040).
-                    self.mir.push(X86Inst::AddRR64 {
-                        dst: Operand::Virtual(addr_vreg),
-                        src: Operand::Virtual(dyn_offset),
-                    });
-                    self.mir.push(X86Inst::MovRMIndexed {
-                        dst: Operand::Virtual(dst),
-                        base: addr_vreg,
-                        offset: 0,
-                    });
-                } else {
-                    // Static offset only
-                    self.mir.push(X86Inst::MovRM {
-                        dst: Operand::Virtual(dst),
-                        base: Reg::Rbp,
-                        offset: base_offset,
-                    });
-                }
-            }
-            PlaceBase::Param(param_slot) => {
-                if self.ctx.cfg.is_param_inout(param_slot) {
-                    // Inout param - use pointer. The received pointer is the
-                    // caller place's low end, so field offsets and the scaled
-                    // index both ADD (ascending, ADR-0040 / RUE-311).
-                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                    let static_byte_offset = (static_slot_offset as i32) * 8;
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        // Compute address: ptr + static_offset + dynamic_offset (ascending)
-                        let addr_vreg = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Virtual(ptr_vreg),
-                        });
-                        if static_byte_offset != 0 {
-                            let offset_vreg = self.mir.alloc_vreg();
-                            self.mir.push(X86Inst::MovRI64 {
-                                dst: Operand::Virtual(offset_vreg),
-                                imm: static_byte_offset as i64,
-                            });
-                            self.mir.push(X86Inst::AddRR64 {
-                                dst: Operand::Virtual(addr_vreg),
-                                src: Operand::Virtual(offset_vreg),
-                            });
-                        }
-                        self.mir.push(X86Inst::AddRR64 {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Virtual(dyn_offset),
-                        });
-                        self.mir.push(X86Inst::MovRMIndexed {
-                            dst: Operand::Virtual(dst),
-                            base: addr_vreg,
-                            offset: 0,
-                        });
-                    } else {
-                        // Static offset only (ascending: field at ptr + off)
-                        self.mir.push(X86Inst::MovRMIndexed {
-                            dst: Operand::Virtual(dst),
-                            base: ptr_vreg,
-                            offset: static_byte_offset,
-                        });
-                    }
-                } else {
-                    // Normal param - treat like local
-                    let base_slot =
-                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_slot);
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        let addr_vreg = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::Lea {
-                            dst: Operand::Virtual(addr_vreg),
-                            base: Reg::Rbp,
-                            disp: base_offset,
-                        });
-                        self.mir.push(X86Inst::AddRR64 {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Virtual(dyn_offset),
-                        });
-                        self.mir.push(X86Inst::MovRMIndexed {
-                            dst: Operand::Virtual(dst),
-                            base: addr_vreg,
-                            offset: 0,
-                        });
-                    } else {
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(dst),
-                            base: Reg::Rbp,
-                            offset: base_offset,
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    /// Lower a PlaceWrite instruction.
-    ///
-    /// This stores a value to the memory location described by the place. `vals`
-    /// holds one vreg per slot of the value (a single element for scalars); all
-    /// slots are stored to consecutive locations. Slot i of an rbp-relative place
-    /// lives at `local_offset(slot + i)`; through a pointer it lives at
-    /// `ptr_offset - i*8` (caller slots descend, stack grows down). (RUE-118)
-    fn lower_place_write(&mut self, place: &Place, vals: &[VReg]) {
-        let projections = self.ctx.cfg.get_place_projections(place);
-
-        // Simple case: no projections, just store to the base slot(s)
-        if projections.is_empty() {
-            match place.base {
-                PlaceBase::Local(slot) => {
-                    crate::agg_slots::store_slots(self, vals, slot);
-                }
-                PlaceBase::Param(param_slot) => {
-                    if self.ctx.cfg.is_param_inout(param_slot) {
-                        // Inout param - store through the pointer
-                        let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                        crate::agg_slots::store_slots_through_ptr(self, vals, ptr_vreg, 0);
-                    } else {
-                        // Normal param - store to local slot
-                        let slot = self.ctx.num_locals + param_slot;
-                        crate::agg_slots::store_slots(self, vals, slot);
-                    }
-                }
-            }
-            return;
-        }
-
-        // Complex case: has projections - compute the address
-        self.lower_place_write_with_projections(place, projections, vals);
-    }
-
-    /// Lower a PlaceWrite with projections.
-    fn lower_place_write_with_projections(
-        &mut self,
-        place: &Place,
-        projections: &[Projection],
-        vals: &[VReg],
-    ) {
-        // Calculate the static field offset
-        let mut static_slot_offset: u32 = 0;
-
-        // Collect index projections for dynamic offset calculation
-        let mut index_levels: Vec<IndexLevel> = Vec::new();
-
-        for proj in projections {
-            match proj {
-                Projection::Field {
-                    struct_id,
-                    field_index,
-                } => {
-                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                    static_slot_offset += field_offset;
-                }
-                Projection::Index { array_type, index } => {
-                    // Emit bounds check for this index
-                    let index_vreg = self.get_vreg(*index);
-                    let array_length = self.ctx.array_length(*array_type);
-                    self.emit_bounds_check(index_vreg, array_length);
-
-                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
-                    // offset from the low-end origin is `index*size`, added
-                    // below; the single root-object origin shift covers the
-                    // array's own origin (no per-array `(N-1)` shift).
-                    index_levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-                }
-            }
-        }
-
-        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311).
-        let root_count = crate::agg_slots::root_slot_count(self, place);
-
-        // Calculate dynamic offset from index projections
-        let dynamic_offset_vreg = if !index_levels.is_empty() {
-            Some(self.compute_index_offset(&index_levels))
-        } else {
-            None
-        };
-
-        // Compute final address based on base type
-        match place.base {
-            PlaceBase::Local(slot) => {
-                // The accessed value's low-end (slot-0) frame slot.
-                let base_low_slot = slot + (root_count - 1) - static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_low_slot);
-
-                if let Some(dyn_offset) = dynamic_offset_vreg {
-                    let addr_vreg = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::Lea {
-                        dst: Operand::Virtual(addr_vreg),
-                        base: Reg::Rbp,
-                        disp: base_offset,
-                    });
-                    // Ascending layout: element i is at base + i*size, so ADD
-                    // the scaled index to the (lowest-address) origin (ADR-0040).
-                    self.mir.push(X86Inst::AddRR64 {
-                        dst: Operand::Virtual(addr_vreg),
-                        src: Operand::Virtual(dyn_offset),
-                    });
-                    crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
-                } else {
-                    crate::agg_slots::store_slots_at_low(self, vals, base_low_slot);
-                }
-            }
-            PlaceBase::Param(param_slot) => {
-                if self.ctx.cfg.is_param_inout(param_slot) {
-                    // Received pointer is the caller place's low end; field
-                    // offsets and the scaled index both ADD (ascending).
-                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                    let static_byte_offset = (static_slot_offset as i32) * 8;
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        let addr_vreg = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Virtual(ptr_vreg),
-                        });
-                        if static_byte_offset != 0 {
-                            let offset_vreg = self.mir.alloc_vreg();
-                            self.mir.push(X86Inst::MovRI64 {
-                                dst: Operand::Virtual(offset_vreg),
-                                imm: static_byte_offset as i64,
-                            });
-                            self.mir.push(X86Inst::AddRR64 {
-                                dst: Operand::Virtual(addr_vreg),
-                                src: Operand::Virtual(offset_vreg),
-                            });
-                        }
-                        self.mir.push(X86Inst::AddRR64 {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Virtual(dyn_offset),
-                        });
-                        crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
-                    } else {
-                        crate::agg_slots::store_slots_through_ptr(
-                            self,
-                            vals,
-                            ptr_vreg,
-                            static_byte_offset,
-                        );
-                    }
-                } else {
-                    let base_low_slot =
-                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_low_slot);
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        let addr_vreg = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::Lea {
-                            dst: Operand::Virtual(addr_vreg),
-                            base: Reg::Rbp,
-                            disp: base_offset,
-                        });
-                        self.mir.push(X86Inst::AddRR64 {
-                            dst: Operand::Virtual(addr_vreg),
-                            src: Operand::Virtual(dyn_offset),
-                        });
-                        crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
-                    } else {
-                        crate::agg_slots::store_slots_at_low(self, vals, base_low_slot);
-                    }
-                }
-            }
-        }
-    }
-
-    /// Compute the byte offset for a series of index projections.
-    ///
-    /// Returns a vreg containing the total byte offset (index * stride for each level).
-    fn compute_index_offset(&mut self, levels: &[IndexLevel]) -> VReg {
-        let mut total_offset_vreg: Option<VReg> = None;
-
-        for level in levels {
-            let level_index_vreg = self.get_vreg(level.index);
-            let level_stride = level.elem_slot_count;
-
-            // Scale this level's index by its stride
-            let scaled = self.mir.alloc_vreg();
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(scaled),
-                src: Operand::Virtual(level_index_vreg),
-            });
-
-            if level_stride == 1 {
-                // Simple case: just shift by 3 (multiply by 8)
-                let shift_count = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRI32 {
-                    dst: Operand::Virtual(shift_count),
-                    imm: 3,
-                });
-                self.mir.push(X86Inst::Shl {
-                    dst: Operand::Virtual(scaled),
-                    count: Operand::Virtual(shift_count),
-                });
-            } else {
-                // Multiply by stride * 8
-                let stride_vreg = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRI64 {
-                    dst: Operand::Virtual(stride_vreg),
-                    imm: (level_stride * 8) as i64,
-                });
-                self.mir.push(X86Inst::ImulRR64 {
-                    dst: Operand::Virtual(scaled),
-                    src: Operand::Virtual(stride_vreg),
-                });
-            }
-
-            // Add to running total
-            if let Some(prev_total) = total_offset_vreg {
-                self.mir.push(X86Inst::AddRR64 {
-                    dst: Operand::Virtual(prev_total),
-                    src: Operand::Virtual(scaled),
-                });
-                // prev_total is modified in place
-            } else {
-                total_offset_vreg = Some(scaled);
-            }
-        }
-
-        total_offset_vreg.expect("compute_index_offset called with empty levels")
-    }
-
-    /// Compute the address of a place (for the @raw intrinsic and for by-ref
-    /// call arguments via `crate::byref_args`, RUE-143).
-    ///
-    /// This is similar to lower_place_read but returns the address instead of
-    /// loading. Index projections are NOT bounds-checked here (@raw is
-    /// deliberately unchecked); by-ref arguments bounds-check first in
-    /// `byref_args::lower_byref_arg_addr`.
-    fn lower_place_addr(&mut self, dst: VReg, place: &Place) {
-        let projections = self.ctx.cfg.get_place_projections(place);
-
-        // Calculate static slot offset from field projections
-        let mut static_slot_offset: u32 = 0;
-        let mut index_levels: Vec<IndexLevel> = Vec::new();
-
-        for proj in projections {
-            match proj {
-                Projection::Field {
-                    struct_id,
-                    field_index,
-                } => {
-                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                    static_slot_offset += field_offset;
-                }
-                Projection::Index { array_type, index } => {
-                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
-                    // offset from the low-end origin is `index*size`, added
-                    // below; the single root-object origin shift covers the
-                    // array's own origin (no per-array `(N-1)` shift).
-                    index_levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-                }
-            }
-        }
-
-        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311); the
-        // resulting address is the accessed place's LOW end, from which slots
-        // ascend. The place's explicit logical base type supplies root_count.
-        let root_count = crate::agg_slots::root_slot_count(self, place);
-
-        // Calculate dynamic offset from index projections
-        let dynamic_offset_vreg = if !index_levels.is_empty() {
-            Some(self.compute_index_offset(&index_levels))
-        } else {
-            None
-        };
-
-        // Compute address based on base type
-        match place.base {
-            PlaceBase::Local(slot) => {
-                let base_low_slot = slot + (root_count - 1) - static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_low_slot);
-
-                self.mir.push(X86Inst::Lea {
-                    dst: Operand::Virtual(dst),
-                    base: Reg::Rbp,
-                    disp: base_offset,
-                });
-
-                if let Some(dyn_offset) = dynamic_offset_vreg {
-                    self.mir.push(X86Inst::AddRR64 {
-                        dst: Operand::Virtual(dst),
-                        src: Operand::Virtual(dyn_offset),
-                    });
-                }
-            }
-            PlaceBase::Param(param_slot) => {
-                if self.ctx.cfg.is_param_inout(param_slot) {
-                    // Received pointer is the caller place's low end; field
-                    // offset and scaled index both ADD (ascending).
-                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                    let static_byte_offset = (static_slot_offset as i32) * 8;
-
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(dst),
-                        src: Operand::Virtual(ptr_vreg),
-                    });
-
-                    if static_byte_offset != 0 {
-                        let offset_vreg = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::MovRI64 {
-                            dst: Operand::Virtual(offset_vreg),
-                            imm: static_byte_offset as i64,
-                        });
-                        self.mir.push(X86Inst::AddRR64 {
-                            dst: Operand::Virtual(dst),
-                            src: Operand::Virtual(offset_vreg),
-                        });
-                    }
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        self.mir.push(X86Inst::AddRR64 {
-                            dst: Operand::Virtual(dst),
-                            src: Operand::Virtual(dyn_offset),
-                        });
-                    }
-                } else {
-                    let base_low_slot =
-                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_low_slot);
-
-                    self.mir.push(X86Inst::Lea {
-                        dst: Operand::Virtual(dst),
-                        base: Reg::Rbp,
-                        disp: base_offset,
-                    });
-
-                    if let Some(dyn_offset) = dynamic_offset_vreg {
-                        self.mir.push(X86Inst::AddRR64 {
-                            dst: Operand::Virtual(dst),
-                            src: Operand::Virtual(dyn_offset),
-                        });
-                    }
-                }
-            }
-        }
-    }
-
     /// Get the vreg for a CFG value.
     fn get_vreg(&mut self, value: CfgValue) -> VReg {
         if let Some(&vreg) = self.value_map.get(&value) {
@@ -4854,7 +4271,80 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         CfgLower::emit_bounds_check(self, index_vreg, length)
     }
     fn emit_place_addr(&mut self, dst: VReg, place: &Place) {
-        CfgLower::lower_place_addr(self, dst, place)
+        crate::place_lower::lower_place_addr(self, dst, place)
+    }
+}
+
+impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
+    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
+        CfgLower::ensure_inout_param_ptr(self, param_slot)
+    }
+
+    fn emit_frame_addr(&mut self, dst: VReg, slot: u32) {
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(X86Inst::Lea {
+            dst: Operand::Virtual(dst),
+            base: Reg::Rbp,
+            disp: offset,
+        });
+    }
+
+    fn emit_addr_add(&mut self, dst: VReg, rhs: VReg) {
+        self.mir.push(X86Inst::AddRR64 {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(rhs),
+        });
+    }
+
+    fn emit_addr_add_imm(&mut self, dst: VReg, byte_offset: i32) {
+        let offset = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(offset),
+            imm: byte_offset as i64,
+        });
+        self.mir.push(X86Inst::AddRR64 {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(offset),
+        });
+    }
+
+    fn emit_scale_index_bytes(&mut self, scaled: VReg, elem_slot_count: u32) {
+        if elem_slot_count == 1 {
+            let shift_count = self.mir.alloc_vreg();
+            self.mir.push(X86Inst::MovRI32 {
+                dst: Operand::Virtual(shift_count),
+                imm: 3,
+            });
+            self.mir.push(X86Inst::Shl {
+                dst: Operand::Virtual(scaled),
+                count: Operand::Virtual(shift_count),
+            });
+        } else {
+            let stride = self.mir.alloc_vreg();
+            self.mir.push(X86Inst::MovRI64 {
+                dst: Operand::Virtual(stride),
+                imm: (elem_slot_count * 8) as i64,
+            });
+            self.mir.push(X86Inst::ImulRR64 {
+                dst: Operand::Virtual(scaled),
+                src: Operand::Virtual(stride),
+            });
+        }
+    }
+
+    fn emit_zero_sized_place(&mut self, dst: VReg) {
+        self.mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(dst),
+            imm: 0,
+        });
+    }
+
+    fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg) {
+        self.mir.push(X86Inst::MovRMIndexed {
+            dst: Operand::Virtual(dst),
+            base: ptr,
+            offset: 0,
+        });
     }
 }
 
@@ -4912,17 +4402,6 @@ impl crate::aggregate_eq::AggregateEqBackend for CfgLower<'_> {
 }
 
 impl crate::byref_args::ByrefAddrBackend for CfgLower<'_> {
-    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
-        CfgLower::ensure_inout_param_ptr(self, param_slot)
-    }
-    fn emit_frame_addr(&mut self, dst: VReg, slot: u32) {
-        let offset = self.ctx.local_offset(slot);
-        self.mir.push(X86Inst::Lea {
-            dst: Operand::Virtual(dst),
-            base: Reg::Rbp,
-            disp: offset,
-        });
-    }
     fn record_deferred_error(&mut self, err: CompileError) {
         self.deferred_error.get_or_insert(err);
     }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -196,16 +196,6 @@ impl<'a> CfgLower<'a> {
         })
     }
 
-    /// Check if a slot corresponds to an inout parameter.
-    fn slot_to_inout_param_index(&self, slot: u32) -> Option<u32> {
-        if let Some(param_index) = self.ctx.slot_to_inout_param_index(slot) {
-            if self.ctx.cfg.is_param_inout(param_index) {
-                return Some(param_index);
-            }
-        }
-        None
-    }
-
     /// Ensure the inout parameter pointer vreg exists for the given param slot.
     /// If the pointer has already been loaded (via a Param instruction), returns the cached vreg.
     /// Otherwise, loads the pointer from the parameter slot and caches it.
@@ -1698,212 +1688,22 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Alloc { slot, init } => {
-                let init_type = self.ctx.cfg.get_inst(*init).ty;
-                if matches!(init_type.kind(), TypeKind::Array(_)) {
-                    // Array: store all element slots. Try the accessor first —
-                    // it materializes lazily-sourced arrays (Load/Param/
-                    // PlaceRead, including array-typed struct fields `s.arr`
-                    // and indexed reads `m[i]`, RUE-188) and cache-hits eager
-                    // ones. Fall back to the recursive flattener for ArrayInit.
-                    let scalar_vregs = self
-                        .get_or_compute_field_vregs(*init)
-                        .unwrap_or_else(|| self.collect_array_scalar_vregs(*init));
-                    crate::agg_slots::store_slots(self, &scalar_vregs, *slot);
-                } else if self.ctx.is_builtin_string(init_type) {
-                    // Builtin String: store ptr, len, and cap to consecutive slots
-                    // Check this before generic Struct case so builtin String uses this path
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*init)
-                        .expect("string should have fat pointer fields in Alloc");
-                    // Correctness guard (must run in release): storing the wrong
-                    // number of fat-pointer slots miscompiles the String, so this
-                    // is a plain `assert!` not `debug_assert!` (RUE-45).
-                    assert_eq!(
-                        field_vregs.len(),
-                        3,
-                        "string should have 3 fields (ptr, len, cap)"
-                    );
-                    crate::agg_slots::store_slots(self, &field_vregs, *slot);
-                } else if self.ctx.is_multislot_aggregate(init_type) {
-                    // Struct or payload enum (RUE-221): store all slots via the
-                    // single accessor. It materializes a struct read from a place
-                    // (`let q = a.p`) by loading its slot_count consecutive slots,
-                    // and cache-hits StructInit/EnumVariant/Load/Param/Call/
-                    // BlockParam — all of which carry fully-flattened slot lists.
-                    // Fall back to the flattener for any source the accessor
-                    // doesn't model. (RUE-118 / RUE-22)
-                    let scalar_vregs = self
-                        .get_or_compute_field_vregs(*init)
-                        .unwrap_or_else(|| self.collect_struct_scalar_vregs(*init));
-                    crate::agg_slots::store_slots(self, &scalar_vregs, *slot);
-                } else {
-                    let init_vreg = self.get_vreg(*init);
-                    let offset = self.ctx.local_offset(*slot);
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset,
-                        src: Operand::Virtual(init_vreg),
-                    });
-                }
+                crate::storage_lower::lower_alloc(self, *slot, *init);
             }
 
             CfgInstData::Load { slot } => {
-                let load_type = self.ctx.cfg.get_inst(value).ty;
-
-                if self.ctx.is_builtin_string(load_type) {
-                    // Builtin String fat pointer (ptr, len, cap). Ascending
-                    // layout (ADR-0040 / RUE-311): logical slot 0 (ptr) is at
-                    // the region's low end (highest-numbered slot `slot + 2`),
-                    // slot k at `slot + 2 - k`.
-                    let slot_vregs = crate::agg_slots::load_slots_at_low(self, slot + 2, 3);
-                    let ptr_vreg = slot_vregs[0];
-                    // Register String fields (ptr, len, cap)
-                    self.struct_slot_vregs.insert(value, slot_vregs);
-                    self.value_map.insert(value, ptr_vreg);
-                } else if let TypeKind::Array(_) = load_type.kind() {
-                    // Array: load every logical slot (ascending, ADR-0040 /
-                    // RUE-311): slot 0 at the region's low end.
-                    let slot_count = self.ctx.type_slot_count(load_type);
-                    let slot_vregs = if slot_count > 0 {
-                        crate::agg_slots::load_slots_at_low(self, slot + slot_count - 1, slot_count)
-                    } else {
-                        Vec::new()
-                    };
-
-                    // Register array element vregs
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-
-                    // Use first element as the primary vreg
-                    if let Some(&first_vreg) = slot_vregs.first() {
-                        self.value_map.insert(value, first_vreg);
-                    } else {
-                        let vreg = self.mir.alloc_vreg();
-                        self.value_map.insert(value, vreg);
-                    }
-                } else if self.ctx.is_multislot_aggregate(load_type) {
-                    // Struct or payload enum (RUE-221): load all slots
-                    // ascending (ADR-0040 / RUE-311). For an enum, slot 0 is the
-                    // discriminant, so the primary vreg set below is what a
-                    // `match` switches on.
-                    let slot_count = self.ctx.type_slot_count(load_type);
-                    let slot_vregs = if slot_count > 0 {
-                        crate::agg_slots::load_slots_at_low(self, slot + slot_count - 1, slot_count)
-                    } else {
-                        Vec::new()
-                    };
-
-                    // Register struct field vregs
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-
-                    // Use first field as the primary vreg
-                    if let Some(&first_vreg) = slot_vregs.first() {
-                        self.value_map.insert(value, first_vreg);
-                    } else {
-                        let vreg = self.mir.alloc_vreg();
-                        self.value_map.insert(value, vreg);
-                    }
-                } else {
-                    let vreg = self.mir.alloc_vreg();
-                    self.value_map.insert(value, vreg);
-
-                    let offset = self.ctx.local_offset(*slot);
-                    self.mir.push(X86Inst::MovRM {
-                        dst: Operand::Virtual(vreg),
-                        base: Reg::Rbp,
-                        offset,
-                    });
-                }
+                crate::storage_lower::lower_load(self, value, *slot);
             }
 
             CfgInstData::Store { slot, value: val } => {
-                let val_type = self.ctx.cfg.get_inst(*val).ty;
-                // Multi-slot aggregate (struct, builtin String fat pointer, or array):
-                // store ALL slots, not just the first. The accessor materializes
-                // lazily-sourced values and cache-hits eager ones; if it can't model
-                // the source (e.g. a dynamically-indexed place-read) fall back to the
-                // old single-slot behavior rather than ICE. (RUE-118, RUE-80)
-                let aggregate_vregs = if self.ctx.is_multislot_aggregate(val_type) {
-                    self.get_or_compute_field_vregs(*val)
-                } else {
-                    None
-                };
-
-                if let Some(slot_vregs) = aggregate_vregs {
-                    // Check if this slot corresponds to an inout parameter
-                    if let Some(param_index) = self.slot_to_inout_param_index(*slot) {
-                        // Whole-aggregate store through the inout pointer. The
-                        // pointer denotes the value's low end, so logical slot i
-                        // lives at ptr + i*8 (ADR-0040 / RUE-311).
-                        let ptr_vreg = self.ensure_inout_param_ptr(param_index);
-                        crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
-                    } else {
-                        crate::agg_slots::store_slots(self, &slot_vregs, *slot);
-                    }
-                } else {
-                    let val_vreg = self.get_vreg(*val);
-
-                    // Check if this slot corresponds to an inout parameter
-                    if let Some(param_index) = self.slot_to_inout_param_index(*slot) {
-                        // For inout params, store through the pointer
-                        // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                        let ptr_vreg = self.ensure_inout_param_ptr(param_index);
-                        self.mir.push(X86Inst::MovMRIndexed {
-                            base: ptr_vreg,
-                            offset: 0,
-                            src: Operand::Virtual(val_vreg),
-                        });
-                    } else {
-                        // Normal local variable: store to stack slot
-                        let offset = self.ctx.local_offset(*slot);
-                        self.mir.push(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset,
-                            src: Operand::Virtual(val_vreg),
-                        });
-                    }
-                }
+                crate::storage_lower::lower_store(self, *slot, *val);
             }
 
             CfgInstData::ParamStore {
                 param_slot,
                 value: val,
             } => {
-                // ParamStore is used for inout params - store through the pointer.
-                //
-                // For inout params, param_slot is the first ABI slot for that param.
-                // For scalar params, param_slot = param_index.
-                // For struct params, param_slot is the first slot (same as param_index for first param).
-                // We use is_param_inout(param_slot) to check if this slot is inout.
-                if !self.ctx.cfg.is_param_inout(*param_slot) {
-                    panic!("ParamStore used on non-inout param slot {}", param_slot);
-                }
-
-                // Whole-value reassignment of a multi-slot aggregate (struct,
-                // builtin String, or array) through inout must write ALL slots
-                // through the pointer, not just the first — same shape as the
-                // aggregate branch of Store above. The pointer denotes the
-                // value's low end, so logical slot i lives at ptr + i*8
-                // (ADR-0040 / RUE-311). Unmodeled sources fall back to
-                // single-slot. (RUE-145)
-                let val_type = self.ctx.cfg.get_inst(*val).ty;
-                let aggregate_vregs = if self.ctx.is_multislot_aggregate(val_type) {
-                    self.get_or_compute_field_vregs(*val)
-                } else {
-                    None
-                };
-
-                // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
-                if let Some(slot_vregs) = aggregate_vregs {
-                    crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
-                } else {
-                    let val_vreg = self.get_vreg(*val);
-                    self.mir.push(X86Inst::MovMRIndexed {
-                        base: ptr_vreg,
-                        offset: 0,
-                        src: Operand::Virtual(val_vreg),
-                    });
-                }
+                crate::storage_lower::lower_param_store(self, *param_slot, *val);
             }
 
             CfgInstData::Call {
@@ -4344,6 +4144,20 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
             dst: Operand::Virtual(dst),
             base: ptr,
             offset: 0,
+        });
+    }
+}
+
+impl crate::storage_lower::StorageLowerBackend for CfgLower<'_> {
+    fn collect_struct_scalars(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.collect_struct_scalar_vregs(value)
+    }
+
+    fn emit_store_ptr_base(&mut self, src: VReg, ptr: VReg) {
+        self.mir.push(X86Inst::MovMRIndexed {
+            base: ptr,
+            offset: 0,
+            src: Operand::Virtual(src),
         });
     }
 }

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -355,6 +355,7 @@ impl<'a> Emitter<'a> {
     pub fn emit_all(mut self) -> CompileResult<EmittedCode> {
         self.emit_asm = true;
         self.emit_internal()?;
+        crate::synchronize_emitted_bytes(&mut self.instructions, &self.code)?;
         Ok(EmittedCode {
             instructions: self.instructions,
             relocations: self.relocations,

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -36,6 +36,48 @@ use rue_error::CompileResult;
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation, MachineCode};
 
+fn prepare_backend(
+    cfg: &Cfg,
+    type_pool: &TypeInternPool,
+    interner: &ThreadedRodeo,
+) -> CompileResult<crate::codegen_pipeline::PreparedMir<X86Mir, Reg>> {
+    crate::codegen_pipeline::prepare_mir(
+        cfg,
+        type_pool,
+        cfg_lower::RET_REGS.len() as u32,
+        || CfgLower::new(cfg, type_pool, interner).lower(),
+        |mir, existing_slots| RegAlloc::new(mir, existing_slots).allocate_with_spills(),
+        |mir| {
+            peephole::optimize(mir.instructions_vec_mut());
+        },
+        schedule::schedule,
+        verify::verify_stack_alignment,
+    )
+}
+
+fn generate_inner<T, Emit>(
+    cfg: &Cfg,
+    type_pool: &TypeInternPool,
+    strings: &[String],
+    interner: &ThreadedRodeo,
+    emit: Emit,
+) -> CompileResult<T>
+where
+    Emit: for<'a> FnOnce(Emitter<'a>) -> CompileResult<T>,
+{
+    let prepared = prepare_backend(cfg, type_pool, interner)?;
+    let emitter = Emitter::new(
+        &prepared.mir,
+        prepared.total_locals,
+        prepared.num_locals_original,
+        prepared.num_params,
+        &prepared.used_callee_saved,
+        strings,
+    )
+    .with_sret(prepared.has_sret);
+    emit(emitter)
+}
+
 /// Generate machine code from CFG.
 ///
 /// This is the main entry point for x86-64 code generation.
@@ -46,54 +88,14 @@ pub fn generate(
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<MachineCode> {
-    let num_locals = cfg.num_locals();
-    let num_params = cfg.num_params();
-    // sret returns reserve one extra frame slot (one past the param area)
-    // for the incoming buffer pointer; see crate::cfg_lower::type_uses_sret_return.
-    let has_sret =
-        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
-
-    // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner).lower()?;
-
-    // Allocate physical registers (may add spill slots)
-    // Spill slots go after locals, parameters AND the sret pointer slot to avoid conflicts
-    let existing_slots = num_locals + num_params + has_sret as u32;
-    let (mut mir, num_spills, used_callee_saved) =
-        RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
-
-    // Apply peephole optimizations after register allocation
-    peephole::optimize(mir.instructions_vec_mut());
-
-    // Schedule instructions for better performance
-    schedule::schedule(&mut mir);
-
-    // Verify stack alignment. This is a correctness check (a misaligned call
-    // violates the SysV ABI and can crash at runtime) and already returns a
-    // real ice_error, so it runs in release too — not gated on
-    // debug_assertions (RUE-45).
-    verify::verify_stack_alignment(&mir)?;
-
-    // Emit machine code bytes (with prologue for stack frame setup)
-    // Total local slots = local variables + spill slots (params handled separately)
-    let total_locals = num_locals + num_spills;
-    // Pass both total_locals (for stack frame size) and num_locals (for param offset calculation)
-    // CfgLower generates param offsets based on num_locals, so the prologue must match
-    let (code, relocations) = Emitter::new(
-        &mir,
-        total_locals,
-        num_locals,
-        num_params,
-        &used_callee_saved,
-        strings,
-    )
-    .with_sret(has_sret)
-    .emit()?;
-
-    Ok(MachineCode {
-        code,
-        relocations,
-        strings: strings.to_vec(),
+    generate_inner(cfg, type_pool, strings, interner, |emitter| {
+        // Keep the normal path allocation-free with respect to assembly text.
+        let (code, relocations) = emitter.emit()?;
+        Ok(MachineCode {
+            code,
+            relocations,
+            strings: strings.to_vec(),
+        })
     })
 }
 
@@ -107,52 +109,16 @@ pub fn generate_with_asm(
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<(MachineCode, String)> {
-    let num_locals = cfg.num_locals();
-    let num_params = cfg.num_params();
-    let has_sret =
-        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
-
-    // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner).lower()?;
-
-    // Allocate physical registers (may add spill slots)
-    let existing_slots = num_locals + num_params + has_sret as u32;
-    let (mut mir, num_spills, used_callee_saved) =
-        RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
-
-    // Apply peephole optimizations after register allocation
-    peephole::optimize(mir.instructions_vec_mut());
-
-    // Schedule instructions for better performance
-    schedule::schedule(&mut mir);
-
-    // Verify stack alignment. This is a correctness check (a misaligned call
-    // violates the SysV ABI and can crash at runtime) and already returns a
-    // real ice_error, so it runs in release too — not gated on
-    // debug_assertions (RUE-45).
-    verify::verify_stack_alignment(&mir)?;
-
-    // Emit machine code bytes with assembly text
-    let total_locals = num_locals + num_spills;
-    let emitted = Emitter::new(
-        &mir,
-        total_locals,
-        num_locals,
-        num_params,
-        &used_callee_saved,
-        strings,
-    )
-    .with_sret(has_sret)
-    .emit_all()?;
-
-    let asm = emitted.to_asm();
-    let machine_code = MachineCode {
-        code: emitted.to_bytes(),
-        relocations: emitted.relocations,
-        strings: strings.to_vec(),
-    };
-
-    Ok((machine_code, asm))
+    generate_inner(cfg, type_pool, strings, interner, |emitter| {
+        let emitted = emitter.emit_all()?;
+        let asm = emitted.to_asm();
+        let machine_code = MachineCode {
+            code: emitted.to_bytes(),
+            relocations: emitted.relocations,
+            strings: strings.to_vec(),
+        };
+        Ok((machine_code, asm))
+    })
 }
 
 /// Generate register allocation debug info from CFG.

--- a/crates/rue-spec/cases/golden/ir-dumps.toml
+++ b/crates/rue-spec/cases/golden/ir-dumps.toml
@@ -149,6 +149,90 @@ function main:
     bl __rue_exit
 """
 
+# =============================================================================
+# Local and parameter storage lowering (RUE-612)
+# =============================================================================
+
+[[case]]
+name = "storage_lowering_mir_x86_64"
+spec = ["5.2:1", "5.2:2", "5.2:3", "6.1:14", "6.1:18"]
+description = "Scalar allocation, local load/store, and inout ParamStore retain their exact x86-64 MIR sequence."
+source = """
+fn set(inout x: i32) { x = 42; }
+
+fn main() -> i32 {
+    let mut x = 0;
+    x = 1;
+    set(inout x);
+    x
+}
+"""
+target = "x86-64-linux"
+expected_mir = """
+function main:
+    mov v0, 0
+    mov [rbp-8], v0
+    mov v1, 1
+    mov [rbp-8], v1
+    mov v2, [rbp-8]
+    lea v4, [rbp-8]
+    mov rax, v4
+    push rax
+    pop rdi
+    call set
+    mov v3, rax
+    mov v5, [rbp-8]
+    mov rdi, v5
+    call __rue_exit
+
+function set:
+    mov v0, [rbp-8]
+    mov v1, 42
+    mov [v0], v1
+    mov v2, 0
+    mov rax, v2
+    ret
+"""
+
+[[case]]
+name = "storage_lowering_mir_aarch64"
+spec = ["5.2:1", "5.2:2", "5.2:3", "6.1:14", "6.1:18"]
+description = "Scalar allocation, local load/store, and inout ParamStore retain their exact AArch64 MIR sequence."
+source = """
+fn set(inout x: i32) { x = 42; }
+
+fn main() -> i32 {
+    let mut x = 0;
+    x = 1;
+    set(inout x);
+    x
+}
+"""
+target = "aarch64-macos"
+expected_mir = """
+function main:
+    mov v0, #0
+    str v0, [fp, #-8]
+    mov v1, #1
+    str v1, [fp, #-8]
+    ldr v2, [fp, #-8]
+    add v4, fp, #-8
+    mov x0, v4
+    bl set
+    mov v3, x0
+    ldr v5, [fp, #-8]
+    mov x0, v5
+    bl __rue_exit
+
+function set:
+    ldr v0, [fp, #-8]
+    mov v1, #42
+    str v1, [v0]
+    mov v2, #0
+    mov x0, v2
+    ret
+"""
+
 [[case]]
 name = "zero_rir"
 spec = ["2.1:1"]

--- a/crates/rue-spec/cases/golden/ir-dumps.toml
+++ b/crates/rue-spec/cases/golden/ir-dumps.toml
@@ -832,3 +832,85 @@ Layout (rbp-relative):
 
 Return: rax (Type::I32)
 """
+
+# =============================================================================
+# Projected-place lowering (RUE-604)
+# =============================================================================
+
+[[case]]
+name = "projected_place_mir_x86_64"
+spec = ["7.1:19", "7.1:25"]
+description = "Nested index+field projection pins bounds-before-address ordering, element scaling, root anchoring, and the final x86 indexed load."
+source = """
+struct P { a: i32, b: i32 }
+fn main() -> i32 {
+    let xs = [P { a: 1, b: 42 }];
+    let i = 0;
+    xs[i].b
+}
+"""
+target = "x86-64-linux"
+expected_mir = """
+function main:
+    mov v0, 1
+    mov v1, 42
+    mov v2, v0
+    mov v3, 0
+    mov [rbp-16], v0
+    mov [rbp-8], v1
+    mov v4, 0
+    mov [rbp-24], v4
+    mov v5, [rbp-24]
+    mov v7, 1
+    cmpq v5, v7
+    jb .L0
+    call __rue_bounds_check
+    .L0:
+    mov v8, v5
+    mov v9, 16
+    imulq v8, v9
+    lea v10, [rbp-8]
+    addq v10, v8
+    mov v6, [v10]
+    mov rdi, v6
+    call __rue_exit
+"""
+
+[[case]]
+name = "projected_place_mir_aarch64"
+spec = ["7.1:19", "7.1:25"]
+description = "Nested index+field projection pins bounds-before-address ordering, element scaling, root anchoring, and the final AArch64 base-only load."
+source = """
+struct P { a: i32, b: i32 }
+fn main() -> i32 {
+    let xs = [P { a: 1, b: 42 }];
+    let i = 0;
+    xs[i].b
+}
+"""
+target = "aarch64-macos"
+expected_mir = """
+function main:
+    mov v0, #1
+    mov v1, #42
+    mov v2, v0
+    mov v3, #0
+    str v0, [fp, #-16]
+    str v1, [fp, #-8]
+    mov v4, #0
+    str v4, [fp, #-24]
+    ldr v5, [fp, #-24]
+    mov v7, #1
+    cmp v5, v7 // 64-bit
+    b.lo .L0
+    bl __rue_bounds_check
+    .L0:
+    mov v8, v5
+    mov v9, #16
+    mul v8, v8, v9
+    add v10, fp, #-8
+    add v10, v10, v8
+    ldr v6, [v10]
+    mov x0, v6
+    bl __rue_exit
+"""


### PR DESCRIPTION
## Summary

- share projected-place lowering across x86-64 and AArch64
- centralize lower → regalloc → peephole → schedule → verify orchestration and frame accounting
- preserve assembly-mode branch fixups by synchronizing emitted bytes after fixup application
- share local and parameter `Alloc`, `Load`, `Store`, and `ParamStore` lowering

The two lowering extractions remove roughly 770 lines of duplicated backend logic while retaining narrow target-specific MIR leaves.

## Why

The x86-64 and AArch64 backends hand-mirrored target-independent control flow, so every aggregate, place, inout, and pipeline correction had to be implemented twice. This moves the common policy behind statically dispatched capability traits without introducing a universal MIR or dynamic dispatch.

Exact-output auditing also exposed a pre-existing correctness bug: assembly-mode `emit_all()` captured instruction bytes before branch fixups, then `EmittedCode::to_bytes()` could rebuild stale bytes. The normal emission path remains unchanged; assembly-mode bytes are synchronized only after fixups.

## Review shape

The four ordered commits keep each concern independently reviewable:

1. RUE-604 — projected-place lowering
2. RUE-607 — backend pipeline orchestration
3. RUE-611 — assembly-mode branch-byte fix
4. RUE-612 — local/parameter storage lowering

The stack is rebased onto current trunk. The rebase preserves trunk's new `Place.base_type` contract: shared place lowering derives root width through `root_slot_count(b, place)`, including the one-slot address anchor for zero-sized roots.

## Validation

- 126/126 exact cross-target pipeline artifacts unchanged versus current trunk
  - 7 representative programs
  - x86-64 Linux, AArch64 Linux, AArch64 macOS
  - lowering, MIR, liveness, regalloc, asm, stackframe
- 8/8 representative x86-64 O0/O2 executables byte-identical
- 488/488 focused rue-codegen tests
- `./fmt.sh`
- `./clippy.sh` — 41 first-party targets
- `./test.sh` — all 33 Buck targets
- full release build: `./buck2 build //crates/... --target-platforms //platforms:release`
- compiler/oracle agreement across the modeled corpus and 64 generated smoke programs
- independent x86-64/AArch64 architecture reviews found no blockers

Linear: RUE-3, RUE-604, RUE-607, RUE-611, RUE-612
