### PR TITLE
RUE-619: stabilize ad-hoc Mach-O signing identity

### DIFF
--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1744,8 +1744,21 @@ fn main() {
             {
                 // Only codesign if target is macOS (cross-compilation check)
                 if compile_options.target.is_macho() {
+                    // A command-line Mach-O has no Info.plist, so codesign's
+                    // default identifier comes from the output filename. Pin
+                    // both identity and timestamp policy: choosing a different
+                    // destination path must not change the program bytes
+                    // (RUE-619).
                     let result = Command::new("codesign")
-                        .args(["-f", "-s", "-", &options.output_path])
+                        .args([
+                            "-f",
+                            "-s",
+                            "-",
+                            "--identifier",
+                            "org.rue-lang.program",
+                            "--timestamp=none",
+                            &options.output_path,
+                        ])
                         .output();
                     match result {
                         Ok(output) => {

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -16,9 +16,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Different-length roots catch accidental absolute-path capture.  Keep the
-# output basenames equal: filename-derived macOS signing identity is covered by
-# the dedicated RUE-619 test, while this test varies the containing path.
+# Different-length roots catch accidental absolute-path capture. Different
+# output basenames additionally catch filename-derived macOS signing identity:
+# the output path selects a destination, not different program semantics.
 root_a="$scratch/a"
 root_b="$scratch/a-deliberately-much-longer-reproducibility-root"
 mkdir -p "$root_a/project" "$root_b/project" "$root_a/tmp" "$root_b/tmp"
@@ -82,9 +82,28 @@ assert_fixture_runs() {
     fi
 }
 
+assert_macos_signature() {
+    local program="$1" metadata
+    if [ "$(uname -s)" != "Darwin" ]; then
+        return
+    fi
+
+    if ! codesign --verify --strict --verbose=4 "$program"; then
+        printf 'FAIL: reproducible Mach-O artifact has an invalid code signature: %s\n' \
+            "$program" >&2
+        return 1
+    fi
+    metadata="$(codesign --display --verbose=4 "$program" 2>&1)"
+    if ! grep -Fqx 'Identifier=org.rue-lang.program' <<< "$metadata"; then
+        printf 'FAIL: Mach-O signing identifier is not stable\n%s\n' "$metadata" >&2
+        return 1
+    fi
+}
+
 compile_pair() {
-    local opt="$1" name="program-o$1"
-    local output_a="$root_a/project/$name" output_b="$root_b/project/$name"
+    local opt="$1"
+    local output_a="$root_a/project/program-left-o$1"
+    local output_b="$root_b/project/program-right-with-long-name-o$1"
 
     # First build: relative root spelling, forward manifest, serial compiler,
     # old epoch, permissive umask, and one ambient timezone.
@@ -120,6 +139,8 @@ compile_pair() {
     # Keep the adversarial fixture honest: byte-identical but broken artifacts
     # must not make this test vacuously green.
     assert_fixture_runs "$output_a"
+    assert_macos_signature "$output_a"
+    assert_macos_signature "$output_b"
 }
 
 compile_pair 0


### PR DESCRIPTION
## Summary

- pass an explicit `org.rue-lang.program` identifier to ad-hoc codesign and explicitly disable timestamp services
- strengthen the end-to-end reproducibility gate so its two native artifacts use different output basenames as well as different parent paths
- on macOS, strictly verify both code signatures and assert the exact stable identifier before accepting the artifacts

## Root cause

Standalone Rue Mach-O executables have no Info.plist. When no identifier is supplied, codesign derives one independently from each pathname; command-line tools therefore inherit their output filename. That identifier is sealed into the CodeDirectory, so identical source and options written under different names produce different final bytes.

The codesign contract also leaves timestamp behavior system-specific when no policy is supplied. Ad-hoc signatures are not timestamped today, but `--timestamp=none` makes that reproducibility boundary explicit.

Reference: [Xcode codesign(1)](https://keith.github.io/xcode-man-pages/codesign.1.html)

## Impact

The output path remains a destination choice, not a semantic compiler input. Rue still produces a valid ad-hoc signature required for ARM64 execution; the test runs the artifact and uses strict codesign verification on both copies.

## Validation

- `./fmt.sh check`
- `./buck2 test //crates/rue:rue-test` — 132 passed
- `./buck2 test //:reproducible-programs`
- `bash -n scripts/test-reproducible-output.sh`
- independent audit against Apple Security signing-source behavior and codesign flag semantics

The required macOS CI lane provides the platform-native byte and strict-signature validation.