### PR TITLE
RUE-639: Self.assoc_fn(args) resolves like StructName.assoc_fn; maze example

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2739,10 +2739,18 @@ impl<'a> ConstraintGenerator<'a> {
     /// permissiveness only — sema's module-local resolution is authoritative
     /// and rejects cross-file unqualified references (E0204).
     fn struct_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
-        self.comptime_alias_types
-            .get(type_name)
-            .copied()
+        // `Self` (and comptime type parameters) resolve through the enclosing
+        // substitution first, so `Self.assoc_fn(args)` constrains its
+        // arguments like `StructName.assoc_fn(args)` (RUE-639).
+        self.type_subst
+            .and_then(|subst| subst.get(type_name).copied())
             .filter(|ty| ty.as_struct().is_some())
+            .or_else(|| {
+                self.comptime_alias_types
+                    .get(type_name)
+                    .copied()
+                    .filter(|ty| ty.as_struct().is_some())
+            })
             .or_else(|| {
                 // File-level `const Ints = ArrayBuf(i64);` aliases: without
                 // this, a method chain rooted at the alias (`Ints.new()`)
@@ -2764,10 +2772,15 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     fn enum_type_for(&self, type_name: &Spur, file_id: FileId) -> Option<Type> {
-        self.comptime_alias_types
-            .get(type_name)
-            .copied()
+        self.type_subst
+            .and_then(|subst| subst.get(type_name).copied())
             .filter(|ty| ty.is_enum())
+            .or_else(|| {
+                self.comptime_alias_types
+                    .get(type_name)
+                    .copied()
+                    .filter(|ty| ty.is_enum())
+            })
             .or_else(|| {
                 // File-level const enum aliases, for the same reason as
                 // `struct_type_for` (RUE-633): a construction rooted at the

--- a/crates/rue-cli-tests/cases/basics.toml
+++ b/crates/rue-cli-tests/cases/basics.toml
@@ -117,3 +117,34 @@ files = [
 args = ["a.rue", "b.rue"]
 compile_fail = true
 error_contains = ["-o"]
+
+# `Self.assoc_fn(args)` resolves like `StructName.assoc_fn(args)` with Self
+# bound to the enclosing struct (RUE-639: the parser used to hard-expect `{`
+# after Self in expression position). The negative-literal argument guards
+# the constraint path (the RUE-633 miscompile family).
+[[case]]
+name = "self_assoc_fn_call"
+files = [
+    { path = "main.rue", source = """
+struct Counter {
+    n: i64,
+
+    fn with(n: i64) -> Self {
+        Self { n: n }
+    }
+
+    fn shifted(borrow self) -> Self {
+        Self.with(self.n + (0 - 1))
+    }
+
+    fn value(borrow self) -> i64 { self.n }
+}
+
+fn main() -> i32 {
+    let c = Counter.with(43);
+    let d = c.shifted();
+    @intCast(d.value())
+}
+""" },
+]
+exit_code = 42

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -152,6 +152,12 @@ const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
         stdin: None,
     },
     ExampleExpectation {
+        path: "maze/main.rue",
+        exit_code: 42,
+        stdout: "125\n",
+        stdin: None,
+    },
+    ExampleExpectation {
         path: "dijkstra/main.rue",
         exit_code: 42,
         stdout: "",

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -2205,6 +2205,19 @@ where
             })
         });
 
+    // Bare `Self` as a type-name expression: `Self.assoc_fn(args)` resolves
+    // exactly like `StructName.assoc_fn(args)` through the ordinary postfix
+    // member-call machinery (sema binds `Self` to the enclosing struct in
+    // `comptime_type_vars`, RUE-123). Must come AFTER `self_type_expr` in the
+    // choice so `Self { ... }` still parses as a struct literal (RUE-639).
+    let self_type_name = just(TokenKind::SelfType).map_with(|_, e| {
+        let span = span_from_extra(e);
+        Expr::Ident(Ident {
+            name: e.state().syms.self_type,
+            span,
+        })
+    });
+
     // Primary expression (before field access and indexing)
     // Note: literal_parser() includes unit_lit which must come before paren_expr
     // so () is parsed as unit, not empty parens
@@ -2218,6 +2231,7 @@ where
         control_flow_parser(expr.clone(), block_like.clone()),
         self_expr,
         self_type_expr,
+        self_type_name,
         any_intrinsic_call,
         array_lit,
         anon_struct_type_expr,

--- a/examples/maze/grid.rue
+++ b/examples/maze/grid.rue
@@ -1,0 +1,70 @@
+const std = @import("std");
+const Ints = std.arraybuf.ArrayBuf(i64);
+
+// W x H maze. Each cell is a bitmask of open passages: 1=N, 2=E, 4=S, 8=W.
+pub const N: i64 = 1;
+pub const E: i64 = 2;
+pub const S: i64 = 4;
+pub const W: i64 = 8;
+
+pub struct Maze {
+    w: i64,
+    h: i64,
+    cells: Ints,
+    visited: Ints,
+
+    fn new(w: i64, h: i64) -> Self {
+        let mut cells = Ints.new();
+        let mut visited = Ints.new();
+        let total = w * h;
+        let mut i: i64 = 0;
+        while i < total {
+            cells.push(0);
+            visited.push(0);
+            i = i + 1;
+        }
+        Self { w: w, h: h, cells: cells, visited: visited }
+    }
+
+    fn idx(borrow self, x: i64, y: i64) -> u64 { @intCast(y * self.w + x) }
+    fn width(borrow self) -> i64 { self.w }
+    fn height(borrow self) -> i64 { self.h }
+
+    fn passages(borrow self, x: i64, y: i64) -> i64 {
+        self.cells.get_or(self.idx(x, y), 0)
+    }
+
+    fn open(inout self, x: i64, y: i64, dir: i64) {
+        let i = self.idx(x, y);
+        let old = self.cells.get_or(i, 0);
+        self.cells.set(i, old | dir);
+    }
+
+    fn mark(inout self, x: i64, y: i64) {
+        let i = self.idx(x, y);
+        self.visited.set(i, 1);
+    }
+
+    fn seen(borrow self, x: i64, y: i64) -> bool {
+        self.visited.get_or(self.idx(x, y), 1) == 1
+    }
+
+    fn clear_marks(inout self) {
+        let total = self.w * self.h;
+        let mut i: u64 = 0;
+        while i < @intCast(total) {
+            self.visited.set(i, 0);
+            i = i + 1;
+        }
+    }
+}
+
+pub fn dx(dir: i64) -> i64 {
+    if dir == E { 1 } else if dir == W { 0 - 1 } else { 0 }
+}
+pub fn dy(dir: i64) -> i64 {
+    if dir == S { 1 } else if dir == N { 0 - 1 } else { 0 }
+}
+pub fn opposite(dir: i64) -> i64 {
+    if dir == N { S } else if dir == S { N } else if dir == E { W } else { E }
+}

--- a/examples/maze/main.rue
+++ b/examples/maze/main.rue
@@ -1,0 +1,103 @@
+// Dogfood #7: maze generation (iterative recursive-backtracker with an
+// explicit ArrayBuf stack + deterministic LCG) and BFS solving (ring-buffer
+// queue + parent tracking). Bitmask walls, heavy 2D index arithmetic.
+const std = @import("std");
+const rand = @import("rand.rue");
+const grid = @import("grid.rue");
+const Ints = std.arraybuf.ArrayBuf(i64);
+
+fn generate(inout m: grid.Maze, inout rng: rand.Lcg) {
+    let mut stack_x = Ints.new();
+    let mut stack_y = Ints.new();
+    stack_x.push(0);
+    stack_y.push(0);
+    m.mark(0, 0);
+    while !stack_x.is_empty() {
+        let x = stack_x.get_or(stack_x.len() - 1, 0);
+        let y = stack_y.get_or(stack_y.len() - 1, 0);
+        // Collect unvisited neighbors.
+        let mut dirs = Ints.new();
+        if y > 0 { if !m.seen(x, y - 1) { dirs.push(grid.N); } }
+        if x < m.width() - 1 { if !m.seen(x + 1, y) { dirs.push(grid.E); } }
+        if y < m.height() - 1 { if !m.seen(x, y + 1) { dirs.push(grid.S); } }
+        if x > 0 { if !m.seen(x - 1, y) { dirs.push(grid.W); } }
+        if dirs.is_empty() {
+            stack_x.pop_or(0);
+            stack_y.pop_or(0);
+        } else {
+            let pick: u64 = @intCast(rng.next(@intCast(dirs.len())));
+            let dir = dirs.get_or(pick, grid.N);
+            let nx = x + grid.dx(dir);
+            let ny = y + grid.dy(dir);
+            m.open(x, y, dir);
+            m.open(nx, ny, grid.opposite(dir));
+            m.mark(nx, ny);
+            stack_x.push(nx);
+            stack_y.push(ny);
+        }
+    }
+}
+
+// BFS from (0,0) to (w-1,h-1); returns shortest path length in cells, or -1.
+fn solve(inout m: grid.Maze) -> i64 {
+    m.clear_marks();
+    let w = m.width();
+    let h = m.height();
+    let mut qx = Ints.new();
+    let mut qy = Ints.new();
+    let mut qd = Ints.new();
+    let mut head: u64 = 0;
+    qx.push(0);
+    qy.push(0);
+    qd.push(1);
+    m.mark(0, 0);
+    let mut result: i64 = 0 - 1;
+    while head < qx.len() {
+        let x = qx.get_or(head, 0);
+        let y = qy.get_or(head, 0);
+        let d = qd.get_or(head, 0);
+        head = head + 1;
+        if x == w - 1 {
+            if y == h - 1 {
+                result = d;
+                break;
+            }
+        }
+        let p = m.passages(x, y);
+        if (p & grid.N) != 0 { if !m.seen(x, y - 1) { m.mark(x, y - 1); qx.push(x); qy.push(y - 1); qd.push(d + 1); } }
+        if (p & grid.E) != 0 { if !m.seen(x + 1, y) { m.mark(x + 1, y); qx.push(x + 1); qy.push(y); qd.push(d + 1); } }
+        if (p & grid.S) != 0 { if !m.seen(x, y + 1) { m.mark(x, y + 1); qx.push(x); qy.push(y + 1); qd.push(d + 1); } }
+        if (p & grid.W) != 0 { if !m.seen(x - 1, y) { m.mark(x - 1, y); qx.push(x - 1); qy.push(y); qd.push(d + 1); } }
+    }
+    result
+}
+
+fn main() -> i32 {
+    let mut rng = rand.Lcg.new(20260711);
+    let mut m = grid.Maze.new(16, 16);
+    generate(inout m, inout rng);
+
+    // A perfect maze visits every cell exactly once during generation and
+    // has exactly w*h-1 open passages (tree edges). Count passage bits/2.
+    let mut bits: i64 = 0;
+    let mut y: i64 = 0;
+    while y < 16 {
+        let mut x: i64 = 0;
+        while x < 16 {
+            let mut p = m.passages(x, y);
+            while p != 0 {
+                bits = bits + (p & 1);
+                p = p >> 1;
+            }
+            x = x + 1;
+        }
+        y = y + 1;
+    }
+    @assert(bits == 510, "tree edges * 2");   // (256-1)*2
+
+    let path = solve(inout m);
+    @dbg(path);
+    @assert(path >= 31, "path at least manhattan");
+    @assert(path <= 256, "path fits the grid");
+    42
+}

--- a/examples/maze/rand.rue
+++ b/examples/maze/rand.rue
@@ -1,0 +1,17 @@
+// Deterministic LCG (Numerical Recipes constants) — reproducible "randomness"
+// so the maze, and therefore the test, is pinned.
+pub struct Lcg {
+    state: i64,
+
+    fn new(seed: i64) -> Self {
+        Self { state: seed }
+    }
+
+    // Next value in [0, bound). Uses the high bits for better spread.
+    fn next(inout self, bound: i64) -> i64 {
+        self.state = (self.state * 1664525 + 1013904223) % 4294967296;
+        let hi = self.state / 65536;
+        let r = hi % bound;
+        if r < 0 { r + bound } else { r }
+    }
+}


### PR DESCRIPTION
Fixes RUE-639

`Self.assoc_fn(args)` now resolves exactly like `StructName.assoc_fn(args)`:

- Parser: a bare `Self` in expression position parses as a type-name identifier (ordered after the `Self { ... }` struct-literal alternative, which is unchanged) and flows through the ordinary postfix member-call machinery.
- Sema needed **no change** — `Self` is already bound to the enclosing struct in `comptime_type_vars` (RUE-123).
- Inference: `struct_type_for`/`enum_type_for` consult the enclosing type substitution first, so the call's arguments are constrained to declared parameter types — the CLI case pins a negative-literal argument (the RUE-633 miscompile-family guard).

Also promotes dogfood #7 to `examples/maze/`: recursive-backtracker generation (bitmask walls, deterministic LCG, explicit stack) + BFS solve (ring-buffer queue), self-checking and pinned to its deterministic path length.

Full suite green (Pass 34, traceability 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
