### PR TITLE
RUE-589: compare bounded runtime stderr exactly

### DIFF
--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -3,10 +3,10 @@ load("//crates:defs.bzl", "rue_binary")
 # The differential harness. Two modes:
 #  * default: runs the concrete rue-cli-tests corpus through the rue-oracle
 #    reference interpreter and checks it agrees with each case's expected exit
-#    code / stdout (a mismatch localizes to codegen; wired as the sh_test below).
+#    code / stdout / stderr (a mismatch localizes to codegen; wired as the sh_test below).
 #  * `fuzz`: the differential *fuzzer* (RUE-247) — generates random valid
 #    programs and cross-checks the oracle against the real compiler + native
-#    binary, reporting exit/stdout disagreements as miscompiles and generated
+#    binary, reporting exit/stdout/stderr disagreements as miscompiles and generated
 #    compile/Unsupported results as contract failures, all with seed-based
 #    repros. Driven by `.github/workflows/fuzz.yml` nightly; needs `RUE_BINARY`.
 # The harness driver itself has no #[test] functions — it IS the harness — but

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -6,7 +6,8 @@
 //! 1. the [`rue_oracle`] reference interpreter (`run_source`), and
 //! 2. the real compiler + the produced native binary.
 //!
-//! Then compare the observable behavior — process exit code and `@dbg` stdout.
+//! Then compare the observable behavior — process exit code, stdout, stderr,
+//! and typed trap cause.
 //! A disagreement is an **automatically-discovered miscompile**. A generated
 //! compile failure or oracle `Unsupported` result is a generator-contract
 //! failure. Both are findings with concrete, deterministic repros: the seed
@@ -23,7 +24,8 @@
 
 use crate::{generator, trap::native_runtime_trap_kind};
 use rue_oracle::{
-    MAX_STDOUT_BYTES, RunSourceError, TrapKind, Unsupported, UnsupportedKind, run_source,
+    MAX_STDERR_BYTES, MAX_STDOUT_BYTES, RunSourceError, TrapKind, Unsupported, UnsupportedKind,
+    run_source,
 };
 use std::io::Read;
 use std::os::unix::process::ExitStatusExt;
@@ -48,6 +50,8 @@ enum Compiled {
         /// More stdout existed beyond [`MAX_STDOUT_BYTES`]; `stdout` is only a prefix.
         stdout_truncated: bool,
         stderr: String,
+        /// More stderr existed beyond [`MAX_STDERR_BYTES`]; `stderr` is only a prefix.
+        stderr_truncated: bool,
     },
     /// The binary was killed by a signal (e.g. SIGSEGV) — a hard miscompile.
     Crash(i32),
@@ -298,6 +302,7 @@ pub fn run(args: &[String]) -> ExitCode {
                     source: source.clone(),
                     oracle_exit: oracle.exit_code,
                     oracle_stdout: oracle.stdout.clone(),
+                    oracle_stderr: oracle.stderr.clone(),
                     oracle_panic: oracle.panic.clone(),
                     compiled: describe(&compiled),
                     reason,
@@ -358,6 +363,7 @@ fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
             stdout,
             stdout_truncated,
             stderr,
+            stderr_truncated,
         } => {
             // A retained prefix can equal the oracle's complete output while
             // hiding additional compiled output. Fail before comparing that
@@ -368,9 +374,16 @@ fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
                      retained prefix cannot prove agreement"
                 ));
             }
+            if *stderr_truncated {
+                return Verdict::Disagree(format!(
+                    "compiled stderr exceeded the {MAX_STDERR_BYTES}-byte capture limit; \
+                     retained prefix cannot prove agreement"
+                ));
+            }
             let exit_ok = oracle.exit_code == *exit;
             let stdout_ok = &oracle.stdout == stdout;
-            if !exit_ok || !stdout_ok {
+            let stderr_ok = &oracle.stderr == stderr;
+            if !exit_ok || !stdout_ok || !stderr_ok {
                 let mut r = String::new();
                 if !exit_ok {
                     r += &format!("exit: oracle {} vs compiled {exit}; ", oracle.exit_code);
@@ -379,6 +392,12 @@ fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
                     r += &format!(
                         "stdout: oracle {:?} vs compiled {:?}",
                         oracle.stdout, stdout
+                    );
+                }
+                if !stderr_ok {
+                    r += &format!(
+                        "stderr: oracle {:?} vs compiled {:?}",
+                        oracle.stderr, stderr
                     );
                 }
                 return Verdict::Disagree(r);
@@ -420,14 +439,6 @@ fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
                     }
                     (None, None) => {}
                 }
-            } else if !stderr.is_empty() {
-                // Generated Rue has no modeled normal-stderr channel. Treat
-                // any such output as unexplained native behavior rather than
-                // allowing matching exit/stdout to manufacture agreement.
-                return Verdict::Disagree(format!(
-                    "compiled program wrote unexpected stderr {:?}",
-                    first_line(stderr)
-                ));
             }
             Verdict::Agree
         }
@@ -487,11 +498,6 @@ fn compile_and_run(
     run_with_timeout(cmd, timeout)
 }
 
-/// Maximum stderr bytes retained from a run. Trap messages are short; the cap
-/// only bounds how much we *keep* — the pipe is still drained to EOF (see
-/// [`read_capped`]) so a chatty process can never deadlock the wait loop.
-const STDERR_CAP: usize = 8192;
-
 /// Result of one child process whose stdout/stderr were drained while it ran.
 enum ProcessOutcome {
     Exited {
@@ -499,6 +505,7 @@ enum ProcessOutcome {
         stdout: String,
         stdout_truncated: bool,
         stderr: String,
+        stderr_truncated: bool,
     },
     TimedOut,
 }
@@ -535,7 +542,9 @@ fn wait_for_process(mut child: Child, timeout: Duration) -> std::io::Result<Proc
         })
     });
     let stderr_reader = std::thread::spawn(move || {
-        stderr_pipe.map_or_else(CappedRead::default, |err| read_capped(err, STDERR_CAP))
+        stderr_pipe.map_or_else(CappedRead::default, |err| {
+            read_capped(err, MAX_STDERR_BYTES)
+        })
     });
 
     let start = Instant::now();
