### PR TITLE
RUE-696: fold cross-module zero-arg -> type calls; RUE-671: std.bitset

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2687,7 +2687,30 @@ impl<'a> Sema<'a> {
                 });
                 return Ok(AnalysisResult::new(nop_ref, Type::UNIT));
             }
-            // If it's not a TypeConst, fall through to error (can't store types at runtime)
+            // The analysis path didn't fold this init to a `TypeConst`. One case
+            // is a cross-module zero-arg `-> type` call — `let L = m.Foo()` —
+            // which method-call analysis leaves as a runtime call even though HM
+            // typed it `COMPTIME_TYPE` (RUE-696; a call WITH a type argument, or
+            // a same-file call, already folds via analyze_call). Re-evaluate the
+            // init expression at comptime; if it reduces to a type value, bind it
+            // like the `TypeConst` case above. The reduction is idempotent
+            // (structural dedup), and `for_analysis` supplies the defining file
+            // so a module-qualified `-> type` member resolves.
+            let folded = {
+                let mut env = super::comptime_eval::ComptimeEnv::for_analysis(ctx);
+                self.eval_const_expr(init, &mut env)
+            };
+            if let Ok(Some(ConstValue::Type(ty))) = folded {
+                ctx.bind_comptime_type_var(name, ty);
+                let nop_ref = air.add_inst(AirInst {
+                    data: AirInstData::UnitConst,
+                    ty: Type::UNIT,
+                    span,
+                });
+                return Ok(AnalysisResult::new(nop_ref, Type::UNIT));
+            }
+
+            // Otherwise it genuinely can't be stored at runtime.
             let name_str = self.interner.resolve(&name);
             return Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {

--- a/crates/rue-cli-tests/cases/std_bitset.toml
+++ b/crates/rue-cli-tests/cases/std_bitset.toml
@@ -1,0 +1,65 @@
+# std.collections.BitSet (RUE-671) + the compiler fix that unblocked it
+# (RUE-696: a cross-module zero-argument `-> type` constructor call is now
+# comptime-folded instead of failing E1200). BitSet is a NON-generic std type
+# expressed as `pub fn BitSet() -> type`, which is exactly the zero-arg pattern.
+
+[section]
+id = "cli.std_bitset"
+name = "Standard library v1 — BitSet (RUE-671 / RUE-696)"
+description = "A dense bit set over ArrayBuf(u64), via a cross-module zero-arg `-> type` constructor."
+
+[[case]]
+name = "bitset_set_test_count_clear_toggle"
+description = "BitSet set/test/count/clear/toggle across word boundaries (bits 5, 70, 200) -> exit 42."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let B = std.bitset.BitSet();
+    let mut bs = B.new();
+    let mut score: i64 = 0;
+    bs.set(5); bs.set(70); bs.set(200); bs.set(5);
+    if bs.test(5) { score = score + 1; }
+    if bs.test(70) { score = score + 1; }
+    if bs.test(200) { score = score + 1; }
+    if !bs.test(6) { score = score + 1; }
+    if bs.count() == 3 { score = score + 1; }
+    bs.clear(70);
+    if !bs.test(70) { score = score + 1; }
+    if bs.count() == 2 { score = score + 1; }
+    bs.toggle(5);
+    if !bs.test(5) { score = score + 1; }
+    if score == 8 { 42 } else { @intCast(score) }
+}
+""" }]
+
+# RUE-696 direct regression: a cross-module zero-arg `-> type` constructor bound
+# with `let` used to fail E1200 ("cannot store type value ... at runtime"); a
+# same-file call, or a call with a type argument, always worked.
+[[case]]
+name = "cross_module_zero_arg_type_constructor"
+description = "let W = lib.Widget() where Widget() is a zero-arg `-> type` fn in another module compiles and runs (RUE-696)."
+args = ["main.rue", "-o", "prog"]
+exit_code = 7
+files = [
+  { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let W = lib.Widget();
+    let w = W.new();
+    @intCast(w.get())
+}
+""" },
+  { path = "lib.rue", source = """
+pub fn Widget() -> type {
+    struct {
+        n: i64,
+        fn new() -> Self { Self { n: 7 } }
+        fn get(borrow self) -> i64 { self.n }
+    }
+}
+""" },
+]

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -29,6 +29,7 @@ pub const queue = @import("queue.rue");
 pub const grid = @import("grid.rue");
 pub const binary_heap = @import("binary_heap.rue");
 pub const intmap = @import("intmap.rue");
