### PR TITLE
RUE-719: reuse durable declarations across revisions

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -727,6 +727,34 @@ impl<'a> BoundSema<'a> {
         Ok(convert(&records, work))
     }
 
+    /// Export resolved declarations using the stable shells captured before
+    /// resolution. Unlike [`Self::with_declaration_semantics`], this does not
+    /// materialize the binding manifest or traverse RIR.
+    pub fn with_declaration_semantics_from_shells<R>(
+        &self,
+        shells: &[SemanticDeclarationShell],
+        convert: impl FnOnce(&[SemanticDeclarationExport], SemanticDeclarationExportWork) -> R,
+    ) -> Result<R, SemanticExportFailure> {
+        let bindings = shells
+            .iter()
+            .map(|shell| SemanticBinding {
+                file_id: shell.declaration_span.file_id,
+                declaration_span: shell.declaration_span,
+                namespace: shell.identity.namespace,
+                kind: shell.identity.kind,
+                name: shell.identity.name.clone(),
+                owner: shell.identity.owner.clone(),
+                is_public: shell.is_public,
+            })
+            .collect();
+        let manifest = SemanticBindingManifest {
+            bindings,
+            work: SemanticBindingManifestWork::default(),
+        };
+        let (records, work) = self.sema.build_declaration_semantics(&manifest)?;
+        Ok(convert(&records, work))
+    }
+
     pub fn analyze_all_bodies(self) -> MultiErrorResult<SemaOutput> {
         self.sema.analyze_all_bodies()
     }

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -39,6 +39,13 @@ struct QueryCounts {
     dependency_manifest_reuses: usize,
     invalidation_plan_executions: usize,
     invalidation_plan_reuses: usize,
+    declaration_reuse_plans: usize,
+    durable_records_compared: usize,
+    durable_records_reused: usize,
+    ordinary_declaration_resolutions_skipped: usize,
+    durable_installs: usize,
+    declaration_reuse_fallbacks: usize,
+    durable_cache_population_bindings: usize,
 }
 
 impl QueryCounts {
@@ -59,6 +66,13 @@ impl QueryCounts {
             dependency_manifest_reuses: work.dependency_manifests.reuses,
             invalidation_plan_executions: work.invalidation_plans.executions,
             invalidation_plan_reuses: work.invalidation_plans.reuses,
+            declaration_reuse_plans: work.declaration_reuse_plans,
+            durable_records_compared: work.durable_records_compared,
+            durable_records_reused: work.durable_records_reused,
+            ordinary_declaration_resolutions_skipped: work.ordinary_declaration_resolutions_skipped,
+            durable_installs: work.durable_installs,
+            declaration_reuse_fallbacks: work.declaration_reuse_fallbacks,
+            durable_cache_population_bindings: work.durable_cache_population_bindings,
         }
     }
 
@@ -86,6 +100,17 @@ impl QueryCounts {
                 - before.invalidation_plan_executions,
             invalidation_plan_reuses: self.invalidation_plan_reuses
                 - before.invalidation_plan_reuses,
+            declaration_reuse_plans: self.declaration_reuse_plans - before.declaration_reuse_plans,
+            durable_records_compared: self.durable_records_compared
+                - before.durable_records_compared,
+            durable_records_reused: self.durable_records_reused - before.durable_records_reused,
+            ordinary_declaration_resolutions_skipped: self.ordinary_declaration_resolutions_skipped
+                - before.ordinary_declaration_resolutions_skipped,
+            durable_installs: self.durable_installs - before.durable_installs,
+            declaration_reuse_fallbacks: self.declaration_reuse_fallbacks
+                - before.declaration_reuse_fallbacks,
+            durable_cache_population_bindings: self.durable_cache_population_bindings
+                - before.durable_cache_population_bindings,
         }
     }
 
@@ -106,6 +131,13 @@ impl QueryCounts {
             "dependency_manifest_reuses": self.dependency_manifest_reuses,
             "invalidation_plan_executions": self.invalidation_plan_executions,
             "invalidation_plan_reuses": self.invalidation_plan_reuses,
+            "declaration_reuse_plans": self.declaration_reuse_plans,
+            "durable_records_compared": self.durable_records_compared,
+            "durable_records_reused": self.durable_records_reused,
+            "ordinary_declaration_resolutions_skipped": self.ordinary_declaration_resolutions_skipped,
+            "durable_installs": self.durable_installs,
+            "declaration_reuse_fallbacks": self.declaration_reuse_fallbacks,
+            "durable_cache_population_bindings": self.durable_cache_population_bindings,
         })
     }
 }
