### PR TITLE
RUE-701: add stable source and module inputs

### DIFF
--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -20,6 +20,7 @@ rue_crate(
         "//third-party:annotate-snippets",
         "//third-party:lasso",
         "//third-party:rayon",
+        "//third-party:sha2",
         "//third-party:serde_json",
         "//third-party:tracing",
     ],

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -8,16 +8,14 @@
 //! request's diagnostic locations.
 
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::Arc;
 
-use rue_air::normalize_module_path;
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_parser::{Ident, Item, ast::Visibility};
 use rue_span::{FileId, Span};
 use tracing::info_span;
 
-use crate::{ParsedProgram, SourceMetadata, SourceSnapshot};
+use crate::{ModuleId, ParsedProgram, SourceMetadata, SourceSnapshot};
 
 /// A durable module identity derived from a canonical logical source path.
 ///
@@ -25,57 +23,8 @@ use crate::{ParsedProgram, SourceMetadata, SourceSnapshot};
 /// within the same source graph. It is insensitive to checkout relocation when
 /// callers provide relocation-stable logical paths; metadata that deliberately
 /// falls back to physical paths retains those paths' location dependence.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ModuleKey {
-    logical_path: Arc<str>,
-}
-
-impl ModuleKey {
-    /// Construct a module key by lexically canonicalizing a logical path.
-    ///
-    /// This performs no filesystem access. Empty identities are rejected in
-    /// the same way as [`SourceMetadata`].
-    pub fn from_logical_path(logical_path: impl AsRef<str>) -> CompileResult<Self> {
-        let logical_path = normalize_module_path(logical_path.as_ref());
-        if logical_path.is_empty() {
-            return Err(invalid_input("module key has an empty logical path"));
-        }
-        Ok(Self {
-            logical_path: Arc::from(logical_path),
-        })
-    }
-
-    fn from_validated_canonical(logical_path: &str) -> Self {
-        debug_assert!(!logical_path.is_empty());
-        Self {
-            logical_path: Arc::from(logical_path),
-        }
-    }
-
-    /// The canonical logical source path underlying this key.
-    #[inline]
-    pub fn logical_path(&self) -> &str {
-        self.logical_path.as_ref()
-    }
-
-    /// The canonical logical source path underlying this key.
-    #[inline]
-    pub fn as_str(&self) -> &str {
-        self.logical_path()
-    }
-}
-
-impl AsRef<str> for ModuleKey {
-    fn as_ref(&self) -> &str {
-        self.logical_path()
-    }
-}
-
-impl fmt::Display for ModuleKey {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.logical_path())
-    }
-}
+/// Compatibility name for [`ModuleId`].
+pub type ModuleKey = ModuleId;
 
 /// The concrete syntax kind of a parsed top-level definition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -29,6 +29,7 @@ mod definition_snapshot;
 mod diagnostic;
 mod drop_glue;
 mod semantic_order;
+mod source_identity;
 mod source_metadata;
 mod source_snapshot;
 mod syntax;
