### PR TITLE
RUE-630 completion: struct/enum members as type values; nested-facade payload constraining

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2822,17 +2822,36 @@ impl<'a> ConstraintGenerator<'a> {
             })
     }
 
-    /// The defining file of `module`'s target, when `module` is a `VarRef`
-    /// naming an imported module binding in the current file.
+    /// The defining file of `module`'s target: a `VarRef` naming an imported
+    /// module binding in the current file, or a `FieldGet` chain through
+    /// re-exported module bindings (`db.query.Pred` resolves `db` in the
+    /// current file, then `query` as a module binding in db's file, and so
+    /// on) — without the recursion a nested-facade payload construction left
+    /// its arguments unconstrained (RUE-633 family, reject-valid this time:
+    /// sema's E0206 caught the defaulted literal).
     fn module_member_file(&self, module: InstRef) -> Option<FileId> {
         let inst = self.rir.get(module);
-        let InstData::VarRef { name } = &inst.data else {
-            return None;
-        };
-        let module_ty = self
-            .module_binding_types
-            .and_then(|bindings| bindings.get(&(inst.span.file_id, *name)))
-            .copied()?;
+        match &inst.data {
+            InstData::VarRef { name } => {
+                let module_ty = self
+                    .module_binding_types
+                    .and_then(|bindings| bindings.get(&(inst.span.file_id, *name)))
+                    .copied()?;
+                self.module_file(module_ty)
+            }
+            InstData::FieldGet { base, field } => {
+                let base_file = self.module_member_file(*base)?;
+                let module_ty = self
+                    .module_binding_types
+                    .and_then(|bindings| bindings.get(&(base_file, *field)))
+                    .copied()?;
+                self.module_file(module_ty)
+            }
+            _ => None,
+        }
+    }
+
+    fn module_file(&self, module_ty: Type) -> Option<FileId> {
         let module_id = module_ty.as_module()?;
         self.module_file_ids
             .and_then(|module_file_ids| module_file_ids.get(&module_id))

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -2456,15 +2456,39 @@ impl<'a> Sema<'a> {
             }
         }
 
