### PR TITLE
RUE-589: model panic and assertion observations

### DIFF
--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -576,7 +576,22 @@ fn check_spec_case_with_known_gap(
     };
 
     let preview_features = spec_preview_features(case);
-    let expected_trap = trap::trap_expectation(case.runtime_error.iter().map(String::as_str));
+    let expected_trap = case.runtime_error.as_deref().map_or_else(
+        || {
+            if expected_exit == rue_test_runner::RUNTIME_ERROR_EXIT_CODE {
+                case.stderr_contains
+                    .as_deref()
+                    .and_then(trap::spec_stderr_trap_kind)
+                    .map_or(
+                        trap::TrapExpectation::Undeclared,
+                        trap::TrapExpectation::Modeled,
+                    )
+            } else {
+                trap::TrapExpectation::Undeclared
+            }
+        },
+        |runtime_error| trap::trap_expectation([runtime_error]),
+    );
 
     match run_source_with_preview_features(&case.source, &preview_features) {
         // Only Unsupported values carrying a registrable ModelGapKind count as
@@ -1614,6 +1629,54 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
     }
 
     #[test]
+    fn cli_abort_intrinsics_check_exact_stderr_observations() {
+        for (source, expected, expected_kind) in [
+            (
+                "fn main() -> i32 { @panic(); 0 }",
+                "panic",
+                TrapKind::UserPanic,
+            ),
+            (
+                r#"fn main() -> i32 { @panic("boom"); 0 }"#,
+                "panic: boom",
+                TrapKind::UserPanic,
+            ),
+            (
+                "fn main() -> i32 { @assert(false); 0 }",
+                "assertion failed",
+                TrapKind::AssertionFailure,
+            ),
+            (
+                r#"fn main() -> i32 { @assert(false, "boom"); 0 }"#,
+                "panic: boom",
+                TrapKind::UserPanic,
+            ),
+        ] {
+            let mut case = corpus_case(source, false);
+            case.exit_code = Some(101);
+            case.runtime_error_contains = vec![expected.to_string()];
+            assert_eq!(
+                check_case(Path::new("panic.toml"), &case),
+                CaseOutcome::Agree,
+                "{expected_kind:?} with {expected:?}"
+            );
+        }
+
+        let mut wrong_message = corpus_case(r#"fn main() -> i32 { @panic("actual"); 0 }"#, false);
+        wrong_message.exit_code = Some(101);
+        // Both strings map to UserPanic. Exact stderr comparison must still
+        // reject the wrong user-visible message.
+        wrong_message.runtime_error_contains = vec!["panic: expected".to_string()];
+        let CaseOutcome::Disagreement(message) =
+            check_case(Path::new("panic.toml"), &wrong_message)
+        else {
+            panic!("same-category panic message mismatch was accepted");
+        };
+        assert!(message.contains("missing required substring"));
+        assert!(message.contains("panic: actual"));
+    }
+
+    #[test]
     fn spec_runtime_trap_expectations_use_the_same_typed_comparison() {
         let mut case = rue_test_runner::Case {
             name: "spec trap probe".to_string(),
@@ -1659,6 +1722,36 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
             check_spec_case("test:1", &case),
             CaseOutcome::Disagreement(_)
         ));
+    }
+
+    #[test]
+    fn spec_abort_stderr_has_a_narrow_separate_trap_vocabulary() {
+        let mut case = rue_test_runner::Case {
+            name: "spec panic probe".to_string(),
+            source: r#"fn main() -> i32 { @panic("boom"); 0 }"#.to_string(),
+            exit_code: Some(101),
+            stderr_contains: Some("panic: boom".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(check_spec_case("test:1", &case), CaseOutcome::Agree);
+
+        case.source = "fn main() -> i32 { @assert(false); 0 }".to_string();
+        case.stderr_contains = Some("assertion failed".to_string());
+        assert_eq!(check_spec_case("test:1", &case), CaseOutcome::Agree);
+
+        case.source = r#"fn main() -> i32 { @assert(false, "actual"); 0 }"#.to_string();
+        case.stderr_contains = Some("panic: expected".to_string());
+        assert!(matches!(
+            check_spec_case("test:1", &case),
+            CaseOutcome::Disagreement(_)
+        ));
+
+        case.source = "fn main() -> i32 { let x: i32 = 2147483647; x + 1 }".to_string();
+        case.stderr_contains = Some("error: integer overflow".to_string());
+        let CaseOutcome::Disagreement(message) = check_spec_case("test:1", &case) else {
+            panic!("generic stderr text declared an unrelated arithmetic trap");
+        };
+        assert!(message.contains("trap contract"));
     }
 
     #[test]

--- a/crates/rue-oracle-diff/src/trap.rs
+++ b/crates/rue-oracle-diff/src/trap.rs
@@ -91,6 +91,20 @@ pub(crate) fn cli_trap_expectation<'a>(
     classify_expectation(fragments, cli_expected_trap_kind)
 }
 
+/// A deliberately narrow trap declaration vocabulary for rue-spec's
+/// successful-run `stderr_contains` field. The spec runner does not treat this
+/// field as `runtime_error`, so keep it separate from both that vocabulary and
+/// the CLI registry. Only the two deterministic abort intrinsic spellings are
+/// declarations; arbitrary stderr text must not hide an unrelated typed trap.
+pub(crate) fn spec_stderr_trap_kind(fragment: &str) -> Option<TrapKind> {
+    match fragment {
+        "panic" => Some(TrapKind::UserPanic),
+        "assertion failed" => Some(TrapKind::AssertionFailure),
+        fragment if fragment.starts_with("panic: ") => Some(TrapKind::UserPanic),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,6 +203,21 @@ mod tests {
             trap_expectation(["assertion failed"]),
             TrapExpectation::Unmodeled
         );
+
+        for fragment in ["panic", "panic: boom"] {
+            assert_eq!(spec_stderr_trap_kind(fragment), Some(TrapKind::UserPanic));
+        }
+        assert_eq!(
+            spec_stderr_trap_kind("assertion failed"),
+            Some(TrapKind::AssertionFailure)
+        );
+        for fragment in ["integer overflow", "arbitrary stderr", "boom"] {
+            assert_eq!(
+                spec_stderr_trap_kind(fragment),
+                None,
+                "generic spec stderr must not declare a trap category"
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -18,8 +18,9 @@
 //! Scalars (all integer widths + `bool` + `unit`), the full arithmetic /
 //! comparison / bitwise / shift operator set with **trapping** overflow, locals,
 //! parameters, calls and recursion, block-parameter control flow (`if`/`match`/
-//! `loop` all lower to `Goto`/`Branch`/`Switch`), `@dbg`, `@intCast`, and the
-//! defined panics (overflow, divide/remainder-by-zero, int-cast overflow);
+//! `loop` all lower to `Goto`/`Branch`/`Switch`), `@dbg`, `@intCast`, `@panic`,
+//! `@assert`, and the defined panics (overflow, divide/remainder-by-zero,
+//! int-cast overflow);
 //! aggregates (structs/arrays) with nested place projections and bounds traps;
 //! `inout`/`borrow` parameters (copy-in / copy-out, observably identical to
 //! by-reference under the law of exclusivity); and drop/destructors, executed in
@@ -50,14 +51,13 @@
 //! Generated-program mode has the stronger promise that no `Unsupported` kind
 //! is valid and reports every one as a generator-contract failure.
 //!
-//! - **All CFG intrinsics except `@dbg`.** The `Intrinsic` arm models only
-//!   `@dbg`; every other intrinsic that is allowed to survive to the CFG is a
-//!   typed model gap: the
+//! - **All other CFG intrinsics.** The `Intrinsic` arm models `@dbg`, `@panic`,
+//!   and `@assert`; every other intrinsic that is allowed to survive to the CFG
+//!   is a typed model gap: the
 //!   non-deterministic `@read_line`, `@random_u32`/`@random_u64`, `@syscall`;
 //!   the heap intrinsics `@alloc`/`@free`/`@realloc`; the raw-pointer intrinsics
 //!   `@raw`/`@raw_mut`/`@field_ptr`/`@ptr_read`/`@ptr_write`/`@ptr_offset`/
-//!   `@ptr_to_int`/`@int_to_ptr` (heap-/layout-dependent, and `checked`-only);
-//!   and `@panic`/`@assert` (deterministic, but not yet modeled).
+//!   `@ptr_to_int`/`@int_to_ptr` (heap-/layout-dependent, and `checked`-only).
 //! - **`String::capacity`/`reserve`/`with_capacity` capacity behavior** — the
 //!   exact capacity value is implementation-defined, so `capacity` is reported
 //!   as a typed gap rather than guessed. Specified bounds and growth/preservation
@@ -164,8 +164,6 @@ pub enum UnsupportedClass {
 /// A user-facing intrinsic whose deterministic semantics are not modeled yet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum UnsupportedIntrinsicKind {
-    Panic,
-    Assert,
     ParseI32,
     ParseI64,
     ParseU32,
@@ -621,6 +619,16 @@ enum PlaceAccess {
     Write,
 }
 
+#[derive(Clone, Copy)]
+enum AbortIntrinsic {
+    Panic,
+    Assert,
+}
+
+// `@panic` aborts dynamically but remains an ordinary unit expression in Rue's
+// static contract.
+const PANIC_CFG_RESULT_TYPE: Type = Type::UNIT;
+
 impl From<Unsupported> for Flow {
     fn from(u: Unsupported) -> Self {
         Flow::Unsupported(u)
@@ -637,8 +645,6 @@ fn unsupported_intrinsic_kind(name: &str) -> UnsupportedKind {
     use UnsupportedIntrinsicKind as Intrinsic;
 
     match name {
-        "panic" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Panic)),
-        "assert" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Assert)),
         "parse_i32" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseI32)),
         "parse_i64" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseI64)),
         "parse_u32" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ParseU32)),
