### PR TITLE
RUE-700: allow String/str/slice byte indexing in condition position

### DIFF
--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -459,9 +459,56 @@ impl<'a> Sema<'a> {
         // indexing without checking if the element type is Copy. This enables
         // accessing Copy fields of non-Copy array elements.
         if let InstData::IndexGet { base, index } = &inst.data {
+            // Snapshot the base root's move state before analysis, in case this
+            // is a String/str/slice byte index in projection mode (RUE-700).
+            let base_root = self.extract_root_variable(*base);
+            let base_move_state_before = base_root.and_then(|v| ctx.moved_vars.get(&v).cloned());
+
             // Recursively analyze the base in projection mode
             let base_result = self.analyze_inst_for_projection(air, *base, ctx)?;
             let base_type = base_result.ty;
+
+            // Binary-op operands are analyzed in projection mode (see
+            // `analyze_builtin_binary_op`), so a String/str/slice byte index used
+            // inside a condition — `if s[0] == 45`, `while s[i] != 0` — reaches
+            // here with a non-array base. Mirror `analyze_index_get`'s non-array
+            // delegation (`s[i] -> byte_at`) instead of rejecting it with E0900
+            // (RUE-700); a let-bound `let c = s[0]` already goes through the
+            // String-aware path.
+            if self.is_builtin_string(base_type) {
+                return self.analyze_string_index_get(
+                    air,
+                    base_result,
+                    base_root,
+                    base_move_state_before,
+                    *index,
+                    inst.span,
+                    ctx,
+                );
+            }
+            if self.is_str_like(base_type) {
+                return self.analyze_str_index_get(
+                    air,
+                    base_result,
+                    base_root,
+                    base_move_state_before,
+                    *index,
+                    inst.span,
+                    ctx,
+                );
+            }
+            if let Some(elem_ty) = self.slice_element_type(base_type) {
+                return self.analyze_slice_index_get(
+                    air,
+                    base_result,
+                    base_root,
+                    base_move_state_before,
+                    *index,
+                    elem_ty,
+                    inst.span,
+                    ctx,
+                );
+            }
 
             let array_type_id = match base_type.kind() {
                 TypeKind::Array(id) => id,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5336,7 +5336,7 @@ impl<'a> Sema<'a> {
     /// keeps later uses of `s` valid and ensures the String is dropped exactly
     /// once.
     #[allow(clippy::too_many_arguments)]
-    fn analyze_string_index_get(
+    pub(crate) fn analyze_string_index_get(
         &mut self,
         air: &mut Air,
         base_result: AnalysisResult,
@@ -5409,7 +5409,7 @@ impl<'a> Sema<'a> {
     /// Like `String` indexing, the read only *borrows* the receiver (a `str` is
     /// `Copy` anyway), so the pre-analysis move state is restored and the move
     /// marker cancelled.
-    fn analyze_str_index_get(
+    pub(crate) fn analyze_str_index_get(
         &mut self,
         air: &mut Air,
         base_result: AnalysisResult,
@@ -5481,7 +5481,7 @@ impl<'a> Sema<'a> {
     /// backend-specific work) is required; the fat pointer flows through the
     /// same struct/field/pointer paths the manual `{ptr,len}` form already uses.
     #[allow(clippy::too_many_arguments)]
-    fn analyze_slice_index_get(
+    pub(crate) fn analyze_slice_index_get(
         &mut self,
         air: &mut Air,
         base_result: AnalysisResult,

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -734,6 +734,24 @@ exit_code = 0
 expected_stdout = "104\n5\n101\n"
 
 [[case]]
+name = "string_index_in_condition"
+spec = ["3.7:16"]
+description = "A String byte index reads correctly in condition position (if/while), not only when let-bound first (RUE-700: binary-op operands are analyzed in projection mode, which previously rejected a non-array base with E0900)."
+source = """
+fn main() -> i32 {
+    let s = "a1b2";
+    let mut digits: i32 = 0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        if s[i] >= 48 { if s[i] <= 57 { digits = digits + 1; } }
+        i = i + 1;
+    }
+    digits
+}
+"""
+exit_code = 2
+
+[[case]]
 name = "string_index_out_of_bounds_traps"
 spec = ["3.7:17"]
 source = """


### PR DESCRIPTION
Binary-op operands are analyzed in projection mode, whose `IndexGet` handler only understood array bases and rejected a String/str/slice base with **E0900**. So `if s[0] == 45` / `while s[i] != 0` failed even though the identical `let c = s[0]` compiled (the let path goes through the String-aware `analyze_index_get`).

Fix: mirror `analyze_index_get`s non-array delegation in the projection path — for a String/str/slice base, route to `analyze_string_index_get`/`analyze_str_index_get`/`analyze_slice_index_get` (the `byte_at` lowering) with the base root's pre-analysis move state, instead of erroring. Made those three helpers `pub(crate)`.

Found while building `std.strings` (M3), which had to let-bind every byte index as a workaround; those can now be inlined.

Regression case: `types/strings.toml::string_index_in_condition` (spec 3.7:16). Full `./test.sh` green.

Fixes RUE-700

🤖 Generated with [Claude Code](https://claude.com/claude-code)