### PR TITLE
RUE-620: stabilize textual IR across source ordering

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -24,7 +24,7 @@ const _: () = assert!(std::mem::size_of::<AirInst>() <= 48);
 const _: () = assert!(std::mem::size_of::<AirInstData>() <= 32);
 
 use crate::types::{StructId, Type};
-use lasso::{Key, Spur};
+use lasso::{Key, Spur, ThreadedRodeo};
 use rue_span::Span;
 
 // ============================================================================
@@ -1135,8 +1135,26 @@ impl fmt::Display for AirRef {
     }
 }
 
-impl fmt::Display for Air {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+/// Interner-aware AIR display adapter for stable, human-readable symbols.
+pub struct AirDisplay<'a> {
+    air: &'a Air,
+    interner: &'a ThreadedRodeo,
+}
+
+impl Air {
+    /// Display AIR with interned call and intrinsic symbols resolved to names.
+    pub fn display_with_interner<'a>(&'a self, interner: &'a ThreadedRodeo) -> AirDisplay<'a> {
+        AirDisplay {
+            air: self,
+            interner,
+        }
+    }
+
+    fn fmt_with_interner(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        interner: Option<&ThreadedRodeo>,
+    ) -> fmt::Result {
         writeln!(f, "air (return_type: {}) {{", self.return_type.name())?;
         for (inst_ref, inst) in self.iter() {
             write!(f, "    {} : {} = ", inst_ref, inst.ty.name())?;
@@ -1224,7 +1242,10 @@ impl fmt::Display for Air {
                     args_start,
                     args_len,
                 } => {
-                    write!(f, "call @{}(", name.into_usize())?;
+                    match interner {
+                        Some(interner) => write!(f, "call @{}(", interner.resolve(name))?,
+                        None => write!(f, "call @{}(", name.into_usize())?,
+                    }
                     for (i, arg) in self.get_call_args(*args_start, *args_len).enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;
@@ -1242,7 +1263,10 @@ impl fmt::Display for Air {
                     args_start,
                     args_len,
                 } => {
-                    write!(f, "call_generic @{}<", name.into_usize())?;
+                    match interner {
+                        Some(interner) => write!(f, "call_generic @{}<", interner.resolve(name))?,
+                        None => write!(f, "call_generic @{}<", name.into_usize())?,
+                    }
                     // Show type arguments
                     for i in 0..*type_args_len {
                         if i > 0 {
@@ -1279,7 +1303,10 @@ impl fmt::Display for Air {
                     args_start,
                     args_len,
                 } => {
-                    write!(f, "intrinsic @sym:{}(", name.into_usize())?;
+                    match interner {
+                        Some(interner) => write!(f, "intrinsic @{}(", interner.resolve(name))?,
+                        None => write!(f, "intrinsic @sym:{}(", name.into_usize())?,
+                    }
                     for (i, arg) in self.get_air_refs(*args_start, *args_len).enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;
@@ -1495,6 +1522,18 @@ impl fmt::Display for Air {
     }
 }
 
+impl fmt::Display for AirDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.air.fmt_with_interner(f, Some(self.interner))
+    }
+}
+
+impl fmt::Display for Air {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_with_interner(f, None)
+    }
+}
+
 impl Air {
     /// Format a place for display, showing the base and projections.
     fn fmt_place(&self, f: &mut fmt::Formatter<'_>, place_ref: AirPlaceRef) -> fmt::Result {
@@ -1588,5 +1627,53 @@ mod tests {
         let place = air.get_place(place_ref);
         assert_eq!(place.base, AirPlaceBase::Param(3));
         assert_eq!(place.base_type, base_type);
+    }
+
+    #[test]
+    fn interner_aware_display_resolves_call_symbols() {
+        let interner = ThreadedRodeo::new();
+        let call = interner.get_or_intern("callee");
+        let generic = interner.get_or_intern("generic");
+        let intrinsic = interner.get_or_intern("assert");
+        let mut air = Air::new(Type::UNIT);
+
+        for data in [
+            AirInstData::Call {
+                name: call,
+                args_start: 0,
+                args_len: 0,
+            },
+            AirInstData::CallGeneric {
+                name: generic,
+                type_args_start: 0,
+                type_args_len: 0,
+                value_args_start: 0,
+                value_args_len: 0,
+                args_start: 0,
+                args_len: 0,
+            },
+            AirInstData::Intrinsic {
+                name: intrinsic,
+                args_start: 0,
+                args_len: 0,
+            },
+        ] {
+            air.add_inst(AirInst {
+                data,
+                ty: Type::UNIT,
+                span: Span::new(0, 0),
+            });
+        }
+
+        let resolved = air.display_with_interner(&interner).to_string();
+        assert!(resolved.contains("call @callee()"));
+        assert!(resolved.contains("call_generic @generic<>()"));
+        assert!(resolved.contains("intrinsic @assert()"));
+
+        // The context-free Display API remains backward compatible.
+        let raw = air.to_string();
+        assert!(raw.contains(&format!("call @{}()", call.into_usize())));
+        assert!(raw.contains(&format!("call_generic @{}<>()", generic.into_usize())));
+        assert!(raw.contains(&format!("intrinsic @sym:{}()", intrinsic.into_usize())));
     }
 }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -27,8 +27,8 @@ pub use inference::{
     UnificationError, Unifier, UnifyResult,
 };
 pub use inst::{
-    Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirParamMode, AirPattern, AirPlace,
-    AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
+    Air, AirArgMode, AirCallArg, AirDisplay, AirInst, AirInstData, AirParamMode, AirPattern,
+    AirPlace, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
 };
 pub use intern_pool::{
     EnumData, InternedType, StructData, TypeData, TypeInternPool, TypeInternPoolStats,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -24,7 +24,7 @@ use std::fmt;
 const _: () = assert!(std::mem::size_of::<CfgInst>() <= 48);
 const _: () = assert!(std::mem::size_of::<CfgInstData>() <= 32);
 
-use lasso::{Key, Spur};
+use lasso::{Key, Spur, ThreadedRodeo};
 use rue_air::{EnumId, ParamSlotModes, StructId, Type};
 use rue_span::Span;
 
@@ -1021,8 +1021,26 @@ impl Cfg {
     }
 }
 
-impl fmt::Display for Cfg {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+/// Interner-aware CFG display adapter for stable, human-readable symbols.
+pub struct CfgDisplay<'a> {
+    cfg: &'a Cfg,
+    interner: &'a ThreadedRodeo,
+}
+
+impl Cfg {
+    /// Display this CFG with call and intrinsic symbols resolved to names.
+    pub fn display_with_interner<'a>(&'a self, interner: &'a ThreadedRodeo) -> CfgDisplay<'a> {
+        CfgDisplay {
+            cfg: self,
+            interner,
+        }
+    }
+
+    fn fmt_with_interner(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        interner: Option<&ThreadedRodeo>,
+    ) -> fmt::Result {
         writeln!(
             f,
             "cfg {} (return_type: {}) {{",
@@ -1061,7 +1079,7 @@ impl fmt::Display for Cfg {
             for &val in &block.insts {
                 let inst = self.get_inst(val);
                 write!(f, "    {} : {} = ", val, inst.ty.name())?;
-                self.fmt_inst_data(f, &inst.data)?;
+                self.fmt_inst_data(f, &inst.data, interner)?;
                 writeln!(f)?;
             }
 
@@ -1157,8 +1175,25 @@ impl fmt::Display for Cfg {
     }
 }
 
+impl fmt::Display for CfgDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.cfg.fmt_with_interner(f, Some(self.interner))
+    }
+}
+
+impl fmt::Display for Cfg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_with_interner(f, None)
+    }
+}
+
 impl Cfg {
-    fn fmt_inst_data(&self, f: &mut fmt::Formatter<'_>, data: &CfgInstData) -> fmt::Result {
+    fn fmt_inst_data(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        data: &CfgInstData,
+        interner: Option<&ThreadedRodeo>,
+    ) -> fmt::Result {
         match data {
             CfgInstData::Const(v) => write!(f, "const {}", v),
             CfgInstData::BoolConst(v) => write!(f, "const {}", v),
@@ -1204,8 +1239,10 @@ impl Cfg {
                 args_start,
                 args_len,
             } => {
-                // Display symbol as @{id} since we don't have interner access here
-                write!(f, "call @{}(", name.into_usize())?;
+                match interner {
+                    Some(interner) => write!(f, "call @{}(", interner.resolve(name))?,
+                    None => write!(f, "call @{}(", name.into_usize())?,
+                }
                 let args = self.get_call_args(*args_start, *args_len);
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {
@@ -1224,8 +1261,10 @@ impl Cfg {
                 args_start,
                 args_len,
             } => {
-                // Display symbol as @{id} since we don't have interner access here
-                write!(f, "intrinsic @{}(", name.into_usize())?;
+                match interner {
+                    Some(interner) => write!(f, "intrinsic @{}(", interner.resolve(name))?,
+                    None => write!(f, "intrinsic @{}(", name.into_usize())?,
+                }
                 let args = self.get_extra(*args_start, *args_len);
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {
@@ -1473,5 +1512,50 @@ mod tests {
         );
 
         assert_eq!(cfg.block_count(), 1);
+    }
+
+    #[test]
+    fn interner_aware_display_resolves_call_symbols() {
+        let interner = ThreadedRodeo::new();
+        let call = interner.get_or_intern("callee");
+        let intrinsic = interner.get_or_intern("assert");
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "test".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Call {
+                    name: call,
+                    args_start: 0,
+                    args_len: 0,
+                },
+                ty: Type::UNIT,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Intrinsic {
+                    name: intrinsic,
+                    args_start: 0,
+                    args_len: 0,
+                },
+                ty: Type::UNIT,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: None });
+
+        let resolved = cfg.display_with_interner(&interner).to_string();
+        assert!(resolved.contains("call @callee()"));
+        assert!(resolved.contains("intrinsic @assert()"));
+
+        // The context-free Display API remains backward compatible.
+        let raw = cfg.to_string();
+        assert!(raw.contains(&format!("call @{}()", call.into_usize())));
+        assert!(raw.contains(&format!("intrinsic @{}()", intrinsic.into_usize())));
     }
 }

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -25,8 +25,8 @@ use rue_error::{CompileError, CompileWarning};
 
 pub use build::CfgBuilder;
 pub use inst::{
-    BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData, CfgValue, Place,
-    PlaceBase, Projection, Terminator,
+    BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgDisplay, CfgInst, CfgInstData, CfgValue,
+    Place, PlaceBase, Projection, Terminator,
 };
 pub use opt::OptLevel;
 

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -410,7 +410,7 @@ impl<'a> CfgLower<'a> {
     /// This is like `lower()` but also captures detailed information about
     /// how each CFG instruction maps to MIR instructions.
     pub fn lower_with_debug(mut self) -> CompileResult<(Aarch64Mir, crate::LoweringDebugInfo)> {
-        use crate::cfg_lower::{format_cfg_inst_data, format_terminator};
+        use crate::cfg_lower::{format_cfg_inst_data_with_interner, format_terminator};
         use crate::{
             BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
         };
@@ -477,7 +477,11 @@ impl<'a> CfgLower<'a> {
                 if !mir_insts.is_empty() {
                     block_info.instructions.push(LoweringDecision {
                         cfg_value: value,
-                        cfg_inst_desc: format_cfg_inst_data(self.ctx.cfg, &inst.data),
+                        cfg_inst_desc: format_cfg_inst_data_with_interner(
+                            self.ctx.cfg,
+                            &inst.data,
+                            self.interner,
+                        ),
                         cfg_type: inst.ty.name().to_string(),
                         mir_insts,
                         rationale,

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -19,7 +19,7 @@
 
 use std::fmt;
 
-use lasso::Key;
+use lasso::{Key, ThreadedRodeo};
 use rue_air::{StructId, TypeInternPool, TypeKind};
 use rue_builtins::{BinOp, get_builtin_type};
 use rue_cfg::{BlockId, Cfg, CfgValue, Type};
@@ -125,6 +125,23 @@ impl fmt::Display for LoweringDebugInfo {
 /// so places render with their projections resolved (`$0.#2.1`), not as raw
 /// projection-arena index ranges (`$0[3..5]`).
 pub fn format_cfg_inst_data(cfg: &rue_cfg::Cfg, data: &rue_cfg::CfgInstData) -> String {
+    format_cfg_inst_data_impl(cfg, data, None)
+}
+
+/// Format CFG instruction data with interned symbols resolved to stable names.
+pub fn format_cfg_inst_data_with_interner(
+    cfg: &rue_cfg::Cfg,
+    data: &rue_cfg::CfgInstData,
+    interner: &ThreadedRodeo,
+) -> String {
+    format_cfg_inst_data_impl(cfg, data, Some(interner))
+}
+
+fn format_cfg_inst_data_impl(
+    cfg: &rue_cfg::Cfg,
+    data: &rue_cfg::CfgInstData,
+    interner: Option<&ThreadedRodeo>,
+) -> String {
     use rue_cfg::CfgInstData;
 
     match data {
@@ -163,14 +180,15 @@ pub fn format_cfg_inst_data(cfg: &rue_cfg::Cfg, data: &rue_cfg::CfgInstData) -> 
             args_start,
             args_len,
         } => {
-            // Names display as @{id}: there is no interner access here. Args
-            // ARE renderable now that this fn takes the Cfg.
             let args: Vec<String> = cfg
                 .get_call_args(*args_start, *args_len)
                 .iter()
                 .map(|a| format!("{}", a.value))
                 .collect();
-            format!("call @{}({})", name.into_usize(), args.join(", "))
+            let name = interner
+                .map(|interner| interner.resolve(name).to_string())
+                .unwrap_or_else(|| name.into_usize().to_string());
+            format!("call @{}({})", name, args.join(", "))
         }
         CfgInstData::Intrinsic {
             name,
@@ -182,7 +200,10 @@ pub fn format_cfg_inst_data(cfg: &rue_cfg::Cfg, data: &rue_cfg::CfgInstData) -> 
                 .iter()
                 .map(|v| format!("{}", v))
                 .collect();
-            format!("intrinsic @{}({})", name.into_usize(), args.join(", "))
+            let name = interner
+                .map(|interner| interner.resolve(name).to_string())
+                .unwrap_or_else(|| name.into_usize().to_string());
+            format!("intrinsic @{}({})", name, args.join(", "))
         }
         CfgInstData::StructInit {
             struct_id,

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -354,7 +354,7 @@ pub use x86_64::generate;
 // Re-export shared types
 pub use cfg_lower::{
     BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
-    format_cfg_inst_data, format_terminator,
+    format_cfg_inst_data, format_cfg_inst_data_with_interner, format_terminator,
 };
 pub use index_map::{Handle, IndexMap};
 pub use regalloc::{

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -583,7 +583,7 @@ impl<'a> CfgLower<'a> {
     /// This is like `lower()` but also captures detailed information about
     /// how each CFG instruction maps to MIR instructions.
     pub fn lower_with_debug(mut self) -> CompileResult<(X86Mir, crate::LoweringDebugInfo)> {
-        use crate::cfg_lower::{format_cfg_inst_data, format_terminator};
+        use crate::cfg_lower::{format_cfg_inst_data_with_interner, format_terminator};
         use crate::{
             BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
         };
@@ -650,7 +650,11 @@ impl<'a> CfgLower<'a> {
                 if !mir_insts.is_empty() {
                     block_info.instructions.push(LoweringDecision {
                         cfg_value: value,
-                        cfg_inst_desc: format_cfg_inst_data(self.ctx.cfg, &inst.data),
+                        cfg_inst_desc: format_cfg_inst_data_with_interner(
+                            self.ctx.cfg,
+                            &inst.data,
+                            self.interner,
+                        ),
                         cfg_type: inst.ty.name().to_string(),
                         mir_insts,
                         rationale,

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -2094,7 +2094,10 @@ fn handle_emit_multi_file(
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
                         println!("function {}:", func.analyzed.name);
-                        println!("{}", func.analyzed.air);
+                        println!(
+                            "{}",
+                            func.analyzed.air.display_with_interner(&state.interner)
+                        );
                     }
                 }
                 println!();
@@ -2103,7 +2106,7 @@ fn handle_emit_multi_file(
                 println!("=== CFG ===");
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
-                        println!("{}", func.cfg);
+                        println!("{}", func.cfg.display_with_interner(&state.interner));
                     }
                 }
                 println!();

--- a/reproducibility/fixture/source-order/main.rue
+++ b/reproducibility/fixture/source-order/main.rue
@@ -1,0 +1,17 @@
+fn rotate(value: i32) -> i32 {
+    value * 3 + 1
+}
+
+fn finish(value: i32) -> i32 {
+    value / 2 - 4
+}
+
+fn identity(comptime T: type, value: T) -> T {
+    value
+}
+
+fn main() -> i32 {
+    let result = finish(rotate(identity(i32, 10)));
+    @assert(result == 11);
+    result
+}

--- a/reproducibility/fixture/source-order/noise-a.rue
+++ b/reproducibility/fixture/source-order/noise-a.rue
@@ -1,0 +1,13 @@
+struct AmberRecord {
+    first: i32,
+    second: bool,
+}
+
+enum AmberChoice {
+    Empty,
+    Number(i32),
+}
+
+fn _amber_transform(value: i32) -> i32 {
+    value + 101
+}

--- a/reproducibility/fixture/source-order/noise-b.rue
+++ b/reproducibility/fixture/source-order/noise-b.rue
@@ -1,0 +1,13 @@
+struct VioletRecord {
+    count: i32,
+    enabled: bool,
+}
+
+enum VioletChoice {
+    Missing,
+    Present(i32),
+}
+
+fn _violet_transform(value: i32) -> i32 {
+    value - 203
+}

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -138,6 +138,38 @@ assert_relocated_symbol_names() {
     fi
 }
 
+assert_source_order_independent_ir() {
+    local ir_a="$root_a/tmp/source-order-ir.txt"
+    local ir_b="$root_b/tmp/source-order-ir.txt"
+
+    # RUE-620: keep noise-a as the semantic root while moving main across an
+    # unrelated sibling. That changes process-local interner allocation without
+    # changing which files or definitions make up the program.
+    (
+        cd "$root_a/project/source-order"
+        "$RUE_BINARY" -j1 \
+            --emit air --emit cfg --emit lowering \
+            noise-a.rue main.rue noise-b.rue > "$ir_a"
+    )
+    "$RUE_BINARY" -j32 \
+        --emit air --emit cfg --emit lowering \
+        "$root_b/project/source-order/noise-a.rue" \
+        "$root_b/project/source-order/noise-b.rue" \
+        "$root_b/project/source-order/main.rue" > "$ir_b"
+
+    assert_identical "source-order-permuted AIR/CFG/lowering" "$ir_a" "$ir_b"
+
+    # Make the comparison non-vacuous: each adapter must have resolved the
+    # symbols exercised by ordinary, generic, and intrinsic calls.
+    local expected_symbol
+    for expected_symbol in '@rotate(' '@finish(' '@identity.i32(' '@assert('; do
+        if ! grep -Fq "$expected_symbol" "$ir_a"; then
+            printf 'FAIL: stable IR omitted resolved symbol %s\n' "$expected_symbol" >&2
+            return 1
+        fi
+    done
+}
+
 compile_pair() {
     local opt="$1"
     local output_a="$root_a/project/program-left-o$1"
@@ -182,5 +214,6 @@ compile_pair() {
 }
 
 assert_relocated_symbol_names
+assert_source_order_independent_ir
 compile_pair 0
 compile_pair 2


### PR DESCRIPTION
## Summary

- add interner-aware AIR and CFG display adapters, while preserving the existing numeric context-free Display APIs
- resolve call, specialized-call, and intrinsic symbols in CLI AIR/CFG/lowering output on both codegen backends
- extend the required reproducibility gate with a fixed-root sibling-order permutation and pin the resolved semantic names

The regression is non-vacuous: the RUE-618 parent differs at byte 157 because raw symbols shift from @25/@26/@31 to @32/@33/@38. This change produces an exact match with SHA-256 6dcf9d7658463772a49c58156fca2076d225f4b42ca741e1f5f03ab65aa39e1c.

This PR intentionally does not claim final artifact stability under source permutations. The separate real binary-ordering defect is tracked by RUE-624.

## Validation

- ./fmt.sh check
- ./clippy.sh
- ./buck2 test //... (34 targets)
- parent-vs-working-copy black-box non-vacuity check

Linear: https://linear.app/steve-klabnik/issue/RUE-620/emit-stabilize-textual-ir-dumps-across-source-ordering
