### PR TITLE
RUE-652: make expected types expression-directed

### DIFF
--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -36,6 +36,54 @@ impl<'a> Sema<'a> {
         inst_ref: InstRef,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // These expressions synthesize their result from their own operands or
+        // declaration. A surrounding result expectation belongs to the whole
+        // expression and must not contextually type those operands. Keep this
+        // boundary at dispatch so every implementation path (including
+        // String `+` and place/projection fast paths) gets identical cleanup.
+        let clears_result_expectation = matches!(
+            &self.rir.get(inst_ref).data,
+            InstData::Add { .. }
+                | InstData::Sub { .. }
+                | InstData::Mul { .. }
+                | InstData::Div { .. }
+                | InstData::Mod { .. }
+                | InstData::BitAnd { .. }
+                | InstData::BitOr { .. }
+                | InstData::BitXor { .. }
+                | InstData::Shl { .. }
+                | InstData::Shr { .. }
+                | InstData::Eq { .. }
+                | InstData::Ne { .. }
+                | InstData::Lt { .. }
+                | InstData::Gt { .. }
+                | InstData::Le { .. }
+                | InstData::Ge { .. }
+                | InstData::And { .. }
+                | InstData::Or { .. }
+                | InstData::Neg { .. }
+                | InstData::Not { .. }
+                | InstData::BitNot { .. }
+                | InstData::Loop { .. }
+                | InstData::InfiniteLoop { .. }
+                | InstData::FieldGet { .. }
+                | InstData::FieldSet { .. }
+                | InstData::IndexGet { .. }
+                | InstData::IndexSet { .. }
+        );
+        if clears_result_expectation {
+            return ctx
+                .with_expected_type(None, |ctx| self.analyze_inst_dispatch(air, inst_ref, ctx));
+        }
+        self.analyze_inst_dispatch(air, inst_ref, ctx)
+    }
+
+    fn analyze_inst_dispatch(
+        &mut self,
+        air: &mut Air,
+        inst_ref: InstRef,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
         let inst = self.rir.get(inst_ref);
 
         match &inst.data {

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -155,7 +155,9 @@ impl<'a> Sema<'a> {
                 });
                 AnalysisResult::new(air_ref, pointee_type)
             }
-            _ => self.analyze_inst(air, args[1].value, ctx)?,
+            _ => ctx.with_expected_type(Some(pointee_type), |ctx| {
+                self.analyze_inst(air, args[1].value, ctx)
+            })?,
         };
         let value_type = value_result.ty;
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -815,7 +815,7 @@ impl<'a> Sema<'a> {
         }
 
         // Condition must be bool
-        let cond_result = self.analyze_inst(air, cond, ctx)?;
+        let cond_result = ctx.with_expected_type(None, |ctx| self.analyze_inst(air, cond, ctx))?;
 
         if let Some(else_b) = else_block {
             // Save move state before entering branches.
@@ -1417,13 +1417,11 @@ impl<'a> Sema<'a> {
                 None
             }
         });
-        let prev_expected = ctx.expected_type.take();
-        ctx.expected_type = expected_scrutinee;
-
-        // Analyze the scrutinee to determine its type
-        let scrutinee_outcome = self.analyze_inst(air, scrutinee, ctx);
-        ctx.expected_type = prev_expected;
-        let scrutinee_result = scrutinee_outcome?;
+        // Analyze the scrutinee under only the pattern-derived contract. The
+        // match expression's own result expectation belongs to its arms.
+        let scrutinee_result = ctx.with_expected_type(expected_scrutinee, |ctx| {
+            self.analyze_inst(air, scrutinee, ctx)
+        })?;
         let scrutinee_type = scrutinee_result.ty;
 
         // Validate that we can match on this type (integers, booleans, and enums)
