### PR TITLE
RUE-650: own immutable source snapshots

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -29,9 +29,11 @@ mod diagnostic;
 mod drop_glue;
 mod semantic_order;
 mod source_metadata;
+mod source_snapshot;
 mod unit;
 
 pub use source_metadata::SourceMetadata;
+pub use source_snapshot::{MAX_SOURCE_BYTES, SourceSnapshot};
 pub use unit::{CompilationUnit, SourceStats};
 
 use rayon::prelude::*;
@@ -248,7 +250,9 @@ pub use rue_target::{Arch, Target};
 
 /// A source file with its path and content.
 ///
-/// Used for multi-file compilation to associate source content with file paths.
+/// This is the borrowed compatibility view used by existing multi-file APIs.
+/// Long-lived compiler and tooling inputs should use [`SourceSnapshot`], which
+/// owns immutable text and keeps paths in validated [`SourceMetadata`].
 #[derive(Debug, Clone)]
 pub struct SourceFile<'a> {
     /// Path to the source file (used for error messages).
@@ -273,7 +277,9 @@ impl<'a> SourceFile<'a> {
 /// Result of parsing a single file.
 ///
 /// Per-file ASTs share the [`ParsedProgram::interner`] returned by
-/// [`parse_all_files`]; there is no per-file interner state.
+/// [`parse_all_files`]; there is no per-file interner state. The raw interned
+/// symbols in these ASTs are valid only with that returned interner from the
+/// same parse invocation.
 #[derive(Debug)]
 pub struct ParsedFile {
     /// Path to the source file.
@@ -333,25 +339,35 @@ pub fn parse_all_files(sources: &[SourceFile<'_>]) -> MultiErrorResult<ParsedPro
     parse_all_files_with_source_metadata(sources, &source_metadata)
 }
 
-/// Parse source files after validating them against immutable metadata.
+/// Parse borrowed source files after validating them against immutable metadata.
 ///
-/// This is the canonical multi-file parsing boundary. Invalid source IDs,
+/// This compatibility adapter materializes one owned [`SourceSnapshot`] and
+/// delegates to [`parse_all_files_with_source_snapshot`]. Invalid source IDs,
 /// paths, or descriptor membership are rejected before any source is lexed.
 pub fn parse_all_files_with_source_metadata(
     sources: &[SourceFile<'_>],
     source_metadata: &SourceMetadata,
 ) -> MultiErrorResult<ParsedProgram> {
-    source_metadata
-        .validate_sources(sources)
+    let snapshot = SourceSnapshot::from_sources(sources, source_metadata.clone())
         .map_err(CompileErrors::from)?;
+    parse_all_files_with_source_snapshot(&snapshot)
+}
 
+/// Parse an immutable owned source snapshot with one shared interner.
+///
+/// This is the canonical multi-file parsing boundary. Snapshot construction
+/// has already validated exact source/metadata membership, so no caller-owned
+/// source storage is borrowed while parsing.
+pub fn parse_all_files_with_source_snapshot(
+    snapshot: &SourceSnapshot,
+) -> MultiErrorResult<ParsedProgram> {
     // Parse all files sequentially with a shared interner
     // This ensures Spur values are consistent across files for cross-file symbol resolution
-    let mut parsed_files = Vec::with_capacity(sources.len());
+    let mut parsed_files = Vec::with_capacity(snapshot.len());
     let mut interner = ThreadedRodeo::new();
     let mut errors = CompileErrors::new();
 
-    for source in sources {
+    for source in snapshot.files() {
         // Create lexer with shared interner and file ID for proper error reporting
         let lexer = Lexer::with_interner_and_file_id(source.source, interner, source.file_id);
 
@@ -1327,22 +1343,19 @@ fn source_metadata_from_sources(
         .map_err(CompileErrors::from)
 }
 
-/// Compile sources using an explicit, immutable root and source descriptor.
+/// Compile borrowed sources using an explicit immutable source descriptor.
 ///
-/// This is the canonical batch compilation boundary. The descriptor must
+/// This compatibility adapter materializes one owned [`SourceSnapshot`] and
+/// delegates to [`compile_source_snapshot_with_options`]. The descriptor must
 /// describe exactly `sources`; validation happens before lexing.
 pub fn compile_multi_file_with_source_metadata_and_options(
     sources: &[SourceFile<'_>],
     source_metadata: &SourceMetadata,
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
-    compile_multi_file_with_source_metadata_and_options_impl(
-        sources,
-        source_metadata,
-        options,
-        false,
-    )
-    .map(|(output, _stats)| output)
+    let snapshot = SourceSnapshot::from_sources(sources, source_metadata.clone())
+        .map_err(CompileErrors::from)?;
+    compile_source_snapshot_with_options(&snapshot, options)
 }
 
 /// Compile sources with explicit metadata and return live frontend metrics.
@@ -1351,23 +1364,39 @@ pub fn compile_multi_file_with_source_metadata_and_options_and_stats(
     source_metadata: &SourceMetadata,
     options: &CompileOptions,
 ) -> MultiErrorResult<(CompileOutput, SourceStats)> {
-    let (output, stats) = compile_multi_file_with_source_metadata_and_options_impl(
-        sources,
-        source_metadata,
-        options,
-        true,
-    )?;
+    let snapshot = SourceSnapshot::from_sources(sources, source_metadata.clone())
+        .map_err(CompileErrors::from)?;
+    compile_source_snapshot_with_options_and_stats(&snapshot, options)
+}
+
+/// Compile an immutable owned source snapshot.
+///
+/// This is the canonical batch compilation boundary. Cloning the snapshot for
+/// the compilation unit shares both its validated metadata and source text.
+pub fn compile_source_snapshot_with_options(
+    snapshot: &SourceSnapshot,
+    options: &CompileOptions,
+) -> MultiErrorResult<CompileOutput> {
+    compile_source_snapshot_with_options_impl(snapshot, options, false)
+        .map(|(output, _stats)| output)
+}
+
+/// Compile an immutable owned source snapshot and return live frontend metrics.
+pub fn compile_source_snapshot_with_options_and_stats(
+    snapshot: &SourceSnapshot,
+    options: &CompileOptions,
+) -> MultiErrorResult<(CompileOutput, SourceStats)> {
+    let (output, stats) = compile_source_snapshot_with_options_impl(snapshot, options, true)?;
     let mut stats = stats.expect("source stats requested");
-    stats.lines = sources
-        .iter()
+    stats.lines = snapshot
+        .files()
         .map(|source| source.source.lines().count())
         .sum();
     Ok((output, stats))
 }
 
-fn compile_multi_file_with_source_metadata_and_options_impl(
-    sources: &[SourceFile<'_>],
-    source_metadata: &SourceMetadata,
+fn compile_source_snapshot_with_options_impl(
+    snapshot: &SourceSnapshot,
     options: &CompileOptions,
     collect_stats: bool,
 ) -> MultiErrorResult<(CompileOutput, Option<SourceStats>)> {
@@ -1377,22 +1406,17 @@ fn compile_multi_file_with_source_metadata_and_options_impl(
     // (RUE-352). The jobs setting is now applied once in the driver's `main()`
     // via `configure_thread_pool` before dispatching to any path.
 
-    let total_source_bytes: usize = sources.iter().map(|s| s.source.len()).sum();
+    let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
     let _span = info_span!(
         "compile",
         target = %options.target,
-        file_count = sources.len(),
+        file_count = snapshot.len(),
         source_bytes = total_source_bytes
     )
     .entered();
 
     // Use CompilationUnit for the entire pipeline
-    let mut unit = CompilationUnit::with_source_metadata(
-        sources.to_vec(),
-        source_metadata.clone(),
-        options.clone(),
-    )
-    .map_err(CompileErrors::from)?;
+    let mut unit = CompilationUnit::from_source_snapshot(snapshot.clone(), options.clone());
     let output = unit.run_all()?;
     let stats = collect_stats.then(|| unit.collected_source_stats());
     Ok((output, stats))
@@ -2092,6 +2116,37 @@ mod tests {
     }
 
     #[test]
+    fn borrowed_and_snapshot_parse_routes_report_identical_errors() {
+        let root = FileId::new(4);
+        let helper = FileId::new(9);
+        let sources = [
+            SourceFile::new("helper.rue", "fn helper() -> i32 { # }", helper),
+            SourceFile::new("main.rue", "fn main() -> i32 { $ }", root),
+        ];
+        let metadata =
+            SourceMetadata::from_sources(&sources, root, std::collections::HashMap::new()).unwrap();
+        let snapshot = SourceSnapshot::from_sources(&sources, metadata.clone()).unwrap();
+
+        let borrowed = parse_all_files_with_source_metadata(&sources, &metadata).unwrap_err();
+        let owned = parse_all_files_with_source_snapshot(&snapshot).unwrap_err();
+        let fingerprint = |errors: &CompileErrors| {
+            errors
+                .iter()
+                .map(|error| {
+                    (
+                        error.kind.code(),
+                        error.span(),
+                        error.to_string(),
+                        format!("{:?}", error.diagnostic()),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(fingerprint(&borrowed), fingerprint(&owned));
+    }
+
+    #[test]
     fn raw_ast_boundary_rejects_undeclared_file_ids_before_lowering() {
         let declared = FileId::new(2);
         let metadata = SourceMetadata::new(
@@ -2201,6 +2256,61 @@ mod tests {
         assert_invalid_compiler_input(
             errors,
             "invalid compiler input: physical path for 3 is \"expected.rue\", but source file uses \"actual.rue\"",
+        );
+    }
+
+    #[test]
+    fn borrowed_and_snapshot_batch_routes_produce_identical_artifacts() {
+        let root = FileId::new(7);
+        let helper = FileId::new(2);
+        let sources = [
+            SourceFile::new(
+                "/checkout/main.rue",
+                "const helper = @import(\"helper.rue\"); fn main() -> i32 { let unused = 0; helper.answer() }",
+                root,
+            ),
+            SourceFile::new(
+                "/checkout/helper.rue",
+                "pub fn answer() -> i32 { 42 }",
+                helper,
+            ),
+        ];
+        let metadata = SourceMetadata::from_sources(
+            &sources,
+            root,
+            std::collections::HashMap::from([
+                (root, "main.rue".to_string()),
+                (helper, "helper.rue".to_string()),
+            ]),
+        )
+        .unwrap();
+        let snapshot = SourceSnapshot::from_sources(&sources, metadata.clone()).unwrap();
+
+        let (borrowed, borrowed_stats) =
+            compile_multi_file_with_source_metadata_and_options_and_stats(
+                &sources,
+                &metadata,
+                &CompileOptions::default(),
+            )
+            .unwrap();
+        let (owned, owned_stats) =
+            compile_source_snapshot_with_options_and_stats(&snapshot, &CompileOptions::default())
+                .unwrap();
+
+        assert_eq!(borrowed.elf, owned.elf);
+        assert_eq!(borrowed_stats, owned_stats);
+        assert!(!borrowed.warnings.is_empty());
+        assert_eq!(
+            borrowed
+                .warnings
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            owned
+                .warnings
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/rue-compiler/src/source_metadata.rs
+++ b/crates/rue-compiler/src/source_metadata.rs
@@ -199,8 +199,10 @@ impl SourceMetadata {
 
     /// The canonical logical semantic identity for `file_id`.
     ///
-    /// Logical paths are lexically normalized once during construction, so
-    /// this value is safe to use directly as an identity or query key.
+    /// Logical paths are lexically normalized once during construction. They
+    /// identify modules within this descriptor, but do not identify source
+    /// contents, snapshots, or interner epochs and are not standalone cache
+    /// keys.
     pub fn logical_path(&self, file_id: FileId) -> Option<&str> {
         self.logical_paths.get(&file_id).map(String::as_str)
     }

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -1,0 +1,458 @@
+//! Immutable, owned source text at compiler API boundaries.
+//!
+//! [`SourceMetadata`] owns source identities and paths, while this module owns
+//! the corresponding text. Keeping those responsibilities separate lets a
+//! snapshot cheaply share source buffers without duplicating or allowing path
+//! information to drift.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_span::FileId;
+
+use crate::{SourceFile, SourceMetadata};
+
+/// Maximum source byte length representable by Rue's `u32` span offsets.
+pub const MAX_SOURCE_BYTES: usize = u32::MAX as usize;
+
+/// An immutable, validated set of source texts and their metadata.
+///
+/// Cloning a snapshot is constant time: clones share both the descriptor and
+/// source table through a single [`Arc`]. Source text can also be retained
+/// independently through [`Self::shared_source_text`]. A [`FileId`] denotes
+/// diagnostic membership within the snapshot; it does not identify content or
+/// form a standalone cache key.
+#[derive(Debug, Clone)]
+pub struct SourceSnapshot {
+    data: Arc<SourceSnapshotData>,
+}
+
+#[derive(Debug)]
+struct SourceSnapshotData {
+    metadata: SourceMetadata,
+    contents: Vec<(FileId, Arc<String>)>,
+    index: HashMap<FileId, usize>,
+}
+
+impl SourceSnapshot {
+    /// Build a snapshot from validated metadata and owned source buffers.
+    ///
+    /// `contents` may be in any order, and that caller-supplied order is
+    /// retained by [`Self::files`]. Its `FileId` set must exactly match the
+    /// metadata descriptor. Validation errors are selected in ascending
+    /// `FileId` order and are reported before any frontend work begins.
+    pub fn new(
+        metadata: SourceMetadata,
+        contents: Vec<(FileId, Arc<String>)>,
+    ) -> CompileResult<Self> {
+        let mut counts = HashMap::<FileId, usize>::new();
+        for (file_id, _) in &contents {
+            *counts.entry(*file_id).or_default() += 1;
+        }
+
+        let mut duplicate_ids: Vec<_> = counts
+            .iter()
+            .filter_map(|(&file_id, &count)| (count > 1).then_some(file_id))
+            .collect();
+        duplicate_ids.sort_by_key(|file_id| file_id.index());
+        if !duplicate_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "source contents contain duplicate file IDs: {}",
+                display_file_ids(&duplicate_ids)
+            )));
+        }
+
+        let seen: HashSet<_> = counts.keys().copied().collect();
+        let mut unknown_ids: Vec<_> = seen
+            .iter()
+            .copied()
+            .filter(|&file_id| !metadata.contains_file(file_id))
+            .collect();
+        unknown_ids.sort_by_key(|file_id| file_id.index());
+        if !unknown_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "source contents contain unknown file IDs: {}",
+                display_file_ids(&unknown_ids)
+            )));
+        }
+
+        let missing_ids: Vec<_> = metadata
+            .file_ids()
+            .filter(|file_id| !seen.contains(file_id))
+            .collect();
+        if !missing_ids.is_empty() {
+            return Err(invalid_input(format!(
+                "source contents are missing metadata file IDs: {}",
+                display_file_ids(&missing_ids)
+            )));
+        }
+
+        validate_source_lengths(
+            contents
+                .iter()
+                .map(|(file_id, source)| (*file_id, source.len())),
+            &metadata,
+        )?;
+
+        let index = contents
+            .iter()
+            .enumerate()
+            .map(|(index, (file_id, _))| (*file_id, index))
+            .collect();
+
+        Ok(Self {
+            data: Arc::new(SourceSnapshotData {
+                metadata,
+                contents,
+                index,
+            }),
+        })
+    }
+
+    /// Copy borrowed compatibility inputs into one immutable snapshot.
+    ///
+    /// Physical paths are validated against `metadata` before source text is
+    /// copied. Each source is then copied directly into its final owned
+    /// [`String`] buffer.
+    pub fn from_sources(
+        sources: &[SourceFile<'_>],
+        metadata: SourceMetadata,
+    ) -> CompileResult<Self> {
+        metadata.validate_sources(sources)?;
+        validate_source_lengths(
+            sources
+                .iter()
+                .map(|source| (source.file_id, source.source.len())),
+            &metadata,
+        )?;
+        let contents = sources
+            .iter()
+            .map(|source| (source.file_id, Arc::new(source.source.to_owned())))
+            .collect();
+        Self::new(metadata, contents)
+    }
+
+    /// The validated identities and paths for this snapshot.
+    #[inline]
+    pub fn metadata(&self) -> &SourceMetadata {
+        &self.data.metadata
+    }
+
+    /// Number of source files in this snapshot.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.data.contents.len()
+    }
+
+    /// Whether this snapshot contains no source files.
+    ///
+    /// Validated metadata is never empty, so a constructed snapshot always
+    /// returns `false`.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.data.contents.is_empty()
+    }
+
+    /// Borrow the source text for `file_id`.
+    pub fn source_text(&self, file_id: FileId) -> Option<&str> {
+        self.content(file_id).map(|source| source.as_str())
+    }
+
+    /// Share ownership of the source text for `file_id`.
+    pub fn shared_source_text(&self, file_id: FileId) -> Option<Arc<String>> {
+        self.content(file_id).cloned()
+    }
+
+    /// Borrow one source as a compatibility [`SourceFile`] view.
+    pub fn source_file(&self, file_id: FileId) -> Option<SourceFile<'_>> {
+        let index = *self.data.index.get(&file_id)?;
+        Some(self.file_at(index))
+    }
+
+    /// Borrow all sources in caller-supplied order.
+    pub fn files(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = SourceFile<'_>> + ExactSizeIterator + '_ {
+        (0..self.data.contents.len()).map(|index| self.file_at(index))
+    }
+
+    fn content(&self, file_id: FileId) -> Option<&Arc<String>> {
+        let index = *self.data.index.get(&file_id)?;
+        let (stored_file_id, source) = &self.data.contents[index];
+        debug_assert_eq!(*stored_file_id, file_id);
+        Some(source)
+    }
+
+    fn file_at(&self, index: usize) -> SourceFile<'_> {
+        let (file_id, source) = &self.data.contents[index];
+        let path = self
+            .data
+            .metadata
+            .physical_path(*file_id)
+            .expect("snapshot contents validated against metadata");
+        SourceFile::new(path, source.as_str(), *file_id)
+    }
+}
+
+fn validate_source_len(file_id: FileId, path: &str, len: usize) -> CompileResult<()> {
+    if len > MAX_SOURCE_BYTES {
+        return Err(invalid_input(format!(
+            "source text for file ID {} ({path:?}) is {len} bytes, exceeding the maximum supported length of {} bytes",
+            file_id.index(),
+            MAX_SOURCE_BYTES
+        )));
+    }
+    Ok(())
+}
+
+fn validate_source_lengths(
+    lengths: impl IntoIterator<Item = (FileId, usize)>,
+    metadata: &SourceMetadata,
+) -> CompileResult<()> {
+    let mut lengths: Vec<_> = lengths.into_iter().collect();
+    lengths.sort_by_key(|(file_id, _)| file_id.index());
+    for (file_id, len) in lengths {
+        let path = metadata
+            .physical_path(file_id)
+            .expect("source length IDs validated against metadata");
+        validate_source_len(file_id, path, len)?;
+    }
+    Ok(())
+}
+
+fn invalid_input(message: impl Into<String>) -> CompileError {
+    CompileError::without_span(ErrorKind::InvalidCompilerInput(message.into()))
+}
+
+fn display_file_ids(file_ids: &[FileId]) -> String {
+    file_ids
+        .iter()
+        .map(|file_id| file_id.index().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata(entries: &[(u32, &str)]) -> SourceMetadata {
+        let paths: HashMap<_, _> = entries
+            .iter()
+            .map(|&(file_id, path)| (FileId::new(file_id), path.to_owned()))
+            .collect();
+        SourceMetadata::new(FileId::new(entries[0].0), paths.clone(), paths).unwrap()
+    }
+
+    fn contents(entries: &[(u32, &str)]) -> Vec<(FileId, Arc<String>)> {
+        entries
+            .iter()
+            .map(|&(file_id, source)| (FileId::new(file_id), Arc::new(source.to_owned())))
+            .collect()
+    }
+
+    fn error_message(result: CompileResult<SourceSnapshot>) -> String {
+        result.unwrap_err().to_string()
+    }
+
+    #[test]
+    fn requires_exact_metadata_membership() {
+        let descriptor = metadata(&[(2, "two.rue"), (4, "four.rue"), (8, "eight.rue")]);
+        assert_eq!(
+            error_message(SourceSnapshot::new(
+                descriptor.clone(),
+                contents(&[(8, "eight"), (2, "two"), (8, "duplicate"), (2, "again")])
+            )),
+            "invalid compiler input: source contents contain duplicate file IDs: 2, 8"
+        );
+        assert_eq!(
+            error_message(SourceSnapshot::new(
+                descriptor.clone(),
+                contents(&[(9, "nine"), (7, "seven"), (2, "two")])
+            )),
+            "invalid compiler input: source contents contain unknown file IDs: 7, 9"
+        );
+        assert_eq!(
+            error_message(SourceSnapshot::new(descriptor, contents(&[(8, "eight")]))),
+            "invalid compiler input: source contents are missing metadata file IDs: 2, 4"
+        );
+    }
+
+    #[test]
+    fn validation_diagnostics_do_not_depend_on_caller_order() {
+        let first = error_message(SourceSnapshot::new(
+            metadata(&[(1, "one.rue")]),
+            contents(&[(9, "nine"), (4, "four")]),
+        ));
+        let second = error_message(SourceSnapshot::new(
+            metadata(&[(1, "one.rue")]),
+            contents(&[(4, "four"), (9, "nine")]),
+        ));
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first,
+            "invalid compiler input: source contents contain unknown file IDs: 4, 9"
+        );
+    }
+
+    #[test]
+    fn preserves_caller_order_for_borrowed_file_views() {
+        let snapshot = SourceSnapshot::new(
+            metadata(&[(10, "ten.rue"), (20, "twenty.rue"), (30, "thirty.rue")]),
+            contents(&[(30, "thirty"), (10, "ten"), (20, "twenty")]),
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.len(), 3);
+        assert!(!snapshot.is_empty());
+        assert_eq!(
+            snapshot
+                .files()
+                .map(|file| (file.file_id, file.path, file.source))
+                .collect::<Vec<_>>(),
+            [
+                (FileId::new(30), "thirty.rue", "thirty"),
+                (FileId::new(10), "ten.rue", "ten"),
+                (FileId::new(20), "twenty.rue", "twenty"),
+            ]
+        );
+        let first_from_back = snapshot.files().next_back().unwrap();
+        assert_eq!(first_from_back.file_id, FileId::new(20));
+    }
+
+    #[test]
+    fn indexed_access_uses_metadata_paths_and_shares_source_arcs() {
+        let source = Arc::new("fn main() {}".to_owned());
+        let snapshot = SourceSnapshot::new(
+            metadata(&[(7, "src/main.rue")]),
+            vec![(FileId::new(7), Arc::clone(&source))],
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.source_text(FileId::new(7)), Some("fn main() {}"));
+        assert_eq!(snapshot.source_text(FileId::new(8)), None);
+        let shared = snapshot.shared_source_text(FileId::new(7)).unwrap();
+        assert!(Arc::ptr_eq(&source, &shared));
+        assert!(snapshot.shared_source_text(FileId::new(8)).is_none());
+        let file = snapshot.source_file(FileId::new(7)).unwrap();
+        assert_eq!(file.path, "src/main.rue");
+        assert_eq!(file.source, "fn main() {}");
+        assert!(snapshot.source_file(FileId::new(8)).is_none());
+    }
+
+    #[test]
+    fn clones_share_snapshot_data_and_external_arc_mutation_is_isolated() {
+        let source = Arc::new("original".to_owned());
+        let snapshot = SourceSnapshot::new(
+            metadata(&[(1, "main.rue")]),
+            vec![(FileId::new(1), Arc::clone(&source))],
+        )
+        .unwrap();
+        let clone = snapshot.clone();
+
+        assert!(Arc::ptr_eq(&snapshot.data, &clone.data));
+
+        let mut external = source;
+        Arc::make_mut(&mut external).push_str(" changed");
+        assert_eq!(external.as_str(), "original changed");
+        assert_eq!(snapshot.source_text(FileId::new(1)), Some("original"));
+        assert_eq!(clone.source_text(FileId::new(1)), Some("original"));
+    }
+
+    #[test]
+    fn edited_snapshots_reuse_unchanged_text_without_mutating_old_views() {
+        let root = FileId::new(1);
+        let helper = FileId::new(2);
+        let old_root = Arc::new("fn main() -> i32 { helper() }".to_owned());
+        let shared_helper = Arc::new("fn helper() -> i32 { 1 }".to_owned());
+        let old = SourceSnapshot::new(
+            metadata(&[(1, "/old/main.rue"), (2, "/old/helper.rue")]),
+            vec![
+                (root, Arc::clone(&old_root)),
+                (helper, Arc::clone(&shared_helper)),
+            ],
+        )
+        .unwrap();
+
+        let edited_root = Arc::new("fn main() -> i32 { helper() + 1 }".to_owned());
+        let edited = SourceSnapshot::new(
+            metadata(&[(1, "/new/main.rue"), (2, "/new/helper.rue")]),
+            vec![
+                (root, Arc::clone(&edited_root)),
+                (helper, old.shared_source_text(helper).unwrap()),
+            ],
+        )
+        .unwrap();
+
+        assert!(Arc::ptr_eq(
+            &old.shared_source_text(helper).unwrap(),
+            &edited.shared_source_text(helper).unwrap()
+        ));
+        assert!(!Arc::ptr_eq(
+            &old.shared_source_text(root).unwrap(),
+            &edited.shared_source_text(root).unwrap()
+        ));
+        assert_eq!(old.source_text(root), Some("fn main() -> i32 { helper() }"));
+        assert_eq!(old.source_file(root).unwrap().path, "/old/main.rue");
+        assert_eq!(
+            edited.source_text(root),
+            Some("fn main() -> i32 { helper() + 1 }")
+        );
+        assert_eq!(edited.source_file(root).unwrap().path, "/new/main.rue");
+    }
+
+    #[test]
+    fn source_snapshots_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SourceSnapshot>();
+    }
+
+    #[test]
+    fn compatibility_adapter_copies_borrowed_text_and_validates_paths() {
+        let mut borrowed = "borrowed".to_owned();
+        let descriptor = metadata(&[(3, "main.rue")]);
+        let snapshot = SourceSnapshot::from_sources(
+            &[SourceFile::new("main.rue", &borrowed, FileId::new(3))],
+            descriptor.clone(),
+        )
+        .unwrap();
+
+        borrowed.push_str(" changed");
+        assert_eq!(snapshot.source_text(FileId::new(3)), Some("borrowed"));
+
+        let wrong_path = [SourceFile::new("other.rue", "source", FileId::new(3))];
+        assert_eq!(
+            error_message(SourceSnapshot::from_sources(&wrong_path, descriptor)),
+            "invalid compiler input: physical path for 3 is \"main.rue\", but source file uses \"other.rue\""
+        );
+    }
+
+    #[test]
+    fn moving_a_string_into_a_snapshot_preserves_its_buffer() {
+        let source = String::from("a source buffer long enough to make allocation observable");
+        let buffer = source.as_ptr();
+        let snapshot = SourceSnapshot::new(
+            metadata(&[(5, "main.rue")]),
+            vec![(FileId::new(5), Arc::new(source))],
+        )
+        .unwrap();
+
+        assert_eq!(
+            snapshot.source_text(FileId::new(5)).unwrap().as_ptr(),
+            buffer
+        );
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn rejects_source_lengths_that_spans_cannot_represent() {
+        assert_eq!(
+            validate_source_len(FileId::new(12), "large.rue", u32::MAX as usize + 1)
+                .unwrap_err()
+                .to_string(),
+            "invalid compiler input: source text for file ID 12 (\"large.rue\") is 4294967296 bytes, exceeding the maximum supported length of 4294967295 bytes"
+        );
+    }
+}

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -31,7 +31,7 @@
 //! // Or, equivalently: let output = unit.run_all()?;
 //! ```
 
-use std::collections::HashMap;
+use std::{collections::HashMap, marker::PhantomData};
 
 use lasso::ThreadedRodeo;
 use tracing::{info, info_span};
@@ -39,7 +39,7 @@ use tracing::{info, info_span};
 use crate::{
     Ast, AstGen, CompileErrors, CompileOptions, CompileOutput, CompileResult, CompileWarning,
     FunctionWithCfg, Lexer, MultiErrorResult, Parser, Rir, Sema, SourceFile, SourceMetadata,
-    TypeInternPool, build_functions_and_cfgs, compile_backend,
+    SourceSnapshot, TypeInternPool, build_functions_and_cfgs, compile_backend,
 };
 use rue_span::FileId;
 
@@ -82,12 +82,12 @@ pub struct CompilationUnit<'src> {
     options: CompileOptions,
 
     // === Source ===
-    /// Source files being compiled.
-    sources: Vec<SourceFile<'src>>,
+    /// Immutable source contents and validated identities being compiled.
+    source_snapshot: SourceSnapshot,
     /// Work metrics collected from those sources and the live parse.
     source_stats: SourceStats,
-    /// Validated physical paths, logical identities, and designated root.
-    source_metadata: SourceMetadata,
+    /// Retains the lifetime-shaped API of the borrowed compatibility constructors.
+    _source_lifetime: PhantomData<&'src ()>,
 
     // === Phase 1: Parsing ===
     /// Merged AST containing all items (populated by `parse()`).
@@ -107,6 +107,16 @@ pub struct CompilationUnit<'src> {
     strings: Option<Vec<String>>,
     /// Warnings collected during compilation.
     warnings: Vec<CompileWarning>,
+}
+
+impl CompilationUnit<'static> {
+    /// Create a compilation unit from an already validated, immutable snapshot.
+    ///
+    /// Unlike the borrowed compatibility constructors, the returned unit does
+    /// not retain a source lifetime: the snapshot owns and shares its contents.
+    pub fn from_source_snapshot(source_snapshot: SourceSnapshot, options: CompileOptions) -> Self {
+        Self::from_validated_snapshot(source_snapshot, options)
+    }
 }
 
 impl<'src> CompilationUnit<'src> {
@@ -132,11 +142,8 @@ impl<'src> CompilationUnit<'src> {
             .map(|source| source.file_id)
             .unwrap_or(FileId::DEFAULT);
         let source_metadata = SourceMetadata::from_sources(&sources, root_file_id, HashMap::new())?;
-        Ok(Self::from_validated_metadata(
-            sources,
-            source_metadata,
-            options,
-        ))
+        let source_snapshot = SourceSnapshot::from_sources(&sources, source_metadata)?;
+        Ok(Self::from_validated_snapshot(source_snapshot, options))
     }
 
     /// Create a compilation unit with validated, caller-provided source identities.
@@ -155,23 +162,17 @@ impl<'src> CompilationUnit<'src> {
         source_metadata: SourceMetadata,
         options: CompileOptions,
     ) -> CompileResult<Self> {
-        source_metadata.validate_sources(&sources)?;
-
-        Ok(Self::from_validated_metadata(
-            sources,
-            source_metadata,
-            options,
-        ))
+        let source_snapshot = SourceSnapshot::from_sources(&sources, source_metadata)?;
+        Ok(Self::from_validated_snapshot(source_snapshot, options))
     }
 
-    fn from_validated_metadata(
-        sources: Vec<SourceFile<'src>>,
-        source_metadata: SourceMetadata,
-        options: CompileOptions,
-    ) -> Self {
+    fn from_validated_snapshot(source_snapshot: SourceSnapshot, options: CompileOptions) -> Self {
         let source_stats = SourceStats {
-            files: sources.len(),
-            bytes: sources.iter().map(|source| source.source.len()).sum(),
+            files: source_snapshot.len(),
+            bytes: source_snapshot
+                .files()
+                .map(|source| source.source.len())
+                .sum(),
             // Count lines lazily in source_stats(); ordinary compilation does
             // not need to scan every source solely for benchmark metadata.
             lines: 0,
@@ -180,9 +181,9 @@ impl<'src> CompilationUnit<'src> {
 
         Self {
             options,
-            sources,
+            source_snapshot,
             source_stats,
-            source_metadata,
+            _source_lifetime: PhantomData,
             merged_ast: None,
             interner: None,
             rir: None,
@@ -209,15 +210,15 @@ impl<'src> CompilationUnit<'src> {
     /// - Any file fails to lex or parse
     /// - Duplicate function, struct, or enum definitions are found
     pub fn parse(&mut self) -> MultiErrorResult<()> {
-        let _span = info_span!("parse", file_count = self.sources.len()).entered();
+        let _span = info_span!("parse", file_count = self.source_snapshot.len()).entered();
 
         // Parse all files with a shared interner
-        let mut parsed_files = Vec::with_capacity(self.sources.len());
+        let mut parsed_files = Vec::with_capacity(self.source_snapshot.len());
         let mut interner = ThreadedRodeo::new();
         let mut errors = CompileErrors::new();
         self.source_stats.tokens = 0;
 
-        for source in &self.sources {
+        for source in self.source_snapshot.files() {
             let _file_span = info_span!("parse_file", path = %source.path).entered();
 
             // Create lexer with shared interner and file ID
@@ -364,7 +365,7 @@ impl<'src> CompilationUnit<'src> {
         // while sema consumes a private logical-path-ordered lowering. This
         // makes allocation and artifact layout canonical without changing the
         // caller-visible AST/RIR contract (RUE-624).
-        let semantic_ast = crate::semantic_order::for_sema(ast, &self.source_metadata);
+        let semantic_ast = crate::semantic_order::for_sema(ast, self.source_snapshot.metadata());
         let semantic_rir = {
             let _span = info_span!("semantic_astgen").entered();
             AstGen::new(&semantic_ast, interner).generate()
@@ -379,9 +380,9 @@ impl<'src> CompilationUnit<'src> {
                 self.options.preview_features.clone(),
                 self.options.target,
             );
-            sema.set_root_file_id(self.source_metadata.root_file_id());
-            sema.set_file_paths(self.source_metadata.physical_path_map().clone());
-            sema.set_symbol_paths(self.source_metadata.logical_path_map().clone());
+            sema.set_root_file_id(self.source_snapshot.metadata().root_file_id());
+            sema.set_file_paths(self.source_snapshot.metadata().physical_path_map().clone());
+            sema.set_symbol_paths(self.source_snapshot.metadata().logical_path_map().clone());
             let output = sema.analyze_all()?;
             info!(
                 function_count = output.functions.len(),
@@ -551,20 +552,25 @@ impl<'src> CompilationUnit<'src> {
 
     /// Get the file paths map.
     pub fn file_paths(&self) -> &HashMap<FileId, String> {
-        self.source_metadata.physical_path_map()
+        self.source_snapshot.metadata().physical_path_map()
     }
 
     /// Get the validated source identities and designated semantic root.
     pub fn source_metadata(&self) -> &SourceMetadata {
-        &self.source_metadata
+        self.source_snapshot.metadata()
+    }
+
+    /// Get the immutable source snapshot owned by this compilation unit.
+    pub fn source_snapshot(&self) -> &SourceSnapshot {
+        &self.source_snapshot
     }
 
     /// Get source metrics collected by the live frontend.
     pub fn source_stats(&self) -> SourceStats {
         SourceStats {
             lines: self
-                .sources
-                .iter()
+                .source_snapshot
+                .files()
                 .map(|source| source.source.lines().count())
                 .sum(),
             ..self.source_stats
@@ -635,7 +641,7 @@ impl<'src> CompilationUnit<'src> {
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::Write as _;
+    use std::{fmt::Write as _, sync::Arc};
 
     use super::*;
     use crate::{FileId, RirPrinter};
@@ -659,6 +665,39 @@ mod tests {
         assert!(unit.is_lowered());
         assert!(unit.is_analyzed());
         assert_eq!(unit.functions().len(), 1);
+    }
+
+    #[test]
+    fn source_snapshot_unit_owns_and_shares_source_text() {
+        let file_id = FileId::new(1);
+        let metadata = SourceMetadata::new(
+            file_id,
+            HashMap::from([(file_id, "main.rue".to_string())]),
+            HashMap::from([(file_id, "main.rue".to_string())]),
+        )
+        .unwrap();
+
+        let mut unit = {
+            let source = Arc::new("fn main() -> i32 { 42 }".to_string());
+            let snapshot =
+                SourceSnapshot::new(metadata, vec![(file_id, Arc::clone(&source))]).unwrap();
+            let unit = CompilationUnit::from_source_snapshot(snapshot, CompileOptions::default());
+            let retained = unit
+                .source_snapshot()
+                .shared_source_text(file_id)
+                .expect("snapshot should retain the source");
+
+            assert!(Arc::ptr_eq(&source, &retained));
+            unit
+        };
+
+        fn assert_static<T: 'static>(_: &T) {}
+        assert_static(&unit);
+        assert_eq!(
+            unit.source_snapshot().source_text(file_id),
+            Some("fn main() -> i32 { 42 }")
+        );
+        unit.run_frontend().unwrap();
     }
 
     #[test]
@@ -824,6 +863,12 @@ mod tests {
         artifact: Vec<u8>,
     }
 
+    #[derive(Clone, Copy)]
+    enum SourceRoute {
+        Borrowed,
+        Snapshot,
+    }
+
     fn compile_repro_fingerprint(
         physical_root: &str,
         root_id: FileId,
@@ -831,6 +876,7 @@ mod tests {
         right_id: FileId,
         shared_id: FileId,
         reverse_siblings: bool,
+        source_route: SourceRoute,
     ) -> ReproFingerprint {
         let main_path = format!("{physical_root}/main.rue");
         let left_path = format!("{physical_root}/left/types.rue");
@@ -901,12 +947,18 @@ mod tests {
             ]),
         )
         .unwrap();
-        let mut unit = CompilationUnit::with_source_metadata(
-            sources,
-            source_metadata,
-            CompileOptions::default(),
-        )
-        .unwrap();
+        let mut unit = match source_route {
+            SourceRoute::Borrowed => CompilationUnit::with_source_metadata(
+                sources,
+                source_metadata,
+                CompileOptions::default(),
+            )
+            .unwrap(),
+            SourceRoute::Snapshot => {
+                let snapshot = SourceSnapshot::from_sources(&sources, source_metadata).unwrap();
+                CompilationUnit::from_source_snapshot(snapshot, CompileOptions::default())
+            }
+        };
         unit.run_frontend().expect("frontend should compile");
 
         let pool = unit.type_pool();
@@ -971,6 +1023,7 @@ mod tests {
             FileId::new(3),
             FileId::new(4),
             false,
+            SourceRoute::Borrowed,
         );
         let reversed = compile_repro_fingerprint(
             "/tmp/a-deliberately-much-longer-relocated-rue-root",
@@ -979,6 +1032,7 @@ mod tests {
             FileId::new(7),
             FileId::new(55),
             true,
+            SourceRoute::Borrowed,
         );
 
         assert_eq!(forward.type_symbols, reversed.type_symbols);
@@ -1032,6 +1086,35 @@ mod tests {
             forward.artifact.len(),
             reversed.artifact.len()
         );
+    }
+
+    #[test]
+    fn borrowed_and_snapshot_units_match_adversarial_frontend_artifacts() {
+        let borrowed = compile_repro_fingerprint(
+            "/tmp/rue-snapshot-parity",
+            FileId::new(40),
+            FileId::new(9),
+            FileId::new(2),
+            FileId::new(77),
+            true,
+            SourceRoute::Borrowed,
+        );
+        let snapshot = compile_repro_fingerprint(
+            "/tmp/rue-snapshot-parity",
+            FileId::new(40),
+            FileId::new(9),
+            FileId::new(2),
+            FileId::new(77),
+            true,
+            SourceRoute::Snapshot,
+        );
+
+        assert_eq!(borrowed.type_symbols, snapshot.type_symbols);
+        assert_eq!(borrowed.function_names, snapshot.function_names);
+        assert_eq!(borrowed.strings, snapshot.strings);
+        assert_eq!(borrowed.observable_rir, snapshot.observable_rir);
+        assert_eq!(borrowed.textual_frontend, snapshot.textual_frontend);
+        assert_eq!(borrowed.artifact, snapshot.artifact);
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -5,6 +5,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 #[cfg(target_os = "macos")]
 use std::process::Command;
+use std::sync::Arc;
 
 use tracing::Level;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -14,13 +15,13 @@ mod timing;
 
 use rue_compiler::{
     CompileError, CompileErrors, CompileOptions, CompileWarning, ErrorKind, FileId, Lexer,
-    LinkerMode, MultiFileFormatter, MultiFileJsonFormatter, OptLevel, ParsedProgram,
-    PreviewFeature, PreviewFeatures, SourceFile, SourceInfo, SourceMetadata, Span, TokenKind,
-    compile_multi_file_with_source_metadata_and_options,
-    compile_multi_file_with_source_metadata_and_options_and_stats, configure_thread_pool,
-    generate_emitted_asm, generate_liveness_info, generate_lowering_info, generate_mir,
-    generate_regalloc_info, generate_stack_frame_info, import_candidate_groups, merge_symbols,
-    parse_all_files_with_source_metadata,
+    LinkerMode, MAX_SOURCE_BYTES, MultiFileFormatter, MultiFileJsonFormatter, OptLevel,
+    ParsedProgram, PreviewFeature, PreviewFeatures, SourceInfo, SourceMetadata, SourceSnapshot,
+    Span, TokenKind, compile_source_snapshot_with_options,
+    compile_source_snapshot_with_options_and_stats, configure_thread_pool, generate_emitted_asm,
+    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
+    generate_stack_frame_info, import_candidate_groups, merge_symbols,
+    parse_all_files_with_source_snapshot,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -1348,6 +1349,30 @@ impl DependencyGraph {
     }
 }
 
+/// Reject a source before discovery lexing if Rue's span representation cannot
+/// describe its byte offsets.
+fn validate_source_len_before_discovery(
+    file_id: FileId,
+    path: &str,
+    source: &str,
+    error_format: ErrorFormat,
+) -> Result<(), ()> {
+    if source.len() <= MAX_SOURCE_BYTES {
+        return Ok(());
+    }
+
+    let error = CompileError::without_span(ErrorKind::InvalidCompilerInput(format!(
+        "source text for file ID {} ({path:?}) is {} bytes, exceeding the maximum supported length of {} bytes",
+        file_id.index(),
+        source.len(),
+        MAX_SOURCE_BYTES
+    )));
+    let diagnostics =
+        DiagnosticOutput::new(error_format, vec![(file_id, SourceInfo::new(source, path))]);
+    diagnostics.print_error(&error);
+    Err(())
+}
+
 /// Discover `@import("...")` references in the given sources and load the
 /// referenced module files from disk, transitively, appending them to
 /// `sources`.
@@ -1380,6 +1405,7 @@ fn discover_and_load_imports(
     sources: &mut Vec<(String, String)>,
     source_manifest: Option<&SourceManifest>,
     dependency_graph: &mut DependencyGraph,
+    error_format: ErrorFormat,
 ) -> Result<ImportDiscoveryResult, ()> {
     use std::collections::HashSet;
 
@@ -1403,13 +1429,23 @@ fn discover_and_load_imports(
 
     let mut i = 0;
     while i < sources.len() {
+        let source_index = i;
         let importer_file_id = FileId::new((i + 1) as u32);
-        let (importer_path, content) = (sources[i].0.clone(), sources[i].1.clone());
+        let importer_path = sources[source_index].0.clone();
         let importer_canonical = fs::canonicalize(&importer_path).ok();
         i += 1;
 
-        let lexer = Lexer::new(&content);
-        let Ok((tokens, interner)) = lexer.tokenize() else {
+        let tokenized = {
+            let content = &sources[source_index].1;
+            validate_source_len_before_discovery(
+                importer_file_id,
+                &importer_path,
+                content,
+                error_format,
+            )?;
+            Lexer::new(content).tokenize()
+        };
+        let Ok((tokens, interner)) = tokenized else {
             // Lex errors will be reported properly during compilation.
             continue;
         };
@@ -1650,6 +1686,7 @@ fn main() {
         &mut sources,
         source_manifest.as_ref(),
         &mut dependency_graph,
+        options.error_format,
     ) {
         Ok(result) => result,
         Err(()) => std::process::exit(1),
@@ -1686,51 +1723,78 @@ fn main() {
         std::process::exit(1);
     }
 
-    // Build SourceFile structs for multi-file compilation. Physical paths stay
+    // Give every loaded source a stable ID in caller order. Physical paths stay
     // available for imports and diagnostics; generated symbols use a separate,
     // relocation-stable identity (RUE-618).
-    let source_files: Vec<SourceFile<'_>> = sources
-        .iter()
-        .enumerate()
-        .map(|(i, (path, content))| {
-            SourceFile::new(path.as_str(), content.as_str(), FileId::new((i + 1) as u32))
-        })
+    let file_ids: Vec<_> = (1..=sources.len())
+        .map(|index| FileId::new(index as u32))
         .collect();
-    // Create multi-file diagnostic formatters for diagnostics that may span multiple files.
-    let source_infos: Vec<_> = sources
-        .iter()
-        .enumerate()
-        .map(|(i, (path, content))| {
-            (
-                FileId::new((i + 1) as u32),
-                SourceInfo::new(content.as_str(), path.as_str()),
-            )
-        })
-        .collect();
-    let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
     let symbol_paths = match derive_symbol_paths(&sources) {
         Ok(paths) => paths,
         Err(message) => {
+            let source_infos = sources
+                .iter()
+                .zip(file_ids.iter().copied())
+                .map(|((path, content), file_id)| {
+                    (file_id, SourceInfo::new(content.as_str(), path.as_str()))
+                })
+                .collect();
+            let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
             diagnostics.print_error(&CompileError::without_span(
                 ErrorKind::InvalidCompilerInput(message),
             ));
             std::process::exit(1);
         }
     };
-    let symbol_path_map: std::collections::HashMap<FileId, String> = source_files
+    let physical_path_map = sources
         .iter()
-        .zip(symbol_paths)
-        .map(|(source, symbol_path)| (source.file_id, symbol_path))
+        .zip(file_ids.iter().copied())
+        .map(|((path, _), file_id)| (file_id, path.clone()))
         .collect();
+    let logical_path_map = file_ids.iter().copied().zip(symbol_paths).collect();
     let source_metadata =
-        match SourceMetadata::from_sources(&source_files, source_files[0].file_id, symbol_path_map)
-        {
+        match SourceMetadata::new(file_ids[0], physical_path_map, logical_path_map) {
             Ok(source_metadata) => source_metadata,
             Err(error) => {
+                let source_infos = sources
+                    .iter()
+                    .zip(file_ids.iter().copied())
+                    .map(|((path, content), file_id)| {
+                        (file_id, SourceInfo::new(content.as_str(), path.as_str()))
+                    })
+                    .collect();
+                let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
                 diagnostics.print_error(&error);
                 std::process::exit(1);
             }
         };
+
+    // Move each loaded String directly behind an Arc: this transfers its
+    // allocation without copying the source bytes. The snapshot now owns the
+    // complete, immutable compiler input used by every compilation path.
+    let source_contents = sources
+        .into_iter()
+        .zip(file_ids)
+        .map(|((_path, content), file_id)| (file_id, Arc::new(content)))
+        .collect();
+    let source_snapshot = match SourceSnapshot::new(source_metadata, source_contents) {
+        Ok(source_snapshot) => source_snapshot,
+        Err(error) => {
+            // Snapshot validation errors are unspanned. At this point the
+            // snapshot constructor owns the source buffers on both paths, so
+            // no borrowed source view remains available for formatting.
+            let diagnostics = DiagnosticOutput::new(options.error_format, Vec::new());
+            diagnostics.print_error(&error);
+            std::process::exit(1);
+        }
+    };
+    // Create multi-file diagnostic formatters from the snapshot's borrowed
+    // views so diagnostics and compilation necessarily observe the same input.
+    let source_infos = source_snapshot
+        .files()
+        .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+        .collect();
+    let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
 
     if options.emit_stages.contains(&EmitStage::Deps) {
         if options.emit_stages.len() != 1 {
@@ -1783,9 +1847,7 @@ fn main() {
 
     // Handle emit modes with multi-file support
     if !options.emit_stages.is_empty() {
-        if let Err(()) =
-            handle_emit_multi_file(&source_files, &source_metadata, &options, &diagnostics)
-        {
+        if let Err(()) = handle_emit_multi_file(&source_snapshot, &options, &diagnostics) {
             std::process::exit(1);
         }
         print_timing_output(
@@ -1806,19 +1868,11 @@ fn main() {
         preview_features: options.preview_features.clone(),
     };
     let compile_result = if options.benchmark_json {
-        compile_multi_file_with_source_metadata_and_options_and_stats(
-            &source_files,
-            &source_metadata,
-            &compile_options,
-        )
-        .map(|(output, stats)| (output, Some(stats)))
+        compile_source_snapshot_with_options_and_stats(&source_snapshot, &compile_options)
+            .map(|(output, stats)| (output, Some(stats)))
     } else {
-        compile_multi_file_with_source_metadata_and_options(
-            &source_files,
-            &source_metadata,
-            &compile_options,
-        )
-        .map(|output| (output, None))
+        compile_source_snapshot_with_options(&source_snapshot, &compile_options)
+            .map(|output| (output, None))
     };
     match compile_result {
         Ok((output, source_stats)) => {
@@ -1938,8 +1992,7 @@ fn main() {
 /// For early stages (tokens, ast), each file is processed and labeled individually.
 /// For later stages (rir, air, cfg, etc.), the merged program is used.
 fn handle_emit_multi_file(
-    sources: &[SourceFile<'_>],
-    source_metadata: &SourceMetadata,
+    source_snapshot: &SourceSnapshot,
     options: &Options,
     diagnostics: &DiagnosticOutput<'_>,
 ) -> Result<(), ()> {
@@ -1964,8 +2017,8 @@ fn handle_emit_multi_file(
     // For tokens, we need to lex each file separately (before parsing merges interners)
     // We'll collect per-file tokens if needed
     let per_file_tokens: Option<Vec<(String, Vec<rue_compiler::Token>)>> = if needs_tokens {
-        let mut file_tokens = Vec::with_capacity(sources.len());
-        for source in sources {
+        let mut file_tokens = Vec::with_capacity(source_snapshot.len());
+        for source in source_snapshot.files() {
             // Lex with the file's real FileId so a lex error in the Nth file
             // is attributed to that file, not to the first one (RUE-38).
             let lexer = Lexer::with_file_id(source.source, source.file_id);
@@ -1986,7 +2039,7 @@ fn handle_emit_multi_file(
 
     // Parse all files (needed for AST output or later stages)
     let mut parsed: Option<ParsedProgram> = if needs_ast || needs_later_stages {
-        match parse_all_files_with_source_metadata(sources, source_metadata) {
+        match parse_all_files_with_source_snapshot(source_snapshot) {
             Ok(program) => Some(program),
             Err(errors) => {
                 diagnostics.print_errors(&errors);
@@ -2031,7 +2084,7 @@ fn handle_emit_multi_file(
             options.opt_level,
             &options.preview_features,
             options.target,
-            source_metadata,
+            source_snapshot.metadata(),
         ) {
             Ok(state) => state,
             Err(errors) => {
@@ -2629,7 +2682,7 @@ mod tests {
             fs::read_to_string(&main_path).unwrap(),
         )];
         let mut graph = DependencyGraph::default();
-        let result = discover_and_load_imports(&mut sources, None, &mut graph);
+        let result = discover_and_load_imports(&mut sources, None, &mut graph, ErrorFormat::Text);
         assert!(
             result.is_err(),
             "unreadable existing candidate must error, not resolve or vanish"
@@ -2642,7 +2695,7 @@ mod tests {
             fs::read_to_string(&main_path).unwrap(),
         )];
         let mut graph = DependencyGraph::default();
-        let result = discover_and_load_imports(&mut sources, None, &mut graph);
+        let result = discover_and_load_imports(&mut sources, None, &mut graph, ErrorFormat::Text);
         assert!(result.is_ok());
         assert_eq!(sources.len(), 2, "helper must be discovered and loaded");
 


### PR DESCRIPTION
## Summary

- add an immutable, `Arc`-backed `SourceSnapshot` that atomically owns validated source metadata and caller-ordered `Arc<String>` contents, with exact deterministic membership checks and O(1) `FileId` lookup
- make snapshot-native parsing, `CompilationUnit`, batch compilation, benchmark statistics, diagnostics, and emit paths canonical while retaining borrowed `SourceFile` APIs as compatibility adapters
- move CLI-owned source `String` allocations directly into the snapshot, remove import discovery's full source-text clone, and reject sources larger than Rue's `u32` span limit before copying or discovery lexing
- document that logical paths, snapshot-local `FileId`s, and interner-bound `Spur`s are not standalone content/cache identities; no cache, revision, edit API, or identity rollout is introduced here

## Why

The compiler had validated immutable paths and an explicit root, but its source text still lived in caller-borrowed vectors. That prevented compilation inputs from becoming cheap isolated snapshots suitable for future in-process queries and tooling. This change creates that ownership seam without changing AST/interner representation or pretending reuse exists yet.

Snapshot clones and unchanged per-file texts share allocations. Edited snapshots remain isolated, and the existing `CompilationUnit<'src>` shape is preserved for borrowed callers while `CompilationUnit::from_source_snapshot` produces an owned `'static` unit.

## Validation

- `./fmt.sh check`
- `./clippy.sh` (41 first-party targets)
- `./buck2 test //...` (34 targets)
- focused compiler tests: 266 passed
- focused driver tests: 138 passed
- CLI suite: 1,346 passed, 2 ignored
- `./buck2 test //:reproducible-programs` across relocation, source order, O0/O2, x86-64 Linux, AArch64 Linux, and AArch64 macOS
- `./scripts/check-reproducible-compiler.sh` (`sha256 16baeb01c3902959dc598c0cc4ae4536173050b706063403672766cf7499c2b9`)
- independent API/lifetime, behavioral, and query-seam reviews found no remaining medium-or-higher issues

Parity tests cover diagnostics, nonempty warnings, source statistics, RIR, AIR/CFG text, native bytes, Arc sharing, edited-snapshot isolation, and `Send + Sync`.
