### PR TITLE
RUE-719: expose stable semantic dependency manifests

### DIFF
--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -6,11 +6,11 @@ use rue_air::{DeclarationBindingWork, SemanticBindingManifestWork};
 
 use crate::{
     BoundDefinitionSet, BoundDefinitionWork, CanonicalImportGraph, CanonicalImportGraphValidation,
-    CanonicalMergeWork, CanonicalMergedProgram, CanonicalParseSession, CanonicalRirOutput,
-    CanonicalRirWork, CanonicalSemanticOutput, CanonicalSemanticWork, CodegenInputDescriptor,
-    CompileError, CompileErrors, CompileOptions, CompileWarning, ErrorKind, ModuleResolutionInputs,
-    ParseInvalidationSummary, ParsedModulesWork, SemanticInputDescriptor, SourceRevision,
-    SourceSnapshot, analyze_canonical_program,
+    CanonicalImportResolution, CanonicalMergeWork, CanonicalMergedProgram, CanonicalParseSession,
+    CanonicalRirOutput, CanonicalRirWork, CanonicalSemanticOutput, CanonicalSemanticWork,
+    CodegenInputDescriptor, CompileError, CompileErrors, CompileOptions, CompileWarning, ErrorKind,
+    ModuleResolutionInputs, ParseInvalidationSummary, ParsedModulesWork, SemanticInputDescriptor,
+    SourceRevision, SourceSnapshot, StableDefinitionKey, analyze_canonical_program,
     bound_definitions::bind_canonical_definitions_with_work,
     canonical_merge::merge_parsed_modules_reusing_definitions, lower_canonical_rir,
     parsed_modules::ParsedProgram, resolve_canonical_import_graph, validate_canonical_import_graph,
@@ -47,6 +47,66 @@ pub struct CanonicalFrontendSessionWork {
     pub diagnostic_publications: usize,
     pub diagnostic_reuses: usize,
     pub diagnostic_invalidations: usize,
+    pub dependency_manifests: FrontendQueryWork,
+    pub dependency_manifest_records_visited: usize,
+    pub dependency_manifest_import_records_visited: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticDependencyManifestWork {
+    pub definition_records_visited: usize,
+    pub import_records_visited: usize,
+    pub extra_rir_instructions_visited: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StableModuleImportDependency {
+    Resolved {
+        importer: crate::ModuleId,
+        normalized_specifier: Arc<str>,
+        target: crate::ModuleId,
+    },
+    Missing {
+        importer: crate::ModuleId,
+        normalized_specifier: Arc<str>,
+    },
+    Ambiguous {
+        importer: crate::ModuleId,
+        normalized_specifier: Arc<str>,
+        file_module: crate::ModuleId,
+        directory_module: crate::ModuleId,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct SemanticDependencyInputManifest {
+    input: SemanticInputDescriptor,
+    imports: CanonicalImportGraph,
+    definitions: Arc<[StableDefinitionKey]>,
+    module_imports: Arc<[StableModuleImportDependency]>,
+    definition_universe_complete: bool,
+    work: SemanticDependencyManifestWork,
+}
+
+impl SemanticDependencyInputManifest {
+    pub fn input(&self) -> &SemanticInputDescriptor {
+        &self.input
+    }
+    pub fn imports(&self) -> &CanonicalImportGraph {
+        &self.imports
+    }
+    pub fn definitions(&self) -> &[StableDefinitionKey] {
+        &self.definitions
+    }
+    pub fn module_imports(&self) -> &[StableModuleImportDependency] {
+        &self.module_imports
+    }
+    pub fn definition_universe_complete(&self) -> bool {
+        self.definition_universe_complete
+    }
+    pub fn work(&self) -> SemanticDependencyManifestWork {
+        self.work
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -171,6 +231,7 @@ pub struct CanonicalFrontendSession {
     work: CanonicalFrontendSessionWork,
     diagnostic_cache: Vec<Arc<FrontendDiagnosticSnapshot>>,
     latest_diagnostics: Option<Arc<FrontendDiagnosticSnapshot>>,
+    dependency_manifest_cache: Vec<Arc<SemanticDependencyInputManifest>>,
 }
 
 #[derive(Debug)]
@@ -297,6 +358,7 @@ impl CanonicalFrontendSession {
                     self.work.semantic_records.clear();
                     self.work.definition_entries = 0;
                     self.work.definition_records.clear();
+                    self.dependency_manifest_cache.clear();
                     self.published = Some(candidate.clone());
                     self.published_snapshot = Some(snapshot.clone());
                     CanonicalFrontendUpdate {
@@ -582,6 +644,91 @@ impl CanonicalFrontendSession {
             failed: result.is_err(),
         });
         result
+    }
+
+    /// Materialize stable semantic inputs for future dependency-edge capture.
+    ///
+    /// This tooling-only query shares the existing import and stable-definition
+    /// queries. It performs no additional RIR traversal; reference edges are not
+    /// yet claimed until every semantic reference surface can be captured.
+    pub fn semantic_dependency_inputs(
+        &mut self,
+        options: &CompileOptions,
+        std_dir: Option<&str>,
+    ) -> Result<Arc<SemanticDependencyInputManifest>, CompileErrors> {
+        self.work.dependency_manifests.calls += 1;
+        let imports = self.import_graph(std_dir)?;
+        let snapshot = self
+            .published_snapshot
+            .as_ref()
+            .expect("stable definitions retain a published source snapshot");
+        let input =
+            SemanticInputDescriptor::new(snapshot, options.target, &options.preview_features);
+        if let Some(cached) = self
+            .dependency_manifest_cache
+            .iter()
+            .find(|manifest| manifest.input == input && manifest.imports == *imports.graph())
+        {
+            self.work.dependency_manifests.reuses += 1;
+            return Ok(cached.clone());
+        }
+        self.work.dependency_manifests.executions += 1;
+        let definitions = self.stable_definitions(options);
+        let definition_universe_complete = definitions.is_ok();
+        let definition_records = definitions
+            .as_ref()
+            .map(|definitions| definitions.definitions())
+            .unwrap_or(&[]);
+        let mut keys = definition_records
+            .iter()
+            .map(|record| record.stable_key().clone())
+            .collect::<Vec<_>>();
+        keys.sort();
+        keys.dedup();
+        let work = SemanticDependencyManifestWork {
+            definition_records_visited: definition_records.len(),
+            import_records_visited: imports.graph().records().len(),
+            extra_rir_instructions_visited: 0,
+        };
+        self.work.dependency_manifest_records_visited += work.definition_records_visited;
+        self.work.dependency_manifest_import_records_visited += work.import_records_visited;
+        let module_imports = imports
+            .graph()
+            .records()
+            .iter()
+            .map(|record| match record.resolution() {
+                CanonicalImportResolution::Resolved(target) => {
+                    StableModuleImportDependency::Resolved {
+                        importer: record.importer().clone(),
+                        normalized_specifier: Arc::from(record.normalized_specifier()),
+                        target: target.clone(),
+                    }
+                }
+                CanonicalImportResolution::Missing => StableModuleImportDependency::Missing {
+                    importer: record.importer().clone(),
+                    normalized_specifier: Arc::from(record.normalized_specifier()),
+                },
+                CanonicalImportResolution::Ambiguous {
+                    file_module,
+                    directory_module,
+                } => StableModuleImportDependency::Ambiguous {
+                    importer: record.importer().clone(),
+                    normalized_specifier: Arc::from(record.normalized_specifier()),
+                    file_module: file_module.clone(),
+                    directory_module: directory_module.clone(),
+                },
+            })
+            .collect::<Vec<_>>();
+        let manifest = Arc::new(SemanticDependencyInputManifest {
+            input,
+            imports: imports.graph().clone(),
+            definitions: keys.into(),
+            module_imports: module_imports.into(),
+            definition_universe_complete,
+            work,
+        });
+        self.dependency_manifest_cache.push(manifest.clone());
+        Ok(manifest)
     }
 }
 
@@ -1323,6 +1470,87 @@ mod tests {
         let record = &session.work().definition_records[0];
         assert_eq!(record.binding.bind_invocations, 1);
         assert_eq!(record.manifest.build_invocations, 1);
+    }
+
+    #[test]
+    fn dependency_input_manifest_is_stable_ordered_and_adds_no_rir_scan() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SemanticDependencyInputManifest>();
+        let source = base();
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        let first = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        let second = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(first.definitions().windows(2).all(|pair| pair[0] < pair[1]));
+        assert_eq!(
+            first.work().definition_records_visited,
+            first.definitions().len()
+        );
+        assert_eq!(first.work().extra_rir_instructions_visited, 0);
+        assert_eq!(session.work().dependency_manifests.executions, 1);
+        assert_eq!(session.work().dependency_manifests.reuses, 1);
+        assert_eq!(session.work().rir.executions, 1);
+        assert_eq!(session.work().semantic.executions, 1);
+    }
+
+    #[test]
+    fn dependency_manifest_carries_resolved_and_fail_closed_module_edges() {
+        let original = snapshot(
+            &[
+                (
+                    1,
+                    "/p/app/main.rue",
+                    "app/main.rue",
+                    "fn main() -> i32 { let h = @import(\"helper.rue\"); 0 }",
+                ),
+                (2, "/p/app/helper.rue", "app/helper.rue", "fn helper() {}"),
+            ],
+            1,
+        );
+        let moved = snapshot(
+            &[
+                (
+                    1,
+                    "/p/app/main.rue",
+                    "app/main.rue",
+                    "fn main() -> i32 { let h = @import(\"helper.rue\"); 0 }",
+                ),
+                (2, "/else/helper.rue", "app/helper.rue", "fn helper() {}"),
+            ],
+            1,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&original).into_result().unwrap();
+        let resolved = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        assert!(resolved.definition_universe_complete());
+        assert!(matches!(
+            &resolved.module_imports()[0],
+            StableModuleImportDependency::Resolved { importer, target, .. }
+                if importer.as_str() == "app/main.rue" && target.as_str() == "app/helper.rue"
+        ));
+
+        let update = session.update(&moved);
+        assert_eq!(update.work().syntax.lexer_invocations, 0);
+        update.into_result().unwrap();
+        let missing = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        assert!(!missing.definition_universe_complete());
+        assert!(matches!(
+            &missing.module_imports()[0],
+            StableModuleImportDependency::Missing { importer, .. }
+                if importer.as_str() == "app/main.rue"
+        ));
+        assert_eq!(missing.work().import_records_visited, 1);
+        assert_eq!(missing.work().extra_rir_instructions_visited, 0);
+        assert_eq!(session.work().dependency_manifests.executions, 2);
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -63,7 +63,9 @@ pub use definition_snapshot::{
 pub use frontend_session::{
     CanonicalFrontendSession, CanonicalFrontendSessionWork, CanonicalFrontendUpdate,
     CanonicalImportGraphOutput, DefinitionQueryRecord, FrontendDiagnosticSnapshot,
-    FrontendDiagnosticStage, FrontendQueryWork, ImportGraphInputDescriptor, SemanticQueryRecord,
+    FrontendDiagnosticStage, FrontendQueryWork, ImportGraphInputDescriptor,
+    SemanticDependencyInputManifest, SemanticDependencyManifestWork, SemanticQueryRecord,
+    StableModuleImportDependency,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -1,0 +1,94 @@
+---
+id: 0050
+title: Stable semantic dependency manifests
+status: proposal
+tags: [compiler, incremental, tooling]
+feature-flag: null
+created: 2026-07-12
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+---
+
+# Stable semantic dependency manifests
+
+## Goal
+
+Permit sound declaration and body invalidation without retaining request-local
+`Spur`, `InstRef`, `FileId`, `StructId`, specialization order, or CFG identity.
+This proposal does not authorize CFG reuse until every dependency surface below
+is captured and closure tests prove it.
+
+## Stable model
+
+Each manifest is keyed by `SemanticInputDescriptor`, canonical import graph, and
+an ordered definition universe of `StableDefinitionKey`. A future record has:
+
+- `owner: StableDefinitionKey`;
+- separate declaration/signature and body fingerprints;
+- ordered direct `declaration_dependencies` and `body_dependencies`;
+- explicit non-definition dependencies: root, canonical imports, target and
+  preview features; optimization belongs only to CFG/codegen reuse;
+- specialization descriptors made from stable callee key plus canonical type and
+  comptime-value arguments, never discovery order.
+
+Consumers compute deterministic reverse edges and transitive closure from sorted
+direct edges. Missing owners or unresolved targets fail closed by invalidating
+the requesting record, never by silently dropping an edge.
+
+## Current capture audit
+
+The existing compiler does not yet expose a complete sound graph:
+
+- declaration binding resolves types, constants, functions, methods, associated
+  functions, module bindings and destructors, but retains results under
+  request-local IDs;
+- constant initialization recursively discovers const dependencies inside
+  `declarations.rs`; those edges are not returned;
+- reachable body analysis returns `HashSet<Spur>` and
+  `HashSet<(StructId, Spur)>` from function/method/destructor analysis, sorts them
+  only for worklist scheduling, then discards the owner-to-target edges;
+- type syntax and struct/enum payload resolution can reference constructors,
+  constants and types without appearing as ordinary call edges;
+- implicit drop glue and anonymous destructors add roots after type/comptime
+  evaluation;
+- generic specialization creates concrete callees from type/comptime values and
+  may discover more bodies; specialization identity is not durable;
+- import resolution is already a stable separate query and must be included as
+  an explicit input rather than rediscovered from RIR;
+- CFG construction consumes typed AIR and optimization level. Reusing it before
+  stable AIR/type/string identity exists would be unsound.
+
+Adding a second RIR scan would still miss semantic choices made during binding
+and specialization, so extraction must occur at the points above.
+
+## First implemented slice
+
+`CanonicalFrontendSession::semantic_dependency_inputs` is tooling-only and
+shares `import_graph` plus `stable_definitions`. It publishes an immutable,
+ordered stable definition universe with semantic and import inputs. It also
+contains the first complete edge surface: ordered module import dependencies
+from importer to resolved target, with missing and ambiguous outcomes retained
+as fail-closed records. Work records visited definition/import records and
+asserts zero extra RIR visits. This is the destination index required to
+translate future definition-level edges; it makes no body or CFG reuse claim.
+
+## Required next slices
+
+1. During declaration binding, translate winning bindings to stable keys and
+   capture signature/type/const/module/destructor direct edges.
+2. Thread an owner stable key through body analysis and translate each returned
+   free-function/method/destructor reference before the worklist sets are
+   discarded.
+3. Define durable canonical type/comptime specialization arguments and record
+   generic-origin edges.
+4. Split declaration/signature and body fingerprints at parsed syntax boundaries.
+5. Gate deterministic closure on recursion, mutual recursion, methods,
+   destructors, constants, imports, generics, relocation/FileId/input order, and
+   target/feature/root changes.
+6. Only then retain typed AIR or CFG results; CFG keys additionally include
+   optimization inputs and any global string/type remapping identity.
+
+Acceptance requires one existing semantic execution to emit the complete
+manifest with no second whole-RIR traversal and unchanged diagnostic bytes/order.

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -211,4 +211,5 @@ The table is generated from ADR frontmatter. Run
 | [0046](0046-delete-flat-mode.md) | Delete flat multi-file mode (all cross-file references go through @import) | Accepted | modules, semantics, cli, language-shape, ergonomics |
 | [0047](0047-root-module-build-inputs.md) | Root-module compilation units and build-system inputs | Accepted | modules, compiler, build-system, packages, cli, language-shape |
 | [0048](0048-shared-codegen-middle-layer.md) | Shared codegen middle layer (reduce x86-64/aarch64 backend duplication) | Proposal | codegen, architecture, backends, refactor, maintainability |
+| [0050](0050-semantic-dependency-manifest.md) | Stable semantic dependency manifests | Proposal | compiler, incremental, tooling |
 <!-- ADR-INDEX:END -->

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -41,6 +41,11 @@ incremental-compilation goal is complete.
    to one request-global universe. Acceptance: introduce fragment-local handles
    plus deterministic global remapping, or choose a dependency-keyed declaration
    or body boundary whose outputs contain no request-global handles.
+   ADR-0050 audits the missing const/type/call/method/destructor/generic capture
+   surfaces. The first tooling-only `semantic_dependency_inputs` slice supplies
+   a stable ordered destination universe, explicit semantic inputs, and complete
+   resolved/missing/ambiguous module-import edges. Definition-level edges and
+   body/CFG reuse remain intentionally absent.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## What changed

- adds an immutable semantic dependency-input manifest keyed by stable module and definition identities
- records definition universe, module-import edges, target/features, and explicit completeness/work metadata
- exposes a canonical frontend-session query with memoization and no extra RIR traversal
- documents the fail-closed dependency-manifest contract in ADR 0050

## Why

Sound invalidation requires explicit evidence about which semantic inputs and edges are known. This foundation makes incompleteness observable and conservative before progressively adding stable dependency categories.

## Validation

- formatting passed
- focused compiler tests passed
- workspace clippy passed
- quick test suite passed