### PR TITLE
RUE-720: measure body and CFG work

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -134,6 +134,7 @@ fn finalize_function_body_analysis(
 
     let mut functions: Vec<AnalyzedFunction> = Vec::new();
     for (mut analyzed, local_strings) in functions_with_strings {
+        sema.body_analysis_work.string_ids_remapped += local_strings.len();
         if !local_strings.is_empty() {
             let local_to_global: Vec<u32> = local_strings
                 .into_iter()
@@ -708,6 +709,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
 
             let params = sema.rir.get_params(params_start, params_len);
 
+            sema.body_analysis_work.bodies_attempted += 1;
             match sema.analyze_single_function(
                 &infer_ctx,
                 &fn_name_str,
@@ -719,6 +721,10 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 fn_info.allow_unreachable_code,
             ) {
                 Ok((mut analyzed, warnings, local_strings, referenced_fns, referenced_meths)) => {
+                    sema.body_analysis_work.bodies_succeeded += 1;
+                    sema.body_analysis_work.air_instructions_produced +=
+                        analyzed.air.instructions().len();
+                    sema.body_analysis_work.local_strings_produced += local_strings.len();
                     analyzed.implicit_drop_source =
                         Some(super::ImplicitDropDependencySourceEvent::FreeFunction {
                             file: fn_info.file_id.index(),
@@ -755,7 +761,10 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                         &mut pending_methods,
                     );
                 }
-                Err(e) => errors.push(e),
+                Err(e) => {
+                    sema.body_analysis_work.bodies_failed += 1;
+                    errors.push(e)
+                }
             }
         }
 
@@ -858,6 +867,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                     )
                 };
 
+                sema.body_analysis_work.bodies_attempted += 1;
                 match analysis_result {
                     Ok((
                         air,
@@ -869,6 +879,10 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                         referenced_fns,
                         referenced_meths,
                     )) => {
+                        sema.body_analysis_work.bodies_succeeded += 1;
+                        sema.body_analysis_work.air_instructions_produced +=
+                            air.instructions().len();
+                        sema.body_analysis_work.local_strings_produced += local_strings.len();
                         let analyzed = AnalyzedFunction {
                             name: full_name,
                             implicit_drop_source: Some(
@@ -893,7 +907,10 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                             &mut pending_methods,
                         );
                     }
-                    Err(e) => errors.push(e),
+                    Err(e) => {
+                        sema.body_analysis_work.bodies_failed += 1;
+                        errors.push(e)
+                    }
                 }
                 continue;
             }
@@ -931,6 +948,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
 
             let params = sema.rir.get_params(*params_start, *params_len);
             let full_name = sema.method_symbol(struct_id, &method_name_str, *has_self);
+            sema.body_analysis_work.bodies_attempted += 1;
             match sema.analyze_method_function(
                 &infer_ctx,
                 &full_name,
@@ -943,6 +961,10 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 *self_mode,
             ) {
                 Ok((mut analyzed, warnings, local_strings, referenced_fns, referenced_meths)) => {
+                    sema.body_analysis_work.bodies_succeeded += 1;
+                    sema.body_analysis_work.air_instructions_produced +=
+                        analyzed.air.instructions().len();
+                    sema.body_analysis_work.local_strings_produced += local_strings.len();
                     analyzed.implicit_drop_source =
                         Some(super::ImplicitDropDependencySourceEvent::NamedMethod {
                             file: method_info.span.file_id.index(),
@@ -977,7 +999,10 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                         &mut pending_methods,
                     );
                 }
-                Err(e) => errors.push(e),
+                Err(e) => {
+                    sema.body_analysis_work.bodies_failed += 1;
+                    errors.push(e)
+                }
             }
         }
 
@@ -1023,6 +1048,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 let struct_type = Type::new_struct(struct_id);
                 let full_name = sema.destructor_symbol(struct_id);
 
+                sema.body_analysis_work.bodies_attempted += 1;
                 match sema.analyze_destructor_function(
                     &infer_ctx,
                     &full_name,
@@ -1037,6 +1063,10 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                         referenced_fns,
                         referenced_meths,
                     )) => {
+                        sema.body_analysis_work.bodies_succeeded += 1;
+                        sema.body_analysis_work.air_instructions_produced +=
+                            analyzed.air.instructions().len();
+                        sema.body_analysis_work.local_strings_produced += local_strings.len();
                         analyzed.implicit_drop_source =
                             Some(super::ImplicitDropDependencySourceEvent::NamedDestructor {
                                 file: destructor.span.file_id.index(),
@@ -1071,7 +1101,10 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                             &mut pending_methods,
                         );
                     }
-                    Err(e) => errors.push(e),
+                    Err(e) => {
+                        sema.body_analysis_work.bodies_failed += 1;
+                        errors.push(e)
+                    }
                 }
             }
             continue;

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -289,6 +289,21 @@ pub struct SemaOutput {
 /// These counters deliberately expose no request-local RIR instruction handles.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BodyAnalysisWork {
+    pub bodies_attempted: usize,
+    pub bodies_succeeded: usize,
+    pub bodies_failed: usize,
+    pub air_instructions_produced: usize,
+    pub local_strings_produced: usize,
+    pub string_ids_remapped: usize,
+    pub specialization_air_instructions_scanned: usize,
+    pub generic_calls_observed: usize,
+    pub specialization_requests_unique: usize,
+    pub specialization_requests_duplicate: usize,
+    pub specialization_rewrites: usize,
+    pub specialization_rounds: usize,
+    pub specialized_bodies_attempted: usize,
+    pub specialized_bodies_succeeded: usize,
+    pub specialized_bodies_failed: usize,
     pub ordinary_free_function_dependency_events: usize,
     pub specialized_origin_records: usize,
     pub specialized_free_function_dependency_events: usize,

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -41,6 +41,45 @@ mod tests {
         assert_eq!(air.len(), 2); // Const + Ret
     }
 
+    #[test]
+    fn body_work_counts_reachable_call_graph_exactly() {
+        let output = compile_to_air(
+            "fn leaf() -> i32 { 1 }\nfn middle() -> i32 { leaf() }\nfn main() -> i32 { middle() }",
+        )
+        .unwrap();
+        let work = output.body_analysis_work;
+        assert_eq!(work.bodies_attempted, 3);
+        assert_eq!(work.bodies_succeeded, 3);
+        assert_eq!(work.bodies_failed, 0);
+        assert_eq!(
+            work.air_instructions_produced,
+            output
+                .functions
+                .iter()
+                .map(|function| function.air.len())
+                .sum()
+        );
+        assert_eq!(work.local_strings_produced, 0);
+        assert_eq!(work.string_ids_remapped, 0);
+    }
+
+    #[test]
+    fn specialization_work_separates_unique_and_duplicate_requests() {
+        let output = compile_to_air(
+            "fn identity(comptime T: type, value: T) -> T { value }\nfn main() -> i32 { identity(i32, 1) + identity(i32, 2) }",
+        )
+        .unwrap();
+        let work = output.body_analysis_work;
+        assert_eq!(work.generic_calls_observed, 2);
+        assert_eq!(work.specialization_requests_unique, 1);
+        assert_eq!(work.specialization_requests_duplicate, 1);
+        assert_eq!(work.specialization_rewrites, 2);
+        assert_eq!(work.specialization_rounds, 1);
+        assert_eq!(work.specialized_bodies_attempted, 1);
+        assert_eq!(work.specialized_bodies_succeeded, 1);
+        assert_eq!(work.specialized_bodies_failed, 0);
+    }
+
     fn named_method_lookup_work(irrelevant: usize) -> crate::BodyAnalysisWork {
         let mut source = String::from(
             "struct Target { fn answer() -> i32 { 42 } }\n\

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -228,12 +228,17 @@ impl Specializer {
                     interner,
                     &mut self.specializations,
                     &mut pending,
+                    &mut sema.body_analysis_work,
                 );
             }
 
             // Previously scanned bodies have no CallGeneric instructions left.
             for (function, _) in &mut functions_with_strings[self.next_unscanned..scan_end] {
-                rewrite_call_generic(&mut function.air, &self.specializations);
+                rewrite_call_generic(
+                    &mut function.air,
+                    &self.specializations,
+                    &mut sema.body_analysis_work,
+                );
             }
             self.next_unscanned = scan_end;
 
@@ -242,6 +247,7 @@ impl Specializer {
             }
 
             self.rounds += 1;
+            sema.body_analysis_work.specialization_rounds += 1;
             if self.rounds > MAX_SPECIALIZATION_ROUNDS {
                 let key = &pending[0];
                 return Err(CompileError::new(
@@ -262,6 +268,7 @@ impl Specializer {
             // Create specialized function bodies by re-analyzing with type
             // substitution. Newly created bodies are scanned next round.
             for key in &pending {
+                sema.body_analysis_work.specialized_bodies_attempted += 1;
                 let info = &self.specializations[key];
                 let base_info = match sema.functions.get(&key.base_name) {
                     Some(info) => info.clone(),
@@ -273,14 +280,24 @@ impl Specializer {
                         ));
                     }
                 };
-                let specialized = create_specialized_function(
+                let specialized = match create_specialized_function(
                     sema,
                     infer_ctx,
                     key,
                     info.mangled_name,
                     &base_info,
                     interner,
-                )?;
+                ) {
+                    Ok(body) => body,
+                    Err(error) => {
+                        sema.body_analysis_work.specialized_bodies_failed += 1;
+                        return Err(error);
+                    }
+                };
+                sema.body_analysis_work.specialized_bodies_succeeded += 1;
+                sema.body_analysis_work.air_instructions_produced +=
+                    specialized.function.air.instructions().len();
+                sema.body_analysis_work.local_strings_produced += specialized.local_strings.len();
                 let specialized_name = specialized.function.name.clone();
                 let base_name = interner
                     .resolve(&sema.source_function_name(key.base_name))
@@ -360,8 +377,10 @@ fn collect_specializations(
     interner: &ThreadedRodeo,
     specializations: &mut HashMap<SpecializationKey, SpecializationInfo>,
     pending: &mut Vec<SpecializationKey>,
+    work: &mut crate::BodyAnalysisWork,
 ) {
     for inst in air.instructions() {
+        work.specialization_air_instructions_scanned += 1;
         if let AirInstData::CallGeneric {
             name,
             type_args_start,
@@ -371,6 +390,7 @@ fn collect_specializations(
             ..
         } = &inst.data
         {
+            work.generic_calls_observed += 1;
             let type_args: Vec<Type> = air
                 .get_extra(*type_args_start, *type_args_len)
                 .iter()
@@ -385,6 +405,7 @@ fn collect_specializations(
             };
 
             if let Entry::Vacant(entry) = specializations.entry(key) {
+                work.specialization_requests_unique += 1;
                 let base_name = interner.resolve(name);
                 let mangled = mangle_specialized_name(
                     base_name,
@@ -397,6 +418,8 @@ fn collect_specializations(
                     mangled_name: mangled_sym,
                     call_site_span: inst.span,
                 });
+            } else {
+                work.specialization_requests_duplicate += 1;
             }
         }
     }
@@ -405,6 +428,7 @@ fn collect_specializations(
 fn rewrite_call_generic(
     air: &mut Air,
     specializations: &HashMap<SpecializationKey, SpecializationInfo>,
+    work: &mut crate::BodyAnalysisWork,
 ) {
     let mut rewrites: Vec<(usize, AirInstData)> = Vec::new();
 
@@ -446,6 +470,7 @@ fn rewrite_call_generic(
     }
 
     for (index, new_data) in rewrites {
+        work.specialization_rewrites += 1;
         air.rewrite_inst_data(index, new_data);
     }
 }

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -225,6 +225,35 @@ fn semantic_work_json(work: &CanonicalFrontendSessionWork, from: usize) -> Value
     json!({
         "bind_invocations": records.iter().map(|record| record.work.binding.bind_invocations).sum::<usize>(),
         "body_free_function_lookups": records.iter().map(|record| record.work.body_analysis.free_function_record_lookups).sum::<usize>(),
+        "bodies_attempted": records.iter().map(|record| record.work.body_analysis.bodies_attempted).sum::<usize>(),
+        "bodies_succeeded": records.iter().map(|record| record.work.body_analysis.bodies_succeeded).sum::<usize>(),
+        "bodies_failed": records.iter().map(|record| record.work.body_analysis.bodies_failed).sum::<usize>(),
+        "air_instructions_produced": records.iter().map(|record| record.work.body_analysis.air_instructions_produced).sum::<usize>(),
+        "local_strings_produced": records.iter().map(|record| record.work.body_analysis.local_strings_produced).sum::<usize>(),
+        "string_ids_remapped": records.iter().map(|record| record.work.body_analysis.string_ids_remapped).sum::<usize>(),
+        "specialization_air_instructions_scanned": records.iter().map(|record| record.work.body_analysis.specialization_air_instructions_scanned).sum::<usize>(),
+        "generic_calls_observed": records.iter().map(|record| record.work.body_analysis.generic_calls_observed).sum::<usize>(),
+        "specialization_requests_unique": records.iter().map(|record| record.work.body_analysis.specialization_requests_unique).sum::<usize>(),
+        "specialization_requests_duplicate": records.iter().map(|record| record.work.body_analysis.specialization_requests_duplicate).sum::<usize>(),
+        "specialization_rewrites": records.iter().map(|record| record.work.body_analysis.specialization_rewrites).sum::<usize>(),
+        "specialization_rounds": records.iter().map(|record| record.work.body_analysis.specialization_rounds).sum::<usize>(),
+        "specialized_bodies_attempted": records.iter().map(|record| record.work.body_analysis.specialized_bodies_attempted).sum::<usize>(),
+        "specialized_bodies_succeeded": records.iter().map(|record| record.work.body_analysis.specialized_bodies_succeeded).sum::<usize>(),
+        "specialized_bodies_failed": records.iter().map(|record| record.work.body_analysis.specialized_bodies_failed).sum::<usize>(),
+        "cfg": {
+            "drop_glue_functions_synthesized": records.iter().map(|record| record.work.cfg.drop_glue_functions_synthesized).sum::<usize>(),
+            "functions_considered": records.iter().map(|record| record.work.cfg.functions_considered).sum::<usize>(),
+            "comptime_functions_filtered": records.iter().map(|record| record.work.cfg.comptime_functions_filtered).sum::<usize>(),
+            "builds_attempted": records.iter().map(|record| record.work.cfg.cfg_builds_attempted).sum::<usize>(),
+            "builds_succeeded": records.iter().map(|record| record.work.cfg.cfg_builds_succeeded).sum::<usize>(),
+            "builds_failed": records.iter().map(|record| record.work.cfg.cfg_builds_failed).sum::<usize>(),
+            "air_instructions_consumed": records.iter().map(|record| record.work.cfg.air_instructions_consumed).sum::<usize>(),
+            "optimization_attempts": records.iter().map(|record| record.work.cfg.optimization_attempts).sum::<usize>(),
+            "optimization_completions": records.iter().map(|record| record.work.cfg.optimization_completions).sum::<usize>(),
+            "optimized_level_attempts": records.iter().map(|record| record.work.cfg.optimized_level_attempts).sum::<usize>(),
+            "warnings_emitted": records.iter().map(|record| record.work.cfg.cfg_warnings_emitted).sum::<usize>(),
+            "implicit_destructor_targets_emitted": records.iter().map(|record| record.work.cfg.implicit_destructor_targets_emitted).sum::<usize>(),
+        },
         "ordinary_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.ordinary_free_function_dependency_events).sum::<usize>(),
         "specialized_origin_records": records.iter().map(|record| record.work.body_analysis.specialized_origin_records).sum::<usize>(),
         "specialized_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.specialized_free_function_dependency_events).sum::<usize>(),
@@ -652,6 +681,7 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
     assert_eq!(root_reuse["ordinary_declaration_resolutions_skipped"], 1);
     assert_eq!(root_reuse["install_invocations"], 1);
     assert_eq!(root_reuse["fallbacks"], 0);
+    assert_body_cfg_work_equal(cold, root_edit);
     assert_eq!(
         count(root_edit, &["semantic_work", "semantic_epochs_started"]),
         1
@@ -765,6 +795,35 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
     let plan_identity = get("invalidation_plan_module_identity_change");
     assert_eq!(count(plan_identity, &["parse", "modules_rebound"]), 1);
     assert_production_incremental_plan(plan_identity, 1, 0, 2, modules - 1, modules - 1, 2);
+}
+
+fn assert_body_cfg_work_equal(left: &Value, right: &Value) {
+    for field in [
+        "bodies_attempted",
+        "bodies_succeeded",
+        "bodies_failed",
+        "air_instructions_produced",
+        "local_strings_produced",
+        "string_ids_remapped",
+        "specialization_air_instructions_scanned",
+        "generic_calls_observed",
+        "specialization_requests_unique",
+        "specialization_requests_duplicate",
+        "specialization_rewrites",
+        "specialization_rounds",
+        "specialized_bodies_attempted",
+        "specialized_bodies_succeeded",
+        "specialized_bodies_failed",
+    ] {
+        assert_eq!(
+            left["semantic_work"][field], right["semantic_work"][field],
+            "body work field {field} differs before body reuse exists"
+        );
+    }
+    assert_eq!(
+        left["semantic_work"]["cfg"], right["semantic_work"]["cfg"],
+        "CFG work differs before CFG reuse exists"
+    );
 }
 
 fn assert_production_incremental_plan(
@@ -918,7 +977,7 @@ fn main() {
     println!(
         "{}",
         json!({
-            "schema_version": 3,
+            "schema_version": 4,
             "workload": "canonical_frontend_session_invalidation",
             "configuration": {
                 "modules": config.modules,

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -90,9 +90,27 @@ pub struct CanonicalSemanticWork {
     pub bound_definitions: Option<BoundDefinitionWork>,
     /// Demand-driven function-body analysis work.
     pub body_analysis: BodyAnalysisWork,
+    /// Drop-glue, CFG construction, and optimization work.
+    pub cfg: CfgConstructionWork,
     /// Whether this request asked for stable source definition IDs.
     pub stable_ids_requested: bool,
     pub declaration_reuse: CanonicalDeclarationReuseWork,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CfgConstructionWork {
+    pub drop_glue_functions_synthesized: usize,
+    pub functions_considered: usize,
+    pub comptime_functions_filtered: usize,
+    pub cfg_builds_attempted: usize,
+    pub cfg_builds_succeeded: usize,
+    pub cfg_builds_failed: usize,
+    pub air_instructions_consumed: usize,
+    pub optimization_attempts: usize,
+    pub optimization_completions: usize,
+    pub optimized_level_attempts: usize,
+    pub cfg_warnings_emitted: usize,
+    pub implicit_destructor_targets_emitted: usize,
 }
 
 /// Owned semantic and optimized CFG artifacts from the canonical frontend.
@@ -530,6 +548,7 @@ fn finish_canonical_analysis(
         manifest: manifest_work,
         bound_definitions: bound_definitions.as_ref().map(BoundDefinitionSet::work),
         body_analysis,
+        cfg: cfg.work,
         stable_ids_requested: request_stable_ids,
         declaration_reuse,
     };
@@ -956,5 +975,42 @@ mod tests {
         let different_root = snapshot(&sources, 2);
         let (different_root, _) = canonical(&different_root, &base_options, false);
         assert_ne!(base.input(), different_root.input());
+    }
+
+    #[test]
+    fn cfg_work_is_exact_and_distinguishes_optimized_levels() {
+        let source = snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn helper() -> i32 { 1 } fn main() -> i32 { helper() }",
+            )],
+            1,
+        );
+        let o0_options = CompileOptions::default();
+        let (o0, _) = canonical(&source, &o0_options, false);
+        let mut o1_options = o0_options.clone();
+        o1_options.opt_level = crate::OptLevel::O1;
+        let (o1, _) = canonical(&source, &o1_options, false);
+
+        let o0 = o0.work().cfg;
+        let o1 = o1.work().cfg;
+        assert_eq!(o0.functions_considered, 2);
+        assert_eq!(o0.comptime_functions_filtered, 0);
+        assert_eq!(o0.drop_glue_functions_synthesized, 0);
+        assert_eq!(o0.cfg_builds_attempted, 2);
+        assert_eq!(o0.cfg_builds_succeeded, 2);
+        assert_eq!(o0.cfg_builds_failed, 0);
+        assert_eq!(o0.optimization_attempts, 2);
+        assert_eq!(o0.optimization_completions, 2);
+        assert_eq!(o0.optimized_level_attempts, 0);
+
+        assert_eq!(o1.cfg_builds_attempted, o0.cfg_builds_attempted);
+        assert_eq!(o1.cfg_builds_succeeded, o0.cfg_builds_succeeded);
+        assert_eq!(o1.cfg_builds_failed, o0.cfg_builds_failed);
+        assert_eq!(o1.optimization_attempts, 2);
+        assert_eq!(o1.optimization_completions, 2);
+        assert_eq!(o1.optimized_level_attempts, 2);
     }
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -891,6 +891,7 @@ struct CfgFrontendOutput {
     warnings: Vec<CompileWarning>,
     implicit_named_destructor_dependencies: Vec<rue_air::ImplicitNamedDestructorDependencyEvent>,
     implicit_named_destructor_dependencies_complete: bool,
+    work: canonical_semantic::CfgConstructionWork,
 }
 
 /// Lower semantic-analysis output through drop-glue synthesis, comptime filtering,
@@ -914,6 +915,15 @@ fn build_functions_and_cfgs(
 
     // Synthesize drop glue functions.
     let drop_glue_functions = drop_glue::synthesize_drop_glue(&type_pool);
+    let mut work = canonical_semantic::CfgConstructionWork {
+        drop_glue_functions_synthesized: drop_glue_functions.len(),
+        functions_considered: functions.len() + drop_glue_functions.len(),
+        comptime_functions_filtered: functions
+            .iter()
+            .filter(|f| f.air.return_type() == Type::COMPTIME_TYPE)
+            .count(),
+        ..Default::default()
+    };
 
     // Combine user functions with drop glue, filtering out comptime-only functions.
     let mut all_functions: Vec<_> = functions
@@ -928,20 +938,15 @@ fn build_functions_and_cfgs(
 
     let _span = info_span!("cfg_construction").entered();
 
-    let results: Vec<
-        Result<
-            (
-                FunctionWithCfg,
-                Vec<CompileWarning>,
-                Vec<rue_air::ImplicitNamedDestructorDependencyEvent>,
-                bool,
-            ),
-            CompileErrors,
-        >,
-    > = all_functions
+    let results: Vec<_> = all_functions
         .into_par_iter()
         .map(|func| {
             let dependency_source = func.implicit_drop_source.clone();
+            let mut function_work = canonical_semantic::CfgConstructionWork {
+                cfg_builds_attempted: 1,
+                air_instructions_consumed: func.air.instructions().len(),
+                ..Default::default()
+            };
             let cfg_output = CfgBuilder::build(
                 &func.air,
                 func.num_locals,
@@ -957,15 +962,23 @@ fn build_functions_and_cfgs(
             // (an internal compiler error, RUE-7). Abort before optimizing
             // the discarded CFG rather than working on it.
             if !cfg_output.errors.is_empty() {
+                function_work.cfg_builds_failed = 1;
                 let mut errs = CompileErrors::new();
                 for e in cfg_output.errors {
                     errs.push(e);
                 }
-                return Err(errs);
+                return Err((errs, function_work));
             }
 
+            function_work.cfg_builds_succeeded = 1;
+            function_work.optimization_attempts = 1;
+            function_work.optimized_level_attempts = usize::from(opt_level != OptLevel::O0);
             let mut cfg = cfg_output.cfg;
             rue_cfg::opt::optimize(&mut cfg, opt_level);
+            function_work.optimization_completions = 1;
+            function_work.cfg_warnings_emitted = cfg_output.warnings.len();
+            function_work.implicit_destructor_targets_emitted =
+                cfg_output.implicit_named_destructors.len();
 
             let mut implicit_edges = Vec::new();
             let mut complete = !cfg_output.anonymous_destructor_dependency_incomplete;
@@ -1009,13 +1022,16 @@ fn build_functions_and_cfgs(
             }
 
             Ok((
-                FunctionWithCfg {
-                    analyzed: func,
-                    cfg,
-                },
-                cfg_output.warnings,
-                implicit_edges,
-                complete,
+                (
+                    FunctionWithCfg {
+                        analyzed: func,
+                        cfg,
+                    },
+                    cfg_output.warnings,
+                    implicit_edges,
+                    complete,
+                ),
+                function_work,
             ))
         })
         .collect();
@@ -1024,7 +1040,20 @@ fn build_functions_and_cfgs(
     let mut implicit_named_destructor_dependencies = Vec::new();
     let mut implicit_named_destructor_dependencies_complete = true;
     for result in results {
-        let (func, func_warnings, mut implicit_edges, complete) = result?;
+        let ((func, func_warnings, mut implicit_edges, complete), function_work) = match result {
+            Ok(value) => value,
+            Err((errors, _discarded_work)) => return Err(errors),
+        };
+        work.cfg_builds_attempted += function_work.cfg_builds_attempted;
+        work.cfg_builds_succeeded += function_work.cfg_builds_succeeded;
+        work.cfg_builds_failed += function_work.cfg_builds_failed;
+        work.air_instructions_consumed += function_work.air_instructions_consumed;
+        work.optimization_attempts += function_work.optimization_attempts;
+        work.optimization_completions += function_work.optimization_completions;
+        work.optimized_level_attempts += function_work.optimized_level_attempts;
+        work.cfg_warnings_emitted += function_work.cfg_warnings_emitted;
+        work.implicit_destructor_targets_emitted +=
+            function_work.implicit_destructor_targets_emitted;
         functions.push(func);
         warnings.extend(func_warnings);
         implicit_named_destructor_dependencies.append(&mut implicit_edges);
@@ -1045,6 +1074,7 @@ fn build_functions_and_cfgs(
         warnings,
         implicit_named_destructor_dependencies,
         implicit_named_destructor_dependencies_complete,
+        work,
     })
 }
 

--- a/docs/process/session-invalidation-benchmark.md
+++ b/docs/process/session-invalidation-benchmark.md
@@ -66,10 +66,18 @@ smoke test through
 `//crates/rue-compiler-session-bench:rue-compiler-session-bench-test`; the
 128-module timing workload remains opt-in.
 
-RUE-720 must extend this ledger before body or CFG reuse is introduced. The
+The
 [body-analysis and CFG incrementality audit](../notes/body-analysis-cfg-incrementality-audit.md)
-enumerates the missing body attempts/completions, specialization scans and
-rounds, string remaps, glue synthesis, CFG build/optimization attempts, failed
-work, import attempts, and fallbacks. Counters must describe actual operations,
-including discarded work, and parallel CFG counters must reduce deterministic
-per-function values rather than timing-dependent shared state.
+requires this ledger before body or CFG reuse is introduced. Counters describe
+actual operations, and parallel CFG counters reduce deterministic per-function
+values rather than timing-dependent shared state.
+
+Schema version 4 adds value-only body and CFG work. Top-level
+`semantic_work` records body attempts/successes/failures, AIR and local-string
+production, string remapping, specialization scans/calls/unique and duplicate
+requests/rewrites/rounds, and specialized-body attempts/successes/failures.
+`semantic_work.cfg` records synthesized glue, functions considered and
+filtered, CFG attempts/successes/failures, AIR consumed, optimization attempts
+and completions (including non-O0 attempts), warnings, and implicit destructor
+targets. Counts describe completed semantic records; failed requests cannot yet
+be retained by the session record API and are tested at their owning phase.


### PR DESCRIPTION
## What changed

- adds value-only structural counters for body attempts/results, AIR and string production/remapping
- measures specialization scans, requests, rewrites, rounds, and specialized body work
- adds deterministic per-function CFG work reduction covering glue, filtering, builds, optimization, warnings, and destructor targets
- threads the ledgers through canonical semantic work and benchmark schema version 4
- hard-gates exact call-graph, duplicate-specialization, CFG optimization-level, and N=4 pre-reuse behavior

## Why

RUE-720 needs structural evidence before retaining body or CFG artifacts. The previous counters could not distinguish avoided work from hidden reanalysis. This PR establishes the counter-only baseline and adds no cache, durable AIR, body reuse, or CFG reuse.

Failed attempts are counted at their owning semantic/CFG seams, but failed requests cannot yet publish those records through the current `MultiErrorResult` and session-record APIs. The benchmark contract documents that limitation rather than expanding error plumbing in this slice.

## Checks

- formatting
- rue-air: 402 tests
- rue-compiler: 459 tests
- canonical frontend session benchmark smoke test