### PR TITLE
RUE-634: require concrete specialized signatures

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6047,11 +6047,8 @@ impl<'a> Sema<'a> {
         let param_comptime_type = self.comptime_type_param_flags(&fn_info);
         let param_names = param_names.to_vec();
         let param_modes = param_modes.to_vec();
-        let return_type_sym = fn_info.return_type_sym;
         let base_return_type = fn_info.return_type;
         let fn_body = fn_info.body;
-        let rir_params_start = fn_info.rir_params_start;
-        let rir_params_len = fn_info.rir_params_len;
 
         // `-> type` functions with no runtime parameters reduce immediately,
         // but their arguments still obey the ordinary comptime contract. Build
@@ -6246,12 +6243,6 @@ impl<'a> Sema<'a> {
             // generation, so this is the check that rejects e.g. passing a `B`
             // where `T == A` - without it the callee would read B-shaped fields
             // out of an A-sized allocation (RUE-99, RUE-73).
-            let rir_param_type_syms: Vec<Spur> = self
-                .rir
-                .get_params(rir_params_start, rir_params_len)
-                .iter()
-                .map(|p| p.ty)
-                .collect();
             for (i, (air_arg, &is_comptime)) in
                 air_args.iter().zip(param_comptime.iter()).enumerate()
             {
@@ -6260,26 +6251,13 @@ impl<'a> Sema<'a> {
                     // The comptime type argument itself - already validated above.
                     continue;
                 }
-                let expected = if declared == Type::COMPTIME_TYPE {
-                    // Generic parameter like `x: T` or a composite mentioning a
-                    // type parameter like `a: [T; 3]` (RUE-172) - substitute T.
-                    // If the type parameter wasn't resolved (e.g. it's a local
-                    // bound to a type value), the check happens after
-                    // specialization instead.
-                    let sym = rir_param_type_syms.get(i).copied();
-                    match sym.and_then(|sym| {
-                        self.resolve_type_for_comptime_with_subst_and_values(
-                            sym,
-                            &type_subst,
-                            &value_subst,
-                        )
-                    }) {
-                        Some(ty) => ty,
-                        None => continue,
-                    }
-                } else {
-                    declared
-                };
+                let expected = self.resolve_substituted_param_type(
+                    &fn_info,
+                    i,
+                    declared,
+                    &type_subst,
+                    &value_subst,
+                )?;
                 let found = air.get(air_arg.value).ty;
                 if found != expected
                     && !found.is_error()
@@ -6300,16 +6278,8 @@ impl<'a> Sema<'a> {
             // Handles bare type parameters (`-> T`), composites mentioning one
             // (`-> [T; 3]`, RUE-172), and the literal `type` return (which
             // resolves back to COMPTIME_TYPE and is comptime-evaluated below).
-            let return_type = if base_return_type == Type::COMPTIME_TYPE {
-                self.resolve_type_for_comptime_with_subst_and_values(
-                    return_type_sym,
-                    &type_subst,
-                    &value_subst,
-                )
-                .unwrap_or(base_return_type)
-            } else {
-                base_return_type
-            };
+            let return_type =
+                self.resolve_substituted_return_type(&fn_info, &type_subst, &value_subst)?;
 
             // Special case: functions that return `type` (not a type parameter) with only comptime args
             // can be fully evaluated at compile time to produce a concrete anonymous struct type.

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1516,6 +1516,297 @@ impl<'a> Sema<'a> {
         flags
     }
 
+    /// Resolve one parameter of a generic function under a concrete
+    /// specialization.
+    ///
+    /// Declaration gathering uses [`Type::COMPTIME_TYPE`] as a placeholder
+    /// for runtime parameter types that mention comptime type/value
+    /// parameters (`x: T`, `a: [T; N]`, and so on). Both the call site and the
+    /// specialized callee must replace that placeholder through this exact
+    /// path. Retaining it after the substitution is known would let them
+    /// independently classify the parameter and silently disagree.
+    pub(crate) fn resolve_substituted_param_type(
+        &mut self,
+        function: &FunctionInfo,
+        param_index: usize,
+        declared: Type,
+        type_subst: &HashMap<Spur, Type>,
+        value_subst: &HashMap<Spur, ConstValue>,
+    ) -> CompileResult<Type> {
+        if declared != Type::COMPTIME_TYPE {
+            return Ok(declared);
+        }
+
+        let rir_params = self
+            .rir
+            .get_params(function.rir_params_start, function.rir_params_len);
+        let param = rir_params.get(param_index).ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::InternalError(format!(
+                    "generic parameter index {} is missing from its RIR declaration",
+                    param_index
+                )),
+                function.span,
+            )
+        })?;
+        let type_sym = param.ty;
+        let param_name = param.name;
+
+        // Speculative comptime callers intentionally collapse errors to
+        // `None`; a concrete specialized signature is authoritative. Validate
+        // it first so malformed source types keep their source diagnostics.
+        self.validate_substituted_signature_type(type_sym, type_subst, value_subst, function.span)?;
+
+        self.resolve_type_for_comptime_with_subst_and_values_at_span(
+            type_sym,
+            type_subst,
+            value_subst,
+            function.span,
+        )
+        .ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::InternalError(format!(
+                    "generic parameter '{}' still has an unresolved runtime type after specialization",
+                    self.interner.resolve(&param_name)
+                )),
+                function.span,
+            )
+        })
+    }
+
+    /// Resolve the return half of the same specialized signature contract.
+    /// Caller and callee must agree on it just as strictly as on parameter
+    /// widths; silently retaining the placeholder (or substituting unit) would
+    /// merely move the disagreement to the returned value.
+    pub(crate) fn resolve_substituted_return_type(
+        &mut self,
+        function: &FunctionInfo,
+        type_subst: &HashMap<Spur, Type>,
+        value_subst: &HashMap<Spur, ConstValue>,
+    ) -> CompileResult<Type> {
+        if function.return_type != Type::COMPTIME_TYPE {
+            return Ok(function.return_type);
+        }
+        self.validate_substituted_signature_type(
+            function.return_type_sym,
+            type_subst,
+            value_subst,
+            function.span,
+        )?;
+        self.resolve_type_for_comptime_with_subst_and_values_at_span(
+            function.return_type_sym,
+            type_subst,
+            value_subst,
+            function.span,
+        )
+        .ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::InternalError(
+                    "generic return type remained unresolved after specialization".to_string(),
+                ),
+                function.span,
+            )
+        })
+    }
+
+    fn validate_substituted_signature_type(
+        &mut self,
+        type_sym: Spur,
+        type_subst: &HashMap<Spur, Type>,
+        value_subst: &HashMap<Spur, ConstValue>,
+        span: Span,
+    ) -> CompileResult<()> {
+        if type_subst.contains_key(&type_sym) {
+            return Ok(());
+        }
+
+        let type_name = self.interner.resolve(&type_sym).to_string();
+        if let Some((element, len)) = parse_array_type_syntax(&type_name) {
+            let element_sym = self.interner.get_or_intern(&element);
+            self.validate_substituted_signature_type(element_sym, type_subst, value_subst, span)?;
+            self.resolve_array_length(&len, span, Some(value_subst))?;
+        } else if let Some(pointee) = type_name
+            .strip_prefix("ptr const ")
+            .or_else(|| type_name.strip_prefix("ptr mut "))
+        {
+            let pointee_sym = self.interner.get_or_intern(pointee);
+            self.validate_substituted_signature_type(pointee_sym, type_subst, value_subst, span)?;
+        } else if let Some((call_name, arg_strs)) = parse_type_call_syntax(&type_name) {
+            self.resolve_type_call_for_comptime_with_subst_diagnostic(
+                &call_name,
+                &arg_strs,
+                type_subst,
+                value_subst,
+                span,
+            )?;
+        } else {
+            // Resolve concrete leaves in the declaration's file, not through
+            // global compatibility maps. This keeps same-named module-local
+            // types isolated inside deferred arrays and pointers.
+            self.resolve_type(type_sym, span)?;
+        }
+        Ok(())
+    }
+
+    /// Resolve a type-constructor application while preserving diagnostics.
+    /// The general comptime resolver is intentionally Option-based because
+    /// many callers probe whether an expression is reducible. Once a generic
+    /// signature is concrete, malformed arity, kind, or constructor-body
+    /// failures are authoritative source errors.
+    fn resolve_type_call_for_comptime_with_subst_diagnostic(
+        &mut self,
+        call_name: &str,
+        arg_strs: &[String],
+        type_subst: &HashMap<Spur, Type>,
+        value_subst: &HashMap<Spur, ConstValue>,
+        span: Span,
+    ) -> CompileResult<Option<Type>> {
+        if call_name == "Str" {
+            return self
+                .resolve_str_fixed_type(call_name, arg_strs, span)
+                .map(Some);
+        }
+        if call_name.contains('.') {
+            return Ok(self.resolve_qualified_type_call_for_comptime(
+                call_name,
+                arg_strs,
+                type_subst,
+                value_subst,
+                span,
+            ));
+        }
+
+        let name_sym = self.interner.get_or_intern(call_name);
+        let function_key = if span == Span::default() {
+            Some(name_sym)
+        } else {
+            let mut key = self.resolve_function_name_local(name_sym, span.file_id);
+            if key.is_none() {
+                self.ensure_free_function_signature(name_sym, Some(span.file_id))?;
+                key = self.resolve_function_name_local(name_sym, span.file_id);
+            }
+            key
+        }
+        .ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::UnknownType(format!("{}({})", call_name, arg_strs.join(", "))),
+                span,
+            )
+        })?;
+        let fn_info = self.functions.get(&function_key).copied().ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::UnknownType(format!("{}({})", call_name, arg_strs.join(", "))),
+                span,
+            )
+        })?;
+        self.check_unqualified_visibility(
+            "function",
+            call_name,
+            fn_info.file_id,
+            fn_info.is_pub,
+            span,
+        )?;
+        if fn_info.return_type != Type::COMPTIME_TYPE {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "'{}' is not a type: only a function returning `type` can be applied here",
+                        call_name
+                    ),
+                },
+                span,
+            ));
+        }
+
+        let params = fn_info.params;
+        let param_names = self.param_arena.names(params).to_vec();
+        let param_comptime = self.param_arena.comptime(params).to_vec();
+        if arg_strs.len() != param_names.len()
+            || !(param_names.is_empty() || param_comptime.iter().all(|&flag| flag))
+        {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "type constructor '{}' expects {} comptime argument(s), but {} were provided",
+                        call_name,
+                        param_names.len(),
+                        arg_strs.len()
+                    ),
+                },
+                span,
+            ));
+        }
+
+        let param_comptime_type = self.comptime_type_param_flags(&fn_info);
+        let mut callee_types = HashMap::new();
+        let mut callee_values = HashMap::new();
+        for (i, arg) in arg_strs.iter().enumerate() {
+            if param_comptime_type[i] {
+                let arg_ty =
+                    if let Some((nested_name, nested_args)) = parse_type_call_syntax(arg) {
+                        self.resolve_type_call_for_comptime_with_subst_diagnostic(
+                            &nested_name,
+                            &nested_args,
+                            type_subst,
+                            value_subst,
+                            span,
+                        )?
+                    } else {
+                        let arg_sym = self.interner.get_or_intern(arg);
+                        self.resolve_type_for_comptime_with_subst_and_values_at_span(
+                            arg_sym,
+                            type_subst,
+                            value_subst,
+                            span,
+                        )
+                    }
+                    .ok_or_else(|| {
+                        CompileError::new(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: format!(
+                                    "argument '{}' for '{}' did not resolve to a type",
+                                    arg, call_name
+                                ),
+                            },
+                            span,
+                        )
+                    })?;
+                callee_types.insert(param_names[i], arg_ty);
+            } else {
+                let value = self
+                    .resolve_comptime_type_ctor_value_arg(arg, value_subst, span)
+                    .ok_or_else(|| {
+                        CompileError::new(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: format!(
+                                    "argument '{}' for '{}' is not a compile-time value",
+                                    arg, call_name
+                                ),
+                            },
+                            span,
+                        )
+                    })?;
+                callee_values.insert(param_names[i], value);
+            }
+        }
+
+        match self
+            .reduce_type_ctor_body(function_key, &callee_types, &callee_values)
+            .map_err(|error| Self::label_ctor_instantiation_site(error, span))?
+        {
+            Some(ConstValue::Type(ty)) => Ok(Some(ty)),
+            _ => Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "the type constructor '{}' did not reduce to a concrete type",
+                        call_name
+                    ),
+                },
+                span,
+            )),
+        }
+    }
+
     /// Resolve a type symbol to a Type, returning None if the type is unknown.
     ///
     /// This is used in comptime evaluation where we can't produce a compile error.