@@ -113,7 +145,7 @@ impl QueryCounts {
 struct Fixture {
     modules: usize,
     base: SourceSnapshot,
-    leaf_edit: SourceSnapshot,
+    reachable_root_body_edit: SourceSnapshot,
     identity_edit: SourceSnapshot,
     syntax_error: SourceSnapshot,
 }
@@ -124,7 +156,7 @@ impl Fixture {
         Self {
             modules,
             base: snapshot(modules, Variant::Base),
-            leaf_edit: snapshot(modules, Variant::LeafEdit),
+            reachable_root_body_edit: snapshot(modules, Variant::ReachableRootBodyEdit),
             identity_edit: snapshot(modules, Variant::IdentityEdit),
             syntax_error: snapshot(modules, Variant::SyntaxError),
         }
@@ -134,7 +166,7 @@ impl Fixture {
 #[derive(Clone, Copy)]
 enum Variant {
     Base,
-    LeafEdit,
+    ReachableRootBodyEdit,
     IdentityEdit,
     SyntaxError,
 }
@@ -158,15 +190,14 @@ fn snapshot(modules: usize, variant: Variant) -> SourceSnapshot {
     let sources = (0..modules)
         .map(|index| {
             let source = if index == 0 {
-                "fn main() -> i32 { 0 }".to_string()
+                format!(
+                    "fn main() -> i32 {{ {} }}",
+                    usize::from(!matches!(variant, Variant::Base))
+                )
             } else if index == changed && matches!(variant, Variant::SyntaxError) {
                 format!("fn leaf{index}( {{")
             } else {
-                let value = usize::from(
-                    index == changed
-                        && matches!(variant, Variant::LeafEdit | Variant::IdentityEdit),
-                );
-                format!("fn leaf{index}() -> i32 {{ {value} }}")
+                format!("fn leaf{index}() -> i32 {{ 0 }}")
             };
             (FileId::new(index as u32), Arc::new(source))
         })
@@ -203,6 +234,24 @@ fn semantic_work_json(work: &CanonicalFrontendSessionWork, from: usize) -> Value
         "declaration_type_call_head_dependency_events": records.iter().map(|record| record.work.body_analysis.declaration_type_call_head_dependency_events).sum::<usize>(),
         "named_const_dependency_events": records.iter().map(|record| record.work.body_analysis.named_const_dependency_events).sum::<usize>(),
         "manifest_build_invocations": records.iter().map(|record| record.work.manifest.build_invocations).sum::<usize>(),
+        "declaration_reuse": {
+            "plan_executions": records.iter().map(|record| record.work.declaration_reuse.plan_executions).sum::<usize>(),
+            "durable_records_compared": records.iter().map(|record| record.work.declaration_reuse.durable_records_compared).sum::<usize>(),
+            "durable_records_reused": records.iter().map(|record| record.work.declaration_reuse.durable_records_reused).sum::<usize>(),
+            "ordinary_declaration_resolutions_skipped": records.iter().map(|record| record.work.declaration_reuse.ordinary_declaration_resolutions_skipped).sum::<usize>(),
+            "install_invocations": records.iter().map(|record| record.work.declaration_reuse.install_invocations).sum::<usize>(),
+            "fallbacks": records.iter().map(|record| record.work.declaration_reuse.fallbacks).sum::<usize>(),
+            "semantic_epochs_started": records.iter().map(|record| record.work.declaration_reuse.semantic_epochs_started).sum::<usize>(),
+            "declaration_indexes_built": records.iter().map(|record| record.work.declaration_reuse.declaration_indexes_built).sum::<usize>(),
+            "shell_predeclaration_epochs": records.iter().map(|record| record.work.declaration_reuse.shell_predeclaration_epochs).sum::<usize>(),
+            "durable_cache_population_exports": records.iter().map(|record| record.work.declaration_reuse.durable_cache_population_exports).sum::<usize>(),
+            "fallback_epochs_started": records.iter().map(|record| record.work.declaration_reuse.fallback_epochs_started).sum::<usize>(),
+        },
+        "semantic_epochs_started": records.iter().map(|record| record.work.declaration_reuse.semantic_epochs_started).sum::<usize>(),
+        "declaration_indexes_built": records.iter().map(|record| record.work.declaration_reuse.declaration_indexes_built).sum::<usize>(),
+        "shell_predeclaration_epochs": records.iter().map(|record| record.work.declaration_reuse.shell_predeclaration_epochs).sum::<usize>(),
+        "durable_cache_population_exports": records.iter().map(|record| record.work.declaration_reuse.durable_cache_population_exports).sum::<usize>(),
+        "fallback_epochs_started": records.iter().map(|record| record.work.declaration_reuse.fallback_epochs_started).sum::<usize>(),
     })
 }
 
@@ -227,10 +276,26 @@ where
     let parse = operation(session);
     let elapsed = started.elapsed();
     let work = session.work();
+    let query_delta = QueryCounts::from(work).delta(before);
+    // Successful updates replace the current-revision record vectors. Treat
+    // that reset as a new zero-based measurement window.
+    let semantic_records =
+        if query_delta.semantic_executions > 0 && work.semantic_records.len() <= semantic_records {
+            0
+        } else {
+            semantic_records
+        };
+    let definition_records = if query_delta.definition_executions > 0
+        && work.definition_records.len() <= definition_records
+    {
+        0
+    } else {
+        definition_records
+    };
     json!({
         "wall_time_ns": elapsed.as_nanos(),
         "parse": parse_json(parse),
-        "queries": QueryCounts::from(work).delta(before).json(),
+        "queries": query_delta.json(),
         "merge_work": {
             "definition_shards_indexed": work.last_merge.definition_shards_indexed,
             "definition_shards_reused": work.last_merge.definition_shards_reused,
@@ -394,9 +459,9 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         }),
     ));
     scenarios.push(named(
-        "leaf_body_edit",
+        "reachable_root_body_edit",
         measure(&mut session, |session| {
-            let update = session.update(&fixture.leaf_edit);
+            let update = session.update(&fixture.reachable_root_body_edit);
             assert!(update.downstream_invalidated());
             let parse = update.work();
             update.into_result().unwrap();
@@ -465,17 +530,20 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
     let (noop_plan, noop_manifest) =
         measure_manifest_plan(&mut planner, &fixture.base, Some(&base_manifest), &options);
     scenarios.push(named("invalidation_plan_exact_noop", noop_plan));
-    let (leaf_plan, leaf_manifest) = measure_manifest_plan(
+    let (root_plan, root_manifest) = measure_manifest_plan(
         &mut planner,
-        &fixture.leaf_edit,
+        &fixture.reachable_root_body_edit,
         Some(&noop_manifest),
         &options,
     );
-    scenarios.push(named("invalidation_plan_leaf_body_edit", leaf_plan));
+    scenarios.push(named(
+        "invalidation_plan_reachable_root_body_edit",
+        root_plan,
+    ));
     let (identity_plan, _) = measure_manifest_plan(
         &mut planner,
         &fixture.identity_edit,
-        Some(&leaf_manifest),
+        Some(&root_manifest),
         &options,
     );
     scenarios.push(named(
@@ -514,6 +582,15 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
     );
     assert_query_executions(cold, 1, 1, 1, 0);
     assert_semantic_work(cold, 1, 1, 0);
+    assert_declaration_epoch_work(cold, 1, 1, 1, 1, 0);
+    assert_eq!(
+        cold["semantic_work"]["declaration_reuse"]["plan_executions"],
+        0
+    );
+    assert_eq!(
+        count(cold, &["queries", "durable_cache_population_bindings"]),
+        0
+    );
 
     let noop = get("exact_noop");
     assert_eq!(count(noop, &["parse", "modules_reused"]), modules as u64);
@@ -524,21 +601,77 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
     assert_eq!(count(noop, &["queries", "rir_reuses"]), 2);
     assert_eq!(count(noop, &["queries", "semantic_reuses"]), 1);
 
-    let leaf = get("leaf_body_edit");
+    let root_edit = get("reachable_root_body_edit");
     assert_eq!(
-        count(leaf, &["parse", "modules_reused"]),
+        count(root_edit, &["parse", "modules_reused"]),
         (modules - 1) as u64
     );
-    assert_eq!(count(leaf, &["parse", "modules_reparsed"]), 1);
-    assert_eq!(count(leaf, &["parse", "lexer_invocations"]), 1);
-    assert_eq!(count(leaf, &["parse", "parser_invocations"]), 1);
-    assert_query_executions(leaf, 1, 1, 1, 0);
+    assert_eq!(count(root_edit, &["parse", "modules_reparsed"]), 1);
+    assert_eq!(count(root_edit, &["parse", "lexer_invocations"]), 1);
+    assert_eq!(count(root_edit, &["parse", "parser_invocations"]), 1);
+    assert_query_executions(root_edit, 1, 1, 1, 0);
     assert_eq!(
-        count(leaf, &["merge_work", "definition_shards_reused"]),
+        count(root_edit, &["merge_work", "definition_shards_reused"]),
         modules as u64
     );
-    assert_eq!(count(leaf, &["merge_work", "definition_shards_rebuilt"]), 0);
-    assert_eq!(count(leaf, &["queries", "downstream_invalidations"]), 1);
+    assert_eq!(
+        count(root_edit, &["merge_work", "definition_shards_rebuilt"]),
+        0
+    );
+    assert_eq!(
+        count(root_edit, &["queries", "downstream_invalidations"]),
+        1
+    );
+    assert_eq!(count(root_edit, &["queries", "declaration_reuse_plans"]), 1);
+    assert_eq!(
+        count(root_edit, &["queries", "durable_records_compared"]),
+        modules as u64
+    );
+    assert_eq!(
+        count(root_edit, &["queries", "durable_records_reused"]),
+        modules as u64
+    );
+    assert_eq!(
+        count(
+            root_edit,
+            &["queries", "ordinary_declaration_resolutions_skipped"]
+        ),
+        1
+    );
+    assert_eq!(count(root_edit, &["queries", "durable_installs"]), 1);
+    assert_eq!(
+        count(root_edit, &["queries", "declaration_reuse_fallbacks"]),
+        0
+    );
+    assert_semantic_work(root_edit, 1, 1, 0);
+    assert_declaration_epoch_work(root_edit, 1, 1, 1, 0, 0);
+    let root_reuse = &root_edit["semantic_work"]["declaration_reuse"];
+    assert_eq!(root_reuse["plan_executions"], 1);
+    assert_eq!(root_reuse["durable_records_compared"], modules as u64);
+    assert_eq!(root_reuse["durable_records_reused"], modules as u64);
+    assert_eq!(root_reuse["ordinary_declaration_resolutions_skipped"], 1);
+    assert_eq!(root_reuse["install_invocations"], 1);
+    assert_eq!(root_reuse["fallbacks"], 0);
+    assert_eq!(
+        count(root_edit, &["semantic_work", "semantic_epochs_started"]),
+        1
+    );
+    assert_eq!(
+        count(root_edit, &["semantic_work", "declaration_indexes_built"]),
+        1
+    );
+    assert_eq!(
+        count(root_edit, &["semantic_work", "shell_predeclaration_epochs"]),
+        1
+    );
+    assert_eq!(
+        count(root_edit, &["semantic_work", "fallback_epochs_started"]),
+        0
+    );
+    assert_eq!(
+        count(root_edit, &["queries", "durable_cache_population_bindings"]),
+        0
+    );
 
     let identity = get("module_identity_change");
     assert_eq!(count(identity, &["parse", "modules_rebound"]), 1);
@@ -626,9 +759,9 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
         1
     );
     assert_production_incremental_plan(plan_noop, 0, 0, 0, modules, modules, 0);
-    let plan_leaf = get("invalidation_plan_leaf_body_edit");
-    assert_eq!(count(plan_leaf, &["parse", "modules_reparsed"]), 1);
-    assert_production_incremental_plan(plan_leaf, 1, 1, 1, modules - 1, modules, 1);
+    let plan_root_edit = get("invalidation_plan_reachable_root_body_edit");
+    assert_eq!(count(plan_root_edit, &["parse", "modules_reparsed"]), 1);
+    assert_production_incremental_plan(plan_root_edit, 1, 1, 1, modules - 1, modules, 1);
     let plan_identity = get("invalidation_plan_module_identity_change");
     assert_eq!(count(plan_identity, &["parse", "modules_rebound"]), 1);
     assert_production_incremental_plan(plan_identity, 1, 0, 2, modules - 1, modules - 1, 2);
@@ -713,7 +846,9 @@ fn assert_query_executions(
 fn assert_semantic_work(scenario: &Value, binds: u64, bodies: u64, manifests: u64) {
     assert_eq!(
         count(scenario, &["semantic_work", "bind_invocations"]),
-        binds
+        binds,
+        "{}",
+        scenario["name"]
     );
     assert_eq!(
         count(scenario, &["semantic_work", "body_free_function_lookups"]),
@@ -723,6 +858,22 @@ fn assert_semantic_work(scenario: &Value, binds: u64, bodies: u64, manifests: u6
         count(scenario, &["semantic_work", "manifest_build_invocations"]),
         manifests
     );
+}
+
+fn assert_declaration_epoch_work(
+    scenario: &Value,
+    epochs: u64,
+    indexes: u64,
+    shell_predeclarations: u64,
+    population_exports: u64,
+    fallback_epochs: u64,
+) {
+    let work = &scenario["semantic_work"]["declaration_reuse"];
+    assert_eq!(work["semantic_epochs_started"], epochs);
+    assert_eq!(work["declaration_indexes_built"], indexes);
+    assert_eq!(work["shell_predeclaration_epochs"], shell_predeclarations);
+    assert_eq!(work["durable_cache_population_exports"], population_exports);
+    assert_eq!(work["fallback_epochs_started"], fallback_epochs);
 }
 
 fn parse_config() -> Config {
@@ -767,7 +918,7 @@ fn main() {
     println!(
         "{}",
         json!({
-            "schema_version": 2,
+            "schema_version": 3,
             "workload": "canonical_frontend_session_invalidation",
             "configuration": {
                 "modules": config.modules,

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use rue_air::{
     DeclarationBindingWork, Sema, SemanticBinding, SemanticBindingKind,
-    SemanticBindingManifestWork, SemanticBindingNamespace,
+    SemanticBindingManifestWork, SemanticBindingNamespace, SemanticDeclarationShell,
 };
 use rue_error::{CompileError, CompileErrors, ErrorKind, MultiErrorResult};
 use rue_parser::ast::{Item, Visibility};
@@ -604,6 +604,35 @@ pub(crate) fn issue_bound_definitions(
         manifest_work,
         work,
     })
+}
+
+/// Issue the current revision's stable definition universe from declaration
+/// shells, before payload resolution. Shells contain the same authoritative
+/// identity, span, ownership, and visibility fields consumed by the ordinary
+/// post-binding manifest; no semantic type/value is inferred here.
+pub(crate) fn issue_shell_definitions(
+    merged: &CanonicalMergedProgram,
+    revision: &SourceRevision,
+    shells: &[SemanticDeclarationShell],
+) -> Result<BoundDefinitionSet, CompileError> {
+    let bindings = shells
+        .iter()
+        .map(|shell| SemanticBinding {
+            file_id: shell.declaration_span.file_id,
+            declaration_span: shell.declaration_span,
+            namespace: shell.identity.namespace,
+            kind: shell.identity.kind,
+            name: shell.identity.name.clone(),
+            owner: shell.identity.owner.clone(),
+            is_public: shell.is_public,
+        })
+        .collect::<Vec<_>>();
+    issue_bound_definitions(
+        merged,
+        revision,
+        &bindings,
+        SemanticBindingManifestWork::default(),
+    )
 }
 
 fn definition_input_partition(

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -11,11 +11,71 @@ use tracing::info_span;
 
 use crate::{
     BoundDefinitionSet, BoundDefinitionWork, CanonicalMergedProgram, CanonicalRirOutput,
-    CodegenInputDescriptor, CompileOptions, CompileWarning, FunctionWithCfg, MultiErrorResult,
-    SemanticInputDescriptor, TypeInternPool,
-    bound_definitions::{configure_canonical_sema, issue_bound_definitions},
+    CodegenInputDescriptor, CompileOptions, CompileWarning, DurableDeclarationSemantic,
+    FunctionWithCfg, MultiErrorResult, SemanticInputDescriptor, TypeInternPool,
+    bound_definitions::{
+        configure_canonical_sema, issue_bound_definitions, issue_shell_definitions,
+    },
     build_functions_and_cfgs,
 };
+
+pub(crate) struct CanonicalOrdinaryAnalysis {
+    pub output: CanonicalSemanticOutput,
+    pub definitions: BoundDefinitionSet,
+    pub durable_declarations: Option<std::sync::Arc<[DurableDeclarationSemantic]>>,
+}
+
+/// One current-revision declaration epoch prepared for either ordinary
+/// resolution or durable installation. Stable identities are issued from the
+/// same shells that the selected analysis path subsequently consumes.
+pub(crate) struct CanonicalPreparedDeclarations<'a> {
+    shells: rue_air::DeclarationShells<'a>,
+    shell_records: Vec<rue_air::SemanticDeclarationShell>,
+    definitions: BoundDefinitionSet,
+    declaration_index: RirDeclarationIndexWork,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CanonicalDeclarationReuseWork {
+    pub plan_executions: usize,
+    pub durable_records_compared: usize,
+    pub durable_records_reused: usize,
+    pub ordinary_declaration_resolutions_skipped: usize,
+    pub install_invocations: usize,
+    pub fallbacks: usize,
+    /// Actual request-local semantic epochs constructed, including a fresh
+    /// epoch required after a consuming installation failure.
+    pub semantic_epochs_started: usize,
+    pub declaration_indexes_built: usize,
+    pub shell_predeclaration_epochs: usize,
+    pub durable_cache_population_exports: usize,
+    pub fallback_epochs_started: usize,
+}
+
+pub(crate) fn prepare_canonical_declarations<'a>(
+    merged: &CanonicalMergedProgram,
+    rir: &'a CanonicalRirOutput,
+    options: &CompileOptions,
+) -> MultiErrorResult<CanonicalPreparedDeclarations<'a>> {
+    let sema = configure_timed_canonical_sema(merged, rir, options)?;
+    let declaration_index = sema.rir_declaration_index_work();
+    let shells = sema.predeclare_declaration_shells()?;
+    let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
+    let definitions = issue_shell_definitions(merged, rir.source_revision(), &shell_records)
+        .map_err(crate::CompileErrors::from)?;
+    Ok(CanonicalPreparedDeclarations {
+        shells,
+        shell_records,
+        definitions,
+        declaration_index,
+    })
+}
+
+impl CanonicalPreparedDeclarations<'_> {
+    pub(crate) fn definitions(&self) -> &BoundDefinitionSet {
+        &self.definitions
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 /// Structural work from one canonical semantic request.
@@ -32,6 +92,7 @@ pub struct CanonicalSemanticWork {
     pub body_analysis: BodyAnalysisWork,
     /// Whether this request asked for stable source definition IDs.
     pub stable_ids_requested: bool,
+    pub declaration_reuse: CanonicalDeclarationReuseWork,
 }
 
 /// Owned semantic and optimized CFG artifacts from the canonical frontend.
@@ -200,21 +261,193 @@ pub fn analyze_canonical_program(
         ),
         opt_level: options.opt_level.into(),
     };
-    let sema = {
-        let _span =
-            info_span!("rir_declaration_index", instruction_count = rir.rir().len()).entered();
-        configure_canonical_sema(
-            merged,
-            rir,
-            options.preview_features.clone(),
-            options.target,
-        )?
-    };
-    let sema_span = info_span!("sema").entered();
+    let sema = configure_timed_canonical_sema(merged, rir, options)?;
     let declaration_index = sema.rir_declaration_index_work();
     let bound = sema.bind_declarations()?;
-    let binding = bound.binding_work();
+    finish_canonical_analysis(
+        input,
+        merged,
+        rir,
+        options,
+        request_stable_ids,
+        declaration_index,
+        bound,
+        CanonicalDeclarationReuseWork::default(),
+        info_span!("sema").entered(),
+    )
+}
 
+/// Run the ordinary canonical path once and opportunistically export its
+/// resolved declaration payloads before body analysis consumes the binder.
+/// Export is fail-closed: unsupported payloads disable reuse without changing
+/// the successful batch semantic result.
+pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
+    merged: &CanonicalMergedProgram,
+    rir: &CanonicalRirOutput,
+    options: &CompileOptions,
+    prepared: CanonicalPreparedDeclarations<'_>,
+) -> MultiErrorResult<CanonicalOrdinaryAnalysis> {
+    let input = CodegenInputDescriptor {
+        semantic: SemanticInputDescriptor::new(
+            merged.definitions().source_snapshot(),
+            options.target,
+            &options.preview_features,
+        ),
+        opt_level: options.opt_level.into(),
+    };
+    let sema_span = info_span!("sema").entered();
+    let CanonicalPreparedDeclarations {
+        shells,
+        shell_records,
+        definitions,
+        declaration_index,
+    } = prepared;
+    let bound = shells.resolve_declarations()?;
+
+    let durable_declarations = bound
+        .with_declaration_semantics_from_shells(&shell_records, |records, _work| {
+            crate::durable_semantics::convert_declaration_semantics(merged, &definitions, records)
+        })
+        .ok()
+        .and_then(Result::ok);
+
+    let output = finish_canonical_analysis(
+        input,
+        merged,
+        rir,
+        options,
+        false,
+        declaration_index,
+        bound,
+        CanonicalDeclarationReuseWork {
+            semantic_epochs_started: 1,
+            declaration_indexes_built: declaration_index.build_invocations,
+            shell_predeclaration_epochs: 1,
+            durable_cache_population_exports: usize::from(durable_declarations.is_some()),
+            ..CanonicalDeclarationReuseWork::default()
+        },
+        sema_span,
+    )?;
+    Ok(CanonicalOrdinaryAnalysis {
+        output,
+        definitions,
+        durable_declarations,
+    })
+}
+
+/// Analyze bodies in a fresh semantic epoch whose declaration payloads are
+/// installed from stable, request-independent records. Any projection or
+/// installation failure is typed internally and falls back to a wholly fresh
+/// ordinary binder; partially installed state is never observed.
+pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
+    merged: &CanonicalMergedProgram,
+    rir: &CanonicalRirOutput,
+    options: &CompileOptions,
+    prepared: CanonicalPreparedDeclarations<'_>,
+    definitions: &BoundDefinitionSet,
+    durable: &[DurableDeclarationSemantic],
+) -> MultiErrorResult<CanonicalSemanticOutput> {
+    let input = CodegenInputDescriptor {
+        semantic: SemanticInputDescriptor::new(
+            merged.definitions().source_snapshot(),
+            options.target,
+            &options.preview_features,
+        ),
+        opt_level: options.opt_level.into(),
+    };
+    let mut reuse = CanonicalDeclarationReuseWork {
+        plan_executions: 1,
+        durable_records_compared: durable.len(),
+        semantic_epochs_started: 1,
+        shell_predeclaration_epochs: 1,
+        ..CanonicalDeclarationReuseWork::default()
+    };
+    let CanonicalPreparedDeclarations {
+        shells,
+        shell_records,
+        definitions: _,
+        declaration_index,
+    } = prepared;
+    reuse.declaration_indexes_built = declaration_index.build_invocations;
+    let bound = match crate::project_durable_declaration_semantics(
+        merged,
+        definitions,
+        &shell_records,
+        durable,
+    ) {
+        Err(_) => {
+            reuse.fallbacks = 1;
+            // Projection is read-only, so ordinary resolution consumes the
+            // exact same unmutated shells and does not create a hidden epoch.
+            shells.resolve_declarations()?
+        }
+        Ok((projected, _)) => {
+            reuse.install_invocations += 1;
+            match shells.install_declaration_semantics(&projected) {
+                Ok(bound) => {
+                    reuse.durable_records_reused = durable.len();
+                    reuse.ordinary_declaration_resolutions_skipped = 1;
+                    bound
+                }
+                Err(_) => {
+                    // Installation consumes potentially mutated shells. Only
+                    // this failure requires a wholly fresh ordinary epoch.
+                    reuse.fallbacks = 1;
+                    reuse.fallback_epochs_started = 1;
+                    reuse.semantic_epochs_started += 1;
+                    let fallback = configure_timed_canonical_sema(merged, rir, options)?;
+                    reuse.declaration_indexes_built +=
+                        fallback.rir_declaration_index_work().build_invocations;
+                    fallback.bind_declarations()?
+                }
+            }
+        }
+    };
+    let sema_span = info_span!("sema").entered();
+    finish_canonical_analysis(
+        input,
+        merged,
+        rir,
+        options,
+        false,
+        declaration_index,
+        bound,
+        reuse,
+        sema_span,
+    )
+}
+
+/// Construct one request-local declaration index under the authoritative leaf
+/// timing boundary. Keeping this wrapper at every canonical entry point gives
+/// ordinary and durable-reuse requests the same non-nested span shape. A typed
+/// durable-install fallback records a second leaf only because it genuinely
+/// constructs a second semantic epoch.
+fn configure_timed_canonical_sema<'a>(
+    merged: &CanonicalMergedProgram,
+    rir: &'a CanonicalRirOutput,
+    options: &CompileOptions,
+) -> MultiErrorResult<rue_air::Sema<'a>> {
+    let _span = info_span!("rir_declaration_index", instruction_count = rir.rir().len()).entered();
+    configure_canonical_sema(
+        merged,
+        rir,
+        options.preview_features.clone(),
+        options.target,
+    )
+}
+
+fn finish_canonical_analysis(
+    input: CodegenInputDescriptor,
+    merged: &CanonicalMergedProgram,
+    rir: &CanonicalRirOutput,
+    options: &CompileOptions,
+    request_stable_ids: bool,
+    declaration_index: RirDeclarationIndexWork,
+    bound: rue_air::BoundSema<'_>,
+    declaration_reuse: CanonicalDeclarationReuseWork,
+    sema_span: tracing::span::EnteredSpan,
+) -> MultiErrorResult<CanonicalSemanticOutput> {
+    let binding = bound.binding_work();
     let (bound_definitions, manifest_work) = if request_stable_ids {
         let manifest = bound.binding_manifest();
         let definitions = issue_bound_definitions(
@@ -267,6 +500,30 @@ pub fn analyze_canonical_program(
         options.opt_level,
         rir.semantic_symbols().interner(),
     )?;
+    let mut warnings = cfg.warnings;
+    warnings.sort_by(|left, right| {
+        let key = |warning: &CompileWarning| {
+            let span = warning.span();
+            let module = span
+                .and_then(|span| {
+                    merged
+                        .ast()
+                        .modules()
+                        .iter()
+                        .find(|module| module.file_id() == span.file_id)
+                })
+                .map(|module| module.module_id().as_str())
+                .unwrap_or("");
+            (
+                module,
+                span.map(|span| span.start).unwrap_or(0),
+                span.map(|span| span.end).unwrap_or(0),
+                warning.to_string(),
+                format!("{:?}", warning.diagnostic()),
+            )
+        };
+        key(left).cmp(&key(right))
+    });
     let work = CanonicalSemanticWork {
         declaration_index,
         binding,
@@ -274,13 +531,14 @@ pub fn analyze_canonical_program(
         bound_definitions: bound_definitions.as_ref().map(BoundDefinitionSet::work),
         body_analysis,
         stable_ids_requested: request_stable_ids,
+        declaration_reuse,
     };
     Ok(CanonicalSemanticOutput {
         input,
         functions: cfg.functions,
         type_pool: cfg.type_pool,
         strings: cfg.strings,
-        warnings: cfg.warnings,
+        warnings,
         bound_definitions,
         work,
         ordinary_free_function_dependencies,

--- a/crates/rue-compiler/src/frontend_session.rs
+++ b/crates/rue-compiler/src/frontend_session.rs
@@ -11,13 +11,19 @@ use crate::{
     BoundDefinitionSet, BoundDefinitionWork, CanonicalImportGraph, CanonicalImportGraphValidation,
     CanonicalImportResolution, CanonicalMergeWork, CanonicalMergedProgram, CanonicalParseSession,
     CanonicalRirOutput, CanonicalRirWork, CanonicalSemanticOutput, CanonicalSemanticWork,
-    CodegenInputDescriptor, CompileError, CompileErrors, CompileOptions, CompileWarning, ErrorKind,
-    ModuleResolutionInputs, ParseInvalidationSummary, ParsedModulesWork, SemanticInputDescriptor,
-    SourceRevision, SourceSnapshot, StableDefinitionKey, StableDefinitionKind,
-    StableDefinitionNamespace, analyze_canonical_program,
+    CodegenInputDescriptor, CompileError, CompileErrors, CompileOptions, CompileWarning,
+    DurableDeclarationSemantic, ErrorKind, ModuleResolutionInputs, ParseInvalidationSummary,
+    ParsedModulesWork, SemanticInputDescriptor, SourceRevision, SourceSnapshot,
+    StableDefinitionKey, StableDefinitionKind, StableDefinitionNamespace,
     bound_definitions::bind_canonical_definitions_with_work,
-    canonical_merge::merge_parsed_modules_reusing_definitions, lower_canonical_rir,
-    parsed_modules::ParsedProgram, resolve_canonical_import_graph, validate_canonical_import_graph,
+    canonical_merge::merge_parsed_modules_reusing_definitions,
+    canonical_semantic::{
+        analyze_prepared_canonical_program_reusing_declarations,
+        analyze_prepared_canonical_program_with_durable_export, prepare_canonical_declarations,
+    },
+    lower_canonical_rir,
+    parsed_modules::ParsedProgram,
+    resolve_canonical_import_graph, validate_canonical_import_graph,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -55,6 +61,16 @@ pub struct CanonicalFrontendSessionWork {
     pub dependency_manifest_records_visited: usize,
     pub dependency_manifest_import_records_visited: usize,
     pub invalidation_plans: FrontendQueryWork,
+    pub declaration_reuse_plans: usize,
+    pub durable_records_compared: usize,
+    pub durable_records_reused: usize,
+    pub ordinary_declaration_resolutions_skipped: usize,
+    pub durable_installs: usize,
+    pub declaration_reuse_fallbacks: usize,
+    /// Extra ordinary declaration binds currently used to populate the
+    /// successful durable baseline. Kept explicit until export is folded into
+    /// the primary ordinary bind.
+    pub durable_cache_population_bindings: usize,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -546,6 +562,16 @@ pub struct CanonicalFrontendSession {
     latest_diagnostics: Option<Arc<FrontendDiagnosticSnapshot>>,
     dependency_manifest_cache: Vec<Arc<SemanticDependencyInputManifest>>,
     invalidation_plan_cache: Vec<InvalidationPlanCacheEntry>,
+    durable_declaration_cache: Option<DurableDeclarationCache>,
+}
+
+#[derive(Debug)]
+struct DurableDeclarationCache {
+    root: crate::ModuleId,
+    target: crate::Target,
+    preview_features: crate::PreviewFeatures,
+    fingerprints: Arc<[StableDefinitionInputFingerprint]>,
+    semantics: Arc<[DurableDeclarationSemantic]>,
 }
 
 #[derive(Debug)]
@@ -851,7 +877,61 @@ impl CanonicalFrontendSession {
         }
 
         self.work.semantic.executions += 1;
-        let result = analyze_canonical_program(&merged, &rir, options, false).map(Arc::new);
+        let prepared = prepare_canonical_declarations(&merged, &rir, options);
+        let current_fingerprints: Result<Vec<StableDefinitionInputFingerprint>, CompileErrors> =
+            match &prepared {
+                Ok(definitions) => definitions
+                    .definitions()
+                    .definitions()
+                    .iter()
+                    .map(|record| {
+                        stable_definition_input_fingerprint(
+                            merged.definitions().source_snapshot(),
+                            record,
+                        )
+                    })
+                    .collect(),
+                Err(errors) => Err(errors.clone()),
+            };
+        let reusable = self.durable_declaration_cache.as_ref().and_then(|cache| {
+            self.work.declaration_reuse_plans += 1;
+            if cache.root != *merged.ast().root()
+                || cache.target != options.target
+                || cache.preview_features != options.preview_features
+            {
+                return None;
+            }
+            let fingerprints = current_fingerprints.as_ref().ok()?;
+            let (matches, compared) = declaration_surfaces_match(&cache.fingerprints, fingerprints);
+            self.work.durable_records_compared += compared;
+            matches.then(|| cache.semantics.clone())
+        });
+        let mut cold_durable = None;
+        let result = prepared
+            .and_then(|prepared| {
+                if let Some(durable) = reusable {
+                    let definitions = prepared.definitions().clone();
+                    analyze_prepared_canonical_program_reusing_declarations(
+                        &merged,
+                        &rir,
+                        options,
+                        prepared,
+                        &definitions,
+                        &durable,
+                    )
+                } else {
+                    analyze_prepared_canonical_program_with_durable_export(
+                        &merged, &rir, options, prepared,
+                    )
+                    .map(|analysis| {
+                        cold_durable = analysis
+                            .durable_declarations
+                            .map(|semantics| (analysis.definitions, semantics));
+                        analysis.output
+                    })
+                }
+            })
+            .map(Arc::new);
         let semantic_work = result
             .as_ref()
             .map(|output| output.work())
@@ -861,6 +941,44 @@ impl CanonicalFrontendSession {
             debug_assert_eq!(semantic_work.binding.bind_invocations, 1);
             debug_assert_eq!(semantic_work.manifest.build_invocations, 0);
             debug_assert!(!semantic_work.stable_ids_requested);
+            let reuse = semantic_work.declaration_reuse;
+            self.work.durable_records_reused += reuse.durable_records_reused;
+            self.work.ordinary_declaration_resolutions_skipped +=
+                reuse.ordinary_declaration_resolutions_skipped;
+            self.work.durable_installs += reuse.install_invocations;
+            self.work.declaration_reuse_fallbacks += reuse.fallbacks;
+
+            // Populate or refresh the durable baseline only after a successful
+            // ordinary execution. Reused executions retain the stable payload
+            // and merely advance its exact provenance below.
+            if reuse.ordinary_declaration_resolutions_skipped == 0 {
+                if let Some((definitions, semantics)) = cold_durable {
+                    if let Ok(fingerprints) = definitions
+                        .definitions()
+                        .iter()
+                        .map(|record| {
+                            stable_definition_input_fingerprint(
+                                merged.definitions().source_snapshot(),
+                                record,
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                    {
+                        self.durable_declaration_cache = Some(DurableDeclarationCache {
+                            root: merged.ast().root().clone(),
+                            target: options.target,
+                            preview_features: options.preview_features.clone(),
+                            fingerprints: fingerprints.into(),
+                            semantics,
+                        });
+                    }
+                }
+            } else if let (Some(cache), Ok(fingerprints)) = (
+                self.durable_declaration_cache.as_mut(),
+                current_fingerprints,
+            ) {
+                cache.fingerprints = fingerprints.into();
+            }
         }
         self.semantic_cache.push(SemanticCacheEntry {
             input: input.clone(),
@@ -1719,6 +1837,42 @@ fn stable_definition_input_fingerprint(
     })
 }
 
+fn declaration_surfaces_match(
+    previous: &[StableDefinitionInputFingerprint],
+    current: &[StableDefinitionInputFingerprint],
+) -> (bool, usize) {
+    if previous.len() != current.len() {
+        return (false, 0);
+    }
+    let mut compared = 0;
+    for (left, right) in previous.iter().zip(current) {
+        compared += 1;
+        let supported = matches!(
+            left.key.kind(),
+            StableDefinitionKind::Function
+                | StableDefinitionKind::Struct
+                | StableDefinitionKind::Enum
+                | StableDefinitionKind::Destructor
+                | StableDefinitionKind::Method
+                | StableDefinitionKind::AssociatedFunction
+        ) && !matches!(
+            left.precision,
+            StableDefinitionFingerprintPrecision::SignatureAndInitializer
+                | StableDefinitionFingerprintPrecision::ConservativeFullDeclaration
+        );
+        let matches = supported
+            && left.schema_version == right.schema_version
+            && left.key == right.key
+            && left.declaration == right.declaration
+            && left.signature == right.signature
+            && left.precision == right.precision;
+        if !matches {
+            return (false, compared);
+        }
+    }
+    (true, compared)
+}
+
 struct FramedDefinitionHasher(Sha256);
 
 impl FramedDefinitionHasher {
@@ -2069,6 +2223,311 @@ mod tests {
             ],
             7,
         )
+    }
+
+    fn function_modules(count: usize, edited: Option<usize>) -> SourceSnapshot {
+        let owned = (0..count)
+            .map(|index| {
+                let id = u32::try_from(index + 1).unwrap();
+                let logical = if index == 0 {
+                    "main.rue".to_owned()
+                } else {
+                    format!("m{index}.rue")
+                };
+                let physical = format!("/p/{logical}");
+                let body = if index == 0 {
+                    format!(
+                        "fn main() -> i32 {{ {} }}",
+                        usize::from(edited == Some(index))
+                    )
+                } else {
+                    format!(
+                        "fn f{index}() -> i32 {{ {} }}",
+                        if edited == Some(index) {
+                            index + 1
+                        } else {
+                            index
+                        }
+                    )
+                };
+                (id, physical, logical, body)
+            })
+            .collect::<Vec<_>>();
+        let borrowed = owned
+            .iter()
+            .map(|(id, physical, logical, body)| {
+                (*id, physical.as_str(), logical.as_str(), body.as_str())
+            })
+            .collect::<Vec<_>>();
+        snapshot(&borrowed, 1)
+    }
+
+    #[test]
+    fn leaf_body_edit_reuses_128_durable_declarations_and_skips_ordinary_resolution() {
+        let options = CompileOptions::default();
+        let first = function_modules(128, None);
+        // Edit the reachable entry body while retaining all 128 declarations;
+        // this proves reuse does not accidentally pass by changing dead code.
+        let second = function_modules(128, Some(0));
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&first).into_result().unwrap();
+        let cold = session.semantic(&options).unwrap();
+        assert_eq!(cold.work().binding.bind_invocations, 1);
+        assert_eq!(cold.work().binding.declaration_resolution_invocations, 1);
+        assert_eq!(cold.work().manifest.rir_instructions_visited, 0);
+        assert_eq!(session.work().durable_cache_population_bindings, 0);
+        session.update(&second).into_result().unwrap();
+        let reused = session.semantic(&options).unwrap();
+
+        assert_eq!(reused.work().binding.declaration_resolution_invocations, 0);
+        assert_eq!(reused.work().binding.bind_invocations, 1);
+        assert_eq!(reused.work().declaration_reuse.semantic_epochs_started, 1);
+        assert_eq!(reused.work().declaration_reuse.declaration_indexes_built, 1);
+        assert_eq!(
+            reused.work().declaration_reuse.shell_predeclaration_epochs,
+            1
+        );
+        assert_eq!(reused.work().declaration_reuse.fallback_epochs_started, 0);
+        assert_eq!(reused.work().binding.durable_payloads_installed, 128);
+        assert_eq!(reused.work().declaration_reuse.durable_records_reused, 128);
+        assert_eq!(
+            reused
+                .work()
+                .declaration_reuse
+                .ordinary_declaration_resolutions_skipped,
+            1
+        );
+        let mut fresh = CanonicalFrontendSession::new();
+        fresh.update(&second).into_result().unwrap();
+        let ordinary = fresh.semantic(&options).unwrap();
+        assert_eq!(
+            ordinary.work().binding.declaration_resolution_invocations,
+            1
+        );
+        assert_eq!(reused.work().body_analysis, ordinary.work().body_analysis);
+        assert_eq!(
+            format!("{:?}", reused.functions()),
+            format!("{:?}", ordinary.functions())
+        );
+        assert_eq!(reused.strings(), ordinary.strings());
+        assert_eq!(
+            format!("{:?}", reused.warnings()),
+            format!("{:?}", ordinary.warnings())
+        );
+    }
+
+    #[test]
+    fn const_presence_forces_fresh_ordinary_resolution_without_partial_install() {
+        let first = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "const n: i32 = 1; fn main() -> i32 { n }",
+            )],
+            1,
+        );
+        let second = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "const n: i32 = 1; fn main() -> i32 { n + 1 }",
+            )],
+            1,
+        );
+        let options = CompileOptions::default();
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&first).into_result().unwrap();
+        session.semantic(&options).unwrap();
+        session.update(&second).into_result().unwrap();
+        let output = session.semantic(&options).unwrap();
+        assert_eq!(output.work().binding.declaration_resolution_invocations, 1);
+        assert_eq!(output.work().binding.durable_install_invocations, 0);
+        assert_eq!(output.work().declaration_reuse.durable_records_reused, 0);
+    }
+
+    fn assert_semantic_artifact_parity(
+        session: &CanonicalFrontendSession,
+        actual: &CanonicalSemanticOutput,
+        fresh: &CanonicalSemanticOutput,
+    ) {
+        assert_eq!(
+            format!("{:?}", actual.functions()),
+            format!("{:?}", fresh.functions())
+        );
+        assert_eq!(actual.strings(), fresh.strings());
+        assert_eq!(
+            format!("{:?}", actual.warnings()),
+            format!("{:?}", fresh.warnings())
+        );
+        let diagnostics = session
+            .latest_diagnostics()
+            .expect("semantic query publishes diagnostics");
+        assert!(diagnostics.is_success());
+        assert_eq!(
+            format!("{:?}", diagnostics.warnings()),
+            format!("{:?}", fresh.warnings())
+        );
+    }
+
+    #[test]
+    fn generic_named_method_reuse_fails_closed_without_poisoning_recovery() {
+        let source = |body: &str| snapshot(&[(1, "/p/main.rue", "main.rue", body)], 1);
+        let first = source(
+            "struct Value { fn choose(borrow self, comptime n: i32) -> i32 { n } } fn main() -> i32 { let value = Value {}; value.choose(1) }",
+        );
+        let edited = source(
+            "struct Value { fn choose(borrow self, comptime n: i32) -> i32 { n + 1 } } fn main() -> i32 { let value = Value {}; value.choose(1) }",
+        );
+        let supported = source("fn main() -> i32 { 1 }");
+        let supported_edit = source("fn main() -> i32 { 2 }");
+        let options = CompileOptions::default();
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&first).into_result().unwrap();
+        let cold = session.semantic(&options).unwrap();
+        assert_eq!(cold.work().binding.declaration_resolution_invocations, 1);
+        assert_eq!(cold.work().binding.durable_install_invocations, 0);
+
+        session.update(&edited).into_result().unwrap();
+        let ordinary = session.semantic(&options).unwrap();
+        assert_eq!(
+            ordinary.work().binding.declaration_resolution_invocations,
+            1
+        );
+        assert_eq!(ordinary.work().binding.durable_install_invocations, 0);
+        assert_eq!(ordinary.work().declaration_reuse.durable_records_reused, 0);
+        let mut fresh = CanonicalFrontendSession::new();
+        fresh.update(&edited).into_result().unwrap();
+        let expected = fresh.semantic(&options).unwrap();
+        assert_semantic_artifact_parity(&session, &ordinary, &expected);
+
+        // Unsupported revisions did not leave a partial baseline: a supported
+        // revision seeds normally, and its next body edit can reuse normally.
+        session.update(&supported).into_result().unwrap();
+        let seeded = session.semantic(&options).unwrap();
+        assert_eq!(seeded.work().binding.declaration_resolution_invocations, 1);
+        assert_eq!(seeded.work().binding.durable_install_invocations, 0);
+        session.update(&supported_edit).into_result().unwrap();
+        let recovered = session.semantic(&options).unwrap();
+        assert_eq!(
+            recovered.work().binding.declaration_resolution_invocations,
+            0
+        );
+        assert_eq!(recovered.work().binding.durable_payloads_installed, 1);
+    }
+
+    #[test]
+    fn anonymous_structural_reuse_fails_closed_without_partial_install() {
+        let first = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn Box(comptime T: type) -> type { struct { value: T, fn get(borrow self) -> T { self.value } } } fn main() -> i32 { let B = Box(i32); let value = B { value: 1 }; value.get() }",
+            )],
+            1,
+        );
+        let edited = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn Box(comptime T: type) -> type { struct { value: T, fn get(borrow self) -> T { self.value } } } fn main() -> i32 { let B = Box(i32); let value = B { value: 2 }; value.get() }",
+            )],
+            1,
+        );
+        let options = CompileOptions::default();
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&first).into_result().unwrap();
+        let cold = session.semantic(&options).unwrap();
+        assert_eq!(cold.work().binding.declaration_resolution_invocations, 1);
+        assert_eq!(cold.work().binding.durable_install_invocations, 0);
+
+        session.update(&edited).into_result().unwrap();
+        let ordinary = session.semantic(&options).unwrap();
+        assert_eq!(
+            ordinary.work().binding.declaration_resolution_invocations,
+            1
+        );
+        assert_eq!(ordinary.work().binding.durable_install_invocations, 0);
+        assert_eq!(ordinary.work().declaration_reuse.durable_records_reused, 0);
+        let mut fresh = CanonicalFrontendSession::new();
+        fresh.update(&edited).into_result().unwrap();
+        let expected = fresh.semantic(&options).unwrap();
+        assert_semantic_artifact_parity(&session, &ordinary, &expected);
+
+        let supported = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
+            1,
+        );
+        let supported_edit = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 2 }")],
+            1,
+        );
+        session.update(&supported).into_result().unwrap();
+        let seeded = session.semantic(&options).unwrap();
+        assert_eq!(seeded.work().binding.declaration_resolution_invocations, 1);
+        assert_eq!(seeded.work().binding.durable_install_invocations, 0);
+        session.update(&supported_edit).into_result().unwrap();
+        let recovered = session.semantic(&options).unwrap();
+        assert_eq!(
+            recovered.work().binding.declaration_resolution_invocations,
+            0
+        );
+        assert_eq!(recovered.work().binding.durable_payloads_installed, 1);
+    }
+
+    #[test]
+    fn signature_target_and_failed_body_changes_fail_closed_and_recovery_reuses() {
+        let base = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
+            1,
+        );
+        let signature = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i64 { 1 }")],
+            1,
+        );
+        let broken_body = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i64 { missing }")],
+            1,
+        );
+        let recovered = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i64 { 2 }")],
+            1,
+        );
+        let options = CompileOptions::default();
+        let mut session = CanonicalFrontendSession::new();
+        session.update(&base).into_result().unwrap();
+        session.semantic(&options).unwrap();
+
+        session.update(&signature).into_result().unwrap();
+        let changed = session.semantic(&options).unwrap();
+        assert_eq!(changed.work().binding.declaration_resolution_invocations, 1);
+
+        session.update(&broken_body).into_result().unwrap();
+        assert!(session.semantic(&options).is_err());
+        session.update(&recovered).into_result().unwrap();
+        let recovered = session.semantic(&options).unwrap();
+        assert_eq!(
+            recovered.work().binding.declaration_resolution_invocations,
+            0
+        );
+        assert_eq!(recovered.work().declaration_reuse.durable_records_reused, 1);
+
+        let mut other_target = options.clone();
+        other_target.target = *Target::all()
+            .iter()
+            .find(|target| **target != options.target)
+            .unwrap();
+        let target_changed = session.semantic(&other_target).unwrap();
+        assert_eq!(
+            target_changed
+                .work()
+                .binding
+                .declaration_resolution_invocations,
+            1
+        );
     }
 
     #[test]

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -81,11 +81,14 @@ Records are projected in stable-key order; missing, duplicate, extra,
 ambiguous, namespace/kind/owner/module/visibility, and unsupported cases are
 typed failures. Work counters pin zero RIR traversal.
 
