### PR TITLE
RUE-719: translate named-method dependency edges

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -38,11 +38,11 @@ pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
     AnalyzedFunction, BodyAnalysisWork, BoundSema, ConstValue, DeclarationBindingWork,
-    DirResolution, FunctionInfo, GatherOutput, MethodInfo, ModulePath,
-    OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
-    SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
-    SemanticBindingNamespace, SpecializedFreeFunctionDependencyEvent,
-    SpecializedFreeFunctionOrigin, import_candidate_groups,
+    DirResolution, FunctionInfo, GatherOutput, MethodInfo, ModulePath, NamedMethodDependencyEvent,
+    NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
+    RirDeclarationIndexWork, Sema, SemaOutput, SemanticBinding, SemanticBindingKind,
+    SemanticBindingManifest, SemanticBindingManifestWork, SemanticBindingNamespace,
+    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -181,6 +181,14 @@ fn finalize_function_body_analysis(
             sema.specialized_free_function_dependencies.clone()
         },
         specialized_free_function_dependencies_complete: true,
+        named_method_dependencies: {
+            sema.named_method_dependencies.sort();
+            sema.named_method_dependencies.dedup();
+            sema.named_method_dependencies.clone()
+        },
+        non_generic_named_method_dependencies_complete: sema
+            .non_generic_named_method_dependencies_complete,
+        generic_named_method_dependencies_complete: false,
     };
 
     errors.into_result_with(output)
@@ -376,6 +384,81 @@ fn enqueue_references_sorted(
         .collect();
     meths.sort_by_key(|&(sid, name)| (sid.0, interner.resolve(&name)));
     pending_methods.extend(meths);
+}
+
+fn named_method_dependency_events(
+    sema: &Sema<'_>,
+    caller_struct: StructId,
+    caller_method: Spur,
+    referenced_functions: &HashSet<Spur>,
+    referenced_methods: &HashSet<(StructId, Spur)>,
+) -> CompileResult<Vec<super::NamedMethodDependencyEvent>> {
+    let caller_info = sema
+        .methods
+        .get(&(caller_struct, caller_method))
+        .ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::InvalidCompilerInput(
+                    "named-method dependency caller is absent from semantic declarations".into(),
+                ),
+                rue_span::Span::default(),
+            )
+        })?;
+    let caller_owner_name = sema.type_pool.struct_def(caller_struct).name.clone();
+    let caller_method_name = sema.interner.resolve(&caller_method).to_string();
+    let mut events = Vec::new();
+    for callee in referenced_functions {
+        let info = sema.functions.get(callee).ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::InvalidCompilerInput(
+                    "named method references a free function absent from semantic declarations"
+                        .into(),
+                ),
+                caller_info.span,
+            )
+        })?;
+        events.push(super::NamedMethodDependencyEvent {
+            caller_file: caller_info.span.file_id.index(),
+            caller_owner_name: caller_owner_name.clone(),
+            caller_method_name: caller_method_name.clone(),
+            target: super::NamedMethodDependencyTargetEvent::FreeFunction {
+                file: info.file_id.index(),
+                name: sema
+                    .interner
+                    .resolve(&sema.source_function_name(*callee))
+                    .to_string(),
+            },
+        });
+    }
+    for (callee_struct, callee_method) in referenced_methods {
+        let owner_name = sema.type_pool.struct_def(*callee_struct).name.clone();
+        if owner_name.starts_with("__anon_struct_") {
+            continue;
+        }
+        let info = sema
+            .methods
+            .get(&(*callee_struct, *callee_method))
+            .ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::InvalidCompilerInput(
+                        "named method references a named method absent from semantic declarations"
+                            .into(),
+                    ),
+                    caller_info.span,
+                )
+            })?;
+        events.push(super::NamedMethodDependencyEvent {
+            caller_file: caller_info.span.file_id.index(),
+            caller_owner_name: caller_owner_name.clone(),
+            caller_method_name: caller_method_name.clone(),
+            target: super::NamedMethodDependencyTargetEvent::NamedMethod {
+                file: info.span.file_id.index(),
+                owner_name,
+                method_name: sema.interner.resolve(callee_method).to_string(),
+            },
+        });
+    }
+    Ok(events)
 }
 
 /// Enqueue anonymous destructors registered by comptime evaluation.
