### PR TITLE
RUE-719: remap durable semantics into fresh AIR epochs

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -18,6 +18,7 @@ mod param_arena;
 mod path_norm;
 mod scope;
 mod sema;
+mod semantic_import;
 pub mod specialize;
 mod types;
 
@@ -51,6 +52,11 @@ pub use sema::{
     SemanticDeclarationPayload, SemanticExportConstValue, SemanticExportFailure,
     SemanticExportParameter, SemanticExportType, SemanticNominalIdentity, SemanticParameterMode,
     SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin, import_candidate_groups,
+};
+pub use semantic_import::{
+    SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,
+    SemanticImportNominalKind, SemanticImportType, SemanticImportedConstValue,
+    SemanticImportedType,
 };
 pub use types::{
     ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -1,0 +1,763 @@
+//! Request-independent semantic values imported into a fresh AIR epoch.
+//!
+//! This module deliberately stops short of installing declarations into
+//! [`crate::Sema`]. Bodies, source spans, and RIR declaration handles belong to
+//! an exact semantic request. The importer reconstructs only values that AIR
+//! can represent without borrowing handles from the exporting request.
+
+use std::collections::BTreeMap;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use lasso::{Spur, ThreadedRodeo};
+use rue_span::FileId;
+
+use crate::{
+    ConstValue, EnumDef, EnumId, ModuleId, ModuleRegistry, StructDef, StructField, StructId, Type,
+    TypeInternPool,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SemanticImportNominalKind {
+    Struct,
+    Enum,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SemanticImportNominal<K> {
+    pub key: K,
+    pub module_path: Arc<str>,
+    pub name: Arc<str>,
+    pub kind: SemanticImportNominalKind,
+    pub is_public: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SemanticImportType<K, M> {
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    Bool,
+    Unit,
+    Never,
+    ComptimeType,
+    Nominal(K),
+    Array {
+        element: Box<Self>,
+        len: u64,
+    },
+    PtrConst(Box<Self>),
+    PtrMut(Box<Self>),
+    Module(M),
+    GenericParameter(u32),
+    Tuple(Arc<[Self]>),
+    Function {
+        parameters: Arc<[Self]>,
+        result: Box<Self>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SemanticImportConstValue<K, M> {
+    Integer(i128),
+    Bool(bool),
+    Type(SemanticImportType<K, M>),
+    Function(K),
+    Unit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SemanticImportFailure {
+    DuplicateNominal,
+    DuplicateNominalLocalIdentity,
+    DuplicateFunction,
+    DuplicateFunctionLocalIdentity,
+    DeclarationKindMismatch,
+    NominalKindMismatch,
+    MissingNominal,
+    MissingModule,
+    MissingFunction,
+    GenericParameterNeedsDeclarationContext,
+    UnsupportedTuple,
+    UnsupportedFunctionType,
+    ForeignLocalType,
+    ForeignLocalValue,
+}
+
+/// An AIR type branded with the import epoch which issued it.
+#[derive(Debug, Clone)]
+pub struct SemanticImportedType {
+    epoch: Arc<()>,
+    value: Type,
+}
+
+impl PartialEq for SemanticImportedType {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.epoch, &other.epoch) && self.value == other.value
+    }
+}
+impl Eq for SemanticImportedType {}
+
+/// An AIR constant branded with the import epoch which issued it.
+#[derive(Debug, Clone)]
+pub struct SemanticImportedConstValue {
+    epoch: Arc<()>,
+    value: ConstValue,
+}
+
+impl PartialEq for SemanticImportedConstValue {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.epoch, &other.epoch) && self.value == other.value
+    }
+}
+impl Eq for SemanticImportedConstValue {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalNominal {
+    Struct(StructId),
+    Enum(EnumId),
+}
+
+/// A fresh AIR-owned interning epoch joined to caller-owned stable keys.
+///
+/// Stable keys never become AIR IDs. They are retained only in the maps at
+/// this boundary. Imported types and constants are returned through opaque,
+/// epoch-branded wrappers, so request-local IDs cannot cross epoch boundaries.
+pub struct SemanticImportEpoch<K: Ord, M: Ord> {
+    epoch: Arc<()>,
+    interner: ThreadedRodeo,
+    type_pool: TypeInternPool,
+    module_registry: ModuleRegistry,
+    nominals: BTreeMap<K, LocalNominal>,
+    functions: BTreeMap<K, Spur>,
+    modules: BTreeMap<M, ModuleId>,
+}
+
+impl<K, M> SemanticImportEpoch<K, M>
+where
+    K: Clone + Ord,
+    M: Clone + Ord + AsRef<str>,
+{
+    pub fn new(
+        mut nominals: Vec<SemanticImportNominal<K>>,
+        mut function_keys: Vec<(K, Arc<str>)>,
+        mut module_keys: Vec<M>,
+    ) -> Result<Self, SemanticImportFailure> {
+        nominals.sort_by(|a, b| a.key.cmp(&b.key));
+        function_keys.sort_by(|a, b| a.0.cmp(&b.0));
+        module_keys.sort();
+
+        let interner = ThreadedRodeo::new();
+        let type_pool = TypeInternPool::new();
+        let module_registry = ModuleRegistry::new();
+        let mut modules = BTreeMap::new();
+        for key in module_keys {
+            let path = key.as_ref().to_owned();
+            let (id, _) = module_registry.get_or_create(path.clone(), path);
+            modules.insert(key, id);
+        }
+
+        let mut functions = BTreeMap::new();
+        let mut function_identities = std::collections::BTreeSet::new();
+        for (key, name) in function_keys {
+            if !function_identities.insert(name.clone()) {
+                return Err(SemanticImportFailure::DuplicateFunctionLocalIdentity);
+            }
+            let symbol = interner.get_or_intern(name.as_ref());
+            if functions.insert(key, symbol).is_some() {
+                return Err(SemanticImportFailure::DuplicateFunction);
+            }
+        }
+
+        let mut module_files = BTreeMap::<Arc<str>, FileId>::new();
+        for nominal in &nominals {
+            let next = u32::try_from(module_files.len() + 1).expect("too many semantic modules");
+            module_files
+                .entry(nominal.module_path.clone())
+                .or_insert(FileId::new(next));
+        }
+        let mut local = BTreeMap::new();
+        let mut local_identities = std::collections::BTreeSet::new();
+        for nominal in nominals {
+            if local.contains_key(&nominal.key) {
+                return Err(SemanticImportFailure::DuplicateNominal);
+            }
+            if !local_identities.insert((
+                nominal.kind,
+                nominal.module_path.clone(),
+                nominal.name.clone(),
+            )) {
+                return Err(SemanticImportFailure::DuplicateNominalLocalIdentity);
+            }
+            let file_id = module_files[&nominal.module_path];
+            let name = nominal.name.to_string();
+            let symbol = interner.get_or_intern(&name);
+            let value = match nominal.kind {
+                SemanticImportNominalKind::Struct => {
+                    let (id, _) = type_pool.register_struct(
+                        symbol,
+                        StructDef {
+                            name,
+                            fields: vec![],
+                            is_copy: false,
+                            is_linear: false,
+                            destructor: None,
+                            is_builtin: false,
+                            is_pub: nominal.is_public,
+                            file_id,
+                        },
+                    );
+                    LocalNominal::Struct(id)
+                }
+                SemanticImportNominalKind::Enum => {
+                    let (id, _) = type_pool.register_enum(
+                        symbol,
+                        EnumDef {
+                            name,
+                            variants: vec![],
+                            variant_payloads: vec![],
+                            is_pub: nominal.is_public,
+                            file_id,
+                        },
+                    );
+                    LocalNominal::Enum(id)
+                }
+            };
+            local.insert(nominal.key, value);
+        }
+        Ok(Self {
+            epoch: Arc::new(()),
+            interner,
+            type_pool,
+            module_registry,
+            nominals: local,
+            functions,
+            modules,
+        })
+    }
+
+    pub fn import_type(
+        &self,
+        value: &SemanticImportType<K, M>,
+    ) -> Result<SemanticImportedType, SemanticImportFailure> {
+        self.import_type_local(value)
+            .map(|value| SemanticImportedType {
+                epoch: self.epoch.clone(),
+                value,
+            })
+    }
+
+    fn import_type_local(
+        &self,
+        value: &SemanticImportType<K, M>,
+    ) -> Result<Type, SemanticImportFailure> {
+        Ok(match value {
+            SemanticImportType::I8 => Type::I8,
+            SemanticImportType::I16 => Type::I16,
+            SemanticImportType::I32 => Type::I32,
+            SemanticImportType::I64 => Type::I64,
+            SemanticImportType::U8 => Type::U8,
+            SemanticImportType::U16 => Type::U16,
+            SemanticImportType::U32 => Type::U32,
+            SemanticImportType::U64 => Type::U64,
+            SemanticImportType::Bool => Type::BOOL,
+            SemanticImportType::Unit => Type::UNIT,
+            SemanticImportType::Never => Type::NEVER,
+            SemanticImportType::ComptimeType => Type::COMPTIME_TYPE,
+            SemanticImportType::Nominal(key) => match self.nominals.get(key) {
+                Some(LocalNominal::Struct(id)) => Type::new_struct(*id),
+                Some(LocalNominal::Enum(id)) => Type::new_enum(*id),
+                None => return Err(SemanticImportFailure::MissingNominal),
+            },
+            SemanticImportType::Array { element, len } => Type::new_array(
+                self.type_pool
+                    .intern_array_from_type(self.import_type_local(element)?, *len),
+            ),
+            SemanticImportType::PtrConst(value) => Type::new_ptr_const(
+                self.type_pool
+                    .intern_ptr_const_from_type(self.import_type_local(value)?),
+            ),
+            SemanticImportType::PtrMut(value) => Type::new_ptr_mut(
+                self.type_pool
+                    .intern_ptr_mut_from_type(self.import_type_local(value)?),
+            ),
+            SemanticImportType::Module(key) => Type::new_module(
+                *self
+                    .modules
+                    .get(key)
+                    .ok_or(SemanticImportFailure::MissingModule)?,
+            ),
+            SemanticImportType::GenericParameter(_) => {
+                return Err(SemanticImportFailure::GenericParameterNeedsDeclarationContext);
+            }
+            SemanticImportType::Tuple(_) => return Err(SemanticImportFailure::UnsupportedTuple),
+            SemanticImportType::Function { .. } => {
+                return Err(SemanticImportFailure::UnsupportedFunctionType);
+            }
+        })
+    }
+
+    /// Import an ordered declaration parameter or payload sequence.
+    pub fn import_types(
+        &self,
+        values: &[SemanticImportType<K, M>],
+    ) -> Result<Arc<[SemanticImportedType]>, SemanticImportFailure> {
+        values
+            .iter()
+            .map(|value| self.import_type(value))
+            .collect::<Result<Vec<_>, _>>()
+            .map(Arc::from)
+    }
+
+    pub fn import_const_value(
+        &self,
+        value: &SemanticImportConstValue<K, M>,
+    ) -> Result<SemanticImportedConstValue, SemanticImportFailure> {
+        self.import_const_value_local(value)
+            .map(|value| SemanticImportedConstValue {
+                epoch: self.epoch.clone(),
+                value,
+            })
+    }
+
+    fn import_const_value_local(
+        &self,
+        value: &SemanticImportConstValue<K, M>,
+    ) -> Result<ConstValue, SemanticImportFailure> {
+        Ok(match value {
+            SemanticImportConstValue::Integer(v) => ConstValue::Integer(*v),
+            SemanticImportConstValue::Bool(v) => ConstValue::Bool(*v),
+            SemanticImportConstValue::Type(v) => ConstValue::Type(self.import_type_local(v)?),
+            SemanticImportConstValue::Function(key) => ConstValue::Function(
+                *self
+                    .functions
+                    .get(key)
+                    .ok_or(SemanticImportFailure::MissingFunction)?,
+            ),
+            SemanticImportConstValue::Unit => ConstValue::Unit,
+        })
+    }
+
+    /// Project an imported local type back through this epoch's stable join.
+    /// This rejects local values which were not issued by this epoch.
+    pub fn export_type(
+        &self,
+        value: SemanticImportedType,
+    ) -> Result<SemanticImportType<K, M>, SemanticImportFailure> {
+        if !Arc::ptr_eq(&value.epoch, &self.epoch) {
+            return Err(SemanticImportFailure::ForeignLocalType);
+        }
+        self.export_type_local(value.value)
+    }
+
+    fn export_type_local(
+        &self,
+        value: Type,
+    ) -> Result<SemanticImportType<K, M>, SemanticImportFailure> {
+        Ok(match value.kind() {
+            crate::TypeKind::I8 => SemanticImportType::I8,
+            crate::TypeKind::I16 => SemanticImportType::I16,
+            crate::TypeKind::I32 => SemanticImportType::I32,
+            crate::TypeKind::I64 => SemanticImportType::I64,
+            crate::TypeKind::U8 => SemanticImportType::U8,
+            crate::TypeKind::U16 => SemanticImportType::U16,
+            crate::TypeKind::U32 => SemanticImportType::U32,
+            crate::TypeKind::U64 => SemanticImportType::U64,
+            crate::TypeKind::Bool => SemanticImportType::Bool,
+            crate::TypeKind::Unit => SemanticImportType::Unit,
+            crate::TypeKind::Never => SemanticImportType::Never,
+            crate::TypeKind::ComptimeType => SemanticImportType::ComptimeType,
+            crate::TypeKind::Struct(id) => SemanticImportType::Nominal(
+                self.nominals
+                    .iter()
+                    .find_map(|(key, local)| {
+                        (*local == LocalNominal::Struct(id)).then(|| key.clone())
+                    })
+                    .ok_or(SemanticImportFailure::ForeignLocalType)?,
+            ),
+            crate::TypeKind::Enum(id) => SemanticImportType::Nominal(
+                self.nominals
+                    .iter()
+                    .find_map(|(key, local)| {
+                        (*local == LocalNominal::Enum(id)).then(|| key.clone())
+                    })
+                    .ok_or(SemanticImportFailure::ForeignLocalType)?,
+            ),
+            crate::TypeKind::Array(id) => {
+                let (element, len) = self.type_pool.array_def(id);
+                SemanticImportType::Array {
+                    element: Box::new(self.export_type_local(element)?),
+                    len,
+                }
+            }
+            crate::TypeKind::PtrConst(id) => SemanticImportType::PtrConst(Box::new(
+                self.export_type_local(self.type_pool.ptr_const_def(id))?,
+            )),
+            crate::TypeKind::PtrMut(id) => SemanticImportType::PtrMut(Box::new(
+                self.export_type_local(self.type_pool.ptr_mut_def(id))?,
+            )),
+            crate::TypeKind::Module(id) => SemanticImportType::Module(
+                self.modules
+                    .iter()
+                    .find_map(|(key, local)| (*local == id).then(|| key.clone()))
+                    .ok_or(SemanticImportFailure::ForeignLocalType)?,
+            ),
+            crate::TypeKind::Error => return Err(SemanticImportFailure::ForeignLocalType),
+        })
+    }
+
+    pub fn export_const_value(
+        &self,
+        value: SemanticImportedConstValue,
+    ) -> Result<SemanticImportConstValue<K, M>, SemanticImportFailure> {
+        if !Arc::ptr_eq(&value.epoch, &self.epoch) {
+            return Err(SemanticImportFailure::ForeignLocalValue);
+        }
+        Ok(match value.value {
+            ConstValue::Integer(v) => SemanticImportConstValue::Integer(v),
+            ConstValue::Bool(v) => SemanticImportConstValue::Bool(v),
+            ConstValue::Type(v) => SemanticImportConstValue::Type(self.export_type_local(v)?),
+            ConstValue::Function(symbol) => SemanticImportConstValue::Function(
+                self.functions
+                    .iter()
+                    .find_map(|(key, local)| (*local == symbol).then(|| key.clone()))
+                    .ok_or(SemanticImportFailure::ForeignLocalValue)?,
+            ),
+            ConstValue::Unit => SemanticImportConstValue::Unit,
+        })
+    }
+
+    pub fn complete_struct(
+        &self,
+        key: &K,
+        fields: &[(Arc<str>, SemanticImportType<K, M>)],
+        is_copy: bool,
+        is_linear: bool,
+    ) -> Result<(), SemanticImportFailure> {
+        let LocalNominal::Struct(id) = self
+            .nominals
+            .get(key)
+            .copied()
+            .ok_or(SemanticImportFailure::MissingNominal)?
+        else {
+            return Err(SemanticImportFailure::NominalKindMismatch);
+        };
+        let mut def = self.type_pool.struct_def(id);
+        def.fields = fields
+            .iter()
+            .map(|(name, ty)| {
+                Ok(StructField {
+                    name: name.to_string(),
+                    ty: self.import_type_local(ty)?,
+                })
+            })
+            .collect::<Result<_, _>>()?;
+        def.is_copy = is_copy;
+        def.is_linear = is_linear;
+        self.type_pool.update_struct_def(id, def);
+        Ok(())
+    }
+
+    pub fn complete_enum(
+        &self,
+        key: &K,
+        variants: &[(Arc<str>, Arc<[SemanticImportType<K, M>]>)],
+    ) -> Result<(), SemanticImportFailure> {
+        let LocalNominal::Enum(id) = self
+            .nominals
+            .get(key)
+            .copied()
+            .ok_or(SemanticImportFailure::MissingNominal)?
+        else {
+            return Err(SemanticImportFailure::NominalKindMismatch);
+        };
+        let mut def = self.type_pool.enum_def(id);
+        def.variants = variants.iter().map(|(name, _)| name.to_string()).collect();
+        def.variant_payloads = variants
+            .iter()
+            .map(|(_, payload)| {
+                payload
+                    .iter()
+                    .map(|ty| self.import_type_local(ty))
+                    .collect()
+            })
+            .collect::<Result<_, _>>()?;
+        self.type_pool.update_enum_def(id, def);
+        Ok(())
+    }
+
+    pub fn type_pool(&self) -> &TypeInternPool {
+        &self.type_pool
+    }
+    pub fn interner(&self) -> &ThreadedRodeo {
+        &self.interner
+    }
+    pub fn module_registry(&self) -> &ModuleRegistry {
+        &self.module_registry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TypeKind;
+
+    type Epoch = SemanticImportEpoch<&'static str, &'static str>;
+    type ImportType = SemanticImportType<&'static str, &'static str>;
+
+    fn nominal(
+        key: &'static str,
+        name: &'static str,
+        kind: SemanticImportNominalKind,
+    ) -> SemanticImportNominal<&'static str> {
+        SemanticImportNominal {
+            key,
+            module_path: Arc::from("pkg/main.rue"),
+            name: Arc::from(name),
+            kind,
+            is_public: true,
+        }
+    }
+
+    fn projection(epoch: &Epoch, ty: Type) -> String {
+        match ty.kind() {
+            TypeKind::I32 => "i32".into(),
+            TypeKind::Bool => "bool".into(),
+            TypeKind::Struct(id) => format!("struct {}", epoch.type_pool().struct_def(id).name),
+            TypeKind::Enum(id) => format!("enum {}", epoch.type_pool().enum_def(id).name),
+            TypeKind::PtrConst(id) => format!(
+                "ptr const {}",
+                projection(epoch, epoch.type_pool().ptr_const_def(id))
+            ),
+            TypeKind::PtrMut(id) => format!(
+                "ptr mut {}",
+                projection(epoch, epoch.type_pool().ptr_mut_def(id))
+            ),
+            TypeKind::Array(id) => {
+                let (element, len) = epoch.type_pool().array_def(id);
+                format!("[{element}; {len}]", element = projection(epoch, element))
+            }
+            TypeKind::Module(id) => {
+                format!("module {}", epoch.module_registry().get_def(id).file_path)
+            }
+            other => format!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn fresh_epochs_remap_to_equivalent_values_despite_different_local_ids() {
+        let a = Epoch::new(
+            vec![nominal("node", "Node", SemanticImportNominalKind::Struct)],
+            vec![("f", Arc::from("f"))],
+            vec!["pkg/main.rue"],
+        )
+        .unwrap();
+        let b = Epoch::new(
+            vec![
+                nominal("noise", "Aardvark", SemanticImportNominalKind::Enum),
+                nominal("node", "Node", SemanticImportNominalKind::Struct),
+            ],
+            vec![("f", Arc::from("f"))],
+            vec!["pkg/main.rue"],
+        )
+        .unwrap();
+        let durable = ImportType::PtrConst(Box::new(ImportType::Nominal("node")));
+        let ta = a.import_type(&durable).unwrap();
+        let tb = b.import_type(&durable).unwrap();
+        assert_ne!(
+            ta.value, tb.value,
+            "the test must exercise different request-local IDs"
+        );
+        assert_eq!(projection(&a, ta.value), projection(&b, tb.value));
+        let va = a
+            .import_const_value(&SemanticImportConstValue::Function("f"))
+            .unwrap();
+        let vb = b
+            .import_const_value(&SemanticImportConstValue::Function("f"))
+            .unwrap();
+        assert_eq!(
+            matches!(va.value, ConstValue::Function(_)),
+            matches!(vb.value, ConstValue::Function(_))
+        );
+    }
+
+    #[test]
+    fn two_phase_shells_support_cycles_and_input_order_is_irrelevant() {
+        let declarations = vec![
+            nominal("right", "Right", SemanticImportNominalKind::Struct),
+            nominal("left", "Left", SemanticImportNominalKind::Struct),
+        ];
+        let first = Epoch::new(declarations.clone(), vec![], vec!["pkg/main.rue"]).unwrap();
+        let second = Epoch::new(
+            declarations.into_iter().rev().collect(),
+            vec![],
+            vec!["pkg/main.rue"],
+        )
+        .unwrap();
+        let left_fields = [(
+            Arc::from("next"),
+            ImportType::PtrConst(Box::new(ImportType::Nominal("right"))),
+        )];
+        let right_fields = [(
+            Arc::from("next"),
+            ImportType::PtrMut(Box::new(ImportType::Nominal("left"))),
+        )];
+        first
+            .complete_struct(&"left", &left_fields, false, false)
+            .unwrap();
+        first
+            .complete_struct(&"right", &right_fields, false, false)
+            .unwrap();
+        second
+            .complete_struct(&"right", &right_fields, false, false)
+            .unwrap();
+        second
+            .complete_struct(&"left", &left_fields, false, false)
+            .unwrap();
+        for key in ["left", "right"] {
+            let ty = ImportType::Nominal(key);
+            assert_eq!(
+                projection(&first, first.import_type(&ty).unwrap().value),
+                projection(&second, second.import_type(&ty).unwrap().value)
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_and_foreign_values_fail_closed() {
+        let epoch = Epoch::new(vec![], vec![], vec![]).unwrap();
+        assert_eq!(
+            epoch.import_type(&ImportType::Nominal("missing")),
+            Err(SemanticImportFailure::MissingNominal)
+        );
+        assert_eq!(
+            epoch.import_type(&ImportType::Module("missing")),
+            Err(SemanticImportFailure::MissingModule)
+        );
+        assert_eq!(
+            epoch.import_type(&ImportType::GenericParameter(0)),
+            Err(SemanticImportFailure::GenericParameterNeedsDeclarationContext)
+        );
+        assert_eq!(
+            epoch.import_type(&ImportType::Tuple(Arc::from([]))),
+            Err(SemanticImportFailure::UnsupportedTuple)
+        );
+        assert_eq!(
+            epoch.import_const_value(&SemanticImportConstValue::Function("missing")),
+            Err(SemanticImportFailure::MissingFunction)
+        );
+    }
+
+    #[test]
+    fn supported_types_and_values_round_trip_exactly() {
+        let epoch = Epoch::new(
+            vec![nominal("node", "Node", SemanticImportNominalKind::Struct)],
+            vec![("f", Arc::from("f"))],
+            vec!["pkg/main.rue"],
+        )
+        .unwrap();
+        let values = [
+            ImportType::Array {
+                element: Box::new(ImportType::PtrConst(Box::new(ImportType::Nominal("node")))),
+                len: 7,
+            },
+            ImportType::Module("pkg/main.rue"),
+            ImportType::Bool,
+        ];
+        for value in values {
+            assert_eq!(
+                epoch
+                    .export_type(epoch.import_type(&value).unwrap())
+                    .unwrap(),
+                value
+            );
+        }
+        assert_eq!(
+            epoch
+                .import_types(&[ImportType::Bool, ImportType::I32])
+                .unwrap()
+                .as_ref(),
+            &[
+                SemanticImportedType {
+                    epoch: epoch.epoch.clone(),
+                    value: Type::BOOL
+                },
+                SemanticImportedType {
+                    epoch: epoch.epoch.clone(),
+                    value: Type::I32
+                },
+            ]
+        );
+        let value = SemanticImportConstValue::Function("f");
+        assert_eq!(
+            epoch
+                .export_const_value(epoch.import_const_value(&value).unwrap())
+                .unwrap(),
+            value
+        );
+    }
+
+    #[test]
+    fn foreign_epoch_values_fail_closed_even_when_raw_ids_alias() {
+        let a = Epoch::new(
+            vec![nominal("node", "Node", SemanticImportNominalKind::Struct)],
+            vec![("f", Arc::from("f"))],
+            vec![],
+        )
+        .unwrap();
+        let b = Epoch::new(
+            vec![nominal("node", "Node", SemanticImportNominalKind::Struct)],
+            vec![("f", Arc::from("f"))],
+            vec![],
+        )
+        .unwrap();
+        let ty = a.import_type(&ImportType::Nominal("node")).unwrap();
+        let value = a
+            .import_const_value(&SemanticImportConstValue::Function("f"))
+            .unwrap();
+        assert_eq!(
+            b.export_type(ty),
+            Err(SemanticImportFailure::ForeignLocalType)
+        );
+        assert_eq!(
+            b.export_const_value(value),
+            Err(SemanticImportFailure::ForeignLocalValue)
+        );
+    }
+
+    #[test]
+    fn duplicate_stable_and_local_identities_are_rejected() {
+        assert!(matches!(
+            Epoch::new(
+                vec![],
+                vec![("f", Arc::from("a")), ("f", Arc::from("b"))],
+                vec![]
+            ),
+            Err(SemanticImportFailure::DuplicateFunction)
+        ));
+        assert!(matches!(
+            Epoch::new(
+                vec![],
+                vec![("a", Arc::from("same")), ("b", Arc::from("same"))],
+                vec![]
+            ),
+            Err(SemanticImportFailure::DuplicateFunctionLocalIdentity)
+        ));
+        assert!(matches!(
+            Epoch::new(
+                vec![
+                    nominal("a", "Node", SemanticImportNominalKind::Struct),
+                    nominal("b", "Node", SemanticImportNominalKind::Struct),
+                ],
+                vec![],
+                vec![]
+            ),
+            Err(SemanticImportFailure::DuplicateNominalLocalIdentity)
+        ));
+    }
+}

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -84,6 +84,28 @@ impl StableDefinitionKey {
     pub fn owner(&self) -> Option<&StableNamedTypeKey> {
         self.owner.as_ref()
     }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        module: ModuleId,
+        namespace: StableDefinitionNamespace,
+        kind: StableDefinitionKind,
+        name: impl Into<Arc<str>>,
+        owner: Option<(StableDefinitionKind, Arc<str>)>,
+    ) -> Self {
+        let owner = owner.map(|(kind, name)| StableNamedTypeKey {
+            module: module.clone(),
+            kind,
+            name,
+        });
+        Self {
+            module,
+            namespace,
+            kind,
+            name: name.into(),
+            owner,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -8,8 +8,252 @@ use std::sync::Arc;
 
 use rue_air::{
     SemanticBindingKind, SemanticDeclarationExport, SemanticDeclarationPayload,
-    SemanticExportConstValue, SemanticExportFailure, SemanticExportType, SemanticParameterMode,
+    SemanticExportConstValue, SemanticExportFailure, SemanticExportType, SemanticImportConstValue,
+    SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal, SemanticImportNominalKind,
+    SemanticImportType, SemanticParameterMode,
 };
+
+/// A fresh AIR epoch populated only from request-independent semantic values.
+pub type DurableSemanticImportEpoch = SemanticImportEpoch<StableDefinitionKey, Arc<str>>;
+
+impl DurableType {
+    fn import_dto(&self) -> SemanticImportType<StableDefinitionKey, Arc<str>> {
+        match self {
+            Self::I8 => SemanticImportType::I8,
+            Self::I16 => SemanticImportType::I16,
+            Self::I32 => SemanticImportType::I32,
+            Self::I64 => SemanticImportType::I64,
+            Self::U8 => SemanticImportType::U8,
+            Self::U16 => SemanticImportType::U16,
+            Self::U32 => SemanticImportType::U32,
+            Self::U64 => SemanticImportType::U64,
+            Self::Bool => SemanticImportType::Bool,
+            Self::Unit => SemanticImportType::Unit,
+            Self::Never => SemanticImportType::Never,
+            Self::ComptimeType => SemanticImportType::ComptimeType,
+            Self::Nominal(key) => SemanticImportType::Nominal(key.clone()),
+            Self::Array { element, len } => SemanticImportType::Array {
+                element: Box::new(element.import_dto()),
+                len: *len,
+            },
+            Self::PtrConst(value) => SemanticImportType::PtrConst(Box::new(value.import_dto())),
+            Self::PtrMut(value) => SemanticImportType::PtrMut(Box::new(value.import_dto())),
+            Self::Tuple(values) => SemanticImportType::Tuple(
+                values
+                    .iter()
+                    .map(Self::import_dto)
+                    .collect::<Vec<_>>()
+                    .into(),
+            ),
+            Self::Function { parameters, result } => SemanticImportType::Function {
+                parameters: parameters
+                    .iter()
+                    .map(Self::import_dto)
+                    .collect::<Vec<_>>()
+                    .into(),
+                result: Box::new(result.import_dto()),
+            },
+            Self::Module(module) => SemanticImportType::Module(Arc::from(module.as_str())),
+            Self::GenericParameter(index) => SemanticImportType::GenericParameter(*index),
+        }
+    }
+}
+
+impl DurableConstValue {
+    fn import_dto(&self) -> SemanticImportConstValue<StableDefinitionKey, Arc<str>> {
+        match self {
+            Self::Integer(value) => SemanticImportConstValue::Integer(*value),
+            Self::Bool(value) => SemanticImportConstValue::Bool(*value),
+            Self::Type(value) => SemanticImportConstValue::Type(value.import_dto()),
+            Self::Function(key) => SemanticImportConstValue::Function(key.clone()),
+            Self::Unit => SemanticImportConstValue::Unit,
+        }
+    }
+}
+
+/// Reconstruct the representable declaration universe in a new AIR epoch.
+///
+/// Nominal shells are issued in stable-key order before any field or variant
+/// type is imported, so mutually recursive pointer graphs are supported. The
+/// returned epoch contains no handles from the exporting semantic request.
+pub fn import_durable_declaration_semantics(
+    declarations: &[DurableDeclarationSemantic],
+) -> Result<DurableSemanticImportEpoch, SemanticImportFailure> {
+    fn payload_matches_key(declaration: &DurableDeclarationSemantic) -> bool {
+        matches!(
+            (declaration.key.kind(), &declaration.payload),
+            (
+                StableDefinitionKind::Function
+                    | StableDefinitionKind::Method
+                    | StableDefinitionKind::AssociatedFunction,
+                DurableDeclarationPayload::Callable { .. }
+            ) | (
+                StableDefinitionKind::Struct,
+                DurableDeclarationPayload::Struct { .. }
+            ) | (
+                StableDefinitionKind::Enum,
+                DurableDeclarationPayload::Enum { .. }
+            ) | (
+                StableDefinitionKind::ValueConst,
+                DurableDeclarationPayload::Const { .. }
+            ) | (
+                StableDefinitionKind::Destructor,
+                DurableDeclarationPayload::Destructor
+            )
+        )
+    }
+
+    if declarations
+        .iter()
+        .any(|declaration| !payload_matches_key(declaration))
+    {
+        return Err(SemanticImportFailure::DeclarationKindMismatch);
+    }
+    fn collect_modules(ty: &DurableType, modules: &mut std::collections::BTreeSet<Arc<str>>) {
+        match ty {
+            DurableType::Module(module) => {
+                modules.insert(Arc::from(module.as_str()));
+            }
+            DurableType::Array { element, .. }
+            | DurableType::PtrConst(element)
+            | DurableType::PtrMut(element) => collect_modules(element, modules),
+            DurableType::Tuple(elements) => {
+                for element in elements.iter() {
+                    collect_modules(element, modules);
+                }
+            }
+            DurableType::Function { parameters, result } => {
+                for parameter in parameters.iter() {
+                    collect_modules(parameter, modules);
+                }
+                collect_modules(result, modules);
+            }
+            _ => {}
+        }
+    }
+    let mut modules = std::collections::BTreeSet::<Arc<str>>::new();
+    let mut nominals = Vec::new();
+    let mut functions = Vec::new();
+    for declaration in declarations {
+        modules.insert(Arc::from(declaration.key.module().as_str()));
+        match &declaration.payload {
+            DurableDeclarationPayload::Callable {
+                parameters, result, ..
+            } => {
+                for parameter in parameters.iter() {
+                    collect_modules(&parameter.ty, &mut modules);
+                }
+                collect_modules(result, &mut modules);
+            }
+            DurableDeclarationPayload::Struct { fields, .. } => {
+                for (_, ty) in fields.iter() {
+                    collect_modules(ty, &mut modules);
+                }
+            }
+            DurableDeclarationPayload::Enum { variants } => {
+                for (_, payload) in variants.iter() {
+                    for ty in payload.iter() {
+                        collect_modules(ty, &mut modules);
+                    }
+                }
+            }
+            DurableDeclarationPayload::Const { ty, value } => {
+                collect_modules(ty, &mut modules);
+                if let DurableConstValue::Type(ty) = value {
+                    collect_modules(ty, &mut modules);
+                }
+            }
+            DurableDeclarationPayload::Destructor => {}
+        }
+        match &declaration.payload {
+            DurableDeclarationPayload::Struct { .. } => nominals.push(SemanticImportNominal {
+                key: declaration.key.clone(),
+                module_path: Arc::from(declaration.key.module().as_str()),
+                name: Arc::from(declaration.key.name()),
+                kind: SemanticImportNominalKind::Struct,
+                is_public: declaration.is_public,
+            }),
+            DurableDeclarationPayload::Enum { .. } => nominals.push(SemanticImportNominal {
+                key: declaration.key.clone(),
+                module_path: Arc::from(declaration.key.module().as_str()),
+                name: Arc::from(declaration.key.name()),
+                kind: SemanticImportNominalKind::Enum,
+                is_public: declaration.is_public,
+            }),
+            DurableDeclarationPayload::Callable { .. } => {
+                // Length-prefix every component. Unlike a source-like name this
+                // is injective for the full stable key, including its owner.
+                let owner = declaration.key.owner();
+                let owner_module = owner.map(|owner| owner.module().as_str()).unwrap_or("");
+                let owner_name = owner.map(|owner| owner.name()).unwrap_or("");
+                let kind = format!("{:?}", declaration.key.kind());
+                let identity = format!(
+                    "{}:{}|{:?}|{}:{}|{}:{}|{}:{}|{:?}|{}:{}",
+                    declaration.key.module().as_str().len(),
+                    declaration.key.module().as_str(),
+                    declaration.key.namespace(),
+                    kind.len(),
+                    kind,
+                    declaration.key.name().len(),
+                    declaration.key.name(),
+                    owner_module.len(),
+                    owner_module,
+                    owner.map(|owner| owner.kind()),
+                    owner_name.len(),
+                    owner_name,
+                );
+                functions.push((declaration.key.clone(), Arc::from(identity)));
+            }
+            _ => {}
+        }
+    }
+    let epoch = SemanticImportEpoch::new(nominals, functions, modules.into_iter().collect())?;
+    for declaration in declarations {
+        match &declaration.payload {
+            DurableDeclarationPayload::Struct {
+                fields,
+                is_copy,
+                is_linear,
+            } => {
+                let fields = fields
+                    .iter()
+                    .map(|(name, ty)| (name.clone(), ty.import_dto()))
+                    .collect::<Vec<_>>();
+                epoch.complete_struct(&declaration.key, &fields, *is_copy, *is_linear)?;
+            }
+            DurableDeclarationPayload::Enum { variants } => {
+                let variants = variants
+                    .iter()
+                    .map(|(name, payload)| {
+                        (
+                            name.clone(),
+                            payload
+                                .iter()
+                                .map(DurableType::import_dto)
+                                .collect::<Vec<_>>()
+                                .into(),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                epoch.complete_enum(&declaration.key, &variants)?;
+            }
+            DurableDeclarationPayload::Const { ty, value } => {
+                epoch.import_type(&ty.import_dto())?;
+                epoch.import_const_value(&value.import_dto())?;
+            }
+            DurableDeclarationPayload::Callable {
+                parameters, result, ..
+            } => {
+                for parameter in parameters.iter() {
+                    epoch.import_type(&parameter.ty.import_dto())?;
+                }
+                epoch.import_type(&result.import_dto())?;
+            }
+            DurableDeclarationPayload::Destructor => {}
+        }
+    }
+    Ok(epoch)
+}
 
 use crate::{
     BoundDefinitionSet, CanonicalMergedProgram, ModuleId, StableDefinitionKey, StableDefinitionKind,
@@ -361,6 +605,7 @@ impl From<SemanticExportFailure> for DurableSemanticExportFailure {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::StableDefinitionNamespace;
 
     fn assert_query_value<T: Send + Sync + Clone + Eq + Ord + std::hash::Hash>() {}
 
@@ -385,5 +630,140 @@ mod tests {
             len: 4,
         });
         assert_eq!(first.clone(), first);
+    }
+
+    fn test_key(
+        kind: StableDefinitionKind,
+        name: &str,
+        owner: Option<&str>,
+    ) -> StableDefinitionKey {
+        StableDefinitionKey::for_test(
+            ModuleId::from_logical_path("pkg/main.rue").unwrap(),
+            match kind {
+                StableDefinitionKind::Method | StableDefinitionKind::AssociatedFunction => {
+                    StableDefinitionNamespace::Method
+                }
+                _ => StableDefinitionNamespace::Value,
+            },
+            kind,
+            Arc::from(name),
+            owner.map(|name| (StableDefinitionKind::Struct, Arc::from(name))),
+        )
+    }
+
+    fn callable(key: StableDefinitionKey) -> DurableDeclarationSemantic {
+        DurableDeclarationSemantic {
+            key,
+            is_public: true,
+            payload: DurableDeclarationPayload::Callable {
+                parameters: Arc::from([]),
+                result: DurableType::Unit,
+                has_self: false,
+                is_unchecked: false,
+            },
+        }
+    }
+
+    #[test]
+    fn sibling_owned_callables_have_distinct_symbols_and_exact_round_trip() {
+        let left = test_key(
+            StableDefinitionKind::AssociatedFunction,
+            "make",
+            Some("Left"),
+        );
+        let right = test_key(
+            StableDefinitionKind::AssociatedFunction,
+            "make",
+            Some("Right"),
+        );
+        let epoch = import_durable_declaration_semantics(&[
+            callable(left.clone()),
+            callable(right.clone()),
+        ])
+        .unwrap();
+
+        let left_value = epoch
+            .import_const_value(&SemanticImportConstValue::Function(left.clone()))
+            .unwrap();
+        let right_value = epoch
+            .import_const_value(&SemanticImportConstValue::Function(right.clone()))
+            .unwrap();
+        assert_ne!(left_value, right_value);
+        assert_eq!(
+            epoch.export_const_value(left_value).unwrap(),
+            SemanticImportConstValue::Function(left)
+        );
+        assert_eq!(
+            epoch.export_const_value(right_value).unwrap(),
+            SemanticImportConstValue::Function(right)
+        );
+    }
+
+    #[test]
+    fn callable_kind_is_part_of_the_local_identity() {
+        let method = StableDefinitionKey::for_test(
+            ModuleId::from_logical_path("pkg/main.rue").unwrap(),
+            StableDefinitionNamespace::Method,
+            StableDefinitionKind::Method,
+            "same",
+            Some((StableDefinitionKind::Struct, Arc::from("Owner"))),
+        );
+        let associated = StableDefinitionKey::for_test(
+            ModuleId::from_logical_path("pkg/main.rue").unwrap(),
+            StableDefinitionNamespace::Method,
+            StableDefinitionKind::AssociatedFunction,
+            "same",
+            Some((StableDefinitionKind::Struct, Arc::from("Owner"))),
+        );
+        let epoch = import_durable_declaration_semantics(&[
+            callable(method.clone()),
+            callable(associated.clone()),
+        ])
+        .unwrap();
+        let method_value = epoch
+            .import_const_value(&SemanticImportConstValue::Function(method.clone()))
+            .unwrap();
+        let associated_value = epoch
+            .import_const_value(&SemanticImportConstValue::Function(associated.clone()))
+            .unwrap();
+        assert_ne!(method_value, associated_value);
+        assert_eq!(
+            epoch.export_const_value(method_value).unwrap(),
+            SemanticImportConstValue::Function(method)
+        );
+        assert_eq!(
+            epoch.export_const_value(associated_value).unwrap(),
+            SemanticImportConstValue::Function(associated)
+        );
+    }
+
+    #[test]
+    fn import_rejects_payload_kind_mismatch_before_building_an_epoch() {
+        let declaration = DurableDeclarationSemantic {
+            key: test_key(StableDefinitionKind::Function, "wrong", None),
+            is_public: true,
+            payload: DurableDeclarationPayload::Struct {
+                fields: Arc::from([]),
+                is_copy: false,
+                is_linear: false,
+            },
+        };
+        assert!(matches!(
+            import_durable_declaration_semantics(&[declaration]),
+            Err(SemanticImportFailure::DeclarationKindMismatch)
+        ));
+
+        let module_binding = DurableDeclarationSemantic {
+            key: test_key(StableDefinitionKind::ModuleBinding, "module", None),
+            is_public: true,
+            payload: DurableDeclarationPayload::Const {
+                ty: DurableType::Module(ModuleId::from_logical_path("pkg/dep.rue").unwrap()),
+                value: DurableConstValue::Unit,
+            },
+        };
+        assert!(matches!(
+            import_durable_declaration_semantics(&[module_binding]),
+            Err(SemanticImportFailure::DeclarationKindMismatch)
+        ));
     }
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -64,7 +64,8 @@ pub use definition_snapshot::{
 pub use durable_semantics::{
     DURABLE_SEMANTIC_SCHEMA_VERSION, DurableConstValue, DurableDeclarationPayload,
     DurableDeclarationSemantic, DurableParameterMode, DurableSemanticExportFailure,
-    DurableSemanticParameter, DurableType,
+    DurableSemanticImportEpoch, DurableSemanticParameter, DurableType,
+    import_durable_declaration_semantics,
 };
 pub use frontend_session::{
     CanonicalFrontendSession, CanonicalFrontendSessionWork, CanonicalFrontendUpdate,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -327,3 +327,23 @@ surface. Cyclic or otherwise rejected initializers publish no partial manifest.
 `named_value_const_dependencies_complete=true` covers successful named value
 constants; anonymous/dynamic values and the overall semantic graph remain
 explicitly incomplete. Capture is sorted/deduplicated and adds no RIR scan.
+
+## Fresh-epoch semantic import boundary
+
+Durable declaration values can now be remapped into a fresh AIR-owned epoch
+without retaining an exporting request's `Type`, `StructId`, `EnumId`,
+`ModuleId`, or `Spur`. AIR exposes a neutral, generic stable-key import DTO and
+`SemanticImportEpoch`; the compiler alone translates `StableDefinitionKey` and
+logical `ModuleId` values into it. Nominal shells are predeclared in stable-key
+order and completed in a second phase, allowing recursive pointer graphs.
+Primitive, nominal, array, pointer and module types plus scalar/type/function
+constant values round-trip through the epoch's stable join.
+
+This is intentionally not declaration-cache installation. AIR has no local
+representation for the durable reserved tuple/function type forms or for an
+unsubstituted declaration generic parameter, so those fail closed. Installing
+callables and constants into `Sema` additionally requires exact-revision RIR
+bodies/initializers, source spans, parameter names and declaration indices.
+The split-binding seam must provide those constructor inputs and decide generic
+substitution context; the importer must not synthesize them or mutate private
+`Sema` tables. No AIR body, CFG, or RIR fragment is reused by this boundary.


### PR DESCRIPTION
## Summary
- predeclare stable-keyed nominal and callable shells in a fresh AIR-owned epoch before importing structural values
- reconstruct supported types and constants through epoch-branded values backed exclusively by fresh pool, interner, and module-registry identities
- reject duplicate, foreign, kind-mismatched, generic, or unsupported inputs atomically without retaining any exporting-request handle

## Testing
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test`