### PR TITLE
RUE-657: index reachable method bodies

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -37,8 +37,9 @@ pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
-    AnalyzedFunction, ConstValue, DirResolution, FunctionInfo, GatherOutput, MethodInfo,
-    ModulePath, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput, import_candidate_groups,
+    AnalyzedFunction, BodyAnalysisWork, ConstValue, DirResolution, FunctionInfo, GatherOutput,
+    MethodInfo, ModulePath, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
+    import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -163,6 +163,7 @@ fn finalize_function_body_analysis(
         // Specialization can intern new composite types, so snapshot only
         // after its fixed point has completed.
         type_pool: sema.type_pool.clone(),
+        body_analysis_work: sema.body_analysis_work,
     };
 
     errors.into_result_with(output)
@@ -455,6 +456,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
             // function has the same FnDecl shape as a free function and must
             // never win this lookup merely because it occurs first in RIR.
             let source_name = sema.source_function_name(fn_name);
+            sema.body_analysis_work.free_function_record_lookups += 1;
             let declaration = sema
                 .declaration_index
                 .first_free_function(source_name, Some(fn_info.file_id));
@@ -545,11 +547,11 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
             // Get the struct definition to find its name for impl block lookup
             let struct_def = sema.type_pool.struct_def(struct_id);
             let type_name_str = struct_def.name.clone();
-            let type_name_sym = sema.interner.get_or_intern(&type_name_str);
             let method_name_str = sema.interner.resolve(&method_name).to_string();
 
             // For anonymous structs, use the MethodInfo directly since there's no named StructDecl
             if type_name_str.starts_with("__anon_struct_") {
+                sema.body_analysis_work.anonymous_method_record_lookups += 1;
                 let full_name =
                     sema.method_symbol(struct_id, &method_name_str, method_info.has_self);
 
@@ -665,91 +667,64 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 continue;
             }
 
