### PR TITLE
stdlib v1 M3: ascii, strings, sort, rand

### DIFF
--- a/crates/rue-cli-tests/cases/std_m3.toml
+++ b/crates/rue-cli-tests/cases/std_m3.toml
@@ -1,0 +1,172 @@
+# Standard library — M3 tier (std.ascii / std.strings / std.sort / std.rand),
+# exercised through the real std bundle via RUE_STD_PATH.
+#
+# NOTE: cross-module calls to generic (`comptime T`) std helpers require typed
+# local bindings, not bare integer literals (RUE-693). The sort cases below bind
+# typed values before passing them to the generic sort/search functions.
+#
+# std.rand.Lcg is a plain named `struct` (not a `fn Lcg() -> type`): a
+# cross-module call to a zero-comptime-argument type function is currently
+# mis-evaluated at runtime (E1200), so a named struct is used instead — it also
+# reads more naturally for a non-generic type (`std.rand.Lcg.new(seed)`).
+
+[section]
+id = "cli.std_m3"
+name = "Standard library — M3 (ascii / strings / sort / rand)"
+description = "std.ascii, std.strings, std.sort, std.rand exercised end-to-end through @import(\"std\")."
+
+[[case]]
+name = "std_ascii_m3"
+description = "ascii byte classification and case mapping (11 checks -> exit 61)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 61
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut score: i32 = 0;
+
+    if std.ascii.is_digit(52) { score = score + 1; }        // '4'
+    if !std.ascii.is_digit(65) { score = score + 1; }       // 'A'
+    if std.ascii.is_alpha(65) { score = score + 1; }        // 'A'
+    if std.ascii.is_alnum(57) { score = score + 1; }        // '9'
+    if std.ascii.is_whitespace(32) { score = score + 1; }   // space
+    if std.ascii.is_upper(90) { score = score + 1; }        // 'Z'
+    if std.ascii.is_lower(97) { score = score + 1; }        // 'a'
+    if std.ascii.to_upper(97) == 65 { score = score + 1; }  // 'a' -> 'A'
+    if std.ascii.to_lower(90) == 122 { score = score + 1; } // 'Z' -> 'z'
+    if std.ascii.is_ascii(127) { score = score + 1; }
+
+    let Ob = std.option.Option(u8);
+    match std.ascii.digit_value(55) {                       // '7' -> 7
+        Ob.Some(v) => { if v == 7 { score = score + 1; } },
+        Ob.None => {},
+    }
+
+    if score == 11 { 61 } else { @intCast(score) }
+}
+""" }]
+
+[[case]]
+name = "std_strings_m3"
+description = "strings parse/find/trim/repeat helpers (14 checks -> exit 62)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 62
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut score: i32 = 0;
+    let Oi = std.option.Option(i64);
+    let Ou = std.option.Option(u64);
+
+    match std.strings.parse_int("-42") { Oi.Some(v) => { if v == -42 { score = score + 1; } }, Oi.None => {} }
+    match std.strings.parse_int("1000") { Oi.Some(v) => { if v == 1000 { score = score + 1; } }, Oi.None => {} }
+    match std.strings.parse_int("") { Oi.Some(v) => {}, Oi.None => { score = score + 1; } }
+    match std.strings.parse_int("12x") { Oi.Some(v) => {}, Oi.None => { score = score + 1; } }
+    match std.strings.parse_int("99999999999999999999999") { Oi.Some(v) => {}, Oi.None => { score = score + 1; } }
+
+    match std.strings.find("hello", 108) { Ou.Some(i) => { if i == 2 { score = score + 1; } }, Ou.None => {} }
+    match std.strings.rfind("hello", 108) { Ou.Some(i) => { if i == 3 { score = score + 1; } }, Ou.None => {} }
+    if std.strings.count("hello", 108) == 2 { score = score + 1; }
+    if std.strings.starts_with_byte("hello", 104) { score = score + 1; }
+    if !std.strings.starts_with_byte("", 104) { score = score + 1; }
+
+    if std.strings.trim("  hi  ").len() == 2 { score = score + 1; }
+    if std.strings.trim_start("  hi").len() == 2 { score = score + 1; }
+    if std.strings.trim_end("hi  ").len() == 2 { score = score + 1; }
+    if std.strings.repeat("ab", 3).len() == 6 { score = score + 1; }
+
+    if score == 14 { 62 } else { @intCast(score) }
+}
+""" }]
+
+[[case]]
+name = "std_sort_m3"
+description = "sort insertion/quick/is_sorted/binary_search over ArrayBuf(i64) (6 checks -> exit 63)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 63
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut score: i32 = 0;
+    let B = std.arraybuf.ArrayBuf(i64);
+    let Ou = std.option.Option(u64);
+
+    let v5: i64 = 5;
+    let v2: i64 = 2;
+    let v9: i64 = 9;
+    let v1: i64 = 1;
+    let v7: i64 = 7;
+
+    // quicksort
+    let mut a = B.new();
+    a.push(v5); a.push(v2); a.push(v9); a.push(v1); a.push(v7);
+    std.sort.quicksort(i64, inout a);
+    if std.sort.is_sorted(i64, borrow a) { score = score + 1; }
+    if a.get_or(0, -1) == 1 { score = score + 1; }
+    if a.get_or(4, -1) == 9 { score = score + 1; }
+
+    // binary_search: present and absent
+    match std.sort.binary_search(i64, borrow a, v7) {
+        Ou.Some(i) => { if a.get_or(i, -1) == 7 { score = score + 1; } },
+        Ou.None => {},
+    }
+    let miss: i64 = 3;
+    match std.sort.binary_search(i64, borrow a, miss) {
+        Ou.Some(i) => {},
+        Ou.None => { score = score + 1; },
+    }
+
+    // insertion_sort
+    let mut b = B.new();
+    b.push(v9); b.push(v1); b.push(v5); b.push(v2);
+    std.sort.insertion_sort(i64, inout b);
+    if std.sort.is_sorted(i64, borrow b) { score = score + 1; }
+
+    if score == 6 { 63 } else { @intCast(score) }
+}
+""" }]
+
+[[case]]
+name = "std_rand_m3"
+description = "rand Lcg determinism, bounds, and next_bool (5 checks -> exit 64)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 64
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut score: i32 = 0;
+
+    // Same seed -> identical stream (determinism).
+    let mut r1 = std.rand.Lcg.new(12345);
+    let mut r2 = std.rand.Lcg.new(12345);
+    if r1.next_u64() == r2.next_u64() { score = score + 1; }
+    if r1.next_u64() == r2.next_u64() { score = score + 1; }
+
+    // next_below stays in range.
+    let mut inrange = true;
+    let mut i: u64 = 0;
+    while i < 100 {
+        if r1.next_below(6) >= 6 { inrange = false; }
+        i = i + 1;
+    }
+    if inrange { score = score + 1; }
+
+    // next_below(0) == 0.
+    if r1.next_below(0) == 0 { score = score + 1; }
+
+    // next_u64 stays within the 32-bit state range.
+    if r1.next_u64() < 4294967296 { score = score + 1; }
+
+    let _ = r1.next_bool();
+
+    if score == 5 { 64 } else { @intCast(score) }
+}
+""" }]

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -30,6 +30,12 @@ pub const grid = @import("grid.rue");
 pub const binary_heap = @import("binary_heap.rue");
 pub const intmap = @import("intmap.rue");
 
