### PR TITLE
RUE-624: make colliding type symbols path-stable

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -41,6 +41,7 @@ use std::sync::{PoisonError, RwLock};
 use lasso::Spur;
 use rue_span::FileId;
 
+use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::types::{
     ArrayTypeId, EnumDef, EnumId, PtrConstTypeId, PtrMutTypeId, StructDef, StructId, Type, TypeKind,
 };
@@ -287,6 +288,9 @@ struct TypeInternPoolInner {
 
     /// Nominal enum lookup: (defining file, source name) -> InternedType.
     enum_by_file_name: HashMap<(FileId, Spur), InternedType>,
+
+    /// Relocation-stable logical identity for each defining source file.
+    symbol_paths: HashMap<FileId, String>,
 }
 
 impl TypeInternPool {
@@ -302,8 +306,38 @@ impl TypeInternPool {
                 struct_by_file_name: HashMap::new(),
                 enum_by_name: HashMap::new(),
                 enum_by_file_name: HashMap::new(),
+                symbol_paths: HashMap::new(),
             }),
         }
+    }
+
+    /// Set relocation-stable source identities for type-derived symbols.
+    pub(crate) fn set_symbol_paths(&self, symbol_paths: HashMap<FileId, String>) {
+        self.inner
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .symbol_paths = symbol_paths;
+    }
+
+    fn file_symbol_component(inner: &TypeInternPoolInner, file_id: FileId) -> String {
+        inner
+            .symbol_paths
+            .get(&file_id)
+            .map(|path| mangle_symbol_component(&normalize_module_path(path)))
+            // Preserve the context-free pool's historical fallback. Compiler
+            // entry points install logical identities before analysis.
+            .unwrap_or_else(|| file_id.index().to_string())
+    }
+
+    fn nominal_name_collides(inner: &TypeInternPoolInner, name: Spur) -> bool {
+        inner
+            .struct_by_file_name
+            .keys()
+            .chain(inner.enum_by_file_name.keys())
+            .filter(|(_, existing_name)| *existing_name == name)
+            .take(2)
+            .count()
+            > 1
     }
 
     /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
@@ -793,14 +827,14 @@ impl TypeInternPool {
     /// methods (`P.get`), associated functions (`P::make`), destructors
     /// (`P.__drop`), and drop glue (`__rue_drop_P`) — RUE-571.
     ///
-    /// Same-named structs across files are legal (RUE-558), but these symbols
-    /// are program-wide identities: when this struct's source name is
-    /// registered by more than one file, the name is qualified with the
-    /// defining file (`P$2`). `$` cannot appear in a source identifier, so a
-    /// qualified name can never collide with a real type; unambiguous names
-    /// (the common case) are returned bare, keeping symbols and `--emit`
-    /// output unchanged. Builtins are never qualified (their symbols pair
-    /// with runtime-provided definitions).
+    /// Same-named nominal types across files are legal (RUE-558), but these
+    /// symbols are program-wide identities: when this struct's source name is
+    /// registered by more than one struct or enum, the name is qualified with
+    /// the defining file (`P$left_2fmodel_2erue`). `$` cannot appear in a source
+    /// identifier, so a qualified name can never collide with a real type;
+    /// unambiguous names (the common case) are returned bare, keeping symbols
+    /// and `--emit` output unchanged. Builtins are never qualified (their
+    /// symbols pair with runtime-provided definitions).
     ///
     /// Every layer that names a function after a type — sema (definition and
     /// call sites), the drop-glue generator in `rue-compiler`, and both
@@ -816,22 +850,18 @@ impl TypeInternPool {
                 pool_index, other
             ),
         };
-        if !data.def.is_builtin {
-            let defining_files = inner
-                .struct_by_file_name
-                .keys()
-                .filter(|(_, n)| *n == data.name)
-                .take(2)
-                .count();
-            if defining_files > 1 {
-                return format!("{}${}", data.def.name, data.def.file_id.0);
-            }
+        if !data.def.is_builtin && Self::nominal_name_collides(&inner, data.name) {
+            return format!(
+                "{}${}",
+                data.def.name,
+                Self::file_symbol_component(&inner, data.def.file_id)
+            );
         }
         data.def.name.clone()
     }
 
     /// The symbol-name component for an enum's drop glue (`__rue_drop_E`),
-    /// file-qualified when the enum name is registered by more than one file.
+    /// file-qualified when another struct or enum has the same source name.
     /// See [`Self::struct_symbol_name`] (RUE-571) — same rule, same reason.
     pub fn enum_symbol_name(&self, enum_id: EnumId) -> String {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
@@ -843,14 +873,12 @@ impl TypeInternPool {
                 pool_index, other
             ),
         };
