### PR TITLE
RUE-719: enable sound production invalidation plans

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -212,7 +212,12 @@ fn finalize_function_body_analysis(
             sema.declaration_type_call_head_dependencies.dedup();
             sema.declaration_type_call_head_dependencies.clone()
         },
-        declaration_type_call_head_dependencies_complete: false,
+        // Every successful declaration type-call is resolved through one of
+        // the observer-backed paths above: a named free type constructor or
+        // the separately tagged `Str(N)` builtin. Unsupported/dynamic heads
+        // fail type checking and therefore cannot produce a successful
+        // manifest that silently omits an edge.
+        declaration_type_call_head_dependencies_complete: true,
         declaration_builtin_type_call_head_dependencies: {
             sema.declaration_builtin_type_call_head_dependencies.sort();
             sema.declaration_builtin_type_call_head_dependencies.dedup();

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -611,7 +611,7 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
         ),
         1
     );
-    assert_production_full_plan(plan_cold, 1, 0, modules);
+    assert_production_incremental_plan(plan_cold, 1, 0, 0, modules, modules, 0);
     let plan_noop = get("invalidation_plan_exact_noop");
     assert_reuse_parse_is_all_zero(plan_noop);
     assert_eq!(
@@ -625,31 +625,32 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
         count(plan_noop, &["planner_queries", "invalidation_plan_reuses"]),
         1
     );
-    assert_production_full_plan(plan_noop, 0, 0, modules);
+    assert_production_incremental_plan(plan_noop, 0, 0, 0, modules, modules, 0);
     let plan_leaf = get("invalidation_plan_leaf_body_edit");
     assert_eq!(count(plan_leaf, &["parse", "modules_reparsed"]), 1);
-    assert_production_full_plan(plan_leaf, 1, 1, modules);
+    assert_production_incremental_plan(plan_leaf, 1, 1, 1, modules - 1, modules, 1);
     let plan_identity = get("invalidation_plan_module_identity_change");
     assert_eq!(count(plan_identity, &["parse", "modules_rebound"]), 1);
-    assert_production_full_plan(plan_identity, 1, 0, modules - 1);
+    assert_production_incremental_plan(plan_identity, 1, 0, 2, modules - 1, modules - 1, 2);
 }
 
