### PR TITLE
RUE-719: remove duplicate CompilationUnit definition snapshot work

### DIFF
--- a/crates/rue-compiler/src/canonical_merge.rs
+++ b/crates/rue-compiler/src/canonical_merge.rs
@@ -100,10 +100,51 @@ pub(crate) fn merge_parsed_modules_for_batch(
     merge_parsed_modules_in_order(program, Some(diagnostic_order))
 }
 
+pub(crate) struct UnitMergeOutcome {
+    pub result: Result<CanonicalMergedProgram, CompileErrors>,
+    /// Retained only when merge diagnostics reject the program.
+    pub rejected_definitions: Option<DefinitionSnapshot>,
+}
+
+/// Merge for `CompilationUnit`, moving its one compatibility definition
+/// snapshot into the canonical artifact on success and returning it on error.
+pub(crate) fn merge_parsed_modules_for_unit(
+    program: &ParsedProgram,
+    diagnostic_order: &[ModuleId],
+    definitions: DefinitionSnapshot,
+) -> UnitMergeOutcome {
+    let (work, ordered_modules) = merge_inputs(program, Some(diagnostic_order));
+    let errors = canonical_duplicate_errors(&ordered_modules);
+    if !errors.is_empty() {
+        return UnitMergeOutcome {
+            result: Err(CompileErrors::from(errors)),
+            rejected_definitions: Some(definitions),
+        };
+    }
+    UnitMergeOutcome {
+        result: Ok(assemble_merged_program(program, definitions, work)),
+        rejected_definitions: None,
+    }
+}
+
 fn merge_parsed_modules_in_order(
     program: &ParsedProgram,
     diagnostic_order: Option<&[ModuleId]>,
 ) -> Result<CanonicalMergedProgram, CompileErrors> {
+    let (work, ordered_modules) = merge_inputs(program, diagnostic_order);
+    let errors = canonical_duplicate_errors(&ordered_modules);
+    if !errors.is_empty() {
+        return Err(CompileErrors::from(errors));
+    }
+    let definitions =
+        DefinitionSnapshot::from_parsed_modules(program).map_err(CompileErrors::from)?;
+    Ok(assemble_merged_program(program, definitions, work))
+}
+
+fn merge_inputs<'a>(
+    program: &'a ParsedProgram,
+    diagnostic_order: Option<&[ModuleId]>,
+) -> (CanonicalMergeWork, Vec<&'a Arc<ParsedModule>>) {
     let work = CanonicalMergeWork {
         modules_visited: program.modules().len(),
         items_visited: program
@@ -133,20 +174,22 @@ fn merge_parsed_modules_in_order(
     } else {
         program.modules().iter().collect()
     };
-    let errors = canonical_duplicate_errors(&ordered_modules);
-    if !errors.is_empty() {
-        return Err(CompileErrors::from(errors));
-    }
-    let definitions =
-        DefinitionSnapshot::from_parsed_modules(program).map_err(CompileErrors::from)?;
-    Ok(CanonicalMergedProgram {
+    (work, ordered_modules)
+}
+
+fn assemble_merged_program(
+    program: &ParsedProgram,
+    definitions: DefinitionSnapshot,
+    work: CanonicalMergeWork,
+) -> CanonicalMergedProgram {
+    CanonicalMergedProgram {
         ast: CanonicalMergedAst {
             source_revision: program.source_revision().clone(),
             modules: program.modules().to_vec().into(),
         },
         definitions,
         work,
-    })
+    }
 }
 
 fn canonical_duplicate_errors(modules: &[&Arc<ParsedModule>]) -> Vec<CompileError> {

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -86,6 +86,8 @@ pub struct CompilationUnitWork {
     pub parse: PhaseReuseWork,
     pub lower: PhaseReuseWork,
     pub analyze: PhaseReuseWork,
+    /// Compatibility definition snapshots built from canonical parsed modules.
+    pub definition_snapshot_builds: usize,
     pub compatibility_projections: usize,
 }
 
@@ -295,9 +297,9 @@ impl<'src> CompilationUnit<'src> {
             // snapshot builder reports its more precise modules traversal.
             let _span = info_span!("definition_snapshot").entered();
         }
+        self.work.definition_snapshot_builds += 1;
         let definition_snapshot = DefinitionSnapshot::from_parsed_modules(&parsed.program)
             .map_err(CompileErrors::from)?;
-        self.definition_snapshot = Some(definition_snapshot);
         let diagnostic_order = self
             .source_snapshot
             .files()
@@ -324,12 +326,20 @@ impl<'src> CompilationUnit<'src> {
                 .sum(),
             ..CanonicalMergeWork::default()
         };
-        let merged = {
+        let outcome = {
             let _span = info_span!("merge_symbols").entered();
-            crate::canonical_merge::merge_parsed_modules_for_batch(
+            crate::canonical_merge::merge_parsed_modules_for_unit(
                 &parsed.program,
                 &diagnostic_order,
-            )?
+                definition_snapshot,
+            )
+        };
+        let merged = match outcome.result {
+            Ok(merged) => merged,
+            Err(errors) => {
+                self.definition_snapshot = outcome.rejected_definitions;
+                return Err(errors);
+            }
         };
         debug_assert_eq!(self.work.merged, merged.work());
         self.compatibility_ast_files = parsed.ast_files;
@@ -647,7 +657,11 @@ impl<'src> CompilationUnit<'src> {
     /// This remains available when duplicate-symbol merging rejects the parsed
     /// program. It returns `None` before parsing and after a syntax error.
     pub fn definition_snapshot(&self) -> Option<&DefinitionSnapshot> {
-        self.definition_snapshot.as_ref()
+        self.definition_snapshot.as_ref().or_else(|| {
+            self.merged
+                .as_ref()
+                .map(CanonicalMergedProgram::definitions)
+        })
     }
 
     /// Direct syntax work performed by the most recent [`Self::parse`] attempt.
@@ -914,6 +928,7 @@ mod tests {
         assert_eq!(initial.semantic.binding.bind_invocations, 1);
         assert_eq!(initial.semantic.manifest.build_invocations, 0);
         assert!(!initial.semantic.stable_ids_requested);
+        assert_eq!(initial.definition_snapshot_builds, 1);
         assert_eq!(initial.compatibility_projections, 0);
 
         unit.parse().unwrap();
@@ -924,6 +939,7 @@ mod tests {
         assert_eq!(reused.lower.reuses, 1);
         assert_eq!(reused.analyze.reuses, 1);
         assert_eq!(reused.semantic.binding.bind_invocations, 1);
+        assert_eq!(reused.definition_snapshot_builds, 1);
         assert_eq!(reused.compatibility_projections, 0);
 
         assert_eq!(unit.ast().item_count(), 1);
@@ -1101,6 +1117,7 @@ mod tests {
         let first_errors = unit
             .parse()
             .expect_err("the compilation unit should reject the duplicate");
+        assert_eq!(unit.work().definition_snapshot_builds, 1);
         assert_eq!(fingerprint(&direct_errors), fingerprint(&first_errors));
         assert_eq!(unit.syntax_work(), expected_work);
         assert_eq!(unit.source_stats(), expected_stats);
@@ -1124,6 +1141,7 @@ mod tests {
         let second_errors = unit
             .parse()
             .expect_err("a repeated parse should still reject the duplicate");
+        assert_eq!(unit.work().definition_snapshot_builds, 2);
         assert_eq!(fingerprint(&first_errors), fingerprint(&second_errors));
         assert_eq!(unit.syntax_work(), expected_work);
         assert_eq!(unit.source_stats(), expected_stats);

--- a/docs/notes/compiler-compatibility-followups.md
+++ b/docs/notes/compiler-compatibility-followups.md
@@ -1,0 +1,25 @@
+# Compiler compatibility cleanup follow-ups
+
+The canonical snapshot and `CompilationUnit` pipelines no longer repeat parsing,
+RIR lowering, or semantic analysis. The remaining compatibility paths are
+separate API/driver concerns and should be removed in this order:
+
+1. **Migrate `--emit` to canonical artifacts.** `crates/rue/src/main.rs` still
+   calls the public shared-interner `parse_all_files_with_source_snapshot`,
+   `merge_symbols`, and caller-positional `AstGen` path. Preserve the public
+   parse/merge APIs, but make emit consume canonical parsed, merged, and RIR
+   artifacts and add byte/diagnostic parity tests for every emit mode.
+2. **Retire duplicate RIR import extraction from production concepts.**
+   `extract_import_directives` remains a public compatibility query and has
+   direct tests, but production snapshot/unit compilation now retains import
+   directives from canonical parsed modules. Deprecate rather than delete the
+   API, with parity tests covering nested and type-position imports.
+3. **Remove raw-AST semantic re-lowering.** The public raw `Ast` frontend in
+   `lib.rs` creates positional RIR and then lowers a semantic-order RIR again.
+   Eliminating that second walk requires an explicit provenance/ordering
+   contract for caller-created ASTs; it must not be folded into snapshot work.
+4. **Keep the legacy AST/interner projection demand-driven.** `ast()`,
+   pre-lower `interner()`, and pre-lower `take_interner()` are deliberately
+   public compatibility surfaces. They should remain lazy and counted until a
+   versioned API change can replace the shared-interner `MergedAst` contract.
+


### PR DESCRIPTION
## Summary

- build DefinitionSnapshot once per genuine CompilationUnit parse attempt
- move that snapshot into the canonical merged artifact on success or retain it for duplicate diagnostics on failure
- expose structural build counts and preserve retry/diagnostic behavior
- record the remaining compatibility cleanup boundaries in ranked order

## Verification

- `./test.sh` (34 targets at slice freeze)
- compiler tests 379/379
- `./clippy.sh` and `./fmt.sh --check`
- reproducible-programs check

Linear: RUE-719