### PR TITLE
RUE-645: clean stack-overflow abort via a SIGSEGV guard handler

### DIFF
--- a/crates/rue-cli-tests/cases/stack_overflow.toml
+++ b/crates/rue-cli-tests/cases/stack_overflow.toml
@@ -1,0 +1,52 @@
+# Stack overflow aborts cleanly (RUE-645).
+#
+# Deep/unbounded recursion exhausts the main stack; the next push faults on the
+# kernel guard page and raises SIGSEGV. Before this fix there was no handler, so
+# the default disposition killed the process and the program "died by signal"
+# (the shell reports exit 139 = 128 + SIGSEGV) — an ugly crash, not a diagnosable
+# abort.
+#
+# The runtime now installs, in `_start`, an alternate signal stack (`sigaltstack`)
+# plus a SIGSEGV handler (`rt_sigaction`, `SA_ONSTACK`) that runs on that alt
+# stack even though the main stack is exhausted. The handler writes
+# "stack overflow" to stderr and exits 101 — the same clean-abort code the other
+# runtime traps use (division by zero, overflow, bounds, @panic). This matches
+# how Rust and Go report a blown stack. Any SIGSEGV from safe Rue is treated as a
+# stack overflow: safe Rue has no other way to segfault (bounds-checked, no null
+# derefs, arithmetic traps). See crates/rue-runtime/src/entry.rs.
+#
+# Platform scope (`only_on` the two Linux targets): the handler is implemented
+# for x86-64 Linux and aarch64 Linux. macOS is a documented TODO — Darwin's
+# `sigaction(2)` requires a caller-supplied signal trampoline that cannot be
+# verified on a Linux host, so its `install_stack_overflow_handler` is a no-op
+# there (a macOS stack overflow still exits 139). We use `only_on` rather than
+# `known_bug_on = ["aarch64-macos"]` because a program that dies by signal is a
+# FATAL failure the harness cannot mask with a known_bug marker, so the case is
+# simply not run on macOS. See the macOS stub in
+# crates/rue-runtime/src/aarch64_macos.rs.
+
+[section]
+id = "cli.stack_overflow"
+name = "Stack overflow clean abort"
+description = "Deep recursion aborts with 'stack overflow' + exit 101, not a raw SIGSEGV (exit 139) (RUE-645)."
+
+# Unbounded-depth recursion (10 million frames, far past any reasonable stack)
+# blows the stack and must abort cleanly: "stack overflow" on stderr, exit 101,
+# no stdout. `1 + depth(n - 1)` is not a tail call, so every level is a real
+# frame that consumes stack.
+[[case]]
+name = "deep_recursion_aborts_cleanly"
+description = "depth(10_000_000) overflows the stack and aborts with 'stack overflow' + exit 101 (not SIGSEGV/139)."
+only_on = ["x86-64-linux", "aarch64-linux"]
+files = [{ path = "prog.rue", source = """
+fn depth(n: i64) -> i64 { if n == 0 { 0 } else { 1 + depth(n - 1) } }
+fn main() -> i32 { @dbg(depth(10000000)); 0 }
+""" }]
+stdout = ""
+exit_code = 101
+runtime_error_contains = ["stack overflow"]
+
+# (The "handler doesn't disturb ordinary recursion / normal programs" control is
+# the rest of the suite: every CLI and spec case runs on this handler-installed
+# runtime. A dedicated shallow-recursion control is omitted because its depth
+# exceeds the in-process oracle's recursion budget, making it oracle-ineligible.)

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -880,6 +880,18 @@ fn check_case(path: &Path, case: &Case) -> CaseOutcome {
     if !case.env.is_empty() {
         return CaseOutcome::Ineligible(IneligibleReason::CompilerEnvironment);
     }
+    // A stack-overflow trap (deep/unbounded recursion) is structurally
+    // un-modelable: reproducing it means actually exhausting the machine stack,
+    // which the in-process interpreter cannot do — its own recursion budget
+    // aborts first with a ResourceLimit. So a case expecting this trap is an
+    // oracle gap, not a case the harness can judge (RUE-645).
+    if case
+        .runtime_error_contains
+        .iter()
+        .any(|fragment| fragment == "stack overflow")
+    {
+        return CaseOutcome::Ineligible(IneligibleReason::KnownOracleGap);
+    }
     // `source_path` names a repository input that the oracle-diff Buck target
     // does not own; do not silently substitute an inline file.
     if case.source_path.is_some() {

--- a/crates/rue-runtime/src/aarch64_linux.rs
+++ b/crates/rue-runtime/src/aarch64_linux.rs
@@ -366,6 +366,129 @@ pub fn munmap(addr: *mut u8, size: usize) -> i64 {
     result
 }
 
+// ============================================================================
+// Stack-overflow trapping (RUE-645)
+// ============================================================================
+//
+// A stack overflow faults on the guard page and raises SIGSEGV. With no handler
+// the kernel kills the process (exit 139). To abort cleanly we register a small
+// alternate signal stack and a SIGSEGV handler that runs on it (SA_ONSTACK),
+// prints "stack overflow", and exits 101. See `entry::__rue_stack_overflow_handler`
+// for why any SIGSEGV from safe Rue is treated as a stack overflow.
+//
+// Unlike x86-64, aarch64 Linux needs no user-supplied signal-return trampoline:
+// the kernel installs the sigreturn trampoline from the vDSO automatically when
+// `SA_RESTORER` is absent, so we leave `sa_restorer` null. (Our handler exits
+// and never returns, so it is never reached regardless.)
+
+/// Linux aarch64 syscall number for rt_sigaction (from asm-generic/unistd.h).
+const SYS_RT_SIGACTION: u64 = 134;
+
+/// Linux aarch64 syscall number for sigaltstack (from asm-generic/unistd.h).
+const SYS_SIGALTSTACK: u64 = 132;
+
+/// `SIGSEGV` signal number on Linux.
+const SIGSEGV: u64 = 11;
+
+/// `SA_ONSTACK`: run the handler on the alternate signal stack.
+const SA_ONSTACK: u64 = 0x0800_0000;
+
+/// Kernel `struct sigaction` layout on aarch64 Linux (asm-generic ABI): handler,
+/// flags, restorer, then mask last.
+#[repr(C)]
+struct KernelSigaction {
+    sa_handler: usize,
+    sa_flags: u64,
+    sa_restorer: usize,
+    sa_mask: u64,
+}
+
+/// `stack_t` layout for `sigaltstack` on aarch64 Linux.
+#[repr(C)]
+struct StackT {
+    ss_sp: *mut u8,
+    ss_flags: i32,
+    ss_size: usize,
+}
+
+/// Register the alternate signal stack with `sigaltstack(2)`.
+///
+/// Returns 0 on success or a negative errno on failure.
+///
+/// # Safety
+///
+/// `ss` must point to a valid `StackT` describing a live, writable region.
+unsafe fn sigaltstack(ss: *const StackT) -> i64 {
+    let result: i64;
+    // SAFETY: sigaltstack(ss, oldss=NULL); the kernel validates the pointer.
+    unsafe {
+        asm!(
+            "svc #0",
+            in("x8") SYS_SIGALTSTACK,
+            inlateout("x0") ss => result,
+            in("x1") 0u64, // oldss = NULL
+        );
+    }
+    result
+}
+
+/// Install a signal handler with `rt_sigaction(2)`.
+///
+/// Returns 0 on success or a negative errno on failure.
+///
+/// # Safety
+///
+/// `act` must point to a valid `KernelSigaction`.
+unsafe fn rt_sigaction(sig: u64, act: *const KernelSigaction) -> i64 {
+    let result: i64;
+    // SAFETY: rt_sigaction(sig, act, oldact=NULL, sigsetsize=8).
+    unsafe {
+        asm!(
+            "svc #0",
+            in("x8") SYS_RT_SIGACTION,
+            inlateout("x0") sig => result,
+            in("x1") act,
+            in("x2") 0u64, // oldact = NULL
+            in("x3") 8u64, // sigsetsize
+        );
+    }
+    result
+}
+
+/// Install the stack-overflow SIGSEGV handler (see module comment above).
+///
+/// Best-effort: if the alt stack cannot be mapped or a syscall fails, we return
+/// without installing anything and keep the default SIGSEGV disposition.
+pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
+    /// Size of the alternate signal stack (16 KiB).
+    const ALT_STACK_SIZE: usize = 16 * 1024;
+
+    let stack = mmap(ALT_STACK_SIZE);
+    if stack.is_null() {
+        return;
+    }
+
+    let ss = StackT {
+        ss_sp: stack,
+        ss_flags: 0,
+        ss_size: ALT_STACK_SIZE,
+    };
+    // SAFETY: `ss` describes the region just mmap'd, mapped for the rest of the
+    // process lifetime.
+    if unsafe { sigaltstack(&ss) } < 0 {
+        return;
+    }
+
+    let act = KernelSigaction {
+        sa_handler: handler as usize,
+        sa_flags: SA_ONSTACK,
+        sa_restorer: 0,
+        sa_mask: 0,
+    };
+    // SAFETY: `act` is a valid KernelSigaction; SIGSEGV is a valid signal.
+    let _ = unsafe { rt_sigaction(SIGSEGV, &act) };
+}
+
 /// Exit the process with the given status code.
 ///
 /// This performs a direct syscall to `exit(2)` and never returns.
@@ -526,5 +649,16 @@ mod tests {
         // Zero-size mmap should fail (returns EINVAL on Linux)
         let ptr = mmap(0);
         assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn stack_overflow_handler_is_installable() {
+        // Reference the installer (and, transitively, its `sigaltstack` /
+        // `rt_sigaction` wrappers and structs) so the RUE-645 stack-overflow
+        // trap machinery is type-checked by the unit-test build. We only take
+        // its address: calling it would install a process-wide SIGSEGV handler,
+        // which must not happen inside the test harness.
+        let installer: fn(extern "C" fn(i32) -> !) = install_stack_overflow_handler;
+        assert!(installer as usize != 0);
     }
 }

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -402,6 +402,40 @@ pub fn munmap(addr: *mut u8, size: usize) -> i64 {
     if err_flag != 0 { -result } else { result }
 }
 
+/// Install the stack-overflow SIGSEGV handler.
+///
+/// # TODO(RUE-645): not yet implemented on macOS
+///
+/// On Linux this maps an alternate signal stack (`sigaltstack`) and installs a
+/// `SIGSEGV` handler (`rt_sigaction`) with `SA_ONSTACK`, turning a stack
+/// overflow into a clean "stack overflow" abort (exit 101) instead of a raw
+/// SIGSEGV (exit 139).
+///
+/// Darwin's signal ABI is materially more divergent and cannot be verified on
+/// this (x86-64 Linux) host, so it is intentionally left as a no-op for now:
+///
+/// - The BSD `sigaction(2)` syscall (SYS_sigaction = 46) takes a
+///   `struct __sigaction` that, unlike Linux, includes a **caller-supplied
+///   signal trampoline** (`sa_tramp`). macOS provides no kernel/vDSO
+///   trampoline; libc passes its own `_sigtramp`, which saves/restores the
+///   full register + FP/SIMD state and finally issues the `sigreturn` syscall.
+///   A freestanding runtime would have to hand-write and correctly align that
+///   trampoline in assembly.
+/// - The `struct __sigaction` / `stack_t` layouts and flag values differ from
+///   Linux and would need separate, untestable-locally verification.
+///
+/// Getting the trampoline subtly wrong re-crashes inside signal delivery, so
+/// shipping it unverified is worse than leaving it off. Until it can be
+/// implemented and exercised on real Apple Silicon (CI `test (macos)`), a stack
+/// overflow on macOS keeps the default SIGSEGV disposition (exit 139). The CLI
+/// regression test is marked `known_bug_on = ["aarch64-macos"]` to track this.
+///
+/// The `_handler` argument matches the Linux signature so `entry::_main` can
+/// call this unconditionally.
+pub fn install_stack_overflow_handler(_handler: extern "C" fn(i32) -> !) {
+    // Intentionally a no-op on macOS; see the doc comment above (RUE-645 TODO).
+}
+
 /// Exit the process with the given status code.
 ///
 /// This performs a direct syscall to `exit(2)` and never returns.
@@ -562,5 +596,15 @@ mod tests {
         // Zero-size mmap should fail (returns EINVAL on macOS)
         let ptr = mmap(0);
         assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn stack_overflow_handler_is_installable() {
+        // Reference the installer so the unit-test build type-checks it. On
+        // macOS this is currently a no-op stub (RUE-645 TODO); taking its
+        // address keeps the signature in sync with the Linux backends without
+        // executing anything.
+        let installer: fn(extern "C" fn(i32) -> !) = install_stack_overflow_handler;
+        assert!(installer as usize != 0);
     }
 }

--- a/crates/rue-runtime/src/entry.rs
+++ b/crates/rue-runtime/src/entry.rs
@@ -32,6 +32,74 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     platform::exit(101)
 }
 