@@ -746,6 +829,31 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 *self_mode,
             ) {
                 Ok((analyzed, warnings, local_strings, referenced_fns, referenced_meths)) => {
+                    let caller_is_generic = sema
+                        .param_arena
+                        .comptime(method_info.params)
+                        .iter()
+                        .any(|is_comptime| *is_comptime);
+                    if caller_is_generic {
+                    } else {
+                        match named_method_dependency_events(
+                            sema,
+                            struct_id,
+                            method_name,
+                            &referenced_fns,
+                            &referenced_meths,
+                        ) {
+                            Ok(events) => {
+                                sema.body_analysis_work.named_method_dependency_events +=
+                                    events.len();
+                                sema.named_method_dependencies.extend(events);
+                            }
+                            Err(error) => {
+                                errors.push(error);
+                                continue;
+                            }
+                        }
+                    }
                     functions_with_strings.push((analyzed, local_strings));
                     all_warnings.extend(warnings);
                     enqueue_references_sorted(
@@ -1415,6 +1523,9 @@ mod error_invariant_tests {
             specialized_free_function_origins: Vec::new(),
             specialized_free_function_dependencies: Vec::new(),
             specialized_free_function_dependencies_complete: false,
+            named_method_dependencies: Vec::new(),
+            non_generic_named_method_dependencies_complete: false,
+            generic_named_method_dependencies_complete: false,
         }
     }
 

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -143,6 +143,8 @@ impl<'a> GatherOutput<'a> {
             ordinary_free_function_dependencies: Vec::new(),
             specialized_free_function_origins: Vec::new(),
             specialized_free_function_dependencies: Vec::new(),
+            named_method_dependencies: Vec::new(),
+            non_generic_named_method_dependencies_complete: true,
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,
             module_bindings: self.module_bindings,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -58,7 +58,8 @@ pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
 pub use output::{
-    AnalyzedFunction, BodyAnalysisWork, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
+    AnalyzedFunction, BodyAnalysisWork, NamedMethodDependencyEvent,
+    NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
     SemaOutput, SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
 
@@ -106,6 +107,8 @@ pub struct Sema<'a> {
     pub(crate) ordinary_free_function_dependencies: Vec<OrdinaryFreeFunctionDependencyEvent>,
     pub(crate) specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
     pub(crate) specialized_free_function_dependencies: Vec<SpecializedFreeFunctionDependencyEvent>,
+    pub(crate) named_method_dependencies: Vec<NamedMethodDependencyEvent>,
+    pub(crate) non_generic_named_method_dependencies_complete: bool,
     /// Compatibility value-constant table for globally unique bare names.
     /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`]. If a value-constant name appears in
@@ -235,6 +238,8 @@ impl<'a> Sema<'a> {
             ordinary_free_function_dependencies: Vec::new(),
             specialized_free_function_origins: Vec::new(),
             specialized_free_function_dependencies: Vec::new(),
+            named_method_dependencies: Vec::new(),
+            non_generic_named_method_dependencies_complete: true,
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),
             module_bindings: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -32,6 +32,25 @@ pub struct SpecializedFreeFunctionDependencyEvent {
     pub type_arguments: Vec<u32>,
     pub value_arguments: Vec<u32>,
 }
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NamedMethodDependencyTargetEvent {
+    FreeFunction {
+        file: u32,
+        name: String,
+    },
+    NamedMethod {
+        file: u32,
+        owner_name: String,
+        method_name: String,
+    },
+}
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NamedMethodDependencyEvent {
+    pub caller_file: u32,
+    pub caller_owner_name: String,
+    pub caller_method_name: String,
+    pub target: NamedMethodDependencyTargetEvent,
+}
 
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
@@ -115,6 +134,9 @@ pub struct SemaOutput {
     pub specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
     pub specialized_free_function_dependencies: Vec<SpecializedFreeFunctionDependencyEvent>,
     pub specialized_free_function_dependencies_complete: bool,
+    pub named_method_dependencies: Vec<NamedMethodDependencyEvent>,
+    pub non_generic_named_method_dependencies_complete: bool,
+    pub generic_named_method_dependencies_complete: bool,
 }
 
 /// Value-only workload counters for demand-driven body dispatch.
@@ -125,6 +147,7 @@ pub struct BodyAnalysisWork {
     pub ordinary_free_function_dependency_events: usize,
     pub specialized_origin_records: usize,
     pub specialized_free_function_dependency_events: usize,
+    pub named_method_dependency_events: usize,
     /// Indexed declaration-record lookups for reachable, non-generic free functions.
     pub free_function_record_lookups: usize,
     /// Private declaration-record lookups for reachable named-struct methods.

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -175,6 +175,7 @@ fn semantic_work_json(work: &CanonicalFrontendSessionWork, from: usize) -> Value
         "ordinary_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.ordinary_free_function_dependency_events).sum::<usize>(),
         "specialized_origin_records": records.iter().map(|record| record.work.body_analysis.specialized_origin_records).sum::<usize>(),
         "specialized_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.specialized_free_function_dependency_events).sum::<usize>(),
+        "named_method_dependency_events": records.iter().map(|record| record.work.body_analysis.named_method_dependency_events).sum::<usize>(),
         "manifest_build_invocations": records.iter().map(|record| record.work.manifest.build_invocations).sum::<usize>(),
     })
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1,9 +1,9 @@
 //! One-pass canonical declaration binding, body analysis, and CFG lowering.
 
 use rue_air::{
-    BodyAnalysisWork, DeclarationBindingWork, OrdinaryFreeFunctionDependencyEvent,
-    RirDeclarationIndexWork, SemanticBindingManifestWork, SpecializedFreeFunctionDependencyEvent,
-    SpecializedFreeFunctionOrigin,
+    BodyAnalysisWork, DeclarationBindingWork, NamedMethodDependencyEvent,
+    OrdinaryFreeFunctionDependencyEvent, RirDeclarationIndexWork, SemanticBindingManifestWork,
+    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
 use tracing::info_span;
 
@@ -47,6 +47,9 @@ pub struct CanonicalSemanticOutput {
     specialized_free_function_origins: Vec<SpecializedFreeFunctionOrigin>,
     specialized_free_function_dependencies: Vec<SpecializedFreeFunctionDependencyEvent>,
     specialized_free_function_dependencies_complete: bool,
+    named_method_dependencies: Vec<NamedMethodDependencyEvent>,
+    non_generic_named_method_dependencies_complete: bool,
+    generic_named_method_dependencies_complete: bool,
 }
 
 impl CanonicalSemanticOutput {
@@ -86,6 +89,15 @@ impl CanonicalSemanticOutput {
     }
     pub fn specialized_free_function_dependencies_complete(&self) -> bool {
         self.specialized_free_function_dependencies_complete
+    }
+    pub fn named_method_dependencies(&self) -> &[NamedMethodDependencyEvent] {
+        &self.named_method_dependencies
+    }
+    pub fn non_generic_named_method_dependencies_complete(&self) -> bool {
+        self.non_generic_named_method_dependencies_complete
+    }
+    pub fn generic_named_method_dependencies_complete(&self) -> bool {
+        self.generic_named_method_dependencies_complete
     }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -172,6 +184,11 @@ pub fn analyze_canonical_program(
         sema_output.specialized_free_function_dependencies.clone();
     let specialized_free_function_dependencies_complete =
         sema_output.specialized_free_function_dependencies_complete;
+    let named_method_dependencies = sema_output.named_method_dependencies.clone();
+    let non_generic_named_method_dependencies_complete =
+        sema_output.non_generic_named_method_dependencies_complete;
+    let generic_named_method_dependencies_complete =
+        sema_output.generic_named_method_dependencies_complete;
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
@@ -199,6 +216,9 @@ pub fn analyze_canonical_program(
         specialized_free_function_origins,
         specialized_free_function_dependencies,
         specialized_free_function_dependencies_complete,
+        named_method_dependencies,
+        non_generic_named_method_dependencies_complete,
+        generic_named_method_dependencies_complete,
     })
 }
 
@@ -498,6 +518,31 @@ mod tests {
         assert_eq!(many.body_analysis.reachable_declaration_rir_visits, 0);
         assert!(many.binding.input_rir_instructions > one.binding.input_rir_instructions);
         assert!(many.binding.indexed_free_functions > one.binding.indexed_free_functions);
+    }
+
+    fn named_method_capture_with_irrelevant_declarations(count: usize) -> CanonicalSemanticWork {
+        let mut source = String::from(
+            "fn helper() -> i32 { 1 } struct Value { fn run(borrow self) -> i32 { helper() } } fn main() -> i32 { let value = Value {}; value.run() }",
+        );
+        for index in 0..count {
+            source.push_str(&format!(" fn irrelevant{index}() -> i32 {{ {index} }}"));
+        }
+        let snapshot = snapshot(&[(1, "/main.rue", "main.rue", &source)], 1);
+        canonical(&snapshot, &CompileOptions::default(), false)
+            .0
+            .work()
+    }
+
+    #[test]
+    fn named_method_capture_work_is_constant_with_128_irrelevant_declarations() {
+        let one = named_method_capture_with_irrelevant_declarations(1);
+        let many = named_method_capture_with_irrelevant_declarations(128);
+        assert_eq!(one.body_analysis.named_method_dependency_events, 1);
+        assert_eq!(many.body_analysis.named_method_dependency_events, 1);
+        assert_eq!(one.body_analysis.named_method_record_lookups, 1);
+        assert_eq!(many.body_analysis.named_method_record_lookups, 1);
+        assert_eq!(one.body_analysis.reachable_declaration_rir_visits, 0);
+        assert_eq!(many.body_analysis.reachable_declaration_rir_visits, 0);
     }
 
     #[test]

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -59,6 +59,7 @@ pub struct SemanticDependencyManifestWork {
     pub import_records_visited: usize,
     pub free_function_events_translated: usize,
     pub specialization_origins_validated: usize,
+    pub named_method_events_translated: usize,
     pub extra_rir_instructions_visited: usize,
 }
 
@@ -66,6 +67,18 @@ pub struct SemanticDependencyManifestWork {
 pub struct StableFreeFunctionDependency {
     pub caller: StableDefinitionKey,
     pub callee: StableDefinitionKey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StableNamedMethodDependencyTarget {
+    FreeFunction(StableDefinitionKey),
+    NamedMethod(StableDefinitionKey),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StableNamedMethodDependency {
+    pub caller: StableDefinitionKey,
+    pub target: StableNamedMethodDependencyTarget,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -95,6 +108,9 @@ pub struct SemanticDependencyInputManifest {
     module_imports: Arc<[StableModuleImportDependency]>,
     free_function_dependencies: Arc<[StableFreeFunctionDependency]>,
     free_function_caller_dependencies_complete: bool,
+    named_method_dependencies: Arc<[StableNamedMethodDependency]>,
+    non_generic_named_method_dependencies_complete: bool,
+    generic_named_method_dependencies_complete: bool,
     semantic_dependency_graph_complete: bool,
     definition_universe_complete: bool,
     work: SemanticDependencyManifestWork,
@@ -118,6 +134,15 @@ impl SemanticDependencyInputManifest {
     }
     pub fn free_function_caller_dependencies_complete(&self) -> bool {
         self.free_function_caller_dependencies_complete
+    }
+    pub fn named_method_dependencies(&self) -> &[StableNamedMethodDependency] {
+        &self.named_method_dependencies
+    }
+    pub fn non_generic_named_method_dependencies_complete(&self) -> bool {
+        self.non_generic_named_method_dependencies_complete
+    }
+    pub fn generic_named_method_dependencies_complete(&self) -> bool {
+        self.generic_named_method_dependencies_complete
     }
     pub fn semantic_dependency_graph_complete(&self) -> bool {
         self.semantic_dependency_graph_complete
@@ -709,9 +734,12 @@ impl CanonicalFrontendSession {
         keys.dedup();
         let (
             mut free_function_dependencies,
+            mut named_method_dependencies,
             free_function_events_translated,
             specialization_origins_validated,
+            named_method_events_translated,
             free_function_caller_dependencies_complete,
+            named_method_dependencies_complete,
         ) = match (&semantic, &definitions) {
             (Ok(semantic), Ok(definitions)) => {
                 if definitions.source_revision() != &input.sources {
@@ -755,24 +783,59 @@ impl CanonicalFrontendSession {
                         )?,
                     });
                 }
+                let mut method_edges = Vec::new();
+                for event in semantic.named_method_dependencies() {
+                    let caller = stable_named_method_endpoint(
+                        definitions,
+                        event.caller_file,
+                        &event.caller_owner_name,
+                        &event.caller_method_name,
+                    )?;
+                    let target = match &event.target {
+                        rue_air::NamedMethodDependencyTargetEvent::FreeFunction { file, name } => {
+                            StableNamedMethodDependencyTarget::FreeFunction(
+                                stable_free_function_endpoint(definitions, *file, name)?,
+                            )
+                        }
+                        rue_air::NamedMethodDependencyTargetEvent::NamedMethod {
+                            file,
+                            owner_name,
+                            method_name,
+                        } => StableNamedMethodDependencyTarget::NamedMethod(
+                            stable_named_method_endpoint(
+                                definitions,
+                                *file,
+                                owner_name,
+                                method_name,
+                            )?,
+                        ),
+                    };
+                    method_edges.push(StableNamedMethodDependency { caller, target });
+                }
                 (
                     edges,
+                    method_edges,
                     semantic.ordinary_free_function_dependencies().len()
                         + semantic.specialized_free_function_dependencies().len(),
                     semantic.specialized_free_function_origins().len(),
+                    semantic.named_method_dependencies().len(),
                     semantic.ordinary_free_function_dependencies_complete()
                         && semantic.specialized_free_function_dependencies_complete(),
+                    semantic.non_generic_named_method_dependencies_complete(),
                 )
             }
-            _ => (Vec::new(), 0, 0, false),
+            _ => (Vec::new(), Vec::new(), 0, 0, 0, false, false),
         };
         free_function_dependencies.sort();
         free_function_dependencies.dedup();
+        named_method_dependencies.sort();
+        named_method_dependencies.dedup();
         let work = SemanticDependencyManifestWork {
             definition_records_visited: definition_records.len(),
             import_records_visited: imports.graph().records().len(),
             free_function_events_translated,
             specialization_origins_validated,
+            named_method_events_translated,
             extra_rir_instructions_visited: 0,
         };
         self.work.dependency_manifest_records_visited += work.definition_records_visited;
@@ -811,6 +874,9 @@ impl CanonicalFrontendSession {
             module_imports: module_imports.into(),
             free_function_dependencies: free_function_dependencies.into(),
             free_function_caller_dependencies_complete,
+            named_method_dependencies: named_method_dependencies.into(),
+            non_generic_named_method_dependencies_complete: named_method_dependencies_complete,
+            generic_named_method_dependencies_complete: false,
             semantic_dependency_graph_complete: false,
             definition_universe_complete,
             work,
@@ -838,6 +904,35 @@ fn stable_free_function_endpoint(
     let [record] = matches.as_slice() else {
         return Err(invalid_dependency_manifest(&format!(
             "free-function dependency endpoint ({file}, '{name}') did not join exactly one bound function",
+        )));
+    };
+    Ok(record.stable_key().clone())
+}
+
+fn stable_named_method_endpoint(
+    definitions: &BoundDefinitionSet,
+    file: u32,
+    owner_name: &str,
+    method_name: &str,
+) -> Result<StableDefinitionKey, CompileErrors> {
+    let matches = definitions
+        .definitions()
+        .iter()
+        .filter(|record| {
+            let key = record.stable_key();
+            record.declaration_span().file_id.index() == file
+                && key.name() == method_name
+                && key.namespace() == StableDefinitionNamespace::Method
+                && matches!(
+                    key.kind(),
+                    StableDefinitionKind::Method | StableDefinitionKind::AssociatedFunction
+                )
+                && key.owner().is_some_and(|owner| owner.name() == owner_name)
+        })
+        .collect::<Vec<_>>();
+    let [record] = matches.as_slice() else {
+        return Err(invalid_dependency_manifest(&format!(
+            "named-method dependency endpoint ({file}, '{owner_name}', '{method_name}') did not join exactly one bound method",
         )));
     };
     Ok(record.stable_key().clone())
@@ -1862,6 +1957,7 @@ mod tests {
             .unwrap();
         assert!(stable_free_function_endpoint(&definitions, 1, "missing").is_err());
         assert!(stable_free_function_endpoint(&definitions, 1, "answer").is_err());
+        assert!(stable_named_method_endpoint(&definitions, 1, "answer", "answer").is_err());
 
         let rejected = snapshot(
             &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { true }")],
@@ -1874,6 +1970,13 @@ mod tests {
         assert!(!manifest.definition_universe_complete());
         assert!(!manifest.free_function_caller_dependencies_complete());
         assert!(manifest.free_function_dependencies().is_empty());
+    }
+
+    #[test]
+    fn stable_named_method_dependency_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<StableNamedMethodDependency>();
+        assert_send_sync::<StableNamedMethodDependencyTarget>();
     }
 
     #[test]
@@ -1950,6 +2053,88 @@ mod tests {
                 .iter()
                 .all(|edge| { edge.callee.name() != "get" && edge.callee.name() != "Box" })
         );
+    }
+
+    fn named_method_edge_names(
+        manifest: &SemanticDependencyInputManifest,
+    ) -> Vec<(String, String, String, String, String, String)> {
+        manifest
+            .named_method_dependencies()
+            .iter()
+            .map(|edge| {
+                let caller_owner = edge.caller.owner().unwrap().name().to_owned();
+                match &edge.target {
+                    StableNamedMethodDependencyTarget::FreeFunction(target) => (
+                        edge.caller.module().as_str().to_owned(),
+                        caller_owner,
+                        edge.caller.name().to_owned(),
+                        "free".to_owned(),
+                        target.module().as_str().to_owned(),
+                        target.name().to_owned(),
+                    ),
+                    StableNamedMethodDependencyTarget::NamedMethod(target) => (
+                        edge.caller.module().as_str().to_owned(),
+                        caller_owner,
+                        edge.caller.name().to_owned(),
+                        target.owner().unwrap().name().to_owned(),
+                        target.module().as_str().to_owned(),
+                        target.name().to_owned(),
+                    ),
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn named_method_edges_are_stable_exact_and_normalize_generic_free_callees() {
+        let program = r#"fn helper() -> i32 { 1 }
+            fn generic(comptime n: i32) -> i32 { helper() + n }
+            struct B { value: i32, fn ping(borrow self) -> i32 { helper() + self.value } }
+            struct A {
+                value: i32,
+                fn run(borrow self) -> i32 {
+                    let b = B { value: self.value };
+                    b.ping() + self.next()
+                }
+                fn next(borrow self) -> i32 { generic(2) + self.run() }
+            }
+            fn main() -> i32 { let a = A { value: 1 }; a.run() }"#;
+        let first_source = snapshot(&[(9, "/one/main.rue", "main.rue", program)], 9);
+        let moved_source = snapshot(&[(41, "/else/main.rue", "main.rue", program)], 41);
+        let build = |source: &SourceSnapshot| {
+            let mut session = CanonicalFrontendSession::new();
+            session.update(source).into_result().unwrap();
+            session
+                .semantic_dependency_inputs(&CompileOptions::default(), None)
+                .unwrap()
+        };
+        let first = build(&first_source);
+        let moved = build(&moved_source);
+        assert_eq!(
+            named_method_edge_names(&first),
+            named_method_edge_names(&moved)
+        );
+        let edges = named_method_edge_names(&first);
+        for expected in [
+            ("main.rue", "A", "run", "B", "main.rue", "ping"),
+            ("main.rue", "A", "run", "A", "main.rue", "next"),
+            ("main.rue", "A", "next", "A", "main.rue", "run"),
+            ("main.rue", "A", "next", "free", "main.rue", "generic"),
+            ("main.rue", "B", "ping", "free", "main.rue", "helper"),
+        ] {
+            assert!(edges.contains(&(
+                expected.0.into(),
+                expected.1.into(),
+                expected.2.into(),
+                expected.3.into(),
+                expected.4.into(),
+                expected.5.into(),
+            )));
+        }
+        assert!(first.non_generic_named_method_dependencies_complete());
+        assert!(!first.generic_named_method_dependencies_complete());
+        assert_eq!(first.work().named_method_events_translated, edges.len());
+        assert_eq!(first.work().extra_rir_instructions_visited, 0);
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -65,7 +65,8 @@ pub use frontend_session::{
     CanonicalImportGraphOutput, DefinitionQueryRecord, FrontendDiagnosticSnapshot,
     FrontendDiagnosticStage, FrontendQueryWork, ImportGraphInputDescriptor,
     SemanticDependencyInputManifest, SemanticDependencyManifestWork, SemanticQueryRecord,
-    StableFreeFunctionDependency, StableModuleImportDependency,
+    StableFreeFunctionDependency, StableModuleImportDependency, StableNamedMethodDependency,
+    StableNamedMethodDependencyTarget,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -123,3 +123,19 @@ and specialized free-function callers to free-function callees. The overall
 semantic graph remains incomplete until method/destructor callers, declaration
 and type/constant/drop dependencies are captured, so these edges still do not
 authorize AIR or CFG reuse.
+
+Named methods on stable named structs now have a second neutral capture seam.
+The caller is `(FileId, owned owner name, owned method name)` and each target is
+tagged as a free function or another named method. Compiler translation joins
+methods by exact revision, FileId, owner, method namespace and
+method/associated-function kind; anonymous owners and invalid endpoints never
+silently enter the stable graph. Stable named-method edges are sorted and
+deduplicated without another RIR traversal.
+
+`non_generic_named_method_dependencies_complete` covers reachable named methods
+without comptime parameters calling free functions (including generic free
+function bases) or other named methods. Generic named-method bodies have no
+specialization/base-owner provenance equivalent to free functions, so
+`generic_named_method_dependencies_complete` remains false. Anonymous methods,
+destructors, constructors and intrinsics remain outside this surface and keep
+the overall semantic graph incomplete.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -54,8 +54,11 @@ incremental-compilation goal is complete.
    names, and rename sensitivity are gated with zero extra RIR visits; benchmark
    output exposes ordinary events, specialization origins, and specialized
    events. This narrow free-function caller surface is complete, while method
-   and destructor callers plus declaration/type/const/drop surfaces keep the
-   overall graph explicitly incomplete and prevent body/CFG reuse.
+   non-generic named-method callers now also translate exact named owner/method
+   identities to tagged free-function or named-method stable targets. Generic
+   named methods still lack specialization-owner provenance; anonymous methods,
+   destructor callers, and declaration/type/const/drop surfaces keep the overall
+   graph explicitly incomplete and prevent body/CFG reuse.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## What changed

- records dependencies from named method and associated-function bodies during semantic analysis
- distinguishes free-function and named-method callees with stable source owner identity
- translates supported edges into relocation-independent stable definition keys
- fails closed for anonymous or unresolvable endpoints and records explicit work/completeness evidence

## Why

Method bodies participate in semantic invalidation just like free functions, but their identity includes a stable nominal owner. Capturing and translating those edges at the authoritative analysis boundary avoids reconstructing receiver ownership later.

## Validation

- formatting passed
- AIR and compiler tests passed
- benchmark structural gates passed
- workspace clippy, quick, and full suites passed on the integrated stack