### PR TITLE
RUE-624: canonicalize semantic output across source order

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -35,6 +35,7 @@ pub use intern_pool::{
 };
 pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};
+pub use path_norm::normalize_module_path;
 pub use sema::{
     AnalyzedFunction, ConstValue, DirResolution, FunctionInfo, GatherOutput, MethodInfo,
     ModulePath, ParamSlotModes, Sema, SemaOutput, import_candidate_groups,

--- a/crates/rue-air/src/path_norm.rs
+++ b/crates/rue-air/src/path_norm.rs
@@ -26,7 +26,7 @@ use std::path::{Component, Path, PathBuf};
 /// - `sub/./foo.rue` -> `sub/foo.rue`
 /// - `a/../std/opt.rue` -> `std/opt.rue`
 /// - `../std/opt.rue` -> `../std/opt.rue` (leading `..` has nothing to cancel)
-pub(crate) fn normalize_module_path(path: &str) -> String {
+pub fn normalize_module_path(path: &str) -> String {
     let mut out: Vec<Component> = Vec::new();
     for comp in Path::new(path).components() {
         match comp {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -116,21 +116,31 @@ fn finalize_function_body_analysis(
     unused_function_roots: &HashSet<Spur>,
     errors: CompileErrors,
 ) -> MultiErrorResult<SemaOutput> {
-    // Merge strings from all functions into a global table with deduplication.
-    let mut global_string_table: HashMap<String, u32> = HashMap::new();
-    let mut global_strings: Vec<String> = Vec::new();
+    // String IDs flow into AIR, assembly, rodata, and relocations. Assign them
+    // by content rather than function-discovery order so worklist scheduling
+    // cannot change any downstream representation (RUE-624).
+    let mut global_strings: Vec<String> = functions_with_strings
+        .iter()
+        .flat_map(|(_, local_strings)| local_strings.iter().cloned())
+        .collect();
+    global_strings.sort();
+    global_strings.dedup();
+    let global_string_table: HashMap<String, u32> = global_strings
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(id, string)| (string, id as u32))
+        .collect();
 
     let mut functions: Vec<AnalyzedFunction> = Vec::new();
     for (mut analyzed, local_strings) in functions_with_strings {
         if !local_strings.is_empty() {
             let local_to_global: Vec<u32> = local_strings
                 .into_iter()
-                .map(|s| {
-                    *global_string_table.entry(s.clone()).or_insert_with(|| {
-                        let id = global_strings.len() as u32;
-                        global_strings.push(s);
-                        id
-                    })
+                .map(|string| {
+                    *global_string_table
+                        .get(&string)
+                        .expect("every local string was collected globally")
                 })
                 .collect();
 

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -17,10 +17,17 @@ impl<'a> Sema<'a> {
         };
         let importer_dir = self.get_source_path(span).map(&dir_of);
         let root_dir = self
-            .file_paths
-            .iter()
-            .min_by_key(|(id, _)| id.index())
-            .map(|(_, p)| dir_of(p));
+            .root_file_id
+            .and_then(|root_file_id| self.file_paths.get(&root_file_id))
+            // Preserve the historical fallback for direct Sema embedders that
+            // have not supplied explicit root metadata yet.
+            .or_else(|| {
+                self.file_paths
+                    .iter()
+                    .min_by_key(|(id, _)| id.index())
+                    .map(|(_, path)| path)
+            })
+            .map(|path| dir_of(path));
         let mut base_dirs: Vec<String> = Vec::new();
         if let Some(d) = importer_dir {
             base_dirs.push(d);

--- a/crates/rue-air/src/sema/file_paths.rs
+++ b/crates/rue-air/src/sema/file_paths.rs
@@ -11,6 +11,15 @@ use super::Sema;
 use crate::path_norm::normalize_module_path;
 
 impl<'a> Sema<'a> {
+    /// Set the designated semantic root module.
+    ///
+    /// FileIds are diagnostic handles, not semantic ranks. Multi-source
+    /// callers provide the root explicitly so permuting otherwise arbitrary
+    /// FileId assignments cannot change root-relative import behavior.
+    pub fn set_root_file_id(&mut self, root_file_id: FileId) {
+        self.root_file_id = Some(root_file_id);
+    }
+
     /// Set file paths for module resolution in multi-file compilation.
     ///
     /// This maps FileIds to their corresponding source file paths,

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -119,6 +119,7 @@ impl<'a> GatherOutput<'a> {
             module_registry: crate::module_registry::ModuleRegistry::new(),
             file_paths: HashMap::new(),
             symbol_paths: HashMap::new(),
+            root_file_id: None,
             param_arena: self.param_arena,
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -122,6 +122,8 @@ pub struct Sema<'a> {
     pub(crate) file_paths: HashMap<FileId, String>,
     /// Maps FileId to relocation-stable paths used in generated symbols.
     pub(crate) symbol_paths: HashMap<FileId, String>,
+    /// Explicit semantic root module for root-relative import fallback.
+    pub(crate) root_file_id: Option<FileId>,
     /// Arena storage for function/method parameter data.
     pub(crate) param_arena: ParamArena,
     /// Method signatures for anonymous structs, used for structural equality comparison.
@@ -222,6 +224,7 @@ impl<'a> Sema<'a> {
             module_registry: crate::module_registry::ModuleRegistry::new(),
             file_paths: HashMap::new(),
             symbol_paths: HashMap::new(),
+            root_file_id: None,
             param_arena: ParamArena::new(),
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -27,6 +27,7 @@
 
 mod diagnostic;
 mod drop_glue;
+mod semantic_order;
 mod unit;
 
 pub use unit::CompilationUnit;
@@ -788,11 +789,15 @@ fn build_functions_and_cfgs(
     let drop_glue_functions = drop_glue::synthesize_drop_glue(&type_pool);
 
     // Combine user functions with drop glue, filtering out comptime-only functions.
-    let all_functions: Vec<_> = functions
+    let mut all_functions: Vec<_> = functions
         .into_iter()
         .filter(|f| f.air.return_type() != Type::COMPTIME_TYPE)
         .chain(drop_glue_functions)
         .collect();
+    // Function order controls indexed Rayon collection, object-file order,
+    // and final linker layout. Machine symbols are the stable semantic
+    // identity shared by user, specialized, destructor, and glue functions.
+    all_functions.sort_by(|left, right| left.name.cmp(&right.name));
 
     let _span = info_span!("cfg_construction").entered();
 
@@ -1020,7 +1025,36 @@ pub fn compile_frontend_from_ast_with_file_paths_and_symbol_paths_and_target(
     file_paths: std::collections::HashMap<FileId, String>,
     symbol_paths: std::collections::HashMap<FileId, String>,
 ) -> MultiErrorResult<CompileState> {
-    // AST to RIR (untyped IR)
+    let root_file_id = semantic_order::legacy_root_file_id(&ast, &file_paths);
+    compile_frontend_from_ast_with_source_metadata_and_target(
+        ast,
+        interner,
+        opt_level,
+        preview_features,
+        target,
+        root_file_id,
+        file_paths,
+        symbol_paths,
+    )
+}
+
+/// Compile an already-parsed program with complete multi-file source metadata.
+///
+/// Unlike the compatibility wrappers above, this entry point receives the
+/// designated semantic root explicitly. FileIds are arbitrary diagnostic
+/// handles; their numeric order must not affect import fallback, semantic
+/// allocation, or generated artifacts.
+pub fn compile_frontend_from_ast_with_source_metadata_and_target(
+    ast: Ast,
+    interner: ThreadedRodeo,
+    opt_level: OptLevel,
+    preview_features: &PreviewFeatures,
+    target: Target,
+    root_file_id: FileId,
+    file_paths: std::collections::HashMap<FileId, String>,
+    symbol_paths: std::collections::HashMap<FileId, String>,
+) -> MultiErrorResult<CompileState> {
+    // Preserve the caller-visible AST/RIR order for inspection and --emit rir.
     let (rir, interner) = {
         let _span = info_span!("astgen").entered();
         let astgen = AstGen::new(&ast, &interner);
@@ -1029,10 +1063,22 @@ pub fn compile_frontend_from_ast_with_file_paths_and_symbol_paths_and_target(
         (rir, interner)
     };
 
+    // Sema allocation order is a machine-level input: it controls nominal and
+    // composite type IDs, destructor/drop-glue traversal, string IDs, and
+    // object layout. Lower a private logical-path-ordered RIR without changing
+    // the observable AST/RIR above (RUE-624).
+    let semantic_ast = semantic_order::for_sema(&ast, &file_paths, &symbol_paths, root_file_id);
+    let semantic_rir = {
+        let _span = info_span!("semantic_astgen").entered();
+        AstGen::new(&semantic_ast, &interner).generate()
+    };
+
     // Semantic analysis (RIR to AIR) - this now collects multiple errors
     let sema_output = {
         let _span = info_span!("sema").entered();
-        let mut sema = Sema::new_for_target(&rir, &interner, preview_features.clone(), target);
+        let mut sema =
+            Sema::new_for_target(&semantic_rir, &interner, preview_features.clone(), target);
+        sema.set_root_file_id(root_file_id);
         sema.set_file_paths(file_paths);
         sema.set_symbol_paths(symbol_paths);
         let output = sema.analyze_all()?;
@@ -1117,7 +1163,8 @@ pub fn configure_thread_pool(jobs: usize) {
 ///
 /// # Arguments
 ///
-/// * `sources` - Slice of source files to compile
+/// * `sources` - Slice of source files to compile. The first entry is the
+///   designated root for root-relative import fallback.
 /// * `options` - Compilation options (target, linker, optimization level, etc.)
 ///
 /// # Returns
@@ -1153,6 +1200,7 @@ pub fn compile_multi_file_with_options(
 /// relocation-stable identities used in generated symbols.
 ///
 /// This is the driver-facing variant of [`compile_multi_file_with_options`].
+/// As in that function, `sources[0]` is the designated semantic root.
 /// Physical [`SourceFile::path`] values continue to control diagnostics and
 /// module resolution; `symbol_paths` only qualify otherwise-colliding generated
 /// names.

--- a/crates/rue-compiler/src/semantic_order.rs
+++ b/crates/rue-compiler/src/semantic_order.rs
@@ -1,0 +1,116 @@
+//! Canonical ordering for semantic lowering.
+//!
+//! Caller source order remains observable in tokens, AST, RIR, and dependency
+//! output. Semantic allocation has a stricter requirement:
+//! moving sibling modules must not renumber types, strings, functions, or
+//! objects. The compiler therefore lowers a second, top-level-item-reordered
+//! AST to the private RIR consumed by sema.
+
+use std::collections::HashMap;
+
+use rue_air::normalize_module_path;
+use rue_parser::{Ast, Item};
+use rue_span::{FileId, Span};
+
+fn item_span(item: &Item) -> Span {
+    match item {
+        Item::Function(item) => item.span,
+        Item::Struct(item) => item.span,
+        Item::Enum(item) => item.span,
+        Item::DropFn(item) => item.span,
+        Item::Const(item) => item.span,
+        Item::Error(span) => *span,
+    }
+}
+
+/// Clone an observable AST into the canonical order used only by sema.
+///
+/// The explicitly designated root remains first. Siblings are ordered by their
+/// relocation-stable logical paths, while byte positions retain declaration
+/// order within each file. The numeric fallbacks only serve legacy embedders
+/// that do not provide a complete symbol-path map.
+pub(crate) fn for_sema(
+    ast: &Ast,
+    file_paths: &HashMap<FileId, String>,
+    symbol_paths: &HashMap<FileId, String>,
+    root_file_id: FileId,
+) -> Ast {
+    let mut keyed_items: Vec<_> = ast
+        .items
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(original_index, item)| {
+            let span = item_span(&item);
+            let logical_path = symbol_paths
+                .get(&span.file_id)
+                .or_else(|| file_paths.get(&span.file_id))
+                .map(|path| normalize_module_path(path))
+                .unwrap_or_else(|| format!("file{:010}", span.file_id.index()));
+            let key = (
+                span.file_id != root_file_id,
+                logical_path,
+                span.start,
+                span.end,
+                span.file_id.index(),
+                original_index,
+            );
+            (key, item)
+        })
+        .collect();
+    keyed_items.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    Ast {
+        items: keyed_items.into_iter().map(|(_, item)| item).collect(),
+    }
+}
+
+/// Recover the historical minimum-FileId root for compatibility entry points.
+///
+/// New multi-file orchestration must pass the designated root explicitly.
+pub(crate) fn legacy_root_file_id(ast: &Ast, file_paths: &HashMap<FileId, String>) -> FileId {
+    file_paths
+        .keys()
+        .copied()
+        .min_by_key(|file_id| file_id.index())
+        .or_else(|| {
+            ast.items
+                .iter()
+                .map(item_span)
+                .map(|span| span.file_id)
+                .min_by_key(|file_id| file_id.index())
+        })
+        .unwrap_or(FileId::DEFAULT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_effective_paths_from_a_partial_symbol_map() {
+        let logical = FileId::new(20);
+        let physical_fallback = FileId::new(10);
+        let ast = Ast {
+            items: vec![
+                Item::Error(Span::with_file(logical, 0, 1)),
+                Item::Error(Span::with_file(physical_fallback, 0, 1)),
+            ],
+        };
+        let file_paths = HashMap::from([
+            (logical, "unused-physical.rue".to_string()),
+            (physical_fallback, "b.rue".to_string()),
+        ]);
+        let symbol_paths = HashMap::from([(logical, "z/../a.rue".to_string())]);
+
+        let ordered = for_sema(&ast, &file_paths, &symbol_paths, FileId::new(99));
+        let ordered_files: Vec<_> = ordered
+            .items
+            .iter()
+            .map(item_span)
+            .map(|s| s.file_id)
+            .collect();
+
+        assert_eq!(ordered_files, [logical, physical_fallback]);
+    }
+}

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -67,6 +67,8 @@ pub struct CompilationUnit<'src> {
     // === Source ===
     /// Source files being compiled.
     sources: Vec<SourceFile<'src>>,
+    /// Designated semantic root (the first source), independent of FileId rank.
+    root_file_id: FileId,
 
     // === Phase 1: Parsing ===
     /// Merged AST containing all items (populated by `parse()`).
@@ -102,9 +104,14 @@ impl<'src> CompilationUnit<'src> {
     ///
     /// # Arguments
     ///
-    /// * `sources` - Source files to compile
+    /// * `sources` - Source files to compile. The first entry is the designated
+    ///   root for root-relative import fallback.
     /// * `options` - Compilation options (target, optimization, etc.)
     pub fn new(sources: Vec<SourceFile<'src>>, options: CompileOptions) -> Self {
+        let root_file_id = sources
+            .first()
+            .map(|source| source.file_id)
+            .unwrap_or(FileId::DEFAULT);
         let file_paths: HashMap<FileId, String> = sources
             .iter()
             .map(|s| (s.file_id, s.path.to_string()))
@@ -114,6 +121,7 @@ impl<'src> CompilationUnit<'src> {
         Self {
             options,
             sources,
+            root_file_id,
             merged_ast: None,
             interner: None,
             file_paths,
@@ -278,18 +286,35 @@ impl<'src> CompilationUnit<'src> {
     ///
     /// Panics if called before [`lower()`](Self::lower).
     pub fn analyze(&mut self) -> MultiErrorResult<()> {
-        let rir = self.rir.as_ref().expect("analyze() called before lower()");
+        self.rir.as_ref().expect("analyze() called before lower()");
+        let ast = self
+            .merged_ast
+            .as_ref()
+            .expect("analyze() called before parse()");
         let interner = self.interner.as_ref().expect("interner not initialized");
+
+        // Keep `self.rir` in positional order for the public phase accessor,
+        // while sema consumes a private logical-path-ordered lowering. This
+        // makes allocation and artifact layout canonical without changing the
+        // caller-visible AST/RIR contract (RUE-624).
+        let semantic_ast = crate::semantic_order::for_sema(
+            ast,
+            &self.file_paths,
+            &self.symbol_paths,
+            self.root_file_id,
+        );
+        let semantic_rir = AstGen::new(&semantic_ast, interner).generate();
 
         // Semantic analysis
         let sema_output = {
             let _span = info_span!("sema").entered();
             let mut sema = Sema::new_for_target(
-                rir,
+                &semantic_rir,
                 interner,
                 self.options.preview_features.clone(),
                 self.options.target,
             );
+            sema.set_root_file_id(self.root_file_id);
             sema.set_file_paths(self.file_paths.clone());
             sema.set_symbol_paths(self.symbol_paths.clone());
             let output = sema.analyze_all()?;
@@ -531,8 +556,10 @@ impl<'src> CompilationUnit<'src> {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use super::*;
-    use crate::FileId;
+    use crate::{FileId, RirPrinter};
 
     fn make_sources(source: &str) -> Vec<SourceFile<'_>> {
         vec![SourceFile::new("<test>", source, FileId::new(1))]
@@ -645,6 +672,216 @@ mod tests {
 
         assert_eq!(unit.warnings().len(), 1);
         assert!(unit.warnings()[0].to_string().contains("unused"));
+    }
+
+    #[derive(Debug)]
+    struct ReproFingerprint {
+        type_symbols: Vec<String>,
+        function_names: Vec<String>,
+        strings: Vec<String>,
+        observable_rir: String,
+        textual_frontend: String,
+        artifact: Vec<u8>,
+    }
+
+    fn compile_repro_fingerprint(
+        physical_root: &str,
+        root_id: FileId,
+        left_id: FileId,
+        right_id: FileId,
+        shared_id: FileId,
+        reverse_siblings: bool,
+    ) -> ReproFingerprint {
+        let main_path = format!("{physical_root}/main.rue");
+        let left_path = format!("{physical_root}/left/types.rue");
+        let right_path = format!("{physical_root}/right/types.rue");
+        let shared_path = format!("{physical_root}/shared.rue");
+        let mut sources = vec![
+            SourceFile::new(
+                &main_path,
+                r#"fn identity(comptime T: type, value: T) -> T { value }
+                    fn main() -> i32 {
+                        let left = @import("left/types.rue");
+                        let right = @import("right/types.rue");
+                        left.entry(identity(i32, 10)) + right.entry(identity(i32, 20))
+                    }"#,
+                root_id,
+            ),
+            SourceFile::new(
+                &left_path,
+                r#"const shared = @import("shared.rue");
+                    pub struct Payload {
+                        value: i32,
+                        text: String,
+                        fn score(borrow self) -> i32 { self.value + 1 }
+                    }
+                    drop fn Payload(self) { @dbg(self.value); }
+                    pub enum Choice { Empty, Text(String), Many([String; 2]) }
+                    pub fn entry(value: i32) -> i32 {
+                        let payload = Payload { value: value, text: "left-value" };
+                        shared.bump(payload.score())
+                    }"#,
+                left_id,
+            ),
+            SourceFile::new(
+                &right_path,
+                r#"const shared = @import("shared.rue");
+                    pub struct Payload {
+                        value: i32,
+                        extra: i32,
+                        text: String,
+                        fn score(borrow self) -> i32 { self.value + self.extra }
+                    }
+                    drop fn Payload(self) { @dbg(self.extra); }
+                    pub enum Choice { Empty, Text(String), Many([String; 3]) }
+                    pub fn entry(value: i32) -> i32 {
+                        let payload = Payload { value: value, extra: 2, text: "right-value" };
+                        shared.bump(payload.score())
+                    }"#,
+                right_id,
+            ),
+            SourceFile::new(
+                &shared_path,
+                "pub fn bump(value: i32) -> i32 { value + 5 }",
+                shared_id,
+            ),
+        ];
+        if reverse_siblings {
+            sources.swap(1, 2);
+        }
+
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        unit.set_symbol_paths(std::collections::HashMap::from([
+            (root_id, "main.rue".to_string()),
+            (left_id, "left/types.rue".to_string()),
+            (right_id, "right/types.rue".to_string()),
+            (shared_id, "shared.rue".to_string()),
+        ]));
+        unit.run_frontend().expect("frontend should compile");
+
+        let pool = unit.type_pool();
+        let mut type_symbols = Vec::new();
+        type_symbols.extend(
+            pool.all_struct_ids()
+                .into_iter()
+                .map(|id| format!("struct:{}", pool.struct_symbol_name(id))),
+        );
+        type_symbols.extend(
+            pool.all_enum_ids()
+                .into_iter()
+                .map(|id| format!("enum:{}", pool.enum_symbol_name(id))),
+        );
+
+        let function_names = unit
+            .functions()
+            .iter()
+            .map(|function| function.analyzed.name.clone())
+            .collect();
+        let observable_rir = RirPrinter::new(unit.rir(), unit.interner()).to_string();
+        let mut textual_frontend = String::new();
+        for function in unit.functions() {
+            writeln!(
+                &mut textual_frontend,
+                "function {}:",
+                function.analyzed.name
+            )
+            .unwrap();
+            writeln!(
+                &mut textual_frontend,
+                "{}",
+                function.analyzed.air.display_with_interner(unit.interner())
+            )
+            .unwrap();
+            writeln!(
+                &mut textual_frontend,
+                "{}",
+                function.cfg.display_with_interner(unit.interner())
+            )
+            .unwrap();
+        }
+        let strings = unit.strings().to_vec();
+        let artifact = unit.compile().expect("backend should compile").elf;
+
+        ReproFingerprint {
+            type_symbols,
+            function_names,
+            strings,
+            observable_rir,
+            textual_frontend,
+            artifact,
+        }
+    }
+
+    #[test]
+    fn test_semantic_and_native_output_ignore_sibling_order_and_file_ids() {
+        let forward = compile_repro_fingerprint(
+            "/tmp/rue-short-root",
+            FileId::new(1),
+            FileId::new(2),
+            FileId::new(3),
+            FileId::new(4),
+            false,
+        );
+        let reversed = compile_repro_fingerprint(
+            "/tmp/a-deliberately-much-longer-relocated-rue-root",
+            FileId::new(100),
+            FileId::new(42),
+            FileId::new(7),
+            FileId::new(55),
+            true,
+        );
+
+        assert_eq!(forward.type_symbols, reversed.type_symbols);
+        assert_eq!(forward.function_names, reversed.function_names);
+        assert_eq!(forward.strings, reversed.strings);
+        assert_eq!(forward.textual_frontend, reversed.textual_frontend);
+        assert_ne!(
+            forward.observable_rir, reversed.observable_rir,
+            "caller-facing RIR should retain positional source order"
+        );
+        let forward_left = forward
+            .observable_rir
+            .find("left-value")
+            .expect("forward RIR should contain the left literal");
+        let forward_right = forward
+            .observable_rir
+            .find("right-value")
+            .expect("forward RIR should contain the right literal");
+        let reversed_left = reversed
+            .observable_rir
+            .find("left-value")
+            .expect("reversed RIR should contain the left literal");
+        let reversed_right = reversed
+            .observable_rir
+            .find("right-value")
+            .expect("reversed RIR should contain the right literal");
+        assert!(forward_left < forward_right);
+        assert!(reversed_right < reversed_left);
+        assert!(forward.function_names.is_sorted());
+        assert!(forward.strings.is_sorted());
+        for expected_name in [
+            "Payload$left_2ftypes_2erue.score",
+            "Payload$right_2ftypes_2erue.score",
+            "Payload$left_2ftypes_2erue.__drop",
+            "Payload$right_2ftypes_2erue.__drop",
+            "__rue_drop_Choice$left_2ftypes_2erue",
+            "__rue_drop_Choice$right_2ftypes_2erue",
+        ] {
+            assert!(
+                forward
+                    .function_names
+                    .iter()
+                    .any(|name| name == expected_name),
+                "missing non-vacuity symbol {expected_name}"
+            );
+        }
+        assert_eq!(forward.strings, ["left-value", "right-value"]);
+        assert!(
+            forward.artifact == reversed.artifact,
+            "complete native artifacts differ ({} versus {} bytes)",
+            forward.artifact.len(),
+            reversed.artifact.len()
+        );
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -2037,12 +2037,13 @@ fn handle_emit_multi_file(
             .iter()
             .map(|s| (s.file_id, s.path.to_string()))
             .collect();
-        let state = match rue_compiler::compile_frontend_from_ast_with_file_paths_and_symbol_paths_and_target(
+        let state = match rue_compiler::compile_frontend_from_ast_with_source_metadata_and_target(
             merged.ast,
             merged.interner,
             options.opt_level,
             &options.preview_features,
             options.target,
+            sources[0].file_id,
             file_paths,
             symbol_paths.clone(),
         ) {


### PR DESCRIPTION
## Summary

- lower a private logical-path-ordered RIR for semantic allocation while preserving caller-order AST and public/`--emit rir` output
- thread the designated root explicitly through `CompilationUnit`, the complete frontend API, CLI emission, and Sema import fallback instead of inferring it from `FileId` rank
- assign global string IDs by sorted content and order CFG/codegen/link inputs by final machine symbol
- normalize effective logical/physical path identities consistently, including partial stable-path maps
- add an adversarial regression covering relocation, arbitrary FileIds with a non-minimal root, reversed siblings, colliding types/methods/destructors, strings, composites, exact AIR/CFG, and complete native bytes

This is the second independently integratable RUE-624 slice. A final stacked PR adds the black-box all-stage, cross-target, O0/O2, environment, and native-execution gate.

Linear: https://linear.app/rue-language/issue/RUE-624

## Validation

- `./fmt.sh check`
- `./clippy.sh`
- `./buck2 test //...` (34 targets, 0 failures)