+pub const bitset = @import("bitset.rue");
 
 // Algorithms & text (Standard library v1, M3).
 pub const ascii = @import("ascii.rue");

--- a/std/bitset.rue
+++ b/std/bitset.rue
@@ -1,0 +1,88 @@
+// std.collections — BitSet: a dense growable set of bit indices over
+// ArrayBuf(u64). A non-generic collection: `BitSet()` is a zero-argument
+// `-> type` constructor (usable cross-module since RUE-696).
+//
+//     const std = @import("std");
+//     let B = std.bitset.BitSet();
+//     let mut bs = B.new();
+//     bs.set(5);
+//     bs.test(5);      // true
+//     bs.count();      // 1
+
+const arraybuf = @import("arraybuf.rue");
+
+fn all_ones() -> u64 {
+    18446744073709551615
+}
+
+pub fn BitSet() -> type {
+    struct {
+        words: arraybuf.ArrayBuf(u64),
+
+        fn new() -> Self {
+            let w = arraybuf.ArrayBuf(u64);
+            Self { words: w.new() }
+        }
+
+        // Grow the backing store so word `word_idx` exists.
+        fn _ensure(inout self, word_idx: u64) {
+            while self.words.len() <= word_idx {
+                self.words.push(0);
+            }
+        }
+
+        // Add index `i` to the set.
+        fn set(inout self, i: u64) {
+            let wi = i >> 6;
+            self._ensure(wi);
+            let bit: u64 = 1 << (i & 63);
+            let cur = self.words.get_or(wi, 0);
+            self.words.set(wi, cur | bit);
+        }
+
+        // Remove index `i` from the set.
+        fn clear(inout self, i: u64) {
+            let wi = i >> 6;
+            if wi < self.words.len() {
+                let bit: u64 = 1 << (i & 63);
+                let cur = self.words.get_or(wi, 0);
+                self.words.set(wi, cur & (all_ones() ^ bit));
+            }
+        }
+
+        // Flip index `i`.
+        fn toggle(inout self, i: u64) {
+            let wi = i >> 6;
+            self._ensure(wi);
+            let bit: u64 = 1 << (i & 63);
+            let cur = self.words.get_or(wi, 0);
+            self.words.set(wi, cur ^ bit);
+        }
+
+        // Whether index `i` is in the set.
+        fn test(borrow self, i: u64) -> bool {
+            let wi = i >> 6;
+            if wi >= self.words.len() {
+                false
+            } else {
+                let bit: u64 = 1 << (i & 63);
+                (self.words.get_or(wi, 0) & bit) != 0
+            }
+        }
+
+        // Number of indices in the set (popcount over the words).
+        fn count(borrow self) -> u64 {
+            let mut total: u64 = 0;
+            let mut w: u64 = 0;
+            while w < self.words.len() {
+                let mut v = self.words.get_or(w, 0);
+                while v != 0 {
+                    total = total + (v & 1);
+                    v = v >> 1;
+                }
+                w = w + 1;
+            }
+            total
+        }
+    }
+}


### PR DESCRIPTION
A cross-module zero-argument `-> type` constructor bound with `let` (`let L = m.Foo()`) failed with **E1200** ("cannot store type value ... at runtime"), even though a same-file call or a call *with* a type argument folds fine. HM typed the init `COMPTIME_TYPE`, but method-call analysis left it a runtime call, so the `let` saw a non-`TypeConst` init and errored.

**Fix** (`analyze_alloc`, the `COMPTIME_TYPE` let path): when the init isn't already a `TypeConst`, re-evaluate the init RIR with `eval_const_expr` under a `for_analysis` env (which supplies the defining file so a module-qualified member resolves); if it reduces to `ConstValue::Type`, bind it as a comptime type var. Idempotent.

**RUE-671**: with that unblocked, add **std.bitset.BitSet()** — a dense growable bit set over `ArrayBuf(u64)` (`set/clear/test/toggle/count`), the first non-generic source-level std collection (a zero-arg `-> type` constructor, exactly the pattern the fix enables).

Tests: `std_bitset.toml` (BitSet end-to-end + a direct zero-arg-type-fn regression). Full `./test.sh` green.

RUE-696 part 2 (top-level struct with a module-alias *field* type still E0204 cross-module) is split to a separate low-priority follow-up — BitSet uses the working `-> type` form.

Fixes RUE-696
Fixes RUE-671

🤖 Generated with [Claude Code](https://claude.com/claude-code)