### PR TITLE
RUE-719: split declaration shell binding from resolution

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -39,7 +39,7 @@ pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
     AnalyzedFunction, BodyAnalysisWork, BoundSema, BuiltinTypeCallHead, ConstValue,
-    DeclarationBindingWork, DeclarationBuiltinTypeCallHeadDependencyEvent,
+    DeclarationBindingWork, DeclarationBuiltinTypeCallHeadDependencyEvent, DeclarationShells,
     DeclarationTypeCallHeadDependencyEvent, DeclarationTypeDependencyEvent,
     DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
     DeclarationTypeDependencyTargetKind, DirResolution, FunctionInfo, GatherOutput,

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -3,7 +3,7 @@
 use std::sync::{Arc, OnceLock};
 
 use lasso::Spur;
-use rue_error::MultiErrorResult;
+use rue_error::{CompileErrors, MultiErrorResult};
 use rue_rir::InstData;
 use rue_span::{FileId, Span};
 
@@ -122,6 +122,14 @@ pub struct SemanticDeclarationExportWork {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct DeclarationBindingWork {
     pub bind_invocations: usize,
+    /// Global collision validation and builtin/module namespace setup.
+    pub namespace_setup_invocations: usize,
+    /// Deterministic named struct/enum shell predeclaration.
+    pub nominal_type_predeclaration_invocations: usize,
+    /// Resolution of declaration payloads, constants, and cycles.
+    pub declaration_resolution_invocations: usize,
+    /// Construction of the body-analysis-ready state.
+    pub body_readiness_finalization_invocations: usize,
     /// Size of the input RIR, not a claim that binding visited every entry.
     pub input_rir_instructions: usize,
     pub declaration_index_build_invocations: usize,
@@ -205,6 +213,35 @@ pub struct BoundSema<'a> {
     sema: Sema<'a>,
     manifest: OnceLock<SemanticBindingManifest>,
     binding_work: DeclarationBindingWork,
+}
+
+/// A semantic request whose global namespace and nominal declaration shells
+/// are complete, but whose declaration payloads have not yet been resolved.
+///
+/// This boundary deliberately owns the request-local `Sema` state.  A future
+/// durable-declaration importer can populate that state here without making
+/// raw AIR handles part of the reusable representation.  Today the only
+/// transition performs the ordinary current-revision resolution pass.
+pub struct DeclarationShells<'a> {
+    pub(super) sema: Sema<'a>,
+    pub(super) binding_work: DeclarationBindingWork,
+}
+
+impl<'a> DeclarationShells<'a> {
+    /// Work completed before declaration payload resolution.
+    pub fn binding_work(&self) -> DeclarationBindingWork {
+        self.binding_work
+    }
+
+    /// Resolve declaration payloads and finalize a body-analysis-ready binder.
+    pub fn resolve_declarations(mut self) -> MultiErrorResult<BoundSema<'a>> {
+        self.sema
+            .resolve_declarations()
+            .map_err(CompileErrors::from)?;
+        self.binding_work.declaration_resolution_invocations += 1;
+        self.binding_work.body_readiness_finalization_invocations += 1;
+        Ok(self.sema.into_bound_with_work(self.binding_work))
+    }
 }
 
 impl<'a> BoundSema<'a> {
@@ -540,10 +577,12 @@ impl<'a> Sema<'a> {
             },
         ))
     }
-    pub(super) fn into_bound(self) -> BoundSema<'a> {
-        let index = self.declaration_index.work();
+    pub(super) fn into_bound_with_work(
+        self,
+        binding_work: DeclarationBindingWork,
+    ) -> BoundSema<'a> {
         BoundSema {
-            binding_work: DeclarationBindingWork::from_inputs(self.rir.len(), index),
+            binding_work,
             sema: self,
             manifest: OnceLock::new(),
         }
