### PR TITLE
RUE-589: audit exact CLI model-gap registry

### DIFF
--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -37,12 +37,14 @@
 //! Every mode exits non-zero if an eligible program is rejected by the front
 //! end, interpretation hits a resource limit or compiler/oracle contract
 //! violation, or the oracle disagrees with expected behavior. Only typed
-//! [`rue_oracle::ModelGapKind`] values can count as unmodeled corpus coverage.
+//! [`rue_oracle::ModelGapKind`] values can count as unmodeled corpus coverage;
+//! CLI corpus mode also requires an exact registry entry.
 //! Generated fuzz mode has the stronger contract that every `Unsupported` is a
 //! failure because its generator promises to stay within the modeled subset.
 
 mod fuzz;
 mod generator;
+mod model_gaps;
 mod trap;
 
 use rue_error::{PreviewFeature, PreviewFeatures};
@@ -56,8 +58,16 @@ use std::str::FromStr;
 
 #[derive(Deserialize)]
 struct TestFile {
+    section: Section,
     #[serde(default, rename = "case")]
     cases: Vec<Case>,
+}
+
+/// The stable identity-bearing subset of a rue-cli-tests section. The
+/// differential schema remains permissive about every field it does not use.
+#[derive(Deserialize)]
+struct Section {
+    id: String,
 }
 
 /// A permissive subset of the rue-cli-tests case schema — only the fields the
