### PR TITLE
RUE-658: lower semantic order without cloning AST

### DIFF
--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -1020,7 +1020,7 @@ mod tests {
             1,
         )];
         let (mut program, source_snapshot) = parse(&inputs, FileId::new(1));
-        program.files[0].ast.items.reverse();
+        Arc::make_mut(&mut program.files[0].ast).items.reverse();
         let snapshot = DefinitionSnapshot::from_parsed_program(&program, &source_snapshot).unwrap();
         let definitions: Vec<_> = snapshot.definitions().collect();
 
@@ -1296,7 +1296,8 @@ mod tests {
         assert!(message.contains("physical path for parsed file ID 5"));
         program.files[0].path = "/metadata/location.rue".to_owned();
 
-        let Item::Function(function) = &mut program.files[0].ast.items[0] else {
+        let Item::Function(function) = &mut Arc::make_mut(&mut program.files[0].ast).items[0]
+        else {
             panic!("expected function");
         };
         function.name.span.file_id = FileId::new(8);
@@ -1305,7 +1306,8 @@ mod tests {
         );
         assert!(message.contains("definition name uses file ID 8"));
 
-        let Item::Function(function) = &mut program.files[0].ast.items[0] else {
+        let Item::Function(function) = &mut Arc::make_mut(&mut program.files[0].ast).items[0]
+        else {
             panic!("expected function");
         };
         function.name.span.file_id = FileId::new(5);
@@ -1323,7 +1325,8 @@ mod tests {
             input("/two.rue", "two.rue", "fn two() {}", 2),
         ];
         let (mut program, source_snapshot) = parse(&inputs, FileId::new(1));
-        let Item::Function(function) = &mut program.files[0].ast.items[0] else {
+        let Item::Function(function) = &mut Arc::make_mut(&mut program.files[0].ast).items[0]
+        else {
             panic!("expected function");
         };
         function.span.file_id = FileId::new(2);
@@ -1335,7 +1338,8 @@ mod tests {
         );
 
         let (mut program, source_snapshot) = parse(&inputs, FileId::new(1));
-        let Item::Function(function) = &mut program.files[0].ast.items[0] else {
+        let Item::Function(function) = &mut Arc::make_mut(&mut program.files[0].ast).items[0]
+        else {
             panic!("expected function");
         };
         function.name.span.file_id = FileId::new(2);
@@ -1357,7 +1361,8 @@ mod tests {
         )];
         let (mut program, source_snapshot) = parse(&inputs, FileId::new(1));
         let source_len = source_snapshot.source_text(FileId::new(1)).unwrap().len();
-        let Item::Function(function) = &mut program.files[0].ast.items[0] else {
+        let Item::Function(function) = &mut Arc::make_mut(&mut program.files[0].ast).items[0]
+        else {
             panic!("expected function");
         };
         function.span.end = u32::try_from(source_len + 1).unwrap();
@@ -1378,7 +1383,8 @@ mod tests {
             .find('é')
             .unwrap()
             + 1;
-        let Item::Function(function) = &mut program.files[0].ast.items[0] else {
+        let Item::Function(function) = &mut Arc::make_mut(&mut program.files[0].ast).items[0]
+        else {
             panic!("expected function");
         };
         function.name.span.start = u32::try_from(interior).unwrap();
@@ -1402,7 +1408,8 @@ mod tests {
         for index in 1..256 {
             foreign_name = foreign_interner.get_or_intern(format!("foreign-{index}"));
         }
-        let Item::Function(function) = &mut program.files[0].ast.items[0] else {
+        let Item::Function(function) = &mut Arc::make_mut(&mut program.files[0].ast).items[0]
+        else {
             panic!("expected function");
         };
         function.name.name = foreign_name;
@@ -1417,7 +1424,8 @@ mod tests {
     fn rejects_recovered_error_items_at_the_success_only_boundary() {
         let inputs = [input("/root.rue", "root.rue", "fn original() {}", 1)];
         let (mut program, metadata) = parse(&inputs, FileId::new(1));
-        program.files[0].ast.items[0] = Item::Error(Span::with_file(FileId::new(1), 0, 1));
+        Arc::make_mut(&mut program.files[0].ast).items[0] =
+            Item::Error(Span::with_file(FileId::new(1), 0, 1));
 
         let message = invalid_message(
             DefinitionSnapshot::from_parsed_program(&program, &metadata).unwrap_err(),

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -54,6 +54,7 @@ pub use diagnostic::{
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 // ============================================================================
@@ -320,7 +321,7 @@ pub struct ParsedFile {
     /// File identifier for error reporting.
     pub file_id: FileId,
     /// The parsed abstract syntax tree.
-    pub ast: Ast,
+    pub ast: Arc<Ast>,
 }
 
 /// Result of parsing all source files.
@@ -403,10 +404,42 @@ pub fn parse_all_files_with_source_snapshot(
 /// Used as input to RIR generation for multi-file compilation.
 #[derive(Debug)]
 pub struct MergedProgram {
-    /// The merged AST containing items from all files.
-    pub ast: Ast,
+    /// Immutable view of the per-file ASTs in caller source order.
+    pub ast: MergedAst,
     /// Shared interner containing all symbols from all files.
     pub interner: ThreadedRodeo,
+}
+
+/// A clone-cheap, immutable view over all ASTs in a parsed program.
+///
+/// Keeping file ASTs behind `Arc` lets a future parse cache retain and reuse
+/// them while lowering traverses the program without cloning item payloads.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MergedAst {
+    files: Vec<Arc<Ast>>,
+}
+
+impl MergedAst {
+    /// Iterate top-level items in file order and declaration order.
+    pub fn items(&self) -> impl Iterator<Item = &Item> {
+        self.files.iter().flat_map(|ast| ast.items.iter())
+    }
+
+    /// Return the number of top-level items across all files.
+    pub fn item_count(&self) -> usize {
+        self.files.iter().map(|ast| ast.items.len()).sum()
+    }
+
+    /// Access the immutable per-file ASTs in source order.
+    pub fn files(&self) -> &[Arc<Ast>] {
+        &self.files
+    }
+
+    fn from_ast(ast: Ast) -> Self {
+        Self {
+            files: vec![Arc::new(ast)],
+        }
+    }
 }
 
 /// Information about a symbol definition for duplicate detection.
@@ -663,7 +696,10 @@ pub fn merge_symbols(program: ParsedProgram) -> MultiErrorResult<MergedProgram> 
     let _span = info_span!("merge_symbols", file_count = program.files.len()).entered();
 
     let check = detect_duplicate_symbols(
-        program.files.iter().map(|f| (f.path.as_str(), &f.ast)),
+        program
+            .files
+            .iter()
+            .map(|f| (f.path.as_str(), f.ast.as_ref())),
         &program.interner,
     );
 
@@ -672,11 +708,9 @@ pub fn merge_symbols(program: ParsedProgram) -> MultiErrorResult<MergedProgram> 
         return Err(CompileErrors::from(check.errors));
     }
 
-    let all_items: Vec<Item> = program
-        .files
-        .iter()
-        .flat_map(|file| file.ast.items.iter().cloned())
-        .collect();
+    let ast = MergedAst {
+        files: program.files.into_iter().map(|file| file.ast).collect(),
+    };
 
     info!(
         function_count = check.function_count,
@@ -686,7 +720,7 @@ pub fn merge_symbols(program: ParsedProgram) -> MultiErrorResult<MergedProgram> 
     );
 
     Ok(MergedProgram {
-        ast: Ast { items: all_items },
+        ast,
         interner: program.interner,
     })
 }
@@ -764,8 +798,8 @@ pub struct FunctionWithCfg {
 /// This allows inspection of the IR at each stage, useful for
 /// debugging and the `--emit` CLI flags.
 pub struct CompileState {
-    /// The abstract syntax tree.
-    pub ast: Ast,
+    /// Immutable program AST view.
+    pub ast: MergedAst,
     /// String interner used during compilation.
     pub interner: ThreadedRodeo,
     /// The untyped IR (RIR).
@@ -1134,15 +1168,35 @@ pub fn compile_frontend_from_ast_with_source_metadata_and_target(
     target: Target,
     source_metadata: &SourceMetadata,
 ) -> MultiErrorResult<CompileState> {
-    source_metadata
-        .validate_ast(&ast)
-        .map_err(CompileErrors::from)?;
+    compile_frontend_from_merged_ast_with_source_metadata_and_target(
+        MergedAst::from_ast(ast),
+        interner,
+        opt_level,
+        preview_features,
+        target,
+        source_metadata,
+    )
+}
+
+/// Compile a shareable multi-file AST view through all frontend phases.
+pub fn compile_frontend_from_merged_ast_with_source_metadata_and_target(
+    ast: MergedAst,
+    interner: ThreadedRodeo,
+    opt_level: OptLevel,
+    preview_features: &PreviewFeatures,
+    target: Target,
+    source_metadata: &SourceMetadata,
+) -> MultiErrorResult<CompileState> {
+    for file_ast in ast.files() {
+        source_metadata
+            .validate_ast(file_ast)
+            .map_err(CompileErrors::from)?;
+    }
 
     // Preserve the caller-visible AST/RIR order for inspection and --emit rir.
     let (rir, interner) = {
         let _span = info_span!("astgen").entered();
-        let astgen = AstGen::new(&ast, &interner);
-        let rir = astgen.generate();
+        let rir = AstGen::generate_items(&interner, ast.items());
         info!(instruction_count = rir.len(), "AST generation complete");
         (rir, interner)
     };
@@ -1151,10 +1205,17 @@ pub fn compile_frontend_from_ast_with_source_metadata_and_target(
     // composite type IDs, destructor/drop-glue traversal, string IDs, and
     // object layout. Lower a private logical-path-ordered RIR without changing
     // the observable AST/RIR above (RUE-624).
-    let semantic_ast = semantic_order::for_sema(&ast, source_metadata);
     let semantic_rir = {
         let _span = info_span!("semantic_astgen").entered();
-        AstGen::new(&semantic_ast, &interner).generate()
+        let order = semantic_order::SemanticItemOrder::from_items(ast.items(), source_metadata);
+        let work = order.work();
+        let rir = AstGen::generate_items(&interner, order.iter());
+        info!(
+            items_indexed = work.items_indexed,
+            item_payloads_cloned = work.item_payloads_cloned,
+            "semantic item order lowered"
+        );
+        rir
     };
 
     let mut sema =
@@ -2518,11 +2579,21 @@ mod tests {
             SourceFile::new("utils.rue", "fn helper() -> i32 { 42 }", FileId::new(2)),
         ];
         let parsed = parse_all_files(&sources).unwrap();
+        let parsed_asts: Vec<_> = parsed.files.iter().map(|file| file.ast.clone()).collect();
         let merged = merge_symbols(parsed);
         assert!(merged.is_ok(), "merge should succeed with no duplicates");
 
         let program = merged.unwrap();
-        assert_eq!(program.ast.items.len(), 2, "should have 2 items");
+        assert_eq!(program.ast.item_count(), 2, "should have 2 items");
+        assert!(
+            program
+                .ast
+                .files()
+                .iter()
+                .zip(&parsed_asts)
+                .all(|(merged, parsed)| Arc::ptr_eq(merged, parsed)),
+            "merging must retain the parsed AST allocations"
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/semantic_order.rs
+++ b/crates/rue-compiler/src/semantic_order.rs
@@ -3,8 +3,8 @@
 //! Caller source order remains observable in tokens, AST, RIR, and dependency
 //! output. Semantic allocation has a stricter requirement:
 //! moving sibling modules must not renumber types, strings, functions, or
-//! objects. The compiler therefore lowers a second, top-level-item-reordered
-//! AST to the private RIR consumed by sema.
+//! objects. The compiler therefore lowers an immutable, borrowed item-order
+//! view to the private RIR consumed by sema.
 
 use std::collections::HashMap;
 
@@ -24,38 +24,66 @@ pub(crate) fn item_span(item: &Item) -> Span {
     }
 }
 
-/// Clone an observable AST into the canonical order used only by sema.
-///
-/// The explicitly designated root remains first. Siblings are ordered by their
-/// validated, canonical logical paths, while byte positions retain
-/// declaration order within each file. Compiler entry points validate that
-/// every AST item is described by `source_metadata` before calling this.
-pub(crate) fn for_sema(ast: &Ast, source_metadata: &SourceMetadata) -> Ast {
-    let mut keyed_items: Vec<_> = ast
-        .items
-        .iter()
-        .cloned()
-        .enumerate()
-        .map(|(original_index, item)| {
-            let span = item_span(&item);
-            let logical_path = source_metadata
-                .logical_path(span.file_id)
-                .expect("AST file ID validated against source metadata");
-            let key = (
-                span.file_id != source_metadata.root_file_id(),
-                logical_path,
-                span.start,
-                span.end,
-                span.file_id.index(),
-                original_index,
-            );
-            (key, item)
-        })
-        .collect();
-    keyed_items.sort_by(|(left, _), (right, _)| left.cmp(right));
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SemanticItemOrderWork {
+    pub(crate) items_indexed: usize,
+    pub(crate) item_payloads_cloned: usize,
+}
 
-    Ast {
-        items: keyed_items.into_iter().map(|(_, item)| item).collect(),
+/// Borrowed canonical item order used only by semantic lowering.
+pub(crate) struct SemanticItemOrder<'a> {
+    items: Vec<&'a Item>,
+    work: SemanticItemOrderWork,
+}
+
+impl<'a> SemanticItemOrder<'a> {
+    /// Index an observable AST without cloning any item payloads.
+    ///
+    /// The explicitly designated root remains first. Siblings are ordered by their
+    /// validated, canonical logical paths, while byte positions retain
+    /// declaration order within each file. Compiler entry points validate that
+    /// every AST item is described by `source_metadata` before calling this.
+    pub(crate) fn from_items(
+        items: impl IntoIterator<Item = &'a Item>,
+        source_metadata: &SourceMetadata,
+    ) -> Self {
+        let mut keyed_items: Vec<_> = items
+            .into_iter()
+            .enumerate()
+            .map(|(original_index, item)| {
+                let span = item_span(item);
+                let logical_path = source_metadata
+                    .logical_path(span.file_id)
+                    .expect("AST file ID validated against source metadata");
+                let key = (
+                    span.file_id != source_metadata.root_file_id(),
+                    logical_path,
+                    span.start,
+                    span.end,
+                    span.file_id.index(),
+                    original_index,
+                );
+                (key, item)
+            })
+            .collect();
+        let keyed_items_len = keyed_items.len();
+        keyed_items.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+        Self {
+            items: keyed_items.into_iter().map(|(_, item)| item).collect(),
+            work: SemanticItemOrderWork {
+                items_indexed: keyed_items_len,
+                item_payloads_cloned: 0,
+            },
+        }
+    }
+
+    pub(crate) fn iter(&self) -> impl ExactSizeIterator<Item = &'a Item> + '_ {
+        self.items.iter().copied()
+    }
+
+    pub(crate) fn work(&self) -> SemanticItemOrderWork {
+        self.work
     }
 }
 
@@ -108,14 +136,19 @@ mod tests {
         )
         .unwrap();
 
-        let ordered = for_sema(&ast, &source_metadata);
-        let ordered_files: Vec<_> = ordered
-            .items
-            .iter()
-            .map(item_span)
-            .map(|s| s.file_id)
-            .collect();
+        let ordered = SemanticItemOrder::from_items(ast.items.iter(), &source_metadata);
+        let ordered_files: Vec<_> = ordered.iter().map(item_span).map(|s| s.file_id).collect();
 
         assert_eq!(ordered_files, [root, logical_first, logical_second]);
+        assert_eq!(
+            ordered.work(),
+            SemanticItemOrderWork {
+                items_indexed: 3,
+                item_payloads_cloned: 0,
+            }
+        );
+        for item in ordered.iter() {
+            assert!(ast.items.iter().any(|source| std::ptr::eq(source, item)));
+        }
     }
 }

--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -88,7 +88,7 @@ fn parse_file(source: SourceFile<'_>, interner: ThreadedRodeo) -> FileParseOutco
         result: Ok(ParsedFile {
             path: source.path.to_owned(),
             file_id: source.file_id,
-            ast,
+            ast: std::sync::Arc::new(ast),
         }),
         interner,
         work,

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -37,10 +37,10 @@ use lasso::ThreadedRodeo;
 use tracing::{info, info_span};
 
 use crate::{
-    Ast, AstGen, CompileErrors, CompileOptions, CompileOutput, CompileResult, CompileWarning,
-    DefinitionSnapshot, FunctionWithCfg, MultiErrorResult, Rir, SourceFile, SourceMetadata,
-    SourceSnapshot, SyntaxWork, TypeInternPool, build_functions_and_cfgs, build_sema_for_target,
-    compile_backend,
+    AstGen, CompileErrors, CompileOptions, CompileOutput, CompileResult, CompileWarning,
+    DefinitionSnapshot, FunctionWithCfg, MergedAst, MultiErrorResult, Rir, SourceFile,
+    SourceMetadata, SourceSnapshot, SyntaxWork, TypeInternPool, build_functions_and_cfgs,
+    build_sema_for_target, compile_backend,
 };
 use rue_span::FileId;
 
@@ -95,7 +95,7 @@ pub struct CompilationUnit<'src> {
 
     // === Phase 1: Parsing ===
     /// Merged AST containing all items (populated by `parse()`).
-    merged_ast: Option<Ast>,
+    merged_ast: Option<MergedAst>,
     /// String interner shared across all files.
     interner: Option<ThreadedRodeo>,
     /// Durable module/name keys and snapshot-local definition occurrences from
@@ -264,8 +264,7 @@ impl<'src> CompilationUnit<'src> {
 
         let _span = info_span!("astgen").entered();
 
-        let astgen = AstGen::new(ast, interner);
-        let rir = astgen.generate();
+        let rir = AstGen::generate_items(interner, ast.items());
 
         info!(instruction_count = rir.len(), "RIR generation complete");
 
@@ -298,10 +297,20 @@ impl<'src> CompilationUnit<'src> {
         // while sema consumes a private logical-path-ordered lowering. This
         // makes allocation and artifact layout canonical without changing the
         // caller-visible AST/RIR contract (RUE-624).
-        let semantic_ast = crate::semantic_order::for_sema(ast, self.source_snapshot.metadata());
         let semantic_rir = {
             let _span = info_span!("semantic_astgen").entered();
-            AstGen::new(&semantic_ast, interner).generate()
+            let order = crate::semantic_order::SemanticItemOrder::from_items(
+                ast.items(),
+                self.source_snapshot.metadata(),
+            );
+            let work = order.work();
+            let rir = AstGen::generate_items(interner, order.iter());
+            info!(
+                items_indexed = work.items_indexed,
+                item_payloads_cloned = work.item_payloads_cloned,
+                "semantic item order lowered"
+            );
+            rir
         };
 
         let mut sema = build_sema_for_target(
@@ -430,7 +439,7 @@ impl<'src> CompilationUnit<'src> {
     /// # Panics
     ///
     /// Panics if called before [`parse()`](Self::parse).
-    pub fn ast(&self) -> &Ast {
+    pub fn ast(&self) -> &MergedAst {
         self.merged_ast
             .as_ref()
             .expect("ast() called before parse()")

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -34,8 +34,8 @@ use crate::inst::{
 
 /// Generates RIR from an AST.
 pub struct AstGen<'a> {
-    /// The AST being processed
-    ast: &'a Ast,
+    /// The AST being processed by the compatibility constructor.
+    ast: Option<&'a Ast>,
     /// String interner for symbols (thread-safe, takes shared reference)
     interner: &'a ThreadedRodeo,
     /// Output RIR
@@ -50,7 +50,7 @@ impl<'a> AstGen<'a> {
     /// Create a new AstGen for the given AST.
     pub fn new(ast: &'a Ast, interner: &'a ThreadedRodeo) -> Self {
         Self {
-            ast,
+            ast: Some(ast),
             interner,
             rir: Rir::new(),
             for_counter: 0,
@@ -59,10 +59,32 @@ impl<'a> AstGen<'a> {
 
     /// Generate RIR from the AST.
     pub fn generate(mut self) -> Rir {
-        for item in &self.ast.items {
+        let ast = self.ast.expect("AstGen::new always stores an AST");
+        for item in &ast.items {
             self.gen_item(item);
         }
         self.rir
+    }
+
+    /// Generate RIR from an immutable borrowed sequence of AST items.
+    ///
+    /// The iterator order is the lowering order. This lets compiler
+    /// orchestration supply a canonical query/view without cloning item
+    /// payloads or constructing a second [`Ast`].
+    pub fn generate_items<'item>(
+        interner: &'a ThreadedRodeo,
+        items: impl IntoIterator<Item = &'item Item>,
+    ) -> Rir {
+        let mut generator = Self {
+            ast: None,
+            interner,
+            rir: Rir::new(),
+            for_counter: 0,
+        };
+        for item in items {
+            generator.gen_item(item);
+        }
+        generator.rir
     }
 
     fn gen_item(&mut self, item: &Item) {
@@ -1607,6 +1629,25 @@ mod tests {
         let astgen = AstGen::new(&ast, &interner);
         let rir = astgen.generate();
         (rir, interner)
+    }
+
+    #[test]
+    fn borrowed_item_lowering_matches_reordered_ast_lowering() {
+        let lexer = Lexer::new("fn first() -> i32 { 1 } fn main() -> i32 { first() }");
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        let parser = Parser::new(tokens, interner);
+        let (ast, interner) = parser.parse().unwrap();
+
+        let reordered = Ast {
+            items: ast.items.iter().rev().cloned().collect(),
+        };
+        let compatibility = AstGen::new(&reordered, &interner).generate();
+        let borrowed = AstGen::generate_items(&interner, ast.items.iter().rev());
+
+        assert_eq!(
+            RirPrinter::new(&borrowed, &interner).to_string(),
+            RirPrinter::new(&compatibility, &interner).to_string()
+        );
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -2051,7 +2051,7 @@ fn handle_emit_multi_file(
     };
 
     // For AST output, collect the per-file AST info before merging (which consumes the program)
-    let per_file_asts: Option<Vec<(String, rue_compiler::Ast)>> = if needs_ast {
+    let per_file_asts: Option<Vec<(String, std::sync::Arc<rue_compiler::Ast>)>> = if needs_ast {
         parsed.as_ref().map(|program| {
             program
                 .files
@@ -2078,20 +2078,21 @@ fn handle_emit_multi_file(
             }
         };
 
-        let state = match rue_compiler::compile_frontend_from_ast_with_source_metadata_and_target(
-            merged.ast,
-            merged.interner,
-            options.opt_level,
-            &options.preview_features,
-            options.target,
-            source_snapshot.metadata(),
-        ) {
-            Ok(state) => state,
-            Err(errors) => {
-                diagnostics.print_errors(&errors);
-                return Err(());
-            }
-        };
+        let state =
+            match rue_compiler::compile_frontend_from_merged_ast_with_source_metadata_and_target(
+                merged.ast,
+                merged.interner,
+                options.opt_level,
+                &options.preview_features,
+                options.target,
+                source_snapshot.metadata(),
+            ) {
+                Ok(state) => state,
+                Err(errors) => {
+                    diagnostics.print_errors(&errors);
+                    return Err(());
+                }
+            };
 
         // Warnings used to be silently dropped in all --emit modes (RUE-130).
         diagnostics.print_warnings(&state.warnings);


### PR DESCRIPTION
## Summary

- retain each parsed file AST behind `Arc` and merge programs as an ordered `MergedAst` view instead of recursively cloning every item payload
- replace the second canonical semantic AST clone with a borrowed `SemanticItemOrder` over the same immutable items
- add borrowed-item lowering to AstGen while preserving `AstGen::new(&Ast, ...).generate()` and raw-AST frontend adapters
- keep semantic ordering inside the existing `semantic_astgen` timing span and report value-only structural work (`items_indexed`, zero payload clones)
- update CompilationUnit, DefinitionSnapshot, and CLI consumers to preserve caller source order, duplicate/error order, and share parsed allocations

## Why

The frontend previously deep-cloned top-level AST payloads once while merging files and again while constructing canonical semantic order. Besides allocation cost, those owned copies were the wrong boundary for future in-process parse reuse: semantic lowering should consume immutable views of cached per-file syntax, not require rebuilding an owned aggregate AST.

`MergedAst` now owns only ordered `Arc<Ast>` handles, and canonical lowering owns only a vector of borrowed item references. Tests prove merge retains the exact parsed AST allocations by pointer identity and semantic ordering borrows the original item payloads.

## Performance evidence

Standard harness: `scripts/perf-baseline.py --iterations 3 --warmup 1 --jobs 1 --format json`, isolated parent/current workspaces.

Representative merge-span medians (before → after):

- many_functions: 2.280 → 1.612 ms
- large_structs: 3.647 → 2.211 ms
- arithmetic_heavy: 3.873 → 0.444 ms
- control_flow: 2.618 → 0.571 ms
- register_pressure: 2.353 → 0.397 ms

Peak RSS medians fell on all five large cases: 41.76 → 40.49 MB, 46.96 → 43.78 MB, 62.98 → 54.10 MB, 48.14 → 44.24 MB, and 45.96 → 42.61 MB respectively.

Overall compile medians were mixed (four of five large cases down, register_pressure slightly up; the tiny multi_file case also slightly up), and phase MAD is not exposed by the harness. This PR therefore claims elimination of payload clones and lower measured allocation/RSS, not a general throughput speedup.

## Validation

- `./fmt.sh check`
- `./clippy.sh` — 41 first-party targets passed
- `./buck2 test //... //:reproducible-programs` — 34 targets passed, zero failures
- structural tests for parsed-AST pointer retention, borrowed semantic items, and borrowed/owned AstGen equivalence
- existing semantic permutation, diagnostic ordering, native/textual reproducibility, and timing topology tests remain green

Linear: RUE-658