-The result feeds AIR's atomic installer only through a comparison seam today.
-That seam proves durable re-export equality and exercises body analysis in a
-fresh epoch. Constants, module values, function aliases, and anonymous owners
-remain explicit clean fallbacks; production does not cache or skip declaration
-resolution yet.
+The result now feeds AIR's atomic installer from the canonical in-process
+session for a deliberately narrow production subset. The session issues the
+current stable universe directly from pre-resolution shells, compares
+parser-authored declaration/signature fingerprints, projects retained durable
+payloads, and then runs current-revision body analysis and CFG construction.
+Function, method, associated-function, and destructor bodies are never cached.
+Constants, module values, function aliases, generics, and anonymous owners
+remain explicit clean fallbacks.
 
 ## Current capture audit
 
@@ -347,13 +350,33 @@ fresh binder and runs ordinary resolution rather than observing partial state.
 Installation and installed-payload counters distinguish this path from ordinary
 declaration resolution, and installation performs no additional RIR scan.
 
-This is not yet production declaration caching. Module types and constants
-(including function aliases) fail closed: module/value classification is not
+The canonical session now retains a successful stable-keyed durable baseline
+across source updates. Exact no-op/relocation and body-only edits of the
+supported universe install that baseline into current shells; a 128-module
+workload pins 128 records installed and zero ordinary declaration-resolution
+invocations while exact fresh-batch functions, strings, and canonically ordered
+warnings remain equal. Signature/declaration/root/target/feature changes fail
+closed before installation. Module types and constants (including function
+aliases) still fail closed because module/value classification is not
 authoritative until dependency-ordered initializer evaluation. AIR's reserved
