### PR TITLE
RUE-634: validate comptime arguments before type reduction

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6052,48 +6052,55 @@ impl<'a> Sema<'a> {
         let rir_params_start = fn_info.rir_params_start;
         let rir_params_len = fn_info.rir_params_len;
 
-        // Special case: functions that return `type` with no parameters or only comptime parameters
-        // are implicitly comptime and should be evaluated at compile time.
-        // This handles both:
-        //   - `fn SimpleType() -> type { struct { x: i32 } }`  (no params)
-        //   - `fn FixedBuffer(comptime N: i32) -> type { struct { fn capacity(self) -> i32 { N } } }`
-        let all_params_comptime = param_comptime.iter().all(|&c| c);
+        // `-> type` functions with no runtime parameters reduce immediately,
+        // but their arguments still obey the ordinary comptime contract. Build
+        // the maps through the propagating evaluator before reducing the body;
+        // otherwise a constructor that ignores a wrong-kind/private argument
+        // can accidentally accept it.
+        let all_params_comptime = param_comptime.iter().all(|&flag| flag);
         if base_return_type == Type::COMPTIME_TYPE && (args.is_empty() || all_params_comptime) {
-            // Build the substitutions for the callee body from its comptime
-            // arguments: TYPE parameters (`comptime T: type`) into `type_subst`
-            // and VALUE parameters (`comptime N: i32`) into `value_subst`. Both
-            // are needed so a type constructor whose body mentions a type
-            // parameter (`struct { value: T }`) reduces here — including when
-            // this call is itself a nested argument (`WrapA(WrapA(i32))`), so
-            // the inner call analyzes to a `TypeConst` (RUE-251).
-            let mut type_subst: std::collections::HashMap<Spur, Type> =
-                std::collections::HashMap::new();
-            let mut value_subst: std::collections::HashMap<Spur, ConstValue> =
-                std::collections::HashMap::new();
+            let mut type_subst = std::collections::HashMap::new();
+            let mut value_subst = std::collections::HashMap::new();
             for (i, is_comptime) in param_comptime.iter().enumerate() {
                 if !*is_comptime {
                     continue;
                 }
-                // Evaluated in the calling function's context so comptime
-                // parameters in scope and resolved types are visible.
-                match self.try_evaluate_const_in_fn(args[i].value, ctx) {
-                    Some(ConstValue::Type(t)) if param_types[i] == Type::COMPTIME_TYPE => {
-                        type_subst.insert(param_names[i], t);
+                let value = self.evaluate_const_in_fn(args[i].value, ctx)?;
+                if param_types[i] == Type::COMPTIME_TYPE {
+                    match value {
+                        Some(ConstValue::Type(ty)) => {
+                            type_subst.insert(param_names[i], ty);
+                        }
+                        Some(ConstValue::Unit) => {
+                            type_subst.insert(param_names[i], Type::UNIT);
+                        }
+                        Some(_) => {
+                            return Err(CompileError::new(
+                                ErrorKind::ComptimeEvaluationFailed {
+                                    reason: "comptime type parameter must be a type literal"
+                                        .to_string(),
+                                },
+                                self.rir.get(args[i].value).span,
+                            ));
+                        }
+                        None => {
+                            return Err(CompileError::new(
+                                ErrorKind::ComptimeArgNotConst {
+                                    param_name: self.interner.resolve(&param_names[i]).to_string(),
+                                },
+                                self.rir.get(args[i].value).span,
+                            ));
+                        }
                     }
-                    // A unit argument to a `comptime T: type` parameter is the
-                    // unit TYPE (RUE-565): `()` is ambiguous between the unit
-                    // value and the unit type, and the parameter's declared
-                    // `type` kind is exactly the context that disambiguates
-                    // (spec Appendix A treats `()` as an unambiguous type
-                    // argument). Only this position converts; a unit value
-                    // elsewhere stays a value.
-                    Some(ConstValue::Unit) if param_types[i] == Type::COMPTIME_TYPE => {
-                        type_subst.insert(param_names[i], Type::UNIT);
-                    }
-                    Some(const_val) if param_types[i] != Type::COMPTIME_TYPE => {
-                        value_subst.insert(param_names[i], const_val);
-                    }
-                    _ => {}
+                } else if let Some(value) = value {
+                    value_subst.insert(param_names[i], value);
+                } else {
+                    return Err(CompileError::new(
+                        ErrorKind::ComptimeArgNotConst {
+                            param_name: self.interner.resolve(&param_names[i]).to_string(),
+                        },
+                        self.rir.get(args[i].value).span,
+                    ));
                 }
             }
             // Try to evaluate the function body at compile time. A hard error
@@ -6128,7 +6135,7 @@ impl<'a> Sema<'a> {
                     // reference to a comptime parameter of the *current*
                     // function also counts: its value is compile-time known
                     // at every call site, so it may be forwarded (spec 4.14:5).
-                    let is_comptime_known = self.try_evaluate_const_in_fn(arg.value, ctx).is_some()
+                    let is_comptime_known = self.evaluate_const_in_fn(arg.value, ctx)?.is_some()
                         || self.is_comptime_type_var(arg.value, ctx)
                         || self.is_comptime_param_forward(arg.value, ctx);
                     if !is_comptime_known {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -55,7 +55,7 @@ use rue_rir::{InstData, InstRef, RepeatCount, RirPattern};
 use rue_span::{FileId, Span};
 
 use super::Sema;
-use super::context::{AnalysisContext, ConstValue, LocalVar};
+use super::context::{AnalysisContext, ConstValue, LocalVar, ParamInfo};
 use crate::specialize::MAX_SPECIALIZATION_ROUNDS;
 use crate::types::{ArrayLen, StructField, Type, TypeKind};
 
@@ -82,6 +82,10 @@ pub(crate) struct ComptimeEnv<'a> {
     /// `let n = x; g(n)` inside a body with `comptime n` in scope would
     /// wrongly evaluate `n` to the parameter's value (spec 4.14:6).
     runtime_locals: Option<&'a HashMap<Spur, LocalVar>>,
+    /// Runtime parameters in scope. They shadow same-named type values and
+    /// constants just like locals; comptime parameters resolve through the
+    /// substitution maps before this guard is consulted.
+    runtime_params: Option<&'a [ParamInfo]>,
     /// `let` bindings introduced by blocks inside the comptime expression.
     locals: HashMap<Spur, ConstValue>,
     /// Values of module-member accesses (`m.CONST`) appearing in this
@@ -134,6 +138,7 @@ impl<'a> ComptimeEnv<'a> {
             value_subst: &EMPTY_VALUE_SUBST,
             resolved_types: None,
             runtime_locals: None,
+            runtime_params: None,
             locals: HashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
             defining_file: None,
@@ -151,6 +156,7 @@ impl<'a> ComptimeEnv<'a> {
             value_subst,
             resolved_types: None,
             runtime_locals: None,
+            runtime_params: None,
             locals: HashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
             defining_file: None,
@@ -165,6 +171,7 @@ impl<'a> ComptimeEnv<'a> {
             value_subst: &ctx.comptime_value_vars,
             resolved_types: Some(ctx.resolved_types),
             runtime_locals: Some(&ctx.locals),
+            runtime_params: Some(ctx.params),
             locals: HashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
             defining_file: Some(ctx.current_file_id),
@@ -196,6 +203,7 @@ impl<'a> ComptimeEnv<'a> {
             value_subst: &EMPTY_VALUE_SUBST,
             resolved_types: Some(resolved_types),
             runtime_locals: None,
+            runtime_params: None,
             locals: HashMap::new(),
             const_module_members,
             defining_file: Some(defining_file),
@@ -285,6 +293,19 @@ impl Sema<'_> {
     ) -> Option<ConstValue> {
         let mut env = ComptimeEnv::for_analysis(ctx);
         self.eval_const_expr(inst_ref, &mut env).ok().flatten()
+    }
+
+    /// Evaluate an expression in the current function while preserving hard
+    /// diagnostics. Required comptime arguments use this entry point: preview
+    /// gates, privacy failures, and constant operations that would panic are
+    /// source errors, not evidence that the argument is merely runtime.
+    pub(crate) fn evaluate_const_in_fn(
+        &mut self,
+        inst_ref: InstRef,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<Option<ConstValue>> {
+        let mut env = ComptimeEnv::for_analysis(ctx);
+        self.eval_const_expr(inst_ref, &mut env)
     }
 
     /// Try to evaluate an RIR instruction to a compile-time constant value
@@ -453,24 +474,16 @@ impl Sema<'_> {
         }
     }
 
-    /// Resolve a name to a type value (primitive type names, structs, enums).
-    fn resolve_named_type_value(&self, name: &Spur) -> Option<Type> {
-        let name_str = self.interner.resolve(name);
-        // Primitive names come from the single shared table (RUE-155) so the
-        // evaluator can never drift from the resolver.
-        let ty = match Type::from_primitive_name(name_str) {
-            Some(t) => t,
-            None => {
-                if let Some(&struct_id) = self.structs.get(name) {
-                    Type::new_struct(struct_id)
-                } else if let Some(&enum_id) = self.enums.get(name) {
-                    Type::new_enum(enum_id)
-                } else {
-                    return None;
-                }
-            }
-        };
-        Some(ty)
+    /// Resolve a bare name used as a type value through the canonical type
+    /// resolver. Preview types such as `str` are registered lazily, so looking
+    /// only in the already-populated struct and enum maps made their first use
+    /// as a generic type argument spuriously non-constant.
+    fn resolve_named_type_value(&mut self, name: Spur, span: Span) -> CompileResult<Option<Type>> {
+        match self.resolve_type(name, span) {
+            Ok(ty) => Ok(Some(ty)),
+            Err(error) if matches!(error.kind, ErrorKind::UnknownType(_)) => Ok(None),
+            Err(error) => Err(error),
+        }
     }
 
     /// Evaluate both operands of a binary operation as integers.
@@ -1068,7 +1081,7 @@ impl Sema<'_> {
                     return Ok(Some(ConstValue::Type(ty)));
                 }
                 // A named type (primitive / struct / enum) resolves directly.
-                if let Some(ty) = self.resolve_named_type_value(&type_name) {
+                if let Some(ty) = self.resolve_named_type_value(type_name, span)? {
                     return Ok(Some(ConstValue::Type(ty)));
                 }
                 // A *composite* or *unit* type value — `[i32; 2]`, `()`,
@@ -1142,7 +1155,15 @@ impl Sema<'_> {
                 if let Some(&v) = env.value_subst.get(name) {
                     return Ok(Some(v));
                 }
-                // 5. File-level constants: the value was evaluated once
+                // 5. Runtime parameters shadow file-level constants and type
+                //    names. A comptime parameter with a concrete value was
+                //    already handled by the substitution maps above.
+                if let Some(params) = env.runtime_params {
+                    if params.iter().any(|param| param.name == *name) {
+                        return Ok(None);
+                    }
+                }
+                // 6. File-level constants: the value was evaluated once
                 //    (and range-checked against the declared type) during
                 //    declaration gathering — use it directly. Re-evaluating
                 //    the initializer here would fail for forms only the
@@ -1166,9 +1187,11 @@ impl Sema<'_> {
                     )?;
                     return Ok(Some(info.value));
                 }
-                // 6. Type names used as values (e.g. `Point` in
+                // 7. Type names used as values (e.g. `Point` in
                 //    `fn make_type() -> type { Point }`)
-                Ok(self.resolve_named_type_value(name).map(ConstValue::Type))
+                Ok(self
+                    .resolve_named_type_value(*name, span)?
+                    .map(ConstValue::Type))
             }
 
             // Call to a `-> type` function: reduce it to the resulting type

--- a/crates/rue-cli-tests/cases/comptime_value_params.toml
+++ b/crates/rue-cli-tests/cases/comptime_value_params.toml
@@ -144,6 +144,23 @@ compile_fail = true
 error_contains = ["comptime parameter requires a compile-time known value"]
 
 [[case]]
+name = "runtime_parameter_shadows_file_const_during_comptime_evaluation"
+description = "A runtime parameter must not resolve to a same-named file constant when passed to a comptime parameter."
+files = [{ path = "main.rue", source = """
+const N: i32 = 7;
+
+fn need(comptime value: i32) -> i32 { value }
+
+fn outer(N: i32) -> i32 {
+    need(N)
+}
+
+fn main() -> i32 { outer(42) }
+""" }]
+compile_fail = true
+error_contains = ["E1201", "comptime parameter requires a compile-time known value"]
+
+[[case]]
 name = "comptime_recursion_factorial_via_match"
 description = "RUE-191: comptime recursion written with `match` instead of `if` — arm selection on the comptime-known scrutinee lets the recursion terminate instead of spuriously hitting the depth cap."
 files = [{ path = "main.rue", source = """

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -324,6 +324,67 @@ fn main() -> i32 {
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 4
 
+# The comptime evaluator must use the canonical type resolver: `str` is
+# registered lazily, and this is deliberately its first use in the program.
+[[case]]
+name = "generic_first_use_lazy_str_type_argument"
+files = [{ path = "main.rue", source = """
+fn choose(comptime T: type, trailing: i32) -> i32 {
+    trailing
+}
+
+fn main() -> i32 {
+    choose(str, 42)
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "generic_lazy_str_type_argument_preserves_preview_diagnostic"
+files = [{ path = "main.rue", source = """
+fn choose(comptime T: type, trailing: i32) -> i32 {
+    trailing
+}
+
+fn main() -> i32 {
+    choose(str, 42)
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1100", "requires preview feature"]
+
+[[case]]
+name = "runtime_parameter_shadows_lazy_str_type_value"
+files = [{ path = "main.rue", source = """
+fn choose(comptime T: type, value: T) -> i32 { 0 }
+
+fn outer(str: i32) -> i32 {
+    choose(str, str)
+}
+
+fn main() -> i32 { outer(42) }
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+compile_fail = true
+error_contains = ["compile-time known value"]
+
+[[case]]
+name = "ignored_type_parameter_still_validates_argument_kind"
+files = [{ path = "main.rue", source = """
+fn Ignore(comptime T: type) -> type {
+    struct { value: i32 }
+}
+
+fn main() -> i32 {
+    let I = Ignore(7);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["must be a type"]
+
 # RUE-559: a `StrBuf` struct FIELD as the borrowed view source — the coercion
 # traces the place projection, not just whole variables.
 [[case]]


### PR DESCRIPTION
## Summary

- resolve bare type values through the canonical resolver, including lazily registered preview types
- make runtime parameters shadow same-named constants and type values during comptime evaluation
- preserve hard source diagnostics for required comptime arguments
- validate eager type-constructor arguments before reducing the constructor body
- pin lazy resolution, preview gates, shadowing, and ignored-argument validation as a behavior class

Linear: RUE-634

## Verification

- `./test.sh` — 34 targets passed, 0 failed
- `./clippy.sh` — 41 targets passed
- `./fmt.sh check`
- `./buck2 test //:cli-tests` — 1351 passed, 2 ignored
- `./buck2 test //crates/rue-air:rue-air-test` — 372 passed
- independent read-only diff audit: no blocking findings