### PR TITLE
RUE-719: capture generic named-method dependencies

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -188,7 +188,13 @@ fn finalize_function_body_analysis(
         },
         non_generic_named_method_dependencies_complete: sema
             .non_generic_named_method_dependencies_complete,
-        generic_named_method_dependencies_complete: false,
+        // Named methods currently have one analyzed runtime body even when
+        // they accept comptime parameters. Unlike free functions, there is no
+        // method-specialization table whose substitution identity could split
+        // this caller. The dependency events below therefore describe the
+        // authoritative method body for both generic and non-generic callers.
+        generic_named_method_dependencies_complete: sema
+            .non_generic_named_method_dependencies_complete,
         named_destructor_dependencies: {
             sema.named_destructor_dependencies.sort();
             sema.named_destructor_dependencies.dedup();
@@ -938,29 +944,20 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                             owner_name: type_name_str.clone(),
                             method_name: method_name_str.clone(),
                         });
-                    let caller_is_generic = sema
-                        .param_arena
-                        .comptime(method_info.params)
-                        .iter()
-                        .any(|is_comptime| *is_comptime);
-                    if caller_is_generic {
-                    } else {
-                        match named_method_dependency_events(
-                            sema,
-                            struct_id,
-                            method_name,
-                            &referenced_fns,
-                            &referenced_meths,
-                        ) {
-                            Ok(events) => {
-                                sema.body_analysis_work.named_method_dependency_events +=
-                                    events.len();
-                                sema.named_method_dependencies.extend(events);
-                            }
-                            Err(error) => {
-                                errors.push(error);
-                                continue;
-                            }
+                    match named_method_dependency_events(
+                        sema,
+                        struct_id,
+                        method_name,
+                        &referenced_fns,
+                        &referenced_meths,
+                    ) {
+                        Ok(events) => {
+                            sema.body_analysis_work.named_method_dependency_events += events.len();
+                            sema.named_method_dependencies.extend(events);
+                        }
+                        Err(error) => {
+                            errors.push(error);
+                            continue;
                         }
                     }
                     functions_with_strings.push((analyzed, local_strings));

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -646,7 +646,7 @@ fn assert_production_full_plan(scenario: &Value, executions: u64, changed: u64, 
     assert!(
         scenario["plan"]["dependency_blockers"]
             .as_array()
-            .is_some_and(|blockers| blockers.len() >= 3)
+            .is_some_and(|blockers| blockers.len() >= 2)
     );
     assert_eq!(count(scenario, &["plan", "reusable"]), 0);
     assert_eq!(count(scenario, &["plan", "invalidated"]), 0);

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -637,7 +637,7 @@ mod tests {
                 1,
                 "/main.rue",
                 "main.rue",
-                "struct Value { fn choose(borrow self, comptime n: i32) -> i32 { n } } fn main() -> i32 { let value = Value {}; value.choose(1) + value.choose(2) }",
+                "fn helper() -> i32 { 1 } struct Value { fn choose(borrow self, comptime n: i32) -> i32 { helper() + n } } fn main() -> i32 { let value = Value {}; value.choose(1) + value.choose(2) }",
             )],
             1,
         );
@@ -651,7 +651,8 @@ mod tests {
             1
         );
         assert!(output.specialized_free_function_origins().is_empty());
-        assert!(!output.generic_named_method_dependencies_complete());
+        assert_eq!(output.named_method_dependencies().len(), 1);
+        assert!(output.generic_named_method_dependencies_complete());
     }
 
     #[test]

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -3060,11 +3060,6 @@ mod tests {
             vec![
                 (
                     None,
-                    SemanticDependencySurface::GenericNamedMethodCall,
-                    SemanticDependencyIncompleteReason::GenericSubstitutionIdentityUnavailable,
-                ),
-                (
-                    None,
                     SemanticDependencySurface::DeclarationType,
                     SemanticDependencyIncompleteReason::ResolvedTypeIdentityUnavailable,
                 ),
@@ -3629,18 +3624,64 @@ mod tests {
             ("main.rue", "A", "next", "free", "main.rue", "generic"),
             ("main.rue", "B", "ping", "free", "main.rue", "helper"),
         ] {
-            assert!(edges.contains(&(
-                expected.0.into(),
-                expected.1.into(),
-                expected.2.into(),
-                expected.3.into(),
-                expected.4.into(),
-                expected.5.into(),
-            )));
+            assert!(
+                edges.contains(&(
+                    expected.0.into(),
+                    expected.1.into(),
+                    expected.2.into(),
+                    expected.3.into(),
+                    expected.4.into(),
+                    expected.5.into(),
+                )),
+                "missing {expected:?} from {edges:?}"
+            );
         }
         assert!(first.non_generic_named_method_dependencies_complete());
-        assert!(!first.generic_named_method_dependencies_complete());
+        assert!(first.generic_named_method_dependencies_complete());
+        assert!(!first.dependency_blockers().iter().any(|blocker| {
+            blocker.surface() == SemanticDependencySurface::GenericNamedMethodCall
+                && blocker.reason()
+                    == SemanticDependencyIncompleteReason::GenericSubstitutionIdentityUnavailable
+        }));
         assert_eq!(first.work().named_method_events_translated, edges.len());
+        assert_eq!(first.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn generic_named_method_uses_single_body_caller_and_needs_no_substitution_blocker() {
+        let program = "fn helper() -> i32 { 1 } struct Value { fn choose(borrow self, comptime n: i32) -> i32 { helper() + n } } fn main() -> i32 { let value = Value {}; value.choose(1) + value.choose(2) }";
+        let first_source = snapshot(&[(7, "/one/main.rue", "main.rue", program)], 7);
+        let moved_source = snapshot(&[(71, "/else/main.rue", "main.rue", program)], 71);
+        let build = |source: &SourceSnapshot| {
+            let mut session = CanonicalFrontendSession::new();
+            session.update(source).into_result().unwrap();
+            session
+                .semantic_dependency_inputs(&CompileOptions::default(), None)
+                .unwrap()
+        };
+        let first = build(&first_source);
+        let moved = build(&moved_source);
+        assert_eq!(
+            named_method_edge_names(&first),
+            named_method_edge_names(&moved)
+        );
+        assert_eq!(
+            named_method_edge_names(&first),
+            vec![(
+                "main.rue".into(),
+                "Value".into(),
+                "choose".into(),
+                "free".into(),
+                "main.rue".into(),
+                "helper".into(),
+            )]
+        );
+        assert!(first.generic_named_method_dependencies_complete());
+        assert!(!first.dependency_blockers().iter().any(|blocker| {
+            blocker.reason()
+                == SemanticDependencyIncompleteReason::GenericSubstitutionIdentityUnavailable
+        }));
+        assert_eq!(first.work().named_method_events_translated, 1);
         assert_eq!(first.work().extra_rir_instructions_visited, 0);
     }
 

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -117,9 +117,9 @@ Synthetic complete-manifest tests exercise exact deltas and transitive closure;
 the incremental branch cannot authorize production reuse until every capture
 surface below is complete.
 
-The remaining unconditional production blockers are generic named-method
-substitution identity, fully resolved declaration-type identity, and complete
-declaration type-call-head identity. Individual programs can add evidence-based
+The remaining unconditional production blockers are fully resolved
+declaration-type identity and complete declaration type-call-head identity.
+Individual programs can add evidence-based
 blockers, including anonymous drop owners and unsupported dynamic heads. The
 records are sorted/deduplicated, independent of FileId and physical location,
 and require no second RIR scan.
@@ -200,9 +200,8 @@ deduplicated without another RIR traversal.
 
 `non_generic_named_method_dependencies_complete` covers reachable named methods
 without comptime parameters calling free functions (including generic free
-function bases) or other named methods. Generic named-method bodies have no
-specialization/base-owner provenance equivalent to free functions, so
-`generic_named_method_dependencies_complete` remains false. Anonymous methods,
+function bases) or other named methods. The same authoritative reference sets
+now retain edges for named methods with comptime parameters. Anonymous methods,
 destructors, constructors and intrinsics remain outside this surface and keep
 the overall semantic graph incomplete.
 
@@ -211,9 +210,12 @@ receiver resolution records only `(StructId, method)`, coerces every explicit
 argument as a runtime argument, emits one direct `Call` symbol, and the lazy
 driver analyzes the declaration once. `MethodInfo` has no specialization key or
 substitution/origin fields. Tests pin two distinct comptime arguments producing
-one analyzed method body and no specialization origins. Until language support
-routes these methods through a real instantiation path, generic named-method
-stable provenance is unsupported rather than missing capture data.
+one analyzed method body and no specialization origins. The declaration is
+therefore the exact stable caller identity, and
+`generic_named_method_dependencies_complete` is production-derived from the
+same successful named-method traversal. Future method instantiation support
+must add substitution identity before this flag may remain true; rejected or
+endpoint-incomplete traversals still publish no manifest.
 
 Named destructor bodies now use the same existing reference sets to capture
 tagged free-function and named-method targets. Their caller handle is the exact

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -64,10 +64,11 @@ incremental-compilation goal is complete.
    explicitly incomplete and prevent body/CFG reuse. Completeness is now a
    production-derived, sorted blocker set rather than an opaque global boolean;
    the planner carries the exact union from both revisions. No production
-   fixture reaches `Incremental` yet: generic method substitution identity,
-   resolved declaration-type identity, and declaration type-call-head identity
-   remain unconditional blockers, while anonymous drop owners and unsupported
-   heads add surface-specific blockers when observed.
+   fixture reaches `Incremental` yet: resolved declaration-type identity and
+   declaration type-call-head identity remain unconditional blockers, while
+   anonymous drop owners and unsupported heads add surface-specific blockers
+   when observed. Generic named methods now retain the authoritative reference
+   sets from their single runtime body under the stable declaration caller key.
    A conservative resolved declaration-type slice now translates nominal
    signature/field/payload/constant/owner edges without rescanning RIR. A
    separate resolver-time observer records resolved user-defined type-call


### PR DESCRIPTION
## Summary
- retain dependency events for named method bodies with comptime parameters
- derive generic named-method completeness from the same successful single-body traversal used by ordinary named methods
- remove the substitution blocker under Rue’s current unspecialized method model and document the invariant future specialization must preserve

## Testing
- `./buck2 test //crates/rue-compiler:rue-compiler-test //crates/rue-compiler-session-bench:rue-compiler-session-bench-test`