### PR TITLE
RUE-717: normalize module symbols during canonical RIR lowering

### DIFF
--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -1,0 +1,323 @@
+//! Canonical, provenance-safe lowering from parsed modules to RIR.
+
+use std::cell::RefCell;
+
+use rue_error::{CompileError, CompileResult};
+use rue_rir::{AstGen, Rir};
+
+use crate::{CanonicalMergedProgram, SemanticSymbolUniverse, SourceRevision};
+
+/// Structural work performed by canonical RIR lowering.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CanonicalRirWork {
+    pub modules_visited: usize,
+    pub items_visited: usize,
+    pub symbol_fields_translated: usize,
+    pub semantic_intern_attempts: usize,
+    pub unique_semantic_strings: usize,
+    /// All strings retained by the final RIR universe, including synthesized names.
+    pub semantic_strings_retained: usize,
+    pub parser_invocations: usize,
+    pub ast_payload_clones: usize,
+    pub source_text_clones: usize,
+}
+
+/// RIR paired with the exact source revision and symbol universe that created it.
+#[derive(Debug)]
+pub struct CanonicalRirOutput {
+    source_revision: SourceRevision,
+    rir: Rir,
+    symbols: SemanticSymbolUniverse,
+    work: CanonicalRirWork,
+}
+
+impl CanonicalRirOutput {
+    pub fn source_revision(&self) -> &SourceRevision {
+        &self.source_revision
+    }
+
+    pub fn rir(&self) -> &Rir {
+        &self.rir
+    }
+
+    pub fn semantic_symbols(&self) -> &SemanticSymbolUniverse {
+        &self.symbols
+    }
+
+    pub fn work(&self) -> CanonicalRirWork {
+        self.work
+    }
+}
+
+/// Lower canonical module views in stable `ModuleId` order into one RIR.
+pub fn lower_canonical_rir(merged: &CanonicalMergedProgram) -> CompileResult<CanonicalRirOutput> {
+    let ast = merged.ast();
+    let symbols = SemanticSymbolUniverse::from_modules(ast.modules());
+    let current_view = RefCell::<Option<crate::parsed_modules::ParsedAstView>>::new(None);
+    let first_error = RefCell::<Option<CompileError>>::new(None);
+
+    let rir = {
+        let mut generator = AstGen::with_symbol_normalizer(symbols.interner(), |local| {
+            let view = current_view.borrow();
+            let translated = symbols.translate_ast_symbol(
+                view.as_ref()
+                    .expect("canonical lowering installs a module view before lowering items"),
+                local,
+            );
+            match translated {
+                Ok(symbol) => symbol.spur(),
+                Err(error) => {
+                    let mut slot = first_error.borrow_mut();
+                    if slot.is_none() {
+                        *slot = Some(error);
+                    }
+                    symbols
+                        .interner()
+                        .get_or_intern("__rue_invalid_local_symbol")
+                }
+            }
+        });
+
+        for view in ast.ast_views() {
+            ast.validate_view(&view)?;
+            *current_view.borrow_mut() = Some(view.clone());
+            generator.append_items(&view.module().ast().items);
+            if let Some(error) = first_error.borrow_mut().take() {
+                return Err(error);
+            }
+        }
+        generator.finish()
+    };
+
+    let translation = symbols.work();
+    let work = CanonicalRirWork {
+        modules_visited: ast.modules().len(),
+        items_visited: ast
+            .modules()
+            .iter()
+            .map(|module| module.ast().items.len())
+            .sum(),
+        symbol_fields_translated: translation.local_symbol_resolutions,
+        semantic_intern_attempts: translation.semantic_intern_attempts,
+        unique_semantic_strings: translation.unique_semantic_strings,
+        semantic_strings_retained: symbols.interner().len(),
+        ..CanonicalRirWork::default()
+    };
+    Ok(CanonicalRirOutput {
+        source_revision: ast.source_revision().clone(),
+        rir,
+        symbols,
+        work,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use rue_rir::{AstGen, RirPrinter};
+    use rue_span::FileId;
+
+    use super::*;
+    use crate::parsed_modules::{ParsedProgram, parse_source_snapshot_modules};
+    use crate::{
+        SourceMetadata, SourceSnapshot, merge_parsed_modules, merge_symbols,
+        parse_all_files_with_source_snapshot,
+    };
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn canonical_output_is_send_and_sync() {
+        assert_send_sync::<SemanticSymbolUniverse>();
+        assert_send_sync::<CanonicalRirOutput>();
+    }
+
+    fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
+        let physical = entries
+            .iter()
+            .map(|(id, path, _, _)| (FileId::new(*id), (*path).to_owned()))
+            .collect::<HashMap<_, _>>();
+        let logical = entries
+            .iter()
+            .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).to_owned()))
+            .collect::<HashMap<_, _>>();
+        let metadata = SourceMetadata::new(FileId::new(root), physical, logical).unwrap();
+        SourceSnapshot::new(
+            metadata,
+            entries
+                .iter()
+                .map(|(id, _, _, text)| (FileId::new(*id), Arc::new((*text).to_owned())))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    fn print(output: &CanonicalRirOutput) -> String {
+        RirPrinter::new(output.rir(), output.symbols.interner()).to_string()
+    }
+
+    #[test]
+    fn equal_local_spurs_lower_to_distinct_semantic_names() {
+        let source = snapshot(
+            &[
+                (1, "/a.rue", "a.rue", "fn alpha() {}"),
+                (2, "/b.rue", "b.rue", "fn beta() {}"),
+            ],
+            1,
+        );
+        let parsed = parse_source_snapshot_modules(&source).unwrap();
+        let merged = merge_parsed_modules(&parsed).unwrap();
+        let output = lower_canonical_rir(&merged).unwrap();
+        let rendered = print(&output);
+
+        assert!(rendered.contains("alpha"));
+        assert!(rendered.contains("beta"));
+        assert_eq!(output.source_revision(), merged.ast().source_revision());
+        assert_eq!(output.work().modules_visited, 2);
+        assert_eq!(output.work().items_visited, 2);
+        assert_eq!(output.work().parser_invocations, 0);
+        assert_eq!(output.work().ast_payload_clones, 0);
+        assert_eq!(output.work().source_text_clones, 0);
+    }
+
+    #[test]
+    fn reordered_arc_assembly_has_identical_rir_and_work() {
+        let source = snapshot(
+            &[
+                (8, "/z.rue", "z.rue", "fn zed() {}"),
+                (3, "/a.rue", "a.rue", "fn alpha() {}"),
+            ],
+            8,
+        );
+        let first = parse_source_snapshot_modules(&source).unwrap();
+        let mut modules = first.modules().to_vec();
+        modules.reverse();
+        let second = ParsedProgram::new(first.root().clone(), modules).unwrap();
+        let first = lower_canonical_rir(&merge_parsed_modules(&first).unwrap()).unwrap();
+        let second = lower_canonical_rir(&merge_parsed_modules(&second).unwrap()).unwrap();
+
+        assert_eq!(print(&first), print(&second));
+        assert_eq!(first.work(), second.work());
+    }
+
+    #[test]
+    fn canonical_rir_matches_the_legacy_shared_interner_lowering() {
+        let source = snapshot(
+            &[
+                (
+                    1,
+                    "/a.rue",
+                    "a.rue",
+                    "struct Point { x: i32 } fn make(value: i32) -> Point { Point { x: value } }",
+                ),
+                (2, "/b.rue", "b.rue", "fn answer() -> i32 { 42 }"),
+            ],
+            1,
+        );
+        let parsed = parse_source_snapshot_modules(&source).unwrap();
+        let canonical = lower_canonical_rir(&merge_parsed_modules(&parsed).unwrap()).unwrap();
+
+        let legacy = merge_symbols(parse_all_files_with_source_snapshot(&source).unwrap()).unwrap();
+        let legacy_rir = AstGen::generate_items(&legacy.interner, legacy.ast.items());
+        let legacy = RirPrinter::new(&legacy_rir, &legacy.interner).to_string();
+
+        assert_eq!(print(&canonical), legacy);
+    }
+
+    #[test]
+    fn adversarial_symbol_surfaces_match_legacy_lowering() {
+        let source = snapshot(
+            &[
+                (
+                    1,
+                    "/seed.rue",
+                    "a-seed.rue",
+                    "fn seed() { let displaced = 0; }",
+                ),
+                (
+                    2,
+                    "/symbols.rue",
+                    "b-symbols.rue",
+                    r#"
+                        struct Resource {
+                            value: i32,
+                            fn set(self, next: i32) { self.value = next; }
+                            fn make() -> Resource { Resource { value: 0 } }
+                        }
+                        enum Choice { None, Some(i32) }
+                        const imported = @import("other.rue");
+                        const LENGTH: u64 = 2;
+                        drop fn Resource(self) { () }
+
+                        @allow(unused_function)
+                        fn exercise(values: [i32; LENGTH], text: String) -> i32 {
+                            let mut resource = Resource.make();
+                            resource.set(1);
+                            resource.value = 2;
+                            let field = resource.value;
+                            let choice = Choice.Some(field);
+                            let payload = match choice {
+                                Choice.Some(inner) => inner,
+                                Choice.None => 0,
+                            };
+                            let _ = "symbolic text";
+                            for element in values { resource.value = element; }
+                            for byte in text { resource.value = byte; }
+                            @dbg(payload);
+                            @sizeOf([i32; LENGTH]);
+                            payload
+                        }
+
+                        fn TypeFactory(comptime T: type) -> type {
+                            struct {
+                                member: T,
+                                fn get(self) -> T { self.member }
+                            }
+                        }
+                    "#,
+                ),
+                (
+                    3,
+                    "/other.rue",
+                    "c-other.rue",
+                    "fn imported_name() -> i32 { 1 }",
+                ),
+            ],
+            2,
+        );
+        let parsed = parse_source_snapshot_modules(&source).unwrap();
+        let canonical = lower_canonical_rir(&merge_parsed_modules(&parsed).unwrap()).unwrap();
+        let rendered = print(&canonical);
+
+        let legacy = merge_symbols(parse_all_files_with_source_snapshot(&source).unwrap()).unwrap();
+        let legacy_rir = AstGen::generate_items(&legacy.interner, legacy.ast.items());
+        let legacy = RirPrinter::new(&legacy_rir, &legacy.interner).to_string();
+
+        assert_eq!(rendered, legacy);
+        assert!(canonical.work().symbol_fields_translated > 40);
+        assert!(
+            canonical
+                .semantic_symbols()
+                .interner()
+                .get("unused_function")
+                .is_some(),
+            "directive arguments must resolve in the destination universe"
+        );
+        for expected in [
+            "Resource",
+            "Some",
+            "inner",
+            "LENGTH",
+            "symbolic text",
+            "element",
+            "member",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "missing normalized `{expected}`"
+            );
+        }
+    }
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -25,6 +25,7 @@
 //! This crate is instrumented with `tracing` spans for performance analysis.
 //! Use `--log-level info` or `--time-passes` to see timing information.
 
