### PR TITLE
RUE-661: bind free bodies by indexed declaration

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -427,22 +427,6 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
     let mut errors = CompileErrors::new();
     let mut all_warnings = Vec::new();
 
-    // Collect method refs from struct declarations (for later lookup)
-    let mut method_refs: HashSet<InstRef> = HashSet::new();
-    for (_, inst) in sema.rir.iter() {
-        if let InstData::StructDecl {
-            methods_start,
-            methods_len,
-            ..
-        } = &inst.data
-        {
-            let methods = sema.rir.get_inst_refs(*methods_start, *methods_len);
-            for method_ref in methods {
-                method_refs.insert(method_ref);
-            }
-        }
-    }
-
     // Process the transitive reference frontier until neither source-level
     // calls nor implicit destructor roots discover more work.
     loop {
@@ -466,66 +450,82 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
 
             let fn_name_str = sema.interner.resolve(&fn_name).to_string();
 
-            // Find the function declaration in RIR to get params
-            let mut found = false;
-            for (inst_ref, inst) in sema.rir.iter() {
+            // Bind the body through the exact free-function declaration that
+            // declaration gathering indexed. A receiverless associated
+            // function has the same FnDecl shape as a free function and must
+            // never win this lookup merely because it occurs first in RIR.
+            let source_name = sema.source_function_name(fn_name);
+            let declaration = sema
+                .declaration_index
+                .first_free_function(source_name, Some(fn_info.file_id));
+
+            let Some(declaration) = declaration else {
+                // This could be a builtin or otherwise non-existent function.
+                // Preserve the historical defensive behavior and skip it.
+                continue;
+            };
+            let inst = sema.rir.get(declaration);
+            let (name, params_start, params_len, return_type, body, has_self, span) =
                 if let InstData::FnDecl {
                     name,
                     params_start,
                     params_len,
                     return_type,
                     body,
+                    has_self,
                     ..
                 } = &inst.data
                 {
-                    let function_key = sema
-                        .resolve_function_name_local(*name, inst.span.file_id)
-                        .unwrap_or(*name);
-                    if function_key == fn_name && !method_refs.contains(&inst_ref) {
-                        found = true;
-                        let params = sema.rir.get_params(*params_start, *params_len);
+                    (
+                        *name,
+                        *params_start,
+                        *params_len,
+                        *return_type,
+                        *body,
+                        *has_self,
+                        inst.span,
+                    )
+                } else {
+                    unreachable!("free-function index contains only FnDecl instructions");
+                };
 
-                        match sema.analyze_single_function(
-                            &infer_ctx,
-                            &fn_name_str,
-                            *return_type,
-                            &params,
-                            *body,
-                            inst.span,
-                            fn_info.allow_unused_variable,
-                            fn_info.allow_unreachable_code,
-                        ) {
-                            Ok((
-                                analyzed,
-                                warnings,
-                                local_strings,
-                                referenced_fns,
-                                referenced_meths,
-                            )) => {
-                                functions_with_strings.push((analyzed, local_strings));
-                                all_warnings.extend(warnings);
+            debug_assert_eq!(name, source_name);
+            debug_assert!(!has_self);
+            debug_assert_eq!(params_start, fn_info.rir_params_start);
+            debug_assert_eq!(params_len, fn_info.rir_params_len);
+            debug_assert_eq!(return_type, fn_info.return_type_sym);
+            debug_assert_eq!(body, fn_info.body);
+            debug_assert_eq!(span, fn_info.span);
+            debug_assert_eq!(span.file_id, fn_info.file_id);
 
-                                // Add newly referenced functions to the work queue
-                                enqueue_references_sorted(
-                                    sema.interner,
-                                    referenced_fns,
-                                    referenced_meths,
-                                    &analyzed_functions,
-                                    &analyzed_methods,
-                                    &mut pending_functions,
-                                    &mut pending_methods,
-                                );
-                            }
-                            Err(e) => errors.push(e),
-                        }
-                        break;
-                    }
+            let params = sema.rir.get_params(params_start, params_len);
+
+            match sema.analyze_single_function(
+                &infer_ctx,
+                &fn_name_str,
+                return_type,
+                &params,
+                body,
+                span,
+                fn_info.allow_unused_variable,
+                fn_info.allow_unreachable_code,
+            ) {
+                Ok((analyzed, warnings, local_strings, referenced_fns, referenced_meths)) => {
+                    functions_with_strings.push((analyzed, local_strings));
+                    all_warnings.extend(warnings);
+
+                    // Add newly referenced functions to the work queue
+                    enqueue_references_sorted(
+                        sema.interner,
+                        referenced_fns,
+                        referenced_meths,
+                        &analyzed_functions,
+                        &analyzed_methods,
+                        &mut pending_functions,
+                        &mut pending_methods,
+                    );
                 }
-            }
-
-            if !found {
-                // This could be a builtin or otherwise non-existent function
-                // Just skip it
+                Err(e) => errors.push(e),
             }
         }
 

--- a/crates/rue-cli-tests/cases/free_function_binding.toml
+++ b/crates/rue-cli-tests/cases/free_function_binding.toml
@@ -1,0 +1,49 @@
+# Free-function body binding regressions (RUE-661).
+#
+# Receiverless functions owned by an anonymous type are represented as FnDecls,
+# just like free functions. Demand-driven analysis must use the declaration
+# index's ownership classification rather than selecting the first same-named
+# FnDecl in raw RIR order.
+
+[section]
+id = "cli.free_function_binding"
+name = "Free-function body binding"
+description = "Reachable free functions bind to their exact indexed declarations."
+
+[[case]]
+name = "anonymous_associated_function_cannot_hijack_free_body"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn HiddenType() -> type {
+    struct {
+        fn collide() -> i32 { 99 }
+    }
+}
+
+const Hidden = HiddenType();
+
+fn collide() -> i32 { 42 }
+
+fn main() -> i32 {
+    if Hidden.collide() == 99 { collide() } else { 1 }
+}
+""" }]
+stdout = ""
+exit_code = 42
+
+[[case]]
+name = "free_body_binding_is_source_order_independent"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn collide() -> i32 { 42 }
+
+fn main() -> i32 { collide() }
+
+fn HiddenType() -> type {
+    struct {
+        fn collide() -> i32 { 99 }
+    }
+}
+""" }]
+stdout = ""
+exit_code = 42