@@ -1137,8 +1143,6 @@ impl<'a> Interp<'a> {
         }
 
         let arity_matches = match name {
-            "panic" => args.len() <= 1,
-            "assert" => (1..=2).contains(&args.len()),
             "read_line" | "random_u32" | "random_u64" => args.is_empty(),
             "ptr_write" | "ptr_offset" | "free" => args.len() == 2,
             "realloc" => args.len() == 3,
@@ -1153,12 +1157,6 @@ impl<'a> Interp<'a> {
         let is_owned_string = |index: usize| self.is_owned_string_type(ty(index));
         let mut validated_kind = kind;
         let signature_matches = match name {
-            "panic" => result_ty == Type::UNIT && (args.is_empty() || is_owned_string(0)),
-            "assert" => {
-                result_ty == Type::UNIT
-                    && ty(0) == Type::BOOL
-                    && (args.len() == 1 || is_owned_string(1))
-            }
             "parse_i32" => is_owned_string(0) && self.is_option_of(result_ty, Type::I32),
             "parse_i64" => is_owned_string(0) && self.is_option_of(result_ty, Type::I64),
             "parse_u32" => is_owned_string(0) && self.is_option_of(result_ty, Type::U32),
@@ -1243,6 +1241,141 @@ impl<'a> Interp<'a> {
             validated_kind
         } else {
             UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature)
+        }
+    }
+
+    /// Validate every static part of `@panic` / `@assert` before evaluating an
+    /// operand. This keeps malformed outer CFG from being hidden by an
+    /// external-dependency or model-gap operand and mirrors the native
+    /// lowering's exact ABI assumptions.
+    fn preflight_abort_intrinsic(
+        &self,
+        cfg: &Cfg,
+        name: &str,
+        args: &[CfgValue],
+        result_ty: Type,
+    ) -> Step<Option<AbortIntrinsic>> {
+        let intrinsic = match name {
+            "panic" => AbortIntrinsic::Panic,
+            "assert" => AbortIntrinsic::Assert,
+            _ => return Ok(None),
+        };
+        let arity_matches = match intrinsic {
+            AbortIntrinsic::Panic => args.len() <= 1,
+            AbortIntrinsic::Assert => (1..=2).contains(&args.len()),
+        };
+        if !arity_matches {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicArity),
+                format!("intrinsic @{name} arity"),
+            ));
+        }
+
+        let ty = |index: usize| cfg.get_inst(args[index]).ty;
+        let signature_matches = match intrinsic {
+            AbortIntrinsic::Panic => {
+                result_ty == PANIC_CFG_RESULT_TYPE
+                    && (args.is_empty() || self.is_owned_string_type(ty(0)))
+            }
+            AbortIntrinsic::Assert => {
+                result_ty == Type::UNIT
+                    && ty(0) == Type::BOOL
+                    && (args.len() == 1 || self.is_owned_string_type(ty(1)))
+            }
+        };
+        if !signature_matches {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+                format!("intrinsic @{name} signature"),
+            ));
+        }
+        Ok(Some(intrinsic))
+    }
+
+    fn abort_with_stderr(&self, kind: TrapKind, parts: &[&[u8]]) -> Step<Value> {
+        let raw_stderr_bytes = parts
+            .iter()
+            .try_fold(0usize, |total, part| total.checked_add(part.len()));
+        let Some(raw_stderr_bytes) = raw_stderr_bytes else {
+            return Err(unsupported(
+                UnsupportedKind::ResourceLimit(ResourceLimitKind::StderrBytes),
+                format!(
+                    "stderr byte limit exceeded ({}-byte limit)",
+                    self.stderr_cap
+                ),
+            ));
+        };
+        if raw_stderr_bytes > self.stderr_cap {
+            return Err(unsupported(
+                UnsupportedKind::ResourceLimit(ResourceLimitKind::StderrBytes),
+                format!(
+                    "stderr byte limit exceeded ({}-byte limit)",
+                    self.stderr_cap
+                ),
+            ));
+        }
+
+        // Decode exactly as the native differential runner does. Capacity is
+        // bounded by the raw-byte cap; invalid UTF-8 can expand to replacement
+        // characters but by at most a small constant factor.
+        let mut stderr = String::with_capacity(raw_stderr_bytes);
+        for part in parts {
+            stderr.push_str(&String::from_utf8_lossy(part));
+        }
+        Err(Flow::Panic(Panic::with_stderr(
+            kind,
+            stderr,
+            raw_stderr_bytes,
+        )))
+    }
+
+    fn eval_abort_intrinsic(
+        &mut self,
+        cfg: &'a Cfg,
+        frame: &mut Frame,
+        intrinsic: AbortIntrinsic,
+        args: &[CfgValue],
+    ) -> Step<Value> {
+        // Native lowering materializes both `@assert` operands before testing
+        // the condition. Keep that eager, source-ordered behavior even on the
+        // true path.
+        let values = self.eval_all(cfg, frame, args)?;
+        match intrinsic {
+            AbortIntrinsic::Panic => match values.as_slice() {
+                [] => self.abort_with_stderr(TrapKind::UserPanic, &[b"panic\n"]),
+                [Value::Str { bytes, slots: 3 }] => self
+                    .abort_with_stderr(TrapKind::UserPanic, &[b"panic: ", bytes.as_slice(), b"\n"]),
+                [_] => Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+                    "intrinsic @panic runtime value shape",
+                )),
+                _ => unreachable!("@panic arity was preflighted"),
+            },
+            AbortIntrinsic::Assert => {
+                let (condition, message) = match values.as_slice() {
+                    [Value::Bool(condition)] => (*condition, None),
+                    [Value::Bool(condition), Value::Str { bytes, slots: 3 }] => {
+                        (*condition, Some(bytes.as_slice()))
+                    }
+                    _ => {
+                        return Err(unsupported(
+                            UnsupportedKind::ContractViolation(
+                                ContractViolationKind::IntrinsicSignature,
+                            ),
+                            "intrinsic @assert runtime value shape",
+                        ));
+                    }
+                };
+                if condition {
+                    Ok(Value::Unit)
+                } else if let Some(message) = message {
+                    // The message-carrying assertion uses the same runtime path
+                    // and trap category as `@panic(message)`.
+                    self.abort_with_stderr(TrapKind::UserPanic, &[b"panic: ", message, b"\n"])
+                } else {
+                    self.abort_with_stderr(TrapKind::AssertionFailure, &[b"assertion failed\n"])
+                }
+            }
         }
     }
 
