### PR TITLE
RUE-651: gate ArrayBuf get/get_or against by-copy reads of drop-glue elements

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6717,7 +6717,7 @@ impl<'a> Sema<'a> {
             }),
 
             InstData::TypeIntrinsic { name, type_arg } => {
-                self.analyze_type_intrinsic(air, *name, *type_arg, inst.span)
+                self.analyze_type_intrinsic(air, *name, *type_arg, inst.span, ctx)
             }
 
             InstData::OffsetOf { type_arg, field } => {
@@ -6734,16 +6734,21 @@ impl<'a> Sema<'a> {
         }
     }
 
-    /// Analyze a type intrinsic (@size_of, @align_of).
+    /// Analyze a type intrinsic (@size_of, @align_of, @require_droppable,
+    /// @require_trivially_droppable). Resolves the type argument through the
+    /// current analysis context so a type parameter (`T` in a monomorphized
+    /// generic method body, e.g. `ArrayBuf(T)::get`) binds to its concrete
+    /// element type via `ctx.comptime_type_vars` (RUE-651).
     fn analyze_type_intrinsic(
         &mut self,
         air: &mut Air,
         name: Spur,
         type_arg: Spur,
         span: Span,
+        ctx: &AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         let intrinsic_name = self.interner.resolve(&name).to_string();
-        let ty = self.resolve_type(type_arg, span)?;
+        let ty = self.resolve_type_with_ctx(type_arg, span, ctx)?;
 
         // `@require_droppable(T)` is the owning-container well-formedness gate
         // (RUE-388): it has no runtime value and evaluates to unit. It is
@@ -6753,6 +6758,24 @@ impl<'a> Sema<'a> {
         // linear/destructor rejection instead of falling to E0700.
         if intrinsic_name == "require_droppable" {
             self.check_require_droppable(ty, span)?;
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::Const(0),
+                ty: Type::UNIT,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
+        }
+
+        // `@require_trivially_droppable(T)` is the by-copy-read gate (RUE-651).
+        // Unlike `@require_droppable`, this one normally *does* reach runtime
+        // analysis: it lives in `ArrayBuf(T)`'s `get`/`get_or` method bodies, and
+        // demand-driven analysis (ADR-0045) monomorphizes those bodies with the
+        // concrete element type only when a program actually calls a by-copy read.
+        // If that `T` has drop glue, reading it by copy would alias its owned
+        // resources (double-free), so reject it (E0711) and point the caller at
+        // `pop`. It has no runtime value and evaluates to unit.
+        if intrinsic_name == "require_trivially_droppable" {
+            self.check_trivially_droppable(ty, span)?;
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::Const(0),
                 ty: Type::UNIT,

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -231,4 +231,40 @@ impl<'a> Sema<'a> {
             _ => false,
         }
     }
+
+    /// Whether a type has drop glue — a destructor that runs at scope exit,
+    /// either directly or through a by-value field/payload/element. Mirrors the
+    /// traversal `rue_cfg`'s `type_needs_drop` performs (the codegen authority):
+    /// a struct has glue if it has a destructor or any field does; an enum if any
+    /// variant payload does; an array if its element type does; pointers and
+    /// scalars have none (a pointer does not own its pointee).
+    ///
+    /// Used to gate by-copy element reads (`ArrayBuf(T)::get`/`get_or`, RUE-651):
+    /// copying a drop-glue element by `@ptr_read` would alias its owned resources
+    /// and double-free at scope exit, so those reads are rejected for such `T`.
+    pub(crate) fn type_has_drop_glue(&self, ty: Type) -> bool {
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
+                let struct_def = self.type_pool.struct_def(struct_id);
+                struct_def.destructor.is_some()
+                    || struct_def
+                        .fields
+                        .iter()
+                        .any(|f| self.type_has_drop_glue(f.ty))
+            }
+            TypeKind::Enum(enum_id) => {
+                let enum_def = self.type_pool.enum_def(enum_id);
+                enum_def
+                    .variant_payloads
+                    .iter()
+                    .flatten()
+                    .any(|&payload_ty| self.type_has_drop_glue(payload_ty))
+            }
+            TypeKind::Array(array_id) => {
+                let (element_type, _length) = self.type_pool.array_def(array_id);
+                self.type_has_drop_glue(element_type)
+            }
+            _ => false,
+        }
+    }
 }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1231,7 +1231,15 @@ impl Sema<'_> {
             // are not comptime-foldable here and stay non-evaluable.
             InstData::TypeIntrinsic { name, type_arg } => {
                 let (name, type_arg) = (*name, *type_arg);
-                if self.interner.resolve(&name) != "require_droppable" {
+                let gate = self.interner.resolve(&name);
+                // Both well-formedness gates reduce to unit at comptime:
+                // `@require_droppable` (instantiation-time, rejects `linear`) and
+                // `@require_trivially_droppable` (read-time, rejects drop glue —
+                // RUE-651). Any other type intrinsic (`@size_of`/`@align_of`) is
+                // not comptime-foldable here.
+                let is_droppable_gate = gate == "require_droppable";
+                let is_trivial_gate = gate == "require_trivially_droppable";
+                if !is_droppable_gate && !is_trivial_gate {
                     return Ok(None);
                 }
                 // Resolve the element type through the enclosing comptime
@@ -1246,7 +1254,11 @@ impl Sema<'_> {
                 ) else {
                     return Ok(None);
                 };
-                self.check_require_droppable(elem_ty, span)?;
+                if is_trivial_gate {
+                    self.check_trivially_droppable(elem_ty, span)?;
+                } else {
+                    self.check_require_droppable(elem_ty, span)?;
+                }
                 Ok(Some(ConstValue::Unit))
             }
 
