### PR TITLE
RUE-693: coerce integer literals to callee param type across module boundaries

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2025,8 +2025,32 @@ impl<'a> ConstraintGenerator<'a> {
                                 }),
                             _ => None,
                         };
-                        match member_const_ty {
-                            Some(const_ty) => self.type_to_infer(const_ty),
+                        // A module member that is itself a (re-exported) module:
+                        // `std.cmp` where std's file has `pub const cmp =
+                        // @import("cmp.rue")`. Resolve it to the member module's
+                        // type so a nested call `std.cmp.min(..)` reaches the
+                        // module-member call path and its arguments are
+                        // constrained to the callee's parameters — without this
+                        // the receiver was a fresh variable, so a generic std call
+                        // with a literal (`std.cmp.min(i64, 3, 7)`) left the
+                        // literal unconstrained and defaulted to i32 (RUE-693).
+                        let member_module_ty = match &base_info.ty {
+                            InferType::Concrete(ty) if ty.is_module() => ty
+                                .as_module()
+                                .and_then(|module_id| {
+                                    self.module_file_ids
+                                        .and_then(|ids| ids.get(&module_id))
+                                        .copied()
+                                })
+                                .and_then(|file_id| {
+                                    self.module_binding_types
+                                        .and_then(|m| m.get(&(file_id, *field)))
+                                        .copied()
+                                }),
+                            _ => None,
+                        };
+                        match member_const_ty.or(member_module_ty) {
+                            Some(member_ty) => self.type_to_infer(member_ty),
                             None => InferType::Var(self.fresh_var()),
                         }
                     }
@@ -2307,9 +2331,78 @@ impl<'a> ConstraintGenerator<'a> {
                                         arg_info.span,
                                     ));
                                 }
