### PR TITLE
RUE-636: preserve exact fixed-string byref ABI

### DIFF
--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -351,7 +351,13 @@ impl<'a> Sema<'a> {
             // (RUE-385).
             let is_slice = self.slice_element_type(*ptype).is_some();
             let is_inout_str = *mode == RirParamMode::Inout && self.is_str_struct(*ptype);
-            let is_slice_by_value = is_slice && !is_inout_str;
+            // Exact `borrow Str(N)` / `inout Str(N)` parameters retain their
+            // nominal fixed-capacity type and use the ordinary one-pointer
+            // by-reference ABI. Only actual slice views (including bare
+            // `borrow str`) use the materialized two-slot by-value ABI.
+            let is_exact_str_fixed_ref = matches!(mode, RirParamMode::Borrow | RirParamMode::Inout)
+                && self.is_str_fixed_struct(*ptype);
+            let is_slice_by_value = is_slice && !is_inout_str && !is_exact_str_fixed_ref;
             let is_by_ref = (*mode == RirParamMode::Inout || *mode == RirParamMode::Borrow)
                 && !is_slice_by_value;
             let slot_count = if is_by_ref {

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -958,7 +958,10 @@ impl<'a> Sema<'a> {
             let is_str_param = self.is_str_like(param_ty);
             let is_inout_str_param =
                 param_mode == RirParamMode::Inout && self.is_str_struct(param_ty);
-            if is_str_param && !is_inout_str_param {
+            let is_exact_str_fixed_ref =
+                matches!(param_mode, RirParamMode::Borrow | RirParamMode::Inout)
+                    && self.is_str_fixed_struct(param_ty);
+            if is_str_param && !is_inout_str_param && !is_exact_str_fixed_ref {
                 let str_ty = param_ty;
                 // A `borrow` argument to a `borrow s: str` parameter views an
                 // existing string place — a `StrBuf`, `Str(N)`, `str`, or a
@@ -986,7 +989,8 @@ impl<'a> Sema<'a> {
                 // string view. Contextual literals materialize directly as
                 // the expected capacity above; every other value must retain
                 // exact capacity identity (RUE-636). This check is semantic
-                // only: its Borrow/Inout ABI correction remains in RUE-636.
+                // across by-value calls as well as the exact by-reference path
+                // below.
                 if self.is_str_fixed_struct(str_ty) && !arg_result.ty.can_coerce_to(&str_ty) {
                     return Err(self.type_mismatch_error(
                         str_ty,
@@ -1027,7 +1031,7 @@ impl<'a> Sema<'a> {
             let is_slice_param = param_types
                 .get(i)
                 .is_some_and(|pt| self.slice_element_type(*pt).is_some());
-            if is_slice_param && !is_inout_str_param {
+            if is_slice_param && !is_inout_str_param && !is_exact_str_fixed_ref {
                 let slice_ty = param_types[i];
                 let value = self.coerce_borrow_array_to_slice(air, arg, slice_ty, ctx)?;
                 air_args.push(AirCallArg {

--- a/crates/rue-cli-tests/cases/str_fixed_type.toml
+++ b/crates/rue-cli-tests/cases/str_fixed_type.toml
@@ -149,6 +149,40 @@ fn main() -> i32 {
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 42
 
+# Exact fixed-string borrows retain Str(N)'s nominal capacity and pass one
+# pointer to the caller-owned two-word value, rather than materializing a
+# second bare-str view value.
+[[case]]
+name = "str_fixed_exact_borrow_is_by_reference"
+files = [{ path = "main.rue", source = """
+fn exact_len_of(borrow s: Str(8)) -> u64 {
+    s.len()
+}
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    if exact_len_of(borrow s) == 5 { 42 } else { 0 }
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 42
+
+# An exact inout fixed string is likewise one-pointer by-reference and may
+# replace the caller's value with another value of precisely the same capacity.
+[[case]]
+name = "str_fixed_exact_inout_is_by_reference"
+files = [{ path = "main.rue", source = """
+fn exact_replace(inout s: Str(8)) {
+    s = "bye";
+}
+fn main() -> i32 {
+    let mut s: Str(8) = "hello";
+    exact_replace(inout s);
+    if s.len() == 3 { 42 } else { 0 }
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 42
+
 # `Str(N)` requires the preview flag; without it, a clean gate error.
 [[case]]
 name = "str_fixed_requires_preview"

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -483,6 +483,18 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.str_fixed_type",
+        "str_fixed_exact_borrow_is_by_reference",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_fixed_type",
+        "str_fixed_exact_inout_is_by_reference",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_fixed_type",
         "str_fixed_len_and_first_byte",
         semantic(SemanticGapKind::TextProjectionRead),
         &[],


### PR DESCRIPTION
## Summary

- keep exact `borrow Str(N)` and `inout Str(N)` on the ordinary one-pointer by-reference ABI
- preserve bare `borrow str` view coercion as a two-slot by-value view
- add runtime regressions for exact fixed-string borrow and inout replacement

## Root cause

Fixed strings participate in broad string/slice classification for indexing and view coercion. Call analysis and parameter layout reused that classification too broadly, so exact fixed-string references were materialized as slice views and lost their nominal capacity/physical reference contract.

## Validation

- `./fmt.sh --check`
- `./buck2 test //crates/rue-air:rue-air-test` (400 passed)
- filtered fixed-string CLI suite (11 passed)