### PR TITLE
RUE-719: retain resolved nominal declaration dependencies

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -38,8 +38,10 @@ pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
     AnalyzedFunction, BodyAnalysisWork, BoundSema, ConstValue, DeclarationBindingWork,
-    DirResolution, FunctionInfo, GatherOutput, MethodInfo, ModulePath,
-    NamedDestructorDependencyEvent, NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
+    DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,
+    DeclarationTypeDependencySourceKind, DeclarationTypeDependencyTargetKind, DirResolution,
+    FunctionInfo, GatherOutput, MethodInfo, ModulePath, NamedDestructorDependencyEvent,
+    NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
     OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
     SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
     SemanticBindingNamespace, SpecializedFreeFunctionDependencyEvent,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -195,6 +195,12 @@ fn finalize_function_body_analysis(
             sema.named_destructor_dependencies.clone()
         },
         named_destructor_dependencies_complete: true,
+        declaration_type_dependencies: {
+            sema.declaration_type_dependencies.sort();
+            sema.declaration_type_dependencies.dedup();
+            sema.declaration_type_dependencies.clone()
+        },
+        declaration_type_dependencies_complete: false,
     };
 
     errors.into_result_with(output)
@@ -1610,6 +1616,8 @@ mod error_invariant_tests {
             generic_named_method_dependencies_complete: false,
             named_destructor_dependencies: Vec::new(),
             named_destructor_dependencies_complete: false,
+            declaration_type_dependencies: Vec::new(),
+            declaration_type_dependencies_complete: false,
         }
     }
 

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -669,7 +669,221 @@ impl<'a> Sema<'a> {
         // any value-constant name that collides with a function/struct/enum
         // (order-independent E0436, spec 10.3:1/10.5:1, RUE-239).
         self.check_const_cross_kind_collisions()?;
+        self.capture_resolved_declaration_type_dependencies();
         Ok(())
+    }
+
+    fn capture_resolved_declaration_type_dependencies(&mut self) {
+        use super::{
+            DeclarationTypeDependencyKind as Edge, DeclarationTypeDependencySourceKind as Source,
+        };
+        let structs = self
+            .structs_by_file_name
+            .iter()
+            .map(|((_, name), id)| (*name, *id))
+            .collect::<Vec<_>>();
+        for (name, id) in structs {
+            let def = self.type_pool.struct_def(id);
+            for field in def.fields {
+                self.capture_declaration_type(
+                    def.file_id,
+                    self.interner.resolve(&name).to_string(),
+                    None,
+                    Source::Struct,
+                    Edge::Field,
+                    field.ty,
+                );
+            }
+        }
+        let enums = self
+            .enums_by_file_name
+            .iter()
+            .map(|((_, name), id)| (*name, *id))
+            .collect::<Vec<_>>();
+        for (name, id) in enums {
+            let def = self.type_pool.enum_def(id);
+            for ty in def.variant_payloads.into_iter().flatten() {
+                self.capture_declaration_type(
+                    def.file_id,
+                    self.interner.resolve(&name).to_string(),
+                    None,
+                    Source::Enum,
+                    Edge::Payload,
+                    ty,
+                );
+            }
+        }
+        let functions = self
+            .functions
+            .iter()
+            .map(|(name, info)| (*name, *info))
+            .collect::<Vec<_>>();
+        for (name, info) in functions {
+            let source_name = self
+                .interner
+                .resolve(&self.source_function_name(name))
+                .to_string();
+            let mut types = self.param_arena.types(info.params).to_vec();
+            types.push(info.return_type);
+            for ty in types {
+                self.capture_declaration_type(
+                    info.file_id,
+                    source_name.clone(),
+                    None,
+                    Source::Function,
+                    Edge::Signature,
+                    ty,
+                );
+            }
+        }
+        let methods = self
+            .methods
+            .iter()
+            .map(|(key, info)| (*key, *info))
+            .collect::<Vec<_>>();
+        for ((struct_id, method_name), info) in methods {
+            let owner = self.type_pool.struct_def(struct_id);
+            if owner.name.starts_with("__anon_struct_") {
+                continue;
+            }
+            let source_kind = if info.has_self {
+                Source::Method
+            } else {
+                Source::AssociatedFunction
+            };
+            self.capture_declaration_type(
+                info.span.file_id,
+                self.interner.resolve(&method_name).to_string(),
+                Some(owner.name.clone()),
+                source_kind,
+                Edge::Owner,
+                Type::new_struct(struct_id),
+            );
+            let mut types = self.param_arena.types(info.params).to_vec();
+            types.push(info.return_type);
+            for ty in types {
+                self.capture_declaration_type(
+                    info.span.file_id,
+                    self.interner.resolve(&method_name).to_string(),
+                    Some(owner.name.clone()),
+                    source_kind,
+                    Edge::Signature,
+                    ty,
+                );
+            }
+        }
+        let constants = self
+            .constants_by_file_name
+            .iter()
+            .map(|((file, name), info)| (*file, *name, info.ty))
+            .collect::<Vec<_>>();
+        for (file, name, ty) in constants {
+            self.capture_declaration_type(
+                file,
+                self.interner.resolve(&name).to_string(),
+                None,
+                Source::ValueConst,
+                Edge::DeclaredType,
+                ty,
+            );
+        }
+        let destructors = self.declaration_index.destructors().to_vec();
+        for destructor in destructors {
+            if let Some(id) = self
+                .structs_by_file_name
+                .get(&(destructor.span.file_id, destructor.type_name))
+                .copied()
+            {
+                self.capture_declaration_type(
+                    destructor.span.file_id,
+                    self.interner.resolve(&destructor.type_name).to_string(),
+                    Some(self.interner.resolve(&destructor.type_name).to_string()),
+                    Source::Destructor,
+                    Edge::Owner,
+                    Type::new_struct(id),
+                );
+            }
+        }
+    }
+
+    fn capture_declaration_type(
+        &mut self,
+        source_file: FileId,
+        source_name: String,
+        source_owner_name: Option<String>,
+        source_kind: super::DeclarationTypeDependencySourceKind,
+        dependency_kind: super::DeclarationTypeDependencyKind,
+        ty: Type,
+    ) {
+        let target = match ty.kind() {
+            TypeKind::Struct(id) => {
+                let def = self.type_pool.struct_def(id);
+                if def.is_builtin || def.name.starts_with("__anon_struct_") {
+                    return;
+                }
+                Some((
+                    def.file_id,
+                    def.name,
+                    super::DeclarationTypeDependencyTargetKind::Struct,
+                ))
+            }
+            TypeKind::Enum(id) => {
+                let def = self.type_pool.enum_def(id);
+                Some((
+                    def.file_id,
+                    def.name,
+                    super::DeclarationTypeDependencyTargetKind::Enum,
+                ))
+            }
+            TypeKind::Array(id) => {
+                self.capture_declaration_type(
+                    source_file,
+                    source_name,
+                    source_owner_name,
+                    source_kind,
+                    dependency_kind,
+                    self.type_pool.array_def(id).0,
+                );
+                return;
+            }
+            TypeKind::PtrConst(id) => {
+                self.capture_declaration_type(
+                    source_file,
+                    source_name,
+                    source_owner_name,
+                    source_kind,
+                    dependency_kind,
+                    self.type_pool.ptr_const_def(id),
+                );
+                return;
+            }
+            TypeKind::PtrMut(id) => {
+                self.capture_declaration_type(
+                    source_file,
+                    source_name,
+                    source_owner_name,
+                    source_kind,
+                    dependency_kind,
+                    self.type_pool.ptr_mut_def(id),
+                );
+                return;
+            }
+            _ => None,
+        };
+        if let Some((target_file, target_name, target_kind)) = target {
+            self.declaration_type_dependencies
+                .push(super::DeclarationTypeDependencyEvent {
+                    source_file: source_file.index(),
+                    source_name,
+                    source_owner_name,
+                    source_kind,
+                    dependency_kind,
+                    target_file: target_file.index(),
+                    target_name,
+                    target_kind,
+                });
+            self.body_analysis_work.declaration_type_dependency_events += 1;
+        }
     }
 
     /// Phase 2: Resolve tuple-variant payload types (RUE-221, ADR-0038).

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -146,6 +146,7 @@ impl<'a> GatherOutput<'a> {
             named_method_dependencies: Vec::new(),
             non_generic_named_method_dependencies_complete: true,
             named_destructor_dependencies: Vec::new(),
+            declaration_type_dependencies: Vec::new(),
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,
             module_bindings: self.module_bindings,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -58,9 +58,12 @@ pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
 pub use output::{
-    AnalyzedFunction, BodyAnalysisWork, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
-    NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
-    SemaOutput, SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
+    AnalyzedFunction, BodyAnalysisWork, DeclarationTypeDependencyEvent,
+    DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
+    DeclarationTypeDependencyTargetKind, NamedDestructorDependencyEvent,
+    NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
+    OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, SemaOutput,
+    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
 
 use std::collections::{HashMap, HashSet};
@@ -110,6 +113,7 @@ pub struct Sema<'a> {
     pub(crate) named_method_dependencies: Vec<NamedMethodDependencyEvent>,
     pub(crate) non_generic_named_method_dependencies_complete: bool,
     pub(crate) named_destructor_dependencies: Vec<NamedDestructorDependencyEvent>,
+    pub(crate) declaration_type_dependencies: Vec<DeclarationTypeDependencyEvent>,
     /// Compatibility value-constant table for globally unique bare names.
     /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`]. If a value-constant name appears in
@@ -242,6 +246,7 @@ impl<'a> Sema<'a> {
             named_method_dependencies: Vec::new(),
             non_generic_named_method_dependencies_complete: true,
             named_destructor_dependencies: Vec::new(),
+            declaration_type_dependencies: Vec::new(),
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),
             module_bindings: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -57,6 +57,40 @@ pub struct NamedDestructorDependencyEvent {
     pub caller_owner_name: String,
     pub target: NamedMethodDependencyTargetEvent,
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DeclarationTypeDependencySourceKind {
+    Function,
+    Struct,
+    Enum,
+    ValueConst,
+    Method,
+    AssociatedFunction,
+    Destructor,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DeclarationTypeDependencyTargetKind {
+    Struct,
+    Enum,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DeclarationTypeDependencyKind {
+    Signature,
+    Field,
+    Payload,
+    DeclaredType,
+    Owner,
+}
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DeclarationTypeDependencyEvent {
+    pub source_file: u32,
+    pub source_name: String,
+    pub source_owner_name: Option<String>,
+    pub source_kind: DeclarationTypeDependencySourceKind,
+    pub dependency_kind: DeclarationTypeDependencyKind,
+    pub target_file: u32,
+    pub target_name: String,
+    pub target_kind: DeclarationTypeDependencyTargetKind,
+}
 
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
@@ -145,6 +179,8 @@ pub struct SemaOutput {
     pub generic_named_method_dependencies_complete: bool,
     pub named_destructor_dependencies: Vec<NamedDestructorDependencyEvent>,
     pub named_destructor_dependencies_complete: bool,
+    pub declaration_type_dependencies: Vec<DeclarationTypeDependencyEvent>,
+    pub declaration_type_dependencies_complete: bool,
 }
 
 /// Value-only workload counters for demand-driven body dispatch.
@@ -157,6 +193,7 @@ pub struct BodyAnalysisWork {
     pub specialized_free_function_dependency_events: usize,
     pub named_method_dependency_events: usize,
     pub named_destructor_dependency_events: usize,
+    pub declaration_type_dependency_events: usize,
     /// Indexed declaration-record lookups for reachable, non-generic free functions.
     pub free_function_record_lookups: usize,
     /// Private declaration-record lookups for reachable named-struct methods.

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -177,6 +177,7 @@ fn semantic_work_json(work: &CanonicalFrontendSessionWork, from: usize) -> Value
         "specialized_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.specialized_free_function_dependency_events).sum::<usize>(),
         "named_method_dependency_events": records.iter().map(|record| record.work.body_analysis.named_method_dependency_events).sum::<usize>(),
         "named_destructor_dependency_events": records.iter().map(|record| record.work.body_analysis.named_destructor_dependency_events).sum::<usize>(),
+        "declaration_type_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_dependency_events).sum::<usize>(),
         "manifest_build_invocations": records.iter().map(|record| record.work.manifest.build_invocations).sum::<usize>(),
     })
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1,10 +1,10 @@
 //! One-pass canonical declaration binding, body analysis, and CFG lowering.
 
 use rue_air::{
-    BodyAnalysisWork, DeclarationBindingWork, NamedDestructorDependencyEvent,
-    NamedMethodDependencyEvent, OrdinaryFreeFunctionDependencyEvent, RirDeclarationIndexWork,
-    SemanticBindingManifestWork, SpecializedFreeFunctionDependencyEvent,
-    SpecializedFreeFunctionOrigin,
+    BodyAnalysisWork, DeclarationBindingWork, DeclarationTypeDependencyEvent,
+    NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
+    OrdinaryFreeFunctionDependencyEvent, RirDeclarationIndexWork, SemanticBindingManifestWork,
+    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
 use tracing::info_span;
 
@@ -53,6 +53,8 @@ pub struct CanonicalSemanticOutput {
     generic_named_method_dependencies_complete: bool,
     named_destructor_dependencies: Vec<NamedDestructorDependencyEvent>,
     named_destructor_dependencies_complete: bool,
+    declaration_type_dependencies: Vec<DeclarationTypeDependencyEvent>,
+    declaration_type_dependencies_complete: bool,
 }
 
 impl CanonicalSemanticOutput {
@@ -107,6 +109,12 @@ impl CanonicalSemanticOutput {
     }
     pub fn named_destructor_dependencies_complete(&self) -> bool {
         self.named_destructor_dependencies_complete
+    }
+    pub fn declaration_type_dependencies(&self) -> &[DeclarationTypeDependencyEvent] {
+        &self.declaration_type_dependencies
+    }
+    pub fn declaration_type_dependencies_complete(&self) -> bool {
+        self.declaration_type_dependencies_complete
     }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -200,6 +208,8 @@ pub fn analyze_canonical_program(
         sema_output.generic_named_method_dependencies_complete;
     let named_destructor_dependencies = sema_output.named_destructor_dependencies.clone();
     let named_destructor_dependencies_complete = sema_output.named_destructor_dependencies_complete;
+    let declaration_type_dependencies = sema_output.declaration_type_dependencies.clone();
+    let declaration_type_dependencies_complete = sema_output.declaration_type_dependencies_complete;
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
@@ -232,6 +242,8 @@ pub fn analyze_canonical_program(
         generic_named_method_dependencies_complete,
         named_destructor_dependencies,
         named_destructor_dependencies_complete,
+        declaration_type_dependencies,
+        declaration_type_dependencies_complete,
     })
 }
 

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -61,6 +61,7 @@ pub struct SemanticDependencyManifestWork {
     pub specialization_origins_validated: usize,
     pub named_method_events_translated: usize,
     pub named_destructor_events_translated: usize,
+    pub declaration_type_events_translated: usize,
     pub extra_rir_instructions_visited: usize,
 }
 
@@ -86,6 +87,13 @@ pub struct StableNamedMethodDependency {
 pub struct StableNamedDestructorDependency {
     pub caller: StableDefinitionKey,
     pub target: StableNamedMethodDependencyTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StableDeclarationTypeDependency {
+    pub source: StableDefinitionKey,
+    pub target: StableDefinitionKey,
+    pub kind: rue_air::DeclarationTypeDependencyKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -120,6 +128,8 @@ pub struct SemanticDependencyInputManifest {
     generic_named_method_dependencies_complete: bool,
     named_destructor_dependencies: Arc<[StableNamedDestructorDependency]>,
     named_destructor_dependencies_complete: bool,
+    declaration_type_dependencies: Arc<[StableDeclarationTypeDependency]>,
+    declaration_type_dependencies_complete: bool,
     semantic_dependency_graph_complete: bool,
     definition_universe_complete: bool,
     work: SemanticDependencyManifestWork,
@@ -158,6 +168,12 @@ impl SemanticDependencyInputManifest {
     }
     pub fn named_destructor_dependencies_complete(&self) -> bool {
         self.named_destructor_dependencies_complete
+    }
+    pub fn declaration_type_dependencies(&self) -> &[StableDeclarationTypeDependency] {
+        &self.declaration_type_dependencies
+    }
+    pub fn declaration_type_dependencies_complete(&self) -> bool {
+        self.declaration_type_dependencies_complete
     }
     pub fn semantic_dependency_graph_complete(&self) -> bool {
         self.semantic_dependency_graph_complete
@@ -751,13 +767,16 @@ impl CanonicalFrontendSession {
             mut free_function_dependencies,
             mut named_method_dependencies,
             mut named_destructor_dependencies,
+            mut declaration_type_dependencies,
             free_function_events_translated,
             specialization_origins_validated,
             named_method_events_translated,
             named_destructor_events_translated,
+            declaration_type_events_translated,
             free_function_caller_dependencies_complete,
             named_method_dependencies_complete,
             named_destructor_dependencies_complete,
+            declaration_type_dependencies_complete,
         ) = match (&semantic, &definitions) {
             (Ok(semantic), Ok(definitions)) => {
                 if definitions.source_revision() != &input.sources {
@@ -858,29 +877,43 @@ impl CanonicalFrontendSession {
                     };
                     destructor_edges.push(StableNamedDestructorDependency { caller, target });
                 }
+                let mut type_edges = Vec::new();
+                for event in semantic.declaration_type_dependencies() {
+                    type_edges.push(StableDeclarationTypeDependency {
+                        source: stable_declaration_source_endpoint(definitions, event)?,
+                        target: stable_named_type_endpoint(definitions, event)?,
+                        kind: event.dependency_kind,
+                    });
+                }
                 (
                     edges,
                     method_edges,
                     destructor_edges,
+                    type_edges,
                     semantic.ordinary_free_function_dependencies().len()
                         + semantic.specialized_free_function_dependencies().len(),
                     semantic.specialized_free_function_origins().len(),
                     semantic.named_method_dependencies().len(),
                     semantic.named_destructor_dependencies().len(),
+                    semantic.declaration_type_dependencies().len(),
                     semantic.ordinary_free_function_dependencies_complete()
                         && semantic.specialized_free_function_dependencies_complete(),
                     semantic.non_generic_named_method_dependencies_complete(),
                     semantic.named_destructor_dependencies_complete(),
+                    semantic.declaration_type_dependencies_complete(),
                 )
             }
             _ => (
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),
+                Vec::new(),
                 0,
                 0,
                 0,
                 0,
+                0,
+                false,
                 false,
                 false,
                 false,
@@ -892,6 +925,8 @@ impl CanonicalFrontendSession {
         named_method_dependencies.dedup();
         named_destructor_dependencies.sort();
         named_destructor_dependencies.dedup();
+        declaration_type_dependencies.sort();
+        declaration_type_dependencies.dedup();
         let work = SemanticDependencyManifestWork {
             definition_records_visited: definition_records.len(),
             import_records_visited: imports.graph().records().len(),
@@ -899,6 +934,7 @@ impl CanonicalFrontendSession {
             specialization_origins_validated,
             named_method_events_translated,
             named_destructor_events_translated,
+            declaration_type_events_translated,
             extra_rir_instructions_visited: 0,
         };
         self.work.dependency_manifest_records_visited += work.definition_records_visited;
@@ -942,6 +978,8 @@ impl CanonicalFrontendSession {
             generic_named_method_dependencies_complete: false,
             named_destructor_dependencies: named_destructor_dependencies.into(),
             named_destructor_dependencies_complete,
+            declaration_type_dependencies: declaration_type_dependencies.into(),
+            declaration_type_dependencies_complete,
             semantic_dependency_graph_complete: false,
             definition_universe_complete,
             work,
@@ -1024,6 +1062,96 @@ fn stable_named_destructor_endpoint(
         return Err(invalid_dependency_manifest(&format!(
             "named-destructor dependency endpoint ({file}, '{owner_name}') did not join exactly one bound destructor",
         )));
+    };
+    Ok(record.stable_key().clone())
+}
+
+fn stable_declaration_source_endpoint(
+    definitions: &BoundDefinitionSet,
+    event: &rue_air::DeclarationTypeDependencyEvent,
+) -> Result<StableDefinitionKey, CompileErrors> {
+    use rue_air::DeclarationTypeDependencySourceKind as K;
+    match event.source_kind {
+        K::Function => {
+            stable_free_function_endpoint(definitions, event.source_file, &event.source_name)
+        }
+        K::Method | K::AssociatedFunction => stable_named_method_endpoint(
+            definitions,
+            event.source_file,
+            event.source_owner_name.as_deref().unwrap_or(""),
+            &event.source_name,
+        ),
+        K::Destructor => stable_named_destructor_endpoint(
+            definitions,
+            event.source_file,
+            event
+                .source_owner_name
+                .as_deref()
+                .unwrap_or(&event.source_name),
+        ),
+        K::Struct => stable_top_level_endpoint(
+            definitions,
+            event.source_file,
+            &event.source_name,
+            StableDefinitionNamespace::Type,
+            StableDefinitionKind::Struct,
+        ),
+        K::Enum => stable_top_level_endpoint(
+            definitions,
+            event.source_file,
+            &event.source_name,
+            StableDefinitionNamespace::Type,
+            StableDefinitionKind::Enum,
+        ),
+        K::ValueConst => stable_top_level_endpoint(
+            definitions,
+            event.source_file,
+            &event.source_name,
+            StableDefinitionNamespace::Value,
+            StableDefinitionKind::ValueConst,
+        ),
+    }
+}
+
+fn stable_named_type_endpoint(
+    definitions: &BoundDefinitionSet,
+    event: &rue_air::DeclarationTypeDependencyEvent,
+) -> Result<StableDefinitionKey, CompileErrors> {
+    let kind = match event.target_kind {
+        rue_air::DeclarationTypeDependencyTargetKind::Struct => StableDefinitionKind::Struct,
+        rue_air::DeclarationTypeDependencyTargetKind::Enum => StableDefinitionKind::Enum,
+    };
+    stable_top_level_endpoint(
+        definitions,
+        event.target_file,
+        &event.target_name,
+        StableDefinitionNamespace::Type,
+        kind,
+    )
+}
+
+fn stable_top_level_endpoint(
+    definitions: &BoundDefinitionSet,
+    file: u32,
+    name: &str,
+    namespace: StableDefinitionNamespace,
+    kind: StableDefinitionKind,
+) -> Result<StableDefinitionKey, CompileErrors> {
+    let matches = definitions
+        .definitions()
+        .iter()
+        .filter(|record| {
+            record.declaration_span().file_id.index() == file
+                && record.stable_key().name() == name
+                && record.stable_key().namespace() == namespace
+                && record.stable_key().kind() == kind
+                && record.stable_key().owner().is_none()
+        })
+        .collect::<Vec<_>>();
+    let [record] = matches.as_slice() else {
+        return Err(invalid_dependency_manifest(
+            "declaration-type dependency endpoint did not join exactly one stable definition",
+        ));
     };
     Ok(record.stable_key().clone())
 }
@@ -2257,6 +2385,69 @@ mod tests {
         assert!(first.named_destructor_dependencies_complete());
         assert_eq!(first.work().named_destructor_events_translated, 1);
         assert_eq!(first.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn resolved_declaration_type_edges_translate_without_rir_rescan() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                r#"
+                struct Leaf { n: i32 }
+                struct Holder { leaf: Leaf, fn get(borrow self, value: Leaf) -> Leaf { value } }
+                enum Choice { One(Leaf) }
+                fn convert(value: Leaf) -> Holder { Holder { leaf: value } }
+                drop fn Holder(self) {}
+                fn main() -> i32 { 0 }
+            "#,
+            )],
+            1,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        let manifest = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        let names = manifest
+            .declaration_type_dependencies()
+            .iter()
+            .map(|edge| {
+                (
+                    edge.source.name().to_owned(),
+                    edge.target.name().to_owned(),
+                    edge.kind,
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(names.contains(&(
+            "Holder".into(),
+            "Leaf".into(),
+            rue_air::DeclarationTypeDependencyKind::Field
+        )));
+        assert!(names.contains(&(
+            "Choice".into(),
+            "Leaf".into(),
+            rue_air::DeclarationTypeDependencyKind::Payload
+        )));
+        assert!(names.contains(&(
+            "convert".into(),
+            "Leaf".into(),
+            rue_air::DeclarationTypeDependencyKind::Signature
+        )));
+        assert!(names.contains(&(
+            "get".into(),
+            "Leaf".into(),
+            rue_air::DeclarationTypeDependencyKind::Signature
+        )));
+        assert!(names.contains(&(
+            "Holder".into(),
+            "Holder".into(),
+            rue_air::DeclarationTypeDependencyKind::Owner
+        )));
+        assert!(!manifest.declaration_type_dependencies_complete());
+        assert_eq!(manifest.work().extra_rir_instructions_visited, 0);
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -65,8 +65,9 @@ pub use frontend_session::{
     CanonicalImportGraphOutput, DefinitionQueryRecord, FrontendDiagnosticSnapshot,
     FrontendDiagnosticStage, FrontendQueryWork, ImportGraphInputDescriptor,
     SemanticDependencyInputManifest, SemanticDependencyManifestWork, SemanticQueryRecord,
-    StableFreeFunctionDependency, StableModuleImportDependency, StableNamedDestructorDependency,
-    StableNamedMethodDependency, StableNamedMethodDependencyTarget,
+    StableDeclarationTypeDependency, StableFreeFunctionDependency, StableModuleImportDependency,
+    StableNamedDestructorDependency, StableNamedMethodDependency,
+    StableNamedMethodDependencyTarget,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -155,3 +155,21 @@ named owner declaration FileId/name and compiler translation joins the
 Destructor namespace/kind and owner in the exact `BoundDefinitionSet`.
 `named_destructor_dependencies_complete` covers named destructors; anonymous
 destructors remain a separate incomplete surface.
+
+Resolved declaration tables now publish a conservative nominal-type edge slice
+for struct fields, enum payloads, ordinary function signatures, named
+method/associated-function signatures and owners, constant value types, and
+named destructor owners. Arrays and pointers are traversed to their nominal
+leaf; builtins and anonymous/structural types do not invent definition keys.
+Compiler translation joins both endpoints against the exact bound-definition
+revision and retains the field/payload/signature/declared-type/owner edge kind,
+with zero additional RIR traversal.
+
+This slice deliberately reports `declaration_type_dependencies_complete=false`.
+Generic signatures replace any type mentioning a comptime parameter with
+`COMPTIME_TYPE`, so outer type-constructor syntax such as `Option(Result(T))`
+is not present in the resolved table. In Rue those heads are comptime type
+functions rather than named type definitions. A future pre-substitution
+observer must classify stable type-function dependencies and aliases before
+this surface can become complete; the conservative resolved edges must not
+drive reuse meanwhile.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -62,6 +62,11 @@ incremental-compilation goal is complete.
    owner identities and tagged free/method targets. Anonymous methods and
    destructors plus declaration/type/const/drop surfaces keep the overall graph
    explicitly incomplete and prevent body/CFG reuse.
+   A conservative resolved declaration-type slice now translates nominal
+   signature/field/payload/constant/owner edges without rescanning RIR. Generic
+   composites are still erased to `COMPTIME_TYPE` before this observer, and Rue
+   type-call heads are functions rather than named types, so this surface stays
+   explicitly incomplete pending a pre-substitution constructor/alias model.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## What changed

- records resolved nominal type dependencies while binding function, method, struct, enum, constant, and destructor declarations
- preserves authoritative source owner and target identities before generic/type-pool erasure
- translates declaration-type edges into stable definition keys without rescanning RIR
- exposes deterministic completeness/work evidence with cross-module and relocation coverage

## Why

Changes to a named struct or enum signature must invalidate declarations whose resolved types depend on it. Capturing those edges during declaration binding avoids unreliable syntax reconstruction after aliases and generics have been resolved.

## Validation

- formatting passed
- AIR and compiler tests passed
- benchmark structural gates passed
- workspace clippy, quick, and full suites passed on the integrated stack