### PR TITLE
Close source function lookup after binding

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -46,6 +46,9 @@ use crate::types::{
 pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResult<SemaOutput> {
     debug_assert!(!sema.declaration_binding_active);
     debug_assert!(sema.const_resolution_in_progress.is_empty());
+    debug_assert!(sema.fn_signatures_in_flight.is_empty());
+    debug_assert!(sema.source_free_function_signatures_are_complete());
+    let bound_source_function_signature_count = sema.functions_by_file_name.len();
 
     // Declarations are complete: re-point destructor symbols of struct
     // names that span multiple files at their file-qualified form (RUE-571).
@@ -56,6 +59,12 @@ pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResul
     // ADR-0045 defines reachability from `main` as the function-body analysis
     // frontier for every executable.
     let result = analyze_function_bodies_lazy(&mut sema);
+    debug_assert_eq!(
+        sema.functions_by_file_name.len(),
+        bound_source_function_signature_count,
+        "body analysis may not insert or remove source function signatures"
+    );
+    debug_assert!(sema.source_free_function_signatures_are_complete());
 
     // Sema→CFG boundary invariant (RUE-153): a value may only carry the
     // `<error>` type as part of error recovery, i.e. when at least one

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -703,6 +703,16 @@ impl Sema<'_> {
 }
 
 impl<'a> BoundSema<'a> {
+    #[cfg(test)]
+    pub(crate) fn source_free_function_signatures_are_complete(&self) -> bool {
+        self.sema.source_free_function_signatures_are_complete()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn source_free_function_signature_count(&self) -> usize {
+        self.sema.functions_by_file_name.len()
+    }
+
     /// Install the compiler-issued identity universe used by ordinary body
     /// analysis. Installation is atomic and rejects duplicate, mixed-issuer,
     /// or non-existent endpoints.

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1396,9 +1396,12 @@ impl Sema<'_> {
             };
             module_file_id
         };
-        // Ensure the member's signature is collected, then require membership:
-        // the resolved function must actually be declared in the module's file.
-        self.ensure_free_function_signature(method, Some(module_file_id))?;
+        // Declaration binding may reach this call before its source-order
+        // signature pass. Once `BoundSema` exists, membership is read-only and
+        // a missing signature is authoritative.
+        if self.declaration_binding_active {
+            self.collect_free_function_signature_during_binding(method, Some(module_file_id))?;
+        }
         let function_key = self
             .resolve_function_name_local(method, module_file_id)
             .unwrap_or(method);
@@ -1524,7 +1527,7 @@ impl Sema<'_> {
         let (name_key, fn_info) = if let Some(info) = self.functions.get(&name).copied() {
             (name, info)
         } else {
-            // The callee may simply not be collected yet: declaration-bound
+            // During declaration binding, the callee may simply not be collected yet:
             // constant initializers and struct-field / enum-payload types can
             // evaluate before the source-order sweep reaches the callee's
             // `FnDecl` (RUE-603). Collect the evaluating expression's own file's
@@ -1533,7 +1536,9 @@ impl Sema<'_> {
             let Some(file_id) = env.defining_file else {
                 return Ok(None);
             };
-            self.ensure_free_function_signature(name, Some(file_id))?;
+            if self.declaration_binding_active {
+                self.collect_free_function_signature_during_binding(name, Some(file_id))?;
+            }
             let Some((key, info)) = self
                 .resolve_function_name_local(name, file_id)
                 .and_then(|key| self.functions.get(&key).copied().map(|info| (key, info)))

--- a/crates/rue-air/src/sema/declaration_index.rs
+++ b/crates/rue-air/src/sema/declaration_index.rs
@@ -295,6 +295,13 @@ impl RirDeclarationIndex {
         candidates.first().copied()
     }
 
+    /// Every source free-function declaration in deterministic RIR order.
+    /// Used to verify that declaration binding has materialized the complete
+    /// source-function namespace before constructing `BoundSema`.
+    pub(super) fn all_free_functions(&self) -> &[InstRef] {
+        &self.free_functions
+    }
+
     #[inline]
     pub(super) fn is_named_method(&self, inst_ref: InstRef) -> bool {
         self.named_method_refs.contains(&inst_ref)
@@ -316,7 +323,7 @@ impl RirDeclarationIndex {
 
     #[cfg(test)]
     fn free_functions(&self) -> &[InstRef] {
-        &self.free_functions
+        self.all_free_functions()
     }
 
     #[cfg(test)]

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -530,7 +530,31 @@ impl<'a> Sema<'a> {
         })();
         self.declaration_binding_active = false;
         debug_assert!(self.const_resolution_in_progress.is_empty());
+        if result.is_ok() {
+            debug_assert!(
+                self.source_free_function_signatures_are_complete(),
+                "BoundSema requires every indexed source free-function signature"
+            );
+            debug_assert!(self.fn_signatures_in_flight.is_empty());
+        }
         result
+    }
+
+    /// Whether every indexed source free function has a resolved signature.
+    /// Anonymous methods are intentionally absent: their signatures belong to
+    /// body-time comptime type construction rather than the source namespace.
+    pub(crate) fn source_free_function_signatures_are_complete(&self) -> bool {
+        self.declaration_index
+            .all_free_functions()
+            .iter()
+            .all(|&declaration| {
+                let inst = self.rir.get(declaration);
+                let InstData::FnDecl { name, .. } = inst.data else {
+                    unreachable!("free-function index contains only FnDecl instructions")
+                };
+                self.resolve_function_name_local(name, inst.span.file_id)
+                    .is_some_and(|key| self.functions.contains_key(&key))
+            })
     }
 
     pub(super) fn capture_resolved_declaration_type_dependencies(&mut self) {
@@ -1920,7 +1944,7 @@ impl<'a> Sema<'a> {
                     return Ok(ConstInit::Value(info.value));
                 }
                 if let Some((fn_file_id, is_pub)) =
-                    self.ensure_free_function_signature(name, Some(file_id))?
+                    self.collect_free_function_signature_during_binding(name, Some(file_id))?
                 {
                     self.record_named_const_dependency(
                         super::NamedConstDependencyTargetEvent::FreeFunction {
@@ -2640,7 +2664,7 @@ impl<'a> Sema<'a> {
             ));
         };
         let Some((_fn_file_id, is_pub)) =
-            self.ensure_free_function_signature(member, Some(mfile))?
+            self.collect_free_function_signature_during_binding(member, Some(mfile))?
         else {
             return Err(CompileError::new(
                 ErrorKind::UnknownModuleMember {
@@ -2798,15 +2822,26 @@ impl<'a> Sema<'a> {
         Some((inst.span.file_id, *is_pub))
     }
 
-    /// Ensure a free function's signature is available during const
-    /// collection, struct-field/enum-payload type resolution, and
-    /// signature-type resolution — all of which can run before the main
-    /// declaration walk reaches the callee's `FnDecl` (RUE-603).
-    pub(crate) fn ensure_free_function_signature(
+    /// Materialize a free function's signature during declaration binding.
+    ///
+    /// This supports dependency-ordered const, aggregate, and signature type
+    /// resolution before the main declaration walk reaches the callee. It is
+    /// deliberately unavailable as a body-phase fallback: after `BoundSema`,
+    /// source function lookup is read-only and a miss is authoritative.
+    ///
+    /// These declaration-time callers include const collection,
+    /// struct-field/enum-payload type resolution, and signature-type
+    /// resolution, all of which can run before the main declaration walk
+    /// reaches the callee's `FnDecl` (RUE-603).
+    pub(crate) fn collect_free_function_signature_during_binding(
         &mut self,
         target: Spur,
         file_id: Option<FileId>,
     ) -> CompileResult<Option<(FileId, bool)>> {
+        debug_assert!(
+            self.declaration_binding_active,
+            "source function signatures may only be materialized during declaration binding"
+        );
         let Some(inst_ref) = self.declaration_index.first_free_function(target, file_id) else {
             return Ok(None);
         };

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -223,8 +223,8 @@ pub struct Sema<'a> {
     /// `MAX_SPECIALIZATION_ROUNDS`, emitting the same E1200 (RUE-261).
     pub(crate) comptime_type_call_depth: usize,
     /// Internal names of free functions whose signatures are mid-collection in
-    /// [`Self::ensure_free_function_signature`]. Collecting a signature
-    /// resolves its parameter/return types, which may name other type
+    /// [`Self::collect_free_function_signature_during_binding`]. Collecting a
+    /// signature resolves its parameter/return types, which may name other type
     /// constructors and collect *them* on demand (RUE-603); a signature cycle
     /// (`fn A(x: B(i32))` / `fn B(x: A(i32))`) must not re-enter a
     /// mid-collection signature, or the reduction would recurse forever.

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -422,6 +422,36 @@ mod tests {
     }
 
     #[test]
+    fn bound_sema_contains_every_source_free_function_signature() {
+        // The struct and `main` both use a type constructor declared later in
+        // source order. Declaration binding may collect that signature early,
+        // but the resulting BoundSema must contain the complete source
+        // function namespace before any body is analyzed.
+        let source = "struct Holder { value: Wrapper(i32) }\n\
+                      fn helper(value: i32) -> i32 { value }\n\
+                      fn main() -> i32 { helper(1) }\n\
+                      fn Wrapper(comptime T: type) -> type { struct { value: T } }";
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        let parser = Parser::new(tokens, interner);
+        let (ast, mut interner) = parser.parse().unwrap();
+        let rir = AstGen::new(&ast, &mut interner).generate();
+
+        let bound = Sema::new(&rir, &mut interner, PreviewFeatures::new())
+            .bind_declarations()
+            .unwrap();
+        assert_eq!(bound.binding_work().indexed_free_functions, 3);
+        assert_eq!(bound.source_free_function_signature_count(), 3);
+        assert!(bound.source_free_function_signatures_are_complete());
+
+        // Body analysis exercises ordinary source-function lookup; the shared
+        // boundary invariant rejects source-signature mutation on every body
+        // path, including anonymous and specialized bodies.
+        let output = bound.analyze_all_bodies().unwrap();
+        assert_eq!(output.body_analysis_work.bodies_failed, 0);
+    }
+
+    #[test]
     fn late_qualified_import_types_use_one_declaration_index() {
         // Put every import after the declaration that uses it. Binding must
         // resolve each dependency from the declaration index; qualified type

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -977,8 +977,10 @@ impl<'a> Sema<'a> {
             self.resolve_type_module_prefix(&segments[..segments.len() - 1], span)?;
         let member = segments[segments.len() - 1];
         let member_sym = self.interner.get_or_intern(member);
-        if let Some(module_file_id) = module_file_id {
-            self.ensure_free_function_signature(member_sym, Some(module_file_id))?;
+        if self.declaration_binding_active
+            && let Some(module_file_id) = module_file_id
+        {
+            self.collect_free_function_signature_during_binding(member_sym, Some(module_file_id))?;
         }
         let function_key = module_file_id
             .and_then(|file_id| self.resolve_function_name_local(member_sym, file_id))
@@ -1144,8 +1146,10 @@ impl<'a> Sema<'a> {
         let module_file_id = module_file_id?;
         let member = segments[segments.len() - 1];
         let member_sym = self.interner.get_or_intern(member);
-        self.ensure_free_function_signature(member_sym, Some(module_file_id))
-            .ok()?;
+        if self.declaration_binding_active {
+            self.collect_free_function_signature_during_binding(member_sym, Some(module_file_id))
+                .ok()?;
+        }
         let function_key = self
             .resolve_function_name_local(member_sym, module_file_id)
             .unwrap_or(member_sym);
@@ -1443,7 +1447,7 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<Type> {
         let declaration_type_observer = self.declaration_type_observer.clone();
         let name_sym = self.interner.get_or_intern(call_name);
-        // The constructor may not be collected yet: struct-field and
+        // During declaration binding, the constructor may not be collected yet: struct-field and
         // enum-payload types, const initializers, and earlier function
         // signatures all resolve before the main declaration sweep reaches
         // the callee's `FnDecl`, so `struct S { v: Vec(i32) }` — or a
@@ -1452,8 +1456,8 @@ impl<'a> Sema<'a> {
         // Collect the same-file declaration on demand, mirroring the
         // declaration-time indexed const-alias resolution path.
         let mut name_key = self.resolve_function_name_local(name_sym, span.file_id);
-        if name_key.is_none() {
-            self.ensure_free_function_signature(name_sym, Some(span.file_id))?;
+        if name_key.is_none() && self.declaration_binding_active {
+            self.collect_free_function_signature_during_binding(name_sym, Some(span.file_id))?;
             name_key = self.resolve_function_name_local(name_sym, span.file_id);
         }
         let Some(name_key) = name_key else {
@@ -1728,8 +1732,8 @@ impl<'a> Sema<'a> {
             Some(name_sym)
         } else {
             let mut key = self.resolve_function_name_local(name_sym, span.file_id);
-            if key.is_none() {
-                self.ensure_free_function_signature(name_sym, Some(span.file_id))?;
+            if key.is_none() && self.declaration_binding_active {
+                self.collect_free_function_signature_during_binding(name_sym, Some(span.file_id))?;
                 key = self.resolve_function_name_local(name_sym, span.file_id);
             }
             key
@@ -2437,7 +2441,12 @@ impl<'a> Sema<'a> {
             let module_file_id = module_file_id.ok_or_else(unknown)?;
             let member = segments[segments.len() - 1];
             let member_sym = self.interner.get_or_intern(member);
-            self.ensure_free_function_signature(member_sym, Some(module_file_id))?;
+            if self.declaration_binding_active {
+                self.collect_free_function_signature_during_binding(
+                    member_sym,
+                    Some(module_file_id),
+                )?;
+            }
             let key = self
                 .resolve_function_name_local(member_sym, module_file_id)
                 .ok_or_else(unknown)?;
@@ -2450,8 +2459,8 @@ impl<'a> Sema<'a> {
         } else {
             let name_sym = self.interner.get_or_intern(call_name);
             let mut key = self.resolve_function_name_local(name_sym, span.file_id);
-            if key.is_none() {
-                self.ensure_free_function_signature(name_sym, Some(span.file_id))?;
+            if key.is_none() && self.declaration_binding_active {
+                self.collect_free_function_signature_during_binding(name_sym, Some(span.file_id))?;
                 key = self.resolve_function_name_local(name_sym, span.file_id);
             }
             let key = key.ok_or_else(unknown)?;


### PR DESCRIPTION
## Why

Source free-function signatures could still be materialized on demand from type checking and comptime evaluation after declaration binding. That made the body phase capable of mutating the source declaration namespace and hid incomplete binding.

## What

- make signature materialization explicitly declaration-binding-only
- make all body/type/comptime lookup paths read-only after `BoundSema`
- verify every indexed source free function is bound at the phase boundary
- assert body analysis neither adds nor removes source signatures
- add a late-declared constructor/body-lookup regression

Implementation was farmed to the Luna high task and integration-reviewed locally.

## Validation

- focused `rue-air`: 415 passed
- `scripts/rue quick`: 24 targets passed after rebasing onto merged PR #1584
- `git diff --check`: clean