@@ -37,6 +38,11 @@ mod unit;
 pub use definition_snapshot::{
     DefinitionId, DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionRecord,
     DefinitionSnapshot, ModuleDefinition, ModuleKey,
+};
+pub use source_identity::{
+    CodegenInputDescriptor, LinkInputDescriptor, ModuleId, ModuleResolutionInput,
+    ModuleResolutionInputs, ModuleRevision, SemanticInputDescriptor, SourceId, SourceIdVersion,
+    SourceRevision, StableLinkerInput, StableOptLevel, StablePreviewFeatures,
 };
 pub use source_metadata::SourceMetadata;
 pub use source_snapshot::{MAX_SOURCE_BYTES, SourceSnapshot};

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -1,0 +1,448 @@
+//! Stable, immutable identities for source and externally supplied compiler inputs.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use rue_air::normalize_module_path;
+use rue_cfg::OptLevel;
+use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeatures};
+use rue_target::Target;
+use sha2::{Digest, Sha256};
+
+use crate::{CompileOptions, LinkerMode, SourceMetadata, SourceSnapshot};
+
+const SOURCE_DOMAIN_V1: &[u8] = b"rue.source\0v1\0sha256\0";
+
+trait SourceDigester {
+    fn digest(&self, text: &[u8]) -> [u8; 32];
+}
+
+struct Sha256Digester;
+
+impl SourceDigester for Sha256Digester {
+    fn digest(&self, text: &[u8]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(SOURCE_DOMAIN_V1);
+        hasher.update((text.len() as u64).to_le_bytes());
+        hasher.update(text);
+        hasher.finalize().into()
+    }
+}
+
+/// Version of Rue's source-content identity scheme.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum SourceIdVersion {
+    /// Domain-separated SHA-256 over the exact UTF-8 bytes.
+    V1Sha256,
+}
+
+#[derive(Debug)]
+struct SourceIdentity {
+    version: SourceIdVersion,
+    digest: [u8; 32],
+    text: Arc<String>,
+}
+
+/// Exact source-content identity.
+///
+/// Cloning an ID is constant time but intentionally pins the shared source
+/// text. Exact bytes participate in equality so digest collisions cannot make
+/// distinct sources equal. Its textual form contains only the versioned digest
+/// and may therefore collide; use `SourceId` equality, not `Display`, for exact
+/// identity.
+#[derive(Clone)]
+pub struct SourceId(Arc<SourceIdentity>);
+
+impl SourceId {
+    /// Identify exact shared UTF-8 source text with the current production scheme.
+    ///
+    /// The returned ID retains this `Arc`; cloning the ID continues to pin the
+    /// source allocation without copying its bytes.
+    pub fn from_shared_text(text: Arc<String>) -> Self {
+        Self::from_shared_text_with(text, &Sha256Digester)
+    }
+
+    fn from_shared_text_with(text: Arc<String>, digester: &dyn SourceDigester) -> Self {
+        Self(Arc::new(SourceIdentity {
+            version: SourceIdVersion::V1Sha256,
+            digest: digester.digest(text.as_bytes()),
+            text,
+        }))
+    }
+
+    /// Identity scheme version.
+    pub fn version(&self) -> SourceIdVersion {
+        self.0.version
+    }
+
+    /// Versioned digest accelerator. Exact identity still compares bytes.
+    pub fn digest(&self) -> [u8; 32] {
+        self.0.digest
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shared_text(&self) -> Arc<String> {
+        self.0.text.clone()
+    }
+}
+
+impl PartialEq for SourceId {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.version == other.0.version
+            && self.0.digest == other.0.digest
+            && self.0.text.as_bytes() == other.0.text.as_bytes()
+    }
+}
+impl Eq for SourceId {}
+impl Hash for SourceId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.version.hash(state);
+        self.0.digest.hash(state);
+        self.0.text.len().hash(state);
+    }
+}
+impl PartialOrd for SourceId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for SourceId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.0.version, self.0.digest, self.0.text.as_bytes()).cmp(&(
+            other.0.version,
+            other.0.digest,
+            other.0.text.as_bytes(),
+        ))
+    }
+}
+impl fmt::Debug for SourceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SourceId({self})")
+    }
+}
+impl fmt::Display for SourceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("rue-source-v1-sha256:")?;
+        for byte in self.0.digest {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Canonical logical identity of one module.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ModuleId {
+    logical_path: Arc<str>,
+}
+
+impl ModuleId {
+    pub fn from_logical_path(path: impl AsRef<str>) -> CompileResult<Self> {
+        let path = normalize_module_path(path.as_ref());
+        if path.is_empty() {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "module ID has an empty logical path".into(),
+            )));
+        }
+        Ok(Self {
+            logical_path: path.into(),
+        })
+    }
+    pub(crate) fn from_validated_canonical(path: &str) -> Self {
+        debug_assert!(!path.is_empty());
+        debug_assert_eq!(normalize_module_path(path), path);
+        Self {
+            logical_path: Arc::from(path),
+        }
+    }
+    pub fn logical_path(&self) -> &str {
+        &self.logical_path
+    }
+    pub fn as_str(&self) -> &str {
+        self.logical_path()
+    }
+}
+impl AsRef<str> for ModuleId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+impl fmt::Display for ModuleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One module/content pair in a source revision.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ModuleRevision {
+    pub module: ModuleId,
+    pub source: SourceId,
+}
+
+/// Root plus complete module/content mapping, sorted by logical module ID.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SourceRevision {
+    root: ModuleId,
+    modules: Arc<[ModuleRevision]>,
+}
+impl SourceRevision {
+    pub fn root(&self) -> &ModuleId {
+        &self.root
+    }
+    pub fn modules(&self) -> &[ModuleRevision] {
+        &self.modules
+    }
+    /// Build a complete, canonical module/source mapping.
+    pub fn new(root: ModuleId, mut modules: Vec<ModuleRevision>) -> CompileResult<Self> {
+        modules.sort_by(|a, b| a.module.cmp(&b.module));
+        if let Some(duplicate) = modules
+            .windows(2)
+            .find(|pair| pair[0].module == pair[1].module)
+            .map(|pair| &pair[0].module)
+        {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("source revision contains duplicate module ID {duplicate:?}"),
+            )));
+        }
+        if modules
+            .binary_search_by(|entry| entry.module.cmp(&root))
+            .is_err()
+        {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("source revision root module {root:?} is absent"),
+            )));
+        }
+        Ok(Self {
+            root,
+            modules: modules.into(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ModuleResolutionInput {
+    pub module: ModuleId,
+    pub physical_path: Arc<str>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ModuleResolutionInputs {
+    root: ModuleId,
+    modules: Arc<[ModuleResolutionInput]>,
+}
+impl ModuleResolutionInputs {
+    pub fn root(&self) -> &ModuleId {
+        &self.root
+    }
+    pub fn modules(&self) -> &[ModuleResolutionInput] {
+        &self.modules
+    }
+    pub fn from_metadata(metadata: &SourceMetadata) -> Self {
+        let root = ModuleId::from_validated_canonical(
+            metadata.logical_path(metadata.root_file_id()).unwrap(),
+        );
+        let mut modules: Vec<_> = metadata
+            .file_ids()
+            .map(|id| ModuleResolutionInput {
+                module: ModuleId::from_validated_canonical(metadata.logical_path(id).unwrap()),
+                physical_path: Arc::from(metadata.physical_path(id).unwrap()),
+            })
+            .collect();
+        modules.sort_by(|a, b| a.module.cmp(&b.module));
+        Self {
+            root,
+            modules: modules.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StablePreviewFeatures(Arc<[Arc<str>]>);
+impl StablePreviewFeatures {
+    pub fn new(features: &PreviewFeatures) -> Self {
+        let mut names: Vec<Arc<str>> = features.iter().map(|f| Arc::from(f.name())).collect();
+        names.sort();
+        names.dedup();
+        Self(names.into())
+    }
+    pub fn names(&self) -> &[Arc<str>] {
+        &self.0
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StableOptLevel {
+    O0,
+    O1,
+    O2,
+    O3,
+}
+impl From<OptLevel> for StableOptLevel {
+    fn from(value: OptLevel) -> Self {
+        match value {
+            OptLevel::O0 => Self::O0,
+            OptLevel::O1 => Self::O1,
+            OptLevel::O2 => Self::O2,
+            OptLevel::O3 => Self::O3,
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StableLinkerInput {
+    Internal,
+    System(Arc<str>),
+}
+impl From<&LinkerMode> for StableLinkerInput {
+    fn from(value: &LinkerMode) -> Self {
+        match value {
+            LinkerMode::Internal => Self::Internal,
+            LinkerMode::System(s) => Self::System(Arc::from(s.as_str())),
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SemanticInputDescriptor {
+    pub sources: SourceRevision,
+    pub resolution: ModuleResolutionInputs,
+    pub target: Target,
+    pub preview_features: StablePreviewFeatures,
+}
+impl SemanticInputDescriptor {
+    pub fn new(snapshot: &SourceSnapshot, target: Target, features: &PreviewFeatures) -> Self {
+        Self {
+            sources: snapshot.source_revision().clone(),
+            resolution: ModuleResolutionInputs::from_metadata(snapshot.metadata()),
+            target,
+            preview_features: StablePreviewFeatures::new(features),
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CodegenInputDescriptor {
+    pub semantic: SemanticInputDescriptor,
+    pub opt_level: StableOptLevel,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LinkInputDescriptor {
+    pub codegen: CodegenInputDescriptor,
+    pub linker: StableLinkerInput,
+}
+impl LinkInputDescriptor {
+    pub fn from_compile_options(snapshot: &SourceSnapshot, options: &CompileOptions) -> Self {
+        Self {
+            codegen: CodegenInputDescriptor {
+                semantic: SemanticInputDescriptor::new(
+                    snapshot,
+                    options.target,
+                    &options.preview_features,
+                ),
+                opt_level: options.opt_level.into(),
+            },
+            linker: (&options.linker).into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_error::PreviewFeature;
+    use std::collections::hash_map::DefaultHasher;
+    struct Constant;
+    impl SourceDigester for Constant {
+        fn digest(&self, _: &[u8]) -> [u8; 32] {
+            [7; 32]
+        }
+    }
+    fn hash(value: &SourceId) -> u64 {
+        let mut h = DefaultHasher::new();
+        value.hash(&mut h);
+        h.finish()
+    }
+    #[test]
+    fn collisions_do_not_equal_or_replace_text() {
+        let a = SourceId::from_shared_text_with(Arc::new("a".into()), &Constant);
+        let b = SourceId::from_shared_text_with(Arc::new("b".into()), &Constant);
+        assert_ne!(a, b);
+        assert_ne!(a.cmp(&b), Ordering::Equal);
+        assert_eq!(a.digest(), b.digest());
+        assert_eq!(a.shared_text().as_str(), "a");
+        assert_eq!(b.shared_text().as_str(), "b");
+    }
+    #[test]
+    fn equal_values_have_equal_hashes_and_share_text() {
+        let text = Arc::new(String::from("same"));
+        let a = SourceId::from_shared_text_with(text.clone(), &Constant);
+        let b = SourceId::from_shared_text_with(text.clone(), &Constant);
+        assert_eq!(a, b);
+        assert_eq!(hash(&a), hash(&b));
+        assert!(Arc::ptr_eq(&a.shared_text(), &text));
+    }
+
+    #[test]
+    fn identical_bytes_in_distinct_allocations_have_identical_value_semantics() {
+        let left_text = Arc::new(String::from("identical"));
+        let right_text = Arc::new(String::from("identical"));
+        assert!(!Arc::ptr_eq(&left_text, &right_text));
+        let left = SourceId::from_shared_text(left_text);
+        let right = SourceId::from_shared_text(right_text);
+        assert_eq!(left, right);
+        assert_eq!(left.cmp(&right), Ordering::Equal);
+        assert_eq!(hash(&left), hash(&right));
+    }
+
+    #[test]
+    fn v1_digest_framing_is_stable() {
+        let id = SourceId::from_shared_text(Arc::new("abc".to_owned()));
+        assert_eq!(
+            id.to_string(),
+            "rue-source-v1-sha256:4aa48dd8273d312c382c549796d09c5dc9b528b6563d3d1913554fcfce735e5e"
+        );
+    }
+
+    #[test]
+    fn preview_feature_identity_ignores_hash_set_insertion_order() {
+        let left = PreviewFeatures::from([PreviewFeature::Slices, PreviewFeature::TestInfra]);
+        let right = PreviewFeatures::from([PreviewFeature::TestInfra, PreviewFeature::Slices]);
+        let left = StablePreviewFeatures::new(&left);
+        let right = StablePreviewFeatures::new(&right);
+        assert_eq!(left, right);
+        assert_eq!(
+            left.names().iter().map(AsRef::as_ref).collect::<Vec<_>>(),
+            ["slices", "test_infra"]
+        );
+    }
+
+    #[test]
+    fn source_revision_rejects_duplicate_modules_and_missing_root() {
+        let root = ModuleId::from_logical_path("root.rue").unwrap();
+        let other = ModuleId::from_logical_path("other.rue").unwrap();
+        let source = SourceId::from_shared_text(Arc::new("fn main() {}".to_owned()));
+        let duplicate = SourceRevision::new(
+            root.clone(),
+            vec![
+                ModuleRevision {
+                    module: root.clone(),
+                    source: source.clone(),
+                },
+                ModuleRevision {
+                    module: root.clone(),
+                    source: source.clone(),
+                },
+            ],
+        )
+        .unwrap_err();
+        assert!(duplicate.to_string().contains("duplicate module ID"));
+        let missing = SourceRevision::new(
+            root,
+            vec![ModuleRevision {
+                module: other,
+                source,
+            }],
+        )
+        .unwrap_err();
+        assert!(missing.to_string().contains("root module"));
+    }
+}

--- a/crates/rue-compiler/src/source_metadata.rs
+++ b/crates/rue-compiler/src/source_metadata.rs
@@ -12,7 +12,7 @@ use rue_air::normalize_module_path;
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::FileId;
 
-use crate::{Ast, SourceFile, semantic_order::item_span};
+use crate::{Ast, ModuleId, SourceFile, semantic_order::item_span};
 
 /// Immutable, validated identities for every source in a compilation.
 ///
@@ -205,6 +205,18 @@ impl SourceMetadata {
     /// keys.
     pub fn logical_path(&self, file_id: FileId) -> Option<&str> {
         self.logical_paths.get(&file_id).map(String::as_str)
+    }
+
+    /// Canonical logical module identity for a request-local file ID.
+    pub fn module_id(&self, file_id: FileId) -> Option<ModuleId> {
+        self.logical_path(file_id)
+            .map(ModuleId::from_validated_canonical)
+    }
+
+    /// Canonical logical identity of the explicitly designated root module.
+    pub fn root_module_id(&self) -> ModuleId {
+        self.module_id(self.root_file_id)
+            .expect("validated root file has a logical path")
     }
 
     /// Physical paths in ascending `FileId` order.

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::FileId;
 
-use crate::{SourceFile, SourceMetadata};
+use crate::{ModuleId, ModuleRevision, SourceFile, SourceId, SourceMetadata, SourceRevision};
 
 /// Maximum source byte length representable by Rue's `u32` span offsets.
 pub const MAX_SOURCE_BYTES: usize = u32::MAX as usize;
@@ -31,8 +31,17 @@ pub struct SourceSnapshot {
 #[derive(Debug)]
 struct SourceSnapshotData {
     metadata: SourceMetadata,
-    contents: Vec<(FileId, Arc<String>)>,
+    contents: Vec<SourceRecord>,
     index: HashMap<FileId, usize>,
+    revision: SourceRevision,
+}
+
+#[derive(Debug)]
+struct SourceRecord {
+    file_id: FileId,
+    module_id: ModuleId,
+    source_id: SourceId,
+    text: Arc<String>,
 }
 
 impl SourceSnapshot {
@@ -95,17 +104,50 @@ impl SourceSnapshot {
             &metadata,
         )?;
 
+        let contents: Vec<_> = contents
+            .into_iter()
+            .map(|(file_id, text)| {
+                let module_id = ModuleId::from_validated_canonical(
+                    metadata
+                        .logical_path(file_id)
+                        .expect("validated membership"),
+                );
+                let source_id = SourceId::from_shared_text(text.clone());
+                SourceRecord {
+                    file_id,
+                    module_id,
+                    source_id,
+                    text,
+                }
+            })
+            .collect();
         let index = contents
             .iter()
             .enumerate()
-            .map(|(index, (file_id, _))| (*file_id, index))
+            .map(|(index, record)| (record.file_id, index))
             .collect();
+        let root_module = ModuleId::from_validated_canonical(
+            metadata
+                .logical_path(metadata.root_file_id())
+                .expect("validated root"),
+        );
+        let revision = SourceRevision::new(
+            root_module,
+            contents
+                .iter()
+                .map(|record| ModuleRevision {
+                    module: record.module_id.clone(),
+                    source: record.source_id.clone(),
+                })
+                .collect(),
+        )?;
 
         Ok(Self {
             data: Arc::new(SourceSnapshotData {
                 metadata,
                 contents,
                 index,
+                revision,
             }),
         })
     }
@@ -161,7 +203,22 @@ impl SourceSnapshot {
 
     /// Share ownership of the source text for `file_id`.
     pub fn shared_source_text(&self, file_id: FileId) -> Option<Arc<String>> {
-        self.content(file_id).cloned()
+        self.record(file_id).map(|record| record.text.clone())
+    }
+
+    /// Stable exact content identity for a request-local file.
+    pub fn source_id(&self, file_id: FileId) -> Option<&SourceId> {
+        self.record(file_id).map(|record| &record.source_id)
+    }
+
+    /// Canonical logical module identity for a request-local file.
+    pub fn module_id(&self, file_id: FileId) -> Option<&ModuleId> {
+        self.record(file_id).map(|record| &record.module_id)
+    }
+
+    /// Load-order-independent root and module/content mapping.
+    pub fn source_revision(&self) -> &SourceRevision {
+        &self.data.revision
     }
 
     /// Borrow one source as a compatibility [`SourceFile`] view.
@@ -178,20 +235,24 @@ impl SourceSnapshot {
     }
 
     fn content(&self, file_id: FileId) -> Option<&Arc<String>> {
-        let index = *self.data.index.get(&file_id)?;
-        let (stored_file_id, source) = &self.data.contents[index];
-        debug_assert_eq!(*stored_file_id, file_id);
-        Some(source)
+        self.record(file_id).map(|record| &record.text)
+    }
+
+    fn record(&self, file_id: FileId) -> Option<&SourceRecord> {
+        let record = &self.data.contents[*self.data.index.get(&file_id)?];
+        debug_assert_eq!(record.file_id, file_id);
+        Some(record)
     }
 
     fn file_at(&self, index: usize) -> SourceFile<'_> {
-        let (file_id, source) = &self.data.contents[index];
+        let record = &self.data.contents[index];
+        let file_id = record.file_id;
         let path = self
             .data
             .metadata
-            .physical_path(*file_id)
+            .physical_path(file_id)
             .expect("snapshot contents validated against metadata");
-        SourceFile::new(path, source.as_str(), *file_id)
+        SourceFile::new(path, record.text.as_str(), file_id)
     }
 }
 
@@ -407,6 +468,75 @@ mod tests {
     fn source_snapshots_are_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<SourceSnapshot>();
+    }
+
+    #[test]
+    fn revisions_ignore_file_ids_physical_roots_and_input_order() {
+        let make = |root_id, helper_id, physical_root: &str, reversed: bool| {
+            let physical = HashMap::from([
+                (FileId::new(root_id), physical_root.to_owned()),
+                (
+                    FileId::new(helper_id),
+                    format!("{physical_root}/../helper.rue"),
+                ),
+            ]);
+            let logical = HashMap::from([
+                (FileId::new(root_id), "app/main.rue".to_owned()),
+                (FileId::new(helper_id), "app/helper.rue".to_owned()),
+            ]);
+            let metadata = SourceMetadata::new(FileId::new(root_id), physical, logical).unwrap();
+            let mut contents = vec![
+                (FileId::new(root_id), Arc::new("fn main() {}".to_owned())),
+                (
+                    FileId::new(helper_id),
+                    Arc::new("fn helper() {}".to_owned()),
+                ),
+            ];
+            if reversed {
+                contents.reverse();
+            }
+            SourceSnapshot::new(metadata, contents).unwrap()
+        };
+        let first = make(9, 2, "/one/main.rue", false);
+        let second = make(100, 7, "/relocated/main.rue", true);
+        assert_eq!(first.source_revision(), second.source_revision());
+        assert_eq!(
+            first
+                .source_revision()
+                .modules()
+                .iter()
+                .map(|m| m.module.as_str())
+                .collect::<Vec<_>>(),
+            ["app/helper.rue", "app/main.rue"]
+        );
+    }
+
+    #[test]
+    fn edits_and_module_renames_change_only_their_respective_identities() {
+        let original = SourceSnapshot::new(
+            metadata(&[(1, "main.rue")]),
+            contents(&[(1, "fn main() {}")]),
+        )
+        .unwrap();
+        let edited = SourceSnapshot::new(
+            metadata(&[(1, "main.rue")]),
+            contents(&[(1, "fn main() { let x = 1; }")]),
+        )
+        .unwrap();
+        let renamed = SourceSnapshot::new(
+            metadata(&[(1, "renamed.rue")]),
+            contents(&[(1, "fn main() {}")]),
+        )
+        .unwrap();
+        let id = FileId::new(1);
+        assert_eq!(original.module_id(id), edited.module_id(id));
+        assert_ne!(original.source_id(id), edited.source_id(id));
+        assert_ne!(original.module_id(id), renamed.module_id(id));
+        assert_eq!(original.source_id(id), renamed.source_id(id));
+        assert!(Arc::ptr_eq(
+            &original.shared_source_text(id).unwrap(),
+            &original.source_id(id).unwrap().shared_text(),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add versioned, domain-separated `SourceId` values that retain exact shared source bytes so SHA-256 collisions cannot alias sources
- add canonical logical-path `ModuleId` while preserving `ModuleKey` as a compatibility name
- derive a deterministic `SourceRevision` from the explicit root and sorted module/content mapping
- add layered immutable semantic, codegen, and link input descriptors with stable preview-feature/optimization/linker representations
- expose additive SourceSnapshot/SourceMetadata identity accessors while retaining existing FileId/path constructors and batch APIs

## Identity contracts

`SourceId` equality is `(version, digest, exact bytes)`, ordering additionally compares exact bytes, and hashing uses `(version, digest, length)`, so equal IDs always hash equally while forced digest collisions remain distinct. Its textual form is intentionally digest-only and may collide; exact identity uses the value itself. Cloning an ID intentionally pins the same shared source buffer held by the snapshot—no duplicate source allocation is created.

`ModuleId` is the normalized logical module path, never a physical path, FileId, load index, or naked hash. Same bytes at two module paths share SourceId and retain distinct ModuleIds. Edits change SourceId; renames change ModuleId. SourceRevision rejects duplicate modules and missing roots and sorts independently of load order/FileId.

The descriptor layers separate source/parse identity from resolution+target+features, optimization, and linker inputs. Derived imports are deliberately deferred to RUE-702; this PR adds no cache, invalidation engine, parse-reuse claim, or public API removal.

## Performance evidence

Standard harness: `scripts/perf-baseline.py --iterations 3 --warmup 1 --jobs 1 --format json`, isolated parent/child workspaces.

Across the 10-workload corpus, median deltas were:

- compile/root: -0.73%
- process: -0.96%
- peak RSS: +0.41%

One noisy workload (`many_functions`) measured +1.49% root / +1.72% process while several larger workloads improved. This does not demonstrate either a regression or a speedup at n=3. SHA-256 adds required O(source bytes) work during SourceSnapshot construction, before the harness compile-root span; it is folded into process/driver overhead and cannot be isolated by the current phase timing. The process results show no measurable corpus-wide slowdown, not that hashing is free.

## Validation

- frozen v1 framing vector
- forced digest collision, exact-byte isolation, distinct-allocation equality/hash/order, and exact Arc-sharing tests
- edit/rename/relocation/load-order/root/duplicate-module/missing-root identity tests
- deterministic preview-feature and descriptor construction tests
- `./fmt.sh check`
- `./clippy.sh` — 41 first-party targets passed
- `./buck2 test //... //:reproducible-programs` — 34 targets passed, zero failures

Linear: RUE-701