### PR TITLE
RUE-719: retain dependency-keyed post-parse work across edits

### DIFF
--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -201,6 +201,11 @@ where
         "wall_time_ns": elapsed.as_nanos(),
         "parse": parse_json(parse),
         "queries": QueryCounts::from(work).delta(before).json(),
+        "merge_work": {
+            "definition_shards_indexed": work.last_merge.definition_shards_indexed,
+            "definition_shards_reused": work.last_merge.definition_shards_reused,
+            "definition_shards_rebuilt": work.last_merge.definition_shards_rebuilt,
+        },
         "semantic_work": semantic_work_json(work, semantic_records),
         "definition_work": definition_work_json(work, definition_records),
     })
@@ -347,12 +352,25 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
     assert_eq!(count(leaf, &["parse", "lexer_invocations"]), 1);
     assert_eq!(count(leaf, &["parse", "parser_invocations"]), 1);
     assert_query_executions(leaf, 1, 1, 1, 0);
+    assert_eq!(
+        count(leaf, &["merge_work", "definition_shards_reused"]),
+        modules as u64
+    );
+    assert_eq!(count(leaf, &["merge_work", "definition_shards_rebuilt"]), 0);
     assert_eq!(count(leaf, &["queries", "downstream_invalidations"]), 1);
 
     let identity = get("module_identity_change");
     assert_eq!(count(identity, &["parse", "modules_rebound"]), 1);
     assert_reuse_parse_is_all_zero(identity);
     assert_query_executions(identity, 1, 1, 1, 0);
+    assert_eq!(
+        count(identity, &["merge_work", "definition_shards_reused"]),
+        (modules - 1) as u64
+    );
+    assert_eq!(
+        count(identity, &["merge_work", "definition_shards_rebuilt"]),
+        1
+    );
     assert_eq!(count(identity, &["queries", "downstream_invalidations"]), 1);
 
     let failed = get("failed_syntax_edit");

