### PR TITLE
RUE-719: retain ordinary free-function dependency events

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -38,10 +38,10 @@ pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
     AnalyzedFunction, BodyAnalysisWork, BoundSema, ConstValue, DeclarationBindingWork,
-    DirResolution, FunctionInfo, GatherOutput, MethodInfo, ModulePath, ParamSlotModes,
-    RirDeclarationIndexWork, Sema, SemaOutput, SemanticBinding, SemanticBindingKind,
-    SemanticBindingManifest, SemanticBindingManifestWork, SemanticBindingNamespace,
-    import_candidate_groups,
+    DirResolution, FunctionInfo, GatherOutput, MethodInfo, ModulePath,
+    OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
+    SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
+    SemanticBindingNamespace, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -164,6 +164,14 @@ fn finalize_function_body_analysis(
         // after its fixed point has completed.
         type_pool: sema.type_pool.clone(),
         body_analysis_work: sema.body_analysis_work,
+        ordinary_free_function_dependencies: {
+            sema.ordinary_free_function_dependencies.sort();
+            sema.ordinary_free_function_dependencies.dedup();
+            sema.ordinary_free_function_dependencies.clone()
+        },
+        // Method/destructor and specialization callers are not yet threaded
+        // through the stable owner capture seam.
+        ordinary_free_function_dependencies_complete: false,
     };
 
     errors.into_result_with(output)
