### PR TITLE
RUE-695: index named destructor roots

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -751,50 +751,46 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
         // by their bodies back through the same deterministic work queues.
         if !named_destructors_analyzed {
             named_destructors_analyzed = true;
-            for (_, inst) in sema.rir.iter() {
-                if let InstData::DropFnDecl { type_name, body } = &inst.data {
-                    sema.body_analysis_work
-                        .named_destructor_declarations_visited += 1;
-                    // File-aware first (RUE-558), matching the sites above.
-                    let struct_id = match sema
-                        .structs_by_file_name
-                        .get(&(inst.span.file_id, *type_name))
-                        .or_else(|| sema.structs.get(type_name))
-                    {
-                        Some(id) => *id,
-                        None => continue,
-                    };
-                    let struct_type = Type::new_struct(struct_id);
-                    let full_name = sema.destructor_symbol(struct_id);
+            // Copy the request-local records before mutating `sema` below.
+            // The loop finishes selecting every destructor before the queued
+            // references are processed on the next fixed-point iteration.
+            let destructor_records = sema.declaration_index.destructors().to_vec();
+            for destructor in destructor_records {
+                sema.body_analysis_work
+                    .named_destructor_declarations_visited += 1;
+                // File-aware first (RUE-558), matching the historical scan.
+                let struct_id = match sema
+                    .structs_by_file_name
+                    .get(&(destructor.span.file_id, destructor.type_name))
+                    .or_else(|| sema.structs.get(&destructor.type_name))
+                {
+                    Some(id) => *id,
+                    None => continue,
+                };
+                let struct_type = Type::new_struct(struct_id);
+                let full_name = sema.destructor_symbol(struct_id);
 
-                    match sema.analyze_destructor_function(
-                        &infer_ctx,
-                        &full_name,
-                        *body,
-                        inst.span,
-                        struct_type,
-                    ) {
-                        Ok((
-                            analyzed,
-                            warnings,
-                            local_strings,
+                match sema.analyze_destructor_function(
+                    &infer_ctx,
+                    &full_name,
+                    destructor.body,
+                    destructor.span,
+                    struct_type,
+                ) {
+                    Ok((analyzed, warnings, local_strings, referenced_fns, referenced_meths)) => {
+                        functions_with_strings.push((analyzed, local_strings));
+                        all_warnings.extend(warnings);
+                        enqueue_references_sorted(
+                            sema.interner,
                             referenced_fns,
                             referenced_meths,
-                        )) => {
-                            functions_with_strings.push((analyzed, local_strings));
-                            all_warnings.extend(warnings);
-                            enqueue_references_sorted(
-                                sema.interner,
-                                referenced_fns,
-                                referenced_meths,
-                                &analyzed_functions,
-                                &analyzed_methods,
-                                &mut pending_functions,
-                                &mut pending_methods,
-                            );
-                        }
-                        Err(e) => errors.push(e),
+                            &analyzed_functions,
+                            &analyzed_methods,
+                            &mut pending_functions,
+                            &mut pending_methods,
+                        );
                     }
+                    Err(e) => errors.push(e),
                 }
             }
             continue;

--- a/crates/rue-air/src/sema/declaration_index.rs
+++ b/crates/rue-air/src/sema/declaration_index.rs
@@ -272,8 +272,11 @@ impl RirDeclarationIndex {
         &self.anonymous_methods
     }
 
-    #[cfg(test)]
-    fn destructors(&self) -> &[RirDestructorDeclaration] {
+    /// Named destructor declarations in exact RIR order.
+    ///
+    /// These records remain private to one `Sema` invocation: their arena and
+    /// interner handles are not durable semantic identities.
+    pub(super) fn destructors(&self) -> &[RirDestructorDeclaration] {
         &self.destructors
     }
 
@@ -474,6 +477,43 @@ mod tests {
             rebuilt.const_candidates(second, same),
             index.const_candidates(second, same)
         );
+    }
+
+    #[test]
+    fn same_named_destructors_across_files_follow_exact_rir_order() {
+        let first = FileId::new(19);
+        let second = FileId::new(3);
+        let (rir, interner) = lower_files(&[
+            ("struct Same { value: i32 } drop fn Same(self) {}", first),
+            ("struct Same { value: bool } drop fn Same(self) {}", second),
+        ]);
+        let index = RirDeclarationIndex::new(&rir);
+        let destructors = index.destructors();
+
+        assert_eq!(destructors.len(), 2);
+        assert_eq!(
+            destructors
+                .iter()
+                .map(|record| record.span.file_id)
+                .collect::<Vec<_>>(),
+            [first, second]
+        );
+        assert!(
+            destructors
+                .windows(2)
+                .all(|pair| { pair[0].declaration.as_u32() < pair[1].declaration.as_u32() })
+        );
+        assert!(
+            destructors
+                .iter()
+                .all(|record| interner.resolve(&record.type_name) == "Same")
+        );
+        for record in destructors {
+            assert!(matches!(
+                rir.get(record.declaration).data,
+                InstData::DropFnDecl { body, .. } if body == record.body
+            ));
+        }
     }
 
     #[test]

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -98,8 +98,11 @@ pub struct BodyAnalysisWork {
     pub named_method_record_lookups: usize,
     /// MethodInfo-driven lookups for reachable anonymous-struct methods.
     pub anonymous_method_record_lookups: usize,
-    /// Named destructor declarations selected during the one-time implicit-root scan.
+    /// Indexed named-destructor records selected as implicit roots.
     pub named_destructor_declarations_visited: usize,
+    /// Raw RIR entries visited specifically to select named-destructor roots.
+    /// Indexed dispatch keeps this value at zero.
+    pub named_destructor_selection_rir_visits: usize,
     /// Raw RIR entries visited specifically to select ordinary reachable free
     /// functions or named methods.
     ///

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -67,6 +67,29 @@ mod tests {
         assert_eq!(many.reachable_declaration_rir_visits, 0);
     }
 
+    fn named_destructor_lookup_work(irrelevant: usize) -> crate::BodyAnalysisWork {
+        let mut source = String::from(
+            "struct Target { value: i32 }\n\
+             drop fn Target(self) {}\n\
+             fn main() -> i32 { 0 }\n",
+        );
+        for index in 0..irrelevant {
+            source.push_str(&format!("fn irrelevant{index}() -> i32 {{ {index} }}\n"));
+        }
+        compile_to_air(&source).unwrap().body_analysis_work
+    }
+
+    #[test]
+    fn named_destructor_selection_is_invariant_to_irrelevant_declarations() {
+        let one = named_destructor_lookup_work(1);
+        let many = named_destructor_lookup_work(128);
+
+        assert_eq!(one.named_destructor_declarations_visited, 1);
+        assert_eq!(many.named_destructor_declarations_visited, 1);
+        assert_eq!(one.named_destructor_selection_rir_visits, 0);
+        assert_eq!(many.named_destructor_selection_rir_visits, 0);
+    }
+
     #[test]
     fn panic_is_never_and_assert_is_unit_in_air() {
         // `@panic` diverges: its AIR result type is `!` (never), matching HM

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -1238,6 +1238,9 @@ pub fn compile_frontend_from_merged_ast_with_source_metadata_and_target(
             named_destructor_declarations_visited = output
                 .body_analysis_work
                 .named_destructor_declarations_visited,
+            named_destructor_selection_rir_visits = output
+                .body_analysis_work
+                .named_destructor_selection_rir_visits,
             reachable_declaration_rir_visits =
                 output.body_analysis_work.reachable_declaration_rir_visits,
             "semantic analysis complete"

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -338,6 +338,9 @@ impl<'src> CompilationUnit<'src> {
                 named_destructor_declarations_visited = output
                     .body_analysis_work
                     .named_destructor_declarations_visited,
+                named_destructor_selection_rir_visits = output
+                    .body_analysis_work
+                    .named_destructor_selection_rir_visits,
                 reachable_declaration_rir_visits =
                     output.body_analysis_work.reachable_declaration_rir_visits,
                 "semantic analysis complete"


### PR DESCRIPTION
## Summary

- expose the declaration index’s ordered named-destructor records to semantic analysis as a private request-local slice
- select implicit destructor roots from those records instead of scanning the complete RIR
- preserve the fixed-point barrier that analyzes every named destructor before processing references their bodies enqueue
- report indexed destructor records and zero raw-RIR selection visits through value-only structural counters

## Why

RUE-656/657/661 removed the repeated full-RIR scans for reachable free functions and methods, but named destructor root selection still performed one final whole-RIR scan. The index already retained the exact destructor records in deterministic RIR order, so this closes the last declaration-selection scan in lazy body dispatch without promoting InstRef, FileId, or Spur into durable identities.

## Correctness and scaling

- a 1-versus-128 irrelevant-declaration regression performs one indexed destructor-record visit and zero raw-RIR selection visits in both programs
- a cross-file regression uses same-named structs/destructors with adversarial FileIds (19 then 3) and proves index/selection order remains exact RIR order
- semantic analysis copies the complete request-local record vector, analyzes every record, and only then continues the outer fixed-point loop, preserving the historical all-destructors-before-queued-references barrier

## Validation

- `./fmt.sh check`
- `./clippy.sh` — 41 first-party targets passed
- `./buck2 test //... //:reproducible-programs` — 34 targets passed, zero failures
- Rue AIR: 379 tests passed
- Rue compiler: 291 tests passed

Linear: RUE-695