-tuple/function forms also remain unsupported. A fresh-epoch comparison test
-proves exact exported-semantic equality and body-analysis readiness for the
-supported subset, but production resolution is not skipped and no saving is
-claimed yet.
+tuple/function forms also remain unsupported.
+
+Cold population exports stable-keyed declaration payloads from the primary
+ordinary binder before body analysis consumes it. The exporter uses the
+already captured declaration shells, so it neither materializes the optional
+binding manifest nor traverses RIR. The session publishes the semantic result
+and its durable baseline only after the whole ordinary request succeeds;
+failed requests leave the last-good baseline untouched. The legacy
+`durable_cache_population_bindings` work counter is hard-gated at zero to make
+an accidental second bind visible. Cold and successful reuse requests each
+construct exactly one semantic epoch, one declaration index, and one shell
+predeclaration epoch. Cold requests report one population export; reuse reports
+none. Projection failure is read-only and resolves the same unmutated shells.
+Only an installation failure, which consumes candidate shells to preserve
+atomicity, may report a second semantic/index epoch and one fallback epoch.
+These values, together with the exact plan/comparison/install/reuse counters,
+are serialized under `semantic_work.declaration_reuse` by the session benchmark
+and are treated as a checked schema rather than inferred timing data.
 
 The split-binding seam now predeclares free-callable, named-method/associated,
 named-const, and named-destructor identities in logical-path order. It retains

