### PR TITLE
RUE-646: ArrayBuf holds droppable-but-non-linear elements (Vec<T> drop discipline)

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1220,12 +1220,13 @@ impl Sema<'_> {
             InstData::FieldGet { .. } => Ok(env.const_module_members.get(&inst_ref).copied()),
 
             // Type intrinsic in comptime position. `@require_droppable(T)` is the
-            // owning-container well-formedness gate (RUE-388): std's `ArrayBuf(T)`
-            // calls it in its `-> type` constructor body so that instantiating
-            // the container with an element type it cannot yet correctly own —
-            // one that is `linear` or carries a destructor — is rejected at
-            // instantiation time (E0499 / E0498) rather than silently leaking the
-            // element's `drop fn`. It reduces to unit so the surrounding block
+            // owning-container well-formedness gate (RUE-388/RUE-646): std's
+            // `ArrayBuf(T)` calls it in its `-> type` constructor body so that
+            // instantiating the container with an element type it cannot yet
+            // correctly own — one that is `linear` — is rejected at instantiation
+            // time (E0499). Droppable-but-non-linear elements are accepted: the
+            // container runs each live element's drop glue before freeing its
+            // buffer (RUE-646). It reduces to unit so the surrounding block
             // body still yields the `struct { .. }` tail. `@size_of`/`@align_of`
             // are not comptime-foldable here and stay non-evaluable.
             InstData::TypeIntrinsic { name, type_arg } => {
@@ -1395,21 +1396,24 @@ impl Sema<'_> {
     /// containers (RUE-388, Steve's 2026-07-09 ruling).
     ///
     /// A source-level owning container such as `std/arraybuf.rue`'s `ArrayBuf(T)`
-    /// owns a heap buffer of `T` and drops it wholesale in its `drop fn` at scope
-    /// exit; it does **not** yet run per-element drop glue, nor track element
-    /// linearity. So an element type that is `linear` (must be consumed) or that
-    /// carries a destructor / drop glue would be silently leaked when the buffer
-    /// is freed. Until container/element multiplicity propagation is designed
-    /// (its own future ADR — deliberately out of scope here), the container gates
-    /// its element type through this check and rejects those two classes:
+    /// owns a heap buffer of `T`. It runs each live element's drop glue in
+    /// ascending index order before freeing the buffer (Rust's `Vec<T>` drop
+    /// discipline, RUE-646), so droppable-but-non-linear elements — nested
+    /// `ArrayBuf`, `ArrayBuf(StrBuf)`, lists of `drop fn` structs — are legal.
+    /// It does **not** yet track element linearity, so a `linear` element (which
+    /// must be consumed exactly once, not merely dropped) would be leaked; this
+    /// gate rejects only that class:
     ///
     /// - `linear` (transitively — infectious linearity, spec 3.8:57): E0499.
-    /// - carries a destructor / drop glue (transitively): E0498.
     ///
-    /// Linearity takes precedence in the message: a linear type is the stronger
-    /// "must be consumed" property. A trivially-droppable element (primitives,
-    /// pointers, `Copy` structs of them) passes.
+    /// Until container/element multiplicity propagation is designed (its own
+    /// future ADR — deliberately out of scope here), linear elements stay
+    /// rejected. A droppable element (primitives, pointers, `Copy` structs,
+    /// destructor-bearing structs, nested containers) passes.
     pub(crate) fn check_require_droppable(&self, ty: Type, span: Span) -> CompileResult<()> {
+        // Linear element types stay rejected (E0499): a linear value must be
+        // consumed exactly once and a container cannot run the consuming
+        // discharge on drop — that is the deferred RUE-649 work.
         if self.type_carries_linear(ty) {
             return Err(CompileError::new(
                 ErrorKind::ContainerElementIsLinear {
@@ -1418,53 +1422,12 @@ impl Sema<'_> {
                 span,
             ));
         }
-        if self.type_needs_drop_gate(ty) {
-            return Err(CompileError::new(
-                ErrorKind::ContainerElementHasDestructor {
-                    ty: self.format_type_name(ty),
-                },
-                span,
-            ));
-        }
+        // Droppable-but-non-linear element types are now ACCEPTED (RUE-646,
+        // Steve's 2026-07-11 ruling): the container runs each live element's
+        // drop glue before freeing its buffer, exactly as Rust's `Vec<T>`
+        // does. The old E0498 rejection is gone; `ArrayBuf(ArrayBuf(i64))`,
+        // `ArrayBuf(StrBuf)`, and lists of `drop fn` structs are legal.
         Ok(())
-    }
-
-    /// Whether dropping `ty` requires running any drop glue — a destructor
-    /// (`drop fn`) on the type itself or, transitively, on a field / array
-    /// element / enum-variant payload. Mirrors `rue-cfg`'s `type_needs_drop`
-    /// (the drop-glue authority at CFG-build time), replicated here because that
-    /// method lives in a different crate; the two must agree so the
-    /// `@require_droppable` gate rejects exactly the element types whose drop
-    /// glue the container would otherwise silently skip (RUE-388). Linearity is
-    /// checked separately by [`Sema::type_carries_linear`].
-    fn type_needs_drop_gate(&self, ty: Type) -> bool {
-        match ty.kind() {
-            TypeKind::Struct(struct_id) => {
-                let struct_def = self.type_pool.struct_def(struct_id);
-                if struct_def.destructor.is_some() {
-                    return true;
-                }
-                let field_types: Vec<Type> = struct_def.fields.iter().map(|f| f.ty).collect();
-                field_types
-                    .iter()
-                    .any(|&fty| self.type_needs_drop_gate(fty))
-            }
-            TypeKind::Enum(enum_id) => {
-                let enum_def = self.type_pool.enum_def(enum_id);
-                let payloads: Vec<Type> = enum_def
-                    .variant_payloads
-                    .iter()
-                    .flatten()
-                    .copied()
-                    .collect();
-                payloads.iter().any(|&pty| self.type_needs_drop_gate(pty))
-            }
-            TypeKind::Array(array_id) => {
-                let (element_type, _length) = self.type_pool.array_def(array_id);
-                self.type_needs_drop_gate(element_type)
-            }
-            _ => false,
-        }
     }
 
     /// Reduce a call to a comptime-evaluable function to its resulting value,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -72,17 +72,13 @@ impl<'a> Sema<'a> {
         }
     }
 
