### PR TITLE
stdlib v1 M1: cmp, math extensions, mem, tuple, fmt

### DIFF
--- a/crates/rue-cli-tests/cases/std_core.toml
+++ b/crates/rue-cli-tests/cases/std_core.toml
@@ -1,0 +1,97 @@
+# Standard library v1 — M1 core utilities (std.cmp / std.math / std.mem /
+# std.tuple / std.fmt), exercised through the real std bundle via RUE_STD_PATH.
+#
+# NOTE: cross-module calls to generic (`comptime T`) std helpers, and to any
+# cross-module fn with an out-of-i32-range integer literal, currently require a
+# typed local binding (RUE-693 — literal args aren't constrained to the callee's
+# parameter type across a module boundary). The passing cases below bind typed
+# values; the final `known_bug` case pins the literal form so it converts to a
+# regression test when RUE-693 lands.
+
+[section]
+id = "cli.std_core"
+name = "Standard library v1 — M1 core utilities"
+description = "std.cmp, std.math, std.mem, std.tuple, std.fmt exercised end-to-end through @import(\"std\")."
+
+[[case]]
+name = "std_core_m1_smoke"
+description = "cmp/math/mem/tuple/fmt all produce correct results (14 checks → exit 42)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut score: i64 = 0;
+    let three: i64 = 3;
+    let seven: i64 = 7;
+    let two: i64 = 2;
+
+    // std.cmp
+    match std.cmp.cmp(i64, three, seven) {
+        std.cmp.Ordering.Less => { score = score + 1; },
+        std.cmp.Ordering.Equal => {},
+        std.cmp.Ordering.Greater => {},
+    }
+    if std.cmp.min(i64, three, seven) == 3 { score = score + 1; }
+    if std.cmp.max(i64, three, seven) == 7 { score = score + 1; }
+
+    // std.math: legacy i32 abs (single-arg) + generic extensions
+    if std.math.abs(-8) == 8 { score = score + 1; }
+    let a48: i64 = 48;
+    let a36: i64 = 36;
+    if std.math.gcd(i64, a48, a36) == 12 { score = score + 1; }
+    let e10: u64 = 10;
+    if std.math.pow(i64, two, e10) == 1024 { score = score + 1; }
+    let n99: i64 = 99;
+    if std.math.isqrt(i64, n99) == 9 { score = score + 1; }
+    let n97: i64 = 97;
+    if std.math.is_prime(i64, n97) { score = score + 1; }
+
+    // std.math (i64 checked_*)
+    let O = std.option.Option(i64);
+    let big: i64 = 9223372036854775807;
+    let one: i64 = 1;
+    match std.math.checked_add(big, one) { O.Some(v) => {}, O.None => { score = score + 1; } }
+    let six: i64 = 6;
+    match std.math.checked_mul(six, seven) { O.Some(v) => { if v == 42 { score = score + 1; } }, O.None => {} }
+
+    // std.mem
+    let mut x: i64 = 1;
+    let mut y: i64 = 2;
+    std.mem.swap(i64, inout x, inout y);
+    if x == 2 { if y == 1 { score = score + 1; } }
+
+    // std.tuple
+    let P = std.tuple.Pair(i64, i64);
+    let forty: i64 = 40;
+    let p = P.new(forty, two);
+    if p.first + p.second == 42 { score = score + 1; }
+
+    // std.fmt
+    let n255: u64 = 255;
+    if std.fmt.to_hex(n255).len() == 2 { score = score + 1; }
+    if std.fmt.bool_to_string(true).len() == 4 { score = score + 1; }
+
+    if score == 14 { 42 } else { @intCast(score) }
+}
+""" }]
+
+# RUE-693: a cross-module generic std call with a bare integer literal argument
+# fails to coerce the literal to the instantiated type param (E0206). When this
+# is fixed, the case will unexpectedly PASS and the suite will tell us to drop
+# the marker — turning it into a regression test that literal args work.
+[[case]]
+name = "std_core_generic_literal_args"
+description = "std.cmp.min(i64, 3, 7) with bare literal args should compile once RUE-693 is fixed."
+known_bug = "RUE-693"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 3
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    @intCast(std.cmp.min(i64, 3, 7))
+}
+""" }]

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -4,13 +4,21 @@
 // Import with: const std = @import("std");
 //
 // The standard library provides common utilities organized into submodules:
-// - std.math: Mathematical functions
+// - std.math: Integer math (generic min/max/abs/gcd/isqrt/pow, i64 checked_*)
+// - std.cmp: Ordering + generic min/max/clamp/cmp
+// - std.mem: swap / replace (inout helpers)
+// - std.tuple: Pair / Triple
+// - std.fmt: scalar-to-string formatting (int/bool, hex/binary)
 // - std.option.Option: Optional values
 // - std.result.Result: Fallible values (Ok/Err), propagated with `?`
 // - std.arraybuf.ArrayBuf: Growable heap-backed collections
 
 // Re-export library modules.
 pub const math = @import("math.rue");
+pub const cmp = @import("cmp.rue");
+pub const mem = @import("mem.rue");
+pub const tuple = @import("tuple.rue");
+pub const fmt = @import("fmt.rue");
 pub const option = @import("option.rue");
 pub const result = @import("result.rue");
 pub const arraybuf = @import("arraybuf.rue");

--- a/std/cmp.rue
+++ b/std/cmp.rue
@@ -1,0 +1,54 @@
+// std.cmp — ordering and comparison utilities.
+//
+// Comparison and the min/max/clamp helpers are generic over any type whose
+// values support the built-in relational operators (`<`, `>`, `==`) — every
+// integer type today. `Ordering` is the three-way comparison result.
+//
+//     const std = @import("std");
+//     let o = std.cmp.cmp(i64, 3, 7);        // Ordering.Less
+//     let m = std.cmp.min(i64, 3, 7);        // 3
+//     let c = std.cmp.clamp(i64, 12, 0, 9);  // 9
+
+// The result of a three-way comparison.
+pub enum Ordering {
+    Less,
+    Equal,
+    Greater,
+}
+
+// Three-way compare: `Less` when `a < b`, `Greater` when `a > b`, else `Equal`.
+pub fn cmp(comptime T: type, a: T, b: T) -> Ordering {
+    if a < b {
+        Ordering.Less
+    } else if a > b {
+        Ordering.Greater
+    } else {
+        Ordering.Equal
+    }
+}
+
+// The lesser of two values (returns `a` on a tie).
+pub fn min(comptime T: type, a: T, b: T) -> T {
+    if a < b { a } else { b }
+}
+
+// The greater of two values (returns `a` on a tie).
+pub fn max(comptime T: type, a: T, b: T) -> T {
+    if a > b { a } else { b }
+}
+
+// Clamp `x` into the inclusive range `[lo, hi]`.
+pub fn clamp(comptime T: type, x: T, lo: T, hi: T) -> T {
+    if x < lo {
+        lo
+    } else if x > hi {
+        hi
+    } else {
+        x
+    }
+}
+
+// Whether two values are equal.
+pub fn eq(comptime T: type, a: T, b: T) -> bool {
+    a == b
+}