@@ -2458,7 +2456,11 @@ impl<'a> Sema<'a> {
         for (i, &raw_ref) in inst_refs.iter().enumerate() {
             let inst_ref = InstRef::from_raw(raw_ref);
             let is_last = i == num_insts - 1;
-            let result = self.analyze_inst(air, inst_ref, ctx)?;
+            let result = if is_last {
+                self.analyze_inst(air, inst_ref, ctx)?
+            } else {
+                ctx.with_expected_type(None, |ctx| self.analyze_inst(air, inst_ref, ctx))?
+            };
 
             if is_last {
                 last_result = Some(result);
@@ -6642,8 +6644,9 @@ impl<'a> Sema<'a> {
         // legality check).
         let mut payload_refs: Vec<u32> = Vec::with_capacity(args.len());
         for (i, arg) in args.iter().enumerate() {
-            let arg_result = self.analyze_inst(air, arg.value, ctx)?;
             let expected = payload_types[i];
+            let arg_result = ctx
+                .with_expected_type(Some(expected), |ctx| self.analyze_inst(air, arg.value, ctx))?;
             let actual = arg_result.ty;
             if actual != expected && !actual.can_coerce_to(&expected) && actual != Type::ERROR {
                 return Err(self.type_mismatch_error(

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -704,6 +704,62 @@ mod tests {
     }
 
     #[test]
+    fn expected_string_type_reaches_only_structural_result_positions() {
+        let source = r#"
+            fn choose(flag: bool) -> Str(8) {
+                if "left" == "right" {
+                    if flag { "yes" } else { "no" }
+                } else {
+                    { let marker = 0; "fallback" }
+                }
+            }
+            fn loop_probe() -> Str(8) {
+                while false { "loop body"; }
+                "tail"
+            }
+            fn main() -> i32 {
+                @intCast(choose(true).len() + loop_probe().len())
+            }
+        "#;
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let output = compile_to_air_with_preview_features(source, preview).unwrap();
+
+        let literal_types: Vec<String> = output
+            .functions
+            .iter()
+            .flat_map(|function| function.air.iter())
+            .filter(|(_, inst)| matches!(inst.data, AirInstData::StringConst(_)))
+            .map(|(_, inst)| inst.ty.safe_name_with_pool(Some(&output.type_pool)))
+            .collect();
+
+        // Comparison operands and a discarded loop-body value synthesize
+        // their own StrBuf representation. If/match-style branches and block
+        // tails remain transparent and materialize as the declared Str(8).
+        assert_eq!(literal_types.iter().filter(|ty| *ty == "StrBuf").count(), 3);
+        assert_eq!(literal_types.iter().filter(|ty| *ty == "Str(8)").count(), 4);
+    }
+
+    #[test]
+    fn declared_enum_payload_and_ptr_write_pointee_contextualize_fixed_strings() {
+        let source = r#"
+            enum Message { Text(Str(8)) }
+            fn make() -> Message { Message.Text("hello") }
+            fn main() -> i32 {
+                let mut value: Str(8) = "old";
+                checked {
+                    let p: ptr mut Str(8) = @raw_mut(value);
+                    @ptr_write(p, "new");
+                };
+                @intCast(value.len())
+            }
+        "#;
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        compile_to_air_with_preview_features(source, preview).unwrap();
+    }
+
+    #[test]
     fn fallible_intrinsic_keeps_structural_result_context() {
         let source = r#"
             fn Option(comptime T: type) -> type { enum { Some(T), None } }


### PR DESCRIPTION
## Summary

- clear ambient result expectations at synthesized operand boundaries
- preserve contextual typing for structural branches, block tails, enum payloads, and pointer writes
- add fixed-string representation sentinels covering operators, loops, branches, enum payloads, and pointee writes

## Root cause

`AnalysisContext.expected_type` was ambient mutable context. Parent result expectations could leak into operands that synthesize their own types, while some declared child positions failed to install their explicit expected type. This made representation selection depend on surrounding expressions rather than the expression grammar and declaration contract.

## Validation

- `./fmt.sh --check`
- `./buck2 test //crates/rue-air:rue-air-test` (404 passed)
- fixed-string CLI subset (11 passed)
- pointer-write CLI subset (7 passed)