### PR TITLE
RUE-719: classify generic methods and capture destructor edges

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -38,11 +38,12 @@ pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
     AnalyzedFunction, BodyAnalysisWork, BoundSema, ConstValue, DeclarationBindingWork,
-    DirResolution, FunctionInfo, GatherOutput, MethodInfo, ModulePath, NamedMethodDependencyEvent,
-    NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
-    RirDeclarationIndexWork, Sema, SemaOutput, SemanticBinding, SemanticBindingKind,
-    SemanticBindingManifest, SemanticBindingManifestWork, SemanticBindingNamespace,
-    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin, import_candidate_groups,
+    DirResolution, FunctionInfo, GatherOutput, MethodInfo, ModulePath,
+    NamedDestructorDependencyEvent, NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
+    OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
+    SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
+    SemanticBindingNamespace, SpecializedFreeFunctionDependencyEvent,
+    SpecializedFreeFunctionOrigin, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -189,6 +189,12 @@ fn finalize_function_body_analysis(
         non_generic_named_method_dependencies_complete: sema
             .non_generic_named_method_dependencies_complete,
         generic_named_method_dependencies_complete: false,
+        named_destructor_dependencies: {
+            sema.named_destructor_dependencies.sort();
+            sema.named_destructor_dependencies.dedup();
+            sema.named_destructor_dependencies.clone()
+        },
+        named_destructor_dependencies_complete: true,
     };
 
     errors.into_result_with(output)