@@ -1581,6 +1872,14 @@ impl<'a> Sema<'a> {
             return Some(ty);
         }
 
+        let is_composite = parse_array_type_syntax(type_name).is_some()
+            || type_name.starts_with("ptr const ")
+            || type_name.starts_with("ptr mut ")
+            || parse_type_call_syntax(type_name).is_some();
+        if span != Span::default() && !is_composite {
+            return self.resolve_type(type_sym, span).ok();
+        }
+
         if let Some(&struct_id) = self.structs.get(&type_sym) {
             Some(Type::new_struct(struct_id))
         } else if let Some(&enum_id) = self.enums.get(&type_sym) {
@@ -1632,81 +1931,15 @@ impl<'a> Sema<'a> {
             let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
             Some(Type::new_ptr_mut(ptr_type_id))
         } else if let Some((call_name, arg_strs)) = parse_type_call_syntax(type_name) {
-            // A *module-qualified* type-function application (`m.Mk(T)`,
-            // `std.option.Option(T)`) appearing in a comptime type position
-            // during body reduction — a field type, an enum-variant payload, or
-            // a method's parameter/return type inside a `-> type` constructor
-            // whose method references a constructor imported from another module
-            // (RUE-511). The unqualified path below can't resolve `m.Mk` as a
-            // function name, so dispatch to the qualified resolver, which walks
-            // the module prefix (keyed by `span.file_id`, the defining file),
-            // enforces membership + visibility, and reduces the callee body.
-            if call_name.contains('.') {
-                return self.resolve_qualified_type_call_for_comptime(
-                    &call_name,
-                    &arg_strs,
-                    type_subst,
-                    value_subst,
-                    span,
-                );
-            }
-            // A type-function application whose arguments may name enclosing
-            // comptime type parameters (`Option(T)` with `T` in `type_subst`).
-            // Resolve each argument under the current substitution, then reduce
-            // the constructor body to its monomorphized type — so a generic
-            // signature/return type applying an enclosing constructor to a type
-            // parameter (`fn wrap(comptime T: type, ...) -> Option(T)`)
-            // monomorphizes at each call site (RUE-272). Shares the reduction
-            // path (and E1200 recursion guard) with the signature-position
-            // resolver `resolve_type_function_call`. On the comptime path we
-            // can't emit a diagnostic, so any failure (unknown callee,
-            // non-`type` callee, arity mismatch, non-reducing body, recursion
-            // guard) just makes the type non-evaluable (`None`); the caller
-            // reports it.
-            let name_sym = self.interner.get_or_intern(&call_name);
-            let function_key = if span == Span::default() {
-                name_sym
-            } else {
-                self.resolve_function_name_local(name_sym, span.file_id)?
-            };
-            let fn_info = self.functions.get(&function_key).copied()?;
-            if fn_info.return_type != Type::COMPTIME_TYPE {
-                return None;
-            }
-            let params = fn_info.params;
-            let param_names = self.param_arena.names(params).to_vec();
-            let param_comptime = self.param_arena.comptime(params).to_vec();
-            if arg_strs.len() != param_names.len()
-                || !(param_names.is_empty() || param_comptime.iter().all(|&c| c))
-            {
-                return None;
-            }
-            // Kind-aware binding (RUE-552): see the qualified resolver above.
-            let param_comptime_type = self.comptime_type_param_flags(&fn_info);
-            let mut callee_types: HashMap<Spur, Type> = HashMap::new();
-            let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
-            for (i, arg) in arg_strs.iter().enumerate() {
-                if param_comptime_type[i] {
-                    let arg_sym = self.interner.get_or_intern(arg);
-                    let arg_ty = self.resolve_type_for_comptime_with_subst_and_values_at_span(
-                        arg_sym,
-                        type_subst,
-                        value_subst,
-                        span,
-                    )?;
-                    callee_types.insert(param_names[i], arg_ty);
-                } else {
-                    let val = self.resolve_comptime_type_ctor_value_arg(arg, value_subst, span)?;
-                    callee_values.insert(param_names[i], val);
-                }
-            }
-            match self
-                .reduce_type_ctor_body(function_key, &callee_types, &callee_values)
-                .ok()?
-            {
-                Some(ConstValue::Type(t)) => Some(t),
-                _ => None,
-            }
+            self.resolve_type_call_for_comptime_with_subst_diagnostic(
+                &call_name,
+                &arg_strs,
+                type_subst,
+                value_subst,
+                span,
+            )
+            .ok()
+            .flatten()
         } else {
             None // Unknown type
         }

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -511,30 +511,49 @@ fn create_specialized_function(
             continue;
         }
         if param_comptime_type[param_index] {
-            if type_arg_idx < key.type_args.len() {
-                type_subst.insert(*name, key.type_args[type_arg_idx]);
-                type_arg_idx += 1;
-            }
-        } else if value_arg_idx < key.value_args.len() {
-            value_subst.insert(*name, key.value_args[value_arg_idx]);
+            let ty = key.type_args.get(type_arg_idx).copied().ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::InternalError(format!(
+                        "specialization is missing type argument {} for '{}'",
+                        type_arg_idx,
+                        interner.resolve(name)
+                    )),
+                    base_info.span,
+                )
+            })?;
+            type_subst.insert(*name, ty);
+            type_arg_idx += 1;
+        } else {
+            let value = key.value_args.get(value_arg_idx).copied().ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::InternalError(format!(
+                        "specialization is missing value argument {} for '{}'",
+                        value_arg_idx,
+                        interner.resolve(name)
+                    )),
+                    base_info.span,
+                )
+            })?;
+            value_subst.insert(*name, value);
             value_arg_idx += 1;
         }