@@ -513,6 +521,23 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 fn_info.allow_unreachable_code,
             ) {
                 Ok((analyzed, warnings, local_strings, referenced_fns, referenced_meths)) => {
+                    for callee in &referenced_fns {
+                        if let Some(callee_info) = sema.functions.get(callee) {
+                            sema.ordinary_free_function_dependencies.push(
+                                super::OrdinaryFreeFunctionDependencyEvent {
+                                    caller_file: fn_info.file_id.index(),
+                                    caller_name: sema.interner.resolve(&source_name).to_string(),
+                                    callee_file: callee_info.file_id.index(),
+                                    callee_name: sema
+                                        .interner
+                                        .resolve(&sema.source_function_name(*callee))
+                                        .to_string(),
+                                },
+                            );
+                            sema.body_analysis_work
+                                .ordinary_free_function_dependency_events += 1;
+                        }
+                    }
                     functions_with_strings.push((analyzed, local_strings));
                     all_warnings.extend(warnings);
 
@@ -1376,6 +1401,8 @@ mod error_invariant_tests {
             warnings: Vec::new(),
             type_pool: TypeInternPool::new(),
             body_analysis_work: crate::BodyAnalysisWork::default(),
+            ordinary_free_function_dependencies: Vec::new(),
+            ordinary_free_function_dependencies_complete: false,
         }
     }
 

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -140,6 +140,7 @@ impl<'a> GatherOutput<'a> {
             methods: self.methods,
             named_method_declarations,
             body_analysis_work: super::BodyAnalysisWork::default(),
+            ordinary_free_function_dependencies: Vec::new(),
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,
             module_bindings: self.module_bindings,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -57,7 +57,10 @@ pub use inference_ctx::InferenceContext;
 pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
-pub use output::{AnalyzedFunction, BodyAnalysisWork, ParamSlotModes, SemaOutput};
+pub use output::{
+    AnalyzedFunction, BodyAnalysisWork, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
+    SemaOutput,
+};
 
 use std::collections::{HashMap, HashSet};
 
@@ -100,6 +103,7 @@ pub struct Sema<'a> {
     /// Exact named-method FnDecl handles for this RIR snapshot only.
     pub(crate) named_method_declarations: HashMap<(StructId, Spur), rue_rir::InstRef>,
     pub(crate) body_analysis_work: BodyAnalysisWork,
+    pub(crate) ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
     /// Compatibility value-constant table for globally unique bare names.
     /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`]. If a value-constant name appears in
@@ -226,6 +230,7 @@ impl<'a> Sema<'a> {
             methods: HashMap::new(),
             named_method_declarations: HashMap::new(),
             body_analysis_work: BodyAnalysisWork::default(),
+            ordinary_free_function_dependencies: Vec::new(),
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),
             module_bindings: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -7,6 +7,13 @@
 use crate::inst::Air;
 use crate::intern_pool::TypeInternPool;
 use rue_error::CompileWarning;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OrdinaryFreeFunctionDependencyEvent {
+    pub caller_file: u32,
+    pub caller_name: String,
+    pub callee_file: u32,
+    pub callee_name: String,
+}
 
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
@@ -85,6 +92,8 @@ pub struct SemaOutput {
     pub type_pool: TypeInternPool,
     /// Exact structural work performed while dispatching reachable bodies.
     pub body_analysis_work: BodyAnalysisWork,
+    pub ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
+    pub ordinary_free_function_dependencies_complete: bool,
 }
 
 /// Value-only workload counters for demand-driven body dispatch.
@@ -92,6 +101,7 @@ pub struct SemaOutput {
 /// These counters deliberately expose no request-local RIR instruction handles.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BodyAnalysisWork {
+    pub ordinary_free_function_dependency_events: usize,
     /// Indexed declaration-record lookups for reachable, non-generic free functions.
     pub free_function_record_lookups: usize,
     /// Private declaration-record lookups for reachable named-struct methods.

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1,7 +1,8 @@
 //! One-pass canonical declaration binding, body analysis, and CFG lowering.
 
 use rue_air::{
-    BodyAnalysisWork, DeclarationBindingWork, RirDeclarationIndexWork, SemanticBindingManifestWork,
+    BodyAnalysisWork, DeclarationBindingWork, OrdinaryFreeFunctionDependencyEvent,
+    RirDeclarationIndexWork, SemanticBindingManifestWork,
 };
 use tracing::info_span;
 
@@ -40,6 +41,8 @@ pub struct CanonicalSemanticOutput {
     warnings: Vec<CompileWarning>,
     bound_definitions: Option<BoundDefinitionSet>,
     work: CanonicalSemanticWork,
+    ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
+    ordinary_free_function_dependencies_complete: bool,
 }
 
 impl CanonicalSemanticOutput {
@@ -62,6 +65,12 @@ impl CanonicalSemanticOutput {
     /// Semantic and CFG warnings in canonical output order.
     pub fn warnings(&self) -> &[CompileWarning] {
         &self.warnings
+    }
+    pub fn ordinary_free_function_dependencies(&self) -> &[OrdinaryFreeFunctionDependencyEvent] {
+        &self.ordinary_free_function_dependencies
+    }
+    pub fn ordinary_free_function_dependencies_complete(&self) -> bool {
+        self.ordinary_free_function_dependencies_complete
     }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -139,6 +148,10 @@ pub fn analyze_canonical_program(
 
     let sema_output = bound.analyze_all_bodies()?;
     let body_analysis = sema_output.body_analysis_work;
+    let ordinary_free_function_dependencies =
+        sema_output.ordinary_free_function_dependencies.clone();
+    let ordinary_free_function_dependencies_complete =
+        sema_output.ordinary_free_function_dependencies_complete;
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
@@ -161,6 +174,8 @@ pub fn analyze_canonical_program(
         warnings: cfg.warnings,
         bound_definitions,
         work,
+        ordinary_free_function_dependencies,
+        ordinary_free_function_dependencies_complete,
     })
 }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -891,6 +891,7 @@ fn build_functions_and_cfgs(
         mut warnings,
         type_pool,
         body_analysis_work: _,
+        ..
     } = sema_output;
 
     // Synthesize drop glue functions.

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -92,3 +92,14 @@ translate future definition-level edges; it makes no body or CFG reuse claim.
 
 Acceptance requires one existing semantic execution to emit the complete
 manifest with no second whole-RIR traversal and unchanged diagnostic bytes/order.
+
+### Free-function capture progress
+
+The first request-local capture seam now records free-function references from
+ordinary reachable free-function bodies at the existing worklist boundary. Its
+neutral endpoints are the defining FileId epoch plus owned source name; methods,
+constructors and intrinsics remain excluded by their separate channels. The
+output explicitly reports incomplete because generic-specialized, method and
+destructor callers have separate driver branches not yet carrying a stable
+owner. These events are not translated to `StableDefinitionKey` and must not
+drive reuse until every branch is captured and unique translation fails closed.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -46,6 +46,10 @@ incremental-compilation goal is complete.
    a stable ordered destination universe, explicit semantic inputs, and complete
    resolved/missing/ambiguous module-import edges. Definition-level edges and
    body/CFG reuse remain intentionally absent.
+   Ordinary free-function bodies now retain request-local direct free-call
+   events at the worklist boundary, but the completeness bit remains false until
+   specialization and method/destructor caller branches plus stable-key
+   translation land.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## What changed

- records ordinary free-function caller-to-callee events during existing semantic body analysis
- carries those events through canonical semantic output without rescanning RIR
- exposes deterministic owned dependency evidence for later stable-key translation
- updates ADR 0050 and the query-completion audit

## Why

A sound semantic invalidation graph needs authoritative call edges from the analysis that resolved them. Retaining these events avoids reconstructing dependencies from lowered IR or syntax after the fact.

## Validation

- formatting passed
- AIR and compiler tests passed
- workspace clippy passed
- quick and full suites passed on the integrated stack