+/// SIGSEGV handler installed by `_start` to turn a stack overflow into a clean
+/// abort (RUE-645).
+///
+/// # Why this exists
+///
+/// Deep/unbounded recursion exhausts the main stack; the next push faults on the
+/// kernel guard page and raises `SIGSEGV`. With no handler the default
+/// disposition kills the process, and the shell reports the raw crash (exit code
+/// 139 = 128 + SIGSEGV). Rust and Go instead catch this and print a readable
+/// "stack overflow" message before exiting non-zero. This handler does the same:
+/// it writes `"stack overflow\n"` to stderr and exits with code 101 — the same
+/// abort code the other runtime traps use (division by zero, overflow, bounds).
+///
+/// # Running on an exhausted stack
+///
+/// The handler cannot run on the main stack, which is what overflowed. `_start`
+/// registers a small alternate signal stack via `sigaltstack` and installs this
+/// handler with `SA_ONSTACK`, so the kernel switches to that alt stack to deliver
+/// the signal. See each platform's `install_stack_overflow_handler`.
+///
+/// # Treating any SIGSEGV as stack overflow
+///
+/// We do not inspect `siginfo.si_addr` to confirm the fault is near the stack
+/// pointer. In safe Rue there is no other way to reach `SIGSEGV`: array accesses
+/// are bounds-checked, there are no null/raw-pointer dereferences, and arithmetic
+/// traps rather than corrupting memory. So any `SIGSEGV` a compiled Rue program
+/// can produce is a stack overflow, and reporting it as such is correct. This
+/// keeps the handler freestanding (no `SA_SIGINFO`, no `siginfo_t` layout).
+///
+/// The signal-number argument is unused for the same reason: this handler is
+/// only ever registered for `SIGSEGV`.
+///
+/// # Never returns
+///
+/// The handler calls `platform::exit` and does not return. Because it never
+/// returns, the kernel's signal-return trampoline is never executed, so no
+/// `sa_restorer` needs to be supplied on Linux.
+#[cfg(all(
+    not(test),
+    any(
+        all(target_arch = "x86_64", target_os = "linux"),
+        all(target_arch = "aarch64", target_os = "macos"),
+        all(target_arch = "aarch64", target_os = "linux")
+    )
+))]
+pub(crate) extern "C" fn __rue_stack_overflow_handler(_sig: i32) -> ! {
+    // "stack overflow\n" built byte-by-byte to avoid the macOS byte-string
+    // linker bug (mirrors the message handlers in `error.rs`).
+    let mut msg = [0u8; 15];
+    msg[0] = b's';
+    msg[1] = b't';
+    msg[2] = b'a';
+    msg[3] = b'c';
+    msg[4] = b'k';
+    msg[5] = b' ';
+    msg[6] = b'o';
+    msg[7] = b'v';
+    msg[8] = b'e';
+    msg[9] = b'r';
+    msg[10] = b'f';
+    msg[11] = b'l';
+    msg[12] = b'o';
+    msg[13] = b'w';
+    msg[14] = b'\n';
+    platform::write_stderr(&msg);
+    platform::exit(101)
+}
+
 /// Program entry point for Linux x86-64.
 ///
 /// The Linux kernel starts execution here with RSP 16-byte aligned.