+    }
+    if type_arg_idx != key.type_args.len() || value_arg_idx != key.value_args.len() {
+        return Err(CompileError::new(
+            ErrorKind::InternalError(format!(
+                "specialization argument streams do not match declaration: consumed {type_arg_idx} type/{value_arg_idx} value, received {}/{}",
+                key.type_args.len(),
+                key.value_args.len()
+            )),
+            base_info.span,
+        ));
     }
 
     // Resolve the return type, substituting type parameters - bare (`-> T`)
     // or inside a composite (`-> [T; 3]`, RUE-172). Value parameters also
     // substitute so an array length can name a `comptime N: i32` (`-> [i32; N]`,
     // RUE-16).
-    let return_type = if base_info.return_type == Type::COMPTIME_TYPE {
-        sema.resolve_type_for_comptime_with_subst_and_values(
-            base_info.return_type_sym,
-            &type_subst,
-            &value_subst,
-        )
-        .unwrap_or(Type::UNIT)
-    } else {
-        base_info.return_type
-    };
+    let return_type = sema.resolve_substituted_return_type(base_info, &type_subst, &value_subst)?;
 
     // Copy out the param data first: substitution needs `&mut Sema` (composite
     // types like `[T; 3]` may intern new array types), which can't overlap a
@@ -552,16 +571,13 @@ fn create_specialized_function(
             // signature (types don't exist at runtime).
             continue;
         }
