### PR TITLE
RUE-530: block-scope local comptime type aliases

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -212,13 +212,28 @@ pub struct ConstraintGenerator<'a> {
     module_file_ids: Option<&'a HashMap<crate::types::ModuleId, FileId>>,
     /// Compile-time type aliases bound by `let` in the current function body
     /// (`let P = F();` where `F` returns `type`), pre-resolved by sema before
-    /// constraint generation. Consulted after `type_subst` when resolving
-    /// struct-literal type names and `let` annotations, so anonymous-struct
-    /// aliases route through the same concrete paths as named structs
-    /// (RUE-170). Like sema's `comptime_type_vars`, the map is flat (not
-    /// scope-aware). `None` only in unit tests; production passes the map via
-    /// [`Self::with_comptime_local_types`].
-    comptime_local_types: Option<&'a HashMap<Spur, Type>>,
+    /// constraint generation and keyed by each binding's own Alloc
+    /// instruction. When the walk reaches a binding site in this map, the
+    /// alias is brought into scope in [`Self::comptime_alias_types`] and
+    /// unwound with its enclosing block (RUE-530). `None` only in unit tests;
+    /// production passes the map via [`Self::with_comptime_local_bindings`].
+    comptime_local_bindings: Option<&'a HashMap<InstRef, Type>>,
+    /// The comptime type aliases currently in scope (name → aliased type),
+    /// maintained live during the walk from [`Self::comptime_local_bindings`]
+    /// via [`Self::enter_scope`]/[`Self::exit_scope`]. Consulted after
+    /// `type_subst` when resolving struct-literal type names and `let`
+    /// annotations, so anonymous-struct aliases route through the same
+    /// concrete paths as named structs (RUE-170), and lexically scoped like
+    /// sema's `comptime_type_vars` so sibling-branch aliases don't collide
+    /// and an alias doesn't outlive its block (RUE-530).
+    comptime_alias_types: HashMap<Spur, Type>,
+    /// Per-scope undo frames for `comptime_alias_types`, parallel to the
+    /// `ConstraintContext` scope stack (both are pushed/popped only by
+    /// [`Self::enter_scope`]/[`Self::exit_scope`]): each frame records the
+    /// shadowed binding (or absence) for every alias bound — or hidden by a
+    /// same-named runtime `let` — in that scope, restored in reverse on exit
+    /// (the RUE-522 pattern).
+    alias_scope_stack: Vec<Vec<(Spur, Option<Type>)>>,
     /// Inline type-constructor heads (`F(args).Variant(..)`, `F(args) { .. }`;
     /// RUE-596, preview `inline_type_ctor_paths`) pre-reduced by sema to their
     /// concrete struct/enum types, keyed by the head's own `InstRef` — the