### PR DESCRIPTION
## What changed

- Bind every reachable non-generic free-function body through the exact snapshot-local declaration index entry keyed by source name and defining file.
- Remove the named-method ownership prescan and the full-RIR scan previously repeated for every reachable free function.
- Assert that the indexed declaration agrees with every gathered `FunctionInfo` identity field before analysis.
- Add executable O0–O3 regressions for both source orders, including a same-named anonymous associated function that remains callable through its type.

## Root cause

AstGen emits an anonymous associated function's `FnDecl` before its enclosing `AnonStructType`. The lazy body driver scanned raw RIR and excluded only methods owned by named `StructDecl` values. Because associated functions have no receiver, the first anonymous `collide` declaration was mistaken for the same-file free function and Rue silently emitted its body instead.

The reproducer therefore returned 99 from the anonymous associated function instead of 42 from the free function. The driver now retains the declaration identity established during gathering and cannot select a body by incidental RIR order.

Linear: RUE-661

## Validation

- `./fmt.sh check`
- `./clippy.sh`
- focused rue-air and compiler suites
- all 1,362 CLI cases, including differential O0–O3 regressions
- `./buck2 test //... //:reproducible-programs`
- `./scripts/check-reproducible-compiler.sh`
  - byte-identical SHA-256: `a6e265b0417080ba1094f60ce27fdd852d25e71c70591e053f2e4e74224b43d9`
  - identical build ID: `e70da7581f81a35ff93fe291793aba6b607cd4f7`