-            // Find the method in struct declarations (for named structs)
-            for (_, inst) in sema.rir.iter() {
-                if let InstData::StructDecl {
-                    name: struct_name,
-                    methods_start,
-                    methods_len,
-                    ..
-                } = &inst.data
-                {
-                    if *struct_name != type_name_sym {
-                        continue;
-                    }
+            sema.body_analysis_work.named_method_record_lookups += 1;
+            let Some(&method_ref) = sema
+                .named_method_declarations
+                .get(&(struct_id, method_name))
+            else {
+                debug_assert!(
+                    false,
+                    "gathered named MethodInfo must have a private declaration record"
+                );
+                continue;
+            };
+            let method_inst = sema.rir.get(method_ref);
+            let InstData::FnDecl {
+                name: m_name,
+                params_start,
+                params_len,
+                return_type,
+                body,
+                has_self,
+                self_mode,
+                ..
+            } = &method_inst.data
+            else {
+                unreachable!("named method record pointed at a non-FnDecl");
+            };
+            debug_assert_eq!(*m_name, method_name);
+            debug_assert_eq!(*body, method_info.body);
+            debug_assert_eq!(method_inst.span, method_info.span);
+            debug_assert_eq!(*has_self, method_info.has_self);
+            debug_assert_eq!(*self_mode, method_info.self_mode);
 
-                    // Several files may declare a struct with this name
-                    // (RUE-558); only the declaration that resolves to THIS
-                    // struct_id owns the method bodies being analyzed —
-                    // matching by name alone would analyze the other file\'s
-                    // same-named method under this struct\'s symbol (RUE-571).
-                    let declared_id = sema
-                        .structs_by_file_name
-                        .get(&(inst.span.file_id, *struct_name))
-                        .or_else(|| sema.structs.get(struct_name))
-                        .copied();
-                    if declared_id != Some(struct_id) {
-                        continue;
-                    }
-
-                    let methods = sema.rir.get_inst_refs(*methods_start, *methods_len);
-                    for method_ref in methods {
-                        let method_inst = sema.rir.get(method_ref);
-                        if let InstData::FnDecl {
-                            name: m_name,
-                            params_start,
-                            params_len,
-                            return_type,
-                            body,
-                            has_self,
-                            self_mode,
-                            ..
-                        } = &method_inst.data
-                        {
-                            if *m_name != method_name {
-                                continue;
-                            }
-
-                            let params = sema.rir.get_params(*params_start, *params_len);
-                            let full_name =
-                                sema.method_symbol(struct_id, &method_name_str, *has_self);
-
-                            match sema.analyze_method_function(
-                                &infer_ctx,
-                                &full_name,
-                                *return_type,
-                                &params,
-                                *body,
-                                method_inst.span,
-                                method_info.struct_type,
-                                *has_self,
-                                *self_mode,
-                            ) {
-                                Ok((
-                                    analyzed,
-                                    warnings,
-                                    local_strings,
-                                    referenced_fns,
-                                    referenced_meths,
-                                )) => {
-                                    functions_with_strings.push((analyzed, local_strings));
-                                    all_warnings.extend(warnings);
-
-                                    enqueue_references_sorted(
-                                        sema.interner,
-                                        referenced_fns,
-                                        referenced_meths,
-                                        &analyzed_functions,
-                                        &analyzed_methods,
-                                        &mut pending_functions,
-                                        &mut pending_methods,
-                                    );
-                                }
-                                Err(e) => errors.push(e),
-                            }
-                        }
-                    }
+            let params = sema.rir.get_params(*params_start, *params_len);
+            let full_name = sema.method_symbol(struct_id, &method_name_str, *has_self);
+            match sema.analyze_method_function(
+                &infer_ctx,
+                &full_name,
+                *return_type,
+                &params,
+                *body,
+                method_inst.span,
+                method_info.struct_type,
+                *has_self,
+                *self_mode,
+            ) {
+                Ok((analyzed, warnings, local_strings, referenced_fns, referenced_meths)) => {
+                    functions_with_strings.push((analyzed, local_strings));
+                    all_warnings.extend(warnings);
+                    enqueue_references_sorted(
+                        sema.interner,
+                        referenced_fns,
+                        referenced_meths,
+                        &analyzed_functions,
+                        &analyzed_methods,
+                        &mut pending_functions,
+                        &mut pending_methods,
+                    );
                 }
+                Err(e) => errors.push(e),
             }
         }
 
@@ -778,6 +753,8 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
             named_destructors_analyzed = true;
             for (_, inst) in sema.rir.iter() {
                 if let InstData::DropFnDecl { type_name, body } = &inst.data {
+                    sema.body_analysis_work
+                        .named_destructor_declarations_visited += 1;
                     // File-aware first (RUE-558), matching the sites above.
                     let struct_id = match sema
                         .structs_by_file_name
@@ -1402,6 +1379,7 @@ mod error_invariant_tests {
             strings: Vec::new(),
             warnings: Vec::new(),
             type_pool: TypeInternPool::new(),
+            body_analysis_work: crate::BodyAnalysisWork::default(),
         }
     }
 

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1485,6 +1485,7 @@ impl<'a> Sema<'a> {
                         span: method_inst.span,
                     },
                 );
+                self.named_method_declarations.insert(key, method_ref);
             }
         }
         Ok(())

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::PreviewFeatures;
-use rue_rir::Rir;
+use rue_rir::{InstData, Rir};
 use rue_span::FileId;
 use rue_target::Target;
 
@@ -18,11 +18,50 @@ use crate::types::{EnumId, StructId};
 use super::info::{ConstInfo, FunctionInfo, MethodInfo};
 use super::{KnownSymbols, Sema};
 
+/// Rebuild private named-method declaration identities for the legacy split
+/// gather/analysis adapter. The adapter has no public constructor today, but
+/// keeping this deterministic RIR-order rebuild prevents its public
+/// `into_sema` compatibility path from falling back to body-time scans.
+pub(super) fn rebuild_named_method_declarations(
+    rir: &Rir,
+    structs: &HashMap<Spur, StructId>,
+    structs_by_file_name: &HashMap<(FileId, Spur), StructId>,
+) -> HashMap<(StructId, Spur), rue_rir::InstRef> {
+    let mut declarations = HashMap::new();
+    for (_, inst) in rir.iter() {
+        let InstData::StructDecl {
+            name,
+            methods_start,
+            methods_len,
+            ..
+        } = &inst.data
+        else {
+            continue;
+        };
+        let Some(&struct_id) = structs_by_file_name
+            .get(&(inst.span.file_id, *name))
+            .or_else(|| structs.get(name))
+        else {
+            continue;
+        };
+        for method_ref in rir.get_inst_refs(*methods_start, *methods_len) {
+            if let InstData::FnDecl { name, .. } = rir.get(method_ref).data {
+                declarations.insert((struct_id, name), method_ref);
+            }
+        }
+    }
+    declarations
+}
+
 /// Output from the declaration gathering phase.
 ///
