### PR TITLE
Remove legacy associated-function call path (RUE-756)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2542,24 +2542,6 @@ impl<'a> ConstraintGenerator<'a> {
                 result_type
             }
 
-            // Associated function call: `Type.function(args)` lowers to an
-            // `AssocFnCall` only through legacy AST nodes; `.`-spelled calls
-            // reach the `MethodCall` arm above, which forwards a type-name
-            // receiver here (RUE-488).
-            InstData::AssocFnCall {
-                type_name,
-                function,
-                args_start,
-                args_len,
-            } => self.generate_type_qualified_call(
-                *type_name,
-                *function,
-                *args_start,
-                *args_len,
-                span,
-                ctx,
-            ),
-
             // Comptime block: the type depends on whether evaluation succeeds at compile time.
             // For type inference, we use a fresh type variable that can unify with
             // whatever type is expected from the context (e.g., a let binding's type annotation).
@@ -2737,8 +2719,8 @@ impl<'a> ConstraintGenerator<'a> {
     /// Generate constraints for a type-qualified call — an associated-function
     /// call or an enum tuple-variant construction — resolving the callee by type
     /// name and constraining each argument to the declared parameter/payload
-    /// type. Shared by the `AssocFnCall` arm and the `MethodCall` arm's
-    /// type-name-receiver forwarding (`Type.function(args)`, RUE-488). Getting
+    /// type. The `MethodCall` arm forwards type-name receivers here
+    /// (`Type.function(args)`, RUE-488). Getting
     /// the argument constraints here — not just in sema — is what pins a literal
     /// like the `8` in `String.with_capacity(8)` to the declared `u64` parameter
     /// instead of letting it default to `i32`.

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -672,7 +672,7 @@ impl<'a> BodySema<'a> {
         ))
     }
 
