### PR TITLE
RUE-589: align panic with its unit result contract

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1157,6 +1157,17 @@ impl<'a> ConstraintGenerator<'a> {
                     // Return type is inferred from context - create a fresh type variable
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
+                } else if intrinsic_name == "panic" || intrinsic_name == "assert" {
+                    // Both abort intrinsics are ordinary unit expressions in the
+                    // surface type system. `@panic` never returns at runtime, but
+                    // it is deliberately not a never-typed control-transfer form
+                    // (spec 3.4:2; formal core §5.7). Keep these names explicit
+                    // instead of relying on the generic unit fallback so HM and
+                    // semantic analysis cannot drift apart again.
+                    for arg_ref in args.iter() {
+                        self.generate(*arg_ref, ctx);
+                    }
+                    InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "read_line" {
                     // @read_line: returns `Option(String)` (RUE-6, ADR-0038).
                     // The concrete Option type comes from context (a `let`
@@ -3084,6 +3095,54 @@ mod tests {
 
         assert_eq!(info.ty, InferType::Concrete(Type::BOOL));
         assert_eq!(cgen.constraints().len(), 0);
+    }
+
+    #[test]
+    fn panic_and_assert_intrinsics_have_explicit_unit_results() {
+        for (name, has_arg) in [("panic", false), ("panic", true), ("assert", true)] {
+            let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
+            let functions = HashMap::new();
+            let structs = HashMap::new();
+            let enums = HashMap::new();
+            let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
+
+            // Argument legality belongs to sema; this probe only pins HM's
+            // result contract and verifies that an operand is still visited.
+            let arg = has_arg.then(|| {
+                rir.add_inst(rue_rir::Inst {
+                    data: InstData::BoolConst(true),
+                    span: Span::new(1, 5),
+                })
+            });
+            let arg_refs: Vec<_> = arg.into_iter().collect();
+            let (args_start, args_len) = rir.add_inst_refs(&arg_refs);
+            let name = interner.get_or_intern(name);
+            let intrinsic = rir.add_inst(rue_rir::Inst {
+                data: InstData::Intrinsic {
+                    name,
+                    args_start,
+                    args_len,
+                },
+                span: Span::new(0, 6),
+            });
+
+            let mut cgen = ConstraintGenerator::new(
+                &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+            );
+            let params = HashMap::new();
+            let mut ctx = ConstraintContext::new(&params, Type::UNIT);
+
+            let info = cgen.generate(intrinsic, &mut ctx);
+            assert_eq!(info.ty, InferType::Concrete(Type::UNIT));
+            if let Some(arg) = arg_refs.first() {
+                assert_eq!(
+                    cgen.expr_types().get(arg),
+                    Some(&InferType::Concrete(Type::BOOL)),
+                    "@{} must still visit its operand",
+                    interner.resolve(&name)
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -541,10 +541,10 @@ impl<'a> Sema<'a> {
                     args_start: 0,
                     args_len: 0,
                 },
-                ty: Type::NEVER,
+                ty: Type::UNIT,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::NEVER));
+            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
         }
 
         // Analyze the message argument
@@ -557,10 +557,10 @@ impl<'a> Sema<'a> {
                 args_start,
                 args_len: 1,
             },
-            ty: Type::NEVER,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::NEVER))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
     pub(super) fn analyze_assert_intrinsic(

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -35,6 +35,43 @@ mod tests {
     }
 
     #[test]
+    fn panic_and_assert_intrinsics_have_unit_air_contracts() {
+        for (name, body) in [
+            ("panic_no_message", "@panic()"),
+            ("panic_with_message", "@panic(\"boom\")"),
+            ("assertion", "@assert(true)"),
+            ("assertion_with_message", "@assert(true, \"ok\")"),
+        ] {
+            let source = format!("fn probe() {{ {body} }} fn main() -> i32 {{ probe(); 0 }}");
+            let output = compile_to_air(&source).unwrap();
+            let function = output
+                .functions
+                .iter()
+                .find(|function| function.name == "probe")
+                .unwrap_or_else(|| panic!("missing analyzed function {name}"));
+            let intrinsic_types: Vec<_> = function
+                .air
+                .iter()
+                .filter_map(|(_, inst)| {
+                    matches!(inst.data, AirInstData::Intrinsic { .. }).then_some(inst.ty)
+                })
+                .collect();
+            assert_eq!(
+                intrinsic_types,
+                vec![Type::UNIT],
+                "{name} intrinsic result must agree with HM"
+            );
+            assert!(
+                function
+                    .air
+                    .iter()
+                    .any(|(_, inst)| matches!(inst.data, AirInstData::Ret(_))),
+                "a unit-valued trailing intrinsic still needs an implicit return"
+            );
+        }
+    }
+
+    #[test]
     fn test_analyze_addition() {
         let output = compile_to_air("fn main() -> i32 { 1 + 2 }").unwrap();
 

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -903,7 +903,7 @@ impl<'a> CfgBuilder<'a> {
                 }
                 // Store args in extra array
                 let (args_start, args_len) = self.cfg.push_extra(arg_vals);
-                let value = self.emit(
+                let intrinsic_value = self.emit(
                     CfgInstData::Intrinsic {
                         name: *name,
                         args_start,
@@ -912,6 +912,17 @@ impl<'a> CfgBuilder<'a> {
                     ty,
                     span,
                 );
+                // Unit has no runtime representation, and side-effect-only
+                // intrinsics such as @panic, @assert, and @dbg deliberately do
+                // not define a backend vreg. Preserve the intrinsic itself in
+                // the block for its side effect, but use the same dummy unit
+                // value as UnitConst whenever the expression needs a value
+                // (notably as the tail of a unit-returning function).
+                let value = if ty == Type::UNIT {
+                    self.emit(CfgInstData::Const(0), Type::UNIT, span)
+                } else {
+                    intrinsic_value
+                };
                 self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -3780,6 +3780,83 @@ mod integration_tests {
         use super::*;
 
         #[test]
+        fn panic_forms_use_the_unit_contract_through_cfg() {
+            for (name, body) in [
+                ("trailing", "@panic()"),
+                ("trailing_message", "@panic(\"boom\")"),
+                ("semicolon", "@panic();"),
+                ("discarded", "let _ = @panic();"),
+                ("unit_binding", "let _: () = @panic();"),
+                ("assertion", "@assert(true)"),
+                ("assertion_with_message", "@assert(true, \"ok\")"),
+            ] {
+                let source = format!("fn probe() {{ {body} }} fn main() -> i32 {{ probe(); 0 }}");
+                let state = compile_to_cfg(&source)
+                    .expect("every unit-valued panic form must reach a verified, terminated CFG");
+                let cfg = &state
+                    .functions
+                    .iter()
+                    .find(|function| function.cfg.fn_name() == "probe")
+                    .unwrap_or_else(|| panic!("missing CFG for {name}"))
+                    .cfg;
+                let intrinsic_types: Vec<_> = cfg
+                    .blocks()
+                    .iter()
+                    .flat_map(|block| block.insts.iter())
+                    .filter_map(|value| {
+                        let inst = cfg.get_inst(*value);
+                        matches!(inst.data, rue_cfg::CfgInstData::Intrinsic { .. })
+                            .then_some(inst.ty)
+                    })
+                    .collect();
+                assert_eq!(
+                    intrinsic_types,
+                    vec![Type::UNIT],
+                    "{name} must carry the unit result into CFG"
+                );
+
+                let return_values: Vec<_> = cfg
+                    .blocks()
+                    .iter()
+                    .filter_map(|block| match block.terminator {
+                        rue_cfg::Terminator::Return { value } => Some(value),
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(return_values.len(), 1, "{name} must have one return");
+                let return_value = return_values[0].expect("unit return must use a dummy value");
+                let return_inst = cfg.get_inst(return_value);
+                assert_eq!(return_inst.ty, Type::UNIT, "{name} return value type");
+                assert!(
+                    matches!(return_inst.data, rue_cfg::CfgInstData::Const(0)),
+                    "{name} must return the established dummy unit value, not a side-effect-only intrinsic"
+                );
+
+                for &target in Target::all() {
+                    generate_mir(cfg, &state.type_pool, &state.interner, target)
+                        .unwrap_or_else(|error| panic!("{name} must lower for {target}: {error}"));
+                }
+                compile(&source).unwrap_or_else(|error| {
+                    panic!("{name} must compile and link natively: {error}")
+                });
+            }
+        }
+
+        #[test]
+        fn panic_does_not_gain_never_coercion() {
+            for src in [
+                "fn main() -> i32 { @panic() }",
+                "fn main() -> i32 { let value: i32 = @panic(); value }",
+                "fn main() -> i32 { if true { 1 } else { @panic() } }",
+            ] {
+                assert!(
+                    compile_to_cfg(src).is_err(),
+                    "unit-valued @panic must not coerce into a non-unit context: {src}"
+                );
+            }
+        }
+
+        #[test]
         fn size_of_intrinsic() {
             // @size_of returns i32
             let src = "fn main() -> i32 { @size_of(i32) }";

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1153,7 +1153,7 @@ impl<'a> Interp<'a> {
         let is_owned_string = |index: usize| self.is_owned_string_type(ty(index));
         let mut validated_kind = kind;
         let signature_matches = match name {
-            "panic" => result_ty == Type::NEVER && (args.is_empty() || is_owned_string(0)),
+            "panic" => result_ty == Type::UNIT && (args.is_empty() || is_owned_string(0)),
             "assert" => {
                 result_ty == Type::UNIT
                     && ty(0) == Type::BOOL

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -448,6 +448,47 @@ fn capacity_and_intrinsic_signature_drift_are_contract_failures() {
 }
 
 #[test]
+fn panic_unit_signature_is_an_oracle_contract_for_both_arities() {
+    let state = compile_to_cfg(
+        r#"fn panic_no_message() { @panic() }
+        fn panic_with_message() { @panic("boom") }
+        fn main() -> i32 {
+            panic_no_message();
+            panic_with_message();
+            0
+        }"#,
+    )
+    .expect("both panic arities must compile with the unit contract");
+    let interp = Interp {
+        state: &state,
+        stdout: String::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+    };
+    let expected =
+        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(UnsupportedIntrinsicKind::Panic));
+
+    for function_name in ["panic_no_message", "panic_with_message"] {
+        let (cfg, intrinsic, args, result_ty) =
+            find_intrinsic_in_function(&state, function_name, "panic");
+        assert_eq!(result_ty, Type::UNIT, "{function_name} compiler metadata");
+        assert_eq!(
+            interp.classify_unsupported_intrinsic(cfg, intrinsic, "panic", &args, result_ty,),
+            expected,
+            "{function_name} unit signature"
+        );
+        assert_eq!(
+            interp.classify_unsupported_intrinsic(cfg, intrinsic, "panic", &args, Type::NEVER,),
+            UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+            "{function_name} must reject the old never-typed metadata"
+        );
+    }
+}
+
+#[test]
 fn malformed_outer_calls_are_rejected_before_unmodeled_operands_run() {
     let mut preview_features = PreviewFeatures::new();
     preview_features.insert(rue_compiler::PreviewFeature::StringTrio);

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -528,8 +528,8 @@ and an infinite `loop { e }` (one with no reachable `break`). (Surface
 `continue` elaborates to the loop's back-edge and is likewise never-typed; it is
 not a distinct core form. `@panic(...)` is **not** a never form — it elaborates
 to an ordinary call of type `unit`, matching `3.4:2`, which lists only these
-control-transfer forms, and the compiler, which types a `@panic` expression at
-`unit`.)
+control-transfer forms, and the compiler's HM, AIR, and CFG contracts, which all
+type a `@panic` expression at `unit`.)
 
 ```
   Γ;Σ;Λ ⊢ e ⇒ T_ret ⊣ _        T_ret = the enclosing function's declared return type

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -93,14 +93,17 @@ The compiler frontend additionally reserves the names `@cast`, `@panic`,
 stabilized, so they are omitted from the normative inventory above, but they
 are no longer no-ops (RUE-319):
 
-- `@panic(msg?)` aborts the process. It writes `panic: <msg>` (or just `panic`
-  when called with no argument) to standard error and exits with status 101 —
-  the same abort discipline as the `@intCast` overflow, division-by-zero, and
-  bounds-check traps.
+- `@panic(msg?)` has type `()`, but aborts the process when evaluated. It writes
+  `panic: <msg>` (or just `panic` when called with no argument) to standard error
+  and exits with status 101 — the same abort discipline as the `@intCast`
+  overflow, division-by-zero, and bounds-check traps. It is not a `!`-typed
+  control-transfer expression and therefore does not participate in never
+  coercion (3.4:2).
 - `@assert(cond, msg?)` evaluates the boolean `cond`. When `cond` is `false` it
   aborts exactly like `@panic`: with a message it writes `panic: <msg>`,
   otherwise it writes `assertion failed`, and in both cases exits with status
-  101. When `cond` is `true` it has no effect.
+  101. When `cond` is `true` it has no effect. The expression has type `()` on
+  both paths.
 - `@cast` is rejected at compile time with a diagnostic directing the programmer
   to `@intCast`; it never had a working inference rule and is fully redundant
   with `@intCast`. Use `@intCast` for integer conversions.


### PR DESCRIPTION
## Summary

- make `@panic` explicitly return `()` in HM and AIR, matching Rue’s formal contract instead of emitting drifted `!` metadata
- preserve every unit-valued intrinsic as a side effect while caching the standard dummy unit value, class-fixing trailing `@panic`, `@assert`, and `@dbg` verifier/vreg failures in the target-independent CFG layer
- align the oracle gap preflight and language documentation with the unit contract
- add regressions for both panic/assert arities, trailing/discard/binding forms, all target lowerings, native linking, and rejection of never coercion

## Validation

- `./fmt.sh check`
- `./clippy.sh` (41 targets)
- `./test.sh` (33/33)
- live CLI/spec oracle audits: 0 frontend failures, 0 oracle failures, 0 disagreements
- independent review found and closed the full-codegen boundary gap; rereview clear

This deliberately does not add panic/assert operand validation; that separate frontend contract hole remains isolated rather than expanding this PR.