### PR TITLE
RUE-378: skip a single leading UTF-8 BOM

### DIFF
--- a/crates/rue-cli-tests/cases/leading_bom.toml
+++ b/crates/rue-cli-tests/cases/leading_bom.toml
@@ -1,0 +1,47 @@
+[section]
+id = "cli.leading_bom"
+name = "Leading UTF-8 BOM handling"
+description = """
+RUE-378: a single leading UTF-8 BOM (U+FEFF, bytes EF BB BF) at the very start
+of a source file is skipped before lexing (Rust/Go precedent), so a file saved
+with a BOM by a Windows editor compiles and runs. The \\uFEFF below is a TOML
+escape, so the on-disk source begins with a real BOM byte sequence. A BOM
+anywhere else stays a lexical error, and an imported module file may also carry
+a leading BOM.
+"""
+
+# A root file that begins with a BOM compiles, runs, and prints — the BOM is
+# skipped and spans stay aligned so @dbg output is unaffected.
+[[case]]
+name = "leading_bom_compiles_and_runs"
+files = [{ path = "main.rue", source = "\uFEFFfn main() -> i32 {\n    @dbg(42);\n    7\n}\n" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "42\n"
+exit_code = 7
+
+# A BOM in the middle of the file is still an invisible-character error (E0001),
+# located at the correct line/column since offsets are byte offsets into the
+# original file.
+[[case]]
+name = "mid_file_bom_rejected"
+files = [{ path = "main.rue", source = "fn main() -> i32 {\n    let \uFEFFx = 42;\n    x\n}\n" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0001", "main.rue:2:9"]
+
+# An IMPORTED module file that carries a leading BOM also compiles: every file
+# goes through the same lexer, so the BOM is skipped for helpers too.
+[[case]]
+name = "imported_module_with_bom"
+files = [
+  { path = "helper.rue", source = "\uFEFFpub fn answer() -> i32 { 42 }\n" },
+  { path = "main.rue", source = """
+const helper = @import("helper.rue");
+
+fn main() -> i32 {
+    helper.answer()
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+exit_code = 42

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -630,6 +630,17 @@ impl<'a> LogosLexer<'a> {
 
         let mut lexer = LogosTokenKind::lexer_with_extras(self.source, self.interner);
 
+        // Skip a single leading UTF-8 BOM (U+FEFF, bytes EF BB BF) per Rust/Go
+        // precedent (RUE-378). We bump the logos read head past it instead of
+        // slicing the source, so every token span stays a byte offset into the
+        // ORIGINAL file — the first real token starts at byte 3 and diagnostics
+        // still line up. Only the *leading* position is skipped: a U+FEFF
+        // anywhere else falls through to the unexpected-character path below
+        // (it is still an invisible character in the middle of the program).
+        if self.source.starts_with('\u{feff}') {
+            lexer.bump('\u{feff}'.len_utf8());
+        }
+
         loop {
             match lexer.next() {
                 Some(result) => {
@@ -755,14 +766,16 @@ impl<'a> LogosLexer<'a> {
                             };
                             let mut error = CompileError::new(kind, rue_span);
                             if matches!(error.kind, ErrorKind::UnexpectedCharacter('\u{feff}')) {
-                                // The "character" is an invisible UTF-8
-                                // byte-order mark (typically emitted by Windows
-                                // editors at the start of the file), so the
-                                // default message and caret point at nothing
-                                // visible. Explain what is actually there.
+                                // A *leading* BOM is skipped before we get here
+                                // (see the bump above), so any BOM that reaches
+                                // this point is in the middle of the file. The
+                                // "character" is an invisible UTF-8 byte-order
+                                // mark, so the default message and caret point
+                                // at nothing visible. Explain what is there.
                                 error = error.with_help(
                                     "this invisible character is a UTF-8 byte-order \
-                                     mark (BOM); save the file without a BOM",
+                                     mark (BOM); a BOM is only ignored at the very \
+                                     start of a file — remove this one",
                                 );
                             }
                             errors.push(error);
@@ -1398,11 +1411,36 @@ mod tests {
     }
 
     #[test]
-    fn test_logos_leading_bom_gets_targeted_help() {
-        // A leading UTF-8 BOM is not accepted (the spec whitespace set is
-        // space/tab/LF/CR only), but the error must explain the invisible
-        // character instead of pointing a caret at nothing.
+    fn test_logos_leading_bom_is_skipped() {
+        // A single leading UTF-8 BOM is ignored (RUE-378, Rust/Go precedent).
+        // Tokenizing succeeds and the first real token starts at byte 3 — the
+        // BOM is skipped without shifting spans off the original file offsets.
         let lexer = LogosLexer::new("\u{feff}fn main() -> i32 { 42 }");
+        let (tokens, _interner) = lexer.tokenize().expect("leading BOM should be skipped");
+        assert!(matches!(tokens[0].kind, TokenKind::Fn));
+        assert_eq!(
+            tokens[0].span.start(),
+            3,
+            "first token must keep its byte offset into the original file (past the 3-byte BOM)"
+        );
+    }
+
+    #[test]
+    fn test_logos_bom_only_file_is_empty() {
+        // A file that is nothing but a BOM must not panic: the read head is
+        // bumped to end-of-source and lexing yields only EOF.
+        let lexer = LogosLexer::new("\u{feff}");
+        let (tokens, _interner) = lexer.tokenize().expect("BOM-only file should lex cleanly");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0].kind, TokenKind::Eof));
+    }
+
+    #[test]
+    fn test_logos_mid_file_bom_errors_with_help() {
+        // A BOM anywhere but the leading position is still an error, and the
+        // error must explain the invisible character instead of pointing a
+        // caret at nothing.
+        let lexer = LogosLexer::new("fn main() -> i32 { \u{feff}42 }");
         let result = lexer.tokenize();
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -1415,7 +1453,7 @@ mod tests {
                 .helps
                 .iter()
                 .any(|h| h.0.contains("byte-order mark")),
-            "BOM error should carry the explanatory help"
+            "mid-file BOM error should carry the explanatory help"
         );
     }
 

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -690,3 +690,26 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "expected"
+
+# =============================================================================
+# Leading byte-order mark (2.0:8) — RUE-378
+# =============================================================================
+
+[[case]]
+name = "leading_bom_is_skipped"
+spec = ["2.0:8"]
+description = "A single leading UTF-8 BOM is ignored; the file compiles and runs"
+source = """
+﻿fn main() -> i32 { 42 }
+"""
+exit_code = 42
+
+[[case]]
+name = "mid_file_bom_rejected"
+spec = ["2.0:8"]
+description = "A U+FEFF anywhere but the leading position is a lexical error (E0001)"
+source = """
+fn main() -> i32 { ﻿42 }
+"""
+compile_fail = true
+error_contains = ["E0001"]

--- a/docs/spec/src/02-lexical-structure/_index.md
+++ b/docs/spec/src/02-lexical-structure/_index.md
@@ -61,3 +61,11 @@ fn main() -> i32 {
     0
 }
 ```
+
+{{ rule(id="2.0:8", cat="normative") }}
+
+A single byte-order mark (`U+FEFF`) at the very start of a source file is
+ignored: it is skipped before lexing and does not produce a token. This
+accommodates editors that prepend a UTF-8 BOM. A `U+FEFF` in any other position
+is not whitespace (2.3:1) and is a lexical error (E0001), like any other
+character that cannot begin a token.


### PR DESCRIPTION
Fixes RUE-378

Steve's ruling: skip a single leading UTF-8 BOM per Rust/Go precedent; a BOM anywhere else stays an error.

- Lexer bumps past the three BOM bytes after construction — spans remain absolute byte offsets into the original file, so diagnostics line up with no offset shifting.
- Mid-file BOM keeps E0001 with the invisible-character help, reworded to note a BOM is only ignored at the start.
- Spec rule 2.0:8 + 2 spec cases, 3 lexer unit tests, 3-case CLI file (compile+run exact stdout, mid-file error position, BOM'd imported module from disk).

Re-verified at integration by execution: leading-BOM file exits 42, mid-file BOM is E0001, BOM'd `@import` helper resolves and runs. Full suite green (Pass 34, traceability 100%).

Worker: cycle-2 Opus in an isolated worktree; integrated per the integrate-worker protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
