### PR TITLE
RUE-369: document SIGPIPE death as the defined default (docs + spec 8.5)

### DIFF
--- a/crates/rue-runtime/src/aarch64_linux.rs
+++ b/crates/rue-runtime/src/aarch64_linux.rs
@@ -171,15 +171,25 @@ pub fn write_all(fd: u64, mut buf: &[u8]) -> Result<(), i64> {
 
 /// Write a message to stderr.
 ///
-/// This is a best-effort write operation. If writing fails, the error is silently
-/// ignored because we're typically about to exit anyway.
+/// Best-effort: the `Err` from [`write_all`] is dropped because there is no
+/// meaningful recovery and the runtime is typically about to exit.
+///
+/// The dropped-`Err` path does **not** cover a broken output pipe. We install
+/// no `SIGPIPE` handler, so a `write` to a pipe whose reader is gone raises
+/// `SIGPIPE` and the kernel terminates the process (exit 141 = 128 + SIGPIPE)
+/// before the syscall returns — `write_all` never sees the `EPIPE`. This is
+/// Rue's intended Unix default (spec §8.5, RUE-369). Swallowing the `Err` still
+/// matters for non-signalling errno failures, e.g. `EBADF` on a closed fd,
+/// where the process keeps running.
 pub fn write_stderr(msg: &[u8]) {
     let _ = write_all(STDERR, msg);
 }
 
 /// Write a message to stdout.
 ///
-/// This is a best-effort write operation similar to `write_stderr`.
+/// Best-effort, exactly like [`write_stderr`]: a broken output pipe kills the
+/// process via `SIGPIPE` (exit 141) before `write_all` returns, while a
+/// non-signalling errno such as `EBADF` from a closed fd is swallowed here.
 pub fn write_stdout(msg: &[u8]) {
     let _ = write_all(STDOUT, msg);
 }

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -190,15 +190,25 @@ pub fn write_all(fd: u64, mut buf: &[u8]) -> Result<(), i64> {
 
 /// Write a message to stderr.
 ///
-/// This is a best-effort write operation. If writing fails, the error is silently
-/// ignored because we're typically about to exit anyway.
+/// Best-effort: the `Err` from [`write_all`] is dropped because there is no
+/// meaningful recovery and the runtime is typically about to exit.
+///
+/// The dropped-`Err` path does **not** cover a broken output pipe. We install
+/// no `SIGPIPE` handler, so a `write` to a pipe whose reader is gone raises
+/// `SIGPIPE` and the kernel terminates the process (exit 141 = 128 + SIGPIPE)
+/// before the syscall returns — `write_all` never sees the `EPIPE`. This is
+/// Rue's intended Unix default (spec §8.5, RUE-369). Swallowing the `Err` still
+/// matters for non-signalling errno failures, e.g. `EBADF` on a closed fd,
+/// where the process keeps running.
 pub fn write_stderr(msg: &[u8]) {
     let _ = write_all(STDERR, msg);
 }
 
 /// Write a message to stdout.
 ///
-/// This is a best-effort write operation similar to `write_stderr`.
+/// Best-effort, exactly like [`write_stderr`]: a broken output pipe kills the
+/// process via `SIGPIPE` (exit 141) before `write_all` returns, while a
+/// non-signalling errno such as `EBADF` from a closed fd is swallowed here.
 pub fn write_stdout(msg: &[u8]) {
     let _ = write_all(STDOUT, msg);
 }

--- a/crates/rue-runtime/src/x86_64_linux.rs
+++ b/crates/rue-runtime/src/x86_64_linux.rs
@@ -193,10 +193,25 @@ pub fn write_all(fd: u64, mut buf: &[u8]) -> Result<(), i64> {
 
 /// Write a message to stderr.
 ///
-/// This is a best-effort write operation. If writing fails (e.g., stderr is
-/// closed or redirected to a broken pipe), the error is silently ignored
-/// because there's no meaningful recovery action - the runtime is typically
-/// about to exit anyway.
+/// This is a best-effort write operation: any error returned by [`write_all`]
+/// is dropped because there is no meaningful recovery action and the runtime is
+/// typically about to exit anyway.
+///
+/// # Broken pipes vs. other write errors (RUE-369)
+///
+/// The dropped-`Err` path is **not** what handles a broken output pipe. We do
+/// not install a `SIGPIPE` handler, so the signal keeps its default
+/// disposition: when the reader on the other end of a pipe or socket is gone,
+/// the `write` syscall raises `SIGPIPE` and the kernel terminates the process
+/// *before* the syscall returns — the process dies with exit code 141 (128 +
+/// SIGPIPE) and `write_all` never observes the `EPIPE` error. This is Rue's
+/// intended Unix default (spec §8.5).
+///
+/// Swallowing the `Err` still matters for failures that return an errno
+/// *without* raising a signal — e.g. a closed or otherwise-invalid file
+/// descriptor yields `EBADF`, and a stuck fd yields the `EIO` we synthesize
+/// below. In those cases no signal fires, the process keeps running, and we
+/// intentionally discard the error.
 ///
 /// This function handles partial writes by looping until all bytes are written
 /// or an error occurs.
@@ -205,14 +220,16 @@ pub fn write_all(fd: u64, mut buf: &[u8]) -> Result<(), i64> {
 ///
 /// * `msg` - The bytes to write to stderr
 pub fn write_stderr(msg: &[u8]) {
-    // Best-effort: ignore errors since we're typically about to exit
-    // and there's no way to report the error anyway
+    // Best-effort: drop non-fatal errno failures (e.g. EBADF on a closed fd).
+    // A broken pipe never reaches here — SIGPIPE kills the process first.
     let _ = write_all(STDERR, msg);
 }
 
 /// Write a message to stdout.
 ///
-/// This is a best-effort write operation similar to `write_stderr`.
+/// Best-effort, exactly like [`write_stderr`]: a broken output pipe kills the
+/// process with `SIGPIPE` (exit 141) before `write_all` returns, while a
+/// non-signalling errno such as `EBADF` from a closed fd is swallowed here.
 ///
 /// # Arguments
 ///

--- a/docs/spec/src/08-runtime-behavior/05-signal-termination.md
+++ b/docs/spec/src/08-runtime-behavior/05-signal-termination.md
@@ -1,0 +1,55 @@
++++
+title = "Signal Termination"
+weight = 5
+template = "spec/page.html"
++++
+
+# Signal Termination
+
+{{ rule(id="8.5:1", cat="informative") }}
+
+The traps of the preceding sections (overflow, division by zero, out-of-bounds
+indexing) end a program *from inside* with the panic exit code 101. A program
+may also be ended *from outside* the language's control flow when the host
+operating system delivers a **signal** whose default disposition is to terminate
+the process. Rue installs no signal handlers, so such signals keep their
+platform-default behavior. This section describes the observable exit status in
+that case; because the trigger is external to the language, these paragraphs are
+informative rather than normative.
+
+{{ rule(id="8.5:2", cat="informative") }}
+
+On a Unix host, a process terminated by signal number `signum` reports the exit
+status `128 + signum` under the conventional shell encoding (for example, the
+`$?` value observed by a parent shell). This follows the platform convention and
+is not defined by Rue itself; the exact encoding is that of the host operating
+system and its shell.
+
+{{ rule(id="8.5:3", cat="informative") }}
+
+A Rue program whose standard output (or any output stream it writes to) is a
+pipe or socket **whose reading end has been closed** is terminated by `SIGPIPE`
+on its next write to that stream, exiting with status `141` (that is,
+`128 + SIGPIPE`, where `SIGPIPE` is `13` on Linux and macOS). This is Rue's
+defined default: it matches the standard Unix behavior for programs in a
+pipeline (such as `rue_program | head`), so a downstream reader that stops
+consuming input promptly and cleanly ends the producer. The runtime's write path
+does **not** intercept this case — the signal is delivered before the failing
+`write` syscall returns, so the write's error result is never observed (see the
+`write_stderr`/`write_stdout` documentation in `rue-runtime`).
+
+{{ rule(id="8.5:4", cat="informative") }}
+
+A write that fails *without* a signal — for example, writing to a file
+descriptor that has been closed outright (`EBADF`) rather than to a broken pipe
+— does not terminate the program. The runtime discards the error and execution
+continues, because there is no meaningful recovery and the process is typically
+about to exit regardless.
+
+{{ rule(id="8.5:5") }}
+
+Making the `SIGPIPE` response configurable (an analogue of Rust's
+`-Zon-broken-pipe`, e.g. resetting the disposition so writes observe `EPIPE`
+instead of dying) is a separate, future feature and is intentionally out of
+scope here; the default described above is the only behavior Rue currently
+provides.


### PR DESCRIPTION
Fixes RUE-369

Steve's ruling: keep the Unix default (SIGPIPE death, exit 141) and fix the documentation to match reality. Zero runtime code change.

- The `write_stdout`/`write_stderr` doc comments in all three runtime backends (x86_64_linux, aarch64_linux, aarch64_macos) falsely claimed broken-pipe writes are silently ignored — the process dies on SIGPIPE before `write()` returns EPIPE. Rewritten to describe both halves accurately (EBADF genuinely is swallowed; verified).
- New spec §8.5 "Signal Termination" (informative) documents 128+signum and SIGPIPE-on-closed-pipe = 141 as the defined default. Informative rather than normative, chosen honestly: the scenario is inexpressible in both harnesses, and an untestable normative rule would break the 100% traceability gate.

Re-verified at integration by execution: compiled print-loop piped to `head -n 2` exits 141. The configurable `-Zon-broken-pipe` analogue stays a separate feature request per the ruling. Full suite green (Pass 34).

Worker: cycle-2 Opus in an isolated worktree; integrated per the integrate-worker protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
