### PR TITLE
RUE-719: retain stable owners for specialized semantic bodies

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -41,7 +41,7 @@ pub use sema::{
     DirResolution, FunctionInfo, GatherOutput, MethodInfo, ModulePath,
     OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
     SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
-    SemanticBindingNamespace, import_candidate_groups,
+    SemanticBindingNamespace, SpecializedFreeFunctionOrigin, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -172,6 +172,11 @@ fn finalize_function_body_analysis(
         // Method/destructor and specialization callers are not yet threaded
         // through the stable owner capture seam.
         ordinary_free_function_dependencies_complete: false,
+        specialized_free_function_origins: {
+            sema.specialized_free_function_origins.sort();
+            sema.specialized_free_function_origins.dedup();
+            sema.specialized_free_function_origins.clone()
+        },
     };
 
     errors.into_result_with(output)
@@ -1403,6 +1408,7 @@ mod error_invariant_tests {
             body_analysis_work: crate::BodyAnalysisWork::default(),
             ordinary_free_function_dependencies: Vec::new(),
             ordinary_free_function_dependencies_complete: false,
+            specialized_free_function_origins: Vec::new(),
         }
     }
 

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -141,6 +141,7 @@ impl<'a> GatherOutput<'a> {
             named_method_declarations,
             body_analysis_work: super::BodyAnalysisWork::default(),
             ordinary_free_function_dependencies: Vec::new(),
+            specialized_free_function_origins: Vec::new(),
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,
             module_bindings: self.module_bindings,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -59,7 +59,7 @@ pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
 pub use output::{
     AnalyzedFunction, BodyAnalysisWork, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
-    SemaOutput,
+    SemaOutput, SpecializedFreeFunctionOrigin,
 };
 
 use std::collections::{HashMap, HashSet};
@@ -104,6 +104,7 @@ pub struct Sema<'a> {
     pub(crate) named_method_declarations: HashMap<(StructId, Spur), rue_rir::InstRef>,
     pub(crate) body_analysis_work: BodyAnalysisWork,
     pub(crate) ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
+    pub(crate) specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
     /// Compatibility value-constant table for globally unique bare names.
     /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`]. If a value-constant name appears in
@@ -231,6 +232,7 @@ impl<'a> Sema<'a> {
             named_method_declarations: HashMap::new(),
             body_analysis_work: BodyAnalysisWork::default(),
             ordinary_free_function_dependencies: Vec::new(),
+            specialized_free_function_origins: Vec::new(),
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),
             module_bindings: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -14,6 +14,14 @@ pub struct OrdinaryFreeFunctionDependencyEvent {
     pub callee_file: u32,
     pub callee_name: String,
 }
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SpecializedFreeFunctionOrigin {
+    pub specialized_name: String,
+    pub base_file: u32,
+    pub base_name: String,
+    pub type_arguments: Vec<u32>,
+    pub value_arguments: Vec<u32>,
+}
 
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
@@ -94,6 +102,7 @@ pub struct SemaOutput {
     pub body_analysis_work: BodyAnalysisWork,
     pub ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
     pub ordinary_free_function_dependencies_complete: bool,
+    pub specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
 }
 
 /// Value-only workload counters for demand-driven body dispatch.
@@ -102,6 +111,7 @@ pub struct SemaOutput {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BodyAnalysisWork {
     pub ordinary_free_function_dependency_events: usize,
+    pub specialized_origin_records: usize,
     /// Indexed declaration-record lookups for reachable, non-generic free functions.
     pub free_function_record_lookups: usize,
     /// Private declaration-record lookups for reachable named-struct methods.

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -281,6 +281,18 @@ impl Specializer {
                     &base_info,
                     interner,
                 )?;
+                sema.specialized_free_function_origins.push(
+                    crate::sema::SpecializedFreeFunctionOrigin {
+                        specialized_name: specialized.function.name.clone(),
+                        base_file: base_info.file_id.index(),
+                        base_name: interner
+                            .resolve(&sema.source_function_name(key.base_name))
+                            .to_string(),
+                        type_arguments: key.type_args.iter().map(|ty| ty.as_u32()).collect(),
+                        value_arguments: encode_const_values(&key.value_args),
+                    },
+                );
+                sema.body_analysis_work.specialized_origin_records += 1;
 
                 discovered
                     .functions

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -2,7 +2,7 @@
 
 use rue_air::{
     BodyAnalysisWork, DeclarationBindingWork, OrdinaryFreeFunctionDependencyEvent,
-    RirDeclarationIndexWork, SemanticBindingManifestWork,
+    RirDeclarationIndexWork, SemanticBindingManifestWork, SpecializedFreeFunctionOrigin,
 };
 use tracing::info_span;
 
@@ -43,6 +43,7 @@ pub struct CanonicalSemanticOutput {
     work: CanonicalSemanticWork,
     ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
     ordinary_free_function_dependencies_complete: bool,
+    specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
 }
 
 impl CanonicalSemanticOutput {
@@ -71,6 +72,9 @@ impl CanonicalSemanticOutput {
     }
     pub fn ordinary_free_function_dependencies_complete(&self) -> bool {
         self.ordinary_free_function_dependencies_complete
+    }
+    pub fn specialized_free_function_origins(&self) -> &[SpecializedFreeFunctionOrigin] {
+        &self.specialized_free_function_origins
     }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -152,6 +156,7 @@ pub fn analyze_canonical_program(
         sema_output.ordinary_free_function_dependencies.clone();
     let ordinary_free_function_dependencies_complete =
         sema_output.ordinary_free_function_dependencies_complete;
+    let specialized_free_function_origins = sema_output.specialized_free_function_origins.clone();
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
@@ -176,6 +181,7 @@ pub fn analyze_canonical_program(
         work,
         ordinary_free_function_dependencies,
         ordinary_free_function_dependencies_complete,
+        specialized_free_function_origins,
     })
 }
 
@@ -239,6 +245,129 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    #[test]
+    fn specialization_origins_preserve_exact_generic_base_and_arguments() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                r#"fn id(comptime n: i32, value: i32) -> i32 { value + n }
+                   fn wrap(comptime n: i32, value: i32) -> i32 { id(n, value) }
+                   fn main() -> i32 {
+                       wrap(1, 1) + wrap(1, 2) + id(2, 3)
+                   }"#,
+            )],
+            1,
+        );
+        let (output, _) = canonical(&source, &CompileOptions::default(), false);
+        let origins = output.specialized_free_function_origins();
+        let wraps = origins
+            .iter()
+            .filter(|origin| origin.base_name == "wrap")
+            .collect::<Vec<_>>();
+        let ids = origins
+            .iter()
+            .filter(|origin| origin.base_name == "id")
+            .collect::<Vec<_>>();
+        assert_eq!(wraps.len(), 1, "identical specialization deduplicates");
+        assert_eq!(ids.len(), 2, "direct and later-fixpoint specializations");
+        assert!(ids.iter().all(|origin| origin.base_file == 1));
+        assert_ne!(ids[0].value_arguments, ids[1].value_arguments);
+        assert!(
+            origins
+                .iter()
+                .all(|origin| origin.specialized_name != origin.base_name)
+        );
+        assert!(
+            output
+                .functions()
+                .iter()
+                .all(|function| function.analyzed.name != "id" && function.analyzed.name != "wrap")
+        );
+        assert_eq!(
+            output.work().body_analysis.specialized_origin_records,
+            origins.len()
+        );
+    }
+
+    #[test]
+    fn recursive_specialization_origins_are_deduplicated() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                r#"fn fib(comptime n: i32) -> i32 {
+                       if n < 2 { n } else { fib(n - 1) + fib(n - 2) }
+                   }
+                   fn main() -> i32 { fib(5) + fib(5) }"#,
+            )],
+            1,
+        );
+        let (output, _) = canonical(&source, &CompileOptions::default(), false);
+        let origins = output
+            .specialized_free_function_origins()
+            .iter()
+            .filter(|origin| origin.base_name == "fib")
+            .collect::<Vec<_>>();
+        assert_eq!(origins.len(), 6, "fib(0) through fib(5), each exactly once");
+        assert!(origins.iter().all(|origin| origin.base_file == 1));
+        assert_eq!(
+            output.work().body_analysis.specialized_origin_records,
+            origins.len()
+        );
+    }
+
+    #[test]
+    fn sibling_same_name_specializations_retain_distinct_base_files() {
+        let source = snapshot(
+            &[
+                (
+                    9,
+                    "/p/main.rue",
+                    "main.rue",
+                    r#"const left = @import("left.rue");
+                       const right = @import("right.rue");
+                       fn main() -> i32 { left.id(1, 20) + right.id(2, 20) }"#,
+                ),
+                (
+                    3,
+                    "/p/left.rue",
+                    "left.rue",
+                    "pub fn id(comptime n: i32, value: i32) -> i32 { value + n }",
+                ),
+                (
+                    7,
+                    "/p/right.rue",
+                    "right.rue",
+                    "pub fn id(comptime n: i32, value: i32) -> i32 { value + n }",
+                ),
+            ],
+            9,
+        );
+        let (output, _) = canonical(&source, &CompileOptions::default(), false);
+        let origins = output
+            .specialized_free_function_origins()
+            .iter()
+            .filter(|origin| origin.base_name == "id")
+            .collect::<Vec<_>>();
+        assert_eq!(origins.len(), 2);
+        assert_eq!(
+            origins
+                .iter()
+                .map(|origin| origin.base_file)
+                .collect::<std::collections::BTreeSet<_>>(),
+            std::collections::BTreeSet::from([3, 7])
+        );
+    }
+
+    #[test]
+    fn specialized_free_function_origin_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<rue_air::SpecializedFreeFunctionOrigin>();
     }
 
     #[test]

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -103,3 +103,9 @@ output explicitly reports incomplete because generic-specialized, method and
 destructor callers have separate driver branches not yet carrying a stable
 owner. These events are not translated to `StableDefinitionKey` and must not
 drive reuse until every branch is captured and unique translation fails closed.
+
+Specialized free-function bodies now retain a neutral origin record containing
+their mangled analyzed name, exact generic base FileId/source name, and
+request-local type/value specialization argument words. This survives fixpoint
+discovery without claiming that the argument encoding is a durable
+cross-request key. Compiler-layer stable-key translation remains prerequisite.


### PR DESCRIPTION
## What changed

- records the ordinary source declaration that owns each specialized semantic body
- carries specialization-origin evidence through AIR and canonical semantic output
- preserves exact source identity without reconstructing ownership from mangled symbols
- adds specialization and canonical-semantic coverage plus ADR documentation

## Why

Dependencies discovered inside a specialized body must be attributed to a stable source definition before they can participate in cross-revision invalidation. Retaining the owner during specialization keeps that provenance authoritative.

## Validation

- formatting passed
- AIR and compiler tests passed
- workspace clippy passed
- quick and full suites passed on the integrated stack