### PR TITLE
RUE-719: define durable semantic value algebra

### DIFF
--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -1,0 +1,101 @@
+//! Request-independent semantic values used at compiler query boundaries.
+//!
+//! These types deliberately have no conversion from `rue_air::Type`. Such a
+//! conversion is only sound while the successful declaration binder, its type
+//! pool, and the exact-revision stable-definition join are available together.
+
+use std::sync::Arc;
+
+use crate::{ModuleId, StableDefinitionKey};
+
+/// Version of the canonical durable type/value encoding.
+pub const DURABLE_SEMANTIC_SCHEMA_VERSION: u32 = 1;
+
+/// An owned, request-independent Rue type.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DurableType {
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    Bool,
+    Unit,
+    Never,
+    ComptimeType,
+    /// A named struct or enum in the exact stable definition universe.
+    Nominal(StableDefinitionKey),
+    Array {
+        element: Box<DurableType>,
+        len: u64,
+    },
+    PtrConst(Box<DurableType>),
+    PtrMut(Box<DurableType>),
+    /// Reserved for the source-level tuple surface once binding supports it.
+    Tuple(Arc<[DurableType]>),
+    /// Reserved for first-class function types. Parameter order is semantic.
+    Function {
+        parameters: Arc<[DurableType]>,
+        result: Box<DurableType>,
+    },
+    /// A module value's resolved logical module identity.
+    Module(ModuleId),
+    /// A declaration-scoped generic parameter, indexed in source order.
+    GenericParameter(u32),
+}
+
+/// An owned, request-independent compile-time value.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DurableConstValue {
+    Integer(i128),
+    Bool(bool),
+    Type(DurableType),
+    /// Function aliases use declaration identity, never a mangled/interner name.
+    Function(StableDefinitionKey),
+    Unit,
+}
+
+/// Typed fail-closed reasons from the future successful-binding exporter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DurableSemanticExportFailure {
+    ErrorType,
+    MissingTypePoolEntry,
+    MissingStableNominalDefinition,
+    MissingStableFunctionDefinition,
+    UnresolvedModule,
+    AnonymousNominalType,
+    UnsupportedLocalType,
+    UnsupportedTypeForm,
+    UnsupportedConstValue,
+    RecursiveStructuralType,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_query_value<T: Send + Sync + Clone + Eq + Ord + std::hash::Hash>() {}
+
+    #[test]
+    fn durable_values_have_query_key_traits() {
+        assert_query_value::<DurableType>();
+        assert_query_value::<DurableConstValue>();
+        assert_query_value::<DurableSemanticExportFailure>();
+    }
+
+    #[test]
+    fn structural_order_is_canonical_and_parameter_order_is_semantic() {
+        let a = DurableType::Tuple(Arc::from([DurableType::Bool, DurableType::I32]));
+        let b = DurableType::Tuple(Arc::from([DurableType::I32, DurableType::Bool]));
+        assert_ne!(a, b);
+
+        let first = DurableConstValue::Type(DurableType::Array {
+            element: Box::new(DurableType::PtrConst(Box::new(DurableType::U8))),
+            len: 4,
+        });
+        assert_eq!(first.clone(), first);
+    }
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -32,6 +32,7 @@ mod canonical_semantic;
 mod definition_snapshot;
 mod diagnostic;
 mod drop_glue;
+mod durable_semantics;
 mod frontend_session;
 mod import_graph;
 pub mod parsed_modules;
