### PR TITLE
RUE-634: isolate nested call expected types

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -52,6 +52,7 @@ impl<'a> Sema<'a> {
         args_start: u32,
         args_len: u32,
         span: Span,
+        result_expected: Option<Type>,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         // Intrinsic arguments are stored as plain InstRefs
@@ -110,11 +111,20 @@ impl<'a> Sema<'a> {
         } else if name == known.test_preview_gate {
             self.analyze_test_preview_gate_intrinsic(air, &args, span)
         } else if name == known.read_line {
-            self.analyze_read_line_intrinsic(air, name, inst_ref, &args, span, ctx)
+            self.analyze_read_line_intrinsic(air, name, inst_ref, &args, span, result_expected, ctx)
         } else if name == known.to_string {
             self.analyze_to_string_intrinsic(air, &args, span, ctx)
         } else if let Some(intrinsic_name_str) = known.get_parse_intrinsic_name(name) {
-            self.analyze_parse_intrinsic(air, name, inst_ref, intrinsic_name_str, &args, span, ctx)
+            self.analyze_parse_intrinsic(
+                air,
+                name,
+                inst_ref,
+                intrinsic_name_str,
+                &args,
+                span,
+                result_expected,
+                ctx,
+            )
         } else if name == known.cast {
             self.analyze_cast_intrinsic(air, inst_ref, &args, span, ctx)
         } else if name == known.panic {
@@ -790,6 +800,7 @@ impl<'a> Sema<'a> {
     pub(super) fn resolve_option_result_type(
         &mut self,
         ctx: &AnalysisContext,
+        result_expected: Option<Type>,
         inst_ref: InstRef,
         expected_payload: Type,
         intrinsic_display: &str,
@@ -801,7 +812,7 @@ impl<'a> Sema<'a> {
         // `Option` reaches us. Without one, there is no context to infer the
         // Option type from — report that plainly rather than letting an
         // unresolved inference variable decay to `<error>` (E9000).
-        let (ty, from_expected) = match ctx.expected_type {
+        let (ty, from_expected) = match result_expected {
             Some(ty) => (ty, true),
             None => (
                 Self::get_resolved_type(ctx, inst_ref, span, intrinsic_display)?,
@@ -874,6 +885,7 @@ impl<'a> Sema<'a> {
         inst_ref: InstRef,
         args: &[RirCallArg],
         span: Span,
+        result_expected: Option<Type>,
         ctx: &AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         // @read_line() - reads a line from stdin. Takes no arguments and
@@ -893,6 +905,7 @@ impl<'a> Sema<'a> {
         let string_type = self.builtin_string_type();
         let option_ty = self.resolve_option_result_type(
             ctx,
+            result_expected,
             inst_ref,
             string_type,
             "read_line",
@@ -1015,6 +1028,7 @@ impl<'a> Sema<'a> {
         intrinsic_name_str: &str,
         args: &[RirCallArg],
         span: Span,
+        result_expected: Option<Type>,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         // Expects exactly one argument
@@ -1060,6 +1074,7 @@ impl<'a> Sema<'a> {
         // context and is validated to carry the matching integer payload.
         let option_ty = self.resolve_option_result_type(
             ctx,
+            result_expected,
             inst_ref,
             payload_type,
             intrinsic_name_str,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5834,9 +5834,14 @@ impl<'a> Sema<'a> {
         inst_ref: InstRef,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        let inst = self.rir.get(inst_ref);
+        let inst = self.rir.get(inst_ref).clone();
 
-        match &inst.data {
+        // A call has a declared result type; an expectation on that result
+        // must not become the context of its receiver or arguments. The
+        // callee's parameter analyzer establishes a fresh context for each
+        // operand instead. Keep the isolation at this shared dispatch so it
+        // covers direct, module, method, associated, builtin, and enum calls.
+        ctx.with_expected_type(None, |ctx| match &inst.data {
             InstData::Call {
                 name,
                 args_start,
@@ -5880,7 +5885,7 @@ impl<'a> Sema<'a> {
                 )),
                 inst.span,
             )),
-        }
+        })
     }
 
     /// Analyze a function call.
@@ -6682,16 +6687,26 @@ impl<'a> Sema<'a> {
         inst_ref: InstRef,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        let inst = self.rir.get(inst_ref);
+        let inst = self.rir.get(inst_ref).clone();
+        let result_expected = ctx.expected_type;
 
         match &inst.data {
             InstData::Intrinsic {
                 name,
                 args_start,
                 args_len,
-            } => {
-                self.analyze_intrinsic(air, inst_ref, *name, *args_start, *args_len, inst.span, ctx)
-            }
+            } => ctx.with_expected_type(None, |ctx| {
+                self.analyze_intrinsic(
+                    air,
+                    inst_ref,
+                    *name,
+                    *args_start,
+                    *args_len,
+                    inst.span,
+                    result_expected,
+                    ctx,
+                )
+            }),
 
             InstData::TypeIntrinsic { name, type_arg } => {
                 self.analyze_type_intrinsic(air, *name, *type_arg, inst.span)
@@ -6864,10 +6879,20 @@ impl<'a> Sema<'a> {
         args_start: u32,
         args_len: u32,
         span: Span,
+        result_expected: Option<Type>,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         // Delegate to the main implementation in analysis.rs
-        self.analyze_intrinsic_impl(air, inst_ref, name, args_start, args_len, span, ctx)
+        self.analyze_intrinsic_impl(
+            air,
+            inst_ref,
+            name,
+            args_start,
+            args_len,
+            span,
+            result_expected,
+            ctx,
+        )
     }
 
     // ========================================================================

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -570,6 +570,25 @@ impl ScopedContext for AnalysisContext<'_> {
 }
 
 impl<'a> AnalysisContext<'a> {
+    /// Run one nested analysis with an explicit expected-type context, then
+    /// restore the caller's context before returning its result.
+    ///
+    /// Expected types are expression-directed: structural result positions
+    /// inherit them, while operands such as a call's arguments establish
+    /// their own context from the callee contract. Keeping the save/restore in
+    /// one helper prevents an early `Err` from leaking either context into a
+    /// sibling expression.
+    pub(crate) fn with_expected_type<T>(
+        &mut self,
+        expected_type: Option<Type>,
+        analyze: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        let previous = std::mem::replace(&mut self.expected_type, expected_type);
+        let result = analyze(self);
+        self.expected_type = previous;
+        result
+    }
+
     /// Bind a `let`-bound comptime type alias (`let P = Point();`), saving
     /// the name's previous binding (or absence) in the current scope's alias
     /// frame so `pop_scope` restores it — the alias is lexically scoped like

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -514,6 +514,129 @@ mod tests {
     }
 
     #[test]
+    fn fixed_string_call_context_stops_at_nested_call_operands() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let cases = [
+            (
+                "conditional result",
+                r#"fn main() -> i32 { @intCast(take(if true { "hi" } else { "bye" })) }"#,
+            ),
+            (
+                "block result",
+                r#"fn main() -> i32 { @intCast(take({ let _marker = 0; "block" })) }"#,
+            ),
+            (
+                "declared fixed-string return",
+                r#"fn main() -> i32 { @intCast(take(make())) }"#,
+            ),
+            (
+                "intrinsic statement before a fixed-string block result",
+                r#"fn main() -> i32 { @intCast(take(with_assert())) }"#,
+            ),
+            (
+                "never-returning user call",
+                r#"fn main() -> i32 { @intCast(take(die("boom"))) }"#,
+            ),
+            (
+                "never-returning generic user call",
+                r#"fn main() -> i32 { @intCast(take(generic_die(StrBuf, "boom"))) }"#,
+            ),
+            (
+                "never-returning intrinsic",
+                r#"fn main() -> i32 { @intCast(take(@panic("boom"))) }"#,
+            ),
+        ];
+
+        for (case, main) in cases {
+            let source = format!(
+                r#"
+                    fn take(value: Str(8)) -> u64 {{ value.len() }}
+                    fn make() -> Str(8) {{ "made" }}
+                    fn with_assert() -> Str(8) {{ @assert(true, "message"); "checked" }}
+                    fn die(message: StrBuf) -> ! {{ @panic(message) }}
+                    fn generic_die(comptime T: type, message: T) -> ! {{ @panic("stop") }}
+                    {main}
+                "#
+            );
+            let output = compile_to_air_with_preview_features(&source, preview.clone())
+                .unwrap_or_else(|errors| panic!("{case} must compile independently: {errors}"));
+
+            if matches!(
+                case,
+                "never-returning user call" | "never-returning generic user call"
+            ) {
+                let main = output
+                    .functions
+                    .iter()
+                    .find(|function| function.name == "main")
+                    .unwrap();
+                let mut literal_call_args = Vec::new();
+                for (_, inst) in main.air.iter() {
+                    let (args_start, args_len) = match &inst.data {
+                        AirInstData::Call {
+                            args_start,
+                            args_len,
+                            ..
+                        }
+                        | AirInstData::CallGeneric {
+                            args_start,
+                            args_len,
+                            ..
+                        } => (*args_start, *args_len),
+                        _ => continue,
+                    };
+                    for arg in main.air.get_call_args(args_start, args_len) {
+                        if matches!(main.air.get(arg.value).data, AirInstData::StringConst(_)) {
+                            literal_call_args.push(arg);
+                        }
+                    }
+                }
+
+                assert_eq!(
+                    literal_call_args.len(),
+                    1,
+                    "{case} must have one literal runtime call argument"
+                );
+                let arg = &literal_call_args[0];
+                assert_eq!(arg.mode, AirArgMode::Normal);
+                let arg_ty = main.air.get(arg.value).ty;
+                assert_eq!(
+                    arg_ty.safe_name_with_pool(Some(&output.type_pool)),
+                    "StrBuf",
+                    "{case} must materialize its nested message from the callee contract"
+                );
+                assert_eq!(
+                    output.type_pool.abi_slot_count(arg_ty),
+                    3,
+                    "{case} must pass the three-slot StrBuf representation"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fallible_intrinsic_keeps_structural_result_context() {
+        let source = r#"
+            fn Option(comptime T: type) -> type { enum { Some(T), None } }
+
+            fn main() -> i32 {
+                let Opt = Option(i64);
+                let parsed: Opt = if true {
+                    @parse_i64("42")
+                } else {
+                    @parse_i64("7")
+                };
+                match parsed {
+                    Opt.Some(value) => @intCast(value),
+                    Opt.None => 0,
+                }
+            }
+        "#;
+        compile_to_air(source).unwrap();
+    }
+
+    #[test]
     fn inout_param_assignment_is_constrained_and_store_typed_exactly() {
         // Parameter assignments participate in inference, so a literal takes
         // the declared integer width instead of defaulting to i32. Sema then


### PR DESCRIPTION
## Summary

- clear a parent result expectation at the shared user/builtin/method/associated/enum call boundary
- snapshot intrinsic result expectations, clear intrinsic operands, and pass the snapshot only to fallible Option result resolution
- structurally prove nested direct and generic messages remain three-slot StrBuf values

## Root cause

`AnalysisContext.expected_type` surrounded an entire argument expression. A fixed `Str(N)` expectation for an outer call could therefore materialize a nested call or intrinsic operand with the outer representation instead of the nested callee contract.

RUE-652 tracks the broader expression-directed operator, loop, projection, and contract-derived child-context matrix; this PR stays on the complete call/intrinsic boundary.

## Validation

- `./fmt.sh check`
- `./clippy.sh` — 41 targets
- `./test.sh` — 34/34 targets
- rue-air — 372/372
- spec — 2,052 passed, 14 ignored
- CLI oracle — 642 agree, 98 modeled gaps, 572 ineligible, 0 failures/disagreements
- spec oracle — 1,347 agree, 101 modeled gaps, 618 ineligible, 0 failures/disagreements
- generated oracle smoke — 64/64 agree