### PR TITLE
RUE-719: translate specialized dependency origins to stable keys

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -41,7 +41,8 @@ pub use sema::{
     DirResolution, FunctionInfo, GatherOutput, MethodInfo, ModulePath,
     OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
     SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
-    SemanticBindingNamespace, SpecializedFreeFunctionOrigin, import_candidate_groups,
+    SemanticBindingNamespace, SpecializedFreeFunctionDependencyEvent,
+    SpecializedFreeFunctionOrigin, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -169,14 +169,18 @@ fn finalize_function_body_analysis(
             sema.ordinary_free_function_dependencies.dedup();
             sema.ordinary_free_function_dependencies.clone()
         },
-        // Method/destructor and specialization callers are not yet threaded
-        // through the stable owner capture seam.
-        ordinary_free_function_dependencies_complete: false,
+        ordinary_free_function_dependencies_complete: true,
         specialized_free_function_origins: {
             sema.specialized_free_function_origins.sort();
             sema.specialized_free_function_origins.dedup();
             sema.specialized_free_function_origins.clone()
         },
+        specialized_free_function_dependencies: {
+            sema.specialized_free_function_dependencies.sort();
+            sema.specialized_free_function_dependencies.dedup();
+            sema.specialized_free_function_dependencies.clone()
+        },
+        specialized_free_function_dependencies_complete: true,
     };
 
     errors.into_result_with(output)
