### PR TITLE
Fix hermetic rustfmt invocation (RUE-737)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
 
       - name: Check formatting
-        # Uses hermetic rustfmt from Buck2 toolchain
-        run: ./fmt.sh check
+        # Buck declares all Rust sources as inputs and applies the hermetic
+        # rustfmt target's platform-specific runtime environment.
+        run: ./buck2 test //:fmt-check
 
   clippy:
     runs-on: ubuntu-latest

--- a/BUCK
+++ b/BUCK
@@ -22,6 +22,24 @@
 # files so that `buck2 test //crates/...` (quick-test.sh, test.sh's filtered
 # path) still means "unit tests only".
 
+# Formatting is a first-class repository check. The source files are both
+# passed to rustfmt and declared as resources, so Buck invalidates the cached
+# result when any Rust source changes. The rustfmt target's RunInfo owns host
+# selection and dynamic-library setup; write-mode formatting remains in
+# fmt.sh because build/test actions must not mutate the source tree.
+_RUST_SOURCES = glob(["crates/**/*.rs"])
+
+sh_test(
+    name = "fmt-check",
+    test = "toolchains//rust:rustfmt",
+    args = [
+        "--edition",
+        "2024",
+        "--check",
+    ] + _RUST_SOURCES,
+    resources = _RUST_SOURCES,
+)
+
 # The std library sources are runtime inputs to the CLI integration tests
 # (compiled programs `@import` them via ${REAL_STD} / RUE_STD_DIR).
 filegroup(

--- a/fmt.sh
+++ b/fmt.sh
@@ -15,54 +15,27 @@ cd "$(dirname "$0")"
 
 MODE="${1:-format}"
 
-# Resolve the hermetic rustfmt binary once and invoke it directly. The old
-# `xargs ./buck2 run toolchains//rust:rustfmt` form paid a buck2 CLI
-# round-trip per xargs chunk; one `--show-output` resolve avoids that.
-# --show-output prints a repo-root-relative path, so make it absolute.
-# Capture Buck's stdout and stderr separately and guard the status: a bare
-# `RUSTFMT="$(./buck2 ... 2>/dev/null | awk ...)"` under `set -euo pipefail`
-# exits at the assignment on build failure, making the "re-running for
-# diagnosis" fallback unreachable and losing all diagnostics (RUE-550).
-fmt_err="$(mktemp)"
-trap 'rm -f "$fmt_err"' EXIT
-fmt_status=0
-rustfmt_show="$(./buck2 build toolchains//rust:rustfmt --show-output 2>"$fmt_err")" \
-    || fmt_status=$?
-if [ "$fmt_status" -ne 0 ]; then
-    echo "fmt.sh: 'buck2 build toolchains//rust:rustfmt' failed (exit $fmt_status):" >&2
-    cat "$fmt_err" >&2
-    exit "$fmt_status"
-fi
-RUSTFMT="$(printf '%s\n' "$rustfmt_show" | awk '/rust:rustfmt /{print $2}' | tail -1)"
-if [ -z "$RUSTFMT" ]; then
-    echo "fmt.sh: build succeeded but --show-output did not name rustfmt:" >&2
-    cat "$fmt_err" >&2
-    exit 1
-fi
-RUSTFMT="$(pwd)/$RUSTFMT"
+# Keep file discovery here because format mode intentionally edits the source
+# tree. Toolchain selection and its runtime environment belong to Buck's
+# rustfmt RunInfo, which `buck2 run` applies on every supported host.
+RUST_FILES=()
+while IFS= read -r -d '' rust_file; do
+    RUST_FILES+=("$rust_file")
+done < <(find "$(pwd)/crates" -name "*.rs" -type f -print0)
 
-# rustfmt needs librustc_driver from the distribution's rustc/lib directory
-# (the toolchains//rust rustfmt rule's RunInfo wrapper does the same; see
-# _rustfmt_impl in toolchains/rust/defs.bzl). The binary lives at
-# <dist>/rustfmt-preview/bin/rustfmt, the libs at <dist>/rustc/lib.
-DIST_ROOT="${RUSTFMT%/rustfmt-preview/bin/rustfmt}"
-export LD_LIBRARY_PATH="$DIST_ROOT/rustc/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-export DYLD_LIBRARY_PATH="$DIST_ROOT/rustc/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
-
-# Absolute paths to all Rust files (no filenames with spaces in this repo).
-RUST_FILES=$(find "$(pwd)/crates" -name "*.rs" -type f)
-
-if [ -z "$RUST_FILES" ]; then
+if [ "${#RUST_FILES[@]}" -eq 0 ]; then
     echo "No Rust files found"
     exit 0
 fi
 
 if [ "$MODE" = "check" ]; then
     echo "Checking Rust formatting..."
-    echo "$RUST_FILES" | xargs "$RUSTFMT" --edition 2024 --check
+    ./buck2 run toolchains//rust:rustfmt -- \
+        --edition 2024 --check "${RUST_FILES[@]}"
     echo "All files formatted correctly!"
 else
     echo "Formatting Rust files..."
-    echo "$RUST_FILES" | xargs "$RUSTFMT" --edition 2024
+    ./buck2 run toolchains//rust:rustfmt -- \
+        --edition 2024 "${RUST_FILES[@]}"
     echo "Done!"
 fi

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -91,10 +91,13 @@ EOF
   rm -rf "$sb"
 }
 
