### PR TITLE
RUE-635: omit zero-width Normal call arguments

### DIFF
--- a/crates/rue-cli-tests/cases/cfg_value_position_unit.toml
+++ b/crates/rue-cli-tests/cases/cfg_value_position_unit.toml
@@ -11,8 +11,8 @@
 # localized compiler-bug panic instead of a mystery SIGABRT.
 #
 # These cases must COMPILE AND RUN: a genuinely Unit-typed expression is a
-# legal argument to a `()` parameter, and its Unit value flows through the ABI
-# like any other value.
+# legal argument to a `()` parameter. It exists as a real CFG value so
+# evaluation can continue, but occupies no physical call-ABI slot.
 
 [section]
 id = "cli.cfg_value_position_unit"

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -114,6 +114,83 @@ stdout = """11
 """
 exit_code = 140
 
+# Zero-width Normal arguments have real CFG values but no physical ABI slots
+# (RUE-635). Interleave unit, an empty struct, and a zero-length array with
+# enough real scalar arguments to cross both x86-64's six-register and
+# AArch64's eight-register limits. The unit-producing call's output proves its
+# evaluation is retained even though its result is not marshalled.
+[[case]]
+name = "zero_width_normal_args_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Empty {}
+
+fn observed_unit() {
+    @dbg(99);
+}
+
+fn sum(
+    a: i32,
+    unit: (),
+    b: i32,
+    empty: Empty,
+    c: i32,
+    zero: [i32; 0],
+    d: i32,
+    e: i32,
+    f: i32,
+    g: i32,
+    h: i32,
+    i: i32,
+) -> i32 {
+    a + b + c + d + e + f + g + h + i
+}
+
+fn main() -> i32 {
+    sum(1, observed_unit(), 2, Empty {}, 3, [], 4, 5, 6, 7, 8, 6)
+}
+""" }]
+stdout = "99\n"
+exit_code = 42
+
+# The same omission rule must compose with a hidden sret pointer, while
+# zero-sized Borrow/Inout arguments retain their one real pointer slot. The
+# trailing scalar lands after the two by-ref pointers and before the returned
+# nine-slot aggregate is copied out.
+[[case]]
+name = "zero_width_args_with_byref_and_sret_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Empty {}
+
+struct Nine {
+    a: i32,
+    b: i32,
+    c: i32,
+    d: i32,
+    e: i32,
+    f: i32,
+    g: i32,
+    h: i32,
+    i: i32,
+}
+
+fn build(borrow shared: Empty, inout writable: Empty, unit: (), tail: i32) -> Nine {
+    writable = Empty {};
+    Nine { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: tail }
+}
+
+fn main() -> i32 {
+    let shared = Empty {};
+    let mut writable = Empty {};
+    let value = build(borrow shared, inout writable, (), 6);
+    value.a + value.b + value.c + value.d + value.e
+        + value.f + value.g + value.h + value.i
+}
+""" }]
+stdout = ""
+exit_code = 42
+
 # Call / recursion: mutual + self recursion, so inlining or tail-call style
 # opts (should they ever land) can't silently change the result.
 [[case]]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1427,6 +1427,16 @@ impl<'a> CfgLower<'a> {
                         continue;
                     }
 
+                    // CFG materializes a value for every continuing
+                    // expression, including unit and other zero-sized values,
+                    // but a Normal argument's physical ABI width comes from
+                    // its static type. Do not mistake the dummy CFG value for
+                    // a scalar slot. Keep this after the by-ref branch: a
+                    // borrow/inout ZST still passes one real pointer.
+                    if self.ctx.type_slot_count(arg_type) == 0 {
+                        continue;
+                    }
+
                     if self.ctx.is_multislot_aggregate(arg_type) {
                         // Pass all slots of the (possibly multi-slot) aggregate arg —
                         // struct, builtin String, fixed-size array, or payload enum

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1781,6 +1781,16 @@ impl<'a> CfgLower<'a> {
                         continue;
                     }
 
+                    // CFG materializes a value for every continuing
+                    // expression, including unit and other zero-sized values,
+                    // but a Normal argument's physical ABI width comes from
+                    // its static type. Do not mistake the dummy CFG value for
+                    // a scalar slot. Keep this after the by-ref branch: a
+                    // borrow/inout ZST still passes one real pointer.
+                    if self.ctx.type_slot_count(arg_type) == 0 {
+                        continue;
+                    }
+
                     if self.ctx.is_multislot_aggregate(arg_type) {
                         // Pass all slots of the (possibly multi-slot) aggregate arg —
                         // struct, builtin String, fixed-size array, or payload enum


### PR DESCRIPTION
## Summary

- derive physical Normal-argument presence from the canonical static ABI slot count on both native backends
- omit unit and every other zero-width value without dropping argument evaluation, while preserving one pointer slot for Borrow/Inout ZSTs and hidden sret setup
- add optimization-differential regressions that cross the x86-64 and AArch64 register limits and compose zero-width Normal arguments with by-reference ZSTs and a large sret return

## Validation

- `./fmt.sh check`
- `./clippy.sh` — 41 targets
- `buck2 test //crates/rue-codegen:rue-codegen-test` — 488/488
- `buck2 test //:cli-tests` — 1322 passed, 2 ignored
- differential-oracle unit suite — 88/88
- live CLI oracle — 641 agree, 96 unmodeled, 559 ineligible, 0 frontend failures, 0 disagreements
- live spec oracle — 1346 agree, 98 unmodeled, 591 ineligible, 0 frontend failures, 0 disagreements
- `./test.sh` — 34/34

Two independent reviews found no blocker. Both new runtime cases fail under the old lowering because a phantom zero-width slot shifts the trailing scalar arguments.