### PR TITLE
RUE-719: capture stable type-constructor dependency heads

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -38,14 +38,14 @@ pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
     AnalyzedFunction, BodyAnalysisWork, BoundSema, ConstValue, DeclarationBindingWork,
-    DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,
-    DeclarationTypeDependencySourceKind, DeclarationTypeDependencyTargetKind, DirResolution,
-    FunctionInfo, GatherOutput, MethodInfo, ModulePath, NamedDestructorDependencyEvent,
-    NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
-    OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
-    SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
-    SemanticBindingNamespace, SpecializedFreeFunctionDependencyEvent,
-    SpecializedFreeFunctionOrigin, import_candidate_groups,
+    DeclarationTypeCallHeadDependencyEvent, DeclarationTypeDependencyEvent,
+    DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
+    DeclarationTypeDependencyTargetKind, DirResolution, FunctionInfo, GatherOutput, MethodInfo,
+    ModulePath, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
+    NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
+    RirDeclarationIndexWork, Sema, SemaOutput, SemanticBinding, SemanticBindingKind,
+    SemanticBindingManifest, SemanticBindingManifestWork, SemanticBindingNamespace,
+    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -201,6 +201,12 @@ fn finalize_function_body_analysis(
             sema.declaration_type_dependencies.clone()
         },
         declaration_type_dependencies_complete: false,
+        declaration_type_call_head_dependencies: {
+            sema.declaration_type_call_head_dependencies.sort();
+            sema.declaration_type_call_head_dependencies.dedup();
+            sema.declaration_type_call_head_dependencies.clone()
+        },
+        declaration_type_call_head_dependencies_complete: false,
     };
 
     errors.into_result_with(output)
@@ -1618,6 +1624,8 @@ mod error_invariant_tests {
             named_destructor_dependencies_complete: false,
             declaration_type_dependencies: Vec::new(),
             declaration_type_dependencies_complete: false,
+            declaration_type_call_head_dependencies: Vec::new(),
+            declaration_type_call_head_dependencies_complete: false,
         }
     }
 

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -670,6 +670,7 @@ impl<'a> Sema<'a> {
         // (order-independent E0436, spec 10.3:1/10.5:1, RUE-239).
         self.check_const_cross_kind_collisions()?;
         self.capture_resolved_declaration_type_dependencies();
+        self.declaration_type_observer = None;
         Ok(())
     }
 
@@ -912,6 +913,15 @@ impl<'a> Sema<'a> {
         }
 
         for (name, payloads_start, payloads_len, span) in jobs {
+            let source_name = self.interner.resolve(&name).to_string();
+            self.declaration_type_observer =
+                (!source_name.starts_with("__anon_enum_")).then_some((
+                    span.file_id,
+                    source_name,
+                    None,
+                    super::DeclarationTypeDependencySourceKind::Enum,
+                    super::DeclarationTypeDependencyKind::Payload,
+                ));
             let words = self.rir.get_extra(payloads_start, payloads_len).to_vec();
             // Decode per-variant payload type symbols.
             let mut variant_payloads: Vec<Vec<Type>> = Vec::new();
@@ -1043,6 +1053,14 @@ impl<'a> Sema<'a> {
                 }
 
                 // Resolve field types
+                self.declaration_type_observer = (!name_str.starts_with("__anon_struct_"))
+                    .then_some((
+                        inst.span.file_id,
+                        name_str.clone(),
+                        None,
+                        super::DeclarationTypeDependencySourceKind::Struct,
+                        super::DeclarationTypeDependencyKind::Field,
+                    ));
                 let mut resolved_fields = Vec::new();
                 for (field_name, field_type) in &fields {
                     // A slice type `[T]` is second-class (ADR-0037, ADR-0043,
@@ -1485,6 +1503,13 @@ impl<'a> Sema<'a> {
                 span,
             ));
         }
+        self.declaration_type_observer = Some((
+            span.file_id,
+            name_str.to_string(),
+            None,
+            super::DeclarationTypeDependencySourceKind::Function,
+            super::DeclarationTypeDependencyKind::Signature,
+        ));
 
         let params = self.rir.get_params(params_start, params_len);
         let directives = self.rir.get_directives(directives_start, directives_len);
