### PR TITLE
RUE-426 closeout: sibling-module identity regression cases + stale CLAUDE.md fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,11 @@ rue main.rue -o program        # @imports resolved and loaded automatically
 **Legacy flat mode is being removed (ADR-0046):** extra positional source files
 (`rue a.rue b.rue -o prog`) are still accepted as legacy inputs, but unqualified
 cross-file name resolution is gone — referencing another file's items without
-`@import` is an undefined-name error (E0202). Top-level names still collide
-program-wide (transitional; RUE-426 tracks module-scoping them). Don't write new
+`@import` is an undefined-name error (E0202). Functions have module-qualified
+internal identity (RUE-426/RUE-441, closed 2026-07-11): sibling modules may
+define the same top-level name — including same-name generics and same-named
+structs' methods — without colliding (regression cases:
+`crates/rue-cli-tests/cases/sibling_module_identity.toml`). Don't write new
 tests or examples that rely on flat file lists.
 
 ### Key Design Decisions

--- a/crates/rue-cli-tests/cases/sibling_module_identity.toml
+++ b/crates/rue-cli-tests/cases/sibling_module_identity.toml
@@ -1,0 +1,95 @@
+# Module-qualified function identity across sibling modules (RUE-426 tree).
+#
+# The basic same-name collision fixture landed with RUE-440; these cases pin
+# the three deeper shapes verified when RUE-442/RUE-426 were closed
+# (2026-07-11): per-module signature resolution, per-module comptime
+# specialization (no key aliasing), and per-module method resolution on
+# same-named structs. Each would regress silently if any function/method
+# table fell back to bare-source-name keys.
+
+[section]
+id = "cli.sibling_module_identity"
+name = "Sibling-module function identity"
+description = "Module-qualified function identity: same-name functions/generics/methods in sibling modules resolve per module (RUE-426/RUE-441/RUE-442)."
+
+[[case]]
+name = "sibling_same_name_different_signatures"
+description = "Same fn name with DIFFERENT signatures in sibling modules: each call resolves its own module's signature (a flat inference table would mix them up)"
+args = ["main.rue", "-o", "prog"]
+stdout = ""
+exit_code = 42
+files = [
+    { path = "main.rue", source = """
+const app = @import("app");
+fn main() -> i32 { app.run() }
+""" },
+    { path = "app/_app.rue", source = """
+pub const left = @import("left/entry.rue");
+pub const right = @import("right/entry.rue");
+pub fn run() -> i32 { @intCast(left.compute(20)) + right.compute(1, 1) }
+""" },
+    { path = "app/left/entry.rue", source = """
+pub fn compute(x: i64) -> i64 { x * 2 }
+""" },
+    { path = "app/right/entry.rue", source = """
+pub fn compute(a: i32, b: i32) -> i32 { a + b }
+""" },
+]
+
+[[case]]
+name = "sibling_same_name_generics_specialize_independently"
+description = "Same-name comptime generics in sibling modules, same T: each module's specialization runs its OWN body (aliased specialization keys would silently run the wrong one)"
+args = ["main.rue", "-o", "prog"]
+stdout = ""
+exit_code = 42
+files = [
+    { path = "main.rue", source = """
+const app = @import("app");
+fn main() -> i32 { app.run() }
+""" },
+    { path = "app/_app.rue", source = """
+pub const left = @import("left/entry.rue");
+pub const right = @import("right/entry.rue");
+pub fn run() -> i32 { left.pick(i32, 40, 1) + right.pick(i32, 1, 2) }
+""" },
+    { path = "app/left/entry.rue", source = """
+pub fn pick(comptime T: type, a: T, b: T) -> T { a }
+""" },
+    { path = "app/right/entry.rue", source = """
+pub fn pick(comptime T: type, a: T, b: T) -> T { b }
+""" },
+]
+
+[[case]]
+name = "sibling_same_name_struct_methods_resolve_per_module"
+description = "Same-named structs with same-named methods in sibling modules: each receiver resolves its own module's method body"
+args = ["main.rue", "-o", "prog"]
+stdout = ""
+exit_code = 42
+files = [
+    { path = "main.rue", source = """
+const app = @import("app");
+fn main() -> i32 { app.run() }
+""" },
+    { path = "app/_app.rue", source = """
+pub const left = @import("left/entry.rue");
+pub const right = @import("right/entry.rue");
+pub fn run() -> i32 { left.value() + right.value() }
+""" },
+    { path = "app/left/entry.rue", source = """
+pub struct Counter {
+    n: i32,
+
+    fn get(self) -> i32 { self.n * 2 }
+}
+pub fn value() -> i32 { Counter { n: 10 }.get() }
+""" },
+    { path = "app/right/entry.rue", source = """
+pub struct Counter {
+    n: i32,
+
+    fn get(self) -> i32 { self.n + 2 }
+}
+pub fn value() -> i32 { Counter { n: 20 }.get() }
+""" },
+]


### PR DESCRIPTION
Part of RUE-424

Closeout for the flat-global-namespace tree: RUE-440/441/443/444 landed earlier (Codex), and I verified + closed RUE-442 and RUE-426 today with nine behavioral probes on trunk (matrix in the RUE-442 closing comment). This PR pins the three deeper shapes the original RUE-440 fixture doesn't cover — each would regress silently if any function/method table fell back to bare-source-name keys:

- **Different signatures, same name** in sibling modules → per-module signature resolution
- **Same-name comptime generics**, same `T` → independent specializations (key aliasing would silently run the wrong body)
- **Same-named structs with same-named methods** → per-module method resolution

Also fixes CLAUDE.md's stale transitional claim that "top-level names still collide program-wide."

All three cases verified passing; full suite green (Pass 34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
