### PR TITLE
Reject non-place by-reference arguments before codegen (RUE-760)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1564,6 +1564,40 @@ fn require_byref_place_arg(rir: &Rir, arg: &RirCallArg) -> CompileResult<Spur> {
     })
 }
 
+/// Validate the semantic shape of an analyzed by-reference operand.
+///
+/// RIR place tracing is intentionally syntactic and therefore treats a named
+/// constant like an ordinary variable reference. After analysis, however, a
+/// real place read has exactly one of these AIR shapes. Keeping this check at
+/// the AIR boundary prevents constants and any other computed values from
+/// reaching CFG/codegen as by-reference arguments (RUE-760).
+pub(crate) fn require_air_byref_place(
+    air: &Air,
+    mut value: AirRef,
+    is_inout: bool,
+    span: Span,
+) -> CompileResult<()> {
+    if let AirInstData::MarkMoved { value: inner, .. } = air.get(value).data {
+        value = inner;
+    }
+
+    if matches!(
+        air.get(value).data,
+        AirInstData::Load { .. } | AirInstData::Param { .. } | AirInstData::PlaceRead { .. }
+    ) {
+        Ok(())
+    } else {
+        Err(CompileError::new(
+            if is_inout {
+                ErrorKind::InoutNonLvalue
+            } else {
+                ErrorKind::BorrowNonLvalue
+            },
+            span,
+        ))
+    }
+}
+
 /// Result of the element-wise linear array consumption check (RUE-186); see
 /// [`Sema::check_array_elementwise_consumption`].
 enum ElementwiseConsumption {

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -373,6 +373,13 @@ impl<'a> BodySema<'a> {
         };
 
         if receiver_mode != AirArgMode::Normal {
+            require_air_byref_place(
+                air,
+                receiver_result.air_ref,
+                receiver_mode == AirArgMode::Inout,
+                self.rir.get(receiver).span,
+            )?;
+
             // The receiver must be a place (a variable or a field/index chain
             // rooted at one): codegen forms its address. A temporary (call
             // result, literal, …) has no caller-visible storage to borrow.

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1009,6 +1009,14 @@ impl<'a> BodySema<'a> {
             let arg_result = self.analyze_inst(air, arg.value, ctx);
             ctx.byref_arg_root = prev_byref_root;
             let arg_result = arg_result?;
+            if arg.is_inout() || arg.is_borrow() {
+                require_air_byref_place(
+                    air,
+                    arg_result.air_ref,
+                    arg.is_inout(),
+                    self.rir.get(arg.value).span,
+                )?;
+            }
             // Two-types model (ADR-0043, RUE-386): an `inout str` parameter is
             // an *exclusive* view and requires local provenance — a first-class
             // / static `str` value is never a legal exclusive operand (closes

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -61,6 +61,87 @@ mod tests {
     }
 
     #[test]
+    fn byref_arguments_reject_non_places_during_air_analysis() {
+        let cases = [
+            (
+                "const VALUE: i32 = 1; fn take(inout x: i32) {} fn main() -> i32 { take(inout VALUE); 0 }",
+                true,
+            ),
+            (
+                "const VALUE: i32 = 1; fn take(borrow x: i32) {} fn main() -> i32 { take(borrow VALUE); 0 }",
+                false,
+            ),
+            (
+                "fn take(inout x: i32) {} fn main() -> i32 { take(inout 1); 0 }",
+                true,
+            ),
+            (
+                "fn take(borrow x: i32) {} fn main() -> i32 { take(borrow (1 + 2)); 0 }",
+                false,
+            ),
+            (
+                "fn value() -> i32 { 1 } fn take(borrow x: i32) {} fn main() -> i32 { take(borrow value()); 0 }",
+                false,
+            ),
+        ];
+
+        for (source, is_inout) in cases {
+            let errors = compile_to_air(source).expect_err("non-place must fail in sema");
+            assert!(
+                errors.iter().any(|error| {
+                    if is_inout {
+                        matches!(error.kind, ErrorKind::InoutNonLvalue)
+                    } else {
+                        matches!(error.kind, ErrorKind::BorrowNonLvalue)
+                    }
+                }),
+                "source: {source}\nerrors: {errors:#?}"
+            );
+        }
+    }
+
+    #[test]
+    fn byref_arguments_accept_places_and_forwarded_projections() {
+        compile_to_air(
+            "struct Pair { value: i32 }
+             fn edit(inout x: i32) { x = x + 1; }
+             fn read(borrow x: i32) -> i32 { x }
+             fn forward(inout edit_pair: Pair, borrow read_pair: Pair) -> i32 {
+                 edit(inout edit_pair.value);
+                 read(borrow read_pair.value)
+             }
+             fn main() -> i32 {
+                 let mut pair = Pair { value: 1 };
+                 let other = Pair { value: 2 };
+                 let mut values = [1, 2];
+                 edit(inout pair.value);
+                 edit(inout values[0]);
+                 read(borrow pair.value) + read(borrow values[1]) + forward(inout pair, borrow other)
+             }",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn byref_method_receiver_rejects_call_result_during_air_analysis() {
+        let errors = compile_to_air(
+            "struct Pair {
+                 value: i32,
+                 fn read(borrow self) -> i32 { self.value }
+             }
+             fn make() -> Pair { Pair { value: 1 } }
+             fn main() -> i32 { make().read() }",
+        )
+        .expect_err("a call result is not an addressable method receiver");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(error.kind, ErrorKind::BorrowNonLvalue)),
+            "errors: {errors:#?}"
+        );
+    }
+
+    #[test]
     fn body_work_counts_reachable_call_graph_exactly() {
         let output = compile_to_air(
             "fn leaf() -> i32 { 1 }\nfn middle() -> i32 { leaf() }\nfn main() -> i32 { middle() }",

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -163,8 +163,8 @@ compile_only = true
 compile_stdout_contains = ["=== Assembly", "main"]
 
 [[case]]
-name = "emit_lowering_reports_deferred_lowering_errors"
-description = "--emit lowering used to ignore deferred by-ref lowering diagnostics and exit successfully (RUE-482)."
+name = "emit_lowering_reports_semantic_byref_errors"
+description = "--emit lowering reports by-ref non-place operands rejected during semantic/AIR construction (RUE-760)."
 files = [{ path = "main.rue", source = """
 const X: i32 = 1;
 
@@ -182,8 +182,8 @@ compile_fail = true
 error_contains = ["E0425", "inout argument must be an lvalue"]
 
 [[case]]
-name = "emit_mir_suppresses_partial_stdout_on_late_lowering_error"
-description = "--emit mir buffers fallible per-function output so a later lowering error does not leave partial MIR on stdout (RUE-483)."
+name = "emit_mir_suppresses_stdout_on_semantic_byref_error"
+description = "--emit mir leaves no partial MIR on stdout when semantic/AIR construction rejects a by-ref non-place operand (RUE-760)."
 files = [{ path = "main.rue", source = """
 const X: i32 = 1;
 

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use lasso::ThreadedRodeo;
 use rue_air::{TypeInternPool, TypeKind};
 use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, Terminator, Type};
-use rue_error::{CompileError, CompileResult};
+use rue_error::CompileResult;
 use rue_target::Target;
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
@@ -67,11 +67,6 @@ pub struct CfgLower<'a> {
     /// For inout params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
     inout_param_ptrs: HashMap<u32, VReg>,
-    /// First user-facing diagnostic recorded during lowering (RUE-52). Lowering
-    /// is infallible for speed; a by-ref argument with no addressable storage
-    /// (a `const` folded to an immediate) records its error here and `lower()`
-    /// surfaces it instead of the process aborting.
-    deferred_error: Option<CompileError>,
 }
 
 impl<'a> CfgLower<'a> {
@@ -104,7 +99,6 @@ impl<'a> CfgLower<'a> {
             fn_name: cfg.fn_name(),
             struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
             inout_param_ptrs: HashMap::with_capacity(estimated_inout_params),
-            deferred_error: None,
         }
     }
 
@@ -399,9 +393,6 @@ impl<'a> CfgLower<'a> {
             self.lower_block(block);
         }
 
-        if let Some(err) = self.deferred_error.take() {
-            return Err(err);
-        }
         Ok(self.mir)
     }
 
@@ -508,10 +499,6 @@ impl<'a> CfgLower<'a> {
             });
 
             debug_info.blocks.push(block_info);
-        }
-
-        if let Some(err) = self.deferred_error.take() {
-            return Err(err);
         }
 
         Ok((self.mir, debug_info))