-        let defining_files = inner
-            .enum_by_file_name
-            .keys()
-            .filter(|(_, n)| *n == data.name)
-            .take(2)
-            .count();
-        if defining_files > 1 {
-            return format!("{}${}", data.def.name, data.def.file_id.0);
+        if Self::nominal_name_collides(&inner, data.name) {
+            return format!(
+                "{}${}",
+                data.def.name,
+                Self::file_symbol_component(&inner, data.def.file_id)
+            );
         }
         data.def.name.clone()
     }
@@ -1278,6 +1306,7 @@ impl Clone for TypeInternPool {
                 struct_by_file_name: inner.struct_by_file_name.clone(),
                 enum_by_name: inner.enum_by_name.clone(),
                 enum_by_file_name: inner.enum_by_file_name.clone(),
+                symbol_paths: inner.symbol_paths.clone(),
             }),
         }
     }
@@ -2002,6 +2031,61 @@ mod tests {
         // colliding user struct still is, so the pair stays distinct.
         assert_eq!(pool.struct_symbol_name(b1), "StrBufTest");
         assert_eq!(pool.struct_symbol_name(b2), "StrBufTest$3");
+    }
+
+    #[test]
+    fn type_symbol_names_use_stable_paths_and_survive_pool_clone() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let left_id = FileId::new(42);
+        let right_id = FileId::new(7);
+        pool.set_symbol_paths(HashMap::from([
+            (left_id, "left/shared.rue".to_string()),
+            (right_id, "right/shared.rue".to_string()),
+        ]));
+
+        let payload = interner.get_or_intern("Payload");
+        let struct_def = |file_id| StructDef {
+            name: "Payload".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+            is_pub: true,
+            file_id,
+        };
+        let (left_struct, _) = pool.register_struct(payload, struct_def(left_id));
+        let (right_struct, _) = pool.register_struct(payload, struct_def(right_id));
+
+        let choice = interner.get_or_intern("Choice");
+        let enum_def = |file_id| EnumDef {
+            name: "Choice".to_string(),
+            variants: vec!["Value".to_string()],
+            variant_payloads: vec![vec![]],
+            is_pub: true,
+            file_id,
+        };
+        let (left_enum, _) = pool.register_enum(choice, enum_def(left_id));
+        let (right_enum, _) = pool.register_enum(choice, enum_def(right_id));
+
+        let cloned = pool.clone();
+        assert_eq!(
+            cloned.struct_symbol_name(left_struct),
+            "Payload$left_2fshared_2erue"
+        );
+        assert_eq!(
+            cloned.struct_symbol_name(right_struct),
+            "Payload$right_2fshared_2erue"
+        );
+        assert_eq!(
+            cloned.enum_symbol_name(left_enum),
+            "Choice$left_2fshared_2erue"
+        );
+        assert_eq!(
+            cloned.enum_symbol_name(right_enum),
+            "Choice$right_2fshared_2erue"
+        );
     }
 
     #[test]

--- a/crates/rue-air/src/path_norm.rs
+++ b/crates/rue-air/src/path_norm.rs
@@ -51,9 +51,27 @@ pub(crate) fn normalize_module_path(path: &str) -> String {
     buf.to_string_lossy().into_owned()
 }
 
+/// Encode an arbitrary path as one injective machine-symbol component.
+///
+/// Rue identifiers contain only ASCII alphanumerics and `_`; encoding every
+/// other byte (including `_` itself) as `_xx` keeps the result unambiguous.
+pub(crate) fn mangle_symbol_component(component: &str) -> String {
+    let mut mangled = String::new();
+    for byte in component.bytes() {
+        match byte {
+            b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z' => mangled.push(byte as char),
+            _ => {
+                use std::fmt::Write as _;
+                write!(&mut mangled, "_{byte:02x}").expect("writing to String cannot fail");
+            }
+        }
+    }
+    mangled
+}
+
 #[cfg(test)]
 mod tests {
-    use super::normalize_module_path as n;
+    use super::{mangle_symbol_component as m, normalize_module_path as n};
 
     #[test]
     fn drops_cur_dir() {
@@ -82,5 +100,12 @@ mod tests {
         // The two spellings of the same physical file must normalize equal.
         assert_eq!(n("a/../std/opt.rue"), n("std/opt.rue"));
         assert_eq!(n("./std/opt.rue"), n("std/opt.rue"));
+    }
+
+    #[test]
+    fn symbol_component_mangling_is_injective_for_escaped_bytes() {
+        assert_eq!(m("left/shared.rue"), "left_2fshared_2erue");
+        assert_eq!(m("a_b"), "a_5fb");
+        assert_ne!(m("a/b"), m("a_2fb"));
     }
 }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -19,7 +19,7 @@ use rue_span::{FileId, Span};
 
 use super::{ConstInfo, ConstValue, FunctionInfo, InferenceContext, MethodInfo, Sema};
 use crate::inference::{FunctionSig, MethodSig};
-use crate::path_norm::normalize_module_path;
+use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::types::{EnumDef, EnumId, StructDef, StructField, StructId, Type, TypeKind};
 
 /// A node in the "contains by value" type graph, used by
@@ -2891,20 +2891,6 @@ impl<'a> Sema<'a> {
             span,
         ))
     }