--- a/std/fmt.rue
+++ b/std/fmt.rue
@@ -1,0 +1,56 @@
+// std.fmt — scalar-to-string formatting for the builtin types.
+//
+// This is the low-level formatting surface: turning individual `i*`/`u*`/`bool`
+// values into `String`. Multi-argument `format("n={}", n)` / interpolation is a
+// separate design (RUE-350) tracked in M5; this module is what it will build on.
+//
+//     const std = @import("std");
+//     let s = std.fmt.to_hex(255);        // "ff"
+//     let t = std.fmt.bool_to_string(true); // "true"
+
+const arraybuf = @import("arraybuf.rue");
+
+// Decimal string of any integer value (wraps the `@to_string` intrinsic, which
+// already handles every integer width).
+pub fn int_to_string(comptime T: type, x: T) -> String {
+    @to_string(x)
+}
+
+// "true" / "false".
+pub fn bool_to_string(b: bool) -> String {
+    if b { "true" } else { "false" }
+}
+
+// Unsigned value in an arbitrary base 2..=16, lowercase, no prefix.
+pub fn to_radix(n: u64, base: u64) -> String {
+    if n == 0 {
+        return "0";
+    }
+    let digits = "0123456789abcdef";
+    let bytes = arraybuf.ArrayBuf(u8);
+    let mut buf = bytes.new();
+    let mut m = n;
+    while m > 0 {
+        let d = m % base;
+        buf.push(digits[d]);
+        m = m / base;
+    }
+    // Digits were produced least-significant first; emit them reversed.
+    let mut out = String.new();
+    let mut i = buf.len();
+    while i > 0 {
+        i = i - 1;
+        out.push(buf.get_or(i, 48));
+    }
+    out
+}
+
+// Hexadecimal (base 16), lowercase, no `0x` prefix.
+pub fn to_hex(n: u64) -> String {
+    to_radix(n, 16)
+}
+
+// Binary (base 2), no `0b` prefix.
+pub fn to_binary(n: u64) -> String {
+    to_radix(n, 2)
+}

--- a/std/math.rue
+++ b/std/math.rue
@@ -1,23 +1,36 @@
-// Standard library: math module
+// std.math — integer math utilities.
 //
-// Provides basic mathematical utilities.
+// The legacy `abs`/`min`/`max`/`clamp` remain `i32` for backward compatibility;
+// the GENERIC (comptime-`T`) min/max/clamp live in `std.cmp`. The extended
+// functions below are generic over a comptime integer type `T` (verified:
+// `+ - * / % < &` all work on a type parameter). `checked_*` are `i64`-concrete:
+// portable generic overflow checks need an integer-bounds intrinsic
+// (`@int_max(T)`/`@int_min(T)`) that does not exist yet (RUE-694).
+//
+// NOTE: calling a generic (`comptime T`) helper here from another module with a
+// bare integer literal currently fails to coerce the literal (RUE-693); bind a
+// typed local until that lands.
 
-/// Returns the absolute value of an integer.
+const option = @import("option.rue");
+
+// --- legacy i32 helpers (unchanged; generic forms live in std.cmp) ---
+
+// Absolute value (i32).
 pub fn abs(x: i32) -> i32 {
     if x < 0 { -x } else { x }
 }
 
-/// Returns the minimum of two values.
+// The lesser of two values (i32).
 pub fn min(a: i32, b: i32) -> i32 {
     if a < b { a } else { b }
 }
 
-/// Returns the maximum of two values.
+// The greater of two values (i32).
 pub fn max(a: i32, b: i32) -> i32 {
     if a > b { a } else { b }
 }
 