@@ -4207,12 +4194,6 @@ impl crate::aggregate_eq::AggregateEqBackend for CfgLower<'_> {
             src: Operand::Virtual(value),
             imm: 1,
         });
-    }
-}
-
-impl crate::byref_args::ByrefAddrBackend for CfgLower<'_> {
-    fn record_deferred_error(&mut self, err: CompileError) {
-        self.deferred_error.get_or_insert(err);
     }
 }
 

--- a/crates/rue-codegen/src/byref_args.rs
+++ b/crates/rue-codegen/src/byref_args.rs
@@ -11,8 +11,7 @@
 //! Like [`crate::agg_slots`], the decision logic here is target-independent —
 //! which argument shapes are addressable, that every index projection is
 //! bounds-checked before the address is formed — so backends only provide
-//! the leaf operations in [`crate::place_lower::PlaceLowerBackend`], plus the
-//! deferred-diagnostic hook on [`ByrefAddrBackend`]. Bounds checks and
+//! the leaf operations in [`crate::place_lower::PlaceLowerBackend`]. Bounds checks and
 //! projected-place address formation are shared through
 //! [`crate::agg_slots::SlotBackend`]
 //! (the indexed-place-read materialization in `agg_slots` needs them too,
@@ -21,33 +20,17 @@
 //! address, from which aggregate slots ascend (`slot k` at `+k*8`), uniform
 //! for frame- and heap-rooted places (ADR-0040 / RUE-311).
 
