### PR TITLE
RUE-641: forbid rebinding inout str views

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3171,6 +3171,24 @@ impl<'a> Sema<'a> {
                 let abi_slot = param_info.abi_slot;
                 let param_ty = param_info.ty;
 
+                // `inout str` is a second-class exclusive view over a caller's
+                // concrete `StrBuf`/`Str(N)` storage (spec 3.7:58-60), not a
+                // first-class header that can be rebound. Treating a whole
+                // assignment as an ordinary ParamStore is representation-
+                // unsafe: the unconstrained literal defaults to 3-word
+                // StrBuf, even when the caller supplied a 2-word Str(N), and
+                // the generated drop/store reads and writes past the caller's
+                // value (RUE-641). Byte-level mutation through the exclusive
+                // view remains distinct from rebinding the view itself.
+                if self.is_str_struct(param_ty) {
+                    return Err(
+                        CompileError::new(ErrorKind::StrViewReassignment, span).with_help(
+                            "use an exact `inout Str(N)` or `inout StrBuf` parameter when \
+                             whole-value replacement is intended",
+                        ),
+                    );
+                }
+
                 // A direct fixed-string literal is contextually typed by its
                 // exact destination capacity (spec 3.7:50). Keep the context
                 // deliberately at the literal boundary: applying it to an

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -378,6 +378,28 @@ mod tests {
     }
 
     #[test]
+    fn inout_str_view_cannot_be_reassigned_as_a_whole_value() {
+        let source = r#"
+            fn replace(inout target: str, replacement: str) {
+                target = replacement;
+            }
+            fn main() -> i32 {
+                let mut value: Str(8) = "hello";
+                replace(inout value, "hi");
+                0
+            }
+        "#;
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let errors = compile_to_air_with_preview_features(source, preview).unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::StrViewReassignment
+        ));
+    }
+
+    #[test]
     fn inout_param_assignment_is_constrained_and_store_typed_exactly() {
         // Parameter assignments participate in inference, so a literal takes
         // the declared integer width instead of defaulting to i32. Sema then

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -111,6 +111,11 @@ impl ErrorCode {
     pub const TYPE_MISMATCH: Self = Self(206);
     pub const WRONG_ARGUMENT_COUNT: Self = Self(207);
     pub const MOVE_WHILE_CALL_LOANED: Self = Self(208);
+    // E0209 is reserved for RUE-634's unexpected call-argument mode error.
+    /// Whole-value assignment to a second-class `inout str` view. The view
+    /// grants exclusive access to the caller's bytes; it is not a first-class
+    /// string header that may be rebound (RUE-641).
+    pub const STR_VIEW_REASSIGNMENT: Self = Self(210);
 
     // ========================================================================
     // Struct/enum errors (E0400-E0499)
@@ -1287,6 +1292,12 @@ pub enum ErrorKind {
     /// (ADR-0043 two-types model, RUE-386).
     #[error("a first-class `str` value cannot be passed as `inout str`")]
     InoutStrRequiresLocalBuffer,
+    /// A whole value was assigned to an `inout str` parameter. The parameter
+    /// is a second-class view over caller-owned bytes, so rebinding its header
+    /// would overwrite storage whose concrete buffer representation is not
+    /// `str` (RUE-641).
+    #[error("an `inout str` view cannot be reassigned as a whole value")]
+    StrViewReassignment,
     /// A borrowed `str` view (a `borrow`/`inout str` parameter) escaped into a
     /// first-class `str` slot (ADR-0043 two-types model, RUE-386). `site`
     /// names the position, as in [`Self::BufferNotFirstClassStr`].
@@ -1593,6 +1604,7 @@ impl ErrorKind {
             ErrorKind::TypeMismatch { .. } => ErrorCode::TYPE_MISMATCH,
             ErrorKind::WrongArgumentCount { .. } => ErrorCode::WRONG_ARGUMENT_COUNT,
             ErrorKind::DuplicatePatternBinding { .. } => ErrorCode::DUPLICATE_PATTERN_BINDING,
+            ErrorKind::StrViewReassignment => ErrorCode::STR_VIEW_REASSIGNMENT,
 
             // Struct/enum errors (E0400-E0499)
             ErrorKind::MissingFields(_) => ErrorCode::MISSING_FIELDS,
@@ -2591,6 +2603,10 @@ mod tests {
             ErrorCode::INOUT_STR_REQUIRES_LOCAL_BUFFER
         );
         assert_eq!(
+            ErrorKind::StrViewReassignment.code(),
+            ErrorCode::STR_VIEW_REASSIGNMENT
+        );
+        assert_eq!(
             ErrorKind::StrViewNotFirstClass {
                 site: "as a return value".to_string(),
             }
@@ -2600,6 +2616,7 @@ mod tests {
         assert_eq!(ErrorCode::BUFFER_NOT_FIRST_CLASS_STR.0, 495);
         assert_eq!(ErrorCode::INOUT_STR_REQUIRES_LOCAL_BUFFER.0, 496);
         assert_eq!(ErrorCode::STR_VIEW_NOT_FIRST_CLASS.0, 497);
+        assert_eq!(ErrorCode::STR_VIEW_REASSIGNMENT.0, 210);
     }
 
     #[test]

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -332,6 +332,28 @@ fn main() -> i32 {
 """
 exit_code = 5
 
+# 3.7:58 — `inout str` is a second-class exclusive view. Its bytes may be
+# accessed through the view, but the view binding itself cannot be rebound as
+# a whole value. This also prevents a default 3-word StrBuf literal from being
+# dropped/stored through a 2-word Str(N) caller allocation (RUE-641).
+[[case]]
+name = "inout_str_view_whole_reassignment_rejected"
+spec = ["3.7:58"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn replace(inout s: str) {
+    s = "hi";
+}
+fn main() -> i32 {
+    let mut s: Str(8) = "hello";
+    replace(inout s);
+    @intCast(s.len())
+}
+"""
+compile_fail = true
+error_contains = "E0210"
+
 # 3.7:60 — a first-class / static `str` value is NOT a legal `inout str` operand
 # (E0496): an exclusive view requires local buffer provenance.
 [[case]]

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -442,6 +442,13 @@ buffer's bytes that is valid only in argument position; it may be read (`.len()`
 byte indexing) or re-borrowed, but it cannot escape the call by being returned,
 stored in a struct field, or bound past its argument scope.
 
+The binding of an `inout str` view cannot be reassigned as a whole value
+(E0210). Whole assignment would rebind the view header rather than mutate the
+caller-owned bytes, and the caller's concrete `StrBuf` or `Str(N)` storage need
+not have the representation of the value being assigned. Exclusive byte-level
+mutation, when provided by the string interface, is distinct from rebinding the
+second-class view itself.
+
 {{ rule(id="3.7:59", cat="legality-rule") }}
 
 A string *buffer* — `StrBuf` or `Str(N)` — or a borrowed `str` view used where a


### PR DESCRIPTION
## Summary

- reject whole-value assignment to a bare `inout str` view with stable E0210 before RHS analysis or `ParamStore` emission
- document the second-class view rule normatively in spec §3.7:58 and add an executable compile-fail case for the original unsafe reproducer
- prove the residual class with a same-typed `str` replacement that PR #1466 alone would accept

## Root cause

A bare `inout str` is an exclusive view over caller-owned `StrBuf` or `Str(N)` storage, not a first-class string header. PR #1466 prevents differently typed or differently sized values from reaching `ParamStore`, but a same-typed `str` RHS could still rebind the view header and erase the caller buffer identity. The language model already limits these views to read and reborrow operations, so whole rebinding must be rejected independently of representation width.

## Impact

Whole assignment to `inout str` now reports E0210 with guidance to use an exact `inout Str(N)` or `inout StrBuf` parameter when replacement is intended. Normal and borrowed parameters retain their existing diagnostics, and exact buffer parameters remain assignable under the representation check from #1466.

## Validation

- `./fmt.sh && ./fmt.sh check`
- `./clippy.sh` — 41 targets clean
- AIR 364/364; rue-error 102 passed with 1 ignored; spec 2,022 passed with 14 ignored
- spec traceability — 738/738 normative paragraphs covered
- `./test.sh` — all 34 Buck targets passed, including UI and CLI suites
- live CLI oracle — 641 agree, 96 registered model gaps, 565 ineligible, 0 frontend failures, 0 disagreements
- live spec oracle — 1,346 agree, 98 registered model gaps, 592 ineligible, 0 frontend failures, 0 disagreements

An independent review reported CLEAR after strengthening the test to cover same-typed rebinding.