### PR TITLE
RUE-653: unify and measure the per-file syntax kernel

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -30,10 +30,12 @@ mod drop_glue;
 mod semantic_order;
 mod source_metadata;
 mod source_snapshot;
+mod syntax;
 mod unit;
 
 pub use source_metadata::SourceMetadata;
 pub use source_snapshot::{MAX_SOURCE_BYTES, SourceSnapshot};
+pub use syntax::SyntaxWork;
 pub use unit::{CompilationUnit, SourceStats};
 
 use rayon::prelude::*;
@@ -361,56 +363,7 @@ pub fn parse_all_files_with_source_metadata(
 pub fn parse_all_files_with_source_snapshot(
     snapshot: &SourceSnapshot,
 ) -> MultiErrorResult<ParsedProgram> {
-    // Parse all files sequentially with a shared interner
-    // This ensures Spur values are consistent across files for cross-file symbol resolution
-    let mut parsed_files = Vec::with_capacity(snapshot.len());
-    let mut interner = ThreadedRodeo::new();
-    let mut errors = CompileErrors::new();
-
-    for source in snapshot.files() {
-        // Create lexer with shared interner and file ID for proper error reporting
-        let lexer = Lexer::with_interner_and_file_id(source.source, interner, source.file_id);
-
-        let tokens = match lexer.tokenize_preserving_interner() {
-            Ok((tokens, returned_interner)) => {
-                interner = returned_interner;
-                tokens
-            }
-            Err((lex_errors, returned_interner)) => {
-                interner = returned_interner;
-                errors.extend(lex_errors);
-                continue;
-            }
-        };
-
-        let parser = Parser::new(tokens, interner);
-        let ast = match parser.parse_preserving_interner() {
-            Ok((ast, returned_interner)) => {
-                interner = returned_interner;
-                ast
-            }
-            Err((parse_errors, returned_interner)) => {
-                interner = returned_interner;
-                errors.extend(parse_errors);
-                continue;
-            }
-        };
-
-        parsed_files.push(ParsedFile {
-            path: source.path.to_string(),
-            file_id: source.file_id,
-            ast,
-        });
-    }
-
-    if !errors.is_empty() {
-        return Err(errors);
-    }
-
-    Ok(ParsedProgram {
-        files: parsed_files,
-        interner,
-    })
+    syntax::parse_snapshot(snapshot).result
 }
 
 /// Result of merging symbols from multiple parsed files.

--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -1,0 +1,326 @@
+//! Shared lexing and parsing kernels.
+//!
+//! Source-snapshot and multi-file compiler entry points use this module so
+//! their syntax work is measured once, at the point where it is performed.
+
+use tracing::{info, info_span};
+
+use crate::{
+    CompileErrors, Lexer, MultiErrorResult, ParsedFile, ParsedProgram, Parser, SourceFile,
+    SourceSnapshot, ThreadedRodeo,
+};
+
+/// Work performed while lexing and parsing source files.
+///
+/// Token counts include the EOF token emitted by the lexer. A file contributes
+/// tokens only when lexing succeeds and produces the token vector passed to the
+/// parser. Source bytes use UTF-8 byte lengths, matching Rue's byte-based spans.
+/// Values describe one syntax run; they are neither process-global totals nor
+/// metadata attached to a reusable parsed artifact.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SyntaxWork {
+    /// Number of lexer invocations.
+    pub lexer_invocations: usize,
+    /// Number of parser invocations.
+    pub parser_invocations: usize,
+    /// Total source bytes presented to the lexer.
+    pub lexed_bytes: usize,
+    /// Total tokens produced by successful lexer invocations.
+    pub tokens: usize,
+}
+
+struct FileParseOutcome {
+    result: MultiErrorResult<ParsedFile>,
+    interner: ThreadedRodeo,
+    work: SyntaxWork,
+}
+
+pub(crate) struct SnapshotParseOutcome {
+    pub(crate) result: MultiErrorResult<ParsedProgram>,
+    pub(crate) work: SyntaxWork,
+}
+
+fn parse_file(source: SourceFile<'_>, interner: ThreadedRodeo) -> FileParseOutcome {
+    let _file_span = info_span!("parse_file", path = %source.path).entered();
+    let mut work = SyntaxWork {
+        lexer_invocations: 1,
+        lexed_bytes: source.source.len(),
+        ..SyntaxWork::default()
+    };
+
+    let lexer = Lexer::with_interner_and_file_id(source.source, interner, source.file_id);
+    let (tokens, interner) = {
+        let _span = info_span!("lexer").entered();
+        match lexer.tokenize_preserving_interner() {
+            Ok(output) => output,
+            Err((errors, interner)) => {
+                return FileParseOutcome {
+                    result: Err(errors),
+                    interner,
+                    work,
+                };
+            }
+        }
+    };
+
+    work.parser_invocations = 1;
+    work.tokens = tokens.len();
+    info!(token_count = tokens.len(), "lexing complete");
+
+    let (ast, interner) = {
+        let _span = info_span!("parser").entered();
+        let parser = Parser::new(tokens, interner);
+        match parser.parse_preserving_interner() {
+            Ok(output) => output,
+            Err((errors, interner)) => {
+                return FileParseOutcome {
+                    result: Err(errors),
+                    interner,
+                    work,
+                };
+            }
+        }
+    };
+
+    info!(item_count = ast.items.len(), "parsing complete");
+
+    FileParseOutcome {
+        result: Ok(ParsedFile {
+            path: source.path.to_owned(),
+            file_id: source.file_id,
+            ast,
+        }),
+        interner,
+        work,
+    }
+}
+
+pub(crate) fn parse_snapshot(snapshot: &SourceSnapshot) -> SnapshotParseOutcome {
+    let _span = info_span!("parse", file_count = snapshot.len()).entered();
+    run_snapshot_unspanned(snapshot)
+}
+
+/// Run the shared snapshot parser without creating its outer `parse` span.
+///
+/// Entry points own that span because `CompilationUnit::parse` historically
+/// includes symbol merging in it, while direct snapshot parsing ends after the
+/// per-file syntax work. The lexer/parser kernel itself remains shared.
+pub(crate) fn run_snapshot_unspanned(snapshot: &SourceSnapshot) -> SnapshotParseOutcome {
+    let mut files = Vec::with_capacity(snapshot.len());
+    let mut interner = ThreadedRodeo::new();
+    let mut errors = CompileErrors::new();
+    let mut work = SyntaxWork::default();
+
+    for source in snapshot.files() {
+        let outcome = parse_file(source, interner);
+        interner = outcome.interner;
+        work.lexer_invocations += outcome.work.lexer_invocations;
+        work.parser_invocations += outcome.work.parser_invocations;
+        work.lexed_bytes += outcome.work.lexed_bytes;
+        work.tokens += outcome.work.tokens;
+
+        match outcome.result {
+            Ok(file) => files.push(file),
+            Err(file_errors) => errors.extend(file_errors),
+        }
+    }
+
+    let result = if errors.is_empty() {
+        Ok(ParsedProgram { files, interner })
+    } else {
+        Err(errors)
+    };
+
+    SnapshotParseOutcome { result, work }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use rue_error::ErrorKind;
+    use rue_span::FileId;
+
+    use super::*;
+    use crate::{Item, SourceMetadata};
+
+    fn snapshot(entries: &[(u32, &str, &str)]) -> SourceSnapshot {
+        let physical_paths: HashMap<_, _> = entries
+            .iter()
+            .map(|&(id, path, _)| (FileId::new(id), path.to_owned()))
+            .collect();
+        let metadata = SourceMetadata::new(
+            FileId::new(entries[0].0),
+            physical_paths.clone(),
+            physical_paths,
+        )
+        .unwrap();
+        let contents = entries
+            .iter()
+            .map(|&(id, _, source)| (FileId::new(id), Arc::new(source.to_owned())))
+            .collect();
+        SourceSnapshot::new(metadata, contents).unwrap()
+    }
+
+    #[test]
+    fn valid_files_report_one_lexer_and_parser_invocation_each() {
+        let sources = [
+            (7, "first.rue", "fn first() {}"),
+            (3, "empty.rue", ""),
+            (9, "third.rue", "fn third() {}"),
+        ];
+        let snapshot = snapshot(&sources);
+
+        let SnapshotParseOutcome { result, work } = parse_snapshot(&snapshot);
+        let program = result.unwrap();
+
+        assert_eq!(
+            program
+                .files
+                .iter()
+                .map(|file| file.file_id)
+                .collect::<Vec<_>>(),
+            vec![FileId::new(7), FileId::new(3), FileId::new(9)]
+        );
+        assert_eq!(
+            work,
+            SyntaxWork {
+                lexer_invocations: 3,
+                parser_invocations: 3,
+                lexed_bytes: sources.iter().map(|(_, _, source)| source.len()).sum(),
+                tokens: 15,
+            }
+        );
+    }
+
+    #[test]
+    fn snapshot_collects_lex_and_parse_errors_in_caller_order_and_continues() {
+        let sources = [
+            (30, "lex.rue", "fn lexed() { $ }"),
+            (10, "parse.rue", "fn parsed( { }"),
+            (20, "good.rue", "fn good() {}"),
+        ];
+        let snapshot = snapshot(&sources);
+
+        let SnapshotParseOutcome { result, work } = parse_snapshot(&snapshot);
+        let errors = result.unwrap_err();
+
+        assert_eq!(errors.len(), 2);
+        assert!(matches!(
+            errors.as_slice()[0].kind,
+            ErrorKind::UnexpectedCharacter('$')
+        ));
+        assert_eq!(
+            errors
+                .iter()
+                .map(|error| error.span().unwrap().file_id)
+                .collect::<Vec<_>>(),
+            vec![FileId::new(30), FileId::new(10)]
+        );
+        assert_eq!(work.lexer_invocations, 3);
+        assert_eq!(work.parser_invocations, 2);
+        assert_eq!(
+            work.lexed_bytes,
+            sources
+                .iter()
+                .map(|(_, _, source)| source.len())
+                .sum::<usize>()
+        );
+        assert_eq!(work.tokens, 13);
+    }
+
+    #[test]
+    fn one_lex_invocation_preserves_all_lex_errors() {
+        let source = "fn broken() { $ # }";
+        let snapshot = snapshot(&[(1, "broken.rue", source)]);
+
+        let SnapshotParseOutcome { result, work } = parse_snapshot(&snapshot);
+        let errors = result.unwrap_err();
+
+        assert_eq!(errors.len(), 2);
+        assert!(matches!(
+            errors.as_slice()[0].kind,
+            ErrorKind::UnexpectedCharacter('$')
+        ));
+        assert!(matches!(
+            errors.as_slice()[1].kind,
+            ErrorKind::UnexpectedCharacter('#')
+        ));
+        assert_eq!(
+            work,
+            SyntaxWork {
+                lexer_invocations: 1,
+                parser_invocations: 0,
+                lexed_bytes: source.len(),
+                tokens: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn returned_interner_survives_lex_and_parse_failures() {
+        let lex_source = SourceFile::new("lex.rue", "fn lex_name() { $ }", FileId::new(1));
+        let FileParseOutcome {
+            result, interner, ..
+        } = parse_file(lex_source, ThreadedRodeo::new());
+        assert!(result.is_err());
+        let lex_name = interner.get("lex_name").unwrap();
+        assert_eq!(interner.resolve(&lex_name), "lex_name");
+
+        let parse_source = SourceFile::new("parse.rue", "fn parse_name( { }", FileId::new(2));
+        let FileParseOutcome {
+            result, interner, ..
+        } = parse_file(parse_source, interner);
+        assert!(result.is_err());
+        let parse_name = interner.get("parse_name").unwrap();
+        assert_eq!(interner.resolve(&lex_name), "lex_name");
+        assert_eq!(interner.resolve(&parse_name), "parse_name");
+
+        let good_source = SourceFile::new("good.rue", "fn good_name() {}", FileId::new(3));
+        let FileParseOutcome {
+            result, interner, ..
+        } = parse_file(good_source, interner);
+        let parsed = result.unwrap();
+        let Item::Function(function) = &parsed.ast.items[0] else {
+            panic!("expected a function");
+        };
+
+        assert_eq!(interner.resolve(&lex_name), "lex_name");
+        assert_eq!(interner.resolve(&parse_name), "parse_name");
+        assert_eq!(interner.resolve(&function.name.name), "good_name");
+    }
+
+    #[test]
+    fn work_uses_utf8_bytes_and_successful_lexer_token_vectors() {
+        let valid = "fn main() { // café\n}";
+        let FileParseOutcome { result, work, .. } = parse_file(
+            SourceFile::new("valid.rue", valid, FileId::new(1)),
+            ThreadedRodeo::new(),
+        );
+        result.unwrap();
+        assert!(valid.len() > valid.chars().count());
+        assert_eq!(work.lexed_bytes, valid.len());
+        assert_eq!(work.tokens, 7);
+        assert_eq!(work.parser_invocations, 1);
+
+        let parse_error = "fn broken( {";
+        let FileParseOutcome { result, work, .. } = parse_file(
+            SourceFile::new("parse.rue", parse_error, FileId::new(2)),
+            ThreadedRodeo::new(),
+        );
+        assert!(result.is_err());
+        assert_eq!(work.lexed_bytes, parse_error.len());
+        assert_eq!(work.tokens, 5);
+        assert_eq!(work.parser_invocations, 1);
+
+        let lex_error = "kept_name $";
+        let FileParseOutcome { result, work, .. } = parse_file(
+            SourceFile::new("lex.rue", lex_error, FileId::new(3)),
+            ThreadedRodeo::new(),
+        );
+        assert!(result.is_err());
+        assert_eq!(work.lexed_bytes, lex_error.len());
+        assert_eq!(work.tokens, 0);
+        assert_eq!(work.parser_invocations, 0);
+    }
+}

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -37,9 +37,9 @@ use lasso::ThreadedRodeo;
 use tracing::{info, info_span};
 
 use crate::{
-    Ast, AstGen, CompileErrors, CompileOptions, CompileOutput, CompileResult, CompileWarning,
-    FunctionWithCfg, Lexer, MultiErrorResult, Parser, Rir, Sema, SourceFile, SourceMetadata,
-    SourceSnapshot, TypeInternPool, build_functions_and_cfgs, compile_backend,
+    Ast, AstGen, CompileOptions, CompileOutput, CompileResult, CompileWarning, FunctionWithCfg,
+    MultiErrorResult, Rir, Sema, SourceFile, SourceMetadata, SourceSnapshot, SyntaxWork,
+    TypeInternPool, build_functions_and_cfgs, compile_backend,
 };
 use rue_span::FileId;
 
@@ -55,7 +55,8 @@ pub struct SourceStats {
     pub bytes: usize,
     /// Total source lines, using [`str::lines`] semantics.
     pub lines: usize,
-    /// Tokens produced by the lexer invocations consumed by the parser.
+    /// Tokens produced by successful lexer invocations, matching
+    /// [`SyntaxWork::tokens`] for the most recent parse attempt.
     pub tokens: usize,
 }
 
@@ -86,6 +87,8 @@ pub struct CompilationUnit<'src> {
     source_snapshot: SourceSnapshot,
     /// Work metrics collected from those sources and the live parse.
     source_stats: SourceStats,
+    /// Direct syntax work performed by the most recent parse attempt.
+    syntax_work: SyntaxWork,
     /// Retains the lifetime-shaped API of the borrowed compatibility constructors.
     _source_lifetime: PhantomData<&'src ()>,
 
@@ -183,6 +186,7 @@ impl<'src> CompilationUnit<'src> {
             options,
             source_snapshot,
             source_stats,
+            syntax_work: SyntaxWork::default(),
             _source_lifetime: PhantomData,
             merged_ast: None,
             interner: None,
@@ -201,8 +205,8 @@ impl<'src> CompilationUnit<'src> {
     /// Parse all source files.
     ///
     /// This runs lexing and parsing on each source file, producing ASTs.
-    /// The ASTs are then merged into a single program, detecting any
-    /// duplicate symbol definitions.
+    /// The ASTs are then merged into a single program, detecting any duplicate
+    /// symbol definitions.
     ///
     /// # Errors
     ///
@@ -210,104 +214,18 @@ impl<'src> CompilationUnit<'src> {
     /// - Any file fails to lex or parse
     /// - Duplicate function, struct, or enum definitions are found
     pub fn parse(&mut self) -> MultiErrorResult<()> {
+        // Keep symbol merging nested under the compilation unit's historical
+        // `parse` timing boundary. Direct snapshot parsing owns a narrower
+        // `parse` span around syntax work only.
         let _span = info_span!("parse", file_count = self.source_snapshot.len()).entered();
+        let parsed = crate::syntax::run_snapshot_unspanned(&self.source_snapshot);
+        self.syntax_work = parsed.work;
+        self.source_stats.tokens = parsed.work.tokens;
 
-        // Parse all files with a shared interner
-        let mut parsed_files = Vec::with_capacity(self.source_snapshot.len());
-        let mut interner = ThreadedRodeo::new();
-        let mut errors = CompileErrors::new();
-        self.source_stats.tokens = 0;
-
-        for source in self.source_snapshot.files() {
-            let _file_span = info_span!("parse_file", path = %source.path).entered();
-
-            // Create lexer with shared interner and file ID
-            let lexer = Lexer::with_interner_and_file_id(source.source, interner, source.file_id);
-
-            // Tokenize
-            let tokens = {
-                let _span = info_span!("lexer").entered();
-                match lexer.tokenize_preserving_interner() {
-                    Ok((tokens, returned_interner)) => {
-                        interner = returned_interner;
-                        tokens
-                    }
-                    Err((lex_errors, returned_interner)) => {
-                        interner = returned_interner;
-                        errors.extend(lex_errors);
-                        continue;
-                    }
-                }
-            };
-
-            self.source_stats.tokens += tokens.len();
-            info!(token_count = tokens.len(), "lexing complete");
-
-            // Parse
-            let ast = {
-                let _span = info_span!("parser").entered();
-                let parser = Parser::new(tokens, interner);
-                match parser.parse_preserving_interner() {
-                    Ok((ast, returned_interner)) => {
-                        interner = returned_interner;
-                        ast
-                    }
-                    Err((parse_errors, returned_interner)) => {
-                        interner = returned_interner;
-                        errors.extend(parse_errors);
-                        continue;
-                    }
-                }
-            };
-
-            info!(item_count = ast.items.len(), "parsing complete");
-
-            parsed_files.push((source.path.to_string(), ast));
-        }
-
-        if !errors.is_empty() {
-            return Err(errors);
-        }
-
-        // Merge symbols and check for duplicates
-        let merged_ast = self.merge_symbols(&parsed_files, &interner)?;
-
-        self.merged_ast = Some(merged_ast);
-        self.interner = Some(interner);
-
+        let merged = crate::merge_symbols(parsed.result?)?;
+        self.merged_ast = Some(merged.ast);
+        self.interner = Some(merged.interner);
         Ok(())
-    }
-
-    /// Merge symbols from all parsed files, checking for duplicates.
-    fn merge_symbols(
-        &self,
-        files: &[(String, Ast)],
-        interner: &ThreadedRodeo,
-    ) -> MultiErrorResult<Ast> {
-        let _span = info_span!("merge_symbols", file_count = files.len()).entered();
-
-        let check = crate::detect_duplicate_symbols(
-            files.iter().map(|(path, ast)| (path.as_str(), ast)),
-            interner,
-        );
-
-        if !check.errors.is_empty() {
-            return Err(CompileErrors::from(check.errors));
-        }
-
-        let all_items: Vec<_> = files
-            .iter()
-            .flat_map(|(_, ast)| ast.items.iter().cloned())
-            .collect();
-
-        info!(
-            function_count = check.function_count,
-            struct_count = check.struct_count,
-            enum_count = check.enum_count,
-            "symbol merging complete"
-        );
-
-        Ok(Ast { items: all_items })
     }
 
     // =========================================================================
@@ -565,6 +483,14 @@ impl<'src> CompilationUnit<'src> {
         &self.source_snapshot
     }
 
+    /// Direct syntax work performed by the most recent [`Self::parse`] attempt.
+    ///
+    /// The counters are stored before parse or merge errors are returned and
+    /// are replaced, rather than accumulated, by a later parse attempt.
+    pub fn syntax_work(&self) -> SyntaxWork {
+        self.syntax_work
+    }
+
     /// Get source metrics collected by the live frontend.
     pub fn source_stats(&self) -> SourceStats {
         SourceStats {
@@ -643,8 +569,10 @@ impl<'src> CompilationUnit<'src> {
 mod tests {
     use std::{fmt::Write as _, sync::Arc};
 
+    use lasso::Key as _;
+
     use super::*;
-    use crate::{FileId, RirPrinter};
+    use crate::{FileId, Lexer, RirPrinter};
 
     fn make_sources(source: &str) -> Vec<SourceFile<'_>> {
         vec![SourceFile::new("<test>", source, FileId::new(1))]
@@ -771,42 +699,131 @@ mod tests {
                 tokens: 0,
             }
         );
+        assert_eq!(unit.syntax_work(), SyntaxWork::default());
 
         unit.parse().unwrap();
         assert_eq!(unit.source_stats().tokens, expected_tokens);
+        let expected_work = SyntaxWork {
+            lexer_invocations: 2,
+            parser_invocations: 2,
+            lexed_bytes: first.len() + second.len(),
+            tokens: expected_tokens,
+        };
+        assert_eq!(unit.syntax_work(), expected_work);
 
         // Re-running a phase may be unusual, but metrics must describe one
         // parse rather than accumulating observer-induced work.
         unit.parse().unwrap();
         assert_eq!(unit.source_stats().tokens, expected_tokens);
+        assert_eq!(unit.syntax_work(), expected_work);
     }
 
     #[test]
-    fn test_duplicate_function_error() {
-        let sources = vec![SourceFile::new(
-            "a.rue",
-            "fn foo() -> i32 { 1 } fn foo() -> i32 { 2 }",
-            FileId::new(1),
-        )];
+    fn direct_parse_and_merge_matches_compilation_unit_artifacts() {
+        let sources = vec![
+            SourceFile::new("main.rue", "fn main() -> i32 { helper() }", FileId::new(7)),
+            SourceFile::new("helper.rue", "fn helper() -> i32 { 42 }", FileId::new(3)),
+        ];
         let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
 
-        let result = unit.parse();
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("function"));
+        let direct = crate::merge_symbols(
+            crate::parse_all_files_with_source_snapshot(unit.source_snapshot()).unwrap(),
+        )
+        .unwrap();
+        unit.parse().unwrap();
+
+        assert_eq!(&direct.ast, unit.ast());
+        let interned_symbols = |interner: &ThreadedRodeo| {
+            let mut symbols = interner
+                .iter()
+                .map(|(key, value)| (key.into_usize(), value.to_owned()))
+                .collect::<Vec<_>>();
+            symbols.sort_by_key(|(key, _)| *key);
+            symbols
+        };
+        assert_eq!(
+            interned_symbols(&direct.interner),
+            interned_symbols(unit.interner())
+        );
+    }
+
+    #[test]
+    fn duplicate_merge_errors_preserve_and_replace_syntax_metrics() {
+        let source = "fn foo() -> i32 { 1 } fn foo() -> i32 { 2 }";
+        let expected_tokens = Lexer::new(source).tokenize().unwrap().0.len();
+        let sources = vec![SourceFile::new("a.rue", source, FileId::new(1))];
+        let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
+
+        let direct_errors = crate::merge_symbols(
+            crate::parse_all_files_with_source_snapshot(unit.source_snapshot()).unwrap(),
+        )
+        .expect_err("direct symbol merging should reject the duplicate");
+        let fingerprint = |errors: &crate::CompileErrors| {
+            errors
+                .iter()
+                .map(|error| {
+                    (
+                        error.kind.code(),
+                        error.span(),
+                        error.to_string(),
+                        format!("{:?}", error.diagnostic()),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        let expected_work = SyntaxWork {
+            lexer_invocations: 1,
+            parser_invocations: 1,
+            lexed_bytes: source.len(),
+            tokens: expected_tokens,
+        };
+        let expected_stats = SourceStats {
+            files: 1,
+            bytes: source.len(),
+            lines: 1,
+            tokens: expected_tokens,
+        };
+
+        let first_errors = unit
+            .parse()
+            .expect_err("the compilation unit should reject the duplicate");
+        assert_eq!(fingerprint(&direct_errors), fingerprint(&first_errors));
+        assert_eq!(unit.syntax_work(), expected_work);
+        assert_eq!(unit.source_stats(), expected_stats);
+
+        let second_errors = unit
+            .parse()
+            .expect_err("a repeated parse should still reject the duplicate");
+        assert_eq!(fingerprint(&first_errors), fingerprint(&second_errors));
+        assert_eq!(unit.syntax_work(), expected_work);
+        assert_eq!(unit.source_stats(), expected_stats);
     }
 
     #[test]
     fn test_parse_collects_cross_file_lex_and_parse_errors() {
+        let lex_bad = "fn lex() -> i32 { $ }";
+        let parse_bad = "fn parse( { }";
+        let good = "fn good() -> i32 { 42 }";
+        let expected_tokens = Lexer::new(parse_bad).tokenize().unwrap().0.len()
+            + Lexer::new(good).tokenize().unwrap().0.len();
         let sources = vec![
-            SourceFile::new("lex.rue", "fn lex() -> i32 { $ }", FileId::new(1)),
-            SourceFile::new("parse.rue", "fn parse( { }", FileId::new(2)),
-            SourceFile::new("good.rue", "fn good() -> i32 { 42 }", FileId::new(3)),
+            SourceFile::new("lex.rue", lex_bad, FileId::new(1)),
+            SourceFile::new("parse.rue", parse_bad, FileId::new(2)),
+            SourceFile::new("good.rue", good, FileId::new(3)),
         ];
         let mut unit = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
 
+        let direct_errors = crate::parse_all_files_with_source_snapshot(unit.source_snapshot())
+            .expect_err("direct parsing should report both broken files");
         let errors = unit.parse().expect_err("both broken files should report");
         assert_eq!(errors.len(), 2);
+        let fingerprint = |errors: &crate::CompileErrors| {
+            errors
+                .iter()
+                .map(|error| (error.kind.code(), error.span(), error.to_string()))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(fingerprint(&direct_errors), fingerprint(&errors));
         let file_ids: Vec<_> = errors
             .iter()
             .map(|error| {
@@ -817,6 +834,15 @@ mod tests {
             })
             .collect();
         assert_eq!(file_ids, vec![FileId::new(1), FileId::new(2)]);
+        assert_eq!(
+            unit.syntax_work(),
+            SyntaxWork {
+                lexer_invocations: 3,
+                parser_invocations: 2,
+                lexed_bytes: lex_bad.len() + parse_bad.len() + good.len(),
+                tokens: expected_tokens,
+            }
+        );
     }
 
     #[test]

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -86,6 +86,13 @@ struct TimingDataInner {
     /// robust to a stale timestamp and gives the ordering invariant a
     /// deterministic regression test.
     last_root_transition: Option<Instant>,
+
+    /// Direct parent-child span names captured by the real timing layer.
+    ///
+    /// This remains test-only so parentage regressions can be checked without
+    /// expanding the public benchmark JSON schema.
+    #[cfg(test)]
+    parent_edges: Vec<(String, String)>,
 }
 
 /// Measurements aggregated across every span with the same name.
@@ -174,6 +181,8 @@ impl TimingData {
                 active_roots: 0,
                 root_active_since: None,
                 last_root_transition: None,
+                #[cfg(test)]
+                parent_edges: Vec::new(),
             })),
         }
     }
@@ -210,6 +219,25 @@ impl TimingData {
             let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
             inner.root_duration += duration;
         }
+    }
+
+    /// Record one real direct parent-child relationship for regression tests.
+    #[cfg(test)]
+    fn record_parent_edge(&self, parent: &str, child: &str) {
+        let mut inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        inner
+            .parent_edges
+            .push((parent.to_owned(), child.to_owned()));
+    }
+
+    /// Snapshot parent-child relationships captured by the real timing layer.
+    #[cfg(test)]
+    fn parent_edges(&self) -> Vec<(String, String)> {
+        self.inner
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .parent_edges
+            .clone()
     }
 
     /// Enter a root span and update both timing views as one serialized event.
@@ -589,6 +617,10 @@ where
         // Initialize timing state for this span
         if let Some(span) = ctx.span(id) {
             let parent_id = span.parent().map(|parent| parent.id().clone());
+            #[cfg(test)]
+            let parent_edge = span
+                .parent()
+                .map(|parent| (parent.name().to_owned(), span.name().to_owned()));
             let is_root = parent_id.is_none();
             let mut extensions = span.extensions_mut();
             extensions.insert(SpanTiming {
@@ -607,6 +639,11 @@ where
                         parent_timing.has_children = true;
                     }
                 }
+            }
+
+            #[cfg(test)]
+            if let Some((parent, child)) = parent_edge {
+                self.data.record_parent_edge(&parent, &child);
             }
         }
     }
@@ -668,7 +705,91 @@ where
 
 #[cfg(test)]
 mod tests {
+    use rue_compiler::{
+        CompilationUnit, CompileOptions, FileId, SourceFile, parse_all_files_with_source_snapshot,
+    };
+    use tracing_subscriber::layer::SubscriberExt as _;
+
     use super::*;
+
+    #[test]
+    fn real_snapshot_and_unit_spans_preserve_parse_boundaries() {
+        let sources = vec![SourceFile::new(
+            "main.rue",
+            "fn main() -> i32 { 42 }",
+            FileId::new(1),
+        )];
+        let seed = CompilationUnit::new(sources, CompileOptions::default()).unwrap();
+        let snapshot = seed.source_snapshot().clone();
+
+        let direct_data = TimingData::new();
+        let direct_subscriber =
+            tracing_subscriber::registry().with(TimingLayer::new(direct_data.clone()));
+        tracing::subscriber::with_default(direct_subscriber, || {
+            parse_all_files_with_source_snapshot(&snapshot).unwrap();
+        });
+
+        let direct_edges = direct_data.parent_edges();
+        assert!(
+            direct_edges.contains(&("parse".to_owned(), "parse_file".to_owned())),
+            "direct parse edges: {direct_edges:?}"
+        );
+        assert!(
+            direct_edges.contains(&("parse_file".to_owned(), "lexer".to_owned())),
+            "direct parse edges: {direct_edges:?}"
+        );
+        assert!(
+            direct_edges.contains(&("parse_file".to_owned(), "parser".to_owned())),
+            "direct parse edges: {direct_edges:?}"
+        );
+
+        let direct_timing =
+            direct_data.to_benchmark_timing_with_metrics("test", "test", None, None);
+        let direct_parse = direct_timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "parse")
+            .unwrap();
+        assert_eq!(direct_parse.invocations, 1);
+        assert_eq!(direct_parse.root_invocations, 1);
+
+        let unit_data = TimingData::new();
+        let unit_subscriber =
+            tracing_subscriber::registry().with(TimingLayer::new(unit_data.clone()));
+        tracing::subscriber::with_default(unit_subscriber, || {
+            let mut unit =
+                CompilationUnit::from_source_snapshot(snapshot, CompileOptions::default());
+            unit.parse().unwrap();
+        });
+
+        let unit_edges = unit_data.parent_edges();
+        for expected in [
+            ("parse", "parse_file"),
+            ("parse_file", "lexer"),
+            ("parse_file", "parser"),
+            ("parse", "merge_symbols"),
+        ] {
+            assert!(
+                unit_edges.contains(&(expected.0.to_owned(), expected.1.to_owned())),
+                "missing {expected:?} in compilation-unit edges: {unit_edges:?}"
+            );
+        }
+
+        let unit_timing = unit_data.to_benchmark_timing_with_metrics("test", "test", None, None);
+        let unit_parse = unit_timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "parse")
+            .unwrap();
+        let merge = unit_timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "merge_symbols")
+            .unwrap();
+        assert_eq!(unit_parse.invocations, 1);
+        assert_eq!(unit_parse.root_invocations, 1);
+        assert_eq!(merge.root_invocations, 0);
+    }
 
     #[test]
     fn test_timing_data_empty_report() {


### PR DESCRIPTION
## Summary

- extract one shared per-file syntax kernel and snapshot runner for immutable `SourceSnapshot` inputs
- thread a single interner through every lexer/parser success and failure path while preserving caller-order files and diagnostics
- expose per-run `SyntaxWork` counters for lexer/parser invocations, UTF-8 source bytes, and successfully lexed tokens
- store the latest syntax work on `CompilationUnit` before propagating syntax or merge errors, and continue deriving legacy `SourceStats.tokens` from it
- reuse the public `merge_symbols` implementation instead of maintaining a second compilation-unit merge path
- preserve the historical `parse > parse_file > lexer/parser` and `parse > merge_symbols` timing hierarchy, with a real tracing-layer regression test

## Why

Rue had two copies of the same sequential shared-interner parsing loop. Their instrumentation and bookkeeping had already diverged, which made them an unsafe foundation for later per-file queries. This change creates one correctness boundary and adds direct work counters so future incremental reuse can prove that lexer/parser work was avoided instead of merely hiding it behind lower wall time.

Raw `--emit tokens` and import discovery intentionally remain separate because they have distinct interner and recovery semantics. This PR adds no cache, revisions, persistent state, parallel parsing, or benchmark schema changes.

## Validation

- `./fmt.sh check`
- `./clippy.sh` (41 targets)
- `./buck2 test //...` (34 targets; includes 272 compiler tests and 139 driver/timing tests)
- `./buck2 test //:reproducible-programs`
- `./scripts/check-reproducible-compiler.sh`
  - byte-identical clean-room compiler rebuilds
  - SHA-256: `77aa6cc3f2e3da9603e78f911b4327f7871a256fdc3b8819a5c1d8b1ea547483`

Linear: [RUE-653](https://linear.app/steve-klabnik/issue/RUE-653/compiler-unify-and-measure-the-per-file-syntax-kernel)
