### PR TITLE
RUE-708: add canonical resolved program revision

### DIFF
--- a/crates/rue-compiler/src/import_graph.rs
+++ b/crates/rue-compiler/src/import_graph.rs
@@ -9,11 +9,11 @@ use std::path::Path;
 use std::sync::Arc;
 
 use lasso::ThreadedRodeo;
-use rue_air::{DirResolution, ModulePath};
+use rue_air::{DirResolution, ModulePath, normalize_module_path};
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_rir::{InstData, Rir};
 
-use crate::{ModuleId, SourceMetadata};
+use crate::{ModuleId, ModuleResolutionInputs, SemanticInputDescriptor, SourceMetadata};
 
 /// One valid import call, identified independently of request-local file IDs.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -101,6 +101,83 @@ pub struct ImportGraph {
     directives: ImportDirectives,
     resolutions: Arc<[ImportResolution]>,
     edges: Arc<[ImportEdge]>,
+}
+
+/// Occurrence-independent outcome in a durable import graph.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CanonicalImportResolution {
+    Resolved(ModuleId),
+    Missing,
+    Ambiguous {
+        file_module: ModuleId,
+        directory_module: ModuleId,
+    },
+}
+
+/// One durable resolved-import value, with no source position or physical path.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CanonicalImportRecord {
+    importer: ModuleId,
+    normalized_specifier: Arc<str>,
+    resolution: CanonicalImportResolution,
+}
+
+impl CanonicalImportRecord {
+    pub fn importer(&self) -> &ModuleId {
+        &self.importer
+    }
+
+    pub fn normalized_specifier(&self) -> &str {
+        &self.normalized_specifier
+    }
+
+    pub fn resolution(&self) -> &CanonicalImportResolution {
+        &self.resolution
+    }
+}
+
+/// Canonical resolved topology, independent of import-site occurrences.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CanonicalImportGraph {
+    root: ModuleId,
+    records: Arc<[CanonicalImportRecord]>,
+}
+
+impl CanonicalImportGraph {
+    pub fn root(&self) -> &ModuleId {
+        &self.root
+    }
+
+    /// Records sorted by importer, normalized spelling, then outcome.
+    pub fn records(&self) -> &[CanonicalImportRecord] {
+        &self.records
+    }
+}
+
+/// Complete downstream semantic identity after import resolution.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResolvedProgramRevision {
+    semantic: SemanticInputDescriptor,
+    imports: CanonicalImportGraph,
+}
+
+impl ResolvedProgramRevision {
+    /// Compose semantic inputs and durable imports.
+    ///
+    /// The canonical graph itself ignores physical relocation, while this
+    /// complete revision intentionally retains the explicit physical
+    /// resolution inputs embedded in `semantic`.
+    pub fn new(semantic: SemanticInputDescriptor, imports: CanonicalImportGraph) -> Self {
+        Self { semantic, imports }
+    }
+
+    pub fn semantic(&self) -> &SemanticInputDescriptor {
+        &self.semantic
+    }
+
+    pub fn imports(&self) -> &CanonicalImportGraph {
+        &self.imports
+    }
 }
 
 impl ImportGraph {
@@ -271,15 +348,155 @@ fn provenance_error(message: String) -> CompileError {
     CompileError::without_span(ErrorKind::InvalidCompilerInput(message))
 }
 
+/// Resolve occurrence-independent durable import identity from explicit inputs.
+///
+/// Resolution uses only `inputs` and the explicitly supplied optional stdlib
+/// directory. It never consults source metadata, file IDs, the environment, or
+/// the filesystem for discovery.
+pub fn resolve_canonical_import_graph(
+    directives: &ImportDirectives,
+    inputs: &ModuleResolutionInputs,
+    std_dir: Option<&str>,
+) -> CompileResult<CanonicalImportGraph> {
+    let dir_of = |path: &str| {
+        Path::new(path)
+            .parent()
+            .map(|dir| dir.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    };
+    let root_path = inputs
+        .physical_path(inputs.root())
+        .expect("validated resolution inputs contain their root");
+    let root_dir = dir_of(root_path);
+    let loaded_paths: Vec<String> = inputs
+        .modules()
+        .iter()
+        .map(|entry| entry.physical_path.to_string())
+        .collect();
+    let module_for_path = |path: &str| -> CompileResult<ModuleId> {
+        inputs
+            .modules()
+            .iter()
+            .find_map(|entry| (entry.physical_path.as_ref() == path).then(|| entry.module.clone()))
+            .ok_or_else(|| {
+                provenance_error(format!(
+                    "resolved import path {path:?} is absent from module resolution inputs"
+                ))
+            })
+    };
+
+    let mut records = Vec::with_capacity(directives.len());
+    for directive in directives.iter() {
+        let importer_path = inputs.physical_path(directive.importer()).ok_or_else(|| {
+            provenance_error(format!(
+                "importer module {:?} is absent from module resolution inputs",
+                directive.importer()
+            ))
+        })?;
+        let importer_dir = dir_of(importer_path);
+        let mut base_dirs = vec![importer_dir];
+        if !base_dirs.contains(&root_dir) {
+            base_dirs.push(root_dir.clone());
+        }
+        let base_refs: Vec<&str> = base_dirs.iter().map(String::as_str).collect();
+        let outcome =
+            resolve_explicit_candidates(directive.specifier(), &base_refs, &loaded_paths, std_dir);
+        let resolution = match outcome {
+            DirResolution::Resolved(path) => {
+                CanonicalImportResolution::Resolved(module_for_path(&path)?)
+            }
+            DirResolution::Ambiguous {
+                file_module,
+                dir_module,
+            } => CanonicalImportResolution::Ambiguous {
+                file_module: module_for_path(&file_module)?,
+                directory_module: module_for_path(&dir_module)?,
+            },
+            DirResolution::NotFound => CanonicalImportResolution::Missing,
+        };
+        records.push(CanonicalImportRecord {
+            importer: directive.importer().clone(),
+            normalized_specifier: Arc::from(normalize_module_path(directive.specifier())),
+            resolution,
+        });
+    }
+    records.sort();
+    records.dedup();
+    Ok(CanonicalImportGraph {
+        root: inputs.root().clone(),
+        records: records.into(),
+    })
+}
+
+/// Pure lexical counterpart of `ModulePath` loaded-file resolution.
+///
+/// Candidate grouping and precedence come from `ModulePath`; matching uses
+/// normalized explicit input strings only and never canonicalizes or probes the
+/// filesystem.
+fn resolve_explicit_candidates(
+    specifier: &str,
+    base_dirs: &[&str],
+    loaded_paths: &[String],
+    std_dir: Option<&str>,
+) -> DirResolution {
+    let loaded: Vec<_> = loaded_paths
+        .iter()
+        .map(|path| (normalize_module_path(path), path))
+        .collect();
+    let find = |candidate: &str| {
+        let normalized = normalize_module_path(candidate);
+        loaded
+            .iter()
+            .find(|(path, _)| *path == normalized)
+            .map(|(_, original)| (*original).clone())
+    };
+    let owned_bases: Vec<String> = base_dirs.iter().map(|base| (*base).to_string()).collect();
+    for group in ModulePath::parse(specifier).candidate_groups(&owned_bases, std_dir) {
+        match group.as_slice() {
+            [candidate] => {
+                if let Some(path) = find(candidate) {
+                    return DirResolution::Resolved(path);
+                }
+            }
+            [file_candidate, directory_candidate] => {
+                let file_module = find(file_candidate);
+                let dir_module = find(directory_candidate);
+                match (file_module, dir_module) {
+                    (Some(file_module), Some(dir_module)) => {
+                        return DirResolution::Ambiguous {
+                            file_module,
+                            dir_module,
+                        };
+                    }
+                    (Some(path), None) | (None, Some(path)) => {
+                        return DirResolution::Resolved(path);
+                    }
+                    (None, None) => {}
+                }
+            }
+            _ => unreachable!("ModulePath candidate groups contain one or two paths"),
+        }
+    }
+    DirResolution::NotFound
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
 
     use rue_error::ErrorKind;
     use rue_span::FileId;
 
     use super::*;
     use crate::{CompilationUnit, CompileOptions, SourceFile};
+
+    fn value_hash(value: &impl Hash) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
 
     fn lower<'a>(
         sources: Vec<SourceFile<'a>>,
@@ -750,6 +967,12 @@ fn main() -> i32 {
         )];
         let mut direct = graph_unit(&entries, 1);
         let mut queried = graph_unit(&entries, 1);
+        resolve_canonical_import_graph(
+            queried.import_directives().unwrap(),
+            &ModuleResolutionInputs::from_metadata(queried.source_metadata()),
+            None,
+        )
+        .unwrap();
         assert!(matches!(
             queried.resolve_import_graph(None).unwrap().resolutions()[0],
             ImportResolution::Missing
@@ -785,5 +1008,180 @@ fn main() -> i32 {
             fingerprint(direct.analyze().unwrap_err()),
             fingerprint(queried.analyze().unwrap_err())
         );
+    }
+
+    #[test]
+    fn durable_graph_normalizes_spelling_and_deduplicates_repeated_sites() {
+        let unit = graph_unit(
+            &[
+                (
+                    1,
+                    "/p/main.rue",
+                    "app/main.rue",
+                    r#"fn main() -> i32 {
+                        let first = @import("./helper.rue");
+                        let second = @import("dir/../helper.rue");
+                        let third = @import("helper.rue");
+                        0
+                    }"#,
+                ),
+                (2, "/p/helper.rue", "app/helper.rue", "fn helper() {}"),
+            ],
+            1,
+        );
+        let inputs = ModuleResolutionInputs::from_metadata(unit.source_metadata());
+        let durable =
+            resolve_canonical_import_graph(unit.import_directives().unwrap(), &inputs, None)
+                .unwrap();
+        assert_eq!(unit.import_directives().unwrap().len(), 3);
+        assert_eq!(unit.resolve_import_graph(None).unwrap().edges().len(), 3);
+        assert_eq!(durable.records().len(), 1);
+        assert_eq!(durable.records()[0].normalized_specifier(), "helper.rue");
+        assert!(matches!(
+            durable.records()[0].resolution(),
+            CanonicalImportResolution::Resolved(module)
+                if module.as_str() == "app/helper.rue"
+        ));
+    }
+
+    fn reordered_durable_graph(source: &str) -> CanonicalImportGraph {
+        let unit = graph_unit(
+            &[
+                (1, "/p/main.rue", "app/main.rue", source),
+                (2, "/p/a.rue", "app/a.rue", "fn a() {}"),
+                (3, "/p/b.rue", "app/b.rue", "fn b() {}"),
+            ],
+            1,
+        );
+        resolve_canonical_import_graph(
+            unit.import_directives().unwrap(),
+            &ModuleResolutionInputs::from_metadata(unit.source_metadata()),
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn durable_graph_ignores_site_order_and_offsets() {
+        let first = reordered_durable_graph(
+            "fn main() -> i32 { let a = @import(\"a.rue\"); let b = @import(\"b.rue\"); 0 }",
+        );
+        let reordered = reordered_durable_graph(
+            "fn main() -> i32 {   let b = @import(\"b.rue\"); let a = @import(\"a.rue\"); 0 }",
+        );
+        assert_eq!(first, reordered);
+    }
+
+    #[test]
+    fn explicit_resolution_changes_graph_but_not_source_identity() {
+        let unit = graph_unit(
+            &[
+                (
+                    1,
+                    "/p/main.rue",
+                    "app/main.rue",
+                    "fn main() -> i32 { let h = @import(\"helper.rue\"); 0 }",
+                ),
+                (2, "/p/helper.rue", "app/helper.rue", "fn helper() {}"),
+            ],
+            1,
+        );
+        let original_inputs = ModuleResolutionInputs::from_metadata(unit.source_metadata());
+        let source_revision = unit.source_snapshot().source_revision().clone();
+        let moved_inputs = ModuleResolutionInputs::new(
+            original_inputs.root().clone(),
+            original_inputs
+                .modules()
+                .iter()
+                .map(|entry| crate::ModuleResolutionInput {
+                    module: entry.module.clone(),
+                    physical_path: if entry.module.as_str() == "app/helper.rue" {
+                        Arc::from("/elsewhere/helper.rue")
+                    } else {
+                        entry.physical_path.clone()
+                    },
+                })
+                .collect(),
+        )
+        .unwrap();
+        let original = resolve_canonical_import_graph(
+            unit.import_directives().unwrap(),
+            &original_inputs,
+            None,
+        )
+        .unwrap();
+        let changed =
+            resolve_canonical_import_graph(unit.import_directives().unwrap(), &moved_inputs, None)
+                .unwrap();
+        assert_ne!(original, changed);
+        assert_eq!(unit.source_snapshot().source_revision(), &source_revision);
+
+        let mut original_semantic = SemanticInputDescriptor::new(
+            unit.source_snapshot(),
+            crate::Target::default(),
+            &rue_error::PreviewFeatures::default(),
+        );
+        let mut moved_semantic = original_semantic.clone();
+        original_semantic.resolution = original_inputs;
+        moved_semantic.resolution = moved_inputs;
+        assert_eq!(original_semantic.sources, moved_semantic.sources);
+        assert_ne!(
+            ResolvedProgramRevision::new(original_semantic, original),
+            ResolvedProgramRevision::new(moved_semantic, changed)
+        );
+    }
+
+    fn relocated_revision(
+        prefix: &str,
+        root_id: u32,
+        helper_id: u32,
+    ) -> (
+        crate::SourceRevision,
+        CanonicalImportGraph,
+        ResolvedProgramRevision,
+    ) {
+        let root_path = format!("{prefix}/main.rue");
+        let helper_path = format!("{prefix}/helper.rue");
+        let unit = lower(
+            vec![
+                SourceFile::new(&helper_path, "fn helper() {}", FileId::new(helper_id)),
+                SourceFile::new(
+                    &root_path,
+                    "fn main() -> i32 { let h = @import(\"helper.rue\"); 0 }",
+                    FileId::new(root_id),
+                ),
+            ],
+            FileId::new(root_id),
+            HashMap::from([
+                (FileId::new(root_id), "app/main.rue".to_string()),
+                (FileId::new(helper_id), "app/helper.rue".to_string()),
+            ]),
+        );
+        let semantic = SemanticInputDescriptor::new(
+            unit.source_snapshot(),
+            crate::Target::default(),
+            &rue_error::PreviewFeatures::default(),
+        );
+        let graph = resolve_canonical_import_graph(
+            unit.import_directives().unwrap(),
+            &semantic.resolution,
+            None,
+        )
+        .unwrap();
+        (
+            semantic.sources.clone(),
+            graph.clone(),
+            ResolvedProgramRevision::new(semantic, graph),
+        )
+    }
+
+    #[test]
+    fn relocation_keeps_graph_and_sources_but_changes_explicit_resolved_revision() {
+        let (first_sources, first_graph, first_revision) = relocated_revision("/one", 1, 2);
+        let (moved_sources, moved_graph, moved_revision) = relocated_revision("/moved", 90, 7);
+        assert_eq!(first_sources, moved_sources);
+        assert_eq!(first_graph, moved_graph);
+        assert_eq!(value_hash(&first_graph), value_hash(&moved_graph));
+        assert_ne!(first_revision, moved_revision);
     }
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -41,8 +41,9 @@ pub use definition_snapshot::{
     DefinitionSnapshot, ModuleDefinition, ModuleKey,
 };
 pub use import_graph::{
-    ImportDirective, ImportDirectives, ImportEdge, ImportGraph, ImportResolution,
-    extract_import_directives, resolve_import_graph,
+    CanonicalImportGraph, CanonicalImportRecord, CanonicalImportResolution, ImportDirective,
+    ImportDirectives, ImportEdge, ImportGraph, ImportResolution, ResolvedProgramRevision,
+    extract_import_directives, resolve_canonical_import_graph, resolve_import_graph,
 };
 pub use source_identity::{
     CodegenInputDescriptor, LinkInputDescriptor, ModuleId, ModuleResolutionInput,

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -240,22 +240,74 @@ impl ModuleResolutionInputs {
     pub fn modules(&self) -> &[ModuleResolutionInput] {
         &self.modules
     }
+    /// Build canonical explicit module-resolution inputs.
+    pub fn new(root: ModuleId, mut modules: Vec<ModuleResolutionInput>) -> CompileResult<Self> {
+        modules.sort_by(|a, b| a.module.cmp(&b.module));
+        if let Some(module) = modules
+            .iter()
+            .find(|entry| entry.physical_path.is_empty())
+            .map(|entry| &entry.module)
+        {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("module resolution input {module:?} has an empty physical path"),
+            )));
+        }
+        if let Some(duplicate) = modules
+            .windows(2)
+            .find(|pair| pair[0].module == pair[1].module)
+            .map(|pair| &pair[0].module)
+        {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("module resolution inputs contain duplicate module ID {duplicate:?}"),
+            )));
+        }
+        if modules
+            .binary_search_by(|entry| entry.module.cmp(&root))
+            .is_err()
+        {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("module resolution root {root:?} is absent"),
+            )));
+        }
+        let mut physical_paths: Vec<_> = modules
+            .iter()
+            .map(|entry| (normalize_module_path(&entry.physical_path), &entry.module))
+            .collect();
+        physical_paths.sort();
+        if let Some((path, _)) = physical_paths
+            .windows(2)
+            .find(|pair| pair[0].0 == pair[1].0)
+            .map(|pair| &pair[0])
+        {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                format!("module resolution inputs contain duplicate physical path {path:?}"),
+            )));
+        }
+        Ok(Self {
+            root,
+            modules: modules.into(),
+        })
+    }
+
+    pub fn physical_path(&self, module: &ModuleId) -> Option<&str> {
+        self.modules
+            .binary_search_by(|entry| entry.module.cmp(module))
+            .ok()
+            .map(|index| self.modules[index].physical_path.as_ref())
+    }
+
     pub fn from_metadata(metadata: &SourceMetadata) -> Self {
         let root = ModuleId::from_validated_canonical(
             metadata.logical_path(metadata.root_file_id()).unwrap(),
         );
-        let mut modules: Vec<_> = metadata
+        let modules: Vec<_> = metadata
             .file_ids()
             .map(|id| ModuleResolutionInput {
                 module: ModuleId::from_validated_canonical(metadata.logical_path(id).unwrap()),
                 physical_path: Arc::from(metadata.physical_path(id).unwrap()),
             })
             .collect();
-        modules.sort_by(|a, b| a.module.cmp(&b.module));
-        Self {
-            root,
-            modules: modules.into(),
-        }
+        Self::new(root, modules).expect("validated source metadata is canonical")
     }
 }
 