--- a/docs/process/session-invalidation-benchmark.md
+++ b/docs/process/session-invalidation-benchmark.md
@@ -13,12 +13,16 @@ Run the full deterministic workload with:
 ```
 
 The defaults are the values shown above. Setup constructs every `SourceSnapshot`
-before warmup starts. Each measured iteration creates fresh sessions and runs:
-cold parse through semantic analysis, an exact no-op, a leaf body edit, a module
-identity change, a failed syntax edit and recovery, then cold and reused stable
-definition queries. A second persistent session measures cold, exact-no-op,
-leaf-body-edit, and module-identity-change dependency-manifest and semantic
-invalidation-plan workloads.
+before warmup starts. Each measured iteration creates fresh sessions and runs
+cold parse through semantic analysis, an exact no-op, a reachable root body edit,
+a module identity change, a failed syntax edit and recovery, then cold and reused
+stable definition queries. The semantic cold path performs one declaration bind
+and exports its durable baseline from that same bind. For supported named
+declarations, the reachable root body edit installs durable declaration payloads
+into a fresh AIR epoch, then analyzes current bodies and builds current CFGs. A
+second persistent session measures cold, exact-noop, reachable-root-body-edit,
+and module-identity-change dependency-manifest and semantic-invalidation-plan
+workloads.
 
 The JSON contains nanosecond wall-time observations and structural work for each
 scenario. Treat structural counters as correctness gates: the driver aborts if
@@ -29,13 +33,33 @@ regression threshold without collecting a stable baseline first. The existing
 so these stateful session samples intentionally use a separate schema rather
 than silently changing dashboard meaning.
 
-Schema version 2 adds dependency-manifest and invalidation-plan query counters,
+Schema version 2 added dependency-manifest and invalidation-plan query counters,
 separate manifest/plan timings, fingerprint comparisons, dependency/closure
-visits, and result cardinalities. Production dependency graphs remain explicitly
-incomplete, so every measured plan must conservatively report full invalidation
-with zero reusable definitions. The gates also require planning itself to run no
-RIR query or RIR instruction scan. These scenarios characterize planning work;
-they do not claim an incremental compilation speedup.
+visits, and result cardinalities. At that historical stage production graphs
+were incomplete and plans conservatively reported full invalidation. Schema
+version 3 exercises complete supported graphs: exact no-op and reachable-root
+edits produce incremental plans with reusable declarations, while unsupported
+surfaces and global semantic-input changes still fail closed. Planning itself
+must run no RIR query or RIR instruction scan.
+
+At N=128 the structural gates require the supported reachable-root-body-edit
+workload to reuse and atomically install all 128 durable declaration records,
+skip ordinary declaration resolution, and perform zero cache-population binds.
+Cold compilation remains one bind. This is a measured declaration-resolution
+saving, not whole-pipeline incremental compilation: canonical merge/RIR and
+current body/CFG work still run. Constants, module values, function aliases,
+generic named methods, and anonymous structural owners currently fail closed to
+ordinary declaration resolution with zero partial installs. Persistent cache
+formats and LSP consumers remain deliberately out of scope.
+
+Schema version 3 adds the exact declaration-reuse ledger under
+`semantic_work.declaration_reuse`: plans, durable comparisons and reuse,
+skipped ordinary resolution, installs, fallbacks, semantic/index/shell epochs,
+population exports, and fallback epochs. Cold and successful declaration-reuse
+scenarios are hard-gated to one epoch/index/shell-predeclaration each. Cold
+reports one export; reuse reports none and no fallback epoch. The legacy
+`queries.durable_cache_population_bindings` value remains present and must be
+zero.
 
 The ordinary test suite runs only a four-module, single-iteration structural
 smoke test through


### PR DESCRIPTION
## Summary
- retain successful stable declaration payloads across compatible source revisions and install them into fresh current shells
- filter reuse by exact root, options, declaration, and signature identity while rebuilding current reachable bodies and CFGs
- expose every epoch, index build, comparison, export, installation, and fallback cost in schema-v3 session benchmarks

## Testing
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test //crates/rue-compiler-session-bench:rue-compiler-session-bench-test`
- `./buck2 run //crates/rue-compiler-session-bench -- --modules 128 --warmup 0 --iterations 1`