-    /// Point a container well-formedness rejection (E0498/E0499, RUE-388) at
+    /// Point a container well-formedness rejection (E0499, RUE-388/RUE-646) at
     /// the user's type-constructor application. The gate raises inside the
     /// constructor's own body (`@require_droppable(T)` in std source), so
     /// without this label the user's file never appears in the diagnostic
     /// (RUE-610). Other reduction errors already carry their own spans.
     pub(crate) fn label_ctor_instantiation_site(err: CompileError, span: Span) -> CompileError {
-        if matches!(
-            err.kind,
-            ErrorKind::ContainerElementHasDestructor { .. }
-                | ErrorKind::ContainerElementIsLinear { .. }
-        ) {
+        if matches!(err.kind, ErrorKind::ContainerElementIsLinear { .. }) {
             err.with_label("required by the type-constructor application here", span)
         } else {
             err

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -421,69 +421,16 @@ pub fn ArrayBuf(comptime T: type) -> type {
 stdout = "20\n-1\n"
 exit_code = 20
 
-# RUE-388 well-formedness gate: an owning growable container (`ArrayBuf(T)`)
-# owns a heap buffer and frees it wholesale in its `drop fn` — it does NOT run
-# per-element drop glue, nor track element linearity. Before the gate, an
-# element type carrying a destructor was accepted and its `drop fn` was silently
-# skipped when the buffer dropped (a leaked destructor effect); a `linear`
-# element would likewise leak. The `@require_droppable(T)` gate in the ArrayBuf
-# constructor rejects both classes at INSTANTIATION time. These cases use an
-# inline ArrayBuf carrying that gate (mirroring std/arraybuf.rue) so the reject
-# is exercised end-to-end through the real binary.
-[[case]]
-name = "arraybuf_rejects_destructor_element"
-description = "ArrayBuf(T) with a destructor-bearing element type is rejected at instantiation (E0498), not silently leaked (RUE-388)."
-args = ["main.rue", "-o", "prog"]
-compile_fail = true
-error_contains = ["E0498", "Inner", "drop fn"]
-files = [
-  { path = "main.rue", source = """
-const arraybuf = @import("arraybuf.rue");
-
-struct Inner { v: i32 }
-drop fn Inner(self) { @panic("dropped element"); }
-
-fn main() -> i32 {
-    let V = arraybuf.ArrayBuf(Inner);
-    let mut v = V.new();
-    v.push(Inner { v: 7 });
-    0
-}
-""" },
-  { path = "arraybuf.rue", source = """
-pub fn ArrayBuf(comptime T: type) -> type {
-    @require_droppable(T);
-    struct {
-        buf: ptr mut T,
-        len: u64,
-        cap: u64,
-
-        fn new() -> Self {
-            let zero: u64 = 0;
-            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
-        }
-        fn reserve(inout self) {
-            if self.len == self.cap {
-                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
-                checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
-                    self.buf = grown;
-                };
-                self.cap = new_cap;
-            }
-        }
-        fn push(inout self, x: T) {
-            self.reserve();
-            checked {
-                let slot = @ptr_offset(self.buf, self.len);
-                @ptr_write(slot, x);
-            };
-            self.len = self.len + 1;
-        }
-    }
-}
-""" },
-]
+# RUE-646 well-formedness gate: an owning growable container (`ArrayBuf(T)`)
+# owns a heap buffer of `T`. At scope exit it runs each live element's drop glue
+# in ascending index order, then frees the buffer (Rust's `Vec<T>` drop
+# discipline). So a destructor-bearing element type is now LEGAL — its `drop fn`
+# runs per-element, no leak. The `@require_droppable(T)` gate now rejects ONLY a
+# `linear` element type (a linear value must be consumed exactly once, not merely
+# dropped, and the container can only drop its elements). The positive drop-trace
+# coverage lives in the dedicated cases further below (they use the real std
+# ArrayBuf via RUE_STD_PATH so per-element drop glue is exercised end-to-end);
+# the case here is the surviving negative control for the linear rejection.
 
 [[case]]
 name = "arraybuf_rejects_linear_element"
@@ -620,6 +567,203 @@ fn main() -> i32 {
     if v.is_empty() { score = score + 100; }
     v.clear();
     if v.is_empty() { score = score + 1000; }
+    score
+}
+""" }]
+exit_code = 243
+
+# ============================================================================
+# RUE-646: droppable-but-non-linear element types are legal; the container runs
+# each live element's drop glue (ascending index order) before freeing its
+# buffer — Rust's `Vec<T>` drop discipline. These cases drive the REAL std
+# ArrayBuf via RUE_STD_PATH so the per-element drop loop is exercised end-to-end.
+# The @dbg drop traces are the double-free / leak sentinels: an element that
+# drops twice, zero times, or out of order changes the exact stdout.
+# ============================================================================
+
+# Nested ArrayBuf(ArrayBuf(i64)): build a jagged 3x3, then DRAIN it by popping
+# each inner row out (moving it — pop retires the slot so the outer's drop won't
+# touch it) and popping every element. Sum of all 9 = 99. Reads a non-Copy inner
+# element the SOUND way: `pop` moves it out (single owner), never `get` (which
+# returns an aliasing bit-copy of the inner buffer — a masked double-free,
+# RUE-651). Proves a container-of-containers compiles, drops correctly, and its
+# elements can be read back by moving them out.
+[[case]]
+name = "arraybuf_nested_i64_drain"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const ArrayBuf = std.arraybuf.ArrayBuf;
+
+fn main() -> i32 {
+    let Inner = ArrayBuf(i64);
+    let Outer = ArrayBuf(Inner);
+    let OInner = std.option.Option(Inner);
+    let Oi = std.option.Option(i64);
+    let mut outer = Outer.new();
+    let mut i: i64 = 0;
+    while i < 3 {
+        let mut inner = Inner.new();
+        let mut j: i64 = 0;
+        while j < 3 {
+            inner.push(i * 10 + j);
+            j = j + 1;
+        }
+        outer.push(inner);
+        i = i + 1;
+    }
+    let mut sum: i64 = 0;
+    while outer.len > 0 {
+        match outer.pop() {
+            OInner.Some(r) => {
+                let mut row = r;
+                while row.len > 0 {
+                    match row.pop() {
+                        Oi.Some(v) => { sum = sum + v; },
+                        Oi.None => {},
+                    }
+                }
+            },
+            OInner.None => {},
+        }
+    }
+    let r: i32 = @intCast(sum);
+    r
+}
+""" }]
+exit_code = 99
+
+# A `drop fn` struct element: push 3, they drop exactly once each in ASCENDING
+# index order at scope exit. `100` prints first (before scope exit), then the
+# element drops `1 2 3`. A double-free would repeat a value; a skipped drop would
+# omit one; a reversed loop would print `3 2 1`. This is the leak/double-free
+# sentinel for the destructor path.
+[[case]]
+name = "arraybuf_drop_trace_ascending"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const ArrayBuf = std.arraybuf.ArrayBuf;
+
+struct D { v: i64 }
+drop fn D(self) { @dbg(self.v); }
+
+fn main() {
+    let Buf = ArrayBuf(D);
+    let mut b = Buf.new();
+    b.push(D { v: 1 });
+    b.push(D { v: 2 });
+    b.push(D { v: 3 });
+    @dbg(100);
+}
+""" }]
+stdout = "100\n1\n2\n3\n"
+exit_code = 0
+
+# Nested ArrayBuf(ArrayBuf(D)): every leaf D drops EXACTLY once, none twice, at
+# scope exit. Two inners of two elements each (v = 0,1,10,11). The outer's drop
+# loop drops each inner in ascending order; each inner's drop loop drops its D
+# leaves in ascending order. Exact stdout pins no double-free across the two
+# levels of drop glue.
+[[case]]
+name = "arraybuf_nested_drop_trace"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const ArrayBuf = std.arraybuf.ArrayBuf;
+
+struct D { v: i64 }
+drop fn D(self) { @dbg(self.v); }
+
+fn main() {
+    let Inner = ArrayBuf(D);
+    let Outer = ArrayBuf(Inner);
+    let mut outer = Outer.new();
+    let mut i: i64 = 0;
+    while i < 2 {
+        let mut inner = Inner.new();
+        let mut j: i64 = 0;
+        while j < 2 {
+            inner.push(D { v: i * 10 + j });
+            j = j + 1;
+        }
+        outer.push(inner);
+        i = i + 1;
+    }
+    @dbg(100);
+}
+""" }]
+stdout = "100\n0\n1\n10\n11\n"
+exit_code = 0
+
+# clear / set / free drop accounting. `clear()` drops all live elements (1, 2)
+# then resets len; `set(0, ..)` drops the OLD element (3) before writing the new
+# one (4); `free()` drops the remaining live element (4) then resets to empty so
+# the scope-exit destructor is a no-op (no trailing double-drop after 903). The
+# interleaved markers pin WHEN each element drops.
+[[case]]
+name = "arraybuf_clear_set_free_drop_accounting"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const ArrayBuf = std.arraybuf.ArrayBuf;
+
+struct D { v: i64 }
+drop fn D(self) { @dbg(self.v); }
+
+fn main() {
+    let Buf = ArrayBuf(D);
+    let mut b = Buf.new();
+    b.push(D { v: 1 });
+    b.push(D { v: 2 });
+    @dbg(900);
+    b.clear();
+    @dbg(901);
+    b.push(D { v: 3 });
+    b.set(0, D { v: 4 });
+    @dbg(902);
+    b.free();
+    @dbg(903);
+}
+""" }]
+stdout = "900\n1\n2\n901\n3\n902\n4\n903\n"
+exit_code = 0
+
+# ArrayBuf(String): a list of owned, heap-backed strings. Push two, then read
+# each back by POPPING it out (moving — the sound way for a non-Copy element;
+# `get` would return an aliasing bit-copy of the String header, a masked
+# double-free, RUE-651). String carries a destructor (it owns a heap buffer), so
+# this exercises the RUE-646 droppable-element path with a builtin owning type:
+# it compiles, round-trips by move-out, and drops each string exactly once. pop
+# returns last-pushed first: world!(6) then hello(5). Score = 1 (len==2) + 1000
+# (first pop len 6) + 10 (second pop len 5) = 1011; exit = 1011 & 0xFF = 243.
+[[case]]
+name = "arraybuf_strbuf_elements"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const ArrayBuf = std.arraybuf.ArrayBuf;
+
+fn main() -> i32 {
+    let Buf = ArrayBuf(String);
+    let OStr = std.option.Option(String);
+    let mut b = Buf.new();
+    let mut s0 = String.new();
+    s0.push_str("hello");
+    let mut s1 = String.new();
+    s1.push_str("world!");
+    b.push(s0);
+    b.push(s1);
+    let mut score: i32 = 0;
+    if b.len == 2 { score = score + 1; }
+    match b.pop() {
+        OStr.Some(g1) => { if g1.len() == 6 { score = score + 1000; } },
+        OStr.None => {},
+    }
+    match b.pop() {
+        OStr.Some(g0) => { if g0.len() == 5 { score = score + 10; } },
+        OStr.None => {},
+    }
     score
 }
 """ }]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -287,13 +287,11 @@ impl ErrorCode {
     /// is second-class: it may only be read (`.len()`, byte indexing) or
     /// re-borrowed, never escape the call as a first-class value.
     pub const STR_VIEW_NOT_FIRST_CLASS: Self = Self(497);
-    /// An owning growable container (e.g. `ArrayBuf(T)`) was instantiated with
-    /// an element type that has a destructor (a `drop fn`), via the
-    /// `@require_droppable(T)` gate. Until container/element multiplicity
-    /// propagation is designed (RUE-388), such containers cannot yet run
-    /// per-element destructors, so a destructor-bearing element would silently
-    /// leak its `drop fn`; the instantiation is rejected instead.
-    pub const CONTAINER_ELEMENT_HAS_DESTRUCTOR: Self = Self(498);
+    // E0498 (CONTAINER_ELEMENT_HAS_DESTRUCTOR) was retired by RUE-646: owning
+    // growable containers now run each live element's drop glue before freeing
+    // their buffer (Rust's `Vec<T>` discipline), so a destructor-bearing element
+    // type is legal. The code number is left retired (a gap is fine) rather than
+    // reused. Linear elements are still rejected — see E0499 below.
     /// An owning growable container (e.g. `ArrayBuf(T)`) was instantiated with a
     /// `linear` element type, via the `@require_droppable(T)` gate. Until
     /// container/element multiplicity propagation is designed (RUE-388), such
@@ -1310,14 +1308,6 @@ pub enum ErrorKind {
     /// names the position, as in [`Self::BufferNotFirstClassStr`].
     #[error("a borrowed `str` view cannot be used as a first-class `str` {site}")]
     StrViewNotFirstClass { site: String },
-    /// An owning growable container (`ArrayBuf(T)`) was instantiated with an
-    /// element type that has a destructor (`drop fn`), via `@require_droppable`
-    /// (RUE-388). The container cannot yet run per-element destructors, so the
-    /// element's `drop fn` would silently leak; the instantiation is rejected.
-    #[error(
-        "`@require_droppable` requires a trivially-droppable type, but `{ty}` carries a destructor (a `drop fn`, on the type itself or one of its fields) — an owning growable container (e.g. `ArrayBuf`) cannot yet run per-element destructors, so that `drop fn` would silently leak (RUE-388)"
-    )]
-    ContainerElementHasDestructor { ty: String },
     /// An owning growable container (`ArrayBuf(T)`) was instantiated with a
     /// `linear` element type, via `@require_droppable` (RUE-388). The container
     /// cannot yet track element linearity, so a linear element would be leaked
