### PR TITLE
RUE-476: specify lexical structure declaratively, not as a lexer stage

### DIFF
--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -8,7 +8,7 @@ template = "spec/page.html"
 
 {{ rule(id="2.1:1", cat="normative") }}
 
-Tokens are the atomic units of syntax in a Rue program. The lexer processes source text and produces a sequence of tokens.
+Tokens are the atomic units of syntax in a Rue program. The text of a source file is decomposed into a sequence of tokens (2.0:1).
 
 ## Token Categories
 

--- a/docs/spec/src/02-lexical-structure/_index.md
+++ b/docs/spec/src/02-lexical-structure/_index.md
@@ -12,17 +12,27 @@ This chapter describes the lexical structure of Rue programs, including tokens, 
 
 {{ rule(id="2.0:1") }}
 
-The lexer processes source text and produces a sequence of tokens. Comments and whitespace are handled but do not produce tokens.
+The text of a source file is decomposed into a sequence of tokens. Comments and whitespace may separate tokens but are not themselves tokens.
+
+{{ rule(id="2.0:9", cat="informative") }}
+
+This chapter specifies the *decomposition*, not a compiler component: the rules
+define which programs are well-formed and what sequence of tokens the later
+chapters' grammar consumes, and an implementation may perform tokenization in
+any manner — or not as a distinct stage at all — provided every program is
+accepted, rejected, and interpreted exactly as these rules require. (This
+follows the framing used by the C, Go, Java, and Rust specifications, which
+define lexical structure declaratively rather than as behavior of a "lexer".)
 
 ## Maximal Munch
 
 {{ rule(id="2.0:2", cat="normative") }}
 
-The lexer uses the *maximal munch* (or *longest match*) principle: at each position in the source text, the lexer consumes the longest sequence of characters that forms a valid token.
+Tokenization follows the *maximal munch* (or *longest match*) principle: at each position in the source text, the next token is the longest sequence of characters that forms a valid token.
 
 {{ rule(id="2.0:3", cat="informative") }}
 
-This principle resolves ambiguity when multiple token patterns could match at a position. For example, `<=` is lexed as a single `<=` token rather than `<` followed by `=`, and `&&` is lexed as a single logical AND token rather than two `&` tokens.
+This principle resolves ambiguity when multiple token patterns could match at a position. For example, `<=` forms a single `<=` token rather than `<` followed by `=`, and `&&` forms a single logical AND token rather than two `&` tokens.
 
 {{ rule(id="2.0:4", cat="example") }}
 
@@ -38,19 +48,19 @@ fn main() -> i32 {
 
 {{ rule(id="2.0:5", cat="normative") }}
 
-Source text is encoded in UTF-8. The compiler reads each source file as a
-sequence of Unicode scalar values decoded from its UTF-8 bytes. A file whose
-bytes are not valid UTF-8 is rejected before lexing begins.
+Source text is encoded in UTF-8. Each source file is read as a sequence of
+Unicode scalar values decoded from its UTF-8 bytes. A file whose bytes are not
+valid UTF-8 is rejected; no tokens are produced from it.
 
 {{ rule(id="2.0:6", cat="legality-rule") }}
 
 A Unicode scalar value outside the ASCII range (`U+0080` and above) **MAY**
 appear only within a comment or a string literal. Everywhere else — in
-identifiers, keywords, numeric literals, operators, and delimiters — the lexer
-recognizes only ASCII characters, and a non-ASCII character encountered in such
-a position is a lexical error (E0001). Identifiers are therefore limited to
-ASCII letters, digits, and underscores (2.1), while the *contents* of a comment
-or string literal may be any UTF-8 text.
+identifiers, keywords, numeric literals, operators, and delimiters — only ASCII
+characters may appear, and a non-ASCII character encountered in such a position
+is a lexical error (E0001). Identifiers are therefore limited to ASCII letters,
+digits, and underscores (2.1), while the *contents* of a comment or string
+literal may be any UTF-8 text.
 
 {{ rule(id="2.0:7", cat="example") }}
 
@@ -65,7 +75,7 @@ fn main() -> i32 {
 {{ rule(id="2.0:8", cat="normative") }}
 
 A single byte-order mark (`U+FEFF`) at the very start of a source file is
-ignored: it is skipped before lexing and does not produce a token. This
-accommodates editors that prepend a UTF-8 BOM. A `U+FEFF` in any other position
-is not whitespace (2.3:1) and is a lexical error (E0001), like any other
-character that cannot begin a token.
+ignored: it does not produce a token and does not participate in tokenization.
+This accommodates editors that prepend a UTF-8 BOM. A `U+FEFF` in any other
+position is not whitespace (2.3:1) and is a lexical error (E0001), like any
+other character that cannot begin a token.

--- a/docs/spec/src/appendices/C-implementation-limits.md
+++ b/docs/spec/src/appendices/C-implementation-limits.md
@@ -18,7 +18,7 @@ Programs that exceed these limits are not guaranteed to compile or execute corre
 
 {{ rule(id="C.2:1", cat="normative") }}
 
-Integer literals **MUST** be representable as unsigned 64-bit integers during lexing. This limits literal values to the range `0` to `18446744073709551615` (2^64 - 1).
+Integer literals **MUST** be representable as unsigned 64-bit integers when tokenized. This limits literal values to the range `0` to `18446744073709551615` (2^64 - 1).
 
 {{ rule(id="C.2:2", cat="normative") }}
 


### PR DESCRIPTION
Fixes RUE-476

Steve delegated the research + call. Survey of how the major specifications treat lexical structure:

| Spec | Framing |
|---|---|
| C (ISO 9899 §6.4 + §5.1.1.2) | "the source file is decomposed into preprocessing tokens"; internal structure non-normative via the as-if rule |
| Go | "the next token is the longest sequence of characters that form a valid token" — process-passive |
| Java (JLS ch. 3) | the character stream "is translated into a sequence of tokens... the longest possible translation is used" |
| ECMA-262 | "the source text is scanned from left to right, repeatedly taking the longest possible sequence of code points" |
| Rust FLS | "the text of a source file is a sequence of lexical elements" — purely declarative |

**Conclusion**: specifying lexical structure is universally appropriate — the chapter stays. What no spec does is mandate a "lexer" as a component, which is exactly the smell the issue flagged. Chapter 2 is reworded to the consensus declarative shape ("the text of a source file is decomposed into a sequence of tokens"; maximal munch as a property of the decomposition), and a new informative paragraph (2.0:9) states the as-if framing explicitly: these rules constrain which programs are accepted and what token sequence the grammar consumes — an implementation need not have a lexing stage at all.

No rule IDs, categories, or semantics changed; the only new paragraph is informative (no traceability burden). Full suite green (Pass 34, traceability 100%).

Sources: [Go spec](https://go.dev/ref/spec), [FLS Lexical Elements](https://spec.ferrocene.dev/lexical-elements.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
