### PR TITLE
RUE-623: use correct reverse-DNS codesign identifier (dev.rue-lang)

### DIFF
--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1925,7 +1925,7 @@ fn main() {
                             "-s",
                             "-",
                             "--identifier",
-                            "org.rue-lang.program",
+                            "dev.rue-lang.program",
                             "--timestamp=none",
                             &options.output_path,
                         ])

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -111,7 +111,7 @@ assert_macos_signature() {
         return 1
     fi
     metadata="$(codesign --display --verbose=4 "$program" 2>&1)"
-    if ! grep -Fqx 'Identifier=org.rue-lang.program' <<< "$metadata"; then
+    if ! grep -Fqx 'Identifier=dev.rue-lang.program' <<< "$metadata"; then
         printf 'FAIL: Mach-O signing identifier is not stable\n%s\n' "$metadata" >&2
         return 1
     fi


### PR DESCRIPTION
The macOS Mach-O codesign `--identifier` was `org.rue-lang.program`, but the project domain is **rue-lang.dev** (`rue-lang.org` is a different Rue). Reverse-DNS of `rue-lang.dev` is `dev.rue-lang`, so the identifier is now `dev.rue-lang.program`.

Addresses Steve's [PR #1445 review comment](https://github.com/rue-language/rue/pull/1445#discussion_r3564338383). One-line string change; builds clean.

Fixes RUE-623

🤖 Generated with [Claude Code](https://claude.com/claude-code)