@@ -1427,6 +1439,33 @@ impl Sema<'_> {
         // drop glue before freeing its buffer, exactly as Rust's `Vec<T>`
         // does. The old E0498 rejection is gone; `ArrayBuf(ArrayBuf(i64))`,
         // `ArrayBuf(StrBuf)`, and lists of `drop fn` structs are legal.
+        Ok(())
+    }
+
+    /// The `@require_trivially_droppable(T)` gate for by-copy element *reads*
+    /// (RUE-651). `ArrayBuf(T)`'s `get`/`get_or` return the element by copying it
+    /// out with `@ptr_read` while leaving the slot live. For a `T` with drop glue
+    /// (a destructor, or a field/payload/element that has one) that copy aliases
+    /// the element's owned resources: both the copy and the still-live slot run
+    /// drop glue at scope exit — a double-free. This gate rejects those reads at
+    /// their call site (E0711); the element must be *moved* out with `pop`/`pop_or`
+    /// instead. It is deliberately placed in the `get`/`get_or` method bodies (not
+    /// the constructor), so demand-driven analysis (ADR-0045) fires it only when a
+    /// program actually calls a by-copy read — storing, pushing, popping, and
+    /// dropping a drop-glue element stay legal (RUE-646). Mirrors Swift's rule
+    /// that a non-copyable element cannot use a by-value `get` subscript.
+    ///
+    /// A `linear` `T` never reaches here: `@require_droppable` already rejects it
+    /// at instantiation, so `ArrayBuf(linear)` cannot be constructed to be read.
+    pub(crate) fn check_trivially_droppable(&self, ty: Type, span: Span) -> CompileResult<()> {
+        if self.type_has_drop_glue(ty) {
+            return Err(CompileError::new(
+                ErrorKind::ContainerElementNotTriviallyDroppable {
+                    ty: self.format_type_name(ty),
+                },
+                span,
+            ));
+        }
         Ok(())
     }
 

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -768,3 +768,33 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 243
+
+# A by-copy read (`get`) of a drop-glue element is REJECTED (E0711, RUE-651).
+# Before this gate, `ArrayBuf(String)::get(0)` returned a bitwise copy of the
+# String that aliased its owned heap buffer; both the copy and the still-live
+# slot ran drop glue at scope exit — a double-free that segfaulted in safe code
+# (verified: this program exited 139 before the fix). The reader now gates on its
+# element type and directs the caller to `pop` (which moves the element out,
+# leaving one owner). Storing/pushing/popping a String element stays legal — the
+# `arraybuf_strbuf_elements` case above (which uses `pop`) still runs.
+[[case]]
+name = "arraybuf_get_on_drop_glue_element_rejected"
+description = "A by-copy `get` of a drop-glue element (String) is rejected with E0711 and pointed at `pop`, instead of a double-free segfault (RUE-651)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0711", "by copy", "move it out with `pop`"]
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let Buf = std.arraybuf.ArrayBuf(String);
+    let OStr = std.option.Option(String);
+    let mut b = Buf.new();
+    let mut s0 = String.new();
+    s0.push_str("hello");
+    b.push(s0);
+    let n = match b.get(0) { OStr.Some(s) => 1, OStr.None => 0 };
+    @intCast(n)
+}
+""" }]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -336,6 +336,7 @@ impl ErrorCode {
     pub const AMBIGUOUS_MODULE: Self = Self(708);
     pub const CANNOT_INFER_CAST_TARGET: Self = Self(709);
     pub const CANNOT_INFER_POINTEE_TYPE: Self = Self(710);
+    pub const CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE: Self = Self(711);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -1317,6 +1318,18 @@ pub enum ErrorKind {
         "`@require_droppable` requires a trivially-droppable type, but `{ty}` is `linear` — an owning growable container (e.g. `ArrayBuf`) cannot yet track element linearity, so the element would be leaked (RUE-388)"
     )]
     ContainerElementIsLinear { ty: String },
+    /// A by-copy element read (`ArrayBuf(T)::get`/`get_or`) was attempted on an
+    /// element type that owns resources — one with drop glue (a destructor, or a
+    /// field/payload that has one). Copying such an element by `@ptr_read` leaves
+    /// the copy and the still-live slot both pointing at the same owned buffer, so
+    /// both run drop glue at scope exit: a double-free (RUE-651). The read is
+    /// rejected; the element must be *moved* out with `pop`/`pop_or` instead (one
+    /// owner) until borrow-returning reads exist. Mirrors Swift's rule that a
+    /// non-copyable element cannot use a by-value `get` subscript.
+    #[error(
+        "cannot read an element of type `{ty}` by copy: it owns resources (has drop glue), so a by-copy read would alias the owned value and double-free it at scope exit — move it out with `pop`/`pop_or` instead (RUE-651)"
+    )]
+    ContainerElementNotTriviallyDroppable { ty: String },
     /// Inout argument is not an lvalue (variable, field, or array element)
     #[error("inout argument must be an lvalue (variable, field, or array element)")]
     InoutNonLvalue,
@@ -1710,6 +1723,9 @@ impl ErrorKind {
             ErrorKind::IntrinsicTypeMismatch(_) => ErrorCode::INTRINSIC_TYPE_MISMATCH,
             ErrorKind::CannotInferCastTarget(_) => ErrorCode::CANNOT_INFER_CAST_TARGET,
             ErrorKind::CannotInferPointeeType(_) => ErrorCode::CANNOT_INFER_POINTEE_TYPE,
+            ErrorKind::ContainerElementNotTriviallyDroppable { .. } => {
+                ErrorCode::CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE
+            }
             ErrorKind::ImportRequiresStringLiteral => ErrorCode::IMPORT_REQUIRES_STRING_LITERAL,
             ErrorKind::ModuleNotFound { .. } => ErrorCode::MODULE_NOT_FOUND,
             ErrorKind::AmbiguousModule { .. } => ErrorCode::AMBIGUOUS_MODULE,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -14,7 +14,12 @@ use lasso::{Key, Spur, ThreadedRodeo};
 /// `linear` element (RUE-388). It takes the element type as its sole argument
 /// and evaluates to unit during comptime type-constructor reduction, so it must
 /// be lowered as a `TypeIntrinsic` (like `@size_of`), not an expression call.
-const TYPE_INTRINSICS: &[&str] = &["size_of", "align_of", "require_droppable"];
+const TYPE_INTRINSICS: &[&str] = &[
+    "size_of",
+    "align_of",
+    "require_droppable",
+    "require_trivially_droppable",
+];
 use rue_parser::ast::{ConstDecl, DropFn};
 use rue_parser::{
     ArgMode, ArrayLength, AssignTarget, Ast, BinaryOp, CallArg, Directive, DirectiveArg, EnumDecl,

--- a/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
@@ -1,0 +1,91 @@
+[section]
+id = "diagnostics.trivially-droppable-gate"
+name = "By-copy element read gate (E0711)"
+description = """
+An owning container's by-copy read (`ArrayBuf(T)::get`/`get_or`, RUE-651) copies
+the element out with `@ptr_read` while the stored slot stays live. For a `T` with
+drop glue that copy would alias the element's owned resources — both the copy and
+the slot run drop glue at scope exit, a double-free. `@require_trivially_droppable(T)`
+in the reader's body rejects those reads (E0711), directing the caller to `pop`
+(which moves the element, leaving one owner). Because the gate lives in the method
+body, demand-driven analysis (ADR-0045) fires it only when a by-copy read is
+actually called — storing/pushing/popping/dropping a drop-glue element stays legal
+(RUE-646). Mirrors Swift's rule that a non-copyable element cannot use a by-value
+`get` subscript. These cases use a self-contained minimal container so the gate is
+tested independent of the std `ArrayBuf` source.
+"""
+
+[[case]]
+name = "e0711_drop_glue_element_read_rejected"
+description = "Calling a by-copy read whose element type has drop glue is rejected with E0711 and pointed at `pop`."
+source = """
+struct D { v: i32 }
+drop fn D(self) {}
+fn Reader(comptime T: type) -> type {
+    struct {
+        x: T,
+        fn first(borrow self) -> T {
+            @require_trivially_droppable(T);
+            self.x
+        }
+    }
+}
+fn main() -> i32 {
+    let R = Reader(D);
+    let r = R { x: D { v: 5 } };
+    let _ = r.first();
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0711",
+    "cannot read an element of type `D` by copy",
+    "move it out with `pop`",
+]
+
+[[case]]
+name = "e0711_copy_element_read_compiles"
+description = "The same by-copy read compiles and runs for a trivially-droppable (Copy) element type."
+source = """
+fn Reader(comptime T: type) -> type {
+    struct {
+        x: T,
+        fn first(borrow self) -> T {
+            @require_trivially_droppable(T);
+            self.x
+        }
+    }
+}
+fn main() -> i32 {
+    let R = Reader(i32);
+    let r = R { x: 42 };
+    @intCast(r.first())
+}
+"""
+compile_fail = false
+exit_code = 42
+
+[[case]]
+name = "drop_glue_element_stored_but_unread_compiles"
+description = "Storing a drop-glue element is legal (RUE-646); the read gate is dormant until a by-copy read is actually called (demand-driven, ADR-0045)."
+source = """
+struct D { v: i32 }
+drop fn D(self) {}
+fn Reader(comptime T: type) -> type {
+    struct {
+        x: T,
+        fn first(borrow self) -> T {
+            @require_trivially_droppable(T);
+            self.x
+        }
+    }
+}
+fn main() -> i32 {
+    let R = Reader(D);
+    let r = R { x: D { v: 5 } };
+    7
+}
+"""
+compile_fail = false
+exit_code = 7

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -51,11 +51,16 @@
 //     READING A NON-COPY ELEMENT — use `pop`, not `get` (RUE-651). `pop`/`pop_or`
 //     MOVE the element out (they retire the slot, so there is exactly one owner)
 //     and are sound for any `T`. `get`/`get_or` return the element *by copy*
