### PR TITLE
RUE-626: derive oracle call layout from static contracts

### DIFF
--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -158,12 +158,6 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
-        "cli.const_array_length_in_aggregate",
-        "const_struct_field_2d_with_methods",
-        semantic(SemanticGapKind::FlattenedParameterSlot),
-        &[],
-    ),
-    Entry::new(
         "cli.differential_opt",
         "raw_pointer_place_operands_across_opt_levels",
         intrinsic(UnsupportedIntrinsicKind::RawAddress),
@@ -215,18 +209,6 @@ const ENTRIES: &[Entry] = &[
         "cli.method_receiver_byref_places",
         "inout_self_through_inout_param",
         semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "cli.method_receivers",
-        "arg_reads_receiver",
-        semantic(SemanticGapKind::FlattenedParameterSlot),
-        &[],
-    ),
-    Entry::new(
-        "cli.method_receivers",
-        "stack_push_top_count",
-        semantic(SemanticGapKind::FlattenedParameterSlot),
         &[],
     ),
     Entry::new(

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -247,38 +247,14 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "items.functions",
-        "borrow_with_regular_param",
-        semantic(SemanticGapKind::FlattenedParameterSlot),
-        &[],
-    ),
-    Entry::new(
-        "items.functions",
         "inout_array_forward",
         semantic(SemanticGapKind::InoutParameterForwarding),
         &[],
     ),
     Entry::new(
         "items.functions",
-        "inout_array_with_index_variable",
-        semantic(SemanticGapKind::FlattenedParameterSlot),
-        &[],
-    ),
-    Entry::new(
-        "items.functions",
         "inout_forward_struct",
         semantic(SemanticGapKind::InoutParameterForwarding),
-        &[],
-    ),
-    Entry::new(
-        "items.impl-blocks",
-        "arg_reads_receiver_allowed",
-        semantic(SemanticGapKind::FlattenedParameterSlot),
-        &[],
-    ),
-    Entry::new(
-        "items.impl-blocks",
-        "inout_self_with_arg_and_field_writes",
-        semantic(SemanticGapKind::FlattenedParameterSlot),
         &[],
     ),
     Entry::new(

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -257,6 +257,7 @@ pub enum ContractViolationKind {
     IntrinsicArity,
     IntrinsicSignature,
     StringConstantIndex,
+    CallParameterLayout,
     ParameterSlotOutOfBounds,
     UnboundBlockParameter,
     EnumPayloadProjection,
@@ -709,27 +710,14 @@ struct Interp<'a> {
 /// values from executed dominators retain their original evaluation snapshot.
 struct Frame {
     /// Parameters laid out by ABI **slot**, not by logical argument: an
-    /// aggregate argument spans one slot per flattened scalar leaf (a `[i32; 3]`
-    /// occupies three slots), so a later parameter's `Param{index}` is offset by
-    /// the widths of the aggregates before it. The whole aggregate value is kept
-    /// at its base slot; the slots it "occupies" after that are `None` (they are
-    /// only ever reached through the base via a projection, never directly).
+    /// by-value aggregate spans one slot per flattened scalar leaf (a
+    /// `[i32; 3]` occupies three slots), while a physical `borrow` / `inout`
+    /// occupies one pointer slot. The whole semantic value is kept at its base
+    /// slot; extra by-value slots are `None` (they are only reached through the
+    /// base via a projection, never directly).
     params: Vec<Option<Value>>,
     locals: Vec<Option<Value>>,
     cache: HashMap<u32, Value>,
-}
-
-/// Number of ABI parameter slots a value occupies: one per flattened scalar
-/// leaf. Matches the CFG's slot numbering for `Param{index}`, including
-/// zero-sized values: `abi_slot_count` (rue-air typeck) gives unit and empty
-/// structs ZERO slots, so a parameter after a ZST is NOT shifted up.
-fn slot_width(v: &Value) -> usize {
-    match v {
-        Value::Aggregate(elems) => elems.iter().map(slot_width).sum(),
-        Value::Str { slots, .. } => *slots,
-        Value::Unit => 0,
-        _ => 1,
-    }
 }
 
 impl<'a> Interp<'a> {
@@ -1462,10 +1450,97 @@ impl<'a> Interp<'a> {
             .find(|c| c.fn_name() == name)
     }
 
+    /// Number of physical parameter slots occupied by one CFG call argument.
+    ///
+    /// `CfgArgMode` is already the physical mode: sema rewrites by-value slice
+    /// views to `Normal`, while real `borrow` / `inout` arguments carry one
+    /// pointer regardless of the pointee's logical width.
+    fn call_arg_slot_width(&self, ty: Type, mode: CfgArgMode) -> usize {
+        match mode {
+            CfgArgMode::Normal => self.state.type_pool.abi_slot_count(ty) as usize,
+            CfgArgMode::Inout | CfgArgMode::Borrow => 1,
+        }
+    }
+
+    /// Validate the caller's complete physical argument layout against the
+    /// callee before any operand runs.
+    ///
+    /// Slot totals alone are insufficient: all three modes occupy one slot
+    /// for scalar arguments, but disagree about whether that slot contains a
+    /// value, a shared pointer, or a writable pointer. `Normal` deliberately
+    /// ignores the writable bit because sema lowers first-class `borrow` /
+    /// `inout` slice views to by-value fat pointers while retaining their
+    /// source-level writability metadata on the callee slots.
+    fn preflight_call_layout(
+        &self,
+        cfg: &Cfg,
+        name: &str,
+        args: impl IntoIterator<Item = (Type, CfgArgMode)>,
+    ) -> Step<()> {
+        let mut base = 0usize;
+        let num_params = cfg.num_params() as usize;
+
+        for (index, (ty, mode)) in args.into_iter().enumerate() {
+            let width = self.call_arg_slot_width(ty, mode);
+            let Some(end) = base.checked_add(width) else {
+                return Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::CallParameterLayout),
+                    format!("call to '{name}' argument {index} overflows the parameter layout"),
+                ));
+            };
+            if end > num_params {
+                return Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::CallParameterLayout),
+                    format!(
+                        "call to '{name}' argument {index} occupies parameter slots {base}..{end}, but the callee declares {num_params}"
+                    ),
+                ));
+            }
+
+            let mode_matches = match mode {
+                CfgArgMode::Normal => (base..end).all(|slot| {
+                    !cfg.is_param_inout(u32::try_from(slot).expect("slot is within u32 CFG bounds"))
+                }),
+                CfgArgMode::Borrow => {
+                    let slot = u32::try_from(base).expect("slot is within u32 CFG bounds");
+                    cfg.is_param_inout(slot) && !cfg.is_param_writable(slot)
+                }
+                CfgArgMode::Inout => {
+                    let slot = u32::try_from(base).expect("slot is within u32 CFG bounds");
+                    cfg.is_param_inout(slot) && cfg.is_param_writable(slot)
+                }
+            };
+            if !mode_matches {
+                return Err(unsupported(
+                    UnsupportedKind::ContractViolation(ContractViolationKind::CallParameterLayout),
+                    format!(
+                        "call to '{name}' argument {index} has physical mode {mode:?}, which contradicts callee parameter slot {base}"
+                    ),
+                ));
+            }
+
+            base = end;
+        }
+
+        if base != num_params {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::CallParameterLayout),
+                format!(
+                    "call to '{name}' occupies {base} parameter slots, but the callee declares {num_params}"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
     /// Returns the call's value **and** its final parameter slots, so the caller
     /// can copy out `inout` parameters (Rue `inout` is copy-in / copy-out, which
     /// is observably identical to by-reference under the law of exclusivity).
-    fn call(&mut self, name: &str, args: &[Value]) -> Step<(Value, Vec<Option<Value>>)> {
+    fn call(
+        &mut self,
+        name: &str,
+        args: &[(Value, Type, CfgArgMode)],
+    ) -> Step<(Value, Vec<Option<Value>>)> {
         // Bound recursion *depth* (shared across activations) before descending,
         // so unbounded Rue recursion resolves to a typed resource failure
         // instead of overflowing the Rust stack and aborting the process
@@ -1482,29 +1557,41 @@ impl<'a> Interp<'a> {
         result
     }
 
-    fn call_inner(&mut self, name: &str, args: &[Value]) -> Step<(Value, Vec<Option<Value>>)> {
+    fn call_inner(
+        &mut self,
+        name: &str,
+        args: &[(Value, Type, CfgArgMode)],
+    ) -> Step<(Value, Vec<Option<Value>>)> {
         let cfg = self.find_cfg(name).ok_or_else(|| {
             unsupported(
                 UnsupportedKind::ContractViolation(ContractViolationKind::MissingFunctionBody),
                 format!("call to '{name}'"),
             )
         })?;
-        // Lay arguments out by slot: place each whole value at its base slot,
-        // then pad with `None` for the extra slots an aggregate occupies. A
-        // zero-sized argument occupies no slot at all (matching
-        // `abi_slot_count`), so it is never materialized in `params` and the
-        // following arguments are not shifted.
+        self.preflight_call_layout(cfg, name, args.iter().map(|(_, ty, mode)| (*ty, *mode)))?;
+        // Lay arguments out by physical slot: place each whole semantic value
+        // at its base slot, then pad with `None` for extra by-value aggregate
+        // slots. A zero-sized `Normal` argument occupies no slot; a physical
+        // borrow/inout still occupies its one pointer slot.
         let mut param_slots: Vec<Option<Value>> = Vec::with_capacity(args.len());
-        for a in args {
-            let w = slot_width(a);
+        for (value, ty, mode) in args {
+            // Parameter indices are a property of the static ABI contract,
+            // never the active runtime value shape. A by-value enum reserves
+            // its widest payload even when its current variant is a bare
+            // discriminant; a physical borrow/inout is one pointer slot even
+            // when its pointee is an aggregate. Slice views reach CFG as
+            // `Normal`, because sema already materialized their by-value fat
+            // pointer.
+            let w = self.call_arg_slot_width(*ty, *mode);
             if w == 0 {
                 continue;
             }
-            param_slots.push(Some(a.clone()));
+            param_slots.push(Some(value.clone()));
             for _ in 1..w {
                 param_slots.push(None);
             }
         }
+        debug_assert_eq!(param_slots.len(), cfg.num_params() as usize);
         let mut frame = Frame {
             params: param_slots,
             locals: vec![None; cfg.num_locals() as usize],
@@ -1919,7 +2006,7 @@ impl<'a> Interp<'a> {
                     return Ok(());
                 }
                 if let Some(dtor) = sd.destructor.clone() {
-                    self.call(&dtor, &[v.clone()])?;
+                    self.call(&dtor, &[(v.clone(), ty, CfgArgMode::Normal)])?;
                 }
                 // A builtin type's destructor is its entire drop glue; a
                 // user struct then drops its fields in declaration order.
@@ -1965,9 +2052,9 @@ impl<'a> Interp<'a> {
         Ok(())
     }
 
-    /// Whether `ty` occupies ZERO ABI parameter slots — the type-level twin of
-    /// [`slot_width`] and of the compiler's `abi_slot_count == 0` (rue-air
-    /// typeck): unit/never/comptime types, structs whose fields are all
+    /// Whether `ty` occupies ZERO by-value ABI parameter slots, matching the
+    /// compiler's `abi_slot_count == 0` (rue-air typeck):
+    /// unit/never/comptime types, structs whose fields are all
     /// zero-sized, and arrays that are empty or have zero-sized elements.
     /// Enums are never zero-sized (they always carry a discriminant slot).
     fn is_zero_sized(&self, ty: Type) -> bool {
@@ -2292,19 +2379,32 @@ impl<'a> Interp<'a> {
                 } else {
                     None
                 };
+                if !is_string_builtin && missing_call_kind.is_none() {
+                    let callee = self
+                        .find_cfg(&fname)
+                        .expect("a present user call has a CFG body");
+                    self.preflight_call_layout(
+                        callee,
+                        &fname,
+                        arg_types.iter().copied().zip(arg_modes.iter().copied()),
+                    )?;
+                }
                 // Copy-in every argument (by value); for `inout` args, remember
                 // the base parameter slot and the caller place to copy back into.
                 let mut argvals = Vec::with_capacity(call_args.len());
                 let mut writebacks: Vec<(usize, Place)> = Vec::new();
                 let mut base = 0usize;
-                for a in &call_args {
+                for (index, a) in call_args.iter().enumerate() {
                     let v = self.eval(cfg, frame, a.value)?;
-                    // A zero-sized argument occupies no parameter slot (see
-                    // `slot_width`): it neither advances `base` nor gets an
-                    // inout write-back (the callee's params hold no slot for
-                    // it to copy back from).
-                    let w = slot_width(&v);
-                    if matches!(a.mode, CfgArgMode::Inout) && w > 0 {
+                    // Derive both callee packing and copy-back bases from the
+                    // same static type + physical passing-mode contract.
+                    let w = self.call_arg_slot_width(arg_types[index], a.mode);
+                    // A physical inout ZST still advances the ABI base by its
+                    // pointer slot, but copying its unique value back has no
+                    // semantic effect and could overwrite a later local that
+                    // shares the ZST's zero-width boundary slot.
+                    if matches!(a.mode, CfgArgMode::Inout) && !self.is_zero_sized(arg_types[index])
+                    {
                         writebacks.push((base, self.lvalue_of(cfg, a.value)?));
                     }
                     argvals.push(v);
@@ -2322,7 +2422,13 @@ impl<'a> Interp<'a> {
                         format!("call to '{fname}'"),
                     ));
                 } else {
-                    let (result, final_params) = self.call(&fname, &argvals)?;
+                    let typed_args: Vec<(Value, Type, CfgArgMode)> = argvals
+                        .into_iter()
+                        .zip(arg_types)
+                        .zip(arg_modes)
+                        .map(|((value, ty), mode)| (value, ty, mode))
+                        .collect();
+                    let (result, final_params) = self.call(&fname, &typed_args)?;
                     // Copy-out: write each inout parameter's final value back into
                     // the caller place it came from.
                     for (slot, place) in writebacks {

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -1092,3 +1092,75 @@ fn zst_param_forwarded_through_two_calls() {
     fn main() -> i32 { let e = E {}; wrap(e, 41) }";
     assert_eq!(exit(src), 42);
 }
+
+#[test]
+fn enum_parameter_width_comes_from_its_static_type() {
+    let src = r#"enum Shape { Empty, One(i32), Pair(i32, i32) }
+        fn marker(shape: Shape, n: i32) -> i32 { n }
+        fn main() -> i32 {
+            marker(Shape.Empty, 10)
+                + marker(Shape.One(1), 20)
+                + marker(Shape.Pair(1, 2), 12)
+        }"#;
+    assert_eq!(exit(src), 42);
+}
+
+#[test]
+fn by_ref_aggregate_width_comes_from_its_physical_mode() {
+    let src = r#"struct Pair { left: i32, right: i32 }
+        fn borrowed_marker(borrow pair: Pair, n: i32) -> i32 {
+            n + pair.left - pair.left
+        }
+        fn inout_marker(inout pair: Pair, n: i32) -> i32 {
+            pair.right = pair.right;
+            n
+        }
+        fn main() -> i32 {
+            let mut pair = Pair { left: 1, right: 2 };
+            borrowed_marker(borrow pair, 20) + inout_marker(inout pair, 22)
+        }"#;
+    assert_eq!(exit(src), 42);
+}
+
+#[test]
+fn borrowed_aggregate_before_inout_uses_the_physical_writeback_slot() {
+    let src = r#"struct Pair { left: i32, right: i32 }
+        fn set_marker(borrow pair: Pair, inout marker: i32) {
+            marker = 40 + pair.right;
+        }
+        fn main() -> i32 {
+            let pair = Pair { left: 1, right: 2 };
+            let mut marker = 0;
+            set_marker(borrow pair, inout marker);
+            marker
+        }"#;
+    assert_eq!(exit(src), 42);
+}
+
+#[test]
+fn inout_zst_uses_a_physical_slot_without_copying_back() {
+    let src = r#"struct Empty {}
+        fn reset(inout value: Empty, n: i32) -> i32 {
+            value = Empty {};
+            n
+        }
+        fn main() -> i32 {
+            let mut value = Empty {};
+            let answer = 42;
+            let observed = reset(inout value, answer);
+            if answer == 42 { observed } else { 1 }
+        }"#;
+    assert_eq!(exit(src), 42);
+}
+
+#[test]
+fn payloadless_enum_before_inout_uses_the_static_writeback_slot() {
+    let src = r#"enum Maybe { Some(i32), None }
+        fn set_marker(value: Maybe, inout marker: i32) { marker = 42; }
+        fn main() -> i32 {
+            let mut marker = 0;
+            set_marker(Maybe.None, inout marker);
+            marker
+        }"#;
+    assert_eq!(exit(src), 42);
+}

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -591,6 +591,125 @@ fn malformed_outer_calls_are_rejected_before_unmodeled_operands_run() {
 }
 
 #[test]
+fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
+    let source = r#"struct Pair { left: u32, right: u32 }
+        fn normal(value: u32) -> u32 { value }
+        fn borrowed(borrow value: u32) -> u32 { value }
+        fn writable(inout value: u32) -> u32 { value }
+        fn pair(value: Pair) -> u32 { value.left + value.right }
+        fn main() -> i32 {
+            let entropy: u32 = @random_u32();
+            let mut value: u32 = 1;
+            let values = Pair { left: 2, right: 3 };
+            @intCast(
+                normal(value)
+                    + borrowed(borrow value)
+                    + writable(inout value)
+                    + pair(values)
+                    + entropy
+            )
+        }"#;
+
+    // Every source/target mode mismatch is one slot wide for this scalar, so
+    // a total-width-only guard cannot distinguish it. The Pair probe instead
+    // replaces a valid two-slot argument with the one-slot entropy value.
+    for (callee_name, replacement_mode) in [
+        ("normal", CfgArgMode::Borrow),
+        ("normal", CfgArgMode::Inout),
+        ("borrowed", CfgArgMode::Normal),
+        ("borrowed", CfgArgMode::Inout),
+        ("writable", CfgArgMode::Normal),
+        ("writable", CfgArgMode::Borrow),
+        ("pair", CfgArgMode::Normal),
+    ] {
+        let mut state = compile_to_cfg(source).expect("call-layout probe must compile");
+        let main_index = state
+            .functions
+            .iter()
+            .position(|function| function.cfg.fn_name() == "main")
+            .expect("main CFG");
+        let (random, call) = {
+            let cfg = &state.functions[main_index].cfg;
+            let mut random = None;
+            let mut call = None;
+            for value in cfg
+                .blocks()
+                .iter()
+                .flat_map(|block| block.insts.iter().copied())
+            {
+                match &cfg.get_inst(value).data {
+                    CfgInstData::Intrinsic { name, .. }
+                        if state.interner.resolve(name) == "random_u32" =>
+                    {
+                        random = Some(value);
+                    }
+                    CfgInstData::Call { name, .. }
+                        if state.interner.resolve(name) == callee_name =>
+                    {
+                        assert!(
+                            call.replace(value).is_none(),
+                            "expected exactly one call to {callee_name}"
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            (
+                random.expect("random intrinsic"),
+                call.unwrap_or_else(|| panic!("missing call to {callee_name}")),
+            )
+        };
+
+        let cfg = &mut state.functions[main_index].cfg;
+        let (args_start, args_len) = match cfg.get_inst(call).data {
+            CfgInstData::Call {
+                args_start,
+                args_len,
+                ..
+            } => (args_start, args_len),
+            _ => unreachable!("selected a Call"),
+        };
+        let mut args = cfg.get_call_args(args_start, args_len).to_vec();
+        assert_eq!(args.len(), 1, "{callee_name} probe arity");
+        args[0].value = random;
+        args[0].mode = replacement_mode;
+        let (args_start, args_len) = cfg.push_call_args(args);
+        let CfgInstData::Call {
+            args_start: stored_start,
+            args_len: stored_len,
+            ..
+        } = &mut cfg.get_inst_mut(call).data
+        else {
+            unreachable!("selected a Call")
+        };
+        *stored_start = args_start;
+        *stored_len = args_len;
+
+        let cfg = &state.functions[main_index].cfg;
+        let mut interp = Interp {
+            state: &state,
+            stdout: String::new(),
+            stdout_bytes: 0,
+            stdout_cap: MAX_STDOUT_BYTES,
+            stderr_cap: MAX_STDERR_BYTES,
+            budget: STEP_BUDGET,
+            depth: 0,
+        };
+        let mut frame = Frame {
+            params: Vec::new(),
+            locals: vec![None; cfg.num_locals() as usize],
+            cache: HashMap::new(),
+        };
+        let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, call));
+        assert_eq!(
+            unsupported.kind(),
+            UnsupportedKind::ContractViolation(ContractViolationKind::CallParameterLayout),
+            "{callee_name} with {replacement_mode:?} must reject malformed static layout before @random_u32"
+        );
+    }
+}
+
+#[test]
 fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
     let source = r#"fn main() -> i32 {
         let entropy: u32 = @random_u32();


### PR DESCRIPTION
## Summary

- derive oracle parameter packing and inout writeback bases from static Type plus physical CfgArgMode instead of dynamic Value shape
- fail closed on exact user-call slot totals and per-base by-ref/writable metadata before evaluating operands
- preserve zero-sized physical inout slots without unsafe semantic copyback
- retire seven exact FlattenedParameterSlot registry entries that now agree

This fixes both sides of the class: payloadless enum values previously under-counted their static ABI, while borrowed/inout aggregates previously over-counted their one-pointer physical ABI.

Linear: https://linear.app/steve-klabnik/issue/RUE-626/oracle-dynamic-value-shape-mispacks-enum-call-arguments-and-inout

## Validation

- independent final review: CLEAR
- fmt: clean
- clippy: 41/41 first-party targets
- oracle: 99 passed, 1 ignored
- differential unit: 88/88
- live CLI: 639 agree, 96 modeled gaps, 559 ineligible; zero failure classes or disagreements
- live spec: 1346 agree, 98 modeled gaps, 591 ineligible; zero failure classes or disagreements
- generated differential smoke: 64/64 agree
- full test.sh: 34/34 targets
