### PR TITLE
RUE-616: gate byte-reproducible Rue programs

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -44,6 +44,14 @@ filegroup(
     srcs = glob(["cli-test-fixtures/**"]),
 )
 
+# A deliberately adversarial multi-module project used to assert that Rue's
+# complete native output is byte-reproducible across relocated source roots and
+# scheduling/environment perturbations (RUE-616).
+filegroup(
+    name = "reproducibility-fixture",
+    srcs = glob(["reproducibility/fixture/**"]),
+)
+
 # Tutorial markdown is an input to the snippet checker. The checker only
 # compiles fences explicitly marked with `rue check` or `rue compile-fail`.
 filegroup(
@@ -120,6 +128,15 @@ sh_test(
         "RUE_EXAMPLES_DIR": "$(location :examples)/examples",
         "RUE_REPO_DIR": "$(location :cli-test-fixtures)",
         "RUE_STD_DIR": "$(location :std)/std",
+    },
+)
+
+sh_test(
+    name = "reproducible-programs",
+    test = "scripts/test-reproducible-output.sh",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_REPRO_FIXTURE": "$(location :reproducibility-fixture)/reproducibility/fixture",
     },
 )
 

--- a/reproducibility/fixture/left/entry.rue
+++ b/reproducibility/fixture/left/entry.rue
@@ -1,0 +1,13 @@
+const common = @import("../shared.rue");
+const local = @import("shared.rue");
+
+pub fn compute(seed: i32) -> i32 {
+    let F = common.Frame(2);
+    let frame = F {
+        values: [seed, common.perturb(seed)],
+        salt: 3,
+    };
+    let selected = common.choose(i32, seed > 0, frame.score(), -1);
+    let payload = local.make(selected);
+    payload.score()
+}

--- a/reproducibility/fixture/left/shared.rue
+++ b/reproducibility/fixture/left/shared.rue
@@ -1,0 +1,19 @@
+pub struct Payload {
+    number: i32,
+    text: String,
+
+    fn score(borrow self) -> i32 {
+        if self.text.len() > 0 { self.number + 11 } else { -1 }
+    }
+}
+
+drop fn Payload(self) {
+    @dbg(self.number + 1000);
+}
+
+pub fn make(value: i32) -> Payload {
+    Payload {
+        number: value,
+        text: "left/shared::Payload",
+    }
+}

--- a/reproducibility/fixture/main.rue
+++ b/reproducibility/fixture/main.rue
@@ -1,0 +1,26 @@
+// Root-only compilation must discover the complete graph below. The sibling
+// branches deliberately export the same function name and each contains a
+// same-basename `shared.rue` module with colliding type, method, factory, and
+// destructor names.
+const left = @import("left/entry.rue");
+const right = @import("right/entry.rue");
+
+fn main() -> i32 {
+    let left_score = left.compute(4);
+    let right_score = right.compute(5);
+
+    // Distinct literals force stable rodata ordering and runtime relocations.
+    let order: String = if left_score < right_score {
+        "left-before-right"
+    } else {
+        "right-before-left"
+    };
+    let order_len = order.len();
+    @dbg(order);
+
+    if order_len == 17 {
+        left_score + right_score
+    } else {
+        1
+    }
+}

--- a/reproducibility/fixture/right/entry.rue
+++ b/reproducibility/fixture/right/entry.rue
@@ -1,0 +1,13 @@
+const common = @import("../shared.rue");
+const local = @import("shared.rue");
+
+pub fn compute(seed: i32) -> i32 {
+    let F = common.Frame(2);
+    let frame = F {
+        values: [seed, common.perturb(seed)],
+        salt: 7,
+    };
+    let selected = common.choose(i32, seed < 0, -1, frame.score());
+    let payload = local.make(selected);
+    payload.score()
+}

