### PR TITLE
RUE-719: capture stable constant initializer dependencies

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -42,11 +42,12 @@ pub use sema::{
     DeclarationTypeCallHeadDependencyEvent, DeclarationTypeDependencyEvent,
     DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
     DeclarationTypeDependencyTargetKind, DirResolution, FunctionInfo, GatherOutput, MethodInfo,
-    ModulePath, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
-    NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
-    RirDeclarationIndexWork, Sema, SemaOutput, SemanticBinding, SemanticBindingKind,
-    SemanticBindingManifest, SemanticBindingManifestWork, SemanticBindingNamespace,
-    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin, import_candidate_groups,
+    ModulePath, NamedConstDependencyEvent, NamedConstDependencyTargetEvent,
+    NamedDestructorDependencyEvent, NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
+    OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
+    SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
+    SemanticBindingNamespace, SpecializedFreeFunctionDependencyEvent,
+    SpecializedFreeFunctionOrigin, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -213,6 +213,18 @@ fn finalize_function_body_analysis(
             sema.declaration_builtin_type_call_head_dependencies.clone()
         },
         supported_type_call_heads_complete: true,
+        named_const_dependencies: {
+            sema.named_const_dependencies.retain(|event| {
+                sema.constants_by_file_name.keys().any(|(file, name)| {
+                    file.index() == event.source_file
+                        && sema.interner.resolve(name) == event.source_name
+                })
+            });
+            sema.named_const_dependencies.sort();
+            sema.named_const_dependencies.dedup();
+            sema.named_const_dependencies.clone()
+        },
+        named_value_const_dependencies_complete: true,
     };
 
     errors.into_result_with(output)
@@ -1634,6 +1646,8 @@ mod error_invariant_tests {
             declaration_type_call_head_dependencies_complete: false,
             declaration_builtin_type_call_head_dependencies: Vec::new(),
             supported_type_call_heads_complete: false,
+            named_const_dependencies: Vec::new(),
+            named_value_const_dependencies_complete: false,
         }
     }
 

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1151,7 +1151,17 @@ impl Sema<'_> {
                 //    VarRef's own span locates the referencing file;
                 //    speculative callers (`try_evaluate_const*`) swallow the
                 //    error and defer to runtime analysis, which re-checks.