@@ -1409,6 +1413,8 @@ mod error_invariant_tests {
             ordinary_free_function_dependencies: Vec::new(),
             ordinary_free_function_dependencies_complete: false,
             specialized_free_function_origins: Vec::new(),
+            specialized_free_function_dependencies: Vec::new(),
+            specialized_free_function_dependencies_complete: false,
         }
     }
 

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -142,6 +142,7 @@ impl<'a> GatherOutput<'a> {
             body_analysis_work: super::BodyAnalysisWork::default(),
             ordinary_free_function_dependencies: Vec::new(),
             specialized_free_function_origins: Vec::new(),
+            specialized_free_function_dependencies: Vec::new(),
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,
             module_bindings: self.module_bindings,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -59,7 +59,7 @@ pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
 pub use output::{
     AnalyzedFunction, BodyAnalysisWork, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
-    SemaOutput, SpecializedFreeFunctionOrigin,
+    SemaOutput, SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
 
 use std::collections::{HashMap, HashSet};
@@ -105,6 +105,7 @@ pub struct Sema<'a> {
     pub(crate) body_analysis_work: BodyAnalysisWork,
     pub(crate) ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
     pub(crate) specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
+    pub(crate) specialized_free_function_dependencies: Vec<SpecializedFreeFunctionDependencyEvent>,
     /// Compatibility value-constant table for globally unique bare names.
     /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`]. If a value-constant name appears in
@@ -233,6 +234,7 @@ impl<'a> Sema<'a> {
             body_analysis_work: BodyAnalysisWork::default(),
             ordinary_free_function_dependencies: Vec::new(),
             specialized_free_function_origins: Vec::new(),
+            specialized_free_function_dependencies: Vec::new(),
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),
             module_bindings: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -22,6 +22,16 @@ pub struct SpecializedFreeFunctionOrigin {
     pub type_arguments: Vec<u32>,
     pub value_arguments: Vec<u32>,
 }
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SpecializedFreeFunctionDependencyEvent {
+    pub specialized_name: String,
+    pub base_file: u32,
+    pub base_name: String,
+    pub callee_file: u32,
+    pub callee_name: String,
+    pub type_arguments: Vec<u32>,
+    pub value_arguments: Vec<u32>,
+}
 
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
@@ -103,6 +113,8 @@ pub struct SemaOutput {
     pub ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
     pub ordinary_free_function_dependencies_complete: bool,
     pub specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
+    pub specialized_free_function_dependencies: Vec<SpecializedFreeFunctionDependencyEvent>,
+    pub specialized_free_function_dependencies_complete: bool,
 }
 
 /// Value-only workload counters for demand-driven body dispatch.
@@ -112,6 +124,7 @@ pub struct SemaOutput {
 pub struct BodyAnalysisWork {
     pub ordinary_free_function_dependency_events: usize,
     pub specialized_origin_records: usize,
+    pub specialized_free_function_dependency_events: usize,
     /// Indexed declaration-record lookups for reachable, non-generic free functions.
     pub free_function_record_lookups: usize,
     /// Private declaration-record lookups for reachable named-struct methods.

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -281,18 +281,52 @@ impl Specializer {
                     &base_info,
                     interner,
                 )?;
+                let specialized_name = specialized.function.name.clone();
+                let base_name = interner
+                    .resolve(&sema.source_function_name(key.base_name))
+                    .to_string();
+                let type_arguments = key
+                    .type_args
+                    .iter()
+                    .map(|ty| ty.as_u32())
+                    .collect::<Vec<_>>();
+                let value_arguments = encode_const_values(&key.value_args);
                 sema.specialized_free_function_origins.push(
                     crate::sema::SpecializedFreeFunctionOrigin {
-                        specialized_name: specialized.function.name.clone(),
+                        specialized_name: specialized_name.clone(),
                         base_file: base_info.file_id.index(),
-                        base_name: interner
-                            .resolve(&sema.source_function_name(key.base_name))
-                            .to_string(),
-                        type_arguments: key.type_args.iter().map(|ty| ty.as_u32()).collect(),
-                        value_arguments: encode_const_values(&key.value_args),
+                        base_name: base_name.clone(),
+                        type_arguments: type_arguments.clone(),
+                        value_arguments: value_arguments.clone(),
                     },
                 );
                 sema.body_analysis_work.specialized_origin_records += 1;
+                for callee in &specialized.referenced_functions {
+                    let callee_info = sema.functions.get(callee).ok_or_else(|| {
+                        CompileError::new(
+                            ErrorKind::InvalidCompilerInput(format!(
+                                "specialized body '{}' references a free function absent from semantic declarations",
+                                specialized_name
+                            )),
+                            base_info.span,
+                        )
+                    })?;
+                    sema.specialized_free_function_dependencies.push(
+                        crate::sema::SpecializedFreeFunctionDependencyEvent {
+                            specialized_name: specialized_name.clone(),
+                            base_file: base_info.file_id.index(),
+                            base_name: base_name.clone(),
+                            callee_file: callee_info.file_id.index(),
+                            callee_name: interner
+                                .resolve(&sema.source_function_name(*callee))
+                                .to_string(),
+                            type_arguments: type_arguments.clone(),
+                            value_arguments: value_arguments.clone(),
+                        },
+                    );
+                    sema.body_analysis_work
+                        .specialized_free_function_dependency_events += 1;
+                }
 
                 discovered
                     .functions

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -172,6 +172,9 @@ fn semantic_work_json(work: &CanonicalFrontendSessionWork, from: usize) -> Value
     json!({
         "bind_invocations": records.iter().map(|record| record.work.binding.bind_invocations).sum::<usize>(),
         "body_free_function_lookups": records.iter().map(|record| record.work.body_analysis.free_function_record_lookups).sum::<usize>(),
+        "ordinary_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.ordinary_free_function_dependency_events).sum::<usize>(),
+        "specialized_origin_records": records.iter().map(|record| record.work.body_analysis.specialized_origin_records).sum::<usize>(),
+        "specialized_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.specialized_free_function_dependency_events).sum::<usize>(),
         "manifest_build_invocations": records.iter().map(|record| record.work.manifest.build_invocations).sum::<usize>(),
     })
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -2,7 +2,8 @@
 
 use rue_air::{
     BodyAnalysisWork, DeclarationBindingWork, OrdinaryFreeFunctionDependencyEvent,
-    RirDeclarationIndexWork, SemanticBindingManifestWork, SpecializedFreeFunctionOrigin,
+    RirDeclarationIndexWork, SemanticBindingManifestWork, SpecializedFreeFunctionDependencyEvent,
+    SpecializedFreeFunctionOrigin,
 };
 use tracing::info_span;
 
@@ -44,6 +45,8 @@ pub struct CanonicalSemanticOutput {
     ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
     ordinary_free_function_dependencies_complete: bool,
     specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
+    specialized_free_function_dependencies: Vec<SpecializedFreeFunctionDependencyEvent>,
+    specialized_free_function_dependencies_complete: bool,
 }
 
 impl CanonicalSemanticOutput {
@@ -75,6 +78,14 @@ impl CanonicalSemanticOutput {
     }
     pub fn specialized_free_function_origins(&self) -> &[SpecializedFreeFunctionOrigin] {
         &self.specialized_free_function_origins
+    }
+    pub fn specialized_free_function_dependencies(
+        &self,
+    ) -> &[SpecializedFreeFunctionDependencyEvent] {
+        &self.specialized_free_function_dependencies
+    }
+    pub fn specialized_free_function_dependencies_complete(&self) -> bool {
+        self.specialized_free_function_dependencies_complete
     }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -157,6 +168,10 @@ pub fn analyze_canonical_program(
     let ordinary_free_function_dependencies_complete =
         sema_output.ordinary_free_function_dependencies_complete;
     let specialized_free_function_origins = sema_output.specialized_free_function_origins.clone();
+    let specialized_free_function_dependencies =
+        sema_output.specialized_free_function_dependencies.clone();
+    let specialized_free_function_dependencies_complete =
+        sema_output.specialized_free_function_dependencies_complete;
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
@@ -182,6 +197,8 @@ pub fn analyze_canonical_program(
         ordinary_free_function_dependencies,
         ordinary_free_function_dependencies_complete,
         specialized_free_function_origins,
+        specialized_free_function_dependencies,
+        specialized_free_function_dependencies_complete,
     })
 }
 

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -10,7 +10,8 @@ use crate::{
     CanonicalRirOutput, CanonicalRirWork, CanonicalSemanticOutput, CanonicalSemanticWork,
     CodegenInputDescriptor, CompileError, CompileErrors, CompileOptions, CompileWarning, ErrorKind,
     ModuleResolutionInputs, ParseInvalidationSummary, ParsedModulesWork, SemanticInputDescriptor,
-    SourceRevision, SourceSnapshot, StableDefinitionKey, analyze_canonical_program,
+    SourceRevision, SourceSnapshot, StableDefinitionKey, StableDefinitionKind,
+    StableDefinitionNamespace, analyze_canonical_program,
     bound_definitions::bind_canonical_definitions_with_work,
     canonical_merge::merge_parsed_modules_reusing_definitions, lower_canonical_rir,
     parsed_modules::ParsedProgram, resolve_canonical_import_graph, validate_canonical_import_graph,
@@ -56,7 +57,15 @@ pub struct CanonicalFrontendSessionWork {
 pub struct SemanticDependencyManifestWork {
     pub definition_records_visited: usize,
     pub import_records_visited: usize,
+    pub free_function_events_translated: usize,
+    pub specialization_origins_validated: usize,
     pub extra_rir_instructions_visited: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StableFreeFunctionDependency {
+    pub caller: StableDefinitionKey,
+    pub callee: StableDefinitionKey,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -84,6 +93,9 @@ pub struct SemanticDependencyInputManifest {
     imports: CanonicalImportGraph,
     definitions: Arc<[StableDefinitionKey]>,
     module_imports: Arc<[StableModuleImportDependency]>,
+    free_function_dependencies: Arc<[StableFreeFunctionDependency]>,
+    free_function_caller_dependencies_complete: bool,
+    semantic_dependency_graph_complete: bool,
     definition_universe_complete: bool,
     work: SemanticDependencyManifestWork,
 }
@@ -100,6 +112,15 @@ impl SemanticDependencyInputManifest {
     }
     pub fn module_imports(&self) -> &[StableModuleImportDependency] {
         &self.module_imports
+    }
+    pub fn free_function_dependencies(&self) -> &[StableFreeFunctionDependency] {
+        &self.free_function_dependencies
+    }
+    pub fn free_function_caller_dependencies_complete(&self) -> bool {
+        self.free_function_caller_dependencies_complete
+    }
+    pub fn semantic_dependency_graph_complete(&self) -> bool {
+        self.semantic_dependency_graph_complete
     }
     pub fn definition_universe_complete(&self) -> bool {
         self.definition_universe_complete
@@ -673,6 +694,7 @@ impl CanonicalFrontendSession {
             return Ok(cached.clone());
         }
         self.work.dependency_manifests.executions += 1;
+        let semantic = self.semantic(options);
         let definitions = self.stable_definitions(options);
         let definition_universe_complete = definitions.is_ok();
         let definition_records = definitions
@@ -685,9 +707,72 @@ impl CanonicalFrontendSession {
             .collect::<Vec<_>>();
         keys.sort();
         keys.dedup();
+        let (
+            mut free_function_dependencies,
+            free_function_events_translated,
+            specialization_origins_validated,
+            free_function_caller_dependencies_complete,
+        ) = match (&semantic, &definitions) {
+            (Ok(semantic), Ok(definitions)) => {
+                if definitions.source_revision() != &input.sources {
+                    return Err(invalid_dependency_manifest(
+                        "semantic dependency translation used a foreign definition revision",
+                    ));
+                }
+                let mut edges = Vec::new();
+                for origin in semantic.specialized_free_function_origins() {
+                    stable_free_function_endpoint(
+                        definitions,
+                        origin.base_file,
+                        &origin.base_name,
+                    )?;
+                }
+                for event in semantic.ordinary_free_function_dependencies() {
+                    edges.push(StableFreeFunctionDependency {
+                        caller: stable_free_function_endpoint(
+                            definitions,
+                            event.caller_file,
+                            &event.caller_name,
+                        )?,
+                        callee: stable_free_function_endpoint(
+                            definitions,
+                            event.callee_file,
+                            &event.callee_name,
+                        )?,
+                    });
+                }
+                for event in semantic.specialized_free_function_dependencies() {
+                    edges.push(StableFreeFunctionDependency {
+                        caller: stable_free_function_endpoint(
+                            definitions,
+                            event.base_file,
+                            &event.base_name,
+                        )?,
+                        callee: stable_free_function_endpoint(
+                            definitions,
+                            event.callee_file,
+                            &event.callee_name,
+                        )?,
+                    });
+                }
+                (
+                    edges,
+                    semantic.ordinary_free_function_dependencies().len()
+                        + semantic.specialized_free_function_dependencies().len(),
+                    semantic.specialized_free_function_origins().len(),
+                    semantic.ordinary_free_function_dependencies_complete()
+                        && semantic.specialized_free_function_dependencies_complete(),
+                )
+            }
+            _ => (Vec::new(), 0, 0, false),
+        };
+        free_function_dependencies.sort();
+        free_function_dependencies.dedup();
         let work = SemanticDependencyManifestWork {
             definition_records_visited: definition_records.len(),
             import_records_visited: imports.graph().records().len(),
+            free_function_events_translated,
+            specialization_origins_validated,
             extra_rir_instructions_visited: 0,
         };
         self.work.dependency_manifest_records_visited += work.definition_records_visited;
@@ -724,12 +809,44 @@ impl CanonicalFrontendSession {
             imports: imports.graph().clone(),
             definitions: keys.into(),
             module_imports: module_imports.into(),
+            free_function_dependencies: free_function_dependencies.into(),
+            free_function_caller_dependencies_complete,
+            semantic_dependency_graph_complete: false,
             definition_universe_complete,
             work,
         });
         self.dependency_manifest_cache.push(manifest.clone());
         Ok(manifest)
     }
+}
+
+fn stable_free_function_endpoint(
+    definitions: &BoundDefinitionSet,
+    file: u32,
+    name: &str,
+) -> Result<StableDefinitionKey, CompileErrors> {
+    let matches = definitions
+        .definitions()
+        .iter()
+        .filter(|record| {
+            record.declaration_span().file_id.index() == file
+                && record.stable_key().name() == name
+                && record.stable_key().namespace() == StableDefinitionNamespace::Value
+                && record.stable_key().kind() == StableDefinitionKind::Function
+        })
+        .collect::<Vec<_>>();
+    let [record] = matches.as_slice() else {
+        return Err(invalid_dependency_manifest(&format!(
+            "free-function dependency endpoint ({file}, '{name}') did not join exactly one bound function",
+        )));
+    };
+    Ok(record.stable_key().clone())
+}
+
+fn invalid_dependency_manifest(reason: &str) -> CompileErrors {
+    CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+        reason.to_owned(),
+    )))
 }
 
 fn same_attempt(left: &SourceSnapshot, right: &SourceSnapshot) -> bool {
@@ -1551,6 +1668,288 @@ mod tests {
         assert_eq!(missing.work().import_records_visited, 1);
         assert_eq!(missing.work().extra_rir_instructions_visited, 0);
         assert_eq!(session.work().dependency_manifests.executions, 2);
+    }
+
+    fn stable_edge_names(
+        manifest: &SemanticDependencyInputManifest,
+    ) -> Vec<(String, String, String, String)> {
+        manifest
+            .free_function_dependencies()
+            .iter()
+            .map(|edge| {
+                (
+                    edge.caller.module().as_str().to_owned(),
+                    edge.caller.name().to_owned(),
+                    edge.callee.module().as_str().to_owned(),
+                    edge.callee.name().to_owned(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn specialized_free_function_edges_are_stable_and_deduplicate_instances() {
+        let first = snapshot(
+            &[
+                (
+                    9,
+                    "/one/main.rue",
+                    "main.rue",
+                    r#"const lib = @import("lib.rue");
+                       fn main() -> i32 { lib.wrap(1, 10) + lib.wrap(2, 20) }"#,
+                ),
+                (
+                    3,
+                    "/one/lib.rue",
+                    "lib.rue",
+                    r#"fn leaf(value: i32) -> i32 { value }
+                       fn inner(comptime n: i32, value: i32) -> i32 { leaf(value) + n }
+                       pub fn wrap(comptime n: i32, value: i32) -> i32 { inner(n, value) }"#,
+                ),
+            ],
+            9,
+        );
+        let moved = snapshot(
+            &[
+                (
+                    41,
+                    "/else/lib.rue",
+                    "lib.rue",
+                    r#"fn leaf(value: i32) -> i32 { value }
+                       fn inner(comptime n: i32, value: i32) -> i32 { leaf(value) + n }
+                       pub fn wrap(comptime n: i32, value: i32) -> i32 { inner(n, value) }"#,
+                ),
+                (
+                    7,
+                    "/else/main.rue",
+                    "main.rue",
+                    r#"const lib = @import("lib.rue");
+                       fn main() -> i32 { lib.wrap(1, 10) + lib.wrap(2, 20) }"#,
+                ),
+            ],
+            7,
+        );
+        let build = |source: &SourceSnapshot| {
+            let mut session = CanonicalFrontendSession::new();
+            session.update(source).into_result().unwrap();
+            session
+                .semantic_dependency_inputs(&CompileOptions::default(), None)
+                .unwrap()
+        };
+        let first = build(&first);
+        let moved = build(&moved);
+        assert_eq!(stable_edge_names(&first), stable_edge_names(&moved));
+        assert_eq!(
+            stable_edge_names(&first),
+            vec![
+                (
+                    "lib.rue".into(),
+                    "inner".into(),
+                    "lib.rue".into(),
+                    "leaf".into()
+                ),
+                (
+                    "lib.rue".into(),
+                    "wrap".into(),
+                    "lib.rue".into(),
+                    "inner".into()
+                ),
+                (
+                    "main.rue".into(),
+                    "main".into(),
+                    "lib.rue".into(),
+                    "wrap".into()
+                ),
+            ]
+        );
+        assert!(first.free_function_caller_dependencies_complete());
+        assert!(!first.semantic_dependency_graph_complete());
+        assert_eq!(first.work().specialization_origins_validated, 4);
+        assert_eq!(first.work().free_function_events_translated, 5);
+        assert_eq!(first.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn recursive_specialization_edges_and_renames_are_exact() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                r#"fn leaf(value: i32) -> i32 { value }
+                   fn fib(comptime n: i32) -> i32 {
+                       if n < 2 { leaf(n) } else { fib(n - 1) + fib(n - 2) }
+                   }
+                   fn main() -> i32 { fib(5) + fib(5) }"#,
+            )],
+            1,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        let manifest = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        assert_eq!(
+            stable_edge_names(&manifest),
+            vec![
+                (
+                    "main.rue".into(),
+                    "fib".into(),
+                    "main.rue".into(),
+                    "fib".into()
+                ),
+                (
+                    "main.rue".into(),
+                    "fib".into(),
+                    "main.rue".into(),
+                    "leaf".into()
+                ),
+                (
+                    "main.rue".into(),
+                    "main".into(),
+                    "main.rue".into(),
+                    "fib".into()
+                ),
+            ]
+        );
+        assert_eq!(manifest.work().specialization_origins_validated, 6);
+        assert!(manifest.work().free_function_events_translated > 3);
+
+        let renamed = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                r#"fn terminal(value: i32) -> i32 { value }
+                   fn fib(comptime n: i32) -> i32 {
+                       if n < 2 { terminal(n) } else { fib(n - 1) + fib(n - 2) }
+                   }
+                   fn main() -> i32 { fib(5) + fib(5) }"#,
+            )],
+            1,
+        );
+        session.update(&renamed).into_result().unwrap();
+        let renamed = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        assert!(
+            stable_edge_names(&renamed)
+                .iter()
+                .any(|edge| edge.3 == "terminal")
+        );
+        assert!(
+            !stable_edge_names(&renamed)
+                .iter()
+                .any(|edge| edge.3 == "leaf")
+        );
+    }
+
+    #[test]
+    fn dependency_endpoint_translation_fails_closed_for_missing_and_non_functions() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "const answer: i32 = 42; fn main() -> i32 { answer }",
+            )],
+            1,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        let definitions = session
+            .stable_definitions(&CompileOptions::default())
+            .unwrap();
+        assert!(stable_free_function_endpoint(&definitions, 1, "missing").is_err());
+        assert!(stable_free_function_endpoint(&definitions, 1, "answer").is_err());
+
+        let rejected = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { true }")],
+            1,
+        );
+        session.update(&rejected).into_result().unwrap();
+        let manifest = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        assert!(!manifest.definition_universe_complete());
+        assert!(!manifest.free_function_caller_dependencies_complete());
+        assert!(manifest.free_function_dependencies().is_empty());
+    }
+
+    #[test]
+    fn sibling_generic_owners_stay_distinct_and_non_function_calls_are_excluded() {
+        let source = snapshot(
+            &[
+                (
+                    1,
+                    "/p/main.rue",
+                    "main.rue",
+                    r#"const left = @import("left.rue");
+                       const right = @import("right.rue");
+                       fn main() -> i32 { left.id(1) + right.id(2) }"#,
+                ),
+                (
+                    2,
+                    "/p/left.rue",
+                    "left.rue",
+                    r#"struct Box { value: i32, fn get(borrow self) -> i32 { self.value } }
+                       fn leaf(value: i32) -> i32 { value }
+                       pub fn id(comptime n: i32) -> i32 {
+                           let value = Box { value: n };
+                           @dbg(n);
+                           leaf(value.get())
+                       }"#,
+                ),
+                (
+                    3,
+                    "/p/right.rue",
+                    "right.rue",
+                    r#"fn leaf(value: i32) -> i32 { value }
+                       pub fn id(comptime n: i32) -> i32 { leaf(n) }"#,
+                ),
+            ],
+            1,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        let manifest = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        assert_eq!(
+            stable_edge_names(&manifest),
+            vec![
+                (
+                    "left.rue".into(),
+                    "id".into(),
+                    "left.rue".into(),
+                    "leaf".into()
+                ),
+                (
+                    "main.rue".into(),
+                    "main".into(),
+                    "left.rue".into(),
+                    "id".into()
+                ),
+                (
+                    "main.rue".into(),
+                    "main".into(),
+                    "right.rue".into(),
+                    "id".into()
+                ),
+                (
+                    "right.rue".into(),
+                    "id".into(),
+                    "right.rue".into(),
+                    "leaf".into()
+                ),
+            ]
+        );
+        assert!(
+            manifest
+                .free_function_dependencies()
+                .iter()
+                .all(|edge| { edge.callee.name() != "get" && edge.callee.name() != "Box" })
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -65,7 +65,7 @@ pub use frontend_session::{
     CanonicalImportGraphOutput, DefinitionQueryRecord, FrontendDiagnosticSnapshot,
     FrontendDiagnosticStage, FrontendQueryWork, ImportGraphInputDescriptor,
     SemanticDependencyInputManifest, SemanticDependencyManifestWork, SemanticQueryRecord,
-    StableModuleImportDependency,
+    StableFreeFunctionDependency, StableModuleImportDependency,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -99,13 +99,27 @@ The first request-local capture seam now records free-function references from
 ordinary reachable free-function bodies at the existing worklist boundary. Its
 neutral endpoints are the defining FileId epoch plus owned source name; methods,
 constructors and intrinsics remain excluded by their separate channels. The
-output explicitly reports incomplete because generic-specialized, method and
-destructor callers have separate driver branches not yet carrying a stable
-owner. These events are not translated to `StableDefinitionKey` and must not
-drive reuse until every branch is captured and unique translation fails closed.
+ordinary-caller output reports this surface complete; method and destructor
+callers remain separate, explicitly incomplete surfaces.
 
 Specialized free-function bodies now retain a neutral origin record containing
 their mangled analyzed name, exact generic base FileId/source name, and
 request-local type/value specialization argument words. This survives fixpoint
 discovery without claiming that the argument encoding is a durable
-cross-request key. Compiler-layer stable-key translation remains prerequisite.
+cross-request key.
+
+Specialized-body free-function references are now captured alongside that
+origin at the existing specialization-analysis seam, including later fixpoint
+rounds and recursion. `semantic_dependency_inputs` joins every ordinary and
+specialized endpoint against the exact-revision `BoundDefinitionSet` by FileId,
+owned source name, value namespace, and function kind. Missing, ambiguous, or
+non-function endpoints fail closed. The resulting sorted stable edges use only
+the generic base caller and callee `StableDefinitionKey`; specialization
+argument words remain request-local evidence and distinct instances deduplicate
+to one stable edge. Work counters pin zero additional RIR visits.
+
+The narrow `free_function_caller_dependencies_complete` flag covers ordinary
+and specialized free-function callers to free-function callees. The overall
+semantic graph remains incomplete until method/destructor callers, declaration
+and type/constant/drop dependencies are captured, so these edges still do not
+authorize AIR or CFG reuse.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -46,10 +46,16 @@ incremental-compilation goal is complete.
    a stable ordered destination universe, explicit semantic inputs, and complete
    resolved/missing/ambiguous module-import edges. Definition-level edges and
    body/CFG reuse remain intentionally absent.
-   Ordinary free-function bodies now retain request-local direct free-call
-   events at the worklist boundary, but the completeness bit remains false until
-   specialization and method/destructor caller branches plus stable-key
-   translation land.
+   Ordinary and specialized free-function callers now retain direct free-call
+   events at their existing analysis boundaries. The dependency-input query
+   validates specialized origins against the exact source revision and
+   translates endpoints to sorted, deduplicated `StableDefinitionKey` edges.
+   Relocation/FileId/input order, recursion, later specialization rounds, sibling
+   names, and rename sensitivity are gated with zero extra RIR visits; benchmark
+   output exposes ordinary events, specialization origins, and specialized
+   events. This narrow free-function caller surface is complete, while method
+   and destructor callers plus declaration/type/const/drop surfaces keep the
+   overall graph explicitly incomplete and prevent body/CFG reuse.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## What changed

- records dependencies discovered in specialized free-function bodies together with their authoritative source owners
- translates ordinary and specialized call edges into relocation-independent `StableDefinitionKey` endpoints
- validates specialization-origin coverage and fails closed when an endpoint cannot be proven
- adds cross-module, recursion, specialization, relocation, and zero-extra-RIR tests plus benchmark work counters

## Why

Specialized bodies use request-local identities, but invalidation must operate on stable source definitions. Translating while both semantic evidence and the stable definition universe are available prevents mangled symbols or specialization IDs from leaking into query keys.

## Validation

- formatting passed
- AIR and compiler tests passed
- 128-module benchmark structural gates passed
- workspace clippy, quick, and full suites passed on the integrated stack