### PR TITLE
RUE-719: retain resolved declaration type identities

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -206,7 +206,7 @@ fn finalize_function_body_analysis(
             sema.declaration_type_dependencies.dedup();
             sema.declaration_type_dependencies.clone()
         },
-        declaration_type_dependencies_complete: false,
+        declaration_type_dependencies_complete: true,
         declaration_type_call_head_dependencies: {
             sema.declaration_type_call_head_dependencies.sort();
             sema.declaration_type_call_head_dependencies.dedup();

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -71,6 +71,7 @@ pub enum DeclarationTypeDependencySourceKind {
 pub enum DeclarationTypeDependencyTargetKind {
     Struct,
     Enum,
+    ValueConst,
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeclarationTypeDependencyKind {

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -583,11 +583,22 @@ impl<'a> Sema<'a> {
             let (file_id, is_pub) = (info.span.file_id, info.is_pub);
             let type_name = self.interner.resolve(&type_sym).to_string();
             self.check_unqualified_visibility("constant", &type_name, file_id, is_pub, span)?;
+            self.record_resolved_declaration_type_target(
+                file_id,
+                type_name,
+                super::DeclarationTypeDependencyTargetKind::ValueConst,
+            );
         }
         Ok(Some(alias_ty))
     }
 
     pub(crate) fn resolve_type(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
+        let ty = self.resolve_type_inner(type_sym, span)?;
+        self.record_resolved_declaration_type(ty);
+        Ok(ty)
+    }
+
+    fn resolve_type_inner(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
         // Own the name so the read-only branches below borrow this local rather
         // than `self.interner`, leaving `self` free for the `&mut self` slice
         // path (`try_resolve_slice_type` lazily registers a synthetic struct).
@@ -719,6 +730,64 @@ impl<'a> Sema<'a> {
                 ))
             }
         }
+    }
+
+    fn record_resolved_declaration_type(&mut self, ty: Type) {
+        match ty.kind() {
+            TypeKind::Struct(id) => {
+                let def = self.type_pool.struct_def(id);
+                if !def.is_builtin && !def.name.starts_with("__anon_struct_") {
+                    self.record_resolved_declaration_type_target(
+                        def.file_id,
+                        def.name,
+                        super::DeclarationTypeDependencyTargetKind::Struct,
+                    );
+                }
+            }
+            TypeKind::Enum(id) => {
+                let def = self.type_pool.enum_def(id);
+                self.record_resolved_declaration_type_target(
+                    def.file_id,
+                    def.name,
+                    super::DeclarationTypeDependencyTargetKind::Enum,
+                );
+            }
+            TypeKind::Array(id) => {
+                self.record_resolved_declaration_type(self.type_pool.array_def(id).0)
+            }
+            TypeKind::PtrConst(id) => {
+                self.record_resolved_declaration_type(self.type_pool.ptr_const_def(id));
+            }
+            TypeKind::PtrMut(id) => {
+                self.record_resolved_declaration_type(self.type_pool.ptr_mut_def(id));
+            }
+            _ => {}
+        }
+    }
+
+    fn record_resolved_declaration_type_target(
+        &mut self,
+        target_file: FileId,
+        target_name: String,
+        target_kind: super::DeclarationTypeDependencyTargetKind,
+    ) {
+        let Some((source_file, source_name, source_owner_name, source_kind, dependency_kind)) =
+            self.declaration_type_observer.clone()
+        else {
+            return;
+        };
+        self.declaration_type_dependencies
+            .push(super::DeclarationTypeDependencyEvent {
+                source_file: source_file.index(),
+                source_name,
+                source_owner_name,
+                source_kind,
+                dependency_kind,
+                target_file: target_file.index(),
+                target_name,
+                target_kind,
+            });
+        self.body_analysis_work.declaration_type_dependency_events += 1;
     }
 
     /// Resolve a type-annotation symbol to a `Type`, consulting the analysis

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -646,7 +646,7 @@ fn assert_production_full_plan(scenario: &Value, executions: u64, changed: u64, 
     assert!(
         scenario["plan"]["dependency_blockers"]
             .as_array()
-            .is_some_and(|blockers| blockers.len() >= 2)
+            .is_some_and(|blockers| !blockers.is_empty())
     );
     assert_eq!(count(scenario, &["plan", "reusable"]), 0);
     assert_eq!(count(scenario, &["plan", "invalidated"]), 0);

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -1215,12 +1215,20 @@ impl CanonicalFrontendSession {
                                 rue_air::DeclarationTypeDependencyTargetKind::Enum => {
                                     StableDefinitionKind::Enum
                                 }
+                                rue_air::DeclarationTypeDependencyTargetKind::ValueConst => {
+                                    StableDefinitionKind::ValueConst
+                                }
+                            };
+                            let namespace = if matches!(kind, StableDefinitionKind::ValueConst) {
+                                StableDefinitionNamespace::Value
+                            } else {
+                                StableDefinitionNamespace::Type
                             };
                             StableNamedConstDependencyTarget::NamedType(stable_top_level_endpoint(
                                 definitions,
                                 *file,
                                 name,
-                                StableDefinitionNamespace::Type,
+                                namespace,
                                 kind,
                             )?)
                         }
