### PR TITLE
RUE-716: retain parsed module provenance in canonical merge

### DIFF
--- a/crates/rue-compiler/src/canonical_merge.rs
+++ b/crates/rue-compiler/src/canonical_merge.rs
@@ -1,0 +1,471 @@
+//! Provenance-retaining canonical syntax assembly.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rue_error::{CompileError, CompileErrors, ErrorKind};
+use rue_span::Span;
+
+use crate::parsed_modules::{ParsedAstView, ParsedItemView, ParsedModule, ParsedProgram};
+use crate::{DefinitionKind, DefinitionSnapshot, ModuleId, SourceRevision};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CanonicalMergeWork {
+    pub modules_visited: usize,
+    pub items_visited: usize,
+    pub candidates_visited: usize,
+    pub parser_invocations: usize,
+    /// Deep AST payload clones (Arc handle retention is not a payload clone).
+    pub ast_payload_clones: usize,
+    /// Deep source-buffer clones (Arc handle retention is not a payload clone).
+    pub source_text_clones: usize,
+    pub source_bytes_rehashed: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct CanonicalMergedAst {
+    source_revision: SourceRevision,
+    modules: Arc<[Arc<ParsedModule>]>,
+}
+
+impl CanonicalMergedAst {
+    pub fn source_revision(&self) -> &SourceRevision {
+        &self.source_revision
+    }
+    pub fn root(&self) -> &ModuleId {
+        self.source_revision.root()
+    }
+    pub fn modules(&self) -> &[Arc<ParsedModule>] {
+        &self.modules
+    }
+    pub fn ast_views(&self) -> impl ExactSizeIterator<Item = ParsedAstView> + '_ {
+        self.modules.iter().cloned().map(ParsedAstView::from_module)
+    }
+    pub fn item_views(&self) -> impl Iterator<Item = ParsedItemView> + '_ {
+        self.modules.iter().flat_map(|module| {
+            let module = module.clone();
+            (0..module.ast().items.len())
+                .map(move |index| ParsedItemView::from_module_index(module.clone(), index))
+        })
+    }
+    pub fn validate_view(&self, view: &ParsedAstView) -> Result<(), CompileError> {
+        let index = self
+            .modules
+            .binary_search_by(|module| module.module_id().cmp(view.module_id()))
+            .map_err(|_| invalid_input("module view is absent from canonical merged syntax"))?;
+        if !Arc::ptr_eq(&self.modules[index], view.module()) {
+            return Err(invalid_input(
+                "module view belongs to a foreign parsed artifact",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CanonicalMergedProgram {
+    ast: CanonicalMergedAst,
+    definitions: DefinitionSnapshot,
+    work: CanonicalMergeWork,
+}
+
+impl CanonicalMergedProgram {
+    pub fn ast(&self) -> &CanonicalMergedAst {
+        &self.ast
+    }
+    pub fn definitions(&self) -> &DefinitionSnapshot {
+        &self.definitions
+    }
+    pub fn work(&self) -> CanonicalMergeWork {
+        self.work
+    }
+}
+
+#[derive(Clone)]
+struct CandidateDef {
+    span: Span,
+    physical_path: Arc<str>,
+}
+
+pub fn merge_parsed_modules(
+    program: &ParsedProgram,
+) -> Result<CanonicalMergedProgram, CompileErrors> {
+    let work = CanonicalMergeWork {
+        modules_visited: program.modules().len(),
+        items_visited: program
+            .modules()
+            .iter()
+            .map(|module| module.ast().items.len())
+            .sum(),
+        candidates_visited: program
+            .modules()
+            .iter()
+            .map(|module| module.definitions().candidates().len())
+            .sum(),
+        ..CanonicalMergeWork::default()
+    };
+    let errors = canonical_duplicate_errors(program);
+    if !errors.is_empty() {
+        return Err(CompileErrors::from(errors));
+    }
+    let definitions =
+        DefinitionSnapshot::from_parsed_modules(program).map_err(CompileErrors::from)?;
+    Ok(CanonicalMergedProgram {
+        ast: CanonicalMergedAst {
+            source_revision: program.source_revision().clone(),
+            modules: program.modules().to_vec().into(),
+        },
+        definitions,
+        work,
+    })
+}
+
+fn canonical_duplicate_errors(program: &ParsedProgram) -> Vec<CompileError> {
+    let mut errors = Vec::new();
+    let mut program_main: Option<CandidateDef> = None;
+    for module in program.modules() {
+        let mut functions = HashMap::<&str, CandidateDef>::new();
+        let mut function_names = HashMap::<&str, CandidateDef>::new();
+        let mut type_names = HashMap::<&str, CandidateDef>::new();
+        let mut structs = HashMap::<&str, CandidateDef>::new();
+        let mut enums = HashMap::<&str, CandidateDef>::new();
+        for candidate in module.definitions().candidates() {
+            let name = candidate.name();
+            let definition = || CandidateDef {
+                span: candidate.declaration_span(),
+                physical_path: Arc::from(module.physical_path()),
+            };
+            match candidate.kind() {
+                DefinitionKind::Function => {
+                    if let Some(first) = functions.get(name) {
+                        errors.push(function_conflict(candidate.declaration_span(), name, first));
+                    } else if name == "main"
+                        && let Some(first) = &program_main
+                    {
+                        errors.push(
+                            CompileError::new(
+                                ErrorKind::DuplicateFunctionDefinition {
+                                    function_name: name.to_owned(),
+                                },
+                                candidate.declaration_span(),
+                            )
+                            .with_label("first defined here", first.span),
+                        );
+                    } else {
+                        let value = definition();
+                        if name == "main" {
+                            program_main = Some(value.clone());
+                        }
+                        functions.insert(name, value);
+                    }
+                    if let Some(first) = type_names.get(name) {
+                        errors.push(function_conflict(candidate.declaration_span(), name, first));
+                    }
+                    function_names.entry(name).or_insert_with(definition);
+                }
+                DefinitionKind::Struct => {
+                    if let Some(first) = function_names.get(name) {
+                        errors.push(function_conflict(candidate.declaration_span(), name, first));
+                    } else if let Some(first) = structs.get(name) {
+                        errors.push(type_conflict(
+                            candidate.declaration_span(),
+                            format!("struct `{name}`"),
+                            format!("first defined in {}", first.physical_path),
+                            first.span,
+                        ));
+                    } else if let Some(first) = enums.get(name) {
+                        errors.push(type_conflict(
+                            candidate.declaration_span(),
+                            format!("struct `{name}` (conflicts with enum)"),
+                            format!("enum first defined in {}", first.physical_path),
+                            first.span,
+                        ));
+                    } else {
+                        type_names.entry(name).or_insert_with(definition);
+                        structs.insert(name, definition());
+                    }
+                }
+                DefinitionKind::Enum => {
+                    if let Some(first) = function_names.get(name) {
+                        errors.push(function_conflict(candidate.declaration_span(), name, first));
+                    } else if let Some(first) = enums.get(name) {
+                        errors.push(type_conflict(
+                            candidate.declaration_span(),
+                            format!("enum `{name}`"),
+                            format!("first defined in {}", first.physical_path),
+                            first.span,
+                        ));
+                    } else if let Some(first) = structs.get(name) {
+                        errors.push(type_conflict(
+                            candidate.declaration_span(),
+                            format!("enum `{name}` (conflicts with struct)"),
+                            format!("struct first defined in {}", first.physical_path),
+                            first.span,
+                        ));
+                    } else {
+                        type_names.entry(name).or_insert_with(definition);
+                        enums.insert(name, definition());
+                    }
+                }
+                DefinitionKind::Destructor | DefinitionKind::Const => {}
+            }
+        }
+    }
+    errors
+}
+
+fn function_conflict(span: Span, name: &str, first: &CandidateDef) -> CompileError {
+    CompileError::new(
+        ErrorKind::DuplicateFunctionDefinition {
+            function_name: name.to_owned(),
+        },
+        span,
+    )
+    .with_label(
+        format!("first defined in {}", first.physical_path),
+        first.span,
+    )
+}
+
+fn type_conflict(span: Span, type_name: String, label: String, first_span: Span) -> CompileError {
+    CompileError::new(ErrorKind::DuplicateTypeDefinition { type_name }, span)
+        .with_label(label, first_span)
+}
+
+fn invalid_input(message: impl Into<String>) -> CompileError {
+    CompileError::without_span(ErrorKind::InvalidCompilerInput(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rue_span::FileId;
+
+    use super::*;
+    use crate::parsed_modules::parse_source_snapshot_modules;
+    use crate::{
+        SourceFile, SourceMetadata, SourceSnapshot, merge_symbols,
+        parse_all_files_with_source_snapshot,
+    };
+
+    fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
+        let physical = entries
+            .iter()
+            .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
+            .collect::<HashMap<_, _>>();
+        let logical = entries
+            .iter()
+            .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
+            .collect::<HashMap<_, _>>();
+        let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
+        SourceSnapshot::new(
+            metadata,
+            entries
+                .iter()
+                .map(|(id, _, _, text)| (FileId::new(*id), Arc::new((*text).to_owned())))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    fn errors(errors: &CompileErrors) -> Vec<String> {
+        errors
+            .iter()
+            .map(|error| {
+                format!(
+                    "{}|{:?}|{}|{:?}",
+                    error.kind.code(),
+                    error.span(),
+                    error,
+                    error.diagnostic()
+                )
+            })
+            .collect()
+    }
+
+    fn definitions(snapshot: &DefinitionSnapshot) -> Vec<String> {
+        snapshot
+            .definitions()
+            .map(|record| {
+                format!(
+                    "{}|{:?}|{}|{:?}|{:?}",
+                    record.name_key().module(),
+                    record.name_key().namespace(),
+                    record.name_key().name(),
+                    record.kind(),
+                    record.declaration_span()
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn canonical_duplicate_and_cross_kind_diagnostics_match_legacy() {
+        let source =
+            "fn dup() {} fn dup() {} struct clash {} fn clash() {} enum kind {} struct kind {}";
+        let snapshot = snapshot(&[(1, "main.rue", "main.rue", source)], 1);
+        let canonical = parse_source_snapshot_modules(&snapshot).unwrap();
+        let canonical_errors = merge_parsed_modules(&canonical).unwrap_err();
+
+        let legacy = parse_all_files_with_source_snapshot(&snapshot).unwrap();
+        let legacy_errors = merge_symbols(legacy).unwrap_err();
+        assert_eq!(errors(&canonical_errors), errors(&legacy_errors));
+    }
+
+    #[test]
+    fn canonical_cross_module_main_diagnostics_match_legacy_and_ignore_input_order() {
+        let snapshot = snapshot(
+            &[
+                (1, "a.rue", "a.rue", "fn main() {}"),
+                (2, "b.rue", "b.rue", "fn main() {}"),
+            ],
+            1,
+        );
+        let canonical = parse_source_snapshot_modules(&snapshot).unwrap();
+        let expected = merge_parsed_modules(&canonical).unwrap_err();
+        let mut reversed = canonical.modules().to_vec();
+        reversed.reverse();
+        let reordered = ParsedProgram::new(canonical.root().clone(), reversed).unwrap();
+        let reordered = merge_parsed_modules(&reordered).unwrap_err();
+        assert_eq!(errors(&expected), errors(&reordered));
+
+        let legacy = parse_all_files_with_source_snapshot(&snapshot).unwrap();
+        let legacy = merge_symbols(legacy).unwrap_err();
+        assert_eq!(errors(&expected), errors(&legacy));
+    }
+
+    #[test]
+    fn reordered_same_arcs_have_identical_values_work_and_definitions() {
+        let snapshot = snapshot(
+            &[
+                (9, "z.rue", "z.rue", "fn zed() {}"),
+                (2, "a.rue", "a.rue", "fn alpha() {} const value: i32 = 1;"),
+            ],
+            9,
+        );
+        let first = parse_source_snapshot_modules(&snapshot).unwrap();
+        let mut reversed = first.modules().to_vec();
+        reversed.reverse();
+        let second = ParsedProgram::new(first.root().clone(), reversed).unwrap();
+        let first_merged = merge_parsed_modules(&first).unwrap();
+        let second_merged = merge_parsed_modules(&second).unwrap();
+
+        assert_eq!(first_merged.work(), second_merged.work());
+        assert_eq!(
+            first_merged.ast().source_revision(),
+            second_merged.ast().source_revision()
+        );
+        assert_eq!(
+            definitions(first_merged.definitions()),
+            definitions(second_merged.definitions())
+        );
+        assert!(
+            first_merged
+                .ast()
+                .modules()
+                .iter()
+                .zip(second_merged.ast().modules())
+                .all(|(left, right)| Arc::ptr_eq(left, right))
+        );
+        assert_eq!(first_merged.work().parser_invocations, 0);
+        assert_eq!(first_merged.work().ast_payload_clones, 0);
+        assert_eq!(first_merged.work().source_text_clones, 0);
+        assert_eq!(first_merged.work().source_bytes_rehashed, 0);
+    }
+
+    #[test]
+    fn equal_numeric_local_spurs_use_owned_distinct_names() {
+        let snapshot = snapshot(
+            &[
+                (1, "a.rue", "a.rue", "fn alpha() {}"),
+                (2, "b.rue", "b.rue", "fn beta() {}"),
+            ],
+            1,
+        );
+        let program = parse_source_snapshot_modules(&snapshot).unwrap();
+        let left = &program.modules()[0].definitions().candidates()[0];
+        let right = &program.modules()[1].definitions().candidates()[0];
+        assert_eq!(
+            left.symbol().test_local_ordinal(),
+            right.symbol().test_local_ordinal()
+        );
+        let merged = merge_parsed_modules(&program).unwrap();
+        assert_eq!(
+            definitions(merged.definitions())
+                .iter()
+                .map(|value| value.split('|').nth(2).unwrap())
+                .collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+    }
+
+    #[test]
+    fn definition_snapshot_retains_duplicate_occurrences_without_resolving_spurs() {
+        let snapshot = snapshot(
+            &[(1, "main.rue", "main.rue", "fn same() {} fn same() {}")],
+            1,
+        );
+        let program = parse_source_snapshot_modules(&snapshot).unwrap();
+        let definitions = DefinitionSnapshot::from_parsed_modules(&program).unwrap();
+        let key = crate::DefinitionNameKey::new(
+            program.root().clone(),
+            crate::DefinitionNamespace::ModuleItem,
+            "same",
+        );
+        let matches = definitions.definitions_named(&key).collect::<Vec<_>>();
+        assert_eq!(matches.len(), 2);
+        assert_ne!(matches[0].id(), matches[1].id());
+    }
+
+    #[test]
+    fn trusted_snapshot_canonicalizes_equal_bytes_without_rehashing() {
+        let text = "fn same() {}";
+        let left_snapshot = snapshot(&[(1, "left.rue", "left.rue", text)], 1);
+        let right_snapshot = snapshot(&[(2, "right.rue", "right.rue", text)], 2);
+        let left = parse_source_snapshot_modules(&left_snapshot).unwrap();
+        let right = parse_source_snapshot_modules(&right_snapshot).unwrap();
+        assert!(!Arc::ptr_eq(
+            &left.modules()[0].shared_source_text(),
+            &right.modules()[0].shared_source_text()
+        ));
+        let program = ParsedProgram::new(
+            left.root().clone(),
+            vec![left.modules()[0].clone(), right.modules()[0].clone()],
+        )
+        .unwrap();
+        let merged = merge_parsed_modules(&program).unwrap();
+        let rebuilt = merged.definitions().source_snapshot();
+        assert_eq!(rebuilt.source_store().len(), 1);
+        assert!(Arc::ptr_eq(
+            &rebuilt.shared_source_text(FileId::new(1)).unwrap(),
+            &rebuilt.shared_source_text(FileId::new(2)).unwrap()
+        ));
+        assert_eq!(merged.work().source_bytes_rehashed, 0);
+    }
+
+    #[test]
+    fn canonical_merged_ast_rejects_independently_reparsed_view() {
+        let snapshot = snapshot(&[(1, "main.rue", "main.rue", "fn main() {}")], 1);
+        let admitted = parse_source_snapshot_modules(&snapshot).unwrap();
+        let foreign = parse_source_snapshot_modules(&snapshot).unwrap();
+        let merged = merge_parsed_modules(&admitted).unwrap();
+        let admitted_view = admitted.ast_views().next().unwrap();
+        let foreign_view = foreign.ast_views().next().unwrap();
+        merged.ast().validate_view(&admitted_view).unwrap();
+        assert_eq!(
+            merged
+                .ast()
+                .validate_view(&foreign_view)
+                .unwrap_err()
+                .to_string(),
+            "invalid compiler input: module view belongs to a foreign parsed artifact"
+        );
+    }
+
+    #[test]
+    fn legacy_source_file_constructor_remains_available() {
+        let source = SourceFile::new("main.rue", "fn main() {}", FileId::new(1));
+        assert_eq!(source.path, "main.rue");
+    }
+}

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -250,6 +250,73 @@ pub struct DefinitionSnapshot {
 }
 
 impl DefinitionSnapshot {
+    /// Build durable definition candidates from self-contained parsed modules.
+    ///
+    /// Names are already owned values in each module's definition index; this
+    /// path performs no interner lookup, AST traversal, or source-byte hashing.
+    pub fn from_parsed_modules(
+        program: &crate::parsed_modules::ParsedProgram,
+    ) -> CompileResult<Self> {
+        let _span = info_span!(
+            "definition_snapshot_modules",
+            module_count = program.modules().len()
+        )
+        .entered();
+        let source_snapshot = SourceSnapshot::from_parsed_modules(program)?;
+        let mut modules = Vec::with_capacity(program.modules().len());
+        let definition_count = program
+            .modules()
+            .iter()
+            .map(|module| module.definitions().candidates().len())
+            .sum();
+        let mut definitions_by_name =
+            HashMap::<DefinitionNameKey, Vec<DefinitionId>>::with_capacity(definition_count);
+
+        for (module_index, module) in program.modules().iter().enumerate() {
+            let mut definitions = Vec::with_capacity(module.definitions().candidates().len());
+            for (definition_index, candidate) in
+                module.definitions().candidates().iter().enumerate()
+            {
+                debug_assert_eq!(candidate.occurrence().index(), definition_index);
+                let id = DefinitionId {
+                    module_index,
+                    definition_index,
+                };
+                let name_key = DefinitionNameKey::new(
+                    module.module_id().clone(),
+                    candidate.namespace(),
+                    candidate.name(),
+                );
+                definitions_by_name
+                    .entry(name_key.clone())
+                    .or_default()
+                    .push(id);
+                definitions.push(DefinitionRecord {
+                    id,
+                    name_key,
+                    kind: candidate.kind(),
+                    visibility: candidate.visibility(),
+                    file_id: module.file_id(),
+                    name_span: candidate.name_span(),
+                    declaration_span: candidate.declaration_span(),
+                });
+            }
+            modules.push(ModuleDefinition {
+                key: module.module_id().clone(),
+                file_id: module.file_id(),
+                definitions,
+            });
+        }
+
+        Ok(Self {
+            source_snapshot,
+            root_module: program.root().clone(),
+            modules,
+            definition_count,
+            definitions_by_name,
+        })
+    }
+
     /// Resolve a parsed program into durable name candidates and source records.
     ///
     /// The parsed-file ID multiset and physical paths must exactly match

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -25,6 +25,7 @@
 //! This crate is instrumented with `tracing` spans for performance analysis.
 //! Use `--log-level info` or `--time-passes` to see timing information.
 
+mod canonical_merge;
 mod definition_snapshot;
 mod diagnostic;
 mod drop_glue;
@@ -38,6 +39,9 @@ mod source_snapshot;
 mod syntax;
 mod unit;
 
+pub use canonical_merge::{
+    CanonicalMergeWork, CanonicalMergedAst, CanonicalMergedProgram, merge_parsed_modules,
+};
 pub use definition_snapshot::{
     DefinitionId, DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionRecord,
     DefinitionSnapshot, ModuleDefinition, ModuleKey,

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -195,6 +195,10 @@ pub struct ParsedAstView {
 }
 
 impl ParsedAstView {
+    pub(crate) fn from_module(module: Arc<ParsedModule>) -> Self {
+        Self { module }
+    }
+
     pub fn module(&self) -> &Arc<ParsedModule> {
         &self.module
     }
@@ -223,6 +227,11 @@ pub struct ParsedItemView {
 }
 
 impl ParsedItemView {
+    pub(crate) fn from_module_index(module: Arc<ParsedModule>, index: usize) -> Self {
+        debug_assert!(index < module.ast().items.len());
+        Self { module, index }
+    }
+
     pub fn module(&self) -> &Arc<ParsedModule> {
         &self.module
     }
@@ -254,6 +263,9 @@ impl ParsedModule {
     }
     pub fn source_text(&self) -> &str {
         &self.source_text
+    }
+    pub(crate) fn shared_source_text(&self) -> Arc<String> {
+        self.source_text.clone()
     }
     pub fn ast(&self) -> &Ast {
         &self.ast.ast

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -84,7 +84,6 @@ impl SourceId {
         self.0.digest
     }
 
-    #[cfg(test)]
     pub(crate) fn shared_text(&self) -> Arc<String> {
         self.0.text.clone()
     }

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -48,6 +48,86 @@ struct SourceRecord {
 }
 
 impl SourceSnapshot {
+    /// Reassemble diagnostic source records from already-validated parsed
+    /// artifacts without hashing source bytes again.
+    pub(crate) fn from_parsed_modules(
+        program: &crate::parsed_modules::ParsedProgram,
+    ) -> CompileResult<Self> {
+        let root_file_id = program
+            .modules()
+            .iter()
+            .find(|module| module.module_id() == program.root())
+            .expect("parsed program validates its root")
+            .file_id();
+        let physical_paths = program
+            .modules()
+            .iter()
+            .map(|module| (module.file_id(), module.physical_path().to_owned()))
+            .collect();
+        let logical_paths = program
+            .modules()
+            .iter()
+            .map(|module| (module.file_id(), module.module_id().as_str().to_owned()))
+            .collect();
+        let metadata = SourceMetadata::new(root_file_id, physical_paths, logical_paths)?;
+        validate_source_lengths(
+            program
+                .modules()
+                .iter()
+                .map(|module| (module.file_id(), module.source_text().len())),
+            &metadata,
+        )?;
+
+        let source_store = SourceStore::from_ids(
+            program
+                .modules()
+                .iter()
+                .map(|module| module.source_id().clone()),
+        );
+        let contents: Vec<_> = program
+            .modules()
+            .iter()
+            .map(|module| {
+                let module_text = module.shared_source_text();
+                if !Arc::ptr_eq(&module_text, &module.source_id().shared_text()) {
+                    return Err(invalid_input(format!(
+                        "parsed module {} source text has foreign identity provenance",
+                        module.module_id()
+                    )));
+                }
+                let source_id = source_store
+                    .get(module.source_id())
+                    .expect("store was built from every parsed module source")
+                    .clone();
+                let text = source_store
+                    .shared_text(&source_id)
+                    .expect("canonical store identity retains exact source text");
+                Ok(SourceRecord {
+                    file_id: module.file_id(),
+                    module_id: module.module_id().clone(),
+                    source_id,
+                    text,
+                })
+            })
+            .collect::<CompileResult<_>>()?;
+        let index = contents
+            .iter()
+            .enumerate()
+            .map(|(index, record)| (record.file_id, index))
+            .collect();
+        let revision = program.source_revision().clone();
+
+        Ok(Self {
+            data: Arc::new(SourceSnapshotData {
+                metadata,
+                contents,
+                index,
+                revision,
+                source_store,
+            }),
+        })
+    }
+
     /// Build a snapshot from validated metadata and owned source buffers.
     ///
     /// `contents` may be in any order, and that caller-supplied order is


### PR DESCRIPTION
## Summary

- add a canonical merge boundary that retains exact module-qualified parsed artifacts
- build durable definition snapshots from owned parsed-definition candidates without reparsing, AST cloning, or source rehashing
- preserve legacy duplicate diagnostics and compatibility APIs while rejecting foreign parsed views

## Verification

- `./buck2 test //crates/rue-compiler:rue-compiler-test` (354 tests)
- `./test.sh` (34 targets)
- `./fmt.sh --check`
- `./clippy.sh` (41 targets)

Linear: RUE-716