-    /// Implementation for AssocFnCall.
+    /// Analyze a type-qualified associated-function call.
     ///
     /// `resolved` carries a struct already resolved (and visibility-checked,
     /// E0706) by the module-qualified path (`m.Type.assoc()`, RUE-525): the

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -27,7 +27,7 @@ impl<'a> BodySema<'a> {
     /// - **Structs**: StructDecl, StructInit, FieldGet, FieldSet
     /// - **Arrays**: ArrayInit, IndexGet, IndexSet
     /// - **Enums**: EnumDecl, EnumVariant
-    /// - **Calls**: Call, MethodCall, AssocFnCall
+    /// - **Calls**: Call, MethodCall
     /// - **Intrinsics**: Intrinsic, TypeIntrinsic, OffsetOf
     /// - **Declarations**: DropFnDecl, FnDecl
     pub(crate) fn analyze_inst(
@@ -192,7 +192,7 @@ impl<'a> BodySema<'a> {
             }
 
             // Call operations
-            InstData::Call { .. } | InstData::MethodCall { .. } | InstData::AssocFnCall { .. } => {
+            InstData::Call { .. } | InstData::MethodCall { .. } => {
                 self.analyze_call_ops(air, inst_ref, ctx)
             }
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -10,7 +10,7 @@
 //! - [`analyze_struct_ops`] - StructDecl, StructInit, FieldGet, FieldSet
 //! - [`analyze_array_ops`] - ArrayInit, IndexGet, IndexSet
 //! - [`analyze_enum_ops`] - EnumDecl, EnumVariant
-//! - [`analyze_call_ops`] - Call, MethodCall, AssocFnCall
+//! - [`analyze_call_ops`] - Call and MethodCall
 //! - [`analyze_intrinsic_ops`] - Intrinsic, TypeIntrinsic
 //! - [`analyze_decl_noop`] - DropFnDecl (declarations that produce Unit)
 //!
@@ -5867,12 +5867,12 @@ impl<'a> BodySema<'a> {
     }
 
     // ========================================================================
-    // Call operations: Call, MethodCall, AssocFnCall
+    // Call operations: Call, MethodCall
     // ========================================================================
 
     /// Analyze a call operation instruction.
     ///
-    /// Handles: Call, MethodCall, AssocFnCall
+    /// Handles: Call and MethodCall.
     pub(crate) fn analyze_call_ops(
         &mut self,
         air: &mut Air,
@@ -5902,21 +5902,6 @@ impl<'a> BodySema<'a> {
                 air,
                 *receiver,
                 *method,
-                *args_start,
-                *args_len,
-                inst.span,
-                ctx,
-            ),
-
-            InstData::AssocFnCall {
-                type_name,
-                function,
-                args_start,
-                args_len,
-            } => self.analyze_assoc_fn_call(
-                air,
-                *type_name,
-                *function,
                 *args_start,
                 *args_len,
                 inst.span,

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -84,7 +84,6 @@ mod tests {
         "IndexSet",
         // Methods
         "MethodCall",
-        "AssocFnCall",
         "DropFnDecl",
     ];
 

--- a/crates/rue-air/src/sema/sema_ctx_builder.rs
+++ b/crates/rue-air/src/sema/sema_ctx_builder.rs
@@ -83,11 +83,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                 );
             }
 
-            // Associated functions (e.g. `String::new`, `String::with_capacity`) are
-            // resolved by inference through the same `(StructId, name)` method map (see
-            // `InstData::AssocFnCall` in inference/generate.rs). Like methods, they live
+            // Associated functions (e.g. `StrBuf.new`, `StrBuf.with_capacity`) are
+            // resolved by inference through the same `(StructId, name)` method map. Like methods, they live
             // only in the rue-builtins registry, so without registering them an untyped
-            // literal arg (`String::with_capacity(8)`) isn't constrained to the param's
+            // literal arg (`StrBuf.with_capacity(8)`) isn't constrained to the param's
             // `u64` and a result feeding a literal resolves to `<error>`. (RUE-95 sibling)
             for assoc_fn in builtin.associated_fns {
                 let Some(fn_spur) = self.interner.get(assoc_fn.name) else {

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -1214,12 +1214,6 @@ fn walk_expr(
                 walk_expr(base, module, resolver, imports)?;
             }
         }
-        Expr::AssocFnCall(value) => {
-            if let Some(base) = &value.base {
-                walk_expr(base, module, resolver, imports)?;
-            }
-            walk_args(&value.args, module, resolver, imports)?;
-        }
         Expr::Comptime(value) => walk_expr(&value.expr, module, resolver, imports)?,
         Expr::Checked(value) => walk_expr(&value.expr, module, resolver, imports)?,
     }

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -637,8 +637,6 @@ pub enum Expr {
     Index(IndexExpr),
     /// Path expression (e.g., `Color::Red`)
     Path(PathExpr),
-    /// Associated function call (e.g., `Point::origin()`)
-    AssocFnCall(AssocFnCallExpr),
     /// Self expression (e.g., `self` in method bodies)
     SelfExpr(SelfExpr),
     /// Comptime block expression (e.g., `comptime { 1 + 2 }`)
@@ -1018,20 +1016,6 @@ pub struct PathExpr {
     pub span: Span,
 }
 
-/// An associated function call expression (e.g., `Point::origin()` or `module.Point::origin()`).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AssocFnCallExpr {
-    /// Optional module/namespace prefix (e.g., `utils` in `utils.Point::origin()`)
-    pub base: Option<Box<Expr>>,
-    /// The type name (e.g., `Point`)
-    pub type_name: Ident,
-    /// The function name (e.g., `origin`)
-    pub function: Ident,
-    /// Arguments
-    pub args: Vec<CallArg>,
-    pub span: Span,
-}
-
 /// A statement (does not produce a value).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Statement {
@@ -1224,7 +1208,6 @@ impl Expr {
             Expr::ArrayLit(array_lit) => array_lit.span,
             Expr::Index(index_expr) => index_expr.span,
             Expr::Path(path_expr) => path_expr.span,
-            Expr::AssocFnCall(assoc_fn_call) => assoc_fn_call.span,
             Expr::SelfExpr(self_expr) => self_expr.span,
             Expr::Comptime(comptime_expr) => comptime_expr.span,
             Expr::Checked(checked_expr) => checked_expr.span,
@@ -1589,18 +1572,6 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
             path.type_name.name.into_usize(),
             path.variant.name.into_usize()
         ),
-        Expr::AssocFnCall(assoc_fn_call) => {
-            writeln!(
-                f,
-                "AssocFnCall sym:{}::sym:{}",
-                assoc_fn_call.type_name.name.into_usize(),
-                assoc_fn_call.function.name.into_usize()
-            )?;
-            for arg in &assoc_fn_call.args {
-                fmt_call_arg(f, arg, level + 1)?;
-            }
-            Ok(())
-        }
         Expr::SelfExpr(_) => {
             writeln!(f, "SelfExpr")
         }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -299,14 +299,6 @@ impl Validator<'_> {
                     self.check_expr(base);
                 }
             }
-            Expr::AssocFnCall(a) => {
-                if let Some(base) = &a.base {
-                    self.check_expr(base);
-                }
-                for arg in &a.args {
-                    self.check_expr(&arg.expr);
-                }
-            }
             Expr::Comptime(c) => self.check_expr(&c.expr),
             Expr::Checked(c) => self.check_expr(&c.expr),
             Expr::TypeLit(t) => self.check_type_expr(&t.type_expr),

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -976,24 +976,6 @@ impl<'a> AstGen<'a> {
                     span: method_call.span,
                 })
             }