-use rue_cfg::{CfgInstData, CfgValue, Place, Projection};
-use rue_error::{CompileError, ErrorKind};
-
 use crate::place_lower::PlaceLowerBackend;
 use crate::vreg::VReg;
-
-/// The deferred-diagnostic hook by-ref argument lowering needs on top of the
-/// shared place-lowering operations.
-pub trait ByrefAddrBackend: PlaceLowerBackend {
-    /// Record a user-facing diagnostic discovered during the (infallible)
-    /// lowering pass, to be surfaced by `generate()` once lowering finishes.
-    /// Only the FIRST recorded error is kept. See [`lower_byref_arg_addr`].
-    fn record_deferred_error(&mut self, err: CompileError);
-}
+use rue_cfg::{CfgInstData, CfgValue, Place, Projection};
 
 /// Lower a by-ref (inout/borrow) call argument to the vreg holding its
 /// address.
 ///
 /// Sema accepts as a by-ref argument a place: a variable (`Load`/`Param`) or a
 /// field/index projection chain rooted at one (`PlaceRead`). A non-place value
-/// with no storage to address — most reachably a `const` folded to an
-/// immediate, which sema currently lets slip through as a bare identifier
-/// (RUE-52) — records a clean diagnostic (`inout`/`borrow` argument must be an
-/// lvalue) via [`ByrefAddrBackend::record_deferred_error`] and falls back to a
-/// dummy vreg so lowering finishes before `generate()` surfaces the error,
-/// rather than aborting the process.
-pub fn lower_byref_arg_addr<B: ByrefAddrBackend + ?Sized>(
+/// with no storage to address is a violated sema/CFG invariant (RUE-760).
+pub fn lower_byref_arg_addr<B: PlaceLowerBackend + ?Sized>(
     b: &mut B,
     arg_value: CfgValue,
     is_inout: bool,
@@ -60,9 +43,6 @@ pub fn lower_byref_arg_addr<B: ByrefAddrBackend + ?Sized>(
         Place(Place),
         NotAPlace,
     }
-    // The argument span, captured (Copy) before the match so the borrow of the
-    // CFG ends and a diagnostic can carry a source location.
-    let arg_span = b.ctx().cfg.get_inst(arg_value).span;
     // Slot count of the addressed value: a by-ref pointer must point at the
     // place's LOW end (ADR-0040 / RUE-311), which for a frame-resident
     // aggregate is its highest-numbered slot `base + count - 1`.
@@ -77,15 +57,10 @@ pub fn lower_byref_arg_addr<B: ByrefAddrBackend + ?Sized>(
 
     match shape {
         ArgShape::NotAPlace => {
-            let kind = if is_inout {
-                ErrorKind::InoutNonLvalue
-            } else {
-                ErrorKind::BorrowNonLvalue
-            };
-            b.record_deferred_error(CompileError::new(kind, arg_span));
-            // Dead value: the whole codegen result is discarded once the
-            // deferred error is surfaced, but lowering must produce SOME vreg.
-            b.alloc_vreg()
+            unreachable!(
+                "malformed CFG: {} argument is not an addressable place",
+                if is_inout { "inout" } else { "borrow" }
+            )
         }
         ArgShape::Local(slot) => {
             let addr_vreg = b.alloc_vreg();

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -31,7 +31,7 @@ use lasso::ThreadedRodeo;
 use rue_air::{TypeInternPool, TypeKind};
 use rue_builtins::BinOp;
 use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, Terminator, Type};
-use rue_error::{CompileError, CompileResult};
+use rue_error::CompileResult;
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 use crate::cfg_lower::CfgLowerContext;
@@ -75,11 +75,6 @@ pub struct CfgLower<'a> {
     /// For inout params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
     inout_param_ptrs: HashMap<u32, VReg>,
-    /// First user-facing diagnostic recorded during lowering (RUE-52). Lowering
-    /// is infallible for speed; a by-ref argument with no addressable storage
-    /// (a `const` folded to an immediate) records its error here and `lower()`
-    /// surfaces it instead of the process aborting.
-    deferred_error: Option<CompileError>,
 }
 
 impl<'a> CfgLower<'a> {
@@ -107,7 +102,6 @@ impl<'a> CfgLower<'a> {
             fn_name: cfg.fn_name(),
             struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
             inout_param_ptrs: HashMap::with_capacity(estimated_inout_params),
-            deferred_error: None,
         }
     }
 
@@ -572,9 +566,6 @@ impl<'a> CfgLower<'a> {
             self.lower_block(block);
         }
 
-        if let Some(err) = self.deferred_error.take() {
-            return Err(err);
-        }
         Ok(self.mir)
     }
 
@@ -681,10 +672,6 @@ impl<'a> CfgLower<'a> {
             });
 
             debug_info.blocks.push(block_info);
-        }
-
-        if let Some(err) = self.deferred_error.take() {
-            return Err(err);
         }
 
         Ok((self.mir, debug_info))