@@ -1951,6 +1959,15 @@ fn stable_named_type_endpoint(
     let kind = match event.target_kind {
         rue_air::DeclarationTypeDependencyTargetKind::Struct => StableDefinitionKind::Struct,
         rue_air::DeclarationTypeDependencyTargetKind::Enum => StableDefinitionKind::Enum,
+        rue_air::DeclarationTypeDependencyTargetKind::ValueConst => {
+            return stable_top_level_endpoint(
+                definitions,
+                event.target_file,
+                &event.target_name,
+                StableDefinitionNamespace::Value,
+                StableDefinitionKind::ValueConst,
+            );
+        }
     };
     stable_top_level_endpoint(
         definitions,
@@ -3057,18 +3074,11 @@ mod tests {
                 .iter()
                 .map(|blocker| (blocker.owner(), blocker.surface(), blocker.reason()))
                 .collect::<Vec<_>>(),
-            vec![
-                (
-                    None,
-                    SemanticDependencySurface::DeclarationType,
-                    SemanticDependencyIncompleteReason::ResolvedTypeIdentityUnavailable,
-                ),
-                (
-                    None,
-                    SemanticDependencySurface::DeclarationTypeCallHead,
-                    SemanticDependencyIncompleteReason::TypeCallHeadIdentityUnavailable,
-                ),
-            ]
+            vec![(
+                None,
+                SemanticDependencySurface::DeclarationTypeCallHead,
+                SemanticDependencyIncompleteReason::TypeCallHeadIdentityUnavailable,
+            ),]
         );
         assert!(first.reusable().is_empty());
         assert!(first.invalidated().is_empty());
@@ -3861,7 +3871,7 @@ mod tests {
             "Holder".into(),
             rue_air::DeclarationTypeDependencyKind::Owner
         )));
-        assert!(!manifest.declaration_type_dependencies_complete());
+        assert!(manifest.declaration_type_dependencies_complete());
         assert_eq!(manifest.work().extra_rir_instructions_visited, 0);
     }
 
@@ -3909,6 +3919,70 @@ mod tests {
         );
         assert!(!first.declaration_type_call_head_dependencies_complete());
         assert_eq!(first.work().declaration_type_call_head_events_translated, 2);
