### PR TITLE
RUE-719: export durable declaration semantics from AIR

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -47,8 +47,10 @@ pub use sema::{
     NamedDestructorDependencyEvent, NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
     OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
     SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
-    SemanticBindingNamespace, SpecializedFreeFunctionDependencyEvent,
-    SpecializedFreeFunctionOrigin, import_candidate_groups,
+    SemanticBindingNamespace, SemanticDeclarationExport, SemanticDeclarationExportWork,
+    SemanticDeclarationPayload, SemanticExportConstValue, SemanticExportFailure,
+    SemanticExportParameter, SemanticExportType, SemanticNominalIdentity, SemanticParameterMode,
+    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin, import_candidate_groups,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -8,7 +8,115 @@ use rue_rir::InstData;
 use rue_span::{FileId, Span};
 
 use super::RirDeclarationIndexWork;
-use super::{Sema, SemaOutput};
+use super::{ConstValue, Sema, SemaOutput};
+use crate::types::{Type, TypeKind};
+
+/// A nominal declaration identity valid for one successful binding request.
+/// Consumers must join this identity to their own stable definition universe
+/// while the callback passed to [`BoundSema::with_declaration_semantics`] runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticNominalIdentity {
+    pub file_id: FileId,
+    pub name: Arc<str>,
+    pub kind: SemanticBindingKind,
+}
+
+/// An owned resolved type with no `Type`, pool ID, interner symbol, or RIR handle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SemanticExportType {
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    Bool,
+    Unit,
+    Never,
+    ComptimeType,
+    GenericParameter(u32),
+    Nominal(SemanticNominalIdentity),
+    Array {
+        element: Box<Self>,
+        len: u64,
+    },
+    PtrConst(Box<Self>),
+    PtrMut(Box<Self>),
+    /// Resolved module path. It is deliberately converted by the compiler
+    /// during the callback rather than retained as AIR's request-local ModuleId.
+    Module(Arc<str>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SemanticParameterMode {
+    Value,
+    Borrow,
+    Inout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticExportParameter {
+    pub ty: SemanticExportType,
+    pub mode: SemanticParameterMode,
+    pub is_comptime: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SemanticExportConstValue {
+    Integer(i128),
+    Bool(bool),
+    Type(SemanticExportType),
+    Function { file_id: FileId, name: Arc<str> },
+    Unit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SemanticDeclarationPayload {
+    Callable {
+        parameters: Arc<[SemanticExportParameter]>,
+        result: SemanticExportType,
+        has_self: bool,
+        is_unchecked: bool,
+    },
+    Struct {
+        fields: Arc<[(Arc<str>, SemanticExportType)]>,
+        is_copy: bool,
+        is_linear: bool,
+    },
+    Enum {
+        variants: Arc<[(Arc<str>, Arc<[SemanticExportType]>)]>,
+    },
+    Const {
+        ty: SemanticExportType,
+        value: SemanticExportConstValue,
+    },
+    Destructor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticDeclarationExport {
+    pub identity: SemanticBinding,
+    pub payload: SemanticDeclarationPayload,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SemanticExportFailure {
+    ErrorType,
+    AnonymousNominalType,
+    UnmappedNominalType,
+    UnmappedFunction,
+    UnsupportedParameterMode,
+    RecursiveStructuralType,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticDeclarationExportWork {
+    pub build_invocations: usize,
+    pub declarations_exported: usize,
+    pub rir_instructions_visited: usize,
+}
 
 /// Structural descriptors for one completed declaration-binding pass.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -115,12 +223,323 @@ impl<'a> BoundSema<'a> {
         self.manifest.get().is_some()
     }
 
+    /// Lazily export resolved declaration semantics and invoke `convert` while
+    /// the binder, type pool, interner and module registry are all alive.
+    /// No RIR traversal or second bind is performed.
+    pub fn with_declaration_semantics<R>(
+        &self,
+        convert: impl FnOnce(&[SemanticDeclarationExport], SemanticDeclarationExportWork) -> R,
+    ) -> Result<R, SemanticExportFailure> {
+        let manifest = self.binding_manifest();
+        let (records, work) = self.sema.build_declaration_semantics(manifest)?;
+        Ok(convert(&records, work))
+    }
+
     pub fn analyze_all_bodies(self) -> MultiErrorResult<SemaOutput> {
         self.sema.analyze_all_bodies()
     }
 }
 
 impl<'a> Sema<'a> {
+    fn export_type(
+        &self,
+        ty: Type,
+        stack: &mut Vec<Type>,
+    ) -> Result<SemanticExportType, SemanticExportFailure> {
+        if stack.contains(&ty) {
+            return Err(SemanticExportFailure::RecursiveStructuralType);
+        }
+        let primitive = match ty.kind() {
+            TypeKind::I8 => Some(SemanticExportType::I8),
+            TypeKind::I16 => Some(SemanticExportType::I16),
+            TypeKind::I32 => Some(SemanticExportType::I32),
+            TypeKind::I64 => Some(SemanticExportType::I64),
+            TypeKind::U8 => Some(SemanticExportType::U8),
+            TypeKind::U16 => Some(SemanticExportType::U16),
+            TypeKind::U32 => Some(SemanticExportType::U32),
+            TypeKind::U64 => Some(SemanticExportType::U64),
+            TypeKind::Bool => Some(SemanticExportType::Bool),
+            TypeKind::Unit => Some(SemanticExportType::Unit),
+            TypeKind::Never => Some(SemanticExportType::Never),
+            TypeKind::ComptimeType => Some(SemanticExportType::ComptimeType),
+            TypeKind::Error => return Err(SemanticExportFailure::ErrorType),
+            _ => None,
+        };
+        if let Some(value) = primitive {
+            return Ok(value);
+        }
+        stack.push(ty);
+        let result = match ty.kind() {
+            TypeKind::Struct(id) => {
+                let def = self.type_pool.struct_def(id);
+                if def.is_builtin {
+                    return Err(SemanticExportFailure::UnmappedNominalType);
+                }
+                let symbol = self.interner.get_or_intern(&def.name);
+                if self.structs_by_file_name.get(&(def.file_id, symbol)) != Some(&id) {
+                    return Err(SemanticExportFailure::AnonymousNominalType);
+                }
+                Ok(SemanticExportType::Nominal(SemanticNominalIdentity {
+                    file_id: def.file_id,
+                    name: Arc::from(def.name),
+                    kind: SemanticBindingKind::Struct,
+                }))
+            }
+            TypeKind::Enum(id) => {
+                let def = self.type_pool.enum_def(id);
+                Ok(SemanticExportType::Nominal(SemanticNominalIdentity {
+                    file_id: def.file_id,
+                    name: Arc::from(def.name),
+                    kind: SemanticBindingKind::Enum,
+                }))
+            }
+            TypeKind::Array(id) => {
+                let (element, len) = self.type_pool.array_def(id);
+                Ok(SemanticExportType::Array {
+                    element: Box::new(self.export_type(element, stack)?),
+                    len,
+                })
+            }
+            TypeKind::PtrConst(id) => Ok(SemanticExportType::PtrConst(Box::new(
+                self.export_type(self.type_pool.ptr_const_def(id), stack)?,
+            ))),
+            TypeKind::PtrMut(id) => Ok(SemanticExportType::PtrMut(Box::new(
+                self.export_type(self.type_pool.ptr_mut_def(id), stack)?,
+            ))),
+            TypeKind::Module(id) => Ok(SemanticExportType::Module(Arc::from(
+                self.module_registry.get_def(id).file_path,
+            ))),
+            _ => unreachable!(),
+        };
+        stack.pop();
+        result
+    }
+
+    fn export_function_signature(
+        &self,
+        info: &super::FunctionInfo,
+    ) -> Result<(Arc<[SemanticExportParameter]>, SemanticExportType), SemanticExportFailure> {
+        self.export_callable_signature(
+            info.params,
+            info.return_type,
+            info.rir_params_start,
+            info.rir_params_len,
+            info.return_type_sym,
+        )
+    }
+
+    fn export_callable_signature(
+        &self,
+        range: crate::ParamRange,
+        return_type: Type,
+        params_start: u32,
+        params_len: u32,
+        return_type_sym: Spur,
+    ) -> Result<(Arc<[SemanticExportParameter]>, SemanticExportType), SemanticExportFailure> {
+        let rir_params = self.rir.get_params(params_start, params_len);
+        let type_name = self.interner.get("type");
+        let generic_names = rir_params
+            .iter()
+            .filter(|param| param.is_comptime && Some(param.ty) == type_name)
+            .map(|param| param.name)
+            .collect::<Vec<_>>();
+        let convert = |ty: Type, symbol: Spur| {
+            if ty == Type::COMPTIME_TYPE {
+                if let Some(index) = generic_names.iter().position(|name| *name == symbol) {
+                    return Ok(SemanticExportType::GenericParameter(index as u32));
+                }
+            }
+            self.export_type(ty, &mut Vec::new())
+        };
+        let parameters = self
+            .param_arena
+            .types(range)
+            .iter()
+            .zip(self.param_arena.modes(range))
+            .zip(self.param_arena.comptime(range))
+            .zip(&rir_params)
+            .map(|(((&ty, &mode), &is_comptime), rir)| {
+                use rue_rir::RirParamMode;
+                let mode = match mode {
+                    RirParamMode::Normal | RirParamMode::Comptime => SemanticParameterMode::Value,
+                    RirParamMode::Borrow => SemanticParameterMode::Borrow,
+                    RirParamMode::Inout => SemanticParameterMode::Inout,
+                };
+                Ok(SemanticExportParameter {
+                    ty: convert(ty, rir.ty)?,
+                    mode,
+                    is_comptime,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok((parameters.into(), convert(return_type, return_type_sym)?))
+    }
+
+    fn build_declaration_semantics(
+        &self,
+        manifest: &SemanticBindingManifest,
+    ) -> Result<
+        (
+            Vec<SemanticDeclarationExport>,
+            SemanticDeclarationExportWork,
+        ),
+        SemanticExportFailure,
+    > {
+        let mut records = Vec::with_capacity(manifest.bindings.len());
+        for identity in manifest
+            .bindings
+            .iter()
+            .filter(|b| b.kind != SemanticBindingKind::ModuleBinding)
+        {
+            let name = self.interner.get_or_intern(identity.name.as_ref());
+            let payload = match identity.kind {
+                SemanticBindingKind::Function => {
+                    let internal = *self
+                        .functions_by_file_name
+                        .get(&(identity.file_id, name))
+                        .ok_or(SemanticExportFailure::UnmappedFunction)?;
+                    let info = self
+                        .functions
+                        .get(&internal)
+                        .ok_or(SemanticExportFailure::UnmappedFunction)?;
+                    let (parameters, result) = self.export_function_signature(info)?;
+                    SemanticDeclarationPayload::Callable {
+                        parameters,
+                        result,
+                        has_self: false,
+                        is_unchecked: info.is_unchecked,
+                    }
+                }
+                SemanticBindingKind::Method | SemanticBindingKind::AssociatedFunction => {
+                    let owner = self.interner.get_or_intern(
+                        identity
+                            .owner
+                            .as_deref()
+                            .ok_or(SemanticExportFailure::UnmappedNominalType)?,
+                    );
+                    let sid = *self
+                        .structs_by_file_name
+                        .get(&(identity.file_id, owner))
+                        .ok_or(SemanticExportFailure::UnmappedNominalType)?;
+                    let info = self
+                        .methods
+                        .get(&(sid, name))
+                        .ok_or(SemanticExportFailure::UnmappedFunction)?;
+                    let declaration = *self
+                        .named_method_declarations
+                        .get(&(sid, name))
+                        .ok_or(SemanticExportFailure::UnmappedFunction)?;
+                    let InstData::FnDecl {
+                        params_start,
+                        params_len,
+                        return_type,
+                        ..
+                    } = &self.rir.get(declaration).data
+                    else {
+                        return Err(SemanticExportFailure::UnmappedFunction);
+                    };
+                    let (parameters, result) = self.export_callable_signature(
+                        info.params,
+                        info.return_type,
+                        *params_start,
+                        *params_len,
+                        *return_type,
+                    )?;
+                    SemanticDeclarationPayload::Callable {
+                        parameters,
+                        result,
+                        has_self: info.has_self,
+                        is_unchecked: false,
+                    }
+                }
+                SemanticBindingKind::Struct => {
+                    let sid = *self
+                        .structs_by_file_name
+                        .get(&(identity.file_id, name))
+                        .ok_or(SemanticExportFailure::UnmappedNominalType)?;
+                    let def = self.type_pool.struct_def(sid);
+                    let fields = def
+                        .fields
+                        .into_iter()
+                        .map(|f| Ok((Arc::from(f.name), self.export_type(f.ty, &mut Vec::new())?)))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    SemanticDeclarationPayload::Struct {
+                        fields: fields.into(),
+                        is_copy: def.is_copy,
+                        is_linear: def.is_linear,
+                    }
+                }
+                SemanticBindingKind::Enum => {
+                    let eid = *self
+                        .enums_by_file_name
+                        .get(&(identity.file_id, name))
+                        .ok_or(SemanticExportFailure::UnmappedNominalType)?;
+                    let def = self.type_pool.enum_def(eid);
+                    let variants = def
+                        .variants
+                        .iter()
+                        .enumerate()
+                        .map(|(i, n)| {
+                            let payload = def
+                                .variant_payload(i)
+                                .iter()
+                                .map(|&t| self.export_type(t, &mut Vec::new()))
+                                .collect::<Result<Vec<_>, _>>()?;
+                            Ok((Arc::from(n.as_str()), Arc::from(payload)))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    SemanticDeclarationPayload::Enum {
+                        variants: variants.into(),
+                    }
+                }
+                SemanticBindingKind::ValueConst => {
+                    let info = self
+                        .constants_by_file_name
+                        .get(&(identity.file_id, name))
+                        .ok_or(SemanticExportFailure::UnmappedFunction)?;
+                    let value = match info.value {
+                        ConstValue::Integer(v) => SemanticExportConstValue::Integer(v),
+                        ConstValue::Bool(v) => SemanticExportConstValue::Bool(v),
+                        ConstValue::Type(t) => {
+                            SemanticExportConstValue::Type(self.export_type(t, &mut Vec::new())?)
+                        }
+                        ConstValue::Unit => SemanticExportConstValue::Unit,
+                        ConstValue::Function(symbol) => {
+                            let fi = self
+                                .functions
+                                .get(&symbol)
+                                .ok_or(SemanticExportFailure::UnmappedFunction)?;
+                            let source =
+                                *self.function_source_names.get(&symbol).unwrap_or(&symbol);
+                            SemanticExportConstValue::Function {
+                                file_id: fi.file_id,
+                                name: Arc::from(self.interner.resolve(&source)),
+                            }
+                        }
+                    };
+                    SemanticDeclarationPayload::Const {
+                        ty: self.export_type(info.ty, &mut Vec::new())?,
+                        value,
+                    }
+                }
+                SemanticBindingKind::Destructor => SemanticDeclarationPayload::Destructor,
+                SemanticBindingKind::ModuleBinding => unreachable!(),
+            };
+            records.push(SemanticDeclarationExport {
+                identity: identity.clone(),
+                payload,
+            });
+        }
+        let len = records.len();
+        Ok((
+            records,
+            SemanticDeclarationExportWork {
+                build_invocations: 1,
+                declarations_exported: len,
+                rir_instructions_visited: 0,
+            },
+        ))
+    }
     pub(super) fn into_bound(self) -> BoundSema<'a> {
         let index = self.declaration_index.work();
         BoundSema {
@@ -336,6 +755,64 @@ mod tests {
         let rir = AstGen::new(&ast, &interner).generate();
         let bound = Sema::new(&rir, &interner, PreviewFeatures::new()).bind_declarations()?;
         Ok(bound.binding_manifest().clone())
+    }
+
+    fn export(
+        source: &str,
+    ) -> Result<
+        (
+            Vec<SemanticDeclarationExport>,
+            SemanticDeclarationExportWork,
+        ),
+        SemanticExportFailure,
+    > {
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();
+        let rir = AstGen::new(&ast, &interner).generate();
+        let bound = Sema::new(&rir, &interner, PreviewFeatures::new())
+            .bind_declarations()
+            .unwrap();
+        bound.with_declaration_semantics(|records, work| (records.to_vec(), work))
+    }
+
+    #[test]
+    fn declaration_export_is_resolved_owned_lazy_and_rir_free() {
+        let (records, work) = export(
+            r#"
+            struct Leaf { value: i32 }
+            struct Boxed { nested: [[Leaf; 2]; 4] }
+            enum Maybe { None, Some(Leaf) }
+            const LIMIT: i32 = 7;
+            fn id(comptime T: type, value: T) -> T { value }
+            fn helper(value: ptr const Leaf) -> bool { true }
+            const alias = helper;
+            drop fn Boxed(self) {}
+            fn main() {}
+            "#,
+        )
+        .unwrap();
+        assert_eq!(work.build_invocations, 1);
+        assert_eq!(work.rir_instructions_visited, 0);
+        assert_eq!(work.declarations_exported, records.len());
+        assert!(records.iter().any(|record| matches!(
+            &record.payload,
+            SemanticDeclarationPayload::Callable { parameters, result, .. }
+                if record.identity.name.as_ref() == "id"
+                    && parameters.iter().map(|p| p.is_comptime).collect::<Vec<_>>() == [true, false]
+                    && parameters[1].ty == SemanticExportType::GenericParameter(0)
+                    && *result == SemanticExportType::GenericParameter(0)
+        )));
+        assert!(records.iter().any(|record| matches!(
+            &record.payload,
+            SemanticDeclarationPayload::Const { value: SemanticExportConstValue::Function { name, .. }, .. }
+                if record.identity.name.as_ref() == "alias" && name.as_ref() == "helper"
+        )));
+        assert!(records.iter().any(|record| {
+            record.identity.name.as_ref() == "Boxed"
+                && matches!(record.payload, SemanticDeclarationPayload::Destructor)
+        }));
+        // The callback DTO contains no request-local Type/Spur/InstRef/nominal IDs.
+        assert!(std::mem::size_of::<SemanticExportType>() > 0);
     }
 
     fn bind_with_module_paths(source: &str) -> Result<SemanticBindingManifest, CompileErrors> {

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -49,6 +49,9 @@ mod visibility;
 pub use binding_manifest::{
     BoundSema, DeclarationBindingWork, SemanticBinding, SemanticBindingKind,
     SemanticBindingManifest, SemanticBindingManifestWork, SemanticBindingNamespace,
+    SemanticDeclarationExport, SemanticDeclarationExportWork, SemanticDeclarationPayload,
+    SemanticExportConstValue, SemanticExportFailure, SemanticExportParameter, SemanticExportType,
+    SemanticNominalIdentity, SemanticParameterMode,
 };
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -216,6 +216,53 @@ pub fn bind_canonical_definitions(
         .map(|(definitions, _)| definitions)
 }
 
+/// Bind once and export stable, request-independent declaration semantics
+/// before the successful binder is consumed. This performs no body analysis,
+/// second bind, syntax reconstruction, or additional RIR traversal.
+pub fn bind_canonical_declaration_semantics(
+    merged: &CanonicalMergedProgram,
+    rir: &CanonicalRirOutput,
+    preview_features: PreviewFeatures,
+    target: Target,
+) -> MultiErrorResult<(
+    BoundDefinitionSet,
+    Arc<[crate::DurableDeclarationSemantic]>,
+    rue_air::SemanticDeclarationExportWork,
+)> {
+    let sema = configure_canonical_sema(merged, rir, preview_features, target)?;
+    let bound = sema.bind_declarations()?;
+    let manifest = bound.binding_manifest();
+    let definitions = issue_bound_definitions(
+        merged,
+        rir.source_revision(),
+        manifest.bindings(),
+        manifest.work(),
+    )
+    .map_err(CompileErrors::from)?;
+    let converted = bound
+        .with_declaration_semantics(|records, work| {
+            (
+                crate::durable_semantics::convert_declaration_semantics(
+                    merged,
+                    &definitions,
+                    records,
+                ),
+                work,
+            )
+        })
+        .map_err(|failure| {
+            CompileErrors::from(invalid(&format!(
+                "durable semantic AIR export failed: {failure:?}"
+            )))
+        })?;
+    let semantics = converted.0.map_err(|failure| {
+        CompileErrors::from(invalid(&format!(
+            "durable semantic conversion failed: {failure:?}"
+        )))
+    })?;
+    Ok((definitions, semantics, converted.1))
+}
+
 pub(crate) fn bind_canonical_definitions_with_work(
     merged: &CanonicalMergedProgram,
     rir: &CanonicalRirOutput,
@@ -634,6 +681,25 @@ mod tests {
             .unwrap()
     }
 
+    fn export(
+        snapshot: &SourceSnapshot,
+    ) -> (
+        BoundDefinitionSet,
+        Arc<[crate::DurableDeclarationSemantic]>,
+        rue_air::SemanticDeclarationExportWork,
+    ) {
+        let parsed = parse_source_snapshot_modules(snapshot).unwrap();
+        let merged = merge_parsed_modules(&parsed).unwrap();
+        let rir = lower_canonical_rir(&merged).unwrap();
+        bind_canonical_declaration_semantics(
+            &merged,
+            &rir,
+            PreviewFeatures::new(),
+            Target::default(),
+        )
+        .unwrap()
+    }
+
     fn keys(set: &BoundDefinitionSet) -> Vec<StableDefinitionKey> {
         set.definitions()
             .iter()
@@ -652,6 +718,107 @@ mod tests {
         drop fn Resource(self) {}
         fn main() -> i32 { Resource.make().get() + LIMIT }
     "#;
+
+    #[test]
+    fn durable_declaration_export_is_relocation_and_order_stable_without_extra_rir() {
+        let first = snapshot(
+            &[
+                (
+                    9,
+                    "/old/z.rue",
+                    "z.rue",
+                    "fn helper(x: ptr const i32) -> bool { true } const alias = helper;",
+                ),
+                (2, "/old/main.rue", "main.rue", PROGRAM),
+            ],
+            2,
+        );
+        let moved = snapshot(
+            &[
+                (71, "/new/main.rue", "main.rue", PROGRAM),
+                (
+                    4,
+                    "/new/z.rue",
+                    "z.rue",
+                    "fn helper(x: ptr const i32) -> bool { true } const alias = helper;",
+                ),
+            ],
+            71,
+        );
+        let (_, first, first_work) = export(&first);
+        let (_, moved, moved_work) = export(&moved);
+        assert_eq!(first, moved);
+        assert_eq!(first_work, moved_work);
+        assert_eq!(first_work.build_invocations, 1);
+        assert_eq!(first_work.rir_instructions_visited, 0);
+        assert!(first.iter().any(|record| matches!(
+            record.payload,
+            crate::DurableDeclarationPayload::Const {
+                value: crate::DurableConstValue::Function(_),
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn durable_member_export_joins_same_named_members_through_their_stable_owner() {
+        const MEMBERS: &str = r#"
+            struct Alpha {
+                fn shared(self) -> i32 { 1 }
+                fn make() -> i32 { 2 }
+            }
+            struct Beta {
+                fn shared(self) -> bool { true }
+                fn make() -> bool { false }
+            }
+            fn main() {}
+        "#;
+        let first = snapshot(
+            &[
+                (9, "/old/z.rue", "z.rue", "fn helper() {}"),
+                (2, "/old/main.rue", "main.rue", MEMBERS),
+            ],
+            2,
+        );
+        let moved = snapshot(
+            &[
+                (71, "/new/main.rue", "main.rue", MEMBERS),
+                (4, "/new/z.rue", "z.rue", "fn helper() {}"),
+            ],
+            71,
+        );
+        let (_, first, _) = export(&first);
+        let (_, moved, _) = export(&moved);
+        assert_eq!(first, moved);
+
+        let members = first
+            .iter()
+            .filter(|record| {
+                matches!(
+                    record.key.kind(),
+                    StableDefinitionKind::Method | StableDefinitionKind::AssociatedFunction
+                )
+            })
+            .map(|record| {
+                (
+                    record.key.kind(),
+                    record.key.name().to_owned(),
+                    record.key.owner().unwrap().name().to_owned(),
+                    record.payload.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(members.len(), 4);
+        for name in ["make", "shared"] {
+            let same_name = members
+                .iter()
+                .filter(|member| member.1 == name)
+                .collect::<Vec<_>>();
+            assert_eq!(same_name.len(), 2);
+            assert_ne!(same_name[0].2, same_name[1].2);
+            assert_ne!(same_name[0].3, same_name[1].3);
+        }
+    }
 
     #[test]
     fn stable_keys_ignore_relocation_file_ids_and_batch_order() {

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -6,7 +6,14 @@
 
 use std::sync::Arc;
 
-use crate::{ModuleId, StableDefinitionKey};
+use rue_air::{
+    SemanticBindingKind, SemanticDeclarationExport, SemanticDeclarationPayload,
+    SemanticExportConstValue, SemanticExportFailure, SemanticExportType, SemanticParameterMode,
+};
+
+use crate::{
+    BoundDefinitionSet, CanonicalMergedProgram, ModuleId, StableDefinitionKey, StableDefinitionKind,
+};
 
 /// Version of the canonical durable type/value encoding.
 pub const DURABLE_SEMANTIC_SCHEMA_VERSION: u32 = 1;
@@ -58,6 +65,50 @@ pub enum DurableConstValue {
     Unit,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DurableParameterMode {
+    Value,
+    Borrow,
+    Inout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DurableSemanticParameter {
+    pub ty: DurableType,
+    pub mode: DurableParameterMode,
+    pub is_comptime: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DurableDeclarationPayload {
+    Callable {
+        parameters: Arc<[DurableSemanticParameter]>,
+        result: DurableType,
+        has_self: bool,
+        is_unchecked: bool,
+    },
+    Struct {
+        fields: Arc<[(Arc<str>, DurableType)]>,
+        is_copy: bool,
+        is_linear: bool,
+    },
+    Enum {
+        variants: Arc<[(Arc<str>, Arc<[DurableType]>)]>,
+    },
+    Const {
+        ty: DurableType,
+        value: DurableConstValue,
+    },
+    Destructor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DurableDeclarationSemantic {
+    pub key: StableDefinitionKey,
+    pub is_public: bool,
+    pub payload: DurableDeclarationPayload,
+}
+
 /// Typed fail-closed reasons from the future successful-binding exporter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DurableSemanticExportFailure {
@@ -73,6 +124,240 @@ pub enum DurableSemanticExportFailure {
     RecursiveStructuralType,
 }
 
+pub(crate) fn convert_declaration_semantics(
+    merged: &CanonicalMergedProgram,
+    definitions: &BoundDefinitionSet,
+    exports: &[SemanticDeclarationExport],
+) -> Result<Arc<[DurableDeclarationSemantic]>, DurableSemanticExportFailure> {
+    fn stable_kind(kind: SemanticBindingKind) -> Option<StableDefinitionKind> {
+        Some(match kind {
+            SemanticBindingKind::Function => StableDefinitionKind::Function,
+            SemanticBindingKind::Struct => StableDefinitionKind::Struct,
+            SemanticBindingKind::Enum => StableDefinitionKind::Enum,
+            SemanticBindingKind::ValueConst => StableDefinitionKind::ValueConst,
+            SemanticBindingKind::Destructor => StableDefinitionKind::Destructor,
+            SemanticBindingKind::Method => StableDefinitionKind::Method,
+            SemanticBindingKind::AssociatedFunction => StableDefinitionKind::AssociatedFunction,
+            SemanticBindingKind::ModuleBinding => return None,
+        })
+    }
+    let module_for_file = |file_id| {
+        merged
+            .ast()
+            .modules()
+            .iter()
+            .find(|m| m.file_id() == file_id)
+            .map(|m| m.module_id())
+    };
+    let key_for = |file_id, name: &str, kind, owner: Option<&str>| {
+        let module = module_for_file(file_id)?;
+        let stable_kind = stable_kind(kind)?;
+        let owner_is_valid = match kind {
+            SemanticBindingKind::Method | SemanticBindingKind::AssociatedFunction => {
+                owner.is_some()
+            }
+            SemanticBindingKind::Destructor => owner == Some(name),
+            _ => owner.is_none(),
+        };
+        if !owner_is_valid {
+            return None;
+        }
+        let matches = definitions
+            .definitions()
+            .iter()
+            .map(|r| r.stable_key())
+            .filter(|key| {
+                key.module() == module
+                    && key.kind() == stable_kind
+                    && key.name() == name
+                    && key.owner().map(|owner| owner.name()) == owner
+            })
+            .collect::<Vec<_>>();
+        let [key] = matches.as_slice() else {
+            return None;
+        };
+        Some((*key).clone())
+    };
+    fn ty(
+        value: &SemanticExportType,
+        merged: &CanonicalMergedProgram,
+        definitions: &BoundDefinitionSet,
+    ) -> Result<DurableType, DurableSemanticExportFailure> {
+        let nominal = |identity: &rue_air::SemanticNominalIdentity| {
+            let module = merged
+                .ast()
+                .modules()
+                .iter()
+                .find(|m| m.file_id() == identity.file_id)
+                .map(|m| m.module_id())
+                .ok_or(DurableSemanticExportFailure::MissingStableNominalDefinition)?;
+            let kind = match identity.kind {
+                SemanticBindingKind::Struct => StableDefinitionKind::Struct,
+                SemanticBindingKind::Enum => StableDefinitionKind::Enum,
+                _ => return Err(DurableSemanticExportFailure::MissingStableNominalDefinition),
+            };
+            definitions
+                .definitions()
+                .iter()
+                .map(|r| r.stable_key())
+                .find(|key| {
+                    key.module() == module
+                        && key.kind() == kind
+                        && key.name() == identity.name.as_ref()
+                })
+                .cloned()
+                .map(DurableType::Nominal)
+                .ok_or(DurableSemanticExportFailure::MissingStableNominalDefinition)
+        };
+        Ok(match value {
+            SemanticExportType::I8 => DurableType::I8,
+            SemanticExportType::I16 => DurableType::I16,
+            SemanticExportType::I32 => DurableType::I32,
+            SemanticExportType::I64 => DurableType::I64,
+            SemanticExportType::U8 => DurableType::U8,
+            SemanticExportType::U16 => DurableType::U16,
+            SemanticExportType::U32 => DurableType::U32,
+            SemanticExportType::U64 => DurableType::U64,
+            SemanticExportType::Bool => DurableType::Bool,
+            SemanticExportType::Unit => DurableType::Unit,
+            SemanticExportType::Never => DurableType::Never,
+            SemanticExportType::ComptimeType => DurableType::ComptimeType,
+            SemanticExportType::GenericParameter(index) => DurableType::GenericParameter(*index),
+            SemanticExportType::Nominal(n) => nominal(n)?,
+            SemanticExportType::Array { element, len } => DurableType::Array {
+                element: Box::new(ty(element, merged, definitions)?),
+                len: *len,
+            },
+            SemanticExportType::PtrConst(v) => {
+                DurableType::PtrConst(Box::new(ty(v, merged, definitions)?))
+            }
+            SemanticExportType::PtrMut(v) => {
+                DurableType::PtrMut(Box::new(ty(v, merged, definitions)?))
+            }
+            SemanticExportType::Module(path) => {
+                let module = merged
+                    .ast()
+                    .modules()
+                    .iter()
+                    .find(|m| m.physical_path() == path.as_ref())
+                    .map(|m| m.module_id().clone())
+                    .ok_or(DurableSemanticExportFailure::UnresolvedModule)?;
+                DurableType::Module(module)
+            }
+        })
+    }
+    let mut result = Vec::with_capacity(exports.len());
+    for export in exports {
+        let key = key_for(
+            export.identity.file_id,
+            &export.identity.name,
+            export.identity.kind,
+            export.identity.owner.as_deref(),
+        )
+        .ok_or(DurableSemanticExportFailure::MissingStableNominalDefinition)?;
+        let payload = match &export.payload {
+            SemanticDeclarationPayload::Callable {
+                parameters,
+                result,
+                has_self,
+                is_unchecked,
+            } => DurableDeclarationPayload::Callable {
+                parameters: parameters
+                    .iter()
+                    .map(|p| {
+                        Ok(DurableSemanticParameter {
+                            ty: ty(&p.ty, merged, definitions)?,
+                            mode: match p.mode {
+                                SemanticParameterMode::Value => DurableParameterMode::Value,
+                                SemanticParameterMode::Borrow => DurableParameterMode::Borrow,
+                                SemanticParameterMode::Inout => DurableParameterMode::Inout,
+                            },
+                            is_comptime: p.is_comptime,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, DurableSemanticExportFailure>>()?
+                    .into(),
+                result: ty(result, merged, definitions)?,
+                has_self: *has_self,
+                is_unchecked: *is_unchecked,
+            },
+            SemanticDeclarationPayload::Struct {
+                fields,
+                is_copy,
+                is_linear,
+            } => DurableDeclarationPayload::Struct {
+                fields: fields
+                    .iter()
+                    .map(|(n, t)| Ok((n.clone(), ty(t, merged, definitions)?)))
+                    .collect::<Result<Vec<_>, DurableSemanticExportFailure>>()?
+                    .into(),
+                is_copy: *is_copy,
+                is_linear: *is_linear,
+            },
+            SemanticDeclarationPayload::Enum { variants } => DurableDeclarationPayload::Enum {
+                variants: variants
+                    .iter()
+                    .map(|(n, p)| {
+                        Ok((
+                            n.clone(),
+                            p.iter()
+                                .map(|t| ty(t, merged, definitions))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into(),
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, DurableSemanticExportFailure>>()?
+                    .into(),
+            },
+            SemanticDeclarationPayload::Const {
+                ty: const_ty,
+                value,
+            } => {
+                let value = match value {
+                    SemanticExportConstValue::Integer(v) => DurableConstValue::Integer(*v),
+                    SemanticExportConstValue::Bool(v) => DurableConstValue::Bool(*v),
+                    SemanticExportConstValue::Type(t) => {
+                        DurableConstValue::Type(ty(t, merged, definitions)?)
+                    }
+                    SemanticExportConstValue::Unit => DurableConstValue::Unit,
+                    SemanticExportConstValue::Function { file_id, name } => {
+                        DurableConstValue::Function(
+                            key_for(*file_id, name, SemanticBindingKind::Function, None).ok_or(
+                                DurableSemanticExportFailure::MissingStableFunctionDefinition,
+                            )?,
+                        )
+                    }
+                };
+                DurableDeclarationPayload::Const {
+                    ty: ty(const_ty, merged, definitions)?,
+                    value,
+                }
+            }
+            SemanticDeclarationPayload::Destructor => DurableDeclarationPayload::Destructor,
+        };
+        result.push(DurableDeclarationSemantic {
+            key,
+            is_public: export.identity.is_public,
+            payload,
+        });
+    }
+    result.sort_by(|a, b| a.key.cmp(&b.key));
+    Ok(result.into())
+}
+
+impl From<SemanticExportFailure> for DurableSemanticExportFailure {
+    fn from(value: SemanticExportFailure) -> Self {
+        match value {
+            SemanticExportFailure::ErrorType => Self::ErrorType,
+            SemanticExportFailure::AnonymousNominalType => Self::AnonymousNominalType,
+            SemanticExportFailure::UnmappedNominalType => Self::MissingStableNominalDefinition,
+            SemanticExportFailure::UnmappedFunction => Self::MissingStableFunctionDefinition,
+            SemanticExportFailure::UnsupportedParameterMode => Self::UnsupportedTypeForm,
+            SemanticExportFailure::RecursiveStructuralType => Self::RecursiveStructuralType,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -83,6 +368,9 @@ mod tests {
     fn durable_values_have_query_key_traits() {
         assert_query_value::<DurableType>();
         assert_query_value::<DurableConstValue>();
+        assert_query_value::<DurableSemanticParameter>();
+        assert_query_value::<DurableDeclarationPayload>();
+        assert_query_value::<DurableDeclarationSemantic>();
         assert_query_value::<DurableSemanticExportFailure>();
     }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -47,7 +47,7 @@ mod unit;
 pub use bound_definitions::{
     BoundDefinitionId, BoundDefinitionRecord, BoundDefinitionSet, BoundDefinitionWork,
     StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace, StableNamedTypeKey,
-    bind_canonical_definitions,
+    bind_canonical_declaration_semantics, bind_canonical_definitions,
 };
 pub use canonical_lower::{CanonicalRirOutput, CanonicalRirWork, lower_canonical_rir};
 pub use canonical_merge::{
@@ -62,7 +62,9 @@ pub use definition_snapshot::{
     ModuleKey,
 };
 pub use durable_semantics::{
-    DURABLE_SEMANTIC_SCHEMA_VERSION, DurableConstValue, DurableSemanticExportFailure, DurableType,
+    DURABLE_SEMANTIC_SCHEMA_VERSION, DurableConstValue, DurableDeclarationPayload,
+    DurableDeclarationSemantic, DurableParameterMode, DurableSemanticExportFailure,
+    DurableSemanticParameter, DurableType,
 };
 pub use frontend_session::{
     CanonicalFrontendSession, CanonicalFrontendSessionWork, CanonicalFrontendUpdate,


### PR DESCRIPTION
## Summary
- lazily export resolved declaration semantics while the successful binder, type pool, interner, and module registry coexist
- convert every transient nominal, callable, and module identity through the exact stable definition/module universe before publishing durable records
- fail atomically on anonymous, unresolved, recursive, ambiguous, or owner-mismatched values without a second bind, body analysis, or RIR scan

## Testing
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test`