### PR TITLE
RUE-733: Migrate consumers to canonical frontend queries

### DIFF
--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -48,6 +48,10 @@ pub struct CanonicalRirPresentationOrder {
 }
 
 impl CanonicalRirOutput {
+    pub(crate) fn into_parts(self) -> (Rir, SemanticSymbolUniverse) {
+        (self.rir, self.symbols)
+    }
+
     pub fn source_revision(&self) -> &SourceRevision {
         &self.source_revision
     }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -173,6 +173,17 @@ pub struct CanonicalSemanticOutput {
 }
 
 impl CanonicalSemanticOutput {
+    pub(crate) fn into_frontend_parts(
+        self,
+    ) -> (
+        Vec<FunctionWithCfg>,
+        TypeInternPool,
+        Vec<String>,
+        Vec<CompileWarning>,
+    ) {
+        (self.functions, self.type_pool, self.strings, self.warnings)
+    }
+
     /// Exact semantic and optimization identity of this output.
     pub fn input(&self) -> &CodegenInputDescriptor {
         &self.input

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -1133,9 +1133,11 @@ pub fn compile_frontend_with_options(
     opt_level: OptLevel,
     preview_features: &PreviewFeatures,
 ) -> MultiErrorResult<CompileState> {
-    let mut options = CompileOptions::default();
-    options.opt_level = opt_level;
-    options.preview_features = preview_features.clone();
+    let options = CompileOptions {
+        opt_level,
+        preview_features: preview_features.clone(),
+        ..CompileOptions::default()
+    };
     query_canonical_frontend_source(source, &options)
         .map(CanonicalFrontendArtifacts::into_compile_state)
 }
@@ -2459,8 +2461,10 @@ pub fn compile_to_cfg_with_preview_features(
     source: &str,
     preview_features: &PreviewFeatures,
 ) -> MultiErrorResult<CompileState> {
-    let mut options = CompileOptions::default();
-    options.preview_features = preview_features.clone();
+    let options = CompileOptions {
+        preview_features: preview_features.clone(),
+        ..CompileOptions::default()
+    };
     query_canonical_frontend_source(source, &options)
         .map(CanonicalFrontendArtifacts::into_compile_state)
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -1117,7 +1117,8 @@ pub struct CompileOutput {
 /// Uses default optimization level (O0) and no preview features. For custom options,
 /// use [`compile_frontend_with_options`].
 pub fn compile_frontend(source: &str) -> MultiErrorResult<CompileState> {
-    compile_frontend_with_options(source, OptLevel::default(), &PreviewFeatures::new())
+    query_canonical_frontend_source(source, &CompileOptions::default())
+        .map(CanonicalFrontendArtifacts::into_compile_state)
 }
 
 /// Compile source code through all frontend phases with optimization.
@@ -1132,27 +1133,11 @@ pub fn compile_frontend_with_options(
     opt_level: OptLevel,
     preview_features: &PreviewFeatures,
 ) -> MultiErrorResult<CompileState> {
-    let _span = info_span!("frontend", source_bytes = source.len()).entered();
-
-    // Lexing - errors here are fatal (can't continue without tokens)
-    let (tokens, interner) = {
-        let _span = info_span!("lexer").entered();
-        let lexer = Lexer::new(source);
-        let (tokens, interner) = lexer.tokenize().map_err(CompileErrors::from)?;
-        info!(token_count = tokens.len(), "lexing complete");
-        (tokens, interner)
-    };
-
-    // Parsing - errors here are fatal (can't continue without AST)
-    let (ast, interner) = {
-        let _span = info_span!("parser").entered();
-        let parser = Parser::new(tokens, interner);
-        let (ast, interner) = parser.parse()?;
-        info!(item_count = ast.items.len(), "parsing complete");
-        (ast, interner)
-    };
-
-    compile_frontend_from_ast_with_options(ast, interner, opt_level, preview_features)
+    let mut options = CompileOptions::default();
+    options.opt_level = opt_level;
+    options.preview_features = preview_features.clone();
+    query_canonical_frontend_source(source, &options)
+        .map(CanonicalFrontendArtifacts::into_compile_state)
 }
 
 /// Compile from an already-parsed AST through all remaining frontend phases.
@@ -1660,6 +1645,91 @@ impl CanonicalFrontendArtifacts {
     pub fn interner(&self) -> &ThreadedRodeo {
         self.rir.semantic_symbols().interner()
     }
+
+    /// Consume the canonical artifacts as the inspection-oriented frontend state.
+    ///
+    /// This is an ownership projection only: parsing, lowering, binding, and CFG
+    /// construction have already happened in the canonical session query.
+    ///
+    /// This transitional projection exists for CFG consumers being migrated in
+    /// RUE-733 and is expected to narrow again when RUE-734/RUE-736 retire the
+    /// compatibility inspection structs. It cannot invoke or optimize phases.
+    pub fn into_compile_state(self) -> CompileState {
+        let parsed = Arc::try_unwrap(self.parsed)
+            .expect("one-shot canonical artifacts uniquely own their parsed program");
+        let rir =
+            Arc::try_unwrap(self.rir).expect("one-shot canonical artifacts uniquely own their RIR");
+        let semantic = Arc::try_unwrap(self.semantic)
+            .expect("one-shot canonical artifacts uniquely own their semantic output");
+        let ast = MergedAst {
+            files: parsed
+                .modules()
+                .iter()
+                .map(|module| module.shared_ast())
+                .collect(),
+        };
+        let (rir, symbols) = rir.into_parts();
+        let (functions, type_pool, strings, warnings) = semantic.into_frontend_parts();
+        CompileState {
+            ast,
+            interner: symbols.into_interner(),
+            rir,
+            functions,
+            type_pool,
+            strings,
+            warnings,
+        }
+    }
+
+    fn into_air_output(self) -> AirOutput {
+        let parsed = Arc::try_unwrap(self.parsed)
+            .expect("one-shot canonical artifacts uniquely own their parsed program");
+        let rir =
+            Arc::try_unwrap(self.rir).expect("one-shot canonical artifacts uniquely own their RIR");
+        let semantic = Arc::try_unwrap(self.semantic)
+            .expect("one-shot canonical artifacts uniquely own their semantic output");
+        let ast = parsed
+            .modules()
+            .first()
+            .expect("single-source canonical query has one module")
+            .ast()
+            .clone();
+        let (rir, symbols) = rir.into_parts();
+        let (functions, type_pool, strings, warnings) = semantic.into_frontend_parts();
+        AirOutput {
+            ast,
+            interner: symbols.into_interner(),
+            rir,
+            functions: functions
+                .into_iter()
+                .map(|function| function.analyzed)
+                .collect(),
+            type_pool,
+            strings,
+            warnings,
+        }
+    }
+}
+
+/// Query the canonical frontend for one anonymous in-memory source.
+///
+/// This thin adapter exists for fuzzers, oracles, and tests that do not have a
+/// filesystem import graph. It preserves the legacy anonymous source identity
+/// while routing all phase work through [`CanonicalFrontendSession`].
+pub fn query_canonical_frontend_source(
+    source: &str,
+    options: &CompileOptions,
+) -> MultiErrorResult<CanonicalFrontendArtifacts> {
+    let source_file = SourceFile::new("<source>", source, FileId::DEFAULT);
+    let metadata = SourceMetadata::new(
+        FileId::DEFAULT,
+        [(FileId::DEFAULT, "<source>".to_owned())].into(),
+        [(FileId::DEFAULT, "<source>".to_owned())].into(),
+    )
+    .map_err(CompileErrors::from)?;
+    let snapshot =
+        SourceSnapshot::from_sources(&[source_file], metadata).map_err(CompileErrors::from)?;
+    query_canonical_frontend(&snapshot, options)
 }
 
 /// Update a fresh canonical session and query its complete frontend artifacts.
@@ -2355,31 +2425,8 @@ pub struct AirOutput {
 /// assert!(result.is_ok());
 /// ```
 pub fn compile_to_air(source: &str) -> MultiErrorResult<AirOutput> {
-    // Lexing
-    let lexer = Lexer::new(source);
-    let (tokens, interner) = lexer.tokenize().map_err(CompileErrors::from)?;
-
-    // Parsing
-    let parser = Parser::new(tokens, interner);
-    let (ast, interner) = parser.parse()?;
-
-    // AST to RIR (untyped IR)
-    let astgen = AstGen::new(&ast, &interner);
-    let rir = astgen.generate();
-
-    // Semantic analysis (RIR to AIR)
-    let sema = Sema::new(&rir, &interner, PreviewFeatures::new());
-    let sema_output = sema.analyze_all()?;
-
-    Ok(AirOutput {
-        ast,
-        interner,
-        rir,
-        functions: sema_output.functions,
-        type_pool: sema_output.type_pool,
-        strings: sema_output.strings,
-        warnings: sema_output.warnings,
-    })
+    query_canonical_frontend_source(source, &CompileOptions::default())
+        .map(CanonicalFrontendArtifacts::into_air_output)
 }
 
 /// Compile source code up to CFG (control flow graph).
@@ -2399,7 +2446,8 @@ pub fn compile_to_air(source: &str) -> MultiErrorResult<AirOutput> {
 /// assert_eq!(state.functions.len(), 1);
 /// ```
 pub fn compile_to_cfg(source: &str) -> MultiErrorResult<CompileState> {
-    compile_frontend(source)
+    query_canonical_frontend_source(source, &CompileOptions::default())
+        .map(CanonicalFrontendArtifacts::into_compile_state)
 }
 
 /// Compile source code up to CFG with explicit preview features enabled.
@@ -2411,12 +2459,33 @@ pub fn compile_to_cfg_with_preview_features(
     source: &str,
     preview_features: &PreviewFeatures,
 ) -> MultiErrorResult<CompileState> {
-    compile_frontend_with_options(source, OptLevel::default(), preview_features)
+    let mut options = CompileOptions::default();
+    options.preview_features = preview_features.clone();
+    query_canonical_frontend_source(source, &options)
+        .map(CanonicalFrontendArtifacts::into_compile_state)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_single_source_adapter_executes_each_frontend_phase_once() {
+        let frontend =
+            query_canonical_frontend_source("fn main() -> i32 { 42 }", &CompileOptions::default())
+                .unwrap();
+        let work = frontend.work();
+        let session = frontend.session_work();
+        assert_eq!(work.parsed.syntax.parser_invocations, 1);
+        assert_eq!(session.rir.executions, 1);
+        assert_eq!(work.lowered.modules_visited, 1);
+        assert_eq!(work.semantic.binding.bind_invocations, 1);
+        assert_eq!(work.semantic.cfg.cfg_builds_attempted, 1);
+        assert_eq!(work.semantic.cfg.cfg_builds_succeeded, 1);
+
+        let state = frontend.into_compile_state();
+        assert_eq!(state.functions.len(), 1);
+    }
 
     fn assert_invalid_compiler_input(errors: CompileErrors, expected: &str) {
         assert_eq!(errors.len(), 1);

--- a/crates/rue-compiler/src/semantic_symbols.rs
+++ b/crates/rue-compiler/src/semantic_symbols.rs
@@ -46,6 +46,10 @@ pub struct SemanticSymbolUniverse {
 }
 
 impl SemanticSymbolUniverse {
+    pub(crate) fn into_interner(self) -> ThreadedRodeo {
+        self.interner
+    }
+
     /// Start a destination universe for one canonical program traversal.
     pub fn new(program: &ParsedProgram) -> Self {
         let universe = Self::from_modules(program.modules());

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -89,7 +89,7 @@ impl FuzzTarget for ParserTarget {
 /// - Type IDs are valid
 /// - Symbol references exist in the interner
 ///
-/// Currently uses source-level fuzzing through compile_frontend.
+/// Uses source-level fuzzing through the canonical frontend session.
 /// Future enhancement: structured RIR generation with Arbitrary trait.
 pub struct SemaTarget;
 
@@ -101,13 +101,16 @@ impl FuzzTarget for SemaTarget {
     fn fuzz(&self, input: &[u8]) {
         // Only test valid UTF-8
         if let Ok(source) = std::str::from_utf8(input) {
-            // compile_frontend runs through sema (semantic analysis)
+            // The canonical frontend runs through sema (semantic analysis)
             // without code generation. This tests:
             // - Type inference (Hindley-Milner with Algorithm W)
             // - Affine type checking (partial moves, linearity)
             // - Name resolution
             // - Multi-error collection
-            let result = rue_compiler::compile_frontend(source);
+            let result = rue_compiler::query_canonical_frontend_source(
+                source,
+                &rue_compiler::CompileOptions::default(),
+            );
             assert_no_ice(&result);
         }
     }
@@ -126,9 +129,12 @@ impl FuzzTarget for CompilerTarget {
     fn fuzz(&self, input: &[u8]) {
         // Only test valid UTF-8
         if let Ok(source) = std::str::from_utf8(input) {
-            // Use compile_frontend to avoid code generation (which is slower)
+            // Query the canonical frontend without code generation (which is slower)
             // and focus on the analysis phases where bugs are more likely
-            let result = rue_compiler::compile_frontend(source);
+            let result = rue_compiler::query_canonical_frontend_source(
+                source,
+                &rue_compiler::CompileOptions::default(),
+            );
             assert_no_ice(&result);
         }
     }

--- a/crates/rue-oracle-diff/src/generator.rs
+++ b/crates/rue-oracle-diff/src/generator.rs
@@ -956,7 +956,11 @@ impl Program {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rue_compiler::compile_to_cfg;
+    use rue_compiler::{CompileOptions, query_canonical_frontend_source};
+
+    fn compile_to_cfg(source: &str) -> rue_compiler::MultiErrorResult<()> {
+        query_canonical_frontend_source(source, &CompileOptions::default()).map(|_| ())
+    }
 
     const COMPILE_CONTRACT_SEEDS: u64 = 500;
 

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1,7 +1,7 @@
 //! # rue-oracle — the executable reference semantics
 //!
 //! A tree-walking interpreter over the compiler's **CFG** (the typed
-//! control-flow IR, produced by [`rue_compiler::compile_to_cfg`], *before* the
+//! control-flow IR, produced by the canonical frontend session, *before* the
 //! MIR/codegen lowering where every miscompile of the 2026-07 work lived).
 //! Running a program through this interpreter and through the compiled binary
 //! and comparing the observable behavior (exit code, stdout, stderr, trap cause)
@@ -68,12 +68,25 @@ use lasso::ThreadedRodeo;
 use rue_air::{Type, TypeKind, parse_array_type_syntax};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
 use rue_compiler::{
-    CompileErrors, CompileState, PreviewFeatures, compile_to_cfg,
-    compile_to_cfg_with_preview_features,
+    CompileErrors, CompileOptions, CompileState, PreviewFeatures, query_canonical_frontend_source,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
+
+fn compile_to_cfg(source: &str) -> Result<CompileState, CompileErrors> {
+    query_canonical_frontend_source(source, &CompileOptions::default())
+        .map(|frontend| frontend.into_compile_state())
+}
+
+fn compile_to_cfg_with_preview_features(
+    source: &str,
+    preview_features: &PreviewFeatures,
+) -> Result<CompileState, CompileErrors> {
+    let mut options = CompileOptions::default();
+    options.preview_features = preview_features.clone();
+    query_canonical_frontend_source(source, &options).map(|frontend| frontend.into_compile_state())
+}
 
 /// A modeled oracle trap category.
 ///

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -83,8 +83,10 @@ fn compile_to_cfg_with_preview_features(
     source: &str,
     preview_features: &PreviewFeatures,
 ) -> Result<CompileState, CompileErrors> {
-    let mut options = CompileOptions::default();
-    options.preview_features = preview_features.clone();
+    let options = CompileOptions {
+        preview_features: preview_features.clone(),
+        ..CompileOptions::default()
+    };
     query_canonical_frontend_source(source, &options).map(|frontend| frontend.into_compile_state())
 }
 


### PR DESCRIPTION
## Summary

- add a thin single-source adapter over the canonical frontend session
- migrate compiler compatibility helpers, fuzz targets, oracle execution/tests, and oracle-diff generator validation onto canonical artifacts
- add a consuming transitional projection that only moves already-built canonical AST/RIR/semantic/CFG artifacts into existing inspection structs
- preserve target, optimization, preview features, anonymous source identity, diagnostics, and malformed-input behavior
- pin exactly one parser, RIR execution/lower, bind, and CFG build

## Why

Fuzz, oracle, and many tests still exercised hand-assembled compatibility frontend paths rather than the production session. They now validate the same canonical parsed modules, lowering, semantics, and CFG construction used by batch compilation.

## Validation

- `scripts/rue quick` — 23/23 targets passed independently after integration
- compiler tests — 458/458 passed
- oracle spec-corpus audit reports zero frontend failures, oracle failures, or disagreements
- source audit finds no qualified calls/imports of `compile_frontend`, `compile_to_air`, or `compile_to_cfg` in fuzz/oracle/oracle-diff consumers
- host rustfmt check passed for all seven touched files
- full-run unit layers, oracle corpus audits, UI (176/176), reproducibility, wrapper, and cleanup tests passed locally

The concurrent local full suite again exhausted generated-smoke's 2-second compiled-process timeout while other long-running suites were active, then left spec actions stalled. The clean quick suite, focused compiler suite, and oracle corpus audit pass; CI is the authoritative isolated full-suite/cross-platform gate.

Fixes RUE-733