@@ -451,6 +457,65 @@ fn named_method_dependency_events(
             caller_file: caller_info.span.file_id.index(),
             caller_owner_name: caller_owner_name.clone(),
             caller_method_name: caller_method_name.clone(),
+            target: super::NamedMethodDependencyTargetEvent::NamedMethod {
+                file: info.span.file_id.index(),
+                owner_name,
+                method_name: sema.interner.resolve(callee_method).to_string(),
+            },
+        });
+    }
+    Ok(events)
+}
+
+fn named_destructor_dependency_events(
+    sema: &Sema<'_>,
+    caller_struct: StructId,
+    caller_span: rue_span::Span,
+    referenced_functions: &HashSet<Spur>,
+    referenced_methods: &HashSet<(StructId, Spur)>,
+) -> CompileResult<Vec<super::NamedDestructorDependencyEvent>> {
+    let caller_owner_name = sema.type_pool.struct_def(caller_struct).name.clone();
+    let mut events = Vec::new();
+    for callee in referenced_functions {
+        let info = sema.functions.get(callee).ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::InvalidCompilerInput(
+                    "named destructor references an absent free function".into(),
+                ),
+                caller_span,
+            )
+        })?;
+        events.push(super::NamedDestructorDependencyEvent {
+            caller_file: caller_span.file_id.index(),
+            caller_owner_name: caller_owner_name.clone(),
+            target: super::NamedMethodDependencyTargetEvent::FreeFunction {
+                file: info.file_id.index(),
+                name: sema
+                    .interner
+                    .resolve(&sema.source_function_name(*callee))
+                    .to_string(),
+            },
+        });
+    }
+    for (callee_struct, callee_method) in referenced_methods {
+        let owner_name = sema.type_pool.struct_def(*callee_struct).name.clone();
+        if owner_name.starts_with("__anon_struct_") {
+            continue;
+        }
+        let info = sema
+            .methods
+            .get(&(*callee_struct, *callee_method))
+            .ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::InvalidCompilerInput(
+                        "named destructor references an absent named method".into(),
+                    ),
+                    caller_span,
+                )
+            })?;
+        events.push(super::NamedDestructorDependencyEvent {
+            caller_file: caller_span.file_id.index(),
+            caller_owner_name: caller_owner_name.clone(),
             target: super::NamedMethodDependencyTargetEvent::NamedMethod {
                 file: info.span.file_id.index(),
                 owner_name,
@@ -920,6 +985,23 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                     struct_type,
                 ) {
                     Ok((analyzed, warnings, local_strings, referenced_fns, referenced_meths)) => {
+                        match named_destructor_dependency_events(
+                            sema,
+                            struct_id,
+                            destructor.span,
+                            &referenced_fns,
+                            &referenced_meths,
+                        ) {
+                            Ok(events) => {
+                                sema.body_analysis_work.named_destructor_dependency_events +=
+                                    events.len();
+                                sema.named_destructor_dependencies.extend(events);
+                            }
+                            Err(error) => {
+                                errors.push(error);
+                                continue;
+                            }
+                        }
                         functions_with_strings.push((analyzed, local_strings));
                         all_warnings.extend(warnings);
                         enqueue_references_sorted(
@@ -1526,6 +1608,8 @@ mod error_invariant_tests {
             named_method_dependencies: Vec::new(),
             non_generic_named_method_dependencies_complete: false,
             generic_named_method_dependencies_complete: false,
+            named_destructor_dependencies: Vec::new(),
+            named_destructor_dependencies_complete: false,
         }
     }
 

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -145,6 +145,7 @@ impl<'a> GatherOutput<'a> {
             specialized_free_function_dependencies: Vec::new(),
             named_method_dependencies: Vec::new(),
             non_generic_named_method_dependencies_complete: true,
+            named_destructor_dependencies: Vec::new(),
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,
             module_bindings: self.module_bindings,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -58,7 +58,7 @@ pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
 pub use output::{
-    AnalyzedFunction, BodyAnalysisWork, NamedMethodDependencyEvent,
+    AnalyzedFunction, BodyAnalysisWork, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
     NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
     SemaOutput, SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
@@ -109,6 +109,7 @@ pub struct Sema<'a> {
     pub(crate) specialized_free_function_dependencies: Vec<SpecializedFreeFunctionDependencyEvent>,
     pub(crate) named_method_dependencies: Vec<NamedMethodDependencyEvent>,
     pub(crate) non_generic_named_method_dependencies_complete: bool,
+    pub(crate) named_destructor_dependencies: Vec<NamedDestructorDependencyEvent>,
     /// Compatibility value-constant table for globally unique bare names.
     /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`]. If a value-constant name appears in
@@ -240,6 +241,7 @@ impl<'a> Sema<'a> {
             specialized_free_function_dependencies: Vec::new(),
             named_method_dependencies: Vec::new(),
             non_generic_named_method_dependencies_complete: true,
+            named_destructor_dependencies: Vec::new(),
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),
             module_bindings: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -51,6 +51,12 @@ pub struct NamedMethodDependencyEvent {
     pub caller_method_name: String,
     pub target: NamedMethodDependencyTargetEvent,
 }
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NamedDestructorDependencyEvent {
+    pub caller_file: u32,
+    pub caller_owner_name: String,
+    pub target: NamedMethodDependencyTargetEvent,
+}
 
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
@@ -137,6 +143,8 @@ pub struct SemaOutput {
     pub named_method_dependencies: Vec<NamedMethodDependencyEvent>,
     pub non_generic_named_method_dependencies_complete: bool,
     pub generic_named_method_dependencies_complete: bool,
+    pub named_destructor_dependencies: Vec<NamedDestructorDependencyEvent>,
+    pub named_destructor_dependencies_complete: bool,
 }
 
 /// Value-only workload counters for demand-driven body dispatch.
@@ -148,6 +156,7 @@ pub struct BodyAnalysisWork {
     pub specialized_origin_records: usize,
     pub specialized_free_function_dependency_events: usize,
     pub named_method_dependency_events: usize,
+    pub named_destructor_dependency_events: usize,
     /// Indexed declaration-record lookups for reachable, non-generic free functions.
     pub free_function_record_lookups: usize,
     /// Private declaration-record lookups for reachable named-struct methods.

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -176,6 +176,7 @@ fn semantic_work_json(work: &CanonicalFrontendSessionWork, from: usize) -> Value
         "specialized_origin_records": records.iter().map(|record| record.work.body_analysis.specialized_origin_records).sum::<usize>(),
         "specialized_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.specialized_free_function_dependency_events).sum::<usize>(),
         "named_method_dependency_events": records.iter().map(|record| record.work.body_analysis.named_method_dependency_events).sum::<usize>(),
+        "named_destructor_dependency_events": records.iter().map(|record| record.work.body_analysis.named_destructor_dependency_events).sum::<usize>(),
         "manifest_build_invocations": records.iter().map(|record| record.work.manifest.build_invocations).sum::<usize>(),
     })
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1,9 +1,10 @@
 //! One-pass canonical declaration binding, body analysis, and CFG lowering.
 
 use rue_air::{
-    BodyAnalysisWork, DeclarationBindingWork, NamedMethodDependencyEvent,
-    OrdinaryFreeFunctionDependencyEvent, RirDeclarationIndexWork, SemanticBindingManifestWork,
-    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
+    BodyAnalysisWork, DeclarationBindingWork, NamedDestructorDependencyEvent,
+    NamedMethodDependencyEvent, OrdinaryFreeFunctionDependencyEvent, RirDeclarationIndexWork,
+    SemanticBindingManifestWork, SpecializedFreeFunctionDependencyEvent,
+    SpecializedFreeFunctionOrigin,
 };
 use tracing::info_span;
 
@@ -50,6 +51,8 @@ pub struct CanonicalSemanticOutput {
     named_method_dependencies: Vec<NamedMethodDependencyEvent>,
     non_generic_named_method_dependencies_complete: bool,
     generic_named_method_dependencies_complete: bool,
+    named_destructor_dependencies: Vec<NamedDestructorDependencyEvent>,
+    named_destructor_dependencies_complete: bool,
 }
 
 impl CanonicalSemanticOutput {
@@ -98,6 +101,12 @@ impl CanonicalSemanticOutput {
     }
     pub fn generic_named_method_dependencies_complete(&self) -> bool {
         self.generic_named_method_dependencies_complete
+    }
+    pub fn named_destructor_dependencies(&self) -> &[NamedDestructorDependencyEvent] {
+        &self.named_destructor_dependencies
+    }
+    pub fn named_destructor_dependencies_complete(&self) -> bool {
+        self.named_destructor_dependencies_complete
     }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -189,6 +198,8 @@ pub fn analyze_canonical_program(
         sema_output.non_generic_named_method_dependencies_complete;
     let generic_named_method_dependencies_complete =
         sema_output.generic_named_method_dependencies_complete;
+    let named_destructor_dependencies = sema_output.named_destructor_dependencies.clone();
+    let named_destructor_dependencies_complete = sema_output.named_destructor_dependencies_complete;
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
@@ -219,6 +230,8 @@ pub fn analyze_canonical_program(
         named_method_dependencies,
         non_generic_named_method_dependencies_complete,
         generic_named_method_dependencies_complete,
+        named_destructor_dependencies,
+        named_destructor_dependencies_complete,
     })
 }
 
@@ -543,6 +556,30 @@ mod tests {
         assert_eq!(many.body_analysis.named_method_record_lookups, 1);
         assert_eq!(one.body_analysis.reachable_declaration_rir_visits, 0);
         assert_eq!(many.body_analysis.reachable_declaration_rir_visits, 0);
+    }
+
+    #[test]
+    fn comptime_named_methods_are_single_runtime_bodies_not_specializations() {
+        let source = snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "struct Value { fn choose(borrow self, comptime n: i32) -> i32 { n } } fn main() -> i32 { let value = Value {}; value.choose(1) + value.choose(2) }",
+            )],
+            1,
+        );
+        let (output, _) = canonical(&source, &CompileOptions::default(), false);
+        assert_eq!(
+            output
+                .functions()
+                .iter()
+                .filter(|function| function.analyzed.name.ends_with("Value.choose"))
+                .count(),
+            1
+        );
+        assert!(output.specialized_free_function_origins().is_empty());
+        assert!(!output.generic_named_method_dependencies_complete());
     }
 
     #[test]

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -60,6 +60,7 @@ pub struct SemanticDependencyManifestWork {
     pub free_function_events_translated: usize,
     pub specialization_origins_validated: usize,
     pub named_method_events_translated: usize,
+    pub named_destructor_events_translated: usize,
     pub extra_rir_instructions_visited: usize,
 }
 
@@ -77,6 +78,12 @@ pub enum StableNamedMethodDependencyTarget {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StableNamedMethodDependency {
+    pub caller: StableDefinitionKey,
+    pub target: StableNamedMethodDependencyTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StableNamedDestructorDependency {
     pub caller: StableDefinitionKey,
     pub target: StableNamedMethodDependencyTarget,
 }
@@ -111,6 +118,8 @@ pub struct SemanticDependencyInputManifest {
     named_method_dependencies: Arc<[StableNamedMethodDependency]>,
     non_generic_named_method_dependencies_complete: bool,
     generic_named_method_dependencies_complete: bool,
+    named_destructor_dependencies: Arc<[StableNamedDestructorDependency]>,
+    named_destructor_dependencies_complete: bool,
     semantic_dependency_graph_complete: bool,
     definition_universe_complete: bool,
     work: SemanticDependencyManifestWork,
@@ -143,6 +152,12 @@ impl SemanticDependencyInputManifest {
     }
     pub fn generic_named_method_dependencies_complete(&self) -> bool {
         self.generic_named_method_dependencies_complete
+    }
+    pub fn named_destructor_dependencies(&self) -> &[StableNamedDestructorDependency] {
+        &self.named_destructor_dependencies
+    }
+    pub fn named_destructor_dependencies_complete(&self) -> bool {
+        self.named_destructor_dependencies_complete
     }
     pub fn semantic_dependency_graph_complete(&self) -> bool {
         self.semantic_dependency_graph_complete
@@ -735,11 +750,14 @@ impl CanonicalFrontendSession {
         let (
             mut free_function_dependencies,
             mut named_method_dependencies,
+            mut named_destructor_dependencies,
             free_function_events_translated,
             specialization_origins_validated,
             named_method_events_translated,
+            named_destructor_events_translated,
             free_function_caller_dependencies_complete,
             named_method_dependencies_complete,
+            named_destructor_dependencies_complete,
         ) = match (&semantic, &definitions) {
             (Ok(semantic), Ok(definitions)) => {
                 if definitions.source_revision() != &input.sources {
@@ -812,30 +830,75 @@ impl CanonicalFrontendSession {
                     };
                     method_edges.push(StableNamedMethodDependency { caller, target });
                 }
+                let mut destructor_edges = Vec::new();
+                for event in semantic.named_destructor_dependencies() {
+                    let caller = stable_named_destructor_endpoint(
+                        definitions,
+                        event.caller_file,
+                        &event.caller_owner_name,
+                    )?;
+                    let target = match &event.target {
+                        rue_air::NamedMethodDependencyTargetEvent::FreeFunction { file, name } => {
+                            StableNamedMethodDependencyTarget::FreeFunction(
+                                stable_free_function_endpoint(definitions, *file, name)?,
+                            )
+                        }
+                        rue_air::NamedMethodDependencyTargetEvent::NamedMethod {
+                            file,
+                            owner_name,
+                            method_name,
+                        } => StableNamedMethodDependencyTarget::NamedMethod(
+                            stable_named_method_endpoint(
+                                definitions,
+                                *file,
+                                owner_name,
+                                method_name,
+                            )?,
+                        ),
+                    };
+                    destructor_edges.push(StableNamedDestructorDependency { caller, target });
+                }
                 (
                     edges,
                     method_edges,
+                    destructor_edges,
                     semantic.ordinary_free_function_dependencies().len()
                         + semantic.specialized_free_function_dependencies().len(),
                     semantic.specialized_free_function_origins().len(),
                     semantic.named_method_dependencies().len(),
+                    semantic.named_destructor_dependencies().len(),
                     semantic.ordinary_free_function_dependencies_complete()
                         && semantic.specialized_free_function_dependencies_complete(),
                     semantic.non_generic_named_method_dependencies_complete(),
+                    semantic.named_destructor_dependencies_complete(),
                 )
             }
-            _ => (Vec::new(), Vec::new(), 0, 0, 0, false, false),
+            _ => (
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                0,
+                0,
+                0,
+                0,
+                false,
+                false,
+                false,
+            ),
         };
         free_function_dependencies.sort();
         free_function_dependencies.dedup();
         named_method_dependencies.sort();
         named_method_dependencies.dedup();
+        named_destructor_dependencies.sort();
+        named_destructor_dependencies.dedup();
         let work = SemanticDependencyManifestWork {
             definition_records_visited: definition_records.len(),
             import_records_visited: imports.graph().records().len(),
             free_function_events_translated,
             specialization_origins_validated,
             named_method_events_translated,
+            named_destructor_events_translated,
             extra_rir_instructions_visited: 0,
         };
         self.work.dependency_manifest_records_visited += work.definition_records_visited;
@@ -877,6 +940,8 @@ impl CanonicalFrontendSession {
             named_method_dependencies: named_method_dependencies.into(),
             non_generic_named_method_dependencies_complete: named_method_dependencies_complete,
             generic_named_method_dependencies_complete: false,
+            named_destructor_dependencies: named_destructor_dependencies.into(),
+            named_destructor_dependencies_complete,
             semantic_dependency_graph_complete: false,
             definition_universe_complete,
             work,
@@ -933,6 +998,31 @@ fn stable_named_method_endpoint(
     let [record] = matches.as_slice() else {
         return Err(invalid_dependency_manifest(&format!(
             "named-method dependency endpoint ({file}, '{owner_name}', '{method_name}') did not join exactly one bound method",
+        )));
+    };
+    Ok(record.stable_key().clone())
+}
+
+fn stable_named_destructor_endpoint(
+    definitions: &BoundDefinitionSet,
+    file: u32,
+    owner_name: &str,
+) -> Result<StableDefinitionKey, CompileErrors> {
+    let matches = definitions
+        .definitions()
+        .iter()
+        .filter(|record| {
+            let key = record.stable_key();
+            record.declaration_span().file_id.index() == file
+                && key.name() == owner_name
+                && key.namespace() == StableDefinitionNamespace::Destructor
+                && key.kind() == StableDefinitionKind::Destructor
+                && key.owner().is_some_and(|owner| owner.name() == owner_name)
+        })
+        .collect::<Vec<_>>();
+    let [record] = matches.as_slice() else {
+        return Err(invalid_dependency_manifest(&format!(
+            "named-destructor dependency endpoint ({file}, '{owner_name}') did not join exactly one bound destructor",
         )));
     };
     Ok(record.stable_key().clone())
@@ -2134,6 +2224,38 @@ mod tests {
         assert!(first.non_generic_named_method_dependencies_complete());
         assert!(!first.generic_named_method_dependencies_complete());
         assert_eq!(first.work().named_method_events_translated, edges.len());
+        assert_eq!(first.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn named_destructor_edges_translate_to_stable_owner_and_target() {
+        let program = "fn cleanup() {} struct Value { n: i32 } drop fn Value(self) { cleanup(); } fn main() -> i32 { let value = Value { n: 1 }; 0 }";
+        let first_source = snapshot(&[(3, "/one/main.rue", "main.rue", program)], 3);
+        let moved_source = snapshot(&[(71, "/else/main.rue", "main.rue", program)], 71);
+        let build = |source: &SourceSnapshot| {
+            let mut session = CanonicalFrontendSession::new();
+            session.update(source).into_result().unwrap();
+            session
+                .semantic_dependency_inputs(&CompileOptions::default(), None)
+                .unwrap()
+        };
+        let first = build(&first_source);
+        let moved = build(&moved_source);
+        assert_eq!(
+            first.named_destructor_dependencies(),
+            moved.named_destructor_dependencies()
+        );
+        let [edge] = first.named_destructor_dependencies() else {
+            panic!("expected one destructor dependency");
+        };
+        assert_eq!(edge.caller.owner().unwrap().name(), "Value");
+        assert_eq!(edge.caller.kind(), StableDefinitionKind::Destructor);
+        let StableNamedMethodDependencyTarget::FreeFunction(target) = &edge.target else {
+            panic!("cleanup is a free function");
+        };
+        assert_eq!(target.name(), "cleanup");
+        assert!(first.named_destructor_dependencies_complete());
+        assert_eq!(first.work().named_destructor_events_translated, 1);
         assert_eq!(first.work().extra_rir_instructions_visited, 0);
     }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -65,8 +65,8 @@ pub use frontend_session::{
     CanonicalImportGraphOutput, DefinitionQueryRecord, FrontendDiagnosticSnapshot,
     FrontendDiagnosticStage, FrontendQueryWork, ImportGraphInputDescriptor,
     SemanticDependencyInputManifest, SemanticDependencyManifestWork, SemanticQueryRecord,
-    StableFreeFunctionDependency, StableModuleImportDependency, StableNamedMethodDependency,
-    StableNamedMethodDependencyTarget,
+    StableFreeFunctionDependency, StableModuleImportDependency, StableNamedDestructorDependency,
+    StableNamedMethodDependency, StableNamedMethodDependencyTarget,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -139,3 +139,19 @@ specialization/base-owner provenance equivalent to free functions, so
 `generic_named_method_dependencies_complete` remains false. Anonymous methods,
 destructors, constructors and intrinsics remain outside this surface and keep
 the overall semantic graph incomplete.
+
+Audit of comptime-parameter named methods found no specialization mechanism:
+receiver resolution records only `(StructId, method)`, coerces every explicit
+argument as a runtime argument, emits one direct `Call` symbol, and the lazy
+driver analyzes the declaration once. `MethodInfo` has no specialization key or
+substitution/origin fields. Tests pin two distinct comptime arguments producing
+one analyzed method body and no specialization origins. Until language support
+routes these methods through a real instantiation path, generic named-method
+stable provenance is unsupported rather than missing capture data.
+
+Named destructor bodies now use the same existing reference sets to capture
+tagged free-function and named-method targets. Their caller handle is the exact
+named owner declaration FileId/name and compiler translation joins the
+Destructor namespace/kind and owner in the exact `BoundDefinitionSet`.
+`named_destructor_dependencies_complete` covers named destructors; anonymous
+destructors remain a separate incomplete surface.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -56,9 +56,12 @@ incremental-compilation goal is complete.
    events. This narrow free-function caller surface is complete, while method
    non-generic named-method callers now also translate exact named owner/method
    identities to tagged free-function or named-method stable targets. Generic
-   named methods still lack specialization-owner provenance; anonymous methods,
-   destructor callers, and declaration/type/const/drop surfaces keep the overall
-   graph explicitly incomplete and prevent body/CFG reuse.
+   named methods are proven to have no specialization path today: comptime
+   arguments still produce one runtime method body, so their generic provenance
+   is explicitly unsupported. Named destructor callers now translate exact
+   owner identities and tagged free/method targets. Anonymous methods and
+   destructors plus declaration/type/const/drop surfaces keep the overall graph
+   explicitly incomplete and prevent body/CFG reuse.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## What changed

- classifies named method bodies with comptime parameters so dependency completeness is explicit
- captures named-destructor callers and their free-function/method dependencies during semantic analysis
- translates destructor and supported method edges to stable definition keys
- retains fail-closed completeness/work evidence without rescanning RIR

## Why

Generic method bodies and destructors are distinct semantic dependency surfaces. Modeling them explicitly prevents silent gaps in invalidation while keeping unsupported ownership cases conservative.

## Validation

- formatting passed
- AIR and compiler tests passed
- benchmark structural gates passed
- workspace clippy, quick, and full suites passed on the integrated stack