@@ -356,6 +366,11 @@ fn run() -> ExitCode {
 /// oracle and check it agrees with the case's expected exit code / stdout /
 /// stderr.
 fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
+    let inventory_scope = if raw_args.is_empty() {
+        model_gaps::InventoryScope::Authoritative
+    } else {
+        model_gaps::InventoryScope::Partial
+    };
     let dirs: Vec<PathBuf> = {
         let args: Vec<String> = raw_args;
         if !args.is_empty() {
@@ -370,9 +385,12 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
     };
 
     let mut report = Report::default();
+    let mut gap_audit = model_gaps::cli::audit(inventory_scope);
     let (toml_files, discovery_failures) = discover_toml(&dirs);
+    let mut inventory_complete = discovery_failures.is_empty();
     report.harness_failures.extend(discovery_failures);
     if toml_files.is_empty() && report.harness_failures.is_empty() {
+        inventory_complete = false;
         report.harness_failures.push(format!(
             "no .toml case files found under {dirs:?} (run from the repo root)"
         ));
@@ -382,17 +400,61 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
         let file = match load_cli_test_file(path) {
             Ok(file) => file,
             Err(failure) => {
+                inventory_complete = false;
                 report.harness_failures.push(failure);
                 continue;
             }
         };
         for case in &file.cases {
-            report.record(check_case(path, case));
+            let outcome = check_case(path, case);
+            gap_audit.observe(
+                model_gaps::cli::CaseId::new(&file.section.id, &case.name),
+                &case.only_on,
+                model_gap_observation(case, &outcome),
+            );
+            report.record(outcome);
         }
     }
+    report
+        .harness_failures
+        .extend(gap_audit.finish(inventory_complete));
     report.harness_failures.sort();
 
     finish_report(&report, "rue-cli-tests")
+}
+
+/// Translate the closed corpus classification into equally closed registry
+/// policy. In particular, trap observation gaps are not
+/// [`ModelGapKind`] values and cannot be accepted by the typed registry.
+fn model_gap_observation(case: &Case, outcome: &CaseOutcome) -> model_gaps::Observation {
+    // Eligibility wrappers deliberately prevent inactive cases from making
+    // claims on this host. For every active executable case, however, audit
+    // its declared trap contract independently of whether interpretation
+    // produced an Outcome or stopped first at a typed model gap. Otherwise an
+    // Unsupported result could hide unrelated harness observation debt.
+    if !matches!(outcome, CaseOutcome::Ineligible(_))
+        && trap::cli_trap_expectation(case.runtime_error_contains.iter().map(String::as_str))
+            == trap::TrapExpectation::Unmodeled
+    {
+        return model_gaps::Observation::Unregistrable("runtime trap expectation");
+    }
+
+    match outcome {
+        CaseOutcome::Agree => model_gaps::Observation::Agreement,
+        CaseOutcome::Unmodeled(UnmodeledReason::ModelGap(kind)) => {
+            model_gaps::Observation::ModelGap(*kind)
+        }
+        CaseOutcome::Unmodeled(UnmodeledReason::TrapExpectation) => {
+            model_gaps::Observation::Unregistrable("runtime trap expectation")
+        }
+        CaseOutcome::Ineligible(IneligibleReason::HostFiltered) => {
+            model_gaps::Observation::InactiveHost
+        }
+        CaseOutcome::Ineligible(_) => model_gaps::Observation::OtherIneligible,
+        CaseOutcome::FrontendFailure(_)
+        | CaseOutcome::OracleFailure(_)
+        | CaseOutcome::Disagreement(_) => model_gaps::Observation::HardFailure,
+    }
 }
 
 /// Print the tallied report and turn it into a process exit code: success when
@@ -1162,6 +1224,9 @@ mod tests {
             path,
             format!(
                 r#"
+[section]
+id = "cli.fixture"
+
 [[case]]
 name = "{name}"
 compile_fail = true
@@ -1239,6 +1304,9 @@ files = [{{ path = "probe.rue", source = "not Rue" }}]
         std::fs::write(
             &invalid,
             r#"
+[section]
+id = "cli.invalid_platform"
+
 [[case]]
 name = "misspelled platform"
 only_on = ["x86_64-linux"]
@@ -1261,6 +1329,28 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
             corpus_mode(vec![temp.path().to_string_lossy().into_owned()]),
             ExitCode::FAILURE
         );
+    }
+
+    #[test]
+    fn cli_section_id_is_required_for_stable_registry_identity() {
+        let temp = tempfile::tempdir().expect("create temporary cases root");
+        let missing_section = temp.path().join("missing-section.toml");
+        std::fs::write(
+            &missing_section,
+            r#"
+[[case]]
+name = "identity-less"
+compile_fail = true
+files = [{ path = "probe.rue", source = "not Rue" }]
+"#,
+        )
+        .expect("write missing-section fixture");
+
+        let failure = load_cli_test_file(&missing_section)
+            .err()
+            .expect("a CLI corpus file without section.id must not load");
+        assert!(failure.contains("could not parse"));
+        assert!(failure.contains("missing field `section`"));
     }
 
     #[test]
@@ -2039,6 +2129,45 @@ files = [{ path = "probe.rue", source = "fn main() -> i32 { 0 }" }]
         report.record(stderr_outcome);
         assert_eq!(report.unmodeled_count(), 0);
         assert_eq!(report.disagreements.len(), 2);
+    }
+
+    #[test]
+    fn non_oracle_unmodeled_reasons_are_unregistrable() {
+        let case = corpus_case("fn main() -> i32 { 0 }", false);
+        assert_eq!(
+            model_gap_observation(
+                &case,
+                &CaseOutcome::Unmodeled(UnmodeledReason::TrapExpectation)
+            ),
+            model_gaps::Observation::Unregistrable("runtime trap expectation")
+        );
+    }
+
+    #[test]
+    fn active_unknown_trap_contract_cannot_hide_behind_a_typed_model_gap() {
+        let mut case = corpus_case(
+            "fn main() -> u32 { let value: u32 = @random_u32(); value }",
+            false,
+        );
+        case.runtime_error_contains = vec!["custom trap wording".to_string()];
+        let outcome = check_case(Path::new("trap-plus-gap.toml"), &case);
+        assert!(matches!(
+            outcome,
+            CaseOutcome::Unmodeled(UnmodeledReason::ModelGap(_))
+        ));
+        assert_eq!(
+            model_gap_observation(&case, &outcome),
+            model_gaps::Observation::Unregistrable("runtime trap expectation")
+        );
+
+        // The same declaration on a case that is inactive on this host makes
+        // no runtime claim here and must remain a scope-checked inactive case.
+        case.only_on = vec![other_known_target()];
+        let outcome = check_case(Path::new("inactive-trap-plus-gap.toml"), &case);
+        assert_eq!(
+            model_gap_observation(&case, &outcome),
+            model_gaps::Observation::InactiveHost
+        );
     }
 
     #[test]

--- a/crates/rue-oracle-diff/src/model_gaps.rs
+++ b/crates/rue-oracle-diff/src/model_gaps.rs
@@ -1,0 +1,451 @@
+//! Exact, fail-closed corpus model-gap registries.
+//!
+//! A typed oracle model gap is accepted only when the corpus case identity,
+//! exact [`ModelGapKind`], and platform scope all match an explicit registry
+//! entry. The audit is generic over case identity so the same policy can be
+//! reused by other corpora without weakening it to strings or paths.
+
+pub(crate) mod cli;
+
+use rue_oracle::ModelGapKind;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+/// Whether this invocation intends to enumerate the corpus's complete
+/// authoritative inventory or only a caller-selected subset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InventoryScope {
+    Authoritative,
+    Partial,
+}
+
+/// One accepted item of oracle coverage debt.
+///
+/// The gap is deliberately a [`ModelGapKind`], not an `UnsupportedKind` or a
+/// display string. Resource limits, compiler/oracle contract violations, and
+/// harness observation gaps therefore cannot be registered by construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelGapRegistration<I> {
+    identity: I,
+    kind: ModelGapKind,
+    only_on: Vec<String>,
+}
+
+impl<I> ModelGapRegistration<I> {
+    pub(crate) fn new(
+        identity: I,
+        kind: ModelGapKind,
+        only_on: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        Self {
+            identity,
+            kind,
+            only_on: canonical_scope(only_on),
+        }
+    }
+}
+
+/// The part of a corpus outcome relevant to model-gap registry policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Observation {
+    ModelGap(ModelGapKind),
+    Agreement,
+    /// The case is inactive solely because its `only_on` scope excludes this
+    /// host. It remains valid registered debt when that exact scope matches.
+    InactiveHost,
+    /// Some other eligibility rule now prevents the case from reaching the
+    /// oracle. A registered gap must not silently turn into such a skip.
+    OtherIneligible,
+    /// An unmodeled harness observation such as an unparsed trap expectation
+    /// or another unsupported assertion. These are not oracle implementation debt.
+    Unregistrable(&'static str),
+    /// A front-end failure, hard oracle failure, or disagreement already makes
+    /// the enclosing corpus report fail. Avoid adding a misleading stale-gap
+    /// diagnosis on top of the primary failure.
+    HardFailure,
+}
+
+type RenderRegistration<I> = fn(&I, ModelGapKind, &[String]) -> String;
+
+/// Stateful exact-registry audit for one corpus invocation.
+pub(crate) struct ModelGapAudit<I> {
+    corpus: &'static str,
+    scope: InventoryScope,
+    registry: BTreeMap<I, ModelGapRegistration<I>>,
+    discovered: BTreeSet<I>,
+    failures: Vec<String>,
+    render_registration: RenderRegistration<I>,
+}
+
+impl<I> ModelGapAudit<I>
+where
+    I: Clone + Ord + fmt::Display,
+{
+    pub(crate) fn new(
+        corpus: &'static str,
+        scope: InventoryScope,
+        registrations: impl IntoIterator<Item = ModelGapRegistration<I>>,
+        render_registration: RenderRegistration<I>,
+    ) -> Self {
+        let mut registry = BTreeMap::new();
+        let mut failures = Vec::new();
+        for registration in registrations {
+            let identity = registration.identity.clone();
+            if let Some(previous) = registry.insert(identity.clone(), registration) {
+                failures.push(format!(
+                    "{corpus} model-gap registry has duplicate identity {identity}; first entry \
+                     was {:?} on {:?}",
+                    previous.kind, previous.only_on
+                ));
+            }
+        }
+
+        Self {
+            corpus,
+            scope,
+            registry,
+            discovered: BTreeSet::new(),
+            failures,
+            render_registration,
+        }
+    }
+
+    /// Record one discovered, expanded corpus case and its terminal outcome.
+    pub(crate) fn observe(&mut self, identity: I, only_on: &[String], observation: Observation) {
+        if !self.discovered.insert(identity.clone()) {
+            self.failures.push(format!(
+                "{} corpus discovered duplicate case identity {identity}; identities are \
+                 (section.id, expanded case.name), never file paths",
+                self.corpus
+            ));
+            return;
+        }
+
+        let actual_scope = canonical_scope(only_on.iter().cloned());
+        let registration = self.registry.get(&identity);
+
+        match (registration, observation) {
+            (None, Observation::ModelGap(kind)) => self.failures.push(format!(
+                "unknown {} oracle model gap for {identity}: {kind:?}\n      add:\n{}",
+                self.corpus,
+                (self.render_registration)(&identity, kind, &actual_scope)
+            )),
+            (Some(registration), Observation::ModelGap(actual)) => {
+                let kind_drift = registration.kind != actual;
+                let scope_drift = registration.only_on != actual_scope;
+                if kind_drift || scope_drift {
+                    let drift = match (kind_drift, scope_drift) {
+                        (true, true) => "kind and scope drift",
+                        (true, false) => "kind drift",
+                        (false, true) => "scope drift",
+                        (false, false) => unreachable!(),
+                    };
+                    self.failures.push(format!(
+                        "{} model-gap {drift} for {identity}: registered {:?} on {:?}, observed \
+                         {actual:?} on {:?}\n      replace it with:\n{}",
+                        self.corpus,
+                        registration.kind,
+                        registration.only_on,
+                        actual_scope,
+                        (self.render_registration)(&identity, actual, &actual_scope)
+                    ));
+                }
+            }
+            (Some(_), Observation::Agreement) => self.failures.push(format!(
+                "stale {} model-gap registry entry for {identity}: the oracle now agrees; \
+                 delete the entry",
+                self.corpus
+            )),
+            (Some(_), Observation::OtherIneligible) => self.failures.push(format!(
+                "{} model-gap eligibility drift for {identity}: the registered case is now \
+                 ineligible for a reason other than its declared only_on host scope",
+                self.corpus
+            )),
+            (_, Observation::Unregistrable(reason)) => self.failures.push(format!(
+                "unregistrable {} unmodeled observation for {identity}: {reason}; this is \
+                 harness coverage, not typed oracle model debt",
+                self.corpus
+            )),
+            (Some(registration), Observation::InactiveHost | Observation::HardFailure)
+                if registration.only_on != actual_scope =>
+            {
+                self.failures.push(format!(
+                    "{} model-gap registry scope drift for {identity}: registered only_on {:?}, \
+                     corpus declares {:?}\n      replace it with:\n{}",
+                    self.corpus,
+                    registration.only_on,
+                    actual_scope,
+                    (self.render_registration)(&identity, registration.kind, &actual_scope)
+                ));
+            }
+            (
+                None,
+                Observation::Agreement
+                | Observation::InactiveHost
+                | Observation::OtherIneligible
+                | Observation::HardFailure,
+            )
+            | (Some(_), Observation::InactiveHost | Observation::HardFailure) => {}
+        }
+    }
+
+    /// Complete the audit.
+    ///
+    /// Orphans are meaningful only for a full authoritative run whose input
+    /// discovery and parsing completed. Partial runs still enforce every seen
+    /// identity but never treat unseen registry entries as stale or missing.
+    pub(crate) fn finish(mut self, inventory_complete: bool) -> Vec<String> {
+        if self.scope == InventoryScope::Authoritative && inventory_complete {
+            for identity in self.registry.keys() {
+                if !self.discovered.contains(identity) {
+                    self.failures.push(format!(
+                        "orphaned {} model-gap registry entry for {identity}: no case with this \
+                         (section.id, expanded case.name) identity was discovered; delete or \
+                         correct the entry",
+                        self.corpus
+                    ));
+                }
+            }
+        }
+        self.failures.sort();
+        self.failures
+    }
+}
+
+fn canonical_scope(values: impl IntoIterator<Item = impl Into<String>>) -> Vec<String> {
+    let mut values: Vec<String> = values.into_iter().map(Into::into).collect();
+    values.sort();
+    values.dedup();
+    values
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_oracle::{ExternalDependencyKind, ModelGapKind};
+
+    const STDIN: ModelGapKind =
+        ModelGapKind::ExternalDependency(ExternalDependencyKind::StandardInput);
+    const RANDOM: ModelGapKind =
+        ModelGapKind::ExternalDependency(ExternalDependencyKind::RandomU32);
+
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    struct Id(&'static str);
+
+    impl fmt::Display for Id {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    fn registration(
+        id: &'static str,
+        kind: ModelGapKind,
+        only_on: &[&str],
+    ) -> ModelGapRegistration<Id> {
+        ModelGapRegistration::new(Id(id), kind, only_on.iter().copied())
+    }
+
+    fn render(id: &Id, kind: ModelGapKind, only_on: &[String]) -> String {
+        format!("entry({:?}, {kind:?}, {only_on:?}),", id.0)
+    }
+
+    fn audit(
+        scope: InventoryScope,
+        entries: impl IntoIterator<Item = ModelGapRegistration<Id>>,
+    ) -> ModelGapAudit<Id> {
+        ModelGapAudit::new("test", scope, entries, render)
+    }
+
+    #[test]
+    fn exact_registered_gap_is_accepted() {
+        let mut audit = audit(
+            InventoryScope::Authoritative,
+            [registration("case", STDIN, &[])],
+        );
+        audit.observe(Id("case"), &[], Observation::ModelGap(STDIN));
+        assert!(audit.finish(true).is_empty());
+    }
+
+    #[test]
+    fn unknown_gap_is_fail_closed_with_paste_ready_entry() {
+        let mut audit = audit(InventoryScope::Partial, []);
+        audit.observe(
+            Id("new"),
+            &["aarch64-macos".to_string()],
+            Observation::ModelGap(STDIN),
+        );
+        let failures = audit.finish(true);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("unknown test oracle model gap"));
+        assert!(failures[0].contains("entry(\"new\", ExternalDependency(StandardInput)"));
+        assert!(failures[0].contains("aarch64-macos"));
+    }
+
+    #[test]
+    fn exact_kind_drift_is_rejected() {
+        let mut audit = audit(InventoryScope::Partial, [registration("case", STDIN, &[])]);
+        audit.observe(Id("case"), &[], Observation::ModelGap(RANDOM));
+        let failures = audit.finish(true);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("kind drift"));
+        assert!(failures[0].contains("ExternalDependency(RandomU32)"));
+    }
+
+    #[test]
+    fn seen_agreement_makes_a_registration_stale() {
+        let mut audit = audit(
+            InventoryScope::Partial,
+            [registration("case", STDIN, &["x86-64-linux"])],
+        );
+        audit.observe(Id("case"), &[], Observation::Agreement);
+        let failures = audit.finish(true);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("stale"));
+        assert!(!failures[0].contains("replace it with"));
+        assert!(!failures[0].contains("scope drift"));
+    }
+
+    #[test]
+    fn other_ineligibility_cannot_hide_registered_debt() {
+        let mut audit = audit(
+            InventoryScope::Partial,
+            [registration("case", STDIN, &["x86-64-linux"])],
+        );
+        audit.observe(Id("case"), &[], Observation::OtherIneligible);
+        let failures = audit.finish(true);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("eligibility drift"));
+        assert!(!failures[0].contains("scope drift"));
+    }
+
+    #[test]
+    fn inactive_host_is_not_stale_but_its_scope_is_exact() {
+        let mut matching = audit(
+            InventoryScope::Authoritative,
+            [registration("case", STDIN, &["x86-64-linux"])],
+        );
+        matching.observe(
+            Id("case"),
+            &["x86-64-linux".to_string()],
+            Observation::InactiveHost,
+        );
+        assert!(matching.finish(true).is_empty());
+
+        let mut drifted = audit(
+            InventoryScope::Partial,
+            [registration("case", STDIN, &["aarch64-macos"])],
+        );
+        drifted.observe(
+            Id("case"),
+            &["x86-64-linux".to_string()],
+            Observation::InactiveHost,
+        );
+        let failures = drifted.finish(true);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("scope drift"));
+    }
+
+    #[test]
+    fn simultaneous_kind_and_scope_drift_has_one_current_replacement() {
+        let mut audit = audit(
+            InventoryScope::Partial,
+            [registration("case", STDIN, &["x86-64-linux"])],
+        );
+        audit.observe(
+            Id("case"),
+            &["aarch64-macos".to_string()],
+            Observation::ModelGap(RANDOM),
+        );
+        let failures = audit.finish(true);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("kind and scope drift"));
+        assert!(failures[0].contains(concat!(
+            "entry(\"case\", ExternalDependency(RandomU32), ",
+            "[\"aarch64-macos\"]),"
+        )));
+    }
+
+    #[test]
+    fn only_on_is_compared_as_an_exact_platform_set() {
+        let mut reordered = audit(
+            InventoryScope::Partial,
+            [registration(
+                "case",
+                STDIN,
+                &["x86-64-linux", "aarch64-macos"],
+            )],
+        );
+        reordered.observe(
+            Id("case"),
+            &["aarch64-macos".to_string(), "x86-64-linux".to_string()],
+            Observation::ModelGap(STDIN),
+        );
+        assert!(reordered.finish(true).is_empty());
+
+        let mut drifted = audit(
+            InventoryScope::Partial,
+            [registration("case", STDIN, &["x86-64-linux"])],
+        );
+        drifted.observe(Id("case"), &[], Observation::ModelGap(STDIN));
+        assert_eq!(drifted.finish(true).len(), 1);
+    }
+
+    #[test]
+    fn duplicate_registry_and_discovered_identities_are_rejected() {
+        let duplicate_entries = audit(
+            InventoryScope::Partial,
+            [
+                registration("case", STDIN, &[]),
+                registration("case", RANDOM, &[]),
+            ],
+        )
+        .finish(true);
+        assert_eq!(duplicate_entries.len(), 1);
+        assert!(duplicate_entries[0].contains("duplicate identity"));
+
+        let mut duplicate_cases = audit(InventoryScope::Partial, []);
+        duplicate_cases.observe(Id("case"), &[], Observation::Agreement);
+        duplicate_cases.observe(Id("case"), &[], Observation::Agreement);
+        let failures = duplicate_cases.finish(true);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("discovered duplicate case identity"));
+    }
+
+    #[test]
+    fn only_complete_authoritative_inventory_checks_orphans() {
+        let partial = audit(
+            InventoryScope::Partial,
+            [registration("unseen", STDIN, &[])],
+        )
+        .finish(true);
+        assert!(partial.is_empty());
+
+        let incomplete = audit(
+            InventoryScope::Authoritative,
+            [registration("unseen", STDIN, &[])],
+        )
+        .finish(false);
+        assert!(incomplete.is_empty());
+
+        let complete = audit(
+            InventoryScope::Authoritative,
+            [registration("unseen", STDIN, &[])],
+        )
+        .finish(true);
+        assert_eq!(complete.len(), 1);
+        assert!(complete[0].contains("orphaned"));
+    }
+
+    #[test]
+    fn unregistrable_observations_are_always_hard_drift() {
+        for reason in ["runtime trap expectation", "other harness expectation"] {
+            let mut audit = audit(InventoryScope::Partial, []);
+            audit.observe(Id("case"), &[], Observation::Unregistrable(reason));
+            let failures = audit.finish(true);
+            assert_eq!(failures.len(), 1);
+            assert!(failures[0].contains("unregistrable"));
+            assert!(failures[0].contains(reason));
+        }
+    }
+}

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -1,0 +1,769 @@
+//! Exact model-gap inventory for the `rue-cli-tests` corpus.
+
+use super::{InventoryScope, ModelGapAudit, ModelGapRegistration};
+use rue_oracle::{
+    ExternalDependencyKind, ImplementationDefinedKind, ModelGapKind, SemanticGapKind,
+    UnsupportedIntrinsicKind, UnsupportedRuntimeCallKind,
+};
+use std::fmt;
+
+/// Stable CLI corpus identity. File paths are deliberately excluded: cases
+/// may move without resetting debt, while section/case renames must update it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct CaseId {
+    section: String,
+    case: String,
+}
+
+impl CaseId {
+    pub(crate) fn new(section: impl Into<String>, case: impl Into<String>) -> Self {
+        Self {
+            section: section.into(),
+            case: case.into(),
+        }
+    }
+}
+
+impl fmt::Display for CaseId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} :: {}", self.section, self.case)
+    }
+}
+
+struct Entry {
+    section: &'static str,
+    case: &'static str,
+    kind: ModelGapKind,
+    only_on: &'static [&'static str],
+}
+
+impl Entry {
+    const fn new(
+        section: &'static str,
+        case: &'static str,
+        kind: ModelGapKind,
+        only_on: &'static [&'static str],
+    ) -> Self {
+        Self {
+            section,
+            case,
+            kind,
+            only_on,
+        }
+    }
+
+    fn registration(&self) -> ModelGapRegistration<CaseId> {
+        ModelGapRegistration::new(
+            CaseId::new(self.section, self.case),
+            self.kind,
+            self.only_on.iter().copied(),
+        )
+    }
+}
+
+/// The complete accepted CLI oracle-debt inventory.
+///
+/// Entries are generated from unknown-gap diagnostics emitted by the real
+/// production classifier, then reviewed into this typed list. Dynamic
+/// `Unsupported::detail` text is intentionally absent from the policy key.
+const ENTRIES: &[Entry] = &[
+    Entry::new(
+        "array_literal_string",
+        "array_of_string_with_capacity",
+        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_abi_matrix",
+        "aos_ptr_rw",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_abi_matrix",
+        "arr_ptr_rw",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_abi_matrix",
+        "enum_ptr_rw",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_abi_matrix",
+        "nest_ptr_rw",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_abi_matrix",
+        "s1_ptr_rw",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_abi_matrix",
+        "s2_ptr_rw",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_abi_matrix",
+        "s3_ptr_rw",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_abi_matrix",
+        "s8_ptr_rw",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_ascending_layout",
+        "heap_multislot_roundtrip_no_clobber",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.aggregate_ascending_layout",
+        "stack_raw_ptr_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.anon_struct_destructor",
+        "generic_heap_buffer_auto_freed",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.builtin_method_infer",
+        "capacity_compare_literal_compiles",
+        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        &[],
+    ),
+    Entry::new(
+        "cli.byref_params",
+        "inout_forwarding_still_works",
+        semantic(SemanticGapKind::InoutParameterForwarding),
+        &[],
+    ),
+    Entry::new(
+        "cli.comptime_type_var_composite",
+        "pointer_to_comptime_type_var",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.const_array_length_in_aggregate",
+        "const_struct_field_2d_with_methods",
+        semantic(SemanticGapKind::FlattenedParameterSlot),
+        &[],
+    ),
+    Entry::new(
+        "cli.differential_opt",
+        "raw_pointer_place_operands_across_opt_levels",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.for_loops",
+        "for_chars_invalid_utf8_traps",
+        runtime_call(UnsupportedRuntimeCallKind::StringSubstring),
+        &[],
+    ),
+    Entry::new(
+        "cli.heap_intrinsics",
+        "alloc_count_size_overflow_traps",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.heap_intrinsics",
+        "alloc_page_rounding_overflow_returns_null",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.heap_intrinsics",
+        "alloc_write_read_free",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.heap_intrinsics",
+        "free_from_destructor",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.heap_intrinsics",
+        "realloc_count_size_overflow_traps",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.heap_intrinsics",
+        "realloc_grows_and_preserves",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.method_receiver_byref_places",
+        "inout_self_through_inout_param",
+        semantic(SemanticGapKind::InoutParameterForwarding),
+        &[],
+    ),
+    Entry::new(
+        "cli.method_receivers",
+        "arg_reads_receiver",
+        semantic(SemanticGapKind::FlattenedParameterSlot),
+        &[],
+    ),
+    Entry::new(
+        "cli.method_receivers",
+        "stack_push_top_count",
+        semantic(SemanticGapKind::FlattenedParameterSlot),
+        &[],
+    ),
+    Entry::new(
+        "cli.offset_of_field_ptr",
+        "field_ptr_on_param_struct",
+        intrinsic(UnsupportedIntrinsicKind::FieldPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.offset_of_field_ptr",
+        "field_ptr_read_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::FieldPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.offset_of_field_ptr",
+        "field_ptr_write_updates_field",
+        intrinsic(UnsupportedIntrinsicKind::FieldPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.offset_of_field_ptr",
+        "offset_of_ptr_offset_agrees_with_field_ptr",
+        intrinsic(UnsupportedIntrinsicKind::FieldPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "array_index_and_ptr_offset_agree",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_across_function",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_int_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_offset_forward_is_higher_address",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_offset_forward_on_mmap_pointer",
+        external(ExternalDependencyKind::SystemCall),
+        &["x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_offset_negative_walks_backward",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_offset_reads_offset_element",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_offset_write_hits_offset_element",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_read_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_write_literal_infers_i64_pointee",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_write_literal_infers_u8_pointee",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "ptr_write_mutates_local",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "raw_mut_of_parameter_mutates_it",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "raw_of_local_still_works",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "raw_of_param_struct_field",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.pointers",
+        "raw_of_parameter_takes_address",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.print",
+        "print_borrows_string_reusable_after_call",
+        runtime_call(UnsupportedRuntimeCallKind::Print),
+        &[],
+    ),
+    Entry::new(
+        "cli.print",
+        "print_empty_and_println_empty",
+        runtime_call(UnsupportedRuntimeCallKind::Print),
+        &[],
+    ),
+    Entry::new(
+        "cli.print",
+        "print_no_trailing_newline",
+        runtime_call(UnsupportedRuntimeCallKind::Print),
+        &[],
+    ),
+    Entry::new(
+        "cli.print",
+        "print_utf8_bytes_verbatim",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.print",
+        "println_adds_single_newline",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.print",
+        "println_composed_with_to_string_and_concat",
+        runtime_call(UnsupportedRuntimeCallKind::StringConcat),
+        &[],
+    ),
+    Entry::new(
+        "cli.ptr_read_write_aggregate",
+        "ptr_read_result_type_match_i32",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.ptr_read_write_aggregate",
+        "ptr_read_two_field_struct",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.ptr_read_write_aggregate",
+        "ptr_read_write_nested_struct",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.ptr_read_write_aggregate",
+        "ptr_read_write_scalar",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.ptr_read_write_aggregate",
+        "ptr_write_two_field_struct",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.raw_ptr_and_method_name",
+        "raw_mut_ptr_does_not_suppress_destructor",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.raw_ptr_and_method_name",
+        "raw_ptr_does_not_suppress_destructor",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.raw_ptr_and_method_name",
+        "raw_ptr_operand_usable_after",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.raw_ptr_and_method_name",
+        "raw_ptr_then_move_operand_single_drop",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "slice_param_constant_index",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "slice_param_empty_array_len_zero",
+        intrinsic(UnsupportedIntrinsicKind::EmptySlicePointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "slice_param_forwarding",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "slice_param_index_out_of_bounds_traps",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "slice_param_len",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "slice_param_negative_signed_index_traps",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "slice_param_sum_len_index",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "slice_param_u8_element",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_fixed_type",
+        "str_fixed_len_and_first_byte",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_fixed_type",
+        "str_fixed_len_independent_of_capacity",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_fixed_type",
+        "str_fixed_packed_byte_indexing",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_fixed_type",
+        "str_fixed_param_roundtrip",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_fixed_type",
+        "str_fixed_read_through_borrow_str_view",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
+        "buffer_read_through_borrow_str_view_ok",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
+        "str_first_class_return_store_reassign",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
+        "str_inout_accepts_local_buffer",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
+        "str_len_and_first_byte",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
+        "str_packed_byte_indexing",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
+        "str_param_literal_and_forward",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
+        "strbuf_field_borrow_str_view",
+        runtime_call(UnsupportedRuntimeCallKind::StringConcat),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
+        "strbuf_literal_binding_borrow_str_len",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
+        "strbuf_read_through_borrow_str_view_values",
+        runtime_call(UnsupportedRuntimeCallKind::StringConcat),
+        &[],
+    ),
+    Entry::new(
+        "cli.strbuf_library",
+        "strbuf_new_push_str_len_print",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.strbuf_library",
+        "strbuf_with_capacity_concat",
+        runtime_call(UnsupportedRuntimeCallKind::StringConcat),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_alloc_failure",
+        "with_capacity_huge_no_segfault",
+        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_alloc_failure",
+        "with_capacity_normal_reserves",
+        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_byte_access",
+        "substring_byte_range",
+        runtime_call(UnsupportedRuntimeCallKind::StringSubstring),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_byte_access",
+        "substring_out_of_range_traps",
+        runtime_call(UnsupportedRuntimeCallKind::StringSubstring),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_byte_access",
+        "substring_result_is_mutable",
+        runtime_call(UnsupportedRuntimeCallKind::StringSubstring),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_phase1",
+        "concat_chained_and_mutable_result",
+        runtime_call(UnsupportedRuntimeCallKind::StringConcat),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_phase1",
+        "concat_is_concatenation_not_addition",
+        runtime_call(UnsupportedRuntimeCallKind::StringConcat),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_phase1",
+        "contains_and_starts_with",
+        runtime_call(UnsupportedRuntimeCallKind::StringContains),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_phase1",
+        "to_string_all_integer_widths",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_phase1",
+        "to_string_i32_no_cast_needed",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+    Entry::new(
+        "cli.try_operator",
+        "try_string_payload",
+        runtime_call(UnsupportedRuntimeCallKind::StringConcat),
+        &[],
+    ),
+    Entry::new(
+        "cli.try_operator",
+        "try_unwrap_and_short_circuit",
+        runtime_call(UnsupportedRuntimeCallKind::StringConcat),
+        &[],
+    ),
+    Entry::new(
+        "cli.wildcard_payload_binding",
+        "discarded_non_copy_payload_drops_once",
+        runtime_call(UnsupportedRuntimeCallKind::Println),
+        &[],
+    ),
+];
+
+pub(crate) fn audit(scope: InventoryScope) -> ModelGapAudit<CaseId> {
+    ModelGapAudit::new(
+        "rue-cli-tests",
+        scope,
+        ENTRIES.iter().map(Entry::registration),
+        render_registration,
+    )
+}
+
+fn render_registration(identity: &CaseId, kind: ModelGapKind, only_on: &[String]) -> String {
+    let only_on = if only_on.is_empty() {
+        "&[]".to_string()
+    } else {
+        format!(
+            "&[{}]",
+            only_on
+                .iter()
+                .map(|platform| format!("{platform:?}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    format!(
+        "        Entry::new({:?}, {:?}, {}, {}),",
+        identity.section,
+        identity.case,
+        render_kind(kind),
+        only_on
+    )
+}
+
+fn render_kind(kind: ModelGapKind) -> String {
+    match kind {
+        ModelGapKind::Semantic(SemanticGapKind::Intrinsic(kind)) => {
+            format!("intrinsic(UnsupportedIntrinsicKind::{kind:?})")
+        }
+        ModelGapKind::Semantic(SemanticGapKind::RuntimeCall(kind)) => {
+            format!("runtime_call(UnsupportedRuntimeCallKind::{kind:?})")
+        }
+        ModelGapKind::Semantic(SemanticGapKind::FlattenedParameterSlot) => {
+            "semantic(SemanticGapKind::FlattenedParameterSlot)".to_string()
+        }
+        ModelGapKind::Semantic(SemanticGapKind::TextProjectionRead) => {
+            "semantic(SemanticGapKind::TextProjectionRead)".to_string()
+        }
+        ModelGapKind::Semantic(SemanticGapKind::InoutParameterForwarding) => {
+            "semantic(SemanticGapKind::InoutParameterForwarding)".to_string()
+        }
+        ModelGapKind::ExternalDependency(kind) => {
+            format!("external(ExternalDependencyKind::{kind:?})")
+        }
+        ModelGapKind::ImplementationDefined(kind) => {
+            format!("implementation_defined(ImplementationDefinedKind::{kind:?})")
+        }
+    }
+}
+
+const fn intrinsic(kind: UnsupportedIntrinsicKind) -> ModelGapKind {
+    ModelGapKind::Semantic(SemanticGapKind::Intrinsic(kind))
+}
+
+const fn runtime_call(kind: UnsupportedRuntimeCallKind) -> ModelGapKind {
+    ModelGapKind::Semantic(SemanticGapKind::RuntimeCall(kind))
+}
+
+const fn semantic(kind: SemanticGapKind) -> ModelGapKind {
+    ModelGapKind::Semantic(kind)
+}
+
+const fn external(kind: ExternalDependencyKind) -> ModelGapKind {
+    ModelGapKind::ExternalDependency(kind)
+}
+
+const fn implementation_defined(kind: ImplementationDefinedKind) -> ModelGapKind {
+    ModelGapKind::ImplementationDefined(kind)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rendered_unknown_entry_is_directly_pasteable_registry_syntax() {
+        assert_eq!(
+            render_registration(
+                &CaseId::new("cli.example", "random"),
+                external(ExternalDependencyKind::RandomU32),
+                &["x86-64-linux".to_string()],
+            ),
+            concat!(
+                "        Entry::new(\"cli.example\", \"random\", ",
+                "external(ExternalDependencyKind::RandomU32), &[\"x86-64-linux\"]),"
+            )
+        );
+    }
+
+    #[test]
+    fn registry_identity_is_section_and_expanded_case_name() {
+        assert_eq!(
+            CaseId::new("cli.example", "case[expanded]").to_string(),
+            "cli.example :: case[expanded]"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- require every live CLI oracle model gap to match an exact typed registry entry
- key debt by stable section id plus expanded case name, exact ModelGapKind, and canonical platform scope
- fail closed on unknown, stale, orphaned, duplicated, reclassified, or newly ineligible entries
- keep partial filtered runs useful without letting them claim an unseen entry is orphaned
- register the current 99-case CLI debt inventory

## Why

The differential gate previously reported unmodeled totals, but any new typed model gap automatically joined that total. A compiler change could therefore expand the blind spot while CI stayed green.

This turns the total into reviewed debt. Resource limits, contract violations, front-end failures, disagreements, and unmodeled harness expectations cannot be registered by construction. Active unknown trap declarations are audited independently so a typed interpreter gap cannot hide them.

The inventory is the unavoidable data portion of this atomic gate: wiring enforcement without the exact current entries would deliberately fail every run.

## Validation

- empty-registry production probe emitted exactly 99 paste-ready entries
- authoritative CLI audit: 627 agree, 99 registered model gaps, 550 ineligible
- zero harness, front-end, oracle, or disagreement failures
- ./fmt.sh check
- ./clippy.sh: 41 first-party targets
- ./test.sh: 34/34 targets
- generated oracle smoke: 64/64 agree
- independent final review: clear