### PR TITLE
Resolve const type aliases in context-free type positions (Part of RUE-706)

### DIFF
--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -703,6 +703,15 @@ impl<'a> Sema<'a> {
                 result
             } else if type_name.contains('.') {
                 self.resolve_qualified_type_name(type_name, span)
+            } else if let Some(alias_ty) = self.resolve_const_type_alias(type_sym, span)? {
+                // A module-level `const Alias = SomeType;` used as a plain type
+                // name — e.g. the field type of a top-level named struct in its
+                // defining file (RUE-706). The struct/enum tables above don't
+                // include const aliases; RUE-603's on-demand const-alias resolver
+                // (which also collects the const if the field pass runs first)
+                // does. The context-aware `resolve_type_with_ctx` already consults
+                // it; this brings the context-free path to parity.
+                Ok(alias_ty)
             } else {
                 Err(CompileError::new(
                     ErrorKind::UnknownType(type_name.to_string()),

--- a/crates/rue-cli-tests/cases/const_type_alias_fields.toml
+++ b/crates/rue-cli-tests/cases/const_type_alias_fields.toml
@@ -1,0 +1,51 @@
+# A module-level `const Alias = SomeType;` used as a struct FIELD type resolves
+# on the context-free type path (declaration/collection pass), matching the
+# context-aware path — same-file and cross-module (RUE-706, partial: covers a
+# const alias to a simple/builtin type; a const alias to a cross-module GENERIC
+# instantiation as a field type is a deeper RUE-630-family follow-up).
+
+[section]
+id = "cli.const_type_alias_fields"
+name = "Const type alias as a struct field type"
+description = "A `const T = Type;` alias resolves when used as a struct field type, same-file and cross-module."
+
+[[case]]
+name = "same_file_const_alias_field"
+description = "const W = i64; struct with a `W`-typed field compiles and runs."
+args = ["main.rue", "-o", "prog"]
+exit_code = 7
+files = [{ path = "main.rue", source = """
+const W = i64;
+struct Holder {
+    v: W,
+    fn new() -> Self { Self { v: 7 } }
+    fn get(borrow self) -> i64 { self.v }
+}
+fn main() -> i32 {
+    let h = Holder.new();
+    @intCast(h.get())
+}
+""" }]
+
+[[case]]
+name = "cross_module_const_alias_field"
+description = "A pub struct in another module whose field type is that module's `const W = i64;` alias resolves."
+args = ["main.rue", "-o", "prog"]
+exit_code = 5
+files = [
+  { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let h = lib.Holder.new();
+    @intCast(h.get())
+}
+""" },
+  { path = "lib.rue", source = """
+const W = i64;
+pub struct Holder {
+    v: W,
+    fn new() -> Self { Self { v: 5 } }
+    fn get(borrow self) -> i64 { self.v }
+}
+""" },
+]


### PR DESCRIPTION
A `const Alias = SomeType;` used as a plain type name on the **context-free** resolution path (`resolve_type`) — e.g. a top-level named struct's field type, resolved in the declaration/collection pass — fell through to **E0204** because that path (unlike `resolve_type_with_ctx`) never consulted the file's const-type-alias table. RUE-603 built the on-demand resolver (`resolve_const_type_alias`) for exactly this timing; it just wasn't wired into `resolve_type`'s fall-through.

Now same-file and cross-module const-alias field types to a simple/builtin type resolve.

**Remaining (RUE-706 stays open, narrowed):** a const alias to a cross-module *generic* instantiation (`const Words = std.arraybuf.ArrayBuf(u64);`) as a field type still fails — the on-demand collector can't evaluate that cross-module comptime call during declaration collection (RUE-630 family). The idiomatic `-> type` form (which `std.bitset` uses) is unaffected.

CLI test `const_type_alias_fields.toml`. Full `./test.sh` green.

Part of RUE-706

🤖 Generated with [Claude Code](https://claude.com/claude-code)