-            Expr::AssocFnCall(assoc_fn_call) => {
-                let args: Vec<_> = assoc_fn_call
-                    .args
-                    .iter()
-                    .map(|a| self.convert_call_arg(a))
-                    .collect();
-                let (args_start, args_len) = self.rir.add_call_args(&args);
-
-                self.rir.add_inst(Inst {
-                    data: InstData::AssocFnCall {
-                        type_name: self.symbol(assoc_fn_call.type_name.name),
-                        function: self.symbol(assoc_fn_call.function.name),
-                        args_start,
-                        args_len,
-                    },
-                    span: assoc_fn_call.span,
-                })
-            }
             Expr::SelfExpr(self_expr) => {
                 // `self` in method bodies is just a variable reference to the implicit self parameter
                 let name = self.interner.get_or_intern("self");
@@ -2060,7 +2042,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gen_assoc_fn_call() {
+    fn test_gen_associated_function_as_method_call() {
         // Associated functions are called with `.` (RUE-488). At the RIR level
         // `Point.origin()` is a `MethodCall` whose receiver is the type name;
         // sema reinterprets it as an associated-function call.

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1130,19 +1130,6 @@ pub enum InstData {
         args_len: u32,
     },
 
-    /// Associated function call: Type::function(args)
-    /// Args are stored in the extra array using add_call_args/get_call_args.
-    AssocFnCall {
-        /// Type name (e.g., Point)
-        type_name: Spur,
-        /// Function name (e.g., origin)
-        function: Spur,
-        /// Index into extra data where args start
-        args_start: u32,
-        /// Number of arguments
-        args_len: u32,
-    },
-
     /// User-defined destructor declaration: drop fn TypeName(self) { ... }
     DropFnDecl {
         /// The struct type this destructor is for
@@ -2027,22 +2014,6 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         "method_call {}.{}({})",
                         self.display_ref(*receiver),
                         self.interner.resolve(&*method),
-                        self.format_call_args(&args)
-                    )
-                    .unwrap();
-                }
-                InstData::AssocFnCall {
-                    type_name,
-                    function,
-                    args_start,
-                    args_len,
-                } => {
-                    let args = self.rir.get_call_args(*args_start, *args_len);
-                    writeln!(
-                        out,
-                        "assoc_fn_call {}::{}({})",
-                        self.interner.resolve(&*type_name),
-                        self.interner.resolve(&*function),
                         self.format_call_args(&args)
                     )
                     .unwrap();
@@ -3479,71 +3450,6 @@ mod tests {
         let printer = RirPrinter::new(&rir, &interner);
         let output = printer.to_string();
         assert!(output.contains("method_call %0.modify(inout %1, borrow %2)"));
-    }
-
-    #[test]
-    fn test_printer_assoc_fn_call() {
-        let (mut rir, interner) = create_printer_test_rir();
-
-        let type_name = interner.get_or_intern("Point");
-        let function = interner.get_or_intern("origin");
-
-        let (args_start, args_len) = rir.add_call_args(&[]);
-
-        rir.add_inst(Inst {
-            data: InstData::AssocFnCall {
-                type_name,
-                function,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 15),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("assoc_fn_call Point::origin()"));
-    }
-
-    #[test]
-    fn test_printer_assoc_fn_call_with_args() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let arg1 = rir.add_inst(Inst {
-            data: InstData::IntConst(10),
-            span: Span::new(0, 2),
-        });
-        let arg2 = rir.add_inst(Inst {
-            data: InstData::IntConst(20),
-            span: Span::new(0, 2),
-        });
-
-        let type_name = interner.get_or_intern("Point");
-        let function = interner.get_or_intern("new");
-
-        let (args_start, args_len) = rir.add_call_args(&[
-            RirCallArg {
-                value: arg1,
-                mode: RirArgMode::Normal,
-            },
-            RirCallArg {
-                value: arg2,
-                mode: RirArgMode::Normal,
-            },
-        ]);
-
-        rir.add_inst(Inst {
-            data: InstData::AssocFnCall {
-                type_name,
-                function,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 20),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("assoc_fn_call Point::new(%0, %1)"));
     }
 
     #[test]

--- a/docs/designs/0009-struct-methods.md
+++ b/docs/designs/0009-struct-methods.md
@@ -157,10 +157,10 @@ Methods can only be defined for structs in the same compilation unit. (This is a
   - Parse method calls as a variant of field access
 
 - [x] **Phase 2: RIR Generation** - (historical bd ID rue-qs3z.2, pre-Linear)
-  - Add method info to RIR (ImplDecl, MethodCall, AssocFnCall instructions)
+  - Add method info to RIR (ImplDecl and MethodCall instructions)
   - Generate RIR for impl blocks
   - Handle method calls in expression generation
-  - Parse associated function calls (Type::fn() syntax)
+  - Parse associated function calls (`Type.fn()` syntax)
 
 - [x] **Phase 3: Type Checking** - (historical bd ID rue-qs3z.3, pre-Linear)
   - Add method registry to struct definitions

--- a/docs/designs/soa-ast-layout.md
+++ b/docs/designs/soa-ast-layout.md
@@ -152,7 +152,6 @@ pub enum NodeTag {
     Call,               // lhs=callee_name, rhs=extra(args)
     MethodCall,         // lhs=receiver, rhs=extra(method_name, args)
     IntrinsicCall,      // lhs=intrinsic_name, rhs=extra(args)
-    AssocFnCall,        // lhs=type_name, rhs=extra(fn_name, args)
 
     // Struct operations
     StructLit,          // lhs=struct_name, rhs=extra(field_inits)


### PR DESCRIPTION
## Summary

- remove the unreachable `AssocFnCall` parser AST and RIR instruction
- remove its legacy inference/sema dispatch, walkers, printer support, tests, and stale architecture comments
- retain canonical `MethodCall` handling for associated functions and tuple variants
- keep obsolete `::` input rejection at the parser boundary

Fixes RUE-756.

## Validation

- `scripts/rue fmt check`
- `scripts/rue quick`
- `scripts/rue spec associated_function` (5 passed)
- `scripts/rue spec enum_payload_declare_construct` (1 passed)
- `scripts/rue ui warnings.unused` (37 passed)
- full UI target (178 passed)
- `git diff --check`

A local full-suite run passed all relevant targets; the unrelated generated-smoke target hit its two-second child-process timeout under machine contention.