@@ -2207,23 +2340,26 @@ impl<'a> Interp<'a> {
             } => {
                 let iname = self.interner().resolve(name).to_string();
                 let args = cfg.get_extra(*args_start, *args_len).to_vec();
-                if iname != "dbg" {
+                if let Some(intrinsic) = self.preflight_abort_intrinsic(cfg, &iname, &args, ty)? {
+                    self.eval_abort_intrinsic(cfg, frame, intrinsic, &args)?
+                } else if iname != "dbg" {
                     return Err(unsupported(
                         self.classify_unsupported_intrinsic(cfg, v, &iname, &args, ty),
                         format!("intrinsic @{iname}"),
                     ));
+                } else {
+                    let [arg] = args.as_slice() else {
+                        return Err(unsupported(
+                            UnsupportedKind::ContractViolation(ContractViolationKind::DebugArity),
+                            "@dbg arity",
+                        ));
+                    };
+                    let arg = *arg;
+                    let arg_ty = cfg.get_inst(arg).ty;
+                    let val = self.eval(cfg, frame, arg)?;
+                    self.write_dbg(&val, arg_ty)?;
+                    Value::Unit
                 }
-                let [arg] = args.as_slice() else {
-                    return Err(unsupported(
-                        UnsupportedKind::ContractViolation(ContractViolationKind::DebugArity),
-                        "@dbg arity",
-                    ));
-                };
-                let arg = *arg;
-                let arg_ty = cfg.get_inst(arg).ty;
-                let val = self.eval(cfg, frame, arg)?;
-                self.write_dbg(&val, arg_ty)?;
-                Value::Unit
             }
 
             CfgInstData::IntCast { value, from_ty: _ } => {

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -174,6 +174,62 @@ fn dbg_output() {
 }
 
 #[test]
+fn panic_and_assert_have_exact_observable_semantics() {
+    let out = run("fn main() -> i32 { @panic(); 0 }");
+    assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stdout, "");
+    assert_eq!(out.stderr, "panic\n");
+    assert_eq!(out.panic, Some(TrapKind::UserPanic));
+
+    let out = run(r#"fn main() -> i32 { @panic("boom"); 0 }"#);
+    assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stderr, "panic: boom\n");
+    assert_eq!(out.panic, Some(TrapKind::UserPanic));
+
+    let out = run(r#"fn main() -> i32 { @panic(""); 0 }"#);
+    assert_eq!(out.stderr, "panic: \n");
+    assert_eq!(out.panic, Some(TrapKind::UserPanic));
+
+    let out = run("fn main() -> i32 { @assert(true); 42 }");
+    assert_eq!(out.exit_code, 42);
+    assert_eq!(out.stderr, "");
+    assert_eq!(out.panic, None);
+
+    let out = run("fn main() -> i32 { @assert(false); 0 }");
+    assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stderr, "assertion failed\n");
+    assert_eq!(out.panic, Some(TrapKind::AssertionFailure));
+
+    let out = run(r#"fn main() -> i32 { @assert(1 == 2, "not equal"); 0 }"#);
+    assert_eq!(out.exit_code, 101);
+    assert_eq!(out.stderr, "panic: not equal\n");
+    assert_eq!(out.panic, Some(TrapKind::UserPanic));
+}
+
+#[test]
+fn assert_eagerly_evaluates_condition_then_message_even_when_true() {
+    let out = run(r#"fn condition() -> bool { @dbg(1); true }
+        fn message() -> String { @dbg(2); "unused" }
+        fn main() -> i32 { @assert(condition(), message()); 42 }"#);
+    assert_eq!(out.exit_code, 42);
+    assert_eq!(out.stdout, "1\n2\n");
+    assert_eq!(out.stderr, "");
+    assert_eq!(out.panic, None);
+}
+
+#[test]
+fn panic_stderr_uses_raw_message_bytes_and_native_lossy_decoding() {
+    let out = run("fn main() -> i32 {
+            let mut message = String.new();
+            message.push(255);
+            @panic(message);
+            0
+        }");
+    assert_eq!(out.stderr, "panic: \u{fffd}\n");
+    assert_eq!(out.panic, Some(TrapKind::UserPanic));
+}
+
+#[test]
 fn stdout_and_stderr_limits_are_independent_and_fail_closed() {
     let source = "fn main() -> i32 {
         @dbg(7);
@@ -201,6 +257,21 @@ fn stdout_and_stderr_limits_are_independent_and_fail_closed() {
     assert_eq!(
         unsupported.detail(),
         "stderr byte limit exceeded (23-byte limit)"
+    );
+}
+
+#[test]
+fn dynamic_panic_stderr_obeys_the_shared_raw_byte_limit() {
+    let source = r#"fn main() -> i32 { @panic("x"); 0 }"#;
+    let out = run_with_output_caps(source, MAX_STDOUT_BYTES, 9)
+        .unwrap_or_else(|unsupported| panic!("exactly capped panic failed: {unsupported}"));
+    assert_eq!(out.stderr, "panic: x\n");
+
+    let unsupported = run_with_output_caps(source, MAX_STDOUT_BYTES, 8)
+        .expect_err("panic prefix, body, and newline must all count");
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::ResourceLimit(ResourceLimitKind::StderrBytes)
     );
 }
 
@@ -312,8 +383,6 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
     use UnsupportedIntrinsicKind as Intrinsic;
 
     for (name, intrinsic) in [
-        ("panic", Intrinsic::Panic),
-        ("assert", Intrinsic::Assert),
         ("parse_i32", Intrinsic::ParseI32),
         ("parse_i64", Intrinsic::ParseI64),
         ("parse_u32", Intrinsic::ParseU32),
@@ -353,6 +422,8 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
 
     for name in [
         "dbg",
+        "panic",
+        "assert",
         "drop",
         "intCast",
         "cast",

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -448,47 +448,6 @@ fn capacity_and_intrinsic_signature_drift_are_contract_failures() {
 }
 
 #[test]
-fn panic_unit_signature_is_an_oracle_contract_for_both_arities() {
-    let state = compile_to_cfg(
-        r#"fn panic_no_message() { @panic() }
-        fn panic_with_message() { @panic("boom") }
-        fn main() -> i32 {
-            panic_no_message();
-            panic_with_message();
-            0
-        }"#,
-    )
-    .expect("both panic arities must compile with the unit contract");
-    let interp = Interp {
-        state: &state,
-        stdout: String::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-    };
-    let expected =
-        UnsupportedKind::SemanticGap(SemanticGapKind::Intrinsic(UnsupportedIntrinsicKind::Panic));
-
-    for function_name in ["panic_no_message", "panic_with_message"] {
-        let (cfg, intrinsic, args, result_ty) =
-            find_intrinsic_in_function(&state, function_name, "panic");
-        assert_eq!(result_ty, Type::UNIT, "{function_name} compiler metadata");
-        assert_eq!(
-            interp.classify_unsupported_intrinsic(cfg, intrinsic, "panic", &args, result_ty,),
-            expected,
-            "{function_name} unit signature"
-        );
-        assert_eq!(
-            interp.classify_unsupported_intrinsic(cfg, intrinsic, "panic", &args, Type::NEVER,),
-            UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
-            "{function_name} must reject the old never-typed metadata"
-        );
-    }
-}
-
-#[test]
 fn malformed_outer_calls_are_rejected_before_unmodeled_operands_run() {
     let mut preview_features = PreviewFeatures::new();
     preview_features.insert(rue_compiler::PreviewFeature::StringTrio);
@@ -582,6 +541,168 @@ fn malformed_outer_calls_are_rejected_before_unmodeled_operands_run() {
         let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, outer_call));
         assert_eq!(unsupported.kind(), expected, "{call_name}");
     }
+}
+
+#[test]
+fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
+    let source = r#"fn main() -> i32 {
+        let entropy: u32 = @random_u32();
+        @assert(true, "ok");
+        @panic("stop");
+        if entropy == 0 { 0 } else { 1 }
+    }"#;
+
+    for probe in 0..5 {
+        let mut state = compile_to_cfg(source).expect("abort-preflight probe must compile");
+        let main_index = state
+            .functions
+            .iter()
+            .position(|function| function.cfg.fn_name() == "main")
+            .expect("main CFG");
+        let (random, panic, panic_args, assertion, assert_args) = {
+            let cfg = &state.functions[main_index].cfg;
+            let (_, random, random_args, _) =
+                find_intrinsic_in_function(&state, "main", "random_u32");
+            assert!(random_args.is_empty());
+            let (_, panic, panic_args, _) = find_intrinsic_in_function(&state, "main", "panic");
+            let (_, assertion, assert_args, _) =
+                find_intrinsic_in_function(&state, "main", "assert");
+            assert!(cfg.get_inst(random).ty == Type::U32);
+            (random, panic, panic_args, assertion, assert_args)
+        };
+
+        let cfg = &mut state.functions[main_index].cfg;
+        let (outer, replacement_args, replacement_ty, expected) = match probe {
+            0 => (
+                panic,
+                vec![panic_args[0], random],
+                PANIC_CFG_RESULT_TYPE,
+                ContractViolationKind::IntrinsicArity,
+            ),
+            1 => (
+                panic,
+                vec![random],
+                PANIC_CFG_RESULT_TYPE,
+                ContractViolationKind::IntrinsicSignature,
+            ),
+            2 => (
+                assertion,
+                vec![assert_args[0], assert_args[1], random],
+                Type::UNIT,
+                ContractViolationKind::IntrinsicArity,
+            ),
+            3 => (
+                assertion,
+                vec![random, assert_args[1]],
+                Type::UNIT,
+                ContractViolationKind::IntrinsicSignature,
+            ),
+            4 => (
+                assertion,
+                assert_args.clone(),
+                Type::NEVER,
+                ContractViolationKind::IntrinsicSignature,
+            ),
+            _ => unreachable!(),
+        };
+        let (args_start, args_len) = cfg.push_extra(replacement_args);
+        let CfgInstData::Intrinsic {
+            args_start: stored_start,
+            args_len: stored_len,
+            ..
+        } = &mut cfg.get_inst_mut(outer).data
+        else {
+            unreachable!("selected an intrinsic")
+        };
+        *stored_start = args_start;
+        *stored_len = args_len;
+        cfg.get_inst_mut(outer).ty = replacement_ty;
+
+        let cfg = &state.functions[main_index].cfg;
+        let mut interp = Interp {
+            state: &state,
+            stdout: String::new(),
+            stdout_bytes: 0,
+            stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
+            budget: STEP_BUDGET,
+            depth: 0,
+        };
+        let mut frame = Frame {
+            params: Vec::new(),
+            locals: vec![None; cfg.num_locals() as usize],
+            cache: HashMap::new(),
+        };
+        let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, outer));
+        assert_eq!(
+            unsupported.kind(),
+            UnsupportedKind::ContractViolation(expected),
+            "probe {probe} must reject the malformed outer intrinsic before @random_u32"
+        );
+    }
+}
+
+#[test]
+fn abort_intrinsics_require_exact_runtime_value_shapes() {
+    let source = r#"fn main() -> i32 {
+        @assert(true, "ok");
+        @panic("stop");
+        0
+    }"#;
+
+    for name in ["panic", "assert"] {
+        let state = compile_to_cfg(source).expect("abort value-shape probe must compile");
+        let (cfg, intrinsic, args, _) = find_intrinsic_in_function(&state, "main", name);
+        let mut interp = Interp {
+            state: &state,
+            stdout: String::new(),
+            stdout_bytes: 0,
+            stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
+            budget: STEP_BUDGET,
+            depth: 0,
+        };
+        let mut frame = Frame {
+            params: Vec::new(),
+            locals: vec![None; cfg.num_locals() as usize],
+            cache: HashMap::new(),
+        };
+        let corrupted = if name == "panic" { args[0] } else { args[1] };
+        frame
+            .cache
+            .insert(corrupted.as_u32(), Value::str_view("not owned"));
+
+        let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, intrinsic));
+        assert_eq!(
+            unsupported.kind(),
+            UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+            "@{name} must reject a value whose runtime shape contradicts its owned-string type"
+        );
+    }
+
+    let state = compile_to_cfg(source).expect("assert condition-shape probe must compile");
+    let (cfg, assertion, args, _) = find_intrinsic_in_function(&state, "main", "assert");
+    let mut interp = Interp {
+        state: &state,
+        stdout: String::new(),
+        stdout_bytes: 0,
+        stdout_cap: MAX_STDOUT_BYTES,
+        stderr_cap: MAX_STDERR_BYTES,
+        budget: STEP_BUDGET,
+        depth: 0,
+    };
+    let mut frame = Frame {
+        params: Vec::new(),
+        locals: vec![None; cfg.num_locals() as usize],
+        cache: HashMap::new(),
+    };
+    frame.cache.insert(args[0].as_u32(), Value::Int(1));
+    let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, assertion));
+    assert_eq!(
+        unsupported.kind(),
+        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+        "@assert condition must be a runtime Bool, not merely truthy"
+    );
 }
 
 #[test]

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -108,7 +108,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 101
-stderr_contains = "one is not two"
+stderr_contains = "panic: one is not two"
 
 [[case]]
 name = "cast_rejected_use_intcast"


### PR DESCRIPTION
## Summary

- execute valid @panic and @assert CFG intrinsics in the differential oracle
- preserve eager, left-to-right operand evaluation and the static unit result contract
- compare typed trap categories and bounded stderr observations for CLI and spec corpus cases
- reject malformed intrinsic metadata before evaluating a nested model-gap operand

## Why

Panic and assertion programs were previously classified as oracle model gaps even though their runtime behavior is deterministic. That left an avoidable hole in the always-on compiler correctness gate and let corpus coverage describe those cases as unmodeled.

This change models the whole behavior class: both arities, true and false assertions, exact panic diagnostics, raw-byte stderr limits, lossy UTF-8 rendering, eager argument effects, and malformed CFG contracts.

## Validation

- ./fmt.sh check
- ./clippy.sh: 41 first-party targets
- ./test.sh: 34/34 targets
- generated oracle smoke: 64/64 agree
- CLI corpus: 627 agree, 99 model gaps, 550 ineligible, 0 failures or disagreements
- spec corpus: 1325 agree, 102 model gaps, 587 ineligible, 0 failures or disagreements
- independent semantic review: clear