### PR TITLE
RUE-641: type-check inout parameter stores

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -37,6 +37,10 @@ pub struct LocalVarInfo {
 pub struct ParamVarInfo {
     /// The type of this parameter, as InferType for uniform handling.
     pub ty: InferType,
+    /// Whether whole assignment may target this parameter. Only `inout`
+    /// parameters are mutable; constraining an assignment to a normal,
+    /// borrow, or comptime parameter would mask the primary mutability error.
+    pub is_inout: bool,
 }
 
 /// Information about a function during constraint generation.
@@ -1011,14 +1015,29 @@ impl<'a> ConstraintGenerator<'a> {
             // Assignment
             InstData::Assign { name, value } => {
                 let value_info = self.generate(*value, ctx);
-                if let Some(local) = ctx.locals.get(name) {
-                    let local_ty = local.ty.clone();
+                // A local shadows a same-named parameter. Otherwise, constrain
+                // assignment against the declared parameter type too: the
+                // old local-only lookup left every `inout` whole assignment
+                // unconstrained, so an integer literal defaulted to i32 and an
+                // arbitrary differently-shaped value could reach ParamStore
+                // (RUE-641).
+                let target_ty = ctx
+                    .locals
+                    .get(name)
+                    .map(|local| local.ty.clone())
+                    .or_else(|| {
+                        ctx.params
+                            .get(name)
+                            .filter(|param| param.is_inout)
+                            .map(|param| param.ty.clone())
+                    });
+                if let Some(target_ty) = target_ty {
                     // A `str` target (ADR-0043 Phase 3, RUE-324) accepts a string
                     // literal (HM type `String`) by coercion; skip strict
                     // equality and let sema materialize the `str` on the store.
-                    if !self.is_slice_struct_type(local_ty.clone()) {
+                    if !self.is_slice_struct_type(target_ty.clone()) {
                         // Constrain value to match variable type
-                        self.add_constraint(Constraint::equal(value_info.ty, local_ty, span));
+                        self.add_constraint(Constraint::equal(value_info.ty, target_ty, span));
                     }
                 }
                 // Assignment produces unit

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -588,6 +588,14 @@ impl<'a> Sema<'a> {
 
         // For mutation methods, store the result back to the receiver
         if method.receiver_mode == ReceiverMode::ByMutRef {
+            // This is the only ParamStore producer besides whole inout
+            // assignment. The builtin registry requires every ByMutRef method
+            // to return SelfType, so its writeback is representation-identical
+            // to the receiver by construction (RUE-641).
+            debug_assert_eq!(
+                return_ty, receiver.result.ty,
+                "builtin mutation writeback must preserve the receiver type"
+            );
             let storage = receiver.storage.ok_or_else(|| {
                 CompileError::new(ErrorKind::InvalidAssignmentTarget, method_ctx.span)
             })?;

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -127,11 +127,12 @@ impl<'a> Sema<'a> {
         // Convert Type to InferType so arrays are represented structurally.
         let mut param_vars: HashMap<Spur, ParamVarInfo> = params
             .iter()
-            .map(|(name, ty, _mode, _is_comptime)| {
+            .map(|(name, ty, mode, _is_comptime)| {
                 (
                     *name,
                     ParamVarInfo {
                         ty: self.type_to_infer_type(*ty),
+                        is_inout: *mode == RirParamMode::Inout,
                     },
                 )
             })
@@ -159,6 +160,7 @@ impl<'a> Sema<'a> {
                     ConstValue::Integer(_) => {
                         param_vars.entry(*name).or_insert(ParamVarInfo {
                             ty: InferType::Var(cgen.fresh_int_literal_var()),
+                            is_inout: false,
                         });
                         continue;
                     }
@@ -169,6 +171,7 @@ impl<'a> Sema<'a> {
                 };
                 param_vars.entry(*name).or_insert(ParamVarInfo {
                     ty: self.type_to_infer_type(ty),
+                    is_inout: false,
                 });
             }
         }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -449,7 +449,7 @@ impl<'a> Sema<'a> {
                 // Capacity-fits legality (ADR-0043 Phase 5, RUE-326): a string
                 // literal materialized as a fixed `Str(N)` must fit — its UTF-8
                 // byte length must be ≤ N — else it is a clean compile error
-                // (E0210). `str` (no capacity) never triggers this.
+                // (E0492). `str` (no capacity) never triggers this.
                 if let Some(capacity) = self.str_fixed_capacity(ty) {
                     let byte_len = string_content.len() as u64;
                     if byte_len > capacity {
@@ -3171,8 +3171,42 @@ impl<'a> Sema<'a> {
                 let abi_slot = param_info.abi_slot;
                 let param_ty = param_info.ty;
 
-                // Analyze the value
-                let value_result = self.analyze_inst(air, value, ctx)?;
+                // A direct fixed-string literal is contextually typed by its
+                // exact destination capacity (spec 3.7:50). Keep the context
+                // deliberately at the literal boundary: applying it to an
+                // arbitrary RHS would leak Str(N) into call/intrinsic operands
+                // (for example the StrBuf message in a never-returning call).
+                // Non-literal values retain their own type and are checked
+                // exactly below.
+                let contextual_fixed_literal = self.is_str_fixed_struct(param_ty)
+                    && matches!(&self.rir.get(value).data, InstData::StringConst(_));
+                let value_result = if contextual_fixed_literal {
+                    let prev_expected = ctx.expected_type.replace(param_ty);
+                    let result = self.analyze_inst(air, value, ctx);
+                    ctx.expected_type = prev_expected;
+                    result?
+                } else {
+                    self.analyze_inst(air, value, ctx)?
+                };
+
+                // ParamStore has no coercion or conversion step: codegen drops
+                // and copies according to the RHS type. Require semantic type
+                // identity before emitting it so equal source/target layout is
+                // a proved invariant, not an assumption. Never/Error retain
+                // their usual recovery coercions and cannot execute a store.
+                if value_result.ty != param_ty
+                    && !value_result.ty.is_never()
+                    && !value_result.ty.is_error()
+                    && !param_ty.is_error()
+                {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: param_ty.safe_name_with_pool(Some(&self.type_pool)),
+                            found: value_result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        self.rir.get(value).span,
+                    ));
+                }
 
                 // RUE-387: reassigning an `inout` parameter whose type carries
                 // a linear value would silently drop the caller's live value.

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -378,6 +378,228 @@ mod tests {
     }
 
     #[test]
+    fn inout_param_assignment_is_constrained_and_store_typed_exactly() {
+        // Parameter assignments participate in inference, so a literal takes
+        // the declared integer width instead of defaulting to i32. Sema then
+        // proves the same exact type again at the ParamStore chokepoint.
+        let output = compile_to_air(
+            "fn replace(inout value: i64) { value = 42; } \
+             fn main() -> i32 { let mut value: i64 = 0; replace(inout value); 0 }",
+        )
+        .unwrap();
+        let replace = output
+            .functions
+            .iter()
+            .find(|function| function.name == "replace")
+            .unwrap();
+        let stored_value = replace
+            .air
+            .iter()
+            .find_map(|(_, inst)| match inst.data {
+                AirInstData::ParamStore { value, .. } => Some(value),
+                _ => None,
+            })
+            .expect("replace must contain a ParamStore");
+        assert_eq!(replace.air.get(stored_value).ty, Type::I64);
+
+        // An arbitrary differently-typed RHS used to bypass inference and
+        // reach ParamStore. It must now fail in the frontend.
+        let errors = compile_to_air(
+            "fn replace(inout value: i64) { value = true; } \
+             fn main() -> i32 { let mut value: i64 = 0; replace(inout value); 0 }",
+        )
+        .unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            &errors.iter().next().unwrap().kind,
+            ErrorKind::TypeMismatch { expected, found }
+                if expected == "i64" && found == "bool"
+        ));
+
+        // Constraining only mutable parameters preserves the primary target
+        // diagnostic for normal and borrowed bindings; RHS type inference must
+        // not mask these as E0206.
+        let immutable = compile_to_air(
+            "fn replace(value: i64) { value = true; } \
+             fn main() -> i32 { replace(0); 0 }",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            immutable.iter().next().unwrap().kind,
+            ErrorKind::AssignToImmutable(_)
+        ));
+
+        let borrowed = compile_to_air(
+            "fn replace(borrow value: i64) { value = true; } \
+             fn main() -> i32 { let value: i64 = 0; replace(borrow value); 0 }",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            borrowed.iter().next().unwrap().kind,
+            ErrorKind::MutateBorrowedValue { .. }
+        ));
+    }
+
+    #[test]
+    fn inout_fixed_string_assignment_materializes_the_destination_type() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let output = compile_to_air_with_preview_features(
+            r#"
+                fn replace(inout value: Str(8)) { value = "hi"; }
+                fn main() -> i32 {
+                    let mut value: Str(8) = "hello";
+                    replace(inout value);
+                    0
+                }
+            "#,
+            preview.clone(),
+        )
+        .unwrap();
+        let replace = output
+            .functions
+            .iter()
+            .find(|function| function.name == "replace")
+            .unwrap();
+        let stored_value = replace
+            .air
+            .iter()
+            .find_map(|(_, inst)| match inst.data {
+                AirInstData::ParamStore { value, .. } => Some(value),
+                _ => None,
+            })
+            .expect("replace must contain a ParamStore");
+        assert_eq!(
+            replace
+                .air
+                .get(stored_value)
+                .ty
+                .safe_name_with_pool(Some(&output.type_pool)),
+            "Str(8)"
+        );
+
+        // Never coercion remains legal. The outer Str(8) expectation belongs
+        // to the assignment result and must not leak into @panic's StrBuf
+        // message operand.
+        for rhs in ["@panic()", "@panic(\"boom\")"] {
+            compile_to_air_with_preview_features(
+                &format!(
+                    "fn replace(inout value: Str(8)) {{ value = {rhs}; }} \
+                     fn main() -> i32 {{ \
+                         let mut value: Str(8) = \"hello\"; \
+                         replace(inout value); \
+                         0 \
+                     }}"
+                ),
+                preview.clone(),
+            )
+            .unwrap_or_else(|errors| panic!("{rhs} must coerce from never: {errors}"));
+        }
+
+        compile_to_air_with_preview_features(
+            r#"
+                fn die(message: StrBuf) -> ! { @panic(message) }
+                fn replace(inout value: Str(8)) { value = die("boom"); }
+                fn main() -> i32 {
+                    let mut value: Str(8) = "hello";
+                    replace(inout value);
+                    0
+                }
+            "#,
+            preview.clone(),
+        )
+        .unwrap_or_else(|errors| {
+            panic!("a never-returning call must keep its StrBuf argument context: {errors}")
+        });
+
+        // The same expected-type boundary applies to @assert: its message is
+        // a StrBuf, and the assignment is rejected for the unit result rather
+        // than misdiagnosing the message as Str(8).
+        let assertion = compile_to_air_with_preview_features(
+            r#"
+                fn replace(inout value: Str(8)) { value = @assert(false, "boom"); }
+                fn main() -> i32 {
+                    let mut value: Str(8) = "hello";
+                    replace(inout value);
+                    0
+                }
+            "#,
+            preview.clone(),
+        )
+        .unwrap_err();
+        assert_eq!(assertion.len(), 1);
+        assert!(matches!(
+            &assertion.iter().next().unwrap().kind,
+            ErrorKind::TypeMismatch { expected, found }
+                if expected == "Str(8)" && found == "()"
+        ));
+
+        let mismatch = compile_to_air_with_preview_features(
+            r#"
+                fn replace(inout value: Str(8), other: Str(16)) { value = other; }
+                fn main() -> i32 {
+                    let mut value: Str(8) = "small";
+                    let other: Str(16) = "large";
+                    replace(inout value, other);
+                    0
+                }
+            "#,
+            preview.clone(),
+        )
+        .unwrap_err();
+        assert_eq!(mismatch.len(), 1);
+        assert!(matches!(
+            &mismatch.iter().next().unwrap().kind,
+            ErrorKind::TypeMismatch { expected, found }
+                if expected == "Str(8)" && found == "Str(16)"
+        ));
+
+        // Different physical widths must be rejected at the sema chokepoint,
+        // even though fixed-string inference deliberately defers string
+        // coercion checks. This is the original 3-word-through-2-word hazard.
+        let width_mismatch = compile_to_air_with_preview_features(
+            r#"
+                fn replace(inout value: Str(8), other: StrBuf) { value = other; }
+                fn main() -> i32 {
+                    let mut value: Str(8) = "small";
+                    let other: StrBuf = "growable";
+                    replace(inout value, other);
+                    0
+                }
+            "#,
+            preview.clone(),
+        )
+        .unwrap_err();
+        assert_eq!(width_mismatch.len(), 1);
+        assert!(matches!(
+            &width_mismatch.iter().next().unwrap().kind,
+            ErrorKind::TypeMismatch { expected, found }
+                if expected == "Str(8)" && found == "StrBuf"
+        ));
+
+        let too_long = compile_to_air_with_preview_features(
+            r#"
+                fn replace(inout value: Str(8)) { value = "123456789"; }
+                fn main() -> i32 {
+                    let mut value: Str(8) = "hello";
+                    replace(inout value);
+                    0
+                }
+            "#,
+            preview,
+        )
+        .unwrap_err();
+        assert_eq!(too_long.len(), 1);
+        assert!(matches!(
+            too_long.iter().next().unwrap().kind,
+            ErrorKind::StrFixedCapacityExceeded {
+                capacity: 8,
+                byte_len: 9
+            }
+        ));
+    }
+
+    #[test]
     fn test_multiple_variables() {
         let output = compile_to_air("fn main() -> i32 { let x = 10; let y = 20; x + y }").unwrap();
 

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -121,7 +121,8 @@ exit_code = 8
 name = "str_inout_static_operand_rejected"
 files = [{ path = "main.rue", source = """
 fn set_hi(inout s: str) {
-    s = "hi";
+    // The callee never runs: this case isolates the invalid call operand.
+    let _length = s.len();
 }
 fn main() -> i32 {
     let mut s: str = "hello";

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -341,7 +341,7 @@ preview = "string_trio"
 preview_should_pass = true
 source = """
 fn take(inout s: str) {
-    s = "hi";
+    let _length = s.len();
 }
 fn main() -> i32 {
     let mut s: str = "hello";

--- a/crates/rue-ui-tests/cases/diagnostics/str_two_types.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/str_two_types.toml
@@ -94,7 +94,7 @@ name = "static_str_as_inout_is_e0496"
 description = "A static `str` value as an `inout str` operand is E0496 (requires a local buffer)."
 preview = "string_trio"
 source = """
-fn take(inout s: str) { s = "hi"; }
+fn take(inout s: str) { let _length = s.len(); }
 fn main() -> i32 {
     let mut s: str = "hello";
     take(inout s);


### PR DESCRIPTION
## Summary

- include mutable parameter assignments in inference while preserving the existing immutable and borrowed-target diagnostics
- contextualize direct fixed-string literals at the destination boundary, then require exact semantic type identity before emitting `ParamStore`
- preserve Never and error recovery, audit the only other `ParamStore` producer, and keep E0496 call-site fixtures isolated

## Root cause

Whole parameter assignments were absent from inference because assignment lookup considered locals only. Sema then emitted `ParamStore` without checking the declared parameter type against the RHS type, while codegen drops and copies according to the RHS representation. A three-word `StrBuf` could therefore be stored through a two-word string view and overwrite the caller frame.

This is the first of two focused RUE-641 landings. It closes the generic representation-width hole. A follow-up will encode the separate language rule that a bare `inout str` view may not be wholly rebound.

## Impact

Mismatched whole assignments to `inout` parameters now fail in the frontend with E0206. Integer literals infer at the declared width, direct fitting literals materialize as the exact `Str(N)` destination type, over-capacity literals remain E0492, and non-returning RHS expressions remain legal.

## Validation

- `./fmt.sh && ./fmt.sh check`
- `./clippy.sh` — 41 targets clean
- affected suites — AIR 363/363, UI 167/167, CLI 1,328 passed with 2 ignored, spec 2,021 passed with 14 ignored
- `./test.sh` — all 34 Buck targets passed
- live CLI oracle — 641 agree, 96 modeled gaps, 565 ineligible, 0 frontend failures, 0 disagreements
- live spec oracle — 1,346 agree, 98 modeled gaps, 591 ineligible, 0 frontend failures, 0 disagreements

An independent code review reported CLEAR for this intentionally narrowed scope.