### PR TITLE
RUE-613: field-init shorthand (P { x }) behind preview gate

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1783,6 +1783,7 @@ impl<'a> ConstraintGenerator<'a> {
                 type_name,
                 fields_start,
                 fields_len,
+                shorthand_span: _,
             } => {
                 // Inline type-constructor literal heads (`F(args) { ... }`,
                 // RUE-596) resolve through sema's pre-reduced head map, the

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3299,6 +3299,7 @@ impl<'a> Sema<'a> {
                 type_name,
                 fields_start,
                 fields_len,
+                shorthand_span,
             } => self.analyze_struct_init(
                 air,
                 *module,
@@ -3306,6 +3307,7 @@ impl<'a> Sema<'a> {
                 *type_name,
                 *fields_start,
                 *fields_len,
+                *shorthand_span,
                 inst.span,
                 ctx,
             ),
@@ -3338,9 +3340,21 @@ impl<'a> Sema<'a> {
         type_name: Spur,
         fields_start: u32,
         fields_len: u32,
+        shorthand_span: Option<Span>,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // Field-init shorthand (`P { x }` desugaring to `P { x: x }`, RUE-613) is
+        // gated behind its preview flag. AstGen already desugared the shorthand
+        // to explicit `x: x` field inits; `shorthand_span` is `Some` iff at least
+        // one field used the shorthand, and points at the first such field.
+        if let Some(sh_span) = shorthand_span {
+            self.require_preview(
+                PreviewFeature::FieldInitShorthand,
+                "field-init shorthand (`P { x }`)",
+                sh_span,
+            )?;
+        }
         let field_inits = self.rir.get_field_inits(fields_start, fields_len);
         // Look up the struct type
         // First check if it's a comptime type variable (e.g., `let Point = make_point(); Point { ... }`)

--- a/crates/rue-cli-tests/cases/field_init_shorthand.toml
+++ b/crates/rue-cli-tests/cases/field_init_shorthand.toml
@@ -1,0 +1,130 @@
+# Field-init shorthand `P { x }` desugaring to `P { x: x }` (RUE-613, preview
+# `field_init_shorthand`). These cases exercise the driver end-to-end: the
+# shorthand desugars in the parser, the preview gate fires in sema, and the
+# constructed struct's fields are read back at runtime (exact stdout pins the
+# desugaring maps `x` to the in-scope binding). The qualified case crosses a
+# module boundary (`shapes.Point { x, y }`), which the spec harness can't see.
+
+[section]
+id = "cli.field_init_shorthand"
+name = "Field-init shorthand"
+description = "`P { x }` desugars to `P { x: x }` under --preview field_init_shorthand (RUE-613)."
+
+# Mixed shorthand + explicit fields, values read back at runtime.
+[[case]]
+name = "mixed_shorthand_and_explicit"
+description = "`P { x, y: 2 }` takes x from scope and y explicitly."
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let x = 40;
+    let p = Point { x, y: 2 };
+    @dbg(p.x);
+    @dbg(p.y);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "field_init_shorthand", "-o", "prog"]
+stdout = "40\n2\n"
+exit_code = 0
+
+# Shadowing: the innermost `x` binding supplies the shorthand's value.
+[[case]]
+name = "shadowing_uses_innermost_binding"
+description = "A `let` shadowing an outer `x` supplies the shorthand value."
+files = [{ path = "main.rue", source = """
+struct P { x: i32 }
+fn main() -> i32 {
+    let x = 1;
+    let x = 99;
+    let p = P { x };
+    @dbg(p.x);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "field_init_shorthand", "-o", "prog"]
+stdout = "99\n"
+exit_code = 0
+
+# `Self { a, b }` shorthand inside a method.
+[[case]]
+name = "self_shorthand_in_method"
+description = "Shorthand under a `Self { .. }` head inside a method."
+files = [{ path = "main.rue", source = """
+struct Pair {
+    a: i32,
+    b: i32,
+    fn make(a: i32, b: i32) -> Self { Self { a, b } }
+}
+fn main() -> i32 {
+    let p = Pair.make(11, 22);
+    @dbg(p.a);
+    @dbg(p.b);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "field_init_shorthand", "-o", "prog"]
+stdout = "11\n22\n"
+exit_code = 0
+
+# Qualified struct literal across a module boundary: `shapes.Point { x, y }`.
+[[case]]
+name = "qualified_module_shorthand"
+description = "Shorthand works on a module-qualified struct-literal head."
+files = [
+  { path = "shapes.rue", source = """
+pub struct Point { x: i32, y: i32 }
+""" },
+  { path = "main.rue", source = """
+const shapes = @import("shapes.rue");
+fn main() -> i32 {
+    let x = 30;
+    let y = 12;
+    let p = shapes.Point { x, y };
+    @dbg(p.x + p.y);
+    0
+}
+""" },
+]
+args = ["main.rue", "--preview", "field_init_shorthand", "-o", "prog"]
+stdout = "42\n"
+exit_code = 0
+
+# `if cond { y }` must remain a block-valued if, NOT a struct literal, even
+# without the preview flag: the shorthand introduces the sole overlap between
+# struct-literal and block syntax, and the parser must not regress it.
+[[case]]
+name = "if_block_body_not_struct_literal"
+description = "`if c { y }` stays a block-valued if; no preview flag needed."
+files = [{ path = "main.rue", source = """
+fn pick(c: bool) -> i32 {
+    let y = 7;
+    let z = 9;
+    if c { y } else { z }
+}
+fn main() -> i32 {
+    @dbg(pick(true));
+    @dbg(pick(false));
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "7\n9\n"
+exit_code = 0
+
+# The gate: without --preview the shorthand is rejected (E1100).
+[[case]]
+name = "requires_preview_flag"
+description = "Without --preview field_init_shorthand the shorthand errors with E1100."
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let x = 1;
+    let y = 2;
+    let p = Point { x, y };
+    p.x + p.y
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1100", "field_init_shorthand"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -507,6 +507,11 @@ pub enum PreviewFeature {
     /// bind-first form (`let P = F(args); P.NAME`). Elided args (`Option(_)`)
     /// remain out of scope (RUE-401).
     InlineTypeCtorPath,
+    /// Field-init shorthand (RUE-613): a struct-literal field written as a bare
+    /// identifier `P { x }` desugars to `P { x: x }`, taking the value from the
+    /// in-scope binding of the same name. Mixed forms (`P { x, y: 2 }`) and
+    /// `Self { a, b }` in methods are supported.
+    FieldInitShorthand,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -530,6 +535,7 @@ impl PreviewFeature {
             PreviewFeature::Slices => "slices",
             PreviewFeature::StringTrio => "string_trio",
             PreviewFeature::InlineTypeCtorPath => "inline_type_ctor_paths",
+            PreviewFeature::FieldInitShorthand => "field_init_shorthand",
         }
     }
 
@@ -541,6 +547,7 @@ impl PreviewFeature {
             PreviewFeature::Slices => "ADR-0043",
             PreviewFeature::StringTrio => "ADR-0043",
             PreviewFeature::InlineTypeCtorPath => "ADR-0025",
+            PreviewFeature::FieldInitShorthand => "RUE-613",
         }
     }
 
@@ -551,6 +558,7 @@ impl PreviewFeature {
             PreviewFeature::Slices,
             PreviewFeature::StringTrio,
             PreviewFeature::InlineTypeCtorPath,
+            PreviewFeature::FieldInitShorthand,
         ]
     }
 
@@ -577,6 +585,7 @@ impl std::str::FromStr for PreviewFeature {
             "slices" => Ok(PreviewFeature::Slices),
             "string_trio" => Ok(PreviewFeature::StringTrio),
             "inline_type_ctor_paths" => Ok(PreviewFeature::InlineTypeCtorPath),
+            "field_init_shorthand" => Ok(PreviewFeature::FieldInitShorthand),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -2520,7 +2529,7 @@ mod tests {
         let names = PreviewFeature::all_names();
         assert_eq!(
             names,
-            "test_infra, slices, string_trio, inline_type_ctor_paths"
+            "test_infra, slices, string_trio, inline_type_ctor_paths, field_init_shorthand"
         );
     }
 

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -930,6 +930,12 @@ pub struct FieldInit {
     pub name: Ident,
     /// Field value
     pub value: Box<Expr>,
+    /// Whether this initializer used field-init shorthand (`P { x }` desugaring
+    /// to `P { x: x }`, RUE-613, preview `field_init_shorthand`). When `true`,
+    /// `value` is the desugared `Expr::Ident(name)`; the flag is preserved so
+    /// Sema can gate the shorthand form behind its preview flag and so
+    /// diagnostics can point at the shorthand.
+    pub shorthand: bool,
     pub span: Span,
 }
 

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -699,21 +699,40 @@ where
         .collect()
 }
 
-/// Parser for struct field initializers: name: expr
+/// Parser for struct field initializers: `name: expr`, or the field-init
+/// shorthand `name` (RUE-613, preview `field_init_shorthand`) which desugars to
+/// `name: name` at parse time. The explicit `name :` form is tried first; a bare
+/// identifier followed by `,` or `}` (i.e. no `:`) is taken as shorthand. The
+/// `shorthand` flag is recorded so Sema can gate the form behind its preview
+/// flag; downstream stages see the fully desugared `name: Ident(name)` value.
 fn field_init_parser<'src, I>(
     expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone,
 ) -> impl Parser<'src, I, FieldInit, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    ident_parser()
+    let explicit = ident_parser()
         .then_ignore(just(TokenKind::Colon))
         .then(expr)
         .map_with(|(name, value), e| FieldInit {
             name,
             value: Box::new(value),
+            shorthand: false,
             span: span_from_extra(e),
-        })
+        });
+
+    // Shorthand `name` → `name: name`. The desugared value reuses the field
+    // name's identifier (and span), so an out-of-scope name produces the normal
+    // undefined-variable error at the desugared site, and a `let`-shadowed name
+    // resolves to the innermost binding just like writing `name` explicitly.
+    let shorthand = ident_parser().map_with(|name: Ident, e| FieldInit {
+        value: Box::new(Expr::Ident(name.clone())),
+        name,
+        shorthand: true,
+        span: span_from_extra(e),
+    });
+
+    choice((explicit, shorthand))
 }
 
 /// Parser for comma-separated field initializers
@@ -1194,33 +1213,120 @@ fn empty_body_from_reclaimed_struct_lit(lit: &StructLitExpr) -> BlockExpr {
     }
 }
 
-fn reclaim_empty_struct_lit_head(lit: StructLitExpr) -> Option<Expr> {
-    if !lit.fields.is_empty() {
-        return None;
-    }
-
-    Some(match (lit.base, lit.ctor_args) {
+/// Reclaim the *head* of a struct literal that greedily swallowed a
+/// restricted-position brace group (`if`/`while`/`for`/`match` head), ignoring
+/// its fields. Returns the expression the head denotes, or `None` for a form
+/// that is not reclaimable (a qualified inline type-constructor head).
+fn reclaim_struct_lit_head(
+    base: Option<Box<Expr>>,
+    name: Ident,
+    ctor_args: Option<Vec<CallArg>>,
+    span: Span,
+) -> Option<Expr> {
+    Some(match (base, ctor_args) {
         // `F(args) {}` used as a restricted-position head (`if`/`while`/`for`)
-        // reclaims to the constructor call `F(args)`; the empty braces are the
-        // block body, exactly as `if F(args) {}` parsed before the inline
+        // reclaims to the constructor call `F(args)`; the braces are the block
+        // body, exactly as `if F(args) {}` parsed before the inline
         // type-constructor struct-literal head existed (RUE-596). Only the
         // unqualified form is reclaimable here.
-        (None, Some(args)) => Expr::Call(CallExpr {
-            name: lit.name,
-            args,
-            span: lit.span,
-        }),
+        (None, Some(args)) => Expr::Call(CallExpr { name, args, span }),
         (Some(_), Some(_)) => return None,
-        (None, None) => Expr::Ident(lit.name),
+        (None, None) => Expr::Ident(name),
         (Some(base), None) => {
-            let span = base.span().extend_to(lit.name.span.end);
+            let span = base.span().extend_to(name.span.end);
             Expr::Field(FieldExpr {
                 base,
-                field: lit.name,
+                field: name,
                 span,
             })
         }
     })
+}
+
+fn reclaim_empty_struct_lit_head(lit: StructLitExpr) -> Option<Expr> {
+    if !lit.fields.is_empty() {
+        return None;
+    }
+    reclaim_struct_lit_head(lit.base, lit.name, lit.ctor_args, lit.span)
+}
+
+/// Does the condition end (on its right spine) in a struct literal that greedily
+/// swallowed a restricted-position brace group? Used only to choose between the
+/// "struct literal in bare condition" and "expected block" diagnostics once
+/// reclamation has already failed.
+fn cond_tail_is_struct_lit(cond: &Expr) -> bool {
+    match cond {
+        Expr::StructLit(_) => true,
+        Expr::Binary(b) => cond_tail_is_struct_lit(&b.right),
+        Expr::Unary(u) => cond_tail_is_struct_lit(&u.operand),
+        _ => false,
+    }
+}
+
+/// Reclaim a condition expression whose trailing brace group was greedily parsed
+/// as a struct literal back into a `(condition, body)` pair for `if`/`while`/`for`.
+///
+/// The brace group is what should have been the block body; a struct literal is
+/// never permitted unparenthesized as a bare condition (spec 4.6:13 / 4.7:28), so
+/// its braces are reclaimed as the block. Two shapes are reclaimable:
+///
+/// - A top-level `Head {}` → head plus an *empty* body (the pre-existing
+///   zero-field case; only ever arises at the top level).
+/// - A single field-init-shorthand field `Head { ident }` (RUE-613) → head plus
+///   the block `{ ident }`. Because the shorthand makes `{ ident }` look like
+///   both a block and a struct literal, this can appear not only at the top level
+///   but nested on the condition's right spine — e.g. `if a < b { a }` parses as
+///   `a < (b { a })`, so the struct literal must be peeled off the right operand.
+///   `{ a, b }` and `{ a: 1 }` are not blocks, so they remain non-reclaimable and
+///   fall through to the bare-condition error.
+fn reclaim_struct_lit_as_cond_and_body(cond: Expr) -> Option<(Expr, BlockExpr)> {
+    // Top-level empty `Head {}` reclaims to an empty body. (Empty literals are
+    // only reclaimed at the top level; a nested `a < b {}` keeps erroring as a
+    // bare-condition struct literal, unchanged from before RUE-613.)
+    if let Expr::StructLit(lit) = &cond {
+        if lit.fields.is_empty() {
+            let body = empty_body_from_reclaimed_struct_lit(lit);
+            let Expr::StructLit(lit) = cond else {
+                unreachable!("matched StructLit by ref immediately above")
+            };
+            let head = reclaim_struct_lit_head(lit.base, lit.name, lit.ctor_args, lit.span)?;
+            return Some((head, body));
+        }
+    }
+    reclaim_trailing_shorthand_struct_lit(cond)
+}
+
+/// Peel a single-field-init-shorthand struct literal (`Head { ident }`, RUE-613)
+/// off the right spine of `cond`, returning the reclaimed head expression and the
+/// `{ ident }` block. Recurses through binary and unary operators because the
+/// dangling brace group attaches to the right-most operand.
+fn reclaim_trailing_shorthand_struct_lit(cond: Expr) -> Option<(Expr, BlockExpr)> {
+    match cond {
+        Expr::StructLit(lit) if lit.fields.len() == 1 && lit.fields[0].shorthand => {
+            let body = BlockExpr {
+                statements: Vec::new(),
+                expr: Box::new(Expr::Ident(lit.fields[0].name.clone())),
+                span: Span::with_file(lit.span.file_id, lit.name.span.end, lit.span.end),
+            };
+            let head = reclaim_struct_lit_head(lit.base, lit.name, lit.ctor_args, lit.span)?;
+            Some((head, body))
+        }
+        Expr::Binary(mut b) => {
+            let (new_right, body) = reclaim_trailing_shorthand_struct_lit(*b.right)?;
+            let new_right = Box::new(new_right);
+            b.span = b.left.span().extend_to(new_right.span().end);
+            b.right = new_right;
+            Some((Expr::Binary(b), body))
+        }
+        Expr::Unary(mut u) => {
+            let (new_operand, body) = reclaim_trailing_shorthand_struct_lit(*u.operand)?;
+            let new_operand = Box::new(new_operand);
+            u.span = u.span.extend_to(new_operand.span().end);
+            u.operand = new_operand;
+            Some((Expr::Unary(u), body))
+        }
+        _ => None,
+    }
 }
 
 /// Parser for control flow expressions: break, continue, return, if, while, loop, match
@@ -1305,39 +1411,46 @@ where
             )
             .try_map_with(|((cond, then_block), else_block), e| {
                 let span = span_from_extra(e);
-                match (cond, then_block) {
-                    (Expr::StructLit(lit), None) => {
-                        let then_block = empty_body_from_reclaimed_struct_lit(&lit);
-                        let Some(cond) = reclaim_empty_struct_lit_head(lit) else {
-                            return Err(Rich::custom(
-                                e.span(),
-                                "struct literals are not allowed as a bare if condition; \
-                                 wrap the condition in parentheses",
-                            ));
-                        };
-
-                        Ok(Expr::If(IfExpr {
-                            cond: Box::new(cond),
-                            then_block,
-                            else_block,
-                            span,
-                        }))
-                    }
-                    (Expr::StructLit(_), _) => Err(Rich::custom(
+                match then_block {
+                    // A block after a struct-literal-tailed condition is the
+                    // illegal bare struct-literal condition (`if Foo {} {..}`).
+                    Some(_) if cond_tail_is_struct_lit(&cond) => Err(Rich::custom(
                         e.span(),
                         "struct literals are not allowed as a bare if condition; \
                          wrap the condition in parentheses",
                     )),
-                    (cond, Some(then_block)) => Ok(Expr::If(IfExpr {
+                    Some(then_block) => Ok(Expr::If(IfExpr {
                         cond: Box::new(cond),
                         then_block,
                         else_block,
                         span,
                     })),
-                    (_, None) => Err(Rich::custom(
-                        e.span(),
-                        "expected '{' and then block after the if condition",
-                    )),
+                    // No block parsed: the condition greedily swallowed the
+                    // then-block braces as a struct literal. Reclaim them.
+                    None => {
+                        let tail_is_struct = cond_tail_is_struct_lit(&cond);
+                        match reclaim_struct_lit_as_cond_and_body(cond) {
+                            Some((cond, then_block)) => Ok(Expr::If(IfExpr {
+                                cond: Box::new(cond),
+                                then_block,
+                                else_block,
+                                span,
+                            })),
+                            // A non-reclaimable struct-literal tail (explicit
+                            // fields, a qualified inline ctor head) is an illegal
+                            // bare condition; anything else is simply a missing
+                            // block.
+                            None if tail_is_struct => Err(Rich::custom(
+                                e.span(),
+                                "struct literals are not allowed as a bare if condition; \
+                                 wrap the condition in parentheses",
+                            )),
+                            None => Err(Rich::custom(
+                                e.span(),
+                                "expected '{' and then block after the if condition",
+                            )),
+                        }
+                    }
                 }
             })
     })
@@ -1352,37 +1465,36 @@ where
         .then(block_parser(expr.clone(), block_like.clone()).or_not())
         .try_map_with(|(cond, body), e| {
             let span = span_from_extra(e);
-            match (cond, body) {
-                (Expr::StructLit(lit), None) => {
-                    let body = empty_body_from_reclaimed_struct_lit(&lit);
-                    let Some(cond) = reclaim_empty_struct_lit_head(lit) else {
-                        return Err(Rich::custom(
-                            e.span(),
-                            "struct literals are not allowed as a bare while condition; \
-                             wrap the condition in parentheses",
-                        ));
-                    };
-
-                    Ok(Expr::While(WhileExpr {
-                        cond: Box::new(cond),
-                        body,
-                        span,
-                    }))
-                }
-                (Expr::StructLit(_), _) => Err(Rich::custom(
+            match body {
+                Some(_) if cond_tail_is_struct_lit(&cond) => Err(Rich::custom(
                     e.span(),
                     "struct literals are not allowed as a bare while condition; \
                      wrap the condition in parentheses",
                 )),
-                (cond, Some(body)) => Ok(Expr::While(WhileExpr {
+                Some(body) => Ok(Expr::While(WhileExpr {
                     cond: Box::new(cond),
                     body,
                     span,
                 })),
-                (_, None) => Err(Rich::custom(
-                    e.span(),
-                    "expected '{' and body block after the while condition",
-                )),
+                None => {
+                    let tail_is_struct = cond_tail_is_struct_lit(&cond);
+                    match reclaim_struct_lit_as_cond_and_body(cond) {
+                        Some((cond, body)) => Ok(Expr::While(WhileExpr {
+                            cond: Box::new(cond),
+                            body,
+                            span,
+                        })),
+                        None if tail_is_struct => Err(Rich::custom(
+                            e.span(),
+                            "struct literals are not allowed as a bare while condition; \
+                             wrap the condition in parentheses",
+                        )),
+                        None => Err(Rich::custom(
+                            e.span(),
+                            "expected '{' and body block after the while condition",
+                        )),
+                    }
+                }
             }
         })
         .boxed();
@@ -1410,39 +1522,38 @@ where
         .then(block_parser(expr.clone(), block_like.clone()).or_not())
         .try_map_with(|((binder, iterable), body), e| {
             let span = span_from_extra(e);
-            match (iterable, body) {
-                (Expr::StructLit(lit), None) => {
-                    let body = empty_body_from_reclaimed_struct_lit(&lit);
-                    let Some(iterable) = reclaim_empty_struct_lit_head(lit) else {
-                        return Err(Rich::custom(
-                            e.span(),
-                            "struct literals are not allowed as a bare for iterable; \
-                             wrap the iterable in parentheses",
-                        ));
-                    };
-
-                    Ok(Expr::For(ForExpr {
-                        binder,
-                        iterable: Box::new(iterable),
-                        body,
-                        span,
-                    }))
-                }
-                (Expr::StructLit(_), _) => Err(Rich::custom(
+            match body {
+                Some(_) if cond_tail_is_struct_lit(&iterable) => Err(Rich::custom(
                     e.span(),
                     "struct literals are not allowed as a bare for iterable; \
                      wrap the iterable in parentheses",
                 )),
-                (iterable, Some(body)) => Ok(Expr::For(ForExpr {
+                Some(body) => Ok(Expr::For(ForExpr {
                     binder,
                     iterable: Box::new(iterable),
                     body,
                     span,
                 })),
-                (_, None) => Err(Rich::custom(
-                    e.span(),
-                    "expected '{' and body block after the for iterable",
-                )),
+                None => {
+                    let tail_is_struct = cond_tail_is_struct_lit(&iterable);
+                    match reclaim_struct_lit_as_cond_and_body(iterable) {
+                        Some((iterable, body)) => Ok(Expr::For(ForExpr {
+                            binder,
+                            iterable: Box::new(iterable),
+                            body,
+                            span,
+                        })),
+                        None if tail_is_struct => Err(Rich::custom(
+                            e.span(),
+                            "struct literals are not allowed as a bare for iterable; \
+                             wrap the iterable in parentheses",
+                        )),
+                        None => Err(Rich::custom(
+                            e.span(),
+                            "expected '{' and body block after the for iterable",
+                        )),
+                    }
+                }
             }
         })
         .boxed();
@@ -1642,15 +1753,24 @@ where
     // followed by `}` (empty struct) or `ident :` (non-empty struct) to confirm it's
     // a struct literal, not field access followed by a block.
     //
-    // Lookahead check: succeeds (without consuming) if `{ }` or `{ ident : `
+    // Lookahead check: succeeds (without consuming) if `{ }`, `{ ident : `, or
+    // (field-init shorthand, RUE-613) `{ ident }` / `{ ident , `. The shorthand
+    // forms let `module.Point { x }` and `module.Point { x, y }` parse as
+    // qualified struct literals rather than field access + block; `{ ident . `
+    // and `{ ident ( ` do not match, so `obj.field { expr }` blocks are
+    // unaffected.
     let struct_lit_lookahead = just(TokenKind::LBrace)
         .then(
             choice((
                 // Empty struct: { }
                 just(TokenKind::RBrace).ignored(),
-                // Non-empty struct: { ident : ...
+                // Non-empty struct: `{ ident :`, `{ ident ,`, or `{ ident }`
                 select! { TokenKind::Ident(_) => () }
-                    .then_ignore(just(TokenKind::Colon))
+                    .then_ignore(choice((
+                        just(TokenKind::Colon).ignored(),
+                        just(TokenKind::Comma).ignored(),
+                        just(TokenKind::RBrace).ignored(),
+                    )))
                     .ignored(),
             ))
             // We're just checking the pattern exists, not consuming
@@ -3916,6 +4036,78 @@ mod tests {
         let result =
             parse("fn main() -> i32 { let mut x = 0; while x < 10 { x = x + 1; } x }").unwrap();
         assert_eq!(result.ast.items.len(), 1);
+    }
+
+    // ==================== Field-Init Shorthand (RUE-613) ====================
+
+    #[test]
+    fn test_field_init_shorthand_desugars_to_ident() {
+        // `P { x }` desugars to `P { x: x }`: one field whose value is Ident(x)
+        // and whose `shorthand` flag is set.
+        let result = parse_expr("P { x }").unwrap();
+        match result.expr {
+            Expr::StructLit(lit) => {
+                assert_eq!(lit.fields.len(), 1);
+                let f = &lit.fields[0];
+                assert!(f.shorthand, "field should be marked shorthand");
+                assert_eq!(result.interner.resolve(&f.name.name), "x");
+                match f.value.as_ref() {
+                    Expr::Ident(id) => assert_eq!(result.interner.resolve(&id.name), "x"),
+                    other => panic!("expected desugared Ident value, got {other:?}"),
+                }
+            }
+            other => panic!("expected StructLit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_field_init_shorthand_mixed_with_explicit() {
+        // Mixed `P { x, y: 2 }`: first field shorthand, second explicit.
+        let result = parse_expr("P { x, y: 2 }").unwrap();
+        match result.expr {
+            Expr::StructLit(lit) => {
+                assert_eq!(lit.fields.len(), 2);
+                assert!(lit.fields[0].shorthand);
+                assert!(!lit.fields[1].shorthand);
+            }
+            other => panic!("expected StructLit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_if_single_ident_body_is_block_not_struct_literal() {
+        // `if c { y }` must parse as an if whose then-block is the block `{ y }`,
+        // NOT as the struct literal `c { y: y }` used illegally as a condition.
+        let result = parse_expr("if c { y } else { z }").unwrap();
+        match result.expr {
+            Expr::If(if_expr) => match if_expr.cond.as_ref() {
+                Expr::Ident(id) => assert_eq!(result.interner.resolve(&id.name), "c"),
+                other => panic!("expected Ident condition, got {other:?}"),
+            },
+            other => panic!("expected If, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_if_binary_condition_with_single_ident_body_not_struct_literal() {
+        // Regression: `if a < b { a }` must not parse the right operand `b { a }`
+        // as a shorthand struct literal (which would make the whole `a < b { a }`
+        // a struct-literal-tailed binary and swallow the block). The condition
+        // must stay `a < b` with `{ a }` as the block body.
+        let result = parse_expr("if a < b { a } else { b }").unwrap();
+        match result.expr {
+            Expr::If(if_expr) => match if_expr.cond.as_ref() {
+                Expr::Binary(bin) => {
+                    assert_eq!(bin.op, BinaryOp::Lt);
+                    match bin.right.as_ref() {
+                        Expr::Ident(id) => assert_eq!(result.interner.resolve(&id.name), "b"),
+                        other => panic!("expected Ident right operand, got {other:?}"),
+                    }
+                }
+                other => panic!("expected Binary condition, got {other:?}"),
+            },
+            other => panic!("expected If, got {other:?}"),
+        }
     }
 
     // ==================== Struct Method Parsing Tests ====================

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -732,6 +732,15 @@ impl<'a> AstGen<'a> {
                     .collect();
                 let (fields_start, fields_len) = self.rir.add_field_inits(&fields);
 
+                // Field-init shorthand (`P { x }`, RUE-613) is fully desugared to
+                // `x: x` above; carry the first shorthand field's span so Sema can
+                // gate the form behind its preview flag.
+                let shorthand_span = struct_lit
+                    .fields
+                    .iter()
+                    .find(|f| f.shorthand)
+                    .map(|f| f.span);
+
                 self.rir.add_inst(Inst {
                     data: InstData::StructInit {
                         module,
@@ -739,6 +748,7 @@ impl<'a> AstGen<'a> {
                         type_name: struct_lit.name.name, // Already a Spur
                         fields_start,
                         fields_len,
+                        shorthand_span,
                     },
                     span: struct_lit.span,
                 })

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1030,12 +1030,14 @@ impl Rir {
                 type_name,
                 fields_start,
                 fields_len,
+                shorthand_span,
             } => InstData::StructInit {
                 module: module.map(renumber),
                 ctor_head: ctor_head.map(renumber),
                 type_name: *type_name,
                 fields_start: *fields_start + extra_offset,
                 fields_len: *fields_len,
+                shorthand_span: *shorthand_span,
             },
             InstData::FieldGet { base, field } => InstData::FieldGet {
                 base: renumber(*base),
@@ -1696,6 +1698,12 @@ pub enum InstData {
         fields_start: u32,
         /// Number of fields
         fields_len: u32,
+        /// Span of the first field-init-shorthand field, if any (`P { x }`
+        /// desugaring to `P { x: x }`, RUE-613, preview `field_init_shorthand`).
+        /// `Some` iff at least one field used the shorthand; Sema uses it to gate
+        /// the form behind its preview flag and to point the diagnostic. `None`
+        /// when every field was written explicitly (`P { x: x }`).
+        shorthand_span: Option<Span>,
     },
 
     /// Field access: reads a field from a struct
@@ -2260,6 +2268,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     type_name,
                     fields_start,
                     fields_len,
+                    shorthand_span: _,
                 } => {
                     let module_str = match ctor_head {
                         Some(head) => format!("<{}>.", head),
@@ -3526,6 +3535,7 @@ mod tests {
                 type_name,
                 fields_start,
                 fields_len,
+                shorthand_span: None,
             },
             span: Span::new(0, 25),
         });

--- a/crates/rue-spec/cases/types/structs.toml
+++ b/crates/rue-spec/cases/types/structs.toml
@@ -370,3 +370,109 @@ expected_stdout = """
 2
 1
 """
+
+# =============================================================================
+# Field-Init Shorthand (RUE-613, preview field_init_shorthand)
+# =============================================================================
+
+[[case]]
+name = "field_init_shorthand_basic"
+spec = ["3.6:18"]
+preview = "field_init_shorthand"
+preview_should_pass = true
+description = "`P { x }` is shorthand for `P { x: x }`, taking the value from the in-scope `x`"
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let x = 10;
+    let y = 20;
+    let p = Point { x, y };
+    p.x + p.y  // 30
+}
+"""
+exit_code = 30
+
+[[case]]
+name = "field_init_shorthand_mixed_with_explicit"
+spec = ["3.6:18"]
+preview = "field_init_shorthand"
+preview_should_pass = true
+description = "Shorthand and explicit initializers may be mixed within one literal"
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let x = 10;
+    let p = Point { x, y: 20 };
+    p.x + p.y  // 30
+}
+"""
+exit_code = 30
+
+[[case]]
+name = "field_init_shorthand_uses_innermost_binding"
+spec = ["3.6:18"]
+preview = "field_init_shorthand"
+preview_should_pass = true
+description = "A `let` shadowing an outer `x` supplies the shorthand's value (innermost binding)"
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let x = 1;
+    let x = 40;
+    let p = Point { x, y: 2 };
+    p.x + p.y  // 42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "field_init_shorthand_self_in_method"
+spec = ["3.6:18"]
+preview = "field_init_shorthand"
+preview_should_pass = true
+description = "Shorthand is available under a `Self { .. }` head inside a method"
+source = """
+struct Point {
+    x: i32,
+    y: i32,
+    fn make(x: i32, y: i32) -> Self { Self { x, y } }
+}
+fn main() -> i32 {
+    let p = Point.make(40, 2);
+    p.x + p.y  // 42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "field_init_shorthand_requires_preview"
+spec = ["3.6:18"]
+description = "Without the preview feature the shorthand is an error (E1100)"
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let x = 10;
+    let y = 20;
+    let p = Point { x, y };
+    p.x + p.y
+}
+"""
+compile_fail = true
+error_contains = ["E1100", "field_init_shorthand"]
+
+[[case]]
+name = "field_init_shorthand_undefined_name"
+spec = ["3.6:18"]
+preview = "field_init_shorthand"
+preview_should_pass = true
+description = "A shorthand naming a binding not in scope is the normal undefined-name error"
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let y = 20;
+    let p = Point { x, y };
+    p.x + p.y
+}
+"""
+compile_fail = true
+error_contains = ["E0201", "x"]

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -122,3 +122,22 @@ fn main() -> i32 {
     p.x - p.y  // -10, i.e. 10 - 20
 }
 ```
+
+### Field-Init Shorthand
+
+{{ rule(id="3.6:18", cat="normative") }}
+
+A field initializer written as a bare identifier `x` — with no `: expression` — is **field-init shorthand** and is exactly equivalent to `x: x`: the field named `x` is initialized from the value bound to `x` in the enclosing scope, resolved to the innermost binding of that name (a `let` that shadows an outer `x` supplies the shorthand's value). If no `x` is in scope the shorthand is an undefined-name error, exactly as the explicit `x: x` would be. Shorthand and explicit initializers may be freely mixed within one literal (`P { x, y: 2 }`), and the shorthand is available for every struct-literal head, including `Self { .. }`. This form is a preview feature (gated behind `field_init_shorthand`, RUE-613); using it without the feature enabled is an error.
+
+{{ rule(id="3.6:19") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let x = 10;
+    // `x` is shorthand for `x: x`; `y` is written explicitly. Mixed forms are allowed.
+    let p = Point { x, y: 20 };
+    p.x + p.y  // 30
+}
+```

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -175,7 +175,8 @@ array_literal  = "[" ( [ expression { "," expression } ]
                      | expression ";" repeat_count ) "]" ;
 repeat_count   = INTEGER | IDENT ;  (* repeat form: a literal or named compile-time constant (no call form) *)
 field_inits    = field_init { "," field_init } [ "," ] ;
-field_init     = IDENT ":" expression ;
+field_init     = IDENT ":" expression      (* explicit *)
+               | IDENT ;                    (* field-init shorthand: `x` means `x: x` (preview field_init_shorthand, RUE-613) *)
 
 (* Lexical elements *)
 IDENT          = ( letter | "_" ) { letter | digit | "_" } ;


### PR DESCRIPTION
Fixes RUE-613

Field-init shorthand (`P { x }` desugaring to `P { x: x }`), endorsed by Steve + Dorian on the issue. New syntax, so it lands behind a preview gate per CLAUDE.md: `--preview field_init_shorthand`, wired end-to-end mirroring `InlineTypeCtorPath`, with the `require_preview()` call in sema fired off a shorthand marker span threaded through RIR.

The interesting half was grammar ambiguity: `{ ident }` collides with block syntax, and the naive parse broke `if a < b { a } else { b }` (then-block parsed as a `b { a }` struct literal). The parser now peels a trailing single-shorthand struct literal off the right spine of `if`/`while`/`for` conditions back into `(condition, block)`.

Verified at integration by execution: gate errors E1100 without the flag and compiles with it; mixed forms, `Self { a, b }`, innermost-binding shadowing, E0201 for undefined names at the desugared site; condition-position shapes unregressed; and the cross-worker seam with RUE-536 — `P { x, y, }`, shorthand plus trailing comma — verified against the stacked diffs.

4 parser unit + 6 spec (new rule 3.6:18, preview-tagged) + 6 CLI cases. RIR-only marker; no codegen change. Full suite green (Pass 34, traceability 100%).

Worker: cycle-1 Opus in an isolated worktree; integrated per the integrate-worker protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
