### PR TITLE
RUE-719: project durable semantics into current shells

### DIFF
--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -285,6 +285,117 @@ pub fn bind_canonical_declaration_semantics(
     Ok((definitions, semantics, converted.1))
 }
 
+/// Comparison-only proof seam for the durable projection/installation path.
+///
+/// This deliberately does not cache or skip production work. It resolves an
+/// authoritative ordinary epoch, projects its durable result into fresh
+/// current-revision shells, installs atomically, and proves that re-exporting
+/// the installed epoch produces the same stable semantics before exercising
+/// body analysis.
+pub fn compare_canonical_durable_declaration_install(
+    merged: &CanonicalMergedProgram,
+    rir: &CanonicalRirOutput,
+    preview_features: PreviewFeatures,
+    target: Target,
+) -> MultiErrorResult<(crate::DurableSemanticProjectionWork, DeclarationBindingWork)> {
+    let ordinary = configure_canonical_sema(merged, rir, preview_features.clone(), target)?
+        .bind_declarations()?;
+    let manifest = ordinary.binding_manifest();
+    let definitions = issue_bound_definitions(
+        merged,
+        rir.source_revision(),
+        manifest.bindings(),
+        manifest.work(),
+    )
+    .map_err(CompileErrors::from)?;
+    let durable = ordinary
+        .with_declaration_semantics(|records, _| {
+            crate::durable_semantics::convert_declaration_semantics(merged, &definitions, records)
+        })
+        .map_err(|failure| {
+            CompileErrors::from(invalid(format!(
+                "ordinary semantic AIR export failed: {failure:?}"
+            )))
+        })?
+        .map_err(|failure| {
+            CompileErrors::from(invalid(format!(
+                "ordinary durable semantic conversion failed: {failure:?}"
+            )))
+        })?;
+    let shells = configure_canonical_sema(merged, rir, preview_features, target)?
+        .predeclare_declaration_shells()?;
+    let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+    let (projected, projection_work) = crate::project_durable_declaration_semantics(
+        merged,
+        &definitions,
+        &shell_records,
+        &durable,
+    )
+    .map_err(|failure| {
+        CompileErrors::from(invalid(format!(
+            "durable semantic projection failed: {failure:?}"
+        )))
+    })?;
+    let installed = shells
+        .install_declaration_semantics(&projected)
+        .map_err(|failure| {
+            CompileErrors::from(invalid(format!(
+                "durable semantic installation failed: {failure:?}"
+            )))
+        })?;
+    let binding_work = installed.binding_work();
+    let installed_durable = installed
+        .with_declaration_semantics(|records, _| {
+            crate::durable_semantics::convert_declaration_semantics(merged, &definitions, records)
+        })
+        .map_err(|failure| {
+            CompileErrors::from(invalid(format!(
+                "installed semantic AIR export failed: {failure:?}"
+            )))
+        })?
+        .map_err(|failure| {
+            CompileErrors::from(invalid(format!(
+                "installed durable semantic conversion failed: {failure:?}"
+            )))
+        })?;
+    if installed_durable != durable {
+        return Err(CompileErrors::from(invalid(
+            "projected durable install changed declaration semantics",
+        )));
+    }
+    let ordinary_bodies = ordinary.analyze_all_bodies();
+    let installed_bodies = installed.analyze_all_bodies();
+    match (ordinary_bodies, installed_bodies) {
+        (Ok(ordinary), Ok(installed)) => {
+            let ordinary = crate::build_functions_and_cfgs(
+                ordinary,
+                crate::OptLevel::default(),
+                rir.semantic_symbols().interner(),
+            )?;
+            let installed = crate::build_functions_and_cfgs(
+                installed,
+                crate::OptLevel::default(),
+                rir.semantic_symbols().interner(),
+            )?;
+            if format!("{:?}", ordinary.functions) != format!("{:?}", installed.functions)
+                || format!("{:?}", ordinary.warnings) != format!("{:?}", installed.warnings)
+                || ordinary.strings != installed.strings
+            {
+                return Err(CompileErrors::from(invalid(
+                    "projected durable install changed body, CFG, or diagnostic artifacts",
+                )));
+            }
+        }
+        (Err(ordinary), Err(installed)) if format!("{ordinary:?}") == format!("{installed:?}") => {}
+        _ => {
+            return Err(CompileErrors::from(invalid(
+                "projected durable install changed body-analysis diagnostics",
+            )));
+        }
+    }
+    Ok((projection_work, binding_work))
+}
+
 pub(crate) fn bind_canonical_definitions_with_work(
     merged: &CanonicalMergedProgram,
     rir: &CanonicalRirOutput,
@@ -727,6 +838,217 @@ mod tests {
             .iter()
             .map(|record| record.stable_key().clone())
             .collect()
+    }
+
+    fn compare(
+        snapshot: &SourceSnapshot,
+    ) -> (crate::DurableSemanticProjectionWork, DeclarationBindingWork) {
+        let parsed = parse_source_snapshot_modules(snapshot).unwrap();
+        let merged = merge_parsed_modules(&parsed).unwrap();
+        let rir = lower_canonical_rir(&merged).unwrap();
+        compare_canonical_durable_declaration_install(
+            &merged,
+            &rir,
+            PreviewFeatures::new(),
+            Target::default(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn projected_install_matches_ordinary_across_relocation_order_modules_methods_and_drop() {
+        let root = r#"
+            struct Resource {
+                value: i32,
+                fn get(self) -> i32 { self.value }
+                fn make(value: i32) -> Resource { Resource { value } }
+            }
+            enum Choice { None, Some(Resource) }
+            drop fn Resource(self) {}
+            fn main() -> i32 { Resource.make(1).get() }
+        "#;
+        let sibling = "struct Sibling { value: bool } fn helper(value: i32) -> i32 { value }";
+        let first = snapshot(
+            &[
+                (9, "/old/sibling.rue", "sibling.rue", sibling),
+                (2, "/old/main.rue", "main.rue", root),
+            ],
+            2,
+        );
+        let relocated = snapshot(
+            &[
+                (71, "/new/main.rue", "main.rue", root),
+                (4, "/new/sibling.rue", "sibling.rue", sibling),
+            ],
+            71,
+        );
+        for input in [&first, &relocated] {
+            let (projection, install) = compare(input);
+            assert_eq!(projection.projection_invocations, 1);
+            assert_eq!(projection.rir_instructions_visited, 0);
+            assert_eq!(
+                projection.definition_records_indexed,
+                projection.shells_visited
+            );
+            assert_eq!(
+                projection.definition_lookup_probes,
+                projection.shells_visited
+            );
+            assert_eq!(
+                projection.shells_visited,
+                projection.durable_records_visited
+            );
+            assert_eq!(install.declaration_resolution_invocations, 0);
+            assert_eq!(install.durable_install_invocations, 1);
+            assert_eq!(
+                install.durable_payloads_installed,
+                projection.shells_visited
+            );
+        }
+
+        let (_, old_durable, _) = export(&first);
+        let parsed = parse_source_snapshot_modules(&relocated).unwrap();
+        let merged = merge_parsed_modules(&parsed).unwrap();
+        let rir = lower_canonical_rir(&merged).unwrap();
+        let current_definitions = bind(&relocated);
+        let shells =
+            configure_canonical_sema(&merged, &rir, PreviewFeatures::new(), Target::default())
+                .unwrap()
+                .predeclare_declaration_shells()
+                .unwrap();
+        let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+        let (projected, work) = crate::project_durable_declaration_semantics(
+            &merged,
+            &current_definitions,
+            &shell_records,
+            &old_durable,
+        )
+        .unwrap();
+        assert_eq!(projected.len(), old_durable.len());
+        assert_eq!(work.definition_records_indexed, old_durable.len());
+        assert_eq!(work.definition_lookup_probes, old_durable.len());
+    }
+
+    #[test]
+    fn projection_definition_join_work_is_linear_for_128_modules() {
+        let owned = (0..128_u32)
+            .map(|index| {
+                let id = index + 1;
+                let physical = format!("/src/module_{index}.rue");
+                let logical = format!("module_{index}.rue");
+                let source = if index == 0 {
+                    "fn main() -> i32 { 0 }".to_owned()
+                } else {
+                    format!("fn f{index}() -> i32 {{ {index} }}")
+                };
+                (id, physical, logical, source)
+            })
+            .collect::<Vec<_>>();
+        let borrowed = owned
+            .iter()
+            .map(|(id, physical, logical, source)| {
+                (*id, physical.as_str(), logical.as_str(), source.as_str())
+            })
+            .collect::<Vec<_>>();
+        let input = snapshot(&borrowed, 1);
+        let (definitions, durable, _) = export(&input);
+        let parsed = parse_source_snapshot_modules(&input).unwrap();
+        let merged = merge_parsed_modules(&parsed).unwrap();
+        let rir = lower_canonical_rir(&merged).unwrap();
+        let shells =
+            configure_canonical_sema(&merged, &rir, PreviewFeatures::new(), Target::default())
+                .unwrap()
+                .predeclare_declaration_shells()
+                .unwrap();
+        let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+        let (projected, projection) = crate::project_durable_declaration_semantics(
+            &merged,
+            &definitions,
+            &shell_records,
+            &durable,
+        )
+        .unwrap();
+
+        assert_eq!(projection.shells_visited, 128);
+        assert_eq!(projection.durable_records_visited, 128);
+        assert_eq!(projection.definition_records_indexed, 128);
+        assert_eq!(projection.definition_lookup_probes, 128);
+        assert_eq!(projection.rir_instructions_visited, 0);
+        assert_eq!(projected.len(), 128);
+    }
+
+    #[test]
+    fn duplicate_projection_input_fails_before_shells_are_consumed() {
+        let input = snapshot(&[(1, "/main.rue", "main.rue", "fn main() -> i32 { 0 }")], 1);
+        let (definitions, durable, _) = export(&input);
+        let parsed = parse_source_snapshot_modules(&input).unwrap();
+        let merged = merge_parsed_modules(&parsed).unwrap();
+        let rir = lower_canonical_rir(&merged).unwrap();
+        let shells =
+            configure_canonical_sema(&merged, &rir, PreviewFeatures::new(), Target::default())
+                .unwrap()
+                .predeclare_declaration_shells()
+                .unwrap();
+        let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+        let duplicated = durable
+            .iter()
+            .cloned()
+            .chain(durable.iter().cloned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            crate::project_durable_declaration_semantics(
+                &merged,
+                &definitions,
+                &shell_records,
+                &duplicated,
+            )
+            .unwrap_err(),
+            crate::DurableSemanticProjectionFailure::DuplicateDefinition
+        );
+        let (projected, _) = crate::project_durable_declaration_semantics(
+            &merged,
+            &definitions,
+            &shell_records,
+            &durable,
+        )
+        .unwrap();
+        let installed = shells.install_declaration_semantics(&projected).unwrap();
+        assert_eq!(installed.binding_work().durable_payloads_installed, 1);
+    }
+
+    #[test]
+    fn unsupported_const_projection_fails_without_partial_install() {
+        let input = snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "const X: i32 = 1; fn main() -> i32 { X }",
+            )],
+            1,
+        );
+        let parsed = parse_source_snapshot_modules(&input).unwrap();
+        let merged = merge_parsed_modules(&parsed).unwrap();
+        let rir = lower_canonical_rir(&merged).unwrap();
+        let error = compare_canonical_durable_declaration_install(
+            &merged,
+            &rir,
+            PreviewFeatures::new(),
+            Target::default(),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{error:?}").contains("UnsupportedDeclaration"),
+            "{error:?}"
+        );
+        // The failed candidate was consumed; a fresh ordinary epoch remains valid.
+        configure_canonical_sema(&merged, &rir, PreviewFeatures::new(), Target::default())
+            .unwrap()
+            .bind_declarations()
+            .unwrap()
+            .analyze_all_bodies()
+            .unwrap();
     }
 
     const PROGRAM: &str = r#"

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -7,11 +7,13 @@
 use std::sync::Arc;
 
 use rue_air::{
-    SemanticBindingKind, SemanticDeclarationExport, SemanticDeclarationPayload,
-    SemanticExportConstValue, SemanticExportFailure, SemanticExportType, SemanticImportConstValue,
-    SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal, SemanticImportNominalKind,
-    SemanticImportType, SemanticParameterMode,
+    SemanticBinding, SemanticBindingKind, SemanticBindingNamespace, SemanticDeclarationExport,
+    SemanticDeclarationPayload, SemanticDeclarationShell, SemanticExportConstValue,
+    SemanticExportFailure, SemanticExportType, SemanticImportConstValue, SemanticImportEpoch,
+    SemanticImportFailure, SemanticImportNominal, SemanticImportNominalKind, SemanticImportType,
+    SemanticParameterMode,
 };
+use rue_span::FileId;
 
 /// A fresh AIR epoch populated only from request-independent semantic values.
 pub type DurableSemanticImportEpoch = SemanticImportEpoch<StableDefinitionKey, Arc<str>>;
@@ -351,6 +353,365 @@ pub struct DurableDeclarationSemantic {
     pub key: StableDefinitionKey,
     pub is_public: bool,
     pub payload: DurableDeclarationPayload,
+}
+
+/// Work performed by the stable-key/current-revision projection adapter.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DurableSemanticProjectionWork {
+    pub projection_invocations: usize,
+    pub shells_visited: usize,
+    pub durable_records_visited: usize,
+    /// Stable definition records inserted into the exact projection join index.
+    pub definition_records_indexed: usize,
+    /// Exact-key definition index probes performed while joining shells.
+    pub definition_lookup_probes: usize,
+    /// Projection is a metadata join and must never inspect RIR.
+    pub rir_instructions_visited: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ProjectionJoinKey {
+    module: ModuleId,
+    namespace: crate::StableDefinitionNamespace,
+    kind: StableDefinitionKind,
+    name: Arc<str>,
+    owner: Option<Arc<str>>,
+}
+
+impl ProjectionJoinKey {
+    fn from_definition(key: &StableDefinitionKey) -> Self {
+        Self {
+            module: key.module().clone(),
+            namespace: key.namespace(),
+            kind: key.kind(),
+            name: Arc::from(key.name()),
+            owner: key.owner().map(|owner| Arc::from(owner.name())),
+        }
+    }
+
+    fn from_shell(shell: &SemanticDeclarationShell) -> Option<Self> {
+        Some(Self {
+            module: ModuleId::from_validated_canonical(&shell.identity.module_path),
+            namespace: stable_namespace(shell.identity.namespace),
+            kind: stable_kind(shell.identity.kind)?,
+            name: shell.identity.name.clone(),
+            owner: shell.identity.owner.clone(),
+        })
+    }
+}
+
+/// Typed reasons that make durable installation ineligible.  Projection is
+/// atomic: no AIR state is mutated before this validation succeeds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DurableSemanticProjectionFailure {
+    DefinitionUniverseRevisionMismatch,
+    MissingDefinition,
+    DuplicateDefinition,
+    ExtraDefinition,
+    MissingShell,
+    DuplicateShell,
+    AmbiguousDefinition,
+    NamespaceMismatch,
+    KindMismatch,
+    OwnerMismatch,
+    ModuleMismatch,
+    VisibilityMismatch,
+    UnsupportedDeclaration,
+    UnsupportedType,
+}
+
+/// Project stable-keyed semantics into exact-current-revision AIR DTOs.
+///
+/// The definition set supplies provenance and `FileId`/span ownership, while
+/// shells supply authoritative body and parameter metadata. Records are
+/// returned in stable-key order. The join is deliberately total and
+/// bijective for the supported subset.
+pub fn project_durable_declaration_semantics(
+    merged: &CanonicalMergedProgram,
+    definitions: &BoundDefinitionSet,
+    shells: &[SemanticDeclarationShell],
+    durable: &[DurableDeclarationSemantic],
+) -> Result<
+    (
+        Arc<[SemanticDeclarationExport]>,
+        DurableSemanticProjectionWork,
+    ),
+    DurableSemanticProjectionFailure,
+> {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    if definitions.source_revision() != merged.ast().source_revision() {
+        return Err(DurableSemanticProjectionFailure::DefinitionUniverseRevisionMismatch);
+    }
+    let modules = merged.ast().modules();
+    let module_files = modules
+        .iter()
+        .map(|module| (module.module_id().clone(), module.file_id()))
+        .collect::<BTreeMap<_, _>>();
+    if module_files.len() != modules.len() {
+        return Err(DurableSemanticProjectionFailure::AmbiguousDefinition);
+    }
+
+    let mut definition_by_join_key = BTreeMap::new();
+    for record in definitions.definitions() {
+        let join_key = ProjectionJoinKey::from_definition(record.stable_key());
+        if definition_by_join_key
+            .insert(join_key, record.stable_key().clone())
+            .is_some()
+        {
+            return Err(DurableSemanticProjectionFailure::DuplicateDefinition);
+        }
+    }
+
+    let mut shell_by_key = BTreeMap::new();
+    for shell in shells {
+        // The AIR installer does not yet reconstruct the declaration-scoped
+        // type-parameter environment needed by generic callable bodies.
+        if shell.is_generic {
+            return Err(DurableSemanticProjectionFailure::UnsupportedDeclaration);
+        }
+        let join_key = ProjectionJoinKey::from_shell(shell)
+            .ok_or(DurableSemanticProjectionFailure::UnsupportedDeclaration)?;
+        let key = definition_by_join_key
+            .get(&join_key)
+            .cloned()
+            .ok_or(DurableSemanticProjectionFailure::MissingDefinition)?;
+        if shell_by_key.insert(key, shell).is_some() {
+            return Err(DurableSemanticProjectionFailure::DuplicateShell);
+        }
+    }
+    let mut durable_by_key = BTreeMap::new();
+    for record in durable {
+        if durable_by_key.insert(record.key.clone(), record).is_some() {
+            return Err(DurableSemanticProjectionFailure::DuplicateDefinition);
+        }
+    }
+    let expected = shell_by_key.keys().cloned().collect::<BTreeSet<_>>();
+    let supplied = durable_by_key.keys().cloned().collect::<BTreeSet<_>>();
+    if let Some(key) = expected.difference(&supplied).next() {
+        let _ = key;
+        return Err(DurableSemanticProjectionFailure::MissingDefinition);
+    }
+    if supplied.difference(&expected).next().is_some() {
+        return Err(DurableSemanticProjectionFailure::ExtraDefinition);
+    }
+
+    let mut exports = Vec::with_capacity(expected.len());
+    for key in expected {
+        let shell = shell_by_key[&key];
+        let record = durable_by_key[&key];
+        let file_id = *module_files
+            .get(key.module())
+            .ok_or(DurableSemanticProjectionFailure::ModuleMismatch)?;
+        if shell.declaration_span.file_id != file_id
+            || shell.identity.module_path.as_ref() != key.module().as_str()
+        {
+            return Err(DurableSemanticProjectionFailure::ModuleMismatch);
+        }
+        if record.is_public != shell.is_public {
+            return Err(DurableSemanticProjectionFailure::VisibilityMismatch);
+        }
+        let payload = project_payload(&record.payload, definitions, &module_files)?;
+        validate_payload_shape(shell, &payload)?;
+        exports.push(SemanticDeclarationExport {
+            identity: SemanticBinding {
+                file_id,
+                declaration_span: shell.declaration_span,
+                namespace: shell.identity.namespace,
+                kind: shell.identity.kind,
+                name: shell.identity.name.clone(),
+                owner: shell.identity.owner.clone(),
+                is_public: shell.is_public,
+            },
+            payload,
+        });
+    }
+    let work = DurableSemanticProjectionWork {
+        projection_invocations: 1,
+        shells_visited: shells.len(),
+        durable_records_visited: durable.len(),
+        definition_records_indexed: definitions.definitions().len(),
+        definition_lookup_probes: shells.len(),
+        rir_instructions_visited: 0,
+    };
+    Ok((exports.into(), work))
+}
+
+fn stable_namespace(value: SemanticBindingNamespace) -> crate::StableDefinitionNamespace {
+    match value {
+        SemanticBindingNamespace::Value => crate::StableDefinitionNamespace::Value,
+        SemanticBindingNamespace::Type => crate::StableDefinitionNamespace::Type,
+        SemanticBindingNamespace::Destructor => crate::StableDefinitionNamespace::Destructor,
+        SemanticBindingNamespace::Method => crate::StableDefinitionNamespace::Method,
+    }
+}
+
+fn stable_kind(value: SemanticBindingKind) -> Option<StableDefinitionKind> {
+    Some(match value {
+        SemanticBindingKind::Function => StableDefinitionKind::Function,
+        SemanticBindingKind::Struct => StableDefinitionKind::Struct,
+        SemanticBindingKind::Enum => StableDefinitionKind::Enum,
+        SemanticBindingKind::ValueConst => StableDefinitionKind::ValueConst,
+        SemanticBindingKind::ModuleBinding => StableDefinitionKind::ModuleBinding,
+        SemanticBindingKind::Destructor => StableDefinitionKind::Destructor,
+        SemanticBindingKind::Method => StableDefinitionKind::Method,
+        SemanticBindingKind::AssociatedFunction => StableDefinitionKind::AssociatedFunction,
+    })
+}
+
+fn current_nominal(
+    key: &StableDefinitionKey,
+    definitions: &BoundDefinitionSet,
+    module_files: &std::collections::BTreeMap<ModuleId, FileId>,
+) -> Result<rue_air::SemanticNominalIdentity, DurableSemanticProjectionFailure> {
+    definitions
+        .definition_by_key(key)
+        .ok_or(DurableSemanticProjectionFailure::MissingDefinition)?;
+    let kind = match key.kind() {
+        StableDefinitionKind::Struct => SemanticBindingKind::Struct,
+        StableDefinitionKind::Enum => SemanticBindingKind::Enum,
+        _ => return Err(DurableSemanticProjectionFailure::KindMismatch),
+    };
+    Ok(rue_air::SemanticNominalIdentity {
+        file_id: *module_files
+            .get(key.module())
+            .ok_or(DurableSemanticProjectionFailure::ModuleMismatch)?,
+        name: Arc::from(key.name()),
+        kind,
+    })
+}
+
+fn project_type(
+    value: &DurableType,
+    definitions: &BoundDefinitionSet,
+    module_files: &std::collections::BTreeMap<ModuleId, FileId>,
+) -> Result<SemanticExportType, DurableSemanticProjectionFailure> {
+    Ok(match value {
+        DurableType::I8 => SemanticExportType::I8,
+        DurableType::I16 => SemanticExportType::I16,
+        DurableType::I32 => SemanticExportType::I32,
+        DurableType::I64 => SemanticExportType::I64,
+        DurableType::U8 => SemanticExportType::U8,
+        DurableType::U16 => SemanticExportType::U16,
+        DurableType::U32 => SemanticExportType::U32,
+        DurableType::U64 => SemanticExportType::U64,
+        DurableType::Bool => SemanticExportType::Bool,
+        DurableType::Unit => SemanticExportType::Unit,
+        DurableType::Never => SemanticExportType::Never,
+        DurableType::ComptimeType => SemanticExportType::ComptimeType,
+        DurableType::GenericParameter(index) => SemanticExportType::GenericParameter(*index),
+        DurableType::Nominal(key) => {
+            SemanticExportType::Nominal(current_nominal(key, definitions, module_files)?)
+        }
+        DurableType::Array { element, len } => SemanticExportType::Array {
+            element: Box::new(project_type(element, definitions, module_files)?),
+            len: *len,
+        },
+        DurableType::PtrConst(value) => {
+            SemanticExportType::PtrConst(Box::new(project_type(value, definitions, module_files)?))
+        }
+        DurableType::PtrMut(value) => {
+            SemanticExportType::PtrMut(Box::new(project_type(value, definitions, module_files)?))
+        }
+        DurableType::Module(_) | DurableType::Tuple(_) | DurableType::Function { .. } => {
+            return Err(DurableSemanticProjectionFailure::UnsupportedType);
+        }
+    })
+}
+
+fn project_payload(
+    value: &DurableDeclarationPayload,
+    definitions: &BoundDefinitionSet,
+    module_files: &std::collections::BTreeMap<ModuleId, FileId>,
+) -> Result<SemanticDeclarationPayload, DurableSemanticProjectionFailure> {
+    Ok(match value {
+        DurableDeclarationPayload::Callable {
+            parameters,
+            result,
+            has_self,
+            is_unchecked,
+        } => SemanticDeclarationPayload::Callable {
+            parameters: parameters
+                .iter()
+                .map(|parameter| {
+                    Ok(rue_air::SemanticExportParameter {
+                        ty: project_type(&parameter.ty, definitions, module_files)?,
+                        mode: match parameter.mode {
+                            DurableParameterMode::Value => SemanticParameterMode::Value,
+                            DurableParameterMode::Borrow => SemanticParameterMode::Borrow,
+                            DurableParameterMode::Inout => SemanticParameterMode::Inout,
+                        },
+                        is_comptime: parameter.is_comptime,
+                    })
+                })
+                .collect::<Result<Vec<_>, DurableSemanticProjectionFailure>>()?
+                .into(),
+            result: project_type(result, definitions, module_files)?,
+            has_self: *has_self,
+            is_unchecked: *is_unchecked,
+        },
+        DurableDeclarationPayload::Struct {
+            fields,
+            is_copy,
+            is_linear,
+        } => SemanticDeclarationPayload::Struct {
+            fields: fields
+                .iter()
+                .map(|(name, ty)| Ok((name.clone(), project_type(ty, definitions, module_files)?)))
+                .collect::<Result<Vec<_>, DurableSemanticProjectionFailure>>()?
+                .into(),
+            is_copy: *is_copy,
+            is_linear: *is_linear,
+        },
+        DurableDeclarationPayload::Enum { variants } => SemanticDeclarationPayload::Enum {
+            variants: variants
+                .iter()
+                .map(|(name, payload)| {
+                    Ok((
+                        name.clone(),
+                        payload
+                            .iter()
+                            .map(|ty| project_type(ty, definitions, module_files))
+                            .collect::<Result<Vec<_>, _>>()?
+                            .into(),
+                    ))
+                })
+                .collect::<Result<Vec<_>, DurableSemanticProjectionFailure>>()?
+                .into(),
+        },
+        DurableDeclarationPayload::Destructor => SemanticDeclarationPayload::Destructor,
+        DurableDeclarationPayload::Const { .. } => {
+            return Err(DurableSemanticProjectionFailure::UnsupportedDeclaration);
+        }
+    })
+}
+
+fn validate_payload_shape(
+    shell: &SemanticDeclarationShell,
+    payload: &SemanticDeclarationPayload,
+) -> Result<(), DurableSemanticProjectionFailure> {
+    match (shell.identity.kind, payload) {
+        (
+            SemanticBindingKind::Function
+            | SemanticBindingKind::Method
+            | SemanticBindingKind::AssociatedFunction,
+            SemanticDeclarationPayload::Callable {
+                parameters,
+                has_self,
+                is_unchecked,
+                ..
+            },
+        ) if parameters.len() == shell.parameter_names.len()
+            && *has_self == shell.has_self
+            && *is_unchecked == shell.is_unchecked =>
+        {
+            Ok(())
+        }
+        (SemanticBindingKind::Struct, SemanticDeclarationPayload::Struct { .. })
+        | (SemanticBindingKind::Enum, SemanticDeclarationPayload::Enum { .. })
+        | (SemanticBindingKind::Destructor, SemanticDeclarationPayload::Destructor) => Ok(()),
+        _ => Err(DurableSemanticProjectionFailure::KindMismatch),
+    }
 }
 
 /// Typed fail-closed reasons from the future successful-binding exporter.

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -48,6 +48,7 @@ pub use bound_definitions::{
     BoundDefinitionId, BoundDefinitionRecord, BoundDefinitionSet, BoundDefinitionWork,
     StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace, StableNamedTypeKey,
     bind_canonical_declaration_semantics, bind_canonical_definitions,
+    compare_canonical_durable_declaration_install,
 };
 pub use canonical_lower::{CanonicalRirOutput, CanonicalRirWork, lower_canonical_rir};
 pub use canonical_merge::{
@@ -64,8 +65,9 @@ pub use definition_snapshot::{
 pub use durable_semantics::{
     DURABLE_SEMANTIC_SCHEMA_VERSION, DurableConstValue, DurableDeclarationPayload,
     DurableDeclarationSemantic, DurableParameterMode, DurableSemanticExportFailure,
-    DurableSemanticImportEpoch, DurableSemanticParameter, DurableType,
-    import_durable_declaration_semantics,
+    DurableSemanticImportEpoch, DurableSemanticParameter, DurableSemanticProjectionFailure,
+    DurableSemanticProjectionWork, DurableType, import_durable_declaration_semantics,
+    project_durable_declaration_semantics,
 };
 pub use frontend_session::{
     CanonicalFrontendSession, CanonicalFrontendSessionWork, CanonicalFrontendUpdate,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -69,28 +69,23 @@ anonymous/local nominal types, unjoinable function aliases, and unknown future
 type/value forms produce `DurableSemanticExportFailure`; they are never
 stringified. Adding or changing a variant increments the schema version.
 
-### Required producer seam
+### Producer, projection, and installation seams
 
-The owned algebra is implemented, but one-way export is intentionally not yet
-wired: after successful declaration binding, `BoundSema` currently exposes only
-`SemanticBindingManifest` identity metadata. The resolved `FunctionInfo`,
-`MethodInfo`, `StructDef`, `EnumDef`, `ConstInfo`, parameter arena, and
-`TypeInternPool` remain private and are consumed with `BoundSema` by body
-analysis. Re-parsing type syntax or joining pool IDs by display name would be
-unsound.
+The one-way AIR export and stable compiler algebra are implemented. A compiler
+projection adapter now performs the inverse stable-key/current-revision join:
+it validates the exact `BoundDefinitionSet`, current declaration shells, and
+durable record universe before producing AIR `SemanticDeclarationExport` DTOs.
+It supplies current `FileId`s, spans, owners, names, kinds, and visibility while
+leaving authoritative body handles and parameter metadata in the shells.
+Records are projected in stable-key order; missing, duplicate, extra,
+ambiguous, namespace/kind/owner/module/visibility, and unsupported cases are
+typed failures. Work counters pin zero RIR traversal.
 
-The required AIR API is an optional, lazily materialized
-`BoundSema::durable_declaration_export_inputs()` produced before consuming the
-binder. It must return owned request-local records containing binding identity
-(`FileId`, namespace/kind, source name and optional named owner), resolved type
-trees whose nominal leaves carry the defining `(FileId, kind, source name)`,
-resolved module file identity, and const function leaves carrying their defining
-`(FileId, source name)`. It must also expose ordered parameter modes/comptime
-flags and struct/enum members. The compiler then joins every leaf through the
-exact-revision `BoundDefinitionSet` and canonical module table, yielding only
-the durable public algebra. AIR must report typed anonymous/local/missing cases
-instead of substituting pool handles. Materialization work counters must prove
-zero RIR scan and ordinary batch compilation must not request the export.
+The result feeds AIR's atomic installer only through a comparison seam today.
+That seam proves durable re-export equality and exercises body analysis in a
+fresh epoch. Constants, module values, function aliases, and anonymous owners
+remain explicit clean fallbacks; production does not cache or skip declaration
+resolution yet.
 
 ## Current capture audit
 

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -122,6 +122,18 @@ incremental-compilation goal is complete.
    Callers without logical symbol paths receive a request-local fallback that is
    deliberately not cross-relocation joinable. No cached payload is installed,
    and no declaration-resolution work may yet be skipped or reported as reused.
+   The compiler now has a stable-key projection adapter between durable payloads
+   and exact-current-revision declaration shells. Its join is total and
+   bijective for supported named functions, methods, associated functions,
+   structs, enums, and destructors; it fails atomically on universe, identity,
+   shape, or provenance mismatch and reports zero RIR visits. A comparison-only
+   seam runs ordinary and installed epochs through body analysis and CFG
+   construction and compares durable exports, functions/CFGs, strings, warnings,
+   and error diagnostics across relocation, input order, and multiple modules.
+   Constants/module values/function aliases and anonymous owners remain typed
+   fallbacks. Generic named-method installation also remains a prerequisite:
+   its declaration-scoped type-parameter environment is not yet reconstructed
+   by the installer, so production reuse must continue to fail closed there.
 
 3. **Later tooling integration: import validation and compiler diagnostics remain
    distinct artifact families.** Syntax, merge, and semantic diagnostics are now


### PR DESCRIPTION
## Summary
- join stable durable declaration records bijectively to current-revision shells through an indexed definition universe
- project nominal and callable payloads into current FileId and owner identities before atomic fresh-epoch installation
- prove declaration, body, CFG, warning, string, and diagnostic parity with exact linear structural-work accounting

## Testing
- `./buck2 test //crates/rue-compiler:rue-compiler-test`