### PR TITLE
RUE-618: make generated symbols path-stable

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -59,7 +59,7 @@ impl<'a> Sema<'a> {
         }
         if count > 1 {
             let module_component = self
-                .get_file_path(file_id)
+                .get_symbol_path(file_id)
                 .map(normalize_module_path)
                 .unwrap_or_else(|| format!("file{}", file_id.index()));
             let module_component = mangle_symbol_component(&module_component);

--- a/crates/rue-air/src/sema/file_paths.rs
+++ b/crates/rue-air/src/sema/file_paths.rs
@@ -19,6 +19,13 @@ impl<'a> Sema<'a> {
         self.file_paths = file_paths;
     }
 
+    /// Set stable source identities used when generated symbols need a module
+    /// component. These are deliberately separate from physical file paths so
+    /// relocating a source tree cannot change machine-level names.
+    pub fn set_symbol_paths(&mut self, symbol_paths: HashMap<FileId, String>) {
+        self.symbol_paths = symbol_paths;
+    }
+
     /// Get the source file path for a span.
     ///
     /// Looks up the file path using the span's file_id.
@@ -29,6 +36,14 @@ impl<'a> Sema<'a> {
     /// Get the file path for a given FileId.
     pub(crate) fn get_file_path(&self, file_id: FileId) -> Option<&str> {
         self.file_paths.get(&file_id).map(|s| s.as_str())
+    }
+
+    /// Get the relocation-stable symbol path for a given FileId.
+    pub(crate) fn get_symbol_path(&self, file_id: FileId) -> Option<&str> {
+        self.symbol_paths
+            .get(&file_id)
+            .or_else(|| self.file_paths.get(&file_id))
+            .map(|s| s.as_str())
     }
 
     /// Reverse lookup: find the FileId for a given source file path.

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -118,6 +118,7 @@ impl<'a> GatherOutput<'a> {
             type_pool: self.type_pool,
             module_registry: crate::module_registry::ModuleRegistry::new(),
             file_paths: HashMap::new(),
+            symbol_paths: HashMap::new(),
             param_arena: self.param_arena,
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -120,6 +120,8 @@ pub struct Sema<'a> {
     pub(crate) module_registry: crate::module_registry::ModuleRegistry,
     /// Maps FileId to source file paths (for module resolution).
     pub(crate) file_paths: HashMap<FileId, String>,
+    /// Maps FileId to relocation-stable paths used in generated symbols.
+    pub(crate) symbol_paths: HashMap<FileId, String>,
     /// Arena storage for function/method parameter data.
     pub(crate) param_arena: ParamArena,
     /// Method signatures for anonymous structs, used for structural equality comparison.
@@ -219,6 +221,7 @@ impl<'a> Sema<'a> {
             type_pool: TypeInternPool::new(),
             module_registry: crate::module_registry::ModuleRegistry::new(),
             file_paths: HashMap::new(),
+            symbol_paths: HashMap::new(),
             param_arena: ParamArena::new(),
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -992,6 +992,34 @@ pub fn compile_frontend_from_ast_with_file_paths_and_target(
     target: Target,
     file_paths: std::collections::HashMap<FileId, String>,
 ) -> MultiErrorResult<CompileState> {
+    let symbol_paths = file_paths.clone();
+    compile_frontend_from_ast_with_file_paths_and_symbol_paths_and_target(
+        ast,
+        interner,
+        opt_level,
+        preview_features,
+        target,
+        file_paths,
+        symbol_paths,
+    )
+}
+
+/// Like [`compile_frontend_from_ast_with_file_paths_and_target`], but keeps
+/// physical paths used for module resolution separate from stable paths used
+/// in generated symbol names.
+///
+/// The Rue CLI uses this entry point for relocated builds. Most embedders can
+/// continue using [`compile_frontend_from_ast_with_file_paths_and_target`],
+/// which treats the supplied physical paths as symbol paths as well.
+pub fn compile_frontend_from_ast_with_file_paths_and_symbol_paths_and_target(
+    ast: Ast,
+    interner: ThreadedRodeo,
+    opt_level: OptLevel,
+    preview_features: &PreviewFeatures,
+    target: Target,
+    file_paths: std::collections::HashMap<FileId, String>,
+    symbol_paths: std::collections::HashMap<FileId, String>,
+) -> MultiErrorResult<CompileState> {
     // AST to RIR (untyped IR)
     let (rir, interner) = {
         let _span = info_span!("astgen").entered();
@@ -1006,6 +1034,7 @@ pub fn compile_frontend_from_ast_with_file_paths_and_target(
         let _span = info_span!("sema").entered();
         let mut sema = Sema::new_for_target(&rir, &interner, preview_features.clone(), target);
         sema.set_file_paths(file_paths);
+        sema.set_symbol_paths(symbol_paths);
         let output = sema.analyze_all()?;
         info!(
             function_count = output.functions.len(),
@@ -1113,6 +1142,25 @@ pub fn compile_multi_file_with_options(
     sources: &[SourceFile<'_>],
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
+    let symbol_paths = sources
+        .iter()
+        .map(|source| (source.file_id, source.path.to_string()))
+        .collect();
+    compile_multi_file_with_symbol_paths_and_options(sources, symbol_paths, options)
+}
+
+/// Compile multiple source files while keeping physical paths separate from
+/// relocation-stable identities used in generated symbols.
+///
+/// This is the driver-facing variant of [`compile_multi_file_with_options`].
+/// Physical [`SourceFile::path`] values continue to control diagnostics and
+/// module resolution; `symbol_paths` only qualify otherwise-colliding generated
+/// names.
+pub fn compile_multi_file_with_symbol_paths_and_options(
+    sources: &[SourceFile<'_>],
+    symbol_paths: std::collections::HashMap<FileId, String>,
+    options: &CompileOptions,
+) -> MultiErrorResult<CompileOutput> {
     // NOTE: the Rayon global thread pool is deliberately NOT configured here.
     // `build_global()` panics if called twice, and the `--emit` driver path
     // never reaches this function, so it was silently ignoring `-j`/`--jobs`
@@ -1130,6 +1178,7 @@ pub fn compile_multi_file_with_options(
 
     // Use CompilationUnit for the entire pipeline
     let mut unit = CompilationUnit::new(sources.to_vec(), options.clone());
+    unit.set_symbol_paths(symbol_paths);
     unit.run_all()
 }
 
@@ -2642,13 +2691,18 @@ mod tests {
     #[test]
     fn test_module_duplicate_function_symbols_use_stable_paths_not_file_ids() {
         fn duplicate_value_function_names(
+            physical_root: &str,
             main_id: FileId,
             left_id: FileId,
             right_id: FileId,
+            reverse_siblings: bool,
         ) -> Vec<String> {
-            let sources = vec![
+            let main_path = format!("{physical_root}/main.rue");
+            let left_path = format!("{physical_root}/left.rue");
+            let right_path = format!("{physical_root}/right.rue");
+            let mut sources = vec![
                 SourceFile::new(
-                    "main.rue",
+                    &main_path,
                     r#"fn main() -> i32 {
                         let left = @import("left.rue");
                         let right = @import("right.rue");
@@ -2656,10 +2710,18 @@ mod tests {
                     }"#,
                     main_id,
                 ),
-                SourceFile::new("left.rue", "fn value() -> i32 { 10 }", left_id),
-                SourceFile::new("right.rue", "fn value() -> i32 { 20 }", right_id),
+                SourceFile::new(&left_path, "fn value() -> i32 { 10 }", left_id),
+                SourceFile::new(&right_path, "fn value() -> i32 { 20 }", right_id),
             ];
+            if reverse_siblings {
+                sources.swap(1, 2);
+            }
             let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+            unit.set_symbol_paths(std::collections::HashMap::from([
+                (main_id, "main.rue".to_string()),
+                (left_id, "left.rue".to_string()),
+                (right_id, "right.rue".to_string()),
+            ]));
             unit.run_frontend().expect("frontend should compile");
             let mut names: Vec<_> = unit
                 .functions()
@@ -2671,7 +2733,13 @@ mod tests {
             names
         }
 
-        let names = duplicate_value_function_names(FileId::new(1), FileId::new(2), FileId::new(3));
+        let names = duplicate_value_function_names(
+            "/tmp/rue-short-root",
+            FileId::new(1),
+            FileId::new(2),
+            FileId::new(3),
+            false,
+        );
         assert_eq!(
             names,
             vec![
@@ -2682,8 +2750,14 @@ mod tests {
 
         assert_eq!(
             names,
-            duplicate_value_function_names(FileId::new(100), FileId::new(42), FileId::new(7)),
-            "generated symbols should be stable for the same source paths even when FileIds differ"
+            duplicate_value_function_names(
+                "/tmp/a-deliberately-much-longer-relocated-rue-root",
+                FileId::new(100),
+                FileId::new(42),
+                FileId::new(7),
+                true,
+            ),
+            "generated symbols should ignore physical roots, FileIds, and source-vector order"
         );
     }
 

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -75,6 +75,8 @@ pub struct CompilationUnit<'src> {
     interner: Option<ThreadedRodeo>,
     /// Maps FileId to source file path (for error messages).
     file_paths: HashMap<FileId, String>,
+    /// Maps FileId to a relocation-stable path for generated symbols.
+    symbol_paths: HashMap<FileId, String>,
 
     // === Phase 2: RIR Generation ===
     /// Untyped intermediate representation (populated by `lower()`).
@@ -107,6 +109,7 @@ impl<'src> CompilationUnit<'src> {
             .iter()
             .map(|s| (s.file_id, s.path.to_string()))
             .collect();
+        let symbol_paths = file_paths.clone();
 
         Self {
             options,
@@ -114,6 +117,7 @@ impl<'src> CompilationUnit<'src> {
             merged_ast: None,
             interner: None,
             file_paths,
+            symbol_paths,
             rir: None,
             functions: None,
             type_pool: None,
@@ -287,6 +291,7 @@ impl<'src> CompilationUnit<'src> {
                 self.options.target,
             );
             sema.set_file_paths(self.file_paths.clone());
+            sema.set_symbol_paths(self.symbol_paths.clone());
             let output = sema.analyze_all()?;
             info!(
                 function_count = output.functions.len(),
@@ -457,6 +462,14 @@ impl<'src> CompilationUnit<'src> {
     /// Get the file paths map.
     pub fn file_paths(&self) -> &HashMap<FileId, String> {
         &self.file_paths
+    }
+
+    /// Replace the paths used to qualify otherwise-colliding generated names.
+    ///
+    /// These identities do not affect diagnostics or module resolution. Any
+    /// missing entry falls back to the corresponding physical file path.
+    pub fn set_symbol_paths(&mut self, symbol_paths: HashMap<FileId, String>) {
+        self.symbol_paths = symbol_paths;
     }
 
     /// Take the interner out of the compilation unit.

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -16,7 +16,7 @@ use rue_compiler::{
     CompileError, CompileErrors, CompileOptions, CompileWarning, ErrorKind, FileId, Lexer,
     LinkerMode, MultiFileFormatter, MultiFileJsonFormatter, OptLevel, ParsedProgram,
     PreviewFeature, PreviewFeatures, SourceFile, SourceInfo, Span, TokenKind,
-    compile_multi_file_with_options, configure_thread_pool, generate_emitted_asm,
+    compile_multi_file_with_symbol_paths_and_options, configure_thread_pool, generate_emitted_asm,
     generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
     generate_stack_frame_info, import_candidate_groups, merge_symbols, parse_all_files,
 };
@@ -1107,6 +1107,111 @@ fn normalize_lexical_path(path: &Path) -> PathBuf {
     normalized
 }
 
+/// Compute `target` relative to `base` without consulting the filesystem.
+///
+/// Both inputs are expected to be absolute and lexically normalized. Keeping
+/// this lexical is important: following symlinks would turn source identity
+/// back into a property of the machine's physical directory layout.
+fn lexical_relative_path(base: &Path, target: &Path) -> Option<PathBuf> {
+    let base_components: Vec<_> = base.components().collect();
+    let target_components: Vec<_> = target.components().collect();
+    let base_anchor: Vec<_> = base_components
+        .iter()
+        .take_while(|component| matches!(component, Component::Prefix(_) | Component::RootDir))
+        .collect();
+    let target_anchor: Vec<_> = target_components
+        .iter()
+        .take_while(|component| matches!(component, Component::Prefix(_) | Component::RootDir))
+        .collect();
+    if base_anchor != target_anchor {
+        return None;
+    }
+    let common = base_components
+        .iter()
+        .zip(&target_components)
+        .take_while(|(left, right)| left == right)
+        .count();
+
+    let mut relative = PathBuf::new();
+    for component in &base_components[common..] {
+        match component {
+            Component::Normal(_) => relative.push(".."),
+            Component::CurDir | Component::ParentDir => unreachable!("paths are normalized"),
+            Component::Prefix(_) | Component::RootDir => return None,
+        }
+    }
+    for component in &target_components[common..] {
+        match component {
+            Component::Normal(part) => relative.push(part),
+            Component::CurDir | Component::ParentDir => unreachable!("paths are normalized"),
+            Component::Prefix(_) | Component::RootDir => return None,
+        }
+    }
+    Some(relative)
+}
+
+const STD_SYMBOL_NAMESPACE: &str = "\0rue-std";
+
+/// Derive relocation-stable source identities for generated symbol names.
+///
+/// Project files are named relative to the semantic root module's directory,
+/// so relative and absolute command-line spellings agree and `../` imports
+/// remain stable when the whole source layout moves. The standard library has
+/// its own namespace because `$RUE_STD_PATH` may live outside (and at a
+/// different depth from) the relocated project root.
+fn derive_symbol_paths(sources: &[(String, String)]) -> Result<Vec<String>, String> {
+    let std_root = env::var_os("RUE_STD_PATH").map(PathBuf::from);
+    derive_symbol_paths_with_std_root(sources, std_root.as_deref())
+}
+
+fn derive_symbol_paths_with_std_root(
+    sources: &[(String, String)],
+    std_root: Option<&Path>,
+) -> Result<Vec<String>, String> {
+    let absolute_paths: Vec<_> = sources
+        .iter()
+        .map(|(path, _)| normalize_lexical_path(Path::new(path)))
+        .collect();
+    let root_dir = absolute_paths
+        .first()
+        .and_then(|path| path.parent())
+        .unwrap_or_else(|| Path::new("/"));
+    let std_root = std_root.map(normalize_lexical_path);
+
+    let symbol_paths: Vec<String> = absolute_paths
+        .iter()
+        .map(|path| {
+            let logical = std_root
+                .as_deref()
+                .and_then(|std_root| path.strip_prefix(std_root).ok())
+                // A NUL cannot occur in a filesystem path, so this namespace
+                // is provably disjoint from every project-relative identity.
+                .map(|relative| Path::new(STD_SYMBOL_NAMESPACE).join(relative))
+                .or_else(|| lexical_relative_path(root_dir, path))
+                .ok_or_else(|| {
+                    format!(
+                        "source '{}' cannot be assigned a stable identity relative to root '{}'; sources on another filesystem volume require a named dependency root",
+                        path.display(),
+                        root_dir.display()
+                    )
+                })?;
+            Ok(logical.to_string_lossy().into_owned())
+        })
+        .collect::<Result<_, String>>()?;
+
+    let mut seen = std::collections::HashSet::new();
+    for symbol_path in &symbol_paths {
+        if !seen.insert(symbol_path) {
+            return Err(format!(
+                "multiple source files resolve to the same stable identity {:?}",
+                symbol_path
+            ));
+        }
+    }
+
+    Ok(symbol_paths)
+}
+
 fn parse_source_manifest_entry(raw_line: &str) -> String {
     let mut entry = String::new();
     let mut escaped = false;
@@ -1586,13 +1691,27 @@ fn main() {
         std::process::exit(1);
     }
 
-    // Build SourceFile structs for multi-file compilation
+    // Build SourceFile structs for multi-file compilation. Physical paths stay
+    // available for imports and diagnostics; generated symbols use a separate,
+    // relocation-stable identity (RUE-618).
+    let symbol_paths = match derive_symbol_paths(&sources) {
+        Ok(paths) => paths,
+        Err(message) => {
+            eprintln!("Error: {message}");
+            std::process::exit(1);
+        }
+    };
     let source_files: Vec<SourceFile<'_>> = sources
         .iter()
         .enumerate()
         .map(|(i, (path, content))| {
             SourceFile::new(path.as_str(), content.as_str(), FileId::new((i + 1) as u32))
         })
+        .collect();
+    let symbol_path_map: std::collections::HashMap<FileId, String> = source_files
+        .iter()
+        .zip(symbol_paths)
+        .map(|(source, symbol_path)| (source.file_id, symbol_path))
         .collect();
 
     // Create multi-file diagnostic formatters for diagnostics that may span multiple files.
@@ -1684,7 +1803,9 @@ fn main() {
 
     // Handle emit modes with multi-file support
     if !options.emit_stages.is_empty() {
-        if let Err(()) = handle_emit_multi_file(&source_files, &options, &diagnostics) {
+        if let Err(()) =
+            handle_emit_multi_file(&source_files, &symbol_path_map, &options, &diagnostics)
+        {
             std::process::exit(1);
         }
         print_timing_output(
@@ -1704,7 +1825,11 @@ fn main() {
         opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
     };
-    match compile_multi_file_with_options(&source_files, &compile_options) {
+    match compile_multi_file_with_symbol_paths_and_options(
+        &source_files,
+        symbol_path_map,
+        &compile_options,
+    ) {
         Ok(output) => {
             // Print warnings using the diagnostic formatter
             diagnostics.print_warnings(&output.warnings);
@@ -1815,6 +1940,7 @@ fn main() {
 /// For later stages (rir, air, cfg, etc.), the merged program is used.
 fn handle_emit_multi_file(
     sources: &[SourceFile<'_>],
+    symbol_paths: &std::collections::HashMap<FileId, String>,
     options: &Options,
     diagnostics: &DiagnosticOutput<'_>,
 ) -> Result<(), ()> {
@@ -1906,13 +2032,14 @@ fn handle_emit_multi_file(
             .iter()
             .map(|s| (s.file_id, s.path.to_string()))
             .collect();
-        let state = match rue_compiler::compile_frontend_from_ast_with_file_paths_and_target(
+        let state = match rue_compiler::compile_frontend_from_ast_with_file_paths_and_symbol_paths_and_target(
             merged.ast,
             merged.interner,
             options.opt_level,
             &options.preview_features,
             options.target,
             file_paths,
+            symbol_paths.clone(),
         ) {
             Ok(state) => state,
             Err(errors) => {
@@ -2173,6 +2300,107 @@ mod tests {
             fs::write(&path, content).unwrap();
             path
         }
+    }
+
+    #[test]
+    fn symbol_paths_are_root_relative_across_relocated_source_trees() {
+        fn sources_at(root: &Path) -> Vec<(String, String)> {
+            vec![
+                (
+                    root.join("project/main.rue").display().to_string(),
+                    String::new(),
+                ),
+                (
+                    root.join("project/./left/nested/../entry.rue")
+                        .display()
+                        .to_string(),
+                    String::new(),
+                ),
+                (root.join("dep.rue").display().to_string(), String::new()),
+                (
+                    root.join("project/right/shared.rue").display().to_string(),
+                    String::new(),
+                ),
+            ]
+        }
+
+        let base = std::env::temp_dir().join("rue-symbol-path-tests");
+        let short = sources_at(&base.join("a"));
+        let relocated = sources_at(&base.join("a-deliberately-much-longer-relocated-source-root"));
+        let expected = vec![
+            "main.rue",
+            "left/entry.rue",
+            "../dep.rue",
+            "right/shared.rue",
+        ];
+
+        assert_eq!(
+            derive_symbol_paths_with_std_root(&short, None).unwrap(),
+            expected
+        );
+        assert_eq!(
+            derive_symbol_paths_with_std_root(&relocated, None).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn symbol_paths_give_external_std_a_stable_namespace() {
+        fn sources_at(project: &Path, std_root: &Path) -> Vec<(String, String)> {
+            vec![
+                (
+                    project.join("main.rue").display().to_string(),
+                    String::new(),
+                ),
+                (
+                    std_root.join("_std.rue").display().to_string(),
+                    String::new(),
+                ),
+                (
+                    std_root.join("math/float.rue").display().to_string(),
+                    String::new(),
+                ),
+                (
+                    project
+                        .join("@rue-std/math/float.rue")
+                        .display()
+                        .to_string(),
+                    String::new(),
+                ),
+            ]
+        }
+
+        let base = std::env::temp_dir().join("rue-symbol-std-tests");
+        let std_a = base.join("toolchain-a/std");
+        let std_b = base.join("a-different-toolchain-location/std");
+        let first = sources_at(&base.join("build-a/project"), &std_a);
+        let second = sources_at(&base.join("different-depth/build-b/project"), &std_b);
+        let expected = vec![
+            "main.rue",
+            "\0rue-std/_std.rue",
+            "\0rue-std/math/float.rue",
+            "@rue-std/math/float.rue",
+        ];
+
+        assert_eq!(
+            derive_symbol_paths_with_std_root(&first, Some(&std_a)).unwrap(),
+            expected
+        );
+        assert_eq!(
+            derive_symbol_paths_with_std_root(&second, Some(&std_b)).unwrap(),
+            expected
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn symbol_paths_reject_unnamed_cross_volume_sources() {
+        let sources = vec![
+            (r"C:\project\main.rue".to_string(), String::new()),
+            (r"D:\dependency\helper.rue".to_string(), String::new()),
+        ];
+        let error = derive_symbol_paths_with_std_root(&sources, None).unwrap_err();
+        assert!(error.contains("another filesystem volume"));
     }
 
     impl Drop for TestDir {

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -100,6 +100,44 @@ assert_macos_signature() {
     fi
 }
 
+assert_relocated_symbol_names() {
+    local symbols_a="$root_a/tmp/air-symbols.txt"
+    local symbols_b="$root_b/tmp/air-symbols.txt"
+
+    # RUE-618: physical source paths must not enter the machine-level names
+    # carried from AIR through assembly and object relocations. Compare only
+    # generated names here: complete textual IR ordering is covered by RUE-620.
+    (
+        cd "$root_a/project"
+        "$RUE_BINARY" -j1 --emit air \
+            --source-manifest sources.manifest \
+            main.rue \
+            | sed -n 's/^function \(__rue_fn_[^(: ]*\).*/\1/p' \
+            | LC_ALL=C sort -u > "$symbols_a"
+    )
+    "$RUE_BINARY" -j32 --emit air \
+        --source-manifest "$root_b/project/sources.manifest" \
+        "$root_b/project/main.rue" \
+        | sed -n 's/^function \(__rue_fn_[^(: ]*\).*/\1/p' \
+        | LC_ALL=C sort -u > "$symbols_b"
+
+    assert_identical "relocated AIR symbol names" "$symbols_a" "$symbols_b"
+
+    local expected actual
+    expected="$(printf '%s\n' \
+        '__rue_fn_left_2fentry_2erue__compute' \
+        '__rue_fn_left_2fshared_2erue__make' \
+        '__rue_fn_right_2fentry_2erue__compute' \
+        '__rue_fn_right_2fshared_2erue__make')"
+    actual="$(< "$symbols_a")"
+    if [ "$actual" != "$expected" ]; then
+        printf 'FAIL: reproducibility fixture generated unexpected AIR symbols\n' >&2
+        printf '  expected:\n%s\n' "$expected" >&2
+        printf '  actual:\n%s\n' "$actual" >&2
+        return 1
+    fi
+}
+
 compile_pair() {
     local opt="$1"
     local output_a="$root_a/project/program-left-o$1"
@@ -143,5 +181,6 @@ compile_pair() {
     assert_macos_signature "$output_b"
 }
 
+assert_relocated_symbol_names
 compile_pair 0
 compile_pair 2


### PR DESCRIPTION
## Summary

- separate physical source paths used by imports/diagnostics from stable logical identities used in generated symbols
- derive normalized root-relative identities for project sources and a disjoint namespace for relocated `RUE_STD_PATH` sources
- thread the identity map through both normal compilation and `--emit`, while preserving the existing public `SourceFile` shape and legacy APIs
- fail closed for unnamed cross-volume source roots rather than generating order-dependent names (named dependency roots are tracked in RUE-622)
- extend the required reproducibility gate with exact relocated AIR symbol assertions

## Validation

- `./fmt.sh check`
- `./clippy.sh`
- `bash -n scripts/test-reproducible-output.sh`
- `./buck2 test //...` (34 targets passed)
- independent read-only review, including a second pass after cross-volume/API/injectivity fixes

Linear: RUE-618