### PR TITLE
RUE-634: preserve method parameter modes

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -90,6 +90,11 @@ pub struct MethodSig {
     pub has_self: bool,
     /// Parameter types (excluding self), as InferTypes for uniform handling.
     pub param_types: Vec<InferType>,
+    /// Source parameter modes (excluding self), in the same order as
+    /// `param_types`. Keeping modes in the inference signature prevents method
+    /// calls from consulting a type-only shadow of the callee contract
+    /// (RUE-634).
+    pub param_modes: Vec<rue_rir::RirParamMode>,
     /// Return type, as InferType for uniform handling.
     pub return_type: InferType,
 }

--- a/crates/rue-air/src/param_arena.rs
+++ b/crates/rue-air/src/param_arena.rs
@@ -72,7 +72,9 @@
 //! Methods always store parameter names (needed for named argument checking).
 //! Functions only need names for generic functions (for type substitution).
 //! To handle this, both `alloc` and `alloc_method` store names, but functions
-//! can pass empty iterators if names aren't needed.
+//! can pass empty iterators if names aren't needed. Method allocation also
+//! requires the source modes and comptime flags: defaulting either would erase
+//! part of the callable signature and can desynchronize caller and callee ABI.
 
 use crate::types::Type;
 use lasso::Spur;
@@ -214,38 +216,20 @@ impl ParamArena {
         ParamRange::new(start, types_len as u32)
     }
 
-    /// Allocates storage for a method's parameters (without comptime flags).
+    /// Allocates storage for a method's explicit parameters.
     ///
-    /// Methods don't have comptime parameters, so this is a convenience method
-    /// that fills the comptime array with `false` values.
+    /// This deliberately requires the same complete signature data as
+    /// [`Self::alloc`]. A method parameter may be `borrow`, `inout`, or
+    /// `comptime`; synthesizing Normal/non-comptime defaults here would make the
+    /// call-site signature disagree with the method body's ABI (RUE-634).
     pub fn alloc_method(
         &mut self,
         names: impl IntoIterator<Item = Spur>,
         types: impl IntoIterator<Item = Type>,
+        modes: impl IntoIterator<Item = RirParamMode>,
+        comptime: impl IntoIterator<Item = bool>,
     ) -> ParamRange {
-        let start = self.types.len() as u32;
-
-        // Collect names and types
-        self.names.extend(names);
-        let names_len = self.names.len() - start as usize;
-
-        self.types.extend(types);
-        let types_len = self.types.len() - start as usize;
-
-        // Verify lengths match
-        assert_eq!(
-            names_len, types_len,
-            "ParamArena::alloc_method: names ({}) and types ({}) have different lengths",
-            names_len, types_len
-        );
-
-        // Methods use Normal mode and are not comptime by default
-        self.modes
-            .extend(std::iter::repeat(RirParamMode::Normal).take(types_len));
-        self.comptime
-            .extend(std::iter::repeat(false).take(types_len));
-
-        ParamRange::new(start, types_len as u32)
+        self.alloc(names, types, modes, comptime)
     }
 
     /// Returns the parameter names for a range.
@@ -413,17 +397,21 @@ mod tests {
         let x = make_spur(&mut rodeo, "x");
         let y = make_spur(&mut rodeo, "y");
 
-        let range = arena.alloc_method([x, y], [Type::I32, Type::BOOL]);
+        let range = arena.alloc_method(
+            [x, y],
+            [Type::I32, Type::BOOL],
+            [RirParamMode::Borrow, RirParamMode::Inout],
+            [false, true],
+        );
 
         assert_eq!(range.len(), 2);
         assert_eq!(arena.names(range), &[x, y]);
         assert_eq!(arena.types(range), &[Type::I32, Type::BOOL]);
-        // Methods default to Normal mode and non-comptime
         assert_eq!(
             arena.modes(range),
-            &[RirParamMode::Normal, RirParamMode::Normal]
+            &[RirParamMode::Borrow, RirParamMode::Inout]
         );
-        assert_eq!(arena.comptime(range), &[false, false]);
+        assert_eq!(arena.comptime(range), &[false, true]);
     }
 
     #[test]