@@ -61,6 +129,12 @@ pub unsafe extern "C" fn _start() -> ! {
     unsafe extern "C" {
         fn main() -> i32;
     }
+
+    // Install the stack-overflow SIGSEGV handler before running user code so a
+    // deep-recursion overflow aborts cleanly (RUE-645) instead of dying with a
+    // raw SIGSEGV (exit 139). Best-effort: if setup fails the program simply
+    // keeps the default SIGSEGV disposition.
+    platform::install_stack_overflow_handler(__rue_stack_overflow_handler);
 
     let exit_code: i32;
     // SAFETY: This is the program entry point called by the kernel.
@@ -108,6 +182,10 @@ pub unsafe extern "C" fn _main() -> ! {
         fn main() -> i32;
     }
 
+    // Install the stack-overflow SIGSEGV handler before running user code.
+    // (Currently a no-op on macOS — see the platform stub for why. RUE-645.)
+    platform::install_stack_overflow_handler(__rue_stack_overflow_handler);
+
     let exit_code: i32;
     // SAFETY: This is the program entry point called by the kernel.
     // - The kernel starts execution with SP 16-byte aligned
@@ -142,6 +220,12 @@ pub unsafe extern "C" fn _start() -> ! {
     unsafe extern "C" {
         fn main() -> i32;
     }
+
+    // Install the stack-overflow SIGSEGV handler before running user code so a
+    // deep-recursion overflow aborts cleanly (RUE-645) instead of dying with a
+    // raw SIGSEGV (exit 139). Best-effort: if setup fails the program simply
+    // keeps the default SIGSEGV disposition.
+    platform::install_stack_overflow_handler(__rue_stack_overflow_handler);
 
     let exit_code: i32;
     // SAFETY: This is the program entry point called by the kernel.

--- a/crates/rue-runtime/src/x86_64_linux.rs
+++ b/crates/rue-runtime/src/x86_64_linux.rs
@@ -423,6 +423,171 @@ pub fn munmap(addr: *mut u8, size: usize) -> i64 {
     result
 }
 
+// ============================================================================
+// Stack-overflow trapping (RUE-645)
+// ============================================================================
+//
+// A stack overflow faults on the guard page and raises SIGSEGV. With no handler
+// the kernel kills the process (exit 139). To abort cleanly we register a small
+// alternate signal stack and a SIGSEGV handler that runs on it (SA_ONSTACK),
+// prints "stack overflow", and exits 101. See `entry::__rue_stack_overflow_handler`
+// for why any SIGSEGV from safe Rue is treated as a stack overflow.
+
+/// Linux x86-64 syscall number for rt_sigaction (see `man 2 rt_sigaction`).
+const SYS_RT_SIGACTION: i64 = 13;
+
+/// Linux x86-64 syscall number for sigaltstack (see `man 2 sigaltstack`).
+const SYS_SIGALTSTACK: i64 = 131;
+
+/// `SIGSEGV` signal number on Linux.
+const SIGSEGV: i32 = 11;
+
+/// `SA_ONSTACK`: run the handler on the alternate signal stack.
+const SA_ONSTACK: u64 = 0x0800_0000;
+
+/// `SA_RESTORER`: the `sa_restorer` field is valid and should be used as the
+/// signal-return trampoline.
+const SA_RESTORER: u64 = 0x0400_0000;
+
+/// Linux x86-64 syscall number for rt_sigreturn.
+const SYS_RT_SIGRETURN: u64 = 15;
+
+// On x86-64 Linux the kernel provides no signal-return trampoline: the raw
+// `rt_sigaction` syscall requires userspace to supply one via `sa_restorer` +
+// `SA_RESTORER`, and *signal delivery itself fails* (a second, SI_KERNEL
+// SIGSEGV that force-kills the process) if it is missing — even when the
+// handler never returns. glibc hides this by always installing its own
+// trampoline; a freestanding runtime must define its own. This one simply
+// issues the `rt_sigreturn` syscall. Our handler exits and never returns, so
+// this is never actually executed, but it must be present and valid for the
+// kernel to accept and deliver the signal.
+core::arch::global_asm!(
+    ".globl __rue_rt_sigreturn",
+    ".hidden __rue_rt_sigreturn",
+    "__rue_rt_sigreturn:",
+    "mov rax, {sysno}",
+    "syscall",
+    sysno = const SYS_RT_SIGRETURN,
+);
+
+unsafe extern "C" {
+    /// Signal-return trampoline defined in `global_asm!` above. Address only —
+    /// never called directly from Rust.
+    fn __rue_rt_sigreturn();
+}
+
+/// Kernel `struct sigaction` layout on x86-64 Linux (the ABI `rt_sigaction`
+/// expects). Field order differs from the userspace/POSIX struct: on x86-64 the
+/// mask comes last. `sa_restorer` must point at a valid signal-return
+/// trampoline (see `__rue_rt_sigreturn`) or the kernel refuses to deliver.
+#[repr(C)]
+struct KernelSigaction {
+    sa_handler: usize,
+    sa_flags: u64,
+    sa_restorer: usize,
+    sa_mask: u64,
+}
+
+/// `stack_t` layout for `sigaltstack` on x86-64 Linux.
+#[repr(C)]
+struct StackT {
+    ss_sp: *mut u8,
+    ss_flags: i32,
+    ss_size: usize,
+}
+
+/// Register the alternate signal stack with `sigaltstack(2)`.
+///
+/// Returns 0 on success or a negative errno on failure.
+///
+/// # Safety
+///
+/// `ss` must point to a valid `StackT` whose `ss_sp`/`ss_size` describe a live,
+/// writable memory region for the lifetime of the alt stack.
+unsafe fn sigaltstack(ss: *const StackT) -> i64 {
+    let result: i64;
+    // SAFETY: sigaltstack takes a pointer to a stack_t and an optional old
+    // stack_t (NULL here); the kernel validates the pointer. rcx/r11 are
+    // clobbered per the syscall ABI.
+    unsafe {
+        asm!(
+            "syscall",
+            in("rax") SYS_SIGALTSTACK,
+            in("rdi") ss,
+            in("rsi") 0i64, // oldss = NULL
+            lateout("rax") result,
+            out("rcx") _,
+            out("r11") _,
+        );
+    }
+    result
+}
+
+/// Install a signal handler with `rt_sigaction(2)`.
+///
+/// Returns 0 on success or a negative errno on failure.
+///
+/// # Safety
+///
+/// `act` must point to a valid `KernelSigaction`; `sig` must be a valid signal.
+unsafe fn rt_sigaction(sig: i32, act: *const KernelSigaction) -> i64 {
+    let result: i64;
+    // SAFETY: rt_sigaction(sig, act, oldact, sigsetsize). oldact is NULL and
+    // sigsetsize is 8 (bytes in the kernel sigset_t on x86-64). rcx/r11 are
+    // clobbered per the syscall ABI.
+    unsafe {
+        asm!(
+            "syscall",
+            in("rax") SYS_RT_SIGACTION,
+            in("rdi") sig as i64,
+            in("rsi") act,
+            in("rdx") 0i64, // oldact = NULL
+            in("r10") 8i64, // sigsetsize
+            lateout("rax") result,
+            out("rcx") _,
+            out("r11") _,
+        );
+    }
+    result
+}
+
+/// Install the stack-overflow SIGSEGV handler (see module comment above).
+///
+/// Best-effort: if the alt stack cannot be mapped or a syscall fails, we return
+/// without installing anything and the process keeps the default SIGSEGV
+/// disposition.
+///
+/// `handler` never returns, so no `sa_restorer` is supplied.
+pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
+    /// Size of the alternate signal stack (16 KiB — ample for the tiny handler).
+    const ALT_STACK_SIZE: usize = 16 * 1024;
+
+    let stack = mmap(ALT_STACK_SIZE);
+    if stack.is_null() {
+        return;
+    }
+
+    let ss = StackT {
+        ss_sp: stack,
+        ss_flags: 0,
+        ss_size: ALT_STACK_SIZE,
+    };
+    // SAFETY: `ss` describes the region just mmap'd, which stays mapped for the
+    // remaining life of the process.
+    if unsafe { sigaltstack(&ss) } < 0 {
+        return;
+    }
+
+    let act = KernelSigaction {
+        sa_handler: handler as usize,
+        sa_flags: SA_ONSTACK | SA_RESTORER,
+        sa_restorer: __rue_rt_sigreturn as usize,
+        sa_mask: 0,
+    };
+    // SAFETY: `act` is a valid KernelSigaction; SIGSEGV is a valid signal.
+    let _ = unsafe { rt_sigaction(SIGSEGV, &act) };
+}
+
 /// Exit the process with the given status code.
 ///
 /// This performs a direct syscall to `exit(2)` and never returns.
@@ -621,5 +786,17 @@ mod tests {
         // Zero-size mmap should fail (returns EINVAL on Linux)
         let ptr = mmap(0);
         assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn stack_overflow_handler_is_installable() {
+        // Reference the installer (and, transitively, its `sigaltstack` /
+        // `rt_sigaction` wrappers, structs, and the `__rue_rt_sigreturn`
+        // trampoline) so the RUE-645 stack-overflow trap machinery is
+        // type-checked by the unit-test build. We only take its address:
+        // calling it would install a process-wide SIGSEGV handler, which must
+        // not happen inside the test harness.
+        let installer: fn(extern "C" fn(i32) -> !) = install_stack_overflow_handler;
+        assert!(installer as usize != 0);
     }
 }


### PR DESCRIPTION
Deep/unbounded recursion exhausted the stack and the process died by raw SIGSEGV (exit 139). The runtime now installs, in `_start` (before user `main`), an alternate signal stack (`sigaltstack`) + a `SIGSEGV` handler (`rt_sigaction`, `SA_ONSTACK`) that runs on the alt stack even though the main stack is exhausted; it writes `stack overflow` to stderr and exits **101** — the same clean-abort code as the other runtime traps (div-by-zero, overflow, bounds, `@panic`). Matches Rust/Go.

Any SIGSEGV from safe Rue is treated as a stack overflow (safe Rue has no other way to segfault — bounds-checked, no null derefs, arithmetic traps). Verified on x86-64-linux: `depth(10_000_000)` 139 → 101 + `stack overflow`; shallow recursion unaffected.

**Per-platform** (all in this change per CLAUDE.md): x86-64-linux (needs a tiny `rt_sigreturn` trampoline or signal delivery itself double-faults — the key finding), aarch64-linux (kernel supplies the sigtramp). macOS aarch64 is a documented no-op **TODO (RUE-707)** — Darwin `sigaction` needs a caller-supplied `sa_tramp` that can't be verified on a Linux host. Setup is best-effort (a failed syscall just leaves the default disposition).

**Note — touches `rue-oracle-diff`**: a stack-overflow trap is structurally oracle-ineligible (the in-process interpreter can't exhaust the stack; its own recursion budget aborts first with a `ResourceLimit`), so oracle-diff now classifies such a CLI case as a known oracle gap instead of running into that limit. Small additive classification (flagged on RUE-569).

Delegated the runtime implementation to an Opus worker; integrated + re-verified by execution. Full `./test.sh` green (incl. oracle-diff).

Fixes RUE-645

🤖 Generated with [Claude Code](https://claude.com/claude-code)