### PR TITLE
RUE-634: unify call view coercions

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2390,12 +2390,22 @@ impl<'a> ConstraintGenerator<'a> {
                                 for (arg, param_type) in
                                     args.iter().zip(method_sig.param_types.iter())
                                 {
+                                    // View/string compatibility is
+                                    // representation-aware and authoritative
+                                    // in sema. This includes contextual
+                                    // `Str(N)` expressions; sema still
+                                    // requires exact capacity for non-literals
+                                    // (RUE-634/RUE-636).
+                                    let defer_equality =
+                                        self.is_slice_struct_type(param_type.clone());
                                     let arg_info = self.generate(arg.value, ctx);
-                                    self.add_constraint(Constraint::equal(
-                                        arg_info.ty,
-                                        param_type.clone(),
-                                        arg_info.span,
-                                    ));
+                                    if !defer_equality {
+                                        self.add_constraint(Constraint::equal(
+                                            arg_info.ty,
+                                            param_type.clone(),
+                                            arg_info.span,
+                                        ));
+                                    }
                                 }
                                 method_sig.return_type.clone()
                             } else {
@@ -2719,12 +2729,15 @@ impl<'a> ConstraintGenerator<'a> {
         let method_sig = self.method_sig(&(struct_id, function))?;
         let args = self.rir.get_call_args(args_start, args_len);
         for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
+            let defer_equality = self.is_slice_struct_type(param_type.clone());
             let arg_info = self.generate(arg.value, ctx);
-            self.add_constraint(Constraint::equal(
-                arg_info.ty,
-                param_type.clone(),
-                arg_info.span,
-            ));
+            if !defer_equality {
+                self.add_constraint(Constraint::equal(
+                    arg_info.ty,
+                    param_type.clone(),
+                    arg_info.span,
+                ));
+            }
         }
         Some(method_sig.return_type.clone())
     }

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -342,8 +342,8 @@ impl<'a> Sema<'a> {
         }
 
         // Check argument count (method_info.params excludes self)