-                if let Some(info) = self.constants_by_file_name.get(&(span.file_id, *name)) {
+                if let Some(info) = self
+                    .constants_by_file_name
+                    .get(&(span.file_id, *name))
+                    .cloned()
+                {
+                    self.record_named_const_dependency(
+                        super::NamedConstDependencyTargetEvent::ValueConst {
+                            file: info.span.file_id.index(),
+                            name: self.interner.resolve(name).to_string(),
+                        },
+                    );
                     self.check_unqualified_visibility(
                         "constant",
                         self.interner.resolve(name),
@@ -1163,9 +1173,33 @@ impl Sema<'_> {
                 }
                 // 7. Type names used as values (e.g. `Point` in
                 //    `fn make_type() -> type { Point }`)
-                Ok(self
-                    .resolve_named_type_value(*name, span)?
-                    .map(ConstValue::Type))
+                let resolved = self.resolve_named_type_value(*name, span)?;
+                if let Some(ty) = resolved {
+                    match ty.kind() {
+                        TypeKind::Struct(id) => {
+                            let def = self.type_pool.struct_def(id);
+                            self.record_named_const_dependency(
+                                super::NamedConstDependencyTargetEvent::NamedType {
+                                    file: def.file_id.index(),
+                                    name: def.name,
+                                    kind: super::DeclarationTypeDependencyTargetKind::Struct,
+                                },
+                            );
+                        }
+                        TypeKind::Enum(id) => {
+                            let def = self.type_pool.enum_def(id);
+                            self.record_named_const_dependency(
+                                super::NamedConstDependencyTargetEvent::NamedType {
+                                    file: def.file_id.index(),
+                                    name: def.name,
+                                    kind: super::DeclarationTypeDependencyTargetKind::Enum,
+                                },
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(resolved.map(ConstValue::Type))
             }
 
             // Call to a `-> type` function: reduce it to the resulting type
@@ -1495,6 +1529,13 @@ impl Sema<'_> {
             (key, info)
         };
         let is_type_fn = self.function_returns_type(&fn_info);
+        self.record_named_const_dependency(super::NamedConstDependencyTargetEvent::FreeFunction {
+            file: fn_info.file_id.index(),
+            name: self
+                .interner
+                .resolve(&self.source_function_name(name_key))
+                .to_string(),
+        });
         let params = fn_info.params;
         let param_names = self.param_arena.names(params).to_vec();
         let param_modes = self.param_arena.modes(params).to_vec();

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1808,6 +1808,9 @@ impl<'a> Sema<'a> {
         };
         let (file_id, name) = key;
         let name_str = self.interner.resolve(&name).to_string();
+        let previous_dependency_source = self
+            .named_const_dependency_source
+            .replace((file_id, name_str.clone()));
 
         // A value-constant name that collides with a function, struct, or enum
         // is a top-level name collision (E0436), but that decision is made
@@ -1829,6 +1832,7 @@ impl<'a> Sema<'a> {
 
         st.in_progress.push(key);
         let outcome = self.eval_const_initializer(p.init, file_id, st, declared_ty);
+        self.named_const_dependency_source = previous_dependency_source;
         st.in_progress.pop();
         let outcome = outcome?;
         st.done.insert(key);
@@ -2049,12 +2053,24 @@ impl<'a> Sema<'a> {
             InstData::VarRef { name } => {
                 let name = *name;
                 self.ensure_const_collected(name, file_id, st)?;
-                if let Some(binding) = self.module_bindings.get(&(file_id, name)) {
+                if let Some(binding) = self.module_bindings.get(&(file_id, name)).cloned() {
+                    self.record_named_const_dependency(
+                        super::NamedConstDependencyTargetEvent::ModuleBinding {
+                            file: file_id.index(),
+                            name: self.interner.resolve(&name).to_string(),
+                        },
+                    );
                     // `const m2 = m;` — aliasing a module binding declared in
                     // this file yields the same module (RUE-160).
                     return Ok(ConstInit::Module(binding.ty));
                 }
-                if let Some(info) = self.resolve_const_info_in_file(name, file_id) {
+                if let Some(info) = self.resolve_const_info_in_file(name, file_id).cloned() {
+                    self.record_named_const_dependency(
+                        super::NamedConstDependencyTargetEvent::ValueConst {
+                            file: info.span.file_id.index(),
+                            name: self.interner.resolve(&name).to_string(),
+                        },
+                    );
                     // Privacy (E0460, RUE-183): fallback bare-name lookup can
                     // still find a globally unique constant from another
                     // directory. The initializer's own span locates the
@@ -2071,6 +2087,12 @@ impl<'a> Sema<'a> {
                 if let Some((fn_file_id, is_pub)) =
                     self.ensure_free_function_signature(name, Some(file_id))?
                 {
+                    self.record_named_const_dependency(
+                        super::NamedConstDependencyTargetEvent::FreeFunction {
+                            file: fn_file_id.index(),
+                            name: self.interner.resolve(&name).to_string(),
+                        },
+                    );
                     let function_key = self
                         .resolve_function_name_local(name, file_id)
                         .unwrap_or_else(|| self.internal_function_name(name, fn_file_id));
@@ -2150,6 +2172,22 @@ impl<'a> Sema<'a> {
             // evaluated by the comptime engine.
             _ => self.eval_const_value_expr(init, file_id, st, span, declared_ty),
         }
+    }
+
+    pub(crate) fn record_named_const_dependency(
+        &mut self,
+        target: super::NamedConstDependencyTargetEvent,
+    ) {
+        let Some((file, name)) = self.named_const_dependency_source.clone() else {
+            return;
+        };
+        self.named_const_dependencies
+            .push(super::NamedConstDependencyEvent {
+                source_file: file.index(),
+                source_name: name,
+                target,
+            });
+        self.body_analysis_work.named_const_dependency_events += 1;
     }
 
     /// Evaluate a (non-module) constant initializer through the comptime
@@ -2614,6 +2652,12 @@ impl<'a> Sema<'a> {
                     accessing_file,
                     span,
                 )?;
+                self.record_named_const_dependency(
+                    super::NamedConstDependencyTargetEvent::ModuleBinding {
+                        file: mfile.index(),
+                        name: member_str.clone(),
+                    },
+                );
                 return Ok(ConstInit::Module(ty));
             }
         }
@@ -2629,6 +2673,12 @@ impl<'a> Sema<'a> {
                     accessing_file,
                     span,
                 )?;
+                self.record_named_const_dependency(
+                    super::NamedConstDependencyTargetEvent::ValueConst {
+                        file: mfile.index(),
+                        name: member_str.clone(),
+                    },
+                );
                 return Ok(ConstInit::Value(value));
             }
         }
@@ -2646,6 +2696,12 @@ impl<'a> Sema<'a> {
                     accessing_file,
                     span,
                 )?;
+                self.record_named_const_dependency(
+                    super::NamedConstDependencyTargetEvent::FreeFunction {
+                        file: mfile.index(),
+                        name: member_str.clone(),
+                    },
+                );
                 let function_key = self.internal_function_name(member, mfile);
                 return Ok(ConstInit::Value(ConstValue::Function(function_key)));
             }
@@ -2668,6 +2724,13 @@ impl<'a> Sema<'a> {
                     accessing_file,
                     span,
                 )?;
+                self.record_named_const_dependency(
+                    super::NamedConstDependencyTargetEvent::NamedType {
+                        file: mfile.index(),
+                        name: member_str.clone(),
+                        kind: super::DeclarationTypeDependencyTargetKind::Struct,
+                    },
+                );
                 return Ok(ConstInit::Value(ConstValue::Type(Type::new_struct(
                     struct_id,
                 ))));
@@ -2682,6 +2745,13 @@ impl<'a> Sema<'a> {
                     accessing_file,
                     span,
                 )?;
+                self.record_named_const_dependency(
+                    super::NamedConstDependencyTargetEvent::NamedType {
+                        file: mfile.index(),
+                        name: member_str.clone(),
+                        kind: super::DeclarationTypeDependencyTargetKind::Enum,
+                    },
+                );
                 return Ok(ConstInit::Value(ConstValue::Type(Type::new_enum(enum_id))));
             }
         }
@@ -2758,6 +2828,10 @@ impl<'a> Sema<'a> {
                 span,
             ));
         };
+        self.record_named_const_dependency(super::NamedConstDependencyTargetEvent::FreeFunction {
+            file: fn_info.file_id.index(),
+            name: member_str.clone(),
+        });
         if fn_info.return_type != Type::COMPTIME_TYPE {
             return Err(CompileError::new(
                 ErrorKind::ConstExprNotSupported {

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -149,6 +149,8 @@ impl<'a> GatherOutput<'a> {
             declaration_type_dependencies: Vec::new(),
             declaration_type_call_head_dependencies: Vec::new(),
             declaration_builtin_type_call_head_dependencies: Vec::new(),
+            named_const_dependencies: Vec::new(),
+            named_const_dependency_source: None,
             declaration_type_observer: None,
             constants: self.constants,
             constants_by_file_name: self.constants_by_file_name,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -62,7 +62,8 @@ pub use output::{
     DeclarationBuiltinTypeCallHeadDependencyEvent, DeclarationTypeCallHeadDependencyEvent,
     DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,
     DeclarationTypeDependencySourceKind, DeclarationTypeDependencyTargetKind,
-    NamedDestructorDependencyEvent, NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
+    NamedConstDependencyEvent, NamedConstDependencyTargetEvent, NamedDestructorDependencyEvent,
+    NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
     OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, SemaOutput,
     SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
@@ -118,6 +119,8 @@ pub struct Sema<'a> {
     pub(crate) declaration_type_call_head_dependencies: Vec<DeclarationTypeCallHeadDependencyEvent>,
     pub(crate) declaration_builtin_type_call_head_dependencies:
         Vec<DeclarationBuiltinTypeCallHeadDependencyEvent>,
+    pub(crate) named_const_dependencies: Vec<NamedConstDependencyEvent>,
+    pub(crate) named_const_dependency_source: Option<(FileId, String)>,
     pub(crate) declaration_type_observer: Option<(
         FileId,
         String,
@@ -260,6 +263,8 @@ impl<'a> Sema<'a> {
             declaration_type_dependencies: Vec::new(),
             declaration_type_call_head_dependencies: Vec::new(),
             declaration_builtin_type_call_head_dependencies: Vec::new(),
+            named_const_dependencies: Vec::new(),
+            named_const_dependency_source: None,
             declaration_type_observer: None,
             constants: HashMap::new(),
             constants_by_file_name: HashMap::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -117,6 +117,34 @@ pub struct DeclarationBuiltinTypeCallHeadDependencyEvent {
     pub builtin: BuiltinTypeCallHead,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NamedConstDependencyTargetEvent {
+    ValueConst {
+        file: u32,
+        name: String,
+    },
+    FreeFunction {
+        file: u32,
+        name: String,
+    },
+    NamedType {
+        file: u32,
+        name: String,
+        kind: DeclarationTypeDependencyTargetKind,
+    },
+    ModuleBinding {
+        file: u32,
+        name: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NamedConstDependencyEvent {
+    pub source_file: u32,
+    pub source_name: String,
+    pub target: NamedConstDependencyTargetEvent,
+}
+
 /// Per-ABI-slot parameter access metadata preserved into CFG.
 ///
 /// `by_ref` describes the physical calling convention: both `borrow` and
@@ -211,6 +239,8 @@ pub struct SemaOutput {
     pub declaration_builtin_type_call_head_dependencies:
         Vec<DeclarationBuiltinTypeCallHeadDependencyEvent>,
     pub supported_type_call_heads_complete: bool,
+    pub named_const_dependencies: Vec<NamedConstDependencyEvent>,
+    pub named_value_const_dependencies_complete: bool,
 }
 
 /// Value-only workload counters for demand-driven body dispatch.
@@ -225,6 +255,7 @@ pub struct BodyAnalysisWork {
     pub named_destructor_dependency_events: usize,
     pub declaration_type_dependency_events: usize,
     pub declaration_type_call_head_dependency_events: usize,
+    pub named_const_dependency_events: usize,
     /// Indexed declaration-record lookups for reachable, non-generic free functions.
     pub free_function_record_lookups: usize,
     /// Private declaration-record lookups for reachable named-struct methods.

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -179,6 +179,7 @@ fn semantic_work_json(work: &CanonicalFrontendSessionWork, from: usize) -> Value
         "named_destructor_dependency_events": records.iter().map(|record| record.work.body_analysis.named_destructor_dependency_events).sum::<usize>(),
         "declaration_type_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_dependency_events).sum::<usize>(),
         "declaration_type_call_head_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_call_head_dependency_events).sum::<usize>(),
+        "named_const_dependency_events": records.iter().map(|record| record.work.body_analysis.named_const_dependency_events).sum::<usize>(),
         "manifest_build_invocations": records.iter().map(|record| record.work.manifest.build_invocations).sum::<usize>(),
     })
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -3,7 +3,7 @@
 use rue_air::{
     BodyAnalysisWork, DeclarationBindingWork, DeclarationBuiltinTypeCallHeadDependencyEvent,
     DeclarationTypeCallHeadDependencyEvent, DeclarationTypeDependencyEvent,
-    NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
+    NamedConstDependencyEvent, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
     OrdinaryFreeFunctionDependencyEvent, RirDeclarationIndexWork, SemanticBindingManifestWork,
     SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
@@ -61,6 +61,8 @@ pub struct CanonicalSemanticOutput {
     declaration_builtin_type_call_head_dependencies:
         Vec<DeclarationBuiltinTypeCallHeadDependencyEvent>,
     supported_type_call_heads_complete: bool,
+    named_const_dependencies: Vec<NamedConstDependencyEvent>,
+    named_value_const_dependencies_complete: bool,
 }
 
 impl CanonicalSemanticOutput {
@@ -137,6 +139,12 @@ impl CanonicalSemanticOutput {
     }
     pub fn supported_type_call_heads_complete(&self) -> bool {
         self.supported_type_call_heads_complete
+    }
+    pub fn named_const_dependencies(&self) -> &[NamedConstDependencyEvent] {
+        &self.named_const_dependencies
+    }
+    pub fn named_value_const_dependencies_complete(&self) -> bool {
+        self.named_value_const_dependencies_complete
     }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -240,6 +248,9 @@ pub fn analyze_canonical_program(
         .declaration_builtin_type_call_head_dependencies
         .clone();
     let supported_type_call_heads_complete = sema_output.supported_type_call_heads_complete;
+    let named_const_dependencies = sema_output.named_const_dependencies.clone();
+    let named_value_const_dependencies_complete =
+        sema_output.named_value_const_dependencies_complete;
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
@@ -278,6 +289,8 @@ pub fn analyze_canonical_program(
         declaration_type_call_head_dependencies_complete,
         declaration_builtin_type_call_head_dependencies,
         supported_type_call_heads_complete,
+        named_const_dependencies,
+        named_value_const_dependencies_complete,
     })
 }
 

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -64,6 +64,7 @@ pub struct SemanticDependencyManifestWork {
     pub declaration_type_events_translated: usize,
     pub declaration_type_call_head_events_translated: usize,
     pub builtin_type_call_head_inputs_translated: usize,
+    pub named_const_events_translated: usize,
     pub extra_rir_instructions_visited: usize,
 }
 
@@ -113,6 +114,20 @@ pub struct StableBuiltinTypeCallHeadInput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StableNamedConstDependencyTarget {
+    ValueConst(StableDefinitionKey),
+    FreeFunction(StableDefinitionKey),
+    NamedType(StableDefinitionKey),
+    ModuleBinding(StableDefinitionKey),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StableNamedConstDependency {
+    pub source: StableDefinitionKey,
+    pub target: StableNamedConstDependencyTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum StableModuleImportDependency {
     Resolved {
         importer: crate::ModuleId,
@@ -150,6 +165,8 @@ pub struct SemanticDependencyInputManifest {
     declaration_type_call_head_dependencies_complete: bool,
     builtin_type_call_head_inputs: Arc<[StableBuiltinTypeCallHeadInput]>,
     supported_type_call_heads_complete: bool,
+    named_const_dependencies: Arc<[StableNamedConstDependency]>,
+    named_value_const_dependencies_complete: bool,
     semantic_dependency_graph_complete: bool,
     definition_universe_complete: bool,
     work: SemanticDependencyManifestWork,
@@ -208,6 +225,12 @@ impl SemanticDependencyInputManifest {
     }
     pub fn supported_type_call_heads_complete(&self) -> bool {
         self.supported_type_call_heads_complete
+    }
+    pub fn named_const_dependencies(&self) -> &[StableNamedConstDependency] {
+        &self.named_const_dependencies
+    }
+    pub fn named_value_const_dependencies_complete(&self) -> bool {
+        self.named_value_const_dependencies_complete
     }
     pub fn semantic_dependency_graph_complete(&self) -> bool {
         self.semantic_dependency_graph_complete
@@ -804,6 +827,7 @@ impl CanonicalFrontendSession {
             mut declaration_type_dependencies,
             mut declaration_type_call_head_dependencies,
             mut builtin_type_call_head_inputs,
+            mut named_const_dependencies,
             free_function_events_translated,
             specialization_origins_validated,
             named_method_events_translated,
@@ -811,12 +835,14 @@ impl CanonicalFrontendSession {
             declaration_type_events_translated,
             declaration_type_call_head_events_translated,
             builtin_type_call_head_inputs_translated,
+            named_const_events_translated,
             free_function_caller_dependencies_complete,
             named_method_dependencies_complete,
             named_destructor_dependencies_complete,
             declaration_type_dependencies_complete,
             declaration_type_call_head_dependencies_complete,
             supported_type_call_heads_complete,
+            named_value_const_dependencies_complete,
         ) = match (&semantic, &definitions) {
             (Ok(semantic), Ok(definitions)) => {
                 if definitions.source_revision() != &input.sources {
@@ -957,6 +983,65 @@ impl CanonicalFrontendSession {
                         kind: event.dependency_kind,
                     });
                 }
+                let mut const_edges = Vec::new();
+                for event in semantic.named_const_dependencies() {
+                    let source = stable_top_level_endpoint(
+                        definitions,
+                        event.source_file,
+                        &event.source_name,
+                        StableDefinitionNamespace::Value,
+                        StableDefinitionKind::ValueConst,
+                    )?;
+                    let target = match &event.target {
+                        rue_air::NamedConstDependencyTargetEvent::ValueConst { file, name } => {
+                            StableNamedConstDependencyTarget::ValueConst(stable_top_level_endpoint(
+                                definitions,
+                                *file,
+                                name,
+                                StableDefinitionNamespace::Value,
+                                StableDefinitionKind::ValueConst,
+                            )?)
+                        }
+                        rue_air::NamedConstDependencyTargetEvent::FreeFunction { file, name } => {
+                            StableNamedConstDependencyTarget::FreeFunction(
+                                stable_free_function_endpoint(definitions, *file, name)?,
+                            )
+                        }
+                        rue_air::NamedConstDependencyTargetEvent::NamedType {
+                            file,
+                            name,
+                            kind,
+                        } => {
+                            let kind = match kind {
+                                rue_air::DeclarationTypeDependencyTargetKind::Struct => {
+                                    StableDefinitionKind::Struct
+                                }
+                                rue_air::DeclarationTypeDependencyTargetKind::Enum => {
+                                    StableDefinitionKind::Enum
+                                }
+                            };
+                            StableNamedConstDependencyTarget::NamedType(stable_top_level_endpoint(
+                                definitions,
+                                *file,
+                                name,
+                                StableDefinitionNamespace::Type,
+                                kind,
+                            )?)
+                        }
+                        rue_air::NamedConstDependencyTargetEvent::ModuleBinding { file, name } => {
+                            StableNamedConstDependencyTarget::ModuleBinding(
+                                stable_top_level_endpoint(
+                                    definitions,
+                                    *file,
+                                    name,
+                                    StableDefinitionNamespace::Value,
+                                    StableDefinitionKind::ModuleBinding,
+                                )?,
+                            )
+                        }
+                    };
+                    const_edges.push(StableNamedConstDependency { source, target });
+                }
                 (
                     edges,
                     method_edges,
@@ -964,6 +1049,7 @@ impl CanonicalFrontendSession {
                     type_edges,
                     type_call_head_edges,
                     builtin_head_inputs,
+                    const_edges,
                     semantic.ordinary_free_function_dependencies().len()
                         + semantic.specialized_free_function_dependencies().len(),
                     semantic.specialized_free_function_origins().len(),
@@ -974,6 +1060,7 @@ impl CanonicalFrontendSession {
                     semantic
                         .declaration_builtin_type_call_head_dependencies()
                         .len(),
+                    semantic.named_const_dependencies().len(),
                     semantic.ordinary_free_function_dependencies_complete()
                         && semantic.specialized_free_function_dependencies_complete(),
                     semantic.non_generic_named_method_dependencies_complete(),
@@ -981,6 +1068,7 @@ impl CanonicalFrontendSession {
                     semantic.declaration_type_dependencies_complete(),
                     semantic.declaration_type_call_head_dependencies_complete(),
                     semantic.supported_type_call_heads_complete(),
+                    semantic.named_value_const_dependencies_complete(),
                 )
             }
             _ => (
@@ -990,6 +1078,7 @@ impl CanonicalFrontendSession {
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),
+                Vec::new(),
                 0,
                 0,
                 0,
@@ -997,6 +1086,8 @@ impl CanonicalFrontendSession {
                 0,
                 0,
                 0,
+                0,
+                false,
                 false,
                 false,
                 false,
@@ -1017,6 +1108,8 @@ impl CanonicalFrontendSession {
         declaration_type_call_head_dependencies.dedup();
         builtin_type_call_head_inputs.sort();
         builtin_type_call_head_inputs.dedup();
+        named_const_dependencies.sort();
+        named_const_dependencies.dedup();
         let work = SemanticDependencyManifestWork {
             definition_records_visited: definition_records.len(),
             import_records_visited: imports.graph().records().len(),
@@ -1027,6 +1120,7 @@ impl CanonicalFrontendSession {
             declaration_type_events_translated,
             declaration_type_call_head_events_translated,
             builtin_type_call_head_inputs_translated,
+            named_const_events_translated,
             extra_rir_instructions_visited: 0,
         };
         self.work.dependency_manifest_records_visited += work.definition_records_visited;
@@ -1076,6 +1170,8 @@ impl CanonicalFrontendSession {
             declaration_type_call_head_dependencies_complete,
             builtin_type_call_head_inputs: builtin_type_call_head_inputs.into(),
             supported_type_call_heads_complete,
+            named_const_dependencies: named_const_dependencies.into(),
+            named_value_const_dependencies_complete,
             semantic_dependency_graph_complete: false,
             definition_universe_complete,
             work,
@@ -2302,6 +2398,8 @@ mod tests {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<StableNamedMethodDependency>();
         assert_send_sync::<StableNamedMethodDependencyTarget>();
+        assert_send_sync::<StableNamedConstDependency>();
+        assert_send_sync::<StableNamedConstDependencyTarget>();
     }
 
     #[test]
@@ -2698,6 +2796,198 @@ mod tests {
             session.semantic(&CompileOptions::default()).is_err(),
             "dotted type-call heads are module-qualified free functions, not associated functions"
         );
+    }
+
+    #[test]
+    fn named_const_initializer_edges_are_stable_direct_and_zero_scan() {
+        let program = r#"
+            struct Point { x: i32 }
+            fn inc(comptime n: i32) -> i32 { n + 1 }
+            const A: i32 = 1;
+            const B: i32 = inc(A);
+            const C: i32 = A + B;
+            const D: i32 = B + C;
+            const P = Point;
+            fn main() -> i32 { D }
+        "#;
+        let build = |file, path| {
+            let source = snapshot(&[(file, path, "main.rue", program)], file);
+            let mut session = CanonicalFrontendSession::new();
+            session.update(&source).into_result().unwrap();
+            session
+                .semantic_dependency_inputs(&CompileOptions::default(), None)
+                .unwrap()
+        };
+        let first = build(2, "/one/main.rue");
+        let moved = build(88, "/moved/main.rue");
+        assert_eq!(
+            first.named_const_dependencies(),
+            moved.named_const_dependencies()
+        );
+        let names = first
+            .named_const_dependencies()
+            .iter()
+            .map(|edge| {
+                let target = match &edge.target {
+                    StableNamedConstDependencyTarget::ValueConst(key)
+                    | StableNamedConstDependencyTarget::FreeFunction(key)
+                    | StableNamedConstDependencyTarget::NamedType(key)
+                    | StableNamedConstDependencyTarget::ModuleBinding(key) => key.name(),
+                };
+                (edge.source.name(), target)
+            })
+            .collect::<Vec<_>>();
+        for edge in [
+            ("B", "A"),
+            ("B", "inc"),
+            ("C", "A"),
+            ("C", "B"),
+            ("D", "B"),
+            ("D", "C"),
+            ("P", "Point"),
+        ] {
+            assert!(
+                names.contains(&edge),
+                "missing direct edge {edge:?}: {names:?}"
+            );
+        }
+        assert!(first.named_value_const_dependencies_complete());
+        assert_eq!(first.work().named_const_events_translated, names.len());
+        assert_eq!(first.work().extra_rir_instructions_visited, 0);
+
+        let renamed_program = program
+            .replace("const A: i32 = 1", "const Z: i32 = 1")
+            .replace("inc(A)", "inc(Z)")
+            .replace("A + B", "Z + B");
+        let renamed_source = snapshot(&[(2, "/one/main.rue", "main.rue", &renamed_program)], 2);
+        let mut renamed_session = CanonicalFrontendSession::new();
+        renamed_session
+            .update(&renamed_source)
+            .into_result()
+            .unwrap();
+        let renamed = renamed_session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        assert_ne!(
+            first.named_const_dependencies(),
+            renamed.named_const_dependencies()
+        );
+        assert!(renamed.named_const_dependencies().iter().any(|edge| {
+            edge.source.name() == "B"
+                && matches!(&edge.target, StableNamedConstDependencyTarget::ValueConst(key) if key.name() == "Z")
+        }));
+    }
+
+    #[test]
+    fn cyclic_const_initializers_publish_no_partial_dependency_graph() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "const A: i32 = B; const B: i32 = A; fn main() -> i32 { 0 }",
+            )],
+            1,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        assert!(session.semantic(&CompileOptions::default()).is_err());
+        let manifest = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        assert!(manifest.named_const_dependencies().is_empty());
+        assert!(!manifest.named_value_const_dependencies_complete());
+        assert!(!manifest.definition_universe_complete());
+    }
+
+    #[test]
+    fn qualified_const_edges_keep_module_binding_and_exact_member_identity() {
+        let source = snapshot(
+            &[
+                (
+                    3,
+                    "/p/main.rue",
+                    "main.rue",
+                    r#"const lib = @import("lib.rue");
+                       const other = @import("other.rue");
+                       const X: i32 = lib.BASE;
+                       const Y: i32 = other.BASE;
+                       const T = lib.Row;
+                       fn main() -> i32 { X + Y }"#,
+                ),
+                (11, "/p/other.rue", "other.rue", "pub const BASE: i32 = 5;"),
+                (
+                    9,
+                    "/p/lib.rue",
+                    "lib.rue",
+                    "pub const BASE: i32 = 4; pub struct Row { n: i32 }",
+                ),
+            ],
+            3,
+        );
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&source).into_result().unwrap();
+        let manifest = session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+        let tags = manifest
+            .named_const_dependencies()
+            .iter()
+            .map(|edge| {
+                let (tag, target) = match &edge.target {
+                    StableNamedConstDependencyTarget::ValueConst(key) => ("const", key),
+                    StableNamedConstDependencyTarget::NamedType(key) => ("type", key),
+                    StableNamedConstDependencyTarget::ModuleBinding(key) => ("module", key),
+                    StableNamedConstDependencyTarget::FreeFunction(key) => ("fn", key),
+                };
+                (
+                    edge.source.name(),
+                    tag,
+                    target.module().as_str(),
+                    target.name(),
+                )
+            })
+            .collect::<Vec<_>>();
+        for expected in [
+            ("X", "module", "main.rue", "lib"),
+            ("X", "const", "lib.rue", "BASE"),
+            ("T", "module", "main.rue", "lib"),
+            ("T", "type", "lib.rue", "Row"),
+            ("Y", "module", "main.rue", "other"),
+            ("Y", "const", "other.rue", "BASE"),
+        ] {
+            assert!(tags.contains(&expected), "missing {expected:?}: {tags:?}");
+        }
+        assert!(
+            tags.iter()
+                .all(|(source, _, _, _)| *source != "lib" && *source != "other")
+        );
+    }
+
+    #[test]
+    fn const_dependency_capture_work_is_edge_proportional() {
+        let build = |extra: usize| {
+            let mut program = "const A: i32 = 1; const B: i32 = A;".to_string();
+            for i in 0..extra {
+                program.push_str(&format!(" const UNUSED_{i}: i32 = {i};"));
+            }
+            program.push_str(" fn main() -> i32 { B }");
+            let source = snapshot(&[(1, "/p/main.rue", "main.rue", &program)], 1);
+            let mut session = CanonicalFrontendSession::new();
+            session.update(&source).into_result().unwrap();
+            session
+                .semantic_dependency_inputs(&CompileOptions::default(), None)
+                .unwrap()
+        };
+        let one = build(1);
+        let many = build(128);
+        assert_eq!(
+            one.named_const_dependencies(),
+            many.named_const_dependencies()
+        );
+        assert_eq!(one.work().named_const_events_translated, 1);
+        assert_eq!(many.work().named_const_events_translated, 1);
+        assert_eq!(many.work().extra_rir_instructions_visited, 0);
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -67,8 +67,8 @@ pub use frontend_session::{
     SemanticDependencyInputManifest, SemanticDependencyManifestWork, SemanticQueryRecord,
     StableBuiltinTypeCallHeadInput, StableDeclarationTypeCallHeadDependency,
     StableDeclarationTypeDependency, StableFreeFunctionDependency, StableModuleImportDependency,
-    StableNamedDestructorDependency, StableNamedMethodDependency,
-    StableNamedMethodDependencyTarget,
+    StableNamedConstDependency, StableNamedConstDependencyTarget, StableNamedDestructorDependency,
+    StableNamedMethodDependency, StableNamedMethodDependencyTarget,
 };
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -186,3 +186,18 @@ are not successful language forms and emit no partial dependency edge.
 `supported_type_call_heads_complete=true` is intentionally narrow: it covers
 successfully resolved call heads only. Broader declaration-type and semantic
 graph completeness remain false.
+
+Named value-constant initializers record direct dependencies while the existing
+dependency-ordered constant collector and comptime evaluator resolve them.
+Targets are tagged as value constants, free comptime functions/type
+constructors, named struct/enum types, or module bindings. Recursive collection
+temporarily changes and then restores the exact `(FileId, name)` source, so
+chains and diamonds retain direct edges rather than a transitive approximation.
+Compiler translation joins every source and target against the exact bound
+definition revision; module-binding targets are real binding identities whose
+resolved import topology remains in the existing module-import edge channel.
+Module bindings are not value-constant sources and are filtered from this
+surface. Cyclic or otherwise rejected initializers publish no partial manifest.
+`named_value_const_dependencies_complete=true` covers successful named value
+constants; anonymous/dynamic values and the overall semantic graph remain
+explicitly incomplete. Capture is sorted/deduplicated and adds no RIR scan.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -76,6 +76,13 @@ incremental-compilation goal is complete.
    (dotted heads resolve only through modules), which tests pin as fail-closed.
    A narrow supported-head completeness bit is therefore true, while broader
    declaration-type and overall graph completeness remain false.
+   Named value-constant initializers now retain direct tagged dependencies on
+   constants, comptime functions/type constructors, named types, and module
+   bindings at the existing collector/evaluator seams. Recursive source context
+   is preserved, cycles fail before publishing, and exact stable translation
+   adds zero RIR visits. Module bindings remain import-topology inputs rather
+   than value-constant sources. The value-constant slice is narrowly complete;
+   the overall graph remains false for dynamic/anonymous surfaces.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## What changed

- records named-value constant dependencies during dependency-ordered comptime evaluation
- distinguishes constant, function-alias, module, type, and builtin targets with authoritative resolved identity
- translates supported initializer edges to stable definition keys and fails closed on unnameable endpoints
- adds const chains, cross-module aliases, cycles, relocation, and zero-extra-RIR coverage

## Why

Constant initializers can affect declaration types and bodies transitively. Capturing their resolved dependencies during comptime evaluation preserves evaluation order and avoids reconstructing aliases after request-local values are erased.

## Validation

- formatting passed
- AIR and compiler tests passed
- benchmark structural gates passed
- workspace clippy, quick, and full suites passed on the integrated stack