@@ -1673,9 +1663,6 @@ impl ErrorKind {
             ErrorKind::BufferNotFirstClassStr { .. } => ErrorCode::BUFFER_NOT_FIRST_CLASS_STR,
             ErrorKind::InoutStrRequiresLocalBuffer => ErrorCode::INOUT_STR_REQUIRES_LOCAL_BUFFER,
             ErrorKind::StrViewNotFirstClass { .. } => ErrorCode::STR_VIEW_NOT_FIRST_CLASS,
-            ErrorKind::ContainerElementHasDestructor { .. } => {
-                ErrorCode::CONTAINER_ELEMENT_HAS_DESTRUCTOR
-            }
             ErrorKind::ContainerElementIsLinear { .. } => ErrorCode::CONTAINER_ELEMENT_IS_LINEAR,
             ErrorKind::InoutNonLvalue => ErrorCode::INOUT_NON_LVALUE,
             ErrorKind::InoutExclusiveAccess { .. } => ErrorCode::INOUT_EXCLUSIVE_ACCESS,

--- a/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
@@ -1,54 +1,55 @@
 [section]
 id = "diagnostics.droppable-gate"
-name = "Container droppable-gate diagnostics (E0498/E0499)"
+name = "Container droppable-gate diagnostics (E0499)"
 description = """
 The @require_droppable rejection is raised inside the CONSTRUCTOR's body, so
 the diagnostic must still speak the user's language (RUE-610): the offending
-type prints as its instantiation spelling (`Holder(Res)`, not the internal
+type prints as its instantiation spelling (`Holder(Token)`, not the internal
 `__anon_struct_N`), and a label points at the user's type-constructor
-application, not just the constructor's own source.
+application, not just the constructor's own source. Only `linear` element types
+are rejected now (RUE-646): droppable-but-non-linear elements are legal because
+the container runs their per-element drop glue, so all cases below use a
+`linear` element type.
 """
 
 [[case]]
-name = "e0498_names_ctor_spelling_and_user_site"
-description = "A ctor-produced anonymous element type prints as Ctor(args) and the rejection labels the user's application site (RUE-610)"
+name = "e0499_names_ctor_spelling_and_user_site"
+description = "A ctor-produced anonymous linear element type prints as Ctor(args) and the rejection labels the user's application site (RUE-610)"
 source = """
-struct Res { v: i64 }
-drop fn Res(self) { let _ = self.v; }
-fn Holder(comptime T: type) -> type { struct { x: T } }
+linear struct Token { v: i32 }
+fn Wrap(comptime T: type) -> type { enum { Some(T), None } }
 fn Gated(comptime T: type) -> type {
     @require_droppable(T);
     struct { y: T }
 }
-const H = Holder(Res);
-const G = Gated(H);
+const W = Wrap(Token);
+const G = Gated(W);
 fn main() -> i32 { 0 }
 """
 compile_fail = true
 error_contains = [
-    "E0498",
-    "Holder(Res)",
+    "E0499",
+    "Wrap(Token)",
     "required by the type-constructor application here",
 ]
 
 [[case]]
-name = "e0498_value_position_labels_user_site"
+name = "e0499_value_position_labels_user_site"
 description = "The application-site label also appears for a let-bound instantiation inside a function body (RUE-610)"
 source = """
-struct Res { v: i64 }
-drop fn Res(self) { let _ = self.v; }
+linear struct Token { v: i32 }
 fn Gated(comptime T: type) -> type {
     @require_droppable(T);
     struct { y: T }
 }
 fn main() -> i32 {
-    let G = Gated(Res);
+    let G = Gated(Token);
     let _ = G;
     0
 }
 """
 compile_fail = true
-error_contains = ["E0498", "Res", "required by the type-constructor application here"]
+error_contains = ["E0499", "Token", "required by the type-constructor application here"]
 
 [[case]]
 name = "e0499_linear_names_and_labels"

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -38,15 +38,24 @@
 // SCOPE / KNOWN LIMITATIONS (tracked separately — this file deliberately does
 // not work around them):
 //
-//   * Trivially-droppable element types only. `get`/`pop` return an element
-//     *by copy* wrapped in `Option(T)` (`@ptr_read`, RUE-313). Move-out of a
-//     non-Copy element is not yet supported, and the destructor drops only the
-//     backing buffer, not per-element glue. An element type that is `linear` or
-//     carries a destructor is therefore REJECTED at instantiation by the
-//     `@require_droppable(T)` gate in the constructor below (E0498 / E0499,
-//     RUE-388) — otherwise its `drop fn` would silently leak / a linear value
-//     would never be consumed. Lifting this to true per-element ownership needs
-//     container/element multiplicity propagation (a future ADR).
+//   * Droppable element types. The container runs each live element's drop glue
+//     in ascending index order before freeing its buffer (Rust's `Vec<T>` drop
+//     discipline, RUE-646), so droppable-but-non-linear elements — nested
+//     `ArrayBuf`, `ArrayBuf(StrBuf)`, lists of `drop fn` structs — are legal.
+//     Only a `linear` element type is REJECTED at instantiation by the
+//     `@require_droppable(T)` gate in the constructor below (E0499, RUE-388) —
+//     a linear value must be consumed exactly once, and the container can only
+//     drop, not discharge, its elements. Lifting that to true linear-element
+//     ownership needs container/element multiplicity propagation (a future ADR).
+//
+//     READING A NON-COPY ELEMENT — use `pop`, not `get` (RUE-651). `pop`/`pop_or`
+//     MOVE the element out (they retire the slot, so there is exactly one owner)
+//     and are sound for any `T`. `get`/`get_or` return the element *by copy*
+//     (`@ptr_read`): for a `Copy` `T` that is fine, but for a NON-COPY `T` the
+//     copy ALIASES the element's owned buffer — both the copy and the still-live
+//     slot would run drop glue, a double-free (masked today only by the no-op
+//     bump allocator). Until borrow-returning reads exist (RUE-651), treat
+//     `get`/`get_or` as Copy-element-only.
 //   * Multi-slot aggregate element types (e.g. a two-field struct) work as long
 //     as they are trivially droppable: every aggregate is laid out
 //     ascending-in-address and `@ptr_read`/`@ptr_write` walk slots upward from
@@ -64,16 +73,17 @@
 const option = @import("option.rue");
 
 pub fn ArrayBuf(comptime T: type) -> type {
-    // Well-formedness gate (RUE-388): ArrayBuf owns a heap buffer of `T` and
-    // frees it wholesale in its `drop fn` at scope exit — it does NOT yet run
-    // per-element drop glue, nor track element linearity. Instantiating it with
-    // an element type that is `linear` or carries a destructor would silently
-    // leak that element (its `drop fn` would never run / a linear value would
-    // never be consumed). Until container/element multiplicity propagation is
-    // designed (a future ADR — out of scope), reject such element types at
-    // instantiation with a clear compile error (E0498 / E0499) rather than
-    // miscompiling. Trivially-droppable elements (primitives, pointers, `Copy`
-    // structs of them) pass.
+    // Well-formedness gate (RUE-388/RUE-646): ArrayBuf owns a heap buffer of `T`
+    // and, at scope exit, runs each live element's drop glue in ascending index
+    // order before freeing the buffer (Rust's `Vec<T>` drop discipline). It does
+    // NOT yet track element linearity, so instantiating it with a `linear`
+    // element type would leak that element (a linear value must be consumed
+    // exactly once, and the container can only drop, not discharge, its
+    // elements). Until container/element multiplicity propagation is designed (a
+    // future ADR — out of scope), reject only `linear` element types at
+    // instantiation with a clear compile error (E0499) rather than miscompiling.
+    // Droppable elements (primitives, pointers, `Copy` structs, destructor-
+    // bearing structs, nested containers) pass.
     @require_droppable(T);
     struct {
         buf: ptr mut T,
@@ -118,7 +128,9 @@ pub fn ArrayBuf(comptime T: type) -> type {
         // Element `i` by copy, wrapped in `option.Option(T)`: `Some(x)` when in
         // bounds, `None` otherwise (ADR-0041). The enclosing element type `T`
         // is in scope here, so the method can pass it to `option.Option(T)`
-        // (RUE-313).
+        // (RUE-313). COPY-ELEMENT-ONLY: for a non-Copy `T` the copy aliases the
+        // element's owned buffer (double-free — RUE-651); read owned elements
+        // with `pop`.
         fn get(borrow self, i: u64) -> option.Option(T) {
             let O = option.Option(T);
             if i < self.len {
@@ -130,7 +142,8 @@ pub fn ArrayBuf(comptime T: type) -> type {
 
         // Element `i` by copy, or `default` when `i` is out of bounds. An
         // ergonomic default-based read for callers that don't want to match on
-        // `Option`.
+        // `Option`. COPY-ELEMENT-ONLY: aliases an owned element's buffer for a
+        // non-Copy `T` (double-free — RUE-651); read owned elements with `pop`.
         fn get_or(borrow self, i: u64, default: T) -> T {
             if i < self.len {
                 checked { @ptr_read(@ptr_offset(self.buf, i)) }
@@ -189,8 +202,13 @@ pub fn ArrayBuf(comptime T: type) -> type {
         }
 
         // Overwrite element `i` with `x`. Out-of-bounds indices are ignored.
+        // The element previously at `i` is dropped first (RUE-646): reading it
+        // out and `@drop`ping it runs its destructor, so overwriting a
+        // droppable `T` does not leak the old value. For a `Copy` `T`, `@drop`
+        // has no glue and this is free.
         fn set(inout self, i: u64, x: T) {
             if i < self.len {
+                @drop(checked { @ptr_read(@ptr_offset(self.buf, i)) });
                 checked {
                     let slot = @ptr_offset(self.buf, i);
                     @ptr_write(slot, x);
@@ -198,9 +216,15 @@ pub fn ArrayBuf(comptime T: type) -> type {
             }
         }
 
-        // Drop all elements (keeps the allocated capacity). For Copy `T` this
-        // just resets the length.
+        // Drop all elements (keeps the allocated capacity). Each live element's
+        // drop glue runs before the length is reset (RUE-646); for a `Copy` `T`
+        // this is just resetting the length.
         fn clear(inout self) {
+            let mut i: u64 = 0;
+            while i < self.len {
+                @drop(checked { @ptr_read(@ptr_offset(self.buf, i)) });
+                i = i + 1;
+            }
             self.len = 0;
         }
 
@@ -211,6 +235,11 @@ pub fn ArrayBuf(comptime T: type) -> type {
         // scope exit. Call `free()` only to reclaim the buffer before then; it
         // resets `buf`/`cap` so the later scope-exit drop is a safe no-op.
         fn free(inout self) {
+            let mut i: u64 = 0;
+            while i < self.len {
+                @drop(checked { @ptr_read(@ptr_offset(self.buf, i)) });
+                i = i + 1;
+            }
             checked { @free(self.buf, self.cap); };
             let zero: u64 = 0;
             self.buf = checked { @int_to_ptr(zero) };
@@ -218,15 +247,22 @@ pub fn ArrayBuf(comptime T: type) -> type {
             self.cap = 0;
         }
 
-        // Destructor: free the backing buffer automatically when an `ArrayBuf`
-        // value goes out of scope (RUE-312). A `drop fn(self)` inside the
-        // anonymous struct is monomorphized with the type and registered as the
-        // concrete type's destructor, so the ordinary scope-exit drop glue runs
-        // it — the same machinery a named struct's top-level `drop fn` uses. For
-        // a Copy `T` there is no per-element glue, so freeing the buffer is all
-        // that is required. (After an explicit `free()`, `buf` is null and `cap`
-        // is 0, so `@free(null, 0)` here is a no-op.)
+        // Destructor: run each live element's drop glue, then free the backing
+        // buffer, when an `ArrayBuf` value goes out of scope (RUE-312, RUE-646).
+        // A `drop fn(self)` inside the anonymous struct is monomorphized with
+        // the type and registered as the concrete type's destructor, so the
+        // ordinary scope-exit drop glue runs it — the same machinery a named
+        // struct's top-level `drop fn` uses. Elements 0..len are read out and
+        // `@drop`ped in ascending index order (Rust's `Vec<T>` drop order); for
+        // a `Copy` `T` there is no per-element glue and this loop is free.
+        // (After an explicit `free()`, `len` is 0 so the loop is empty, `buf`
+        // is null, and `@free(null, 0)` is a no-op.)
         drop fn(self) {
+            let mut i: u64 = 0;
+            while i < self.len {
+                @drop(checked { @ptr_read(@ptr_offset(self.buf, i)) });
+                i = i + 1;
+            }
             checked { @free(self.buf, self.cap); };
         }
     }


### PR DESCRIPTION
Fixes RUE-646

`ArrayBuf(T)` now runs each live element's drop glue (indices `0..len`, ascending) before freeing its buffer — Rust's `Vec<T>` drop discipline, per Steve's ruling. Droppable-but-non-linear element types are legal (nested `ArrayBuf`, `ArrayBuf(String)`, lists of `drop fn` structs); `linear` elements stay rejected (E0499, deferred to RUE-649).

- Core: `drop fn`/`clear`/`free` loop `@drop(@ptr_read(offset(buf, i)))` per live element; `set` drops the old element before overwriting. The retired E0498 (`ContainerElementHasDestructor`) path is removed.
- **Verified by drop-count traces** (the double-free sentinels — a no-op bump allocator wouldn't crash, so exact `@dbg` traces are the real proof): nested `ArrayBuf(ArrayBuf(D))` drops every leaf exactly once ascending; `clear`/`set`/`free` accounting exact; linear still rejected.

**Soundness boundary — RUE-651 (filed, High):** `get`/`get_or` of a non-Copy element returns a bitwise copy that *aliases* the element's owned buffer (a masked double-free — I reproduced a destructor running twice). `pop`/`pop_or` are sound (they move the element out). So this PR's tests read owned elements via `pop`, and `std/arraybuf.rue` documents `get`/`get_or` as Copy-element-only until borrow-returning reads land (RUE-651). RUE-646 soundly unlocks owned stacks/queues + correct cleanup of nested structures; random-access reads of owned elements wait on RUE-651.

Worker (Opus, isolated worktree) productionized from my verified spike; I did the integration (sound-test rewrites + docs + the RUE-651 filing). Full suite green (Pass 34, traceability 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
