### PR TITLE
RUE-634: classify comptime parameters from source declarations

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -69,6 +69,11 @@ pub struct FunctionSig {
     /// This is separate from param_modes because `comptime T: type` sets
     /// is_comptime=true but mode=Normal.
     pub param_comptime: Vec<bool>,
+    /// Which parameters are specifically declared `comptime ...: type`.
+    /// A deferred comptime value parameter such as `comptime value: T` also
+    /// has a `COMPTIME_TYPE` semantic placeholder, so that placeholder cannot
+    /// distinguish the two source-level kinds.
+    pub param_comptime_type: Vec<bool>,
     /// Parameter names, needed for type substitution in generic returns.
     pub param_names: Vec<lasso::Spur>,
     /// Each parameter's declared type, as the source-level type name symbol
@@ -1134,9 +1139,7 @@ impl<'a> ConstraintGenerator<'a> {
                             {
                                 continue;
                             }
-                            if func.param_types.get(i)
-                                == Some(&InferType::Concrete(Type::COMPTIME_TYPE))
-                            {
+                            if func.param_comptime_type.get(i) == Some(&true) {
                                 if let Some(concrete_ty) =
                                     self.extract_type_argument(arg.value, ctx)
                                 {
@@ -1155,9 +1158,7 @@ impl<'a> ConstraintGenerator<'a> {
                                 break;
                             }
                             let declared = &func.param_types[i];
-                            if func.param_comptime[i]
-                                && *declared == InferType::Concrete(Type::COMPTIME_TYPE)
-                            {
+                            if func.param_comptime_type.get(i) == Some(&true) {
                                 // Comptime TYPE parameter - the argument is a type value
                                 continue;
                             }
@@ -3782,6 +3783,7 @@ mod tests {
             is_generic: false,
             param_modes: vec![rue_rir::RirParamMode::Normal; num_params],
             param_comptime: vec![false; num_params],
+            param_comptime_type: vec![false; num_params],
             param_names: vec![],
             param_type_syms: vec![],
             return_type_sym: lasso::Spur::default(),

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6044,6 +6044,7 @@ impl<'a> Sema<'a> {
         let is_generic = fn_info.is_generic;
         let param_types = param_types.to_vec();
         let param_comptime = param_comptime.to_vec();
+        let param_comptime_type = self.comptime_type_param_flags(&fn_info);
         let param_names = param_names.to_vec();
         let param_modes = param_modes.to_vec();
         let return_type_sym = fn_info.return_type_sym;
@@ -6066,7 +6067,7 @@ impl<'a> Sema<'a> {
                     continue;
                 }
                 let value = self.evaluate_const_in_fn(args[i].value, ctx)?;
-                if param_types[i] == Type::COMPTIME_TYPE {
+                if param_comptime_type[i] {
                     match value {
                         Some(ConstValue::Type(ty)) => {
                             type_subst.insert(param_names[i], ty);
@@ -6179,9 +6180,9 @@ impl<'a> Sema<'a> {
                 air_args.iter().zip(param_comptime.iter()).enumerate()
             {
                 if *is_comptime {
-                    // Check if this is a type parameter (param type is ComptimeType)
-                    // vs a value parameter (param type is i32, bool, etc.)
-                    if param_types[i] == Type::COMPTIME_TYPE {
+                    // The source declaration distinguishes a type parameter
+                    // from a value parameter whose semantic type is deferred.
+                    if param_comptime_type[i] {
                         // This is a TYPE parameter - expect a TypeConst instruction
                         let inst = air.get(air_arg.value);
                         if let AirInstData::TypeConst(ty) = &inst.data {
@@ -6255,7 +6256,7 @@ impl<'a> Sema<'a> {
                 air_args.iter().zip(param_comptime.iter()).enumerate()
             {
                 let declared = param_types[i];
-                if is_comptime && declared == Type::COMPTIME_TYPE {
+                if is_comptime && param_comptime_type[i] {
                     // The comptime type argument itself - already validated above.
                     continue;
                 }
@@ -6323,7 +6324,7 @@ impl<'a> Sema<'a> {
                 let mut value_subst: std::collections::HashMap<Spur, ConstValue> =
                     std::collections::HashMap::new();
                 for (i, is_comptime) in param_comptime.iter().enumerate() {
-                    if *is_comptime && param_types[i] != Type::COMPTIME_TYPE {
+                    if *is_comptime && !param_comptime_type[i] {
                         // This is a comptime VALUE parameter - extract its const value
                         // (evaluated in the calling function's context)
                         if let Some(const_val) = self.try_evaluate_const_in_fn(args[i].value, ctx) {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1527,6 +1527,7 @@ impl Sema<'_> {
         let param_names = self.param_arena.names(params).to_vec();
         let param_modes = self.param_arena.modes(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
+        let param_comptime_type = self.comptime_type_param_flags(&fn_info);
         let args = self.rir.get_call_args(args_start, args_len).to_vec();
         if args.len() != param_names.len() {
             return Ok(None);
@@ -1565,11 +1566,15 @@ impl Sema<'_> {
             let Some(v) = self.eval_const_expr(arg.value, env)? else {
                 return Ok(None);
             };
-            match v {
-                ConstValue::Type(t) => {
+            match (param_comptime_type[i], v) {
+                (true, ConstValue::Type(t)) => {
                     callee_types.insert(param_names[i], t);
                 }
-                value => {
+                (true, ConstValue::Unit) => {
+                    callee_types.insert(param_names[i], Type::UNIT);
+                }
+                (true, _) => return Ok(None),
+                (false, value) => {
                     callee_values.insert(param_names[i], value);
                 }
             }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -154,6 +154,7 @@ impl<'a> Sema<'a> {
                         is_generic: info.is_generic,
                         param_modes: self.param_arena.modes(info.params).to_vec(),
                         param_comptime: self.param_arena.comptime(info.params).to_vec(),
+                        param_comptime_type: self.comptime_type_param_flags(info),
                         param_names: self.param_arena.names(info.params).to_vec(),
                         param_type_syms: self
                             .rir
@@ -2554,7 +2555,7 @@ impl<'a> Sema<'a> {
         let function_key = self
             .resolve_function_name_in_file(member, mfile)
             .unwrap_or_else(|| self.internal_function_name(member, mfile));
-        let Some(fn_info) = self.functions.get(&function_key) else {
+        let Some(fn_info) = self.functions.get(&function_key).copied() else {
             return Err(CompileError::new(
                 ErrorKind::UnknownModuleMember {
                     module_name: import_path,
@@ -2576,6 +2577,7 @@ impl<'a> Sema<'a> {
         let param_names = self.param_arena.names(params).to_vec();
         let param_modes = self.param_arena.modes(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
+        let param_comptime_type = self.comptime_type_param_flags(&fn_info);
         let args = self.rir.get_call_args(args_start, args_len).to_vec();
         if args.len() != param_names.len() {
             return Err(CompileError::new(
@@ -2626,11 +2628,25 @@ impl<'a> Sema<'a> {
                     self.rir.get(arg.value).span,
                 ));
             };
-            match value {
-                ConstValue::Type(ty) => {
+            match (param_comptime_type[i], value) {
+                (true, ConstValue::Type(ty)) => {
                     callee_types.insert(param_names[i], ty);
                 }
-                value => {
+                (true, ConstValue::Unit) => {
+                    callee_types.insert(param_names[i], Type::UNIT);
+                }
+                (true, _) => {
+                    return Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: format!(
+                                "argument for '{}' must be a type",
+                                self.interner.resolve(&param_names[i])
+                            ),
+                        },
+                        self.rir.get(arg.value).span,
+                    ));
+                }
+                (false, value) => {
                     callee_values.insert(param_names[i], value);
                 }
             }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -22,7 +22,7 @@ use super::context::AnalysisContext;
 pub(crate) const MAX_TYPE_SIZE_BYTES: u64 = i32::MAX as u64;
 /// [`MAX_TYPE_SIZE_BYTES`] expressed in 8-byte ABI slots.
 pub(crate) const MAX_TYPE_SLOTS: u64 = MAX_TYPE_SIZE_BYTES / 8;
-use super::info::ConstInfo;
+use super::info::{ConstInfo, FunctionInfo};
 use crate::inference::InferType;
 use crate::sema::ConstValue;
 use crate::types::{
@@ -964,7 +964,7 @@ impl<'a> Sema<'a> {
         // Kind-aware binding: type args resolve as types, value args as
         // comptime constants (RUE-552).
         let (callee_types, callee_values) =
-            self.bind_type_ctor_args(call_path, params, arg_strs, span, ctx)?;
+            self.bind_type_ctor_args(call_path, fn_info, arg_strs, span, ctx)?;
         match self
             .reduce_type_ctor_body(function_key, &callee_types, &callee_values)
             .map_err(|e| Self::label_ctor_instantiation_site(e, span))?
@@ -1093,11 +1093,11 @@ impl<'a> Sema<'a> {
         // Kind-aware binding (RUE-552): type parameters take type arguments;
         // comptime VALUE parameters take value arguments resolved under the
         // enclosing value substitution.
-        let param_types = self.param_arena.types(params).to_vec();
+        let param_comptime_type = self.comptime_type_param_flags(&fn_info);
         let mut callee_types: HashMap<Spur, Type> = HashMap::new();
         let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
         for (i, arg) in arg_strs.iter().enumerate() {
-            if param_types[i] == Type::COMPTIME_TYPE {
+            if param_comptime_type[i] {
                 let arg_sym = self.interner.get_or_intern(arg);
                 let arg_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
                     arg_sym,
@@ -1309,17 +1309,18 @@ impl<'a> Sema<'a> {
     fn bind_type_ctor_args(
         &mut self,
         call_display: &str,
-        params: crate::param_arena::ParamRange,
+        function: FunctionInfo,
         arg_strs: &[String],
         span: Span,
         ctx: Option<&AnalysisContext>,
     ) -> CompileResult<(HashMap<Spur, Type>, HashMap<Spur, ConstValue>)> {
+        let params = function.params;
         let param_names = self.param_arena.names(params).to_vec();
-        let param_types = self.param_arena.types(params).to_vec();
+        let param_comptime_type = self.comptime_type_param_flags(&function);
         let mut callee_types: HashMap<Spur, Type> = HashMap::new();
         let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
         for (i, arg) in arg_strs.iter().enumerate() {
-            if param_types[i] == Type::COMPTIME_TYPE {
+            if param_comptime_type[i] {
                 // A value where a type is expected gets a targeted message
                 // instead of decaying to "unknown type '2'".
                 if arg.trim().parse::<i128>().is_ok() {
@@ -1422,7 +1423,7 @@ impl<'a> Sema<'a> {
         };
 
         // The callee must be a known `-> type` constructor.
-        let Some(fn_info) = self.functions.get(&name_key) else {
+        let Some(fn_info) = self.functions.get(&name_key).copied() else {
             return Err(CompileError::new(
                 ErrorKind::UnknownType(format!("{}(...)", call_name)),
                 span,
@@ -1477,7 +1478,7 @@ impl<'a> Sema<'a> {
         // kind: type arguments resolve as types, value arguments as comptime
         // constants (RUE-552).
         let (callee_types, callee_values) =
-            self.bind_type_ctor_args(call_name, params, arg_strs, span, ctx)?;
+            self.bind_type_ctor_args(call_name, fn_info, arg_strs, span, ctx)?;
 
         // Reduce the constructor body under the substitution. Shares the exact
         // reduction path (and E1200 recursion guard) with value-position calls.
@@ -1497,6 +1498,26 @@ impl<'a> Sema<'a> {
                 span,
             )),
         }
+    }
+
+    /// Return one flag per source parameter identifying declarations of the
+    /// form `comptime T: type`.
+    ///
+    /// This kind cannot be reconstructed from the semantic parameter type:
+    /// both a type parameter and a deferred comptime value parameter such as
+    /// `comptime value: T` carry [`Type::COMPTIME_TYPE`] until substitution.
+    /// The original RIR declaration is therefore the source of truth for
+    /// specialization-stream routing and runtime erasure.
+    pub(crate) fn comptime_type_param_flags(&self, function: &FunctionInfo) -> Vec<bool> {
+        let type_sym = self.interner.get("type");
+        let flags: Vec<bool> = self
+            .rir
+            .get_params(function.rir_params_start, function.rir_params_len)
+            .iter()
+            .map(|param| param.is_comptime && Some(param.ty) == type_sym)
+            .collect();
+        debug_assert_eq!(flags.len(), function.params.len());
+        flags
     }
 
     /// Resolve a type symbol to a Type, returning None if the type is unknown.
@@ -1652,7 +1673,7 @@ impl<'a> Sema<'a> {
             } else {
                 self.resolve_function_name_local(name_sym, span.file_id)?
             };
-            let fn_info = self.functions.get(&function_key)?;
+            let fn_info = self.functions.get(&function_key).copied()?;
             if fn_info.return_type != Type::COMPTIME_TYPE {
                 return None;
             }
@@ -1665,11 +1686,11 @@ impl<'a> Sema<'a> {
                 return None;
             }
             // Kind-aware binding (RUE-552): see the qualified resolver above.
-            let param_types = self.param_arena.types(params).to_vec();
+            let param_comptime_type = self.comptime_type_param_flags(&fn_info);
             let mut callee_types: HashMap<Spur, Type> = HashMap::new();
             let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
             for (i, arg) in arg_strs.iter().enumerate() {
-                if param_types[i] == Type::COMPTIME_TYPE {
+                if param_comptime_type[i] {
                     let arg_sym = self.interner.get_or_intern(arg);
                     let arg_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
                         arg_sym,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -503,11 +503,14 @@ fn create_specialized_function(
     let mut value_subst: HashMap<Spur, ConstValue> = HashMap::new();
     let mut type_arg_idx = 0;
     let mut value_arg_idx = 0;
-    for (name, ty, _, is_comptime) in sema.param_arena.iter(base_info.params) {
+    let param_comptime_type = sema.comptime_type_param_flags(base_info);
+    for (param_index, (name, _, _, is_comptime)) in
+        sema.param_arena.iter(base_info.params).enumerate()
+    {
         if !*is_comptime {
             continue;
         }
-        if *ty == Type::COMPTIME_TYPE {
+        if param_comptime_type[param_index] {
             if type_arg_idx < key.type_args.len() {
                 type_subst.insert(*name, key.type_args[type_arg_idx]);
                 type_arg_idx += 1;
@@ -543,18 +546,10 @@ fn create_specialized_function(
         .collect();
     let mut specialized_params: Vec<(Spur, Type, RirParamMode, bool)> =
         Vec::with_capacity(base_params.len());
-    for (name, ty, mode, is_comptime) in base_params {
-        if is_comptime {
-            if ty == Type::COMPTIME_TYPE {
-                // Comptime TYPE parameters are erased from the specialized
-                // signature (types don't exist at runtime).
-                continue;
-            }
-            // Comptime VALUE parameters stay in the runtime signature — the
-            // call site still passes them (see `analyze_call`); their constant
-            // value is additionally substituted into the body via value_subst
-            // so comptime contexts see it (RUE-166).
-            specialized_params.push((name, ty, mode, true));
+    for (param_index, (name, ty, mode, is_comptime)) in base_params.into_iter().enumerate() {
+        if param_comptime_type[param_index] {
+            // Comptime TYPE parameters are erased from the specialized
+            // signature (types don't exist at runtime).
             continue;
         }
         let concrete_ty = if ty == Type::COMPTIME_TYPE {
@@ -567,7 +562,10 @@ fn create_specialized_function(
         } else {
             ty
         };
-        specialized_params.push((name, concrete_ty, mode, false));
+        // Comptime VALUE parameters stay in the runtime signature — the call
+        // site still passes them. Their constant value is additionally
+        // substituted into the body via value_subst (RUE-166).
+        specialized_params.push((name, concrete_ty, mode, is_comptime));
     }
 
     let (

--- a/crates/rue-cli-tests/cases/comptime_cross_module.toml
+++ b/crates/rue-cli-tests/cases/comptime_cross_module.toml
@@ -62,6 +62,31 @@ fn main() -> i32 {
 ]
 exit_code = 42
 
+[[case]]
+name = "cross_module_const_deferred_value_parameter_kind"
+description = "A module-qualified type constructor keeps `comptime value: T` in the value stream when reduced as a file constant."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "lib.rue", source = """
+pub fn Witness(comptime T: type, comptime value: T) -> type {
+    struct { payload: T }
+}
+""" },
+  { path = "main.rue", source = """
+const lib = @import("lib.rue");
+const W = lib.Witness(i32, 7);
+
+fn read(w: lib.Witness(i32, 7)) -> i32 {
+    w.payload
+}
+
+fn main() -> i32 {
+    read(W { payload: 42 })
+}
+""" },
+]
+exit_code = 42
+
 # --- RUE-511: method return-type + value (let) position ---
 [[case]]
 name = "cross_module_ctor_return_and_let"

--- a/crates/rue-cli-tests/cases/comptime_type_functions.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_functions.toml
@@ -287,3 +287,28 @@ fn main() -> i32 { 0 }
 """ }]
 compile_fail = true
 error_contains = ["E1200", "must be a type"]
+
+[[case]]
+name = "deferred_value_parameter_kind_in_type_constructor_positions"
+description = "A `comptime value: T` parameter stays a value argument when its type constructor is reduced in both value and signature positions."
+files = [{ path = "main.rue", source = """
+fn Witness(comptime T: type, comptime value: T) -> type {
+    struct { payload: T }
+}
+
+fn Wrap(comptime T: type) -> type {
+    struct { inner: T }
+}
+
+fn read(w: Witness(i32, 7)) -> i32 {
+    w.payload
+}
+
+fn main() -> i32 {
+    let W = Witness(i32, 7);
+    let Wrapped = Wrap(Witness(i32, 7));
+    let wrapped = Wrapped { inner: W { payload: 42 } };
+    read(wrapped.inner)
+}
+""" }]
+exit_code = 42

--- a/crates/rue-cli-tests/cases/comptime_value_params.toml
+++ b/crates/rue-cli-tests/cases/comptime_value_params.toml
@@ -342,3 +342,19 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "2\n1\n3\n"
+
+# A deferred semantic type (`T`) does not make this a comptime TYPE parameter.
+# Source-declared kind controls stream routing and erasure: `value` remains one
+# concrete runtime slot in the specialized function.
+[[case]]
+name = "comptime_value_parameter_typed_by_type_parameter"
+files = [{ path = "main.rue", source = """
+fn choose(comptime T: type, comptime value: T, trailing: i32) -> i32 {
+    trailing
+}
+
+fn main() -> i32 {
+    choose(i64, 7, 42)
+}
+""" }]
+exit_code = 42


### PR DESCRIPTION
## Summary

- classify comptime type parameters from the original RIR declaration instead of the ambiguous semantic `COMPTIME_TYPE` placeholder
- use that source-declared kind consistently in inference, eager and compositional type reduction, module constants, generic call streams, and specialization
- retain and concretize `comptime value: T` as a value parameter instead of erasing it as a type parameter
- pin ordinary, nested, signature-position, and cross-module constructor paths

This is the source-kind prerequisite for the later generic call physicalization fix. It deliberately excludes substituted-signature resolver, slice, and call-ABI physicalization changes.

Linear: RUE-634

## Verification

- `./test.sh` — 34 targets passed, 0 failed
- `./clippy.sh` — 41 targets passed
- `./fmt.sh check`
- `./buck2 test //crates/rue-air:rue-air-test` — 372 passed
- three focused CLI regressions passed after the final coverage strengthening
- independent read-only diff audit: no blocking findings