-//     (`@ptr_read`): for a `Copy` `T` that is fine, but for a NON-COPY `T` the
-//     copy ALIASES the element's owned buffer — both the copy and the still-live
-//     slot would run drop glue, a double-free (masked today only by the no-op
-//     bump allocator). Until borrow-returning reads exist (RUE-651), treat
-//     `get`/`get_or` as Copy-element-only.
+//     (`@ptr_read`): for a trivially-droppable `T` that is fine, but for a `T`
+//     with drop glue the copy would ALIAS the element's owned buffer — both the
+//     copy and the still-live slot would run drop glue, a double-free. `get`/
+//     `get_or` therefore GATE on their element type: calling either with a
+//     drop-glue `T` is a compile error (E0711, via `@require_trivially_droppable`
+//     in their bodies) that directs you to `pop`. This is exactly Swift's rule
+//     that a non-copyable element cannot use a by-value `get` subscript. Storing,
+//     pushing, popping, and dropping a drop-glue element stay legal (RUE-646) —
+//     only the by-copy *read* is gated. Lifting that to borrow-returning reads
+//     (a projection/yield accessor, Hylo-style) is the RUE-651 follow-up.
 //   * Multi-slot aggregate element types (e.g. a two-field struct) work as long
 //     as they are trivially droppable: every aggregate is laid out
 //     ascending-in-address and `@ptr_read`/`@ptr_write` walk slots upward from