+                            } else if func.is_generic {
+                                // Generic module-member callee (RUE-693): mirror
+                                // the direct-Call generic path. Build the type
+                                // substitution from the comptime type arguments,
+                                // then constrain each runtime argument to its
+                                // *substituted* parameter type. Without this, a
+                                // literal argument to `h.min(i64, 3, 7)` stayed
+                                // unconstrained across the module boundary and
+                                // defaulted to i32, clashing with the instantiated
+                                // i64 parameter (the non-generic path above already
+                                // constrains, and same-file generic Calls do too).
+                                let arg_infos: Vec<ExprInfo> = args
+                                    .iter()
+                                    .map(|arg| self.generate(arg.value, ctx))
+                                    .collect();
+                                let mut type_subst: std::collections::HashMap<lasso::Spur, Type> =
+                                    std::collections::HashMap::new();
+                                let mut value_subst: std::collections::HashMap<lasso::Spur, i128> =
+                                    std::collections::HashMap::new();
+                                for (i, arg) in args.iter().enumerate() {
+                                    if i >= func.param_comptime.len()
+                                        || !func.param_comptime[i]
+                                        || i >= func.param_names.len()
+                                    {
+                                        continue;
+                                    }
+                                    if func.param_comptime_type.get(i) == Some(&true) {
+                                        if let Some(concrete_ty) =
+                                            self.extract_type_argument(arg.value, ctx)
+                                        {
+                                            type_subst.insert(func.param_names[i], concrete_ty);
+                                        }
+                                    } else if let Some(v) = self.extract_int_argument(arg.value) {
+                                        value_subst.insert(func.param_names[i], v);
+                                    }
+                                }
+                                for (i, arg_info) in arg_infos.iter().enumerate() {
+                                    if i >= func.param_types.len() || i >= func.param_comptime.len()
+                                    {
+                                        break;
+                                    }
+                                    if func.param_comptime_type.get(i) == Some(&true) {
+                                        continue;
+                                    }
+                                    let declared = &func.param_types[i];
+                                    let expected =
+                                        if *declared == InferType::Concrete(Type::COMPTIME_TYPE) {
+                                            match func.param_type_syms.get(i).and_then(|sym| {
+                                                self.resolve_type_sym_with_subst(
+                                                    *sym,
+                                                    &type_subst,
+                                                    &value_subst,
+                                                )
+                                            }) {
+                                                Some(ty) => ty,
+                                                None => continue,
+                                            }
+                                        } else {
+                                            declared.clone()
+                                        };
+                                    if self.is_slice_struct_type(expected.clone()) {
+                                        continue;
+                                    }
+                                    self.add_constraint(Constraint::equal(
+                                        arg_info.ty.clone(),
+                                        expected,
+                                        arg_info.span,
+                                    ));
+                                }
                             } else {
-                                // Generic callee or arity mismatch: just
-                                // process the arguments; sema checks the rest.
+                                // Arity mismatch: just process the arguments;
+                                // sema checks the rest.
                                 for arg in args.iter() {
                                     self.generate(arg.value, ctx);
                                 }

--- a/crates/rue-cli-tests/cases/rue693_cross_module_literal.toml
+++ b/crates/rue-cli-tests/cases/rue693_cross_module_literal.toml
@@ -1,0 +1,57 @@
+# RUE-693: a cross-module call now coerces integer-literal arguments to the
+# callee's parameter type — for a generic (`comptime T`) callee, and for a
+# concrete parameter with a literal that exceeds i32 range. Covers direct
+# imports, aliased/nested module receivers, and the std re-export chain.
+
+[section]
+id = "cli.rue693"
+name = "Cross-module call literal coercion (RUE-693)"
+description = "Integer literals passed to a cross-module callee are coerced to the parameter type."
+
+[[case]]
+name = "direct_import_generic_literal"
+description = "h.mn(i64, 3, 7) with bare literals through a direct import compiles and runs."
+args = ["main.rue", "-o", "prog"]
+exit_code = 3
+files = [
+  { path = "main.rue", source = """
+const h = @import("helper.rue");
+fn main() -> i32 { @intCast(h.mn(i64, 3, 7)) }
+""" },
+  { path = "helper.rue", source = """
+pub fn mn(comptime T: type, a: T, b: T) -> T { if a < b { a } else { b } }
+""" },
+]
+
+[[case]]
+name = "nested_module_generic_literal"
+description = "mid.inner.mn(i64, 3, 7) through a re-exported nested module compiles and runs."
+args = ["main.rue", "-o", "prog"]
+exit_code = 3
+files = [
+  { path = "main.rue", source = """
+const mid = @import("mid.rue");
+fn main() -> i32 { @intCast(mid.inner.mn(i64, 3, 7)) }
+""" },
+  { path = "mid.rue", source = """
+pub const inner = @import("inner.rue");
+""" },
+  { path = "inner.rue", source = """
+pub fn mn(comptime T: type, a: T, b: T) -> T { if a < b { a } else { b } }
+""" },
+]
+
+[[case]]
+name = "concrete_param_large_literal"
+description = "A cross-module concrete-i64 param accepts a literal exceeding i32 range (was E0800)."
+args = ["main.rue", "-o", "prog"]
+exit_code = 1
+files = [
+  { path = "main.rue", source = """
+const h = @import("helper.rue");
+fn main() -> i32 { @intCast(h.hibit(9223372036854775807)) }
+""" },
+  { path = "helper.rue", source = """
+pub fn hibit(x: i64) -> i64 { if x > 0 { 1 } else { 0 } }
+""" },
+]

--- a/crates/rue-cli-tests/cases/std_core.toml
+++ b/crates/rue-cli-tests/cases/std_core.toml
@@ -78,14 +78,12 @@ fn main() -> i32 {
 }
 """ }]
 
-# RUE-693: a cross-module generic std call with a bare integer literal argument
-# fails to coerce the literal to the instantiated type param (E0206). When this
-# is fixed, the case will unexpectedly PASS and the suite will tell us to drop
-# the marker — turning it into a regression test that literal args work.
+# RUE-693 (FIXED): a cross-module generic std call with a bare integer literal
+# argument now coerces the literal to the instantiated type param — including
+# through the std re-export chain (`std.cmp.min`). Regression test.
 [[case]]
 name = "std_core_generic_literal_args"
-description = "std.cmp.min(i64, 3, 7) with bare literal args should compile once RUE-693 is fixed."
-known_bug = "RUE-693"
+description = "std.cmp.min(i64, 3, 7) with bare literal args compiles and runs (RUE-693)."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
 exit_code = 3


### PR DESCRIPTION
A cross-module call dropped integer-literal coercion to the callee's parameter type — the literal defaulted to `i32` and clashed with an `i64` parameter (**E0206** for a generic param; **E0800** for a concrete `i64` param with a >i32 literal). This is why every generic `std.*` call needed a typed local (`std.cmp.min(i64, 3, 7)` failed).

Two gaps in the constraint generator (`inference/generate.rs`), both on the `MethodCall` path:
1. **Generic module-member calls weren't constrained.** The module-member path only constrained args for `!func.is_generic`. Added the generic case, mirroring the direct-`Call` path (build the type substitution from the comptime type args, constrain each runtime arg to its substituted param type).
2. **A re-exported nested module receiver didn't resolve to a module.** `std.cmp` (where std's file has `pub const cmp = @import("cmp.rue")`) resolved to a fresh variable, so `std.cmp.min(..)` never reached the module-member path. `FieldGet` now resolves such a member via `module_file_ids` + `module_binding_types`, at parity with the member-const path.

Now works: `std.cmp.min(i64, 3, 7)`, `std.math.gcd(i64, 48, 36)`, direct imports, aliased submodules, two-level nesting, concrete large literals. Removed the `std_core` `known_bug=RUE-693` marker (now a passing regression test); added `rue693_cross_module_literal.toml`. Full `./test.sh` green.

Claimed on RUE-569 (adjacent to Codex's RUE-629 epic; confined to two additive branches).

Fixes RUE-693

🤖 Generated with [Claude Code](https://claude.com/claude-code)