@@ -4226,12 +4213,6 @@ impl crate::aggregate_eq::AggregateEqBackend for CfgLower<'_> {
             dst: Operand::Virtual(value),
             imm: 1,
         });
-    }
-}
-
-impl crate::byref_args::ByrefAddrBackend for CfgLower<'_> {
-    fn record_deferred_error(&mut self, err: CompileError) {
-        self.deferred_error.get_or_insert(err);
     }
 }
 

--- a/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
@@ -20,3 +20,39 @@ error_contains = [
     "unexpected `borrow` argument: the corresponding parameter is unmarked",
     "remove the `borrow` keyword; this argument is passed without an explicit mode",
 ]
+
+[[case]]
+name = "named_const_is_not_an_inout_place"
+description = "A named constant is rejected during semantic analysis instead of reaching by-reference codegen (RUE-760)."
+source = """
+const VALUE: i32 = 42;
+
+fn take(inout value: i32) {}
+
+fn main() {
+    take(inout VALUE);
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0425]",
+    "inout argument must be an lvalue",
+]
+
+[[case]]
+name = "named_const_is_not_a_borrow_place"
+description = "Borrowing a named constant reports the ordinary non-lvalue diagnostic before CFG construction (RUE-760)."
+source = """
+const VALUE: i32 = 42;
+
+fn take(borrow value: i32) {}
+
+fn main() {
+    take(borrow VALUE);
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0427]",
+    "borrow argument must be a variable, field, or array element",
+]


### PR DESCRIPTION
## Summary

- validate `inout` and `borrow` operands at the shared AIR semantic boundary
- reject non-place user-method receivers before CFG construction
- remove deferred user diagnostics and dummy-address lowering from both codegen backends
- retain a shared internal invariant check for malformed CFG
- add semantic and UI regressions for invalid expressions and valid place projections

## Why

Named constants were syntactically treated as variable roots in RIR, then folded to immediates in AIR. They could therefore reach by-reference codegen without addressable storage, where codegen deferred a user diagnostic and allocated a dummy address register. User legality now ends during semantic analysis, before CFG/codegen.

## Validation

- `scripts/rue quick` — 24 targets passed
- `./buck2 test //crates/rue-air:rue-air-test` — 419 tests passed
- `scripts/rue ui call-argument-modes` — 3 cases passed
- `scripts/rue cli emit_pipeline` — 14 cases passed
- `scripts/rue test` — UI, CLI, spec, and 35 targets passed; generated oracle smoke timed out under concurrent load, then passed 64/64 in isolation

Linear: https://linear.app/steve-klabnik/issue/RUE-760/sema-reject-non-place-by-reference-arguments-before-codegen