@@ -722,9 +761,16 @@ impl<'a> Sema<'a> {
 }
 
 impl DeclarationBindingWork {
-    fn from_inputs(input_rir_instructions: usize, index: RirDeclarationIndexWork) -> Self {
+    pub(super) fn from_inputs(
+        input_rir_instructions: usize,
+        index: RirDeclarationIndexWork,
+    ) -> Self {
         Self {
             bind_invocations: 1,
+            namespace_setup_invocations: 0,
+            nominal_type_predeclaration_invocations: 0,
+            declaration_resolution_invocations: 0,
+            body_readiness_finalization_invocations: 0,
             input_rir_instructions,
             declaration_index_build_invocations: index.build_invocations,
             indexed_free_functions: index.free_functions_indexed,
@@ -991,10 +1037,66 @@ mod tests {
             .unwrap();
         assert!(!bound.manifest_is_materialized());
         assert_eq!(bound.binding_work().bind_invocations, 1);
+        assert_eq!(bound.binding_work().namespace_setup_invocations, 1);
+        assert_eq!(
+            bound.binding_work().nominal_type_predeclaration_invocations,
+            1
+        );
+        assert_eq!(bound.binding_work().declaration_resolution_invocations, 1);
+        assert_eq!(
+            bound.binding_work().body_readiness_finalization_invocations,
+            1
+        );
         assert_eq!(bound.binding_work().input_rir_instructions, rir.len());
         assert_eq!(bound.binding_work().declaration_index_build_invocations, 1);
         assert_eq!(bound.binding_manifest().work().build_invocations, 1);
         assert!(bound.manifest_is_materialized());
+    }
+
+    #[test]
+    fn declaration_shell_boundary_accounts_each_phase_once() {
+        let (tokens, interner) = Lexer::new("struct Item { value: i32 } fn main() {}")
+            .tokenize()
+            .unwrap();
+        let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();
+        let rir = AstGen::new(&ast, &interner).generate();
+
+        let shells = Sema::new(&rir, &interner, PreviewFeatures::new())
+            .predeclare_declaration_shells()
+            .unwrap();
+        let prepared = shells.binding_work();
+        assert_eq!(prepared.bind_invocations, 1);
+        assert_eq!(prepared.namespace_setup_invocations, 1);
+        assert_eq!(prepared.nominal_type_predeclaration_invocations, 1);
+        assert_eq!(prepared.declaration_resolution_invocations, 0);
+        assert_eq!(prepared.body_readiness_finalization_invocations, 0);
+        assert_eq!(prepared.input_rir_instructions, rir.len());
+        assert_eq!(prepared.declaration_index_build_invocations, 1);
+
+        let bound = shells.resolve_declarations().unwrap();
+        let resolved = bound.binding_work();
+        assert_eq!(resolved.declaration_resolution_invocations, 1);
+        assert_eq!(resolved.body_readiness_finalization_invocations, 1);
+        assert!(!bound.manifest_is_materialized());
+    }
+
+    #[test]
+    fn declaration_shell_adapter_preserves_early_failure_provenance() {
+        let (tokens, interner) = Lexer::new("struct Clash {} fn Clash() {} fn main() {}")
+            .tokenize()
+            .unwrap();
+        let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();
+        let rir = AstGen::new(&ast, &interner).generate();
+
+        let direct = Sema::new(&rir, &interner, PreviewFeatures::new())
+            .bind_declarations()
+            .err()
+            .expect("cross-kind collision must fail");
+        let split = Sema::new(&rir, &interner, PreviewFeatures::new())
+            .predeclare_declaration_shells()
+            .err()
+            .expect("collision must short-circuit before nominal predeclaration");
+        assert_eq!(format!("{direct:?}"), format!("{split:?}"));
     }
 
     #[test]

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -47,7 +47,7 @@ mod visibility;
 
 // Public re-exports
 pub use binding_manifest::{
-    BoundSema, DeclarationBindingWork, SemanticBinding, SemanticBindingKind,
+    BoundSema, DeclarationBindingWork, DeclarationShells, SemanticBinding, SemanticBindingKind,
     SemanticBindingManifest, SemanticBindingManifestWork, SemanticBindingNamespace,
     SemanticDeclarationExport, SemanticDeclarationExportWork, SemanticDeclarationPayload,
     SemanticExportConstValue, SemanticExportFailure, SemanticExportParameter, SemanticExportType,
@@ -316,7 +316,19 @@ impl<'a> Sema<'a> {
     }
 
     /// Complete all declaration and namespace binding without analyzing bodies.
-    pub fn bind_declarations(mut self) -> MultiErrorResult<BoundSema<'a>> {
+    pub fn bind_declarations(self) -> MultiErrorResult<BoundSema<'a>> {
+        self.predeclare_declaration_shells()?.resolve_declarations()
+    }
+
+    /// Validate the global namespace and predeclare all nominal type shells.
+    ///
+    /// This is the explicit boundary before resolved declaration semantics are
+    /// installed. The batch adapter [`Self::bind_declarations`] immediately
+    /// executes both sides of the boundary and therefore preserves historical
+    /// ordering and failure behavior.
+    pub fn predeclare_declaration_shells(mut self) -> MultiErrorResult<DeclarationShells<'a>> {
+        let mut binding_work =
+            DeclarationBindingWork::from_inputs(self.rir.len(), self.declaration_index.work());
         // Phase 0a: Reject a top-level name claimed by two of function /
         // struct / enum, order-independently (spec 10.3:1, 10.5:1, RUE-239).
         // Runs before builtin injection so it scans only user RIR. Value
@@ -327,16 +339,18 @@ impl<'a> Sema<'a> {
 
         // Phase 0b: Inject built-in types (String, etc.) before user code
         self.inject_builtin_types();
+        binding_work.namespace_setup_invocations += 1;
 
-        // Phase 1: Register type names
-        // Phase 2: Resolve all declarations (const initializers — including
-        // `const x = @import(...)` module bindings — are evaluated as they
-        // are collected, see `collect_const_by_key`)
+        // Phase 1: Register nominal type shells. Functions, constants,
+        // methods, and destructors are resolved on the far side of this
+        // boundary; splitting those into independently importable records is
+        // intentionally left to the durable-declaration integration.
         self.register_type_names().map_err(CompileErrors::from)?;
-        self.resolve_declarations().map_err(CompileErrors::from)?;
-
-        // Delegate to the analysis module for function body analysis
-        Ok(self.into_bound())
+        binding_work.nominal_type_predeclaration_invocations += 1;
+        Ok(DeclarationShells {
+            sema: self,
+            binding_work,
+        })
     }
 
     /// Analyze all function bodies, assuming declarations are already collected.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -105,6 +105,18 @@ incremental-compilation goal is complete.
    across relocation, FileId assignment, and input order. This improves delta
    classification and now drives production `Incremental` plans. Retaining and
    reusing semantic artifacts remains a separate later slice.
+   Declaration binding now exposes an owned boundary after global namespace
+   validation, builtin injection, and named struct/enum shell registration.
+   The ordinary adapter crosses it immediately, with phase counters proving one
+   setup, predeclaration, resolution, and body-readiness finalization. This is
+   deliberately not described as per-definition independence: free-function,
+   constant, method, and destructor signatures are still collected together in
+   `resolve_remaining_declarations`, and constant evaluation remains
+   dependency-ordered. The next split must predeclare those callable/value
+   identities deterministically, then install either current-revision resolved
+   payloads or remapped durable payloads behind the owned boundary before body
+   analysis. Until that split exists, no declaration-resolution work may be
+   skipped or reported as reused.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## Summary
- expose an owned declaration-shell boundary after namespace validation, builtin setup, and nominal predeclaration
- preserve batch behavior through a consuming adapter that performs the existing declaration-resolution pass exactly once
- add phase work counters and regression coverage for lazy manifests and early-failure diagnostic parity

## Testing
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test`