@@ -309,7 +324,9 @@ impl<'a> ConstraintGenerator<'a> {
             module_binding_types: None,
             functions_by_file_name: None,
             module_file_ids: None,
-            comptime_local_types: None,
+            comptime_local_bindings: None,
+            comptime_alias_types: HashMap::new(),
+            alias_scope_stack: Vec::new(),
             inline_ctor_head_types: None,
             extra_method_sigs: None,
             const_values: None,
@@ -403,14 +420,15 @@ impl<'a> ConstraintGenerator<'a> {
         self
     }
 
-    /// Provide pre-resolved comptime type aliases (local name -> concrete
-    /// type) for struct-literal and `let`-annotation resolution. See the
-    /// `comptime_local_types` field (RUE-170).
-    pub fn with_comptime_local_types(
+    /// Provide pre-resolved comptime type aliases (binding-site Alloc
+    /// `InstRef` -> concrete type) for struct-literal and `let`-annotation
+    /// resolution. See the `comptime_local_bindings` field (RUE-170,
+    /// RUE-530).
+    pub fn with_comptime_local_bindings(
         mut self,
-        comptime_local_types: &'a HashMap<Spur, Type>,
+        comptime_local_bindings: &'a HashMap<InstRef, Type>,
     ) -> Self {
-        self.comptime_local_types = Some(comptime_local_types);
+        self.comptime_local_bindings = Some(comptime_local_bindings);
         self
     }
 
@@ -630,6 +648,53 @@ impl<'a> ConstraintGenerator<'a> {
         )
     }
 
+    /// Enter a lexical scope: pushes the context's local-variable scope and
+    /// this generator's comptime-alias scope together, so the two stacks stay
+    /// in lockstep (RUE-530). Always pair with [`Self::exit_scope`]; scope
+    /// sites must not call `ctx.push_scope()` directly.
+    fn enter_scope(&mut self, ctx: &mut ConstraintContext) {
+        ctx.push_scope();
+        self.alias_scope_stack.push(Vec::new());
+    }
+
+    /// Exit a lexical scope: pops the context's local-variable scope and
+    /// unwinds this scope's comptime-alias frame in reverse, restoring
+    /// shadowed aliases and removing ones introduced here (the RUE-522
+    /// unwind order).
+    fn exit_scope(&mut self, ctx: &mut ConstraintContext) {
+        ctx.pop_scope();
+        if let Some(frame) = self.alias_scope_stack.pop() {
+            for (name, old) in frame.into_iter().rev() {
+                match old {
+                    Some(ty) => self.comptime_alias_types.insert(name, ty),
+                    None => self.comptime_alias_types.remove(&name),
+                };
+            }
+        }
+    }
+
+    /// Bring a comptime type alias into scope, saving the name's previous
+    /// binding (or absence) in the current scope frame for restore on
+    /// [`Self::exit_scope`].
+    fn bind_comptime_alias(&mut self, name: Spur, ty: Type) {
+        let old = self.comptime_alias_types.insert(name, ty);
+        if let Some(frame) = self.alias_scope_stack.last_mut() {
+            frame.push((name, old));
+        }
+    }
+
+    /// A runtime `let` binding hides any same-named comptime type alias for
+    /// the rest of its scope (the inner binding wins, whatever its kind);
+    /// save the alias in the current frame so it is restored when the
+    /// shadowing binding's block ends.
+    fn hide_comptime_alias(&mut self, name: Spur) {
+        if let Some(old) = self.comptime_alias_types.remove(&name)
+            && let Some(frame) = self.alias_scope_stack.last_mut()
+        {
+            frame.push((name, Some(old)));
+        }
+    }
+
     /// Generate constraints for an expression.
     ///
     /// Returns the inferred type of the expression. Records the type in
@@ -828,8 +893,9 @@ impl<'a> ConstraintGenerator<'a> {
                     // tables); without this the annotation was unenforced and
                     // any value typechecked against it (RUE-170).
                     let annotated = self
-                        .comptime_local_types
-                        .and_then(|aliases| aliases.get(ty_sym).copied())
+                        .comptime_alias_types
+                        .get(ty_sym)
+                        .copied()
                         .or_else(|| {
                             self.const_type_aliases
                                 .and_then(|aliases| aliases.get(ty_sym).copied())
@@ -857,10 +923,10 @@ impl<'a> ConstraintGenerator<'a> {
                         // field types match the definition.
                         init_info.ty
                     }
-                } else if name.is_some_and(|n| {
-                    self.comptime_local_types
-                        .is_some_and(|aliases| aliases.contains_key(&n))
-                }) {
+                } else if self
+                    .comptime_local_bindings
+                    .is_some_and(|bindings| bindings.contains_key(&inst_ref))
+                {
                     // Sema pre-resolved this binding as a comptime type alias
                     // (`let O = std.option.Option(i64);`). A module-qualified
                     // constructor init infers as a fresh variable (the module
@@ -869,14 +935,19 @@ impl<'a> ConstraintGenerator<'a> {
                     // and left payload literals unconstrained (RUE-609, the
                     // RUE-599 failure mode through a bound alias). The binding
                     // holds a type value, so type it as one; downstream paths
-                    // read the concrete aliased type from `comptime_local_types`.
+                    // read the concrete aliased type from `comptime_alias_types`.
                     InferType::Concrete(Type::COMPTIME_TYPE)
                 } else {
                     // No annotation - use the init expression's type
                     init_info.ty
                 };
 
-                // Record the variable in scope (if it has a name)
+                // Record the variable in scope (if it has a name), and keep
+                // the comptime-alias view in sync: an alias binding comes
+                // into scope here (its initializer above must not see it —
+                // `let P = Wrap(P);` refers to the outer `P`), and a runtime
+                // binding hides any same-named outer alias for the rest of
+                // this scope (RUE-530).
                 if let Some(var_name) = name {
                     ctx.insert_local(
                         *var_name,
@@ -886,6 +957,13 @@ impl<'a> ConstraintGenerator<'a> {
                             span,
                         },
                     );
+                    match self
+                        .comptime_local_bindings
+                        .and_then(|bindings| bindings.get(&inst_ref).copied())
+                    {
+                        Some(alias_ty) => self.bind_comptime_alias(*var_name, alias_ty),
+                        None => self.hide_comptime_alias(*var_name),
+                    }
                 }
 
                 // Alloc produces unit type
@@ -1394,7 +1472,7 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Block
             InstData::Block { extra_start, len } => {
-                ctx.push_scope();
+                self.enter_scope(ctx);
                 let mut last_ty = InferType::Concrete(Type::UNIT);
                 let block_insts = self.rir.get_extra(*extra_start, *len);
                 for &inst_raw in block_insts {
@@ -1402,7 +1480,7 @@ impl<'a> ConstraintGenerator<'a> {
                     let info = self.generate(block_inst_ref, ctx);
                     last_ty = info.ty;
                 }
-                ctx.pop_scope();
+                self.exit_scope(ctx);
                 last_ty
             }
 
@@ -1439,9 +1517,9 @@ impl<'a> ConstraintGenerator<'a> {
                     };
                     let result_ty = match selected {
                         Some(block) => {
-                            ctx.push_scope();
+                            self.enter_scope(ctx);
                             let info = self.generate(block, ctx);
-                            ctx.pop_scope();
+                            self.exit_scope(ctx);
                             info.ty
                         }
                         // `if false { .. }` with no else: nothing runs, unit.
@@ -1581,9 +1659,9 @@ impl<'a> ConstraintGenerator<'a> {
                 // scrutinees sema prunes, so the selected arm always has an
                 // inferred type when sema later prunes to it.
                 if let Some(selected) = self.comptime_selected_arm(*scrutinee, &arms) {
-                    ctx.push_scope();
+                    self.enter_scope(ctx);
                     let body_info = self.generate(selected, ctx);
-                    ctx.pop_scope();
+                    self.exit_scope(ctx);
                     self.record_type(inst_ref, body_info.ty.clone());
                     return ExprInfo::new(body_info.ty, span);
                 }
@@ -1604,8 +1682,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // types, so the body's references resolve during inference
                     // (RUE-221). Without this, `Circle(r) => r` leaves `r`
                     // unbound and its type poisons the match result.
-                    use crate::scope::ScopedContext;
-                    ctx.push_scope();
+                    self.enter_scope(ctx);
                     if let rue_rir::RirPattern::Path {
                         module,
                         type_name,
@@ -1659,7 +1736,7 @@ impl<'a> ConstraintGenerator<'a> {
 
                     // Generate body and collect its type
                     let body_info = self.generate(*body, ctx);
-                    ctx.pop_scope();
+                    self.exit_scope(ctx);
                     arm_types.push(body_info);
                 }
 
@@ -1731,10 +1808,7 @@ impl<'a> ConstraintGenerator<'a> {
                 } else {
                     self.type_subst
                         .and_then(|subst| subst.get(type_name).copied())
-                        .or_else(|| {
-                            self.comptime_local_types
-                                .and_then(|aliases| aliases.get(type_name).copied())
-                        })
+                        .or_else(|| self.comptime_alias_types.get(type_name).copied())
                         .or_else(|| {
                             self.structs_by_file_name
                                 .and_then(|structs| structs.get(&(span.file_id, *type_name)))
@@ -2521,8 +2595,9 @@ impl<'a> ConstraintGenerator<'a> {
     /// permissiveness only — sema's module-local resolution is authoritative
     /// and rejects cross-file unqualified references (E0204).
     fn struct_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
-        self.comptime_local_types
-            .and_then(|aliases| aliases.get(type_name).copied())
+        self.comptime_alias_types
+            .get(type_name)
+            .copied()
             .filter(|ty| ty.as_struct().is_some())
             .or_else(|| {
                 self.structs_by_file_name
@@ -2533,8 +2608,9 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     fn enum_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
-        self.comptime_local_types
-            .and_then(|aliases| aliases.get(type_name).copied())
+        self.comptime_alias_types
+            .get(type_name)
+            .copied()
             .filter(|ty| ty.is_enum())
             .or_else(|| {
                 self.enums_by_file_name
@@ -2632,7 +2708,7 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::VarRef { name } => {
                 // A local bound to a type value (`let X = i32; identity(X, 42)`
                 // or `let P = Pair(i32); f(P, ..)`) resolves to that bound type
-                // via the precomputed comptime-local-types map — the same map
+                // via the in-scope comptime-alias view — the same map
                 // generic-enum construction/matching consults (`enum_type_for`).
                 // Without this the type argument was left unresolved, so the
                 // call's return type defaulted to the literal `type` and
@@ -2640,10 +2716,7 @@ impl<'a> ConstraintGenerator<'a> {
                 // RUE-281). The literal form (`identity(i32, 42)`) already
                 // worked via the `TypeConst` arm; this makes an aliased type
                 // behave identically.
-                if let Some(ty) = self
-                    .comptime_local_types
-                    .and_then(|aliases| aliases.get(name).copied())
-                {
+                if let Some(ty) = self.comptime_alias_types.get(name).copied() {
                     return Some(ty);
                 }
                 // A local or parameter shadows any same-named struct/enum. A

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -411,6 +411,7 @@ impl<'a> Sema<'a> {
             return_type,
             scope_stack: Vec::new(),
             moved_scope_stack: Vec::new(),
+            comptime_type_scope_stack: Vec::new(),
             resolved_types: &resolved_types,
             moved_vars: HashMap::new(),
             warnings: Vec::new(),

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -32,9 +32,33 @@ impl<'a> Sema<'a> {
         // and methods on `P`-typed receivers all fell through to `<error>`
         // or unconstrained variables (RUE-170, RUE-164). This may create the
         // anonymous structs (idempotently — analysis re-evaluates the same
-        // initializers later and structural equality dedups them).
-        let comptime_local_types =
+        // initializers later and structural equality dedups them). Keyed by
+        // binding site (the `let`'s Alloc); the generator brings each alias
+        // into scope when its statement is reached and unwinds it with the
+        // enclosing block (RUE-530).
+        let comptime_local_bindings =
             self.precompute_comptime_type_locals(body, type_subst, value_subst);
+
+        // The inline-head pre-reduction below evaluates head expressions
+        // without walking the body, so it can't replay lexical scope; give it
+        // the flattened name view. Same-named ties resolve to the later
+        // binding site deterministically (instruction order, which follows
+        // program order) — matching the old flat map for this opportunistic
+        // path.
+        let mut flat_bindings: Vec<(InstRef, Type)> = comptime_local_bindings
+            .iter()
+            .map(|(inst_ref, ty)| (*inst_ref, *ty))
+            .collect();
+        flat_bindings.sort_by_key(|(inst_ref, _)| inst_ref.as_u32());
+        let comptime_local_types: HashMap<Spur, Type> = flat_bindings
+            .into_iter()
+            .filter_map(|(inst_ref, ty)| match self.rir.get(inst_ref).data {
+                rue_rir::InstData::Alloc {
+                    name: Some(name), ..
+                } => Some((name, ty)),
+                _ => None,
+            })
+            .collect();
 
         // Pre-reduce inline type-constructor heads (`F(args).Variant(..)`,
         // `F(args) { ... }`; RUE-596) to their concrete types, keyed by the
@@ -94,7 +118,7 @@ impl<'a> Sema<'a> {
         .with_module_binding_types(&infer_ctx.module_binding_types)
         .with_module_file_ids(&infer_ctx.module_file_ids)
         .with_functions_by_file_name(&infer_ctx.functions_by_file_name)
-        .with_comptime_local_types(&comptime_local_types)
+        .with_comptime_local_bindings(&comptime_local_bindings)
         .with_inline_ctor_head_types(&inline_ctor_head_types)
         .with_comptime_values(value_subst)
         .with_extra_method_sigs(&extra_method_sigs);

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2672,12 +2672,13 @@ impl<'a> Sema<'a> {
         // Special case: comptime type variables
         // When a variable is assigned a comptime type value (e.g., `let P = make_type()`),
         // we store the type in comptime_type_vars instead of creating a runtime variable.
-        // This allows the variable to be used as a type annotation later (e.g., `let p: P = ...`).
+        // This allows the variable to be used as a type annotation later (e.g., `let p: P = ...`),
+        // scoped to the binding's block like any other `let` (RUE-530).
         if var_type == Type::COMPTIME_TYPE {
             // Extract the type value from the TypeConst instruction
             let inst = air.get(init_result.air_ref);
             if let AirInstData::TypeConst(ty) = &inst.data {
-                ctx.comptime_type_vars.insert(name, *ty);
+                ctx.bind_comptime_type_var(name, *ty);
                 // Return Unit - no runtime code is generated for comptime type bindings
                 let nop_ref = air.add_inst(AirInst {
                     data: AirInstData::UnitConst,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1678,10 +1678,14 @@ impl Sema<'_> {
     /// through the same paths as named structs.
     ///
     /// The walk is opportunistic: initializers that can't be evaluated at
-    /// compile time are simply skipped (sema diagnoses them later). Like
-    /// `AnalysisContext::comptime_type_vars`, the resulting map is flat
-    /// (not scope-aware); a shadowed alias resolves to the type value, which
-    /// matches the analysis pass's behavior.
+    /// compile time are simply skipped (sema diagnoses them later). The
+    /// result is keyed by the binding's own `Alloc` instruction, and the
+    /// evaluation environment is block-scoped (RUE-530): an alias is visible
+    /// to later initializers in its block and its nested blocks, then
+    /// unwound — so sibling-branch aliases sharing a name don't collide, and
+    /// a shadowed alias is restored when the shadow's block ends. The
+    /// constraint generator replays the same scoping live via
+    /// `ConstraintGenerator::enter_scope`/`exit_scope`.
     ///
     /// `type_subst` / `value_subst` carry the enclosing comptime parameter
     /// substitutions (specialized generic bodies), so aliases like
@@ -1692,23 +1696,37 @@ impl Sema<'_> {
         body: InstRef,
         type_subst: Option<&HashMap<Spur, Type>>,
         value_subst: Option<&HashMap<Spur, ConstValue>>,
-    ) -> HashMap<Spur, Type> {
-        let mut discovered: HashMap<Spur, Type> = HashMap::new();
+    ) -> HashMap<InstRef, Type> {
+        let mut discovered: HashMap<InstRef, Type> = HashMap::new();
         let mut eval_types: HashMap<Spur, Type> = type_subst.cloned().unwrap_or_default();
         let eval_values: HashMap<Spur, ConstValue> = value_subst.cloned().unwrap_or_default();
-        self.walk_comptime_type_locals(body, &mut discovered, &mut eval_types, &eval_values);
+        let mut root_frame = Vec::new();
+        self.walk_comptime_type_locals(
+            body,
+            &mut discovered,
+            &mut eval_types,
+            &eval_values,
+            &mut root_frame,
+        );
         discovered
     }
 
     /// In-order walk over statement positions for
     /// [`precompute_comptime_type_locals`]. Only containers that can hold
     /// `let` statements are entered; everything else is left alone.
+    ///
+    /// `frame` is the innermost enclosing block's undo list: each alias
+    /// discovered in that block records the name's previous binding there,
+    /// and the block arm unwinds its frame (in reverse, RUE-522-style) when
+    /// its statements are done, restoring `eval_types` to the enclosing
+    /// scope's view.
     fn walk_comptime_type_locals(
         &mut self,
         inst_ref: InstRef,
-        discovered: &mut HashMap<Spur, Type>,
+        discovered: &mut HashMap<InstRef, Type>,
         eval_types: &mut HashMap<Spur, Type>,
         eval_values: &HashMap<Spur, ConstValue>,
+        frame: &mut Vec<(Spur, Option<Type>)>,
     ) {
         match &self.rir.get(inst_ref).data {
             InstData::Block { extra_start, len } => {
@@ -1718,16 +1736,29 @@ impl Sema<'_> {
                     .iter()
                     .map(|&raw| InstRef::from_raw(raw))
                     .collect();
+                let mut inner_frame = Vec::new();
                 for stmt in stmts {
-                    self.walk_comptime_type_locals(stmt, discovered, eval_types, eval_values);
+                    self.walk_comptime_type_locals(
+                        stmt,
+                        discovered,
+                        eval_types,
+                        eval_values,
+                        &mut inner_frame,
+                    );
+                }
+                for (name, old) in inner_frame.into_iter().rev() {
+                    match old {
+                        Some(ty) => eval_types.insert(name, ty),
+                        None => eval_types.remove(&name),
+                    };
                 }
             }
             InstData::Alloc { name, init, .. } => {
                 let (name, init) = (*name, *init);
                 if let Some(name) = name {
                     if let Some(ty) = self.try_eval_type_alias_init(init, eval_types, eval_values) {
-                        discovered.insert(name, ty);
-                        eval_types.insert(name, ty);
+                        discovered.insert(inst_ref, ty);
+                        frame.push((name, eval_types.insert(name, ty)));
                     }
                 }
             }
@@ -1737,14 +1768,26 @@ impl Sema<'_> {
                 ..
             } => {
                 let (then_block, else_block) = (*then_block, *else_block);
-                self.walk_comptime_type_locals(then_block, discovered, eval_types, eval_values);
+                self.walk_comptime_type_locals(
+                    then_block,
+                    discovered,
+                    eval_types,
+                    eval_values,
+                    frame,
+                );
                 if let Some(else_block) = else_block {
-                    self.walk_comptime_type_locals(else_block, discovered, eval_types, eval_values);
+                    self.walk_comptime_type_locals(
+                        else_block,
+                        discovered,
+                        eval_types,
+                        eval_values,
+                        frame,
+                    );
                 }
             }
             InstData::Loop { body, .. } | InstData::InfiniteLoop { body, .. } => {
                 let body = *body;
-                self.walk_comptime_type_locals(body, discovered, eval_types, eval_values);
+                self.walk_comptime_type_locals(body, discovered, eval_types, eval_values, frame);
             }
             InstData::Match {
                 arms_start,
@@ -1758,7 +1801,13 @@ impl Sema<'_> {
                     .map(|(_, body)| *body)
                     .collect();
                 for body in bodies {
-                    self.walk_comptime_type_locals(body, discovered, eval_types, eval_values);
+                    self.walk_comptime_type_locals(
+                        body,
+                        discovered,
+                        eval_types,
+                        eval_values,
+                        frame,
+                    );
                 }
             }
             _ => {}

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -368,6 +368,16 @@ pub(crate) struct AnalysisContext<'a> {
     /// destruction) or a move of the inner shadow outlives its block and
     /// poisons the outer binding with a false E0205 (RUE-522).
     pub moved_scope_stack: Vec<Vec<(Spur, Option<VariableMoveState>)>>,
+    /// Per-scope saved comptime-type-alias bindings, parallel to
+    /// `scope_stack`: each frame records the shadowed binding (or absence)
+    /// for every name bound in `comptime_type_vars` — or hidden there by a
+    /// same-named runtime `let` — in that scope, and `pop_scope` restores
+    /// them in reverse. This gives `let`-bound type aliases lexical block
+    /// scope (RUE-530): without it the flat map let an alias escape its
+    /// block and made sibling-branch aliases collide. Bind aliases through
+    /// [`AnalysisContext::bind_comptime_type_var`], never by inserting into
+    /// `comptime_type_vars` directly.
+    pub comptime_type_scope_stack: Vec<Vec<(Spur, Option<Type>)>>,
     /// Resolved types from HM inference.
     /// Maps RIR instruction refs to their resolved concrete types.
     /// This is populated by running constraint generation and unification
@@ -497,16 +507,29 @@ impl ScopedContext for AnalysisContext<'_> {
         if let Some(move_frame) = self.moved_scope_stack.last_mut() {
             move_frame.push((symbol, old_moves));
         }
+        // A runtime binding hides any same-named comptime type alias for the
+        // rest of this scope — the inner binding wins whatever its kind — and
+        // the alias is restored when this scope pops (RUE-530). Without the
+        // removal, a type-annotation lookup (which consults
+        // `comptime_type_vars` before locals) would resolve through the dead
+        // alias.
+        if let Some(old_alias) = self.comptime_type_vars.remove(&symbol)
+            && let Some(alias_frame) = self.comptime_type_scope_stack.last_mut()
+        {
+            alias_frame.push((symbol, Some(old_alias)));
+        }
     }
 
     fn push_scope(&mut self) {
         self.scope_stack.push(Vec::with_capacity(2));
         self.moved_scope_stack.push(Vec::new());
+        self.comptime_type_scope_stack.push(Vec::new());
     }
 
     fn pop_scope(&mut self) {
         // Mirrors the trait default for locals (reverse order — see the trait
-        // doc), plus the RUE-522 move-state restore from the parallel frame.
+        // doc), plus the RUE-522 move-state and RUE-530 type-alias restores
+        // from the parallel frames.
         if let Some(scope_entries) = self.scope_stack.pop() {
             for (symbol, old_value) in scope_entries.into_iter().rev() {
                 match old_value {
@@ -531,10 +554,45 @@ impl ScopedContext for AnalysisContext<'_> {
                 }
             }
         }
+        if let Some(alias_frame) = self.comptime_type_scope_stack.pop() {
+            for (symbol, old_alias) in alias_frame.into_iter().rev() {
+                match old_alias {
+                    Some(ty) => {
+                        self.comptime_type_vars.insert(symbol, ty);
+                    }
+                    None => {
+                        self.comptime_type_vars.remove(&symbol);
+                    }
+                }
+            }
+        }
     }
 }
 
 impl<'a> AnalysisContext<'a> {
+    /// Bind a `let`-bound comptime type alias (`let P = Point();`), saving
+    /// the name's previous binding (or absence) in the current scope's alias
+    /// frame so `pop_scope` restores it — the alias is lexically scoped like
+    /// any other `let` (RUE-530). Also hides a same-named runtime local for
+    /// this scope: the variable-reference and annotation paths consult
+    /// `comptime_type_vars` and `locals` in different orders, so leaving
+    /// both live would resolve the name inconsistently.
+    pub fn bind_comptime_type_var(&mut self, symbol: Spur, ty: Type) {
+        let old_alias = self.comptime_type_vars.insert(symbol, ty);
+        if let Some(alias_frame) = self.comptime_type_scope_stack.last_mut() {
+            alias_frame.push((symbol, old_alias));
+        }
+        if let Some(old_local) = self.locals.remove(&symbol) {
+            if let Some(current_scope) = self.scope_stack.last_mut() {
+                current_scope.push((symbol, Some(old_local)));
+            }
+            let old_moves = self.moved_vars.remove(&symbol);
+            if let Some(move_frame) = self.moved_scope_stack.last_mut() {
+                move_frame.push((symbol, old_moves));
+            }
+        }
+    }
+
     /// Create a scratch copy of this context for the loop back-edge move check.
     ///
     /// A value moved anywhere in a loop's condition or body is already moved
@@ -562,6 +620,7 @@ impl<'a> AnalysisContext<'a> {
             return_type: self.return_type,
             scope_stack: self.scope_stack.clone(),
             moved_scope_stack: self.moved_scope_stack.clone(),
+            comptime_type_scope_stack: self.comptime_type_scope_stack.clone(),
             resolved_types: self.resolved_types,
             moved_vars: self.moved_vars.clone(),
             warnings: Vec::new(),

--- a/crates/rue-spec/cases/expressions/blocks.toml
+++ b/crates/rue-spec/cases/expressions/blocks.toml
@@ -113,3 +113,66 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["[E0201]", "undefined variable"]
+
+[[case]]
+name = "comptime_type_alias_not_visible_after_block"
+spec = ["4.5:4"]
+description = "A let-bound comptime type alias obeys block scope like any other binding (RUE-530: the flat alias map let it escape its block)"
+source = """
+fn Point() -> type { struct { x: i32 } }
+
+fn main() -> i32 {
+    {
+        let P = Point();
+        let inside: P = P { x: 1 };
+        inside.x;
+    }
+    let outside: P = P { x: 42 };
+    outside.x
+}
+"""
+compile_fail = true
+error_contains = "[E0204]"
+
+[[case]]
+name = "comptime_type_aliases_in_disjoint_branches"
+spec = ["4.5:4"]
+description = "Same-named comptime type aliases in sibling branch blocks are disjoint bindings (RUE-530: the flat alias map made the second overwrite the first function-wide, E0206)"
+source = """
+fn A() -> type { struct { x: i32 } }
+fn B() -> type { struct { x: bool } }
+
+fn main() -> i32 {
+    if true {
+        let T = A();
+        let a: T = T { x: 42 };
+        a.x
+    } else {
+        let T = B();
+        let b: T = T { x: false };
+        7
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_type_alias_shadow_restored_after_block"
+spec = ["4.5:4"]
+description = "An inner comptime type alias shadows an outer same-named one for its block only; the outer alias is restored afterwards (RUE-530)"
+source = """
+fn A() -> type { struct { x: i32 } }
+fn B() -> type { struct { x: i64 } }
+
+fn main() -> i32 {
+    let T = A();
+    {
+        let T = B();
+        let inner: T = T { x: 100 };
+        inner.x;
+    }
+    let outer: T = T { x: 42 };
+    outer.x
+}
+"""
+exit_code = 42


### PR DESCRIPTION
Fixes RUE-530

Local comptime type aliases (`let P = Point();`) lived in flat function-wide maps in both layers that resolve them, causing both faces reported in the issue:

- **accept-invalid**: an alias escaped its block — `let outside: P = P { x: 42 };` after the block compiled and ran (spec 4.5:4 says the binding ends with its block)
- **reject-valid**: same-named aliases in disjoint `if`/`else` branches collided — the later binding overwrote the earlier one function-wide, producing a spurious E0206

## Inference layer

`precompute_comptime_type_locals` now keys its discoveries by each binding's own `Alloc` instruction and evaluates initializers under a block-scoped environment (per-block undo frames), so chained aliases resolve against the right enclosing bindings. The constraint generator maintains the in-scope name view live:

- new `enter_scope`/`exit_scope` wrappers push/pop a comptime-alias undo frame in lockstep with the `ConstraintContext` scope stack; all former direct `ctx.push_scope()` sites route through them
- the `Alloc` arm brings an alias into scope at its statement, after generating the initializer, so `let P = Wrap(P);` refers to the outer `P`
- a runtime `let` hides a same-named outer alias for the rest of its scope (the inner binding wins whatever its kind)

The flat name map still handed to the inline-ctor-head pre-reduction (RUE-596/RUE-599 path, which evaluates heads without walking the body and so can't replay lexical scope) is built deterministically in instruction order rather than by HashMap iteration.

## Sema layer

`AnalysisContext` gains `comptime_type_scope_stack`, a per-scope undo frame parallel to the RUE-522 `moved_scope_stack`. Aliases bind through the new `bind_comptime_type_var`, which also hides a same-named runtime local (the annotation and variable-reference paths consult `comptime_type_vars` and `locals` in different orders, so leaving both live resolves the name inconsistently); `insert_local` symmetrically hides a same-named alias; `pop_scope` restores all three parallel frames in reverse (RUE-522 unwind order).

## Behavior after

- escape face: rejected with `E0204: unknown type 'P'` at the out-of-scope annotation
- branch face: compiles and runs (exit 42 in the spec case)
- inner shadow of an outer alias is restored when the shadow's block ends
- aliases in match arms are disjoint; aliases inside specialized generic bodies unaffected (verified by hand alongside the suite)

Spec tests for all three shapes under 4.5:4. Full suite green (`Tests finished: Pass 33. Fail 0.`), traceability included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
