### PR TITLE
RUE-656: index semantic declarations

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -38,7 +38,7 @@ pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
     AnalyzedFunction, ConstValue, DirResolution, FunctionInfo, GatherOutput, MethodInfo,
-    ModulePath, ParamSlotModes, Sema, SemaOutput, import_candidate_groups,
+    ModulePath, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/declaration_index.rs
+++ b/crates/rue-air/src/sema/declaration_index.rs
@@ -1,0 +1,525 @@
+//! Snapshot-local lookup tables for raw RIR declaration candidates.
+//!
+//! This index is an implementation detail of one [`super::Sema`] invocation.
+//! Its [`InstRef`] values, [`FileId`] values, and [`Spur`] values are meaningful
+//! only with the exact RIR and interner epoch from which it was built. They are
+//! arena locators, not durable semantic or tooling identities.
+
+use std::collections::{HashMap, HashSet};
+
+use lasso::Spur;
+use rue_rir::{InstData, InstRef, Rir};
+use rue_span::{FileId, Span};
+
+/// Exact structural work performed while building one RIR declaration index.
+///
+/// These counters make index construction measurable without exposing any of
+/// its request-local instruction handles.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RirDeclarationIndexWork {
+    /// Number of index builds represented by this value.
+    pub build_invocations: usize,
+    /// Number of entries visited through [`Rir::iter`].
+    pub rir_instructions_visited: usize,
+    /// Number of method-owner edges decoded from named and anonymous structs.
+    pub method_references_visited: usize,
+    /// Number of true free-function candidates retained.
+    pub free_functions_indexed: usize,
+    /// Number of functions owned by named structs.
+    pub named_methods_indexed: usize,
+    /// Number of functions owned by anonymous structs.
+    pub anonymous_methods_indexed: usize,
+    /// Number of named destructor declarations retained.
+    pub destructors_indexed: usize,
+    /// Number of syntactic constant candidates retained before semantic
+    /// evaluation classifies value constants versus module bindings.
+    pub const_candidates_indexed: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RirDestructorDeclaration {
+    pub(super) declaration: InstRef,
+    pub(super) type_name: Spur,
+    pub(super) body: InstRef,
+    pub(super) span: Span,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FunctionCandidate {
+    declaration: InstRef,
+    file_id: FileId,
+    name: Spur,
+    has_self: bool,
+}
+
+/// Immutable declaration candidates tied to one exact RIR arena.
+///
+/// Ordered vectors preserve RIR order, including duplicates in invalid input.
+/// Hash tables are used only for point lookup; their iteration order never
+/// drives diagnostics, allocation, or generated artifacts.
+#[derive(Debug)]
+pub(super) struct RirDeclarationIndex {
+    free_functions: Vec<InstRef>,
+    free_functions_by_file_name: HashMap<(FileId, Spur), Vec<InstRef>>,
+    free_functions_by_name: HashMap<Spur, Vec<InstRef>>,
+    named_methods: Vec<InstRef>,
+    anonymous_methods: Vec<InstRef>,
+    named_method_refs: HashSet<InstRef>,
+    anonymous_method_refs: HashSet<InstRef>,
+    /// Deliberately preserves the historical internal-symbol rule: every
+    /// receiverless `FnDecl` counts, including associated functions.
+    non_receiver_name_multiplicity: HashMap<Spur, usize>,
+    destructors: Vec<RirDestructorDeclaration>,
+    const_candidates: Vec<InstRef>,
+    const_candidates_by_file_name: HashMap<(FileId, Spur), Vec<InstRef>>,
+    work: RirDeclarationIndexWork,
+}
+
+impl RirDeclarationIndex {
+    pub(super) fn new(rir: &Rir) -> Self {
+        let mut function_candidates = Vec::new();
+        let mut named_method_refs = HashSet::new();
+        let mut anonymous_method_refs = HashSet::new();
+        let mut non_receiver_name_multiplicity = HashMap::<Spur, usize>::new();
+        let mut destructors = Vec::new();
+        let mut const_candidates = Vec::new();
+        let mut const_candidates_by_file_name = HashMap::<(FileId, Spur), Vec<InstRef>>::new();
+        let mut work = RirDeclarationIndexWork {
+            build_invocations: 1,
+            ..RirDeclarationIndexWork::default()
+        };
+
+        // AstGen emits method FnDecls before their enclosing type. Retain all
+        // function candidates during this single arena walk, collect owner
+        // edges wherever their containers occur, then classify below.
+        for (inst_ref, inst) in rir.iter() {
+            work.rir_instructions_visited += 1;
+            match &inst.data {
+                InstData::FnDecl { name, has_self, .. } => {
+                    function_candidates.push(FunctionCandidate {
+                        declaration: inst_ref,
+                        file_id: inst.span.file_id,
+                        name: *name,
+                        has_self: *has_self,
+                    });
+                    if !*has_self {
+                        *non_receiver_name_multiplicity.entry(*name).or_default() += 1;
+                    }
+                }
+                InstData::StructDecl {
+                    methods_start,
+                    methods_len,
+                    ..
+                } => {
+                    for method_ref in rir.get_inst_refs(*methods_start, *methods_len) {
+                        work.method_references_visited += 1;
+                        named_method_refs.insert(method_ref);
+                    }
+                }
+                InstData::AnonStructType {
+                    methods_start,
+                    methods_len,
+                    ..
+                } => {
+                    for method_ref in rir.get_inst_refs(*methods_start, *methods_len) {
+                        work.method_references_visited += 1;
+                        anonymous_method_refs.insert(method_ref);
+                    }
+                }
+                InstData::DropFnDecl { type_name, body } => {
+                    destructors.push(RirDestructorDeclaration {
+                        declaration: inst_ref,
+                        type_name: *type_name,
+                        body: *body,
+                        span: inst.span,
+                    });
+                }
+                InstData::ConstDecl { name, .. } => {
+                    const_candidates.push(inst_ref);
+                    const_candidates_by_file_name
+                        .entry((inst.span.file_id, *name))
+                        .or_default()
+                        .push(inst_ref);
+                }
+                _ => {}
+            }
+        }
+
+        let mut free_functions = Vec::new();
+        let mut free_functions_by_file_name = HashMap::<(FileId, Spur), Vec<InstRef>>::new();
+        let mut free_functions_by_name = HashMap::<Spur, Vec<InstRef>>::new();
+        let mut named_methods = Vec::new();
+        let mut anonymous_methods = Vec::new();
+
+        for candidate in function_candidates {
+            if named_method_refs.contains(&candidate.declaration) {
+                named_methods.push(candidate.declaration);
+            } else if anonymous_method_refs.contains(&candidate.declaration) {
+                anonymous_methods.push(candidate.declaration);
+            } else if !candidate.has_self {
+                free_functions.push(candidate.declaration);
+                free_functions_by_file_name
+                    .entry((candidate.file_id, candidate.name))
+                    .or_default()
+                    .push(candidate.declaration);
+                free_functions_by_name
+                    .entry(candidate.name)
+                    .or_default()
+                    .push(candidate.declaration);
+            }
+        }
+
+        work.free_functions_indexed = free_functions.len();
+        work.named_methods_indexed = named_methods.len();
+        work.anonymous_methods_indexed = anonymous_methods.len();
+        work.destructors_indexed = destructors.len();
+        work.const_candidates_indexed = const_candidates.len();
+
+        Self {
+            free_functions,
+            free_functions_by_file_name,
+            free_functions_by_name,
+            named_methods,
+            anonymous_methods,
+            named_method_refs,
+            anonymous_method_refs,
+            non_receiver_name_multiplicity,
+            destructors,
+            const_candidates,
+            const_candidates_by_file_name,
+            work,
+        }
+    }
+
+    #[inline]
+    pub(super) fn work(&self) -> RirDeclarationIndexWork {
+        debug_assert_eq!(self.work.free_functions_indexed, self.free_functions.len());
+        debug_assert_eq!(self.work.named_methods_indexed, self.named_methods.len());
+        debug_assert_eq!(
+            self.work.anonymous_methods_indexed,
+            self.anonymous_methods.len()
+        );
+        debug_assert_eq!(self.work.destructors_indexed, self.destructors.len());
+        debug_assert_eq!(
+            self.work.const_candidates_indexed,
+            self.const_candidates.len()
+        );
+        debug_assert_eq!(
+            self.const_candidates_by_file_name
+                .values()
+                .map(Vec::len)
+                .sum::<usize>(),
+            self.const_candidates.len()
+        );
+        self.work
+    }
+
+    #[inline]
+    pub(super) fn non_receiver_name_multiplicity(&self, name: Spur) -> usize {
+        self.non_receiver_name_multiplicity
+            .get(&name)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub(super) fn first_free_function(
+        &self,
+        name: Spur,
+        file_id: Option<FileId>,
+    ) -> Option<InstRef> {
+        let candidates = match file_id {
+            Some(file_id) => self.free_functions_by_file_name.get(&(file_id, name)),
+            None => self.free_functions_by_name.get(&name),
+        }?;
+        candidates.first().copied()
+    }
+
+    #[inline]
+    pub(super) fn is_named_method(&self, inst_ref: InstRef) -> bool {
+        self.named_method_refs.contains(&inst_ref)
+    }
+
+    #[inline]
+    pub(super) fn is_anonymous_method(&self, inst_ref: InstRef) -> bool {
+        self.anonymous_method_refs.contains(&inst_ref)
+    }
+
+    #[inline]
+    pub(super) fn is_type_scoped_method(&self, inst_ref: InstRef) -> bool {
+        self.is_named_method(inst_ref) || self.is_anonymous_method(inst_ref)
+    }
+
+    #[cfg(test)]
+    fn free_functions(&self) -> &[InstRef] {
+        &self.free_functions
+    }
+
+    #[cfg(test)]
+    fn free_functions_in_file(&self, file_id: FileId, name: Spur) -> &[InstRef] {
+        self.free_functions_by_file_name
+            .get(&(file_id, name))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    fn named_methods(&self) -> &[InstRef] {
+        &self.named_methods
+    }
+
+    #[cfg(test)]
+    fn anonymous_methods(&self) -> &[InstRef] {
+        &self.anonymous_methods
+    }
+
+    #[cfg(test)]
+    fn destructors(&self) -> &[RirDestructorDeclaration] {
+        &self.destructors
+    }
+
+    #[cfg(test)]
+    fn const_candidates(&self, file_id: FileId, name: Spur) -> &[InstRef] {
+        self.const_candidates_by_file_name
+            .get(&(file_id, name))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    fn all_const_candidates(&self) -> &[InstRef] {
+        &self.const_candidates
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use lasso::ThreadedRodeo;
+    use rue_error::PreviewFeatures;
+    use rue_lexer::Lexer;
+    use rue_parser::{Ast, Parser};
+    use rue_rir::{AstGen, InstData};
+
+    use super::*;
+    use crate::sema::Sema;
+
+    fn lower_files(files: &[(&str, FileId)]) -> (Rir, ThreadedRodeo) {
+        let mut interner = ThreadedRodeo::default();
+        let mut items = Vec::new();
+        for &(source, file_id) in files {
+            let lexer = Lexer::with_interner_and_file_id(source, interner, file_id);
+            let (tokens, next_interner) = lexer.tokenize().unwrap();
+            let parser = Parser::new(tokens, next_interner);
+            let (ast, next_interner) = parser.parse().unwrap();
+            items.extend(ast.items);
+            interner = next_interner;
+        }
+        let ast = Ast { items };
+        let rir = AstGen::new(&ast, &interner).generate();
+        (rir, interner)
+    }
+
+    fn names(indexed: &[InstRef], rir: &Rir, interner: &ThreadedRodeo) -> Vec<String> {
+        indexed
+            .iter()
+            .map(|&inst_ref| {
+                let InstData::FnDecl { name, .. } = &rir.get(inst_ref).data else {
+                    panic!("function index contains a non-FnDecl instruction");
+                };
+                interner.resolve(name).to_owned()
+            })
+            .collect()
+    }
+
+    fn assert_rir_order(refs: &[InstRef]) {
+        assert!(
+            refs.windows(2)
+                .all(|pair| pair[0].as_u32() < pair[1].as_u32()),
+            "declarations are not in RIR order: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn classifies_callable_owners_and_unclassified_constants_in_one_scan() {
+        let source = r#"
+            struct Named {
+                value: i32,
+                fn receiver(self) -> i32 { self.value }
+                fn collide() -> i32 { 10 }
+            }
+            fn Factory() -> type {
+                struct {
+                    fn anon_receiver(self) -> i32 { 20 }
+                    fn collide() -> i32 { 30 }
+                }
+            }
+            fn generic(comptime T: type, value: T) -> T { value }
+            fn collide() -> i32 { 40 }
+            const alias = collide;
+            drop fn Named(self) {}
+            fn main() -> i32 { collide() }
+        "#;
+        let (rir, interner) = lower_files(&[(source, FileId::new(7))]);
+        let index = RirDeclarationIndex::new(&rir);
+
+        assert_eq!(
+            names(index.free_functions(), &rir, &interner),
+            ["Factory", "generic", "collide", "main"]
+        );
+        assert_eq!(
+            names(index.named_methods(), &rir, &interner),
+            ["receiver", "collide"]
+        );
+        assert_eq!(
+            names(index.anonymous_methods(), &rir, &interner),
+            ["anon_receiver", "collide"]
+        );
+        assert_rir_order(index.free_functions());
+        assert_rir_order(index.named_methods());
+        assert_rir_order(index.anonymous_methods());
+        for &method in index.named_methods() {
+            assert!(index.is_named_method(method));
+            assert!(index.is_type_scoped_method(method));
+            assert!(!index.is_anonymous_method(method));
+        }
+        for &method in index.anonymous_methods() {
+            assert!(index.is_anonymous_method(method));
+            assert!(index.is_type_scoped_method(method));
+            assert!(!index.is_named_method(method));
+        }
+
+        let collide = interner.get("collide").unwrap();
+        let free_collide = index
+            .first_free_function(collide, Some(FileId::new(7)))
+            .unwrap();
+        assert!(!index.is_type_scoped_method(free_collide));
+        assert_eq!(index.non_receiver_name_multiplicity(collide), 3);
+
+        let destructors = index.destructors();
+        assert_eq!(destructors.len(), 1);
+        assert_eq!(interner.resolve(&destructors[0].type_name), "Named");
+        assert_eq!(destructors[0].span.file_id, FileId::new(7));
+        assert!(matches!(
+            rir.get(destructors[0].declaration).data,
+            InstData::DropFnDecl { body, .. } if body == destructors[0].body
+        ));
+
+        let alias = interner.get("alias").unwrap();
+        assert_eq!(index.const_candidates(FileId::new(7), alias).len(), 1);
+        assert_eq!(index.all_const_candidates().len(), 1);
+
+        let expected_work = RirDeclarationIndexWork {
+            build_invocations: 1,
+            rir_instructions_visited: rir.len(),
+            method_references_visited: 4,
+            free_functions_indexed: 4,
+            named_methods_indexed: 2,
+            anonymous_methods_indexed: 2,
+            destructors_indexed: 1,
+            const_candidates_indexed: 1,
+        };
+        assert_eq!(index.work(), expected_work);
+        let sema = Sema::new(&rir, &interner, PreviewFeatures::new());
+        assert_eq!(sema.rir_declaration_index_work(), expected_work);
+    }
+
+    #[test]
+    fn file_qualified_lookups_retain_duplicates_and_follow_rir_order() {
+        let first = FileId::new(9);
+        let second = FileId::new(2);
+        let (rir, interner) = lower_files(&[
+            (
+                "fn same() -> i32 { 1 } fn same() -> i32 { 2 } fn main() -> i32 { same() }",
+                first,
+            ),
+            ("fn same() -> i32 { 3 } const same = 4;", second),
+        ]);
+        let index = RirDeclarationIndex::new(&rir);
+        let same = interner.get("same").unwrap();
+
+        let first_candidates = index.free_functions_in_file(first, same);
+        let second_candidates = index.free_functions_in_file(second, same);
+        assert_eq!(first_candidates.len(), 2);
+        assert_eq!(second_candidates.len(), 1);
+        assert_rir_order(first_candidates);
+        assert_rir_order(index.free_functions());
+        assert_eq!(
+            index
+                .free_functions()
+                .iter()
+                .map(|&inst_ref| rir.get(inst_ref).span.file_id)
+                .collect::<Vec<_>>(),
+            [first, first, first, second]
+        );
+        assert_eq!(
+            index.first_free_function(same, None),
+            first_candidates.first().copied()
+        );
+        assert_eq!(
+            index.first_free_function(same, Some(first)),
+            first_candidates.first().copied()
+        );
+        assert_eq!(
+            index.first_free_function(same, Some(second)),
+            second_candidates.first().copied()
+        );
+        assert_eq!(index.non_receiver_name_multiplicity(same), 3);
+        assert_eq!(index.const_candidates(second, same).len(), 1);
+
+        let rebuilt = RirDeclarationIndex::new(&rir);
+        assert_eq!(rebuilt.work(), index.work());
+        assert_eq!(rebuilt.free_functions(), index.free_functions());
+        assert_eq!(
+            rebuilt.const_candidates(second, same),
+            index.const_candidates(second, same)
+        );
+    }
+
+    #[test]
+    fn indexed_consumers_preserve_free_function_identity_and_body() {
+        let file_id = FileId::new(17);
+        let source = r#"
+            struct Named {
+                fn collide() -> i64 { 99 }
+            }
+            const alias = collide;
+            fn collide() -> i32 { 42 }
+            fn main() -> i32 { alias() }
+        "#;
+        let (rir, interner) = lower_files(&[(source, file_id)]);
+        let mut sema = Sema::new(&rir, &interner, PreviewFeatures::new());
+        sema.set_symbol_paths(HashMap::from([(file_id, "pkg/main.rue".to_owned())]));
+        let output = sema.analyze_all().unwrap();
+
+        // Receiverless associated functions historically participate in the
+        // free-function name multiplicity used for machine symbols. RUE-656
+        // indexes that rule instead of silently "correcting" the spelling.
+        let expected_name = "__rue_fn_pkg_2fmain_2erue__collide";
+        let free = output
+            .functions
+            .iter()
+            .find(|function| function.name == expected_name)
+            .unwrap_or_else(|| panic!("missing indexed free function {expected_name}"));
+        assert_eq!(free.air.return_type(), crate::Type::I32);
+        assert!(
+            free.air
+                .iter()
+                .any(|(_, inst)| { matches!(inst.data, crate::AirInstData::Const(42)) })
+        );
+
+        // Collection and early const-alias lookup must choose the free
+        // declaration without confusing the same-named, type-owned
+        // associated declaration for a free candidate.
+        assert!(output.functions.iter().any(|function| {
+            function.name == "main"
+                && function.air.iter().any(|(_, inst)| {
+                    matches!(
+                        inst.data,
+                        crate::AirInstData::Call { name, .. }
+                            if interner.resolve(&name) == expected_name
+                    )
+                })
+        }));
+    }
+}

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -45,19 +45,14 @@ impl<'a> Sema<'a> {
         if source == "main" {
             return source_name;
         }
-        let mut count = 0;
-        for (_, inst) in self.rir.iter() {
-            let InstData::FnDecl { name, has_self, .. } = &inst.data else {
-                continue;
-            };
-            if !*has_self && *name == source_name {
-                count += 1;
-                if count > 1 {
-                    break;
-                }
-            }
-        }
-        if count > 1 {
+        // Preserve the historical symbol rule exactly in this preparatory
+        // slice: receiverless associated functions count too. Correct free
+        // function classification is indexed separately for body lookup.
+        if self
+            .declaration_index
+            .non_receiver_name_multiplicity(source_name)
+            > 1
+        {
             let module_component = self
                 .get_symbol_path(file_id)
                 .map(normalize_module_path)
@@ -346,29 +341,6 @@ impl<'a> Sema<'a> {
     /// the global one, so they are excluded here (matching the collection
     /// logic in `resolve_remaining_declarations`).
     pub(crate) fn check_top_level_name_collisions(&self) -> CompileResult<()> {
-        // Gather method / associated-function inst refs to exclude: they are
-        // namespaced under their enclosing type, not the global name space.
-        let mut method_refs: HashSet<InstRef> = HashSet::new();
-        for (_, inst) in self.rir.iter() {
-            match &inst.data {
-                InstData::AnonStructType {
-                    methods_start,
-                    methods_len,
-                    ..
-                }
-                | InstData::StructDecl {
-                    methods_start,
-                    methods_len,
-                    ..
-                } => {
-                    for r in self.rir.get_inst_refs(*methods_start, *methods_len) {
-                        method_refs.insert(r);
-                    }
-                }
-                _ => {}
-            }
-        }
-
         // Free functions duplicate-conflict only within their defining file
         // (RUE-441), except for the program-global `main` entry point (RUE-582).
         // Types and function/type cross-kind collisions are per-file too
@@ -405,7 +377,7 @@ impl<'a> Sema<'a> {
                     seen_types_by_file.insert(key, inst.span);
                 }
                 InstData::FnDecl { name, has_self, .. } => {
-                    if *has_self || method_refs.contains(&inst_ref) {
+                    if *has_self || self.declaration_index.is_type_scoped_method(inst_ref) {
                         continue;
                     }
                     if let Some(first_span) =
@@ -1011,44 +983,6 @@ impl<'a> Sema<'a> {
 
     /// Resolve @copy validation, destructors, functions, and methods.
     pub(crate) fn resolve_remaining_declarations(&mut self) -> CompileResult<()> {
-        // Collect all method InstRefs from anonymous struct types
-        // These need to be skipped during function declaration collection because:
-        // - They may use `Self` type which requires struct context
-        // - They are registered later during comptime evaluation with proper Self resolution
-        let mut anon_struct_method_refs = std::collections::HashSet::new();
-        // Also collect method InstRefs from named struct declarations. Inline
-        // methods (including associated functions with no `self`) are collected
-        // via `collect_struct_methods`, which binds `Self` to the enclosing
-        // type. They must be skipped in the generic FnDecl branch below, whose
-        // `collect_function_signature` has no struct context and would reject a
-        // `Self` return/parameter type as an unknown type (RUE-123).
-        let mut named_struct_method_refs = std::collections::HashSet::new();
-        for (_, inst) in self.rir.iter() {
-            match &inst.data {
-                InstData::AnonStructType {
-                    methods_start,
-                    methods_len,
-                    ..
-                } => {
-                    let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
-                    for method_ref in method_refs {
-                        anon_struct_method_refs.insert(method_ref);
-                    }
-                }
-                InstData::StructDecl {
-                    methods_start,
-                    methods_len,
-                    ..
-                } => {
-                    let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
-                    for method_ref in method_refs {
-                        named_struct_method_refs.insert(method_ref);
-                    }
-                }
-                _ => {}
-            }
-        }
-
         // Pre-scan const declarations: collection is dependency-ordered
         // (an initializer may reference a constant declared later, even in
         // another file), so all pending declarations must be known up front.
@@ -1109,7 +1043,7 @@ impl<'a> Sema<'a> {
 
                     // Skip ALL methods from anonymous structs (including associated functions)
                     // These are registered during comptime evaluation with proper Self type context
-                    if anon_struct_method_refs.contains(&inst_ref) {
+                    if self.declaration_index.is_anonymous_method(inst_ref) {
                         continue;
                     }
 
@@ -1117,7 +1051,7 @@ impl<'a> Sema<'a> {
                     // collected via `collect_struct_methods` with `Self` bound to
                     // the enclosing type (RUE-123). Collecting them here as free
                     // functions would reject a `Self` signature type.
-                    if named_struct_method_refs.contains(&inst_ref) {
+                    if self.declaration_index.is_named_method(inst_ref) {
                         continue;
                     }
                     self.collect_function_signature(
@@ -2670,36 +2604,6 @@ impl<'a> Sema<'a> {
         }
     }
 
-    /// Every `FnDecl` inst that is type-scoped — a method or associated
-    /// function declared inside a named struct or an anonymous struct type —
-    /// as opposed to a free function. These are namespaced under their
-    /// enclosing type (spec 10.5) and must not be found by free-function
-    /// lookups or collected as free functions (a `Self` signature type would
-    /// be rejected outside its struct context, RUE-123).
-    pub(crate) fn type_scoped_method_refs(&self) -> HashSet<InstRef> {
-        let mut refs = HashSet::new();
-        for (_, inst) in self.rir.iter() {
-            match &inst.data {
-                InstData::AnonStructType {
-                    methods_start,
-                    methods_len,
-                    ..
-                }
-                | InstData::StructDecl {
-                    methods_start,
-                    methods_len,
-                    ..
-                } => {
-                    for r in self.rir.get_inst_refs(*methods_start, *methods_len) {
-                        refs.insert(r);
-                    }
-                }
-                _ => {}
-            }
-        }
-        refs
-    }
-
     /// Find a free function declaration in RIR, optionally restricted to one
     /// source file. This is used during const collection, which is
     /// dependency-ordered and can run before the main function-signature pass
@@ -2709,25 +2613,14 @@ impl<'a> Sema<'a> {
         target: Spur,
         file_id: Option<FileId>,
     ) -> Option<(FileId, bool)> {
-        let method_refs = self.type_scoped_method_refs();
-        self.rir.iter().find_map(|(inst_ref, inst)| {
-            let InstData::FnDecl {
-                is_pub,
-                name,
-                has_self,
-                ..
-            } = &inst.data
-            else {
-                return None;
-            };
-            if *has_self || *name != target || method_refs.contains(&inst_ref) {
-                return None;
-            }
-            if file_id.is_some_and(|wanted| inst.span.file_id != wanted) {
-                return None;
-            }
-            Some((inst.span.file_id, *is_pub))
-        })
+        let inst_ref = self
+            .declaration_index
+            .first_free_function(target, file_id)?;
+        let inst = self.rir.get(inst_ref);
+        let InstData::FnDecl { is_pub, .. } = &inst.data else {
+            unreachable!("free-function index contains only FnDecl instructions");
+        };
+        Some((inst.span.file_id, *is_pub))
     }
 
     /// Ensure a free function's signature is available during const
@@ -2739,8 +2632,10 @@ impl<'a> Sema<'a> {
         target: Spur,
         file_id: Option<FileId>,
     ) -> CompileResult<Option<(FileId, bool)>> {
-        let method_refs = self.type_scoped_method_refs();
-        let Some((
+        let Some(inst_ref) = self.declaration_index.first_free_function(target, file_id) else {
+            return Ok(None);
+        };
+        let (
             span,
             is_pub,
             params_start,
@@ -2750,30 +2645,23 @@ impl<'a> Sema<'a> {
             is_unchecked,
             directives_start,
             directives_len,
-        )) = self.rir.iter().find_map(|(inst_ref, inst)| {
+        ) = {
+            let inst = self.rir.get(inst_ref);
             let InstData::FnDecl {
                 is_pub,
-                name,
                 params_start,
                 params_len,
                 return_type,
                 body,
-                has_self,
                 is_unchecked,
                 directives_start,
                 directives_len,
                 ..
             } = &inst.data
             else {
-                return None;
+                unreachable!("free-function index contains only FnDecl instructions");
             };
-            if *has_self || *name != target || method_refs.contains(&inst_ref) {
-                return None;
-            }
-            if file_id.is_some_and(|wanted| inst.span.file_id != wanted) {
-                return None;
-            }
-            Some((
+            (
                 inst.span,
                 *is_pub,
                 *params_start,
@@ -2783,10 +2671,7 @@ impl<'a> Sema<'a> {
                 *is_unchecked,
                 *directives_start,
                 *directives_len,
-            ))
-        })
-        else {
-            return Ok(None);
+            )
         };
 
         let internal_target = self.internal_function_name(target, span.file_id);

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -98,6 +98,7 @@ impl<'a> GatherOutput<'a> {
         Sema {
             rir: self.rir,
             interner: self.interner,
+            declaration_index: super::declaration_index::RirDeclarationIndex::new(self.rir),
             functions: self.functions,
             functions_by_file_name: self.functions_by_file_name,
             function_source_names: self.function_source_names,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -31,6 +31,7 @@ mod anon_structs;
 mod builtins;
 mod comptime_eval;
 mod context;
+mod declaration_index;
 mod declarations;
 mod file_paths;
 mod gather;
@@ -45,6 +46,7 @@ mod visibility;
 
 // Public re-exports
 pub use context::ConstValue;
+pub use declaration_index::RirDeclarationIndexWork;
 pub use gather::GatherOutput;
 pub use inference_ctx::InferenceContext;
 pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
@@ -68,6 +70,8 @@ use crate::types::{EnumId, StructId, Type};
 pub struct Sema<'a> {
     pub(crate) rir: &'a Rir,
     pub(crate) interner: &'a ThreadedRodeo,
+    /// Request-local declaration candidates for this exact RIR arena.
+    declaration_index: declaration_index::RirDeclarationIndex,
     /// Function table: maps internal function name symbols to their info.
     ///
     /// The internal key is normally the source name, but functions with the
@@ -203,6 +207,7 @@ impl<'a> Sema<'a> {
         Self {
             rir,
             interner,
+            declaration_index: declaration_index::RirDeclarationIndex::new(rir),
             functions: HashMap::new(),
             functions_by_file_name: HashMap::new(),
             function_source_names: HashMap::new(),
@@ -235,6 +240,17 @@ impl<'a> Sema<'a> {
             fn_signatures_in_flight: HashSet::new(),
             ctor_type_displays: HashMap::new(),
         }
+    }
+
+    /// Exact structural work used to index this semantic request's raw RIR
+    /// declaration candidates.
+    ///
+    /// The counters contain no instruction handles and are safe to retain for
+    /// profiling. The indexed declarations themselves remain private and
+    /// meaningful only for this `Sema` and its exact RIR/interner epoch.
+    #[inline]
+    pub fn rir_declaration_index_work(&self) -> RirDeclarationIndexWork {
+        self.declaration_index.work()
     }
 
     /// Perform semantic analysis on the RIR.

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -20,6 +20,8 @@ compile_stdout_contains = [
   '"name":"lexer"',
   '"name":"parser"',
   '"name":"semantic_astgen"',
+  '"name":"rir_declaration_index"',
+  '"name":"sema"',
   '"source_metrics":',
   '"files":1',
   '"bytes":24',

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -95,8 +95,9 @@ pub enum DefinitionKind {
 /// The name-resolution namespace containing a parsed definition candidate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DefinitionNamespace {
-    /// Ordinary module items: functions, structures, enumerations, and
-    /// constants all compete for this namespace.
+    /// Presemantic module-item candidates: functions, structures,
+    /// enumerations, and constants share this key space until semantic
+    /// evaluation can distinguish value constants from module bindings.
     ModuleItem,
     /// Destructor declarations, keyed by the type name following `drop fn`.
     Destructor,

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -231,8 +231,8 @@ fn parse_runtime_archive(runtime_bytes: &[u8]) -> Result<Archive, String> {
 // Re-export commonly used types
 pub use lasso::{Spur, ThreadedRodeo};
 pub use rue_air::{
-    Air, AnalyzedFunction, DirResolution, ModulePath, Sema, SemaOutput, StructDef, Type,
-    TypeInternPool, import_candidate_groups,
+    Air, AnalyzedFunction, DirResolution, ModulePath, RirDeclarationIndexWork, Sema, SemaOutput,
+    StructDef, Type, TypeInternPool, import_candidate_groups,
 };
 pub use rue_cfg::{Cfg, CfgBuilder, CfgOutput, OptLevel};
 pub use rue_codegen::{
@@ -251,6 +251,31 @@ pub use rue_parser::{Ast, Expr, Function, Item, Parser};
 pub use rue_rir::{AstGen, Rir, RirPrinter};
 pub use rue_span::{FileId, Span};
 pub use rue_target::{Arch, Target};
+
+/// Construct one semantic request while measuring its snapshot-local RIR
+/// declaration index independently from semantic analysis.
+fn build_sema_for_target<'a>(
+    rir: &'a Rir,
+    interner: &'a ThreadedRodeo,
+    preview_features: PreviewFeatures,
+    target: Target,
+) -> Sema<'a> {
+    let _span = info_span!("rir_declaration_index", instruction_count = rir.len()).entered();
+    let sema = Sema::new_for_target(rir, interner, preview_features, target);
+    let work = sema.rir_declaration_index_work();
+    info!(
+        build_invocations = work.build_invocations,
+        rir_instructions_visited = work.rir_instructions_visited,
+        method_references_visited = work.method_references_visited,
+        free_functions_indexed = work.free_functions_indexed,
+        named_methods_indexed = work.named_methods_indexed,
+        anonymous_methods_indexed = work.anonymous_methods_indexed,
+        destructors_indexed = work.destructors_indexed,
+        const_candidates_indexed = work.const_candidates_indexed,
+        "RIR declaration index built"
+    );
+    sema
+}
 
 // ============================================================================
 // Multi-file Compilation Types
@@ -1131,11 +1156,12 @@ pub fn compile_frontend_from_ast_with_source_metadata_and_target(
         AstGen::new(&semantic_ast, &interner).generate()
     };
 
+    let mut sema =
+        build_sema_for_target(&semantic_rir, &interner, preview_features.clone(), target);
+
     // Semantic analysis (RIR to AIR) - this now collects multiple errors
     let sema_output = {
         let _span = info_span!("sema").entered();
-        let mut sema =
-            Sema::new_for_target(&semantic_rir, &interner, preview_features.clone(), target);
         sema.set_root_file_id(source_metadata.root_file_id());
         sema.set_file_paths(source_metadata.physical_path_map().clone());
         sema.set_symbol_paths(source_metadata.logical_path_map().clone());

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -38,8 +38,9 @@ use tracing::{info, info_span};
 
 use crate::{
     Ast, AstGen, CompileErrors, CompileOptions, CompileOutput, CompileResult, CompileWarning,
-    DefinitionSnapshot, FunctionWithCfg, MultiErrorResult, Rir, Sema, SourceFile, SourceMetadata,
-    SourceSnapshot, SyntaxWork, TypeInternPool, build_functions_and_cfgs, compile_backend,
+    DefinitionSnapshot, FunctionWithCfg, MultiErrorResult, Rir, SourceFile, SourceMetadata,
+    SourceSnapshot, SyntaxWork, TypeInternPool, build_functions_and_cfgs, build_sema_for_target,
+    compile_backend,
 };
 use rue_span::FileId;
 
@@ -303,15 +304,16 @@ impl<'src> CompilationUnit<'src> {
             AstGen::new(&semantic_ast, interner).generate()
         };
 
+        let mut sema = build_sema_for_target(
+            &semantic_rir,
+            interner,
+            self.options.preview_features.clone(),
+            self.options.target,
+        );
+
         // Semantic analysis
         let sema_output = {
             let _span = info_span!("sema").entered();
-            let mut sema = Sema::new_for_target(
-                &semantic_rir,
-                interner,
-                self.options.preview_features.clone(),
-                self.options.target,
-            );
             sema.set_root_file_id(self.source_snapshot.metadata().root_file_id());
             sema.set_file_paths(self.source_snapshot.metadata().physical_path_map().clone());
             sema.set_symbol_paths(self.source_snapshot.metadata().logical_path_map().clone());

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -713,7 +713,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn real_snapshot_and_unit_spans_preserve_parse_boundaries() {
+    fn real_compiler_phase_spans_preserve_leaf_boundaries() {
         let sources = vec![SourceFile::new(
             "main.rue",
             "fn main() -> i32 { 42 }",
@@ -758,8 +758,10 @@ mod tests {
             tracing_subscriber::registry().with(TimingLayer::new(unit_data.clone()));
         tracing::subscriber::with_default(unit_subscriber, || {
             let mut unit =
-                CompilationUnit::from_source_snapshot(snapshot, CompileOptions::default());
+                CompilationUnit::from_source_snapshot(snapshot.clone(), CompileOptions::default());
             unit.parse().unwrap();
+            unit.lower().unwrap();
+            unit.analyze().unwrap();
         });
 
         let unit_edges = unit_data.parent_edges();
@@ -792,12 +794,76 @@ mod tests {
             .iter()
             .find(|pass| pass.name == "definition_snapshot")
             .unwrap();
+        let rir_declaration_index = unit_timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "rir_declaration_index")
+            .unwrap();
+        let sema = unit_timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "sema")
+            .unwrap();
         assert_eq!(unit_parse.invocations, 1);
         assert_eq!(unit_parse.root_invocations, 1);
         assert_eq!(definition_snapshot.invocations, 1);
         assert_eq!(definition_snapshot.root_invocations, 0);
         assert_eq!(definition_snapshot.leaf_invocations, 1);
         assert_eq!(merge.root_invocations, 0);
+        assert_eq!(rir_declaration_index.invocations, 1);
+        assert_eq!(rir_declaration_index.root_invocations, 1);
+        assert_eq!(rir_declaration_index.leaf_invocations, 1);
+        assert_eq!(sema.invocations, 1);
+        assert_eq!(sema.root_invocations, 1);
+        assert_eq!(sema.leaf_invocations, 1);
+        assert!(
+            !unit_edges.contains(&("sema".to_owned(), "rir_declaration_index".to_owned())),
+            "the index and sema analysis must remain sibling leaves: {unit_edges:?}"
+        );
+
+        let compile_data = TimingData::new();
+        let compile_subscriber =
+            tracing_subscriber::registry().with(TimingLayer::new(compile_data.clone()));
+        tracing::subscriber::with_default(compile_subscriber, || {
+            rue_compiler::compile_source_snapshot_with_options(
+                &snapshot,
+                &CompileOptions::default(),
+            )
+            .unwrap();
+        });
+
+        let compile_edges = compile_data.parent_edges();
+        for child in ["rir_declaration_index", "sema"] {
+            assert!(
+                compile_edges.contains(&("compile".to_owned(), child.to_owned())),
+                "missing compile -> {child} in production edges: {compile_edges:?}"
+            );
+        }
+        assert!(
+            !compile_edges.contains(&("sema".to_owned(), "rir_declaration_index".to_owned())),
+            "the production index and sema spans must remain siblings: {compile_edges:?}"
+        );
+
+        let compile_timing =
+            compile_data.to_benchmark_timing_with_metrics("test", "test", None, None);
+        let compile = compile_timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "compile")
+            .unwrap();
+        assert_eq!(compile.invocations, 1);
+        assert_eq!(compile.root_invocations, 1);
+        assert_eq!(compile.leaf_invocations, 0);
+        for phase in ["rir_declaration_index", "sema"] {
+            let timing = compile_timing
+                .passes
+                .iter()
+                .find(|pass| pass.name == phase)
+                .unwrap();
+            assert_eq!(timing.invocations, 1, "{phase}");
+            assert_eq!(timing.root_invocations, 0, "{phase}");
+            assert_eq!(timing.leaf_invocations, 1, "{phase}");
+        }
     }
 
     #[test]

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -49,6 +49,7 @@ compile                 <- compiler pipeline; excludes discovery/driver startup
 │  └─ merge_symbols     <- leaf: cross-file symbol merge
 ├─ astgen               <- leaf: AST -> RIR
 ├─ semantic_astgen      <- leaf: canonical semantic AST -> RIR
+├─ rir_declaration_index <- leaf: snapshot-local RIR declaration candidates
 ├─ sema                 <- leaf: type checking / AIR
 ├─ cfg_construction     <- leaf
 ├─ codegen              <- leaf: MIR lower + regalloc + emit
@@ -96,11 +97,11 @@ per-workload medians, not the accounting for a single run.
 **These are absolute milliseconds and are MACHINE-SPECIFIC — treat them as a
 relative profile (which passes dominate), not a hard threshold.**
 
-This historical table predates schema v2 and the `definition_snapshot` phase,
-so it shows the then-combined `parse_file` leaf rather than separate `lexer`
-and `parser` rows and has no definition-index row. Its totals were already
-taken from the old `compile` row, not the inflated old `total_ms`, and remain
-valid as compiler-pipeline measurements.
+This historical table predates schema v2, `definition_snapshot`, and
+`rir_declaration_index`, so it shows the then-combined `parse_file` leaf rather
+than separate `lexer` and `parser` rows and has neither index row. Its totals
+were already taken from the old `compile` row, not the inflated old `total_ms`,
+and remain valid as compiler-pipeline measurements.
 
 - Host: Intel Core i9-14900K, Linux x86-64 (WSL2), 32 logical CPUs.
 - Build: the buck2 **DEFAULT** profile as produced by `scripts/rue-bin`

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -56,6 +56,7 @@ PASS_COLORS = {
     "validate_and_generate_rir": "#8f984d",  # dry grass
     "astgen": "#a3a25b",  # dry grass
     "semantic_astgen": "#b7ad63",  # straw
+    "rir_declaration_index": "#a98f55",  # muted gold
     "sema": "#c9970e",  # rue yellow
     "cfg": "#8a6d2f",  # ochre
     "cfg_construction": "#8a6d2f",  # ochre
@@ -80,6 +81,7 @@ PASS_ORDER = [
     "validate_and_generate_rir",
     "astgen",
     "semantic_astgen",
+    "rir_declaration_index",
     "sema",
     "cfg_construction",
     "codegen",

--- a/scripts/perf-baseline.py
+++ b/scripts/perf-baseline.py
@@ -27,6 +27,7 @@ the raw JSON contains both leaf passes and their aggregate parents:
     |  `- merge_symbols             <- leaf
     |- astgen                       <- leaf
     |- semantic_astgen              <- leaf
+    |- rir_declaration_index        <- leaf
     |- sema                         <- leaf
     |- cfg_construction             <- leaf
     |- codegen                      <- leaf
@@ -89,6 +90,7 @@ CANONICAL_LEAF_ORDER = [
     "merge_symbols",
     "astgen",
     "semantic_astgen",
+    "rir_declaration_index",
     "sema",
     "cfg_construction",
     "codegen",

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -120,15 +120,26 @@ class PerfBaselineAggregationTests(unittest.TestCase):
             ["lexer", "parser", "codegen"],
         )
 
-    def test_current_leaf_order_includes_definition_snapshot(self):
+    def test_current_leaf_order_includes_semantic_lowering_and_frontend_indexes(self):
         result = perf_baseline.aggregate(
             [
                 self.sample(
                     10.0,
                     12.0,
-                    leaf_names=("codegen", "definition_snapshot", "parser", "lexer"),
+                    leaf_names=(
+                        "codegen",
+                        "rir_declaration_index",
+                        "sema",
+                        "semantic_astgen",
+                        "definition_snapshot",
+                        "parser",
+                        "lexer",
+                    ),
                     leaf_durations={
                         "codegen": 1.0,
+                        "rir_declaration_index": 1.0,
+                        "sema": 1.0,
+                        "semantic_astgen": 1.0,
                         "definition_snapshot": 1.0,
                         "parser": 1.0,
                         "lexer": 1.0,
@@ -138,7 +149,15 @@ class PerfBaselineAggregationTests(unittest.TestCase):
         )
         self.assertEqual(
             [name for name, _ms, _percent in result["rows"]],
-            ["lexer", "parser", "definition_snapshot", "codegen"],
+            [
+                "lexer",
+                "parser",
+                "definition_snapshot",
+                "semantic_astgen",
+                "rir_declaration_index",
+                "sema",
+                "codegen",
+            ],
         )
 
     def test_leaf_accounting_is_paired_before_taking_medians(self):
@@ -697,11 +716,13 @@ class ChartAggregationTests(unittest.TestCase):
         }
         self.assertEqual(charts.get_total_time(run), 4)
 
-    def test_current_phase_order_includes_definition_index_and_semantic_lowering(self):
+    def test_current_phase_order_includes_both_frontend_indexes_and_sema(self):
         ordered = charts.order_pass_times(
             {
                 "linker": 1,
+                "rir_declaration_index": 1,
                 "semantic_astgen": 1,
+                "sema": 1,
                 "definition_snapshot": 1,
                 "parser": 1,
                 "lexer": 1,
@@ -709,7 +730,15 @@ class ChartAggregationTests(unittest.TestCase):
         )
         self.assertEqual(
             list(ordered),
-            ["lexer", "parser", "definition_snapshot", "semantic_astgen", "linker"],
+            [
+                "lexer",
+                "parser",
+                "definition_snapshot",
+                "semantic_astgen",
+                "rir_declaration_index",
+                "sema",
+                "linker",
+            ],
         )
 
 


### PR DESCRIPTION
## What changed

- Build one immutable, request-local RIR declaration index in a deterministic arena walk.
- Preserve RIR order and duplicate candidates while separating free functions, named methods, anonymous methods, destructors, and presemantic constant candidates.
- Replace repeated method-owner and free-function scans in declaration collection with indexed lookups.
- Preserve the historical internal-symbol multiplicity rule exactly, including receiverless associated functions.
- Expose structural work counters and measure index construction as a `rir_declaration_index` leaf beside `sema` in real compiler traces.
- Teach the benchmark tools, CLI timing contract, and performance documentation about the new phase.

## Why

Lazy semantic collection repeatedly rescanned the full RIR to recover the same declaration relationships. Besides wasting work, those ad hoc scans were a fragile basis for the forthcoming reachable-body cleanup and incremental compiler service. This establishes one neutral snapshot-local index without claiming durable semantic identity or changing compilation results.

The focused consumer regression pins callable const-alias resolution, the selected free-function body, and the exact historical machine symbol when a free function shares a name with an associated function.

Linear: RUE-656

## Validation

- `./fmt.sh check`
- `./clippy.sh`
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/test-benchmark-tools.py`
- focused Rue AIR, compiler, timing, and CLI suites
- `./buck2 test //... //:reproducible-programs`
- `./scripts/check-reproducible-compiler.sh`
  - byte-identical SHA-256: `3de0f75db043378e3e3baa33267aad6286f68212a1714c2709b80b6f9d3fe932`
  - identical build ID: `23dca572caaf63f14883ee859f9ef8ed40a0aefa`