@@ -59,6 +60,9 @@ pub use definition_snapshot::{
     DefinitionId, DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionOccurrenceId,
     DefinitionRecord, DefinitionShard, DefinitionShardWork, DefinitionSnapshot, ModuleDefinition,
     ModuleKey,
+};
+pub use durable_semantics::{
+    DURABLE_SEMANTIC_SCHEMA_VERSION, DurableConstValue, DurableSemanticExportFailure, DurableType,
 };
 pub use frontend_session::{
     CanonicalFrontendSession, CanonicalFrontendSessionWork, CanonicalFrontendUpdate,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -37,6 +37,61 @@ Consumers compute deterministic reverse edges and transitive closure from sorted
 direct edges. Missing owners or unresolved targets fail closed by invalidating
 the requesting record, never by silently dropping an edge.
 
+## Durable recursive type and value algebra
+
+The query boundary uses the versioned `DurableType` and `DurableConstValue`
+algebra in `rue-compiler`; schema version 1 is part of every future persistent
+key. It contains only scalar data, `ModuleId`, `StableDefinitionKey`, owned
+structural children, and source-order generic-parameter indices. It is
+`Send + Sync + Eq + Ord + Hash`. It never contains `FileId`, `Span`, `Spur`,
+`InstRef`, request-local `Type`, `StructId`, `EnumId`, or type-pool indices.
+
+The current bound declaration inventory is: signed and unsigned integer widths,
+bool, unit, never, comptime `type`, named structs/enums, arrays, const/mut raw
+pointers, and modules. Constants additionally contain integers, booleans, type
+values, function aliases, and unit. Function/method/destructor signatures use
+the same type forms plus ordered parameter modes and comptime flags at the
+declaration-record layer. Struct fields and enum payloads preserve source order.
+Generic/comptime parameters preserve declaration order; concrete comptime
+arguments use the value algebra. Tuples and first-class function types are
+reserved algebra variants but are not presently emitted by AIR binding.
+
+Named structs and enums are encoded as a single nominal stable-key edge, never
+expanded. This makes self and mutual recursion finite without traversal-order
+backreferences. Structural children are recursively encoded; encountering a
+structural pool cycle is a typed failure. Ordered language constructs retain
+source order. Sets and maps in declaration records must be sorted by stable key
+before construction. No interner number, debug string, physical path, source
+offset, or discovery order participates in equality or hashing.
+
+Export is fail closed. Error types, unresolved modules, missing pool entries,
+anonymous/local nominal types, unjoinable function aliases, and unknown future
+type/value forms produce `DurableSemanticExportFailure`; they are never
+stringified. Adding or changing a variant increments the schema version.
+
+### Required producer seam
+
+The owned algebra is implemented, but one-way export is intentionally not yet
+wired: after successful declaration binding, `BoundSema` currently exposes only
+`SemanticBindingManifest` identity metadata. The resolved `FunctionInfo`,
+`MethodInfo`, `StructDef`, `EnumDef`, `ConstInfo`, parameter arena, and
+`TypeInternPool` remain private and are consumed with `BoundSema` by body
+analysis. Re-parsing type syntax or joining pool IDs by display name would be
+unsound.
+
+The required AIR API is an optional, lazily materialized
+`BoundSema::durable_declaration_export_inputs()` produced before consuming the
+binder. It must return owned request-local records containing binding identity
+(`FileId`, namespace/kind, source name and optional named owner), resolved type
+trees whose nominal leaves carry the defining `(FileId, kind, source name)`,
+resolved module file identity, and const function leaves carrying their defining
+`(FileId, source name)`. It must also expose ordered parameter modes/comptime
+flags and struct/enum members. The compiler then joins every leaf through the
+exact-revision `BoundDefinitionSet` and canonical module table, yielding only
+the durable public algebra. AIR must report typed anonymous/local/missing cases
+instead of substituting pool handles. Materialization work counters must prove
+zero RIR scan and ordinary batch compilation must not request the export.
+
 ## Current capture audit
 
 The existing compiler does not yet expose a complete sound graph:


### PR DESCRIPTION
## Summary
- add versioned, request-handle-free durable type and compile-time value representations for semantic query boundaries
- represent nominal and function identity with stable definition keys and module values with canonical logical module IDs
- define typed fail-closed export failures while deliberately deferring conversion and caching until the binder/pool/stable-definition join is available

## Testing
- `./buck2 test //crates/rue-compiler:rue-compiler-test`