+        assert_eq!(first.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn deferred_nested_nominal_and_alias_types_keep_stable_declaration_edges() {
+        let build = |main_id, lib_id, root: &str, reversed: bool| {
+            let main = (
+                main_id,
+                format!("{root}/main.rue"),
+                "main.rue",
+                r#"const lib = @import("lib.rue");
+                   const Alias = lib.Leaf;
+                   fn consume(comptime N: i32, values: [Alias; N]) -> i32 { 0 }
+                   fn main() -> i32 { 0 }"#,
+            );
+            let lib = (
+                lib_id,
+                format!("{root}/lib.rue"),
+                "lib.rue",
+                "pub struct Leaf { value: i32 }",
+            );
+            let owned = if reversed {
+                vec![lib, main]
+            } else {
+                vec![main, lib]
+            };
+            let entries = owned
+                .iter()
+                .map(|(id, path, module, text)| (*id, path.as_str(), *module, *text))
+                .collect::<Vec<_>>();
+            let source = snapshot(&entries, main_id);
+            let mut session = CanonicalFrontendSession::new();
+            session.update(&source).into_result().unwrap();
+            session
+                .semantic_dependency_inputs(&CompileOptions::default(), None)
+                .unwrap()
+        };
+        let first = build(3, 8, "/p", false);
+        let moved = build(91, 4, "/elsewhere", true);
+        assert_eq!(
+            first.declaration_type_dependencies(),
+            moved.declaration_type_dependencies()
+        );
+        let consume_targets = first
+            .declaration_type_dependencies()
+            .iter()
+            .filter(|edge| edge.source.name() == "consume")
+            .map(|edge| {
+                (
+                    edge.target.module().as_str(),
+                    edge.target.name(),
+                    edge.target.kind(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(consume_targets.contains(&("main.rue", "Alias", StableDefinitionKind::ValueConst)));
+        assert!(consume_targets.contains(&("lib.rue", "Leaf", StableDefinitionKind::Struct)));
+        assert!(first.declaration_type_dependencies_complete());
+        assert!(
+            !first
+                .dependency_blockers()
+                .iter()
+                .any(|blocker| { blocker.surface() == SemanticDependencySurface::DeclarationType })
+        );
         assert_eq!(first.work().extra_rir_instructions_visited, 0);
     }
 

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -233,14 +233,14 @@ Compiler translation joins both endpoints against the exact bound-definition
 revision and retains the field/payload/signature/declared-type/owner edge kind,
 with zero additional RIR traversal.
 
-This slice deliberately reports `declaration_type_dependencies_complete=false`.
-Generic signatures replace any type mentioning a comptime parameter with
-`COMPTIME_TYPE`, so outer type-constructor syntax such as `Option(Result(T))`
-is not present in the resolved table. In Rue those heads are comptime type
-functions rather than named type definitions. A future pre-substitution
-observer must classify stable type-function dependencies and aliases before
-this surface can become complete; the conservative resolved edges must not
-drive reuse meanwhile.
+Declaration-type capture is complete for successful named declarations.
+Resolver-time observation retains nominal leaves before deferred generic
+signatures become `COMPTIME_TYPE`, recursively including arrays and pointers;
+the resolved declaration-table sweep remains a parity backstop. Type aliases
+retain both the exact value-constant declaration endpoint and the resolved
+nominal target. All endpoints join the same bound-definition revision, and no
+RIR rescan or source-text inference is involved. Type-call heads remain a
+separate, independently fail-closed surface.
 
 The pre-substitution observer now classifies every type-call head accepted by
 the current resolver. User-defined free and module-qualified free comptime

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -64,8 +64,8 @@ incremental-compilation goal is complete.
    explicitly incomplete and prevent body/CFG reuse. Completeness is now a
    production-derived, sorted blocker set rather than an opaque global boolean;
    the planner carries the exact union from both revisions. No production
-   fixture reaches `Incremental` yet: resolved declaration-type identity and
-   declaration type-call-head identity remain unconditional blockers, while
+   fixture reaches `Incremental` yet: declaration type-call-head identity
+   remains the sole unconditional blocker, while
    anonymous drop owners and unsupported heads add surface-specific blockers
    when observed. Generic named methods now retain the authoritative reference
    sets from their single runtime body under the stable declaration caller key.
@@ -75,14 +75,17 @@ incremental-compilation goal is complete.
    heads before generic composites are erased to `COMPTIME_TYPE`: nested
    `Option(Result(T))` retains both stable function endpoints, and qualified
    `lib.Box(T)` retains the exact defining module. These events are sorted and
-   deduplicated and add zero RIR visits. This surface remains explicitly
-   `Str(N)` is retained separately as a stable fixed-capacity-string builtin
+   deduplicated and add zero RIR visits. Resolved nominal leaves in deferred
+   generic arrays and pointers are retained before placeholder erasure, and
+   type aliases retain their exact value-constant identity as well as the
+   resolved nominal target. Declaration-type identity is therefore complete
+   for successful named declarations. `Str(N)` is retained separately as a stable fixed-capacity-string builtin
    input whose preview identity is part of the semantic key; it does not invent
    a definition. No intrinsic returns a type today. Named-owner associated,
    anonymous, unnameable, and dynamic heads are not successful type syntax
    (dotted heads resolve only through modules), which tests pin as fail-closed.
    A narrow supported-head completeness bit is therefore true, while broader
-   declaration-type and overall graph completeness remain false.
+   overall graph completeness remains false.
    Named value-constant initializers now retain direct tagged dependencies on
    constants, comptime functions/type constructors, named types, and module
    bindings at the existing collector/evaluator seams. Recursive source context


### PR DESCRIPTION
## Summary
- record stable nominal declaration dependencies at successful resolver boundaries before generic placeholders erase nested type structure
- retain both value-constant alias identity and its resolved nominal target across arrays, pointers, modules, and relocation
- mark named declaration-type capture complete while leaving type-call heads independently fail closed

## Testing
- `./buck2 test //crates/rue-compiler:rue-compiler-test //crates/rue-compiler-session-bench:rue-compiler-session-bench-test`