### PR TITLE
RUE-589: validate panic and assertion operands

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -549,6 +549,7 @@ impl<'a> Sema<'a> {
 
         // Analyze the message argument
         let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
+        self.validate_abort_message_type("panic", arg_result.ty, self.rir.get(args[0].value).span)?;
 
         let args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
@@ -583,11 +584,27 @@ impl<'a> Sema<'a> {
         }
 
         let cond_result = self.analyze_inst(air, args[0].value, ctx)?;
+        let cond_span = self.rir.get(args[0].value).span;
+        if cond_result.ty != Type::BOOL && !cond_result.ty.is_never() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "assert".to_string(),
+                    expected: "bool condition".to_string(),
+                    found: cond_result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                })),
+                cond_span,
+            ));
+        }
 
         // Build args for AIR
         let mut extra_data = vec![cond_result.air_ref.as_u32()];
         if args.len() > 1 {
             let msg_result = self.analyze_inst(air, args[1].value, ctx)?;
+            self.validate_abort_message_type(
+                "assert",
+                msg_result.ty,
+                self.rir.get(args[1].value).span,
+            )?;
             extra_data.push(msg_result.air_ref.as_u32());
         }
 
@@ -603,6 +620,34 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
+    /// Validate the shared message contract of `@panic` and `@assert`.
+    ///
+    /// The runtime ABI consumes the builtin `StrBuf` representation. Checking
+    /// nominal type identity here is important: accepting any aggregate with a
+    /// convenient slot count would let codegen reinterpret its first fields as
+    /// a pointer and length. `String` remains accepted because it is a source
+    /// alias for the same builtin type, while `str`, `Str(N)`, and user structs
+    /// are distinct types even when part of their layout happens to match.
+    fn validate_abort_message_type(
+        &self,
+        intrinsic_name: &str,
+        message_ty: Type,
+        message_span: Span,
+    ) -> CompileResult<()> {
+        if !self.is_builtin_string(message_ty) && !message_ty.is_never() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: intrinsic_name.to_string(),
+                    expected: "StrBuf message".to_string(),
+                    found: message_ty.safe_name_with_pool(Some(&self.type_pool)),
+                })),
+                message_span,
+            ));
+        }
+
+        Ok(())
     }
 
     /// Analyze @intCast intrinsic.

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -3,12 +3,19 @@ mod tests {
     use crate::inst::{AirInstData, AirRef};
     use crate::sema::{Sema, SemaOutput};
     use crate::types::Type;
-    use rue_error::{CompileErrors, ErrorKind, MultiErrorResult, PreviewFeatures};
+    use rue_error::{CompileErrors, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures};
     use rue_lexer::Lexer;
     use rue_parser::Parser;
     use rue_rir::AstGen;
 
     fn compile_to_air(source: &str) -> MultiErrorResult<SemaOutput> {
+        compile_to_air_with_preview_features(source, PreviewFeatures::new())
+    }
+
+    fn compile_to_air_with_preview_features(
+        source: &str,
+        preview_features: PreviewFeatures,
+    ) -> MultiErrorResult<SemaOutput> {
         let lexer = Lexer::new(source);
         let (tokens, interner) = lexer.tokenize().map_err(CompileErrors::from_error)?;
         let parser = Parser::new(tokens, interner);
@@ -17,7 +24,7 @@ mod tests {
         let astgen = AstGen::new(&ast, &mut interner);
         let rir = astgen.generate();
 
-        let sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
+        let sema = Sema::new(&rir, &mut interner, preview_features);
         sema.analyze_all()
     }
 
@@ -41,8 +48,24 @@ mod tests {
             ("panic_with_message", "@panic(\"boom\")"),
             ("assertion", "@assert(true)"),
             ("assertion_with_message", "@assert(true, \"ok\")"),
+            (
+                "panic_with_strbuf",
+                "let message: StrBuf = \"boom\"; @panic(message)",
+            ),
+            (
+                "panic_with_string_alias",
+                "let message: String = \"boom\"; @panic(message)",
+            ),
+            (
+                "assertion_with_strbuf",
+                "let message: StrBuf = \"ok\"; @assert(true, message)",
+            ),
+            ("never assertion condition", "@assert(diverge())"),
+            ("never panic message", "@panic(diverge())"),
         ] {
-            let source = format!("fn probe() {{ {body} }} fn main() -> i32 {{ probe(); 0 }}");
+            let source = format!(
+                "fn diverge() -> ! {{ loop {{}} }} fn probe() {{ {body} }} fn main() -> i32 {{ probe(); 0 }}"
+            );
             let output = compile_to_air(&source).unwrap();
             let function = output
                 .functions
@@ -68,6 +91,137 @@ mod tests {
                     .any(|(_, inst)| matches!(inst.data, AirInstData::Ret(_))),
                 "a unit-valued trailing intrinsic still needs an implicit return"
             );
+        }
+    }
+
+    #[test]
+    fn panic_and_assert_reject_invalid_operand_types_at_the_operand() {
+        for (name, source, preview_string_trio, intrinsic, expected, found, offending) in [
+            (
+                "integer assertion condition",
+                "fn main() -> i32 { @assert(1); 0 }",
+                false,
+                "assert",
+                "bool condition",
+                "i32",
+                "1",
+            ),
+            (
+                "aggregate assertion condition",
+                "fn main() -> i32 { let s: StrBuf = \"truthy\"; @assert(s); 0 }",
+                false,
+                "assert",
+                "bool condition",
+                "StrBuf",
+                "s",
+            ),
+            (
+                "scalar panic message",
+                "fn main() -> i32 { @panic(1); 0 }",
+                false,
+                "panic",
+                "StrBuf message",
+                "i32",
+                "1",
+            ),
+            (
+                "scalar assertion message",
+                "fn main() -> i32 { @assert(false, 7); 0 }",
+                false,
+                "assert",
+                "StrBuf message",
+                "i32",
+                "7",
+            ),
+            (
+                "str view message",
+                "fn main() -> i32 { let s: str = \"view\"; @panic(s); 0 }",
+                true,
+                "panic",
+                "StrBuf message",
+                "str",
+                "s",
+            ),
+            (
+                "fixed string message",
+                "fn main() -> i32 { let s: Str(8) = \"fixed\"; @assert(false, s); 0 }",
+                true,
+                "assert",
+                "StrBuf message",
+                "Str(8)",
+                "s",
+            ),
+            (
+                "array message",
+                "fn main() -> i32 { let a = [1, 2, 3]; @panic(a); 0 }",
+                false,
+                "panic",
+                "StrBuf message",
+                "[i32; 3]",
+                "a",
+            ),
+            (
+                "enum message",
+                "enum Mode { A } fn main() -> i32 { @assert(false, Mode.A); 0 }",
+                false,
+                "assert",
+                "StrBuf message",
+                "Mode",
+                "Mode.A",
+            ),
+            (
+                "three-slot struct impostor",
+                "struct Fake { a: u64, b: u64, c: u64 } fn main() -> i32 { @panic(Fake { a: 0, b: 0, c: 0 }); 0 }",
+                false,
+                "panic",
+                "StrBuf message",
+                "Fake",
+                "Fake { a: 0, b: 0, c: 0 }",
+            ),
+        ] {
+            let mut preview_features = PreviewFeatures::new();
+            if preview_string_trio {
+                preview_features.insert(PreviewFeature::StringTrio);
+            }
+            let errors =
+                compile_to_air_with_preview_features(source, preview_features).unwrap_err();
+            assert_eq!(errors.len(), 1, "{name} should fail once");
+            let error = errors.iter().next().unwrap();
+            match &error.kind {
+                ErrorKind::IntrinsicTypeMismatch(data) => {
+                    assert_eq!(data.name, intrinsic, "{name} intrinsic");
+                    assert_eq!(data.expected, expected, "{name} expected type");
+                    assert_eq!(data.found, found, "{name} found type");
+                }
+                other => panic!("{name} produced {other:?}, expected E0702"),
+            }
+
+            let span = error.span().expect("operand mismatch must be spanned");
+            assert_eq!(
+                &source[span.start as usize..span.end as usize],
+                offending,
+                "{name} must point at the offending operand",
+            );
+        }
+    }
+
+    #[test]
+    fn panic_and_assert_preserve_primary_operand_errors() {
+        for source in [
+            "fn main() -> i32 { @panic(missing); 0 }",
+            "fn main() -> i32 { @assert(missing); 0 }",
+            "fn main() -> i32 { @assert(false, missing); 0 }",
+        ] {
+            let errors = compile_to_air(source).unwrap_err();
+            assert_eq!(errors.len(), 1, "primary operand error must not cascade");
+            let error = errors.iter().next().unwrap();
+            assert!(
+                matches!(&error.kind, ErrorKind::UndefinedVariable(name) if name == "missing"),
+                "expected the operand's primary error, got {:?}",
+                error.kind
+            );
+            let span = error.span().expect("undefined operand must be spanned");
+            assert_eq!(&source[span.start as usize..span.end as usize], "missing");
         }
     }
 

--- a/crates/rue-cli-tests/cases/panic_assert.toml
+++ b/crates/rue-cli-tests/cases/panic_assert.toml
@@ -137,6 +137,38 @@ exit_code = 101
 stdout = ""
 runtime_error_contains = ["panic: one is not two"]
 
+# ── Operand contract rejection ───────────────────────────────────────────────
+
+# The frontend must reject a non-bool condition before backend lowering. It
+# used to accept integers (and aggregates) and compile them as truthy/falsy.
+[[case]]
+name = "assert_non_bool_condition_is_rejected"
+description = "@assert requires an exact bool condition, not integer truthiness."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @assert(1);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0702", "bool condition", "found i32"]
+
+# Message validation is nominal, not layout-based. Before the frontend check,
+# this exact three-slot impostor reached both backends and its first two fields
+# were reinterpreted as the panic runtime's pointer and length.
+[[case]]
+name = "panic_struct_message_impostor_is_rejected"
+description = "@panic accepts only the builtin StrBuf message type."
+files = [{ path = "main.rue", source = """
+struct Fake { a: u64, b: u64, c: u64 }
+fn main() -> i32 {
+    @panic(Fake { a: 0, b: 0, c: 0 });
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0702", "StrBuf message", "found Fake"]
+
 # ── @cast rejection ──────────────────────────────────────────────────────────
 
 # @cast is redundant with @intCast and never had a working inference rule; it

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -3857,6 +3857,30 @@ mod integration_tests {
         }
 
         #[test]
+        fn never_operands_coerce_to_abort_intrinsic_parameters() {
+            for (name, body) in [
+                ("assert condition", "@assert(diverge())"),
+                ("panic message", "@panic(diverge())"),
+            ] {
+                let source = format!(
+                    "fn diverge() -> ! {{ loop {{}} }} fn probe() {{ {body} }} fn main() -> i32 {{ probe(); 0 }}"
+                );
+                let state = compile_to_cfg(&source)
+                    .unwrap_or_else(|error| panic!("never must coerce to {name}: {error}"));
+                for &target in Target::all() {
+                    for function in &state.functions {
+                        generate_mir(&function.cfg, &state.type_pool, &state.interner, target)
+                            .unwrap_or_else(|error| {
+                                panic!("{name} must lower for {target}: {error}")
+                            });
+                    }
+                }
+                compile(&source)
+                    .unwrap_or_else(|error| panic!("{name} must compile and link: {error}"));
+            }
+        }
+
+        #[test]
         fn size_of_intrinsic() {
             // @size_of returns i32
             let src = "fn main() -> i32 { @size_of(i32) }";

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -93,13 +93,17 @@ The compiler frontend additionally reserves the names `@cast`, `@panic`,
 stabilized, so they are omitted from the normative inventory above, but they
 are no longer no-ops (RUE-319):
 
-- `@panic(msg?)` has type `()`, but aborts the process when evaluated. It writes
+- `@panic(msg?: StrBuf)` has type `()`, but aborts the process when evaluated.
+  The optional message must have the builtin `StrBuf` type (`String` is an
+  alias for the same type); `str`, `Str(N)`, and unrelated aggregates are not
+  accepted. It writes
   `panic: <msg>` (or just `panic` when called with no argument) to standard error
   and exits with status 101 — the same abort discipline as the `@intCast`
   overflow, division-by-zero, and bounds-check traps. It is not a `!`-typed
   control-transfer expression and therefore does not participate in never
   coercion (3.4:2).
-- `@assert(cond, msg?)` evaluates the boolean `cond`. When `cond` is `false` it
+- `@assert(cond: bool, msg?: StrBuf)` requires an exact boolean condition and
+  the same optional builtin message type as `@panic`. When `cond` is `false` it
   aborts exactly like `@panic`: with a message it writes `panic: <msg>`,
   otherwise it writes `assertion failed`, and in both cases exits with status
   101. When `cond` is `true` it has no effect. The expression has type `()` on


### PR DESCRIPTION
## Summary

- reject non-`bool` `@assert` conditions before CFG instead of granting backend-specific truthiness
- require nominal builtin `StrBuf`/`String` identity for panic/assert messages, closing scalar, `str`, `Str(N)`, and layout-impostor pointer/length reinterpretation
- preserve universal `!` coercion and primary operand diagnostics
- pin exact E0702 operand spans with a sema class matrix, two real CLI driver witnesses, and all-target/native never-coercion coverage
- document the stabilized operand contract

## Validation

- `./fmt.sh check`
- `./clippy.sh` (41 targets)
- `./test.sh` (33/33)
- rue-air 358/358; rue-compiler 224/224; CLI 1302 passed / 2 ignored; spec 2000 passed / 14 ignored
- generated smoke 64/64; live CLI/spec oracle audits: 0 harness/frontend/oracle failures and 0 disagreements
- independent review caught and closed the universal-never-coercion edge; rereview clear

This intentionally leaves ranged-arity diagnostic wording and oracle execution modeling to separate small PRs.