### PR TITLE
RUE-719: predeclare callable and value shells

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -49,9 +49,10 @@ pub use sema::{
     OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, RirDeclarationIndexWork, Sema, SemaOutput,
     SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
     SemanticBindingNamespace, SemanticDeclarationExport, SemanticDeclarationExportWork,
-    SemanticDeclarationPayload, SemanticExportConstValue, SemanticExportFailure,
-    SemanticExportParameter, SemanticExportType, SemanticNominalIdentity, SemanticParameterMode,
-    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin, import_candidate_groups,
+    SemanticDeclarationPayload, SemanticDeclarationShell, SemanticDeclarationShellIdentity,
+    SemanticExportConstValue, SemanticExportFailure, SemanticExportParameter, SemanticExportType,
+    SemanticNominalIdentity, SemanticParameterMode, SpecializedFreeFunctionDependencyEvent,
+    SpecializedFreeFunctionOrigin, import_candidate_groups,
 };
 pub use semantic_import::{
     SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, OnceLock};
 
 use lasso::Spur;
 use rue_error::{CompileErrors, MultiErrorResult};
-use rue_rir::InstData;
+use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::{FileId, Span};
 
 use super::RirDeclarationIndexWork;
@@ -126,6 +126,13 @@ pub struct DeclarationBindingWork {
     pub namespace_setup_invocations: usize,
     /// Deterministic named struct/enum shell predeclaration.
     pub nominal_type_predeclaration_invocations: usize,
+    /// Deterministic callable/value identity predeclaration, before payload
+    /// resolution or constant evaluation.
+    pub callable_value_predeclaration_invocations: usize,
+    pub callable_value_shells_predeclared: usize,
+    /// Declaration-index records visited while predeclaring callable, value,
+    /// and nominal shells. This must equal the number of produced shells.
+    pub indexed_declaration_records_visited: usize,
     /// Resolution of declaration payloads, constants, and cycles.
     pub declaration_resolution_invocations: usize,
     /// Construction of the body-analysis-ready state.
@@ -138,6 +145,53 @@ pub struct DeclarationBindingWork {
     pub indexed_anonymous_methods: usize,
     pub indexed_destructors: usize,
     pub indexed_const_candidates: usize,
+}
+
+/// Stable-joinable identity of a declaration whose semantic payload is not yet
+/// installed. `module_path` is the caller-provided logical symbol path; neither
+/// the request-local `FileId` nor an RIR arena offset participates in identity.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SemanticDeclarationShellIdentity {
+    pub module_path: Arc<str>,
+    pub namespace: SemanticBindingNamespace,
+    pub kind: SemanticBindingKind,
+    pub name: Arc<str>,
+    pub owner: Option<Arc<str>>,
+}
+
+/// Current-revision syntax metadata retained separately from resolved payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticDeclarationShell {
+    pub identity: SemanticDeclarationShellIdentity,
+    pub declaration_span: Span,
+    pub parameter_names: Arc<[Arc<str>]>,
+    pub parameter_modes: Arc<[RirParamMode]>,
+    pub parameter_comptime: Arc<[bool]>,
+    pub source_order: u32,
+    pub has_self: bool,
+    pub is_generic: bool,
+    pub is_public: bool,
+    pub is_unchecked: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum DeclarationPayloadSource {
+    Callable { body: InstRef },
+    Const { initializer: InstRef },
+    Destructor { body: InstRef },
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PendingDeclarationPayload {
+    pub shell: SemanticDeclarationShell,
+    pub declaration: InstRef,
+    pub source: DeclarationPayloadSource,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PendingNominalPayload {
+    pub shell: SemanticDeclarationShell,
+    pub declaration: InstRef,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -225,6 +279,8 @@ pub struct BoundSema<'a> {
 pub struct DeclarationShells<'a> {
     pub(super) sema: Sema<'a>,
     pub(super) binding_work: DeclarationBindingWork,
+    pub(super) pending_payloads: Vec<PendingDeclarationPayload>,
+    pub(super) pending_nominals: Vec<PendingNominalPayload>,
 }
 
 impl<'a> DeclarationShells<'a> {
@@ -233,8 +289,49 @@ impl<'a> DeclarationShells<'a> {
         self.binding_work
     }
 
+    /// Deterministic identities and source metadata available before semantic
+    /// payload resolution. Arena references remain private to this request.
+    pub fn callable_value_shells(
+        &self,
+    ) -> impl ExactSizeIterator<Item = &SemanticDeclarationShell> {
+        self.pending_payloads.iter().map(|pending| &pending.shell)
+    }
+
+    /// All stable-joinable declaration shells in deterministic category order:
+    /// nominal types by stable identity, followed by callable/value shells by
+    /// stable identity.
+    pub fn declaration_shells(&self) -> impl Iterator<Item = &SemanticDeclarationShell> {
+        self.pending_nominals
+            .iter()
+            .map(|pending| &pending.shell)
+            .chain(self.pending_payloads.iter().map(|pending| &pending.shell))
+    }
+
     /// Resolve declaration payloads and finalize a body-analysis-ready binder.
     pub fn resolve_declarations(mut self) -> MultiErrorResult<BoundSema<'a>> {
+        // This is the explicit payload-install boundary. The ordinary adapter
+        // deliberately resolves from the authoritative current-revision RIR in
+        // historical order. A future importer may validate durable payloads
+        // against these shells before choosing an installation path.
+        debug_assert!(
+            self.pending_payloads
+                .iter()
+                .all(
+                    |pending| pending.declaration.as_u32() < self.sema.rir.len() as u32
+                        && match pending.source {
+                            DeclarationPayloadSource::Callable { body }
+                            | DeclarationPayloadSource::Destructor { body } =>
+                                body.as_u32() < self.sema.rir.len() as u32,
+                            DeclarationPayloadSource::Const { initializer } =>
+                                initializer.as_u32() < self.sema.rir.len() as u32,
+                        }
+                )
+        );
+        debug_assert!(
+            self.pending_nominals
+                .iter()
+                .all(|pending| pending.declaration.as_u32() < self.sema.rir.len() as u32)
+        );
         self.sema
             .resolve_declarations()
             .map_err(CompileErrors::from)?;
@@ -278,6 +375,175 @@ impl<'a> BoundSema<'a> {
 }
 
 impl<'a> Sema<'a> {
+    pub(super) fn predeclare_callable_value_shells(
+        &self,
+    ) -> (Vec<PendingDeclarationPayload>, Vec<PendingNominalPayload>) {
+        let module_path = |file_id: FileId| -> Arc<str> {
+            Arc::from(
+                self.get_symbol_path(file_id)
+                    .map(crate::path_norm::normalize_module_path)
+                    .unwrap_or_else(|| format!("file{}", file_id.index())),
+            )
+        };
+        let mut pending = Vec::new();
+        let mut nominals = Vec::new();
+        for candidate in self.declaration_index.shell_declarations() {
+            let inst_ref = candidate.declaration;
+            let source_order = candidate.source_order;
+            let inst = self.rir.get(inst_ref);
+            if let InstData::StructDecl { name, is_pub, .. }
+            | InstData::EnumDecl { name, is_pub, .. } = &inst.data
+            {
+                let kind = if matches!(inst.data, InstData::StructDecl { .. }) {
+                    SemanticBindingKind::Struct
+                } else {
+                    SemanticBindingKind::Enum
+                };
+                nominals.push(PendingNominalPayload {
+                    shell: SemanticDeclarationShell {
+                        identity: SemanticDeclarationShellIdentity {
+                            module_path: module_path(inst.span.file_id),
+                            namespace: SemanticBindingNamespace::Type,
+                            kind,
+                            name: Arc::from(self.interner.resolve(name)),
+                            owner: None,
+                        },
+                        declaration_span: inst.span,
+                        parameter_names: Arc::from([]),
+                        parameter_modes: Arc::from([]),
+                        parameter_comptime: Arc::from([]),
+                        source_order,
+                        has_self: false,
+                        is_generic: false,
+                        is_public: *is_pub,
+                        is_unchecked: false,
+                    },
+                    declaration: inst_ref,
+                });
+            }
+            let (
+                identity,
+                parameter_names,
+                parameter_modes,
+                parameter_comptime,
+                has_self,
+                is_generic,
+                is_public,
+                is_unchecked,
+                source,
+            ) = match &inst.data {
+                InstData::FnDecl {
+                    is_pub,
+                    is_unchecked,
+                    name,
+                    params_start,
+                    params_len,
+                    body,
+                    has_self,
+                    ..
+                } if !self.declaration_index.is_anonymous_method(inst_ref) => {
+                    let owner = candidate.named_method_owner;
+                    let kind = match (owner, *has_self) {
+                        (Some(_), true) => SemanticBindingKind::Method,
+                        (Some(_), false) => SemanticBindingKind::AssociatedFunction,
+                        (None, _) => SemanticBindingKind::Function,
+                    };
+                    let params = self.rir.get_params(*params_start, *params_len);
+                    let names = params
+                        .iter()
+                        .map(|param| Arc::from(self.interner.resolve(&param.name)))
+                        .collect::<Vec<_>>();
+                    let modes = params.iter().map(|param| param.mode).collect::<Vec<_>>();
+                    let comptime = params
+                        .iter()
+                        .map(|param| param.is_comptime)
+                        .collect::<Vec<_>>();
+                    let identity = SemanticDeclarationShellIdentity {
+                        module_path: module_path(inst.span.file_id),
+                        namespace: if owner.is_some() {
+                            SemanticBindingNamespace::Method
+                        } else {
+                            SemanticBindingNamespace::Value
+                        },
+                        kind,
+                        name: Arc::from(self.interner.resolve(name)),
+                        owner: owner.map(|owner| Arc::from(self.interner.resolve(&owner))),
+                    };
+                    (
+                        identity,
+                        names,
+                        modes,
+                        comptime.clone(),
+                        *has_self,
+                        comptime.into_iter().any(|value| value),
+                        *is_pub,
+                        *is_unchecked,
+                        DeclarationPayloadSource::Callable { body: *body },
+                    )
+                }
+                InstData::ConstDecl {
+                    is_pub, name, init, ..
+                } => (
+                    SemanticDeclarationShellIdentity {
+                        module_path: module_path(inst.span.file_id),
+                        namespace: SemanticBindingNamespace::Value,
+                        // Function aliases are classified only after evaluating
+                        // the initializer; their stable value identity is already
+                        // complete here.
+                        kind: SemanticBindingKind::ValueConst,
+                        name: Arc::from(self.interner.resolve(name)),
+                        owner: None,
+                    },
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    false,
+                    false,
+                    *is_pub,
+                    false,
+                    DeclarationPayloadSource::Const { initializer: *init },
+                ),
+                InstData::DropFnDecl { type_name, body } => (
+                    SemanticDeclarationShellIdentity {
+                        module_path: module_path(inst.span.file_id),
+                        namespace: SemanticBindingNamespace::Destructor,
+                        kind: SemanticBindingKind::Destructor,
+                        name: Arc::from(self.interner.resolve(type_name)),
+                        owner: Some(Arc::from(self.interner.resolve(type_name))),
+                    },
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    true,
+                    false,
+                    false,
+                    false,
+                    DeclarationPayloadSource::Destructor { body: *body },
+                ),
+                _ => continue,
+            };
+            pending.push(PendingDeclarationPayload {
+                shell: SemanticDeclarationShell {
+                    identity,
+                    declaration_span: inst.span,
+                    parameter_names: parameter_names.into(),
+                    parameter_modes: parameter_modes.into(),
+                    parameter_comptime: parameter_comptime.into(),
+                    source_order,
+                    has_self,
+                    is_generic,
+                    is_public,
+                    is_unchecked,
+                },
+                declaration: inst_ref,
+                source,
+            });
+        }
+        pending.sort_by(|left, right| left.shell.identity.cmp(&right.shell.identity));
+        nominals.sort_by(|left, right| left.shell.identity.cmp(&right.shell.identity));
+        (pending, nominals)
+    }
+
     fn export_type(
         &self,
         ty: Type,
@@ -769,6 +1035,9 @@ impl DeclarationBindingWork {
             bind_invocations: 1,
             namespace_setup_invocations: 0,
             nominal_type_predeclaration_invocations: 0,
+            callable_value_predeclaration_invocations: 0,
+            callable_value_shells_predeclared: 0,
+            indexed_declaration_records_visited: 0,
             declaration_resolution_invocations: 0,
             body_readiness_finalization_invocations: 0,
             input_rir_instructions,
@@ -786,10 +1055,12 @@ impl DeclarationBindingWork {
 mod tests {
     use std::collections::HashMap;
 
+    use lasso::ThreadedRodeo;
     use rue_error::{CompileErrors, PreviewFeatures};
     use rue_lexer::Lexer;
     use rue_parser::Parser;
-    use rue_rir::AstGen;
+    use rue_rir::{AstGen, Rir};
+    use rue_span::FileId;
 
     use super::*;
 
@@ -801,6 +1072,21 @@ mod tests {
         let rir = AstGen::new(&ast, &interner).generate();
         let bound = Sema::new(&rir, &interner, PreviewFeatures::new()).bind_declarations()?;
         Ok(bound.binding_manifest().clone())
+    }
+
+    fn lower_files(files: &[(&str, FileId)]) -> (Rir, ThreadedRodeo) {
+        let mut interner = ThreadedRodeo::default();
+        let mut items = Vec::new();
+        for &(source, file_id) in files {
+            let (tokens, next) = Lexer::with_interner_and_file_id(source, interner, file_id)
+                .tokenize()
+                .unwrap();
+            let (ast, next) = Parser::new(tokens, next).parse().unwrap();
+            items.extend(ast.items);
+            interner = next;
+        }
+        let rir = AstGen::new(&rue_parser::Ast { items }, &interner).generate();
+        (rir, interner)
     }
 
     fn export(
@@ -1068,16 +1354,140 @@ mod tests {
         assert_eq!(prepared.bind_invocations, 1);
         assert_eq!(prepared.namespace_setup_invocations, 1);
         assert_eq!(prepared.nominal_type_predeclaration_invocations, 1);
+        assert_eq!(prepared.callable_value_predeclaration_invocations, 1);
+        assert_eq!(prepared.callable_value_shells_predeclared, 1);
+        assert_eq!(prepared.indexed_declaration_records_visited, 2);
+        assert_eq!(
+            prepared.indexed_declaration_records_visited,
+            shells.declaration_shells().count()
+        );
         assert_eq!(prepared.declaration_resolution_invocations, 0);
         assert_eq!(prepared.body_readiness_finalization_invocations, 0);
         assert_eq!(prepared.input_rir_instructions, rir.len());
         assert_eq!(prepared.declaration_index_build_invocations, 1);
+        assert_eq!(
+            shells
+                .sema
+                .rir_declaration_index_work()
+                .rir_instructions_visited,
+            rir.len()
+        );
 
         let bound = shells.resolve_declarations().unwrap();
         let resolved = bound.binding_work();
         assert_eq!(resolved.declaration_resolution_invocations, 1);
         assert_eq!(resolved.body_readiness_finalization_invocations, 1);
         assert!(!bound.manifest_is_materialized());
+    }
+
+    #[test]
+    fn declaration_shell_identities_ignore_file_ids_relocation_and_input_order() {
+        fn identities(
+            files: &[(&str, FileId)],
+            paths: HashMap<FileId, String>,
+        ) -> Vec<SemanticDeclarationShellIdentity> {
+            let (rir, interner) = lower_files(files);
+            let mut sema = Sema::new(&rir, &interner, PreviewFeatures::new());
+            sema.set_symbol_paths(paths);
+            sema.predeclare_declaration_shells()
+                .unwrap()
+                .declaration_shells()
+                .map(|shell| shell.identity.clone())
+                .collect()
+        }
+
+        let left = identities(
+            &[
+                (
+                    "struct Zebra {} enum Amber { One } fn alpha(x: i32) -> i32 { x }",
+                    FileId::new(4),
+                ),
+                (
+                    "struct Birch {} enum Violet { One } const alias = alpha;",
+                    FileId::new(9),
+                ),
+            ],
+            HashMap::from([
+                (FileId::new(4), "/checkout-a/pkg/a.rue".into()),
+                (FileId::new(9), "/checkout-a/pkg/b.rue".into()),
+            ]),
+        );
+        let right = identities(
+            &[
+                (
+                    "struct Birch {} enum Violet { One } const alias = alpha;",
+                    FileId::new(31),
+                ),
+                (
+                    "struct Zebra {} enum Amber { One } fn alpha(x: i32) -> i32 { x }",
+                    FileId::new(2),
+                ),
+            ],
+            HashMap::from([
+                (FileId::new(2), "/checkout-a/pkg/a.rue".into()),
+                (FileId::new(31), "/checkout-a/pkg/b.rue".into()),
+            ]),
+        );
+        assert_eq!(left, right);
+        assert_eq!(left.len(), 6);
+        assert!(
+            left[..4]
+                .iter()
+                .all(|identity| identity.namespace == SemanticBindingNamespace::Type)
+        );
+        assert!(
+            left[4..]
+                .iter()
+                .all(|identity| identity.namespace != SemanticBindingNamespace::Type)
+        );
+    }
+
+    #[test]
+    fn callable_shell_keeps_syntax_metadata_outside_unresolved_payload() {
+        let source = "struct Box { fn map(self, comptime T: type, value: T) -> T { value } fn make(value: i32) -> i32 { value } } const alias = Box.make; drop fn Box(self) {}";
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();
+        let rir = AstGen::new(&ast, &interner).generate();
+        let shells = Sema::new(&rir, &interner, PreviewFeatures::new())
+            .predeclare_declaration_shells()
+            .unwrap();
+        let records = shells.callable_value_shells().collect::<Vec<_>>();
+        assert_eq!(records.len(), 4);
+        let map = records
+            .iter()
+            .find(|shell| shell.identity.name.as_ref() == "map")
+            .unwrap();
+        assert_eq!(map.identity.owner.as_deref(), Some("Box"));
+        assert_eq!(
+            map.parameter_names
+                .iter()
+                .map(AsRef::as_ref)
+                .collect::<Vec<_>>(),
+            vec!["T", "value"]
+        );
+        assert_eq!(map.parameter_comptime.as_ref(), &[true, false]);
+        assert!(map.has_self);
+        assert!(map.is_generic);
+        assert_eq!(shells.binding_work().declaration_resolution_invocations, 0);
+    }
+
+    #[test]
+    fn payload_boundary_preserves_resolution_failure_provenance() {
+        let source = "fn broken(value: Missing) -> i32 { 0 } fn main() {}";
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();
+        let rir = AstGen::new(&ast, &interner).generate();
+        let direct = Sema::new(&rir, &interner, PreviewFeatures::new())
+            .bind_declarations()
+            .err()
+            .expect("ordinary binding must fail");
+        let split = Sema::new(&rir, &interner, PreviewFeatures::new())
+            .predeclare_declaration_shells()
+            .unwrap()
+            .resolve_declarations()
+            .err()
+            .expect("split binding must fail");
+        assert_eq!(format!("{direct:?}"), format!("{split:?}"));
     }
 
     #[test]

--- a/crates/rue-air/src/sema/declaration_index.rs
+++ b/crates/rue-air/src/sema/declaration_index.rs
@@ -47,9 +47,17 @@ pub(super) struct RirDestructorDeclaration {
 #[derive(Debug, Clone, Copy)]
 struct FunctionCandidate {
     declaration: InstRef,
+    source_order: u32,
     file_id: FileId,
     name: Spur,
     has_self: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RirShellDeclaration {
+    pub(super) declaration: InstRef,
+    pub(super) source_order: u32,
+    pub(super) named_method_owner: Option<Spur>,
 }
 
 /// Immutable declaration candidates tied to one exact RIR arena.
@@ -72,6 +80,7 @@ pub(super) struct RirDeclarationIndex {
     destructors: Vec<RirDestructorDeclaration>,
     const_candidates: Vec<InstRef>,
     const_candidates_by_file_name: HashMap<(FileId, Spur), Vec<InstRef>>,
+    shell_declarations: Vec<RirShellDeclaration>,
     work: RirDeclarationIndexWork,
 }
 
@@ -79,7 +88,9 @@ impl RirDeclarationIndex {
     pub(super) fn new(rir: &Rir) -> Self {
         let mut function_candidates = Vec::new();
         let mut named_method_refs = HashSet::new();
+        let mut named_method_owners = HashMap::new();
         let mut anonymous_method_refs = HashSet::new();
+        let mut declaration_source_orders = HashMap::new();
         let mut non_receiver_name_multiplicity = HashMap::<Spur, usize>::new();
         let mut destructors = Vec::new();
         let mut const_candidates = Vec::new();
@@ -92,12 +103,14 @@ impl RirDeclarationIndex {
         // AstGen emits method FnDecls before their enclosing type. Retain all
         // function candidates during this single arena walk, collect owner
         // edges wherever their containers occur, then classify below.
-        for (inst_ref, inst) in rir.iter() {
+        let mut nominal_candidates = Vec::new();
+        for (source_order, (inst_ref, inst)) in rir.iter().enumerate() {
             work.rir_instructions_visited += 1;
             match &inst.data {
                 InstData::FnDecl { name, has_self, .. } => {
                     function_candidates.push(FunctionCandidate {
                         declaration: inst_ref,
+                        source_order: source_order as u32,
                         file_id: inst.span.file_id,
                         name: *name,
                         has_self: *has_self,
@@ -107,6 +120,7 @@ impl RirDeclarationIndex {
                     }
                 }
                 InstData::StructDecl {
+                    name,
                     methods_start,
                     methods_len,
                     ..
@@ -114,7 +128,12 @@ impl RirDeclarationIndex {
                     for method_ref in rir.get_inst_refs(*methods_start, *methods_len) {
                         work.method_references_visited += 1;
                         named_method_refs.insert(method_ref);
+                        // A method may only have one named owner in valid RIR;
+                        // retain the first edge so malformed input preserves
+                        // the historical discovery semantics.
+                        named_method_owners.entry(method_ref).or_insert(*name);
                     }
+                    nominal_candidates.push((source_order as u32, inst_ref));
                 }
                 InstData::AnonStructType {
                     methods_start,
@@ -127,6 +146,7 @@ impl RirDeclarationIndex {
                     }
                 }
                 InstData::DropFnDecl { type_name, body } => {
+                    declaration_source_orders.insert(inst_ref, source_order as u32);
                     destructors.push(RirDestructorDeclaration {
                         declaration: inst_ref,
                         type_name: *type_name,
@@ -135,11 +155,15 @@ impl RirDeclarationIndex {
                     });
                 }
                 InstData::ConstDecl { name, .. } => {
+                    declaration_source_orders.insert(inst_ref, source_order as u32);
                     const_candidates.push(inst_ref);
                     const_candidates_by_file_name
                         .entry((inst.span.file_id, *name))
                         .or_default()
                         .push(inst_ref);
+                }
+                InstData::EnumDecl { .. } => {
+                    nominal_candidates.push((source_order as u32, inst_ref));
                 }
                 _ => {}
             }
@@ -150,6 +174,14 @@ impl RirDeclarationIndex {
         let mut free_functions_by_name = HashMap::<Spur, Vec<InstRef>>::new();
         let mut named_methods = Vec::new();
         let mut anonymous_methods = Vec::new();
+        let mut shell_declarations = nominal_candidates
+            .into_iter()
+            .map(|(source_order, declaration)| RirShellDeclaration {
+                declaration,
+                source_order,
+                named_method_owner: None,
+            })
+            .collect::<Vec<_>>();
 
         for candidate in function_candidates {
             if named_method_refs.contains(&candidate.declaration) {
@@ -167,7 +199,28 @@ impl RirDeclarationIndex {
                     .or_default()
                     .push(candidate.declaration);
             }
+            if !anonymous_method_refs.contains(&candidate.declaration) {
+                shell_declarations.push(RirShellDeclaration {
+                    declaration: candidate.declaration,
+                    source_order: candidate.source_order,
+                    named_method_owner: named_method_owners.get(&candidate.declaration).copied(),
+                });
+            }
         }
+
+        shell_declarations.extend(destructors.iter().map(|candidate| RirShellDeclaration {
+            declaration: candidate.declaration,
+            source_order: declaration_source_orders[&candidate.declaration],
+            named_method_owner: None,
+        }));
+        shell_declarations.extend(const_candidates.iter().map(|&declaration| {
+            RirShellDeclaration {
+                declaration,
+                source_order: declaration_source_orders[&declaration],
+                named_method_owner: None,
+            }
+        }));
+        shell_declarations.sort_by_key(|candidate| candidate.source_order);
 
         work.free_functions_indexed = free_functions.len();
         work.named_methods_indexed = named_methods.len();
@@ -187,6 +240,7 @@ impl RirDeclarationIndex {
             destructors,
             const_candidates,
             const_candidates_by_file_name,
+            shell_declarations,
             work,
         }
     }
@@ -237,6 +291,10 @@ impl RirDeclarationIndex {
     #[inline]
     pub(super) fn is_named_method(&self, inst_ref: InstRef) -> bool {
         self.named_method_refs.contains(&inst_ref)
+    }
+
+    pub(super) fn shell_declarations(&self) -> &[RirShellDeclaration] {
+        &self.shell_declarations
     }
 
     #[inline]

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -50,8 +50,9 @@ pub use binding_manifest::{
     BoundSema, DeclarationBindingWork, DeclarationShells, SemanticBinding, SemanticBindingKind,
     SemanticBindingManifest, SemanticBindingManifestWork, SemanticBindingNamespace,
     SemanticDeclarationExport, SemanticDeclarationExportWork, SemanticDeclarationPayload,
-    SemanticExportConstValue, SemanticExportFailure, SemanticExportParameter, SemanticExportType,
-    SemanticNominalIdentity, SemanticParameterMode,
+    SemanticDeclarationShell, SemanticDeclarationShellIdentity, SemanticExportConstValue,
+    SemanticExportFailure, SemanticExportParameter, SemanticExportType, SemanticNominalIdentity,
+    SemanticParameterMode,
 };
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;
@@ -341,15 +342,23 @@ impl<'a> Sema<'a> {
         self.inject_builtin_types();
         binding_work.namespace_setup_invocations += 1;
 
-        // Phase 1: Register nominal type shells. Functions, constants,
-        // methods, and destructors are resolved on the far side of this
-        // boundary; splitting those into independently importable records is
-        // intentionally left to the durable-declaration integration.
+        // Phase 1: Register nominal type shells.
         self.register_type_names().map_err(CompileErrors::from)?;
         binding_work.nominal_type_predeclaration_invocations += 1;
+
+        // Phase 2: Freeze stable-joinable identities and authoritative
+        // current-revision syntax metadata before resolving semantic payloads.
+        // This does not evaluate constants or resolve any signature.
+        let (pending_payloads, pending_nominals) = self.predeclare_callable_value_shells();
+        binding_work.callable_value_predeclaration_invocations += 1;
+        binding_work.callable_value_shells_predeclared = pending_payloads.len();
+        binding_work.indexed_declaration_records_visited =
+            pending_payloads.len() + pending_nominals.len();
         Ok(DeclarationShells {
             sema: self,
             binding_work,
+            pending_payloads,
+            pending_nominals,
         })
     }
 

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -344,6 +344,15 @@ representation for the durable reserved tuple/function type forms or for an
 unsubstituted declaration generic parameter, so those fail closed. Installing
 callables and constants into `Sema` additionally requires exact-revision RIR
 bodies/initializers, source spans, parameter names and declaration indices.
-The split-binding seam must provide those constructor inputs and decide generic
-substitution context; the importer must not synthesize them or mutate private
-`Sema` tables. No AIR body, CFG, or RIR fragment is reused by this boundary.
+The split-binding seam now predeclares free-callable, named-method/associated,
+named-const, and named-destructor identities in logical-path order. It retains
+exact-revision bodies/initializers, spans, parameter names/modes/comptime flags,
+source order, and generic context in private pending records, apart from any
+resolved payload. The ordinary adapter crosses the explicit install/finalize
+boundary using current resolution and preserves historical diagnostic and
+constant-evaluation order. Anonymous structural methods remain deferred because
+they lack a durable structural-owner identity. Module bindings and value
+constants also cannot be distinguished before dependency-ordered initializer
+evaluation, though their value-namespace identity is already fixed. No cached
+payload is installed and no AIR body, CFG, or RIR fragment is reused by this
+boundary.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -109,14 +109,19 @@ incremental-compilation goal is complete.
    validation, builtin injection, and named struct/enum shell registration.
    The ordinary adapter crosses it immediately, with phase counters proving one
    setup, predeclaration, resolution, and body-readiness finalization. This is
-   deliberately not described as per-definition independence: free-function,
-   constant, method, and destructor signatures are still collected together in
-   `resolve_remaining_declarations`, and constant evaluation remains
-   dependency-ordered. The next split must predeclare those callable/value
-   identities deterministically, then install either current-revision resolved
-   payloads or remapped durable payloads behind the owned boundary before body
-   analysis. Until that split exists, no declaration-resolution work may be
-   skipped or reported as reused.
+   Callable/value shells are now predeclared deterministically at that boundary.
+   Free functions, named methods/associated functions, constants (including
+   function-valued aliases after evaluation), and named destructors carry
+   logical-path identities, while spans, parameter/source order, generic
+   context, and authoritative current-revision body/initializer handles remain
+   separate from resolved payload. The ordinary payload-install/finalize adapter
+   still resolves in historical order exactly once. Anonymous structural methods
+   remain blocked on a durable structural-owner identity. A syntactic `const`
+   cannot be classified as a value versus module binding until dependency-ordered
+   initializer evaluation, so both share the pre-resolution value identity.
+   Callers without logical symbol paths receive a request-local fallback that is
+   deliberately not cross-relocation joinable. No cached payload is installed,
+   and no declaration-resolution work may yet be skipped or reported as reused.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## Summary
- derive stable callable, constant, destructor, and nominal shell identities from the canonical declaration index before payload resolution
- retain current-revision syntax metadata and private body/initializer handles separately from reusable identity
- preserve deterministic ordering and historical resolution behavior while accounting indexed shell work without another RIR scan

## Testing
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test`