### PR TITLE
Resolve module bindings from the declaration index

### DIFF
--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -1,12 +1,16 @@
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use crate::inst::{AirArgMode, AirInstData, AirRef};
     use crate::sema::{Sema, SemaOutput};
     use crate::types::Type;
+    use lasso::ThreadedRodeo;
     use rue_error::{CompileErrors, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures};
     use rue_lexer::Lexer;
     use rue_parser::Parser;
-    use rue_rir::{AstGen, RirParamMode};
+    use rue_rir::{AstGen, Rir, RirParamMode};
+    use rue_span::FileId;
 
     fn compile_to_air(source: &str) -> MultiErrorResult<SemaOutput> {
         compile_to_air_with_preview_features(source, PreviewFeatures::new())
@@ -26,6 +30,21 @@ mod tests {
 
         let sema = Sema::new(&rir, &mut interner, preview_features);
         sema.analyze_all()
+    }
+
+    fn lower_files(files: &[(&str, FileId)]) -> (Rir, ThreadedRodeo) {
+        let mut interner = ThreadedRodeo::default();
+        let mut items = Vec::new();
+        for &(source, file_id) in files {
+            let (tokens, next) = Lexer::with_interner_and_file_id(source, interner, file_id)
+                .tokenize()
+                .unwrap();
+            let (ast, next) = Parser::new(tokens, next).parse().unwrap();
+            items.extend(ast.items);
+            interner = next;
+        }
+        let rir = AstGen::new(&rue_parser::Ast { items }, &mut interner).generate();
+        (rir, interner)
     }
 
     #[test]
@@ -395,6 +414,56 @@ mod tests {
 
         let output = bound.analyze_all_bodies().unwrap();
         assert_eq!(output.body_analysis_work.bodies_succeeded, 2);
+        assert_eq!(output.body_analysis_work.bodies_failed, 0);
+        assert_eq!(
+            output.body_analysis_work.reachable_declaration_rir_visits,
+            0
+        );
+    }
+
+    #[test]
+    fn late_qualified_import_types_use_one_declaration_index() {
+        // Put every import after the declaration that uses it. Binding must
+        // resolve each dependency from the declaration index; qualified type
+        // lookup must never rediscover an import by scanning the full RIR.
+        const IMPORT_COUNT: usize = 64;
+        let mut main = String::from("struct Holder {\n");
+        for index in 0..IMPORT_COUNT {
+            main.push_str(&format!("field{index}: dep{index}.Item,\n"));
+        }
+        main.push_str("}\nfn main() {}\n");
+        for index in 0..IMPORT_COUNT {
+            main.push_str(&format!(
+                "const dep{index} = @import(\"dep{index}.rue\");\n"
+            ));
+        }
+
+        let dependencies = (0..IMPORT_COUNT)
+            .map(|_| "pub struct Item { value: i32 }")
+            .collect::<Vec<_>>();
+        let mut files = vec![(main.as_str(), FileId::DEFAULT)];
+        files.extend(
+            dependencies
+                .iter()
+                .enumerate()
+                .map(|(index, source)| (*source, FileId::new((index + 1) as u32))),
+        );
+        let (rir, mut interner) = lower_files(&files);
+
+        let mut paths = HashMap::from([(FileId::DEFAULT, "/main.rue".to_string())]);
+        for index in 0..IMPORT_COUNT {
+            paths.insert(FileId::new((index + 1) as u32), format!("/dep{index}.rue"));
+        }
+        let mut sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
+        sema.set_root_file_id(FileId::DEFAULT);
+        sema.set_file_paths(paths);
+
+        let bound = sema.bind_declarations().unwrap();
+        let binding_work = bound.binding_work();
+        assert_eq!(binding_work.declaration_index_build_invocations, 1);
+        assert_eq!(binding_work.indexed_const_candidates, IMPORT_COUNT);
+
+        let output = bound.analyze_all_bodies().unwrap();
         assert_eq!(output.body_analysis_work.bodies_failed, 0);
         assert_eq!(
             output.body_analysis_work.reachable_declaration_rir_visits,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 
 use lasso::Spur;
 use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
-use rue_rir::InstData;
 use rue_span::{FileId, Span};
 
 use super::Sema;
@@ -22,7 +21,7 @@ use super::context::AnalysisContext;
 pub(crate) const MAX_TYPE_SIZE_BYTES: u64 = i32::MAX as u64;
 /// [`MAX_TYPE_SIZE_BYTES`] expressed in 8-byte ABI slots.
 pub(crate) const MAX_TYPE_SLOTS: u64 = MAX_TYPE_SIZE_BYTES / 8;
-use super::info::{ConstInfo, FunctionInfo};
+use super::info::FunctionInfo;
 use crate::inference::InferType;
 use crate::sema::ConstValue;
 use crate::types::{
@@ -1233,12 +1232,7 @@ impl<'a> Sema<'a> {
             ));
         };
         let first_sym = self.interner.get_or_intern(first);
-        let Some(binding) = self
-            .module_bindings
-            .get(&(root_file, first_sym))
-            .cloned()
-            .or_else(|| self.resolve_direct_import_module_binding(root_file, first_sym, span))
-        else {
+        let Some(binding) = self.resolve_module_binding_in_file(root_file, first_sym) else {
             return Err(CompileError::new(
                 ErrorKind::UnknownType((*first).to_string()),
                 span,
@@ -1262,13 +1256,7 @@ impl<'a> Sema<'a> {
                     span,
                 ));
             };
-            let Some(binding) = self
-                .module_bindings
-                .get(&(module_file_id, segment_sym))
-                .cloned()
-                .or_else(|| {
-                    self.resolve_direct_import_module_binding(module_file_id, segment_sym, span)
-                })
+            let Some(binding) = self.resolve_module_binding_in_file(module_file_id, segment_sym)
             else {
                 return Err(CompileError::new(
                     ErrorKind::UnknownModuleMember {
@@ -1300,63 +1288,28 @@ impl<'a> Sema<'a> {
         Ok((module_id, module_file_id, module_file_path))
     }
 
-    fn resolve_direct_import_module_binding(
+    /// Look up a module binding in the declaration namespace.
+    ///
+    /// While declaration payloads are being bound, a qualified type may name
+    /// an import whose constant appears later in source order. Resolve that
+    /// dependency through the declaration index, exactly like any other
+    /// constant dependency. Once declaration binding completes, the table is
+    /// authoritative: body analysis never rediscovers imports or mutates the
+    /// source-declaration namespace after the [`super::BoundSema`] boundary.
+    fn resolve_module_binding_in_file(
         &mut self,
         file_id: FileId,
         name: Spur,
-        _span: Span,
-    ) -> Option<ConstInfo> {
-        let found = self.rir.iter().find_map(|(_inst_ref, inst)| {
-            let InstData::ConstDecl {
-                is_pub,
-                name: const_name,
-                init,
-                ..
-            } = inst.data
-            else {
-                return None;
-            };
-            if inst.span.file_id != file_id || const_name != name {
-                return None;
-            }
-            Some((is_pub, init, inst.span))
-        })?;
-
-        let (is_pub, init, const_span) = found;
-        let init_inst = self.rir.get(init);
-        let InstData::Intrinsic {
-            name: intrinsic_name,
-            args_start,
-            args_len,
-        } = &init_inst.data
-        else {
-            return None;
-        };
-        if *intrinsic_name != self.known.import || *args_len != 1 {
+    ) -> Option<super::info::ConstInfo> {
+        if let Some(binding) = self.module_bindings.get(&(file_id, name)) {
+            return Some(binding.clone());
+        }
+        if !self.declaration_binding_active {
             return None;
         }
-        let arg_refs = self.rir.get_inst_refs(*args_start, *args_len);
-        let arg_inst = self.rir.get(arg_refs[0]);
-        let InstData::StringConst(path_spur) = &arg_inst.data else {
-            return None;
-        };
-        let import_path = self.interner.resolve(path_spur).to_string();
-        let resolved_path = self
-            .resolve_import_path(&import_path, init_inst.span)
-            .ok()?;
-        let (module_id, _is_new) = self
-            .module_registry
-            .get_or_create(import_path, resolved_path);
-        let ty = Type::new_module(module_id);
-        let info = ConstInfo {
-            is_pub,
-            ty,
-            init,
-            value: ConstValue::Type(ty),
-            span: const_span,
-        };
-        self.module_bindings.insert((file_id, name), info.clone());
-        Some(info)
+
+        self.try_resolve_indexed_const_during_binding(name, file_id);
+        self.module_bindings.get(&(file_id, name)).cloned()
     }
 
     /// Resolve a type-function application written directly in type position


### PR DESCRIPTION
## What changed

- remove qualified module/type lookup's whole-RIR import rediscovery fallback
- resolve missing import constants through the canonical declaration index only during declaration binding
- make post-`BoundSema` module-binding misses authoritative and read-only
- add a 64-module regression with qualified field types preceding their imports

## Why

`resolve_direct_import_module_binding` linearly scanned the complete RIR and manually mutated the module namespace when qualified type lookup missed. With many late imports, this could produce import-count × RIR work and violated the declaration/body phase boundary.

The indexed constant resolver already owns declaration discovery and dependency ordering. Qualified module lookup now uses that resolver during binding and performs table-only reads afterward.

## Validation

- `./buck2 test //crates/rue-air:rue-air-test` — 414 passed
- `scripts/rue quick` — all 24 targets passed
- `git diff --check`

The implementation was produced by the delegated Luna High task and reviewed in the integration task.
