### PR TITLE
RUE-728: Retire legacy RIR emit frontend

### DIFF
--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -9,6 +9,47 @@ name = "--emit pipeline parity"
 description = "--emit modes resolve modules and report warnings like a normal build."
 
 [[case]]
+name = "emit_rir_uses_canonical_frontend_and_preserves_caller_order"
+description = "RUE-728: canonical RIR presentation retains positional text even when logical module order differs."
+files = [
+    { path = "z.rue", source = "fn main() -> i32 { let z = 40; z + 2 }\n" },
+    { path = "a.rue", source = "fn alpha() -> i32 { let a = 1; a }\n" },
+]
+args = ["--emit", "rir", "z.rue", "a.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "=== RIR ===",
+    "%0 = const 40",
+    "%6 = fn main()",
+    "%7 = const 1",
+    "%11 = fn alpha()",
+]
+
+[[case]]
+name = "combined_rir_air_resolves_imports_once"
+description = "RUE-728: combined RIR and semantic emits consume the same canonical import-aware frontend artifacts."
+files = [
+    { path = "main.rue", source = "const helper = @import(\"helper.rue\"); fn main() -> i32 { helper.answer() }\n" },
+    { path = "helper.rue", source = "pub fn answer() -> i32 { 42 }\n" },
+]
+args = ["--emit", "rir", "--emit", "air", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== RIR ===", "fn answer()", "fn main()", "=== AIR ==="]
+compile_stderr_not_contains = ["E0704", "internal compiler error"]
+
+[[case]]
+name = "emit_rir_preserves_canonical_diagnostic_attribution"
+description = "RUE-728: RIR requests no longer detour around canonical multi-file diagnostics."
+files = [
+    { path = "main.rue", source = "const bad = @import(\"bad.rue\"); fn main() -> i32 { bad.broken() }\n" },
+    { path = "bad.rue", source = "pub fn broken() -> i32 { missing }\n" },
+]
+args = ["--emit", "rir", "main.rue"]
+compile_fail = true
+compile_stderr_contains = ["E0201", "bad.rue:", "undefined variable 'missing'"]
+compile_stdout_not_contains = ["=== RIR ==="]
+
+[[case]]
 name = "emit_air_warnings_not_dropped"
 description = "Warnings were silently dropped in all --emit modes (RUE-130 item 3)."
 files = [{ path = "main.rue", source = """

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -1,9 +1,11 @@
 //! Canonical, provenance-safe lowering from parsed modules to RIR.
 
 use std::cell::RefCell;
+use std::ops::Range;
 
 use rue_error::{CompileError, CompileResult};
-use rue_rir::{AstGen, Rir};
+use rue_rir::{AstGen, InstRef, Rir};
+use rue_span::FileId;
 
 use crate::{CanonicalMergedProgram, SemanticSymbolUniverse, SourceRevision};
 
@@ -29,6 +31,20 @@ pub struct CanonicalRirOutput {
     rir: Rir,
     symbols: SemanticSymbolUniverse,
     work: CanonicalRirWork,
+    module_ranges: Vec<CanonicalRirModuleRange>,
+}
+
+#[derive(Debug)]
+struct CanonicalRirModuleRange {
+    file_id: FileId,
+    instructions: Range<u32>,
+    extra: Range<u32>,
+}
+
+/// Ephemeral caller-order indices consumed by the read-only RIR printer.
+pub struct CanonicalRirPresentationOrder {
+    pub instructions: Vec<InstRef>,
+    pub extra: Vec<u32>,
 }
 
 impl CanonicalRirOutput {
@@ -47,6 +63,33 @@ impl CanonicalRirOutput {
     pub fn work(&self) -> CanonicalRirWork {
         self.work
     }
+
+    /// Return a read-only instruction presentation order for caller-ordered files.
+    ///
+    /// Canonical RIR remains in stable module identity order; this permutation is
+    /// consumed only by presentation printers and never changes semantic refs.
+    pub fn presentation_order(
+        &self,
+        files: impl IntoIterator<Item = FileId>,
+    ) -> CanonicalRirPresentationOrder {
+        let mut instructions = Vec::with_capacity(self.rir.len());
+        let mut extra = Vec::with_capacity(self.rir.extra_len());
+        for file in files {
+            let range = self
+                .module_ranges
+                .iter()
+                .find(|candidate| candidate.file_id == file)
+                .expect("RIR presentation file belongs to the canonical source revision");
+            instructions.extend(range.instructions.clone().map(InstRef::from_raw));
+            extra.extend(range.extra.clone());
+        }
+        assert_eq!(instructions.len(), self.rir.len());
+        assert_eq!(extra.len(), self.rir.extra_len());
+        CanonicalRirPresentationOrder {
+            instructions,
+            extra,
+        }
+    }
 }
 
 /// Lower canonical module views in stable `ModuleId` order into one RIR.
@@ -56,6 +99,7 @@ pub fn lower_canonical_rir(merged: &CanonicalMergedProgram) -> CompileResult<Can
     let current_view = RefCell::<Option<crate::parsed_modules::ParsedAstView>>::new(None);
     let first_error = RefCell::<Option<CompileError>>::new(None);
 
+    let mut module_ranges = Vec::with_capacity(ast.modules().len());
     let rir = {
         let mut generator = AstGen::with_symbol_normalizer(symbols.interner(), |local| {
             let view = current_view.borrow();
@@ -81,7 +125,14 @@ pub fn lower_canonical_rir(merged: &CanonicalMergedProgram) -> CompileResult<Can
         for view in ast.ast_views() {
             ast.validate_view(&view)?;
             *current_view.borrow_mut() = Some(view.clone());
+            let instruction_start = generator.instruction_len() as u32;
+            let extra_start = generator.extra_len() as u32;
             generator.append_items(&view.module().ast().items);
+            module_ranges.push(CanonicalRirModuleRange {
+                file_id: view.module().file_id(),
+                instructions: instruction_start..generator.instruction_len() as u32,
+                extra: extra_start..generator.extra_len() as u32,
+            });
             if let Some(error) = first_error.borrow_mut().take() {
                 return Err(error);
             }
@@ -108,6 +159,7 @@ pub fn lower_canonical_rir(merged: &CanonicalMergedProgram) -> CompileResult<Can
         rir,
         symbols,
         work,
+        module_ranges,
     })
 }
 
@@ -158,6 +210,17 @@ mod tests {
         RirPrinter::new(output.rir(), output.symbols.interner()).to_string()
     }
 
+    fn print_in_snapshot_order(output: &CanonicalRirOutput, source: &SourceSnapshot) -> String {
+        let order = output.presentation_order(source.files().map(|file| file.file_id));
+        RirPrinter::with_presentation_order(
+            output.rir(),
+            output.symbols.interner(),
+            order.instructions,
+            order.extra,
+        )
+        .to_string()
+    }
+
     #[test]
     fn equal_local_spurs_lower_to_distinct_semantic_names() {
         let source = snapshot(
@@ -200,6 +263,70 @@ mod tests {
 
         assert_eq!(print(&first), print(&second));
         assert_eq!(first.work(), second.work());
+    }
+
+    #[test]
+    fn caller_order_presentation_matches_legacy_without_relowering() {
+        let source = snapshot(
+            &[
+                (
+                    8,
+                    "/checkout/z.rue",
+                    "z.rue",
+                    "fn zed() -> i32 { let z = 40; z + 2 }",
+                ),
+                (
+                    3,
+                    "/checkout/a.rue",
+                    "a.rue",
+                    "fn alpha() -> i32 { let a = 1; a }",
+                ),
+            ],
+            8,
+        );
+        let parsed = parse_source_snapshot_modules(&source).unwrap();
+        let canonical = lower_canonical_rir(&merge_parsed_modules(&parsed).unwrap()).unwrap();
+        let legacy = merge_symbols(parse_all_files_with_source_snapshot(&source).unwrap()).unwrap();
+        let legacy_rir = AstGen::generate_items(&legacy.interner, legacy.ast.items());
+
+        assert_ne!(
+            print(&canonical),
+            RirPrinter::new(&legacy_rir, &legacy.interner).to_string()
+        );
+        assert_eq!(
+            print_in_snapshot_order(&canonical, &source),
+            RirPrinter::new(&legacy_rir, &legacy.interner).to_string()
+        );
+        assert_eq!(canonical.work().parser_invocations, 0);
+    }
+
+    #[test]
+    fn presentation_survives_file_id_and_physical_path_relocation() {
+        let first = snapshot(
+            &[
+                (9, "/old/z.rue", "z.rue", "fn zed() -> i32 { 9 }"),
+                (2, "/old/a.rue", "a.rue", "fn alpha() -> i32 { 2 }"),
+            ],
+            9,
+        );
+        let relocated = snapshot(
+            &[
+                (91, "/new/z.rue", "z.rue", "fn zed() -> i32 { 9 }"),
+                (27, "/new/a.rue", "a.rue", "fn alpha() -> i32 { 2 }"),
+            ],
+            91,
+        );
+        let lower = |source: &SourceSnapshot| {
+            let parsed = parse_source_snapshot_modules(source).unwrap();
+            lower_canonical_rir(&merge_parsed_modules(&parsed).unwrap()).unwrap()
+        };
+        let first_rir = lower(&first);
+        let relocated_rir = lower(&relocated);
+
+        assert_eq!(
+            print_in_snapshot_order(&first_rir, &first),
+            print_in_snapshot_order(&relocated_rir, &relocated)
+        );
     }
 
     #[test]

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -113,6 +113,18 @@ impl<'a> AstGen<'a> {
         }
     }
 
+    /// Current instruction count for read-only multi-module presentation metadata.
+    #[doc(hidden)]
+    pub fn instruction_len(&self) -> usize {
+        self.rir.len()
+    }
+
+    /// Current payload word count for read-only multi-module presentation metadata.
+    #[doc(hidden)]
+    pub fn extra_len(&self) -> usize {
+        self.rir.extra_len()
+    }
+
     /// Finish a normalized multi-module lowering session.
     #[doc(hidden)]
     pub fn finish(self) -> Rir {

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -289,6 +289,12 @@ impl Rir {
         self.instructions.len()
     }
 
+    /// The number of words in the variable-length payload store.
+    #[inline]
+    pub fn extra_len(&self) -> usize {
+        self.extra.len()
+    }
+
     /// Whether there are no instructions.
     #[inline]
     pub fn is_empty(&self) -> bool {
@@ -1895,31 +1901,124 @@ impl fmt::Display for InstRef {
     }
 }
 
+struct DisplayedInstRef(u32);
+
+impl fmt::Display for DisplayedInstRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "%{}", self.0)
+    }
+}
+
 /// Printer for RIR that resolves symbols to their string values.
 pub struct RirPrinter<'a, 'b> {
     rir: &'a Rir,
     interner: &'b lasso::ThreadedRodeo,
+    instruction_order: Option<Vec<InstRef>>,
+    displayed_refs: Option<Vec<u32>>,
+    displayed_extra: Option<Vec<u32>>,
 }
 
 impl<'a, 'b> RirPrinter<'a, 'b> {
     /// Create a new RIR printer.
     pub fn new(rir: &'a Rir, interner: &'b lasso::ThreadedRodeo) -> Self {
-        Self { rir, interner }
+        Self {
+            rir,
+            interner,
+            instruction_order: None,
+            displayed_refs: None,
+            displayed_extra: None,
+        }
+    }
+
+    /// Create a read-only presentation of `rir` in a different instruction order.
+    ///
+    /// The supplied order must be a permutation of every instruction in the RIR.
+    /// References are displayed in that order without cloning or rewriting the RIR.
+    pub fn with_instruction_order(
+        rir: &'a Rir,
+        interner: &'b lasso::ThreadedRodeo,
+        instruction_order: Vec<InstRef>,
+    ) -> Self {
+        assert_eq!(instruction_order.len(), rir.len());
+        let mut displayed_refs = vec![u32::MAX; rir.len()];
+        for (displayed, canonical) in instruction_order.iter().enumerate() {
+            let slot = &mut displayed_refs[canonical.as_u32() as usize];
+            assert_eq!(
+                *slot,
+                u32::MAX,
+                "RIR presentation order contains a duplicate"
+            );
+            *slot = displayed as u32;
+        }
+        assert!(
+            displayed_refs
+                .iter()
+                .all(|displayed| *displayed != u32::MAX)
+        );
+        Self {
+            rir,
+            interner,
+            instruction_order: Some(instruction_order),
+            displayed_refs: Some(displayed_refs),
+            displayed_extra: None,
+        }
+    }
+
+    /// Create a presentation that remaps both instruction and payload ordering.
+    pub fn with_presentation_order(
+        rir: &'a Rir,
+        interner: &'b lasso::ThreadedRodeo,
+        instruction_order: Vec<InstRef>,
+        extra_order: Vec<u32>,
+    ) -> Self {
+        let mut printer = Self::with_instruction_order(rir, interner, instruction_order);
+        assert_eq!(extra_order.len(), rir.extra_len());
+        let mut displayed_extra = vec![u32::MAX; rir.extra_len()];
+        for (displayed, canonical) in extra_order.into_iter().enumerate() {
+            let slot = &mut displayed_extra[canonical as usize];
+            assert_eq!(
+                *slot,
+                u32::MAX,
+                "RIR payload presentation contains a duplicate"
+            );
+            *slot = displayed as u32;
+        }
+        assert!(
+            displayed_extra
+                .iter()
+                .all(|displayed| *displayed != u32::MAX)
+        );
+        printer.displayed_extra = Some(displayed_extra);
+        printer
+    }
+
+    fn display_ref(&self, inst: InstRef) -> DisplayedInstRef {
+        DisplayedInstRef(
+            self.displayed_refs
+                .as_ref()
+                .map_or(inst.as_u32(), |refs| refs[inst.as_u32() as usize]),
+        )
+    }
+
+    fn display_extra(&self, index: u32) -> u32 {
+        self.displayed_extra
+            .as_ref()
+            .map_or(index, |extra| extra[index as usize])
     }
 
     /// Format a call argument with its mode prefix.
-    fn format_call_arg(arg: &RirCallArg) -> String {
+    fn format_call_arg(&self, arg: &RirCallArg) -> String {
         match arg.mode {
-            RirArgMode::Inout => format!("inout {}", arg.value),
-            RirArgMode::Borrow => format!("borrow {}", arg.value),
-            RirArgMode::Normal => format!("{}", arg.value),
+            RirArgMode::Inout => format!("inout {}", self.display_ref(arg.value)),
+            RirArgMode::Borrow => format!("borrow {}", self.display_ref(arg.value)),
+            RirArgMode::Normal => format!("{}", self.display_ref(arg.value)),
         }
     }
 
     /// Format a list of call arguments.
-    fn format_call_args(args: &[RirCallArg]) -> String {
+    fn format_call_args(&self, args: &[RirCallArg]) -> String {
         args.iter()
-            .map(Self::format_call_arg)
+            .map(|arg| self.format_call_arg(arg))
             .collect::<Vec<_>>()
             .join(", ")
     }
@@ -1960,7 +2059,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 ..
             } => {
                 let prefix = if let Some(module_ref) = module {
-                    format!("%{}..", module_ref.as_u32())
+                    format!("{}..", self.display_ref(*module_ref))
                 } else {
                     String::new()
                 };
@@ -1986,8 +2085,14 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
         use std::fmt::Write;
 
         let mut out = String::new();
-        for (inst_ref, inst) in self.rir.iter() {
-            write!(out, "{} = ", inst_ref).unwrap();
+        let instruction_order: Box<dyn Iterator<Item = InstRef> + '_> =
+            match &self.instruction_order {
+                Some(order) => Box::new(order.iter().copied()),
+                None => Box::new(self.rir.iter().map(|(inst_ref, _)| inst_ref)),
+            };
+        for inst_ref in instruction_order {
+            let inst = self.rir.get(inst_ref);
+            write!(out, "{} = ", self.display_ref(inst_ref)).unwrap();
             match &inst.data {
                 // Constants
                 InstData::IntConst(v) => writeln!(out, "const {}", v).unwrap(),
@@ -1998,30 +2103,146 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::UnitConst => writeln!(out, "const ()").unwrap(),
 
                 // Binary operations
-                InstData::Add { lhs, rhs } => writeln!(out, "add {}, {}", lhs, rhs).unwrap(),
-                InstData::Sub { lhs, rhs } => writeln!(out, "sub {}, {}", lhs, rhs).unwrap(),
-                InstData::Mul { lhs, rhs } => writeln!(out, "mul {}, {}", lhs, rhs).unwrap(),
-                InstData::Div { lhs, rhs } => writeln!(out, "div {}, {}", lhs, rhs).unwrap(),
-                InstData::Mod { lhs, rhs } => writeln!(out, "mod {}, {}", lhs, rhs).unwrap(),
-                InstData::Eq { lhs, rhs } => writeln!(out, "eq {}, {}", lhs, rhs).unwrap(),
-                InstData::Ne { lhs, rhs } => writeln!(out, "ne {}, {}", lhs, rhs).unwrap(),
-                InstData::Lt { lhs, rhs } => writeln!(out, "lt {}, {}", lhs, rhs).unwrap(),
-                InstData::Gt { lhs, rhs } => writeln!(out, "gt {}, {}", lhs, rhs).unwrap(),
-                InstData::Le { lhs, rhs } => writeln!(out, "le {}, {}", lhs, rhs).unwrap(),
-                InstData::Ge { lhs, rhs } => writeln!(out, "ge {}, {}", lhs, rhs).unwrap(),
-                InstData::And { lhs, rhs } => writeln!(out, "and {}, {}", lhs, rhs).unwrap(),
-                InstData::Or { lhs, rhs } => writeln!(out, "or {}, {}", lhs, rhs).unwrap(),
-                InstData::BitAnd { lhs, rhs } => writeln!(out, "bit_and {}, {}", lhs, rhs).unwrap(),
-                InstData::BitOr { lhs, rhs } => writeln!(out, "bit_or {}, {}", lhs, rhs).unwrap(),
-                InstData::BitXor { lhs, rhs } => writeln!(out, "bit_xor {}, {}", lhs, rhs).unwrap(),
-                InstData::Shl { lhs, rhs } => writeln!(out, "shl {}, {}", lhs, rhs).unwrap(),
-                InstData::Shr { lhs, rhs } => writeln!(out, "shr {}, {}", lhs, rhs).unwrap(),
+                InstData::Add { lhs, rhs } => writeln!(
+                    out,
+                    "add {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Sub { lhs, rhs } => writeln!(
+                    out,
+                    "sub {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Mul { lhs, rhs } => writeln!(
+                    out,
+                    "mul {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Div { lhs, rhs } => writeln!(
+                    out,
+                    "div {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Mod { lhs, rhs } => writeln!(
+                    out,
+                    "mod {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Eq { lhs, rhs } => writeln!(
+                    out,
+                    "eq {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Ne { lhs, rhs } => writeln!(
+                    out,
+                    "ne {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Lt { lhs, rhs } => writeln!(
+                    out,
+                    "lt {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Gt { lhs, rhs } => writeln!(
+                    out,
+                    "gt {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Le { lhs, rhs } => writeln!(
+                    out,
+                    "le {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Ge { lhs, rhs } => writeln!(
+                    out,
+                    "ge {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::And { lhs, rhs } => writeln!(
+                    out,
+                    "and {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Or { lhs, rhs } => writeln!(
+                    out,
+                    "or {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::BitAnd { lhs, rhs } => writeln!(
+                    out,
+                    "bit_and {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::BitOr { lhs, rhs } => writeln!(
+                    out,
+                    "bit_or {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::BitXor { lhs, rhs } => writeln!(
+                    out,
+                    "bit_xor {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Shl { lhs, rhs } => writeln!(
+                    out,
+                    "shl {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
+                InstData::Shr { lhs, rhs } => writeln!(
+                    out,
+                    "shr {}, {}",
+                    self.display_ref(*lhs),
+                    self.display_ref(*rhs)
+                )
+                .unwrap(),
 
                 // Unary operations
-                InstData::Neg { operand } => writeln!(out, "neg {}", operand).unwrap(),
-                InstData::Not { operand } => writeln!(out, "not {}", operand).unwrap(),
-                InstData::BitNot { operand } => writeln!(out, "bit_not {}", operand).unwrap(),
-                InstData::Try { operand } => writeln!(out, "try {}", operand).unwrap(),
+                InstData::Neg { operand } => {
+                    writeln!(out, "neg {}", self.display_ref(*operand)).unwrap()
+                }
+                InstData::Not { operand } => {
+                    writeln!(out, "not {}", self.display_ref(*operand)).unwrap()
+                }
+                InstData::BitNot { operand } => {
+                    writeln!(out, "bit_not {}", self.display_ref(*operand)).unwrap()
+                }
+                InstData::Try { operand } => {
+                    writeln!(out, "try {}", self.display_ref(*operand)).unwrap()
+                }
 
                 // Control flow
                 InstData::Branch {
@@ -2030,17 +2251,42 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     else_block,
                 } => {
                     if let Some(else_b) = else_block {
-                        writeln!(out, "branch {}, {}, {}", cond, then_block, else_b).unwrap();
+                        writeln!(
+                            out,
+                            "branch {}, {}, {}",
+                            self.display_ref(*cond),
+                            self.display_ref(*then_block),
+                            self.display_ref(*else_b)
+                        )
+                        .unwrap();
                     } else {
-                        writeln!(out, "branch {}, {}", cond, then_block).unwrap();
+                        writeln!(
+                            out,
+                            "branch {}, {}",
+                            self.display_ref(*cond),
+                            self.display_ref(*then_block)
+                        )
+                        .unwrap();
                     }
                 }
-                InstData::Loop { cond, body } => writeln!(out, "loop {}, {}", cond, body).unwrap(),
+                InstData::Loop { cond, body } => writeln!(
+                    out,
+                    "loop {}, {}",
+                    self.display_ref(*cond),
+                    self.display_ref(*body)
+                )
+                .unwrap(),
                 InstData::InfiniteLoop { body, iter_borrow } => {
                     let borrow_str = iter_borrow
                         .map(|c| format!(" borrows {}", self.interner.resolve(&c)))
                         .unwrap_or_default();
-                    writeln!(out, "infinite_loop {}{}", body, borrow_str).unwrap()
+                    writeln!(
+                        out,
+                        "infinite_loop {}{}",
+                        self.display_ref(*body),
+                        borrow_str
+                    )
+                    .unwrap()
                 }
                 InstData::Match {
                     scrutinee,
@@ -2050,12 +2296,24 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let arms = self.rir.get_match_arms(*arms_start, *arms_len);
                     let arms_str: Vec<String> = arms
                         .iter()
-                        .map(|(pat, body)| format!("{} => {}", self.format_pattern(pat), body))
+                        .map(|(pat, body)| {
+                            format!(
+                                "{} => {}",
+                                self.format_pattern(pat),
+                                self.display_ref(*body)
+                            )
+                        })
                         .collect();
-                    writeln!(out, "match {} {{ {} }}", scrutinee, arms_str.join(", ")).unwrap();
+                    writeln!(
+                        out,
+                        "match {} {{ {} }}",
+                        self.display_ref(*scrutinee),
+                        arms_str.join(", ")
+                    )
+                    .unwrap();
                 }
                 InstData::Break { value } => match value {
-                    Some(v) => writeln!(out, "break {}", v).unwrap(),
+                    Some(v) => writeln!(out, "break {}", self.display_ref(*v)).unwrap(),
                     None => writeln!(out, "break").unwrap(),
                 },
                 InstData::Continue => writeln!(out, "continue").unwrap(),
@@ -2118,7 +2376,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         ret_str
                     )
                     .unwrap();
-                    writeln!(out, "    {}", body).unwrap();
+                    writeln!(out, "    {}", self.display_ref(*body)).unwrap();
                     writeln!(out, "}}").unwrap();
                 }
                 InstData::ConstDecl {
@@ -2138,13 +2396,17 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     writeln!(
                         out,
                         "{}{}const {}{} = {}",
-                        directives_str, pub_str, name_str, ty_str, init
+                        directives_str,
+                        pub_str,
+                        name_str,
+                        ty_str,
+                        self.display_ref(*init)
                     )
                     .unwrap();
                 }
                 InstData::Ret(inner) => {
                     if let Some(inner) = inner {
-                        writeln!(out, "ret {}", inner).unwrap();
+                        writeln!(out, "ret {}", self.display_ref(*inner)).unwrap();
                     } else {
                         writeln!(out, "ret").unwrap();
                     }
@@ -2156,7 +2418,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 } => {
                     let name_str = self.interner.resolve(&*name);
                     let args = self.rir.get_call_args(*args_start, *args_len);
-                    writeln!(out, "call {}({})", name_str, Self::format_call_args(&args)).unwrap();
+                    writeln!(out, "call {}({})", name_str, self.format_call_args(&args)).unwrap();
                 }
                 InstData::Intrinsic {
                     name,
@@ -2165,7 +2427,10 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 } => {
                     let name_str = self.interner.resolve(&*name);
                     let args = self.rir.get_inst_refs(*args_start, *args_len);
-                    let args_str: Vec<String> = args.iter().map(|a| format!("{}", a)).collect();
+                    let args_str: Vec<String> = args
+                        .iter()
+                        .map(|a| self.display_ref(*a).to_string())
+                        .collect();
                     writeln!(out, "intrinsic @{}({})", name_str, args_str.join(", ")).unwrap();
                 }
                 InstData::TypeIntrinsic { name, type_arg } => {
@@ -2179,7 +2444,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     writeln!(out, "offset_of @offset_of({}, {})", type_str, field_str).unwrap();
                 }
                 InstData::Block { extra_start, len } => {
-                    writeln!(out, "block({}, {})", extra_start, len).unwrap();
+                    writeln!(out, "block({}, {})", self.display_extra(*extra_start), len).unwrap();
                 }
 
                 // Variables
@@ -2204,7 +2469,12 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     writeln!(
                         out,
                         "{}alloc {}{}{}= {}{}",
-                        directives_str, mut_str, name_str, ty_str, init, iter_str
+                        directives_str,
+                        mut_str,
+                        name_str,
+                        ty_str,
+                        self.display_ref(*init),
+                        iter_str
                     )
                     .unwrap();
                 }
@@ -2212,7 +2482,13 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     writeln!(out, "var_ref {}", self.interner.resolve(&*name)).unwrap();
                 }
                 InstData::Assign { name, value } => {
-                    writeln!(out, "assign {} = {}", self.interner.resolve(&*name), value).unwrap();
+                    writeln!(
+                        out,
+                        "assign {} = {}",
+                        self.interner.resolve(&*name),
+                        self.display_ref(*value)
+                    )
+                    .unwrap();
                 }
 
                 // Structs
@@ -2246,8 +2522,10 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let methods_str = if methods.is_empty() {
                         String::new()
                     } else {
-                        let method_refs: Vec<String> =
-                            methods.iter().map(|m| format!("{}", m)).collect();
+                        let method_refs: Vec<String> = methods
+                            .iter()
+                            .map(|m| self.display_ref(*m).to_string())
+                            .collect();
                         format!(" methods: [{}]", method_refs.join(", "))
                     };
                     writeln!(
@@ -2271,15 +2549,21 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     shorthand_span: _,
                 } => {
                     let module_str = match ctor_head {
-                        Some(head) => format!("<{}>.", head),
-                        None => module.map(|m| format!("{}.", m)).unwrap_or_default(),
+                        Some(head) => format!("<{}>.", self.display_ref(*head)),
+                        None => module
+                            .map(|m| format!("{}.", self.display_ref(m)))
+                            .unwrap_or_default(),
                     };
                     let type_str = self.interner.resolve(&*type_name);
                     let fields = self.rir.get_field_inits(*fields_start, *fields_len);
                     let fields_str: Vec<String> = fields
                         .iter()
                         .map(|(fname, value)| {
-                            format!("{}: {}", self.interner.resolve(&*fname), value)
+                            format!(
+                                "{}: {}",
+                                self.interner.resolve(&*fname),
+                                self.display_ref(*value)
+                            )
                         })
                         .collect();
                     writeln!(
@@ -2292,15 +2576,21 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     .unwrap();
                 }
                 InstData::FieldGet { base, field } => {
-                    writeln!(out, "field_get {}.{}", base, self.interner.resolve(&*field)).unwrap();
+                    writeln!(
+                        out,
+                        "field_get {}.{}",
+                        self.display_ref(*base),
+                        self.interner.resolve(&*field)
+                    )
+                    .unwrap();
                 }
                 InstData::FieldSet { base, field, value } => {
                     writeln!(
                         out,
                         "field_set {}.{} = {}",
-                        base,
+                        self.display_ref(*base),
                         self.interner.resolve(&*field),
-                        value
+                        self.display_ref(*value)
                     )
                     .unwrap();
                 }
@@ -2351,7 +2641,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     type_name,
                     variant,
                 } => {
-                    let module_str = module.map(|m| format!("{}.", m)).unwrap_or_default();
+                    let module_str = module
+                        .map(|m| format!("{}.", self.display_ref(m)))
+                        .unwrap_or_default();
                     writeln!(
                         out,
                         "enum_variant {}{}::{}",
@@ -2368,8 +2660,10 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     elems_len,
                 } => {
                     let elements = self.rir.get_inst_refs(*elems_start, *elems_len);
-                    let elems_str: Vec<String> =
-                        elements.iter().map(|e| format!("{}", e)).collect();
+                    let elems_str: Vec<String> = elements
+                        .iter()
+                        .map(|e| self.display_ref(*e).to_string())
+                        .collect();
                     writeln!(out, "array_init [{}]", elems_str.join(", ")).unwrap();
                 }
                 InstData::ArrayRepeat { value, count } => {
@@ -2379,13 +2673,32 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                             format!("sym:{}", sym.into_usize())
                         }
                     };
-                    writeln!(out, "array_repeat [{}; {}]", value, count_str).unwrap();
+                    writeln!(
+                        out,
+                        "array_repeat [{}; {}]",
+                        self.display_ref(*value),
+                        count_str
+                    )
+                    .unwrap();
                 }
                 InstData::IndexGet { base, index } => {
-                    writeln!(out, "index_get {}[{}]", base, index).unwrap();
+                    writeln!(
+                        out,
+                        "index_get {}[{}]",
+                        self.display_ref(*base),
+                        self.display_ref(*index)
+                    )
+                    .unwrap();
                 }
                 InstData::IndexSet { base, index, value } => {
-                    writeln!(out, "index_set {}[{}] = {}", base, index, value).unwrap();
+                    writeln!(
+                        out,
+                        "index_set {}[{}] = {}",
+                        self.display_ref(*base),
+                        self.display_ref(*index),
+                        self.display_ref(*value)
+                    )
+                    .unwrap();
                 }
 
                 // Methods
@@ -2399,9 +2712,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     writeln!(
                         out,
                         "method_call {}.{}({})",
-                        receiver,
+                        self.display_ref(*receiver),
                         self.interner.resolve(&*method),
-                        Self::format_call_args(&args)
+                        self.format_call_args(&args)
                     )
                     .unwrap();
                 }
@@ -2417,7 +2730,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         "assoc_fn_call {}::{}({})",
                         self.interner.resolve(&*type_name),
                         self.interner.resolve(&*function),
-                        Self::format_call_args(&args)
+                        self.format_call_args(&args)
                     )
                     .unwrap();
                 }
@@ -2430,18 +2743,18 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         self.interner.resolve(&*type_name)
                     )
                     .unwrap();
-                    writeln!(out, "    {}", body).unwrap();
+                    writeln!(out, "    {}", self.display_ref(*body)).unwrap();
                     writeln!(out, "}}").unwrap();
                 }
 
                 // Comptime block
                 InstData::Comptime { expr } => {
-                    writeln!(out, "comptime {{ {} }}", expr).unwrap();
+                    writeln!(out, "comptime {{ {} }}", self.display_ref(*expr)).unwrap();
                 }
 
                 // Checked block
                 InstData::Checked { expr } => {
-                    writeln!(out, "checked {{ {} }}", expr).unwrap();
+                    writeln!(out, "checked {{ {} }}", self.display_ref(*expr)).unwrap();
                 }
 
                 // Type constant
@@ -2470,8 +2783,10 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     // Print methods if any
                     if *methods_len > 0 {
                         let methods = self.rir.get_inst_refs(*methods_start, *methods_len);
-                        let methods_str: Vec<String> =
-                            methods.iter().map(|m| format!("{}", m)).collect();
+                        let methods_str: Vec<String> = methods
+                            .iter()
+                            .map(|m| self.display_ref(*m).to_string())
+                            .collect();
                         if !fields.is_empty() {
                             write!(out, ", ").unwrap();
                         }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -15,14 +15,13 @@ mod timing;
 
 use rue_compiler::{
     CanonicalFrontendArtifacts, CanonicalPipelineWork, CompileError, CompileErrors, CompileOptions,
-    CompileState, CompileWarning, ErrorKind, FileId, Lexer, LinkerMode, MAX_SOURCE_BYTES,
-    MultiFileFormatter, MultiFileJsonFormatter, OptLevel, ParsedProgram, PreviewFeature,
-    PreviewFeatures, SourceInfo, SourceMetadata, SourceSnapshot, Span, TokenKind,
-    compile_source_snapshot_with_options, compile_source_snapshot_with_options_and_stats,
-    configure_thread_pool, generate_emitted_asm, generate_liveness_info, generate_lowering_info,
-    generate_mir, generate_regalloc_info, generate_stack_frame_info, import_candidate_groups,
-    merge_symbols, parse_all_files_with_source_snapshot,
-    parse_source_snapshot_for_ast_presentation, query_canonical_frontend,
+    CompileWarning, ErrorKind, FileId, Lexer, LinkerMode, MAX_SOURCE_BYTES, MultiFileFormatter,
+    MultiFileJsonFormatter, OptLevel, PreviewFeature, PreviewFeatures, SourceInfo, SourceMetadata,
+    SourceSnapshot, Span, TokenKind, compile_source_snapshot_with_options,
+    compile_source_snapshot_with_options_and_stats, configure_thread_pool, generate_emitted_asm,
+    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
+    generate_stack_frame_info, import_candidate_groups, parse_source_snapshot_for_ast_presentation,
+    query_canonical_frontend,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -57,26 +56,21 @@ enum EmitStage {
     Deps,
 }
 
-enum EmitFrontend {
-    Canonical(Box<CanonicalFrontendArtifacts>),
-    LegacyRir(Box<CompileState>),
-}
+struct EmitFrontend(Box<CanonicalFrontendArtifacts>);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EmitFrontendRoute {
     None,
-    AstOnlyLegacy,
+    AstOnlySyntax,
     Canonical,
-    LegacyRir,
 }
 
 fn emit_frontend_route(stages: &[EmitStage]) -> EmitFrontendRoute {
-    if stages.contains(&EmitStage::Rir) {
-        EmitFrontendRoute::LegacyRir
-    } else if stages.iter().any(|stage| {
+    if stages.iter().any(|stage| {
         matches!(
             stage,
-            EmitStage::Air
+            EmitStage::Rir
+                | EmitStage::Air
                 | EmitStage::Cfg
                 | EmitStage::Lowering
                 | EmitStage::Mir
@@ -88,7 +82,7 @@ fn emit_frontend_route(stages: &[EmitStage]) -> EmitFrontendRoute {
     }) {
         EmitFrontendRoute::Canonical
     } else if stages.contains(&EmitStage::Ast) {
-        EmitFrontendRoute::AstOnlyLegacy
+        EmitFrontendRoute::AstOnlySyntax
     } else {
         EmitFrontendRoute::None
     }
@@ -103,52 +97,31 @@ fn build_canonical_emit_frontend(
 
 impl EmitFrontend {
     fn rir(&self) -> &rue_compiler::Rir {
-        match self {
-            Self::Canonical(frontend) => frontend.rir().rir(),
-            Self::LegacyRir(state) => &state.rir,
-        }
+        self.0.rir().rir()
     }
 
     fn interner(&self) -> &rue_compiler::ThreadedRodeo {
-        match self {
-            Self::Canonical(frontend) => frontend.interner(),
-            Self::LegacyRir(state) => &state.interner,
-        }
+        self.0.interner()
     }
 
     fn functions(&self) -> &[rue_compiler::FunctionWithCfg] {
-        match self {
-            Self::Canonical(frontend) => frontend.semantic().functions(),
-            Self::LegacyRir(state) => &state.functions,
-        }
+        self.0.semantic().functions()
     }
 
     fn type_pool(&self) -> &rue_compiler::TypeInternPool {
-        match self {
-            Self::Canonical(frontend) => frontend.semantic().type_pool(),
-            Self::LegacyRir(state) => &state.type_pool,
-        }
+        self.0.semantic().type_pool()
     }
 
     fn strings(&self) -> &[String] {
-        match self {
-            Self::Canonical(frontend) => frontend.semantic().strings(),
-            Self::LegacyRir(state) => &state.strings,
-        }
+        self.0.semantic().strings()
     }
 
     fn warnings(&self) -> &[CompileWarning] {
-        match self {
-            Self::Canonical(frontend) => frontend.semantic().warnings(),
-            Self::LegacyRir(state) => &state.warnings,
-        }
+        self.0.semantic().warnings()
     }
 
-    fn canonical_work(&self) -> Option<CanonicalPipelineWork> {
-        match self {
-            Self::Canonical(frontend) => Some(frontend.work()),
-            Self::LegacyRir(_) => None,
-        }
+    fn canonical_work(&self) -> CanonicalPipelineWork {
+        self.0.work()
     }
 }
 
@@ -2119,28 +2092,11 @@ fn handle_emit_multi_file(
         None
     };
 
-    // Exact RIR text remains caller-positional. Keep that one presentation
-    // route isolated until it has a read-only InstRef remapping printer; every
-    // other frontend emit consumes the canonical unit artifacts.
     let frontend_route = emit_frontend_route(&options.emit_stages);
-    let needs_legacy_rir = frontend_route == EmitFrontendRoute::LegacyRir;
-    let needs_legacy_parse = frontend_route == EmitFrontendRoute::LegacyRir;
-    let mut parsed: Option<ParsedProgram> = if needs_legacy_parse {
-        match parse_all_files_with_source_snapshot(source_snapshot) {
-            Ok(program) => Some(program),
-            Err(errors) => {
-                diagnostics.print_errors(&errors);
-                return Err(());
-            }
-        }
-    } else {
-        None
-    };
-
     // AST-only preserves its syntax-only behavior (duplicates are printable).
     // Combined AST+later canonical modes reuse the unit's once-only projection.
     let mut per_file_asts: Option<Vec<(String, std::sync::Arc<rue_compiler::Ast>)>> =
-        if frontend_route == EmitFrontendRoute::AstOnlyLegacy {
+        if frontend_route == EmitFrontendRoute::AstOnlySyntax {
             match parse_source_snapshot_for_ast_presentation(source_snapshot) {
                 Ok(presentation) => {
                     debug_assert_eq!(
@@ -2154,51 +2110,11 @@ fn handle_emit_multi_file(
                     return Err(());
                 }
             }
-        } else if needs_ast {
-            parsed.as_ref().map(|program| {
-                program
-                    .files
-                    .iter()
-                    .map(|f| (f.path.clone(), f.ast.clone()))
-                    .collect()
-            })
         } else {
             None
         };
 
-    // Merge symbols and compile frontend (needed for later stages)
-    let frontend_state = if needs_legacy_rir {
-        // Take ownership of the parsed program (already parsed above)
-        let program = parsed
-            .take()
-            .expect("legacy RIR route parses before merging");
-
-        let merged = match merge_symbols(program) {
-            Ok(m) => m,
-            Err(errors) => {
-                diagnostics.print_errors(&errors);
-                return Err(());
-            }
-        };
-
-        let state =
-            match rue_compiler::compile_frontend_from_merged_ast_with_source_metadata_and_target(
-                merged.ast,
-                merged.interner,
-                options.opt_level,
-                &options.preview_features,
-                options.target,
-                source_snapshot.metadata(),
-            ) {
-                Ok(state) => state,
-                Err(errors) => {
-                    diagnostics.print_errors(&errors);
-                    return Err(());
-                }
-            };
-
-        Some(EmitFrontend::LegacyRir(Box::new(state)))
-    } else if frontend_route == EmitFrontendRoute::Canonical {
+    let frontend_state = if frontend_route == EmitFrontendRoute::Canonical {
         let compile_options = CompileOptions {
             target: options.target,
             linker: options.linker.clone(),
@@ -2228,19 +2144,18 @@ fn handle_emit_multi_file(
                     .collect(),
             );
         }
-        Some(EmitFrontend::Canonical(Box::new(frontend)))
+        Some(EmitFrontend(Box::new(frontend)))
     } else {
         None
     };
     if let Some(state) = &frontend_state {
         // Warnings used to be silently dropped in all --emit modes (RUE-130).
         diagnostics.print_warnings(state.warnings());
-        if let Some(work) = state.canonical_work() {
-            debug_assert_eq!(work.parsed.syntax.parser_invocations, source_snapshot.len());
-            debug_assert_eq!(work.lowered.parser_invocations, 0);
-            debug_assert_eq!(work.semantic.binding.bind_invocations, 1);
-            debug_assert_eq!(work.semantic.manifest.build_invocations, 1);
-        }
+        let work = state.canonical_work();
+        debug_assert_eq!(work.parsed.syntax.parser_invocations, source_snapshot.len());
+        debug_assert_eq!(work.lowered.parser_invocations, 0);
+        debug_assert_eq!(work.semantic.binding.bind_invocations, 1);
+        debug_assert_eq!(work.semantic.manifest.build_invocations, 1);
     }
 
     use std::fmt::Write as _;
@@ -2271,7 +2186,16 @@ fn handle_emit_multi_file(
             EmitStage::Rir => {
                 println!("=== RIR ===");
                 if let Some(ref state) = frontend_state {
-                    let printer = RirPrinter::new(state.rir(), state.interner());
+                    let order = state
+                        .0
+                        .rir()
+                        .presentation_order(source_snapshot.files().map(|source| source.file_id));
+                    let printer = RirPrinter::with_presentation_order(
+                        state.rir(),
+                        state.interner(),
+                        order.instructions,
+                        order.extra,
+                    );
                     println!("{}", printer);
                 }
                 println!();
@@ -2465,6 +2389,7 @@ fn handle_emit_multi_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_compiler::parse_all_files_with_source_snapshot;
 
     struct TestDir {
         path: PathBuf,
@@ -2785,8 +2710,9 @@ mod tests {
     // ========== --emit tests ==========
 
     #[test]
-    fn emit_frontend_routes_isolate_only_exact_rir_and_ast_only_compatibility() {
+    fn rir_and_later_emits_share_the_canonical_frontend_route() {
         for stage in [
+            EmitStage::Rir,
             EmitStage::Air,
             EmitStage::Cfg,
             EmitStage::Lowering,
@@ -2804,11 +2730,11 @@ mod tests {
         );
         assert_eq!(
             emit_frontend_route(&[EmitStage::Rir, EmitStage::Air]),
-            EmitFrontendRoute::LegacyRir
+            EmitFrontendRoute::Canonical
         );
         assert_eq!(
             emit_frontend_route(&[EmitStage::Ast]),
-            EmitFrontendRoute::AstOnlyLegacy
+            EmitFrontendRoute::AstOnlySyntax
         );
         assert_eq!(
             emit_frontend_route(&[EmitStage::Tokens]),
@@ -2851,6 +2777,9 @@ mod tests {
         assert_eq!(work.lowered.ast_payload_clones, 0);
         assert_eq!(work.semantic.binding.bind_invocations, 1);
         assert_eq!(work.semantic.manifest.build_invocations, 1);
+        assert_eq!(work.semantic.cfg.cfg_builds_attempted, 2);
+        assert_eq!(work.semantic.cfg.cfg_builds_succeeded, 2);
+        assert_eq!(work.semantic.cfg.cfg_builds_failed, 0);
         let session_work = frontend.session_work();
         assert_eq!(session_work.updates, 1);
         assert_eq!(session_work.merge.executions, 1);


### PR DESCRIPTION
## Summary

- add a read-only canonical RIR presentation order that remaps displayed instruction and payload indices without mutating canonical artifacts
- record per-module instruction/payload ranges during the single canonical lowering
- route RIR-only and combined RIR emits through `CanonicalFrontendArtifacts`
- remove `LegacyRir` routing and the emit-only compatibility parse/merge/lower sequence
- preserve syntax-only AST and token behavior

## Why

Requesting `--emit rir` previously selected a separate AST-based frontend and, for combined emits, performed duplicate lowering. RIR presentation now remains caller-order compatible while all semantic emit modes consume the same canonical session artifacts.

## Validation

- `scripts/rue quick` — 23/23 targets passed independently after integration
- `scripts/rue cli emit_pipeline` — 13/13 cases passed
- exact canonical-vs-legacy RIR presentation parity, including `InstRef` and block payload offsets
- relocation and source/logical-order coverage
- structural assertions pin one session update, merge, RIR execution, bind, manifest, and expected CFG builds
- host `rustfmt --edition 2024 --check ...` passed for all touched Rust files
- full-run reproducibility, UI (176/176), traceability (738/738 normative), wrapper, cleanup, and unit layers passed

The local concurrent full suite again exhausted the generated oracle's 2-second per-phase timeout budget while other long-running suites were active. Isolated verification reached 63/64 at 2 seconds; the remaining seed agreed at a 10-second timeout. The repository formatter's bundled rustfmt artifact also intermittently cannot load its `librustc_driver` dylib; host rustfmt passes. CI is the final clean cross-platform/full-suite gate.

Fixes RUE-728
