### PR TITLE
Eliminate aggregate single-slot fallbacks (RUE-758)

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -328,6 +328,12 @@ impl<'a> CfgLower<'a> {
         crate::agg_slots::get_or_compute_field_vregs(self, value)
     }
 
+    /// Materialize every slot of a multi-slot aggregate or fail the CFG
+    /// representation invariant.
+    fn require_aggregate_slots(&mut self, value: CfgValue) -> Vec<VReg> {
+        crate::agg_slots::require_aggregate_slots(self, value)
+    }
+
     /// Copy an aggregate value's slot vregs to a block parameter's slot vregs.
     /// Covers structs, builtin String, and fixed-size arrays — every slot must
     /// cross the join edge, not just the primary vreg (RUE-167).
@@ -339,17 +345,7 @@ impl<'a> CfgLower<'a> {
     ) {
         let target_param = self.ctx.cfg.get_block(target_block).params[param_idx as usize].0;
 
-        // The accessor covers StructInit/ArrayInit/Call/BlockParam (cache
-        // hits) and Load/Param/static PlaceRead; fall back to the recursive
-        // flatteners for anything it doesn't model (mirrors Alloc lowering).
-        let src_slots = self.get_or_compute_field_vregs(arg).unwrap_or_else(|| {
-            let arg_ty = self.ctx.cfg.get_inst(arg).ty;
-            if arg_ty.is_array() {
-                self.collect_array_scalar_vregs(arg)
-            } else {
-                self.collect_struct_scalar_vregs(arg)
-            }
-        });
+        let src_slots = self.require_aggregate_slots(arg);
         let dst_slots = self
             .struct_slot_vregs
             .get(&target_param)
@@ -1431,14 +1427,11 @@ impl<'a> CfgLower<'a> {
                         // materializes lazily-sourced values (Load/Param/PlaceRead) and
                         // cache-hits eager ones (StructInit/ArrayInit/Call/BlockParam).
                         // Reversed for Rue callees, natural for runtime (RUE-311).
-                        if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
-                            if callee_is_runtime {
-                                flattened_vregs.extend(field_vregs);
-                            } else {
-                                flattened_vregs.extend(field_vregs.into_iter().rev());
-                            }
+                        let field_vregs = self.require_aggregate_slots(arg_value);
+                        if callee_is_runtime {
+                            flattened_vregs.extend(field_vregs);
                         } else {
-                            flattened_vregs.push(self.get_vreg(arg_value));
+                            flattened_vregs.extend(field_vregs.into_iter().rev());
                         }
                     } else {
                         flattened_vregs.push(self.get_vreg(arg_value));
@@ -1524,11 +1517,9 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(slot_vregs[0]),
                     });
                 } else if self.ctx.is_multislot_aggregate(ty) {
-                    // Aggregates that fit return in registers. Capture
-                    // every slot from RET_REGS, not just x0 — arrays previously fell
-                    // to the scalar path and lost all elements but the first (RUE-78),
-                    // and payload enums fell there too, leaving the call result with
-                    // no slot vregs and ICEing the enum-payload read (RUE-237).
+                    // Aggregates that fit return in registers have a complete
+                    // cached representation populated from RET_REGS, including
+                    // arrays and payload enums. (RUE-78, RUE-237)
                     let slot_count = ret_slot_count;
                     let mut slot_vregs = Vec::new();
                     for slot_idx in 0..slot_count {
@@ -2018,9 +2009,7 @@ impl<'a> CfgLower<'a> {
                         // RUE-566). Logical effects (`len` bookkeeping) live
                         // in the caller.
                     } else if slot_count > 1 {
-                        let slot_vregs = self
-                            .get_or_compute_field_vregs(value_val)
-                            .unwrap_or_else(|| vec![self.get_vreg(value_val)]);
+                        let slot_vregs = self.require_aggregate_slots(value_val);
                         crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
                     } else {
                         let value_vreg = self.get_vreg(value_val);
@@ -2425,9 +2414,7 @@ impl<'a> CfgLower<'a> {
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
                 } else {
-                    let base_slots = self
-                        .get_or_compute_field_vregs(base)
-                        .expect("enum payload base must have slot vregs");
+                    let base_slots = self.require_aggregate_slots(base);
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
                     if field_slots > 1 {
@@ -2499,9 +2486,7 @@ impl<'a> CfgLower<'a> {
                     // String requires all 3 slots as arguments to __rue_drop_String.
                     // The accessor handles every source (cache for StructInit/Call/
                     // BlockParam; materialize for Load/Param/PlaceRead). (RUE-118)
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*dropped_value)
-                        .expect("String value should have field vregs");
+                    let field_vregs = self.require_aggregate_slots(*dropped_value);
 
                     // Correctness guard (must run in release): passing the wrong
                     // slot count to __rue_drop_String corrupts the drop call, so
@@ -2520,14 +2505,14 @@ impl<'a> CfgLower<'a> {
                 if let Some(struct_id) = dropped_ty.as_struct() {
                     let struct_def = self.ctx.type_pool.struct_def(struct_id);
 
-                    // All flattened field slots. The accessor materializes
-                    // lazily-sourced values (Load/Param/PlaceRead) so glue
-                    // functions dropping a multi-slot Param element pass real
-                    // slots, not just slot 0 + garbage (RUE-193); fall back to
-                    // the recursive flattener for StructInit.
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*dropped_value)
-                        .unwrap_or_else(|| self.collect_struct_scalar_vregs(*dropped_value));
+                    // Multi-slot structs use the complete aggregate
+                    // representation. Zero- and one-slot structs use their
+                    // scalar/ZST flattening.
+                    let field_vregs = if self.ctx.is_multislot_aggregate(dropped_ty) {
+                        self.require_aggregate_slots(*dropped_value)
+                    } else {
+                        self.collect_struct_scalar_vregs(*dropped_value)
+                    };
 
                     // For user-defined destructor, we need to call it first with all fields.
                     if let Some(ref destructor_name) = struct_def.destructor {
@@ -2581,9 +2566,11 @@ impl<'a> CfgLower<'a> {
                     // slot counts past the argument registers go on the stack
                     // via emit_call_with_slot_args — e.g. [String; 3] is 9
                     // slots, RUE-193)
-                    let mut element_vregs = self
-                        .get_or_compute_field_vregs(*dropped_value)
-                        .unwrap_or_else(|| self.collect_array_scalar_vregs(*dropped_value));
+                    let mut element_vregs = if self.ctx.is_multislot_aggregate(dropped_ty) {
+                        self.require_aggregate_slots(*dropped_value)
+                    } else {
+                        self.collect_array_scalar_vregs(*dropped_value)
+                    };
 
                     // The array drop glue reconstructs each multi-slot element
                     // via one aggregate `Param` read, which uses the reversed
@@ -2607,9 +2594,7 @@ impl<'a> CfgLower<'a> {
                 // which switches on the discriminant and drops the active
                 // variant's payload.
                 if let Some(enum_id) = dropped_ty.as_enum() {
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*dropped_value)
-                        .expect("payload enum value should have field vregs");
+                    let field_vregs = self.require_aggregate_slots(*dropped_value);
                     // File-qualified when the enum name spans files (RUE-571).
                     let drop_fn_name = format!(
                         "__rue_drop_{}",
@@ -2647,12 +2632,8 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::PlaceWrite { place, value: val } => {
                 // A multi-slot aggregate value (struct, String, array, or
-                // payload enum) must write ALL its slots to the place, not just
-                // the first. Single is_multislot_aggregate predicate so enum
-                // payloads are covered by construction (RUE-248). The accessor
-                // materializes lazily-sourced values; if it can't model the
-                // source, fall back to the old single-slot behavior. (RUE-118,
-                // RUE-23)
+                // payload enum) has one vreg per logical slot; PlaceWrite must
+                // store that complete representation. (RUE-118, RUE-23)
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
                 // A zero-sized value has no bytes to store (RUE-577): writing
                 // the dummy vreg CFG carries for unit would clobber a
@@ -2662,8 +2643,7 @@ impl<'a> CfgLower<'a> {
                     return;
                 }
                 let vals = if self.ctx.is_multislot_aggregate(val_type) {
-                    self.get_or_compute_field_vregs(*val)
-                        .unwrap_or_else(|| vec![self.get_vreg(*val)])
+                    self.require_aggregate_slots(*val)
                 } else {
                     vec![self.get_vreg(*val)]
                 };
@@ -3770,30 +3750,16 @@ impl<'a> CfgLower<'a> {
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
                 } else if self.ctx.is_multislot_aggregate(return_type) {
-                    // Return a multi-slot aggregate (struct, array, or a
-                    // payload-carrying enum). Payload enums were previously
-                    // omitted from this gate (it tested `struct || array`
-                    // only), so a by-value enum return fell into the scalar
-                    // branch, shipping only the discriminant in x0 while the
-                    // payload slot base had no slot vregs — ICEing at the
-                    // enum-payload place-read (RUE-237).
-                    // Gather all slots through the single accessor, regardless of source
-                    // (StructInit/ArrayInit/Call/BlockParam cache-hit; Load/Param/
-                    // PlaceRead materialize). Previously the `_` arm returned only slot 0
-                    // of a place-read aggregate, and arrays had NO return path at all —
-                    // only the ArrayInit placeholder vreg reached x0. (RUE-118, RUE-78)
-                    let slot_vregs = self
-                        .get_or_compute_field_vregs(*value)
-                        .unwrap_or_else(|| vec![self.get_vreg(*value)]);
+                    // Return a multi-slot aggregate (struct, array, or payload
+                    // enum). Every valid source has exactly `type_slot_count`
+                    // materialized vregs. (RUE-118, RUE-78, RUE-237)
+                    let slot_vregs = self.require_aggregate_slots(*value);
                     if self.ctx.uses_sret_return(RET_REGS.len() as u32) {
                         // sret return (String always; aggregates that don't fit
                         // the return registers): the caller passed a buffer
                         // pointer as a hidden first argument, which the
                         // prologue saved at the dedicated frame slot one past
                         // the param area. Store every slot through it.
-                        // Previously String returns took the register path
-                        // here while the caller read the (never-written) sret
-                        // buffer — len/cap arrived as garbage. (RUE-92)
                         crate::agg_slots::store_slots_to_sret(self, &slot_vregs);
                     } else {
                         for (i, slot_vreg) in slot_vregs.iter().enumerate() {
@@ -3989,10 +3955,6 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
 }
 
 impl crate::storage_lower::StorageLowerBackend for CfgLower<'_> {
-    fn collect_struct_scalars(&mut self, value: CfgValue) -> Vec<VReg> {
-        self.collect_struct_scalar_vregs(value)
-    }
-
     fn emit_store_ptr_base(&mut self, src: VReg, ptr: VReg) {
         self.mir.push(Aarch64Inst::StrIndexed {
             src: Operand::Virtual(src),
@@ -4011,8 +3973,8 @@ impl crate::aggregate_eq::AggregateEqBackend for CfgLower<'_> {
     fn map_value(&mut self, value: CfgValue, vreg: VReg) {
         self.value_map.insert(value, vreg);
     }
-    fn aggregate_slots(&mut self, value: CfgValue) -> Option<Vec<VReg>> {
-        self.get_or_compute_field_vregs(value)
+    fn aggregate_slots(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.require_aggregate_slots(value)
     }
     fn emit_bool_const(&mut self, dst: VReg, value: bool) {
         self.mir.push(Aarch64Inst::MovImm {

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -2,11 +2,8 @@
 //!
 //! Multi-slot aggregates (structs, fixed-size arrays, the 3-slot `String` fat
 //! pointer) are tracked during CFG lowering as a list of one vreg per slot in
-//! the lowerer's `struct_slot_vregs` cache. Historically each backend carried
-//! its own hand-mirrored copy of the logic that produces that list, and the
-//! copies drifted — several confirmed miscompiles (the RUE-118 family, the
-//! `is_struct`-before-`is_builtin_string` ordering bug) were pure drift
-//! between the two `cfg_lower.rs` files.
+//! the lowerer's `struct_slot_vregs` cache. Both backends use this module so
+//! every aggregate consumer observes the same representation.
 //!
 //! This module is the single implementation. The slot *logic* is entirely
 //! target-independent — "load N consecutive frame slots", "walk static field
@@ -107,7 +104,9 @@ pub trait SlotBackend {
 ///   `s.rows[i]`) or a by-ref param base: bounds-check every index, form the
 ///   place's address, and load all `slot_count` slots through it (RUE-188)
 ///
-/// Returns `None` for non-aggregate types and unmodeled sources.
+/// Returns `None` for non-aggregate types. Valid multi-slot aggregate values
+/// are either materialized directly here or are lowered on demand and read
+/// from the cache populated by their lowering rule.
 pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) -> Option<Vec<VReg>> {
     // Check cache first
     if let Some(vregs) = b.slot_cache().get(&value).cloned() {
@@ -127,24 +126,6 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
     }
 
     match data {
-        CfgInstData::StructInit {
-            fields_start,
-            fields_len,
-            ..
-        } => {
-            let fields = b.ctx().cfg.get_extra(fields_start, fields_len).to_vec();
-            // Zero-sized fields (unit, [T; 0]) occupy no slots (RUE-577):
-            // including their dummy vregs would shift every later field.
-            let mut vregs = Vec::with_capacity(fields.len());
-            for f in &fields {
-                let field_ty = b.ctx().cfg.get_inst(*f).ty;
-                if b.ctx().type_slot_count(field_ty) == 0 {
-                    continue;
-                }
-                vregs.push(b.get_vreg(*f));
-            }
-            Some(vregs)
-        }
         CfgInstData::Load { slot } => {
             let slot_count = b.ctx().type_slot_count(ty);
             Some(load_consecutive(b, slot, slot_count))
@@ -213,9 +194,6 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
             // every index projection, form the place's low-end address, then
             // load each slot through it. Slot k lives at addr + k*8 (ascending,
             // ADR-0040 / RUE-311), matching `store_slots_through_ptr`.
-            // Previously these sources returned None and every consumer's
-            // fallback materialized only slot 0 — the RUE-188 miscompile
-            // family. (RUE-188/192)
             for proj in &projections {
                 if let Projection::Index { array_type, index } = proj {
                     let length = b.ctx().array_length(*array_type);
@@ -227,9 +205,52 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
             b.emit_place_addr(addr_vreg, &place);
             Some(load_through_ptr(b, addr_vreg, slot_count))
         }
-        // BlockParam and Call should already have slot vregs in the cache
-        _ => None,
+        // Eager aggregate producers (StructInit, ArrayInit, EnumVariant,
+        // EnumPayloadGet, Call, Intrinsic, and BlockParam) establish their
+        // complete slot list as part of lowering. Trigger lazy lowering when
+        // necessary, then retrieve that representation. A missing entry is
+        // malformed internal IR and is rejected by `require_aggregate_slots`.
+        _ => {
+            b.get_vreg(value);
+            b.slot_cache().get(&value).cloned()
+        }
     }
+}
+
+/// Materialize and return the complete representation of a multi-slot
+/// aggregate value.
+///
+/// Every valid CFG producer of a multi-slot aggregate has exactly one vreg per
+/// logical type slot. Consumers must use this total accessor: continuing with
+/// a primary vreg alone would emit a partial value. Missing or incorrectly
+/// sized representations therefore indicate malformed internal IR and fail an
+/// invariant in release builds.
+pub fn require_aggregate_slots<B: SlotBackend>(b: &mut B, value: CfgValue) -> Vec<VReg> {
+    let ty = b.ctx().cfg.get_inst(value).ty;
+    assert!(
+        b.ctx().is_multislot_aggregate(ty),
+        "aggregate slot materialization requires a multi-slot aggregate value: {value}"
+    );
+    let expected = b.ctx().type_slot_count(ty) as usize;
+    let slots = get_or_compute_field_vregs(b, value).unwrap_or_else(|| {
+        if expected == 1 {
+            // A one-slot aggregate's primary vreg is its complete
+            // representation. Some scalar-producing intrinsics intentionally
+            // do not populate the aggregate slot cache for that case.
+            vec![b.get_vreg(value)]
+        } else {
+            panic!("multi-slot aggregate {value} has no complete slot representation")
+        }
+    });
+    assert_complete_slot_count(value, slots.len(), expected);
+    slots
+}
+
+fn assert_complete_slot_count(value: CfgValue, actual: usize, expected: usize) {
+    assert_eq!(
+        actual, expected,
+        "multi-slot aggregate {value} slot count mismatch: representation has {actual} slots, type requires {expected}"
+    );
 }
 
 /// Total slot count of the ROOT object a place is rooted at. Ascending place addressing
@@ -306,29 +327,16 @@ pub fn lower_struct_init<B: SlotBackend>(
         }
         match field_ty.kind() {
             TypeKind::Struct(_) | TypeKind::Enum(_) => {
-                // Struct/payload-enum field: contribute every slot. A
-                // payload enum here previously fell to the scalar `_` arm and
-                // contributed only its discriminant vreg, so the struct stored
-                // just the tag and dropped the payload (RUE-237). The accessor
-                // returns None for a discriminant-only (1-slot) enum, which
-                // correctly falls back to the single-vreg push.
-                if let Some(nested) = get_or_compute_field_vregs(b, *field) {
-                    slot_vregs.extend(nested);
+                // Struct/payload-enum fields contribute their complete slot
+                // representation. Discriminant-only enums remain scalars.
+                if b.ctx().is_multislot_aggregate(field_ty) {
+                    slot_vregs.extend(require_aggregate_slots(b, *field));
                 } else {
                     slot_vregs.push(b.get_vreg(*field));
                 }
             }
             TypeKind::Array(_) => {
-                // Try the accessor first: it materializes lazily-sourced
-                // arrays (Load/Param/PlaceRead — including an indexed read
-                // like `S { arr: m[i], .. }`, RUE-188) and cache-hits eager
-                // ones. Fall back to the recursive flattener for ArrayInit,
-                // whose element vregs it gathers directly.
-                if let Some(nested) = get_or_compute_field_vregs(b, *field) {
-                    slot_vregs.extend(nested);
-                } else {
-                    slot_vregs.extend(b.collect_array_scalars(*field));
-                }
+                slot_vregs.extend(require_aggregate_slots(b, *field));
             }
             _ => {
                 // Scalar field - single vreg
@@ -388,18 +396,14 @@ pub fn lower_enum_variant<B: SlotBackend>(
         }
         match field_ty.kind() {
             TypeKind::Struct(_) | TypeKind::Enum(_) => {
-                if let Some(nested) = get_or_compute_field_vregs(b, *field) {
-                    slot_vregs.extend(nested);
+                if b.ctx().is_multislot_aggregate(field_ty) {
+                    slot_vregs.extend(require_aggregate_slots(b, *field));
                 } else {
                     slot_vregs.push(b.get_vreg(*field));
                 }
             }
             TypeKind::Array(_) => {
-                if let Some(nested) = get_or_compute_field_vregs(b, *field) {
-                    slot_vregs.extend(nested);
-                } else {
-                    slot_vregs.extend(b.collect_array_scalars(*field));
-                }
+                slot_vregs.extend(require_aggregate_slots(b, *field));
             }
             _ => slot_vregs.push(b.get_vreg(*field)),
         }
@@ -454,8 +458,8 @@ pub fn lower_array_init<B: SlotBackend>(
             e_ty.kind(),
             TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_)
         ) {
-            if let Some(nested) = get_or_compute_field_vregs(b, *e) {
-                element_vregs.extend(nested);
+            if b.ctx().is_multislot_aggregate(e_ty) {
+                element_vregs.extend(require_aggregate_slots(b, *e));
             } else {
                 element_vregs.push(b.get_vreg(*e));
             }
@@ -566,4 +570,24 @@ fn load_through_ptr<B: SlotBackend>(b: &mut B, addr_vreg: VReg, count: u32) -> V
         vregs.push(vreg);
     }
     vregs
+}
+
+#[cfg(test)]
+mod tests {
+    use rue_cfg::CfgValue;
+
+    use super::assert_complete_slot_count;
+
+    #[test]
+    fn complete_aggregate_slot_count_is_valid() {
+        assert_complete_slot_count(CfgValue::from_raw(7), 4, 4);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "multi-slot aggregate v7 slot count mismatch: representation has 1 slots, type requires 4"
+    )]
+    fn partial_aggregate_slot_representation_panics() {
+        assert_complete_slot_count(CfgValue::from_raw(7), 1, 4);
+    }
 }

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -232,15 +232,16 @@ pub fn require_aggregate_slots<B: SlotBackend>(b: &mut B, value: CfgValue) -> Ve
         "aggregate slot materialization requires a multi-slot aggregate value: {value}"
     );
     let expected = b.ctx().type_slot_count(ty) as usize;
-    let slots = get_or_compute_field_vregs(b, value).unwrap_or_else(|| {
-        if expected == 1 {
-            // A one-slot aggregate's primary vreg is its complete
-            // representation. Some scalar-producing intrinsics intentionally
-            // do not populate the aggregate slot cache for that case.
-            vec![b.get_vreg(value)]
-        } else {
-            panic!("multi-slot aggregate {value} has no complete slot representation")
-        }
+    let slots = get_or_compute_field_vregs(b, value).unwrap_or_else(|| match expected {
+        // A zero-slot aggregate's empty representation is complete. Producers
+        // intentionally have no slot-cache entry because there are no vregs to
+        // record (for example, an ArrayBuf element whose type is a ZST).
+        0 => Vec::new(),
+        // A one-slot aggregate's primary vreg is its complete representation.
+        // Some scalar-producing intrinsics intentionally do not populate the
+        // aggregate slot cache for that case.
+        1 => vec![b.get_vreg(value)],
+        _ => panic!("multi-slot aggregate {value} has no complete slot representation"),
     });
     assert_complete_slot_count(value, slots.len(), expected);
     slots
@@ -581,6 +582,11 @@ mod tests {
     #[test]
     fn complete_aggregate_slot_count_is_valid() {
         assert_complete_slot_count(CfgValue::from_raw(7), 4, 4);
+    }
+
+    #[test]
+    fn empty_zero_sized_aggregate_representation_is_valid() {
+        assert_complete_slot_count(CfgValue::from_raw(7), 0, 0);
     }
 
     #[test]

--- a/crates/rue-codegen/src/aggregate_eq.rs
+++ b/crates/rue-codegen/src/aggregate_eq.rs
@@ -23,7 +23,7 @@ pub trait AggregateEqBackend {
     fn map_value(&mut self, value: CfgValue, vreg: VReg);
 
     /// Return the flattened slot vregs for an aggregate CFG value.
-    fn aggregate_slots(&mut self, value: CfgValue) -> Option<Vec<VReg>>;
+    fn aggregate_slots(&mut self, value: CfgValue) -> Vec<VReg>;
 
     /// Emit `dst = value` for boolean values represented as 0/1 integers.
     fn emit_bool_const(&mut self, dst: VReg, value: bool);
@@ -59,12 +59,8 @@ pub fn emit_aggregate_equality<B: AggregateEqBackend>(
         return;
     }
 
-    let lhs_slots = b
-        .aggregate_slots(lhs)
-        .expect("aggregate should have slot vregs");
-    let rhs_slots = b
-        .aggregate_slots(rhs)
-        .expect("aggregate should have slot vregs");
+    let lhs_slots = b.aggregate_slots(lhs);
+    let rhs_slots = b.aggregate_slots(rhs);
     assert_aggregate_slot_count("lhs", lhs_slots.len(), leaf_types.len());
     assert_aggregate_slot_count("rhs", rhs_slots.len(), leaf_types.len());
 

--- a/crates/rue-codegen/src/storage_lower.rs
+++ b/crates/rue-codegen/src/storage_lower.rs
@@ -13,9 +13,6 @@ use crate::vreg::VReg;
 
 /// Narrow target-specific leaves used by shared storage lowering.
 pub(crate) trait StorageLowerBackend: PlaceLowerBackend {
-    /// Recursively flatten a struct value not modeled by the slot accessor.
-    fn collect_struct_scalars(&mut self, value: CfgValue) -> Vec<VReg>;
-
     /// Store through `ptr` using the backend's base-only MIR form.
     ///
     /// AArch64 intentionally distinguishes `StrIndexed` from
@@ -27,17 +24,10 @@ pub(crate) trait StorageLowerBackend: PlaceLowerBackend {
 /// Lower a local allocation and its initializer.
 pub(crate) fn lower_alloc<B: StorageLowerBackend>(b: &mut B, slot: u32, init: CfgValue) {
     let init_type = b.ctx().cfg.get_inst(init).ty;
-    if init_type.is_array() {
-        // Materialize lazily-sourced arrays through the accessor and fall back
-        // to recursively flattening ArrayInit values.
-        let scalar_vregs = agg_slots::get_or_compute_field_vregs(b, init)
-            .unwrap_or_else(|| b.collect_array_scalars(init));
-        agg_slots::store_slots(b, &scalar_vregs, slot);
-    } else if b.ctx().is_builtin_string(init_type) {
+    if b.ctx().is_builtin_string(init_type) {
         // StrBuf is always the ptr/len/cap three-slot fat pointer. Keep this
-        // before generic structs so a layout drift fails loudly.
-        let field_vregs = agg_slots::get_or_compute_field_vregs(b, init)
-            .expect("string should have fat pointer fields in Alloc");
+        // before generic aggregates so a layout drift fails loudly.
+        let field_vregs = agg_slots::require_aggregate_slots(b, init);
         assert_eq!(
             field_vregs.len(),
             3,
@@ -45,10 +35,12 @@ pub(crate) fn lower_alloc<B: StorageLowerBackend>(b: &mut B, slot: u32, init: Cf
         );
         agg_slots::store_slots(b, &field_vregs, slot);
     } else if b.ctx().is_multislot_aggregate(init_type) {
-        // Struct or payload enum: the accessor handles cached and lazy values;
-        // retain the recursive fallback for sources it does not model.
-        let scalar_vregs = agg_slots::get_or_compute_field_vregs(b, init)
-            .unwrap_or_else(|| b.collect_struct_scalars(init));
+        // Every multi-slot aggregate initializer has one vreg per logical slot.
+        let scalar_vregs = agg_slots::require_aggregate_slots(b, init);
+        agg_slots::store_slots(b, &scalar_vregs, slot);
+    } else if init_type.is_array() {
+        // Zero- and one-slot arrays use their scalar/ZST representation.
+        let scalar_vregs = b.collect_array_scalars(init);
         agg_slots::store_slots(b, &scalar_vregs, slot);
     } else {
         let init_vreg = b.get_vreg(init);
@@ -90,11 +82,10 @@ pub(crate) fn lower_load<B: StorageLowerBackend>(b: &mut B, value: CfgValue, slo
 /// Lower a store to either a local frame slot or an inout parameter's pointee.
 pub(crate) fn lower_store<B: StorageLowerBackend>(b: &mut B, slot: u32, value: CfgValue) {
     let value_type = b.ctx().cfg.get_inst(value).ty;
-    let aggregate_vregs = if b.ctx().is_multislot_aggregate(value_type) {
-        agg_slots::get_or_compute_field_vregs(b, value)
-    } else {
-        None
-    };
+    let aggregate_vregs = b
+        .ctx()
+        .is_multislot_aggregate(value_type)
+        .then(|| agg_slots::require_aggregate_slots(b, value));
 
     if let Some(slot_vregs) = aggregate_vregs {
         if let Some(param_slot) = inout_param_for_slot(b, slot) {
@@ -125,11 +116,10 @@ pub(crate) fn lower_param_store<B: StorageLowerBackend>(
     }
 
     let value_type = b.ctx().cfg.get_inst(value).ty;
-    let aggregate_vregs = if b.ctx().is_multislot_aggregate(value_type) {
-        agg_slots::get_or_compute_field_vregs(b, value)
-    } else {
-        None
-    };
+    let aggregate_vregs = b
+        .ctx()
+        .is_multislot_aggregate(value_type)
+        .then(|| agg_slots::require_aggregate_slots(b, value));
 
     let ptr = b.ensure_inout_param_ptr(param_slot);
     if let Some(slot_vregs) = aggregate_vregs {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -501,6 +501,12 @@ impl<'a> CfgLower<'a> {
         crate::agg_slots::get_or_compute_field_vregs(self, value)
     }
 
+    /// Materialize every slot of a multi-slot aggregate or fail the CFG
+    /// representation invariant.
+    fn require_aggregate_slots(&mut self, value: CfgValue) -> Vec<VReg> {
+        crate::agg_slots::require_aggregate_slots(self, value)
+    }
+
     /// Copy an aggregate value's slot vregs to a block parameter's slot vregs.
     /// Covers structs, builtin String, and fixed-size arrays — every slot must
     /// cross the join edge, not just the primary vreg (RUE-167).
@@ -512,17 +518,7 @@ impl<'a> CfgLower<'a> {
     ) {
         let target_param = self.ctx.cfg.get_block(target_block).params[param_idx as usize].0;
 
-        // The accessor covers StructInit/ArrayInit/Call/BlockParam (cache
-        // hits) and Load/Param/static PlaceRead; fall back to the recursive
-        // flatteners for anything it doesn't model (mirrors Alloc lowering).
-        let src_slots = self.get_or_compute_field_vregs(arg).unwrap_or_else(|| {
-            let arg_ty = self.ctx.cfg.get_inst(arg).ty;
-            if arg_ty.is_array() {
-                self.collect_array_scalar_vregs(arg)
-            } else {
-                self.collect_struct_scalar_vregs(arg)
-            }
-        });
+        let src_slots = self.require_aggregate_slots(arg);
         let dst_slots = self
             .struct_slot_vregs
             .get(&target_param)
@@ -1786,26 +1782,20 @@ impl<'a> CfgLower<'a> {
                         // The old per-source array ladder iterated array_len (element
                         // count), not slot_count, so a multidimensional array dropped
                         // every row after the first. (RUE-118, RUE-79)
-                        if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
-                            // Pass a Rue callee's aggregate slots in REVERSED
-                            // logical order (ADR-0040 / RUE-311). The callee
-                            // prologue spills ABI slot j to frame slot base+j, so
-                            // pushing logical slot k at ABI slot (C-1-k) lands it
-                            // at frame slot base + (C-1-k) — exactly the
-                            // ascending frame layout `store_slots`/
-                            // `load_consecutive` use for locals (logical slot 0
-                            // at the low-address end). Without this, by-value
-                            // aggregate params would sit in descending order
-                            // while every other aggregate is ascending, and field
-                            // reads (which now assume ascending) would transpose
-                            // the fields. Runtime callees keep natural order.
-                            if callee_is_runtime {
-                                flattened_vregs.extend(field_vregs);
-                            } else {
-                                flattened_vregs.extend(field_vregs.into_iter().rev());
-                            }
+                        let field_vregs = self.require_aggregate_slots(arg_value);
+                        // Pass a Rue callee's aggregate slots in REVERSED
+                        // logical order (ADR-0040 / RUE-311). The callee
+                        // prologue spills ABI slot j to frame slot base+j, so
+                        // pushing logical slot k at ABI slot (C-1-k) lands it
+                        // at frame slot base + (C-1-k) — exactly the
+                        // ascending frame layout `store_slots`/
+                        // `load_consecutive` use for locals (logical slot 0
+                        // at the low-address end). Runtime callees keep
+                        // natural order.
+                        if callee_is_runtime {
+                            flattened_vregs.extend(field_vregs);
                         } else {
-                            flattened_vregs.push(self.get_vreg(arg_value));
+                            flattened_vregs.extend(field_vregs.into_iter().rev());
                         }
                     } else {
                         // Note: String is now Type::Struct, handled above
@@ -1900,9 +1890,8 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(slot_vregs[0]),
                     });
                 } else if self.ctx.is_multislot_aggregate(ty) {
-                    // Aggregates that fit return in registers. Capture
-                    // every slot from RET_REGS, not just rax — arrays previously fell
-                    // to the scalar path and lost all elements but the first. (RUE-78)
+                    // Aggregates that fit return in registers have a complete
+                    // cached representation populated from RET_REGS. (RUE-78)
                     let slot_count = ret_slot_count;
                     let mut slot_vregs = Vec::new();
                     for slot_idx in 0..slot_count {
@@ -2361,9 +2350,7 @@ impl<'a> CfgLower<'a> {
                         // RUE-566). Logical effects (`len` bookkeeping) live
                         // in the caller.
                     } else if slot_count > 1 {
-                        let slot_vregs = self
-                            .get_or_compute_field_vregs(value_val)
-                            .unwrap_or_else(|| vec![self.get_vreg(value_val)]);
+                        let slot_vregs = self.require_aggregate_slots(value_val);
                         crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
                     } else {
                         let value_vreg = self.get_vreg(value_val);
@@ -2779,9 +2766,7 @@ impl<'a> CfgLower<'a> {
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
                 } else {
-                    let base_slots = self
-                        .get_or_compute_field_vregs(base)
-                        .expect("enum payload base must have slot vregs");
+                    let base_slots = self.require_aggregate_slots(base);
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
                     if field_slots > 1 {
@@ -2856,9 +2841,7 @@ impl<'a> CfgLower<'a> {
                     // String requires all 3 slots as arguments to __rue_drop_String.
                     // The accessor handles every source (cache for StructInit/Call/
                     // BlockParam; materialize for Load/Param/PlaceRead). (RUE-118)
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*dropped_value)
-                        .expect("String value should have field vregs");
+                    let field_vregs = self.require_aggregate_slots(*dropped_value);
 
                     // Correctness guard (must run in release): passing the wrong
                     // slot count to __rue_drop_String corrupts the drop call, so
@@ -2877,14 +2860,14 @@ impl<'a> CfgLower<'a> {
                 if let TypeKind::Struct(struct_id) = dropped_ty.kind() {
                     let struct_def = self.ctx.type_pool.struct_def(struct_id);
 
-                    // All flattened field slots. The accessor materializes
-                    // lazily-sourced values (Load/Param/PlaceRead) so glue
-                    // functions dropping a multi-slot Param element pass real
-                    // slots, not just slot 0 + garbage (RUE-193); fall back to
-                    // the recursive flattener for StructInit.
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*dropped_value)
-                        .unwrap_or_else(|| self.collect_struct_scalar_vregs(*dropped_value));
+                    // Multi-slot structs use the complete aggregate
+                    // representation. Zero- and one-slot structs use their
+                    // scalar/ZST flattening.
+                    let field_vregs = if self.ctx.is_multislot_aggregate(dropped_ty) {
+                        self.require_aggregate_slots(*dropped_value)
+                    } else {
+                        self.collect_struct_scalar_vregs(*dropped_value)
+                    };
 
                     // For builtin types (e.g., String), the destructor IS the drop glue.
                     // We call only the destructor and skip the drop glue to avoid double-calling.
@@ -2945,9 +2928,11 @@ impl<'a> CfgLower<'a> {
                     // slot counts past the argument registers go on the stack
                     // via emit_call_with_slot_args — e.g. [String; 3] is 9
                     // slots, RUE-193)
-                    let mut element_vregs = self
-                        .get_or_compute_field_vregs(*dropped_value)
-                        .unwrap_or_else(|| self.collect_array_scalar_vregs(*dropped_value));
+                    let mut element_vregs = if self.ctx.is_multislot_aggregate(dropped_ty) {
+                        self.require_aggregate_slots(*dropped_value)
+                    } else {
+                        self.collect_array_scalar_vregs(*dropped_value)
+                    };
 
                     // The array drop glue reconstructs each multi-slot element
                     // via one aggregate `Param` read, which uses the reversed
@@ -2971,9 +2956,7 @@ impl<'a> CfgLower<'a> {
                 // which switches on the discriminant and drops the active
                 // variant's payload.
                 if let TypeKind::Enum(enum_id) = dropped_ty.kind() {
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*dropped_value)
-                        .expect("payload enum value should have field vregs");
+                    let field_vregs = self.require_aggregate_slots(*dropped_value);
                     // File-qualified when the enum name spans files (RUE-571).
                     let drop_fn_name = format!(
                         "__rue_drop_{}",
@@ -3010,10 +2993,9 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::PlaceWrite { place, value: val } => {
-                // A multi-slot aggregate value (struct, String, array) must write
-                // ALL its slots to the place, not just the first. The accessor
-                // materializes lazily-sourced values; if it can't model the source,
-                // fall back to the old single-slot behavior. (RUE-118, RUE-23)
+                // A multi-slot aggregate value (struct, String, array, or
+                // payload enum) has one vreg per logical slot; PlaceWrite must
+                // store that complete representation. (RUE-118, RUE-23)
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
                 // A zero-sized value has no bytes to store (RUE-577): writing
                 // the dummy vreg CFG carries for unit would clobber a
@@ -3023,8 +3005,7 @@ impl<'a> CfgLower<'a> {
                     return;
                 }
                 let vals = if self.ctx.is_multislot_aggregate(val_type) {
-                    self.get_or_compute_field_vregs(*val)
-                        .unwrap_or_else(|| vec![self.get_vreg(*val)])
+                    self.require_aggregate_slots(*val)
                 } else {
                     vec![self.get_vreg(*val)]
                 };
@@ -3723,29 +3704,16 @@ impl<'a> CfgLower<'a> {
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(X86Inst::CallRel { symbol_id });
                 } else if self.ctx.is_multislot_aggregate(return_type) {
-                    // Return a multi-slot aggregate (struct, array, or a
-                    // payload-carrying enum). Payload enums were previously
-                    // omitted from this gate (it tested `struct || array`
-                    // only), so a by-value enum return fell into the scalar
-                    // branch and shipped only the discriminant in rax while
-                    // the payload slot in rdx was never written (RUE-237).
-                    // Gather all slots through the single accessor, regardless of source
-                    // (StructInit/ArrayInit/Call/BlockParam cache-hit; Load/Param/
-                    // PlaceRead materialize). Previously the `_` arm returned only slot 0
-                    // of a place-read aggregate, and arrays had NO return path at all —
-                    // only the ArrayInit placeholder vreg reached rax. (RUE-118, RUE-78)
-                    let slot_vregs = self
-                        .get_or_compute_field_vregs(*value)
-                        .unwrap_or_else(|| vec![self.get_vreg(*value)]);
+                    // Return a multi-slot aggregate (struct, array, or payload
+                    // enum). Every valid source has exactly `type_slot_count`
+                    // materialized vregs. (RUE-118, RUE-78, RUE-237)
+                    let slot_vregs = self.require_aggregate_slots(*value);
                     if self.ctx.uses_sret_return(RET_REGS.len() as u32) {
                         // sret return (String always; aggregates that don't fit
                         // the return registers): the caller passed a buffer
                         // pointer as a hidden first argument, which the
                         // prologue saved at the dedicated frame slot one past
                         // the param area. Store every slot through it.
-                        // Previously String returns took the register path
-                        // here while the caller read the (never-written) sret
-                        // buffer — len/cap arrived as garbage. (RUE-92)
                         crate::agg_slots::store_slots_to_sret(self, &slot_vregs);
                     } else {
                         // Move slot values to return registers in REVERSE order: regalloc
@@ -3952,10 +3920,6 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
 }
 
 impl crate::storage_lower::StorageLowerBackend for CfgLower<'_> {
-    fn collect_struct_scalars(&mut self, value: CfgValue) -> Vec<VReg> {
-        self.collect_struct_scalar_vregs(value)
-    }
-
     fn emit_store_ptr_base(&mut self, src: VReg, ptr: VReg) {
         self.mir.push(X86Inst::MovMRIndexed {
             base: ptr,
@@ -3975,8 +3939,8 @@ impl crate::aggregate_eq::AggregateEqBackend for CfgLower<'_> {
     fn map_value(&mut self, value: CfgValue, vreg: VReg) {
         self.value_map.insert(value, vreg);
     }
-    fn aggregate_slots(&mut self, value: CfgValue) -> Option<Vec<VReg>> {
-        self.get_or_compute_field_vregs(value)
+    fn aggregate_slots(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.require_aggregate_slots(value)
     }
     fn emit_bool_const(&mut self, dst: VReg, value: bool) {
         self.mir.push(X86Inst::MovRI32 {


### PR DESCRIPTION
## Summary

- make aggregate-slot materialization total through a shared invariant-checked accessor
- remove scalar fallbacks from x86-64, AArch64, shared storage, equality, call, block-parameter, pointer-write, place-write, drop, and return lowering
- reject missing or partial multi-slot representations instead of emitting slot 0

## Why

Valid multi-slot CFG values must have exactly one virtual register per logical slot. The old fallback could silently emit only the primary register when a source was not already cached, partially materializing structs, arrays, payload enums, calls, block parameters, and register/sret returns.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (24 targets, 0 failures; rue-codegen 490/490)
- `scripts/rue cli aggregate_abi_matrix` (33/33)
- isolated `//:ui-tests` (178/178)
- `git diff --check`

The all-target local run encountered macOS load-sensitive two-second oracle-smoke timeouts; an affected seed agreed when rerun directly with a ten-second phase timeout. Merge-queue CI remains the authoritative full-platform gate.

Fixes RUE-758.
