### PR TITLE
RUE-617: gate reproducible Rue compiler builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,25 @@ jobs:
       - name: Build all targets
         run: ./buck2 build //crates/...
 
+      # RUE-617: the compiler built above is the first half of this comparison.
+      # On the required Linux x64 lane, rebuild Rue locally with remote caching
+      # disabled from a relocated clean source tree and compare the complete
+      # compiler artifacts.  Limiting the extra cold build to one lane keeps the
+      # merge queue moving while still turning path/scheduling/environment leaks
+      # into a required failure.
+      - name: Verify compiler build reproducibility
+        id: compiler_repro
+        if: matrix.name == 'linux-x64'
+        run: ./scripts/check-reproducible-compiler.sh
+
+      - name: Upload compiler reproducibility diagnostics
+        if: failure() && matrix.name == 'linux-x64' && steps.compiler_repro.outcome == 'failure'
+        uses: actions/upload-artifact@v6
+        with:
+          name: compiler-reproducibility-diagnostics
+          path: ${{ runner.temp }}/rue-compiler-repro-artifacts
+          if-no-files-found: ignore
+
       - name: Run tests
         run: ./test.sh
 

--- a/scripts/check-reproducible-compiler.sh
+++ b/scripts/check-reproducible-compiler.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# RUE-617: rebuild the Rue compiler from a relocated clean source tree and
+# compare the complete artifact with the compiler already built by CI.
+set -euo pipefail
+
+for tool in awk cmp git readelf sha256sum strings tar; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        printf 'error: compiler reproducibility check requires %s\n' "$tool" >&2
+        exit 1
+    fi
+done
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+temp_base="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+scratch="$(mktemp -d "$temp_base/rue-compiler-reproducibility-long-root.XXXXXX")"
+candidate_root="$scratch/second-clean-checkout"
+candidate_tmp="$scratch/tmp"
+artifact_dir="$temp_base/rue-compiler-repro-artifacts"
+mkdir -p "$candidate_root" "$candidate_tmp"
+mkdir -p "$artifact_dir"
+rm -f \
+    "$artifact_dir/reference-rue" \
+    "$artifact_dir/candidate-rue" \
+    "$artifact_dir/diagnostics.txt" \
+    "$artifact_dir/reference-readelf.txt" \
+    "$artifact_dir/candidate-readelf.txt"
+
+cleanup() {
+    if [ -x "$candidate_root/buck2" ]; then
+        (
+            cd "$candidate_root"
+            ./buck2 --isolation-dir compiler-repro kill >/dev/null 2>&1 || true
+        )
+    fi
+    rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+if [ -e "$repo_root/.buckconfig.local" ]; then
+    printf 'error: .buckconfig.local would make the reference and archived candidate use different configuration\n' >&2
+    printf '       move it aside before running the reproducibility check\n' >&2
+    exit 1
+fi
+
+materialize_source_tree() {
+    if git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        if [ -n "$(git -C "$repo_root" status --porcelain --untracked-files=normal)" ]; then
+            printf 'error: conventional Git checkout must be clean so HEAD matches the reference build inputs\n' >&2
+            return 1
+        fi
+        # Actions checks out the exact synthetic PR commit. git archive keeps
+        # the candidate independent of the first checkout's .git metadata and
+        # excludes untracked/build outputs by construction.
+        git -C "$repo_root" archive --format=tar HEAD | tar -xpf - -C "$candidate_root"
+        return
+    fi
+
+    # Local development uses pure jj workspaces without a colocated .git. The
+    # working-copy commit is already exported to jj's backing Git store, so use
+    # the same immutable archive path CI exercises rather than copying live
+    # filesystem bytes.
+    if command -v jj >/dev/null 2>&1 && jj -R "$repo_root" root >/dev/null 2>&1; then
+        local revision git_dir
+        revision="$(jj -R "$repo_root" log -r @ --no-graph -T commit_id)"
+        git_dir="$(jj -R "$repo_root" git root)"
+        git --git-dir="$git_dir" archive --format=tar "$revision" |
+            tar -xpf - -C "$candidate_root"
+        return
+    fi
+
+    printf 'error: cannot materialize a tracked source tree (git or jj required)\n' >&2
+    return 1
+}
+
+sha256() {
+    sha256sum "$1" | awk '{print $1}'
+}
+
+build_id() {
+    if command -v readelf >/dev/null 2>&1; then
+        readelf -n "$1" 2>/dev/null | awk '/Build ID:/ { print $3; exit }'
+    fi
+}
+
+assert_no_root_leak() {
+    local binary="$1" root="$2" label="$3"
+    # Do not use grep -m/-q here: with pipefail, an early grep exit can turn
+    # strings' SIGPIPE into a false negative.
+    if strings -a "$binary" | grep -F -- "$root" >/dev/null; then
+        printf 'FAIL: %s embeds checkout path %s\n' "$label" "$root" >&2
+        return 1
+    fi
+}
+
+preserve_failure_artifacts() {
+    mkdir -p "$artifact_dir"
+    cp "$reference_binary" "$artifact_dir/reference-rue"
+    cp "$candidate_binary" "$artifact_dir/candidate-rue"
+    {
+        printf 'reference: %s\n' "$reference_binary"
+        printf 'reference sha256: %s\n' "$reference_hash"
+        printf 'reference build-id: %s\n' "${reference_build_id:-none}"
+        printf 'candidate: %s\n' "$candidate_binary"
+        printf 'candidate sha256: %s\n' "$candidate_hash"
+        printf 'candidate build-id: %s\n' "${candidate_build_id:-none}"
+    } > "$artifact_dir/diagnostics.txt"
+    if command -v readelf >/dev/null 2>&1; then
+        readelf -h -S -n "$reference_binary" > "$artifact_dir/reference-readelf.txt" 2>&1 || true
+        readelf -h -S -n "$candidate_binary" > "$artifact_dir/candidate-readelf.txt" 2>&1 || true
+    fi
+    printf '  failure artifacts: %s\n' "$artifact_dir" >&2
+}
+
+materialize_source_tree
+
+# File mtimes are not declared compiler inputs. Make the relocated tree
+# conspicuously different from actions/checkout before Buck fingerprints it.
+find "$candidate_root" -type f -exec touch -t 203001010000 {} +
+
+reference_binary="${RUE_REPRO_REFERENCE_BINARY:-}"
+if [ -z "$reference_binary" ]; then
+    reference_binary="$($repo_root/scripts/rue-bin --local-only --no-remote-cache)"
+fi
+if [ ! -f "$reference_binary" ]; then
+    printf 'error: reference compiler does not exist: %s\n' "$reference_binary" >&2
+    exit 1
+fi
+
+# Use one isolated daemon/output tree, disable both remote execution and remote
+# cache reads, and perturb scheduling plus ambient process state. Dotslash and
+# the pinned Buck/Rust inputs may reuse their download caches; compilation
+# actions themselves must execute cold in this source root.
+candidate_binary="$(
+    cd "$candidate_root"
+    umask 077
+    env \
+        LC_ALL=C \
+        SOURCE_DATE_EPOCH=2000000000 \
+        TMPDIR="$candidate_tmp" \
+        TZ=Pacific/Honolulu \
+        ./buck2 --isolation-dir compiler-repro build //crates/rue:rue \
+            --local-only \
+            --no-remote-cache \
+            --num-threads 2 \
+            --show-full-simple-output
+)"
+if [ ! -f "$candidate_binary" ]; then
+    printf 'error: candidate compiler does not exist: %s\n' "$candidate_binary" >&2
+    exit 1
+fi
+
+reference_hash="$(sha256 "$reference_binary")"
+candidate_hash="$(sha256 "$candidate_binary")"
+reference_build_id="$(build_id "$reference_binary")"
+candidate_build_id="$(build_id "$candidate_binary")"
+
+if ! cmp -s "$reference_binary" "$candidate_binary"; then
+    first_diff="$(cmp -l "$reference_binary" "$candidate_binary" 2>/dev/null |
+        awk 'NR == 1 { print $1; exit }' || true)"
+    printf 'FAIL: independently rebuilt Rue compilers differ\n' >&2
+    printf '  reference: %s (%s bytes, sha256 %s, build-id %s)\n' \
+        "$reference_binary" "$(wc -c < "$reference_binary" | tr -d ' ')" \
+        "$reference_hash" "${reference_build_id:-none}" >&2
+    printf '  candidate: %s (%s bytes, sha256 %s, build-id %s)\n' \
+        "$candidate_binary" "$(wc -c < "$candidate_binary" | tr -d ' ')" \
+        "$candidate_hash" "${candidate_build_id:-none}" >&2
+    if [ -n "$first_diff" ]; then
+        printf '  first differing byte offset (1-based): %s\n' "$first_diff" >&2
+    fi
+    preserve_failure_artifacts
+    exit 1
+fi
+
+if [ "$reference_build_id" != "$candidate_build_id" ]; then
+    printf 'FAIL: compiler GNU build IDs differ: %s != %s\n' \
+        "${reference_build_id:-none}" "${candidate_build_id:-none}" >&2
+    preserve_failure_artifacts
+    exit 1
+fi
+
+if ! assert_no_root_leak "$reference_binary" "$repo_root" "reference compiler" ||
+    ! assert_no_root_leak "$reference_binary" "$candidate_root" "reference compiler" ||
+    ! assert_no_root_leak "$candidate_binary" "$repo_root" "candidate compiler" ||
+    ! assert_no_root_leak "$candidate_binary" "$candidate_root" "candidate compiler"; then
+    preserve_failure_artifacts
+    exit 1
+fi
+
+printf 'Rue compiler rebuild is byte-reproducible\n'
+printf '  sha256:  %s\n' "$reference_hash"
+printf '  build-id: %s\n' "${reference_build_id:-none}"
+rmdir "$artifact_dir" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- add a Linux compiler-rebuild checker that archives the exact triggering commit into a different-length clean source root
- reuse the compiler already produced by the normal CI build, then perform one cold local-only build with a separate Buck daemon/output tree and remote caching disabled
- perturb source mtimes, Buck scheduling, TMPDIR, timezone, umask, and SOURCE_DATE_EPOCH
- compare the complete compiler bytes, SHA-256, and GNU build ID, and reject either checkout path appearing in either binary
- preserve both compilers plus readelf diagnostics as a workflow artifact on mismatch
- run the check only in the required Linux-x64 lane to bound merge-queue cost

## Why

The Rue compiler already measured as byte-reproducible across relocated cold builds, including DWARF and GNU build IDs, but CI did not protect that property. This check exercises the final Rust/linker artifact rather than inferring reproducibility from component ordering.

The initial contract is intentionally same-host and same pinned repository inputs. The system linker/CRT/sysroot closure remains a separate hermeticity boundary tracked by RUE-320 and RUE-615.

## Cost

The added build is deliberately cold: 336 local actions, zero cache or remote hits, about 77 seconds locally, and roughly 550 MiB of pinned toolchain downloads. Reusing the first compiler and limiting the second build to one required lane avoids duplicating that cost across the host matrix.

## Validation

- full checker from a pure-jj snapshot: byte-identical, 336 local actions, zero cache/remote hits
- full checker from a conventional clean Git checkout: byte-identical, 336 local actions, zero cache/remote hits
- `bash -n scripts/check-reproducible-compiler.sh`
- actionlint on `.github/workflows/ci.yml`
- independent read-only review of archive completeness, cleanup safety, Buck isolation, and failure-artifact behavior