### PR TITLE
RUE-536: accept trailing commas uniformly; fix @import discovery bypass

### DIFF
--- a/crates/rue-cli-tests/cases/import_trailing_comma.toml
+++ b/crates/rue-cli-tests/cases/import_trailing_comma.toml
@@ -1,0 +1,46 @@
+# Trailing comma inside `@import("...",)` must still be discovered from disk
+# (RUE-536). The parser accepted `@import("x",)` as a one-argument list, but the
+# driver's import-discovery scan matched only the exact four-token shape
+# `@import ( String )`, so the trailing comma made the import silently bypass
+# discovery and the module failed to load (E0704 cannot find module). The scan
+# now tolerates a comma before the close paren. Driven through the real binary
+# with the imported file resolved from disk.
+
+[section]
+id = "cli.import_trailing_comma"
+name = "@import trailing comma discovery"
+description = "A trailing comma in @import(\"path\",) still resolves and loads the module (RUE-536)."
+
+[[case]]
+name = "import_trailing_comma_resolves"
+description = "`const helper = @import(\"helper.rue\",);` loads helper.rue and its pub fn is callable."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "helper.rue", source = """
+pub fn val() -> i32 { 42 }
+""" },
+  { path = "main.rue", source = """
+const helper = @import("helper.rue",);
+fn main() -> i32 {
+    helper.val()
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "import_directory_module_trailing_comma"
+description = "A directory-module facade import with a trailing comma still resolves via the discovery scan (RUE-536)."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "lib/_lib.rue", source = """
+pub fn seven() -> i32 { 7 }
+""" },
+  { path = "main.rue", source = """
+const lib = @import("lib",);
+fn main() -> i32 {
+    lib.seven()
+}
+""" },
+]
+exit_code = 7

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -619,6 +619,7 @@ where
 {
     param_parser()
         .separated_by(just(TokenKind::Comma))
+        .allow_trailing()
         .collect()
 }
 
@@ -696,6 +697,7 @@ where
 {
     call_arg_parser(expr)
         .separated_by(just(TokenKind::Comma))
+        .allow_trailing()
         .collect()
 }
 
@@ -1948,9 +1950,11 @@ where
             .map(|count| (Vec::new(), Some(count))),
         just(TokenKind::Comma)
             .ignore_then(
+                // A trailing comma is allowed uniformly (RUE-536): `[1,]` yields
+                // zero further elements, `[1, 2, 3,]` drops the final separator.
                 expr.clone()
                     .separated_by(just(TokenKind::Comma))
-                    .at_least(1)
+                    .allow_trailing()
                     .collect::<Vec<_>>(),
             )
             .map(|rest| (rest, None)),

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -586,3 +586,107 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0001"]
+
+# =============================================================================
+# Trailing Commas in Comma-Separated Lists (RUE-536)
+# A single optional trailing comma is accepted uniformly in every list form.
+# =============================================================================
+
+[[case]]
+name = "trailing_comma_call_arguments"
+spec = ["2.1:23"]
+source = """
+fn add(a: i32, b: i32) -> i32 { a + b }
+fn main() -> i32 {
+    add(40, 2,)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "trailing_comma_function_parameters"
+spec = ["2.1:23"]
+source = """
+fn triple(a: i32, b: i32, c: i32,) -> i32 { a + b + c }
+fn main() -> i32 {
+    triple(20, 15, 7)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "trailing_comma_array_literal"
+spec = ["2.1:23"]
+source = """
+fn main() -> i32 {
+    let xs = [10, 20, 12,];
+    xs[0] + xs[1] + xs[2]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "trailing_comma_array_literal_single_element"
+spec = ["2.1:23"]
+source = """
+fn main() -> i32 {
+    let xs = [42,];
+    xs[0]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "trailing_comma_struct_literal_fields"
+spec = ["2.1:23"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 40, y: 2, };
+    p.x + p.y
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "trailing_comma_struct_declaration_fields"
+spec = ["2.1:23"]
+source = """
+struct Point { x: i32, y: i32, }
+fn main() -> i32 {
+    let p = Point { x: 40, y: 2 };
+    p.x + p.y
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "trailing_comma_enum_variants_and_payload"
+spec = ["2.1:23"]
+source = """
+enum Shape {
+    Dot,
+    Line(i32, i32,),
+}
+fn main() -> i32 {
+    let s = Shape.Line(40, 2,);
+    match s {
+        Shape.Dot => 0,
+        Shape.Line(a, b) => a + b,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "trailing_comma_empty_call_is_error"
+spec = ["2.1:23"]
+description = "A trailing comma requires a preceding element: `f(,)` is a syntax error."
+source = """
+fn f() -> i32 { 0 }
+fn main() -> i32 {
+    f(,)
+}
+"""
+compile_fail = true
+error_contains = "expected"

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1319,16 +1319,21 @@ fn discover_and_load_imports(
             continue;
         };
 
-        for w in tokens.windows(4) {
-            let (
-                TokenKind::AtImport(_),
-                TokenKind::LParen,
-                TokenKind::String(s),
-                TokenKind::RParen,
-            ) = (&w[0].kind, &w[1].kind, &w[2].kind, &w[3].kind)
+        for w in tokens.windows(5) {
+            // Match `@import ( "<path>" )`, tolerating a trailing comma before
+            // the close paren (RUE-536): `@import("x",)` is a valid one-argument
+            // list and must still be discovered. The 5-token window lets us peek
+            // past the string at either `)` or `, )`.
+            let (TokenKind::AtImport(_), TokenKind::LParen, TokenKind::String(s)) =
+                (&w[0].kind, &w[1].kind, &w[2].kind)
             else {
                 continue;
             };
+            match (&w[3].kind, &w[4].kind) {
+                (TokenKind::RParen, _) => {}
+                (TokenKind::Comma, TokenKind::RParen) => {}
+                _ => continue,
+            }
             let import_str = interner.resolve(s);
 
             let importer_dir = Path::new(&importer_path)

--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -180,3 +180,29 @@ fn main() -> i32 {
     x + my_variable + _unused + x1
 }
 ```
+
+## Comma-Separated Lists
+
+{{ rule(id="2.1:23", cat="normative") }}
+
+Every comma-separated list in the grammar accepts a single optional *trailing
+comma* after its final element. This applies uniformly to all list forms —
+call arguments, intrinsic and `@import` arguments, function and method
+parameters, array-literal elements, struct-literal field initializers, struct
+and enum declaration fields, enum tuple-variant payloads, match arms, and
+pattern bindings. A trailing comma is accepted only after at least one element;
+it has no semantic effect and never changes the number of elements. An empty
+list (`f()`, `[]`) followed by a comma remains a syntax error, because there is
+no final element for the comma to follow.
+
+{{ rule(id="2.1:24") }}
+
+```rue
+fn add(a: i32, b: i32,) -> i32 {   // trailing comma in parameters
+    a + b
+}
+fn main() -> i32 {
+    let xs = [1, 2, 3,];           // trailing comma in an array literal
+    add(xs[0], xs[1],)             // trailing comma in call arguments
+}
+```

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -32,7 +32,7 @@ intrinsic_arg  = type | expression ;
 (* Functions *)
 function       = directives [ "pub" ] [ "unchecked" ]
                  "fn" IDENT "(" [ params ] ")" [ "->" type ] "{" block "}" ;
-params         = param { "," param } ;
+params         = param { "," param } [ "," ] ;
 param          = [ param_mode ] IDENT ":" type ;
 param_mode     = "comptime" | "inout" | "borrow" ;
 block          = { statement } [ expression ] ;
@@ -122,7 +122,7 @@ suffix         = "." IDENT                                     (* field access /
    argument itself is parsed as an arbitrary expression; the requirement that
    an inout/borrow argument denote a place (a variable, optionally with field/
    index projections) is a legality rule (6.1:17), not a syntactic one. *)
-call_args      = call_arg { "," call_arg } ;
+call_args      = call_arg { "," call_arg } [ "," ] ;
 call_arg       = [ "inout" | "borrow" ] expression ;
 
 primary        = INTEGER | STRING | BOOL | "()"
@@ -171,7 +171,7 @@ for_expr       = "for" ( IDENT | "_" ) "in" expression "{" block "}" ;
 break_expr     = "break" [ expression ] ;   (* an operand parses but is always
                                                rejected in semantic analysis *)
 return_expr    = "return" [ expression ] ;
-array_literal  = "[" ( [ expression { "," expression } ]
+array_literal  = "[" ( [ expression { "," expression } [ "," ] ]
                      | expression ";" repeat_count ) "]" ;
 repeat_count   = INTEGER | IDENT ;  (* repeat form: a literal or named compile-time constant (no call form) *)
 field_inits    = field_init { "," field_init } [ "," ] ;


### PR DESCRIPTION
Fixes RUE-536

Steve ruled on the issue: accept trailing commas uniformly in every comma-separated list, and fix the `@import("x",)` discovery bypass.

- `allow_trailing()` added to the three parsers missing it: fn params, call args, array literals (restructured so `[1,]` and `[1,2,3,]` both parse). All other list forms already accepted trailing commas.
- `discover_and_load_imports` now tolerates a comma before the close paren, so a trailing-comma import resolves from disk instead of silently bypassing discovery (was E0704 downstream).
- Grammar appendix EBNF updated; new rule 2.1:23 (uniform policy; empty-list comma stays an error). 8 spec cases + 2 CLI cases (real-file @import, plain + directory-facade module).

Integration re-verified on fresh trunk by execution: all list forms in one program (exit 43), @import case (exit 42), `[,]` still E0100. Full suite green (Pass 34, traceability 100