--- a/crates/rue-air/src/sema/analysis/anon_methods.rs
+++ b/crates/rue-air/src/sema/analysis/anon_methods.rs
@@ -57,6 +57,8 @@ impl<'a> Sema<'a> {
                 // Resolve parameter types (Self -> this anonymous struct's type)
                 let params = self.rir.get_params(*params_start, *params_len);
                 let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
+                let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
+                let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
                 let param_types: Vec<Type> = params
                     .iter()
                     .map(|p| {
@@ -68,9 +70,12 @@ impl<'a> Sema<'a> {
                     self.resolve_type_with_self(*return_type, struct_type, method_inst.span)?;
 
                 // Allocate method parameters in the arena
-                let param_range = self
-                    .param_arena
-                    .alloc_method(param_names.into_iter(), param_types.into_iter());
+                let param_range = self.param_arena.alloc_method(
+                    param_names,
+                    param_types,
+                    param_modes,
+                    param_comptime,
+                );
 
                 self.methods.insert(
                     key,
@@ -134,6 +139,8 @@ impl<'a> Sema<'a> {
                 // Resolve parameter types using comptime-safe resolution
                 let params = self.rir.get_params(*params_start, *params_len);
                 let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
+                let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
+                let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
                 let mut param_types: Vec<Type> = Vec::with_capacity(params.len());
 
                 for p in params {
@@ -156,9 +163,12 @@ impl<'a> Sema<'a> {
                 };
 
                 // Allocate method parameters in the arena
-                let param_range = self
-                    .param_arena
-                    .alloc_method(param_names.into_iter(), param_types.into_iter());
+                let param_range = self.param_arena.alloc_method(
+                    param_names,
+                    param_types,
+                    param_modes,
+                    param_comptime,
+                );
 
                 self.methods.insert(
                     key,
@@ -287,6 +297,8 @@ impl<'a> Sema<'a> {
                 // Resolve parameter types using comptime-safe resolution with substitution
                 let params = self.rir.get_params(*params_start, *params_len);
                 let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
+                let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
+                let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
                 let mut param_types: Vec<Type> = Vec::with_capacity(params.len());
 
                 for p in params {
@@ -319,9 +331,12 @@ impl<'a> Sema<'a> {
                 };
 
                 // Allocate method parameters in the arena
-                let param_range = self
-                    .param_arena
-                    .alloc_method(param_names.into_iter(), param_types.into_iter());
+                let param_range = self.param_arena.alloc_method(
+                    param_names,
+                    param_types,
+                    param_modes,
+                    param_comptime,
+                );
 
                 staged.push((
                     key,
@@ -380,17 +395,26 @@ impl<'a> Sema<'a> {
                 params_len,
                 return_type,
                 has_self,
+                self_mode,
                 ..
             } = &method_inst.data
             {
-                // Extract parameter types as symbols (excluding self)
+                // Extract the complete explicit-parameter signature. Passing
+                // modes and comptime flags affect the callable contract just as
+                // types do, so anonymous types that differ in any of them must
+                // not share one StructId/method body (RUE-634).
                 let params = self.rir.get_params(*params_start, *params_len);
                 let param_types: Vec<Spur> = params.iter().map(|p| p.ty).collect();
+                let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
+                let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
 
                 sigs.push(super::super::AnonMethodSig {
                     name: *name,
                     has_self: *has_self,
+                    self_mode: *self_mode,
                     param_types,
+                    param_modes,
+                    param_comptime,
                     return_type: *return_type,
                 });
             }

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -92,6 +92,7 @@ impl<'a> Sema<'a> {
                             .iter()
                             .map(|t| self.type_to_infer_type(*t))
                             .collect(),
+                        param_modes: self.param_arena.modes(info.params).to_vec(),
                         return_type: self.type_to_infer_type(info.return_type),
                     },
                 )

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -209,6 +209,7 @@ impl<'a> Sema<'a> {
                             .iter()
                             .map(|t| self.type_to_infer_type(*t))
                             .collect(),
+                        param_modes: self.param_arena.modes(info.params).to_vec(),
                         return_type: self.type_to_infer_type(info.return_type),
                     },
                 )
@@ -1516,6 +1517,8 @@ impl<'a> Sema<'a> {
 
                 let params = self.rir.get_params(*params_start, *params_len);
                 let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
+                let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
+                let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
                 // `Self` in a method signature (parameter or return position)
                 // resolves to the enclosing struct's type, just like the
                 // receiver does. Named-struct inline methods reach this path;
@@ -1528,9 +1531,12 @@ impl<'a> Sema<'a> {
                     self.resolve_type_with_self(*return_type, struct_type, method_inst.span)?;
 
                 // Allocate method parameters in the arena
-                let param_range = self
-                    .param_arena
-                    .alloc_method(param_names.into_iter(), param_types.into_iter());
+                let param_range = self.param_arena.alloc_method(
+                    param_names,
+                    param_types,
+                    param_modes,
+                    param_comptime,
+                );
 
                 self.methods.insert(
                     key,

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -75,8 +75,9 @@ pub struct MethodInfo {
 /// Method signature for anonymous struct structural equality comparison.
 ///
 /// This captures only the parts of a method that affect structural equality:
-/// method name, whether it has self, parameter types (as symbols), and return type.
-/// Method bodies do NOT affect structural equality - only signatures matter.
+/// method name, receiver presence and mode, explicit parameter types/modes,
+/// comptime flags, and return type. Method bodies do NOT affect structural
+/// equality - only signatures matter.
 ///
 /// Type symbols are stored as Spur (interned strings) rather than resolved Types
 /// because at comparison time, `Self` hasn't been resolved to a concrete StructId yet.
@@ -87,8 +88,15 @@ pub struct AnonMethodSig {
     pub name: Spur,
     /// Whether this is a method (has self) or associated function (no self)
     pub has_self: bool,
+    /// Receiver passing mode. Meaningful when `has_self` is true; associated
+    /// functions carry Normal.
+    pub self_mode: rue_rir::RirParamMode,
     /// Parameter type symbols (excluding self parameter)
     pub param_types: Vec<Spur>,
+    /// Explicit parameter passing modes, parallel to `param_types`.
+    pub param_modes: Vec<rue_rir::RirParamMode>,
+    /// Explicit parameter comptime flags, parallel to `param_types`.
+    pub param_comptime: Vec<bool>,
     /// Return type symbol
     pub return_type: Spur,
 }

--- a/crates/rue-air/src/sema/sema_ctx_builder.rs
+++ b/crates/rue-air/src/sema/sema_ctx_builder.rs
@@ -77,6 +77,7 @@ impl<'a> Sema<'a> {
                         struct_type,
                         has_self: true,
                         param_types,
+                        param_modes: vec![rue_rir::RirParamMode::Normal; method.params.len()],
                         return_type: self.type_to_infer_type(return_ty),
                     },
                 );
@@ -118,6 +119,7 @@ impl<'a> Sema<'a> {
                         struct_type,
                         has_self: false,
                         param_types,
+                        param_modes: vec![rue_rir::RirParamMode::Normal; assoc_fn.params.len()],
                         return_type: self.type_to_infer_type(return_ty),
                     },
                 );

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -6,7 +6,7 @@ mod tests {
     use rue_error::{CompileErrors, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures};
     use rue_lexer::Lexer;
     use rue_parser::Parser;
-    use rue_rir::AstGen;
+    use rue_rir::{AstGen, RirParamMode};
 
     fn compile_to_air(source: &str) -> MultiErrorResult<SemaOutput> {
         compile_to_air_with_preview_features(source, PreviewFeatures::new())
@@ -1360,6 +1360,155 @@ mod tests {
         sema.register_type_names().unwrap();
         sema.resolve_declarations().unwrap();
         sema
+    }
+
+    #[test]
+    fn named_method_registration_preserves_complete_parameter_contract() {
+        let sema = gather_declarations_for_testing(
+            "struct Probe {
+                value: i32,
+                fn modes(
+                    borrow self,
+                    borrow read: i32,
+                    inout write: i32,
+                    comptime scale: i32,
+                ) -> i32 { read + write + scale }
+            }
+            fn main() -> i32 { 0 }",
+        );
+
+        let probe_name = sema.interner.get("Probe").unwrap();
+        let method_name = sema.interner.get("modes").unwrap();
+        let struct_id = *sema.structs.get(&probe_name).unwrap();
+        let method = sema.methods.get(&(struct_id, method_name)).unwrap();
+
+        assert_eq!(
+            sema.param_arena.modes(method.params),
+            &[
+                RirParamMode::Borrow,
+                RirParamMode::Inout,
+                RirParamMode::Normal,
+            ]
+        );
+        assert_eq!(
+            sema.param_arena.comptime(method.params),
+            &[false, false, true]
+        );
+
+        // The inference-side signature must carry the identical source-mode
+        // vector rather than a type-only shadow of MethodInfo (RUE-634).
+        let inference = sema.build_inference_context();
+        let signature = inference
+            .method_sigs
+            .get(&(struct_id, method_name))
+            .unwrap();
+        assert_eq!(
+            signature.param_modes,
+            vec![
+                RirParamMode::Borrow,
+                RirParamMode::Inout,
+                RirParamMode::Normal,
+            ]
+        );
+    }
+
+    #[test]
+    fn anonymous_method_self_mode_participates_in_structural_identity() {
+        let output = compile_to_air(
+            "fn ByValue() -> type {
+                struct { value: i32, fn f(self) -> i32 { self.value } }
+            }
+            fn ByBorrow() -> type {
+                struct { value: i32, fn f(borrow self) -> i32 { self.value } }
+            }
+            fn main() -> i32 {
+                let V = ByValue();
+                let B = ByBorrow();
+                let v = V { value: 20 };
+                let b = B { value: 22 };
+                v.f() + b.f()
+            }",
+        )
+        .unwrap();
+
+        let mut physical_modes: Vec<Vec<bool>> = output
+            .functions
+            .iter()
+            .filter(|function| {
+                function.name.starts_with("__anon_struct_") && function.name.ends_with(".f")
+            })
+            .map(|function| function.param_modes.by_ref().to_vec())
+            .collect();
+        physical_modes.sort();
+        assert_eq!(physical_modes, vec![vec![false], vec![true]]);
+    }
+
+    #[test]
+    fn anonymous_method_explicit_mode_participates_in_structural_identity() {
+        let output = compile_to_air(
+            "fn Normal() -> type {
+                struct { fn f(borrow self, x: i64) -> i64 { x } }
+            }
+            fn Borrowed() -> type {
+                struct { fn f(borrow self, borrow x: i64) -> i64 { x } }
+            }
+            fn main() -> i32 {
+                let N = Normal();
+                let B = Borrowed();
+                let n = N {};
+                let b = B {};
+                let x: i64 = 20;
+                let y: i64 = 22;
+                @intCast(n.f(x) + b.f(borrow y))
+            }",
+        )
+        .unwrap();
+
+        let mut physical_modes: Vec<Vec<bool>> = output
+            .functions
+            .iter()
+            .filter(|function| {
+                function.name.starts_with("__anon_struct_") && function.name.ends_with(".f")
+            })
+            .map(|function| function.param_modes.by_ref().to_vec())
+            .collect();
+        physical_modes.sort();
+        assert_eq!(physical_modes, vec![vec![true, false], vec![true, true]]);
+    }
+
+    #[test]
+    fn anonymous_method_comptime_flag_participates_in_structural_identity() {
+        let output = compile_to_air(
+            "fn Runtime() -> type {
+                struct { fn f(x: i32) -> i32 { x } }
+            }
+            fn Compiletime() -> type {
+                struct { fn f(comptime x: i32) -> i32 { x } }
+            }
+            fn main() -> i32 {
+                let R = Runtime();
+                let C = Compiletime();
+                let _r = R {};
+                let _c = C {};
+                0
+            }",
+        )
+        .unwrap();
+
+        let main = output
+            .functions
+            .iter()
+            .find(|function| function.name == "main")
+            .unwrap();
+        let struct_ids: std::collections::HashSet<_> = main
+            .air
+            .iter()
+            .filter_map(|(_, inst)| match inst.data {
+                AirInstData::StructInit { struct_id, .. } => Some(struct_id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(struct_ids.len(), 2);
     }
 
     #[test]

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1042,6 +1042,38 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "anon_struct_method_parameter_modes_are_structural"
+spec = ["4.14:15"]
+description = "Anonymous methods whose explicit parameter modes differ have distinct structural types and ABIs"
+source = """
+fn Normal() -> type {
+    struct {
+        zero: i32,
+        fn combine(borrow self, value: i64) -> i32 {
+            self.zero + @intCast(value)
+        }
+    }
+}
+fn Borrowed() -> type {
+    struct {
+        zero: i32,
+        fn combine(borrow self, borrow value: i64) -> i32 {
+            self.zero + @intCast(value)
+        }
+    }
+}
+fn main() -> i32 {
+    let N = Normal();
+    let B = Borrowed();
+    let n = N { zero: 0 };
+    let b = B { zero: 0 };
+    let value: i64 = 22;
+    n.combine(20) + b.combine(borrow value)
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "anon_struct_swap_method"
 spec = ["4.14:11"]
 description = "Swap method from spec example"

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -223,7 +223,10 @@ fn main() -> i32 {
 
 {{ rule(id="4.14:8", cat="normative") }}
 
-Two anonymous struct types are structurally equal if and only if they have the same field names in the same order with the same types.
+Two anonymous struct types that contain no method definitions are structurally
+equal if and only if they have the same field names in the same order with the
+same types. Structural equality for anonymous structs with methods is specified
+by rule 4.14:15.
 
 ```rue
 fn make_point1() -> type { struct { x: i32, y: i32 } }
@@ -349,8 +352,10 @@ It is a compile-time error to define two methods with the same name in an anonym
 {{ rule(id="4.14:15", cat="normative") }}
 
 Two anonymous struct types are structurally equal if and only if they have:
+
 1. The same field names in the same order with the same types, AND
-2. The same method names with the same parameter types and return types
+2. The same method names, receiver presence and passing mode, explicit
+   parameter types, passing modes and `comptime` modifiers, and return types
 
 Method bodies do not affect structural equality—only signatures matter.
 


### PR DESCRIPTION
## Summary

- preserve declared passing modes and comptime flags in every named and anonymous method-registration path
- carry parameter modes into inference signatures
- make receiver mode, explicit parameter modes, and comptime modifiers part of anonymous-struct structural identity
- align rules 4.14:8 and 4.14:15 and add an executable ABI-sensitive spec witness

## Root cause

ParamArena::alloc_method synthesized every explicit method parameter as Normal and non-comptime, while AnonMethodSig compared only parameter types. That let the caller contract drift from the callee ABI and allowed ABI-distinct anonymous method types to collapse to one StructId and implementation.

## Scope

This is the first of three focused RUE-634 landings. It establishes complete signature truth. The next PR will enforce one exact source-mode validator across call-like surfaces; the final PR will repair method and associated-function view coercions.

## Validation

- ./fmt.sh check
- ./clippy.sh
- ./test.sh: 34 targets passed
- rue-air: 368/368
- spec: 2023 passed, 14 ignored
- traceability: 738/738 normative paragraphs
- live CLI oracle: 641 agree, 96 modeled gaps, 565 ineligible, 0 frontend/oracle failures, 0 disagreements
- live spec oracle: 1347 agree, 98 modeled gaps, 592 ineligible, 0 frontend/oracle failures, 0 disagreements
- independent review: no findings