### PR TITLE
RUE-719: model import-resolution queries and invalidation

### DIFF
--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -5,13 +5,15 @@ use std::sync::Arc;
 use rue_air::{DeclarationBindingWork, SemanticBindingManifestWork};
 
 use crate::{
-    BoundDefinitionSet, BoundDefinitionWork, CanonicalMergeWork, CanonicalMergedProgram,
-    CanonicalParseSession, CanonicalRirOutput, CanonicalRirWork, CanonicalSemanticOutput,
-    CanonicalSemanticWork, CodegenInputDescriptor, CompileError, CompileErrors, CompileOptions,
-    ErrorKind, ParseInvalidationSummary, ParsedModulesWork, SemanticInputDescriptor,
+    BoundDefinitionSet, BoundDefinitionWork, CanonicalImportGraph, CanonicalImportGraphValidation,
+    CanonicalMergeWork, CanonicalMergedProgram, CanonicalParseSession, CanonicalRirOutput,
+    CanonicalRirWork, CanonicalSemanticOutput, CanonicalSemanticWork, CodegenInputDescriptor,
+    CompileError, CompileErrors, CompileOptions, ErrorKind, ModuleResolutionInputs,
+    ParseInvalidationSummary, ParsedModulesWork, SemanticInputDescriptor, SourceRevision,
     SourceSnapshot, analyze_canonical_program,
     bound_definitions::bind_canonical_definitions_with_work, lower_canonical_rir,
-    merge_parsed_modules, parsed_modules::ParsedProgram,
+    merge_parsed_modules, parsed_modules::ParsedProgram, resolve_canonical_import_graph,
+    validate_canonical_import_graph,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -26,6 +28,9 @@ pub struct CanonicalFrontendSessionWork {
     pub updates: usize,
     pub last_parse: ParsedModulesWork,
     pub last_invalidation: ParseInvalidationSummary,
+    pub imports: FrontendQueryWork,
+    pub import_entries: usize,
+    pub import_entries_invalidated: usize,
     pub merge: FrontendQueryWork,
     pub rir: FrontendQueryWork,
     pub downstream_invalidations: usize,
@@ -39,6 +44,32 @@ pub struct CanonicalFrontendSessionWork {
     pub definition_entries: usize,
     pub definition_entries_invalidated: usize,
     pub definition_records: Vec<DefinitionQueryRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ImportGraphInputDescriptor {
+    pub sources: SourceRevision,
+    pub resolution: ModuleResolutionInputs,
+    pub std_dir: Option<Arc<str>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CanonicalImportGraphOutput {
+    input: ImportGraphInputDescriptor,
+    graph: CanonicalImportGraph,
+    validation: CanonicalImportGraphValidation,
+}
+
+impl CanonicalImportGraphOutput {
+    pub fn input(&self) -> &ImportGraphInputDescriptor {
+        &self.input
+    }
+    pub fn graph(&self) -> &CanonicalImportGraph {
+        &self.graph
+    }
+    pub fn validation(&self) -> &CanonicalImportGraphValidation {
+        &self.validation
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,9 +120,16 @@ pub struct CanonicalFrontendSession {
     published: Option<Arc<ParsedProgram>>,
     merge_cache: Option<Result<Arc<CanonicalMergedProgram>, CompileErrors>>,
     rir_cache: Option<Arc<CanonicalRirOutput>>,
+    import_cache: Vec<ImportCacheEntry>,
     semantic_cache: Vec<SemanticCacheEntry>,
     definition_cache: Vec<DefinitionCacheEntry>,
     work: CanonicalFrontendSessionWork,
+}
+
+#[derive(Debug)]
+struct ImportCacheEntry {
+    input: ImportGraphInputDescriptor,
+    result: Result<Arc<CanonicalImportGraphOutput>, CompileErrors>,
 }
 
 #[derive(Debug)]
@@ -143,6 +181,9 @@ impl CanonicalFrontendSession {
                     }
                     self.merge_cache = None;
                     self.rir_cache = None;
+                    self.work.import_entries_invalidated += self.import_cache.len();
+                    self.import_cache.clear();
+                    self.work.import_entries = 0;
                     self.work.semantic_entries_invalidated += self.semantic_cache.len();
                     self.semantic_cache.clear();
                     self.work.definition_entries_invalidated += self.definition_cache.len();
@@ -169,6 +210,54 @@ impl CanonicalFrontendSession {
                 downstream_invalidated: false,
             },
         }
+    }
+
+    /// Resolve canonical parsed import sites without lowering or semantic work.
+    pub fn import_graph(
+        &mut self,
+        std_dir: Option<&str>,
+    ) -> Result<Arc<CanonicalImportGraphOutput>, CompileErrors> {
+        self.work.imports.calls += 1;
+        let parsed = self.published.as_deref().ok_or_else(no_published_program)?;
+        let resolution = ModuleResolutionInputs::new(
+            parsed.root().clone(),
+            parsed
+                .modules()
+                .iter()
+                .map(|module| crate::ModuleResolutionInput {
+                    module: module.module_id().clone(),
+                    physical_path: Arc::from(module.physical_path()),
+                })
+                .collect(),
+        )
+        .expect("published parsed modules have validated resolution inputs");
+        let input = ImportGraphInputDescriptor {
+            sources: parsed.source_revision().clone(),
+            resolution,
+            std_dir: std_dir.map(Arc::from),
+        };
+        if let Some(entry) = self.import_cache.iter().find(|entry| entry.input == input) {
+            self.work.imports.reuses += 1;
+            return entry.result.clone();
+        }
+        self.work.imports.executions += 1;
+        let result =
+            resolve_canonical_import_graph(parsed.import_directives(), &input.resolution, std_dir)
+                .map(|graph| {
+                    let validation = validate_canonical_import_graph(&graph, &input.resolution);
+                    Arc::new(CanonicalImportGraphOutput {
+                        input: input.clone(),
+                        graph,
+                        validation,
+                    })
+                })
+                .map_err(CompileErrors::from);
+        self.import_cache.push(ImportCacheEntry {
+            input,
+            result: result.clone(),
+        });
+        self.work.import_entries = self.import_cache.len();
+        result
     }
 
     pub fn merge(&mut self) -> Result<Arc<CanonicalMergedProgram>, CompileErrors> {
@@ -361,8 +450,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        LinkerMode, ModuleId, OptLevel, PreviewFeature, PreviewFeatures, SourceMetadata,
-        SourceSnapshot, Target,
+        CanonicalImportResolution, LinkerMode, ModuleId, OptLevel, PreviewFeature, PreviewFeatures,
+        SourceMetadata, SourceSnapshot, Target,
     };
 
     fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
@@ -831,6 +920,131 @@ mod tests {
                 .expect("definition by stable key"),
             record
         ));
+    }
+
+    #[test]
+    fn import_graph_query_reuses_and_recomputes_only_after_resolution_changes() {
+        let original = snapshot(
+            &[
+                (
+                    1,
+                    "/p/app/main.rue",
+                    "app/main.rue",
+                    "fn main() -> i32 { let h = @import(\"helper.rue\"); 0 }",
+                ),
+                (2, "/p/app/helper.rue", "app/helper.rue", "fn helper() {}"),
+            ],
+            1,
+        );
+        let relocated = snapshot(
+            &[
+                (
+                    1,
+                    "/p/app/main.rue",
+                    "app/main.rue",
+                    "fn main() -> i32 { let h = @import(\"helper.rue\"); 0 }",
+                ),
+                (2, "/else/helper.rue", "app/helper.rue", "fn helper() {}"),
+            ],
+            1,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&original).into_result().unwrap();
+        let first = session.import_graph(None).unwrap();
+        let reused = session.import_graph(None).unwrap();
+        assert!(Arc::ptr_eq(&first, &reused));
+        assert!(matches!(
+            first.graph().records()[0].resolution(),
+            CanonicalImportResolution::Resolved(module) if module.as_str() == "app/helper.rue"
+        ));
+
+        let update = session.update(&relocated);
+        assert_eq!(update.work().syntax.lexer_invocations, 0);
+        assert_eq!(update.work().syntax.parser_invocations, 0);
+        assert_eq!(update.work().modules_rebound, 1);
+        assert!(update.downstream_invalidated());
+        update.into_result().unwrap();
+        let moved = session.import_graph(None).unwrap();
+        assert!(matches!(
+            moved.graph().records()[0].resolution(),
+            CanonicalImportResolution::Missing
+        ));
+        assert_eq!(session.work().imports.calls, 3);
+        assert_eq!(session.work().imports.executions, 2);
+        assert_eq!(session.work().imports.reuses, 1);
+        assert_eq!(session.work().import_entries_invalidated, 1);
+        assert_eq!(session.work().merge.executions, 0);
+        assert_eq!(session.work().rir.executions, 0);
+        assert_eq!(session.work().semantic.executions, 0);
+        assert_eq!(session.work().definitions.executions, 0);
+    }
+
+    #[test]
+    fn import_graph_keys_root_std_context_and_preserves_last_good_graph() {
+        let source = snapshot(
+            &[
+                (
+                    1,
+                    "/p/main.rue",
+                    "main.rue",
+                    "fn main() -> i32 { let s = @import(\"std\"); 0 }",
+                ),
+                (2, "/sdk/_std.rue", "std/_std.rue", "fn helper() {}"),
+            ],
+            1,
+        );
+        let other_root = snapshot(
+            &[
+                (
+                    1,
+                    "/p/main.rue",
+                    "main.rue",
+                    "fn main() -> i32 { let s = @import(\"std\"); 0 }",
+                ),
+                (2, "/sdk/_std.rue", "std/_std.rue", "fn helper() {}"),
+            ],
+            2,
+        );
+        let broken = snapshot(&[(1, "/p/main.rue", "main.rue", "fn main( {")], 1);
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        let missing = session.import_graph(None).unwrap();
+        let resolved = session.import_graph(Some("/sdk")).unwrap();
+        assert!(matches!(
+            missing.graph().records()[0].resolution(),
+            CanonicalImportResolution::Missing
+        ));
+        assert!(matches!(
+            resolved.graph().records()[0].resolution(),
+            CanonicalImportResolution::Resolved(_)
+        ));
+        assert_eq!(session.work().import_entries, 2);
+        assert!(session.update(&broken).result().is_err());
+        assert!(Arc::ptr_eq(
+            &resolved,
+            &session.import_graph(Some("/sdk")).unwrap()
+        ));
+
+        session.update(&other_root).into_result().unwrap();
+        let rerooted = session.import_graph(Some("/sdk")).unwrap();
+        assert_eq!(rerooted.graph().root().as_str(), "std/_std.rue");
+        assert_ne!(
+            resolved.input().sources.root(),
+            rerooted.input().sources.root()
+        );
+    }
+
+    #[test]
+    fn empty_import_graph_is_send_sync_and_concurrently_readable() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CanonicalImportGraphOutput>();
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&base()).into_result().unwrap();
+        let graph = session.import_graph(None).unwrap();
+        assert!(graph.graph().records().is_empty());
+        std::thread::spawn(move || assert!(graph.validation().is_valid()))
+            .join()
+            .unwrap();
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -61,7 +61,8 @@ pub use definition_snapshot::{
 };
 pub use frontend_session::{
     CanonicalFrontendSession, CanonicalFrontendSessionWork, CanonicalFrontendUpdate,
-    DefinitionQueryRecord, FrontendQueryWork, SemanticQueryRecord,
+    CanonicalImportGraphOutput, DefinitionQueryRecord, FrontendQueryWork,
+    ImportGraphInputDescriptor, SemanticQueryRecord,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -15,22 +15,22 @@ incremental-compilation goal is complete.
 | Immutable per-file/query inputs | Satisfied. `SourceSnapshot` owns `Arc<String>` text plus validated metadata. `SemanticInputDescriptor` owns source revision, module-resolution inputs, target, and stable preview features; `CodegenInputDescriptor` adds optimization level. |
 | Batch compatibility | Satisfied with deliberate diagnostic-order adapters. `compile_source_snapshot_with_options_impl` uses `parse_source_snapshot_modules_for_batch` and `merge_parsed_modules_for_batch`; batch/borrowed compatibility tests compare artifacts and diagnostics. |
 | Reusable in-process invalidation | Satisfied at whole-query granularity, not fine-grained semantic granularity. `CanonicalFrontendSession::update` reuses parsed module Arcs, preserves the last good revision after syntax failure, and invalidates merge/RIR/semantic/definition caches when the published program changes. The benchmark makes this behavior measurable. |
-| Tooling seams | Partially satisfied. Backend-free `published`, `merge`, `rir`, `semantic`, and `stable_definitions` queries exist; semantic output exposes warnings. This slice adds binary-search `ParsedProgram::module(ModuleId)` and `BoundDefinitionSet::definition_by_key(StableDefinitionKey)`. Diagnostics remain returned errors rather than a retained query result. |
+| Tooling seams | Partially satisfied. Backend-free `published`, `import_graph`, `merge`, `rir`, `semantic`, and `stable_definitions` queries exist; semantic output exposes warnings. Import resolution is lazy, memoized, keyed by owned source/resolution/std-dir inputs, and consumes canonical parsed import sites without RIR. Binary-search `ParsedProgram::module(ModuleId)` and `BoundDefinitionSet::definition_by_key(StableDefinitionKey)` support keyed artifact access. Diagnostics remain returned errors rather than a retained query result. |
 | No disk cache or full-LSP shortcut | Satisfied by scope. Session caches are process-owned values only; the benchmark performs no measured filesystem discovery and no backend/link. No persistent cache format, watcher, protocol server, or LSP is introduced. |
 | Small mergeable, tracked delivery | Satisfied operationally: the stack is split into described RUE-719 jj changes and independently gated slices. This audit cannot prove external Linear state; commit descriptions are the locally falsifiable tracking evidence. |
 
 ## Ranked remaining gaps
 
-1. **Must finish: import-resolution invalidation is over-broad and not directly
-   session-gated.** `SemanticInputDescriptor::new` includes all physical paths in
-   `ModuleResolutionInputs`, while `CanonicalFrontendSession::update` clears all
-   downstream queries whenever parsed-program pointer equivalence changes.
-   `import_graph::explicit_resolution_changes_graph_but_not_source_identity`
-   proves graph sensitivity and the session root/relocation test proves broad
-   invalidation, but no session test changes only an import resolution input and
-   asserts the exact graph/query outcome. Acceptance: a session-level test changes
-   one resolution mapping, observes no lex/parse, observes the intended import
-   graph change, and documents whether semantic execution is required.
+1. **Must finish: resolution-only downstream invalidation remains broad.** The
+   direct `CanonicalFrontendSession::import_graph` query now has session tests for
+   physical relocation, root and std-dir variants, pointer reuse, failed syntax,
+   empty graphs, and zero lower/bind work. A physical-only change performs zero
+   lex/parse and recomputes import resolution exactly once. It still invalidates
+   merge/RIR/semantic artifacts because canonical merged and RIR provenance owns
+   exact rebound parsed-module/source-snapshot inputs. Acceptance: either prove
+   and implement a relocation-independent merged/RIR artifact boundary, or retain
+   current invalidation and make the first dependency-keyed semantic slice reuse
+   only values whose provenance excludes physical resolution.
 
 2. **Must finish: semantic invalidation is still revision-wide.** One leaf edit
    reparses one module but clears and reruns merge, RIR, binding, and reachable


### PR DESCRIPTION
## What changed

- adds a canonical import-graph query to `CanonicalFrontendSession`
- keys import resolution by immutable source/module inputs and preserves logical module identity
- reports deterministic invalidation and work records without lowering to RIR
- adds relocation, root, identity-change, failure-isolation, and cache-reuse tests

## Why

Import resolution is a natural tooling and incremental boundary. Making it an explicit query allows dependency inspection and invalidation before semantic lowering while preserving existing batch behavior.

## Validation

- formatting passed
- focused compiler tests passed
- workspace clippy passed
- quick test suite passed