@@ -132,6 +137,14 @@ pub fn ArrayBuf(comptime T: type) -> type {
         // element's owned buffer (double-free — RUE-651); read owned elements
         // with `pop`.
         fn get(borrow self, i: u64) -> option.Option(T) {
+            // By-copy reads are sound only for a trivially-droppable `T`
+            // (RUE-651): reading a drop-glue element out by `@ptr_read` while the
+            // slot stays live would alias its owned buffer and double-free at
+            // scope exit. This gate fires only when a program actually calls
+            // `get` (demand-driven analysis, ADR-0045); storing/pushing/popping a
+            // drop-glue element stays legal (RUE-646). Read owned elements out
+            // with `pop`, which moves the element (one owner).
+            @require_trivially_droppable(T);
             let O = option.Option(T);
             if i < self.len {
                 O.Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
@@ -145,6 +158,10 @@ pub fn ArrayBuf(comptime T: type) -> type {
         // `Option`. COPY-ELEMENT-ONLY: aliases an owned element's buffer for a
         // non-Copy `T` (double-free — RUE-651); read owned elements with `pop`.
         fn get_or(borrow self, i: u64, default: T) -> T {
+            // Trivially-droppable `T` only, same reason as `get` (RUE-651): a
+            // by-copy read of a drop-glue element would alias its owned buffer
+            // (double-free). Read owned elements out with `pop_or` instead.
+            @require_trivially_droppable(T);
             if i < self.len {
                 checked { @ptr_read(@ptr_offset(self.buf, i)) }
             } else {


### PR DESCRIPTION
ArrayBuf(T)::get/get_or return an element by copying it out with @ptr_read while the stored slot stays live. For a `T` with drop glue (a destructor, or a field/payload/element that has one) that copy aliases the elements owned resources: both the copy and the slot run drop glue at scope exit — a double-free. For a heap-owning element (String, nested ArrayBuf) this **segfaulted in safe code** (verified: `ArrayBuf(String)::get(0)` exited 139).

## Fix

Gate the two by-copy readers with a new `@require_trivially_droppable(T)` intrinsic placed in their method bodies. Because method analysis is demand-driven (ADR-0045), the gate fires **only when a program actually calls a by-copy read** — storing, pushing, popping, and dropping a drop-glue element stay legal (RUE-646 preserved). A drop-glue read is now a clean **E0711** that directs the caller to `pop` (which moves the element, leaving one owner).

This mirrors Swifts rule that a non-copyable element cannot use a by-value `get` subscript. Borrow-returning reads (a Hylo-style projection/yield accessor) remain the RUE-651 capability follow-up.

The type-intrinsic analysis now resolves its type argument through the current analysis context (`resolve_type_with_ctx`), so `T` binds to the concrete element type in a monomorphized generic method body.

## Verified

- The segfault repros (String and nested-ArrayBuf `get`) now report E0711 instead of exit 139
- Copy-element `get`/`get_or` still compile and run
- Drop-glue storage via push/pop/drop still runs (RUE-646 drop-trace cases all green)
- New UI cases (`trivially_droppable_gate.toml`) + CLI case (`arraybuf_get_on_drop_glue_element_rejected`)
- Full `./test.sh` + traceability green

Fixes RUE-651

🤖 Generated with [Claude Code](https://claude.com/claude-code)