### PR TITLE
RUE-634: enforce exact call argument modes

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1190,8 +1190,8 @@ fn check_exclusive_access_in(
     Ok(())
 }
 
-/// Shared checks for a module-member function call. Validates module membership, visibility, arity, and argument modes
-/// against the callee.
+/// Shared checks for a module-member function call. Validates module
+/// membership, visibility, and arity against the callee.
 ///
 /// Membership (spec 4.13:90, RUE-140): a module's type contains only the
 /// declarations from the imported file, but the function table is a flat
@@ -1208,13 +1208,11 @@ fn check_exclusive_access_in(
 /// check (whose shared core is `check_exclusive_access_in`, RUE-141).
 #[allow(clippy::too_many_arguments)]
 fn check_module_member_call(
-    rir: &Rir,
     module_name: &str,
     module_file_id: Option<FileId>,
     member_file_id: FileId,
     fn_name_str: &str,
     param_types: &[Type],
-    param_modes: &[RirParamMode],
     args: &[RirCallArg],
     accessible: bool,
     via_reexport: bool,
@@ -1256,33 +1254,6 @@ fn check_module_member_call(
         ));
     }
 
-    // Check that call-site argument modes match function parameter modes
-    for (arg, expected_mode) in args.iter().zip(param_modes.iter()) {
-        match expected_mode {
-            RirParamMode::Inout => {
-                if arg.mode != RirArgMode::Inout {
-                    return Err(CompileError::new(
-                        ErrorKind::InoutKeywordMissing,
-                        rir.get(arg.value).span,
-                    ));
-                }
-            }
-            RirParamMode::Borrow => {
-                if arg.mode != RirArgMode::Borrow {
-                    return Err(CompileError::new(
-                        ErrorKind::BorrowKeywordMissing,
-                        rir.get(arg.value).span,
-                    ));
-                }
-            }
-            RirParamMode::Normal => {
-                // Normal params accept any mode
-            }
-            RirParamMode::Comptime => {
-                // Comptime params - handled elsewhere
-            }
-        }
-    }
     Ok(())
 }
 

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -152,6 +152,7 @@ impl<'a> Sema<'a> {
             )
             .with_help(format!("`{fn_name}` takes exactly one StrBuf argument")));
         }
+        self.validate_explicit_call_modes(&args, std::iter::once(RirParamMode::Normal))?;
         let arg_value = args[0].value;
 
         // Borrow the argument (like a `+` operand): analyze in projection mode
@@ -368,6 +369,13 @@ impl<'a> Sema<'a> {
             ));
         }
 
+        // Builtin registry parameters have types but no source mode marker, so
+        // every explicit argument is an ordinary unmarked value.
+        self.validate_explicit_call_modes(
+            args,
+            std::iter::repeat_n(RirParamMode::Normal, args.len()),
+        )?;
+
         // Analyze arguments and check types
         let mut air_args: Vec<(AirRef, AirArgMode)> = Vec::with_capacity(args.len());
         for (i, arg) in args.iter().enumerate() {
@@ -497,6 +505,13 @@ impl<'a> Sema<'a> {
                 method_ctx.span,
             ));
         }