-}
-
-fn mangle_symbol_component(component: &str) -> String {
-    let mut mangled = String::new();
-    for byte in component.bytes() {
-        match byte {
-            b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z' => mangled.push(byte as char),
-            _ => {
-                use std::fmt::Write as _;
-                write!(&mut mangled, "_{byte:02x}").expect("writing to String cannot fail");
-            }
-        }
-    }
-    mangled
 }
 
 /// A constant declaration captured by the pre-scan, waiting to be collected.

--- a/crates/rue-air/src/sema/file_paths.rs
+++ b/crates/rue-air/src/sema/file_paths.rs
@@ -17,6 +17,7 @@ impl<'a> Sema<'a> {
     /// enabling relative import resolution during @import.
     pub fn set_file_paths(&mut self, file_paths: HashMap<FileId, String>) {
         self.file_paths = file_paths;
+        self.refresh_type_symbol_paths();
     }
 
     /// Set stable source identities used when generated symbols need a module
@@ -24,6 +25,13 @@ impl<'a> Sema<'a> {
     /// relocating a source tree cannot change machine-level names.
     pub fn set_symbol_paths(&mut self, symbol_paths: HashMap<FileId, String>) {
         self.symbol_paths = symbol_paths;
+        self.refresh_type_symbol_paths();
+    }
+
+    fn refresh_type_symbol_paths(&self) {
+        let mut effective_paths = self.file_paths.clone();
+        effective_paths.extend(self.symbol_paths.clone());
+        self.type_pool.set_symbol_paths(effective_paths);
     }
 
     /// Get the source file path for a span.

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2762,6 +2762,166 @@ mod tests {
     }
 
     #[test]
+    fn test_colliding_type_symbols_use_stable_paths_not_file_ids() {
+        fn colliding_type_names(
+            physical_root: &str,
+            left_id: FileId,
+            right_id: FileId,
+            reverse_siblings: bool,
+        ) -> std::collections::BTreeSet<String> {
+            let main_path = format!("{physical_root}/main.rue");
+            let left_path = format!("{physical_root}/left/shared.rue");
+            let right_path = format!("{physical_root}/right/shared.rue");
+            let mut sources = vec![
+                SourceFile::new(
+                    &main_path,
+                    r#"fn main() -> i32 {
+                        let left = @import("left/shared.rue");
+                        let right = @import("right/shared.rue");
+                        left.entry() + right.entry()
+                    }"#,
+                    FileId::new(1),
+                ),
+                SourceFile::new(
+                    &left_path,
+                    r#"pub struct Payload {
+                        value: i32,
+                        text: String,
+                        fn score(borrow self) -> i32 { self.value }
+                    }
+                    drop fn Payload(self) { @dbg(self.value); }
+                    pub enum Choice { Empty, Text(String) }
+                    pub fn entry() -> i32 {
+                        let payload = Payload { value: 10, text: "left" };
+                        payload.score()
+                    }"#,
+                    left_id,
+                ),
+                SourceFile::new(
+                    &right_path,
+                    r#"pub struct Payload {
+                        value: i32,
+                        text: String,
+                        fn score(borrow self) -> i32 { self.value }
+                    }
+                    drop fn Payload(self) { @dbg(self.value); }
+                    pub enum Choice { Empty, Text(String) }
+                    pub fn entry() -> i32 {
+                        let payload = Payload { value: 20, text: "right" };
+                        payload.score()
+                    }"#,
+                    right_id,
+                ),
+            ];
+            if reverse_siblings {
+                sources.swap(1, 2);
+            }
+
+            let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+            unit.set_symbol_paths(std::collections::HashMap::from([
+                (FileId::new(1), "main.rue".to_string()),
+                (left_id, "left/shared.rue".to_string()),
+                (right_id, "right/shared.rue".to_string()),
+            ]));
+            unit.run_frontend().expect("frontend should compile");
+
+            let pool = unit.type_pool();
+            let mut names = std::collections::BTreeSet::new();
+            for id in pool.all_struct_ids() {
+                if pool.struct_def(id).name == "Payload" {
+                    names.insert(format!("struct:{}", pool.struct_symbol_name(id)));
+                }
+            }
+            for id in pool.all_enum_ids() {
+                if pool.enum_def(id).name == "Choice" {
+                    names.insert(format!("enum:{}", pool.enum_symbol_name(id)));
+                }
+            }
+            for function in unit.functions() {
+                let name = &function.analyzed.name;
+                if name.contains("Payload$") || name.contains("Choice$") {
+                    names.insert(format!("fn:{name}"));
+                }
+            }
+            names
+        }
+
+        let expected: std::collections::BTreeSet<_> = [
+            "struct:Payload$left_2fshared_2erue",
+            "struct:Payload$right_2fshared_2erue",
+            "enum:Choice$left_2fshared_2erue",
+            "enum:Choice$right_2fshared_2erue",
+            "fn:Payload$left_2fshared_2erue.score",
+            "fn:Payload$right_2fshared_2erue.score",
+            "fn:Payload$left_2fshared_2erue.__drop",
+            "fn:Payload$right_2fshared_2erue.__drop",
+            "fn:__rue_drop_Payload$left_2fshared_2erue",
+            "fn:__rue_drop_Payload$right_2fshared_2erue",
+            "fn:__rue_drop_Choice$left_2fshared_2erue",
+            "fn:__rue_drop_Choice$right_2fshared_2erue",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+        assert_eq!(
+            colliding_type_names("/tmp/rue-short-root", FileId::new(2), FileId::new(3), false,),
+            expected
+        );
+        assert_eq!(
+            colliding_type_names(
+                "/tmp/a-deliberately-much-longer-relocated-rue-root",
+                FileId::new(42),
+                FileId::new(7),
+                true,
+            ),
+            expected,
+            "type-derived symbols should ignore physical roots, FileIds, and source-vector order"
+        );
+    }
+
+    #[test]
+    fn test_cross_kind_type_collision_qualifies_drop_glue() {
+        let main_id = FileId::new(1);
+        let struct_id = FileId::new(2);
+        let enum_id = FileId::new(3);
+        let sources = vec![
+            SourceFile::new("main.rue", "fn main() -> i32 { 0 }", main_id),
+            SourceFile::new(
+                "left/clash.rue",
+                "pub struct Clash { text: String }",
+                struct_id,
+            ),
+            SourceFile::new(
+                "right/clash.rue",
+                "pub enum Clash { Text(String) }",
+                enum_id,
+            ),
+        ];
+
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        unit.set_symbol_paths(std::collections::HashMap::from([
+            (main_id, "main.rue".to_string()),
+            (struct_id, "left/clash.rue".to_string()),
+            (enum_id, "right/clash.rue".to_string()),
+        ]));
+        unit.run_frontend().expect("frontend should compile");
+
+        let drop_glue_names: std::collections::BTreeSet<_> = unit
+            .functions()
+            .iter()
+            .map(|function| function.analyzed.name.as_str())
+            .filter(|name| name.starts_with("__rue_drop_Clash"))
+            .collect();
+        assert_eq!(
+            drop_glue_names,
+            std::collections::BTreeSet::from([
+                "__rue_drop_Clash$left_2fclash_2erue",
+                "__rue_drop_Clash$right_2fclash_2erue",
+            ])
+        );
+    }
+
+    #[test]
     fn test_imported_private_helper_called_by_public_api_is_not_unused() {
         let sources = vec![
             SourceFile::new(


### PR DESCRIPTION
## Summary

- replace `FileId` qualifiers with stable logical source paths for colliding type-derived machine symbols
- use one collision namespace across structs and enums so cross-kind drop glue stays distinct
- preserve the context-free numeric fallback and keep path state correct across cloning and setter order
- add relocation, file-ID permutation, source-order, and cross-kind collision regressions

This is the first independently integratable RUE-624 slice. A follow-up will canonicalize semantic allocation and final artifact layout across sibling source order, then add the full black-box reproducibility gate.

Linear: https://linear.app/rue-language/issue/RUE-624

## Validation

- `./fmt.sh check`
- `./clippy.sh`
- `./buck2 test //...` (34 targets, 0 failures)