-/// This contains the state built during declaration gathering that is needed
-/// for function body analysis. After gathering, this can be converted back
-/// into a `Sema` for demand-driven function-body analysis.
+/// Compatibility carrier for state produced by a declaration-gathering phase.
+///
+/// Rue's live compiler currently uses [`Sema::analyze_all`] and does not expose
+/// a public producer for this type or a public body-only analysis entry point.
+/// `GatherOutput` remains public for API compatibility and as the intended
+/// boundary for a future split pipeline; [`Self::into_sema`] preserves its
+/// stored declaration state without exposing snapshot-local instruction IDs.
 ///
 /// # Architecture
 ///
@@ -32,18 +71,7 @@ use super::{KnownSymbols, Sema};
 /// 3. **Foundation for incremental** - Gathered declarations can become cacheable inputs
 /// 4. **Better error recovery** - One function's error doesn't block others
 ///
-/// # Usage
-///
-/// ```ignore
-/// // Option A: Simple path - all-in-one analysis
-/// let sema = Sema::new(rir, interner, preview);
-/// let output = sema.analyze_all()?;
-///
-/// // Option B: Split path - gather declarations, then analyze bodies
-/// let gather = sema.gather_declarations()?;
-/// let sema = gather.into_sema();
-/// let output = sema.analyze_all()?;
-/// ```
+/// Callers should use [`Sema::analyze_all`] for the supported end-to-end path.
 #[derive(Debug)]
 pub struct GatherOutput<'a> {
     /// Reference to the RIR being analyzed.
