### PR TITLE
RUE-640: diagnose unknown methods before receiver move checking

### DIFF
--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -129,6 +129,33 @@ impl<'a> Sema<'a> {
         let receiver_byref_root = if is_builtin_mutation_method {
             receiver_var
         } else {
+            // A method that exists on NEITHER the user-method table nor the
+            // builtin registry is diagnosed here, before the receiver is
+            // analyzed: the unknown call would otherwise default to a
+            // by-value receiver, and a field-of-`inout self` receiver then
+            // failed the MOVE check first — reporting E0437 "cannot move out
+            // of inout parameter" for what is actually a typo'd method name
+            // (RUE-640).
+            if receiver_var.is_some()
+                && let Some(struct_id) = self
+                    .peek_place_type(receiver, ctx)
+                    .and_then(|ty| ty.as_struct())
+            {
+                let known = self.methods.contains_key(&(struct_id, method))
+                    || self
+                        .get_builtin_type_def(struct_id)
+                        .is_some_and(|def| def.find_method(&method_name_str).is_some());
+                if !known {
+                    let type_name = self.format_type_name(Type::new_struct(struct_id));
+                    return Err(CompileError::new(
+                        ErrorKind::UndefinedMethod {
+                            type_name,
+                            method_name: method_name_str.clone(),
+                        },
+                        span,
+                    ));
+                }
+            }
             receiver_var.and_then(|root| {
                 let ty = self.peek_place_type(receiver, ctx)?;
                 let struct_id = ty.as_struct()?;

--- a/crates/rue-ui-tests/cases/diagnostics/unknown-method-ordering.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/unknown-method-ordering.toml
@@ -1,0 +1,57 @@
+[section]
+id = "diagnostics.unknown-method-ordering"
+name = "Unknown-method diagnosis precedes receiver move checking"
+description = "A nonexistent method must be reported as unknown, not as a borrow/move violation of its receiver (RUE-640)."
+
+# A typo'd method on a field of `inout self` used to report E0437 "cannot
+# move out of inout parameter 'self'" — the unknown method defaulted to a
+# by-value receiver and the move check fired before method resolution. The
+# user's actual mistake (the name) was never mentioned.
+[[case]]
+name = "unknown_method_on_inout_self_field_names_the_method"
+source = """
+struct Inner { v: i64 }
+
+struct Box {
+    inner: Inner,
+
+    fn grow(inout self) {
+        let old = self.inner.clone_me();
+    }
+}
+
+fn main() -> i32 {
+    let mut b = Box { inner: Inner { v: 1 } };
+    b.grow();
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0411", "no method named 'clone_me'", "Inner"]
+
+# Control: a method that DOES exist and takes self by value still gets the
+# genuine move diagnostic, not an unknown-method error.
+[[case]]
+name = "real_by_value_method_still_reports_move"
+source = """
+struct Inner {
+    v: i64,
+
+    fn consume(self) -> i64 { self.v }
+}
+
+struct Wrap {
+    inner: Inner,
+
+    fn peek(inout self) -> i64 {
+        self.inner.consume()
+    }
+}
+
+fn main() -> i32 {
+    let mut w = Wrap { inner: Inner { v: 42 } };
+    @intCast(w.peek())
+}
+"""
+compile_fail = true
+error_contains = ["E0437"]


### PR DESCRIPTION
Fixes RUE-640

A typo'd method on a field of `inout self` reported `E0437: cannot move out of inout parameter 'self'` — the unknown method defaulted to a by-value receiver and the move check fired before resolution failed, so the diagnostic pointed at borrow semantics instead of the actual mistake.

The method-call path now checks the peeked receiver struct against both the user-method table and the builtin registry **before** analyzing the receiver, reporting `E0411` with the RUE-610 pretty type name (`no method named 'clone_buf' found for type 'ArrayBuf(i64)'`). Genuine by-value methods keep their real move diagnostics — the control case pins that.

Two UI cases (per CLAUDE.md, diagnostics quality belongs in `rue-ui-tests`). Full suite green (Pass 34, traceability 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