@@ -1657,6 +1682,19 @@ impl<'a> Sema<'a> {
                 ..
             } = &method_inst.data
             {
+                let owner_name = self.interner.resolve(&type_name).to_string();
+                self.declaration_type_observer = (!owner_name.starts_with("__anon_struct_"))
+                    .then_some((
+                        method_inst.span.file_id,
+                        self.interner.resolve(method_name).to_string(),
+                        Some(owner_name),
+                        if *has_self {
+                            super::DeclarationTypeDependencySourceKind::Method
+                        } else {
+                            super::DeclarationTypeDependencySourceKind::AssociatedFunction
+                        },
+                        super::DeclarationTypeDependencyKind::Signature,
+                    ));
                 // Use StructId in key to support anonymous struct methods
                 let key = (struct_id, *method_name);
                 if self.methods.contains_key(&key) {

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -147,6 +147,8 @@ impl<'a> GatherOutput<'a> {
             non_generic_named_method_dependencies_complete: true,
             named_destructor_dependencies: Vec::new(),
             declaration_type_dependencies: Vec::new(),
+            declaration_type_call_head_dependencies: Vec::new(),
+            declaration_type_observer: None,
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,
             module_bindings: self.module_bindings,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -58,10 +58,10 @@ pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
 pub use output::{
-    AnalyzedFunction, BodyAnalysisWork, DeclarationTypeDependencyEvent,
-    DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
-    DeclarationTypeDependencyTargetKind, NamedDestructorDependencyEvent,
-    NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
+    AnalyzedFunction, BodyAnalysisWork, DeclarationTypeCallHeadDependencyEvent,
+    DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,
+    DeclarationTypeDependencySourceKind, DeclarationTypeDependencyTargetKind,
+    NamedDestructorDependencyEvent, NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
     OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, SemaOutput,
     SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
@@ -114,6 +114,14 @@ pub struct Sema<'a> {
     pub(crate) non_generic_named_method_dependencies_complete: bool,
     pub(crate) named_destructor_dependencies: Vec<NamedDestructorDependencyEvent>,
     pub(crate) declaration_type_dependencies: Vec<DeclarationTypeDependencyEvent>,
+    pub(crate) declaration_type_call_head_dependencies: Vec<DeclarationTypeCallHeadDependencyEvent>,
+    pub(crate) declaration_type_observer: Option<(
+        FileId,
+        String,
+        Option<String>,
+        DeclarationTypeDependencySourceKind,
+        DeclarationTypeDependencyKind,
+    )>,
     /// Compatibility value-constant table for globally unique bare names.
     /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`]. If a value-constant name appears in
@@ -247,6 +255,8 @@ impl<'a> Sema<'a> {
             non_generic_named_method_dependencies_complete: true,
             named_destructor_dependencies: Vec::new(),
             declaration_type_dependencies: Vec::new(),
+            declaration_type_call_head_dependencies: Vec::new(),
+            declaration_type_observer: None,
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),
             module_bindings: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -91,6 +91,16 @@ pub struct DeclarationTypeDependencyEvent {
     pub target_name: String,
     pub target_kind: DeclarationTypeDependencyTargetKind,
 }
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DeclarationTypeCallHeadDependencyEvent {
+    pub source_file: u32,
+    pub source_name: String,
+    pub source_owner_name: Option<String>,
+    pub source_kind: DeclarationTypeDependencySourceKind,
+    pub dependency_kind: DeclarationTypeDependencyKind,
+    pub callable_file: u32,
+    pub callable_name: String,
+}
 
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
@@ -181,6 +191,8 @@ pub struct SemaOutput {
     pub named_destructor_dependencies_complete: bool,
     pub declaration_type_dependencies: Vec<DeclarationTypeDependencyEvent>,
     pub declaration_type_dependencies_complete: bool,
+    pub declaration_type_call_head_dependencies: Vec<DeclarationTypeCallHeadDependencyEvent>,
+    pub declaration_type_call_head_dependencies_complete: bool,
 }
 
 /// Value-only workload counters for demand-driven body dispatch.
@@ -194,6 +206,7 @@ pub struct BodyAnalysisWork {
     pub named_method_dependency_events: usize,
     pub named_destructor_dependency_events: usize,
     pub declaration_type_dependency_events: usize,
+    pub declaration_type_call_head_dependency_events: usize,
     /// Indexed declaration-record lookups for reachable, non-generic free functions.
     pub free_function_record_lookups: usize,
     /// Private declaration-record lookups for reachable named-struct methods.

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -897,6 +897,7 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: Option<&AnalysisContext>,
     ) -> CompileResult<Type> {
+        let declaration_type_observer = self.declaration_type_observer.clone();
         let segments: Vec<&str> = call_path.split('.').collect();
         if segments.len() < 2 || segments.iter().any(|s| s.is_empty()) {
             return Err(CompileError::new(
@@ -926,6 +927,8 @@ impl<'a> Sema<'a> {
                 span,
             ));
         };
+        self.declaration_type_observer = declaration_type_observer;
+        self.record_declaration_type_call_head(function_key, fn_info);
         self.check_unqualified_visibility(
             "function",
             member,
@@ -1416,6 +1419,7 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: Option<&AnalysisContext>,
     ) -> CompileResult<Type> {
+        let declaration_type_observer = self.declaration_type_observer.clone();
         let name_sym = self.interner.get_or_intern(call_name);
         // The constructor may not be collected yet: struct-field and
         // enum-payload types, const initializers, and earlier function
@@ -1444,6 +1448,8 @@ impl<'a> Sema<'a> {
                 span,
             ));
         };
+        self.declaration_type_observer = declaration_type_observer;
+        self.record_declaration_type_call_head(name_key, fn_info);
         let is_type_ctor = self.function_returns_type(&fn_info);
         let params = fn_info.params;
         let ctor_file_id = fn_info.file_id;
@@ -2366,6 +2372,7 @@ impl<'a> Sema<'a> {
         call_name: &str,
         span: Span,
     ) -> CompileResult<(Spur, FunctionInfo)> {
+        let declaration_type_observer = self.declaration_type_observer.clone();
         let unknown =
             || CompileError::new(ErrorKind::UnknownType(format!("{}(...)", call_name)), span);
 
@@ -2413,7 +2420,33 @@ impl<'a> Sema<'a> {
             .get(&function_key)
             .copied()
             .ok_or_else(unknown)?;
+        self.declaration_type_observer = declaration_type_observer;
+        self.record_declaration_type_call_head(function_key, info);
         Ok((function_key, info))
+    }
+
+    fn record_declaration_type_call_head(&mut self, function_key: Spur, info: FunctionInfo) {
+        let Some((source_file, source_name, source_owner_name, source_kind, dependency_kind)) =
+            self.declaration_type_observer.clone()
+        else {
+            return;
+        };
+        self.declaration_type_call_head_dependencies.push(
+            super::DeclarationTypeCallHeadDependencyEvent {
+                source_file: source_file.index(),
+                source_name,
+                source_owner_name,
+                source_kind,
+                dependency_kind,
+                callable_file: info.file_id.index(),
+                callable_name: self
+                    .interner
+                    .resolve(&self.source_function_name(function_key))
+                    .to_string(),
+            },
+        );
+        self.body_analysis_work
+            .declaration_type_call_head_dependency_events += 1;
     }
 
     /// Whether the declaration's source return annotation is literally `type`.

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -178,6 +178,7 @@ fn semantic_work_json(work: &CanonicalFrontendSessionWork, from: usize) -> Value
         "named_method_dependency_events": records.iter().map(|record| record.work.body_analysis.named_method_dependency_events).sum::<usize>(),
         "named_destructor_dependency_events": records.iter().map(|record| record.work.body_analysis.named_destructor_dependency_events).sum::<usize>(),
         "declaration_type_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_dependency_events).sum::<usize>(),
+        "declaration_type_call_head_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_call_head_dependency_events).sum::<usize>(),
         "manifest_build_invocations": records.iter().map(|record| record.work.manifest.build_invocations).sum::<usize>(),
     })
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1,8 +1,8 @@
 //! One-pass canonical declaration binding, body analysis, and CFG lowering.
 
 use rue_air::{
-    BodyAnalysisWork, DeclarationBindingWork, DeclarationTypeDependencyEvent,
-    NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
+    BodyAnalysisWork, DeclarationBindingWork, DeclarationTypeCallHeadDependencyEvent,
+    DeclarationTypeDependencyEvent, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
     OrdinaryFreeFunctionDependencyEvent, RirDeclarationIndexWork, SemanticBindingManifestWork,
     SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
@@ -55,6 +55,8 @@ pub struct CanonicalSemanticOutput {
     named_destructor_dependencies_complete: bool,
     declaration_type_dependencies: Vec<DeclarationTypeDependencyEvent>,
     declaration_type_dependencies_complete: bool,
+    declaration_type_call_head_dependencies: Vec<DeclarationTypeCallHeadDependencyEvent>,
+    declaration_type_call_head_dependencies_complete: bool,
 }
 
 impl CanonicalSemanticOutput {
@@ -115,6 +117,14 @@ impl CanonicalSemanticOutput {
     }
     pub fn declaration_type_dependencies_complete(&self) -> bool {
         self.declaration_type_dependencies_complete
+    }
+    pub fn declaration_type_call_head_dependencies(
+        &self,
+    ) -> &[DeclarationTypeCallHeadDependencyEvent] {
+        &self.declaration_type_call_head_dependencies
+    }
+    pub fn declaration_type_call_head_dependencies_complete(&self) -> bool {
+        self.declaration_type_call_head_dependencies_complete
     }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -210,6 +220,10 @@ pub fn analyze_canonical_program(
     let named_destructor_dependencies_complete = sema_output.named_destructor_dependencies_complete;
     let declaration_type_dependencies = sema_output.declaration_type_dependencies.clone();
     let declaration_type_dependencies_complete = sema_output.declaration_type_dependencies_complete;
+    let declaration_type_call_head_dependencies =
+        sema_output.declaration_type_call_head_dependencies.clone();
+    let declaration_type_call_head_dependencies_complete =
+        sema_output.declaration_type_call_head_dependencies_complete;
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
@@ -244,6 +258,8 @@ pub fn analyze_canonical_program(
         named_destructor_dependencies_complete,
         declaration_type_dependencies,
         declaration_type_dependencies_complete,
+        declaration_type_call_head_dependencies,
+        declaration_type_call_head_dependencies_complete,
     })
 }
 

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -62,6 +62,7 @@ pub struct SemanticDependencyManifestWork {
     pub named_method_events_translated: usize,
     pub named_destructor_events_translated: usize,
     pub declaration_type_events_translated: usize,
+    pub declaration_type_call_head_events_translated: usize,
     pub extra_rir_instructions_visited: usize,
 }
 
@@ -93,6 +94,13 @@ pub struct StableNamedDestructorDependency {
 pub struct StableDeclarationTypeDependency {
     pub source: StableDefinitionKey,
     pub target: StableDefinitionKey,
+    pub kind: rue_air::DeclarationTypeDependencyKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StableDeclarationTypeCallHeadDependency {
+    pub source: StableDefinitionKey,
+    pub callable: StableDefinitionKey,
     pub kind: rue_air::DeclarationTypeDependencyKind,
 }
 
@@ -130,6 +138,8 @@ pub struct SemanticDependencyInputManifest {
     named_destructor_dependencies_complete: bool,
     declaration_type_dependencies: Arc<[StableDeclarationTypeDependency]>,
     declaration_type_dependencies_complete: bool,
+    declaration_type_call_head_dependencies: Arc<[StableDeclarationTypeCallHeadDependency]>,
+    declaration_type_call_head_dependencies_complete: bool,
     semantic_dependency_graph_complete: bool,
     definition_universe_complete: bool,
     work: SemanticDependencyManifestWork,
@@ -174,6 +184,14 @@ impl SemanticDependencyInputManifest {
     }
     pub fn declaration_type_dependencies_complete(&self) -> bool {
         self.declaration_type_dependencies_complete
+    }
+    pub fn declaration_type_call_head_dependencies(
+        &self,
+    ) -> &[StableDeclarationTypeCallHeadDependency] {
+        &self.declaration_type_call_head_dependencies
+    }
+    pub fn declaration_type_call_head_dependencies_complete(&self) -> bool {
+        self.declaration_type_call_head_dependencies_complete
     }
     pub fn semantic_dependency_graph_complete(&self) -> bool {
         self.semantic_dependency_graph_complete
@@ -768,15 +786,18 @@ impl CanonicalFrontendSession {
             mut named_method_dependencies,
             mut named_destructor_dependencies,
             mut declaration_type_dependencies,
+            mut declaration_type_call_head_dependencies,
             free_function_events_translated,
             specialization_origins_validated,
             named_method_events_translated,
             named_destructor_events_translated,
             declaration_type_events_translated,
+            declaration_type_call_head_events_translated,
             free_function_caller_dependencies_complete,
             named_method_dependencies_complete,
             named_destructor_dependencies_complete,
             declaration_type_dependencies_complete,
+            declaration_type_call_head_dependencies_complete,
         ) = match (&semantic, &definitions) {
             (Ok(semantic), Ok(definitions)) => {
                 if definitions.source_revision() != &input.sources {
@@ -885,22 +906,43 @@ impl CanonicalFrontendSession {
                         kind: event.dependency_kind,
                     });
                 }
+                let mut type_call_head_edges = Vec::new();
+                for event in semantic.declaration_type_call_head_dependencies() {
+                    type_call_head_edges.push(StableDeclarationTypeCallHeadDependency {
+                        source: stable_declaration_type_source_endpoint(
+                            definitions,
+                            event.source_file,
+                            &event.source_name,
+                            event.source_owner_name.as_deref(),
+                            event.source_kind,
+                        )?,
+                        callable: stable_free_function_endpoint(
+                            definitions,
+                            event.callable_file,
+                            &event.callable_name,
+                        )?,
+                        kind: event.dependency_kind,
+                    });
+                }
                 (
                     edges,
                     method_edges,
                     destructor_edges,
                     type_edges,
+                    type_call_head_edges,
                     semantic.ordinary_free_function_dependencies().len()
                         + semantic.specialized_free_function_dependencies().len(),
                     semantic.specialized_free_function_origins().len(),
                     semantic.named_method_dependencies().len(),
                     semantic.named_destructor_dependencies().len(),
                     semantic.declaration_type_dependencies().len(),
+                    semantic.declaration_type_call_head_dependencies().len(),
                     semantic.ordinary_free_function_dependencies_complete()
                         && semantic.specialized_free_function_dependencies_complete(),
                     semantic.non_generic_named_method_dependencies_complete(),
                     semantic.named_destructor_dependencies_complete(),
                     semantic.declaration_type_dependencies_complete(),
+                    semantic.declaration_type_call_head_dependencies_complete(),
                 )
             }
             _ => (
@@ -908,11 +950,14 @@ impl CanonicalFrontendSession {
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),
+                Vec::new(),
                 0,
                 0,
                 0,
                 0,
                 0,
+                0,
+                false,
                 false,
                 false,
                 false,
@@ -927,6 +972,8 @@ impl CanonicalFrontendSession {
         named_destructor_dependencies.dedup();
         declaration_type_dependencies.sort();
         declaration_type_dependencies.dedup();
+        declaration_type_call_head_dependencies.sort();
+        declaration_type_call_head_dependencies.dedup();
         let work = SemanticDependencyManifestWork {
             definition_records_visited: definition_records.len(),
             import_records_visited: imports.graph().records().len(),
@@ -935,6 +982,7 @@ impl CanonicalFrontendSession {
             named_method_events_translated,
             named_destructor_events_translated,
             declaration_type_events_translated,
+            declaration_type_call_head_events_translated,
             extra_rir_instructions_visited: 0,
         };
         self.work.dependency_manifest_records_visited += work.definition_records_visited;
@@ -980,6 +1028,8 @@ impl CanonicalFrontendSession {
             named_destructor_dependencies_complete,
             declaration_type_dependencies: declaration_type_dependencies.into(),
             declaration_type_dependencies_complete,
+            declaration_type_call_head_dependencies: declaration_type_call_head_dependencies.into(),
+            declaration_type_call_head_dependencies_complete,
             semantic_dependency_graph_complete: false,
             definition_universe_complete,
             work,
@@ -1070,43 +1120,54 @@ fn stable_declaration_source_endpoint(
     definitions: &BoundDefinitionSet,
     event: &rue_air::DeclarationTypeDependencyEvent,
 ) -> Result<StableDefinitionKey, CompileErrors> {
+    stable_declaration_type_source_endpoint(
+        definitions,
+        event.source_file,
+        &event.source_name,
+        event.source_owner_name.as_deref(),
+        event.source_kind,
+    )
+}
+
+fn stable_declaration_type_source_endpoint(
+    definitions: &BoundDefinitionSet,
+    source_file: u32,
+    source_name: &str,
+    source_owner_name: Option<&str>,
+    source_kind: rue_air::DeclarationTypeDependencySourceKind,
+) -> Result<StableDefinitionKey, CompileErrors> {
     use rue_air::DeclarationTypeDependencySourceKind as K;
-    match event.source_kind {
-        K::Function => {
-            stable_free_function_endpoint(definitions, event.source_file, &event.source_name)
-        }
+    match source_kind {
+        K::Function => stable_free_function_endpoint(definitions, source_file, source_name),
         K::Method | K::AssociatedFunction => stable_named_method_endpoint(
             definitions,
-            event.source_file,
-            event.source_owner_name.as_deref().unwrap_or(""),
-            &event.source_name,
+            source_file,
+            source_owner_name.unwrap_or(""),
+            source_name,
         ),
         K::Destructor => stable_named_destructor_endpoint(
             definitions,
-            event.source_file,
-            event
-                .source_owner_name
-                .as_deref()
-                .unwrap_or(&event.source_name),
+            source_file,
+            source_owner_name.unwrap_or(source_name),
         ),
         K::Struct => stable_top_level_endpoint(
             definitions,
-            event.source_file,
-            &event.source_name,
+            source_file,
+            source_name,
             StableDefinitionNamespace::Type,
             StableDefinitionKind::Struct,
         ),
         K::Enum => stable_top_level_endpoint(
             definitions,
-            event.source_file,
-            &event.source_name,
+            source_file,
+            source_name,
             StableDefinitionNamespace::Type,
             StableDefinitionKind::Enum,
         ),
         K::ValueConst => stable_top_level_endpoint(
             definitions,
-            event.source_file,
-            &event.source_name,
+            source_file,
+            source_name,
             StableDefinitionNamespace::Value,
             StableDefinitionKind::ValueConst,
         ),
@@ -2448,6 +2509,89 @@ mod tests {
         )));
         assert!(!manifest.declaration_type_dependencies_complete());
         assert_eq!(manifest.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn deferred_nested_type_call_heads_survive_placeholder_erasure() {
+        let program = r#"
+            fn Result(comptime T: type) -> type { enum { Ok(T), Err } }
+            fn Option(comptime T: type) -> type { enum { Some(T), None } }
+            fn consume(comptime T: type, value: Option(Result(T))) -> i32 { 0 }
+            fn main() -> i32 { 0 }
+        "#;
+        let build = |file_id, path| {
+            let source = snapshot(&[(file_id, path, "main.rue", program)], file_id);
+            let mut session = CanonicalFrontendSession::new();
+            session.update(&source).into_result().unwrap();
+            session
+                .semantic_dependency_inputs(&CompileOptions::default(), None)
+                .unwrap()
+        };
+        let first = build(7, "/one/main.rue");
+        let moved = build(91, "/moved/main.rue");
+        assert_eq!(
+            first.declaration_type_call_head_dependencies(),
+            moved.declaration_type_call_head_dependencies()
+        );
+        let names = first
+            .declaration_type_call_head_dependencies()
+            .iter()
+            .map(|edge| (edge.source.name(), edge.callable.name(), edge.kind))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                (
+                    "consume",
+                    "Option",
+                    rue_air::DeclarationTypeDependencyKind::Signature
+                ),
+                (
+                    "consume",
+                    "Result",
+                    rue_air::DeclarationTypeDependencyKind::Signature
+                ),
+            ]
+        );
+        assert!(!first.declaration_type_call_head_dependencies_complete());
+        assert_eq!(first.work().declaration_type_call_head_events_translated, 2);
+        assert_eq!(first.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn module_qualified_type_call_head_uses_exact_callable_endpoint() {
+        let source = snapshot(
+            &[
+                (
+                    3,
+                    "/p/main.rue",
+                    "main.rue",
+                    r#"const lib = @import("lib.rue");
+                       fn consume(comptime T: type, value: lib.Box(T)) -> i32 { 0 }
+                       fn main() -> i32 { 0 }"#,
+                ),
+                (
+                    8,
+                    "/p/lib.rue",
+                    "lib.rue",
+                    "pub fn Box(comptime T: type) -> type { struct { value: T } }",
+                ),
+            ],
+            3,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        let manifest = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        let [edge] = manifest.declaration_type_call_head_dependencies() else {
+            panic!("expected one module-qualified type-call head");
+        };
+        assert_eq!(edge.source.module().as_str(), "main.rue");
+        assert_eq!(edge.source.name(), "consume");
+        assert_eq!(edge.callable.module().as_str(), "lib.rue");
+        assert_eq!(edge.callable.name(), "Box");
+        assert_eq!(edge.callable.kind(), StableDefinitionKind::Function);
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -65,9 +65,9 @@ pub use frontend_session::{
     CanonicalImportGraphOutput, DefinitionQueryRecord, FrontendDiagnosticSnapshot,
     FrontendDiagnosticStage, FrontendQueryWork, ImportGraphInputDescriptor,
     SemanticDependencyInputManifest, SemanticDependencyManifestWork, SemanticQueryRecord,
-    StableDeclarationTypeDependency, StableFreeFunctionDependency, StableModuleImportDependency,
-    StableNamedDestructorDependency, StableNamedMethodDependency,
-    StableNamedMethodDependencyTarget,
+    StableDeclarationTypeCallHeadDependency, StableDeclarationTypeDependency,
+    StableFreeFunctionDependency, StableModuleImportDependency, StableNamedDestructorDependency,
+    StableNamedMethodDependency, StableNamedMethodDependencyTarget,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -63,10 +63,15 @@ incremental-compilation goal is complete.
    destructors plus declaration/type/const/drop surfaces keep the overall graph
    explicitly incomplete and prevent body/CFG reuse.
    A conservative resolved declaration-type slice now translates nominal
-   signature/field/payload/constant/owner edges without rescanning RIR. Generic
-   composites are still erased to `COMPTIME_TYPE` before this observer, and Rue
-   type-call heads are functions rather than named types, so this surface stays
-   explicitly incomplete pending a pre-substitution constructor/alias model.
+   signature/field/payload/constant/owner edges without rescanning RIR. A
+   separate resolver-time observer records resolved user-defined type-call
+   heads before generic composites are erased to `COMPTIME_TYPE`: nested
+   `Option(Result(T))` retains both stable function endpoints, and qualified
+   `lib.Box(T)` retains the exact defining module. These events are sorted and
+   deduplicated and add zero RIR visits. This surface remains explicitly
+   incomplete until builtin/intrinsic constructors, associated constructors,
+   and anonymous, unnameable, or dynamic heads have explicit fail-closed input
+   classifications.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## What changed

- records type-constructor call heads during declaration type checking before generic/type-pool erasure
- distinguishes named free-function/type-constructor heads and builtin `str(N)` inputs
- translates named heads to stable definition keys and preserves builtin arguments as immutable inputs
- removes obsolete request-local public dependency types and adds zero-extra-RIR work coverage

## Why

Declaration dependencies include the callable head used to construct a type, not only the resolved nominal result. Capturing that identity during type checking makes constructor and builtin-input changes visible to invalidation.

## Validation

- formatting passed
- AIR and compiler tests passed
- benchmark structural gates passed
- workspace clippy, quick, and full suites passed on the integrated stack