### PR TITLE
RUE-642: make compiler phase timing honest

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -84,6 +84,7 @@ filegroup(
         "scripts/append-benchmark.py",
         "scripts/benchmark_validation.py",
         "scripts/generate-charts.py",
+        "scripts/perf-baseline.py",
         "scripts/validate-benchmark.py",
     ],
 )

--- a/bench.sh
+++ b/bench.sh
@@ -211,7 +211,9 @@ for i in "${!benchmark_names[@]}"; do
         fi
         rm -f "$time_output"
 
-        # Extract total_ms from the JSON. `|| true`: grep may not match and
+        # Extract the schema-v2 root-span total. Before RUE-642 this field
+        # summed nested spans and was inflated; historical dashboard entries
+        # retain that older meaning. `|| true`: grep may not match and
         # `head -1` closing the pipe early can SIGPIPE grep — neither is fatal
         # (the `-n "$total_ms"` check below handles a missing value).
         total_ms=$(echo "$timing_json" | grep -o '"total_ms":[0-9.]*' | head -1 | cut -d: -f2 || true)
@@ -306,12 +308,21 @@ import sys
 pass_data = {}
 source_metrics = None
 peak_memory_samples = []
+timing_schema_version = None
 
 for json_str in sys.argv[1:]:
     try:
         data = json.loads(json_str)
+        schema_version = data.get('schema_version', 1)
+        if timing_schema_version is None:
+            timing_schema_version = schema_version
         for p in data.get('passes', []):
             pname = p['name']
+            # Schema v2 durations are inclusive. Persist only structural
+            # leaves so parse_file is not stacked with lexer + parser in the
+            # dashboard. V1 had no nesting metadata and parse_file was a leaf.
+            if schema_version >= 2 and p.get('leaf_invocations') != p.get('invocations'):
+                continue
             duration = p['duration_ms']
             if pname not in pass_data:
                 pass_data[pname] = []
@@ -332,6 +343,8 @@ for pname, durations in pass_data.items():
     passes[pname] = {'mean_ms': round(mean, 3)}
 
 result = {'passes': passes}
+if timing_schema_version is not None:
+    result['timing_schema_version'] = timing_schema_version
 if source_metrics:
     result['source_metrics'] = source_metrics
 if peak_memory_samples:
@@ -343,9 +356,10 @@ print(json.dumps(result))
     # Extract components from the JSON
     passes_json=$(echo "$extra_json" | python3 -c "import sys, json; d=json.load(sys.stdin); print(json.dumps(d.get('passes', {})))")
     source_metrics_json=$(echo "$extra_json" | python3 -c "import sys, json; d=json.load(sys.stdin); sm=d.get('source_metrics'); print(json.dumps(sm) if sm else 'null')")
+    timing_schema_version=$(echo "$extra_json" | python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('timing_schema_version', 1))")
 
     # Store result with all data (including memory and binary size from iteration tracking)
-    result_parts=("\"name\":\"$name\"" "\"iterations\":$count" "\"mean_ms\":$mean" "\"std_ms\":$stddev" "\"passes\":$passes_json")
+    result_parts=("\"name\":\"$name\"" "\"iterations\":$count" "\"mean_ms\":$mean" "\"std_ms\":$stddev" "\"timing_schema_version\":$timing_schema_version" "\"passes\":$passes_json")
     [[ "$source_metrics_json" != "null" ]] && result_parts+=("\"source_metrics\":$source_metrics_json")
     [[ "$mem_mean" -gt 0 ]] && result_parts+=("\"peak_memory_bytes\":$mem_mean")
     [[ "$binary_size" -gt 0 ]] && result_parts+=("\"binary_size_bytes\":$binary_size")

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -1,0 +1,28 @@
+[section]
+id = "cli.benchmark_json"
+name = "Benchmark JSON timing contract"
+description = """
+RUE-642 pins the honest inclusive-span schema and ensures a restrictive
+RUST_LOG filter affects log formatting without disabling timing collection.
+"""
+
+[[case]]
+name = "timing_survives_restrictive_log_filter"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 42 }\n" }]
+args = ["--benchmark-json", "main.rue", "-o", "prog"]
+env = { RUST_LOG = "error" }
+exit_code = 42
+compile_stdout_contains = [
+  '"schema_version":2',
+  '"timing_model":"inclusive_spans"',
+  '"name":"compile"',
+  '"root_invocations":1',
+  '"name":"lexer"',
+  '"name":"parser"',
+  '"name":"semantic_astgen"',
+  '"source_metrics":',
+  '"files":1',
+  '"bytes":24',
+  '"lines":1',
+  '"tokens":',
+]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -30,7 +30,7 @@ mod drop_glue;
 mod semantic_order;
 mod unit;
 
-pub use unit::CompilationUnit;
+pub use unit::{CompilationUnit, SourceStats};
 
 use rayon::prelude::*;
 use tracing::{info, info_span};