-        let concrete_ty = if ty == Type::COMPTIME_TYPE {
-            substitute_param_type(sema, base_info, name, &type_subst, &value_subst).unwrap_or_else(
-                || {
-                    debug_assert!(false, "type substitution failed for param");
-                    ty
-                },
-            )
-        } else {
-            ty
-        };
+        let concrete_ty = sema.resolve_substituted_param_type(
+            base_info,
+            param_index,
+            ty,
+            &type_subst,
+            &value_subst,
+        )?;
         // Comptime VALUE parameters stay in the runtime signature — the call
         // site still passes them. Their constant value is additionally
         // substituted into the body via value_subst (RUE-166).
@@ -600,24 +616,4 @@ fn create_specialized_function(
         referenced_functions,
         referenced_methods,
     })
-}
-
-/// Resolve a parameter's concrete type by substituting type parameters into
-/// its declared type symbol - bare (`x: T`) or inside a composite
-/// (`a: [T; 3]`, `p: ptr const T`; RUE-172). Value parameters also substitute
-/// so an array length can name a `comptime N: i32` (`arr: [i32; N]`, RUE-16).
-fn substitute_param_type(
-    sema: &mut Sema<'_>,
-    base_info: &FunctionInfo,
-    param_name: Spur,
-    type_subst: &HashMap<Spur, Type>,
-    value_subst: &HashMap<Spur, ConstValue>,
-) -> Option<Type> {
-    let type_sym = sema
-        .rir
-        .get_params(base_info.rir_params_start, base_info.rir_params_len)
-        .iter()
-        .find(|param| param.name == param_name)
-        .map(|param| param.ty)?;
-    sema.resolve_type_for_comptime_with_subst_and_values(type_sym, type_subst, value_subst)
 }

