### PR TITLE
RUE-634: validate comptime call contracts

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6056,7 +6056,7 @@ impl<'a> Sema<'a> {
         // otherwise a constructor that ignores a wrong-kind/private argument
         // can accidentally accept it.
         let all_params_comptime = param_comptime.iter().all(|&flag| flag);
-        if base_return_type == Type::COMPTIME_TYPE && (args.is_empty() || all_params_comptime) {
+        if self.function_returns_type(&fn_info) && (args.is_empty() || all_params_comptime) {
             let mut type_subst = std::collections::HashMap::new();
             let mut value_subst = std::collections::HashMap::new();
             for (i, is_comptime) in param_comptime.iter().enumerate() {
@@ -6108,7 +6108,7 @@ impl<'a> Sema<'a> {
             // rather than being swallowed into a downstream link error, so use
             // the propagating reduction entry point.
             if let Some(ConstValue::Type(ty)) = self
-                .eval_type_constructor_body(fn_body, &type_subst, &value_subst)
+                .reduce_type_ctor_body(name, &type_subst, &value_subst)
                 .map_err(|e| Self::label_ctor_instantiation_site(e, span))?
             {
                 // Success! Return a TypeConst instruction instead of a runtime call

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -54,8 +54,8 @@ use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
 use rue_rir::{InstData, InstRef, RepeatCount, RirPattern};
 use rue_span::{FileId, Span};
 
-use super::Sema;
 use super::context::{AnalysisContext, ConstValue, LocalVar, ParamInfo};
+use super::{FunctionInfo, Sema};
 use crate::specialize::MAX_SPECIALIZATION_ROUNDS;
 use crate::types::{ArrayLen, StructField, Type, TypeKind};
 
@@ -326,32 +326,6 @@ impl Sema<'_> {
         // its receiver against the expression's own file's imports (RUE-511).
         env.defining_file = Some(self.rir.get(inst_ref).span.file_id);
         self.eval_const_expr(inst_ref, &mut env).ok().flatten()
-    }
-
-    /// Like [`try_evaluate_const_with_subst`], but *propagates* a hard
-    /// diagnostic raised while reducing the body instead of swallowing it.
-    ///
-    /// Reducing a `-> type` constructor body may legitimately be non-evaluable
-    /// (`Ok(None)` — defer to a runtime call) or raise a genuine compile error
-    /// (`Err` — e.g. an arithmetic overflow, a privacy violation, or exceeding
-    /// the comptime-recursion depth limit for a non-terminating type
-    /// constructor, RUE-261). The type-constructor reduction site uses this so
-    /// the latter surfaces as its real diagnostic (E1200) rather than being
-    /// swallowed and mis-reported as a downstream link error.
-    ///
-    /// [`try_evaluate_const_with_subst`]: Sema::try_evaluate_const_with_subst
-    pub(crate) fn eval_type_constructor_body(
-        &mut self,
-        inst_ref: InstRef,
-        type_subst: &HashMap<Spur, Type>,
-        value_subst: &HashMap<Spur, ConstValue>,
-    ) -> CompileResult<Option<ConstValue>> {
-        let mut env = ComptimeEnv::with_subst(type_subst, value_subst);
-        // The body is code from the constructor's file, so a module-qualified
-        // comptime call inside it (`let O = b.Mk(T)`) resolves its receiver
-        // against that file's imports (RUE-511).
-        env.defining_file = Some(self.rir.get(inst_ref).span.file_id);
-        self.eval_const_expr(inst_ref, &mut env)
     }
 
     /// Try to extract a constant integer value from an RIR index expression.
@@ -1423,9 +1397,6 @@ impl Sema<'_> {
     /// rejected. A droppable element (primitives, pointers, `Copy` structs,
     /// destructor-bearing structs, nested containers) passes.
     pub(crate) fn check_require_droppable(&self, ty: Type, span: Span) -> CompileResult<()> {
-        // Linear element types stay rejected (E0499): a linear value must be
-        // consumed exactly once and a container cannot run the consuming
-        // discharge on drop — that is the deferred RUE-649 work.
         if self.type_carries_linear(ty) {
             return Err(CompileError::new(
                 ErrorKind::ContainerElementIsLinear {
@@ -1434,11 +1405,10 @@ impl Sema<'_> {
                 span,
             ));
         }
-        // Droppable-but-non-linear element types are now ACCEPTED (RUE-646,
-        // Steve's 2026-07-11 ruling): the container runs each live element's
-        // drop glue before freeing its buffer, exactly as Rust's `Vec<T>`
-        // does. The old E0498 rejection is gone; `ArrayBuf(ArrayBuf(i64))`,
-        // `ArrayBuf(StrBuf)`, and lists of `drop fn` structs are legal.
+        // Droppable-but-non-linear element types are accepted (RUE-646): the
+        // container runs each live element's drop glue before freeing its
+        // buffer. Linear element types stay rejected because they require a
+        // consuming discharge rather than ordinary drop glue.
         Ok(())
     }
 
@@ -1524,7 +1494,7 @@ impl Sema<'_> {
             };
             (key, info)
         };
-        let is_type_fn = fn_info.return_type == Type::COMPTIME_TYPE;
+        let is_type_fn = self.function_returns_type(&fn_info);
         let params = fn_info.params;
         let param_names = self.param_arena.names(params).to_vec();
         let param_modes = self.param_arena.modes(params).to_vec();
@@ -1586,36 +1556,170 @@ impl Sema<'_> {
         self.reduce_type_ctor_body(name_key, &callee_types, &callee_values)
     }
 
-    /// Reduce a comptime-evaluable function's body to a [`ConstValue`] under
-    /// the given comptime parameter substitutions — a type value for a
-    /// `-> type` constructor, or an integer/bool for a value-returning
-    /// comptime function (RUE-163 facet 1). Shared by
-    /// [`eval_comptime_type_call`] (value/const-expr positions, args evaluated
-    /// via [`eval_const_expr`]) and [`resolve_type_function_call`] (a
-    /// type-function call written directly in a signature/annotation position,
-    /// args resolved as types; RUE-241) so both produce the identical
-    /// monomorphized result.
-    ///
-    /// Guards the reduction against unbounded self-recursion. A `-> type`
-    /// function reduces eagerly on the host stack, so a constructor with no
-    /// compile-time-known base case (`fn Bad() -> type { Bad() }`,
-    /// `fn Wrap(comptime n: i32) -> type { Wrap(n + 1) }`) would overflow that
-    /// stack and abort the compiler (SIGABRT) with no diagnostic. Cap the
-    /// depth at the same bound the specialization pass uses for value
-    /// recursion, emitting the identical E1200 (RUE-261, spec 4.14:18).
-    ///
-    /// [`eval_comptime_type_call`]: Sema::eval_comptime_type_call
-    /// [`eval_const_expr`]: Sema::eval_const_expr
-    /// [`resolve_type_function_call`]: Sema::resolve_type_function_call
+    pub(crate) fn validate_comptime_value_for_type(
+        &self,
+        function_name: Spur,
+        param_name: Spur,
+        value: ConstValue,
+        expected: Type,
+        span: Span,
+    ) -> CompileResult<()> {
+        if matches!(value, ConstValue::Function(_)) {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "callable alias passed to compile-time parameter '{}' of '{}'; callable aliases cannot be passed as arguments",
+                        self.interner.resolve(&param_name),
+                        self.interner.resolve(&function_name)
+                    ),
+                },
+                span,
+            ));
+        }
+
+        if let ConstValue::Integer(integer) = value
+            && expected.is_integer()
+        {
+            if const_int_fits(integer, expected) {
+                return Ok(());
+            }
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "compile-time argument '{}' for '{}' has value {} outside the range of {}",
+                        self.interner.resolve(&param_name),
+                        self.interner.resolve(&function_name),
+                        integer,
+                        expected.safe_name_with_pool(Some(&self.type_pool))
+                    ),
+                },
+                span,
+            ));
+        }
+
+        let found = value.get_type();
+        if found != expected {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: expected.safe_name_with_pool(Some(&self.type_pool)),
+                    found: found.safe_name_with_pool(Some(&self.type_pool)),
+                },
+                span,
+            )
+            .with_help(format!(
+                "compile-time argument '{}' must match its declared type in '{}'",
+                self.interner.resolve(&param_name),
+                self.interner.resolve(&function_name)
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validate the complete comptime argument contract at the shared
+    /// reduction boundary. Binding paths may differ, but none may reduce a
+    /// body until type/value kinds, dependent declared types, and integer
+    /// ranges agree with the source declaration.
+    fn validate_comptime_call_substitutions(
+        &mut self,
+        function_name: Spur,
+        function: &FunctionInfo,
+        callee_types: &HashMap<Spur, Type>,
+        callee_values: &HashMap<Spur, ConstValue>,
+    ) -> CompileResult<()> {
+        let params = function.params;
+        let param_names = self.param_arena.names(params).to_vec();
+        let param_types = self.param_arena.types(params).to_vec();
+        let param_comptime = self.param_arena.comptime(params).to_vec();
+        let param_comptime_type = self.comptime_type_param_flags(function);
+
+        let expected_type_args = param_comptime
+            .iter()
+            .zip(param_comptime_type.iter())
+            .filter(|(is_comptime, is_type)| **is_comptime && **is_type)
+            .count();
+        let expected_value_args = param_comptime
+            .iter()
+            .zip(param_comptime_type.iter())
+            .filter(|(is_comptime, is_type)| **is_comptime && !**is_type)
+            .count();
+        if callee_types.len() != expected_type_args || callee_values.len() != expected_value_args {
+            return Err(CompileError::new(
+                ErrorKind::InternalError(format!(
+                    "comptime argument maps for '{}' do not match its declaration: received {}/{} type/value arguments, expected {expected_type_args}/{expected_value_args}",
+                    self.interner.resolve(&function_name),
+                    callee_types.len(),
+                    callee_values.len(),
+                )),
+                function.span,
+            ));
+        }
+
+        for (index, ((name, declared), is_comptime)) in param_names
+            .iter()
+            .zip(param_types.iter())
+            .zip(param_comptime.iter())
+            .enumerate()
+        {
+            if !is_comptime {
+                continue;
+            }
+            if param_comptime_type[index] {
+                if !callee_types.contains_key(name) {
+                    return Err(CompileError::new(
+                        ErrorKind::InternalError(format!(
+                            "comptime type argument for '{}' is missing while reducing '{}'",
+                            self.interner.resolve(name),
+                            self.interner.resolve(&function_name)
+                        )),
+                        function.span,
+                    ));
+                }
+                continue;
+            }
+            let value = callee_values.get(name).copied().ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::InternalError(format!(
+                        "comptime value argument for '{}' is missing while reducing '{}'",
+                        self.interner.resolve(name),
+                        self.interner.resolve(&function_name)
+                    )),
+                    function.span,
+                )
+            })?;
+            let expected = self.resolve_substituted_param_type(
+                function,
+                index,
+                *declared,
+                callee_types,
+                callee_values,
+            )?;
+
+            self.validate_comptime_value_for_type(
+                function_name,
+                *name,
+                value,
+                expected,
+                function.span,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Reduce a comptime-evaluable function body under concrete substitutions.
+    /// This is the shared path for type constructors and value-returning
+    /// comptime functions, so it validates the argument contract once before
+    /// evaluation and guards recursive reductions with the specialization
+    /// depth limit (RUE-163, RUE-241, RUE-261).
     pub(crate) fn reduce_type_ctor_body(
         &mut self,
         name: Spur,
         callee_types: &HashMap<Spur, Type>,
         callee_values: &HashMap<Spur, ConstValue>,
     ) -> CompileResult<Option<ConstValue>> {
-        let Some(fn_info) = self.functions.get(&name) else {
+        let Some(fn_info) = self.functions.get(&name).copied() else {
             return Ok(None);
         };
+        self.validate_comptime_call_substitutions(name, &fn_info, callee_types, callee_values)?;
         let fn_body = fn_info.body;
         let fn_span = fn_info.span;
         let fn_file = fn_info.file_id;

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -924,7 +924,7 @@ impl<'a> Sema<'a> {
             fn_info.is_pub,
             span,
         )?;
-        if fn_info.return_type != Type::COMPTIME_TYPE {
+        if !self.function_returns_type(&fn_info) {
             return Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
                     reason: format!(
@@ -1066,7 +1066,7 @@ impl<'a> Sema<'a> {
             .get(&function_key)
             .copied()
             .filter(|info| info.file_id == module_file_id)?;
-        if fn_info.return_type != Type::COMPTIME_TYPE {
+        if !self.function_returns_type(&fn_info) {
             return None;
         }
         self.check_unqualified_visibility(
@@ -1425,7 +1425,7 @@ impl<'a> Sema<'a> {
                 span,
             ));
         };
-        let is_type_ctor = fn_info.return_type == Type::COMPTIME_TYPE;
+        let is_type_ctor = self.function_returns_type(&fn_info);
         let params = fn_info.params;
         let ctor_file_id = fn_info.file_id;
         let ctor_is_pub = fn_info.is_pub;
@@ -1514,6 +1514,16 @@ impl<'a> Sema<'a> {
             .collect();
         debug_assert_eq!(flags.len(), function.params.len());
         flags
+    }
+
+    /// Whether the declaration's source return annotation is literally `type`.
+    ///
+    /// `FunctionInfo::return_type` cannot answer this: declaration gathering
+    /// also uses `COMPTIME_TYPE` as the placeholder for a dependent return such
+    /// as `-> T`. Kind-sensitive call paths must therefore consult the original
+    /// source symbol instead of the semantic placeholder.
+    pub(crate) fn function_returns_type(&self, function: &FunctionInfo) -> bool {
+        self.interner.get("type") == Some(function.return_type_sym)
     }
 
     /// Resolve one parameter of a generic function under a concrete
@@ -1706,7 +1716,7 @@ impl<'a> Sema<'a> {
             fn_info.is_pub,
             span,
         )?;
-        if fn_info.return_type != Type::COMPTIME_TYPE {
+        if !self.function_returns_type(&fn_info) {
             return Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
                     reason: format!(
@@ -2002,6 +2012,16 @@ impl<'a> Sema<'a> {
         span: Span,
         value_subst: Option<&HashMap<Spur, ConstValue>>,
     ) -> CompileResult<u64> {
+        self.resolve_array_length_with_subst(len, span, None, value_subst)
+    }
+
+    fn resolve_array_length_with_subst(
+        &mut self,
+        len: &ArrayLen,
+        span: Span,
+        type_subst: Option<&HashMap<Spur, Type>>,
+        value_subst: Option<&HashMap<Spur, ConstValue>>,
+    ) -> CompileResult<u64> {
         match len {
             ArrayLen::Literal(n) => Ok(*n),
             ArrayLen::Named(name) => {
@@ -2012,7 +2032,13 @@ impl<'a> Sema<'a> {
                 // elsewhere (RUE-163). Bare names fall through to the
                 // const/comptime-parameter lookup below.
                 if let Some((callee, args)) = parse_type_call_syntax(name) {
-                    return self.resolve_array_length_call(&callee, &args, span, value_subst);
+                    return self.resolve_array_length_call(
+                        &callee,
+                        &args,
+                        span,
+                        type_subst,
+                        value_subst,
+                    );
                 }
                 let sym = self.interner.get_or_intern(name);
                 // 1. A `comptime` value parameter in scope (per specialization).
@@ -2091,6 +2117,7 @@ impl<'a> Sema<'a> {
         callee: &str,
         args: &[String],
         span: Span,
+        type_subst: Option<&HashMap<Spur, Type>>,
         value_subst: Option<&HashMap<Spur, ConstValue>>,
     ) -> CompileResult<u64> {
         let invalid =
@@ -2103,13 +2130,13 @@ impl<'a> Sema<'a> {
                  `const`, a `comptime` value parameter, or a call to a comptime function"
             )));
         };
-        let Some(fn_info) = self.functions.get(&callee_key) else {
+        let Some(fn_info) = self.functions.get(&callee_key).copied() else {
             return Err(invalid(format!(
                 "'{callee}' is not a function; array lengths must be an integer literal, a \
                  `const`, a `comptime` value parameter, or a call to a comptime function"
             )));
         };
-        if fn_info.return_type == Type::COMPTIME_TYPE {
+        if self.function_returns_type(&fn_info) {
             return Err(invalid(format!(
                 "array length call '{callee}(...)' must return a value, not a type"
             )));
@@ -2117,6 +2144,7 @@ impl<'a> Sema<'a> {
         let params = fn_info.params;
         let param_names = self.param_arena.names(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
+        let param_comptime_type = self.comptime_type_param_flags(&fn_info);
         // Same implicit-comptime gate as `eval_comptime_type_call`: a value
         // function reduces only with at least one parameter, every one
         // `comptime`. A runtime parameter makes this a genuine runtime call.
@@ -2127,8 +2155,38 @@ impl<'a> Sema<'a> {
                  must be a value-returning function whose parameters are all `comptime`"
             )));
         }
+        let empty_type_subst = HashMap::new();
+        let type_subst = type_subst.unwrap_or(&empty_type_subst);
+        let empty_value_subst = HashMap::new();
+        let value_subst = value_subst.unwrap_or(&empty_value_subst);
+        let mut callee_types: HashMap<Spur, Type> = HashMap::new();
         let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
         for (i, arg) in args.iter().enumerate() {
+            if param_comptime_type[i] {
+                let arg_sym = self.interner.get_or_intern(arg.trim());
+                self.validate_substituted_signature_type(arg_sym, type_subst, value_subst, span)?;
+                let Some(ty) = self.resolve_type_for_comptime_with_subst_and_values_at_span(
+                    arg_sym,
+                    type_subst,
+                    value_subst,
+                    span,
+                ) else {
+                    return Err(invalid(format!(
+                        "argument '{}' for comptime type parameter '{}' of array length call '{}(...)' must be a type",
+                        arg,
+                        self.interner.resolve(&param_names[i]),
+                        callee
+                    )));
+                };
+                callee_types.insert(param_names[i], ty);
+                continue;
+            }
+
+            if let Some(value) = self.resolve_comptime_type_ctor_value_arg(arg, value_subst, span) {
+                callee_values.insert(param_names[i], value);
+                continue;
+            }
+
             // Mirror `parse_array_type_syntax`: a decimal literal is a
             // `Literal`, anything else (a name or nested call) is a `Named`
             // resolved recursively.
@@ -2136,11 +2194,15 @@ impl<'a> Sema<'a> {
                 Ok(n) => ArrayLen::Literal(n),
                 Err(_) => ArrayLen::Named(arg.clone()),
             };
-            let v = self.resolve_array_length(&arg_len, span, value_subst)?;
+            let v = self.resolve_array_length_with_subst(
+                &arg_len,
+                span,
+                Some(type_subst),
+                Some(value_subst),
+            )?;
             callee_values.insert(param_names[i], ConstValue::Integer(v as i128));
         }
-        let empty_types: HashMap<Spur, Type> = HashMap::new();
-        match self.reduce_type_ctor_body(callee_key, &empty_types, &callee_values)? {
+        match self.reduce_type_ctor_body(callee_key, &callee_types, &callee_values)? {
             Some(ConstValue::Integer(n)) if n >= 0 => u64::try_from(n)
                 .map_err(|_| invalid(format!("array length '{callee}(...)' ({n}) is too large"))),
             Some(ConstValue::Integer(n)) => Err(invalid(format!(

--- a/crates/rue-cli-tests/cases/array_length_comptime_call.toml
+++ b/crates/rue-cli-tests/cases/array_length_comptime_call.toml
@@ -70,3 +70,20 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0481", "not a function"]
+
+[[case]]
+name = "generic_value_return_is_not_a_type_constructor"
+description = "A dependent `-> T` return keeps its source value kind when used by an array-length comptime call."
+files = [{ path = "main.rue", source = """
+fn id(comptime T: type, comptime value: T) -> T { value }
+const I = i32;
+
+fn sum(value: [i32; id(I, 2)]) -> i32 {
+    value[0] + value[1]
+}
+
+fn main() -> i32 {
+    sum([20, 22])
+}
+""" }]
+exit_code = 42

--- a/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
+++ b/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
@@ -292,3 +292,73 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["expects 2", "provided"]
+
+[[case]]
+name = "dependent_comptime_value_kind_is_validated_before_reduction"
+description = "A type constructor validates an unused comptime value against the type selected by its earlier type argument."
+files = [{ path = "main.rue", source = """
+const FLAG: bool = true;
+
+fn Witness(comptime T: type, comptime value: T) -> type {
+    struct { payload: T }
+}
+
+fn read(value: Witness(i32, FLAG)) -> i32 {
+    value.payload
+}
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["type mismatch", "i32", "bool"]
+
+[[case]]
+name = "dependent_comptime_value_range_is_validated_before_reduction"
+description = "An unused comptime integer argument is range-checked against its substituted declared type."
+files = [{ path = "main.rue", source = """
+fn Witness(comptime T: type, comptime value: T) -> type {
+    struct { payload: T }
+}
+
+fn read(value: Witness(i8, 300)) -> i32 {
+    @intCast(value.payload)
+}
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "outside the range", "i8"]
+
+[[case]]
+name = "callable_alias_is_not_a_comptime_value_argument"
+description = "A callable alias cannot exploit the shared `type` sentinel to masquerade as a first-class comptime value."
+files = [{ path = "main.rue", source = """
+fn id(value: i32) -> i32 { value }
+const F = id;
+
+fn Witness(comptime T: type, comptime value: T) -> type {
+    struct { marker: i32 }
+}
+
+fn bad(value: Witness(type, F)) -> i32 { value.marker }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "callable alias", "cannot be passed"]
+
+[[case]]
+name = "type_and_unit_values_remain_valid_comptime_arguments"
+description = "Type metadata and unit remain valid values when a dependent comptime parameter concretely requires them."
+files = [{ path = "main.rue", source = """
+const META = i32;
+const U: () = ();
+
+fn Witness(comptime T: type, comptime value: T) -> type {
+    struct { marker: i32 }
+}
+
+fn read_meta(value: Witness(type, META)) -> i32 { value.marker }
+fn read_unit(value: Witness((), U)) -> i32 { value.marker }
+fn main() -> i32 { 42 }
+""" }]
+exit_code = 42


### PR DESCRIPTION
## Summary

- validate complete type/value substitution maps at the shared comptime reduction boundary
- check dependent declared value types, integer ranges, and callable-alias rejection before evaluation
- classify source `-> type` separately from deferred generic value returns such as `-> T`
- route eager type-constructor calls through the same validated reducer
- bind array-length comptime arguments by their source-declared kind

## Root cause

The semantic `COMPTIME_TYPE` placeholder represents both source `type` and unresolved generic value types. Treating that placeholder as a source-kind discriminator let independent call paths disagree and allowed some reducers to bypass parameter contracts.

## Validation

- `./test.sh generic_type_call_sigs` (19 focused CLI cases)
- `./test.sh array_length_comptime_call` (5 focused CLI cases)
- `./fmt.sh --check`
- Luna split gate: 41-target Clippy

Both test runs completed with `=== TEST SUITE: PASSED ===` after rebasing onto current trunk.