### PR TITLE
RUE-715: add provenance-safe semantic symbol views

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -31,6 +31,7 @@ mod drop_glue;
 mod import_graph;
 pub mod parsed_modules;
 mod semantic_order;
+pub mod semantic_symbols;
 mod source_identity;
 mod source_metadata;
 mod source_snapshot;
@@ -50,6 +51,7 @@ pub use import_graph::{
     validate_canonical_import_graph,
 };
 pub use parsed_modules::ParsedProgram as CanonicalParsedProgram;
+pub use semantic_symbols::{SemanticSymbol, SemanticSymbolUniverse, SemanticTranslationWork};
 pub use source_identity::{
     CodegenInputDescriptor, LinkInputDescriptor, ModuleId, ModuleResolutionInput,
     ModuleResolutionInputs, ModuleRevision, SemanticInputDescriptor, SourceId, SourceIdVersion,

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -7,6 +7,8 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+#[cfg(test)]
+use lasso::Key;
 use lasso::{RodeoResolver, Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind};
 use rue_parser::{
@@ -28,6 +30,13 @@ struct SymbolProvenance;
 pub struct ParsedSymbol {
     spur: Spur,
     provenance: Arc<SymbolProvenance>,
+}
+
+impl ParsedSymbol {
+    #[cfg(test)]
+    pub(crate) fn test_local_ordinal(&self) -> usize {
+        self.spur.into_usize()
+    }
 }
 
 /// Immutable symbol resolver for one parsed module.
@@ -176,6 +185,57 @@ pub struct ParsedModule {
     imports: Arc<[ParsedImportDirective]>,
 }
 
+/// An AST paired with the exact parsed module that owns all of its symbols.
+///
+/// Views are issued only by [`ParsedProgram`]; cloning a view retains the
+/// pointer-identical parsed module rather than copying its AST payload.
+#[derive(Debug, Clone)]
+pub struct ParsedAstView {
+    module: Arc<ParsedModule>,
+}
+
+impl ParsedAstView {
+    pub fn module(&self) -> &Arc<ParsedModule> {
+        &self.module
+    }
+
+    pub fn module_id(&self) -> &ModuleId {
+        self.module.module_id()
+    }
+
+    pub fn ast(&self) -> &Ast {
+        self.module.ast()
+    }
+
+    pub fn items(&self) -> impl ExactSizeIterator<Item = ParsedItemView> + '_ {
+        (0..self.module.ast().items.len()).map(|index| ParsedItemView {
+            module: self.module.clone(),
+            index,
+        })
+    }
+}
+
+/// One parsed item paired with the module that owns its local symbols.
+#[derive(Debug, Clone)]
+pub struct ParsedItemView {
+    module: Arc<ParsedModule>,
+    index: usize,
+}
+
+impl ParsedItemView {
+    pub fn module(&self) -> &Arc<ParsedModule> {
+        &self.module
+    }
+
+    pub fn module_id(&self) -> &ModuleId {
+        self.module.module_id()
+    }
+
+    pub fn item(&self) -> &Item {
+        &self.module.ast().items[self.index]
+    }
+}
+
 impl ParsedModule {
     pub fn revision(&self) -> &ModuleRevision {
         &self.revision
@@ -269,6 +329,14 @@ impl ParsedProgram {
     }
     pub fn modules(&self) -> &[Arc<ParsedModule>] {
         &self.modules
+    }
+
+    /// Traverse module-qualified ASTs in canonical logical-module order.
+    pub fn ast_views(&self) -> impl ExactSizeIterator<Item = ParsedAstView> + '_ {
+        self.modules
+            .iter()
+            .cloned()
+            .map(|module| ParsedAstView { module })
     }
 
     /// Canonical program-wide import occurrences, ready for graph resolution.

--- a/crates/rue-compiler/src/semantic_symbols.rs
+++ b/crates/rue-compiler/src/semantic_symbols.rs
@@ -1,0 +1,346 @@
+//! Provenance-safe translation from parsed-module symbols into one request.
+
+use std::sync::Arc;
+
+use lasso::{Spur, ThreadedRodeo};
+use rue_error::{CompileError, CompileResult, ErrorKind};
+
+use crate::parsed_modules::{ParsedAstView, ParsedProgram, ParsedSymbol};
+
+#[derive(Debug)]
+struct SemanticSymbolProvenance;
+
+/// A symbol in exactly one request-local semantic universe.
+#[derive(Debug, Clone)]
+pub struct SemanticSymbol {
+    spur: Spur,
+    provenance: Arc<SemanticSymbolProvenance>,
+}
+
+/// Structural work performed by semantic-symbol translation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticTranslationWork {
+    /// Canonical program modules admitted when the universe was constructed.
+    pub modules_visited: usize,
+    pub local_symbol_resolutions: usize,
+    pub semantic_intern_attempts: usize,
+    pub unique_semantic_strings: usize,
+    pub ast_payload_clones: usize,
+    pub parser_invocations: usize,
+}
+
+/// One request-local destination for module-local parsed symbols.
+///
+/// Callers should translate while traversing [`ParsedProgram::ast_views`],
+/// whose module order is canonical. The universe owns no parse cache or
+/// local-to-semantic memo table.
+#[derive(Debug)]
+pub struct SemanticSymbolUniverse {
+    admitted_modules: Arc<[Arc<crate::parsed_modules::ParsedModule>]>,
+    interner: ThreadedRodeo,
+    provenance: Arc<SemanticSymbolProvenance>,
+    work: SemanticTranslationWork,
+}
+
+impl SemanticSymbolUniverse {
+    /// Start a destination universe for one canonical program traversal.
+    pub fn new(program: &ParsedProgram) -> Self {
+        Self {
+            admitted_modules: program.modules().to_vec().into(),
+            interner: ThreadedRodeo::new(),
+            provenance: Arc::new(SemanticSymbolProvenance),
+            work: SemanticTranslationWork {
+                modules_visited: program.modules().len(),
+                ..SemanticTranslationWork::default()
+            },
+        }
+    }
+
+    /// Translate a provenanced local symbol through its owning module view.
+    ///
+    /// This API deliberately accepts no naked local `Spur`.
+    pub fn translate(
+        &mut self,
+        owner: &ParsedAstView,
+        symbol: &ParsedSymbol,
+    ) -> CompileResult<SemanticSymbol> {
+        let admitted = self
+            .admitted_modules
+            .binary_search_by(|module| module.module_id().cmp(owner.module_id()))
+            .map_err(|_| invalid_input("module view is absent from this semantic program"))?;
+        if !Arc::ptr_eq(&self.admitted_modules[admitted], owner.module()) {
+            return Err(invalid_input(
+                "module view belongs to a foreign parsed artifact",
+            ));
+        }
+        let text = owner.module().resolve(symbol)?;
+        self.work.local_symbol_resolutions += 1;
+        self.work.semantic_intern_attempts += 1;
+        if self.interner.get(text).is_none() {
+            self.work.unique_semantic_strings += 1;
+        }
+        Ok(SemanticSymbol {
+            spur: self.interner.get_or_intern(text),
+            provenance: self.provenance.clone(),
+        })
+    }
+
+    /// Resolve only symbols issued by this exact semantic universe.
+    pub fn resolve<'a>(&'a self, symbol: &SemanticSymbol) -> CompileResult<&'a str> {
+        if !Arc::ptr_eq(&self.provenance, &symbol.provenance) {
+            return Err(invalid_input(
+                "semantic symbol belongs to a foreign semantic universe",
+            ));
+        }
+        self.interner
+            .try_resolve(&symbol.spur)
+            .ok_or_else(|| invalid_input("semantic symbol is absent from its universe"))
+    }
+
+    pub fn work(&self) -> SemanticTranslationWork {
+        self.work
+    }
+}
+
+fn invalid_input(message: impl Into<String>) -> CompileError {
+    CompileError::without_span(ErrorKind::InvalidCompilerInput(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rue_span::FileId;
+
+    use super::*;
+    use crate::parsed_modules::parse_source_snapshot_modules;
+    use crate::{ModuleId, SourceMetadata, SourceSnapshot};
+
+    fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
+        let physical = entries
+            .iter()
+            .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
+            .collect::<HashMap<_, _>>();
+        let logical = entries
+            .iter()
+            .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
+            .collect::<HashMap<_, _>>();
+        let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
+        SourceSnapshot::new(
+            metadata,
+            entries
+                .iter()
+                .map(|(id, _, _, text)| (FileId::new(*id), Arc::new((*text).to_owned())))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    fn translated_definitions(
+        program: &ParsedProgram,
+    ) -> (Vec<(String, String)>, SemanticTranslationWork) {
+        let mut universe = SemanticSymbolUniverse::new(program);
+        let mut values = Vec::new();
+        for view in program.ast_views() {
+            for candidate in view.module().definitions().candidates() {
+                let symbol = universe.translate(&view, candidate.symbol()).unwrap();
+                values.push((
+                    view.module_id().as_str().to_owned(),
+                    universe.resolve(&symbol).unwrap().to_owned(),
+                ));
+            }
+        }
+        (values, universe.work())
+    }
+
+    #[test]
+    fn equal_numeric_local_spurs_translate_to_their_distinct_text() {
+        let snapshot = snapshot(
+            &[
+                (1, "/a.rue", "a.rue", "fn alpha() {}"),
+                (2, "/b.rue", "b.rue", "fn beta() {}"),
+            ],
+            1,
+        );
+        let program = parse_source_snapshot_modules(&snapshot).unwrap();
+        let left = &program.modules()[0].definitions().candidates()[0];
+        let right = &program.modules()[1].definitions().candidates()[0];
+        assert_eq!(
+            left.symbol().test_local_ordinal(),
+            right.symbol().test_local_ordinal()
+        );
+
+        let (values, work) = translated_definitions(&program);
+        assert_eq!(
+            values,
+            [
+                (String::from("a.rue"), String::from("alpha")),
+                (String::from("b.rue"), String::from("beta")),
+            ]
+        );
+        assert_eq!(
+            work,
+            SemanticTranslationWork {
+                modules_visited: 2,
+                local_symbol_resolutions: 2,
+                semantic_intern_attempts: 2,
+                unique_semantic_strings: 2,
+                ast_payload_clones: 0,
+                parser_invocations: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn reordered_arc_assemblies_have_identical_views_values_and_work() {
+        let snapshot = snapshot(
+            &[
+                (8, "/z.rue", "z.rue", "fn zed() {}"),
+                (3, "/a.rue", "a.rue", "fn alpha() {}"),
+            ],
+            8,
+        );
+        let first = parse_source_snapshot_modules(&snapshot).unwrap();
+        let first_arcs = first.modules().to_vec();
+        let mut reversed = first_arcs.clone();
+        reversed.reverse();
+        let second = ParsedProgram::new(first.root().clone(), reversed).unwrap();
+
+        assert!(
+            first
+                .modules()
+                .iter()
+                .zip(second.modules())
+                .all(|(left, right)| Arc::ptr_eq(left, right))
+        );
+        assert_eq!(
+            translated_definitions(&first),
+            translated_definitions(&second)
+        );
+    }
+
+    #[test]
+    fn foreign_local_and_semantic_provenance_are_rejected() {
+        let snapshot = snapshot(
+            &[
+                (1, "/a.rue", "a.rue", "fn alpha() {}"),
+                (2, "/b.rue", "b.rue", "fn beta() {}"),
+            ],
+            1,
+        );
+        let program = parse_source_snapshot_modules(&snapshot).unwrap();
+        let views = program.ast_views().collect::<Vec<_>>();
+        let foreign = program.modules()[1].definitions().candidates()[0].symbol();
+        let mut first_universe = SemanticSymbolUniverse::new(&program);
+        assert_eq!(
+            first_universe
+                .translate(&views[0], foreign)
+                .unwrap_err()
+                .to_string(),
+            "invalid compiler input: parsed symbol belongs to a foreign symbol universe"
+        );
+
+        let own = program.modules()[0].definitions().candidates()[0].symbol();
+        let semantic = first_universe.translate(&views[0], own).unwrap();
+        let second_universe = SemanticSymbolUniverse::new(&program);
+        assert_eq!(
+            second_universe.resolve(&semantic).unwrap_err().to_string(),
+            "invalid compiler input: semantic symbol belongs to a foreign semantic universe"
+        );
+    }
+
+    #[test]
+    fn universe_admits_only_the_exact_program_module_artifacts() {
+        let make_snapshot = || snapshot(&[(1, "/main.rue", "main.rue", "fn main() {}")], 1);
+        let admitted = parse_source_snapshot_modules(&make_snapshot()).unwrap();
+        let independently_parsed = parse_source_snapshot_modules(&make_snapshot()).unwrap();
+        assert_eq!(
+            admitted.modules()[0].revision(),
+            independently_parsed.modules()[0].revision()
+        );
+        assert!(!Arc::ptr_eq(
+            &admitted.modules()[0],
+            &independently_parsed.modules()[0]
+        ));
+
+        let foreign_view = independently_parsed.ast_views().next().unwrap();
+        let foreign_symbol =
+            independently_parsed.modules()[0].definitions().candidates()[0].symbol();
+        let mut universe = SemanticSymbolUniverse::new(&admitted);
+        assert_eq!(
+            universe
+                .translate(&foreign_view, foreign_symbol)
+                .unwrap_err()
+                .to_string(),
+            "invalid compiler input: module view belongs to a foreign parsed artifact"
+        );
+
+        let reused =
+            ParsedProgram::new(admitted.root().clone(), vec![admitted.modules()[0].clone()])
+                .unwrap();
+        let reused_view = reused.ast_views().next().unwrap();
+        let reused_symbol = reused.modules()[0].definitions().candidates()[0].symbol();
+        let mut reused_universe = SemanticSymbolUniverse::new(&reused);
+        let translated = reused_universe
+            .translate(&reused_view, reused_symbol)
+            .unwrap();
+        assert_eq!(reused_universe.resolve(&translated).unwrap(), "main");
+    }
+
+    #[test]
+    fn same_bytes_at_distinct_module_ids_remain_distinct_zero_clone_views() {
+        let text = "fn same() {}";
+        let snapshot = snapshot(
+            &[
+                (4, "/left.rue", "left.rue", text),
+                (9, "/right.rue", "right.rue", text),
+            ],
+            4,
+        );
+        let program = parse_source_snapshot_modules(&snapshot).unwrap();
+        assert_eq!(
+            program.modules()[0].source_id(),
+            program.modules()[1].source_id()
+        );
+        let views = program.ast_views().collect::<Vec<_>>();
+        assert_eq!(views[0].module_id().as_str(), "left.rue");
+        assert_eq!(views[1].module_id().as_str(), "right.rue");
+        assert_ne!(views[0].module_id(), views[1].module_id());
+        assert!(Arc::ptr_eq(views[0].module(), &program.modules()[0]));
+        assert!(Arc::ptr_eq(views[1].module(), &program.modules()[1]));
+
+        let (_, work) = translated_definitions(&program);
+        assert_eq!(work.ast_payload_clones, 0);
+        assert_eq!(work.parser_invocations, 0);
+        assert_eq!(work.modules_visited, 2);
+    }
+
+    #[test]
+    fn item_views_retain_their_module_without_copying_ast_payloads() {
+        let snapshot = snapshot(
+            &[(1, "/main.rue", "main.rue", "fn first() {} fn second() {}")],
+            1,
+        );
+        let program = parse_source_snapshot_modules(&snapshot).unwrap();
+        let view = program.ast_views().next().unwrap();
+        let items = view.items().collect::<Vec<_>>();
+        assert_eq!(items.len(), 2);
+        assert!(
+            items
+                .iter()
+                .all(|item| Arc::ptr_eq(item.module(), view.module()))
+        );
+        assert_eq!(items[0].module_id(), view.module_id());
+    }
+
+    #[test]
+    fn missing_stable_module_cannot_construct_a_public_view() {
+        let snapshot = snapshot(&[(1, "/main.rue", "main.rue", "fn main() {}")], 1);
+        let program = parse_source_snapshot_modules(&snapshot).unwrap();
+        assert_eq!(program.ast_views().len(), 1);
+        assert_eq!(
+            ModuleId::from_logical_path("main.rue").unwrap(),
+            program.ast_views().next().unwrap().module_id().clone()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add canonical AST/item views that retain the exact owning `Arc<ParsedModule>`
- add a request-local semantic symbol universe that translates only provenanced symbols through an admitted module view
- bind each universe to the exact parsed artifacts in its canonical program and reject independently reparsed lookalikes
- expose no naked local or semantic numeric symbol identity
- add structural translation counters proving zero parsing and AST payload cloning

## Why

Per-module local Spurs are meaningful only inside their frozen resolver. This establishes the sole safe translation boundary before merge and RIR lowering migrate, preventing accidental cross-universe numeric comparisons without adding a translation cache.

## Validation

- formatting and all 41 clippy targets
- compiler tests (346 passing)
- full 34-target suite and reproducible-program checks
- compiler self-reproducibility
- equal-numeric-local-Spur, reordered Arc reuse, foreign artifact/provenance, and zero-work regressions
- additive infrastructure only; batch path unchanged

Linear: RUE-715