@@ -90,11 +118,14 @@ pub struct GatherOutput<'a> {
 }
 
 impl<'a> GatherOutput<'a> {
-    /// Convert this gather output back into a Sema for function body analysis.
+    /// Convert this compatibility state back into a semantic analyzer.
     ///
-    /// This is used for sequential analysis. The returned Sema has all
-    /// declarations already collected and is ready to analyze function bodies.
+    /// The returned analyzer retains already-collected declarations. Rue does
+    /// not currently expose a public body-only driver, so this conversion is
+    /// not itself a supported replacement for [`Sema::analyze_all`].
     pub fn into_sema(self) -> Sema<'a> {
+        let named_method_declarations =
+            rebuild_named_method_declarations(self.rir, &self.structs, &self.structs_by_file_name);
         Sema {
             rir: self.rir,
             interner: self.interner,
@@ -107,6 +138,8 @@ impl<'a> GatherOutput<'a> {
             enums: self.enums,
             enums_by_file_name: self.enums_by_file_name,
             methods: self.methods,
+            named_method_declarations,
+            body_analysis_work: super::BodyAnalysisWork::default(),
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,
             module_bindings: self.module_bindings,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -52,7 +52,7 @@ pub use inference_ctx::InferenceContext;
 pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
-pub use output::{AnalyzedFunction, ParamSlotModes, SemaOutput};
+pub use output::{AnalyzedFunction, BodyAnalysisWork, ParamSlotModes, SemaOutput};
 
 use std::collections::{HashMap, HashSet};
 
@@ -92,6 +92,9 @@ pub struct Sema<'a> {
     pub(crate) enums_by_file_name: HashMap<(FileId, Spur), EnumId>,
     /// Method table: maps (struct_id, method_name) to method info
     pub(crate) methods: HashMap<(StructId, Spur), MethodInfo>,
+    /// Exact named-method FnDecl handles for this RIR snapshot only.
+    pub(crate) named_method_declarations: HashMap<(StructId, Spur), rue_rir::InstRef>,
+    pub(crate) body_analysis_work: BodyAnalysisWork,
     /// Compatibility value-constant table for globally unique bare names.
     /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`]. If a value-constant name appears in
@@ -216,6 +219,8 @@ impl<'a> Sema<'a> {
             enums: HashMap::new(),
             enums_by_file_name: HashMap::new(),
             methods: HashMap::new(),
+            named_method_declarations: HashMap::new(),
+            body_analysis_work: BodyAnalysisWork::default(),
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),
             module_bindings: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -83,4 +83,27 @@ pub struct SemaOutput {
     pub warnings: Vec<CompileWarning>,
     /// Type intern pool (contains all types including arrays).
     pub type_pool: TypeInternPool,
+    /// Exact structural work performed while dispatching reachable bodies.
+    pub body_analysis_work: BodyAnalysisWork,
+}
+
+/// Value-only workload counters for demand-driven body dispatch.
+///
+/// These counters deliberately expose no request-local RIR instruction handles.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BodyAnalysisWork {
+    /// Indexed declaration-record lookups for reachable, non-generic free functions.
+    pub free_function_record_lookups: usize,
+    /// Private declaration-record lookups for reachable named-struct methods.
+    pub named_method_record_lookups: usize,
+    /// MethodInfo-driven lookups for reachable anonymous-struct methods.
+    pub anonymous_method_record_lookups: usize,
+    /// Named destructor declarations selected during the one-time implicit-root scan.
+    pub named_destructor_declarations_visited: usize,
+    /// Raw RIR entries visited specifically to select ordinary reachable free
+    /// functions or named methods.
+    ///
+    /// This excludes one-time implicit-root scans, unused-reference scans, and
+    /// comptime evaluation. Indexed dispatch keeps this value at zero.
+    pub reachable_declaration_rir_visits: usize,
 }

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -41,6 +41,32 @@ mod tests {
         assert_eq!(air.len(), 2); // Const + Ret
     }
 
+    fn named_method_lookup_work(irrelevant: usize) -> crate::BodyAnalysisWork {
+        let mut source = String::from(
+            "struct Target { fn answer() -> i32 { 42 } }\n\
+             fn main() -> i32 { Target.answer() }\n",
+        );
+        for index in 0..irrelevant {
+            source.push_str(&format!(
+                "struct Irrelevant{index} {{ fn unused() -> i32 {{ {index} }} }}\n"
+            ));
+        }
+        compile_to_air(&source).unwrap().body_analysis_work
+    }
+
+    #[test]
+    fn reachable_named_method_lookup_is_invariant_to_irrelevant_declarations() {
+        let one = named_method_lookup_work(1);
+        let many = named_method_lookup_work(128);
+
+        assert_eq!(one.named_method_record_lookups, 1);
+        assert_eq!(many.named_method_record_lookups, 1);
+        assert_eq!(one.free_function_record_lookups, 1);
+        assert_eq!(many.free_function_record_lookups, 1);
+        assert_eq!(one.reachable_declaration_rir_visits, 0);
+        assert_eq!(many.reachable_declaration_rir_visits, 0);
+    }
+
     #[test]
     fn panic_is_never_and_assert_is_unit_in_air() {
         // `@panic` diverges: its AIR result type is `!` (never), matching HM
@@ -1647,6 +1673,30 @@ mod tests {
                 RirParamMode::Normal,
             ]
         );
+    }
+
+    #[test]
+    fn gather_adapter_rebuilds_exact_named_method_records() {
+        let sema = gather_declarations_for_testing(
+            "struct Probe { fn answer() -> i32 { 42 } }
+             fn main() -> i32 { Probe.answer() }",
+        );
+        let rebuilt = crate::sema::gather::rebuild_named_method_declarations(
+            sema.rir,
+            &sema.structs,
+            &sema.structs_by_file_name,
+        );
+
+        assert_eq!(rebuilt, sema.named_method_declarations);
+        let probe = sema.interner.get("Probe").unwrap();
+        let answer = sema.interner.get("answer").unwrap();
+        let struct_id = sema.structs[&probe];
+        let declaration = rebuilt[&(struct_id, answer)];
+        let rue_rir::InstData::FnDecl { name, body, .. } = sema.rir.get(declaration).data else {
+            panic!("rebuilt named method record must point at FnDecl");
+        };
+        assert_eq!(name, answer);
+        assert_eq!(body, sema.methods[&(struct_id, answer)].body);
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -231,8 +231,8 @@ fn parse_runtime_archive(runtime_bytes: &[u8]) -> Result<Archive, String> {
 // Re-export commonly used types
 pub use lasso::{Spur, ThreadedRodeo};
 pub use rue_air::{
-    Air, AnalyzedFunction, DirResolution, ModulePath, RirDeclarationIndexWork, Sema, SemaOutput,
-    StructDef, Type, TypeInternPool, import_candidate_groups,
+    Air, AnalyzedFunction, BodyAnalysisWork, DirResolution, ModulePath, RirDeclarationIndexWork,
+    Sema, SemaOutput, StructDef, Type, TypeInternPool, import_candidate_groups,
 };
 pub use rue_cfg::{Cfg, CfgBuilder, CfgOutput, OptLevel};
 pub use rue_codegen::{
@@ -807,6 +807,7 @@ fn build_functions_and_cfgs(
         strings,
         mut warnings,
         type_pool,
+        body_analysis_work: _,
     } = sema_output;
 
     // Synthesize drop glue functions.
@@ -1169,6 +1170,15 @@ pub fn compile_frontend_from_ast_with_source_metadata_and_target(
         info!(
             function_count = output.functions.len(),
             struct_count = output.type_pool.stats().struct_count,
+            free_function_record_lookups = output.body_analysis_work.free_function_record_lookups,
+            named_method_record_lookups = output.body_analysis_work.named_method_record_lookups,
+            anonymous_method_record_lookups =
+                output.body_analysis_work.anonymous_method_record_lookups,
+            named_destructor_declarations_visited = output
+                .body_analysis_work
+                .named_destructor_declarations_visited,
+            reachable_declaration_rir_visits =
+                output.body_analysis_work.reachable_declaration_rir_visits,
             "semantic analysis complete"
         );
         output

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -321,6 +321,16 @@ impl<'src> CompilationUnit<'src> {
             info!(
                 function_count = output.functions.len(),
                 struct_count = output.type_pool.stats().struct_count,
+                free_function_record_lookups =
+                    output.body_analysis_work.free_function_record_lookups,
+                named_method_record_lookups = output.body_analysis_work.named_method_record_lookups,
+                anonymous_method_record_lookups =
+                    output.body_analysis_work.anonymous_method_record_lookups,
+                named_destructor_declarations_visited = output
+                    .body_analysis_work
+                    .named_destructor_declarations_visited,
+                reachable_declaration_rir_visits =
+                    output.body_analysis_work.reachable_declaration_rir_visits,
                 "semantic analysis complete"
             );
             output


### PR DESCRIPTION
## Summary

- retain exact private declaration identities for named methods while gathering declarations
- dispatch reachable named-method bodies by point lookup instead of rescanning the full RIR for every method
- expose value-only structural work counters and log them at both compiler semantic-analysis entry points
- preserve the dormant GatherOutput compatibility boundary by deterministically rebuilding private identities without exposing snapshot-local handles

## Why

Lazy semantic analysis previously selected each reachable named method with a whole-RIR scan. That made body selection scale with reachable methods multiplied by total declarations and left a poor seam for future in-process queries. This change makes selection exact and constant-time while preserving traversal order, diagnostics, and batch behavior.

The structural regression compares programs with 1 and 128 irrelevant declarations: both perform exactly one named-method record lookup, one free-function lookup, and zero raw RIR visits for ordinary reachable declaration selection. Wall-clock baseline samples were noisy and mixed, so this PR makes no runtime-speedup claim; it establishes and tests the stronger complexity invariant directly.

## Validation

- `./fmt.sh check`
- `./clippy.sh` — 41 first-party targets passed
- `./buck2 test //... //:reproducible-programs` — 34 targets passed, zero failures
- cold compiler reproducibility check — identical SHA-256 `4ec0de9abca2edb22f7ef3f76c47844199a92d3e59bd96624bc6139b13abf51f` and build ID `85035a47af3fa5ad36d184f521999dc51bbb17c1`

Linear: RUE-657