### PR TITLE
RUE-632: resolve module constants in projection (equality-operand) positions

### DIFF
--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -402,6 +402,17 @@ impl<'a> Sema<'a> {
             let base_result = self.analyze_inst_for_projection(air, base, ctx)?;
             let base_type = base_result.ty;
 
+            // Module member access in a projection position: equality
+            // operands are read through a shared borrow (4.3:3f), so a
+            // module-qualified constant (`tag == m.CONST`) reaches this arm
+            // with a module-typed base. Resolve it as a member access —
+            // mirroring `analyze_field_get`'s fallback — instead of
+            // rejecting it as field access on a non-struct (RUE-632). A
+            // constant inlines a fresh value, so no move state applies.
+            if let Some(module_id) = base_type.as_module() {
+                return self.analyze_module_type_member_access(air, module_id, field, field_span);
+            }
+
             let struct_id = match base_type.kind() {
                 TypeKind::Struct(id) => id,
                 _ => {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -4203,7 +4203,7 @@ impl<'a> Sema<'a> {
     ///
     /// This enables the pattern of importing types through modules and using them
     /// for struct initialization or enum variant access.
-    fn analyze_module_type_member_access(
+    pub(crate) fn analyze_module_type_member_access(
         &mut self,
         air: &mut Air,
         module_id: crate::types::ModuleId,

--- a/crates/rue-cli-tests/cases/module_consts.toml
+++ b/crates/rue-cli-tests/cases/module_consts.toml
@@ -339,3 +339,32 @@ pub const ANSWER: i32 = 42;
 """ },
 ]
 stdout = "42\n"
+
+# A module-qualified const in EVERY expression position, including the
+# equality operand — which routes through sema's place-projection path
+# (equality operands are borrows, 4.3:3f) and used to fail E0423 "field
+# access on non-struct type '<module>'" because that path lacked the
+# module-member fallback the value path has (RUE-632).
+[[case]]
+name = "module_const_in_equality_operand"
+files = [
+    { path = "main.rue", source = """
+const h = @import("helper.rue");
+
+fn take(v: i64) -> i64 { v }
+
+fn main() -> i32 {
+    let a = h.MAGIC;                             // let init
+    let b = take(h.MAGIC);                       // call argument
+    let c = h.MAGIC + 1;                         // arithmetic operand
+    let d = if a == h.MAGIC { 1 } else { 0 };    // equality operand (RUE-632)
+    let e = if h.MAGIC != 8 { 1 } else { 0 };    // inequality operand
+    let f = if h.MAGIC < 8 { 1 } else { 0 };     // ordering operand
+    @intCast(a + b + c + d + e + f + 17)
+}
+""" },
+    { path = "helper.rue", source = """
+pub const MAGIC: i64 = 7;
+""" },
+]
+exit_code = 42


### PR DESCRIPTION
Fixes RUE-632

First fix out of the ambitious-programs dogfood loop. A module-qualified constant (`h.MAGIC`) worked in every expression position except an **equality operand**, where it failed E0423 "field access on non-struct type '<module>'" — equality operands are borrows (4.3:3f), so they route through sema's place-projection path, whose `FieldGet` arm had the `Enum.Variant`/`module.Enum.Variant` reroutes but not the module-member fallback the value path has.

Fix: mirror `analyze_field_get`'s fallback in `analyze_inst_for_projection` — a module-typed base resolves via `analyze_module_type_member_access` (now `pub(crate)`).

Found because the four-module Pratt calculator's parser compares token tags against module constants everywhere; with this fix the whole program runs (exit 42). CLI regression case pins the const in all six positions (let init, call arg, arithmetic, `==`, `!=`, `<`) in one program.

Full suite green (Pass 34, traceability 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