@@ -570,6 +579,7 @@ fn wait_for_process(mut child: Child, timeout: Duration) -> std::io::Result<Proc
             stdout,
             stdout_truncated: stdout_capture.truncated,
             stderr,
+            stderr_truncated: stderr_capture.truncated,
         }),
         None => Ok(ProcessOutcome::TimedOut),
     }
@@ -595,12 +605,14 @@ fn run_with_timeout(mut cmd: Command, timeout: Duration) -> std::io::Result<Comp
             stdout,
             stdout_truncated,
             stderr,
+            stderr_truncated,
         } => match status.code() {
             Some(code) => Compiled::Ran {
                 exit: code,
                 stdout,
                 stdout_truncated,
                 stderr,
+                stderr_truncated,
             },
             None => Compiled::Crash(status.signal().unwrap_or(0)),
         },
@@ -649,6 +661,7 @@ struct Disagreement {
     source: String,
     oracle_exit: i32,
     oracle_stdout: String,
+    oracle_stderr: String,
     oracle_panic: Option<TrapKind>,
     compiled: String,
     reason: String,
@@ -657,13 +670,14 @@ struct Disagreement {
 impl Disagreement {
     fn render(&self) -> String {
         format!(
-            "\n\u{2717} DISAGREEMENT (seed {seed})\n  {reason}\n  oracle:   exit={exit} panic={panic:?} stdout={stdout:?}\n  compiled: {compiled}\n  --- source (regenerate with `fuzz --start {seed} --seeds 1 --timeout {timeout_secs}`) ---\n{source}",
+            "\n\u{2717} DISAGREEMENT (seed {seed})\n  {reason}\n  oracle:   exit={exit} panic={panic:?} stdout={stdout:?} stderr={stderr:?}\n  compiled: {compiled}\n  --- source (regenerate with `fuzz --start {seed} --seeds 1 --timeout {timeout_secs}`) ---\n{source}",
             seed = self.seed,
             timeout_secs = self.timeout_secs,
             reason = self.reason,
             exit = self.oracle_exit,
             panic = self.oracle_panic,
             stdout = self.oracle_stdout,
+            stderr = self.oracle_stderr,
             compiled = self.compiled,
             source = self.source,
         )
@@ -676,6 +690,8 @@ fn describe(c: &Compiled) -> String {
             exit,
             stdout,
             stdout_truncated,
+            stderr,
+            stderr_truncated,
             ..
         } => {
             let label = if *stdout_truncated {
@@ -683,7 +699,10 @@ fn describe(c: &Compiled) -> String {
             } else {
                 "stdout"
             };
-            format!("ran exit={exit} {label}={stdout:?} stdout-truncated={stdout_truncated}")
+            format!(
+                "ran exit={exit} {label}={stdout:?} stdout-truncated={stdout_truncated} \
+                 stderr={stderr:?} stderr-truncated={stderr_truncated}"
+            )
         }
         Compiled::CompileFail(e) => format!("compile-fail: {}", first_line(e)),
         Compiled::CompileTimeout => "compile-timeout".to_string(),
@@ -731,8 +750,8 @@ fn disagreement_repro_contents(d: &Disagreement) -> String {
         &mut contents,
         "oracle",
         &format!(
-            "exit={} panic={:?} stdout={:?}",
-            d.oracle_exit, d.oracle_panic, d.oracle_stdout
+            "exit={} panic={:?} stdout={:?} stderr={:?}",
+            d.oracle_exit, d.oracle_panic, d.oracle_stdout, d.oracle_stderr
         ),
     );
     push_repro_comment(&mut contents, "compiled", &d.compiled);
@@ -822,15 +841,27 @@ mod tests {
         Outcome {
             exit_code: exit,
             stdout: stdout.to_string(),
+            stderr: String::new(),
             panic: None,
         }
     }
 
     /// An oracle outcome that ended in a runtime trap (exit 101).
     fn trap(kind: TrapKind) -> Outcome {
+        let stderr = match kind {
+            TrapKind::ArithmeticOverflow => "error: integer overflow\n",
+            TrapKind::DivisionByZero => "error: division by zero\n",
+            TrapKind::IntegerCastOverflow => "error: integer cast overflow\n",
+            TrapKind::IndexOutOfBounds => "error: index out of bounds\n",
+            TrapKind::InvalidUtf8 => "error: invalid UTF-8\n",
+            TrapKind::UserPanic => "panic: user message\n",
+            TrapKind::AssertionFailure => "assertion failed\n",
+            TrapKind::Unreachable => "",
+        };
         Outcome {
             exit_code: 101,
             stdout: String::new(),
+            stderr: stderr.to_string(),
             panic: Some(kind),
         }
     }
@@ -842,6 +873,7 @@ mod tests {
             stdout: stdout.to_string(),
             stdout_truncated: false,
             stderr: String::new(),
+            stderr_truncated: false,
         }
     }
 
@@ -852,6 +884,7 @@ mod tests {
             stdout: String::new(),
             stdout_truncated: false,
             stderr: stderr.to_string(),
+            stderr_truncated: false,
         }
     }
 
@@ -872,6 +905,7 @@ mod tests {
             stdout: "7\n".to_string(),
             stdout_truncated: false,
             stderr: "unmodeled native diagnostic\n".to_string(),
+            stderr_truncated: false,
         };
         assert!(is_disagree(classify(&oc(42, "7\n"), &compiled)));
     }
@@ -894,6 +928,7 @@ mod tests {
             stdout: "unexpected\n".to_string(),
             stdout_truncated: false,
             stderr: "error: integer overflow\n".to_string(),
+            stderr_truncated: false,
         };
         assert!(is_disagree(classify(
             &trap(TrapKind::ArithmeticOverflow),
@@ -948,6 +983,39 @@ mod tests {
             &ran_trap("assertion failed\n"),
         );
         assert!(matches!(v, Verdict::Agree));
+    }
+
+    #[test]
+    fn same_trap_category_cannot_hide_a_stderr_message_mismatch() {
+        let v = classify(
+            &trap(TrapKind::UserPanic),
+            &ran_trap("panic: different message\n"),
+        );
+        assert!(matches!(
+            v,
+            Verdict::Disagree(reason) if reason.contains("stderr:")
+        ));
+    }
+
+    #[test]
+    fn truncated_stderr_prefix_cannot_manufacture_agreement() {
+        let oracle = Outcome {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: "retained prefix".to_string(),
+            panic: None,
+        };
+        let compiled = Compiled::Ran {
+            exit: 0,
+            stdout: String::new(),
+            stdout_truncated: false,
+            stderr: oracle.stderr.clone(),
+            stderr_truncated: true,
+        };
+        assert!(matches!(
+            classify(&oracle, &compiled),
+            Verdict::Disagree(reason) if reason.contains("stderr exceeded")
+        ));
     }
 
     #[test]
@@ -1079,6 +1147,7 @@ mod tests {
             source: "fn main() -> i32 { 23 }\n".to_string(),
             oracle_exit: 101,
             oracle_stdout: String::new(),
+            oracle_stderr: "error: integer cast overflow\n".to_string(),
             oracle_panic: Some(TrapKind::IntegerCastOverflow),
             compiled: "compile-fail: first\rsecond".to_string(),
             reason: "wrong exit\nconst injected = 1;".to_string(),
@@ -1155,7 +1224,7 @@ mod tests {
                 assert!(!stderr.is_empty(), "some compiler stderr is retained");
                 assert_eq!(
                     stderr.len(),
-                    STDERR_CAP,
+                    MAX_STDERR_BYTES,
                     "large diagnostics must be fully drained while retention stops at the cap"
                 );
             }
@@ -1273,18 +1342,24 @@ mod tests {
     #[test]
     fn large_stderr_does_not_deadlock() {
         // The stderr cap must not reintroduce the deadlock: even though we retain
-        // only STDERR_CAP bytes, the pipe is drained to EOF, so a program spewing
+        // only MAX_STDERR_BYTES bytes, the pipe is drained to EOF, so a program spewing
         // >64KB to stderr still terminates as `Ran` (RUE-338).
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg("yes e | head -c 200000 1>&2");
         let result = run_with_timeout(cmd, Duration::from_secs(30)).expect("spawn");
         match result {
-            Compiled::Ran { exit, stderr, .. } => {
+            Compiled::Ran {
+                exit,
+                stderr,
+                stderr_truncated,
+                ..
+            } => {
                 assert_eq!(exit, 0);
                 assert!(!stderr.is_empty(), "some stderr should be retained");
+                assert!(stderr_truncated, "discarded stderr must remain explicit");
                 assert!(
-                    stderr.len() <= STDERR_CAP,
-                    "stderr retained ({}) must not exceed the cap {STDERR_CAP}",
+                    stderr.len() <= MAX_STDERR_BYTES,
+                    "stderr retained ({}) must not exceed the cap {MAX_STDERR_BYTES}",
                     stderr.len()
                 );
             }
@@ -1297,17 +1372,20 @@ mod tests {
         // The drain-vs-keep contract in isolation: given more bytes than the cap,
         // we consume all of them (Cursor reaches EOF) but retain exactly `cap`.
         let data = vec![b'z'; 100_000];
-        let kept = read_capped(std::io::Cursor::new(data), STDERR_CAP);
-        assert_eq!(kept.bytes.len(), STDERR_CAP);
+        let kept = read_capped(std::io::Cursor::new(data), MAX_STDERR_BYTES);
+        assert_eq!(kept.bytes.len(), MAX_STDERR_BYTES);
         assert!(kept.bytes.iter().all(|&b| b == b'z'));
         assert!(kept.truncated);
         // Fewer bytes than the cap: keep them all.
-        let kept = read_capped(std::io::Cursor::new(vec![b'q'; 10]), STDERR_CAP);
+        let kept = read_capped(std::io::Cursor::new(vec![b'q'; 10]), MAX_STDERR_BYTES);
         assert_eq!(kept.bytes.len(), 10);
         assert!(!kept.truncated);
         // Exactly the cap is still complete, not truncated.
-        let kept = read_capped(std::io::Cursor::new(vec![b'x'; STDERR_CAP]), STDERR_CAP);
-        assert_eq!(kept.bytes.len(), STDERR_CAP);
+        let kept = read_capped(
+            std::io::Cursor::new(vec![b'x'; MAX_STDERR_BYTES]),
+            MAX_STDERR_BYTES,
+        );
+        assert_eq!(kept.bytes.len(), MAX_STDERR_BYTES);
         assert!(!kept.truncated);
     }
 

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Runs the concrete [`rue-cli-tests`] corpus through the [`rue_oracle`]
 //! reference interpreter and checks the oracle agrees with each case's expected
-//! exit code / stdout. Those expectations are what the *compiled binary*
+//! exit code / stdout / stderr. Those expectations are what the *compiled binary*
 //! already produces (the CLI suite enforces that), so a disagreement here means
 //! the oracle and the compiler disagree — which, since the oracle is an
 //! independent implementation of the semantics operating *before* codegen,
@@ -23,7 +23,7 @@
 //!   preview assertions — so we lean on [`rue_test_runner`] (the spec runner's
 //!   own crate) to parse and template-expand every case exactly as the spec
 //!   suite does, then filter to the eligible subset the oracle can model
-//!   (concrete `source` + expected exit/stdout; golden-IR-only, `compile_fail`,
+//!   (concrete `source` + expected exit/stdout/stderr; golden-IR-only, `compile_fail`,
 //!   multi-file and stdin cases are ineligible, not disagreements). Preview-gated
 //!   cases run with their declared preview feature.
 //!   Dir resolution mirrors corpus mode: argv; else `RUE_ORACLE_DIFF_SPEC_CASES`
@@ -200,7 +200,6 @@ enum CaseOutcome {
 enum UnmodeledReason {
     ModelGap(ModelGapKind),
     TrapExpectation,
-    SpecStderrExpectation,
 }
 
 impl fmt::Display for UnmodeledReason {
@@ -208,7 +207,6 @@ impl fmt::Display for UnmodeledReason {
         match self {
             Self::ModelGap(kind) => write!(f, "oracle model gap ({kind:?})"),
             Self::TrapExpectation => f.write_str("runtime trap expectation"),
-            Self::SpecStderrExpectation => f.write_str("spec stderr expectation"),
         }
     }
 }
@@ -355,7 +353,8 @@ fn run() -> ExitCode {
 }
 
 /// The original corpus differential: run each rue-cli-tests case through the
-/// oracle and check it agrees with the case's expected exit code / stdout.
+/// oracle and check it agrees with the case's expected exit code / stdout /
+/// stderr.
 fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
     let dirs: Vec<PathBuf> = {
         let args: Vec<String> = raw_args;
@@ -607,9 +606,17 @@ fn check_spec_case_with_known_gap(
                 rue_test_runner::strip_block_boundary_newlines(&outcome.stdout)
                     == rue_test_runner::strip_block_boundary_newlines(s)
             });
+            // Match the real spec runner's two stderr paths: `runtime_error`
+            // checks its own substring and returns early there; otherwise the
+            // generic `stderr_contains` assertion participates.
+            let expected_stderr = case
+                .runtime_error
+                .as_ref()
+                .or(case.stderr_contains.as_ref());
+            let stderr_ok =
+                expected_stderr.is_none_or(|expected| outcome.stderr.contains(expected));
             let trap_ok = trap_comparison == TrapComparison::Match;
-            let modeled_observations_agree = exit_ok && stdout_ok && trap_ok;
-            let stderr_unmodeled = has_unmodeled_spec_stderr_expectation(case);
+            let modeled_observations_agree = exit_ok && stdout_ok && stderr_ok && trap_ok;
 
             if is_known_gap {
                 // xfail semantics (mirroring rue-cli-tests `known_bug`): the case
@@ -633,21 +640,16 @@ fn check_spec_case_with_known_gap(
                 };
             }
 
-            // A missing trap model cannot erase a concrete exit/stdout
+            // A missing trap model cannot erase a concrete exit/stdout/stderr
             // disagreement or bypass the known-gap registry above. Only
             // classify it as coverage when every independently modeled
             // observation agrees.
-            if exit_ok && stdout_ok && trap_comparison == TrapComparison::UnmodeledExpectation {
+            if exit_ok
+                && stdout_ok
+                && stderr_ok
+                && trap_comparison == TrapComparison::UnmodeledExpectation
+            {
                 return CaseOutcome::Unmodeled(UnmodeledReason::TrapExpectation);
-            }
-
-            // `Outcome` has no stderr channel. Preserve a normal-path stderr
-            // assertion as explicit coverage until the oracle models that
-            // observation, but only after every observation it can judge has
-            // agreed. The real spec runner ignores generic `stderr_contains`
-            // on its separate `runtime_error` path.
-            if modeled_observations_agree && stderr_unmodeled {
-                return CaseOutcome::Unmodeled(UnmodeledReason::SpecStderrExpectation);
             }
 
             if modeled_observations_agree {
@@ -667,6 +669,13 @@ fn check_spec_case_with_known_gap(
                         outcome.stdout
                     );
                 }
+                if !stderr_ok {
+                    msg += &format!(
+                        "\n      stderr: missing required substring {:?} in {:?}",
+                        expected_stderr.map(String::as_str).unwrap_or(""),
+                        outcome.stderr
+                    );
+                }
                 if let TrapComparison::Mismatch { expected, actual } = trap_comparison {
                     msg += &format!("\n      trap: expected {expected:?}, oracle got {actual:?}");
                 }
@@ -674,10 +683,6 @@ fn check_spec_case_with_known_gap(
             }
         }
     }
-}
-
-fn has_unmodeled_spec_stderr_expectation(case: &rue_test_runner::Case) -> bool {
-    case.runtime_error.is_none() && case.stderr_contains.is_some()
 }
 
 fn spec_preview_features(case: &rue_test_runner::Case) -> PreviewFeatures {
@@ -792,15 +797,25 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
                 .stdout_contains
                 .iter()
                 .find(|expected| !outcome.stdout.contains(expected.as_str()));
+            let missing_stderr = case
+                .runtime_error_contains
+                .iter()
+                .find(|expected| !outcome.stderr.contains(expected.as_str()));
             let trap_ok = trap_comparison == TrapComparison::Match;
             if exit_ok
                 && stdout_ok
                 && missing_stdout.is_none()
+                && missing_stderr.is_none()
                 && trap_comparison == TrapComparison::UnmodeledExpectation
             {
                 return CaseOutcome::Unmodeled(UnmodeledReason::TrapExpectation);
             }
-            if exit_ok && stdout_ok && missing_stdout.is_none() && trap_ok {
+            if exit_ok
+                && stdout_ok
+                && missing_stdout.is_none()
+                && missing_stderr.is_none()
+                && trap_ok
+            {
                 CaseOutcome::Agree
             } else {
                 let mut msg = format!("{} :: {}", rel(path), case.name);
@@ -821,6 +836,12 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
                     msg += &format!(
                         "\n      stdout: missing required substring {expected:?} in {:?}",
                         outcome.stdout
+                    );
+                }
+                if let Some(expected) = missing_stderr {
+                    msg += &format!(
+                        "\n      stderr: missing required substring {expected:?} in {:?}",
+                        outcome.stderr
                     );
                 }
                 if let TrapComparison::Mismatch { expected, actual } = trap_comparison {
@@ -1623,7 +1644,7 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
         case.runtime_error = Some("panic: integer overflow".to_string());
         assert!(matches!(
             check_spec_case("test:1", &case),
-            CaseOutcome::Unmodeled(UnmodeledReason::TrapExpectation)
+            CaseOutcome::Disagreement(_)
         ));
 
         case.expected_stdout = Some("required output\n".to_string());
@@ -1641,7 +1662,7 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
     }
 
     #[test]
-    fn spec_stderr_is_unmodeled_only_after_modeled_observations_agree() {
+    fn spec_stderr_expectations_are_enforced_as_modeled_observations() {
         let mut case = rue_test_runner::Case {
             name: "stderr coverage probe".to_string(),
             source: "fn main() -> i32 { 0 }".to_string(),
@@ -1649,10 +1670,11 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
             stderr_contains: Some("required notice".to_string()),
             ..Default::default()
         };
-        assert_eq!(
-            check_spec_case("test:1", &case),
-            CaseOutcome::Unmodeled(UnmodeledReason::SpecStderrExpectation)
-        );
+        let CaseOutcome::Disagreement(message) = check_spec_case("test:1", &case) else {
+            panic!("missing modeled stderr did not disagree");
+        };
+        assert!(message.contains("missing required substring"));
+        assert!(message.contains("required notice"));
 
         case.exit_code = Some(1);
         assert!(matches!(
@@ -1707,17 +1729,15 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
         );
 
         case.exit_code = Some(0);
-        let CaseOutcome::Disagreement(message) =
-            check_spec_case_with_known_gap("test:1", &case, true)
-        else {
-            panic!("generic stderr coverage hid a stale known-gap entry");
-        };
-        assert!(message.contains("KNOWN_ORACLE_GAPS entry is stale"));
         assert_eq!(
-            check_spec_case_with_known_gap("test:1", &case, false),
-            CaseOutcome::Unmodeled(UnmodeledReason::SpecStderrExpectation),
-            "deleting a stale wrong-result exemption must expose stderr coverage"
+            check_spec_case_with_known_gap("test:1", &case, true),
+            CaseOutcome::Ineligible(IneligibleReason::KnownOracleGap),
+            "the remaining stderr mismatch keeps the tracked wrong-result entry live"
         );
+        assert!(matches!(
+            check_spec_case_with_known_gap("test:1", &case, false),
+            CaseOutcome::Disagreement(_)
+        ));
     }
 
     #[test]
@@ -1811,7 +1831,10 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
     fn unknown_runtime_expectations_are_counted_as_unmodeled() {
         let mut case = corpus_case("fn main() -> i32 { let x: i32 = 2147483647; x + 1 }", false);
         case.exit_code = None;
-        case.runtime_error_contains = vec!["custom trap wording".to_string()];
+        // This fragment pins the exact emitted stderr but is intentionally not
+        // part of the typed trap vocabulary, so category coverage alone remains
+        // explicit.
+        case.runtime_error_contains = vec!["error: integer overflow".to_string()];
 
         let mut report = Report::default();
         report.record(check_case(Path::new("trap.toml"), &case));
@@ -1819,6 +1842,13 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
         assert_eq!(report.unmodeled_count(), 1);
         assert!(report.disagreements.is_empty());
         assert_eq!(report.modeled_eligible_count(), 0);
+
+        case.runtime_error_contains = vec!["custom trap wording".to_string()];
+        assert!(matches!(
+            check_case(Path::new("trap.toml"), &case),
+            CaseOutcome::Disagreement(_)
+        ));
+        case.runtime_error_contains = vec!["error: integer overflow".to_string()];
 
         // The same ordering applies to substring output contracts.
         case.stdout_contains = vec!["required output".to_string()];
@@ -1892,7 +1922,7 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
     }
 
     #[test]
-    fn non_oracle_unmodeled_reasons_remain_distinct() {
+    fn modeled_stderr_mismatches_are_not_unmodeled_coverage() {
         let mut trap_case =
             corpus_case("fn main() -> i32 { let x: i32 = 2147483647; x + 1 }", false);
         trap_case.exit_code = None;
@@ -1908,26 +1938,14 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
         };
         let stderr_outcome = check_spec_case("test:1", &stderr_case);
 
-        assert_eq!(
-            trap_outcome,
-            CaseOutcome::Unmodeled(UnmodeledReason::TrapExpectation)
-        );
-        assert_eq!(
-            stderr_outcome,
-            CaseOutcome::Unmodeled(UnmodeledReason::SpecStderrExpectation)
-        );
+        assert!(matches!(trap_outcome, CaseOutcome::Disagreement(_)));
+        assert!(matches!(stderr_outcome, CaseOutcome::Disagreement(_)));
 
         let mut report = Report::default();
         report.record(trap_outcome);
         report.record(stderr_outcome);
-        assert_eq!(report.unmodeled_count(), 2);
-        assert_eq!(
-            report.unmodeled_breakdown_lines(),
-            vec![
-                "    runtime trap expectation: 1",
-                "    spec stderr expectation: 1",
-            ]
-        );
+        assert_eq!(report.unmodeled_count(), 0);
+        assert_eq!(report.disagreements.len(), 2);
     }
 
     #[test]

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -4,7 +4,7 @@
 //! control-flow IR, produced by [`rue_compiler::compile_to_cfg`], *before* the
 //! MIR/codegen lowering where every miscompile of the 2026-07 work lived).
 //! Running a program through this interpreter and through the compiled binary
-//! and comparing the observable behavior (exit code, `@dbg` output, panic-or-not)
+//! and comparing the observable behavior (exit code, stdout, stderr, trap cause)
 //! is the differential-testing oracle of RUE-50, and the executable form of the
 //! operational semantics in `docs/formal/01-core-calculus.md` §6.
 //!
@@ -115,6 +115,10 @@ pub struct Outcome {
     pub exit_code: i32,
     /// Everything `@dbg` wrote, in order, newline-terminated per call.
     pub stdout: String,
+    /// Everything the modeled runtime wrote to stderr, decoded with the same
+    /// lossy UTF-8 boundary as the native differential runner so the resulting
+    /// observation remains exactly comparable.
+    pub stderr: String,
     /// `Some(kind)` if execution ended in a modeled trap, `None` on normal
     /// completion. Runtime-handled kinds mirror the runtime's trap categories.
     pub panic: Option<TrapKind>,
@@ -128,6 +132,14 @@ pub struct Outcome {
 /// remains exact; crossing it is surfaced explicitly and never accepted by
 /// comparing a truncated prefix.
 pub const MAX_STDOUT_BYTES: usize = 256 * 1024;
+
+/// Maximum number of raw bytes accepted from modeled runtime stderr.
+///
+/// Rue currently writes stderr only when terminating in a runtime trap. The
+/// bound matches the native differential runner's retained stderr limit so a
+/// long user panic cannot consume unbounded harness memory or manufacture
+/// agreement from a retained prefix.
+pub const MAX_STDERR_BYTES: usize = 8 * 1024;
 
 /// The policy class of a typed oracle execution failure.
 ///
@@ -227,6 +239,7 @@ pub enum ModelGapKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ResourceLimitKind {
     StdoutBytes,
+    StderrBytes,
     RecursionDepth,
     InterpreterSteps,
 }
@@ -424,6 +437,15 @@ fn run_state_with_limits(
     budget: u64,
     stdout_cap: usize,
 ) -> Result<Outcome, Unsupported> {
+    run_state_with_output_limits(state, budget, stdout_cap, MAX_STDERR_BYTES)
+}
+
+fn run_state_with_output_limits(
+    state: CompileState,
+    budget: u64,
+    stdout_cap: usize,
+    stderr_cap: usize,
+) -> Result<Outcome, Unsupported> {
     // Interpret on a dedicated large-stack worker thread. The tree-walking
     // interpreter recurses per expression *and* per call, so deep-but-valid
     // programs need far more stack than a default thread provides. Running on
@@ -440,6 +462,7 @@ fn run_state_with_limits(
                     stdout: String::new(),
                     stdout_bytes: 0,
                     stdout_cap,
+                    stderr_cap,
                     budget,
                     depth: 0,
                 }
@@ -543,8 +566,44 @@ impl Value {
     }
 }
 
-/// A runtime panic, carrying its category (mirrors the runtime's panic classes).
-struct Panic(TrapKind);
+/// A runtime panic, carrying its typed category and exact stderr observation.
+struct Panic {
+    kind: TrapKind,
+    stderr: String,
+    raw_stderr_bytes: usize,
+}
+
+impl Panic {
+    fn runtime(kind: TrapKind) -> Self {
+        let stderr = match kind {
+            TrapKind::ArithmeticOverflow => "error: integer overflow\n",
+            TrapKind::DivisionByZero => "error: division by zero\n",
+            TrapKind::IntegerCastOverflow => "error: integer cast overflow\n",
+            TrapKind::IndexOutOfBounds => "error: index out of bounds\n",
+            TrapKind::InvalidUtf8 => "error: invalid UTF-8\n",
+            // User-authored panics and assertions require a dynamic diagnostic.
+            // Reaching this fixed-message constructor would erase that
+            // observation, so keep the invariant loud in debug builds.
+            TrapKind::UserPanic | TrapKind::AssertionFailure => {
+                debug_assert!(false, "dynamic trap stderr must be supplied explicitly");
+                ""
+            }
+            // `Unreachable` represents defensive malformed-CFG behavior whose
+            // native counterpart generally faults rather than using the Rue
+            // runtime error channel.
+            TrapKind::Unreachable => "",
+        };
+        Self::with_stderr(kind, stderr.to_string(), stderr.len())
+    }
+
+    fn with_stderr(kind: TrapKind, stderr: String, raw_stderr_bytes: usize) -> Self {
+        Self {
+            kind,
+            stderr,
+            raw_stderr_bytes,
+        }
+    }
+}
 
 type Step<T> = Result<T, Flow>;
 
@@ -624,6 +683,9 @@ struct Interp<'a> {
     /// UTF-8 bytes render as the three-byte replacement character.
     stdout_bytes: usize,
     stdout_cap: usize,
+    /// Maximum raw bytes retained for the single terminating runtime stderr
+    /// observation.
+    stderr_cap: usize,
     /// Remaining total step budget (see [`STEP_BUDGET`]). Shared across every
     /// activation and decremented per instruction, so it bounds total work
     /// including recursion, not just per-frame loops.
@@ -1230,13 +1292,26 @@ impl<'a> Interp<'a> {
             Ok((v, _)) => Ok(Outcome {
                 exit_code: (v.as_int() & 0xFF) as i32,
                 stdout: self.stdout,
+                stderr: String::new(),
                 panic: None,
             }),
-            Err(Flow::Panic(Panic(reason))) => Ok(Outcome {
-                exit_code: 101,
-                stdout: self.stdout,
-                panic: Some(reason),
-            }),
+            Err(Flow::Panic(panic)) => {
+                if panic.raw_stderr_bytes > self.stderr_cap {
+                    return Err(Unsupported::new(
+                        UnsupportedKind::ResourceLimit(ResourceLimitKind::StderrBytes),
+                        format!(
+                            "stderr byte limit exceeded ({}-byte limit)",
+                            self.stderr_cap
+                        ),
+                    ));
+                }
+                Ok(Outcome {
+                    exit_code: 101,
+                    stdout: self.stdout,
+                    stderr: panic.stderr,
+                    panic: Some(panic.kind),
+                })
+            }
             Err(Flow::Unsupported(u)) => Err(u),
         }
     }
@@ -1409,7 +1484,7 @@ impl<'a> Interp<'a> {
                     incoming = Vec::new();
                 }
                 Terminator::Unreachable => {
-                    return Err(Flow::Panic(Panic(TrapKind::Unreachable)));
+                    return Err(Flow::Panic(Panic::runtime(TrapKind::Unreachable)));
                 }
                 Terminator::None => {
                     return Err(unsupported(
@@ -1634,7 +1709,7 @@ impl<'a> Interp<'a> {
                 let bytes = s(&args[0])?;
                 let idx = args[1].as_int();
                 if idx < 0 || idx as u128 >= bytes.len() as u128 {
-                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
+                    return Err(Flow::Panic(Panic::runtime(TrapKind::IndexOutOfBounds)));
                 }
                 Value::Int(bytes[idx as usize] as i128)
             }
@@ -1647,7 +1722,7 @@ impl<'a> Interp<'a> {
                 let bytes = s(&args[0])?;
                 let idx = args[1].as_int();
                 if idx < 0 || idx as u128 >= bytes.len() as u128 {
-                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
+                    return Err(Flow::Panic(Panic::runtime(TrapKind::IndexOutOfBounds)));
                 }
                 Value::Int(bytes[idx as usize] as i128)
             }
@@ -1657,7 +1732,7 @@ impl<'a> Interp<'a> {
                 let bytes = s(&args[0])?;
                 match char_at(&bytes, args[1].as_int()) {
                     Some((scalar, _)) => Value::Int(scalar as i128),
-                    None => return Err(Flow::Panic(Panic(TrapKind::InvalidUtf8))),
+                    None => return Err(Flow::Panic(Panic::runtime(TrapKind::InvalidUtf8))),
                 }
             }
             "__rue_String_char_next" => {
@@ -1665,7 +1740,7 @@ impl<'a> Interp<'a> {
                 let offset = args[1].as_int();
                 match char_at(&bytes, offset) {
                     Some((_, width)) => Value::Int(offset + width as i128),
-                    None => return Err(Flow::Panic(Panic(TrapKind::InvalidUtf8))),
+                    None => return Err(Flow::Panic(Panic::runtime(TrapKind::InvalidUtf8))),
                 }
             }
             // The lossy character view never traps: invalid UTF-8 becomes U+FFFD
@@ -2162,7 +2237,7 @@ impl<'a> Interp<'a> {
                     )
                 })?;
                 if x < lo || x > hi {
-                    return Err(Flow::Panic(Panic(TrapKind::IntegerCastOverflow)));
+                    return Err(Flow::Panic(Panic::runtime(TrapKind::IntegerCastOverflow)));
                 }
                 Value::Int(x)
             }
@@ -2205,14 +2280,14 @@ impl<'a> Interp<'a> {
         let x = self.eval(cfg, frame, a)?.as_int();
         let y = self.eval(cfg, frame, b)?.as_int();
         if y == 0 {
-            return Err(Flow::Panic(Panic(TrapKind::DivisionByZero)));
+            return Err(Flow::Panic(Panic::runtime(TrapKind::DivisionByZero)));
         }
         // MIN / -1 (and MIN % -1) trap at the operand width: the hardware `idiv`
         // faults even though the mathematical remainder is 0. Our i128 model
         // wouldn't otherwise catch it (the value fits in i128).
         if let Some((lo, _)) = int_bounds(ty) {
             if ty.is_signed() && x == lo && y == -1 {
-                return Err(Flow::Panic(Panic(TrapKind::ArithmeticOverflow)));
+                return Err(Flow::Panic(Panic::runtime(TrapKind::ArithmeticOverflow)));
             }
         }
         let r = if is_mod {
@@ -2340,7 +2415,7 @@ impl<'a> Interp<'a> {
                 Projection::Index { index, .. } => {
                     let i = self.eval(cfg, frame, index)?.as_int();
                     if i < 0 {
-                        return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
+                        return Err(Flow::Panic(Panic::runtime(TrapKind::IndexOutOfBounds)));
                     }
                     path.push((i as usize, p));
                 }
@@ -2375,7 +2450,7 @@ impl<'a> Interp<'a> {
             cur = match cur {
                 Value::Aggregate(mut v) if idx < v.len() => v.swap_remove(idx),
                 Value::Aggregate(_) => {
-                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
+                    return Err(Flow::Panic(Panic::runtime(TrapKind::IndexOutOfBounds)));
                 }
                 Value::Str { slots, .. } if self.is_matching_text_projection(projection, slots) => {
                     return Err(unsupported(
@@ -2419,7 +2494,7 @@ impl<'a> Interp<'a> {
             cur = match cur {
                 Value::Aggregate(v) if *idx < v.len() => &mut v[*idx],
                 Value::Aggregate(_) => {
-                    return Err(Flow::Panic(Panic(TrapKind::IndexOutOfBounds)));
+                    return Err(Flow::Panic(Panic::runtime(TrapKind::IndexOutOfBounds)));
                 }
                 _ => {
                     return Err(unsupported(
@@ -2604,9 +2679,11 @@ fn int_bounds(ty: Type) -> Option<(i128, i128)> {
 /// `None` (a checked-arithmetic overflow) or an out-of-range result traps as a
 /// runtime overflow panic (spec 3.1:6/13); otherwise the value is returned.
 fn range_check(v: Option<i128>, ty: Type) -> Step<Value> {
-    let n = v.ok_or(Flow::Panic(Panic(TrapKind::ArithmeticOverflow)))?;
+    let n = v.ok_or(Flow::Panic(Panic::runtime(TrapKind::ArithmeticOverflow)))?;
     match int_bounds(ty) {
-        Some((lo, hi)) if n < lo || n > hi => Err(Flow::Panic(Panic(TrapKind::ArithmeticOverflow))),
+        Some((lo, hi)) if n < lo || n > hi => {
+            Err(Flow::Panic(Panic::runtime(TrapKind::ArithmeticOverflow)))
+        }
         _ => Ok(Value::Int(n)),
     }
 }

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -1,5 +1,5 @@
 //! Correctness corpus for the reference interpreter. Each case asserts the
-//! oracle's observable behavior (exit code, `@dbg` output, panic-or-not) matches
+//! oracle's observable behavior (exit code, stdout, stderr, trap cause) matches
 //! the value the language semantics require — which is also what the compiled
 //! binary must produce. Agreement here is the differential check in miniature;
 //! `tests/differential.rs`-style wiring against the real binary across the whole
@@ -20,8 +20,16 @@ fn run_with_budget(src: &str, budget: u64) -> Result<Outcome, Unsupported> {
 }
 
 fn run_with_stdout_cap(src: &str, stdout_cap: usize) -> Result<Outcome, Unsupported> {
+    run_with_output_caps(src, stdout_cap, MAX_STDERR_BYTES)
+}
+
+fn run_with_output_caps(
+    src: &str,
+    stdout_cap: usize,
+    stderr_cap: usize,
+) -> Result<Outcome, Unsupported> {
     let state = compile_to_cfg(src).unwrap_or_else(|e| panic!("compile error: {e:#?}"));
-    run_state_with_limits(state, STEP_BUDGET, stdout_cap)
+    run_state_with_output_limits(state, STEP_BUDGET, stdout_cap, stderr_cap)
 }
 
 fn run_string_trio(src: &str) -> Outcome {
@@ -161,7 +169,39 @@ fn early_return() {
 fn dbg_output() {
     let out = run("fn main() -> i32 { @dbg(7); @dbg(true); 0 }");
     assert_eq!(out.stdout, "7\ntrue\n");
+    assert_eq!(out.stderr, "");
     assert_eq!(out.exit_code, 0);
+}
+
+#[test]
+fn stdout_and_stderr_limits_are_independent_and_fail_closed() {
+    let source = "fn main() -> i32 {
+        @dbg(7);
+        let max: i32 = 2147483647;
+        max + 1
+    }";
+    let out = run_with_output_caps(source, 2, 24)
+        .unwrap_or_else(|unsupported| panic!("exactly capped streams failed: {unsupported}"));
+    assert_eq!(out.stdout, "7\n");
+    assert_eq!(out.stderr, "error: integer overflow\n");
+
+    let unsupported =
+        run_with_output_caps(source, 1, 24).expect_err("stdout overflow must fail before the trap");
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::ResourceLimit(ResourceLimitKind::StdoutBytes)
+    );
+
+    let unsupported = run_with_output_caps(source, 2, 23)
+        .expect_err("the complete runtime diagnostic must exceed the stderr cap");
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::ResourceLimit(ResourceLimitKind::StderrBytes)
+    );
+    assert_eq!(
+        unsupported.detail(),
+        "stderr byte limit exceeded (23-byte limit)"
+    );
 }
 
 #[test]
@@ -411,6 +451,7 @@ fn overflow_traps() {
         b
     }");
     assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stderr, "error: integer overflow\n");
     assert_eq!(out.panic, Some(TrapKind::ArithmeticOverflow));
 }
 
@@ -418,10 +459,12 @@ fn overflow_traps() {
 fn divide_and_remainder_by_zero_share_a_trap_kind() {
     let out = run("fn main() -> i32 { let z = 0; 10 / z }");
     assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stderr, "error: division by zero\n");
     assert_eq!(out.panic, Some(TrapKind::DivisionByZero));
 
     let out = run("fn main() -> i32 { let z = 0; 10 % z }");
     assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stderr, "error: division by zero\n");
     assert_eq!(out.panic, Some(TrapKind::DivisionByZero));
 }
 
@@ -471,6 +514,7 @@ fn intcast_in_range_and_overflow() {
         y
     }");
     assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stderr, "error: integer cast overflow\n");
     assert_eq!(out.panic, Some(TrapKind::IntegerCastOverflow));
 }
 

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -118,6 +118,7 @@ fn runtime_call_classification_requires_exact_metadata() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -299,6 +300,7 @@ fn capacity_and_intrinsic_signature_drift_are_contract_failures() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -409,6 +411,7 @@ fn capacity_and_intrinsic_signature_drift_are_contract_failures() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -526,6 +529,7 @@ fn malformed_outer_calls_are_rejected_before_unmodeled_operands_run() {
             stdout: String::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
         };
@@ -566,6 +570,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -675,6 +680,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -728,6 +734,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -794,6 +801,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -884,6 +892,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -937,6 +946,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -968,6 +978,7 @@ fn field_pointer_gaps_require_in_bounds_projection_metadata() {
             stdout: String::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
         };
@@ -1019,6 +1030,7 @@ fn field_pointer_gaps_require_in_bounds_projection_metadata() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -1052,6 +1064,7 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -114,6 +114,7 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -164,6 +165,7 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -290,6 +292,7 @@ fn logical_inout_writability_is_distinct_from_the_by_reference_abi() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -371,6 +374,7 @@ fn text_projection_gaps_require_exact_representation_metadata() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -438,6 +442,7 @@ fn text_projection_gaps_require_exact_representation_metadata() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -453,6 +458,7 @@ fn text_projection_gaps_require_exact_representation_metadata() {
                 stdout: String::new(),
                 stdout_bytes: 0,
                 stdout_cap: MAX_STDOUT_BYTES,
+                stderr_cap: MAX_STDERR_BYTES,
                 budget: STEP_BUDGET,
                 depth: 0,
             };
@@ -542,6 +548,7 @@ fn text_projection_gap_requires_the_complete_place_chain_to_be_well_typed() {
             stdout: String::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
         };
@@ -661,6 +668,7 @@ fn place_write_contracts_precede_rhs_model_gaps() {
             stdout: String::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
         };
@@ -732,6 +740,7 @@ fn place_read_base_contract_precedes_index_model_gap() {
             stdout: String::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
         };
@@ -782,6 +791,7 @@ fn zero_sized_place_base_uses_the_canonical_boundary_slot() {
             stdout: String::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
         };
@@ -814,6 +824,7 @@ fn zero_sized_place_base_uses_the_canonical_boundary_slot() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };
@@ -896,6 +907,7 @@ fn whole_place_write_requires_exact_type_and_writable_storage() {
             stdout: String::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
         };
@@ -968,6 +980,7 @@ fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
             stdout: String::new(),
             stdout_bytes: 0,
             stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
             budget: STEP_BUDGET,
             depth: 0,
         };
@@ -1005,6 +1018,7 @@ fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
         stdout: String::new(),
         stdout_bytes: 0,
         stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
         budget: STEP_BUDGET,
         depth: 0,
     };

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -1234,8 +1234,11 @@ result is fixed by running `main`:
 `main`'s returned `i32` is masked to a byte for the process exit code, and a
 `unit`-returning `main` exits 0 (`Interp::run`, `lib.rs:165`); any trap exits 101
 (`lib.rs:172`). These two rules, plus the observable `@dbg` output accumulated
-during reduction, are precisely the `Outcome` (`exit_code`, `stdout`, `panic`) the
-differential harness compares against the compiled binary (RUE-50).
+during reduction and the exact runtime diagnostic emitted by a trap, are
+precisely the `Outcome` (`exit_code`, `stdout`, `stderr`, `panic`) the differential
+harness compares against the compiled binary (RUE-50). Both executions retain
+stderr only up to the same fixed bound and reject overflow or a truncated native
+prefix, so bounded observation cannot manufacture agreement.
 
 The interpreter implementing this whole relation is the executable oracle
 (`crates/rue-oracle`; README § "The executable oracle" / RUE-50). Every rule group


### PR DESCRIPTION
## Summary

- add stderr to oracle outcomes with exact diagnostics for every already-modeled deterministic runtime trap
- share an 8 KiB oracle/native capture bound, propagate truncation, and fail closed instead of comparing retained prefixes
- compare stderr in generated, CLI, and spec differential paths while preserving panic/assert as explicit typed model gaps
- keep the formal Outcome contract synchronized with the executable oracle

## Validation

- `./fmt.sh check`
- `./clippy.sh` (41 targets)
- `./test.sh` (33/33)
- live CLI: 619 agree / 107 typed gaps / 548 ineligible / 0 failures / 0 disagreements
- live spec: 1318 agree / 107 typed gaps / 582 ineligible / 0 failures / 0 disagreements
- generated smoke: 64/64 agree
- independent split/correctness review: clear after formal-contract update