--- a/crates/rue-compiler/src/canonical_merge.rs
+++ b/crates/rue-compiler/src/canonical_merge.rs
@@ -20,6 +20,9 @@ pub struct CanonicalMergeWork {
     /// Deep source-buffer clones (Arc handle retention is not a payload clone).
     pub source_text_clones: usize,
     pub source_bytes_rehashed: usize,
+    pub definition_shards_indexed: usize,
+    pub definition_shards_reused: usize,
+    pub definition_shards_rebuilt: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -93,6 +96,23 @@ pub fn merge_parsed_modules(
     merge_parsed_modules_in_order(program, None)
 }
 
+pub(crate) fn merge_parsed_modules_reusing_definitions(
+    program: &ParsedProgram,
+    previous: Option<&DefinitionSnapshot>,
+) -> Result<CanonicalMergedProgram, CompileErrors> {
+    let (mut work, ordered_modules) = merge_inputs(program, None);
+    let errors = canonical_duplicate_errors(&ordered_modules);
+    if !errors.is_empty() {
+        return Err(CompileErrors::from(errors));
+    }
+    let (definitions, shards) = DefinitionSnapshot::from_parsed_modules_reusing(program, previous)
+        .map_err(CompileErrors::from)?;
+    work.definition_shards_indexed = shards.shards_indexed;
+    work.definition_shards_reused = shards.shards_reused;
+    work.definition_shards_rebuilt = shards.shards_rebuilt;
+    Ok(assemble_merged_program(program, definitions, work))
+}
+
 pub(crate) fn merge_parsed_modules_for_batch(
     program: &ParsedProgram,
     diagnostic_order: &[ModuleId],
@@ -136,8 +156,12 @@ fn merge_parsed_modules_in_order(
     if !errors.is_empty() {
         return Err(CompileErrors::from(errors));
     }
-    let definitions =
-        DefinitionSnapshot::from_parsed_modules(program).map_err(CompileErrors::from)?;
+    let (definitions, shards) = DefinitionSnapshot::from_parsed_modules_reusing(program, None)
+        .map_err(CompileErrors::from)?;
+    let mut work = work;
+    work.definition_shards_indexed = shards.shards_indexed;
+    work.definition_shards_reused = shards.shards_reused;
+    work.definition_shards_rebuilt = shards.shards_rebuilt;
     Ok(assemble_merged_program(program, definitions, work))
 }
 

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -199,6 +199,58 @@ pub struct ModuleDefinition {
     definitions: Vec<DefinitionRecord>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DefinitionShardWork {
+    pub shards_indexed: usize,
+    pub shards_reused: usize,
+    pub shards_rebuilt: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct DefinitionShard {
+    key: ModuleKey,
+    file_id: FileId,
+    records: Arc<[DefinitionShardRecord]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DefinitionShardRecord {
+    namespace: DefinitionNamespace,
+    kind: DefinitionKind,
+    visibility: Option<Visibility>,
+    name: Arc<str>,
+    name_span: Span,
+    declaration_span: Span,
+}
+
+impl DefinitionShard {
+    pub fn key(&self) -> &ModuleKey {
+        &self.key
+    }
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+    fn matches(&self, module: &crate::parsed_modules::ParsedModule) -> bool {
+        self.file_id == module.file_id()
+            && self.records.len() == module.definitions().candidates().len()
+            && self
+                .records
+                .iter()
+                .zip(module.definitions().candidates())
+                .all(|(record, candidate)| {
+                    record.namespace == candidate.namespace()
+                        && record.kind == candidate.kind()
+                        && record.visibility == candidate.visibility()
+                        && record.name.as_ref() == candidate.name()
+                        && record.name_span == candidate.name_span()
+                        && record.declaration_span == candidate.declaration_span()
+                })
+    }
+}
+
 impl ModuleDefinition {
     /// The durable logical identity of this module.
     #[inline]
@@ -250,6 +302,7 @@ pub struct DefinitionSnapshot {
     modules: Vec<ModuleDefinition>,
     definition_count: usize,
     definitions_by_name: HashMap<DefinitionNameKey, Vec<DefinitionId>>,
+    shards: Arc<[Arc<DefinitionShard>]>,
 }
 
 impl DefinitionSnapshot {
@@ -260,6 +313,13 @@ impl DefinitionSnapshot {
     pub fn from_parsed_modules(
         program: &crate::parsed_modules::ParsedProgram,
     ) -> CompileResult<Self> {
+        Self::from_parsed_modules_reusing(program, None).map(|(snapshot, _)| snapshot)
+    }
+
+    pub(crate) fn from_parsed_modules_reusing(
+        program: &crate::parsed_modules::ParsedProgram,
+        previous: Option<&Self>,
+    ) -> CompileResult<(Self, DefinitionShardWork)> {
         let _span = info_span!(
             "definition_snapshot_modules",
             module_count = program.modules().len()
@@ -267,6 +327,11 @@ impl DefinitionSnapshot {
         .entered();
         let source_snapshot = SourceSnapshot::from_parsed_modules(program)?;
         let mut modules = Vec::with_capacity(program.modules().len());
+        let mut work = DefinitionShardWork {
+            shards_indexed: previous.map_or(0, |snapshot| snapshot.shards.len()),
+            ..DefinitionShardWork::default()
+        };
+        let mut shards = Vec::with_capacity(program.modules().len());
         let definition_count = program
             .modules()
             .iter()
@@ -276,19 +341,51 @@ impl DefinitionSnapshot {
             HashMap::<DefinitionNameKey, Vec<DefinitionId>>::with_capacity(definition_count);
 
         for (module_index, module) in program.modules().iter().enumerate() {
-            let mut definitions = Vec::with_capacity(module.definitions().candidates().len());
-            for (definition_index, candidate) in
-                module.definitions().candidates().iter().enumerate()
-            {
-                debug_assert_eq!(candidate.occurrence().index(), definition_index);
+            let candidate_records = || {
+                module
+                    .definitions()
+                    .candidates()
+                    .iter()
+                    .map(|candidate| DefinitionShardRecord {
+                        namespace: candidate.namespace(),
+                        kind: candidate.kind(),
+                        visibility: candidate.visibility(),
+                        name: Arc::from(candidate.name()),
+                        name_span: candidate.name_span(),
+                        declaration_span: candidate.declaration_span(),
+                    })
+                    .collect::<Vec<_>>()
+            };
+            let shard = previous
+                .and_then(|snapshot| {
+                    snapshot
+                        .shards
+                        .binary_search_by(|shard| shard.key.cmp(module.module_id()))
+                        .ok()
+                        .map(|index| snapshot.shards[index].clone())
+                })
+                .filter(|shard| shard.matches(module));
+            let shard = if let Some(shard) = shard {
+                work.shards_reused += 1;
+                shard
+            } else {
+                work.shards_rebuilt += 1;
+                Arc::new(DefinitionShard {
+                    key: module.module_id().clone(),
+                    file_id: module.file_id(),
+                    records: candidate_records().into(),
+                })
+            };
+            let mut definitions = Vec::with_capacity(shard.records.len());
+            for (definition_index, candidate) in shard.records.iter().enumerate() {
                 let id = DefinitionId {
                     module_index,
                     definition_index,
                 };
                 let name_key = DefinitionNameKey::new(
                     module.module_id().clone(),
-                    candidate.namespace(),
-                    candidate.name(),
+                    candidate.namespace,
+                    &candidate.name,
                 );
                 definitions_by_name
                     .entry(name_key.clone())
@@ -297,11 +394,11 @@ impl DefinitionSnapshot {
                 definitions.push(DefinitionRecord {
                     id,
                     name_key,
-                    kind: candidate.kind(),
-                    visibility: candidate.visibility(),
+                    kind: candidate.kind,
+                    visibility: candidate.visibility,
                     file_id: module.file_id(),
-                    name_span: candidate.name_span(),
-                    declaration_span: candidate.declaration_span(),
+                    name_span: candidate.name_span,
+                    declaration_span: candidate.declaration_span,
                 });
             }
             modules.push(ModuleDefinition {
@@ -309,15 +406,20 @@ impl DefinitionSnapshot {
                 file_id: module.file_id(),
                 definitions,
             });
+            shards.push(shard);
         }
 
-        Ok(Self {
-            source_snapshot,
-            root_module: program.root().clone(),
-            modules,
-            definition_count,
-            definitions_by_name,
-        })
+        Ok((
+            Self {
+                source_snapshot,
+                root_module: program.root().clone(),
+                modules,
+                definition_count,
+                definitions_by_name,
+                shards: shards.into(),
+            },
+            work,
+        ))
     }
 
     /// Resolve a parsed program into durable name candidates and source records.
@@ -491,6 +593,7 @@ impl DefinitionSnapshot {
             modules,
             definition_count,
             definitions_by_name,
+            shards: Arc::from([]),
         })
     }
 
@@ -516,6 +619,10 @@ impl DefinitionSnapshot {
     #[inline]
     pub fn modules(&self) -> &[ModuleDefinition] {
         &self.modules
+    }
+
+    pub fn shards(&self) -> &[Arc<DefinitionShard>] {
+        &self.shards
     }
 
     /// Find a module by durable key.

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -11,9 +11,9 @@ use crate::{
     CompileError, CompileErrors, CompileOptions, ErrorKind, ModuleResolutionInputs,
     ParseInvalidationSummary, ParsedModulesWork, SemanticInputDescriptor, SourceRevision,
     SourceSnapshot, analyze_canonical_program,
-    bound_definitions::bind_canonical_definitions_with_work, lower_canonical_rir,
-    merge_parsed_modules, parsed_modules::ParsedProgram, resolve_canonical_import_graph,
-    validate_canonical_import_graph,
+    bound_definitions::bind_canonical_definitions_with_work,
+    canonical_merge::merge_parsed_modules_reusing_definitions, lower_canonical_rir,
+    parsed_modules::ParsedProgram, resolve_canonical_import_graph, validate_canonical_import_graph,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -119,6 +119,7 @@ pub struct CanonicalFrontendSession {
     parse: CanonicalParseSession,
     published: Option<Arc<ParsedProgram>>,
     merge_cache: Option<Result<Arc<CanonicalMergedProgram>, CompileErrors>>,
+    definition_shard_baseline: Option<crate::DefinitionSnapshot>,
     rir_cache: Option<Arc<CanonicalRirOutput>>,
     import_cache: Vec<ImportCacheEntry>,
     semantic_cache: Vec<SemanticCacheEntry>,
@@ -268,10 +269,15 @@ impl CanonicalFrontendSession {
         }
         let parsed = self.published.as_deref().ok_or_else(no_published_program)?;
         self.work.merge.executions += 1;
-        let merged = merge_parsed_modules(parsed).map(Arc::new);
+        let merged = merge_parsed_modules_reusing_definitions(
+            parsed,
+            self.definition_shard_baseline.as_ref(),
+        )
+        .map(Arc::new);
         if let Ok(merged) = &merged {
             debug_assert_eq!(merged.ast().source_revision(), parsed.source_revision());
             self.work.last_merge = merged.work();
+            self.definition_shard_baseline = Some(merged.definitions().clone());
         }
         self.merge_cache = Some(merged.clone());
         merged
@@ -550,15 +556,93 @@ mod tests {
         let mut session = CanonicalFrontendSession::new();
         session.update(&make(false)).into_result().unwrap();
         session.rir().unwrap();
+        let first_shards = session
+            .definition_shard_baseline
+            .as_ref()
+            .unwrap()
+            .shards()
+            .to_vec();
         let update = session.update(&make(true));
         assert!(update.downstream_invalidated());
         assert_eq!(update.work().modules_reused, 127);
         assert_eq!(update.work().modules_reparsed, 1);
         session.rir().unwrap();
+        let second_shards = session.definition_shard_baseline.as_ref().unwrap().shards();
+        assert!(
+            first_shards
+                .iter()
+                .zip(second_shards)
+                .all(|(first, second)| Arc::ptr_eq(first, second))
+        );
+        assert_eq!(session.work().last_merge.definition_shards_indexed, 128);
+        assert_eq!(session.work().last_merge.definition_shards_reused, 128);
+        assert_eq!(session.work().last_merge.definition_shards_rebuilt, 0);
         session.rir().unwrap();
         assert_eq!(session.work().merge.executions, 2);
         assert_eq!(session.work().rir.executions, 2);
         assert_eq!(session.work().downstream_invalidations, 1);
+    }
+
+    #[test]
+    fn definition_shards_fail_closed_on_surface_identity_changes() {
+        let initial = snapshot(
+            &[
+                (1, "/p/main.rue", "main.rue", "fn main() -> i32 { 0 }"),
+                (2, "/p/a.rue", "a.rue", "fn a() -> i32 { 1 }"),
+            ],
+            1,
+        );
+        let body = snapshot(
+            &[
+                (1, "/p/main.rue", "main.rue", "fn main() -> i32 { 0 }"),
+                (2, "/p/a.rue", "a.rue", "fn a() -> i32 { 2 }"),
+            ],
+            1,
+        );
+        let renamed_definition = snapshot(
+            &[
+                (1, "/p/main.rue", "main.rue", "fn main() -> i32 { 0 }"),
+                (2, "/p/a.rue", "a.rue", "fn b() -> i32 { 2 }"),
+            ],
+            1,
+        );
+        let relocated = snapshot(
+            &[
+                (1, "/m/main.rue", "main.rue", "fn main() -> i32 { 0 }"),
+                (2, "/m/a.rue", "a.rue", "fn b() -> i32 { 2 }"),
+            ],
+            1,
+        );
+        let reassigned = snapshot(
+            &[
+                (11, "/m/main.rue", "main.rue", "fn main() -> i32 { 0 }"),
+                (12, "/m/a.rue", "a.rue", "fn b() -> i32 { 2 }"),
+            ],
+            11,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&initial).into_result().unwrap();
+        session.merge().unwrap();
+
+        session.update(&body).into_result().unwrap();
+        session.merge().unwrap();
+        assert_eq!(session.work().last_merge.definition_shards_reused, 2);
+        assert_eq!(session.work().last_merge.definition_shards_rebuilt, 0);
+
+        session.update(&renamed_definition).into_result().unwrap();
+        session.merge().unwrap();
+        assert_eq!(session.work().last_merge.definition_shards_reused, 1);
+        assert_eq!(session.work().last_merge.definition_shards_rebuilt, 1);
+
+        session.update(&relocated).into_result().unwrap();
+        session.merge().unwrap();
+        assert_eq!(session.work().last_merge.definition_shards_reused, 2);
+        assert_eq!(session.work().last_merge.definition_shards_rebuilt, 0);
+
+        session.update(&reassigned).into_result().unwrap();
+        session.merge().unwrap();
+        assert_eq!(session.work().last_merge.definition_shards_reused, 0);
+        assert_eq!(session.work().last_merge.definition_shards_rebuilt, 2);
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -57,7 +57,8 @@ pub use canonical_semantic::{
 };
 pub use definition_snapshot::{
     DefinitionId, DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionOccurrenceId,
-    DefinitionRecord, DefinitionSnapshot, ModuleDefinition, ModuleKey,
+    DefinitionRecord, DefinitionShard, DefinitionShardWork, DefinitionSnapshot, ModuleDefinition,
+    ModuleKey,
 };
 pub use frontend_session::{
     CanonicalFrontendSession, CanonicalFrontendSessionWork, CanonicalFrontendUpdate,

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -14,7 +14,7 @@ incremental-compilation goal is complete.
 | Stable source/module/definition identity | Satisfied at the source boundary. `SourceId` hashes bytes; `ModuleId` canonicalizes logical paths; `SourceRevision` combines explicit root and sorted module/content pairs; `StableDefinitionKey` is module/name/namespace/kind/owner based. Relocation, file-ID, ordering, rename, and module-move tests cover the intended distinctions. |
 | Immutable per-file/query inputs | Satisfied. `SourceSnapshot` owns `Arc<String>` text plus validated metadata. `SemanticInputDescriptor` owns source revision, module-resolution inputs, target, and stable preview features; `CodegenInputDescriptor` adds optimization level. |
 | Batch compatibility | Satisfied with deliberate diagnostic-order adapters. `compile_source_snapshot_with_options_impl` uses `parse_source_snapshot_modules_for_batch` and `merge_parsed_modules_for_batch`; batch/borrowed compatibility tests compare artifacts and diagnostics. |
-| Reusable in-process invalidation | Satisfied at whole-query granularity, not fine-grained semantic granularity. `CanonicalFrontendSession::update` reuses parsed module Arcs, preserves the last good revision after syntax failure, and invalidates merge/RIR/semantic/definition caches when the published program changes. The benchmark makes this behavior measurable. |
+| Reusable in-process invalidation | Partially satisfied below whole-query granularity. `CanonicalFrontendSession::update` reuses parsed module Arcs and preserves the last good revision after syntax failure. Canonical merge now retains immutable definition-surface shards keyed by module identity, FileId epoch, and ordered definition surface; body-only edits reuse all shards and a module rename rebuilds only its shard. Merge/RIR/semantic queries still execute revision-wide. The benchmark makes both reuse and remaining work measurable. |
 | Tooling seams | Partially satisfied. Backend-free `published`, `import_graph`, `merge`, `rir`, `semantic`, and `stable_definitions` queries exist; semantic output exposes warnings. Import resolution is lazy, memoized, keyed by owned source/resolution/std-dir inputs, and consumes canonical parsed import sites without RIR. Binary-search `ParsedProgram::module(ModuleId)` and `BoundDefinitionSet::definition_by_key(StableDefinitionKey)` support keyed artifact access. Diagnostics remain returned errors rather than a retained query result. |
 | No disk cache or full-LSP shortcut | Satisfied by scope. Session caches are process-owned values only; the benchmark performs no measured filesystem discovery and no backend/link. No persistent cache format, watcher, protocol server, or LSP is introduced. |
 | Small mergeable, tracked delivery | Satisfied operationally: the stack is split into described RUE-719 jj changes and independently gated slices. This audit cannot prove external Linear state; commit descriptions are the locally falsifiable tracking evidence. |
@@ -32,12 +32,15 @@ incremental-compilation goal is complete.
    current invalidation and make the first dependency-keyed semantic slice reuse
    only values whose provenance excludes physical resolution.
 
-2. **Must finish: semantic invalidation is still revision-wide.** One leaf edit
-   reparses one module but clears and reruns merge, RIR, binding, and reachable
+2. **Must finish: RIR and semantic invalidation is still revision-wide.** One
+   leaf edit reparses one module and now reuses every unchanged definition-surface
+   shard, but still reruns merge duplicate scanning, RIR, binding, and reachable
    body analysis. This is explicitly visible in the benchmark's
-   `leaf_body_edit` counters. Acceptance: introduce dependency-keyed reuse at one
-   post-parse boundary with a counter proving unaffected work is retained; do
-   not hide whole-pass inefficiency behind only an outer cache.
+   `leaf_body_edit` counters. Per-module RIR fragments are not yet sound because
+   `InstRef` ordering, semantic `Spur` handles, and cross-module references belong
+   to one request-global universe. Acceptance: introduce fragment-local handles
+   plus deterministic global remapping, or choose a dependency-keyed declaration
+   or body boundary whose outputs contain no request-global handles.
 
 3. **Must finish: frontend diagnostics are not durable query artifacts.** Syntax,
    merge, and semantic failures return `CompileErrors`; only successful semantic


### PR DESCRIPTION
## What changed

- introduces immutable per-module definition shards derived from canonical parsed modules
- reuses unchanged shards across session updates by stable module/source identity
- keeps canonical merge and stable definition snapshots deterministic and batch-compatible
- adds structural work counters and benchmark gates for shard rebuild/reuse

## Why

Post-parse compiler work needs a stable reusable unit before semantic caching can be trusted. Definition shards provide a module-keyed seam that avoids reconstructing unchanged definition metadata while preserving the existing global merge result.

## Validation

- formatting passed
- focused compiler tests passed
- 128-module benchmark structural gates passed
- workspace clippy and quick tests passed