-# fmt.sh resolves rustfmt the same way; a failing `./buck2` must be loud too.
+# fmt.sh delegates rustfmt's runtime environment to `buck2 run`; a failing
+# invocation must remain loud.
 test_fmt_build_failure_is_loud() {
   local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/crates"
   cp "$SRC_ROOT/fmt.sh" "$sb/fmt.sh"; chmod +x "$sb/fmt.sh"
+  printf 'fn main() {}\n' >"$sb/crates/sample.rs"
   cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
 echo "BUCK-DIAGNOSTIC: rustfmt toolchain unavailable" >&2
@@ -107,6 +110,38 @@ EOF
   check "fmt.sh: buck failure exits non-zero" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
   check "fmt.sh: buck stderr is surfaced" \
     "$(printf '%s' "$out" | grep -q 'BUCK-DIAGNOSTIC' && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# fmt.sh must make one Buck RunInfo-based invocation and preserve every source
+# path as one argument, including paths containing spaces.
+test_fmt_uses_one_buck_run_and_preserves_paths() {
+  local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/crates/with space"
+  cp "$SRC_ROOT/fmt.sh" "$sb/fmt.sh"; chmod +x "$sb/fmt.sh"
+  printf 'fn a() {}\n' >"$sb/crates/a.rs"
+  printf 'fn b() {}\n' >"$sb/crates/with space/b.rs"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf 'invocation\n' >>"$BUCK_CALLS"
+printf '%s\n' "$@" >"$BUCK_ARGS"
+EOF
+  chmod +x "$sb/buck2"
+
+  local rc=0
+  BUCK_CALLS="$sb/calls" BUCK_ARGS="$sb/args" \
+    bash "$sb/fmt.sh" check >/dev/null 2>&1 || rc=$?
+
+  check "fmt.sh: check succeeds through fake Buck" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  check "fmt.sh: invokes Buck exactly once" \
+    "$([ "$(wc -l <"$sb/calls" 2>/dev/null | tr -d ' ')" = 1 ] && echo 0 || echo 1)"
+  check "fmt.sh: uses the rustfmt RunInfo target" \
+    "$(grep -Fxq 'run' "$sb/args" && grep -Fxq 'toolchains//rust:rustfmt' "$sb/args" && echo 0 || echo 1)"
+  check "fmt.sh: preserves an ordinary source path" \
+    "$(grep -Fxq "$sb/crates/a.rs" "$sb/args" && echo 0 || echo 1)"
+  check "fmt.sh: preserves a source path containing spaces" \
+    "$(grep -Fxq "$sb/crates/with space/b.rs" "$sb/args" && echo 0 || echo 1)"
   rm -rf "$sb"
 }
 
@@ -343,6 +378,7 @@ EOF
 test_ruebin_build_failure_is_loud
 test_ruebin_success_prints_clean_path
 test_fmt_build_failure_is_loud
+test_fmt_uses_one_buck_run_and_preserves_paths
 test_rue_exec_resolves_from_caller_cwd
 test_rue_run_resolves_relative_output
 test_rue_cli_examples_survive_case_chdir


### PR DESCRIPTION
## Summary

- keep `fmt.sh` as a thin developer-facing wrapper that invokes Buck once
- let `toolchains//rust:rustfmt` own host selection and dynamic-library setup through its `RunInfo`
- add a Buck-native `//:fmt-check` target with every Rust source declared as an input
- run the native formatting target in CI and cover the wrapper contract, including paths with spaces

## Root cause

`fmt.sh` resolved rustfmt's raw `DefaultInfo` output and reconstructed its library paths before launching it through macOS `/usr/bin/xargs`. macOS strips `DYLD_*` variables when starting protected system binaries, so rustfmt could not load `librustc_driver`.

The rustfmt Buck rule already provides the correct platform-specific runtime wrapper as `RunInfo`; consuming the raw output bypassed that abstraction.

## Validation

- `./fmt.sh check`
- `./buck2 test //:fmt-check //:wrapper-script-tests`
- `./scripts/test-wrapper-scripts.sh` (26 checks)
- `./buck2 test //...` (36/37 passed under concurrent local load; the timeout-sensitive generated oracle test was the only failure)
- `./buck2 test //:oracle-diff-generated-smoke` (passed in isolation, 64/64 programs agree)

Closes RUE-737.