-        let method_param_types = self.param_arena.types(method_info.params);
-        let method_param_modes = self.param_arena.modes(method_info.params);
+        let method_param_types = self.param_arena.types(method_info.params).to_vec();
+        let method_param_modes = self.param_arena.modes(method_info.params).to_vec();
         if args.len() != method_param_types.len() {
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount {
@@ -470,7 +470,13 @@ impl<'a> Sema<'a> {
         if let Some(frame) = receiver_frame {
             ctx.call_loaned_roots.push(frame);
         }
-        let args_result = self.analyze_call_args(air, &args, ctx);
+        let args_result = self.analyze_call_args_coerced(
+            air,
+            &args,
+            &method_param_types,
+            &method_param_modes,
+            ctx,
+        );
         if receiver_frame_pushed {
             ctx.call_loaned_roots.pop();
         }
@@ -779,8 +785,8 @@ impl<'a> Sema<'a> {
         }
 
         // Check argument count
-        let method_param_types = self.param_arena.types(method_info.params);
-        let method_param_modes = self.param_arena.modes(method_info.params);
+        let method_param_types = self.param_arena.types(method_info.params).to_vec();
+        let method_param_modes = self.param_arena.modes(method_info.params).to_vec();
         if args.len() != method_param_types.len() {
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount {
@@ -799,8 +805,17 @@ impl<'a> Sema<'a> {
         // Clone data needed before mutable borrow
         let return_type = method_info.return_type;
 
-        // Analyze arguments
-        let air_args = self.analyze_call_args(air, &args, ctx)?;
+        // Analyze explicit arguments through the same representation-aware
+        // path as free and module-member calls. In particular, `borrow str`
+        // and `[T]` parameters are physical by-value views even though their
+        // source modes remain Borrow (RUE-634).
+        let air_args = self.analyze_call_args_coerced(
+            air,
+            &args,
+            &method_param_types,
+            &method_param_modes,
+            ctx,
+        )?;
 
         // Generate the associated-function call symbol: `Type::function`.
         // Uses the internal struct name (e.g. "__anon_struct_0") for anonymous

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -743,99 +743,6 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
-    /// Analyze a list of call arguments, enforcing by-ref argument rules.
-    ///
-    /// Inout/borrow arguments are borrows, not moves: `ctx.byref_arg_root` is
-    /// set to the argument's ROOT variable while the argument value is
-    /// analyzed, so the variable-reference and place analyses skip move
-    /// tracking for it (and permit forwarding an inout parameter to another
-    /// function's by-ref parameter). A by-ref argument must be a place — a
-    /// variable, or a field/index projection chain rooted at one (`borrow
-    /// o.f`, `inout a[i]`, RUE-143); codegen forms the place's address.
-    ///
-    /// An `inout` argument rooted at a `borrow` parameter is rejected here:
-    /// it would hand the callee a mutable view of read-only memory.
-    pub(crate) fn analyze_call_args(
-        &mut self,
-        air: &mut Air,
-        args: &[RirCallArg],
-        ctx: &mut AnalysisContext,
-    ) -> CompileResult<Vec<AirCallArg>> {
-        // Collect this call's loan frame up front — every by-ref argument's
-        // root — so a by-value move of a loaned root is caught in EITHER
-        // argument order (`f(inout x, x)` and `f(x, inout x)` alike, RUE-523).
-        // The frame stays pushed while every argument (and anything nested in
-        // one) is analyzed; move-record sites consult it via
-        // `reject_move_of_call_loaned_root`.
-        let frame: Vec<(Spur, CallLoanKind)> = args
-            .iter()
-            .filter_map(|arg| {
-                let kind = if arg.is_inout() {
-                    CallLoanKind::Inout
-                } else if arg.is_borrow() {
-                    CallLoanKind::Borrow
-                } else {
-                    return None;
-                };
-                root_variable_of(self.rir, arg.value).map(|root| (root, kind))
-            })
-            .collect();
-        let pushed = !frame.is_empty();
-        if pushed {
-            ctx.call_loaned_roots.push(frame);
-        }
-        let result = self.analyze_call_args_inner(air, args, ctx);
-        if pushed {
-            ctx.call_loaned_roots.pop();
-        }
-        result
-    }
-
-    /// The argument loop behind [`Sema::analyze_call_args`], factored out so
-    /// the loan frame is popped on every exit path (including `?` errors).
-    fn analyze_call_args_inner(
-        &mut self,
-        air: &mut Air,
-        args: &[RirCallArg],
-        ctx: &mut AnalysisContext,
-    ) -> CompileResult<Vec<AirCallArg>> {
-        let mut air_args = Vec::new();
-        for arg in args.iter() {
-            let byref_root = if arg.is_inout() || arg.is_borrow() {
-                let root = require_byref_place_arg(self.rir, arg)?;
-                if arg.is_inout()
-                    && ctx
-                        .params
-                        .iter()
-                        .any(|p| p.name == root && p.mode == RirParamMode::Borrow)
-                {
-                    return Err(CompileError::new(
-                        ErrorKind::MutateBorrowedValue {
-                            variable: self.interner.resolve(&root).to_string(),
-                        },
-                        self.rir.get(arg.value).span,
-                    ));
-                }
-                Some(root)
-            } else {
-                None
-            };
-
-            // Set while analyzing the argument so the use is treated as a
-            // borrow, not a move; restored afterwards.
-            let prev_byref_root = std::mem::replace(&mut ctx.byref_arg_root, byref_root);
-            let arg_result = self.analyze_inst(air, arg.value, ctx);
-            ctx.byref_arg_root = prev_byref_root;
-            let arg_result = arg_result?;
-
-            air_args.push(AirCallArg {
-                value: arg_result.air_ref,
-                mode: Self::convert_arg_mode(arg.mode),
-            });
-        }
-        Ok(air_args)
-    }
-
     /// Is `operand` a *direct* reference to a `borrow str` / `inout str`
     /// parameter — i.e. a borrowed `str` *view* value (ADR-0043 two-types
     /// model, RUE-386)?
@@ -846,15 +753,32 @@ impl<'a> Sema<'a> {
     /// there is never a second first-class root to chase. This keeps the check
     /// structural (one instruction shape), never a dataflow — exactly what the
     /// no-lifetimes spine requires.
-    pub(crate) fn is_str_view_operand(&self, operand: InstRef, ctx: &AnalysisContext) -> bool {
+    fn str_view_operand_mode(
+        &self,
+        operand: InstRef,
+        ctx: &AnalysisContext,
+    ) -> Option<RirParamMode> {
         if let InstData::VarRef { name } = self.rir.get(operand).data {
-            return ctx.params.iter().any(|p| {
-                p.name == name
-                    && matches!(p.mode, RirParamMode::Borrow | RirParamMode::Inout)
-                    && self.is_str_struct(p.ty)
-            });
+            // Locals shadow parameters. Without this guard a local reusing a
+            // view parameter's name would inherit its second-class provenance.
+            if ctx.locals.contains_key(&name) {
+                return None;
+            }
+            return ctx
+                .params
+                .iter()
+                .find(|p| {
+                    p.name == name
+                        && matches!(p.mode, RirParamMode::Borrow | RirParamMode::Inout)
+                        && self.is_str_struct(p.ty)
+                })
+                .map(|p| p.mode);
         }
-        false
+        None
+    }
+
+    pub(crate) fn is_str_view_operand(&self, operand: InstRef, ctx: &AnalysisContext) -> bool {
+        self.str_view_operand_mode(operand, ctx).is_some()
     }
 
     /// Enforce the ADR-0043 two-types string model at a *first-class* `str`
@@ -913,14 +837,28 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
-    /// Enforce inout-`str`-requires-local-provenance (ADR-0043 two-types model,
-    /// RUE-386): the operand of an `inout str` parameter must be a *local*
-    /// string buffer (`StrBuf`/`Str(N)`), never a first-class / static-backed
-    /// `str`. A static `str` lives in read-only `.rodata`, so an exclusive view
-    /// would enable a write-to-`.rodata` fault once byte mutation lands; and
-    /// since `str` is `Copy`, two roots can alias one static buffer in a way
-    /// per-root exclusivity cannot see. `found` is the operand's analyzed type.
-    pub(crate) fn reject_static_str_inout(&self, found: Type, span: Span) -> CompileResult<()> {
+    /// Validate the source of a bare `inout str` view (ADR-0043 two-types
+    /// model, RUE-386). A locally-backed `StrBuf`/`Str(N)` is accepted, as is
+    /// forwarding an existing `inout str` parameter (which preserves that
+    /// local provenance). A first-class/static `str` is E0496; an unrelated
+    /// type is the ordinary E0206 type mismatch.
+    pub(crate) fn validate_inout_str_operand(
+        &self,
+        operand: InstRef,
+        expected: Type,
+        found: Type,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<()> {
+        if found.is_never() || found.is_error() {
+            return Ok(());
+        }
+        if self.is_builtin_string(found)
+            || self.is_str_fixed_struct(found)
+            || self.str_view_operand_mode(operand, ctx) == Some(RirParamMode::Inout)
+        {
+            return Ok(());
+        }
         if self.is_str_struct(found) {
             return Err(
                 CompileError::new(ErrorKind::InoutStrRequiresLocalBuffer, span).with_help(
@@ -929,7 +867,7 @@ impl<'a> Sema<'a> {
                 ),
             );
         }
-        Ok(())
+        Err(self.type_mismatch_error(expected, found, span))
     }
 
     /// The tail (value) expression of a RIR block, descending through nested
@@ -956,8 +894,8 @@ impl<'a> Sema<'a> {
     /// `borrow arr` (where `arr: [T; N]`) passed to a `borrow s: [T]` parameter
     /// is coerced to a by-value slice `{ptr: @raw(arr[0]), len: N}`, which flows
     /// through the existing by-value aggregate ABI (the parameter is by-value —
-    /// see [`crate::sema::Sema`] parameter setup). Non-slice parameters use the
-    /// ordinary [`Self::analyze_call_args`] argument path unchanged.
+    /// see [`crate::sema::Sema`] parameter setup). All other arguments retain
+    /// the ordinary by-value/by-reference analysis in this same chokepoint.
     pub(crate) fn analyze_call_args_coerced(
         &mut self,
         air: &mut Air,
@@ -966,9 +904,8 @@ impl<'a> Sema<'a> {
         param_modes: &[RirParamMode],
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Vec<AirCallArg>> {
-        // Same loan-frame discipline as `analyze_call_args` (RUE-523): a
-        // by-value move of a root this call passes `inout`/`borrow` conflicts
-        // in either argument order.
+        // Loan-frame discipline (RUE-523): a by-value move of a root this call
+        // passes `inout`/`borrow` conflicts in either argument order.
         let frame: Vec<(Spur, CallLoanKind)> = args
             .iter()
             .filter_map(|arg| {
@@ -1016,11 +953,13 @@ impl<'a> Sema<'a> {
             // address. Unlike a slice view, `str` is first-class and
             // reassignable, so an assignment to the parameter rebinds the
             // caller's fat pointer via ParamStore.
-            let is_str_param = param_types.get(i).is_some_and(|pt| self.is_str_like(*pt));
+            let param_ty = param_types[i];
+            let param_mode = param_modes[i];
+            let is_str_param = self.is_str_like(param_ty);
             let is_inout_str_param =
-                arg.is_inout() && param_types.get(i).is_some_and(|pt| self.is_str_struct(*pt));
+                param_mode == RirParamMode::Inout && self.is_str_struct(param_ty);
             if is_str_param && !is_inout_str_param {
-                let str_ty = param_types[i];
+                let str_ty = param_ty;
                 // A `borrow` argument to a `borrow s: str` parameter views an
                 // existing string place — a `StrBuf`, `Str(N)`, `str`, or a
                 // re-borrowed view (ADR-0043 two-types model). The source is
@@ -1043,12 +982,26 @@ impl<'a> Sema<'a> {
                 let arg_result = self.analyze_inst(air, arg.value, ctx);
                 ctx.expected_type = prev_expected;
                 let arg_result = arg_result?;
+                // `Str(N)` is a nominal fixed-capacity value, not a bare
+                // string view. Contextual literals materialize directly as
+                // the expected capacity above; every other value must retain
+                // exact capacity identity (RUE-636). This check is semantic
+                // only: its Borrow/Inout ABI correction remains in RUE-636.
+                if self.is_str_fixed_struct(str_ty) && !arg_result.ty.can_coerce_to(&str_ty) {
+                    return Err(self.type_mismatch_error(
+                        str_ty,
+                        arg_result.ty,
+                        self.rir.get(arg.value).span,
+                    ));
+                }
                 // Two-types model (ADR-0043, RUE-386): a bare `str` parameter
                 // (Normal mode) requires a first-class `str`; a buffer or a
                 // borrowed view passed here would escape and dangle. A
                 // `borrow str` parameter (Borrow mode) is the sanctioned view
                 // and accepts a buffer, so it is exempt.
-                if param_modes.get(i) == Some(&RirParamMode::Normal) && self.is_str_struct(str_ty) {
+                if matches!(param_mode, RirParamMode::Normal | RirParamMode::Comptime)
+                    && self.is_str_struct(str_ty)
+                {
                     self.reject_non_first_class_str(
                         arg.value,
                         arg_result.ty,
@@ -1056,6 +1009,13 @@ impl<'a> Sema<'a> {
                         self.rir.get(arg.value).span,
                         ctx,
                     )?;
+                    if !arg_result.ty.can_coerce_to(&str_ty) {
+                        return Err(self.type_mismatch_error(
+                            str_ty,
+                            arg_result.ty,
+                            self.rir.get(arg.value).span,
+                        ));
+                    }
                 }
                 air_args.push(AirCallArg {
                     value: arg_result.air_ref,
@@ -1081,6 +1041,7 @@ impl<'a> Sema<'a> {
             let byref_root = if arg.is_inout() || arg.is_borrow() {
                 let root = require_byref_place_arg(self.rir, arg)?;
                 if arg.is_inout()
+                    && !ctx.locals.contains_key(&root)
                     && ctx
                         .params
                         .iter()
@@ -1106,7 +1067,13 @@ impl<'a> Sema<'a> {
             // / static `str` value is never a legal exclusive operand (closes
             // the write-to-`.rodata` and Copy-two-roots aliasing holes).
             if is_inout_str_param {
-                self.reject_static_str_inout(arg_result.ty, self.rir.get(arg.value).span)?;
+                self.validate_inout_str_operand(
+                    arg.value,
+                    param_ty,
+                    arg_result.ty,
+                    self.rir.get(arg.value).span,
+                    ctx,
+                )?;
             }
             air_args.push(AirCallArg {
                 value: arg_result.air_ref,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2814,9 +2814,9 @@ impl<'a> Sema<'a> {
 
                 // Handle move semantics based on parameter mode.
                 // A use as a by-ref call argument is a borrow, not a move
-                // (`analyze_call_args` sets `byref_arg_root`), so it neither marks
-                // the parameter moved nor counts as moving out of it. This is what
-                // permits forwarding an inout parameter: `f(inout v)` inside
+                // (`analyze_call_args_coerced` sets `byref_arg_root`), so it neither
+                // marks the parameter moved nor counts as moving out of it. This is
+                // what permits forwarding an inout parameter: `f(inout v)` inside
                 // `fn g(inout v: T)`.
                 let is_byref_arg_use = ctx.byref_arg_root == Some(name);
                 let mut moves_out = false;
@@ -2849,8 +2849,8 @@ impl<'a> Sema<'a> {
                             // `f(borrow v)` inside `fn g(borrow v: T)` is a sound
                             // read-only re-borrow and is allowed (RUE-143).
                             // `f(inout v)` — a mutable view of read-only memory —
-                            // was already rejected in `analyze_call_args` (E0428),
-                            // so a by-ref use reaching here is borrow-mode.
+                            // was already rejected by call-argument analysis
+                            // (E0428), so a by-ref use reaching here is borrow-mode.
                             // Anything else moves out of the borrow: rejected.
                             if !is_byref_arg_use {
                                 let name_str = self.interner.resolve(&name);

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -418,7 +418,7 @@ pub(crate) struct AnalysisContext<'a> {
     pub referenced_methods: HashSet<(StructId, Spur)>,
     /// While analyzing the value of an `inout`/`borrow` call argument, the ROOT
     /// variable of the place being passed by reference (set by
-    /// `analyze_call_args`; for `f(borrow o.f)` this is `o`). A by-ref argument
+    /// `analyze_call_args_coerced`; for `f(borrow o.f)` this is `o`). A by-ref argument
     /// is a borrow, not a move, so the variable-reference and place analyses
     /// must not mark the root (or the projected path) as moved — and must not
     /// reject forwarding a by-ref parameter to another function's by-ref
@@ -632,7 +632,7 @@ impl<'a> AnalysisContext<'a> {
             referenced_functions: HashSet::new(),
             referenced_methods: HashSet::new(),
             // A by-ref argument's value is a place — a variable or a
-            // field/index projection chain (enforced in analyze_call_args) —
+            // field/index projection chain (enforced in the call-argument analyzer) —
             // and index subexpressions are analyzed with the root cleared
             // (see try_trace_place_inner), so a loop can never be analyzed
             // while this is set; the fork starts between whole-expression

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::inst::{AirInstData, AirRef};
+    use crate::inst::{AirArgMode, AirInstData, AirRef};
     use crate::sema::{Sema, SemaOutput};
     use crate::types::Type;
     use rue_error::{CompileErrors, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures};
@@ -397,6 +397,120 @@ mod tests {
             errors.iter().next().unwrap().kind,
             ErrorKind::StrViewReassignment
         ));
+    }
+
+    #[test]
+    fn method_and_assoc_view_calls_encode_physical_modes() {
+        let source = r#"
+            struct Item { value: i32 }
+
+            struct Probe {
+                bias: i32,
+
+                fn method(
+                    borrow self,
+                    borrow read: str,
+                    inout edit: str,
+                    borrow item: Item,
+                ) -> i32 {
+                    self.bias + @intCast(read.len()) + @intCast(edit.len()) + item.value
+                }
+
+                fn assoc(borrow read: str, inout edit: str, borrow item: Item) -> i32 {
+                    11 + @intCast(read.len()) + @intCast(edit.len()) + item.value
+                }
+            }
+
+            fn main() -> i32 {
+                let probe = Probe { bias: 11 };
+                let read: Str(8) = "read";
+                let mut edit: Str(8) = "editor";
+                let item = Item { value: 0 };
+                probe.method(borrow read, inout edit, borrow item)
+                    + Probe.assoc(borrow read, inout edit, borrow item)
+            }
+        "#;
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let output = compile_to_air_with_preview_features(source, preview).unwrap();
+
+        let main = output
+            .functions
+            .iter()
+            .find(|function| function.name == "main")
+            .unwrap();
+        let call_modes: Vec<Vec<AirArgMode>> = main
+            .air
+            .iter()
+            .filter_map(|(_, inst)| match inst.data {
+                AirInstData::Call {
+                    args_start,
+                    args_len,
+                    ..
+                } => Some(
+                    main.air
+                        .get_call_args(args_start, args_len)
+                        .map(|arg| arg.mode)
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            call_modes,
+            vec![
+                vec![
+                    AirArgMode::Borrow,
+                    AirArgMode::Normal,
+                    AirArgMode::Inout,
+                    AirArgMode::Borrow,
+                ],
+                vec![AirArgMode::Normal, AirArgMode::Inout, AirArgMode::Borrow,],
+            ]
+        );
+
+        let method = output
+            .functions
+            .iter()
+            .find(|function| function.name == "Probe.method")
+            .unwrap();
+        assert_eq!(
+            method.param_modes.by_ref(),
+            &[true, false, false, true, true]
+        );
+        assert_eq!(
+            method.param_modes.writable(),
+            &[false, false, false, true, false]
+        );
+
+        let assoc = output
+            .functions
+            .iter()
+            .find(|function| function.name == "Probe::assoc")
+            .unwrap();
+        assert_eq!(assoc.param_modes.by_ref(), &[false, false, true, true]);
+        assert_eq!(assoc.param_modes.writable(), &[false, false, true, false]);
+    }
+
+    #[test]
+    fn method_and_assoc_fixed_string_literals_are_contextual() {
+        let source = r#"
+            struct Probe {
+                fn method(self, value: Str(8)) -> u64 { value.len() }
+                fn assoc(value: Str(8)) -> u64 { value.len() }
+            }
+
+            fn main() -> i32 {
+                let probe = Probe {};
+                @intCast(
+                    probe.method(if true { "hi" } else { "bye" })
+                        + Probe.assoc(if false { "long" } else { "four" })
+                )
+            }
+        "#;
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        compile_to_air_with_preview_features(source, preview).unwrap();
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -175,6 +175,64 @@ fn main() -> i32 {
 args = ["main.rue", "--preview", "slices", "-o", "prog"]
 exit_code = 60
 
+# User-defined methods and associated functions share the same view
+# materialization contract as free functions. Direct array arguments exercise
+# the method-signature inference seam as well as the AIR lowering seam.
+[[case]]
+name = "method_and_assoc_slice_view_coercions"
+files = [{ path = "main.rue", source = """
+struct Sum {
+    bias: i32,
+
+    fn method(borrow self, borrow s: [i32]) -> i32 {
+        self.bias + s[0] + s[1]
+    }
+
+    fn assoc(borrow s: [i32]) -> i32 {
+        s[0] + s[1]
+    }
+}
+
+fn main() -> i32 {
+    let values: [i32; 2] = [5, 7];
+    let sum = Sum { bias: 18 };
+    sum.method(borrow values) + Sum.assoc(borrow values)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 42
+
+# Forwarding an existing slice is a distinct physical case: the two-word view
+# must pass through by value (Normal AIR mode), not become a one-word Borrow
+# argument merely because the source still spells `borrow`.
+[[case]]
+name = "method_and_assoc_forward_slice_view"
+files = [{ path = "main.rue", source = """
+struct Sum {
+    bias: i32,
+
+    fn method(borrow self, borrow s: [i32]) -> i32 {
+        self.bias + s[0] + s[1]
+    }
+
+    fn assoc(borrow s: [i32]) -> i32 {
+        s[0] + s[1]
+    }
+}
+
+fn forward(borrow s: [i32]) -> i32 {
+    let sum = Sum { bias: 18 };
+    sum.method(borrow s) + Sum.assoc(borrow s)
+}
+
+fn main() -> i32 {
+    let values: [i32; 2] = [5, 7];
+    forward(borrow values)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 42
+
 # Passing an array whose element type does not match the slice element type is
 # a clean compile error (the coercion validates element compatibility, since
 # inference relaxes the whole-type equality for slice parameters).

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -423,6 +423,18 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.slices",
+        "method_and_assoc_forward_slice_view",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
+        "method_and_assoc_slice_view_coercions",
+        intrinsic(UnsupportedIntrinsicKind::RawAddress),
+        &[],
+    ),
+    Entry::new(
+        "cli.slices",
         "slice_param_constant_index",
         intrinsic(UnsupportedIntrinsicKind::RawAddress),
         &[],

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -258,6 +258,18 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "items.impl-blocks",
+        "method_and_assoc_forward_borrow_str_view",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "items.impl-blocks",
+        "method_and_assoc_string_view_coercions",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
         "items.unchecked",
         "ptr_ops_in_checked_ok",
         intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
@@ -531,6 +543,12 @@ const ENTRIES: &[Entry] = &[
         "types.str_type",
         "inout_str_accepts_local_buffer",
         semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "types.str_type",
+        "inout_str_view_can_be_forwarded",
+        semantic(SemanticGapKind::InoutParameterForwarding),
         &[],
     ),
     Entry::new(

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -476,6 +476,115 @@ fn main() -> i32 {
 exit_code = 3
 
 [[case]]
+name = "method_and_assoc_string_view_coercions"
+spec = ["3.7:58", "3.7:60", "4.10:4", "6.4:7", "6.4:12", "6.4:25"]
+description = "Method and associated-function parameters apply borrow/inout str view coercions to projected StrBuf places while receiver autoref stays implicit"
+preview = "string_trio"
+preview_should_pass = true
+source = """
+struct BufferBox { value: StrBuf }
+
+struct Probe {
+    bias: i32,
+
+    fn method(borrow self, borrow read: str, inout edit: str) -> i32 {
+        self.bias + @intCast(read.len()) + @intCast(edit.len())
+    }
+
+    fn assoc(borrow read: str, inout edit: str) -> i32 {
+        11 + @intCast(read.len()) + @intCast(edit.len())
+    }
+}
+
+fn main() -> i32 {
+    let left = BufferBox { value: "abcd" };
+    let mut right = BufferBox { value: "abcdef" };
+    let probe = Probe { bias: 11 };
+    probe.method(borrow left.value, inout right.value)
+        + Probe.assoc(borrow left.value, inout right.value)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "method_and_assoc_forward_borrow_str_view"
+spec = ["3.7:58", "6.1:23", "6.1:26", "6.4:7", "6.4:12", "6.4:25"]
+description = "An existing borrow str view is forwarded by value through method and associated-function parameters"
+preview = "string_trio"
+preview_should_pass = true
+source = """
+struct Probe {
+    bias: i32,
+
+    fn method(borrow self, borrow value: str) -> i32 {
+        self.bias + @intCast(value.len())
+    }
+
+    fn assoc(borrow value: str) -> i32 {
+        @intCast(value.len())
+    }
+}
+
+fn forward(borrow value: str) -> i32 {
+    let probe = Probe { bias: 32 };
+    probe.method(borrow value) + Probe.assoc(borrow value)
+}
+
+fn main() -> i32 {
+    let value = "hello";
+    forward(borrow value)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "method_and_assoc_reject_unrelated_string_arg_{surface}"
+spec = ["4.10:4", "6.4:7", "6.4:12"]
+description = "Method and associated-function view inference defers to sema without admitting unrelated source types"
+preview = "string_trio"
+preview_should_pass = true
+source = """
+struct Probe {
+    fn method(self, value: str) {}
+    fn assoc(value: str) {}
+}
+
+fn main() {
+    {body}
+}
+"""
+compile_fail = true
+error_contains = "E0206"
+params = [
+  { surface = "method", body = "let probe = Probe {}; probe.method(42);" },
+  { surface = "assoc", body = "Probe.assoc(42);" },
+]
+
+[[case]]
+name = "method_and_assoc_reject_mismatched_fixed_string_{surface}"
+spec = ["3.7:50", "4.10:4", "6.4:7", "6.4:12"]
+description = "Deferring contextual Str(N) inference does not erase exact capacity identity"
+preview = "string_trio"
+preview_should_pass = true
+source = """
+struct Probe {
+    fn method(self, value: Str(8)) {}
+    fn assoc(value: Str(8)) {}
+}
+
+fn main() {
+    let value: Str(9) = "value";
+    {body}
+}
+"""
+compile_fail = true
+error_contains = "E0206"
+params = [
+  { surface = "method", body = "let probe = Probe {}; probe.method(value);" },
+  { surface = "assoc", body = "Probe.assoc(value);" },
+]
+
+[[case]]
 name = "inout_self_requires_mut_receiver"
 spec = ["6.4:26"]
 compile_fail = true

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -332,6 +332,69 @@ fn main() -> i32 {
 """
 exit_code = 5
 
+# 6.1:35 — an inout parameter may be forwarded to another inout parameter.
+# An `inout str` parameter is already an exclusive view of caller-owned local
+# storage, not a first-class/static `str` that should trigger E0496.
+[[case]]
+name = "inout_str_view_can_be_forwarded"
+spec = ["3.7:58", "3.7:60", "6.1:35"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn inner(inout s: str) -> u64 {
+    s.len()
+}
+fn outer(inout s: str) -> u64 {
+    inner(inout s)
+}
+fn main() -> i32 {
+    let mut s: Str(8) = "hello";
+    @intCast(outer(inout s))
+}
+"""
+exit_code = 5
+
+# 3.7:60 — a local that shadows an `inout str` parameter is a new first-class
+# binding, not the existing exclusive view. It must not inherit the parameter's
+# local provenance and bypass E0496 for static-backed `str`.
+[[case]]
+name = "shadowed_local_str_is_not_an_inout_view"
+spec = ["3.7:60"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn inner(inout s: str) {}
+fn outer(inout s: str) {
+    let mut s: str = "static";
+    inner(inout s);
+}
+fn main() {
+    let mut buffer: Str(8) = "local";
+    outer(inout buffer);
+}
+"""
+compile_fail = true
+error_contains = "E0496"
+
+# 4.10:4 — contextual string handling is an enumerated compatibility rule,
+# not permission to pass an arbitrary same-width (or unrelated) value through
+# a string parameter's physical ABI. Borrow-str already rejects unrelated
+# places in its view materializer; these are the three formerly open paths.
+[[case]]
+name = "string_param_rejects_unrelated_type_{contract}"
+spec = ["4.10:4"]
+description = "A string or string-view parameter rejects an unrelated value before emitting an ABI-invalid call"
+preview = "string_trio"
+preview_should_pass = true
+source = "{source}"
+compile_fail = true
+error_contains = "E0206"
+params = [
+  { contract = "first_class_str", source = "fn take(s: str) {}\nfn main() { take(42); }" },
+  { contract = "fixed_string", source = "fn take(s: Str(8)) {}\nfn main() { take(42); }" },
+  { contract = "inout_str", source = "fn take(inout s: str) {}\nfn main() { let mut value = 42; take(inout value); }" },
+]
+
 # 3.7:58 — `inout str` is a second-class exclusive view. Its bytes may be
 # accessed through the view, but the view binding itself cannot be rebound as
 # a whole value. This also prevents a default 3-word StrBuf literal from being

--- a/docs/spec/src/04-expressions/10-call-expressions.md
+++ b/docs/spec/src/04-expressions/10-call-expressions.md
@@ -44,7 +44,17 @@ receiver-autoref rule (6.4:25).
 
 {{ rule(id="4.10:4", cat="legality-rule") }}
 
-Each argument's type **MUST** be the corresponding parameter's type. As everywhere, the one admitted coercion is from the never type (3.4:3); no other type difference is accepted (core calculus `docs/formal/01-core-calculus.md` §5.8, rule `(Call)`).
+Each argument's type **MUST** be the corresponding parameter's type after any
+argument-position coercion explicitly defined by that type's rules. Those
+coercions include the never type (3.4:3), a first-class `str` or string buffer
+viewed through a `borrow str` parameter, a caller-owned string buffer viewed
+through an `inout str` parameter (3.7:55, 3.7:58, 3.7:60), and the analogous
+fixed-array-to-slice coercion while the `slices` preview is enabled. View
+materialization may change the physical calling convention — for example, a
+borrowed two-word view is passed by value — but it does not admit an unrelated
+source type or change the exact source-level argument-mode rule (4.10:3). No
+other type difference is accepted (core calculus
+`docs/formal/01-core-calculus.md` §5.8, rule `(Call)`).
 
 {{ rule(id="4.10:5", cat="normative") }}
 

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -142,9 +142,18 @@ The body of a function **MUST NOT** move out of a `borrow` parameter. A borrowed
 {{ rule(id="6.1:26", cat="dynamic-semantics") }}
 
 When a function is called with a `borrow` argument:
-1. The address of the argument place is passed to the callee. For a field access or array index argument, this is the address of that field or element (an out-of-bounds index causes a runtime panic before the call); for a place rooted at a by-ref parameter of the caller, it is computed from the pointer the caller received
-2. The callee reads from the argument through this address
-3. After the call returns, the original variable is unchanged and still valid; a borrowed place is not moved out of its owner
+1. Ordinarily, the address of the argument place is passed to the callee. For a
+   field access or array index argument, this is the address of that field or
+   element (an out-of-bounds index causes a runtime panic before the call); for
+   a place rooted at a by-ref parameter of the caller, it is computed from the
+   pointer the caller received. When the parameter type explicitly defines an
+   argument-position view coercion (4.10:4), the caller instead materializes
+   that view from the place and passes it using the representation specified by
+   the type; `borrow str` and slice views are two-word values passed by value.
+2. The callee reads the original storage through the received address or
+   materialized view.
+3. After the call returns, the original variable is unchanged and still valid;
+   a borrowed place is not moved out of its owner.
 
 {{ rule(id="6.1:27", cat="example") }}
 


### PR DESCRIPTION
## Summary

- route method and associated-function arguments through the same representation-aware coercion path as direct calls while preserving receiver autoref loans
- make string compatibility authoritative in semantic analysis, including contextual Str(N) expressions, exact capacities, and legal inout str view forwarding
- pin caller and callee physical argument modes, native string and slice behavior, rejection boundaries, specification text, and exact oracle-model debt

## Root cause

Method and associated-function calls used a plain argument analyzer while borrowed views are materialized by value. Strict inference equality hid that split for direct values, but forwarded views and string compatibility could be accepted or lowered inconsistently across call surfaces.

## Boundary

This closes the shared call-coercion and source-type class for RUE-634. Exact physical borrow and inout ABI for fixed-capacity Str(N) remains explicitly scoped to RUE-636.

## Validation

- ./fmt.sh check
- ./clippy.sh: 41 targets
- ./test.sh: 34 targets; 0 failures
- spec: 2052 passed, 14 ignored
- traceability: 738/738 normative paragraphs
- CLI oracle: 642 agree, 98 registered gaps, 571 ineligible, 0 frontend failures, 0 disagreements
- spec oracle: 1347 agree, 101 registered gaps, 618 ineligible, 0 frontend failures, 0 disagreements
- generated oracle smoke: 64/64 agree

Independent soundness and coverage reviews completed with no remaining blocker.