-        // A struct/enum member would make this a type-valued constant, which
-        // is not supported (same as `const T = i32;`).
-        if self.structs.contains_key(&member) || self.enums.contains_key(&member) {
-            return Err(CompileError::new(
-                ErrorKind::ConstExprNotSupported {
-                    expr_kind: "a type value".to_string(),
-                },
-                span,
-            ));
+        // A struct/enum member is a TYPE value (`m.Row`): usable anywhere a
+        // type-valued constant is — most importantly as a type argument of a
+        // generic instantiation in a const initializer
+        // (`const Rows = std.arraybuf.ArrayBuf(records.Row);`, RUE-630).
+        // The old behavior rejected this as "a type value ... not supported",
+        // a claim stale since type-valued constants landed.
+        if let Some(mfile) = module_file_id {
+            if let Some(struct_id) = self.structs_by_file_name.get(&(mfile, member)).copied() {
+                let def = self.type_pool.struct_def(struct_id);
+                let is_pub = def.is_pub;
+                self.check_const_member_visibility(
+                    is_pub,
+                    &member_str,
+                    &module_file_path,
+                    accessing_file,
+                    span,
+                )?;
+                return Ok(ConstInit::Value(ConstValue::Type(Type::new_struct(
+                    struct_id,
+                ))));
+            }
+            if let Some(enum_id) = self.enums_by_file_name.get(&(mfile, member)).copied() {
+                let def = self.type_pool.enum_def(enum_id);
+                let is_pub = def.is_pub;
+                self.check_const_member_visibility(
+                    is_pub,
+                    &member_str,
+                    &module_file_path,
+                    accessing_file,
+                    span,
+                )?;
+                return Ok(ConstInit::Value(ConstValue::Type(Type::new_enum(enum_id))));
+            }
         }
 
         Err(CompileError::new(

--- a/crates/rue-cli-tests/cases/const_alias_inference.toml
+++ b/crates/rue-cli-tests/cases/const_alias_inference.toml
@@ -237,3 +237,60 @@ fn main() -> i32 {
 }
 """ },
 ]
+
+[[case]]
+name = "generic_instantiated_with_qualified_type_arg_in_const"
+description = "const Rows = std.arraybuf.ArrayBuf(records.Row) — a generic instantiation with a module-qualified type argument as a const initializer, used as a field type (RUE-630 rows 6/7; struct/enum members are type values)"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const records = @import("records.rue");
+const std = @import("std");
+const Rows = std.arraybuf.ArrayBuf(records.Row);
+
+pub struct Table { rows: Rows }
+
+fn main() -> i32 {
+    let mut rows = Rows.new();
+    rows.push(records.Row { id: 41, bump: 0 - 1 });
+    let t = Table { rows: rows };
+    let r = t.rows.get_or(0, records.Row { id: 0, bump: 0 });
+    @intCast(r.id - r.bump)
+}
+""" },
+    { path = "records.rue", source = """
+pub struct Row {
+    id: i64,
+    bump: i64,
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "nested_facade_variant_payload_constrained"
+description = "db.query.Pred.SalaryAtLeast(100) — payload construction through a nested module facade constrains the literal to the declared i64 (recursive module_member_file)"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [
+    { path = "main.rue", source = """
+const db = @import("db");
+
+fn main() -> i32 {
+    let p = db.inner.Pick.AtLeast(42);
+    match p {
+        db.inner.Pick.AtLeast(v) => @intCast(v),
+        db.inner.Pick.Nothing => 1,
+    }
+}
+""" },
+    { path = "db/_db.rue", source = """
+pub const inner = @import("inner.rue");
+""" },
+    { path = "db/inner.rue", source = """
+pub enum Pick {
+    AtLeast(i64),
+    Nothing,
+}
+""" },
+]
+exit_code = 42

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -146,6 +146,12 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         stdin: None,
     },
     ExampleExpectation {
+        path: "tinydb/main.rue",
+        exit_code: 42,
+        stdout: "",
+        stdin: None,
+    },
+    ExampleExpectation {
         path: "dijkstra/main.rue",
         exit_code: 42,
         stdout: "",

--- a/examples/tinydb/db/_db.rue
+++ b/examples/tinydb/db/_db.rue
@@ -1,0 +1,3 @@
+pub const record = @import("record.rue");
+pub const table = @import("table.rue");
+pub const query = @import("query.rue");

--- a/examples/tinydb/db/query.rue
+++ b/examples/tinydb/db/query.rue
@@ -1,0 +1,50 @@
+const std = @import("std");
+const record = @import("record.rue");
+const table = @import("table.rue");
+
+// Predicates as data: a tiny query language over rows.
+pub enum Pred {
+    ByDept(record.Dept),
+    SalaryAtLeast(i64),
+    Any,
+}
+
+fn matches(borrow row: record.Row, borrow p: Pred) -> bool {
+    match p {
+        Pred.ByDept(d) => row.dept == d,
+        Pred.SalaryAtLeast(min) => row.salary >= min,
+        Pred.Any => true,
+    }
+}
+
+pub fn sum_salaries(borrow t: table.Table, p: Pred) -> i64 {
+    let n = t.count();
+    let mut total: i64 = 0;
+    let mut i: u64 = 0;
+    while i < n {
+        let row = t.row_at(i);
+        if matches(borrow row, borrow p) {
+            total = total + row.salary;
+        }
+        i = i + 1;
+    }
+    total
+}
+
+pub fn top_earner(borrow t: table.Table, p: Pred) -> i64 {
+    let n = t.count();
+    let mut best_id: i64 = 0 - 1;
+    let mut best: i64 = 0 - 1;
+    let mut i: u64 = 0;
+    while i < n {
+        let row = t.row_at(i);
+        if matches(borrow row, borrow p) {
+            if row.salary > best {
+                best = row.salary;
+                best_id = row.id;
+            }
+        }
+        i = i + 1;
+    }
+    best_id
+}

--- a/examples/tinydb/db/record.rue
+++ b/examples/tinydb/db/record.rue
@@ -1,0 +1,16 @@
+// One row: (id, dept, salary). Dept is a small closed enum.
+pub enum Dept {
+    Eng,
+    Sales,
+    Ops,
+}
+
+pub struct Row {
+    id: i64,
+    dept: Dept,
+    salary: i64,
+
+    fn new(id: i64, dept: Dept, salary: i64) -> Self {
+        Self { id: id, dept: dept, salary: salary }
+    }
+}

--- a/examples/tinydb/db/table.rue
+++ b/examples/tinydb/db/table.rue
@@ -1,0 +1,29 @@
+const std = @import("std");
+const record = @import("record.rue");
+
+// The unlocked pattern: ArrayBuf of a cross-module struct via the
+// exporter's own alias would be ideal; rows are same-file-free structs,
+// so instantiate directly with the qualified type.
+pub const Rows = std.arraybuf.ArrayBuf(record.Row);
+
+pub struct Table {
+    rows: Rows,
+    next_id: i64,
+
+    fn new() -> Self {
+        Self { rows: Rows.new(), next_id: 1 }
+    }
+
+    fn insert(inout self, dept: record.Dept, salary: i64) -> i64 {
+        let id = self.next_id;
+        self.next_id = self.next_id + 1;
+        self.rows.push(record.Row.new(id, dept, salary));
+        id
+    }
+
+    fn count(borrow self) -> u64 { self.rows.len() }
+
+    fn row_at(borrow self, i: u64) -> record.Row {
+        self.rows.get_or(i, record.Row.new(0 - 1, record.Dept.Ops, 0))
+    }
+}

--- a/examples/tinydb/main.rue
+++ b/examples/tinydb/main.rue
@@ -1,0 +1,27 @@
+// Dogfood #6: tinydb — a four-module relational engine exercising the
+// full cross-module type surface unlocked today: qualified enums/structs
+// in ArrayBuf fields, cross-module payload enums as query predicates,
+// enum equality, and borrowed row scans.
+const db = @import("db");
+
+fn main() -> i32 {
+    let mut t = db.table.Table.new();
+    t.insert(db.record.Dept.Eng, 120);
+    t.insert(db.record.Dept.Eng, 95);
+    t.insert(db.record.Dept.Sales, 80);
+    t.insert(db.record.Dept.Sales, 110);
+    t.insert(db.record.Dept.Ops, 70);
+
+    let eng = db.query.sum_salaries(borrow t, db.query.Pred.ByDept(db.record.Dept.Eng));
+    @assert(eng == 215, "eng sum");
+    let high = db.query.sum_salaries(borrow t, db.query.Pred.SalaryAtLeast(100));
+    @assert(high == 230, "high sum");
+    let all = db.query.sum_salaries(borrow t, db.query.Pred.Any);
+    @assert(all == 475, "all sum");
+    let top = db.query.top_earner(borrow t, db.query.Pred.Any);
+    @assert(top == 1, "top is row 1 (120)");
+    let top_sales = db.query.top_earner(borrow t, db.query.Pred.ByDept(db.record.Dept.Sales));
+    @assert(top_sales == 4, "top sales is row 4 (110)");
+
+    @intCast(eng - high + top_sales * 14 + 1)   // 215-230+56+1 = 42
+}


### PR DESCRIPTION
Fixes RUE-630

Closes the remaining rows of the cross-module type-alias matrix, hit again in the wild by dogfood #6 — **tinydb**, a four-module relational engine (promoted to `examples/tinydb/`, pinned at exit 42):

- **Rows 4/6/7**: `resolve_module_member_const` rejected struct/enum members as "a type value … not supported (same as `const T = i32`)" — stale since type-valued constants landed. A struct/enum member now yields `ConstValue::Type` (by-file resolution + privacy check), so `const Rows = std.arraybuf.ArrayBuf(records.Row);` evaluates and works as a field type.
- **Nested facades**: inference's `module_member_file` now resolves `FieldGet` chains through re-exported module bindings recursively — `db.query.Pred.SalaryAtLeast(100)` constrains its payload literal to the declared `i64` instead of a spurious E0206 at the defaulted width.

With #1470 earlier, every row of the RUE-630 matrix is fixed; the natural multi-module data-type patterns (qualified aliases in type positions, qualified instantiations in consts, facade-deep constructions) all work with no preview flags and no workarounds. Two new CLI regression cases + the tinydb example.

Full suite green (Pass 34, traceability 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