@@ -444,5 +496,47 @@ mod tests {
         )
         .unwrap_err();
         assert!(missing.to_string().contains("root module"));
+    }
+
+    #[test]
+    fn module_resolution_inputs_are_canonical_and_reject_ambiguous_provenance() {
+        let root = ModuleId::from_logical_path("root.rue").unwrap();
+        let helper = ModuleId::from_logical_path("helper.rue").unwrap();
+        let inputs = ModuleResolutionInputs::new(
+            root.clone(),
+            vec![
+                ModuleResolutionInput {
+                    module: helper.clone(),
+                    physical_path: Arc::from("/p/helper.rue"),
+                },
+                ModuleResolutionInput {
+                    module: root.clone(),
+                    physical_path: Arc::from("/p/root.rue"),
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(inputs.modules()[0].module, helper);
+        assert_eq!(inputs.physical_path(&root), Some("/p/root.rue"));
+
+        let duplicate_path = ModuleResolutionInputs::new(
+            root.clone(),
+            vec![
+                ModuleResolutionInput {
+                    module: root,
+                    physical_path: Arc::from("/p/dir/../same.rue"),
+                },
+                ModuleResolutionInput {
+                    module: ModuleId::from_logical_path("other.rue").unwrap(),
+                    physical_path: Arc::from("/p/same.rue"),
+                },
+            ],
+        )
+        .unwrap_err();
+        assert!(
+            duplicate_path
+                .to_string()
+                .contains("duplicate physical path")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add a durable canonical import graph excluding source offsets, occurrence indices, physical paths, file IDs, and spans
- resolve canonical topology solely from validated `ModuleResolutionInputs` and explicit optional stdlib context
- normalize and deduplicate equivalent import-site records while preserving the existing site-oriented graph API
- compose semantic inputs and canonical topology as `ResolvedProgramRevision`
- make module-resolution inputs publicly constructible and fail closed on duplicate modules, missing roots, empty paths, and normalized physical aliases

## Why

Downstream semantic/interface queries need stable resolved-program identity without treating diagnostic locations or repeated import occurrences as semantic topology. This completes that durable boundary while retaining explicit location-sensitive resolution inputs and changing no batch scheduling behavior.

## Validation

- `./fmt.sh --check`
- `./clippy.sh` (41 targets)
- `./buck2 test //... //:reproducible-programs` (34 targets)
- `./scripts/check-reproducible-compiler.sh`

Linear: RUE-708