### PR TITLE
RUE-644: validate immutable source metadata

### DIFF
--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -77,6 +77,22 @@ compile_stderr_contains = [
     "unexpected character: #",
 ]
 
+[[case]]
+name = "emit_tokens_rejects_duplicate_normalized_source_identity_before_output"
+description = "RUE-644: invalid source identity is E1400 and fails before --emit tokens prints partial output."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { 0 }
+""" }]
+args = ["--emit", "tokens", "--error-format", "json", "main.rue", "./main.rue"]
+compile_fail = true
+compile_stderr_contains = [
+    '"severity":"error"',
+    '"code":"E1400"',
+    'physical paths for 1 and 2 normalize to the same identity',
+]
+compile_stderr_not_contains = ["error[E1400]", "-->"]
+compile_stdout_not_contains = ["=== Tokens"]
+
 # RUE-352: `-j`/`--jobs` was silently ignored under --emit. The jobs setting was
 # only applied inside compile_multi_file_with_options, which the --emit path
 # never calls, so `--emit asm -j1` ran multi-threaded. The pool config is now

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -28,8 +28,10 @@
 mod diagnostic;
 mod drop_glue;
 mod semantic_order;
+mod source_metadata;
 mod unit;
 
+pub use source_metadata::SourceMetadata;
 pub use unit::{CompilationUnit, SourceStats};
 
 use rayon::prelude::*;
@@ -321,6 +323,28 @@ pub struct ParsedProgram {
 /// let program = parse_all_files(&sources)?;
 /// ```
 pub fn parse_all_files(sources: &[SourceFile<'_>]) -> MultiErrorResult<ParsedProgram> {
+    let root_file_id = sources
+        .first()
+        .map(|source| source.file_id)
+        .unwrap_or(FileId::DEFAULT);
+    let source_metadata =
+        SourceMetadata::from_sources(sources, root_file_id, std::collections::HashMap::new())
+            .map_err(CompileErrors::from)?;
+    parse_all_files_with_source_metadata(sources, &source_metadata)
+}
+
+/// Parse source files after validating them against immutable metadata.
+///
+/// This is the canonical multi-file parsing boundary. Invalid source IDs,
+/// paths, or descriptor membership are rejected before any source is lexed.
+pub fn parse_all_files_with_source_metadata(
+    sources: &[SourceFile<'_>],
+    source_metadata: &SourceMetadata,
+) -> MultiErrorResult<ParsedProgram> {
+    source_metadata
+        .validate_sources(sources)
+        .map_err(CompileErrors::from)?;
+
     // Parse all files sequentially with a shared interner
     // This ensures Spur values are consistent across files for cross-file symbol resolution
     let mut parsed_files = Vec::with_capacity(sources.len());
@@ -949,20 +973,78 @@ pub fn compile_frontend_from_ast(
 ///
 /// This function collects errors from multiple functions instead of stopping at the
 /// first error, allowing users to see all issues at once.
+///
+/// This compatibility entry point accepts the anonymous `FileId::DEFAULT`
+/// produced by [`Lexer::new`]. ASTs carrying explicit file IDs must use
+/// [`compile_frontend_from_ast_with_source_metadata_and_target`] so their root
+/// and source identities are not inferred.
 pub fn compile_frontend_from_ast_with_options(
     ast: Ast,
     interner: ThreadedRodeo,
     opt_level: OptLevel,
     preview_features: &PreviewFeatures,
 ) -> MultiErrorResult<CompileState> {
-    compile_frontend_from_ast_with_file_paths_and_target(
+    let source_metadata = anonymous_source_metadata(&ast).map_err(CompileErrors::from)?;
+    compile_frontend_from_ast_with_source_metadata_and_target(
         ast,
         interner,
         opt_level,
         preview_features,
         CompileOptions::default().target,
-        std::collections::HashMap::new(),
+        &source_metadata,
     )
+}
+
+fn anonymous_source_metadata(ast: &Ast) -> CompileResult<SourceMetadata> {
+    let mut file_ids: Vec<_> = ast
+        .items
+        .iter()
+        .map(semantic_order::item_span)
+        .map(|span| span.file_id)
+        .collect();
+    file_ids.sort_by_key(|file_id| file_id.index());
+    file_ids.dedup();
+    if file_ids.is_empty() {
+        file_ids.push(FileId::DEFAULT);
+    }
+
+    if file_ids != [FileId::DEFAULT] {
+        let displayed_ids = file_ids
+            .iter()
+            .map(|file_id| file_id.index().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+            format!(
+                "raw AST uses non-anonymous file IDs {displayed_ids}; pass SourceMetadata explicitly"
+            ),
+        )));
+    }
+
+    let physical_paths: std::collections::HashMap<_, _> = file_ids
+        .iter()
+        .copied()
+        .map(|file_id| (file_id, "<source>".to_string()))
+        .collect();
+    SourceMetadata::new(file_ids[0], physical_paths.clone(), physical_paths)
+}
+
+fn source_metadata_from_legacy_maps(
+    ast: &Ast,
+    file_paths: std::collections::HashMap<FileId, String>,
+    mut logical_path_overrides: std::collections::HashMap<FileId, String>,
+) -> CompileResult<SourceMetadata> {
+    if file_paths.is_empty() && logical_path_overrides.is_empty() {
+        return anonymous_source_metadata(ast);
+    }
+
+    let root_file_id = semantic_order::legacy_root_file_id(ast, &file_paths);
+    for (&file_id, physical_path) in &file_paths {
+        logical_path_overrides
+            .entry(file_id)
+            .or_insert_with(|| physical_path.clone());
+    }
+    SourceMetadata::new(root_file_id, file_paths, logical_path_overrides)
 }
 
 /// Like [`compile_frontend_from_ast_with_options`], but with the
@@ -1025,35 +1107,36 @@ pub fn compile_frontend_from_ast_with_file_paths_and_symbol_paths_and_target(
     file_paths: std::collections::HashMap<FileId, String>,
     symbol_paths: std::collections::HashMap<FileId, String>,
 ) -> MultiErrorResult<CompileState> {
-    let root_file_id = semantic_order::legacy_root_file_id(&ast, &file_paths);
+    let source_metadata = source_metadata_from_legacy_maps(&ast, file_paths, symbol_paths)
+        .map_err(CompileErrors::from)?;
     compile_frontend_from_ast_with_source_metadata_and_target(
         ast,
         interner,
         opt_level,
         preview_features,
         target,
-        root_file_id,
-        file_paths,
-        symbol_paths,
+        &source_metadata,
     )
 }
 
 /// Compile an already-parsed program with complete multi-file source metadata.
 ///
-/// Unlike the compatibility wrappers above, this entry point receives the
-/// designated semantic root explicitly. FileIds are arbitrary diagnostic
-/// handles; their numeric order must not affect import fallback, semantic
-/// allocation, or generated artifacts.
+/// Unlike the compatibility wrappers above, this entry point receives one
+/// descriptor carrying the designated semantic root and complete path maps.
+/// FileIds are arbitrary diagnostic handles; their numeric order must not
+/// affect import fallback, semantic allocation, or generated artifacts.
 pub fn compile_frontend_from_ast_with_source_metadata_and_target(
     ast: Ast,
     interner: ThreadedRodeo,
     opt_level: OptLevel,
     preview_features: &PreviewFeatures,
     target: Target,
-    root_file_id: FileId,
-    file_paths: std::collections::HashMap<FileId, String>,
-    symbol_paths: std::collections::HashMap<FileId, String>,
+    source_metadata: &SourceMetadata,
 ) -> MultiErrorResult<CompileState> {
+    source_metadata
+        .validate_ast(&ast)
+        .map_err(CompileErrors::from)?;
+
     // Preserve the caller-visible AST/RIR order for inspection and --emit rir.
     let (rir, interner) = {
         let _span = info_span!("astgen").entered();
@@ -1067,7 +1150,7 @@ pub fn compile_frontend_from_ast_with_source_metadata_and_target(
     // composite type IDs, destructor/drop-glue traversal, string IDs, and
     // object layout. Lower a private logical-path-ordered RIR without changing
     // the observable AST/RIR above (RUE-624).
-    let semantic_ast = semantic_order::for_sema(&ast, &file_paths, &symbol_paths, root_file_id);
+    let semantic_ast = semantic_order::for_sema(&ast, source_metadata);
     let semantic_rir = {
         let _span = info_span!("semantic_astgen").entered();
         AstGen::new(&semantic_ast, &interner).generate()
@@ -1078,9 +1161,9 @@ pub fn compile_frontend_from_ast_with_source_metadata_and_target(
         let _span = info_span!("sema").entered();
         let mut sema =
             Sema::new_for_target(&semantic_rir, &interner, preview_features.clone(), target);
-        sema.set_root_file_id(root_file_id);
-        sema.set_file_paths(file_paths);
-        sema.set_symbol_paths(symbol_paths);
+        sema.set_root_file_id(source_metadata.root_file_id());
+        sema.set_file_paths(source_metadata.physical_path_map().clone());
+        sema.set_symbol_paths(source_metadata.logical_path_map().clone());
         let output = sema.analyze_all()?;
         info!(
             function_count = output.functions.len(),
@@ -1189,28 +1272,29 @@ pub fn compile_multi_file_with_options(
     sources: &[SourceFile<'_>],
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
-    let symbol_paths = sources
-        .iter()
-        .map(|source| (source.file_id, source.path.to_string()))
-        .collect();
-    compile_multi_file_with_symbol_paths_and_options(sources, symbol_paths, options)
+    compile_multi_file_with_symbol_paths_and_options(
+        sources,
+        std::collections::HashMap::new(),
+        options,
+    )
 }
 
 /// Compile multiple source files while keeping physical paths separate from
-/// relocation-stable identities used in generated symbols.
+/// caller-provided logical identities used in generated symbols.
 ///
 /// This is the driver-facing variant of [`compile_multi_file_with_options`].
 /// As in that function, `sources[0]` is the designated semantic root.
 /// Physical [`SourceFile::path`] values continue to control diagnostics and
 /// module resolution; `symbol_paths` only qualify otherwise-colliding generated
-/// names.
+/// names. The map may omit IDs (physical paths are the compatibility fallback),
+/// but it may not contain IDs absent from `sources`.
 pub fn compile_multi_file_with_symbol_paths_and_options(
     sources: &[SourceFile<'_>],
     symbol_paths: std::collections::HashMap<FileId, String>,
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
-    compile_multi_file_with_symbol_paths_and_options_impl(sources, symbol_paths, options, false)
-        .map(|(output, _stats)| output)
+    let source_metadata = source_metadata_from_sources(sources, symbol_paths)?;
+    compile_multi_file_with_source_metadata_and_options(sources, &source_metadata, options)
 }
 
 /// Compile multiple source files and return metrics collected by the live frontend.
@@ -1223,9 +1307,53 @@ pub fn compile_multi_file_with_symbol_paths_and_options_and_stats(
     symbol_paths: std::collections::HashMap<FileId, String>,
     options: &CompileOptions,
 ) -> MultiErrorResult<(CompileOutput, SourceStats)> {
-    let (output, stats) = compile_multi_file_with_symbol_paths_and_options_impl(
+    let source_metadata = source_metadata_from_sources(sources, symbol_paths)?;
+    compile_multi_file_with_source_metadata_and_options_and_stats(
         sources,
-        symbol_paths,
+        &source_metadata,
+        options,
+    )
+}
+
+fn source_metadata_from_sources(
+    sources: &[SourceFile<'_>],
+    logical_path_overrides: std::collections::HashMap<FileId, String>,
+) -> MultiErrorResult<SourceMetadata> {
+    let root_file_id = sources
+        .first()
+        .map(|source| source.file_id)
+        .unwrap_or(FileId::DEFAULT);
+    SourceMetadata::from_sources(sources, root_file_id, logical_path_overrides)
+        .map_err(CompileErrors::from)
+}
+
+/// Compile sources using an explicit, immutable root and source descriptor.
+///
+/// This is the canonical batch compilation boundary. The descriptor must
+/// describe exactly `sources`; validation happens before lexing.
+pub fn compile_multi_file_with_source_metadata_and_options(
+    sources: &[SourceFile<'_>],
+    source_metadata: &SourceMetadata,
+    options: &CompileOptions,
+) -> MultiErrorResult<CompileOutput> {
+    compile_multi_file_with_source_metadata_and_options_impl(
+        sources,
+        source_metadata,
+        options,
+        false,
+    )
+    .map(|(output, _stats)| output)
+}
+
+/// Compile sources with explicit metadata and return live frontend metrics.
+pub fn compile_multi_file_with_source_metadata_and_options_and_stats(
+    sources: &[SourceFile<'_>],
+    source_metadata: &SourceMetadata,
+    options: &CompileOptions,
+) -> MultiErrorResult<(CompileOutput, SourceStats)> {
+    let (output, stats) = compile_multi_file_with_source_metadata_and_options_impl(
+        sources,
+        source_metadata,
         options,
         true,
     )?;
@@ -1237,9 +1365,9 @@ pub fn compile_multi_file_with_symbol_paths_and_options_and_stats(
     Ok((output, stats))
 }
 
-fn compile_multi_file_with_symbol_paths_and_options_impl(
+fn compile_multi_file_with_source_metadata_and_options_impl(
     sources: &[SourceFile<'_>],
-    symbol_paths: std::collections::HashMap<FileId, String>,
+    source_metadata: &SourceMetadata,
     options: &CompileOptions,
     collect_stats: bool,
 ) -> MultiErrorResult<(CompileOutput, Option<SourceStats>)> {
@@ -1259,8 +1387,12 @@ fn compile_multi_file_with_symbol_paths_and_options_impl(
     .entered();
 
     // Use CompilationUnit for the entire pipeline
-    let mut unit = CompilationUnit::new(sources.to_vec(), options.clone());
-    unit.set_symbol_paths(symbol_paths);
+    let mut unit = CompilationUnit::with_source_metadata(
+        sources.to_vec(),
+        source_metadata.clone(),
+        options.clone(),
+    )
+    .map_err(CompileErrors::from)?;
     let output = unit.run_all()?;
     let stats = collect_stats.then(|| unit.collected_source_stats());
     Ok((output, stats))
@@ -1915,6 +2047,162 @@ pub fn compile_to_cfg_with_preview_features(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_invalid_compiler_input(errors: CompileErrors, expected: &str) {
+        assert_eq!(errors.len(), 1);
+        let error = errors.iter().next().unwrap();
+        assert!(
+            matches!(&error.kind, ErrorKind::InvalidCompilerInput(_)),
+            "expected E1400, got {error:?}"
+        );
+        assert_eq!(error.to_string(), expected);
+    }
+
+    #[test]
+    fn parse_rejects_invalid_source_identity_before_lexing() {
+        let duplicate_id = FileId::new(7);
+        let sources = [
+            SourceFile::new("z.rue", "$", duplicate_id),
+            SourceFile::new("a.rue", "#", duplicate_id),
+        ];
+
+        let errors = parse_all_files(&sources).unwrap_err();
+        assert_invalid_compiler_input(
+            errors,
+            "invalid compiler input: source files contain duplicate file IDs: 7",
+        );
+    }
+
+    #[test]
+    fn canonical_parse_rejects_source_metadata_drift_before_lexing() {
+        let file_id = FileId::new(3);
+        let metadata = SourceMetadata::new(
+            file_id,
+            std::collections::HashMap::from([(file_id, "expected.rue".to_string())]),
+            std::collections::HashMap::from([(file_id, "stable.rue".to_string())]),
+        )
+        .unwrap();
+        let sources = [SourceFile::new("actual.rue", "$", file_id)];
+
+        let errors = parse_all_files_with_source_metadata(&sources, &metadata).unwrap_err();
+        assert_invalid_compiler_input(
+            errors,
+            "invalid compiler input: physical path for 3 is \"expected.rue\", but source file uses \"actual.rue\"",
+        );
+    }
+
+    #[test]
+    fn raw_ast_boundary_rejects_undeclared_file_ids_before_lowering() {
+        let declared = FileId::new(2);
+        let metadata = SourceMetadata::new(
+            declared,
+            std::collections::HashMap::from([(declared, "main.rue".to_string())]),
+            std::collections::HashMap::from([(declared, "main.rue".to_string())]),
+        )
+        .unwrap();
+        let ast = Ast {
+            items: vec![Item::Error(Span::with_file(FileId::new(9), 0, 1))],
+        };
+
+        let result = compile_frontend_from_ast_with_source_metadata_and_target(
+            ast,
+            ThreadedRodeo::new(),
+            OptLevel::default(),
+            &PreviewFeatures::new(),
+            CompileOptions::default().target,
+            &metadata,
+        );
+        let errors = match result {
+            Ok(_) => panic!("undeclared AST file ID should fail"),
+            Err(errors) => errors,
+        };
+        assert_invalid_compiler_input(
+            errors,
+            "invalid compiler input: AST contains unknown file IDs: 9",
+        );
+    }
+
+    #[test]
+    fn legacy_raw_ast_wrapper_only_synthesizes_truly_anonymous_metadata() {
+        let ast = Ast {
+            items: vec![Item::Error(Span::with_file(FileId::new(9), 0, 1))],
+        };
+        let result = compile_frontend_from_ast_with_options(
+            ast,
+            ThreadedRodeo::new(),
+            OptLevel::default(),
+            &PreviewFeatures::new(),
+        );
+        let errors = match result {
+            Ok(_) => panic!("non-anonymous AST should require source metadata"),
+            Err(errors) => errors,
+        };
+        assert_invalid_compiler_input(
+            errors,
+            "invalid compiler input: raw AST uses non-anonymous file IDs 9; pass SourceMetadata explicitly",
+        );
+    }
+
+    #[test]
+    fn legacy_raw_ast_maps_materialize_partial_logical_paths_and_reject_unknown_ids() {
+        let root = FileId::new(2);
+        let empty_file = FileId::new(8);
+        let unknown = FileId::new(9);
+        let ast = Ast {
+            items: vec![Item::Error(Span::with_file(root, 0, 1))],
+        };
+        let file_paths = std::collections::HashMap::from([
+            (root, "physical/root.rue".to_string()),
+            (empty_file, "physical/empty.rue".to_string()),
+        ]);
+
+        let metadata = source_metadata_from_legacy_maps(
+            &ast,
+            file_paths.clone(),
+            std::collections::HashMap::from([(root, "stable/root.rue".to_string())]),
+        )
+        .unwrap();
+        assert_eq!(metadata.root_file_id(), root);
+        assert_eq!(metadata.logical_path(root), Some("stable/root.rue"));
+        assert_eq!(
+            metadata.logical_path(empty_file),
+            Some("physical/empty.rue")
+        );
+
+        let error = source_metadata_from_legacy_maps(
+            &ast,
+            file_paths,
+            std::collections::HashMap::from([(unknown, "unknown.rue".to_string())]),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "invalid compiler input: logical path map contains unknown file IDs: 9"
+        );
+    }
+
+    #[test]
+    fn canonical_batch_rejects_metadata_drift_before_lexing() {
+        let file_id = FileId::new(3);
+        let metadata = SourceMetadata::new(
+            file_id,
+            std::collections::HashMap::from([(file_id, "expected.rue".to_string())]),
+            std::collections::HashMap::from([(file_id, "stable.rue".to_string())]),
+        )
+        .unwrap();
+        let sources = [SourceFile::new("actual.rue", "$", file_id)];
+
+        let errors = compile_multi_file_with_source_metadata_and_options(
+            &sources,
+            &metadata,
+            &CompileOptions::default(),
+        )
+        .unwrap_err();
+        assert_invalid_compiler_input(
+            errors,
+            "invalid compiler input: physical path for 3 is \"expected.rue\", but source file uses \"actual.rue\"",
+        );
+    }
 
     #[test]
     fn test_embedded_runtime_is_valid() {
@@ -2800,12 +3088,22 @@ mod tests {
             if reverse_siblings {
                 sources.swap(1, 2);
             }
-            let mut unit = CompilationUnit::new(sources, CompileOptions::default());
-            unit.set_symbol_paths(std::collections::HashMap::from([
-                (main_id, "main.rue".to_string()),
-                (left_id, "left.rue".to_string()),
-                (right_id, "right.rue".to_string()),
-            ]));
+            let source_metadata = SourceMetadata::from_sources(
+                &sources,
+                main_id,
+                std::collections::HashMap::from([
+                    (main_id, "main.rue".to_string()),
+                    (left_id, "left.rue".to_string()),
+                    (right_id, "right.rue".to_string()),
+                ]),
+            )
+            .unwrap();
+            let mut unit = CompilationUnit::with_source_metadata(
+                sources,
+                source_metadata,
+                CompileOptions::default(),
+            )
+            .unwrap();
             unit.run_frontend().expect("frontend should compile");
             let mut names: Vec<_> = unit
                 .functions()
@@ -2901,12 +3199,22 @@ mod tests {
                 sources.swap(1, 2);
             }
 
-            let mut unit = CompilationUnit::new(sources, CompileOptions::default());
-            unit.set_symbol_paths(std::collections::HashMap::from([
-                (FileId::new(1), "main.rue".to_string()),
-                (left_id, "left/shared.rue".to_string()),
-                (right_id, "right/shared.rue".to_string()),
-            ]));
+            let source_metadata = SourceMetadata::from_sources(
+                &sources,
+                FileId::new(1),
+                std::collections::HashMap::from([
+                    (FileId::new(1), "main.rue".to_string()),
+                    (left_id, "left/shared.rue".to_string()),
+                    (right_id, "right/shared.rue".to_string()),
+                ]),
+            )
+            .unwrap();
+            let mut unit = CompilationUnit::with_source_metadata(
+                sources,
+                source_metadata,
+                CompileOptions::default(),
+            )
+            .unwrap();
             unit.run_frontend().expect("frontend should compile");
 
             let pool = unit.type_pool();
@@ -2982,12 +3290,22 @@ mod tests {
             ),
         ];
 
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
-        unit.set_symbol_paths(std::collections::HashMap::from([
-            (main_id, "main.rue".to_string()),
-            (struct_id, "left/clash.rue".to_string()),
-            (enum_id, "right/clash.rue".to_string()),
-        ]));
+        let source_metadata = SourceMetadata::from_sources(
+            &sources,
+            main_id,
+            std::collections::HashMap::from([
+                (main_id, "main.rue".to_string()),
+                (struct_id, "left/clash.rue".to_string()),
+                (enum_id, "right/clash.rue".to_string()),
+            ]),
+        )
+        .unwrap();
+        let mut unit = CompilationUnit::with_source_metadata(
+            sources,
+            source_metadata,
+            CompileOptions::default(),
+        )
+        .unwrap();
         unit.run_frontend().expect("frontend should compile");
 
         let drop_glue_names: std::collections::BTreeSet<_> = unit
@@ -3023,7 +3341,7 @@ mod tests {
                 FileId::new(2),
             ),
         ];
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
         unit.run_frontend().expect("frontend should compile");
 
         let warnings = unit

--- a/crates/rue-compiler/src/semantic_order.rs
+++ b/crates/rue-compiler/src/semantic_order.rs
@@ -8,11 +8,12 @@
 
 use std::collections::HashMap;
 
-use rue_air::normalize_module_path;
 use rue_parser::{Ast, Item};
 use rue_span::{FileId, Span};
 
-fn item_span(item: &Item) -> Span {
+use crate::SourceMetadata;
+
+pub(crate) fn item_span(item: &Item) -> Span {
     match item {
         Item::Function(item) => item.span,
         Item::Struct(item) => item.span,
@@ -26,15 +27,10 @@ fn item_span(item: &Item) -> Span {
 /// Clone an observable AST into the canonical order used only by sema.
 ///
 /// The explicitly designated root remains first. Siblings are ordered by their
-/// relocation-stable logical paths, while byte positions retain declaration
-/// order within each file. The numeric fallbacks only serve legacy embedders
-/// that do not provide a complete symbol-path map.
-pub(crate) fn for_sema(
-    ast: &Ast,
-    file_paths: &HashMap<FileId, String>,
-    symbol_paths: &HashMap<FileId, String>,
-    root_file_id: FileId,
-) -> Ast {
+/// validated, canonical logical paths, while byte positions retain
+/// declaration order within each file. Compiler entry points validate that
+/// every AST item is described by `source_metadata` before calling this.
+pub(crate) fn for_sema(ast: &Ast, source_metadata: &SourceMetadata) -> Ast {
     let mut keyed_items: Vec<_> = ast
         .items
         .iter()
@@ -42,13 +38,11 @@ pub(crate) fn for_sema(
         .enumerate()
         .map(|(original_index, item)| {
             let span = item_span(&item);
-            let logical_path = symbol_paths
-                .get(&span.file_id)
-                .or_else(|| file_paths.get(&span.file_id))
-                .map(|path| normalize_module_path(path))
-                .unwrap_or_else(|| format!("file{:010}", span.file_id.index()));
+            let logical_path = source_metadata
+                .logical_path(span.file_id)
+                .expect("AST file ID validated against source metadata");
             let key = (
-                span.file_id != root_file_id,
+                span.file_id != source_metadata.root_file_id(),
                 logical_path,
                 span.start,
                 span.end,
@@ -88,22 +82,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn normalizes_effective_paths_from_a_partial_symbol_map() {
-        let logical = FileId::new(20);
-        let physical_fallback = FileId::new(10);
+    fn uses_explicit_root_and_normalized_logical_paths() {
+        let root = FileId::new(30);
+        let logical_first = FileId::new(20);
+        let logical_second = FileId::new(10);
         let ast = Ast {
             items: vec![
-                Item::Error(Span::with_file(logical, 0, 1)),
-                Item::Error(Span::with_file(physical_fallback, 0, 1)),
+                Item::Error(Span::with_file(logical_second, 0, 1)),
+                Item::Error(Span::with_file(logical_first, 0, 1)),
+                Item::Error(Span::with_file(root, 0, 1)),
             ],
         };
-        let file_paths = HashMap::from([
-            (logical, "unused-physical.rue".to_string()),
-            (physical_fallback, "b.rue".to_string()),
-        ]);
-        let symbol_paths = HashMap::from([(logical, "z/../a.rue".to_string())]);
+        let source_metadata = SourceMetadata::new(
+            root,
+            HashMap::from([
+                (root, "z-root.rue".to_string()),
+                (logical_first, "z-physical.rue".to_string()),
+                (logical_second, "a-physical.rue".to_string()),
+            ]),
+            HashMap::from([
+                (root, "z-root.rue".to_string()),
+                (logical_first, "z/../a.rue".to_string()),
+                (logical_second, "b.rue".to_string()),
+            ]),
+        )
+        .unwrap();
 
-        let ordered = for_sema(&ast, &file_paths, &symbol_paths, FileId::new(99));
+        let ordered = for_sema(&ast, &source_metadata);
         let ordered_files: Vec<_> = ordered
             .items
             .iter()
@@ -111,6 +116,6 @@ mod tests {
             .map(|s| s.file_id)
             .collect();
 
-        assert_eq!(ordered_files, [logical, physical_fallback]);
+        assert_eq!(ordered_files, [root, logical_first, logical_second]);
     }
 }

--- a/crates/rue-compiler/src/source_metadata.rs
+++ b/crates/rue-compiler/src/source_metadata.rs
@@ -1,0 +1,754 @@
+//! Validated source identities at compiler API boundaries.
+//!
+//! Physical paths are used for diagnostics and module resolution. Logical
+//! paths are semantic identities used for ordering and generated symbols;
+//! callers that need relocation stability provide logical paths independent
+//! of the checkout location. Keeping both maps together with an explicit root
+//! makes it impossible for those coupled inputs to drift after construction.
+
+use std::collections::{HashMap, HashSet};
+
+use rue_air::normalize_module_path;
+use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_span::FileId;
+
+use crate::{Ast, SourceFile, semantic_order::item_span};
+
+/// Immutable, validated identities for every source in a compilation.
+///
+/// The descriptor owns its path maps and keeps a separate ascending `FileId`
+/// index. Callers therefore retain constant-time lookup while deterministic
+/// iterators never depend on `HashMap` iteration order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceMetadata {
+    root_file_id: FileId,
+    sorted_ids: Vec<FileId>,
+    physical_paths: HashMap<FileId, String>,
+    logical_paths: HashMap<FileId, String>,
+}
+
+impl SourceMetadata {
+    /// Validate complete physical and logical path maps for an explicit root.
+    ///
+    /// Both maps must have exactly the same nonempty set of `FileId` keys.
+    /// Logical values are lexically normalized before storage. Use
+    /// [`Self::from_sources`] when logical identities may fall back to physical
+    /// paths.
+    pub fn new(
+        root_file_id: FileId,
+        physical_paths: HashMap<FileId, String>,
+        logical_paths: HashMap<FileId, String>,
+    ) -> CompileResult<Self> {
+        if physical_paths.is_empty() {
+            return Err(invalid_input("source metadata contains no files"));
+        }
+
+        let mut file_ids: Vec<_> = physical_paths.keys().copied().collect();
+        file_ids.sort_by_key(|file_id| file_id.index());
+
+        if !physical_paths.contains_key(&root_file_id) {
+            return Err(invalid_input(format!(
+                "root file ID {} is absent from source metadata",
+                display_file_id(root_file_id)
+            )));
+        }
+
+        let missing_logical_ids: Vec<_> = file_ids
+            .iter()
+            .copied()
+            .filter(|file_id| !logical_paths.contains_key(file_id))
+            .collect();
+        if !missing_logical_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "logical path map is missing file IDs: {}",
+                display_file_ids(&missing_logical_ids)
+            )));
+        }
+
+        let mut unknown_logical_ids: Vec<_> = logical_paths
+            .keys()
+            .copied()
+            .filter(|file_id| !physical_paths.contains_key(file_id))
+            .collect();
+        unknown_logical_ids.sort_by_key(|file_id| file_id.index());
+        if !unknown_logical_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "logical path map contains unknown file IDs: {}",
+                display_file_ids(&unknown_logical_ids)
+            )));
+        }
+
+        let logical_paths: HashMap<_, _> = logical_paths
+            .into_iter()
+            .map(|(file_id, path)| (file_id, normalize_module_path(&path)))
+            .collect();
+
+        validate_nonempty_paths("physical", &file_ids, &physical_paths)?;
+        validate_nonempty_paths("logical", &file_ids, &logical_paths)?;
+        validate_normalized_collisions("physical", &file_ids, &physical_paths)?;
+        validate_normalized_collisions("logical", &file_ids, &logical_paths)?;
+
+        Ok(Self {
+            root_file_id,
+            sorted_ids: file_ids,
+            physical_paths,
+            logical_paths,
+        })
+    }
+
+    /// Build metadata from source files and optional logical-path overrides.
+    ///
+    /// Every omitted logical path is materialized from the corresponding
+    /// physical [`SourceFile::path`]. Callers that require identities to be
+    /// stable across relocations must therefore override location-dependent
+    /// physical paths. Overrides for IDs not present in `sources` are rejected
+    /// rather than ignored.
+    pub fn from_sources(
+        sources: &[SourceFile<'_>],
+        root_file_id: FileId,
+        logical_path_overrides: HashMap<FileId, String>,
+    ) -> CompileResult<Self> {
+        if sources.is_empty() {
+            return Err(invalid_input("source metadata contains no files"));
+        }
+
+        let mut counts = HashMap::<FileId, usize>::new();
+        for source in sources {
+            *counts.entry(source.file_id).or_default() += 1;
+        }
+        let mut duplicate_ids: Vec<_> = counts
+            .into_iter()
+            .filter_map(|(file_id, count)| (count > 1).then_some(file_id))
+            .collect();
+        duplicate_ids.sort_by_key(|file_id| file_id.index());
+        if !duplicate_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "source files contain duplicate file IDs: {}",
+                display_file_ids(&duplicate_ids)
+            )));
+        }
+
+        let physical_paths: HashMap<_, _> = sources
+            .iter()
+            .map(|source| (source.file_id, source.path.to_owned()))
+            .collect();
+
+        let mut unknown_override_ids: Vec<_> = logical_path_overrides
+            .keys()
+            .copied()
+            .filter(|file_id| !physical_paths.contains_key(file_id))
+            .collect();
+        unknown_override_ids.sort_by_key(|file_id| file_id.index());
+        if !unknown_override_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "logical path overrides contain unknown file IDs: {}",
+                display_file_ids(&unknown_override_ids)
+            )));
+        }
+
+        let logical_paths = physical_paths
+            .iter()
+            .map(|(&file_id, physical_path)| {
+                let logical_path = logical_path_overrides
+                    .get(&file_id)
+                    .cloned()
+                    .unwrap_or_else(|| physical_path.clone());
+                (file_id, logical_path)
+            })
+            .collect();
+
+        Self::new(root_file_id, physical_paths, logical_paths)
+    }
+
+    /// The explicitly designated semantic root.
+    #[inline]
+    pub fn root_file_id(&self) -> FileId {
+        self.root_file_id
+    }
+
+    /// Number of files described by this metadata.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.sorted_ids.len()
+    }
+
+    /// Whether this descriptor contains no files.
+    ///
+    /// Validated descriptors are never empty; this conventional companion to
+    /// [`Self::len`] therefore always returns `false`.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.sorted_ids.is_empty()
+    }
+
+    /// Whether this descriptor contains `file_id`.
+    #[inline]
+    pub fn contains_file(&self, file_id: FileId) -> bool {
+        self.physical_paths.contains_key(&file_id)
+    }
+
+    /// File IDs in ascending numeric order.
+    pub fn file_ids(&self) -> impl DoubleEndedIterator<Item = FileId> + ExactSizeIterator + '_ {
+        self.sorted_ids.iter().copied()
+    }
+
+    /// The physical diagnostic/module path for `file_id`.
+    pub fn physical_path(&self, file_id: FileId) -> Option<&str> {
+        self.physical_paths.get(&file_id).map(String::as_str)
+    }
+
+    /// The canonical logical semantic identity for `file_id`.
+    ///
+    /// Logical paths are lexically normalized once during construction, so
+    /// this value is safe to use directly as an identity or query key.
+    pub fn logical_path(&self, file_id: FileId) -> Option<&str> {
+        self.logical_paths.get(&file_id).map(String::as_str)
+    }
+
+    /// Physical paths in ascending `FileId` order.
+    pub fn physical_paths(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (FileId, &str)> + ExactSizeIterator + '_ {
+        self.sorted_ids.iter().map(|&file_id| {
+            let path = self
+                .physical_paths
+                .get(&file_id)
+                .expect("validated physical path key");
+            (file_id, path.as_str())
+        })
+    }
+
+    /// Logical paths in ascending `FileId` order.
+    pub fn logical_paths(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (FileId, &str)> + ExactSizeIterator + '_ {
+        self.sorted_ids.iter().map(|&file_id| {
+            let path = self
+                .logical_paths
+                .get(&file_id)
+                .expect("validated logical path key");
+            (file_id, path.as_str())
+        })
+    }
+
+    /// The complete physical path map.
+    ///
+    /// The map is immutable but its iteration order is unspecified. Use
+    /// [`Self::physical_paths`] when deterministic iteration matters.
+    pub fn physical_path_map(&self) -> &HashMap<FileId, String> {
+        &self.physical_paths
+    }
+
+    /// The complete logical path map.
+    ///
+    /// The map is immutable but its iteration order is unspecified. Use
+    /// [`Self::logical_paths`] when deterministic iteration matters.
+    pub fn logical_path_map(&self) -> &HashMap<FileId, String> {
+        &self.logical_paths
+    }
+
+    /// Validate that a source slice exactly matches this descriptor.
+    ///
+    /// Source contents and vector order are intentionally not metadata.
+    /// Validation diagnostics are selected in ascending `FileId` order.
+    pub(crate) fn validate_sources(&self, sources: &[SourceFile<'_>]) -> CompileResult<()> {
+        let mut counts = HashMap::<FileId, usize>::new();
+        for source in sources {
+            *counts.entry(source.file_id).or_default() += 1;
+        }
+
+        let mut duplicate_ids: Vec<_> = counts
+            .iter()
+            .filter_map(|(&file_id, &count)| (count > 1).then_some(file_id))
+            .collect();
+        duplicate_ids.sort_by_key(|file_id| file_id.index());
+        if !duplicate_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "source files contain duplicate file IDs: {}",
+                display_file_ids(&duplicate_ids)
+            )));
+        }
+
+        let seen: HashSet<_> = counts.keys().copied().collect();
+        let mut unknown_ids: Vec<_> = seen
+            .iter()
+            .copied()
+            .filter(|&file_id| !self.contains_file(file_id))
+            .collect();
+        unknown_ids.sort_by_key(|file_id| file_id.index());
+        if !unknown_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "source files contain unknown file IDs: {}",
+                display_file_ids(&unknown_ids)
+            )));
+        }
+
+        let mut mismatched_paths: Vec<_> = sources
+            .iter()
+            .filter_map(|source| {
+                let expected_path = self
+                    .physical_path(source.file_id)
+                    .expect("unknown source IDs rejected above");
+                (source.path != expected_path).then_some((
+                    source.file_id,
+                    expected_path,
+                    source.path,
+                ))
+            })
+            .collect();
+        mismatched_paths.sort_by_key(|(file_id, _, _)| file_id.index());
+        if let Some((file_id, expected_path, actual_path)) = mismatched_paths.first() {
+            return Err(invalid_input(format!(
+                "physical path for {} is {:?}, but source file uses {:?}",
+                display_file_id(*file_id),
+                expected_path,
+                actual_path
+            )));
+        }
+
+        let missing_ids: Vec<_> = self
+            .file_ids()
+            .filter(|file_id| !seen.contains(file_id))
+            .collect();
+        if !missing_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "source files are missing metadata file IDs: {}",
+                display_file_ids(&missing_ids)
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Validate that every top-level AST item belongs to a described source.
+    ///
+    /// Descriptors may contain files with no items, but an AST may never
+    /// introduce an undeclared `FileId`. Diagnostics list IDs in numeric order
+    /// and are therefore independent of item order. Parser-produced items have
+    /// one file ID throughout their descendants; callers constructing ASTs by
+    /// hand must preserve that parser invariant.
+    pub(crate) fn validate_ast(&self, ast: &Ast) -> CompileResult<()> {
+        let mut unknown_ids: Vec<_> = ast
+            .items
+            .iter()
+            .map(item_span)
+            .map(|span| span.file_id)
+            .filter(|&file_id| !self.contains_file(file_id))
+            .collect();
+        unknown_ids.sort_by_key(|file_id| file_id.index());
+        unknown_ids.dedup();
+
+        if !unknown_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "AST contains unknown file IDs: {}",
+                display_file_ids(&unknown_ids)
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_nonempty_paths(
+    kind: &str,
+    file_ids: &[FileId],
+    paths: &HashMap<FileId, String>,
+) -> CompileResult<()> {
+    for &file_id in file_ids {
+        let path = paths.get(&file_id).expect("validated path key");
+        if path.is_empty() || normalize_module_path(path).is_empty() {
+            return Err(invalid_input(format!(
+                "{kind} path for {} has an empty identity",
+                display_file_id(file_id)
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_normalized_collisions(
+    kind: &str,
+    file_ids: &[FileId],
+    paths: &HashMap<FileId, String>,
+) -> CompileResult<()> {
+    let mut seen = HashMap::<String, FileId>::new();
+    let mut collisions = Vec::new();
+    for &file_id in file_ids {
+        let normalized = normalize_module_path(paths.get(&file_id).expect("validated path key"));
+        if let Some(&first_file_id) = seen.get(&normalized) {
+            collisions.push((first_file_id, file_id, normalized));
+        } else {
+            seen.insert(normalized, file_id);
+        }
+    }
+
+    collisions.sort_by_key(|(first, second, _)| (first.index(), second.index()));
+    if let Some((first, second, normalized)) = collisions.into_iter().next() {
+        return Err(invalid_input(format!(
+            "{kind} paths for {} and {} normalize to the same identity {:?}",
+            display_file_id(first),
+            display_file_id(second),
+            normalized
+        )));
+    }
+
+    Ok(())
+}
+
+fn invalid_input(message: impl Into<String>) -> CompileError {
+    CompileError::without_span(ErrorKind::InvalidCompilerInput(message.into()))
+}
+
+fn display_file_id(file_id: FileId) -> u32 {
+    file_id.index()
+}
+
+fn display_file_ids(file_ids: &[FileId]) -> String {
+    file_ids
+        .iter()
+        .map(|file_id| file_id.index().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source<'a>(path: &'a str, file_id: u32) -> SourceFile<'a> {
+        SourceFile::new(path, "", FileId::new(file_id))
+    }
+
+    fn physical(entries: &[(u32, &str)]) -> HashMap<FileId, String> {
+        entries
+            .iter()
+            .map(|&(file_id, path)| (FileId::new(file_id), path.to_owned()))
+            .collect()
+    }
+
+    fn error_message(result: CompileResult<SourceMetadata>) -> String {
+        result.unwrap_err().to_string()
+    }
+
+    #[test]
+    fn materializes_partial_logical_paths_and_preserves_explicit_root() {
+        let sources = [source("src/root.rue", 20), source("src/util.rue", 10)];
+        let metadata = SourceMetadata::from_sources(
+            &sources,
+            FileId::new(20),
+            physical(&[(10, "stable/util.rue")]),
+        )
+        .unwrap();
+
+        assert_eq!(metadata.root_file_id(), FileId::new(20));
+        assert_eq!(
+            metadata.file_ids().collect::<Vec<_>>(),
+            [FileId::new(10), FileId::new(20)]
+        );
+        assert_eq!(
+            metadata.physical_path(FileId::new(10)),
+            Some("src/util.rue")
+        );
+        assert_eq!(
+            metadata.logical_path(FileId::new(10)),
+            Some("stable/util.rue")
+        );
+        assert_eq!(metadata.logical_path(FileId::new(20)), Some("src/root.rue"));
+        assert_eq!(metadata.physical_path_map().len(), 2);
+        assert_eq!(metadata.logical_path_map().len(), 2);
+    }
+
+    #[test]
+    fn canonicalizes_logical_paths_but_preserves_physical_spellings() {
+        let physical_paths = physical(&[(1, "pkg/a/../main.rue")]);
+        let metadata = SourceMetadata::new(
+            FileId::new(1),
+            physical_paths.clone(),
+            physical(&[(1, "pkg/a/../main.rue")]),
+        )
+        .unwrap();
+        let canonical = SourceMetadata::new(
+            FileId::new(1),
+            physical_paths,
+            physical(&[(1, "pkg/main.rue")]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            metadata.physical_path(FileId::new(1)),
+            Some("pkg/a/../main.rue")
+        );
+        assert_eq!(
+            metadata.logical_path(FileId::new(1)),
+            Some(normalize_module_path("pkg/main.rue").as_str())
+        );
+        assert_eq!(metadata, canonical);
+    }
+
+    #[test]
+    fn preserves_leading_parent_and_std_sentinel_logical_identities() {
+        let metadata = SourceMetadata::new(
+            FileId::new(1),
+            physical(&[(1, "dep.rue"), (2, "std.rue"), (3, "project.rue")]),
+            physical(&[
+                (1, "a/../../dep.rue"),
+                (2, "\0rue-std/math/./float.rue"),
+                (3, "@rue-std/math/float.rue"),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            metadata.logical_path(FileId::new(1)),
+            Some(normalize_module_path("../dep.rue").as_str())
+        );
+        assert_eq!(
+            metadata.logical_path(FileId::new(2)),
+            Some(normalize_module_path("\0rue-std/math/float.rue").as_str())
+        );
+        assert_ne!(
+            metadata.logical_path(FileId::new(2)),
+            metadata.logical_path(FileId::new(3))
+        );
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert_eq!(
+            error_message(SourceMetadata::new(
+                FileId::new(1),
+                HashMap::new(),
+                HashMap::new()
+            )),
+            "invalid compiler input: source metadata contains no files"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_source_ids_before_collection() {
+        let sources = [
+            source("z.rue", 9),
+            source("b.rue", 2),
+            source("a.rue", 2),
+            source("y.rue", 9),
+        ];
+        assert_eq!(
+            error_message(SourceMetadata::from_sources(
+                &sources,
+                FileId::new(2),
+                HashMap::new()
+            )),
+            "invalid compiler input: source files contain duplicate file IDs: 2, 9"
+        );
+    }
+
+    #[test]
+    fn permits_default_id_for_compatibility() {
+        let metadata = SourceMetadata::new(
+            FileId::DEFAULT,
+            physical(&[(0, "main.rue"), (1, "util.rue")]),
+            physical(&[(0, "main.rue"), (1, "util.rue")]),
+        )
+        .unwrap();
+        assert_eq!(metadata.root_file_id(), FileId::DEFAULT);
+    }
+
+    #[test]
+    fn rejects_missing_root() {
+        assert_eq!(
+            error_message(SourceMetadata::new(
+                FileId::new(7),
+                physical(&[(2, "main.rue")]),
+                physical(&[(2, "main.rue")]),
+            )),
+            "invalid compiler input: root file ID 7 is absent from source metadata"
+        );
+    }
+
+    #[test]
+    fn rejects_mismatched_raw_map_keys_deterministically() {
+        assert_eq!(
+            error_message(SourceMetadata::new(
+                FileId::new(1),
+                physical(&[(4, "four.rue"), (1, "one.rue"), (2, "two.rue")]),
+                physical(&[(1, "one.rue"), (7, "seven.rue")]),
+            )),
+            "invalid compiler input: logical path map is missing file IDs: 2, 4"
+        );
+
+        assert_eq!(
+            error_message(SourceMetadata::new(
+                FileId::new(1),
+                physical(&[(1, "one.rue")]),
+                physical(&[(1, "one.rue"), (8, "eight.rue"), (3, "three.rue")]),
+            )),
+            "invalid compiler input: logical path map contains unknown file IDs: 3, 8"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_logical_override_ids() {
+        assert_eq!(
+            error_message(SourceMetadata::from_sources(
+                &[source("main.rue", 1)],
+                FileId::new(1),
+                physical(&[(9, "nine.rue"), (4, "four.rue")]),
+            )),
+            "invalid compiler input: logical path overrides contain unknown file IDs: 4, 9"
+        );
+    }
+
+    #[test]
+    fn rejects_raw_and_normalized_empty_identities() {
+        assert_eq!(
+            error_message(SourceMetadata::new(
+                FileId::new(1),
+                physical(&[(1, "")]),
+                physical(&[(1, "main.rue")]),
+            )),
+            "invalid compiler input: physical path for 1 has an empty identity"
+        );
+        assert_eq!(
+            error_message(SourceMetadata::new(
+                FileId::new(1),
+                physical(&[(1, "main.rue")]),
+                physical(&[(1, "./")]),
+            )),
+            "invalid compiler input: logical path for 1 has an empty identity"
+        );
+    }
+
+    #[test]
+    fn rejects_physical_and_logical_normalization_collisions_separately() {
+        assert_eq!(
+            error_message(SourceMetadata::new(
+                FileId::new(5),
+                physical(&[(5, "src/./main.rue"), (8, "src/main.rue")]),
+                physical(&[(5, "main.rue"), (8, "util.rue")]),
+            )),
+            "invalid compiler input: physical paths for 5 and 8 normalize to the same identity \"src/main.rue\""
+        );
+
+        assert_eq!(
+            error_message(SourceMetadata::new(
+                FileId::new(5),
+                physical(&[(5, "src/main.rue"), (8, "src/util.rue")]),
+                physical(&[(5, "pkg/a/../main.rue"), (8, "pkg/main.rue")]),
+            )),
+            "invalid compiler input: logical paths for 5 and 8 normalize to the same identity \"pkg/main.rue\""
+        );
+    }
+
+    #[test]
+    fn normalized_collision_selection_is_file_id_ordered() {
+        let result = SourceMetadata::new(
+            FileId::new(1),
+            physical(&[
+                (9, "z/../same.rue"),
+                (7, "same.rue"),
+                (2, "a/../other.rue"),
+                (1, "other.rue"),
+            ]),
+            physical(&[(1, "one"), (2, "two"), (7, "seven"), (9, "nine")]),
+        );
+        assert_eq!(
+            error_message(result),
+            "invalid compiler input: physical paths for 1 and 2 normalize to the same identity \"other.rue\""
+        );
+    }
+
+    #[test]
+    fn validates_source_ids_and_physical_paths() {
+        let metadata = SourceMetadata::new(
+            FileId::new(2),
+            physical(&[(2, "root.rue"), (8, "util.rue")]),
+            physical(&[(2, "root"), (8, "util")]),
+        )
+        .unwrap();
+
+        metadata
+            .validate_sources(&[source("util.rue", 8), source("root.rue", 2)])
+            .unwrap();
+
+        let duplicate = metadata
+            .validate_sources(&[source("root.rue", 2), source("root.rue", 2)])
+            .unwrap_err();
+        assert_eq!(
+            duplicate.to_string(),
+            "invalid compiler input: source files contain duplicate file IDs: 2"
+        );
+
+        let unknown = metadata
+            .validate_sources(&[source("root.rue", 2), source("other.rue", 3)])
+            .unwrap_err();
+        assert_eq!(
+            unknown.to_string(),
+            "invalid compiler input: source files contain unknown file IDs: 3"
+        );
+
+        let wrong_path = metadata
+            .validate_sources(&[source("wrong.rue", 2), source("util.rue", 8)])
+            .unwrap_err();
+        assert_eq!(
+            wrong_path.to_string(),
+            "invalid compiler input: physical path for 2 is \"root.rue\", but source file uses \"wrong.rue\""
+        );
+
+        let missing = metadata
+            .validate_sources(&[source("root.rue", 2)])
+            .unwrap_err();
+        assert_eq!(
+            missing.to_string(),
+            "invalid compiler input: source files are missing metadata file IDs: 8"
+        );
+    }
+
+    #[test]
+    fn source_validation_is_independent_of_vector_order() {
+        let metadata = SourceMetadata::new(
+            FileId::new(2),
+            physical(&[(2, "root.rue"), (8, "util.rue")]),
+            physical(&[(2, "root"), (8, "util")]),
+        )
+        .unwrap();
+
+        let first = metadata
+            .validate_sources(&[source("wrong-util.rue", 8), source("wrong-root.rue", 2)])
+            .unwrap_err();
+        let second = metadata
+            .validate_sources(&[source("wrong-root.rue", 2), source("wrong-util.rue", 8)])
+            .unwrap_err();
+
+        assert_eq!(first.to_string(), second.to_string());
+        assert_eq!(
+            first.to_string(),
+            "invalid compiler input: physical path for 2 is \"root.rue\", but source file uses \"wrong-root.rue\""
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_ast_file_ids_deterministically() {
+        use rue_parser::Item;
+        use rue_span::Span;
+
+        let metadata = SourceMetadata::new(
+            FileId::new(2),
+            physical(&[(2, "root.rue"), (8, "empty.rue")]),
+            physical(&[(2, "root"), (8, "empty")]),
+        )
+        .unwrap();
+        let ast = Ast {
+            items: vec![
+                Item::Error(Span::with_file(FileId::new(9), 0, 1)),
+                Item::Error(Span::with_file(FileId::new(2), 1, 2)),
+                Item::Error(Span::with_file(FileId::new(4), 2, 3)),
+                Item::Error(Span::with_file(FileId::new(9), 3, 4)),
+            ],
+        };
+
+        assert_eq!(
+            metadata.validate_ast(&ast).unwrap_err().to_string(),
+            "invalid compiler input: AST contains unknown file IDs: 4, 9"
+        );
+    }
+}

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -21,8 +21,9 @@
 //! ];
 //!
 //! // Run the phases IN ORDER — skipping one (e.g. analyze() before lower())
-//! // panics. `new` is infallible; the phase methods return results.
-//! let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+//! // panics. Construction validates source identities, and the phase methods
+//! // return results.
+//! let mut unit = CompilationUnit::new(sources, CompileOptions::default())?;
 //! unit.parse()?;
 //! unit.lower()?;
 //! unit.analyze()?;
@@ -36,9 +37,9 @@ use lasso::ThreadedRodeo;
 use tracing::{info, info_span};
 
 use crate::{
-    Ast, AstGen, CompileErrors, CompileOptions, CompileOutput, CompileWarning, FunctionWithCfg,
-    Lexer, MultiErrorResult, Parser, Rir, Sema, SourceFile, TypeInternPool,
-    build_functions_and_cfgs, compile_backend,
+    Ast, AstGen, CompileErrors, CompileOptions, CompileOutput, CompileResult, CompileWarning,
+    FunctionWithCfg, Lexer, MultiErrorResult, Parser, Rir, Sema, SourceFile, SourceMetadata,
+    TypeInternPool, build_functions_and_cfgs, compile_backend,
 };
 use rue_span::FileId;
 
@@ -85,19 +86,14 @@ pub struct CompilationUnit<'src> {
     sources: Vec<SourceFile<'src>>,
     /// Work metrics collected from those sources and the live parse.
     source_stats: SourceStats,
-    /// Designated semantic root (the first source), independent of FileId rank.
-    root_file_id: FileId,
+    /// Validated physical paths, logical identities, and designated root.
+    source_metadata: SourceMetadata,
 
     // === Phase 1: Parsing ===
     /// Merged AST containing all items (populated by `parse()`).
     merged_ast: Option<Ast>,
     /// String interner shared across all files.
     interner: Option<ThreadedRodeo>,
-    /// Maps FileId to source file path (for error messages).
-    file_paths: HashMap<FileId, String>,
-    /// Maps FileId to a relocation-stable path for generated symbols.
-    symbol_paths: HashMap<FileId, String>,
-
     // === Phase 2: RIR Generation ===
     /// Untyped intermediate representation (populated by `lower()`).
     rir: Option<Rir>,
@@ -125,16 +121,54 @@ impl<'src> CompilationUnit<'src> {
     /// * `sources` - Source files to compile. The first entry is the designated
     ///   root for root-relative import fallback.
     /// * `options` - Compilation options (target, optimization, etc.)
-    pub fn new(sources: Vec<SourceFile<'src>>, options: CompileOptions) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-compiler-input error if there are no sources, source
+    /// IDs are duplicated, or physical paths do not form unique identities.
+    pub fn new(sources: Vec<SourceFile<'src>>, options: CompileOptions) -> CompileResult<Self> {
         let root_file_id = sources
             .first()
             .map(|source| source.file_id)
             .unwrap_or(FileId::DEFAULT);
-        let file_paths: HashMap<FileId, String> = sources
-            .iter()
-            .map(|s| (s.file_id, s.path.to_string()))
-            .collect();
-        let symbol_paths = file_paths.clone();
+        let source_metadata = SourceMetadata::from_sources(&sources, root_file_id, HashMap::new())?;
+        Ok(Self::from_validated_metadata(
+            sources,
+            source_metadata,
+            options,
+        ))
+    }
+
+    /// Create a compilation unit with validated, caller-provided source identities.
+    ///
+    /// Unlike [`Self::new`], this constructor lets callers designate a root that
+    /// is not the first or numerically smallest file and provide relocation-stable
+    /// logical paths. The metadata must describe exactly the supplied sources,
+    /// including their physical paths.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-compiler-input error if `source_metadata` does not
+    /// describe exactly the supplied source IDs and physical paths.
+    pub fn with_source_metadata(
+        sources: Vec<SourceFile<'src>>,
+        source_metadata: SourceMetadata,
+        options: CompileOptions,
+    ) -> CompileResult<Self> {
+        source_metadata.validate_sources(&sources)?;
+
+        Ok(Self::from_validated_metadata(
+            sources,
+            source_metadata,
+            options,
+        ))
+    }
+
+    fn from_validated_metadata(
+        sources: Vec<SourceFile<'src>>,
+        source_metadata: SourceMetadata,
+        options: CompileOptions,
+    ) -> Self {
         let source_stats = SourceStats {
             files: sources.len(),
             bytes: sources.iter().map(|source| source.source.len()).sum(),
@@ -148,11 +182,9 @@ impl<'src> CompilationUnit<'src> {
             options,
             sources,
             source_stats,
-            root_file_id,
+            source_metadata,
             merged_ast: None,
             interner: None,
-            file_paths,
-            symbol_paths,
             rir: None,
             functions: None,
             type_pool: None,
@@ -332,12 +364,7 @@ impl<'src> CompilationUnit<'src> {
         // while sema consumes a private logical-path-ordered lowering. This
         // makes allocation and artifact layout canonical without changing the
         // caller-visible AST/RIR contract (RUE-624).
-        let semantic_ast = crate::semantic_order::for_sema(
-            ast,
-            &self.file_paths,
-            &self.symbol_paths,
-            self.root_file_id,
-        );
+        let semantic_ast = crate::semantic_order::for_sema(ast, &self.source_metadata);
         let semantic_rir = {
             let _span = info_span!("semantic_astgen").entered();
             AstGen::new(&semantic_ast, interner).generate()
@@ -352,9 +379,9 @@ impl<'src> CompilationUnit<'src> {
                 self.options.preview_features.clone(),
                 self.options.target,
             );
-            sema.set_root_file_id(self.root_file_id);
-            sema.set_file_paths(self.file_paths.clone());
-            sema.set_symbol_paths(self.symbol_paths.clone());
+            sema.set_root_file_id(self.source_metadata.root_file_id());
+            sema.set_file_paths(self.source_metadata.physical_path_map().clone());
+            sema.set_symbol_paths(self.source_metadata.logical_path_map().clone());
             let output = sema.analyze_all()?;
             info!(
                 function_count = output.functions.len(),
@@ -524,7 +551,12 @@ impl<'src> CompilationUnit<'src> {
 
     /// Get the file paths map.
     pub fn file_paths(&self) -> &HashMap<FileId, String> {
-        &self.file_paths
+        self.source_metadata.physical_path_map()
+    }
+
+    /// Get the validated source identities and designated semantic root.
+    pub fn source_metadata(&self) -> &SourceMetadata {
+        &self.source_metadata
     }
 
     /// Get source metrics collected by the live frontend.
@@ -542,14 +574,6 @@ impl<'src> CompilationUnit<'src> {
     /// Get counters collected during compilation without scanning source text.
     pub(crate) fn collected_source_stats(&self) -> SourceStats {
         self.source_stats
-    }
-
-    /// Replace the paths used to qualify otherwise-colliding generated names.
-    ///
-    /// These identities do not affect diagnostics or module resolution. Any
-    /// missing entry falls back to the corresponding physical file path.
-    pub fn set_symbol_paths(&mut self, symbol_paths: HashMap<FileId, String>) {
-        self.symbol_paths = symbol_paths;
     }
 
     /// Take the interner out of the compilation unit.
@@ -623,7 +647,7 @@ mod tests {
     #[test]
     fn test_compilation_unit_basic() {
         let sources = make_sources("fn main() -> i32 { 42 }");
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
 
         assert!(!unit.is_parsed());
         assert!(!unit.is_lowered());
@@ -638,9 +662,39 @@ mod tests {
     }
 
     #[test]
+    fn explicit_source_metadata_preserves_a_nonminimum_root() {
+        let helper_id = FileId::new(2);
+        let root_id = FileId::new(40);
+        let sources = vec![
+            SourceFile::new("helper.rue", "fn helper() -> i32 { 1 }", helper_id),
+            SourceFile::new("main.rue", "fn main() -> i32 { 42 }", root_id),
+        ];
+        let metadata = SourceMetadata::from_sources(
+            &sources,
+            root_id,
+            HashMap::from([
+                (helper_id, "stable/helper.rue".to_string()),
+                (root_id, "stable/main.rue".to_string()),
+            ]),
+        )
+        .unwrap();
+
+        let mut unit =
+            CompilationUnit::with_source_metadata(sources, metadata, CompileOptions::default())
+                .unwrap();
+
+        assert_eq!(unit.source_metadata().root_file_id(), root_id);
+        assert_eq!(
+            unit.source_metadata().logical_path(helper_id),
+            Some("stable/helper.rue")
+        );
+        unit.run_frontend().unwrap();
+    }
+
+    #[test]
     fn test_phase_ordering() {
         let sources = make_sources("fn main() -> i32 { 42 }");
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
 
         // Parse first
         unit.parse().unwrap();
@@ -667,7 +721,7 @@ mod tests {
             SourceFile::new("main.rue", first, FileId::new(1)),
             SourceFile::new("helper.rue", second, FileId::new(2)),
         ];
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
 
         assert_eq!(
             unit.source_stats(),
@@ -695,7 +749,7 @@ mod tests {
             "fn foo() -> i32 { 1 } fn foo() -> i32 { 2 }",
             FileId::new(1),
         )];
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
 
         let result = unit.parse();
         assert!(result.is_err());
@@ -710,7 +764,7 @@ mod tests {
             SourceFile::new("parse.rue", "fn parse( { }", FileId::new(2)),
             SourceFile::new("good.rue", "fn good() -> i32 { 42 }", FileId::new(3)),
         ];
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
 
         let errors = unit.parse().expect_err("both broken files should report");
         assert_eq!(errors.len(), 2);
@@ -733,7 +787,7 @@ mod tests {
             "fn lex() -> i32 { $ # }",
             FileId::new(1),
         )];
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
 
         let errors = unit
             .parse()
@@ -753,7 +807,7 @@ mod tests {
     #[test]
     fn test_warnings_collected() {
         let sources = make_sources("fn main() -> i32 { let x = 42; 0 }");
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
         unit.run_frontend().unwrap();
 
         assert_eq!(unit.warnings().len(), 1);
@@ -836,13 +890,23 @@ mod tests {
             sources.swap(1, 2);
         }
 
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
-        unit.set_symbol_paths(std::collections::HashMap::from([
-            (root_id, "main.rue".to_string()),
-            (left_id, "left/types.rue".to_string()),
-            (right_id, "right/types.rue".to_string()),
-            (shared_id, "shared.rue".to_string()),
-        ]));
+        let source_metadata = SourceMetadata::from_sources(
+            &sources,
+            root_id,
+            HashMap::from([
+                (root_id, "main.rue".to_string()),
+                (left_id, "left/types.rue".to_string()),
+                (right_id, "right/types.rue".to_string()),
+                (shared_id, "shared.rue".to_string()),
+            ]),
+        )
+        .unwrap();
+        let mut unit = CompilationUnit::with_source_metadata(
+            sources,
+            source_metadata,
+            CompileOptions::default(),
+        )
+        .unwrap();
         unit.run_frontend().expect("frontend should compile");
 
         let pool = unit.type_pool();
@@ -974,7 +1038,7 @@ mod tests {
     #[should_panic(expected = "lower() called before parse()")]
     fn test_lower_before_parse_panics() {
         let sources = make_sources("fn main() -> i32 { 42 }");
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
         unit.lower().unwrap();
     }
 
@@ -982,7 +1046,7 @@ mod tests {
     #[should_panic(expected = "analyze() called before lower()")]
     fn test_analyze_before_lower_panics() {
         let sources = make_sources("fn main() -> i32 { 42 }");
-        let mut unit = CompilationUnit::new(sources, CompileOptions::default());
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
         unit.parse().unwrap();
         unit.analyze().unwrap();
     }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -59,6 +59,7 @@ use thiserror::Error;
 /// - **E1100-E1199**: Preview feature errors
 /// - **E1200-E1299**: Comptime errors
 /// - **E1300-E1399**: Unchecked-code errors (raw pointers, `checked` blocks)
+/// - **E1400-E1499**: Compiler-input errors
 /// - **E9000-E9999**: Internal compiler errors
 ///
 /// Once assigned, error codes must never change to maintain stability for
@@ -376,6 +377,12 @@ impl ErrorCode {
     // Unchecked-code errors (E1300-E1399)
     // ========================================================================
     pub const UNCHECKED_OP_REQUIRES_CHECKED: Self = Self(1300);
+
+    // ========================================================================
+    // Compiler-input errors (E1400-E1499)
+    // ========================================================================
+    /// Invalid metadata supplied at a compiler API boundary.
+    pub const INVALID_COMPILER_INPUT: Self = Self(1400);
 
     // ========================================================================
     // Internal compiler errors (E9000-E9999)
@@ -1567,6 +1574,10 @@ pub enum ErrorKind {
     #[error("{what} requires a `checked` block")]
     UncheckedOpRequiresChecked { what: String },
 
+    // Compiler-input errors
+    #[error("invalid compiler input: {0}")]
+    InvalidCompilerInput(String),
+
     // Internal compiler errors (bugs in the compiler itself)
     #[error("internal compiler error: {0}")]
     InternalError(String),
@@ -1743,9 +1754,14 @@ impl ErrorKind {
             // Comptime errors (E1200-E1299)
             ErrorKind::ComptimeEvaluationFailed { .. } => ErrorCode::COMPTIME_EVALUATION_FAILED,
             ErrorKind::ComptimeArgNotConst { .. } => ErrorCode::COMPTIME_ARG_NOT_CONST,
+
+            // Unchecked-code errors (E1300-E1399)
             ErrorKind::UncheckedOpRequiresChecked { .. } => {
                 ErrorCode::UNCHECKED_OP_REQUIRES_CHECKED
             }
+
+            // Compiler-input errors (E1400-E1499)
+            ErrorKind::InvalidCompilerInput(_) => ErrorCode::INVALID_COMPILER_INPUT,
 
             // Internal compiler errors (E9000-E9999)
             ErrorKind::InternalError(_) => ErrorCode::INTERNAL_ERROR,
@@ -2952,6 +2968,17 @@ mod tests {
         set.insert(ErrorCode::UNDEFINED_VARIABLE);
         assert_eq!(set.len(), 2);
         assert!(set.contains(&ErrorCode::TYPE_MISMATCH));
+    }
+
+    #[test]
+    fn test_invalid_compiler_input_error_code_and_message() {
+        let kind = ErrorKind::InvalidCompilerInput("duplicate file ID 7".into());
+        assert_eq!(kind.code(), ErrorCode::INVALID_COMPILER_INPUT);
+        assert_eq!(ErrorCode::INVALID_COMPILER_INPUT.0, 1400);
+        assert_eq!(
+            kind.to_string(),
+            "invalid compiler input: duplicate file ID 7"
+        );
     }
 
     // ========================================================================

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -15,12 +15,12 @@ mod timing;
 use rue_compiler::{
     CompileError, CompileErrors, CompileOptions, CompileWarning, ErrorKind, FileId, Lexer,
     LinkerMode, MultiFileFormatter, MultiFileJsonFormatter, OptLevel, ParsedProgram,
-    PreviewFeature, PreviewFeatures, SourceFile, SourceInfo, Span, TokenKind,
-    compile_multi_file_with_symbol_paths_and_options,
-    compile_multi_file_with_symbol_paths_and_options_and_stats, configure_thread_pool,
+    PreviewFeature, PreviewFeatures, SourceFile, SourceInfo, SourceMetadata, Span, TokenKind,
+    compile_multi_file_with_source_metadata_and_options,
+    compile_multi_file_with_source_metadata_and_options_and_stats, configure_thread_pool,
     generate_emitted_asm, generate_liveness_info, generate_lowering_info, generate_mir,
     generate_regalloc_info, generate_stack_frame_info, import_candidate_groups, merge_symbols,
-    parse_all_files,
+    parse_all_files_with_source_metadata,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -1199,16 +1199,6 @@ fn derive_symbol_paths_with_std_root(
         })
         .collect::<Result<_, String>>()?;
 
-    let mut seen = std::collections::HashSet::new();
-    for symbol_path in &symbol_paths {
-        if !seen.insert(symbol_path) {
-            return Err(format!(
-                "multiple source files resolve to the same stable identity {:?}",
-                symbol_path
-            ));
-        }
-    }
-
     Ok(symbol_paths)
 }
 
@@ -1699,13 +1689,6 @@ fn main() {
     // Build SourceFile structs for multi-file compilation. Physical paths stay
     // available for imports and diagnostics; generated symbols use a separate,
     // relocation-stable identity (RUE-618).
-    let symbol_paths = match derive_symbol_paths(&sources) {
-        Ok(paths) => paths,
-        Err(message) => {
-            eprintln!("Error: {message}");
-            std::process::exit(1);
-        }
-    };
     let source_files: Vec<SourceFile<'_>> = sources
         .iter()
         .enumerate()
@@ -1713,12 +1696,6 @@ fn main() {
             SourceFile::new(path.as_str(), content.as_str(), FileId::new((i + 1) as u32))
         })
         .collect();
-    let symbol_path_map: std::collections::HashMap<FileId, String> = source_files
-        .iter()
-        .zip(symbol_paths)
-        .map(|(source, symbol_path)| (source.file_id, symbol_path))
-        .collect();
-
     // Create multi-file diagnostic formatters for diagnostics that may span multiple files.
     let source_infos: Vec<_> = sources
         .iter()
@@ -1731,6 +1708,29 @@ fn main() {
         })
         .collect();
     let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
+    let symbol_paths = match derive_symbol_paths(&sources) {
+        Ok(paths) => paths,
+        Err(message) => {
+            diagnostics.print_error(&CompileError::without_span(
+                ErrorKind::InvalidCompilerInput(message),
+            ));
+            std::process::exit(1);
+        }
+    };
+    let symbol_path_map: std::collections::HashMap<FileId, String> = source_files
+        .iter()
+        .zip(symbol_paths)
+        .map(|(source, symbol_path)| (source.file_id, symbol_path))
+        .collect();
+    let source_metadata =
+        match SourceMetadata::from_sources(&source_files, source_files[0].file_id, symbol_path_map)
+        {
+            Ok(source_metadata) => source_metadata,
+            Err(error) => {
+                diagnostics.print_error(&error);
+                std::process::exit(1);
+            }
+        };
 
     if options.emit_stages.contains(&EmitStage::Deps) {
         if options.emit_stages.len() != 1 {
@@ -1784,7 +1784,7 @@ fn main() {
     // Handle emit modes with multi-file support
     if !options.emit_stages.is_empty() {
         if let Err(()) =
-            handle_emit_multi_file(&source_files, &symbol_path_map, &options, &diagnostics)
+            handle_emit_multi_file(&source_files, &source_metadata, &options, &diagnostics)
         {
             std::process::exit(1);
         }
@@ -1806,16 +1806,16 @@ fn main() {
         preview_features: options.preview_features.clone(),
     };
     let compile_result = if options.benchmark_json {
-        compile_multi_file_with_symbol_paths_and_options_and_stats(
+        compile_multi_file_with_source_metadata_and_options_and_stats(
             &source_files,
-            symbol_path_map,
+            &source_metadata,
             &compile_options,
         )
         .map(|(output, stats)| (output, Some(stats)))
     } else {
-        compile_multi_file_with_symbol_paths_and_options(
+        compile_multi_file_with_source_metadata_and_options(
             &source_files,
-            symbol_path_map,
+            &source_metadata,
             &compile_options,
         )
         .map(|output| (output, None))
@@ -1939,7 +1939,7 @@ fn main() {
 /// For later stages (rir, air, cfg, etc.), the merged program is used.
 fn handle_emit_multi_file(
     sources: &[SourceFile<'_>],
-    symbol_paths: &std::collections::HashMap<FileId, String>,
+    source_metadata: &SourceMetadata,
     options: &Options,
     diagnostics: &DiagnosticOutput<'_>,
 ) -> Result<(), ()> {
@@ -1986,7 +1986,7 @@ fn handle_emit_multi_file(
 
     // Parse all files (needed for AST output or later stages)
     let mut parsed: Option<ParsedProgram> = if needs_ast || needs_later_stages {
-        match parse_all_files(sources) {
+        match parse_all_files_with_source_metadata(sources, source_metadata) {
             Ok(program) => Some(program),
             Err(errors) => {
                 diagnostics.print_errors(&errors);
@@ -2025,21 +2025,13 @@ fn handle_emit_multi_file(
             }
         };
 
-        // Thread file paths through so @import resolution works under --emit
-        // exactly as in a normal build (RUE-130).
-        let file_paths: std::collections::HashMap<FileId, String> = sources
-            .iter()
-            .map(|s| (s.file_id, s.path.to_string()))
-            .collect();
         let state = match rue_compiler::compile_frontend_from_ast_with_source_metadata_and_target(
             merged.ast,
             merged.interner,
             options.opt_level,
             &options.preview_features,
             options.target,
-            sources[0].file_id,
-            file_paths,
-            symbol_paths.clone(),
+            source_metadata,
         ) {
             Ok(state) => state,
             Err(errors) => {


### PR DESCRIPTION
## Summary

- add an immutable `SourceMetadata` descriptor for the explicit semantic root, complete physical paths, and canonical logical identities
- validate empty inputs, duplicate/unknown IDs, absent roots, mismatched source descriptors, empty identities, normalized collisions, and raw-AST ownership with deterministic E1400 diagnostics
- make `CompilationUnit` source metadata immutable and thread the same descriptor through batch, raw-AST, CLI, emit, and benchmark paths
- retain compatibility wrappers while requiring non-anonymous raw ASTs to provide explicit metadata

## Why

The compiler previously reconstructed its root, diagnostic/module paths, and generated-symbol paths independently. Duplicate IDs could collapse in maps, callers could replace logical paths after construction, and raw-AST/emit entry points inferred different roots or fallback identities. Those represent invalid semantic inputs and would become unsound cache keys for query and incremental compilation.

This change makes those coupled inputs one validated compiler-owned value before the next query/snapshot work begins.

## Details

- logical paths are normalized once at construction and can be used directly as identity/query keys; physical spellings remain unchanged for diagnostics and module resolution
- `CompilationUnit::new` is now fallible, and `with_source_metadata` supports a root that is neither first nor numerically smallest
- legacy partial logical maps still materialize physical-path fallbacks, while unknown logical IDs fail
- parser and batch boundaries validate before lexing; raw-AST boundaries reject undeclared file IDs before lowering
- the CLI constructs one descriptor and shares it across normal compilation, `--benchmark-json`, and every `--emit` stage
- invalid compiler input has stable code E1400, including JSON diagnostics before `--emit tokens` can print partial output

## Validation

- `./fmt.sh check`
- `./clippy.sh` (41 first-party Rust targets)
- `./buck2 test //...` (34 test targets)
- `//crates/rue-compiler:rue-compiler-test` (252 tests)
- `//:cli-tests` (1,341 passed, 2 ignored)
- `//:reproducible-programs` (relocated/source-permuted O0/O2 fingerprints across x86-64 Linux, AArch64 Linux, and AArch64 macOS)
- `./scripts/check-reproducible-compiler.sh` (independent relocated clean rebuild)
