### PR TITLE
RUE-669: std.deque — Copy-T growable double-ended ring buffer

### DIFF
--- a/crates/rue-cli-tests/cases/std_deque.toml
+++ b/crates/rue-cli-tests/cases/std_deque.toml
@@ -1,0 +1,45 @@
+# std.collections.Deque(T) (RUE-669) — a growable double-ended ring buffer.
+# Copy-element only (RUE-651); `new(filler)` seeds unused slots.
+
+[section]
+id = "cli.std_deque"
+name = "Standard library v1 — Deque"
+description = "Double-ended queue over a growable ring buffer, through @import(\"std\")."
+
+[[case]]
+name = "deque_both_ends_grow_drain"
+description = "push_back/push_front across a grow, front/back/pop_front/pop_back, then drain -> exit 42."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let D = std.deque.Deque(i64);
+    let OI = std.option.Option(i64);
+    let mut d = D.new(0);
+    let mut score: i64 = 0;
+
+    let mut k: i64 = 0;
+    while k < 10 { d.push_back(k); k = k + 1; }   // forces a grow past cap 8
+    d.push_front(100);
+    d.push_front(200);
+    if d.len() == 12 { score = score + 1; }
+    match d.front() { OI.Some(v) => { if v == 200 { score = score + 1; } }, OI.None => {} }
+    match d.back() { OI.Some(v) => { if v == 9 { score = score + 1; } }, OI.None => {} }
+    match d.pop_front() { OI.Some(v) => { if v == 200 { score = score + 1; } }, OI.None => {} }
+    match d.pop_back() { OI.Some(v) => { if v == 9 { score = score + 1; } }, OI.None => {} }
+    if d.len() == 10 { score = score + 1; }
+
+    let mut sum: i64 = 0;
+    let mut done = false;
+    while !done {
+        match d.pop_front() { OI.Some(v) => { sum = sum + v; }, OI.None => { done = true; } }
+    }
+    if sum == 136 { score = score + 1; }
+    if d.is_empty() { score = score + 1; }
+
+    if score == 8 { 42 } else { @intCast(score) }
+}
+""" }]

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -26,6 +26,7 @@ pub const arraybuf = @import("arraybuf.rue");
 // Collections (Standard library v1, M2).
 pub const stack = @import("stack.rue");
 pub const queue = @import("queue.rue");
+pub const deque = @import("deque.rue");
 pub const grid = @import("grid.rue");
 pub const binary_heap = @import("binary_heap.rue");
 pub const intmap = @import("intmap.rue");

--- a/std/deque.rue
+++ b/std/deque.rue
@@ -1,0 +1,133 @@
+// std.collections — Deque(T): a growable double-ended queue over a ring buffer.
+//
+// Elements are read by copy (get_or), so `T` must be trivially-droppable
+// (`Copy`) — RUE-651. `new(filler)` takes a throwaway `T` used to initialise the
+// unused ring slots (Rue has no generic zero-init, same convention as IntMap);
+// it is never read as a live value (the `count` guards that).
+//
+//     const std = @import("std");
+//     let D = std.deque.Deque(i64);
+//     let mut d = D.new(0);
+//     d.push_back(2);
+//     d.push_front(1);
+//     d.pop_front();     // Some(1)
+//     d.pop_back();      // Some(2)
+
+const arraybuf = @import("arraybuf.rue");
+const option = @import("option.rue");
+
+pub fn Deque(comptime T: type) -> type {
+    struct {
+        buf: arraybuf.ArrayBuf(T),
+        head: u64,
+        count: u64,
+        cap: u64,
+        filler: T,
+
+        fn new(filler: T) -> Self {
+            let b = arraybuf.ArrayBuf(T);
+            let mut d = Self {
+                buf: b.new(),
+                head: 0,
+                count: 0,
+                cap: 0,
+                filler: filler,
+            };
+            d._grow_to(8);
+            d
+        }
+
+        fn len(borrow self) -> u64 {
+            self.count
+        }
+        fn is_empty(borrow self) -> bool {
+            self.count == 0
+        }
+
+        // Re-lay the live elements contiguously into a fresh `new_cap`-slot ring
+        // (front at index 0), padding the rest with `filler`.
+        fn _grow_to(inout self, new_cap: u64) {
+            let b = arraybuf.ArrayBuf(T);
+            let mut nb = b.new();
+            let mut i: u64 = 0;
+            while i < self.count {
+                // `cap > 0` here whenever `count > 0`, so no divide-by-zero.
+                let idx = (self.head + i) % self.cap;
+                nb.push(self.buf.get_or(idx, self.filler));
+                i = i + 1;
+            }
+            while nb.len() < new_cap {
+                nb.push(self.filler);
+            }
+            self.buf = nb;
+            self.head = 0;
+            self.cap = new_cap;
+        }
+
+        fn _ensure_room(inout self) {
+            if self.count == self.cap {
+                self._grow_to(self.cap * 2);
+            }
+        }
+
+        // Append `x` at the back.
+        fn push_back(inout self, x: T) {
+            self._ensure_room();
+            let idx = (self.head + self.count) % self.cap;
+            self.buf.set(idx, x);
+            self.count = self.count + 1;
+        }
+
+        // Prepend `x` at the front.
+        fn push_front(inout self, x: T) {
+            self._ensure_room();
+            self.head = (self.head + self.cap - 1) % self.cap;
+            self.buf.set(self.head, x);
+            self.count = self.count + 1;
+        }
+
+        // Remove and return the front element, or `None` when empty.
+        fn pop_front(inout self) -> option.Option(T) {
+            let O = option.Option(T);
+            if self.count == 0 {
+                O.None
+            } else {
+                let v = self.buf.get_or(self.head, self.filler);
+                self.head = (self.head + 1) % self.cap;
+                self.count = self.count - 1;
+                O.Some(v)
+            }
+        }
+
+        // Remove and return the back element, or `None` when empty.
+        fn pop_back(inout self) -> option.Option(T) {
+            let O = option.Option(T);
+            if self.count == 0 {
+                O.None
+            } else {
+                self.count = self.count - 1;
+                let idx = (self.head + self.count) % self.cap;
+                O.Some(self.buf.get_or(idx, self.filler))
+            }
+        }
+
+        // The front / back element by copy, or `None` when empty. COPY-`T`.
+        fn front(borrow self) -> option.Option(T) {
+            let O = option.Option(T);
+            if self.count == 0 {
+                O.None
+            } else {
+                O.Some(self.buf.get_or(self.head, self.filler))
+            }
+        }
+        fn back(borrow self) -> option.Option(T) {
+            let O = option.Option(T);
+            if self.count == 0 {
+                O.None
+            } else {
+                let idx = (self.head + self.count - 1) % self.cap;
+                O.Some(self.buf.get_or(idx, self.filler))
+            }
+        }
+    }
+}


### PR DESCRIPTION
A `Deque(T)` over a growable ring buffer: `push_back`/`push_front`/`pop_front`/`pop_back`/`front`/`back`/`len`/`is_empty`. Copy-element only (RUE-651; reads via `get_or`). `new(filler)` seeds unused ring slots (no generic zero-init — same convention as `IntMap`). Grow-and-relinearize doubles capacity and lays live elements out contiguously (front at 0).

Drains RUE-669 with the buildable-now Copy-T version — the originally-noted RUE-662 block only applies to a *move-out* (non-Copy) deque; a Copy-element ring needs no in-place element borrows.

CLI test `std_deque.toml` (both ends across a grow, then full drain → exit 42). Full `./test.sh` green.

Fixes RUE-669

🤖 Generated with [Claude Code](https://claude.com/claude-code)