--- a/reproducibility/fixture/right/shared.rue
+++ b/reproducibility/fixture/right/shared.rue
@@ -1,0 +1,19 @@
+pub struct Payload {
+    number: i32,
+    text: String,
+
+    fn score(borrow self) -> i32 {
+        if self.text.len() > 0 { self.number + 17 } else { -1 }
+    }
+}
+
+drop fn Payload(self) {
+    @dbg(self.number + 2000);
+}
+
+pub fn make(value: i32) -> Payload {
+    Payload {
+        number: value,
+        text: "right/shared::Payload",
+    }
+}

--- a/reproducibility/fixture/shared.rue
+++ b/reproducibility/fixture/shared.rue
@@ -1,0 +1,21 @@
+// Both branches import this file through `../shared.rue`, forming a diamond.
+// Its comptime constructor and generic function create shared specialization
+// work reached through two independent import paths.
+pub fn Frame(comptime N: i32) -> type {
+    struct {
+        values: [i32; N],
+        salt: i32,
+
+        fn score(borrow self) -> i32 {
+            self.values[0] * 3 + self.values[1] + self.salt
+        }
+    }
+}
+
+pub fn choose(comptime T: type, take_first: bool, first: T, second: T) -> T {
+    if take_first { first } else { second }
+}
+
+pub fn perturb(value: i32) -> i32 {
+    if value % 2 == 0 { value / 2 } else { value * 2 + 1 }
+}

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# RUE-616: black-box reproducibility contract for programs produced by Rue.
+#
+# Compile the same logical project in deliberately different environments and
+# compare the complete native artifacts.  This is intentionally an end-to-end
+# test: neither output is stripped, normalized, re-linked, or otherwise changed
+# before cmp sees it.
+set -euo pipefail
+
+: "${RUE_BINARY:?RUE_BINARY must point to the Rue compiler}"
+: "${RUE_REPRO_FIXTURE:?RUE_REPRO_FIXTURE must point to the reproducibility fixture}"
+
+scratch="$(mktemp -d)"
+cleanup() {
+    rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+# Different-length roots catch accidental absolute-path capture.  Keep the
+# output basenames equal: filename-derived macOS signing identity is covered by
+# the dedicated RUE-619 test, while this test varies the containing path.
+root_a="$scratch/a"
+root_b="$scratch/a-deliberately-much-longer-reproducibility-root"
+mkdir -p "$root_a/project" "$root_b/project" "$root_a/tmp" "$root_b/tmp"
+cp -R "$RUE_REPRO_FIXTURE/." "$root_a/project/"
+cp -R "$RUE_REPRO_FIXTURE/." "$root_b/project/"
+
+# Source mtimes and manifest order are not semantic inputs.  Perturb both while
+# declaring the same source set to the compiler.
+find "$root_a/project" -type f -name '*.rue' -exec touch -t 200001010000 {} +
+find "$root_b/project" -type f -name '*.rue' -exec touch -t 203001010000 {} +
+(
+    cd "$root_a/project"
+    find . -type f -name '*.rue' -print | sed 's#^\./##' | LC_ALL=C sort > sources.manifest
+)
+(
+    cd "$root_b/project"
+    find . -type f -name '*.rue' -print | sed 's#^\./##' | LC_ALL=C sort -r > sources.manifest
+)
+
+sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+assert_identical() {
+    local label="$1" left="$2" right="$3"
+    if cmp -s "$left" "$right"; then
+        printf 'ok: %s (%s)\n' "$label" "$(sha256 "$left")"
+        return
+    fi
+
+    local first_diff
+    first_diff="$(cmp -l "$left" "$right" 2>/dev/null | awk 'NR == 1 { print $1; exit }' || true)"
+    printf 'FAIL: %s is not byte-reproducible\n' "$label" >&2
+    printf '  first:  %s (%s bytes, sha256 %s)\n' \
+        "$left" "$(wc -c < "$left" | tr -d ' ')" "$(sha256 "$left")" >&2
+    printf '  second: %s (%s bytes, sha256 %s)\n' \
+        "$right" "$(wc -c < "$right" | tr -d ' ')" "$(sha256 "$right")" >&2
+    if [ -n "$first_diff" ]; then
+        printf '  first differing byte offset (1-based): %s\n' "$first_diff" >&2
+    fi
+    return 1
+}
+
+assert_fixture_runs() {
+    local program="$1" actual status expected
+    set +e
+    actual="$("$program" 2>&1)"
+    status=$?
+    set -e
+    expected="$(printf '1017\n2033\nleft-before-right')"
+
+    if [ "$status" -ne 78 ] || [ "$actual" != "$expected" ]; then
+        printf 'FAIL: reproducibility fixture produced an invalid program\n' >&2
+        printf '  exit: %s (expected 78)\n' "$status" >&2
+        printf '  output:\n%s\n' "$actual" >&2
+        return 1
+    fi
+}
+
+compile_pair() {
+    local opt="$1" name="program-o$1"
+    local output_a="$root_a/project/$name" output_b="$root_b/project/$name"
+
+    # First build: relative root spelling, forward manifest, serial compiler,
+    # old epoch, permissive umask, and one ambient timezone.
+    (
+        umask 022
+        cd "$root_a/project"
+        env \
+            LC_ALL=C \
+            SOURCE_DATE_EPOCH=1 \
+            TMPDIR="$root_a/tmp" \
+            TZ=UTC \
+            "$RUE_BINARY" "-O$opt" -j1 \
+            --source-manifest sources.manifest \
+            main.rue -o "$output_a"
+    )
+
+    # Second build: absolute spellings, reverse manifest, parallel compiler,
+    # future epoch, restrictive umask, and a different timezone.  Each command
+    # is a fresh process, so Rust HashMap seeds are independently randomized.
+    (
+        umask 077
+        env \
+            LC_ALL=C \
+            SOURCE_DATE_EPOCH=2000000000 \
+            TMPDIR="$root_b/tmp" \
+            TZ=Pacific/Honolulu \
+            "$RUE_BINARY" "-O$opt" -j32 \
+            --source-manifest "$root_b/project/sources.manifest" \
+            "$root_b/project/main.rue" -o "$output_b"
+    )
+
+    assert_identical "native -O$opt program" "$output_a" "$output_b"
+    # Keep the adversarial fixture honest: byte-identical but broken artifacts
+    # must not make this test vacuously green.
+    assert_fixture_runs "$output_a"
+}
+
+compile_pair 0
+compile_pair 2


### PR DESCRIPTION
## Summary

- add an adversarial six-file Rue project covering diamond imports, duplicate module basenames and generated symbols, comptime/generic specialization, strings and rodata, aggregates, drop glue, branches, calls, and relocations
- add a root Buck test that compiles the project in two different-length temporary roots and compares the complete native artifacts byte-for-byte at O0 and O2
- perturb source spelling and manifest order, fresh compiler processes, `-j1` versus `-j32`, source mtimes, umask, TMPDIR, timezone, and SOURCE_DATE_EPOCH
- execute the resulting artifact and assert its exact behavior so two identically broken outputs cannot make the gate vacuously pass

## Why

Rue final program output already measured as deterministic across these dimensions, but no permanent end-to-end test protected that property. Component-level ordering tests would not catch metadata, linker, or signing regressions in the complete user artifact.

The test compares raw outputs without stripping or normalization and runs as part of `./test.sh` on each required CI host. Filename-derived macOS signing identity is intentionally isolated to RUE-619; this slice varies the containing output path while preserving the basename.

## Validation

- `./test.sh` — 34 targets passed, including 2,000 spec cases
- `./buck2 test //:reproducible-programs`
- `./buck2 test //:reproducible-programs --target-platforms //platforms:release`
- `bash -n scripts/test-reproducible-output.sh`
- `shellcheck scripts/test-reproducible-output.sh`

The new test completes in about 0.1 seconds locally.