+// Algorithms & text (Standard library v1, M3).
+pub const ascii = @import("ascii.rue");
+pub const strings = @import("strings.rue");
+pub const sort = @import("sort.rue");
+pub const rand = @import("rand.rue");
+
 fn _exit_syscall_number() -> u64 {
     match @target_arch() {
         Arch.X86_64 => {

--- a/std/ascii.rue
+++ b/std/ascii.rue
@@ -1,0 +1,74 @@
+// std.ascii — byte classification and case mapping over `u8` (RUE-676).
+//
+// These are pure functions over a single ASCII byte: the classic C
+// `<ctype.h>` predicates (`isdigit`, `isalpha`, …) plus lowercase/uppercase
+// mapping, written directly against the ASCII code points. They inspect one
+// byte at a time and never look at UTF-8 boundaries, so they compose cleanly
+// with `String`'s byte indexing (`s[i] -> u8`) — see std.strings.
+//
+//     const std = @import("std");
+//     std.ascii.is_digit(52);      // true  ('4')
+//     std.ascii.to_upper(97);      // 65    ('a' -> 'A')
+//     std.ascii.digit_value(55);   // Some(7)
+//
+// ASCII reference: '0'..'9' = 48..57, 'A'..'Z' = 65..90, 'a'..'z' = 97..122,
+// space = 32, tab = 9, newline = 10, carriage return = 13, DEL = 127.
+
+const option = @import("option.rue");
+
+// Whether `b` is an ASCII decimal digit '0'..'9'.
+pub fn is_digit(b: u8) -> bool {
+    b >= 48 && b <= 57
+}
+
+// Whether `b` is an ASCII uppercase letter 'A'..'Z'.
+pub fn is_upper(b: u8) -> bool {
+    b >= 65 && b <= 90
+}
+
+// Whether `b` is an ASCII lowercase letter 'a'..'z'.
+pub fn is_lower(b: u8) -> bool {
+    b >= 97 && b <= 122
+}
+
+// Whether `b` is an ASCII letter (either case).
+pub fn is_alpha(b: u8) -> bool {
+    is_upper(b) || is_lower(b)
+}
+
+// Whether `b` is an ASCII letter or decimal digit.
+pub fn is_alnum(b: u8) -> bool {
+    is_alpha(b) || is_digit(b)
+}
+
+// Whether `b` is ASCII whitespace: space, tab, newline, or carriage return.
+pub fn is_whitespace(b: u8) -> bool {
+    b == 32 || b == 9 || b == 10 || b == 13
+}
+
+// Whether `b` is a 7-bit ASCII byte (0..=127).
+pub fn is_ascii(b: u8) -> bool {
+    b <= 127
+}
+
+// Uppercase mapping: lowercase letters map to their uppercase form; every
+// other byte is returned unchanged.
+pub fn to_upper(b: u8) -> u8 {
+    if is_lower(b) { b - 32 } else { b }
+}
+
+// Lowercase mapping: uppercase letters map to their lowercase form; every
+// other byte is returned unchanged.
+pub fn to_lower(b: u8) -> u8 {
+    if is_upper(b) { b + 32 } else { b }
+}
+
+// Numeric value 0..=9 of an ASCII digit, or `None` when `b` is not a digit.
+pub fn digit_value(b: u8) -> option.Option(u8) {
+    let O = option.Option(u8);
+    if is_digit(b) {
+        O.Some(b - 48)
+    } else {
+        O.None
+    }
+}

--- a/std/rand.rue
+++ b/std/rand.rue
@@ -1,0 +1,68 @@
+// std.rand — a small seedable pseudo-random generator (RUE-678).
+//
+// `Lcg` is a linear congruential generator with 32 bits of state, using the
+// Numerical Recipes constants. The recurrence is
+//
+//     state = (state * 1664525 + 1013904223) % 2^32
+//
+// with the modulus written explicitly as `% 4294967296` so the multiply of a
+// 32-bit state by 1664525 stays well within `u64` (max product ~7.15e15) before
+// the reduction — i.e. it never overflows and never needs a wrapping multiply.
+//
+//     const std = @import("std");
+//     let mut rng = std.rand.Lcg.new(12345);
+//     let x = rng.next_u64();          // a value in [0, 2^32)
+//     let r = rng.next_below(6);       // a value in [0, 6)
+//     let flag = rng.next_bool();      // true/false
+//
+// SHAPE NOTE (compiler limitation): `Lcg` is a plain named `struct`, NOT a
+// zero-argument `pub fn Lcg() -> type` type-function. A generator has no type
+// parameter, so the type-function form would take no comptime arguments — and a
+// cross-module call to a zero-comptime-argument type function is currently
+// mis-evaluated at runtime instead of comptime (E1200 "cannot store type value
+// in variable"; the identical LOCAL call folds fine). A named struct is both
+// idiomatic for a non-generic type and sidesteps that bug: `std.rand.Lcg` names
+// the type directly, so `std.rand.Lcg.new(seed)` needs no `let L = ...()`
+// binding dance. Minimal repro of the underlying bug (filed for the compiler
+// team):
+//
+//     // mod.rue:  pub fn Lcg() -> type { struct { state: u64, ... } }
+//     // main.rue: const m = @import("mod.rue");
+//     //           let L = m.Lcg();   // E1200, but `fn Lcg` defined locally works
+//
+// LIMITATION: this is a 32-bit-state LCG, so `next_u64` returns values only in
+// `[0, 2^32)` and the low bits cycle quickly (a known LCG weakness). A true
+// 64-bit-state generator needs a wrapping 64-bit multiply, which the language
+// does not expose yet — so it is deliberately not attempted here. This
+// generator is for tests, sampling, and shuffling, NOT for cryptography.
+
+pub struct Lcg {
+    state: u64,
+
+    // A generator seeded with `seed` (reduced into the 32-bit state space).
+    fn new(seed: u64) -> Self {
+        Self { state: seed % 4294967296 }
+    }
+
+    // Advance the state and return it: a value in `[0, 2^32)`.
+    fn next_u64(inout self) -> u64 {
+        self.state = (self.state * 1664525 + 1013904223) % 4294967296;
+        self.state
+    }
+
+    // A value uniformly in `[0, bound)`. Returns 0 when `bound == 0`. Uses the
+    // low-bias `% bound` reduction (fine for the small bounds this generator
+    // targets).
+    fn next_below(inout self, bound: u64) -> u64 {
+        if bound == 0 {
+            0
+        } else {
+            self.next_u64() % bound
+        }
+    }
+
+    // A pseudo-random boolean (the low bit of the next output).
+    fn next_bool(inout self) -> bool {
+        self.next_u64() % 2 == 1
+    }
+}

--- a/std/sort.rue
+++ b/std/sort.rue
@@ -1,0 +1,134 @@
+// std.sort — in-place sorting and searching over `ArrayBuf(T)` (RUE-675).
+//
+// These are free functions that take the buffer as an `inout` (mutating) or
+// `borrow` (read-only) parameter and order its elements by the natural `<`
+// relation on the element type `T` (verified: `<` works on a comptime type
+// parameter). They mirror how a method takes `inout self` / `borrow self`, but
+// live as standalone generic functions so any `ArrayBuf(T)` can be sorted
+// without wrapping.
+//
+//     const std = @import("std");
+//     let B = std.arraybuf.ArrayBuf(i64);
+//     let mut v = B.new();
+//     // ... push elements ...
+//     std.sort.quicksort(i64, inout v);
+//     let hit = std.sort.binary_search(i64, v, target);   // Option(u64)
+//
+// COPY-ELEMENT-ONLY. Every element access here is a by-copy read
+// (`ArrayBuf.get_or`), which the container gates to trivially-droppable element
+// types (E0711, RUE-651): reading a drop-glue element out by copy while its
+// slot stays live would alias its owned buffer (double-free). So these routines
+// are for `Copy` element types — integers and other trivially-droppable
+// scalars/aggregates. Sorting owned (drop-glue) elements needs a
+// borrow-returning element accessor (the RUE-651 follow-up); it is out of scope
+// here. The unused out-of-bounds defaults passed to `get_or` are integer `0`
+// literals, so the element type must additionally admit `0` as a value; for
+// `binary_search` the default is `target`, so it is generic over any `Copy` `T`.
+
+const arraybuf = @import("arraybuf.rue");
+const mem = @import("mem.rue");
+const option = @import("option.rue");
+
+// Exchange elements `i` and `j` (both assumed in bounds). Routes the exchange
+// through `std.mem.swap` on two typed locals, then writes them back.
+fn swap_at(comptime T: type, inout xs: arraybuf.ArrayBuf(T), i: u64, j: u64) {
+    let mut a = xs.get_or(i, 0);
+    let mut b = xs.get_or(j, 0);
+    mem.swap(T, inout a, inout b);
+    xs.set(i, a);
+    xs.set(j, b);
+}
+
+// Insertion sort: stable, O(n^2), good on small or nearly-sorted inputs.
+// Shifts each element left past larger predecessors.
+pub fn insertion_sort(comptime T: type, inout xs: arraybuf.ArrayBuf(T)) {
+    let n = xs.len();
+    let mut i: u64 = 1;
+    while i < n {
+        let mut j = i;
+        while j > 0 {
+            let prev = xs.get_or(j - 1, 0);
+            let cur = xs.get_or(j, 0);
+            if cur < prev {
+                swap_at(T, inout xs, j - 1, j);
+                j = j - 1;
+            } else {
+                j = 0;
+            }
+        }
+        i = i + 1;
+    }
+}
+
+// Recursive Lomuto quicksort over the inclusive range `[lo, hi]`. The pivot is
+// the last element; ranges of length <= 1 are already sorted.
+fn qsort_range(comptime T: type, inout xs: arraybuf.ArrayBuf(T), lo: u64, hi: u64) {
+    if lo >= hi {
+        return;
+    }
+    let pivot = xs.get_or(hi, 0);
+    let mut store = lo;
+    let mut j = lo;
+    while j < hi {
+        let vj = xs.get_or(j, 0);
+        if vj < pivot {
+            swap_at(T, inout xs, store, j);
+            store = store + 1;
+        }
+        j = j + 1;
+    }
+    swap_at(T, inout xs, store, hi);
+    if store > lo {
+        qsort_range(T, inout xs, lo, store - 1);
+    }
+    qsort_range(T, inout xs, store + 1, hi);
+}
+
+// Quicksort: average O(n log n), in place. Not stable.
+pub fn quicksort(comptime T: type, inout xs: arraybuf.ArrayBuf(T)) {
+    let n = xs.len();
+    if n > 1 {
+        qsort_range(T, inout xs, 0, n - 1);
+    }
+}
+
+// Whether `xs` is in non-decreasing order under `<`.
+pub fn is_sorted(comptime T: type, borrow xs: arraybuf.ArrayBuf(T)) -> bool {
+    let n = xs.len();
+    if n < 2 {
+        return true;
+    }
+    let mut i: u64 = 1;
+    while i < n {
+        let prev = xs.get_or(i - 1, 0);
+        let cur = xs.get_or(i, 0);
+        if cur < prev {
+            return false;
+        }
+        i = i + 1;
+    }
+    true
+}
+
+// Binary search for `target` in a buffer that is already sorted ascending.
+// Returns `Some(i)` for some index `i` with `xs[i] == target` (equality is
+// tested as `!(a < b) && !(b < a)`), or `None` if absent. Generic over any
+// `Copy` `T`: the unused out-of-bounds default is `target` itself.
+pub fn binary_search(comptime T: type, borrow xs: arraybuf.ArrayBuf(T), target: T) -> option.Option(u64) {
+    let O = option.Option(u64);
+    let n = xs.len();
+    let mut lo: u64 = 0;
+    let mut hi = n;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let v = xs.get_or(mid, target);
+        if v < target {
+            lo = mid + 1;
+        } else if target < v {
+            hi = mid;
+        } else {
+            return O.Some(mid);
+        }
+    }
+    O.None
+}

--- a/std/strings.rue
+++ b/std/strings.rue
@@ -1,0 +1,233 @@
+// std.strings — byte-oriented text helpers over `String` (RUE-677).
+//
+// Built on the working `String` surface: byte indexing (`s[i] -> u8`), `.len()`,
+// and the mutating builders `String.new()` + `.push(byte)`. Everything here is
+// byte-level (ASCII-oriented) and never inspects UTF-8 boundaries, matching
+// std.ascii. Fallible parses/searches return `option.Option(T)`.
+//
+//     const std = @import("std");
+//     std.strings.parse_int("-42");        // Some(-42)
+//     std.strings.find("hello", 108);      // Some(2)  (first 'l')
+//     std.strings.trim("  hi  ");          // "hi"
+//     std.strings.repeat("ab", 3);         // "ababab"
+//
+// COMPILER-BUG WORKAROUND (see below): a `String` byte index `s[i]` used
+// DIRECTLY inside an `if`/`while` condition expression is currently rejected
+// with E0900 "cannot index into non-array type 'StrBuf'" — even though the very
+// same `s[i]` works when bound to a `let` first or used in tail position.
+// Minimal repro:
+//
+//     fn f(s: String) -> u8 { if s[0] == 45 { 1 } else { 9 } }   // E0900
+//     fn f(s: String) -> u8 { let c = s[0]; if c == 45 { 1 } else { 9 } }  // OK
+//
+// So every index below reads the byte into a local in statement position first,
+// then tests the local. This is filed for the compiler team; when it is fixed
+// the local bindings can be inlined back into the conditions.
+
+const ascii = @import("ascii.rue");
+const option = @import("option.rue");
+const math = @import("math.rue");
+
+// Parse a decimal integer with an optional leading '-'. Returns `None` on an
+// empty string, a lone '-', any non-digit byte, or arithmetic overflow of
+// `i64` (overflow is caught with `std.math.checked_mul`/`checked_add`, so no
+// trap). NOTE: because magnitude is accumulated as a positive `i64` before an
+// optional negation, `i64::MIN` (-9223372036854775808) is reported as overflow
+// (`None`) — its magnitude does not fit a positive `i64`.
+pub fn parse_int(s: String) -> option.Option(i64) {
+    let O = option.Option(i64);
+    let n = s.len();
+    if n == 0 {
+        return O.None;
+    }
+    let mut i: u64 = 0;
+    let mut neg = false;
+    let first = s[0];
+    if first == 45 {
+        neg = true;
+        i = 1;
+        if n == 1 {
+            return O.None;
+        }
+    }
+    let mut acc: i64 = 0;
+    let ten: i64 = 10;
+    while i < n {
+        let byte = s[i];
+        if !ascii.is_digit(byte) {
+            return O.None;
+        }
+        let dg: i64 = @intCast(byte - 48);
+        match math.checked_mul(acc, ten) {
+            O.Some(m) => {
+                match math.checked_add(m, dg) {
+                    O.Some(sum) => {
+                        acc = sum;
+                    },
+                    O.None => {
+                        return O.None;
+                    },
+                }
+            },
+            O.None => {
+                return O.None;
+            },
+        }
+        i = i + 1;
+    }
+    if neg {
+        O.Some(-acc)
+    } else {
+        O.Some(acc)
+    }
+}
+
+// Index of the first byte equal to `byte`, or `None`.
+pub fn find(s: String, byte: u8) -> option.Option(u64) {
+    let O = option.Option(u64);
+    let n = s.len();
+    let mut i: u64 = 0;
+    while i < n {
+        let c = s[i];
+        if c == byte {
+            return O.Some(i);
+        }
+        i = i + 1;
+    }
+    O.None
+}
+
+// Index of the last byte equal to `byte`, or `None`.
+pub fn rfind(s: String, byte: u8) -> option.Option(u64) {
+    let O = option.Option(u64);
+    let mut i = s.len();
+    while i > 0 {
+        i = i - 1;
+        let c = s[i];
+        if c == byte {
+            return O.Some(i);
+        }
+    }
+    O.None
+}
+
+// Number of bytes equal to `byte`.
+pub fn count(s: String, byte: u8) -> u64 {
+    let mut c: u64 = 0;
+    let n = s.len();
+    let mut i: u64 = 0;
+    while i < n {
+        let cur = s[i];
+        if cur == byte {
+            c = c + 1;
+        }
+        i = i + 1;
+    }
+    c
+}
+
+// Whether the first byte of `s` equals `byte` (false for the empty string).
+pub fn starts_with_byte(s: String, byte: u8) -> bool {
+    if s.len() == 0 {
+        false
+    } else {
+        let c = s[0];
+        c == byte
+    }
+}
+
+// Copy of `s` with leading ASCII whitespace removed.
+pub fn trim_start(s: String) -> String {
+    let n = s.len();
+    let mut start: u64 = 0;
+    let mut scanning = true;
+    while scanning && start < n {
+        let c = s[start];
+        if ascii.is_whitespace(c) {
+            start = start + 1;
+        } else {
+            scanning = false;
+        }
+    }
+    let mut out = String.new();
+    let mut i = start;
+    while i < n {
+        let c = s[i];
+        out.push(c);
+        i = i + 1;
+    }
+    out
+}
+
+// Copy of `s` with trailing ASCII whitespace removed.
+pub fn trim_end(s: String) -> String {
+    let n = s.len();
+    let mut end = n;
+    let mut scanning = true;
+    while scanning && end > 0 {
+        let c = s[end - 1];
+        if ascii.is_whitespace(c) {
+            end = end - 1;
+        } else {
+            scanning = false;
+        }
+    }
+    let mut out = String.new();
+    let mut i: u64 = 0;
+    while i < end {
+        let c = s[i];
+        out.push(c);
+        i = i + 1;
+    }
+    out
+}
+
+// Copy of `s` with both leading and trailing ASCII whitespace removed.
+pub fn trim(s: String) -> String {
+    let n = s.len();
+    let mut start: u64 = 0;
+    let mut sc = true;
+    while sc && start < n {
+        let c = s[start];
+        if ascii.is_whitespace(c) {
+            start = start + 1;
+        } else {
+            sc = false;
+        }
+    }
+    let mut end = n;
+    let mut ec = true;
+    while ec && end > start {
+        let c = s[end - 1];
+        if ascii.is_whitespace(c) {
+            end = end - 1;
+        } else {
+            ec = false;
+        }
+    }
+    let mut out = String.new();
+    let mut i = start;
+    while i < end {
+        let c = s[i];
+        out.push(c);
+        i = i + 1;
+    }
+    out
+}
+
+// `s` concatenated `n` times (empty string when `n == 0`).
+pub fn repeat(s: String, n: u64) -> String {
+    let mut out = String.new();
+    let len = s.len();
+    let mut k: u64 = 0;
+    while k < n {
+        let mut i: u64 = 0;
+        while i < len {
+            let c = s[i];
+            out.push(c);
+            i = i + 1;
+        }
+        k = k + 1;
+    }
+    out
+}


### PR DESCRIPTION
Third tier of the [Standard library v1](https://linear.app/steve-klabnik/project/standard-library-v1-1bbc20136bb4) project — algorithms & text. Built by an Opus worker, integrated and re-verified by Fable.

## Modules
- **std.ascii** — `is_digit/alpha/alnum/whitespace/upper/lower`, `to_upper/to_lower`, `digit_value → Option(u8)`.
- **std.strings** — `parse_int → Option(i64)` (overflow-guarded via `math.checked_*`), `find/rfind/count`, `starts_with_byte`, `trim/trim_start/trim_end`, `repeat`. Built on `s[i]` byte indexing.
- **std.sort** — `insertion_sort`/`quicksort` (`inout ArrayBuf(T)`), `is_sorted`, `binary_search → Option(u64)`; natural `<` order, Copy-T (RUE-651). Swaps via `std.mem.swap`.
- **std.rand** — `Lcg` 32-bit-state PRNG (`new/next_u64/next_below/next_bool`).

CLI test `std_m3.toml` (ascii→61, strings→62, sort→63, rand→64) plus re-verification here. Full `./test.sh` green (34/34).

## Filed while building
- **RUE-696** — cross-module zero-arg `-> type` call not comptime-classified (E1200); `Lcg` uses a named struct to sidestep it.
- **RUE-700** — `s[i]` rejected in an `if`/`while` condition (E0900); `std.strings` let-binds each index as a workaround.

Copy-element only per RUE-651 (custom-comparator `sort_by` is M4, blocked on function values RUE-643).

Fixes RUE-675
Fixes RUE-676
Fixes RUE-677
Fixes RUE-678

🤖 Generated with [Claude Code](https://claude.com/claude-code)