@@ -1209,6 +1209,40 @@ pub fn compile_multi_file_with_symbol_paths_and_options(
     symbol_paths: std::collections::HashMap<FileId, String>,
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
+    compile_multi_file_with_symbol_paths_and_options_impl(sources, symbol_paths, options, false)
+        .map(|(output, _stats)| output)
+}
+
+/// Compile multiple source files and return metrics collected by the live frontend.
+///
+/// This is the benchmark-facing form of
+/// [`compile_multi_file_with_symbol_paths_and_options`]. It does not perform a
+/// second tokenize pass to measure the input.
+pub fn compile_multi_file_with_symbol_paths_and_options_and_stats(
+    sources: &[SourceFile<'_>],
+    symbol_paths: std::collections::HashMap<FileId, String>,
+    options: &CompileOptions,
+) -> MultiErrorResult<(CompileOutput, SourceStats)> {
+    let (output, stats) = compile_multi_file_with_symbol_paths_and_options_impl(
+        sources,
+        symbol_paths,
+        options,
+        true,
+    )?;
+    let mut stats = stats.expect("source stats requested");
+    stats.lines = sources
+        .iter()
+        .map(|source| source.source.lines().count())
+        .sum();
+    Ok((output, stats))
+}
+
+fn compile_multi_file_with_symbol_paths_and_options_impl(
+    sources: &[SourceFile<'_>],
+    symbol_paths: std::collections::HashMap<FileId, String>,
+    options: &CompileOptions,
+    collect_stats: bool,
+) -> MultiErrorResult<(CompileOutput, Option<SourceStats>)> {
     // NOTE: the Rayon global thread pool is deliberately NOT configured here.
     // `build_global()` panics if called twice, and the `--emit` driver path
     // never reaches this function, so it was silently ignoring `-j`/`--jobs`
@@ -1227,7 +1261,9 @@ pub fn compile_multi_file_with_symbol_paths_and_options(
     // Use CompilationUnit for the entire pipeline
     let mut unit = CompilationUnit::new(sources.to_vec(), options.clone());
     unit.set_symbol_paths(symbol_paths);
-    unit.run_all()
+    let output = unit.run_all()?;
+    let stats = collect_stats.then(|| unit.collected_source_stats());
+    Ok((output, stats))
 }
 
 /// Link using the internal linker.

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -42,6 +42,22 @@ use crate::{
 };
 use rue_span::FileId;
 
+/// Source work performed by one compilation unit.
+///
+/// These values are collected by the real frontend rather than by a separate
+/// benchmarking pre-pass, so observing them cannot warm a second lexer run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SourceStats {
+    /// Number of source files in the unit.
+    pub files: usize,
+    /// Total source bytes.
+    pub bytes: usize,
+    /// Total source lines, using [`str::lines`] semantics.
+    pub lines: usize,
+    /// Tokens produced by the lexer invocations consumed by the parser.
+    pub tokens: usize,
+}
+
 /// A unified compilation unit that owns all artifacts from source to machine code.
 ///
 /// The compilation unit progresses through phases:
@@ -67,6 +83,8 @@ pub struct CompilationUnit<'src> {
     // === Source ===
     /// Source files being compiled.
     sources: Vec<SourceFile<'src>>,
+    /// Work metrics collected from those sources and the live parse.
+    source_stats: SourceStats,
     /// Designated semantic root (the first source), independent of FileId rank.
     root_file_id: FileId,
 
@@ -117,10 +135,19 @@ impl<'src> CompilationUnit<'src> {
             .map(|s| (s.file_id, s.path.to_string()))
             .collect();
         let symbol_paths = file_paths.clone();
+        let source_stats = SourceStats {
+            files: sources.len(),
+            bytes: sources.iter().map(|source| source.source.len()).sum(),
+            // Count lines lazily in source_stats(); ordinary compilation does
+            // not need to scan every source solely for benchmark metadata.
+            lines: 0,
+            tokens: 0,
+        };
 
         Self {
             options,
             sources,
+            source_stats,
             root_file_id,
             merged_ast: None,
             interner: None,
@@ -156,6 +183,7 @@ impl<'src> CompilationUnit<'src> {
         let mut parsed_files = Vec::with_capacity(self.sources.len());
         let mut interner = ThreadedRodeo::new();
         let mut errors = CompileErrors::new();
+        self.source_stats.tokens = 0;
 
         for source in &self.sources {
             let _file_span = info_span!("parse_file", path = %source.path).entered();
@@ -164,31 +192,38 @@ impl<'src> CompilationUnit<'src> {
             let lexer = Lexer::with_interner_and_file_id(source.source, interner, source.file_id);
 
             // Tokenize
-            let tokens = match lexer.tokenize_preserving_interner() {
-                Ok((tokens, returned_interner)) => {
-                    interner = returned_interner;
-                    tokens
-                }
-                Err((lex_errors, returned_interner)) => {
-                    interner = returned_interner;
-                    errors.extend(lex_errors);
-                    continue;
+            let tokens = {
+                let _span = info_span!("lexer").entered();
+                match lexer.tokenize_preserving_interner() {
+                    Ok((tokens, returned_interner)) => {
+                        interner = returned_interner;
+                        tokens
+                    }
+                    Err((lex_errors, returned_interner)) => {
+                        interner = returned_interner;
+                        errors.extend(lex_errors);
+                        continue;
+                    }
                 }
             };
 
+            self.source_stats.tokens += tokens.len();
             info!(token_count = tokens.len(), "lexing complete");
 
             // Parse
-            let parser = Parser::new(tokens, interner);
-            let ast = match parser.parse_preserving_interner() {
-                Ok((ast, returned_interner)) => {
-                    interner = returned_interner;
-                    ast
-                }
-                Err((parse_errors, returned_interner)) => {
-                    interner = returned_interner;
-                    errors.extend(parse_errors);
-                    continue;
+            let ast = {
+                let _span = info_span!("parser").entered();
+                let parser = Parser::new(tokens, interner);
+                match parser.parse_preserving_interner() {
+                    Ok((ast, returned_interner)) => {
+                        interner = returned_interner;
+                        ast
+                    }
+                    Err((parse_errors, returned_interner)) => {
+                        interner = returned_interner;
+                        errors.extend(parse_errors);
+                        continue;
+                    }
                 }
             };
 
@@ -303,7 +338,10 @@ impl<'src> CompilationUnit<'src> {
             &self.symbol_paths,
             self.root_file_id,
         );
-        let semantic_rir = AstGen::new(&semantic_ast, interner).generate();
+        let semantic_rir = {
+            let _span = info_span!("semantic_astgen").entered();
+            AstGen::new(&semantic_ast, interner).generate()
+        };
 
         // Semantic analysis
         let sema_output = {
@@ -489,6 +527,23 @@ impl<'src> CompilationUnit<'src> {
         &self.file_paths
     }
 
+    /// Get source metrics collected by the live frontend.
+    pub fn source_stats(&self) -> SourceStats {
+        SourceStats {
+            lines: self
+                .sources
+                .iter()
+                .map(|source| source.source.lines().count())
+                .sum(),
+            ..self.source_stats
+        }
+    }
+
+    /// Get counters collected during compilation without scanning source text.
+    pub(crate) fn collected_source_stats(&self) -> SourceStats {
+        self.source_stats
+    }
+
     /// Replace the paths used to qualify otherwise-colliding generated names.
     ///
     /// These identities do not affect diagnostics or module resolution. Any
@@ -600,6 +655,37 @@ mod tests {
         // Then analyze
         unit.analyze().unwrap();
         assert!(unit.is_analyzed());
+    }
+
+    #[test]
+    fn source_stats_use_the_tokens_consumed_by_the_live_parse() {
+        let first = "fn main() -> i32 { helper() }\n";
+        let second = "fn helper() -> i32 { 42 }\n";
+        let expected_tokens = Lexer::new(first).tokenize().unwrap().0.len()
+            + Lexer::new(second).tokenize().unwrap().0.len();
+        let sources = vec![
+            SourceFile::new("main.rue", first, FileId::new(1)),
+            SourceFile::new("helper.rue", second, FileId::new(2)),
+        ];
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+
+        assert_eq!(
+            unit.source_stats(),
+            SourceStats {
+                files: 2,
+                bytes: first.len() + second.len(),
+                lines: 2,
+                tokens: 0,
+            }
+        );
+
+        unit.parse().unwrap();
+        assert_eq!(unit.source_stats().tokens, expected_tokens);
+
+        // Re-running a phase may be unusual, but metrics must describe one
+        // parse rather than accumulating observer-induced work.
+        unit.parse().unwrap();
+        assert_eq!(unit.source_stats().tokens, expected_tokens);
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 
 use tracing::Level;
 use tracing_subscriber::fmt::format::FmtSpan;
-use tracing_subscriber::{EnvFilter, fmt};
+use tracing_subscriber::{EnvFilter, Layer as _, fmt};
 
 mod timing;
 
@@ -16,9 +16,11 @@ use rue_compiler::{
     CompileError, CompileErrors, CompileOptions, CompileWarning, ErrorKind, FileId, Lexer,
     LinkerMode, MultiFileFormatter, MultiFileJsonFormatter, OptLevel, ParsedProgram,
     PreviewFeature, PreviewFeatures, SourceFile, SourceInfo, Span, TokenKind,
-    compile_multi_file_with_symbol_paths_and_options, configure_thread_pool, generate_emitted_asm,
-    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
-    generate_stack_frame_info, import_candidate_groups, merge_symbols, parse_all_files,
+    compile_multi_file_with_symbol_paths_and_options,
+    compile_multi_file_with_symbol_paths_and_options_and_stats, configure_thread_pool,
+    generate_emitted_asm, generate_liveness_info, generate_lowering_info, generate_mir,
+    generate_regalloc_info, generate_stack_frame_info, import_candidate_groups, merge_symbols,
+    parse_all_files,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -881,15 +883,13 @@ fn init_tracing(
         // Timing + text logging
         (true, true, LogFormat::Text) => {
             let timing_layer = timing::TimingLayer::new(timing_data.clone().unwrap());
-            let subscriber = tracing_subscriber::registry()
-                .with(filter.unwrap())
-                .with(timing_layer)
-                .with(
-                    fmt::layer()
-                        .with_target(true)
-                        .with_span_events(FmtSpan::CLOSE)
-                        .with_writer(std::io::stderr),
-                );
+            let subscriber = tracing_subscriber::registry().with(timing_layer).with(
+                fmt::layer()
+                    .with_target(true)
+                    .with_span_events(FmtSpan::CLOSE)
+                    .with_writer(std::io::stderr)
+                    .with_filter(filter.unwrap()),
+            );
             tracing::subscriber::set_global_default(subscriber)
                 .expect("failed to set tracing subscriber");
         }
@@ -897,27 +897,26 @@ fn init_tracing(
         // Timing + JSON logging
         (true, true, LogFormat::Json) => {
             let timing_layer = timing::TimingLayer::new(timing_data.clone().unwrap());
-            let subscriber = tracing_subscriber::registry()
-                .with(filter.unwrap())
-                .with(timing_layer)
-                .with(
-                    fmt::layer()
-                        .json()
-                        .with_target(true)
-                        .with_span_events(FmtSpan::CLOSE)
-                        .with_writer(std::io::stderr),
-                );
+            let subscriber = tracing_subscriber::registry().with(timing_layer).with(
+                fmt::layer()
+                    .json()
+                    .with_target(true)
+                    .with_span_events(FmtSpan::CLOSE)
+                    .with_writer(std::io::stderr)
+                    .with_filter(filter.unwrap()),
+            );
             tracing::subscriber::set_global_default(subscriber)
                 .expect("failed to set tracing subscriber");
         }
 
         // Text logging only (no timing)
         (false, true, LogFormat::Text) => {
-            let subscriber = tracing_subscriber::registry().with(filter.unwrap()).with(
+            let subscriber = tracing_subscriber::registry().with(
                 fmt::layer()
                     .with_target(true)
                     .with_span_events(FmtSpan::CLOSE)
-                    .with_writer(std::io::stderr),
+                    .with_writer(std::io::stderr)
+                    .with_filter(filter.unwrap()),
             );
             tracing::subscriber::set_global_default(subscriber)
                 .expect("failed to set tracing subscriber");
@@ -925,12 +924,13 @@ fn init_tracing(
 
         // JSON logging only (no timing)
         (false, true, LogFormat::Json) => {
-            let subscriber = tracing_subscriber::registry().with(filter.unwrap()).with(
+            let subscriber = tracing_subscriber::registry().with(
                 fmt::layer()
                     .json()
                     .with_target(true)
                     .with_span_events(FmtSpan::CLOSE)
-                    .with_writer(std::io::stderr),
+                    .with_writer(std::io::stderr)
+                    .with_filter(filter.unwrap()),
             );
             tracing::subscriber::set_global_default(subscriber)
                 .expect("failed to set tracing subscriber");
@@ -1774,31 +1774,6 @@ fn main() {
         return;
     }
 
-    // Compute source metrics if benchmark JSON is requested
-    let source_metrics = if options.benchmark_json {
-        // Sum metrics across ALL files — measuring only the first file made
-        // multi-file benchmark numbers meaningless (RUE-130).
-        let mut bytes = 0usize;
-        let mut lines = 0usize;
-        let mut tokens = 0usize;
-        for (_, content) in &sources {
-            bytes += content.len();
-            lines += content.lines().count();
-            let lexer = Lexer::new(content);
-            if let Ok((toks, _interner)) = lexer.tokenize() {
-                tokens += toks.len();
-            }
-            // If lexing fails, we'll get the error during compilation anyway
-        }
-        Some(timing::SourceMetrics {
-            bytes,
-            lines,
-            tokens,
-        })
-    } else {
-        None
-    };
-
     // --emit and --benchmark-json both own stdout, so combining them would
     // interleave IR text with the benchmark JSON and corrupt it — reject early.
     if options.benchmark_json && !options.emit_stages.is_empty() {
@@ -1818,7 +1793,7 @@ fn main() {
             options.time_passes,
             options.benchmark_json,
             &options.target,
-            source_metrics,
+            None,
         );
         return;
     }
@@ -1830,12 +1805,23 @@ fn main() {
         opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
     };
-    match compile_multi_file_with_symbol_paths_and_options(
-        &source_files,
-        symbol_path_map,
-        &compile_options,
-    ) {
-        Ok(output) => {
+    let compile_result = if options.benchmark_json {
+        compile_multi_file_with_symbol_paths_and_options_and_stats(
+            &source_files,
+            symbol_path_map,
+            &compile_options,
+        )
+        .map(|(output, stats)| (output, Some(stats)))
+    } else {
+        compile_multi_file_with_symbol_paths_and_options(
+            &source_files,
+            symbol_path_map,
+            &compile_options,
+        )
+        .map(|output| (output, None))
+    };
+    match compile_result {
+        Ok((output, source_stats)) => {
             // Print warnings using the diagnostic formatter
             diagnostics.print_warnings(&output.warnings);
 
@@ -1929,7 +1915,15 @@ fn main() {
                 options.time_passes,
                 options.benchmark_json,
                 &options.target,
-                source_metrics,
+                options.benchmark_json.then(|| {
+                    let source_stats = source_stats.expect("benchmark source stats requested");
+                    timing::SourceMetrics {
+                        files: source_stats.files,
+                        bytes: source_stats.bytes,
+                        lines: source_stats.lines,
+                        tokens: source_stats.tokens,
+                    }
+                }),
             );
         }
         Err(errors) => {

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -62,12 +62,39 @@ pub struct TimingData {
 
 /// The actual timing data storage.
 struct TimingDataInner {
-    /// Accumulated duration per pass name.
+    /// Accumulated measurements per pass name.
     /// Key is the span name (e.g., "lexer", "parser").
-    passes: HashMap<String, Duration>,
+    passes: HashMap<String, PassAggregate>,
 
     /// Order in which passes were first seen, for deterministic output.
     pass_order: Vec<String>,
+
+    /// Union of intervals in which at least one root span was active.
+    ///
+    /// Child spans overlap their parents, so summing every pass duration
+    /// double-counts work. The active-time union is the timing boundary used
+    /// for the benchmark total, even if independent roots overlap.
+    root_duration: Duration,
+    /// Number of root spans currently entered, including re-entrant entries.
+    active_roots: u64,
+    /// Start of the current interval in which at least one root is active.
+    root_active_since: Option<Instant>,
+    /// Most recent timestamp applied to a root-span transition.
+    ///
+    /// Runtime timestamps are sampled while holding `inner`, so they are
+    /// already ordered. Retaining the last timestamp also makes the collector
+    /// robust to a stale timestamp and gives the ordering invariant a
+    /// deterministic regression test.
+    last_root_transition: Option<Instant>,
+}
+
+/// Measurements aggregated across every span with the same name.
+#[derive(Debug, Clone, Copy, Default)]
+struct PassAggregate {
+    duration: Duration,
+    invocations: u64,
+    root_invocations: u64,
+    leaf_invocations: u64,
 }
 
 /// JSON output structure for benchmark timing data.
@@ -77,6 +104,10 @@ struct TimingDataInner {
 /// metadata for historical analysis and comparison across runs.
 #[derive(Debug, Clone, Serialize)]
 pub struct BenchmarkTiming {
+    /// Version of this machine-readable timing contract.
+    pub schema_version: u32,
+    /// Pass durations are inclusive and may overlap their parents.
+    pub timing_model: &'static str,
     /// Metadata about this benchmark run.
     pub metadata: BenchmarkMetadata,
     /// Individual pass timings in milliseconds.
@@ -94,11 +125,13 @@ pub struct BenchmarkTiming {
 /// Source code metrics for throughput calculations.
 #[derive(Debug, Clone, Serialize)]
 pub struct SourceMetrics {
-    /// Number of bytes in the source file.
+    /// Number of source files compiled.
+    pub files: usize,
+    /// Total bytes across source files.
     pub bytes: usize,
-    /// Number of lines in the source file.
+    /// Total lines across source files.
     pub lines: usize,
-    /// Number of tokens produced by the lexer.
+    /// Total tokens produced by the lexer invocations consumed by parsing.
     pub tokens: usize,
 }
 
@@ -122,6 +155,12 @@ pub struct PassTiming {
     pub duration_ms: f64,
     /// Percentage of total compilation time.
     pub percent: f64,
+    /// Number of spans aggregated into this row.
+    pub invocations: u64,
+    /// Number of invocations without a parent span.
+    pub root_invocations: u64,
+    /// Number of invocations without a child span.
+    pub leaf_invocations: u64,
 }
 
 impl TimingData {
@@ -131,23 +170,111 @@ impl TimingData {
             inner: Arc::new(Mutex::new(TimingDataInner {
                 passes: HashMap::new(),
                 pass_order: Vec::new(),
+                root_duration: Duration::ZERO,
+                active_roots: 0,
+                root_active_since: None,
+                last_root_transition: None,
             })),
         }
     }
 
-    /// Record a duration for the given pass.
+    /// Record a standalone leaf pass.
+    ///
+    /// This helper is used by deterministic unit tests. Runtime spans use
+    /// [`Self::record_span`] so their nesting is retained.
+    #[cfg(test)]
     fn record(&self, pass: &str, duration: Duration) {
+        self.record_test_span(pass, duration, true, true);
+    }
+
+    /// Record a duration and its position in the span tree.
+    fn record_span(&self, pass: &str, duration: Duration, is_root: bool, is_leaf: bool) {
         let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
-        let entry = inner
-            .passes
-            .entry(pass.to_string())
-            .or_insert(Duration::ZERO);
-        *entry += duration;
+        let entry = inner.passes.entry(pass.to_string()).or_default();
+        entry.duration += duration;
+        entry.invocations += 1;
+        entry.root_invocations += u64::from(is_root);
+        entry.leaf_invocations += u64::from(is_leaf);
 
         // Track order of first occurrence
         if !inner.pass_order.contains(&pass.to_string()) {
             inner.pass_order.push(pass.to_string());
         }
+    }
+
+    /// Record a synthetic span and its non-overlapping root contribution.
+    #[cfg(test)]
+    fn record_test_span(&self, pass: &str, duration: Duration, is_root: bool, is_leaf: bool) {
+        self.record_span(pass, duration, is_root, is_leaf);
+        if is_root {
+            let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+            inner.root_duration += duration;
+        }
+    }
+
+    /// Enter a root span and update both timing views as one serialized event.
+    ///
+    /// The span's extension lock is held by the caller. Acquiring the global
+    /// timing lock before sampling the clock prevents callbacks for different
+    /// root spans from applying timestamps out of order.
+    fn enter_root_span(&self, timing: &mut SpanTiming) {
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let now = Instant::now();
+        Self::enter_root_span_inner(&mut inner, timing, now);
+    }
+
+    /// Exit a root span and update both timing views as one serialized event.
+    fn exit_root_span(&self, timing: &mut SpanTiming) {
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let now = Instant::now();
+        Self::exit_root_span_inner(&mut inner, timing, now);
+    }
+
+    fn enter_root_span_inner(inner: &mut TimingDataInner, timing: &mut SpanTiming, now: Instant) {
+        let now = ordered_root_timestamp(inner, now);
+        timing.enter_at(now);
+        Self::root_enter_inner(inner, now);
+    }
+
+    fn exit_root_span_inner(inner: &mut TimingDataInner, timing: &mut SpanTiming, now: Instant) {
+        let now = ordered_root_timestamp(inner, now);
+        timing.exit_at(now);
+        Self::root_exit_inner(inner, now);
+    }
+
+    fn root_enter_inner(inner: &mut TimingDataInner, now: Instant) {
+        if inner.active_roots == 0 {
+            inner.root_active_since = Some(now);
+        }
+        inner.active_roots += 1;
+    }
+
+    fn root_exit_inner(inner: &mut TimingDataInner, now: Instant) {
+        if inner.active_roots == 0 {
+            return;
+        }
+        inner.active_roots -= 1;
+        if inner.active_roots == 0 {
+            if let Some(started) = inner.root_active_since.take() {
+                inner.root_duration += now.saturating_duration_since(started);
+            }
+        }
+    }
+
+    /// Begin one synthetic root-span active interval.
+    #[cfg(test)]
+    fn root_enter_at(&self, now: Instant) {
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let now = ordered_root_timestamp(&mut inner, now);
+        Self::root_enter_inner(&mut inner, now);
+    }
+
+    /// End one synthetic root-span active interval.
+    #[cfg(test)]
+    fn root_exit_at(&self, now: Instant) {
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let now = ordered_root_timestamp(&mut inner, now);
+        Self::root_exit_inner(&mut inner, now);
     }
 
     /// Generate the timing report.
@@ -161,18 +288,17 @@ impl TimingData {
             return String::from("No timing data collected (no instrumented passes ran).\n");
         }
 
-        let total: Duration = inner.passes.values().sum();
-        let total_ms = total.as_secs_f64() * 1000.0;
+        let total_ms = current_root_duration(&inner).as_secs_f64() * 1000.0;
 
         let mut output = String::new();
-        output.push_str("=== Compilation Timing ===\n\n");
+        output.push_str("=== Compilation Timing (inclusive spans) ===\n\n");
 
         // Find the longest pass name for alignment
         let max_name_len = inner.pass_order.iter().map(|s| s.len()).max().unwrap_or(0);
 
         for pass in &inner.pass_order {
-            if let Some(&duration) = inner.passes.get(pass) {
-                let ms = duration.as_secs_f64() * 1000.0;
+            if let Some(measurement) = inner.passes.get(pass) {
+                let ms = measurement.duration.as_secs_f64() * 1000.0;
                 let pct = if total_ms > 0.0 {
                     (ms / total_ms) * 100.0
                 } else {
@@ -195,10 +321,11 @@ impl TimingData {
         output.push_str(&format!("  {:-<width$}\n", "", width = max_name_len + 20));
         output.push_str(&format!(
             "  {:<width$} {:>8.1}ms (100%)\n",
-            "Total:",
+            "Total (root spans):",
             total_ms,
             width = max_name_len + 1
         ));
+        output.push_str("\n  Pass rows are inclusive; nested rows overlap their parents.\n");
 
         output
     }
@@ -219,15 +346,14 @@ impl TimingData {
     ) -> BenchmarkTiming {
         let inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
 
-        let total: Duration = inner.passes.values().sum();
-        let total_ms = total.as_secs_f64() * 1000.0;
+        let total_ms = current_root_duration(&inner).as_secs_f64() * 1000.0;
 
         let passes = inner
             .pass_order
             .iter()
             .filter_map(|pass| {
-                inner.passes.get(pass).map(|&duration| {
-                    let duration_ms = duration.as_secs_f64() * 1000.0;
+                inner.passes.get(pass).map(|measurement| {
+                    let duration_ms = measurement.duration.as_secs_f64() * 1000.0;
                     let percent = if total_ms > 0.0 {
                         (duration_ms / total_ms) * 100.0
                     } else {
@@ -237,6 +363,9 @@ impl TimingData {
                         name: pass.clone(),
                         duration_ms,
                         percent,
+                        invocations: measurement.invocations,
+                        root_invocations: measurement.root_invocations,
+                        leaf_invocations: measurement.leaf_invocations,
                     }
                 })
             })
@@ -249,6 +378,8 @@ impl TimingData {
         };
 
         BenchmarkTiming {
+            schema_version: 2,
+            timing_model: "inclusive_spans",
             metadata,
             passes,
             total_ms,
@@ -285,6 +416,23 @@ impl Default for TimingData {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Clamp a root transition to the serialized root timeline.
+fn ordered_root_timestamp(inner: &mut TimingDataInner, now: Instant) -> Instant {
+    let now = inner
+        .last_root_transition
+        .map_or(now, |previous| previous.max(now));
+    inner.last_root_transition = Some(now);
+    now
+}
+
+/// Snapshot the union of intervals in which at least one root span was active.
+fn current_root_duration(inner: &TimingDataInner) -> Duration {
+    let active = inner
+        .root_active_since
+        .map_or(Duration::ZERO, |started| started.elapsed());
+    inner.root_duration + active
 }
 
 /// Capitalize the first letter of a string.
@@ -389,11 +537,48 @@ impl TimingLayer {
 ///
 /// This is stored in the span's extensions and tracks when the span was entered.
 struct SpanTiming {
-    /// When the span was most recently entered.
-    /// None if the span is not currently entered.
-    entered_at: Option<Instant>,
-    /// Total time accumulated across all enter/exit cycles.
+    /// Number of active entries. A span may be re-entered or entered from
+    /// multiple threads, so one optional timestamp is insufficient.
+    active_enters: u64,
+    /// Start of the current interval in which this span has at least one entry.
+    active_since: Option<Instant>,
+    /// Union of intervals in which this span was active.
     accumulated: Duration,
+    /// Whether this span has at least one direct child.
+    has_children: bool,
+    /// Whether the span was created without a parent.
+    ///
+    /// Store this at creation because a child may outlive its parent; looking
+    /// the parent up again during a later enter/close can then be ambiguous.
+    is_root: bool,
+}
+
+impl SpanTiming {
+    fn enter_at(&mut self, now: Instant) {
+        if self.active_enters == 0 {
+            self.active_since = Some(now);
+        }
+        self.active_enters += 1;
+    }
+
+    fn exit_at(&mut self, now: Instant) {
+        if self.active_enters == 0 {
+            return;
+        }
+        self.active_enters -= 1;
+        if self.active_enters == 0 {
+            if let Some(started) = self.active_since.take() {
+                self.accumulated += now.saturating_duration_since(started);
+            }
+        }
+    }
+
+    fn duration(&self) -> Duration {
+        self.accumulated
+            + self
+                .active_since
+                .map_or(Duration::ZERO, |started| started.elapsed())
+    }
 }
 
 impl<S> Layer<S> for TimingLayer
@@ -403,31 +588,54 @@ where
     fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         // Initialize timing state for this span
         if let Some(span) = ctx.span(id) {
+            let parent_id = span.parent().map(|parent| parent.id().clone());
+            let is_root = parent_id.is_none();
             let mut extensions = span.extensions_mut();
             extensions.insert(SpanTiming {
-                entered_at: None,
+                active_enters: 0,
+                active_since: None,
                 accumulated: Duration::ZERO,
+                has_children: false,
+                is_root,
             });
+            drop(extensions);
+
+            if let Some(parent_id) = parent_id {
+                if let Some(parent) = ctx.span(&parent_id) {
+                    let mut parent_extensions = parent.extensions_mut();
+                    if let Some(parent_timing) = parent_extensions.get_mut::<SpanTiming>() {
+                        parent_timing.has_children = true;
+                    }
+                }
+            }
         }
     }
 
     fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
-        // Record when the span was entered
         if let Some(span) = ctx.span(id) {
             let mut extensions = span.extensions_mut();
             if let Some(timing) = extensions.get_mut::<SpanTiming>() {
-                timing.entered_at = Some(Instant::now());
+                if timing.is_root {
+                    self.data.enter_root_span(timing);
+                } else {
+                    // Sample after acquiring the per-span extension lock so
+                    // concurrent callbacks cannot apply stale timestamps.
+                    timing.enter_at(Instant::now());
+                }
             }
         }
     }
 
     fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
-        // Calculate duration and accumulate
         if let Some(span) = ctx.span(id) {
             let mut extensions = span.extensions_mut();
             if let Some(timing) = extensions.get_mut::<SpanTiming>() {
-                if let Some(entered_at) = timing.entered_at.take() {
-                    timing.accumulated += entered_at.elapsed();
+                if timing.is_root {
+                    self.data.exit_root_span(timing);
+                } else {
+                    // Sample after acquiring the per-span extension lock so
+                    // concurrent callbacks cannot apply stale timestamps.
+                    timing.exit_at(Instant::now());
                 }
             }
         }
@@ -436,10 +644,23 @@ where
     fn on_close(&self, id: Id, ctx: Context<'_, S>) {
         // When the span is fully closed, record its total time
         if let Some(span) = ctx.span(&id) {
-            let extensions = span.extensions();
-            if let Some(timing) = extensions.get::<SpanTiming>() {
-                let name = span.name();
-                self.data.record(name, timing.accumulated);
+            let measurement = {
+                let extensions = span.extensions();
+                extensions.get::<SpanTiming>().map(|timing| {
+                    (
+                        span.name().to_string(),
+                        timing.duration(),
+                        timing.is_root,
+                        !timing.has_children,
+                    )
+                })
+            };
+
+            // Do not hold the span's extension lock while acquiring the
+            // aggregate-data lock. Root enter/exit callbacks deliberately use
+            // the opposite pair together (extension, then aggregate data).
+            if let Some((name, duration, is_root, is_leaf)) = measurement {
+                self.data.record_span(&name, duration, is_root, is_leaf);
             }
         }
     }
@@ -540,6 +761,113 @@ mod tests {
     }
 
     #[test]
+    fn nested_spans_do_not_inflate_total() {
+        let data = TimingData::new();
+        data.record_test_span("compile", Duration::from_millis(10), true, false);
+        data.record_test_span("parse", Duration::from_millis(6), false, false);
+        data.record_test_span("lexer", Duration::from_millis(4), false, true);
+        data.record_test_span("parser", Duration::from_millis(2), false, true);
+        data.record_test_span("codegen", Duration::from_millis(4), false, true);
+
+        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
+        assert!((timing.total_ms - 10.0).abs() < f64::EPSILON);
+
+        let compile = timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "compile")
+            .unwrap();
+        assert!((compile.percent - 100.0).abs() < f64::EPSILON);
+        assert_eq!(compile.invocations, 1);
+        assert_eq!(compile.root_invocations, 1);
+        assert_eq!(compile.leaf_invocations, 0);
+
+        let leaf_ms: f64 = timing
+            .passes
+            .iter()
+            .filter(|pass| pass.leaf_invocations == pass.invocations)
+            .map(|pass| pass.duration_ms)
+            .sum();
+        assert!((leaf_ms - timing.total_ms).abs() < f64::EPSILON);
+
+        let inclusive_sum: f64 = timing.passes.iter().map(|pass| pass.duration_ms).sum();
+        assert!(inclusive_sum > timing.total_ms);
+    }
+
+    #[test]
+    fn overlapping_roots_contribute_their_wall_time_union() {
+        let data = TimingData::new();
+        let start = Instant::now();
+        data.root_enter_at(start);
+        data.root_enter_at(start + Duration::from_millis(10));
+        data.root_exit_at(start + Duration::from_millis(20));
+        data.root_exit_at(start + Duration::from_millis(30));
+
+        let inner = data.inner.lock().unwrap();
+        assert_eq!(current_root_duration(&inner), Duration::from_millis(30));
+    }
+
+    #[test]
+    fn stale_root_callback_timestamp_cannot_inflate_either_timing_view() {
+        let data = TimingData::new();
+        let start = Instant::now();
+        let mut first = SpanTiming {
+            active_enters: 0,
+            active_since: None,
+            accumulated: Duration::ZERO,
+            has_children: false,
+            is_root: true,
+        };
+        let mut delayed = SpanTiming {
+            active_enters: 0,
+            active_since: None,
+            accumulated: Duration::ZERO,
+            has_children: false,
+            is_root: true,
+        };
+
+        // Model a callback that captured t=10ms, stalled, and was applied
+        // after another root exited at t=20ms. Runtime callbacks sample their
+        // timestamp only after acquiring this lock; clamping here makes the
+        // invariant explicit and protects both the span and root-union views.
+        let mut inner = data.inner.lock().unwrap();
+        TimingData::enter_root_span_inner(&mut inner, &mut first, start);
+        TimingData::exit_root_span_inner(&mut inner, &mut first, start + Duration::from_millis(20));
+        TimingData::enter_root_span_inner(
+            &mut inner,
+            &mut delayed,
+            start + Duration::from_millis(10),
+        );
+        TimingData::exit_root_span_inner(
+            &mut inner,
+            &mut delayed,
+            start + Duration::from_millis(30),
+        );
+
+        assert_eq!(first.duration(), Duration::from_millis(20));
+        assert_eq!(delayed.duration(), Duration::from_millis(10));
+        assert_eq!(current_root_duration(&inner), Duration::from_millis(30));
+    }
+
+    #[test]
+    fn reentrant_span_contributes_its_wall_time_union() {
+        let start = Instant::now();
+        let mut timing = SpanTiming {
+            active_enters: 0,
+            active_since: None,
+            accumulated: Duration::ZERO,
+            has_children: false,
+            is_root: false,
+        };
+        timing.enter_at(start);
+        timing.enter_at(start + Duration::from_millis(10));
+        timing.exit_at(start + Duration::from_millis(20));
+        timing.exit_at(start + Duration::from_millis(30));
+
+        assert_eq!(timing.duration(), Duration::from_millis(30));
+    }
+
+    #[test]
     fn test_to_benchmark_timing_metadata() {
         let data = TimingData::new();
         data.record("lexer", Duration::from_millis(100));
@@ -558,11 +886,16 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None);
+        assert!(json.contains("\"schema_version\":2"));
+        assert!(json.contains("\"timing_model\":\"inclusive_spans\""));
         assert!(json.contains("\"passes\""));
         assert!(json.contains("\"name\""));
         assert!(json.contains("\"lexer\""));
         assert!(json.contains("\"duration_ms\""));
         assert!(json.contains("\"percent\""));
+        assert!(json.contains("\"invocations\""));
+        assert!(json.contains("\"root_invocations\""));
+        assert!(json.contains("\"leaf_invocations\""));
         assert!(json.contains("\"total_ms\""));
         // Should also contain metadata
         assert!(json.contains("\"metadata\""));

--- a/docs/process/logging.md
+++ b/docs/process/logging.md
@@ -28,6 +28,14 @@ rue --log-format=json --log-level=debug source.rue output
 RUST_LOG=rue_compiler::sema=trace rue source.rue output
 ```
 
+`--time-passes` and `--benchmark-json` use inclusive spans: a parent's time
+contains its children. Their total is therefore the duration of root compiler
+spans, not the sum of every row. Machine-readable schema v2 includes invocation,
+root, and leaf counts so consumers can distinguish aggregate spans from phase
+rows. Distinct parallel leaf spans may overlap and should be interpreted as
+summed work rather than wall time. Logging filters such as `RUST_LOG=error`
+affect log output only; they do not disable timing collection.
+
 ### Adding Instrumentation
 
 Each compilation pass should have a tracing span wrapping the work:
@@ -111,4 +119,3 @@ println!("Lexed {} tokens from {} bytes", tokens.len(), source.len());
 3. **Context in spans**: Include high-level context (file, function count) in span fields
 4. **Metrics in events**: Include computed metrics (instruction counts, sizes) in events
 5. **Zero-cost when off**: Tracing has no overhead when no subscriber is active
-

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -8,18 +8,31 @@ set of guarantees.
 **How to reproduce.** Run the harness from the repo root:
 
 ```bash
-scripts/perf-baseline.py                 # text report (default corpus, 5 warm iters)
+scripts/perf-baseline.py                 # 5 fresh samples after 1 cache warmup
 scripts/perf-baseline.py --iterations 7  # more iterations = steadier medians
-scripts/perf-baseline.py --format markdown   # regenerates the tables below
+scripts/perf-baseline.py --format markdown   # prints compact current tables
 scripts/perf-baseline.py --format json       # machine-readable aggregate
 ```
 
 The harness compiles a representative corpus with the real `rue` binary using
 `--benchmark-json` (the machine-readable form of `--time-passes`, see
-[logging.md](logging.md)), runs several *warm* iterations, and reports the
-**median** per-pass timing plus the end-to-end wall clock. It is separate from
-`bench.sh` (which feeds the historical website dashboard); this one is a quick,
-self-contained snapshot with no history/network side effects.
+[logging.md](logging.md)). Every sample is a **fresh compiler process**; the
+optional warmups warm host/filesystem caches, not compiler state. The harness
+reports median absolute deviation alongside both the compiler pipeline span
+and fresh-process wall time, plus peak resident memory where the host exposes
+it. It is separate from `bench.sh` (which feeds the
+historical website dashboard); this one is a quick, self-contained snapshot
+with no history/network side effects.
+
+Every workload invocation explicitly uses Rue program optimization level
+`-O0`, so changes in the compiler's optimization policy do not silently change
+the amount of generated-program optimization being measured. `--release`
+selects an optimized *compiler binary*; it does not change that workload
+`-O0`. The text and JSON formats include root/process/accounting MAD, the paired
+accounting metrics, and peak RSS. Markdown deliberately stays compact: it
+prints median phase, compile, and process times plus the hot-pass table, but
+omits MAD and RSS. It prints new tables to stdout and does not rewrite the
+historical tables in this document.
 
 ## Reading the numbers
 
@@ -27,37 +40,75 @@ The compiler wraps each pass in a tracing span, and some spans are **nested**,
 so the raw timing JSON contains both leaf passes and their aggregate parents:
 
 ```
-compile                 <- top-level span, ~= end-to-end wall clock
-├─ parse                <- aggregate of the two parse leaves (excluded below)
-│  ├─ parse_file        <- leaf: lex + parse, summed over all input files
+compile                 <- compiler pipeline; excludes discovery/driver startup
+├─ parse                <- aggregate (excluded from the leaf table)
+│  ├─ parse_file        <- aggregate, repeated for each input file
+│  │  ├─ lexer          <- leaf
+│  │  └─ parser         <- leaf
 │  └─ merge_symbols     <- leaf: cross-file symbol merge
 ├─ astgen               <- leaf: AST -> RIR
+├─ semantic_astgen      <- leaf: canonical semantic AST -> RIR
 ├─ sema                 <- leaf: type checking / AIR
 ├─ cfg_construction     <- leaf
 ├─ codegen              <- leaf: MIR lower + regalloc + emit
-└─ linker               <- leaf: ELF link
+└─ linker               <- leaf: built-in ELF link in these baseline runs
 ```
 
-> **Caveat about `--time-passes`.** Its printed **"Total"** line *sums every
-> span*, so it double-counts the aggregate parents (`parse` + `compile`) and
-> comes out ~2× the real wall clock. This document (and the harness) instead
-> use the `compile` span as the wall-clock total and report each **leaf** pass
-> as a percentage of it. When you read `--time-passes` output by hand, ignore
-> the `parse` and `compile` rows and the inflated `Total`.
+Since RUE-642, timing JSON schema v2 labels the model as `inclusive_spans`.
+`total_ms` is the inclusive duration of root compiler spans, and pass
+percentages use that honest total. Pass rows are themselves inclusive, so an
+aggregate still overlaps its children. The harness uses `leaf_invocations` to
+select phase rows. Each displayed phase duration is that phase's own median;
+those independent medians are useful for profiling, but they are **not an
+additive breakdown of one median run** and should not be summed to reconstruct
+the compile median. In JSON, a phase's `median_percent` is separately computed
+as the median of its per-sample phase/root ratios; it is not
+`median_ms / compile median`.
+The harness also rejects malformed v2 trees: `compile` must be the sole root
+and must have children, every reported leaf must be nested beneath it, and the
+source workload counters must be non-negative integers with at least one file.
+
+For accounting, the harness instead computes four values within every sample
+and only then reports their median and MAD: leaf/root ratio, unattributed time
+(`max(root - leaf work, 0)`), overlapping leaf work
+(`max(leaf work - root, 0)`), and driver overhead (`process - root`). Pairing
+before aggregation prevents phase medians from different runs from inventing
+overlap or residual time that occurred in no real run. Rue's current
+coordinator-level leaves are sequential, so overlapping leaf work should be
+zero today; if future parallel leaf spans overlap, their sum is work time and
+may legitimately exceed root wall time.
+`process_ms` additionally covers process startup, source loading/import
+discovery, output handling, and other driver work outside `compile`.
+The corpus-wide hot-pass table is likewise a descriptive ratio of summed
+per-workload medians, not the accounting for a single run.
+
+> **Historical discontinuity.** Before RUE-642, `total_ms` summed every nested
+> span and was commonly about twice the real compiler time. Old dashboard data
+> retains that inflated raw `mean_ms`; the dashboard now prefers the stored
+> `passes.compile.mean_ms` for those runs. The baseline harness had a name-based
+> workaround and can still read schema-v1 samples. Any other comparison across
+> the schema boundary must likewise use the old `compile` row rather than old
+> `total_ms`.
 
 ## Baseline (measured 2026-07-03)
 
 **These are absolute milliseconds and are MACHINE-SPECIFIC — treat them as a
 relative profile (which passes dominate), not a hard threshold.**
 
+This historical table predates schema v2, so it shows the then-combined
+`parse_file` leaf rather than separate `lexer` and `parser` rows. Its totals
+were already taken from the old `compile` row, not the inflated old
+`total_ms`, and remain valid as compiler-pipeline measurements.
+
 - Host: Intel Core i9-14900K, Linux x86-64 (WSL2), 32 logical CPUs.
 - Build: the buck2 **DEFAULT** profile as produced by `scripts/rue-bin`
   (unoptimized — see "Build caveat" below). Numbers on an optimized build
   would be smaller, but the *pass profile* (parse-dominated) holds.
 - Corpus: `examples/` (small/medium) + `benchmarks/stress/` (large) + a
-  synthesized 3-file program (multi-file merge path). `deep_nesting.rue` is
+  synthesized 3-file import graph (discovery + multi-file merge paths).
+  `deep_nesting.rue` is
   excluded — see "Known pathology".
-- 7 warm iterations, median.
+- 7 fresh compiler processes after one host-cache warmup, median.
 
 ### Small / medium programs (ms)
 
@@ -111,8 +162,9 @@ relative profile (which passes dominate), not a hard threshold.**
 3. **`sema` is third (~11%)** and scales with type/expression volume
    (`arithmetic_heavy`, `large_structs`, `register_pressure`).
 
-4. **`linker` is a fixed ~8 ms floor.** On the small programs it is 60–80% of a
-   sub-15 ms compile purely because of that fixed ELF-emit cost; it is
+4. **Rue's built-in `linker` was a fixed ~8 ms floor on this host.** These
+   measurements used Rue's internal ELF linker, not an external host/system
+   linker. On the small programs it was 60–80% of a sub-15 ms compile; it was
    negligible on large programs. It matters for edit-compile-run latency on
    small inputs but is not a throughput bottleneck.
 
@@ -121,10 +173,11 @@ relative profile (which passes dominate), not a hard threshold.**
 
 ### What would speed the hot passes up
 
-- **parse_file:** profile the parser proper (lexing is already cheap). Reduce
-  per-token allocation, avoid re-scanning, and fix the exponential blowup
-  below (which is the extreme tail of "parsing is expensive"). Finer spans
-  (lex vs. parse vs. RIR-build) would sharpen the target.
+- **parser:** the now-separated lexer/parser rows confirm lexing is cheap.
+  Profile parser internals, reduce per-token allocation and re-scanning, and
+  fix the exponential blowup below (the extreme tail of "parsing is
+  expensive"). Split parser sub-phases only where that profile shows another
+  broad boundary hiding the cost.
 - **codegen:** add per-sub-phase spans (lower / regalloc / emit) to see which
   dominates before touching it; regalloc is the usual suspect under pressure.
 - **sema:** watch for quadratic scans over symbols/types as programs grow.

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -46,19 +46,20 @@ COMPARISON_HEIGHT = 400
 
 # Colors for passes (consistent with website theme)
 PASS_COLORS = {
-    "parse_file": "#5c6b34",            # olive
-    "merge_symbols": "#71813f",         # moss
-    "parallel_astgen": "#5c6b34",       # historical olive
-    "merge_rirs": "#71813f",            # historical moss
+    "lexer": "#5c6b34",  # olive
+    "parser": "#7d8f4a",  # moss
+    "parse_file": "#5c6b34",  # historical combined lexer/parser
+    "merge_symbols": "#71813f",  # moss
+    "parallel_astgen": "#5c6b34",  # historical olive
+    "merge_rirs": "#71813f",  # historical moss
     "validate_and_generate_rir": "#8f984d",  # dry grass
-    "lexer": "#5c6b34",     # olive
-    "parser": "#7d8f4a",    # moss
-    "astgen": "#a3a25b",    # dry grass
-    "sema": "#c9970e",      # rue yellow
-    "cfg": "#8a6d2f",       # ochre
+    "astgen": "#a3a25b",  # dry grass
+    "semantic_astgen": "#b7ad63",  # straw
+    "sema": "#c9970e",  # rue yellow
+    "cfg": "#8a6d2f",  # ochre
     "cfg_construction": "#8a6d2f",  # ochre
-    "codegen": "#a14e24",   # sienna
-    "linker": "#6b4788",    # plum
+    "codegen": "#a14e24",  # sienna
+    "linker": "#6b4788",  # plum
 }
 
 # Nested aggregate spans would double-count their leaf timings in a breakdown.
@@ -68,18 +69,19 @@ AGGREGATE_PASSES = {"parse", "compile"}
 # A chart only renders names present in the selected run, then appends unknown
 # future leaves alphabetically so new instrumentation cannot disappear.
 PASS_ORDER = [
+    "lexer",
+    "parser",
     "parse_file",
     "merge_symbols",
     "parallel_astgen",
     "merge_rirs",
     "validate_and_generate_rir",
     "astgen",
+    "semantic_astgen",
     "sema",
     "cfg_construction",
     "codegen",
     "linker",
-    "lexer",
-    "parser",
     "cfg",
 ]
 
@@ -127,6 +129,13 @@ def order_pass_times(passes: dict[str, float]) -> dict[str, float]:
 
 def benchmark_time(bench: dict) -> float:
     """Read one benchmark's mean time across current and legacy schemas."""
+    # Before timing schema v2, mean_ms summed nested spans and was inflated.
+    # Historical runs retained the honest root wall time as passes.compile.
+    compile_timing = bench.get("passes", {}).get("compile")
+    if isinstance(compile_timing, dict):
+        compile_mean = compile_timing.get("mean_ms")
+        if isinstance(compile_mean, (int, float)):
+            return compile_mean
     if "mean_ms" in bench:
         return bench["mean_ms"]
     total = bench.get("total_ms", 0)
@@ -1121,7 +1130,7 @@ def generate_platform_charts(history_path: Path, output_dir: Path, platform: Opt
         for bench in latest_run.get("benchmarks", []):
             bench_info = {
                 "name": bench.get("name", ""),
-                "mean_ms": bench.get("mean_ms", 0),
+                "mean_ms": benchmark_time(bench),
             }
             if "source_metrics" in bench:
                 sm = bench["source_metrics"]

--- a/scripts/perf-baseline.py
+++ b/scripts/perf-baseline.py
@@ -4,8 +4,8 @@ Per-pass compiler performance baseline harness (RUE-249).
 
 Compiles a representative corpus with the real `rue` binary using
 `--benchmark-json` (the machine-readable form of `--time-passes`, see
-docs/process/logging.md), runs several *warm* iterations per program, and
-reports the median per-pass timing plus the end-to-end wall-clock total.
+docs/process/logging.md), runs several fresh compiler processes per program,
+and reports median compiler-span and process wall time plus per-pass timing.
 
 This is the tool behind docs/process/perf-baseline.md: run it, read the
 "hot passes", and re-run it after a "faster compilation" change to see
@@ -18,28 +18,38 @@ human-readable, self-contained snapshot with no history/network side effects.
 The compiler wraps each pass in a tracing span. Some spans are *nested*, so
 the raw JSON contains both leaf passes and their aggregate parents:
 
-    compile                         <- top-level, ~= end-to-end wall clock
-    |- parse                        <- aggregate of the two parse leaves
-    |  |- parse_file                <- leaf (lex + parse, summed over files)
-    |  |- merge_symbols             <- leaf
+    compile                         <- top-level compiler pipeline wall clock
+    |- parse                        <- aggregate
+    |  |- parse_file                <- aggregate, repeated for every file
+    |  |  |- lexer                  <- leaf
+    |  |  `- parser                 <- leaf
+    |  `- merge_symbols             <- leaf
     |- astgen                       <- leaf
+    |- semantic_astgen              <- leaf
     |- sema                         <- leaf
     |- cfg_construction             <- leaf
     |- codegen                      <- leaf
     |- linker                       <- leaf
 
-`--time-passes`'s printed "Total" line SUMS every span, so it double-counts
-the aggregate parents (parse + compile) and is ~2x the real wall clock. This
-harness instead uses the `compile` span as the wall-clock total and reports
-each *leaf* pass as a percentage of it, which is the number you actually want
-when deciding what to optimize.
+Schema v2 marks root and leaf invocations explicitly. `total_ms` is the
+inclusive duration of root compiler spans; nested pass rows are also inclusive
+and therefore overlap their parents. This harness reports only leaves in its
+phase table. Leaf/root ratio, unattributed time, overlap, and driver overhead
+are calculated within each sample before their medians are taken, so unrelated
+samples are never combined into a fictional timing breakdown. It also measures
+the fresh process around `subprocess.run`: that includes startup, source
+discovery, and driver work outside the `compile` span.
+
+In JSON phase rows, `median_percent` is the median of the per-sample
+phase/root ratios. It is intentionally not the ratio between the independently
+aggregated `median_ms` phase duration and compile median.
 
 ## Usage
 
-    scripts/perf-baseline.py                     # default corpus, 5 warm iters
+    scripts/perf-baseline.py                     # 5 samples after 1 warmup
     scripts/perf-baseline.py --iterations 9
     scripts/perf-baseline.py --rue-bin /path/to/rue
-    scripts/perf-baseline.py --format markdown   # tables for the baseline doc
+    scripts/perf-baseline.py --format markdown   # compact median tables
     scripts/perf-baseline.py --format json       # machine-readable aggregate
 
 By default the compiler is located via `scripts/rue-bin` (a normal build).
@@ -52,16 +62,18 @@ them as a relative profile (which passes dominate), not a hard guarantee.
 
 import argparse
 import json
+import math
 import os
 import shutil
 import statistics
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
-# Aggregate/parent spans to exclude from the per-leaf table. `compile` is the
-# end-to-end wall clock; `parse` is just parse_file + merge_symbols.
+# Schema-v1 fallback for benchmark JSON produced before passes described their
+# own nesting. Schema v2 uses invocation metadata instead of this name list.
 AGGREGATE_PASSES = {"parse", "compile"}
 WALL_CLOCK_PASS = "compile"
 
@@ -69,9 +81,12 @@ WALL_CLOCK_PASS = "compile"
 # leaf the compiler emits that is not listed here is appended afterwards in
 # first-seen order, so a newly instrumented pass still shows up.
 CANONICAL_LEAF_ORDER = [
-    "parse_file",
+    "parse_file",  # schema-v1 combined lexer/parser leaf
+    "lexer",
+    "parser",
     "merge_symbols",
     "astgen",
+    "semantic_astgen",
     "sema",
     "cfg_construction",
     "codegen",
@@ -114,11 +129,14 @@ def default_corpus(root: Path):
 # corpus exercises the multi-file merge path (merge_symbols) without depending
 # on files that live in the tree.
 MULTI_MAIN = """\
+const a = @import("a.rue");
+const b = @import("b.rue");
+
 fn main() -> i64 {
     let mut total: i64 = 0;
     let mut i: i64 = 0;
     while i < 100 {
-        total = total + square(i) + cube(i);
+        total = total + a.square(i) + b.cube(i);
         i = i + 1;
     }
     total
@@ -154,48 +172,356 @@ def resolve_rue_bin(args, root: Path) -> str:
     return out.stdout.strip()
 
 
-def compile_once(rue_bin: str, files, out_path: str, timeout: float):
-    """Run one compilation with --benchmark-json; return the parsed JSON."""
-    cmd = [rue_bin, "--benchmark-json"] + [str(f) for f in files] + ["-o", out_path]
+def compile_once(rue_bin: str, files, out_path: str, timeout: float, jobs: int):
+    """Run one fresh compiler process and return timing JSON plus process time."""
+    cmd = (
+        [rue_bin, "--benchmark-json", "--jobs", str(jobs), "-O0"]
+        + [str(f) for f in files]
+        + ["-o", out_path]
+    )
+    output = Path(out_path)
+    output.unlink(missing_ok=True)
+    child_env = os.environ.copy()
+    # Developer logging configuration is not a compiler input and can add
+    # substantial formatting/I/O work to otherwise identical samples.
+    child_env.pop("RUST_LOG", None)
+    started = time.perf_counter_ns()
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=child_env,
+        )
     except subprocess.TimeoutExpired as e:
+        output.unlink(missing_ok=True)
         raise RuntimeError(f"compile exceeded {timeout:.0f}s timeout") from e
+    process_ms = (time.perf_counter_ns() - started) / 1_000_000
     if proc.returncode != 0:
+        output.unlink(missing_ok=True)
         raise RuntimeError(
             f"compile failed ({' '.join(cmd)}):\n{proc.stderr}\n{proc.stdout}"
         )
-    # --benchmark-json prints the JSON object on stdout as the last line.
-    line = proc.stdout.strip().splitlines()[-1]
-    return json.loads(line)
+    if not output.is_file():
+        raise RuntimeError("compiler succeeded without producing its output artifact")
+    try:
+        result = json.loads(proc.stdout)
+    except (json.JSONDecodeError, TypeError) as error:
+        raise RuntimeError("compiler stdout was not exactly one benchmark JSON value") from error
+    finally:
+        output.unlink(missing_ok=True)
+    if not isinstance(result, dict):
+        raise RuntimeError("compiler benchmark JSON must be an object")
+    result["_process_ms"] = process_ms
+    return result
+
+
+def median_and_mad(values):
+    """Return median and median absolute deviation for numeric samples."""
+    if not values:
+        return 0.0, 0.0
+    median = statistics.median(values)
+    mad = statistics.median(abs(value - median) for value in values)
+    return median, mad
+
+
+def finite_nonnegative(value, label):
+    """Validate and normalize one duration from machine-readable timing JSON."""
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+    ):
+        raise ValueError(f"{label} must be a finite non-negative number")
+    return float(value)
+
+
+def nonnegative_int(value, label, *, positive=False):
+    """Validate an integer counter from machine-readable timing JSON."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{label} must be a non-negative integer")
+    if positive and value == 0:
+        raise ValueError(f"{label} must be greater than zero")
+    return value
+
+
+def validate_v2_pass_counters(pass_data, sample_number, name):
+    """Validate the invocation metadata that defines v2 span nesting."""
+    prefix = f"sample {sample_number} pass {name!r}"
+    invocations = nonnegative_int(
+        pass_data.get("invocations"), f"{prefix} invocations", positive=True
+    )
+    root_invocations = nonnegative_int(
+        pass_data.get("root_invocations"), f"{prefix} root_invocations"
+    )
+    leaf_invocations = nonnegative_int(
+        pass_data.get("leaf_invocations"), f"{prefix} leaf_invocations"
+    )
+    if root_invocations > invocations:
+        raise ValueError(f"{prefix} root_invocations exceeds invocations")
+    if leaf_invocations > invocations:
+        raise ValueError(f"{prefix} leaf_invocations exceeds invocations")
+
+
+def validate_source_metrics(source_metrics, sample_number, schema_version):
+    """Validate workload-size metadata used for throughput comparisons."""
+    label = f"sample {sample_number} source_metrics"
+    if not isinstance(source_metrics, dict):
+        if source_metrics is None and schema_version == 1:
+            return
+        raise ValueError(f"{label} must be an object")
+    if schema_version == 2:
+        nonnegative_int(
+            source_metrics.get("files"), f"{label} files", positive=True
+        )
+        for field in ("bytes", "lines", "tokens"):
+            nonnegative_int(source_metrics.get(field), f"{label} {field}")
+
+
+def is_leaf_pass(pass_data, schema_version):
+    """Use v2 nesting metadata, with a name-based fallback for v1 JSON."""
+    if schema_version == 2:
+        return pass_data["leaf_invocations"] == pass_data["invocations"]
+    return pass_data.get("name") not in AGGREGATE_PASSES
 
 
 def aggregate(samples):
     """Given a list of per-run JSON dicts, return the median per-pass timing.
 
-    Returns (leaf_rows, wall_ms, source_metrics) where leaf_rows is an ordered
-    list of (name, median_ms, percent_of_wall).
+    The result separates the compiler's root span from fresh-process wall time.
+    Relationships between leaf work, the root, and process time are calculated
+    per sample before aggregation; the independently reported pass medians are
+    descriptive central tendencies, not an additive breakdown of a median run.
     """
-    # Collect per-pass duration lists.
+    if not samples:
+        return {
+            "rows": [],
+            "compile_ms": 0.0,
+            "compile_mad_ms": 0.0,
+            "process_ms": 0.0,
+            "process_mad_ms": 0.0,
+            "driver_overhead_ms": 0.0,
+            "driver_overhead_mad_ms": 0.0,
+            "leaf_to_root_ratio_percent": 0.0,
+            "leaf_to_root_ratio_mad_percent": 0.0,
+            "unattributed_ms": 0.0,
+            "unattributed_mad_ms": 0.0,
+            "overlapping_leaf_work_ms": 0.0,
+            "overlapping_leaf_work_mad_ms": 0.0,
+            "source_metrics": None,
+            "target": None,
+            "compiler_version": None,
+            "peak_memory_bytes": None,
+            "peak_memory_mad_bytes": None,
+        }
+
     per_pass = {}
     order_seen = []
-    wall_samples = []
+    compile_samples = []
+    process_samples = []
+    overhead_samples = []
+    leaf_to_root_ratio_samples = []
+    unattributed_samples = []
+    overlapping_leaf_work_samples = []
+    memory_samples = []
+    memory_available = None
     source_metrics = None
-    for s in samples:
-        pass_ms = {p["name"]: p["duration_ms"] for p in s.get("passes", [])}
-        wall_samples.append(pass_ms.get(WALL_CLOCK_PASS, s.get("total_ms", 0.0)))
-        if source_metrics is None:
-            source_metrics = s.get("source_metrics")
-        for name, ms in pass_ms.items():
-            if name in AGGREGATE_PASSES:
-                continue
-            if name not in per_pass:
-                per_pass[name] = []
-                order_seen.append(name)
-        for name in per_pass:
-            per_pass[name].append(pass_ms.get(name, 0.0))
+    source_metrics_seen = False
+    compiler_identity = None
+    expected_leaf_names = None
+    expected_schema_version = None
 
-    wall_ms = statistics.median(wall_samples) if wall_samples else 0.0
+    for sample_index, sample in enumerate(samples):
+        sample_number = sample_index + 1
+        if not isinstance(sample, dict):
+            raise ValueError(f"sample {sample_number} must be an object")
+        schema_version = sample.get("schema_version", 1)
+        if (
+            isinstance(schema_version, bool)
+            or not isinstance(schema_version, int)
+            or schema_version not in (1, 2)
+        ):
+            raise ValueError(
+                f"sample {sample_number} schema_version must be integer 1 or 2"
+            )
+        if expected_schema_version is None:
+            expected_schema_version = schema_version
+        elif schema_version != expected_schema_version:
+            raise ValueError(
+                f"sample {sample_index + 1} schema changed from "
+                f"{expected_schema_version} to {schema_version}"
+            )
+        passes = sample.get("passes", [])
+        if not isinstance(passes, list):
+            raise ValueError(f"sample {sample_index + 1} passes must be a list")
+        pass_ms = {}
+        passes_by_name = {}
+        for pass_index, pass_data in enumerate(passes):
+            if not isinstance(pass_data, dict):
+                raise ValueError(
+                    f"sample {sample_index + 1} pass {pass_index + 1} must be an object"
+                )
+            name = pass_data.get("name")
+            if not isinstance(name, str) or not name:
+                raise ValueError(
+                    f"sample {sample_index + 1} pass {pass_index + 1} has no name"
+                )
+            if name in pass_ms:
+                raise ValueError(
+                    f"sample {sample_index + 1} has duplicate pass name {name!r}"
+                )
+            pass_ms[name] = finite_nonnegative(
+                pass_data.get("duration_ms"),
+                f"sample {sample_index + 1} pass {name!r}",
+            )
+            passes_by_name[name] = pass_data
+            if schema_version == 2:
+                validate_v2_pass_counters(pass_data, sample_number, name)
+        if WALL_CLOCK_PASS not in pass_ms:
+            raise ValueError(f"sample {sample_index + 1} has no compile span")
+
+        if schema_version == 2:
+            if sample.get("timing_model") != "inclusive_spans":
+                raise ValueError(
+                    f"sample {sample_index + 1} has unknown timing model "
+                    f"{sample.get('timing_model')!r}"
+                )
+            compile_ms = finite_nonnegative(
+                sample.get("total_ms"), f"sample {sample_index + 1} total_ms"
+            )
+            if abs(compile_ms - pass_ms[WALL_CLOCK_PASS]) > 1e-6:
+                raise ValueError(
+                    f"sample {sample_index + 1} total_ms does not match compile span"
+                )
+            compile_pass = passes_by_name[WALL_CLOCK_PASS]
+            if compile_pass["root_invocations"] != compile_pass["invocations"]:
+                raise ValueError(
+                    f"sample {sample_number} compile span must have every "
+                    "invocation at the root"
+                )
+            if compile_pass["leaf_invocations"] != 0:
+                raise ValueError(
+                    f"sample {sample_number} compile span must not be a leaf"
+                )
+            other_roots = [
+                name
+                for name, pass_data in passes_by_name.items()
+                if name != WALL_CLOCK_PASS and pass_data["root_invocations"] != 0
+            ]
+            if other_roots:
+                raise ValueError(
+                    f"sample {sample_number} compile span must be the sole root; "
+                    f"other rooted pass(es): {other_roots}"
+                )
+        else:
+            # V1's total_ms summed nested spans; its compile row is the only
+            # trustworthy compiler-pipeline wall clock.
+            compile_ms = pass_ms[WALL_CLOCK_PASS]
+
+        leaf_names = [
+            pass_data["name"]
+            for pass_data in passes
+            if is_leaf_pass(pass_data, schema_version)
+        ]
+        leaf_name_set = set(leaf_names)
+        if expected_leaf_names is None:
+            expected_leaf_names = leaf_name_set
+            order_seen.extend(leaf_names)
+            per_pass = {name: [] for name in leaf_names}
+        elif leaf_name_set != expected_leaf_names:
+            missing = sorted(expected_leaf_names - leaf_name_set)
+            extra = sorted(leaf_name_set - expected_leaf_names)
+            raise ValueError(
+                f"sample {sample_index + 1} leaf pass set drifted; "
+                f"missing={missing}, extra={extra}"
+            )
+
+        for name in per_pass:
+            per_pass[name].append(pass_ms[name])
+
+        leaf_work_ms = sum(pass_ms[name] for name in leaf_names)
+        if compile_ms == 0 and leaf_work_ms > 0:
+            raise ValueError(
+                f"sample {sample_number} has positive leaf work with a zero "
+                "compile span"
+            )
+        leaf_to_root_ratio_samples.append(
+            leaf_work_ms / compile_ms * 100.0 if compile_ms > 0 else 0.0
+        )
+        unattributed_samples.append(max(compile_ms - leaf_work_ms, 0.0))
+        overlapping_leaf_work_samples.append(max(leaf_work_ms - compile_ms, 0.0))
+
+        process_ms = finite_nonnegative(
+            sample.get("_process_ms", compile_ms),
+            f"sample {sample_index + 1} process time",
+        )
+        if process_ms + 1e-6 < compile_ms:
+            raise ValueError(
+                f"sample {sample_index + 1} process time is shorter than compile span"
+            )
+        compile_samples.append(compile_ms)
+        process_samples.append(process_ms)
+        overhead_samples.append(max(process_ms - compile_ms, 0.0))
+
+        peak_memory = sample.get("peak_memory_bytes")
+        has_memory = peak_memory is not None
+        if memory_available is None:
+            memory_available = has_memory
+        elif has_memory != memory_available:
+            raise ValueError(f"sample {sample_index + 1} peak-memory availability drifted")
+        if has_memory:
+            memory_samples.append(
+                finite_nonnegative(
+                    peak_memory, f"sample {sample_index + 1} peak_memory_bytes"
+                )
+            )
+
+        sample_source_metrics = sample.get("source_metrics")
+        validate_source_metrics(sample_source_metrics, sample_number, schema_version)
+        if not source_metrics_seen:
+            source_metrics = sample_source_metrics
+            source_metrics_seen = True
+        elif sample_source_metrics != source_metrics:
+            raise ValueError(f"sample {sample_index + 1} source metrics drifted")
+
+        metadata = sample.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise ValueError(f"sample {sample_number} metadata must be an object")
+        if schema_version == 2:
+            for field in ("target", "version"):
+                value = metadata.get(field)
+                if not isinstance(value, str) or not value:
+                    raise ValueError(
+                        f"sample {sample_number} metadata {field} must be a "
+                        "non-empty string"
+                    )
+            # Timestamp is provenance rather than compiler identity. Validate
+            # its schema shape, but leave calendar/format policy to producers.
+            timestamp = metadata.get("timestamp")
+            if not isinstance(timestamp, str) or not timestamp:
+                raise ValueError(
+                    f"sample {sample_number} metadata timestamp must be a "
+                    "non-empty string"
+                )
+        sample_identity = (metadata.get("target"), metadata.get("version"))
+        if compiler_identity is None:
+            compiler_identity = sample_identity
+        elif sample_identity != compiler_identity:
+            raise ValueError(f"sample {sample_index + 1} compiler identity drifted")
+
+    compile_ms, compile_mad_ms = median_and_mad(compile_samples)
+    process_ms, process_mad_ms = median_and_mad(process_samples)
+    overhead_ms, overhead_mad_ms = median_and_mad(overhead_samples)
+    leaf_to_root_ratio_percent, leaf_to_root_ratio_mad_percent = median_and_mad(
+        leaf_to_root_ratio_samples
+    )
+    unattributed_ms, unattributed_mad_ms = median_and_mad(unattributed_samples)
+    overlapping_leaf_work_ms, overlapping_leaf_work_mad_ms = median_and_mad(
+        overlapping_leaf_work_samples
+    )
+    peak_memory_bytes, peak_memory_mad_bytes = median_and_mad(memory_samples)
 
     # Deterministic order: canonical first, then any extras in first-seen order.
     ordered = [n for n in CANONICAL_LEAF_ORDER if n in per_pass]
@@ -204,12 +530,34 @@ def aggregate(samples):
     rows = []
     for name in ordered:
         med = statistics.median(per_pass[name])
-        pct = (med / wall_ms * 100.0) if wall_ms > 0 else 0.0
+        pct = statistics.median(
+            pass_ms / root_ms * 100.0 if root_ms > 0 else 0.0
+            for pass_ms, root_ms in zip(per_pass[name], compile_samples)
+        )
         rows.append((name, med, pct))
-    return rows, wall_ms, source_metrics
+    return {
+        "rows": rows,
+        "compile_ms": compile_ms,
+        "compile_mad_ms": compile_mad_ms,
+        "process_ms": process_ms,
+        "process_mad_ms": process_mad_ms,
+        "driver_overhead_ms": overhead_ms,
+        "driver_overhead_mad_ms": overhead_mad_ms,
+        "leaf_to_root_ratio_percent": leaf_to_root_ratio_percent,
+        "leaf_to_root_ratio_mad_percent": leaf_to_root_ratio_mad_percent,
+        "unattributed_ms": unattributed_ms,
+        "unattributed_mad_ms": unattributed_mad_ms,
+        "overlapping_leaf_work_ms": overlapping_leaf_work_ms,
+        "overlapping_leaf_work_mad_ms": overlapping_leaf_work_mad_ms,
+        "source_metrics": source_metrics,
+        "target": compiler_identity[0] if compiler_identity else None,
+        "compiler_version": compiler_identity[1] if compiler_identity else None,
+        "peak_memory_bytes": peak_memory_bytes if memory_samples else None,
+        "peak_memory_mad_bytes": peak_memory_mad_bytes if memory_samples else None,
+    }
 
 
-def run_corpus(rue_bin, corpus, iterations, warmup, workdir, timeout):
+def run_corpus(rue_bin, corpus, iterations, warmup, workdir, timeout, jobs):
     """Run every corpus program; return an ordered list of result dicts."""
     results = []
     out_bin = os.path.join(workdir, "perf_out")
@@ -223,76 +571,149 @@ def run_corpus(rue_bin, corpus, iterations, warmup, workdir, timeout):
         f.write(MULTI_A)
     with open(os.path.join(multi_dir, "b.rue"), "w") as f:
         f.write(MULTI_B)
-    multi_files = [
-        os.path.join(multi_dir, "main.rue"),
-        os.path.join(multi_dir, "a.rue"),
-        os.path.join(multi_dir, "b.rue"),
-    ]
+    # Pass only the root. The compiler must discover the other two files from
+    # the real import graph, so fresh-process time includes module discovery.
+    multi_files = [os.path.join(multi_dir, "main.rue")]
 
     full = list(corpus) + [("multi_file", "multi", multi_files)]
 
     for label, bucket, files in full:
         missing = [f for f in files if not Path(f).exists()]
         if missing:
-            sys.stderr.write(f"  skip {label}: missing {missing}\n")
-            continue
+            raise RuntimeError(f"workload {label!r} is missing source file(s): {missing}")
         sys.stderr.write(f"  {label} ({bucket}) ... ")
         sys.stderr.flush()
         try:
             for _ in range(warmup):
-                compile_once(rue_bin, files, out_bin, timeout)
+                compile_once(rue_bin, files, out_bin, timeout, jobs)
             samples = [
-                compile_once(rue_bin, files, out_bin, timeout)
+                compile_once(rue_bin, files, out_bin, timeout, jobs)
                 for _ in range(iterations)
             ]
-        except RuntimeError as e:
+            aggregated = aggregate(samples)
+        except (RuntimeError, ValueError) as e:
             sys.stderr.write(f"FAILED\n{e}\n")
-            continue
-        rows, wall_ms, sm = aggregate(samples)
+            raise RuntimeError(f"workload {label!r} failed") from e
         results.append(
             {
                 "name": label,
                 "bucket": bucket,
-                "wall_ms": wall_ms,
+                "target": aggregated["target"],
+                "compiler_version": aggregated["compiler_version"],
+                # Keep wall_ms as a compatibility alias for generated tables.
+                "wall_ms": aggregated["compile_ms"],
+                "compile_ms": {
+                    "median": aggregated["compile_ms"],
+                    "mad": aggregated["compile_mad_ms"],
+                },
+                "process_ms": {
+                    "median": aggregated["process_ms"],
+                    "mad": aggregated["process_mad_ms"],
+                },
+                "driver_overhead_ms": {
+                    "median": aggregated["driver_overhead_ms"],
+                    "mad": aggregated["driver_overhead_mad_ms"],
+                },
+                "leaf_to_root_ratio_percent": {
+                    "median": aggregated["leaf_to_root_ratio_percent"],
+                    "mad": aggregated["leaf_to_root_ratio_mad_percent"],
+                },
+                "unattributed_ms": {
+                    "median": aggregated["unattributed_ms"],
+                    "mad": aggregated["unattributed_mad_ms"],
+                },
+                "overlapping_leaf_work_ms": {
+                    "median": aggregated["overlapping_leaf_work_ms"],
+                    "mad": aggregated["overlapping_leaf_work_mad_ms"],
+                },
+                "peak_memory_bytes": (
+                    {
+                        "median": aggregated["peak_memory_bytes"],
+                        "mad": aggregated["peak_memory_mad_bytes"],
+                    }
+                    if aggregated["peak_memory_bytes"] is not None
+                    else None
+                ),
                 "passes": [
-                    {"name": n, "median_ms": ms, "percent": pct} for n, ms, pct in rows
+                    {"name": n, "median_ms": ms, "median_percent": pct}
+                    for n, ms, pct in aggregated["rows"]
                 ],
-                "source_metrics": sm,
+                "source_metrics": aggregated["source_metrics"],
             }
         )
-        sys.stderr.write(f"{wall_ms:.1f}ms\n")
+        sys.stderr.write(
+            f"{aggregated['compile_ms']:.1f}ms compile / "
+            f"{aggregated['process_ms']:.1f}ms process\n"
+        )
     return results
 
 
 def hot_passes(results, top=3):
-    """Sum each leaf pass's median ms across the corpus; return sorted list."""
+    """Rank summed workload medians; percentages are descriptive, not additive."""
     totals = {}
     for r in results:
         for p in r["passes"]:
             totals[p["name"]] = totals.get(p["name"], 0.0) + p["median_ms"]
-    grand = sum(totals.values()) or 1.0
+    grand = sum(result["compile_ms"]["median"] for result in results) or 1.0
     ranked = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
     return [(name, ms, ms / grand * 100.0) for name, ms in ranked]
 
 
 def print_text(results, iterations):
     for r in results:
-        print(f"\n{r['name']}  ({r['bucket']}, n={iterations} warm, median)")
+        print(f"\n{r['name']}  ({r['bucket']}, n={iterations} fresh processes, median)")
         sm = r["source_metrics"] or {}
         if sm:
             print(
-                f"  source: {sm.get('lines', '?')} lines, "
+                f"  source: {sm.get('files', '?')} files, "
+                f"{sm.get('lines', '?')} lines, "
                 f"{sm.get('bytes', '?')} bytes, {sm.get('tokens', '?')} tokens"
             )
         namew = max((len(p["name"]) for p in r["passes"]), default=8)
         for p in r["passes"]:
             print(
                 f"  {p['name']:<{namew}}  {p['median_ms']:>8.2f} ms  "
-                f"({p['percent']:>4.1f}%)"
+                f"({p['median_percent']:>4.1f}% median phase/root)"
             )
-        print(f"  {'TOTAL':<{namew}}  {r['wall_ms']:>8.2f} ms  (compile span)")
+        print(
+            f"  {'COMPILE':<{namew}}  {r['compile_ms']['median']:>8.2f} ms  "
+            f"(MAD {r['compile_ms']['mad']:.2f}, root span)"
+        )
+        print(
+            f"  {'PROCESS':<{namew}}  {r['process_ms']['median']:>8.2f} ms  "
+            f"(MAD {r['process_ms']['mad']:.2f}, fresh process)"
+        )
+        print(
+            f"  {'DRIVER':<{namew}}  {r['driver_overhead_ms']['median']:>8.2f} ms  "
+            f"(MAD {r['driver_overhead_ms']['mad']:.2f}, paired samples)"
+        )
+        leaf_ratio = r["leaf_to_root_ratio_percent"]
+        print(
+            f"  {'LEAF/ROOT':<{namew}}  {leaf_ratio['median']:>8.1f}%     "
+            f"(MAD {leaf_ratio['mad']:.1f}, paired samples)"
+        )
+        unattributed = r["unattributed_ms"]
+        print(
+            f"  {'UNATTRIBUTED':<{namew}}  {unattributed['median']:>8.2f} ms  "
+            f"(MAD {unattributed['mad']:.2f}, paired samples)"
+        )
+        overlap = r["overlapping_leaf_work_ms"]
+        if overlap["median"] > 0 or overlap["mad"] > 0:
+            print(
+                f"  {'OVERLAP':<{namew}}  {overlap['median']:>8.2f} ms  "
+                f"(MAD {overlap['mad']:.2f}, paired leaf work above root time)"
+            )
+        if r["peak_memory_bytes"] is not None:
+            memory = r["peak_memory_bytes"]
+            print(
+                f"  peak RSS: {memory['median'] / (1024 * 1024):.2f} MiB "
+                f"(MAD {memory['mad'] / (1024 * 1024):.2f} MiB)"
+            )
 
-    print("\nHot passes across the whole corpus (sum of medians):")
+    print(
+        "\nHot passes across the whole corpus "
+        "(ratio of workload medians; profiling only):"
+    )
     for name, ms, pct in hot_passes(results):
         print(f"  {name:<18} {ms:>9.2f} ms  ({pct:>4.1f}%)")
 
@@ -306,14 +727,21 @@ def _md_table(results, bucket_filter=None):
     for n in CANONICAL_LEAF_ORDER:
         if any(p["name"] == n for r in rows for p in r["passes"]):
             names.append(n)
-    header = "| program | " + " | ".join(names) + " | **total** |"
-    sep = "|" + "|".join(["---"] * (len(names) + 2)) + "|"
+    for result in rows:
+        for pass_data in result["passes"]:
+            if pass_data["name"] not in names:
+                names.append(pass_data["name"])
+    header = "| program | " + " | ".join(names) + " | **compile** | **process** |"
+    sep = "|" + "|".join(["---"] * (len(names) + 3)) + "|"
     lines = [header, sep]
     for r in rows:
         pm = {p["name"]: p["median_ms"] for p in r["passes"]}
         cells = [f"{pm.get(n, 0.0):.2f}" for n in names]
         lines.append(
-            f"| {r['name']} | " + " | ".join(cells) + f" | **{r['wall_ms']:.2f}** |"
+            f"| {r['name']} | "
+            + " | ".join(cells)
+            + f" | **{r['compile_ms']['median']:.2f}**"
+            + f" | **{r['process_ms']['median']:.2f}** |"
         )
     return "\n".join(lines)
 
@@ -324,7 +752,7 @@ def print_markdown(results):
     print(_md_table(results, {"small", "medium", "multi"}))
     print("\n### Large (generated stress) programs\n")
     print(_md_table(results, {"large"}))
-    print("\n### Hot passes across the corpus (sum of per-program medians)\n")
+    print("\n### Hot passes across the corpus (ratio of workload medians)\n")
     print("| pass | total ms | share |")
     print("|---|---|---|")
     for name, ms, pct in hot_passes(results):
@@ -333,13 +761,34 @@ def print_markdown(results):
 
 def main():
     ap = argparse.ArgumentParser(description="Per-pass compiler perf baseline (RUE-249)")
-    ap.add_argument("--iterations", type=int, default=5, help="warm iterations (default 5)")
-    ap.add_argument("--warmup", type=int, default=1, help="warmup runs before timing (default 1)")
+    ap.add_argument(
+        "--iterations", type=int, default=5, help="fresh process samples (default 5)"
+    )
+    ap.add_argument(
+        "--warmup",
+        type=int,
+        default=1,
+        help="host-cache warmup processes before sampling (default 1)",
+    )
     ap.add_argument("--timeout", type=float, default=60.0, help="per-compile timeout seconds (default 60)")
+    ap.add_argument(
+        "--jobs",
+        type=int,
+        default=1,
+        help="compiler jobs per fresh process (default 1; use 0 for auto)",
+    )
     ap.add_argument("--rue-bin", help="path to an already-built rue binary")
     ap.add_argument("--release", action="store_true", help="locate the compiler via //platforms:release")
     ap.add_argument("--format", choices=["text", "markdown", "json"], default="text")
     args = ap.parse_args()
+    if args.iterations < 1:
+        ap.error("--iterations must be at least 1")
+    if args.warmup < 0:
+        ap.error("--warmup must be non-negative")
+    if args.jobs < 0:
+        ap.error("--jobs must be non-negative")
+    if args.release and (args.rue_bin or os.environ.get("RUE")):
+        ap.error("--release cannot be combined with --rue-bin or RUE")
 
     root = repo_root()
     rue_bin = resolve_rue_bin(args, root)
@@ -347,18 +796,25 @@ def main():
         sys.exit(f"perf-baseline: rue binary not usable: {rue_bin}")
 
     sys.stderr.write(f"perf-baseline: using {rue_bin}\n")
-    sys.stderr.write(f"perf-baseline: {args.iterations} warm iterations per program\n")
+    sys.stderr.write(
+        f"perf-baseline: {args.iterations} fresh processes per program "
+        f"after {args.warmup} host-cache warmup(s), jobs={args.jobs}\n"
+    )
 
     workdir = tempfile.mkdtemp(prefix="rue-perf-")
     try:
-        results = run_corpus(
-            rue_bin,
-            default_corpus(root),
-            args.iterations,
-            args.warmup,
-            workdir,
-            args.timeout,
-        )
+        try:
+            results = run_corpus(
+                rue_bin,
+                default_corpus(root),
+                args.iterations,
+                args.warmup,
+                workdir,
+                args.timeout,
+                args.jobs,
+            )
+        except RuntimeError as error:
+            sys.exit(f"perf-baseline: {error}")
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
 
@@ -366,7 +822,27 @@ def main():
         sys.exit("perf-baseline: no results collected")
 
     if args.format == "json":
-        print(json.dumps({"iterations": args.iterations, "results": results}, indent=2))
+        print(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "measurement": {
+                        "model": "fresh_process_warm_host",
+                        "iterations": args.iterations,
+                        "warmup_processes": args.warmup,
+                        "jobs": args.jobs,
+                        "compiler_profile": (
+                            "external"
+                            if args.rue_bin or os.environ.get("RUE")
+                            else ("release" if args.release else "default")
+                        ),
+                        "program_opt_level": "O0",
+                    },
+                    "results": results,
+                },
+                indent=2,
+            )
+        )
     elif args.format == "markdown":
         print_markdown(results)
     else:

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 INPUT_ROOT = Path(
@@ -29,6 +30,434 @@ def load_module(name: str, relative_path: str):
 
 validator = load_module("validate_benchmark", "scripts/validate-benchmark.py")
 charts = load_module("generate_charts", "scripts/generate-charts.py")
+perf_baseline = load_module("perf_baseline", "scripts/perf-baseline.py")
+
+
+class PerfBaselineAggregationTests(unittest.TestCase):
+    @staticmethod
+    def sample(
+        compile_ms,
+        process_ms,
+        leaf_names=("lexer", "parser", "codegen"),
+        leaf_durations=None,
+    ):
+        durations = leaf_durations or {"lexer": 3.0, "parser": 2.0, "codegen": 4.0}
+        passes = [
+            {
+                "name": "compile",
+                "duration_ms": compile_ms,
+                "percent": 100.0,
+                "invocations": 1,
+                "root_invocations": 1,
+                "leaf_invocations": 0,
+            },
+            {
+                "name": "parse",
+                "duration_ms": 5.5,
+                "percent": 50.0,
+                "invocations": 1,
+                "root_invocations": 0,
+                "leaf_invocations": 0,
+            },
+        ]
+        for name in leaf_names:
+            passes.append(
+                {
+                    "name": name,
+                    "duration_ms": durations.get(name, 1.0),
+                    "percent": 0.0,
+                    "invocations": 1,
+                    "root_invocations": 0,
+                    "leaf_invocations": 1,
+                }
+            )
+        return {
+            "schema_version": 2,
+            "timing_model": "inclusive_spans",
+            "total_ms": compile_ms,
+            "passes": passes,
+            "source_metrics": {"files": 1, "bytes": 10, "lines": 1, "tokens": 5},
+            "metadata": {
+                "timestamp": "2026-07-11T00:00:00Z",
+                "target": "x86-64-linux",
+                "version": "0.1.0",
+            },
+            "peak_memory_bytes": 1024,
+            "_process_ms": process_ms,
+        }
+
+    def test_v2_uses_paired_root_and_process_samples(self):
+        result = perf_baseline.aggregate(
+            [
+                self.sample(10.0, 15.0),
+                self.sample(12.0, 17.0),
+                self.sample(11.0, 15.0),
+            ]
+        )
+        self.assertEqual(result["compile_ms"], 11.0)
+        self.assertEqual(result["compile_mad_ms"], 1.0)
+        self.assertEqual(result["process_ms"], 15.0)
+        self.assertEqual(result["process_mad_ms"], 0.0)
+        # This is median(process - compile), not the difference of the two
+        # marginal medians (which would be 4 ms for these samples).
+        self.assertEqual(result["driver_overhead_ms"], 5.0)
+        self.assertEqual(result["driver_overhead_mad_ms"], 0.0)
+        self.assertAlmostEqual(
+            result["leaf_to_root_ratio_percent"], 9.0 / 11.0 * 100.0
+        )
+        self.assertAlmostEqual(
+            result["leaf_to_root_ratio_mad_percent"],
+            9.0 / 11.0 * 100.0 - 75.0,
+        )
+        self.assertEqual(result["unattributed_ms"], 2.0)
+        self.assertEqual(result["unattributed_mad_ms"], 1.0)
+        self.assertEqual(result["overlapping_leaf_work_ms"], 0.0)
+        self.assertEqual(result["overlapping_leaf_work_mad_ms"], 0.0)
+        self.assertEqual(result["peak_memory_bytes"], 1024.0)
+        self.assertEqual(result["peak_memory_mad_bytes"], 0.0)
+        self.assertEqual(
+            [name for name, _ms, _percent in result["rows"]],
+            ["lexer", "parser", "codegen"],
+        )
+
+    def test_leaf_accounting_is_paired_before_taking_medians(self):
+        # Every individual run has exactly 100% sequential leaf coverage. The
+        # independent leaf medians are nevertheless 5 + 5 while the root
+        # median is only 5; summing marginal medians would invent 5 ms overlap.
+        result = perf_baseline.aggregate(
+            [
+                self.sample(
+                    5.0,
+                    6.0,
+                    leaf_names=("lexer", "parser"),
+                    leaf_durations={"lexer": 5.0, "parser": 0.0},
+                ),
+                self.sample(
+                    5.0,
+                    12.0,
+                    leaf_names=("lexer", "parser"),
+                    leaf_durations={"lexer": 0.0, "parser": 5.0},
+                ),
+                self.sample(
+                    10.0,
+                    13.0,
+                    leaf_names=("lexer", "parser"),
+                    leaf_durations={"lexer": 5.0, "parser": 5.0},
+                ),
+            ]
+        )
+        self.assertEqual(result["compile_ms"], 5.0)
+        self.assertEqual(sum(row[1] for row in result["rows"]), 10.0)
+        self.assertEqual(
+            result["rows"], [("lexer", 5.0, 50.0), ("parser", 5.0, 50.0)]
+        )
+        self.assertEqual(result["leaf_to_root_ratio_percent"], 100.0)
+        self.assertEqual(result["leaf_to_root_ratio_mad_percent"], 0.0)
+        self.assertEqual(result["unattributed_ms"], 0.0)
+        self.assertEqual(result["overlapping_leaf_work_ms"], 0.0)
+        self.assertEqual(result["driver_overhead_ms"], 3.0)
+        self.assertEqual(result["driver_overhead_mad_ms"], 2.0)
+
+    def test_legacy_json_uses_compile_span_instead_of_inflated_total(self):
+        sample = {
+            "total_ms": 22.0,
+            "passes": [
+                {"name": "compile", "duration_ms": 10.0},
+                {"name": "parse", "duration_ms": 6.0},
+                {"name": "parse_file", "duration_ms": 5.0},
+                {"name": "codegen", "duration_ms": 4.0},
+            ],
+            "_process_ms": 12.0,
+        }
+        result = perf_baseline.aggregate([sample])
+        self.assertEqual(result["compile_ms"], 10.0)
+        self.assertEqual(
+            result["rows"],
+            [("parse_file", 5.0, 50.0), ("codegen", 4.0, 40.0)],
+        )
+
+    def test_rejects_leaf_pass_set_drift(self):
+        first = self.sample(10.0, 12.0)
+        second = self.sample(
+            10.0, 12.0, leaf_names=("lexer", "parser", "codegen", "new_pass")
+        )
+        with self.assertRaisesRegex(ValueError, "leaf pass set drifted"):
+            perf_baseline.aggregate([first, second])
+
+    def test_rejects_inconsistent_root_or_process_measurement(self):
+        wrong_total = self.sample(10.0, 12.0)
+        wrong_total["total_ms"] = 11.0
+        with self.assertRaisesRegex(ValueError, "total_ms does not match compile span"):
+            perf_baseline.aggregate([wrong_total])
+
+        impossible_process = self.sample(10.0, 9.0)
+        with self.assertRaisesRegex(ValueError, "process time is shorter"):
+            perf_baseline.aggregate([impossible_process])
+
+    def test_rejects_unknown_or_non_integer_schema_versions(self):
+        for bad_version in (0, 3, True, 2.0, "2"):
+            with self.subTest(schema_version=bad_version):
+                sample = self.sample(10.0, 12.0)
+                sample["schema_version"] = bad_version
+                with self.assertRaisesRegex(ValueError, "integer 1 or 2"):
+                    perf_baseline.aggregate([sample])
+
+    def test_rejects_malformed_v2_invocation_counters(self):
+        mutations = [
+            ("invocations", 0, "greater than zero"),
+            ("invocations", 1.5, "non-negative integer"),
+            ("invocations", True, "non-negative integer"),
+            ("root_invocations", -1, "non-negative integer"),
+            ("root_invocations", 2, "exceeds invocations"),
+            ("leaf_invocations", 2, "exceeds invocations"),
+        ]
+        for field, value, message in mutations:
+            with self.subTest(field=field, value=value):
+                sample = self.sample(10.0, 12.0)
+                sample["passes"][0][field] = value
+                with self.assertRaisesRegex(ValueError, message):
+                    perf_baseline.aggregate([sample])
+
+    def test_rejects_v2_rows_that_do_not_describe_compile_rooted_leaves(self):
+        cases = [
+            (
+                "compile not root",
+                lambda sample: sample["passes"][0].update(root_invocations=0),
+                "every invocation at the root",
+            ),
+            (
+                "only some compile invocations are roots",
+                lambda sample: sample["passes"][0].update(
+                    invocations=2, root_invocations=1
+                ),
+                "every invocation at the root",
+            ),
+            (
+                "compile is leaf",
+                lambda sample: sample["passes"][0].update(leaf_invocations=1),
+                "compile span must not be a leaf",
+            ),
+            (
+                "selected phase is root",
+                lambda sample: sample["passes"][2].update(root_invocations=1),
+                "compile span must be the sole root",
+            ),
+            (
+                "aggregate phase is another root",
+                lambda sample: sample["passes"][1].update(root_invocations=1),
+                "compile span must be the sole root",
+            ),
+        ]
+        for label, mutate, message in cases:
+            with self.subTest(label=label):
+                sample = self.sample(10.0, 12.0)
+                mutate(sample)
+                with self.assertRaisesRegex(ValueError, message):
+                    perf_baseline.aggregate([sample])
+
+    def test_rejects_positive_leaf_work_with_zero_compile_time(self):
+        sample = self.sample(
+            0.0,
+            0.0,
+            leaf_durations={"lexer": 1.0, "parser": 0.0, "codegen": 0.0},
+        )
+        with self.assertRaisesRegex(ValueError, "positive leaf work with a zero"):
+            perf_baseline.aggregate([sample])
+
+    def test_rejects_malformed_v2_source_metrics(self):
+        cases = [
+            (None, "must be an object"),
+            ([], "must be an object"),
+            (
+                {"files": 0, "bytes": 10, "lines": 1, "tokens": 5},
+                "files must be greater than zero",
+            ),
+            (
+                {"files": True, "bytes": 10, "lines": 1, "tokens": 5},
+                "files must be a non-negative integer",
+            ),
+            (
+                {"files": 1, "bytes": False, "lines": 1, "tokens": 5},
+                "bytes must be a non-negative integer",
+            ),
+            (
+                {"files": 1, "bytes": 10, "lines": -1, "tokens": 5},
+                "lines must be a non-negative integer",
+            ),
+            (
+                {"files": 1, "bytes": 10, "lines": 1, "tokens": 2.5},
+                "tokens must be a non-negative integer",
+            ),
+            (
+                {"files": 1, "bytes": 10, "lines": 1},
+                "tokens must be a non-negative integer",
+            ),
+        ]
+        for source_metrics, message in cases:
+            with self.subTest(source_metrics=source_metrics):
+                sample = self.sample(10.0, 12.0)
+                sample["source_metrics"] = source_metrics
+                with self.assertRaisesRegex(ValueError, message):
+                    perf_baseline.aggregate([sample])
+
+    def test_malformed_sample_and_metadata_have_validation_errors(self):
+        with self.assertRaisesRegex(ValueError, "sample 1 must be an object"):
+            perf_baseline.aggregate([None])
+
+        sample = self.sample(10.0, 12.0)
+        sample["metadata"] = []
+        with self.assertRaisesRegex(ValueError, "metadata must be an object"):
+            perf_baseline.aggregate([sample])
+
+    def test_rejects_missing_or_non_string_v2_metadata_fields(self):
+        cases = [
+            ({}, "metadata target must be a non-empty string"),
+            (
+                {
+                    "timestamp": "2026-07-11T00:00:00Z",
+                    "target": "",
+                    "version": "0.1.0",
+                },
+                "metadata target must be a non-empty string",
+            ),
+            (
+                {
+                    "timestamp": "2026-07-11T00:00:00Z",
+                    "target": 42,
+                    "version": "0.1.0",
+                },
+                "metadata target must be a non-empty string",
+            ),
+            (
+                {
+                    "timestamp": "2026-07-11T00:00:00Z",
+                    "target": "x86-64-linux",
+                },
+                "metadata version must be a non-empty string",
+            ),
+            (
+                {
+                    "timestamp": "2026-07-11T00:00:00Z",
+                    "target": "x86-64-linux",
+                    "version": "",
+                },
+                "metadata version must be a non-empty string",
+            ),
+            (
+                {
+                    "timestamp": "2026-07-11T00:00:00Z",
+                    "target": "x86-64-linux",
+                    "version": False,
+                },
+                "metadata version must be a non-empty string",
+            ),
+            (
+                {"target": "x86-64-linux", "version": "0.1.0"},
+                "metadata timestamp must be a non-empty string",
+            ),
+            (
+                {
+                    "timestamp": 0,
+                    "target": "x86-64-linux",
+                    "version": "0.1.0",
+                },
+                "metadata timestamp must be a non-empty string",
+            ),
+        ]
+        for metadata, message in cases:
+            with self.subTest(metadata=metadata):
+                sample = self.sample(10.0, 12.0)
+                sample["metadata"] = metadata
+                with self.assertRaisesRegex(ValueError, message):
+                    perf_baseline.aggregate([sample])
+
+    def test_hot_pass_share_uses_compiler_time_and_markdown_keeps_new_passes(self):
+        result = {
+            "name": "probe",
+            "bucket": "small",
+            "compile_ms": {"median": 20.0, "mad": 0.0},
+            "process_ms": {"median": 25.0, "mad": 0.0},
+            "passes": [
+                {"name": "lexer", "median_ms": 5.0, "median_percent": 25.0},
+                {
+                    "name": "future_phase",
+                    "median_ms": 3.0,
+                    "median_percent": 15.0,
+                },
+            ],
+        }
+        self.assertEqual(
+            perf_baseline.hot_passes([result]),
+            [("lexer", 5.0, 25.0), ("future_phase", 3.0, 15.0)],
+        )
+        markdown = perf_baseline._md_table([result])
+        self.assertIn("future_phase", markdown)
+        self.assertIn("**20.00**", markdown)
+        self.assertIn("**25.00**", markdown)
+
+    def test_corpus_json_names_paired_phase_ratio_as_a_median(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with mock.patch.object(perf_baseline.sys, "stderr"):
+                with mock.patch.object(
+                    perf_baseline,
+                    "compile_once",
+                    return_value=self.sample(10.0, 12.0),
+                ):
+                    results = perf_baseline.run_corpus(
+                        "rue", [], 1, 0, temp_dir, 1.0, 1
+                    )
+        phase = results[0]["passes"][0]
+        self.assertEqual(phase["median_percent"], 30.0)
+        self.assertNotIn("percent", phase)
+
+    def test_compile_once_sanitizes_logging_checks_artifact_and_exact_json(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "program"
+            sample = self.sample(10.0, 12.0)
+
+            def successful_run(cmd, **kwargs):
+                self.assertNotIn("RUST_LOG", kwargs["env"])
+                Path(cmd[-1]).write_bytes(b"artifact")
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout=json.dumps(sample), stderr=""
+                )
+
+            with mock.patch.dict(os.environ, {"RUST_LOG": "trace"}):
+                with mock.patch.object(
+                    perf_baseline.subprocess, "run", side_effect=successful_run
+                ):
+                    result = perf_baseline.compile_once(
+                        "rue", ["main.rue"], str(output), 1.0, 1
+                    )
+            self.assertEqual(result["schema_version"], 2)
+            self.assertFalse(output.exists())
+
+            def contaminated_run(cmd, **_kwargs):
+                Path(cmd[-1]).write_bytes(b"artifact")
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="debug spew\n{}", stderr=""
+                )
+
+            with mock.patch.object(
+                perf_baseline.subprocess, "run", side_effect=contaminated_run
+            ):
+                with self.assertRaisesRegex(RuntimeError, "exactly one benchmark JSON"):
+                    perf_baseline.compile_once(
+                        "rue", ["main.rue"], str(output), 1.0, 1
+                    )
+            self.assertFalse(output.exists())
+
+            with mock.patch.object(
+                perf_baseline.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    ["rue"], 0, stdout=json.dumps(sample), stderr=""
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "without producing"):
+                    perf_baseline.compile_once(
+                        "rue", ["main.rue"], str(output), 1.0, 1
+                    )
 
 
 class BenchmarkValidationTests(unittest.TestCase):
@@ -208,7 +637,9 @@ class ChartAggregationTests(unittest.TestCase):
         }
 
     def test_suite_metrics_cover_every_benchmark(self):
-        self.assertEqual(charts.get_total_time(self.run), 30)
+        # Historical mean_ms double-counted nested spans. Prefer the stored
+        # compile root (9) when present, then the honest/fallback mean (20).
+        self.assertEqual(charts.get_total_time(self.run), 29)
         self.assertEqual(
             charts.get_pass_times(self.run),
             {"parallel_astgen": 4, "sema": 6, "new_pass": 5},
@@ -217,7 +648,7 @@ class ChartAggregationTests(unittest.TestCase):
         self.assertEqual(charts.get_binary_size(self.run), 10)
 
         summary = charts.generate_summary_data([self.run])
-        self.assertEqual(summary["latest_time_ms"], 30)
+        self.assertEqual(summary["latest_time_ms"], 29)
         self.assertEqual(summary["latest_memory_mb"], 5)
         self.assertEqual(summary["latest_binary_kb"], 10)
 
@@ -244,6 +675,19 @@ class ChartAggregationTests(unittest.TestCase):
             ]
         }
         self.assertEqual(charts.get_total_time(run), 4)
+
+    def test_current_phase_order_includes_split_parse_and_semantic_lowering(self):
+        ordered = charts.order_pass_times(
+            {
+                "linker": 1,
+                "semantic_astgen": 1,
+                "parser": 1,
+                "lexer": 1,
+            }
+        )
+        self.assertEqual(
+            list(ordered), ["lexer", "parser", "semantic_astgen", "linker"]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- define benchmark timing schema v2 around inclusive spans and root-span wall time, with concurrency-safe root/leaf invocation metadata
- collect source metrics from the live frontend and expose lexer, parser, and canonical semantic-lowering phases without a benchmark-only pre-pass
- make the local baseline and historical dashboard consume nested timing honestly, including paired-sample accounting and schema-v1 compatibility
- add adversarial schema, concurrency, CLI, dashboard, and malformed-input coverage

## Why

The previous benchmark total summed nested tracing spans, so it double-counted compiler work and could report roughly twice the real pipeline time. Benchmark mode also re-lexed sources solely to count tokens, contaminating the measurement it was trying to observe. This change gives later compiler-architecture and incremental-recompilation work a trustworthy baseline.

## Validation

- `./test.sh`
- `./clippy.sh`
- `./fmt.sh check`
- focused Rue, compiler, benchmark-tool, and CLI timing tests
- real ten-workload baseline run, including a synthesized three-file import graph

Fixes RUE-642