-/// Clamps a value to be within the given range [lo, hi].
+// Clamp `x` into the inclusive range `[lo, hi]` (i32).
 pub fn clamp(x: i32, lo: i32, hi: i32) -> i32 {
     if x < lo {
         lo
@@ -26,4 +39,184 @@ pub fn clamp(x: i32, lo: i32, hi: i32) -> i32 {
     } else {
         x
     }
+}
+
+// --- generic integer functions ---
+
+// -1, 0, or 1 by the sign of `x`. SIGNED `T` only.
+pub fn sign(comptime T: type, x: T) -> T {
+    if x < 0 {
+        -1
+    } else if x > 0 {
+        1
+    } else {
+        0
+    }
+}
+
+// Greatest common divisor (Euclid). The result is non-negative for signed `T`;
+// `gcd(0, 0) == 0`. Absolute value is inlined so the helper works for any `T`.
+pub fn gcd(comptime T: type, a: T, b: T) -> T {
+    let mut x = if a < 0 { -a } else { a };
+    let mut y = if b < 0 { -b } else { b };
+    while y != 0 {
+        let t = y;
+        y = x % y;
+        x = t;
+    }
+    x
+}
+
+// Least common multiple. `lcm(0, _) == 0`. SIGNED `T`.
+pub fn lcm(comptime T: type, a: T, b: T) -> T {
+    if a == 0 {
+        0
+    } else if b == 0 {
+        0
+    } else {
+        let m = a / gcd(T, a, b) * b;
+        if m < 0 { -m } else { m }
+    }
+}
+
+// Integer exponentiation by squaring: `base ** exp`. Traps on overflow.
+pub fn pow(comptime T: type, base: T, exp: u64) -> T {
+    let mut result: T = 1;
+    let mut b = base;
+    let mut e = exp;
+    while e > 0 {
+        if e % 2 == 1 {
+            result = result * b;
+        }
+        e = e / 2;
+        if e > 0 {
+            b = b * b;
+        }
+    }
+    result
+}
+
+// Integer square root: the largest `r` with `r*r <= n`. `n` must be >= 0.
+// The comparison is done as `mid <= n / mid` to avoid overflowing `mid*mid`.
+pub fn isqrt(comptime T: type, n: T) -> T {
+    if n < 2 {
+        return n;
+    }
+    let mut lo: T = 1;
+    let mut hi = n;
+    let mut ans: T = 1;
+    while lo <= hi {
+        let mid = lo + (hi - lo) / 2;
+        if mid <= n / mid {
+            ans = mid;
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    ans
+}
+
+// Whether `n` is a positive power of two.
+pub fn is_pow_of_two(comptime T: type, n: T) -> bool {
+    n > 0 && (n & (n - 1)) == 0
+}
+
+// Trial-division primality test.
+pub fn is_prime(comptime T: type, n: T) -> bool {
+    if n < 2 {
+        return false;
+    }
+    let mut i: T = 2;
+    while i * i <= n {
+        if n % i == 0 {
+            return false;
+        }
+        i = i + 1;
+    }
+    true
+}
+
+// --- i64 checked arithmetic (None on overflow, no trap) ---
+
+// `i64::MAX` / `i64::MIN` written without overflowing the literal parser.
+fn i64_max() -> i64 {
+    9223372036854775807
+}
+fn i64_min() -> i64 {
+    -9223372036854775807 - 1
+}
+
+// `a + b`, or `None` if it would overflow `i64`.
+pub fn checked_add(a: i64, b: i64) -> option.Option(i64) {
+    let O = option.Option(i64);
+    if b > 0 {
+        if a > i64_max() - b {
+            return O.None;
+        }
+    } else {
+        if a < i64_min() - b {
+            return O.None;
+        }
+    }
+    O.Some(a + b)
+}
+
+// `a - b`, or `None` if it would overflow `i64`.
+pub fn checked_sub(a: i64, b: i64) -> option.Option(i64) {
+    let O = option.Option(i64);
+    if b < 0 {
+        if a > i64_max() + b {
+            return O.None;
+        }
+    } else {
+        if a < i64_min() + b {
+            return O.None;
+        }
+    }
+    O.Some(a - b)
+}
+
+// `a * b`, or `None` if it would overflow `i64`. Pre-checks via division so the
+// multiply itself never traps.
+pub fn checked_mul(a: i64, b: i64) -> option.Option(i64) {
+    let O = option.Option(i64);
+    if a == 0 || b == 0 {
+        return O.Some(0);
+    }
+    // The MIN/-1 corner traps under the division pre-check, so handle it first.
+    if a == -1 {
+        if b == i64_min() {
+            return O.None;
+        }
+        return O.Some(a * b);
+    }
+    if b == -1 {
+        if a == i64_min() {
+            return O.None;
+        }
+        return O.Some(a * b);
+    }
+    if a > 0 {
+        if b > 0 {
+            if a > i64_max() / b {
+                return O.None;
+            }
+        } else {
+            if b < i64_min() / a {
+                return O.None;
+            }
+        }
+    } else {
+        if b > 0 {
+            if a < i64_min() / b {
+                return O.None;
+            }
+        } else {
+            if a < i64_max() / b {
+                return O.None;
+            }
+        }
+    }
+    O.Some(a * b)
 }

--- a/std/mem.rue
+++ b/std/mem.rue
@@ -1,0 +1,27 @@
+// std.mem — low-level value-movement helpers.
+//
+// These operate through `inout` parameters (second-class mutable borrows), so
+// they mutate the caller's storage in place without copying.
+//
+//     const std = @import("std");
+//     let mut a = 1;
+//     let mut b = 2;
+//     std.mem.swap(i64, inout a, inout b);   // a == 2, b == 1
+
+// Exchange the values held in `a` and `b`.
+//
+// Works for any `T` (including move-only aggregates): the three moves leave
+// each binding holding exactly one value, so affine/linear obligations are
+// preserved.
+pub fn swap(comptime T: type, inout a: T, inout b: T) {
+    let tmp = a;
+    a = b;
+    b = tmp;
+}
+
+// Store `v` into `dst` and return the value that was there before.
+pub fn replace(comptime T: type, inout dst: T, v: T) -> T {
+    let old = dst;
+    dst = v;
+    old
+}

--- a/std/tuple.rue
+++ b/std/tuple.rue
@@ -1,0 +1,34 @@
+// std.tuple — small fixed-arity product types.
+//
+// `Pair`/`Triple` are ordinary comptime-generic structs, so they can be stored
+// in an `ArrayBuf` (RUE-646) — the intended replacement for the parallel-array
+// idiom (e.g. a heap of `(priority, payload)` becomes `ArrayBuf(Pair(P, V))`).
+//
+//     const std = @import("std");
+//     let P = std.tuple.Pair(i64, i64);
+//     let p = P.new(40, 2);          // p.first == 40, p.second == 2
+
+// A 2-tuple.
+pub fn Pair(comptime A: type, comptime B: type) -> type {
+    struct {
+        first: A,
+        second: B,
+
+        fn new(a: A, b: B) -> Self {
+            Self { first: a, second: b }
+        }
+    }
+}
+
+// A 3-tuple.
+pub fn Triple(comptime A: type, comptime B: type, comptime C: type) -> type {
+    struct {
+        first: A,
+        second: B,
+        third: C,
+
+        fn new(a: A, b: B, c: C) -> Self {
+            Self { first: a, second: b, third: c }
+        }
+    }
+}


### PR DESCRIPTION
First tier of the [Standard library v1](https://linear.app/steve-klabnik/project/standard-library-v1-1bbc20136bb4) project — the buildable-now core utilities, grounded in what the example programs hand-roll.

## Modules
- **std.cmp**: `Ordering` enum + generic (`comptime T`) `cmp/min/max/clamp/eq`.
- **std.math**: legacy i32 `abs/min/max/clamp` unchanged (zero call-site churn); adds generic `sign/gcd/lcm/pow/isqrt/is_pow_of_two/is_prime` + i64 `checked_add/sub/mul` (Option-returning, no trap). Generic `min/max/clamp` live in `std.cmp`.
- **std.mem**: `swap` / `replace` (`inout` helpers), any `T`.
- **std.tuple**: `Pair(A,B)` / `Triple(A,B,C)` — the parallel-array replacement (works in `ArrayBuf` post-RUE-646).
- **std.fmt**: `int_to_string` / `bool_to_string` / `to_radix` / `to_hex` / `to_binary`.

Facade `_std.rue` re-exports all five. CLI regression test `std_core.toml` exercises them end-to-end through the real std bundle.

## Filed while building
- **RUE-693** (Todo, Codex lane): cross-module generic / large-literal call args aren’t coerced to the callee parameter type — the reason generic `std.*` calls need a typed local for now. A `known_bug` case pins the literal form.
- **RUE-694** (Backlog): `@int_max(T)`/`@int_min(T)` intrinsics to make `checked_*` generic.

Full `./test.sh` green (34/34).

Fixes RUE-663
Fixes RUE-664
Fixes RUE-665
Fixes RUE-666
Fixes RUE-667

🤖 Generated with [Claude Code](https://claude.com/claude-code)