-fn assert_production_full_plan(scenario: &Value, executions: u64, changed: u64, compared: usize) {
-    assert_eq!(scenario["plan"]["scope"], "full");
-    assert!(
-        scenario["plan"]["full_reasons"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|reason| reason == "incomplete_dependency_graph")
+fn assert_production_incremental_plan(
+    scenario: &Value,
+    executions: u64,
+    changed: u64,
+    invalidated: usize,
+    reusable: usize,
+    compared: usize,
+    closure: usize,
+) {
+    assert_eq!(scenario["plan"]["scope"], "incremental");
+    assert_eq!(scenario["plan"]["full_reasons"], json!([]));
+    assert_eq!(scenario["plan"]["dependency_blockers"], json!([]));
+    assert_eq!(count(scenario, &["plan", "reusable"]), reusable as u64);
+    assert_eq!(
+        count(scenario, &["plan", "invalidated"]),
+        invalidated as u64
     );
-    assert!(
-        scenario["plan"]["dependency_blockers"]
-            .as_array()
-            .is_some_and(|blockers| !blockers.is_empty())
-    );
-    assert_eq!(count(scenario, &["plan", "reusable"]), 0);
-    assert_eq!(count(scenario, &["plan", "invalidated"]), 0);
     assert_eq!(count(scenario, &["plan", "changed"]), changed);
     assert_eq!(
         count(
@@ -671,7 +672,7 @@ fn assert_production_full_plan(scenario: &Value, executions: u64, changed: u64, 
     );
     assert_eq!(
         count(scenario, &["plan", "work", "reverse_closure_nodes_visited"]),
-        0
+        closure as u64
     );
     assert_eq!(count(scenario, &["planner_queries", "rir_executions"]), 0);
     assert_eq!(

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -1459,10 +1459,9 @@ impl CanonicalFrontendSession {
 
     /// Compare two immutable semantic manifests without lowering or scanning RIR.
     ///
-    /// Current production manifests deliberately report an incomplete dependency
-    /// graph, so this query returns a conservative full invalidation until capture
-    /// is complete. Keeping the planner real and cached makes that safety boundary
-    /// executable rather than an implicit promise made by a future cache.
+    /// Supported production manifests with complete dependency capture can produce
+    /// an incremental invalidation plan. Unsupported dependency surfaces, incomplete
+    /// capture, and global semantic-input changes fail closed to full invalidation.
     pub fn semantic_invalidation_plan(
         &mut self,
         previous: &Arc<SemanticDependencyInputManifest>,
@@ -3026,7 +3025,8 @@ mod tests {
     }
 
     #[test]
-    fn production_invalidation_is_cached_and_fails_closed_without_rir_work() {
+    fn production_invalidation_is_cached_incremental_and_closes_reverse_dependencies_without_rir_work()
+     {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<SemanticInvalidationPlan>();
         let source = snapshot(
@@ -3060,34 +3060,78 @@ mod tests {
         let first = planner.semantic_invalidation_plan(&previous, &current);
         let second = planner.semantic_invalidation_plan(&previous, &current);
         assert!(Arc::ptr_eq(&first, &second));
-        assert!(matches!(
-            first.scope(),
-            SemanticInvalidationScope::Full { reasons }
-                if reasons.iter().any(|reason| matches!(reason,
-                    SemanticFullInvalidationReason::IncompleteDependencyGraph(blockers)
-                    if blockers.as_ref() == previous.dependency_blockers()
-                ))
-        ));
-        assert_eq!(
-            previous
-                .dependency_blockers()
-                .iter()
-                .map(|blocker| (blocker.owner(), blocker.surface(), blocker.reason()))
-                .collect::<Vec<_>>(),
-            vec![(
-                None,
-                SemanticDependencySurface::DeclarationTypeCallHead,
-                SemanticDependencyIncompleteReason::TypeCallHeadIdentityUnavailable,
-            ),]
-        );
+        assert_eq!(first.scope(), &SemanticInvalidationScope::Incremental);
+        assert!(previous.dependency_blockers().is_empty());
         assert!(first.reusable().is_empty());
-        assert!(first.invalidated().is_empty());
+        assert_eq!(definition_names(first.invalidated()), vec!["leaf", "main"]);
         assert_eq!(definition_names(first.changed()), vec!["leaf"]);
-        assert_eq!(first.work().dependency_edges_visited, 0);
-        assert_eq!(first.work().reverse_closure_nodes_visited, 0);
+        assert_eq!(first.work().dependency_edges_visited, 2);
+        assert_eq!(first.work().reverse_closure_nodes_visited, 2);
         assert_eq!(first.work().extra_rir_instructions_visited, 0);
         assert_eq!(planner.work().invalidation_plans.executions, 1);
         assert_eq!(planner.work().invalidation_plans.reuses, 1);
+        assert_eq!(planner.work().rir.executions, 0);
+
+        let noop = planner.semantic_invalidation_plan(&previous, &previous);
+        assert_eq!(noop.scope(), &SemanticInvalidationScope::Incremental);
+        assert!(noop.changed().is_empty());
+        assert!(noop.invalidated().is_empty());
+        assert_eq!(definition_names(noop.reusable()), vec!["leaf", "main"]);
+        assert_eq!(noop.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn production_invalidation_closes_cross_module_edges_and_ignores_relocation_and_order() {
+        let build = |main_id, lib_id, root: &str, reversed: bool, leaf_value: i32| {
+            let main = (
+                main_id,
+                format!("{root}/main.rue"),
+                "main.rue",
+                r#"const lib = @import("lib.rue");
+                   fn main() -> i32 { lib.leaf() }"#
+                    .to_owned(),
+            );
+            let lib = (
+                lib_id,
+                format!("{root}/lib.rue"),
+                "lib.rue",
+                format!("pub fn leaf() -> i32 {{ {leaf_value} }}"),
+            );
+            let owned = if reversed {
+                vec![lib, main]
+            } else {
+                vec![main, lib]
+            };
+            let entries = owned
+                .iter()
+                .map(|(id, path, module, text)| (*id, path.as_str(), *module, text.as_str()))
+                .collect::<Vec<_>>();
+            let source = snapshot(&entries, main_id);
+            let mut session = CanonicalFrontendSession::new();
+            session.update(&source).into_result().unwrap();
+            session
+                .semantic_dependency_inputs(&CompileOptions::default(), None)
+                .unwrap()
+        };
+        let previous = build(3, 8, "/one", false, 1);
+        let relocated = build(91, 4, "/elsewhere", true, 1);
+        let changed = build(91, 4, "/elsewhere", true, 2);
+        let mut planner = CanonicalFrontendSession::new();
+
+        let moved = planner.semantic_invalidation_plan(&previous, &relocated);
+        assert_eq!(moved.scope(), &SemanticInvalidationScope::Incremental);
+        assert!(moved.invalidated().is_empty());
+        assert_eq!(
+            definition_names(moved.reusable()),
+            vec!["leaf", "main", "lib"]
+        );
+
+        let plan = planner.semantic_invalidation_plan(&relocated, &changed);
+        assert_eq!(plan.scope(), &SemanticInvalidationScope::Incremental);
+        assert_eq!(definition_names(plan.changed()), vec!["leaf"]);
+        assert_eq!(definition_names(plan.invalidated()), vec!["leaf", "main"]);
+        assert_eq!(definition_names(plan.reusable()), vec!["lib"]);
+        assert_eq!(plan.work().extra_rir_instructions_visited, 0);
         assert_eq!(planner.work().rir.executions, 0);
     }
 
@@ -3151,8 +3195,8 @@ mod tests {
             session.update(source).into_result().unwrap();
             session.semantic_dependency_inputs(options, None).unwrap()
         };
-        let previous = synthetic_complete_manifest(&build(&original, &CompileOptions::default()));
-        let moved = synthetic_complete_manifest(&build(&relocated, &CompileOptions::default()));
+        let previous = build(&original, &CompileOptions::default());
+        let moved = build(&relocated, &CompileOptions::default());
         let mut planner = CanonicalFrontendSession::new();
         let plan = planner.semantic_invalidation_plan(&previous, &moved);
         assert_eq!(plan.scope(), &SemanticInvalidationScope::Incremental);
@@ -3164,25 +3208,25 @@ mod tests {
             .find(|&&target| target != moved.input().target)
             .expect("at least one supported target differs from the current target");
         assert_ne!(alternative_target, moved.input().target);
-        let target = synthetic_complete_manifest(&build(
+        let target = build(
             &relocated,
             &CompileOptions {
                 target: alternative_target,
                 ..CompileOptions::default()
             },
-        ));
+        );
         assert!(matches!(
             planner.semantic_invalidation_plan(&moved, &target).scope(),
             SemanticInvalidationScope::Full { reasons }
                 if reasons.contains(&SemanticFullInvalidationReason::TargetChanged)
         ));
-        let features = synthetic_complete_manifest(&build(
+        let features = build(
             &relocated,
             &CompileOptions {
                 preview_features: PreviewFeatures::from([PreviewFeature::TestInfra]),
                 ..CompileOptions::default()
             },
-        ));
+        );
         assert!(matches!(
             planner.semantic_invalidation_plan(&moved, &features).scope(),
             SemanticInvalidationScope::Full { reasons }
@@ -3368,7 +3412,7 @@ mod tests {
             ]
         );
         assert!(first.free_function_caller_dependencies_complete());
-        assert!(!first.semantic_dependency_graph_complete());
+        assert!(first.semantic_dependency_graph_complete());
         assert_eq!(first.work().specialization_origins_validated, 4);
         assert_eq!(first.work().free_function_events_translated, 5);
         assert_eq!(first.work().extra_rir_instructions_visited, 0);
@@ -3810,6 +3854,17 @@ mod tests {
         );
         assert!(!manifest.implicit_named_destructor_dependencies_complete());
         assert_eq!(manifest.work().extra_rir_instructions_visited, 0);
+        let plan = session.semantic_invalidation_plan(&manifest, &manifest);
+        assert!(matches!(
+            plan.scope(),
+            SemanticInvalidationScope::Full { reasons }
+                if reasons.as_ref() == [SemanticFullInvalidationReason::IncompleteDependencyGraph(
+                    Arc::from([blocker.clone()]),
+                )]
+        ));
+        assert!(plan.reusable().is_empty());
+        assert!(plan.invalidated().is_empty());
+        assert_eq!(plan.work().extra_rir_instructions_visited, 0);
     }
 
     #[test]
@@ -3917,7 +3972,7 @@ mod tests {
                 ),
             ]
         );
-        assert!(!first.declaration_type_call_head_dependencies_complete());
+        assert!(first.declaration_type_call_head_dependencies_complete());
         assert_eq!(first.work().declaration_type_call_head_events_translated, 2);
         assert_eq!(first.work().extra_rir_instructions_visited, 0);
     }
@@ -4054,7 +4109,7 @@ mod tests {
                 .is_empty()
         );
         assert!(manifest.supported_type_call_heads_complete());
-        assert!(!manifest.declaration_type_call_head_dependencies_complete());
+        assert!(manifest.declaration_type_call_head_dependencies_complete());
         assert_eq!(manifest.work().builtin_type_call_head_inputs_translated, 1);
         assert_eq!(manifest.work().extra_rir_instructions_visited, 0);
     }

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -103,7 +103,7 @@ target, and preview-feature changes are unconditional full invalidations;
 physical relocation, FileId assignment, and input order are absent from its
 definition comparison.
 
-This is intentionally a safety seam, not incremental semantic reuse. A
+This is intentionally a safety seam, not yet retained semantic artifacts. A
 production manifest carries an immutable sorted set of
 `SemanticDependencyBlocker` records instead of a hard-coded global completeness
 bit. Each record identifies the dependency surface, the precise missing
@@ -111,16 +111,16 @@ semantic identity, and a stable owner when one exists. Compatibility
 `*_complete` accessors and whole-graph completeness are derived from that set.
 The planner unions both revisions' blockers into its
 `IncompleteDependencyGraph` reason, so endpoint loss fails closed and cannot be
-hidden by a boolean toggle. Production plans currently return `Full` with no
-reusable candidates because no production fixture has an empty blocker set.
-Synthetic complete-manifest tests exercise exact deltas and transitive closure;
-the incremental branch cannot authorize production reuse until every capture
-surface below is complete.
+hidden by a boolean toggle. Supported production programs now have an empty
+blocker set and produce `Incremental` plans for exact no-ops and body-only
+changes, including deterministic reverse-dependency closure and reusable-key
+cardinality. That plan is evidence for a later retained-artifact query; it does
+not itself reuse AIR or CFG results.
 
-The remaining unconditional production blockers are fully resolved
-declaration-type identity and complete declaration type-call-head identity.
-Individual programs can add evidence-based
-blockers, including anonymous drop owners and unsupported dynamic heads. The
+There are no unconditional production blockers. Individual programs can still
+add evidence-based blockers, including anonymous drop owners and any future
+unsupported dynamic or unnameable type-call heads. Such programs continue to
+return `Full` with the exact blocker union and no reusable candidates. The
 records are sorted/deduplicated, independent of FileId and physical location,
 and require no second RIR scan.
 
@@ -251,9 +251,12 @@ semantic input descriptor. No intrinsic currently returns a type. Dotted heads
 are exclusively module paths: `Owner.Make()` where `Owner` is a named type is
 rejected, so associated type constructors, dynamic heads, and unnameable heads
 are not successful language forms and emit no partial dependency edge.
-`supported_type_call_heads_complete=true` is intentionally narrow: it covers
-successfully resolved call heads only. Broader declaration-type and semantic
-graph completeness remain false.
+Both type-call-head completeness surfaces are true for successful programs:
+named heads retain their exact stable function endpoint, while `Str(N)` retains
+its tagged builtin input. Unsupported syntax is rejected before a manifest is
+published; if a successful dynamic/unnameable form is introduced later, its
+producer must emit an evidence-based blocker rather than silently broadening
+this claim. Supported programs can therefore have whole-graph completeness.
 
 Named value-constant initializers record direct dependencies while the existing
 dependency-ordered constant collector and comptime evaluator resolve them.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -61,13 +61,15 @@ incremental-compilation goal is complete.
    is explicitly unsupported. Named destructor callers now translate exact
    owner identities and tagged free/method targets. Anonymous methods and
    destructors plus declaration/type/const/drop surfaces keep the overall graph
-   explicitly incomplete and prevent body/CFG reuse. Completeness is now a
+   explicitly fail closed and prevent body/CFG reuse when encountered.
+   Completeness is now a
    production-derived, sorted blocker set rather than an opaque global boolean;
-   the planner carries the exact union from both revisions. No production
-   fixture reaches `Incremental` yet: declaration type-call-head identity
-   remains the sole unconditional blocker, while
-   anonymous drop owners and unsupported heads add surface-specific blockers
-   when observed. Generic named methods now retain the authoritative reference
+   the planner carries the exact union from both revisions. Supported
+   production fixtures now reach `Incremental` for no-op and body-only deltas,
+   with exact reverse closure, reusable-key counts, and zero additional RIR
+   traversal. Anonymous drop owners and future unsupported heads still add
+   surface-specific blockers and force `Full` when observed. Generic named
+   methods now retain the authoritative reference
    sets from their single runtime body under the stable declaration caller key.
    A conservative resolved declaration-type slice now translates nominal
    signature/field/payload/constant/owner edges without rescanning RIR. A
@@ -84,15 +86,16 @@ incremental-compilation goal is complete.
    a definition. No intrinsic returns a type today. Named-owner associated,
    anonymous, unnameable, and dynamic heads are not successful type syntax
    (dotted heads resolve only through modules), which tests pin as fail-closed.
-   A narrow supported-head completeness bit is therefore true, while broader
-   overall graph completeness remains false.
+   Named and builtin call-head completeness are therefore true for successful
+   supported programs; successful programs without evidence-based blockers now
+   have overall graph completeness.
    Named value-constant initializers now retain direct tagged dependencies on
    constants, comptime functions/type constructors, named types, and module
    bindings at the existing collector/evaluator seams. Recursive source context
    is preserved, cycles fail before publishing, and exact stable translation
    adds zero RIR visits. Module bindings remain import-topology inputs rather
    than value-constant sources. The value-constant slice is narrowly complete;
-   the overall graph remains false for dynamic/anonymous surfaces.
+   dynamic/anonymous surfaces remain explicitly fail-closed when encountered.
    Stable definition input fingerprints are now schema-versioned and split at
    authoritative AST boundaries into identity/visibility, signature, and
    body-or-const-initializer components. Named struct signatures frame around
@@ -100,8 +103,8 @@ incremental-compilation goal is complete.
    than its owner type. Struct fields and enum variants remain exact
    signature-only inputs. Malformed joins fail closed, and hashes remain stable
    across relocation, FileId assignment, and input order. This improves delta
-   classification; it does not itself authorize semantic reuse while the graph
-   completeness bit is false.
+   classification and now drives production `Incremental` plans. Retaining and
+   reusing semantic artifacts remains a separate later slice.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## Summary
- mark successful declaration type-call-head capture complete now that every accepted named or builtin head has stable evidence
- enable production incremental plans with deterministic old/new reverse-dependency closure and relocation-stable reusable candidates
- retain full invalidation for global input changes and evidence-based blockers, and gate exact planner work in the session benchmark

## Testing
- `./buck2 test //crates/rue-compiler:rue-compiler-test //crates/rue-compiler-session-bench:rue-compiler-session-bench-test`