+
+        // ReceiverMode governs only the implicit receiver. Every explicit
+        // builtin-method parameter is unmarked at the source level.
+        self.validate_explicit_call_modes(
+            args,
+            std::iter::repeat_n(RirParamMode::Normal, args.len()),
+        )?;
 
         // Analyze arguments and check types
         let mut air_args: Vec<(AirRef, AirArgMode)> = Vec::with_capacity(args.len() + 1);

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -316,6 +316,7 @@ impl<'a> Sema<'a> {
 
         // Check argument count (method_info.params excludes self)
         let method_param_types = self.param_arena.types(method_info.params);
+        let method_param_modes = self.param_arena.modes(method_info.params);
         if args.len() != method_param_types.len() {
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount {
@@ -325,6 +326,10 @@ impl<'a> Sema<'a> {
                 span,
             ));
         }
+
+        // The receiver's autoref is implicit and deliberately excluded; only
+        // explicit arguments must spell the method declaration's exact modes.
+        self.validate_explicit_call_modes(&args, method_param_modes.iter().copied())?;
 
         // Clone data needed before mutable borrow
         let return_type = method_info.return_type;
@@ -551,13 +556,11 @@ impl<'a> Sema<'a> {
         let accessible =
             via_reexport || self.is_accessible(span.file_id, fn_info.file_id, fn_info.is_pub);
         check_module_member_call(
-            self.rir,
             &module_def.import_path,
             module_file_id,
             fn_info.file_id,
             &fn_name_str,
             &param_types,
-            &param_modes,
             &args,
             accessible,
             via_reexport,
@@ -582,6 +585,11 @@ impl<'a> Sema<'a> {
                 false,
             );
         }
+
+        // Generic members delegate to the resolved-call path above, which
+        // performs the same exact source-mode validation. Non-generic members
+        // validate here before treating any explicit marker as a loan/place.
+        self.validate_explicit_call_modes(&args, param_modes.iter().copied())?;
 
         // Check for exclusive access violation. (The old, pre-deduplication
         // copy of this function skipped this check entirely.)
@@ -745,6 +753,7 @@ impl<'a> Sema<'a> {
 
         // Check argument count
         let method_param_types = self.param_arena.types(method_info.params);
+        let method_param_modes = self.param_arena.modes(method_info.params);
         if args.len() != method_param_types.len() {
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount {
@@ -754,6 +763,8 @@ impl<'a> Sema<'a> {
                 span,
             ));
         }
+
+        self.validate_explicit_call_modes(&args, method_param_modes.iter().copied())?;
 
         // Check for exclusive access violation
         self.check_exclusive_access(&args, span)?;

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -636,6 +636,63 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
+    /// Validate the source-level passing mode of each explicit call argument.
+    ///
+    /// Callers perform callee resolution and arity checking first, then invoke
+    /// this before any by-ref lvalue, exclusivity, coercion, or argument-analysis
+    /// work. This deliberately compares RIR source modes rather than AIR modes:
+    /// a correctly spelled `borrow` view may later be lowered as a by-value fat
+    /// pointer, and an implicit method receiver is not part of `args`.
+    pub(crate) fn validate_explicit_call_modes(
+        &self,
+        args: &[RirCallArg],
+        expected_modes: impl ExactSizeIterator<Item = RirParamMode>,
+    ) -> CompileResult<()> {
+        // Keep the shared contract fail-closed in release builds too: a new
+        // call surface must not silently skip trailing arguments by supplying
+        // an iterator of the wrong length.
+        assert_eq!(
+            args.len(),
+            expected_modes.len(),
+            "argument modes must be validated only after arity"
+        );
+
+        for (arg, expected_mode) in args.iter().zip(expected_modes) {
+            match (expected_mode, arg.mode) {
+                (RirParamMode::Inout, RirArgMode::Inout)
+                | (RirParamMode::Borrow, RirArgMode::Borrow)
+                | (RirParamMode::Normal | RirParamMode::Comptime, RirArgMode::Normal) => {}
+                (RirParamMode::Inout, _) => {
+                    return Err(CompileError::new(
+                        ErrorKind::InoutKeywordMissing,
+                        self.rir.get(arg.value).span,
+                    ));
+                }
+                (RirParamMode::Borrow, _) => {
+                    return Err(CompileError::new(
+                        ErrorKind::BorrowKeywordMissing,
+                        self.rir.get(arg.value).span,
+                    ));
+                }
+                (RirParamMode::Normal | RirParamMode::Comptime, actual_mode) => {
+                    let mode = match actual_mode {
+                        RirArgMode::Inout => "inout",
+                        RirArgMode::Borrow => "borrow",
+                        RirArgMode::Normal => unreachable!("normal mode matched above"),
+                    };
+                    return Err(CompileError::new(
+                        ErrorKind::UnexpectedCallArgumentMode { mode },
+                        self.rir.get(arg.value).span,
+                    )
+                    .with_help(format!(
+                        "remove the `{mode}` keyword; this argument is passed without an explicit mode"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Check exclusivity rules for inout and borrow parameters in a call
     /// (adapter over the shared [`check_exclusive_access_in`], RUE-141).
     pub(crate) fn check_exclusive_access(

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -27,7 +27,7 @@ use rue_error::{
     CompileError, CompileResult, CompileWarning, ErrorKind, MissingFieldsError, OptionExt,
     PreviewFeature, WarningKind,
 };
-use rue_rir::{InstData, InstRef, RirArgMode, RirParamMode, RirPattern};
+use rue_rir::{InstData, InstRef, RirParamMode, RirPattern};
 
 use crate::sema::context::ConstValue;
 use rue_span::Span;
@@ -6028,36 +6028,12 @@ impl<'a> Sema<'a> {
             ));
         }
 
+        // Source argument modes must match the declaration exactly before an
+        // explicit by-ref marker is interpreted as a place/loan operation.
+        self.validate_explicit_call_modes(&args, param_modes.iter().copied())?;
+
         // Check for exclusive access violation
         self.check_exclusive_access(&args, span)?;
-
-        // Check that call-site argument modes match function parameter modes
-        // Do this before the mutable borrow in analyze_call_args, accessing fn_info directly
-        for (i, (arg, expected_mode)) in args.iter().zip(param_modes.iter()).enumerate() {
-            match expected_mode {
-                RirParamMode::Inout => {
-                    if arg.mode != RirArgMode::Inout {
-                        return Err(CompileError::new(
-                            ErrorKind::InoutKeywordMissing,
-                            self.rir.get(args[i].value).span,
-                        ));
-                    }
-                }
-                RirParamMode::Borrow => {
-                    if arg.mode != RirArgMode::Borrow {
-                        return Err(CompileError::new(
-                            ErrorKind::BorrowKeywordMissing,
-                            self.rir.get(args[i].value).span,
-                        ));
-                    }
-                }
-                // Normal and comptime params accept any mode
-                // (comptime params are substituted at compile time, not passed at runtime)
-                RirParamMode::Normal | RirParamMode::Comptime => {
-                    // Normal params accept any mode
-                }
-            }
-        }
 
         // Extract info before any mutable borrow
         let is_generic = fn_info.is_generic;
@@ -6540,7 +6516,12 @@ impl<'a> Sema<'a> {
                 "an inline type-constructor call as a pattern head",
                 span,
             )?;
-            return Ok(match self.try_evaluate_const(head_ref) {
+            // Unlike the inference prepass, this is the authoritative pattern
+            // resolver. Preserve hard source diagnostics from comptime call
+            // reduction (including exact argument-mode errors) instead of
+            // degrading them into an unrelated unknown-enum failure.
+            let mut env = super::comptime_eval::ComptimeEnv::for_analysis(ctx);
+            return Ok(match self.eval_const_expr(head_ref, &mut env)? {
                 Some(ConstValue::Type(ty)) => ty.as_enum().map(|id| (id, true)),
                 _ => None,
             });
@@ -6642,6 +6623,13 @@ impl<'a> Sema<'a> {
                 span,
             ));
         }
+
+        // Enum payload fields are ordinary unmarked values. Reject explicit
+        // `borrow`/`inout` before analyzing them or erasing their source modes.
+        self.validate_explicit_call_modes(
+            &args,
+            std::iter::repeat_n(RirParamMode::Normal, args.len()),
+        )?;
 
         // Analyze each payload argument and type-check against the declared
         // payload type (inference already constrained them; this is the final

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1463,10 +1463,12 @@ impl Sema<'_> {
     ///   are not folded here.
     ///
     /// Returns `Ok(None)` — not an error — for an unknown callee, a
-    /// non-const argument, or an arity/mode that does not match the
+    /// non-const argument, an arity mismatch, or a call that does not meet the
     /// implicit-comptime gate: the call is then just a runtime call and simply
-    /// non-evaluable here. Reducing the body may still raise `Err` (arithmetic
-    /// overflow, recursion-depth overrun); opportunistic callers swallow it.
+    /// non-evaluable here. An explicit argument mode that disagrees with the
+    /// callee is a source error and returns `Err`, as does a failure while
+    /// reducing the body (arithmetic overflow, recursion-depth overrun);
+    /// opportunistic callers swallow those errors.
     ///
     /// [`eval_const_expr`]: Sema::eval_const_expr
     fn eval_comptime_type_call(
@@ -1500,11 +1502,17 @@ impl Sema<'_> {
         let is_type_fn = fn_info.return_type == Type::COMPTIME_TYPE;
         let params = fn_info.params;
         let param_names = self.param_arena.names(params).to_vec();
+        let param_modes = self.param_arena.modes(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
         let args = self.rir.get_call_args(args_start, args_len).to_vec();
         if args.len() != param_names.len() {
             return Ok(None);
         }
+        // A comptime reduction is still a source-level call. Validate its
+        // explicit passing modes before the evaluator erases them while
+        // binding constant arguments (RUE-634).
+        self.validate_explicit_call_modes(&args, param_modes.iter().copied())?;
+
         // Same gate as `analyze_call`'s implicit-comptime path. A `-> type`
         // constructor reduces with no args (a nullary type alias) or when every
         // parameter is comptime. A *value*-returning function reduces only when

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -2550,11 +2550,25 @@ impl<'a> Sema<'a> {
 
         let params = fn_info.params;
         let param_names = self.param_arena.names(params).to_vec();
+        let param_modes = self.param_arena.modes(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
         let args = self.rir.get_call_args(args_start, args_len).to_vec();
+        if args.len() != param_names.len() {
+            return Err(CompileError::new(
+                ErrorKind::ConstExprNotSupported {
+                    expr_kind: format!("call to `{member_str}`"),
+                },
+                span,
+            ));
+        }
+        // Module-scope const collection reduces this call before ordinary
+        // function-body analysis can see it. Preserve the same exact source
+        // mode contract as every runtime call (RUE-634).
+        self.validate_explicit_call_modes(&args, param_modes.iter().copied())?;
+
         let all_params_comptime = !param_names.is_empty() && param_comptime.iter().all(|&c| c);
         let eligible = param_names.is_empty() || all_params_comptime;
-        if args.len() != param_names.len() || !eligible {
+        if !eligible {
             return Err(CompileError::new(
                 ErrorKind::ConstExprNotSupported {
                     expr_kind: format!("call to `{member_str}`"),

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -111,7 +111,7 @@ impl ErrorCode {
     pub const TYPE_MISMATCH: Self = Self(206);
     pub const WRONG_ARGUMENT_COUNT: Self = Self(207);
     pub const MOVE_WHILE_CALL_LOANED: Self = Self(208);
-    // E0209 is reserved for RUE-634's unexpected call-argument mode error.
+    pub const UNEXPECTED_CALL_ARGUMENT_MODE: Self = Self(209);
     /// Whole-value assignment to a second-class `inout str` view. The view
     /// grants exclusive access to the caller's bytes; it is not a first-class
     /// string header that may be rebound (RUE-641).
@@ -1349,6 +1349,10 @@ pub enum ErrorKind {
     /// Argument to borrow parameter is missing `borrow` keyword at call site
     #[error("argument to borrow parameter must use 'borrow' keyword")]
     BorrowKeywordMissing,
+    /// An explicitly-mode-marked argument targets an ordinary unmarked
+    /// parameter. Source argument modes must match parameter modes exactly.
+    #[error("unexpected `{mode}` argument: the corresponding parameter is unmarked")]
+    UnexpectedCallArgumentMode { mode: &'static str },
     /// Cannot move a value out of an inout parameter (would leave the caller's
     /// variable moved-from)
     #[error("cannot move out of inout parameter '{variable}'")]
@@ -1671,6 +1675,9 @@ impl ErrorKind {
             ErrorKind::MoveWhileCallLoaned { .. } => ErrorCode::MOVE_WHILE_CALL_LOANED,
             ErrorKind::InoutKeywordMissing => ErrorCode::INOUT_KEYWORD_MISSING,
             ErrorKind::BorrowKeywordMissing => ErrorCode::BORROW_KEYWORD_MISSING,
+            ErrorKind::UnexpectedCallArgumentMode { .. } => {
+                ErrorCode::UNEXPECTED_CALL_ARGUMENT_MODE
+            }
             ErrorKind::MoveOutOfInout { .. } => ErrorCode::MOVE_OUT_OF_INOUT,
             ErrorKind::MoveSelfOutOfDestructor { .. } => ErrorCode::MOVE_SELF_OUT_OF_DESTRUCTOR,
             ErrorKind::MoveFieldOutOfDestructorType { .. } => {

--- a/crates/rue-spec/cases/expressions/call.toml
+++ b/crates/rue-spec/cases/expressions/call.toml
@@ -74,6 +74,60 @@ fn main() -> i32 { foo(true) }
 compile_fail = true
 
 # =============================================================================
+# Exact source-level argument modes (RUE-634)
+# =============================================================================
+
+[[case]]
+name = "call_argument_mode_mismatch_{mismatch}"
+spec = ["4.10:3"]
+description = "Every explicit call argument must exactly match its parameter's source mode; the non-place and duplicate-root instances also pin mode checking before place/exclusivity diagnostics."
+source = "{source}"
+compile_fail = true
+error_contains = "[{error}]"
+params = [
+  { mismatch = "normal_from_inout_before_exclusivity", error = "E0209", source = "fn take(a: i32, b: i32) {}\nfn main() {\n    let mut x = 1;\n    take(inout x, inout x);\n}" },
+  { mismatch = "normal_from_borrow_before_place", error = "E0209", source = "fn take(x: i32) {}\nfn main() { take(borrow 7); }" },
+  { mismatch = "inout_from_normal", error = "E0431", source = "fn take(inout x: i32) {}\nfn main() { take(7); }" },
+  { mismatch = "inout_from_borrow_before_place", error = "E0431", source = "fn take(inout x: i32) {}\nfn main() { take(borrow 7); }" },
+  { mismatch = "borrow_from_normal", error = "E0432", source = "fn take(borrow x: i32) {}\nfn main() { take(7); }" },
+  { mismatch = "borrow_from_inout_before_place", error = "E0432", source = "fn take(borrow x: i32) {}\nfn main() { take(inout 7); }" },
+]
+
+[[case]]
+name = "unmarked_call_surface_rejects_borrow_{surface}"
+spec = ["4.10:3"]
+description = "Every call-like surface rejects an explicit borrow on an unmarked parameter or payload slot."
+source = "{source}"
+compile_fail = true
+error_contains = "[E0209]"
+params = [
+  { surface = "function_alias", source = "fn take(x: i32) {}\nconst alias = take;\nfn main() { let x = 1; alias(borrow x); }" },
+  { surface = "generic_runtime_param", source = "fn take(comptime T: type, x: T) -> T { x }\nfn main() -> i32 { let x = 1; take(i32, borrow x) }" },
+  { surface = "user_method", source = "struct S {\n    value: i32,\n    fn take(self, x: i32) -> i32 { self.value + x }\n}\nfn main() -> i32 { let s = S { value: 40 }; let x = 2; s.take(borrow x) }" },
+  { surface = "user_associated_function", source = "struct S {\n    value: i32,\n    fn take(x: i32) -> i32 { x }\n}\nfn main() -> i32 { let x = 42; S.take(borrow x) }" },
+  { surface = "print_builtin", source = "fn main() { let s: StrBuf = \"x\"; print(borrow s); }" },
+  { surface = "builtin_method", source = "fn main() { let mut s = StrBuf.new(); let byte: u8 = 65; s.push(borrow byte); }" },
+  { surface = "builtin_associated_function", source = "fn main() { let cap: u64 = 8; let _s = StrBuf.with_capacity(borrow cap); }" },
+  { surface = "enum_tuple_payload", source = "enum E { V(i32) }\nfn main() -> i32 { let x = 42; let _e = E.V(borrow x); 0 }" },
+]
+
+[[case]]
+name = "module_member_unmarked_param_rejects_borrow"
+spec = ["4.10:3"]
+description = "A module-qualified function call enforces the same exact source-mode contract as an unqualified call."
+source = """
+const m = @import("mode_helper");
+
+fn main() -> i32 {
+    let x = 42;
+    m.take(borrow x)
+}
+"""
+aux_files = { "mode_helper.rue" = "pub fn take(x: i32) -> i32 { x }" }
+compile_fail = true
+error_contains = "[E0209]"
+
+# =============================================================================
 # Return Type
 # =============================================================================
 

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2295,6 +2295,25 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "inline_type_ctor_pattern_head_propagates_argument_mode_error"
+spec = ["4.10:3", "4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+description = "The authoritative inline pattern-head reducer propagates an exact argument-mode error instead of degrading it to an unresolved-pattern diagnostic (RUE-634)"
+source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn main() -> i32 {
+    let r = Result(i32, i32).Ok(42);
+    match r {
+        Result(inout i32, i32).Ok(v) => v,
+        Result(i32, i32).Err(e) => e,
+    }
+}
+"""
+compile_fail = true
+error_contains = "[E0209]"
+
+[[case]]
 name = "inline_type_ctor_enum_head_wide_payload_literal"
 spec = ["4.14:23"]
 preview = "inline_type_ctor_paths"
@@ -2611,3 +2630,35 @@ fn main() -> i32 { S }
 """
 compile_fail = true
 error_contains = "not supported in const context"
+
+# =============================================================================
+# Exact argument modes in eager comptime evaluation (RUE-634)
+# =============================================================================
+
+[[case]]
+name = "eager_comptime_value_call_rejects_inout_for_unmarked_param"
+spec = ["4.10:3", "4.14:5", "4.14:28"]
+description = "An eagerly reduced value call still validates its explicit source argument modes before evaluating the comptime argument."
+source = """
+fn identity(comptime x: i32) -> i32 { x }
+
+const X: i32 = identity(inout 7);
+
+fn main() -> i32 { X }
+"""
+compile_fail = true
+error_contains = "[E0209]"
+
+[[case]]
+name = "module_eager_type_call_rejects_borrow_for_unmarked_param"
+spec = ["4.10:3", "4.14:22", "4.14:28"]
+description = "A module-qualified type constructor reduced in a module-scope const enforces the same unmarked comptime-parameter spelling."
+source = """
+const helper = @import("mode_type_helper");
+const Boxed = helper.Box(borrow i64);
+
+fn main() -> i32 { 0 }
+"""
+aux_files = { "mode_type_helper.rue" = "pub fn Box(comptime T: type) -> type { struct { value: T } }" }
+compile_fail = true
+error_contains = "[E0209]"

--- a/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
@@ -1,0 +1,22 @@
+[section]
+id = "diagnostics.call-argument-modes"
+name = "Call argument mode diagnostics"
+description = "Pins the targeted diagnostic for an explicit borrow/inout mode on an unmarked call parameter (RUE-634)."
+
+[[case]]
+name = "unexpected_borrow_argument_has_removal_help"
+description = "E0209 names the unexpected source mode and explains that an unmarked parameter is passed without an explicit keyword."
+source = """
+fn take(x: i32) {}
+
+fn main() {
+    let x = 42;
+    take(borrow x);
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0209]",
+    "unexpected `borrow` argument: the corresponding parameter is unmarked",
+    "remove the `borrow` keyword; this argument is passed without an explicit mode",
+]

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -276,14 +276,18 @@ fn main() -> i32 {
 The free function `print(s)` takes a `String` and writes its raw bytes to
 standard output, adding nothing. Unlike `@dbg`, it does not append a newline and
 does not apply any debug formatting. The argument `s` is borrowed, not consumed,
-and remains usable afterwards.
+and remains usable afterwards. This internal non-consuming access does not
+change the call syntax: the source argument is unmarked (`print(s)`, not
+`print(borrow s)`).
 
 {{ rule(id="3.7:36", cat="normative") }}
 
 The free function `println(s)` takes a `String` and writes its raw bytes to
 standard output followed by a single newline (`U+000A`). The argument `s` is
 borrowed, not consumed. Together with `@to_string` and `+`, `println` composes
-line-oriented output; there is no formatting or interpolation syntax.
+line-oriented output; there is no formatting or interpolation syntax. As with
+`print`, the internal borrow does not add a source-level argument mode: the
+argument is unmarked.
 
 {{ rule(id="3.7:37", cat="dynamic-semantics") }}
 

--- a/docs/spec/src/04-expressions/10-call-expressions.md
+++ b/docs/spec/src/04-expressions/10-call-expressions.md
@@ -29,7 +29,18 @@ An `inout` or `borrow` argument must denote a place; that requirement is a post-
 
 {{ rule(id="4.10:3", cat="legality-rule") }}
 
-The number of arguments **MUST** match the number of parameters in the function signature.
+The number of arguments **MUST** match the number of parameters in the
+function signature. Each explicit argument's source-level passing mode
+**MUST** exactly match the corresponding parameter: an `inout` parameter
+requires an `inout` argument, a `borrow` parameter requires a `borrow`
+argument, and every other parameter, including a `comptime` parameter,
+requires an unmarked argument. Arguments to built-in call forms and enum
+tuple-variant payloads are likewise unmarked unless a source-level parameter
+explicitly declares a mode.
+
+A method receiver is not an explicit argument for this rule. Its passing mode
+is selected automatically from the receiver declaration as specified by the
+receiver-autoref rule (6.4:25).
 
 {{ rule(id="4.10:4", cat="legality-rule") }}
 

--- a/docs/spec/src/06-items/03-enums.md
+++ b/docs/spec/src/06-items/03-enums.md
@@ -132,8 +132,10 @@ specification.
 A tuple variant is constructed by applying the variant path to payload
 arguments: `EnumName.Variant(arg, ...)`. The number of arguments **MUST**
 equal the variant's payload arity, and each argument's type **MUST** match the
-corresponding declared payload type. Using a payload-carrying variant as a
-bare path (`EnumName.Variant`, with no arguments) is an error.
+corresponding declared payload type. Payload arguments are unmarked; tuple
+variants do not declare `borrow` or `inout` parameters. Using a
+payload-carrying variant as a bare path (`EnumName.Variant`, with no
+arguments) is an error.
 
 {{ rule(id="6.3:17", cat="normative") }}
 


### PR DESCRIPTION
## Summary

- enforce one exact source-mode contract across direct, module, user method/associated, builtin, enum-payload, and eager-comptime calls
- preserve E0431/E0432 for missing inout/borrow and add E0209 for extra inout/borrow
- validate before lvalue, exclusivity, coercion, and eager evaluation; implicit receiver autoref remains outside the explicit-argument contract
- propagate argument-mode failures through authoritative inline-constructor pattern-head resolution

## Root cause

Call paths had grown separate mode behavior: direct/module calls tolerated unmarked parameters, methods and associated functions skipped validation, and builtin/enum/eager paths erased source modes. The inline pattern resolver also used speculative constant evaluation and could swallow the resulting hard error.

This centralizes the contract at the RIR call boundary and wires every explicit-argument surface through it.

## Scope

This is the second of three focused RUE-634 landings. The first preserved complete method signature modes. A follow-up will handle physical method and associated-function view coercions.

## Validation

- formatting check
- clippy across 41 first-party Rust targets
- full test suite: 34 passed, 0 failed
- AIR: 368 passed
- UI: 168 passed
- spec: 2,041 passed, 14 ignored
- traceability: 738/738 normative paragraphs
- CLI oracle: 641 modeled agreements, 96 registered model gaps, 0 failures, 0 disagreements
- spec oracle: 1,347 modeled agreements, 98 registered model gaps, 0 failures, 0 disagreements
- generated oracle smoke: 64 agreements, 0 disagreements