### PR TITLE
RUE-719: classify supported type-call dependency heads

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -37,7 +37,8 @@ pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
-    AnalyzedFunction, BodyAnalysisWork, BoundSema, ConstValue, DeclarationBindingWork,
+    AnalyzedFunction, BodyAnalysisWork, BoundSema, BuiltinTypeCallHead, ConstValue,
+    DeclarationBindingWork, DeclarationBuiltinTypeCallHeadDependencyEvent,
     DeclarationTypeCallHeadDependencyEvent, DeclarationTypeDependencyEvent,
     DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
     DeclarationTypeDependencyTargetKind, DirResolution, FunctionInfo, GatherOutput, MethodInfo,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -207,6 +207,12 @@ fn finalize_function_body_analysis(
             sema.declaration_type_call_head_dependencies.clone()
         },
         declaration_type_call_head_dependencies_complete: false,
+        declaration_builtin_type_call_head_dependencies: {
+            sema.declaration_builtin_type_call_head_dependencies.sort();
+            sema.declaration_builtin_type_call_head_dependencies.dedup();
+            sema.declaration_builtin_type_call_head_dependencies.clone()
+        },
+        supported_type_call_heads_complete: true,
     };
 
     errors.into_result_with(output)
@@ -1626,6 +1632,8 @@ mod error_invariant_tests {
             declaration_type_dependencies_complete: false,
             declaration_type_call_head_dependencies: Vec::new(),
             declaration_type_call_head_dependencies_complete: false,
+            declaration_builtin_type_call_head_dependencies: Vec::new(),
+            supported_type_call_heads_complete: false,
         }
     }
 

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -148,6 +148,7 @@ impl<'a> GatherOutput<'a> {
             named_destructor_dependencies: Vec::new(),
             declaration_type_dependencies: Vec::new(),
             declaration_type_call_head_dependencies: Vec::new(),
+            declaration_builtin_type_call_head_dependencies: Vec::new(),
             declaration_type_observer: None,
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -58,7 +58,8 @@ pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use module_path::{DirResolution, ModulePath, import_candidate_groups};
 pub use output::{
-    AnalyzedFunction, BodyAnalysisWork, DeclarationTypeCallHeadDependencyEvent,
+    AnalyzedFunction, BodyAnalysisWork, BuiltinTypeCallHead,
+    DeclarationBuiltinTypeCallHeadDependencyEvent, DeclarationTypeCallHeadDependencyEvent,
     DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,
     DeclarationTypeDependencySourceKind, DeclarationTypeDependencyTargetKind,
     NamedDestructorDependencyEvent, NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
@@ -115,6 +116,8 @@ pub struct Sema<'a> {
     pub(crate) named_destructor_dependencies: Vec<NamedDestructorDependencyEvent>,
     pub(crate) declaration_type_dependencies: Vec<DeclarationTypeDependencyEvent>,
     pub(crate) declaration_type_call_head_dependencies: Vec<DeclarationTypeCallHeadDependencyEvent>,
+    pub(crate) declaration_builtin_type_call_head_dependencies:
+        Vec<DeclarationBuiltinTypeCallHeadDependencyEvent>,
     pub(crate) declaration_type_observer: Option<(
         FileId,
         String,
@@ -256,6 +259,7 @@ impl<'a> Sema<'a> {
             named_destructor_dependencies: Vec::new(),
             declaration_type_dependencies: Vec::new(),
             declaration_type_call_head_dependencies: Vec::new(),
+            declaration_builtin_type_call_head_dependencies: Vec::new(),
             declaration_type_observer: None,
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -102,6 +102,21 @@ pub struct DeclarationTypeCallHeadDependencyEvent {
     pub callable_name: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BuiltinTypeCallHead {
+    FixedCapacityString,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DeclarationBuiltinTypeCallHeadDependencyEvent {
+    pub source_file: u32,
+    pub source_name: String,
+    pub source_owner_name: Option<String>,
+    pub source_kind: DeclarationTypeDependencySourceKind,
+    pub dependency_kind: DeclarationTypeDependencyKind,
+    pub builtin: BuiltinTypeCallHead,
+}
+
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
 /// `by_ref` describes the physical calling convention: both `borrow` and
@@ -193,6 +208,9 @@ pub struct SemaOutput {
     pub declaration_type_dependencies_complete: bool,
     pub declaration_type_call_head_dependencies: Vec<DeclarationTypeCallHeadDependencyEvent>,
     pub declaration_type_call_head_dependencies_complete: bool,
+    pub declaration_builtin_type_call_head_dependencies:
+        Vec<DeclarationBuiltinTypeCallHeadDependencyEvent>,
+    pub supported_type_call_heads_complete: bool,
 }
 
 /// Value-only workload counters for demand-driven body dispatch.

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -2005,7 +2005,30 @@ impl<'a> Sema<'a> {
                 ));
             }
         };
+        self.record_declaration_builtin_type_call_head(
+            super::BuiltinTypeCallHead::FixedCapacityString,
+        );
         self.get_or_create_str_fixed_struct(capacity, span)
+    }
+
+    fn record_declaration_builtin_type_call_head(&mut self, builtin: super::BuiltinTypeCallHead) {
+        let Some((source_file, source_name, source_owner_name, source_kind, dependency_kind)) =
+            self.declaration_type_observer.clone()
+        else {
+            return;
+        };
+        self.declaration_builtin_type_call_head_dependencies.push(
+            super::DeclarationBuiltinTypeCallHeadDependencyEvent {
+                source_file: source_file.index(),
+                source_name,
+                source_owner_name,
+                source_kind,
+                dependency_kind,
+                builtin,
+            },
+        );
+        self.body_analysis_work
+            .declaration_type_call_head_dependency_events += 1;
     }
 
     /// Resolve the capacity argument `N` of a fixed-capacity string `Str(N)`

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -1,8 +1,9 @@
 //! One-pass canonical declaration binding, body analysis, and CFG lowering.
 
 use rue_air::{
-    BodyAnalysisWork, DeclarationBindingWork, DeclarationTypeCallHeadDependencyEvent,
-    DeclarationTypeDependencyEvent, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
+    BodyAnalysisWork, DeclarationBindingWork, DeclarationBuiltinTypeCallHeadDependencyEvent,
+    DeclarationTypeCallHeadDependencyEvent, DeclarationTypeDependencyEvent,
+    NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
     OrdinaryFreeFunctionDependencyEvent, RirDeclarationIndexWork, SemanticBindingManifestWork,
     SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
@@ -57,6 +58,9 @@ pub struct CanonicalSemanticOutput {
     declaration_type_dependencies_complete: bool,
     declaration_type_call_head_dependencies: Vec<DeclarationTypeCallHeadDependencyEvent>,
     declaration_type_call_head_dependencies_complete: bool,
+    declaration_builtin_type_call_head_dependencies:
+        Vec<DeclarationBuiltinTypeCallHeadDependencyEvent>,
+    supported_type_call_heads_complete: bool,
 }
 
 impl CanonicalSemanticOutput {
@@ -125,6 +129,14 @@ impl CanonicalSemanticOutput {
     }
     pub fn declaration_type_call_head_dependencies_complete(&self) -> bool {
         self.declaration_type_call_head_dependencies_complete
+    }
+    pub fn declaration_builtin_type_call_head_dependencies(
+        &self,
+    ) -> &[DeclarationBuiltinTypeCallHeadDependencyEvent] {
+        &self.declaration_builtin_type_call_head_dependencies
+    }
+    pub fn supported_type_call_heads_complete(&self) -> bool {
+        self.supported_type_call_heads_complete
     }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -224,6 +236,10 @@ pub fn analyze_canonical_program(
         sema_output.declaration_type_call_head_dependencies.clone();
     let declaration_type_call_head_dependencies_complete =
         sema_output.declaration_type_call_head_dependencies_complete;
+    let declaration_builtin_type_call_head_dependencies = sema_output
+        .declaration_builtin_type_call_head_dependencies
+        .clone();
+    let supported_type_call_heads_complete = sema_output.supported_type_call_heads_complete;
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
@@ -260,6 +276,8 @@ pub fn analyze_canonical_program(
         declaration_type_dependencies_complete,
         declaration_type_call_head_dependencies,
         declaration_type_call_head_dependencies_complete,
+        declaration_builtin_type_call_head_dependencies,
+        supported_type_call_heads_complete,
     })
 }
 

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -63,6 +63,7 @@ pub struct SemanticDependencyManifestWork {
     pub named_destructor_events_translated: usize,
     pub declaration_type_events_translated: usize,
     pub declaration_type_call_head_events_translated: usize,
+    pub builtin_type_call_head_inputs_translated: usize,
     pub extra_rir_instructions_visited: usize,
 }
 
@@ -105,6 +106,13 @@ pub struct StableDeclarationTypeCallHeadDependency {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StableBuiltinTypeCallHeadInput {
+    pub source: StableDefinitionKey,
+    pub builtin: rue_air::BuiltinTypeCallHead,
+    pub kind: rue_air::DeclarationTypeDependencyKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum StableModuleImportDependency {
     Resolved {
         importer: crate::ModuleId,
@@ -140,6 +148,8 @@ pub struct SemanticDependencyInputManifest {
     declaration_type_dependencies_complete: bool,
     declaration_type_call_head_dependencies: Arc<[StableDeclarationTypeCallHeadDependency]>,
     declaration_type_call_head_dependencies_complete: bool,
+    builtin_type_call_head_inputs: Arc<[StableBuiltinTypeCallHeadInput]>,
+    supported_type_call_heads_complete: bool,
     semantic_dependency_graph_complete: bool,
     definition_universe_complete: bool,
     work: SemanticDependencyManifestWork,
@@ -192,6 +202,12 @@ impl SemanticDependencyInputManifest {
     }
     pub fn declaration_type_call_head_dependencies_complete(&self) -> bool {
         self.declaration_type_call_head_dependencies_complete
+    }
+    pub fn builtin_type_call_head_inputs(&self) -> &[StableBuiltinTypeCallHeadInput] {
+        &self.builtin_type_call_head_inputs
+    }
+    pub fn supported_type_call_heads_complete(&self) -> bool {
+        self.supported_type_call_heads_complete
     }
     pub fn semantic_dependency_graph_complete(&self) -> bool {
         self.semantic_dependency_graph_complete
@@ -787,17 +803,20 @@ impl CanonicalFrontendSession {
             mut named_destructor_dependencies,
             mut declaration_type_dependencies,
             mut declaration_type_call_head_dependencies,
+            mut builtin_type_call_head_inputs,
             free_function_events_translated,
             specialization_origins_validated,
             named_method_events_translated,
             named_destructor_events_translated,
             declaration_type_events_translated,
             declaration_type_call_head_events_translated,
+            builtin_type_call_head_inputs_translated,
             free_function_caller_dependencies_complete,
             named_method_dependencies_complete,
             named_destructor_dependencies_complete,
             declaration_type_dependencies_complete,
             declaration_type_call_head_dependencies_complete,
+            supported_type_call_heads_complete,
         ) = match (&semantic, &definitions) {
             (Ok(semantic), Ok(definitions)) => {
                 if definitions.source_revision() != &input.sources {
@@ -924,12 +943,27 @@ impl CanonicalFrontendSession {
                         kind: event.dependency_kind,
                     });
                 }
+                let mut builtin_head_inputs = Vec::new();
+                for event in semantic.declaration_builtin_type_call_head_dependencies() {
+                    builtin_head_inputs.push(StableBuiltinTypeCallHeadInput {
+                        source: stable_declaration_type_source_endpoint(
+                            definitions,
+                            event.source_file,
+                            &event.source_name,
+                            event.source_owner_name.as_deref(),
+                            event.source_kind,
+                        )?,
+                        builtin: event.builtin,
+                        kind: event.dependency_kind,
+                    });
+                }
                 (
                     edges,
                     method_edges,
                     destructor_edges,
                     type_edges,
                     type_call_head_edges,
+                    builtin_head_inputs,
                     semantic.ordinary_free_function_dependencies().len()
                         + semantic.specialized_free_function_dependencies().len(),
                     semantic.specialized_free_function_origins().len(),
@@ -937,12 +971,16 @@ impl CanonicalFrontendSession {
                     semantic.named_destructor_dependencies().len(),
                     semantic.declaration_type_dependencies().len(),
                     semantic.declaration_type_call_head_dependencies().len(),
+                    semantic
+                        .declaration_builtin_type_call_head_dependencies()
+                        .len(),
                     semantic.ordinary_free_function_dependencies_complete()
                         && semantic.specialized_free_function_dependencies_complete(),
                     semantic.non_generic_named_method_dependencies_complete(),
                     semantic.named_destructor_dependencies_complete(),
                     semantic.declaration_type_dependencies_complete(),
                     semantic.declaration_type_call_head_dependencies_complete(),
+                    semantic.supported_type_call_heads_complete(),
                 )
             }
             _ => (
@@ -951,12 +989,15 @@ impl CanonicalFrontendSession {
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),
+                Vec::new(),
                 0,
                 0,
                 0,
                 0,
                 0,
                 0,
+                0,
+                false,
                 false,
                 false,
                 false,
@@ -974,6 +1015,8 @@ impl CanonicalFrontendSession {
         declaration_type_dependencies.dedup();
         declaration_type_call_head_dependencies.sort();
         declaration_type_call_head_dependencies.dedup();
+        builtin_type_call_head_inputs.sort();
+        builtin_type_call_head_inputs.dedup();
         let work = SemanticDependencyManifestWork {
             definition_records_visited: definition_records.len(),
             import_records_visited: imports.graph().records().len(),
@@ -983,6 +1026,7 @@ impl CanonicalFrontendSession {
             named_destructor_events_translated,
             declaration_type_events_translated,
             declaration_type_call_head_events_translated,
+            builtin_type_call_head_inputs_translated,
             extra_rir_instructions_visited: 0,
         };
         self.work.dependency_manifest_records_visited += work.definition_records_visited;
@@ -1030,6 +1074,8 @@ impl CanonicalFrontendSession {
             declaration_type_dependencies_complete,
             declaration_type_call_head_dependencies: declaration_type_call_head_dependencies.into(),
             declaration_type_call_head_dependencies_complete,
+            builtin_type_call_head_inputs: builtin_type_call_head_inputs.into(),
+            supported_type_call_heads_complete,
             semantic_dependency_graph_complete: false,
             definition_universe_complete,
             work,
@@ -2592,6 +2638,66 @@ mod tests {
         assert_eq!(edge.callable.module().as_str(), "lib.rue");
         assert_eq!(edge.callable.name(), "Box");
         assert_eq!(edge.callable.kind(), StableDefinitionKind::Function);
+    }
+
+    #[test]
+    fn fixed_string_type_head_is_a_builtin_input_not_a_definition() {
+        let source = snapshot(
+            &[(
+                4,
+                "/p/main.rue",
+                "main.rue",
+                "fn consume(value: Str(8)) -> i32 { 0 } fn main() -> i32 { 0 }",
+            )],
+            4,
+        );
+        let mut options = CompileOptions::default();
+        options
+            .preview_features
+            .insert("string_trio".parse().unwrap());
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        let manifest = session.semantic_dependency_inputs(&options, None).unwrap();
+        let [input] = manifest.builtin_type_call_head_inputs() else {
+            panic!("expected one fixed-string builtin input");
+        };
+        assert_eq!(input.source.name(), "consume");
+        assert_eq!(
+            input.builtin,
+            rue_air::BuiltinTypeCallHead::FixedCapacityString
+        );
+        assert!(
+            manifest
+                .declaration_type_call_head_dependencies()
+                .is_empty()
+        );
+        assert!(manifest.supported_type_call_heads_complete());
+        assert!(!manifest.declaration_type_call_head_dependencies_complete());
+        assert_eq!(manifest.work().builtin_type_call_head_inputs_translated, 1);
+        assert_eq!(manifest.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn named_owner_associated_type_head_is_not_supported_type_syntax() {
+        let source = snapshot(
+            &[(
+                6,
+                "/p/main.rue",
+                "main.rue",
+                r#"struct Factory {
+                       fn Make() -> type { struct { value: i32 } }
+                   }
+                   fn consume(value: Factory.Make()) -> i32 { 0 }
+                   fn main() -> i32 { 0 }"#,
+            )],
+            6,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        assert!(
+            session.semantic(&CompileOptions::default()).is_err(),
+            "dotted type-call heads are module-qualified free functions, not associated functions"
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -65,9 +65,10 @@ pub use frontend_session::{
     CanonicalImportGraphOutput, DefinitionQueryRecord, FrontendDiagnosticSnapshot,
     FrontendDiagnosticStage, FrontendQueryWork, ImportGraphInputDescriptor,
     SemanticDependencyInputManifest, SemanticDependencyManifestWork, SemanticQueryRecord,
-    StableDeclarationTypeCallHeadDependency, StableDeclarationTypeDependency,
-    StableFreeFunctionDependency, StableModuleImportDependency, StableNamedDestructorDependency,
-    StableNamedMethodDependency, StableNamedMethodDependencyTarget,
+    StableBuiltinTypeCallHeadInput, StableDeclarationTypeCallHeadDependency,
+    StableDeclarationTypeDependency, StableFreeFunctionDependency, StableModuleImportDependency,
+    StableNamedDestructorDependency, StableNamedMethodDependency,
+    StableNamedMethodDependencyTarget,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -173,3 +173,16 @@ functions rather than named type definitions. A future pre-substitution
 observer must classify stable type-function dependencies and aliases before
 this surface can become complete; the conservative resolved edges must not
 drive reuse meanwhile.
+
+The pre-substitution observer now classifies every type-call head accepted by
+the current resolver. User-defined free and module-qualified free comptime
+functions retain exact declaration endpoints. The preview-gated `Str(N)` head
+is a `FixedCapacityString` language-builtin input, not a fabricated source
+definition; its target and preview-feature identity are already part of the
+semantic input descriptor. No intrinsic currently returns a type. Dotted heads
+are exclusively module paths: `Owner.Make()` where `Owner` is a named type is
+rejected, so associated type constructors, dynamic heads, and unnameable heads
+are not successful language forms and emit no partial dependency edge.
+`supported_type_call_heads_complete=true` is intentionally narrow: it covers
+successfully resolved call heads only. Broader declaration-type and semantic
+graph completeness remain false.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -69,9 +69,13 @@ incremental-compilation goal is complete.
    `Option(Result(T))` retains both stable function endpoints, and qualified
    `lib.Box(T)` retains the exact defining module. These events are sorted and
    deduplicated and add zero RIR visits. This surface remains explicitly
-   incomplete until builtin/intrinsic constructors, associated constructors,
-   and anonymous, unnameable, or dynamic heads have explicit fail-closed input
-   classifications.
+   `Str(N)` is retained separately as a stable fixed-capacity-string builtin
+   input whose preview identity is part of the semantic key; it does not invent
+   a definition. No intrinsic returns a type today. Named-owner associated,
+   anonymous, unnameable, and dynamic heads are not successful type syntax
+   (dotted heads resolve only through modules), which tests pin as fail-closed.
+   A narrow supported-head completeness bit is therefore true, while broader
+   declaration-type and overall graph completeness remain false.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## What changed

- classifies declaration type-call heads as stable named constructors, supported builtins, or explicitly unsupported dynamic forms
- propagates completeness evidence from type checking through canonical semantic output
- keeps named and `str(N)` inputs deterministic while unsupported heads force conservative invalidation
- adds supported/unsupported, relocation, and zero-extra-RIR tests plus ADR/audit updates

## Why

A dependency graph is sound only if it distinguishes captured edges from unrepresentable ones. Explicit head classification allows supported programs to become complete without silently ignoring dynamic or anonymous cases.

## Validation

- formatting passed
- AIR and compiler tests passed
- benchmark structural gates passed
- workspace clippy, quick, and full suites passed on the integrated stack