--- a/crates/rue-cli-tests/cases/comptime_array_length.toml
+++ b/crates/rue-cli-tests/cases/comptime_array_length.toml
@@ -85,6 +85,21 @@ compile_fail = true
 error_contains = ["not a compile-time constant"]
 
 [[case]]
+name = "negative_specialized_parameter_length_is_source_error"
+description = "A bad call-site substitution preserves E0481 instead of becoming an unresolved-signature internal error."
+files = [{ path = "main.rue", source = """
+fn first(comptime N: i32, values: [i32; N]) -> i32 {
+    values[0]
+}
+
+fn main() -> i32 {
+    first(-1, [1])
+}
+""" }]
+compile_fail = true
+error_contains = ["negative"]
+
+[[case]]
 name = "negative_const_length_rejected"
 files = [{ path = "main.rue", source = """
 const NEG: i32 = -3;

--- a/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
+++ b/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
@@ -273,3 +273,22 @@ fn f(x: i32) -> i32 {
 fn main() -> i32 { f(5) }
 """ }]
 exit_code = 10
+
+[[case]]
+name = "malformed_deferred_type_call_preserves_source_diagnostic"
+description = "Physicalizing a deferred generic signature preserves constructor arity errors instead of reporting an internal unresolved placeholder."
+files = [{ path = "main.rue", source = """
+fn Pair(comptime T: type, comptime U: type) -> type {
+    struct { left: T, right: U }
+}
+
+fn take(comptime T: type, value: Pair(T)) -> i32 {
+    1
+}
+
+fn main() -> i32 {
+    take(i32, @panic("stop"))
+}
+""" }]
+compile_fail = true
+error_contains = ["expects 2", "provided"]


### PR DESCRIPTION
## Summary

- resolve deferred generic parameter and return types through one authoritative substitution path
- make caller analysis and specialization require the same concrete signature
- reject missing or extra specialization type/value streams instead of retaining placeholders
- preserve source diagnostics for malformed deferred arrays and type-constructor calls

## Root cause

Generic declarations use a compile-time placeholder for signature types that depend on comptime parameters. Caller analysis and specialization previously resolved that placeholder through separate, fallible paths, allowing them to disagree or silently retain an unresolved type.

## Validation

- `./test.sh generic_type_call_sigs`
- `./test.sh comptime_array_length`
- `./fmt.sh --check`

Both filtered test runs completed with the authoritative `=== TEST SUITE: PASSED ===` sentinel.