+mod canonical_lower;
 mod canonical_merge;
 mod definition_snapshot;
 mod diagnostic;
@@ -39,6 +40,7 @@ mod source_snapshot;
 mod syntax;
 mod unit;
 
+pub use canonical_lower::{CanonicalRirOutput, CanonicalRirWork, lower_canonical_rir};
 pub use canonical_merge::{
     CanonicalMergeWork, CanonicalMergedAst, CanonicalMergedProgram, merge_parsed_modules,
 };

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -280,6 +280,10 @@ impl ParsedModule {
     pub fn resolve(&self, symbol: &ParsedSymbol) -> CompileResult<&str> {
         self.resolver.resolve(symbol)
     }
+
+    pub(crate) fn parsed_symbol(&self, spur: Spur) -> CompileResult<ParsedSymbol> {
+        self.resolver.symbol(spur)
+    }
 }
 
 /// Deterministically ordered collection of independently parsed modules.

--- a/crates/rue-compiler/src/semantic_symbols.rs
+++ b/crates/rue-compiler/src/semantic_symbols.rs
@@ -1,6 +1,7 @@
 //! Provenance-safe translation from parsed-module symbols into one request.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileResult, ErrorKind};
@@ -39,20 +40,25 @@ pub struct SemanticSymbolUniverse {
     admitted_modules: Arc<[Arc<crate::parsed_modules::ParsedModule>]>,
     interner: ThreadedRodeo,
     provenance: Arc<SemanticSymbolProvenance>,
-    work: SemanticTranslationWork,
+    local_symbol_resolutions: AtomicUsize,
+    semantic_intern_attempts: AtomicUsize,
+    unique_semantic_strings: AtomicUsize,
 }
 
 impl SemanticSymbolUniverse {
     /// Start a destination universe for one canonical program traversal.
     pub fn new(program: &ParsedProgram) -> Self {
+        Self::from_modules(program.modules())
+    }
+
+    pub(crate) fn from_modules(modules: &[Arc<crate::parsed_modules::ParsedModule>]) -> Self {
         Self {
-            admitted_modules: program.modules().to_vec().into(),
+            admitted_modules: modules.to_vec().into(),
             interner: ThreadedRodeo::new(),
             provenance: Arc::new(SemanticSymbolProvenance),
-            work: SemanticTranslationWork {
-                modules_visited: program.modules().len(),
-                ..SemanticTranslationWork::default()
-            },
+            local_symbol_resolutions: AtomicUsize::new(0),
+            semantic_intern_attempts: AtomicUsize::new(0),
+            unique_semantic_strings: AtomicUsize::new(0),
         }
     }
 
@@ -61,6 +67,16 @@ impl SemanticSymbolUniverse {
     /// This API deliberately accepts no naked local `Spur`.
     pub fn translate(
         &mut self,
+        owner: &ParsedAstView,
+        symbol: &ParsedSymbol,
+    ) -> CompileResult<SemanticSymbol> {
+        self.translate_shared(owner, symbol)
+    }
+
+    /// Canonical lowering is a single-threaded builder even though its frozen
+    /// output remains `Send + Sync`.
+    fn translate_shared(
+        &self,
         owner: &ParsedAstView,
         symbol: &ParsedSymbol,
     ) -> CompileResult<SemanticSymbol> {
@@ -74,10 +90,12 @@ impl SemanticSymbolUniverse {
             ));
         }
         let text = owner.module().resolve(symbol)?;
-        self.work.local_symbol_resolutions += 1;
-        self.work.semantic_intern_attempts += 1;
+        self.local_symbol_resolutions
+            .fetch_add(1, Ordering::Relaxed);
+        self.semantic_intern_attempts
+            .fetch_add(1, Ordering::Relaxed);
         if self.interner.get(text).is_none() {
-            self.work.unique_semantic_strings += 1;
+            self.unique_semantic_strings.fetch_add(1, Ordering::Relaxed);
         }
         Ok(SemanticSymbol {
             spur: self.interner.get_or_intern(text),
@@ -98,7 +116,33 @@ impl SemanticSymbolUniverse {
     }
 
     pub fn work(&self) -> SemanticTranslationWork {
-        self.work
+        SemanticTranslationWork {
+            modules_visited: self.admitted_modules.len(),
+            local_symbol_resolutions: self.local_symbol_resolutions.load(Ordering::Relaxed),
+            semantic_intern_attempts: self.semantic_intern_attempts.load(Ordering::Relaxed),
+            unique_semantic_strings: self.unique_semantic_strings.load(Ordering::Relaxed),
+            ast_payload_clones: 0,
+            parser_invocations: 0,
+        }
+    }
+
+    pub(crate) fn translate_ast_symbol(
+        &self,
+        owner: &ParsedAstView,
+        symbol: Spur,
+    ) -> CompileResult<SemanticSymbol> {
+        let symbol = owner.module().parsed_symbol(symbol)?;
+        self.translate_shared(owner, &symbol)
+    }
+
+    pub(crate) fn interner(&self) -> &ThreadedRodeo {
+        &self.interner
+    }
+}
+
+impl SemanticSymbol {
+    pub(crate) fn spur(&self) -> Spur {
+        self.spur
     }
 }
 

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -44,6 +44,7 @@ pub struct AstGen<'a> {
     /// temporaries of a `for`-loop desugaring (RUE-220), so nested for-loops
     /// don't shadow one another's position/length/collection bindings.
     for_counter: u32,
+    normalize_symbol: Box<dyn Fn(Spur) -> Spur + 'a>,
 }
 
 impl<'a> AstGen<'a> {
@@ -54,6 +55,7 @@ impl<'a> AstGen<'a> {
             interner,
             rir: Rir::new(),
             for_counter: 0,
+            normalize_symbol: Box::new(|symbol| symbol),
         }
     }
 
@@ -80,11 +82,45 @@ impl<'a> AstGen<'a> {
             interner,
             rir: Rir::new(),
             for_counter: 0,
+            normalize_symbol: Box::new(|symbol| symbol),
         };
         for item in items {
             generator.gen_item(item);
         }
         generator.rir
+    }
+
+    /// Create a generator whose AST-origin symbols are normalized before use.
+    #[doc(hidden)]
+    pub fn with_symbol_normalizer(
+        interner: &'a ThreadedRodeo,
+        normalize_symbol: impl Fn(Spur) -> Spur + 'a,
+    ) -> Self {
+        Self {
+            ast: None,
+            interner,
+            rir: Rir::new(),
+            for_counter: 0,
+            normalize_symbol: Box::new(normalize_symbol),
+        }
+    }
+
+    /// Append borrowed items while preserving generator-global state.
+    #[doc(hidden)]
+    pub fn append_items<'item>(&mut self, items: impl IntoIterator<Item = &'item Item>) {
+        for item in items {
+            self.gen_item(item);
+        }
+    }
+
+    /// Finish a normalized multi-module lowering session.
+    #[doc(hidden)]
+    pub fn finish(self) -> Rir {
+        self.rir
+    }
+
+    fn symbol(&self, symbol: Spur) -> Spur {
+        (self.normalize_symbol)(symbol)
     }
 
     fn gen_item(&mut self, item: &Item) {
@@ -113,7 +149,7 @@ impl<'a> AstGen<'a> {
     /// For named types, returns the existing symbol. For compound types, interns a new string.
     fn intern_type(&mut self, ty: &TypeExpr) -> Spur {
         match ty {
-            TypeExpr::Named(ident) => ident.name, // Already a Spur
+            TypeExpr::Named(ident) => self.symbol(ident.name),
             TypeExpr::Qualified { segments, .. } => {
                 let name = self.render_type_path(segments);
                 self.interner.get_or_intern(&name)
@@ -153,7 +189,8 @@ impl<'a> AstGen<'a> {
                     if i > 0 {
                         s.push_str(", ");
                     }
-                    let name = self.interner.resolve(&field.name.name);
+                    let field_name = self.symbol(field.name.name);
+                    let name = self.interner.resolve(&field_name);
                     let ty_sym = self.intern_type(&field.ty);
                     let ty_name = self.interner.resolve(&ty_sym);
                     s.push_str(name);
@@ -172,7 +209,8 @@ impl<'a> AstGen<'a> {
                     if i > 0 {
                         s.push_str(", ");
                     }
-                    let name = self.interner.resolve(&variant.name.name);
+                    let variant_name = self.symbol(variant.name.name);
+                    let name = self.interner.resolve(&variant_name);
                     s.push_str(name);
                     if !variant.payload.is_empty() {
                         s.push('(');
@@ -210,7 +248,8 @@ impl<'a> AstGen<'a> {
                 // to the monomorphized concrete type. Arguments are interned
                 // recursively so nested calls compose
                 // (`Result(Option(i32), i32)`).
-                let mut s = self.interner.resolve(&name.name).to_string();
+                let name = self.symbol(name.name);
+                let mut s = self.interner.resolve(&name).to_string();
                 s.push('(');
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {
@@ -246,20 +285,22 @@ impl<'a> AstGen<'a> {
                 // (ADR-0043 Phase 5, RUE-326). Canonicalize to `Name(N)` — the
                 // same string the const-capacity `TypeCall` spelling produces —
                 // so sema's `resolve_type` reduces both to one `Str(N)` type.
-                let callee = self.interner.resolve(&name.name);
+                let name = self.symbol(name.name);
+                let callee = self.interner.resolve(&name);
                 let s = format!("{}({})", callee, length);
                 self.interner.get_or_intern(&s)
             }
         }
     }
 
-    fn render_type_path(&self, segments: &[rue_parser::ast::Ident]) -> String {
+    fn render_type_path(&mut self, segments: &[rue_parser::ast::Ident]) -> String {
         let mut s = String::new();
         for (i, segment) in segments.iter().enumerate() {
             if i > 0 {
                 s.push('.');
             }
-            s.push_str(self.interner.resolve(&segment.name));
+            let segment = self.symbol(segment.name);
+            s.push_str(self.interner.resolve(&segment));
         }
         s
     }
@@ -271,12 +312,16 @@ impl<'a> AstGen<'a> {
     /// and a call as `callee(arg, ...)` with each argument rendered by the same
     /// rule so nested calls compose (RUE-309). Sema parses these forms back out
     /// of the type string and folds them to a concrete length (RUE-16).
-    fn render_array_length(&self, length: &ArrayLength) -> String {
+    fn render_array_length(&mut self, length: &ArrayLength) -> String {
         match length {
             ArrayLength::Literal(n) => n.to_string(),
-            ArrayLength::Named(ident) => self.interner.resolve(&ident.name).to_string(),
+            ArrayLength::Named(ident) => {
+                let name = self.symbol(ident.name);
+                self.interner.resolve(&name).to_string()
+            }
             ArrayLength::Call { name, args } => {
-                let callee = self.interner.resolve(&name.name);
+                let name = self.symbol(name.name);
+                let callee = self.interner.resolve(&name).to_owned();
                 let rendered: Vec<String> =
                     args.iter().map(|a| self.render_array_length(a)).collect();
                 format!("{}({})", callee, rendered.join(", "))
@@ -287,12 +332,12 @@ impl<'a> AstGen<'a> {
     fn gen_struct(&mut self, struct_decl: &StructDecl) -> InstRef {
         let directives = self.convert_directives(&struct_decl.directives);
         let (directives_start, directives_len) = self.rir.add_directives(&directives);
-        let name = struct_decl.name.name; // Already a Spur
+        let name = self.symbol(struct_decl.name.name);
         let fields: Vec<_> = struct_decl
             .fields
             .iter()
             .map(|f| {
-                let field_name = f.name.name; // Already a Spur
+                let field_name = self.symbol(f.name.name);
                 let field_type = self.intern_type(&f.ty);
                 (field_name, field_type)
             })
@@ -324,11 +369,11 @@ impl<'a> AstGen<'a> {
     }
 
     fn gen_enum(&mut self, enum_decl: &EnumDecl) -> InstRef {
-        let name = enum_decl.name.name; // Already a Spur
+        let name = self.symbol(enum_decl.name.name);
         let variants: Vec<_> = enum_decl
             .variants
             .iter()
-            .map(|v| v.name.name) // Already a Spur
+            .map(|v| self.symbol(v.name.name))
             .collect();
         let (variants_start, variants_len) = self.rir.add_symbols(&variants);
 
@@ -368,7 +413,7 @@ impl<'a> AstGen<'a> {
     fn gen_const(&mut self, const_decl: &ConstDecl) -> InstRef {
         let directives = self.convert_directives(&const_decl.directives);
         let (directives_start, directives_len) = self.rir.add_directives(&directives);
-        let name = const_decl.name.name; // Already a Spur
+        let name = self.symbol(const_decl.name.name);
         let ty = const_decl.ty.as_ref().map(|t| self.intern_type(t));
         let init = self.gen_expr(&const_decl.init);
 
@@ -386,7 +431,7 @@ impl<'a> AstGen<'a> {
     }
 
     fn gen_drop_fn(&mut self, drop_fn: &DropFn) -> InstRef {
-        let type_name = drop_fn.type_name.name; // Already a Spur
+        let type_name = self.symbol(drop_fn.type_name.name);
 
         // Generate the body expression
         let body = self.gen_expr(&drop_fn.body);
@@ -403,7 +448,7 @@ impl<'a> AstGen<'a> {
         let (directives_start, directives_len) = self.rir.add_directives(&directives);
 
         // Get the method name (already a Symbol) and return type
-        let name = method.name.name; // Already a Spur
+        let name = self.symbol(method.name.name);
         let return_type = match &method.return_type {
             Some(ty) => self.intern_type(ty),
             None => self.interner.get_or_intern("()"), // Default to unit type
@@ -414,7 +459,7 @@ impl<'a> AstGen<'a> {
             .params
             .iter()
             .map(|p| RirParam {
-                name: p.name.name, // Already a Spur
+                name: self.symbol(p.name.name),
                 ty: self.intern_type(&p.ty),
                 mode: self.convert_param_mode(p.mode),
                 is_comptime: p.mode == ParamMode::Comptime,
@@ -465,12 +510,12 @@ impl<'a> AstGen<'a> {
         directives
             .iter()
             .map(|d| RirDirective {
-                name: d.name.name, // Already a Spur
+                name: self.symbol(d.name.name),
                 args: d
                     .args
                     .iter()
                     .map(|arg| match arg {
-                        DirectiveArg::Ident(ident) => ident.name, // Already a Spur
+                        DirectiveArg::Ident(ident) => self.symbol(ident.name),
                     })
                     .collect(),
                 span: d.span,
@@ -517,7 +562,7 @@ impl<'a> AstGen<'a> {
         let (directives_start, directives_len) = self.rir.add_directives(&directives);
 
         // Get the function name (already a Symbol) and return type
-        let name = func.name.name; // Already a Spur
+        let name = self.symbol(func.name.name);
         let return_type = match &func.return_type {
             Some(ty) => self.intern_type(ty),
             None => self.interner.get_or_intern("()"), // Default to unit type
@@ -528,7 +573,7 @@ impl<'a> AstGen<'a> {
             .params
             .iter()
             .map(|p| RirParam {
-                name: p.name.name, // Already a Spur
+                name: self.symbol(p.name.name),
                 ty: self.intern_type(&p.ty),
                 mode: self.convert_param_mode(p.mode),
                 is_comptime: p.mode == ParamMode::Comptime,
@@ -572,22 +617,20 @@ impl<'a> AstGen<'a> {
                 data: InstData::BoolConst(lit.value),
                 span: lit.span,
             }),
-            Expr::String(lit) => {
-                self.rir.add_inst(Inst {
-                    data: InstData::StringConst(lit.value), // Already a Spur
-                    span: lit.span,
-                })
-            }
+            Expr::String(lit) => self.rir.add_inst(Inst {
+                data: InstData::StringConst(self.symbol(lit.value)),
+                span: lit.span,
+            }),
             Expr::Unit(lit) => self.rir.add_inst(Inst {
                 data: InstData::UnitConst,
                 span: lit.span,
             }),
-            Expr::Ident(ident) => {
-                self.rir.add_inst(Inst {
-                    data: InstData::VarRef { name: ident.name }, // Already a Spur
-                    span: ident.span,
-                })
-            }
+            Expr::Ident(ident) => self.rir.add_inst(Inst {
+                data: InstData::VarRef {
+                    name: self.symbol(ident.name),
+                },
+                span: ident.span,
+            }),
             Expr::Binary(bin) => {
                 let lhs = self.gen_expr(&bin.left);
                 let rhs = self.gen_expr(&bin.right);
@@ -701,7 +744,7 @@ impl<'a> AstGen<'a> {
 
                 self.rir.add_inst(Inst {
                     data: InstData::Call {
-                        name: call.name.name, // Already a Spur
+                        name: self.symbol(call.name.name),
                         args_start,
                         args_len,
                     },
@@ -741,7 +784,7 @@ impl<'a> AstGen<'a> {
                     let (args_start, args_len) = self.rir.add_call_args(&arg_refs);
                     self.rir.add_inst(Inst {
                         data: InstData::Call {
-                            name: struct_lit.name.name,
+                            name: self.symbol(struct_lit.name.name),
                             args_start,
                             args_len,
                         },
@@ -754,7 +797,7 @@ impl<'a> AstGen<'a> {
                     .iter()
                     .map(|f| {
                         let field_value = self.gen_expr(&f.value);
-                        (f.name.name, field_value) // name is already a Symbol
+                        (self.symbol(f.name.name), field_value)
                     })
                     .collect();
                 let (fields_start, fields_len) = self.rir.add_field_inits(&fields);
@@ -772,7 +815,7 @@ impl<'a> AstGen<'a> {
                     data: InstData::StructInit {
                         module,
                         ctor_head,
-                        type_name: struct_lit.name.name, // Already a Spur
+                        type_name: self.symbol(struct_lit.name.name),
                         fields_start,
                         fields_len,
                         shorthand_span,
@@ -786,13 +829,13 @@ impl<'a> AstGen<'a> {
                 self.rir.add_inst(Inst {
                     data: InstData::FieldGet {
                         base,
-                        field: field_expr.field.name, // Already a Spur
+                        field: self.symbol(field_expr.field.name),
                     },
                     span: field_expr.span,
                 })
             }
             Expr::IntrinsicCall(intrinsic) => {
-                let name = intrinsic.name.name; // Already a Spur
+                let name = self.symbol(intrinsic.name.name);
                 let intrinsic_name_str = self.interner.resolve(&name);
 
                 // `@offset_of(T, field)` (RUE-301) is compiler-mediated field
@@ -806,7 +849,7 @@ impl<'a> AstGen<'a> {
                 if intrinsic_name_str == "offset_of" && intrinsic.args.len() == 2 {
                     let type_arg = match &intrinsic.args[0] {
                         IntrinsicArg::Type(ty) => Some(self.intern_type(ty)),
-                        IntrinsicArg::Expr(Expr::Ident(ident)) => Some(ident.name),
+                        IntrinsicArg::Expr(Expr::Ident(ident)) => Some(self.symbol(ident.name)),
                         _ => None,
                     };
                     if let (Some(type_arg), IntrinsicArg::Expr(Expr::Ident(field))) =
@@ -815,7 +858,7 @@ impl<'a> AstGen<'a> {
                         return self.rir.add_inst(Inst {
                             data: InstData::OffsetOf {
                                 type_arg,
-                                field: field.name,
+                                field: self.symbol(field.name),
                             },
                             span: intrinsic.span,
                         });
@@ -843,7 +886,7 @@ impl<'a> AstGen<'a> {
                         return self.rir.add_inst(Inst {
                             data: InstData::TypeIntrinsic {
                                 name,
-                                type_arg: ident.name, // Already a Spur
+                                type_arg: self.symbol(ident.name),
                             },
                             span: intrinsic.span,
                         });
@@ -890,7 +933,7 @@ impl<'a> AstGen<'a> {
                     let value = self.gen_expr(&array_lit.elements[0]);
                     let count = match count {
                         ArrayLength::Literal(n) => RepeatCount::Literal(*n),
-                        ArrayLength::Named(ident) => RepeatCount::Named(ident.name),
+                        ArrayLength::Named(ident) => RepeatCount::Named(self.symbol(ident.name)),
                         // The array-literal repeat grammar (`[value; count]`)
                         // only parses a literal or a bare name, never a call,
                         // so this arm is unreachable. The call form is accepted
@@ -939,8 +982,8 @@ impl<'a> AstGen<'a> {
                 self.rir.add_inst(Inst {
                     data: InstData::EnumVariant {
                         module,
-                        type_name: path_expr.type_name.name, // Already a Spur
-                        variant: path_expr.variant.name,     // Already a Spur
+                        type_name: self.symbol(path_expr.type_name.name),
+                        variant: self.symbol(path_expr.variant.name),
                     },
                     span: path_expr.span,
                 })
@@ -957,7 +1000,7 @@ impl<'a> AstGen<'a> {
                 self.rir.add_inst(Inst {
                     data: InstData::MethodCall {
                         receiver,
-                        method: method_call.method.name, // Already a Spur
+                        method: self.symbol(method_call.method.name),
                         args_start,
                         args_len,
                     },
@@ -974,8 +1017,8 @@ impl<'a> AstGen<'a> {
 
                 self.rir.add_inst(Inst {
                     data: InstData::AssocFnCall {
-                        type_name: assoc_fn_call.type_name.name, // Already a Spur
-                        function: assoc_fn_call.function.name,   // Already a Spur
+                        type_name: self.symbol(assoc_fn_call.type_name.name),
+                        function: self.symbol(assoc_fn_call.function.name),
                         args_start,
                         args_len,
                     },
@@ -1018,7 +1061,7 @@ impl<'a> AstGen<'a> {
                         let field_decls: Vec<(Spur, Spur)> = fields
                             .iter()
                             .map(|f| {
-                                let name = f.name.name;
+                                let name = self.symbol(f.name.name);
                                 let ty = self.intern_type(&f.ty);
                                 (name, ty)
                             })
@@ -1047,7 +1090,7 @@ impl<'a> AstGen<'a> {
                         // as `gen_enum` does for a top-level `enum` declaration
                         // (RUE-221, ADR-0038).
                         let variant_syms: Vec<Spur> =
-                            variants.iter().map(|v| v.name.name).collect();
+                            variants.iter().map(|v| self.symbol(v.name.name)).collect();
                         let (variants_start, variants_len) = self.rir.add_symbols(&variant_syms);
 
                         let has_any_payload = variants.iter().any(|v| !v.payload.is_empty());
@@ -1079,7 +1122,7 @@ impl<'a> AstGen<'a> {
                     _ => {
                         // For named types, unit, never, arrays, and pointers, generate TypeConst
                         let type_name = match &type_lit.type_expr {
-                            TypeExpr::Named(ident) => ident.name,
+                            TypeExpr::Named(ident) => self.symbol(ident.name),
                             TypeExpr::Qualified { .. } => self.intern_type(&type_lit.type_expr),
                             TypeExpr::Unit(_) => self.interner.get_or_intern_static("()"),
                             TypeExpr::Never(_) => self.interner.get_or_intern_static("!"),
@@ -1167,7 +1210,7 @@ impl<'a> AstGen<'a> {
                     let (args_start, args_len) = self.rir.add_call_args(&arg_refs);
                     self.rir.add_inst(Inst {
                         data: InstData::Call {
-                            name: path.type_name.name,
+                            name: self.symbol(path.type_name.name),
                             args_start,
                             args_len,
                         },
@@ -1175,12 +1218,13 @@ impl<'a> AstGen<'a> {
                     })
                 });
                 // Payload binding names for a tuple-variant pattern (RUE-221).
-                let bindings: Vec<Spur> = path.bindings.iter().map(|b| b.name).collect();
+                let bindings: Vec<Spur> =
+                    path.bindings.iter().map(|b| self.symbol(b.name)).collect();
                 RirPattern::Path {
                     module,
                     ctor_head,
-                    type_name: path.type_name.name, // Already a Spur
-                    variant: path.variant.name,     // Already a Spur
+                    type_name: self.symbol(path.type_name.name),
+                    variant: self.symbol(path.variant.name),
                     bindings,
                     span: path.span,
                 }
@@ -1259,7 +1303,8 @@ impl<'a> AstGen<'a> {
         // the call is the actual collection.
         let (coll_expr, is_chars, is_lossy): (&Expr, bool, bool) = match &*for_expr.iterable {
             Expr::MethodCall(mc) if mc.args.is_empty() => {
-                match self.interner.resolve(&mc.method.name) {
+                let method = self.symbol(mc.method.name);
+                match self.interner.resolve(&method) {
                     "chars" => (&mc.receiver, true, false),
                     "chars_lossy" => (&mc.receiver, true, true),
                     _ => (&*for_expr.iterable, false, false),
@@ -1275,7 +1320,7 @@ impl<'a> AstGen<'a> {
         // borrow); any other expression is a temporary bound once.
         let coll_is_var = matches!(coll_expr, Expr::Ident(_));
         let coll_name: Spur = if let Expr::Ident(id) = coll_expr {
-            id.name
+            self.symbol(id.name)
         } else {
             let init = self.gen_expr(coll_expr);
             let name = self.interner.get_or_intern(format!("__rue_for_coll_{n}"));
@@ -1394,7 +1439,7 @@ impl<'a> AstGen<'a> {
         // drop the borrowed element as a temporary and double-free it (the
         // collection still owns and drops it, RUE-259).
         let binder_name: Option<Spur> = match &for_expr.binder {
-            LetPattern::Ident(id) => Some(id.name),
+            LetPattern::Ident(id) => Some(self.symbol(id.name)),
             LetPattern::Wildcard(_) => {
                 Some(self.interner.get_or_intern(format!("_rue_for_elem_{n}")))
             }
@@ -1553,7 +1598,7 @@ impl<'a> AstGen<'a> {
                 let directives = self.convert_directives(&let_stmt.directives);
                 let (directives_start, directives_len) = self.rir.add_directives(&directives);
                 let name = match &let_stmt.pattern {
-                    LetPattern::Ident(ident) => Some(ident.name), // Already a Spur
+                    LetPattern::Ident(ident) => Some(self.symbol(ident.name)),
                     LetPattern::Wildcard(_) => None,
                 };
                 let ty = let_stmt.ty.as_ref().map(|t| self.intern_type(t));
@@ -1574,21 +1619,19 @@ impl<'a> AstGen<'a> {
             Statement::Assign(assign) => {
                 let value = self.gen_expr(&assign.value);
                 match &assign.target {
-                    AssignTarget::Var(ident) => {
-                        self.rir.add_inst(Inst {
-                            data: InstData::Assign {
-                                name: ident.name, // Already a Spur
-                                value,
-                            },
-                            span: assign.span,
-                        })
-                    }
+                    AssignTarget::Var(ident) => self.rir.add_inst(Inst {
+                        data: InstData::Assign {
+                            name: self.symbol(ident.name),
+                            value,
+                        },
+                        span: assign.span,
+                    }),
                     AssignTarget::Field(field_expr) => {
                         let base = self.gen_expr(&field_expr.base);
                         self.rir.add_inst(Inst {
                             data: InstData::FieldSet {
                                 base,
-                                field: field_expr.field.name, // Already a Spur
+                                field: self.symbol(field_expr.field.name),
                                 value,
                             },
                             span: assign.span,


### PR DESCRIPTION
## Summary

- add canonical RIR lowering over exact module-qualified parsed artifacts without merging or cloning AST payloads
- normalize every AST-origin symbol into one provenance-safe semantic universe while preserving generator-global deterministic state
- retain exact source revision, thread-safe semantic artifacts, and phase-local structural work metrics
- preserve legacy AstGen behavior and prove canonical/legacy RIR parity across adversarial symbol surfaces

## Verification

- compiler tests: 359/359
- RIR tests: 97/97
- `./test.sh` (34 targets)
- `./fmt.sh --check`
- `./clippy.sh` (41 targets)
- `./scripts/check-reproducible-compiler.sh` (byte-identical SHA-256 `55cef1f4f575ee2f7d43b3b1a508b835a504070d70bbb94adf1ed3a34ae5a94f`)

Linear: RUE-717