### PR TITLE
RUE-757: retire deprecated String type alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ graph LR
 | `rue-cli-tests` | CLI integration tests (real binary, real files) |
 | `rue-fuzz` | Fuzz testing infrastructure |
 | `rue-runtime` | Runtime support |
-| `rue-builtins` | Built-in type definitions (String) |
+| `rue-builtins` | Built-in type definitions (StrBuf) |
 
 ### Modules and Multi-File Compilation
 
@@ -120,11 +120,11 @@ tests or examples that rely on flat file lists.
 - **Index-based references**: Instructions stored in vectors, referenced by u32 indices (cache-friendly, no lifetimes)
 - **Direct code emission**: No LLVM dependency; machine code emitted directly
 - **Minimal linking**: Static executables with direct syscalls
-- **Built-in types as synthetic structs**: Types like `String` are defined in `rue-builtins` and injected as synthetic structs, not as hardcoded special-cased built-in types (see [ADR-0020](docs/designs/0020-builtin-types-as-structs.md))
+- **Built-in types as synthetic structs**: Types like `StrBuf` are defined in `rue-builtins` and injected as synthetic structs, not as hardcoded special-cased built-in types (see [ADR-0020](docs/designs/0020-builtin-types-as-structs.md))
 
 ### Built-in Types Architecture
 
-Built-in types (currently `String`) are "synthetic structs" injected before user
+Built-in types (currently `StrBuf`) are "synthetic structs" injected before user
 code, so they flow through the same paths as user structs (see
 [ADR-0020](docs/designs/0020-builtin-types-as-structs.md)). Collection types
 like `ArrayBuf` are NOT builtins — they are ordinary Rue source in `std/`,

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2222,7 +2222,7 @@ impl<'a> ConstraintGenerator<'a> {
                 // associated-function call / enum tuple-variant construction
                 // (RUE-488): forward to the type-qualified path so arguments are
                 // constrained to the callee signature (a bare `MethodCall` arm
-                // would leave a literal like the `8` in `String.with_capacity(8)`
+                // would leave a literal like the `8` in `StrBuf.with_capacity(8)`
                 // unconstrained, defaulting it to `i32` and later clashing with a
                 // `u64` parameter). Skip when a runtime value (a parameter, or a
                 // local that is not itself a comptime type value) shadows the type
@@ -2740,7 +2740,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// type. Shared by the `AssocFnCall` arm and the `MethodCall` arm's
     /// type-name-receiver forwarding (`Type.function(args)`, RUE-488). Getting
     /// the argument constraints here — not just in sema — is what pins a literal
-    /// like the `8` in `String.with_capacity(8)` to the declared `u64` parameter
+    /// like the `8` in `StrBuf.with_capacity(8)` to the declared `u64` parameter
     /// instead of letting it default to `i32`.
     fn generate_type_qualified_call(
         &mut self,
@@ -2795,7 +2795,7 @@ impl<'a> ConstraintGenerator<'a> {
     /// type: enum tuple-variant construction (`Shape.Circle(5)`, RUE-221) or a
     /// struct associated-function call. Imposing the declared payload/parameter
     /// types on the arguments here — not just in sema — is what pins a literal
-    /// like the `8` in `String.with_capacity(8)` to the declared `u64` instead
+    /// like the `8` in `StrBuf.with_capacity(8)` to the declared `u64` instead
     /// of letting it default to `i32`. Shared by
     /// [`Self::generate_type_qualified_call`] (name-resolved heads) and the
     /// inline type-constructor head path (sema-reduced heads, RUE-599).

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -409,18 +409,6 @@ impl TypeInternPool {
         (StructId::from_pool_index(pool_index), true)
     }
 
-    /// Register an additional (alias) name for an already-registered struct.
-    ///
-    /// Register an additional file-qualified name for an existing struct.
-    pub fn alias_struct_name_in_file(&self, file_id: FileId, alias: Spur, struct_id: StructId) {
-        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
-        if inner.struct_by_file_name.contains_key(&(file_id, alias)) {
-            return;
-        }
-        let interned = InternedType::from_pool_index(struct_id.pool_index());
-        inner.struct_by_file_name.insert((file_id, alias), interned);
-    }
-
     /// Reserve a struct ID without registering the full definition yet.
     ///
     /// This is used for anonymous structs where we need to know the ID before

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -646,9 +646,8 @@ impl<'a> BodySema<'a> {
     /// The runtime ABI consumes the builtin `StrBuf` representation. Checking
     /// nominal type identity here is important: accepting any aggregate with a
     /// convenient slot count would let codegen reinterpret its first fields as
-    /// a pointer and length. `String` remains accepted because it is a source
-    /// alias for the same builtin type, while `str`, `Str(N)`, and user structs
-    /// are distinct types even when part of their layout happens to match.
+    /// a pointer and length. `str`, `Str(N)`, and user structs are distinct
+    /// types even when part of their layout happens to match.
     fn validate_abort_message_type(
         &self,
         intrinsic_name: &str,

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -2057,7 +2057,7 @@ mod tests {
 
     #[test]
     fn declaration_shell_adapter_preserves_semantic_predeclaration_failure_provenance() {
-        let (tokens, interner) = Lexer::new("struct String {} fn main() {}")
+        let (tokens, interner) = Lexer::new("struct StrBuf {} fn main() {}")
             .tokenize()
             .unwrap();
         let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -14,7 +14,7 @@ use crate::types::{EnumDef, StructDef, StructField, StructId, Type, TypeKind};
 impl<'a> Sema<'a> {
     /// Phase 0: Inject built-in types as synthetic structs and enums.
     ///
-    /// This creates `StructDef` entries for built-in types like `String` and
+    /// This creates `StructDef` entries for built-in types like `StrBuf` and
     /// `EnumDef` entries for built-in enums like `Arch` and `Os` before
     /// processing user code. The built-in types are registered in the `structs`
     /// and `enums` HashMaps so they can be looked up by name, and their IDs are
@@ -23,7 +23,7 @@ impl<'a> Sema<'a> {
     /// Built-in types are marked with `is_builtin: true` and have their fields,
     /// destructor, and copy status derived from the `rue-builtins` registry.
     pub(crate) fn inject_builtin_types(&mut self) {
-        // Inject built-in struct types (String, etc.)
+        // Inject built-in struct types (StrBuf, etc.)
         for builtin in BUILTIN_TYPES {
             // Convert builtin field types to our Type enum
             let fields: Vec<StructField> = builtin
@@ -65,19 +65,6 @@ impl<'a> Sema<'a> {
             // Store special IDs for quick access
             if builtin.name == "StrBuf" {
                 self.builtin_string_id = Some(struct_id);
-
-                // ADR-0043 renamed `String` -> `StrBuf`. Keep `String` as a
-                // deprecated source-level alias for one migration cycle: it
-                // resolves to the *same* synthetic struct, so existing code
-                // (`let s: String = ...`) keeps type-checking while new code
-                // uses `StrBuf`. The name also stays reserved
-                // (`is_reserved_type_name`) so users cannot shadow it.
-                let alias_spur = self.interner.get_or_intern(rue_builtins::STRING_ALIAS_NAME);
-                self.builtin_structs.insert(alias_spur, struct_id);
-                self.structs_by_file_name
-                    .insert((file_id, alias_spur), struct_id);
-                self.type_pool
-                    .alias_struct_name_in_file(file_id, alias_spur, struct_id);
             }
 
             // Note: Associated functions and methods are not registered here.

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -675,7 +675,7 @@ mod tests {
         // and CFG (RUE-512). `@assert` returns on the success path, so it stays
         // unit-typed. Both must agree with the inference contract. The message
         // operand's own type never changes the intrinsic's result type
-        // (StrBuf/String-alias messages, never-typed operands).
+        // (StrBuf messages, never-typed operands).
         for (name, body, expected) in [
             ("panic_no_message", "@panic()", Type::NEVER),
             ("panic_with_message", "@panic(\"boom\")", Type::NEVER),
@@ -688,11 +688,6 @@ mod tests {
             (
                 "panic_with_strbuf",
                 "let message: StrBuf = \"boom\"; @panic(message)",
-                Type::NEVER,
-            ),
-            (
-                "panic_with_string_alias",
-                "let message: String = \"boom\"; @panic(message)",
                 Type::NEVER,
             ),
             (
@@ -2416,15 +2411,6 @@ mod tests {
             "StrBuf should be in struct registry"
         );
 
-        // The deprecated `String` alias resolves to the *same* struct id in the
-        // registry, so existing `s: String` annotations keep type-checking.
-        let alias_name = sema.interner.get("String").unwrap();
-        assert_eq!(
-            sema.builtin_structs.get(&alias_name),
-            registry_string,
-            "`String` alias should resolve to the StrBuf struct"
-        );
-
         // Check the pool definition
         let pool_def = sema.type_pool.get_struct_def(pool_string.unwrap()).unwrap();
 
@@ -2528,7 +2514,7 @@ mod tests {
 
         let stats = sema.type_pool.stats();
 
-        // 3 structs: String (builtin) + A + B
+        // 3 structs: StrBuf (builtin) + A + B
         assert_eq!(stats.struct_count, 3);
         // 3 enums: Arch (builtin) + Os (builtin) + E
         assert_eq!(stats.enum_count, 3);

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -271,7 +271,7 @@ pub struct BuiltinMethod {
 /// its layout (fields), behavior (operators), and available operations (methods).
 #[derive(Debug, Clone)]
 pub struct BuiltinTypeDef {
-    /// Type name as it appears in source code (e.g., "String")
+    /// Type name as it appears in source code (e.g., "StrBuf")
     pub name: &'static str,
     /// Fields that make up the struct layout
     pub fields: &'static [BuiltinField],
@@ -304,10 +304,9 @@ pub struct BuiltinTypeDef {
 /// literals (with `cap = 0`) to be safely dropped without freeing.
 ///
 /// ADR-0043 renamed this type `String` -> `StrBuf` (the growable-string rung of
-/// the collection/string trio, the string analog of `ArrayBuf`). `String`
-/// remains a deprecated source-level alias for one migration cycle (see
-/// [`STRING_ALIAS_NAME`]); the runtime symbols keep their `__rue_String_*`
-/// spelling as an internal implementation detail (not user-visible).
+/// the collection/string trio, the string analog of `ArrayBuf`). The runtime
+/// symbols keep their `__rue_String_*` spelling as an internal implementation
+/// detail (not user-visible).
 pub static STRING_TYPE: BuiltinTypeDef = BuiltinTypeDef {
     name: "StrBuf",
     fields: &[
@@ -595,19 +594,9 @@ pub fn get_builtin_type(name: &str) -> Option<&'static BuiltinTypeDef> {
     BUILTIN_TYPES.iter().find(|t| t.name == name).copied()
 }
 
-/// Deprecated source-level alias for the growable-string type [`STRING_TYPE`],
-/// which ADR-0043 renamed `String` -> `StrBuf`. Accepted as a spelling of
-/// `StrBuf` for one migration cycle; a type annotation `s: String` resolves to
-/// the same synthetic struct as `s: StrBuf`. The name stays reserved (users may
-/// not define their own `String`) so the alias can later be removed cleanly.
-pub const STRING_ALIAS_NAME: &str = "String";
-
 /// Check if a name is reserved for a built-in type.
-///
-/// Reserves the canonical built-in names (currently just `StrBuf`) plus the
-/// deprecated [`STRING_ALIAS_NAME`] (`String`) that still resolves to `StrBuf`.
 pub fn is_reserved_type_name(name: &str) -> bool {
-    name == STRING_ALIAS_NAME || BUILTIN_TYPES.iter().any(|t| t.name == name)
+    BUILTIN_TYPES.iter().any(|t| t.name == name)
 }
 
 /// Runtime symbols exported UNMANGLED outside the `__rue_` prefix, because
@@ -693,7 +682,7 @@ mod tests {
 
     #[test]
     fn test_string_type_exists() {
-        // ADR-0043: canonical name is `StrBuf`; `String` is a deprecated alias.
+        // ADR-0043: the growable string's source-level name is `StrBuf`.
         assert_eq!(STRING_TYPE.name, "StrBuf");
         assert_eq!(STRING_TYPE.fields.len(), 3);
         assert!(!STRING_TYPE.is_copy);
@@ -759,8 +748,6 @@ mod tests {
 
     #[test]
     fn test_get_builtin_type() {
-        // Canonical lookup is by `StrBuf`; the `String` alias is resolved to
-        // the same synthetic struct at injection time, not here.
         assert!(get_builtin_type("StrBuf").is_some());
         assert!(get_builtin_type("String").is_none());
         assert!(get_builtin_type("Vec").is_none());
@@ -768,10 +755,8 @@ mod tests {
 
     #[test]
     fn test_is_reserved_type_name() {
-        // Both the canonical name and the deprecated alias are reserved.
         assert!(is_reserved_type_name("StrBuf"));
-        assert!(is_reserved_type_name("String"));
-        assert_eq!(STRING_ALIAS_NAME, "String");
+        assert!(!is_reserved_type_name("String"));
         assert!(!is_reserved_type_name("MyStruct"));
     }
 

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -3195,9 +3195,9 @@ mod tests {
         // local (s and t) is dropped exactly once.
         let cfg = build_cfg(
             "fn main() -> i32 {\n\
-                 let mut s = String.with_capacity(8);\n\
+                 let mut s = StrBuf.with_capacity(8);\n\
                  loop {\n\
-                     let mut t = String.with_capacity(8);\n\
+                     let mut t = StrBuf.with_capacity(8);\n\
                      break;\n\
                      let unreachable_tail = 0;\n\
                  }\n\
@@ -3218,7 +3218,7 @@ mod tests {
         // scope exit; s's drop is suppressed by the MarkMoved marker.
         let cfg = build_cfg(
             "fn main() -> i32 {\n\
-                 let s = String.with_capacity(8);\n\
+                 let s = StrBuf.with_capacity(8);\n\
                  let t = s;\n\
                  0\n\
              }",
@@ -3231,11 +3231,11 @@ mod tests {
         // The callee owns its pass-by-value parameters and drops them at
         // function exit (unless moved out).
         let cfg = build_cfg_named(
-            "fn f(s: String) -> i32 { 0 }\n\
-             fn main() -> i32 { f(String.with_capacity(8)) }",
+            "fn f(s: StrBuf) -> i32 { 0 }\n\
+             fn main() -> i32 { f(StrBuf.with_capacity(8)) }",
             "f",
         );
-        assert_eq!(count_drops(&cfg), 1, "owned String param must be dropped");
+        assert_eq!(count_drops(&cfg), 1, "owned StrBuf param must be dropped");
     }
 
     #[test]
@@ -3243,8 +3243,8 @@ mod tests {
         // A param moved into a local is dropped via the local, not again as
         // a param at exit.
         let cfg = build_cfg_named(
-            "fn f(s: String) -> i32 { let t = s; 0 }\n\
-             fn main() -> i32 { f(String.with_capacity(8)) }",
+            "fn f(s: StrBuf) -> i32 { let t = s; 0 }\n\
+             fn main() -> i32 { f(StrBuf.with_capacity(8)) }",
             "f",
         );
         assert_eq!(count_drops(&cfg), 1, "moved param must drop only via t");
@@ -3259,7 +3259,7 @@ mod tests {
         // flag plumbing: a conditional branch on the flag around s's drop.
         let cfg = build_cfg(
             "fn main() -> i32 {\n\
-                 let s = String.with_capacity(8);\n\
+                 let s = StrBuf.with_capacity(8);\n\
                  let c = true;\n\
                  if c {\n\
                      let t = s;\n\
@@ -3287,9 +3287,9 @@ mod tests {
     #[test]
     fn test_move_on_both_branches_suppresses_drop() {
         // Moved in BOTH branches => moved on all paths => exit drop suppressed.
-        let source = "fn consume(s: String) -> i32 { 0 }\n\
+        let source = "fn consume(s: StrBuf) -> i32 { 0 }\n\
              fn main() -> i32 {\n\
-                 let s = String.with_capacity(8);\n\
+                 let s = StrBuf.with_capacity(8);\n\
                  let c = true;\n\
                  if c {\n\
                      consume(s);\n\
@@ -3318,10 +3318,10 @@ mod tests {
         // field-granular — only the still-owned droppable field is dropped
         // (one Drop), not the whole struct (which would re-drop the moved
         // field via the drop glue).
-        let source = "fn eat(s: String) -> i32 { 0 }\n\
-             struct H { a: String, b: String }\n\
+        let source = "fn eat(s: StrBuf) -> i32 { 0 }\n\
+             struct H { a: StrBuf, b: StrBuf }\n\
              fn main() -> i32 {\n\
-                 let h = H { a: String.with_capacity(8), b: String.with_capacity(8) };\n\
+                 let h = H { a: StrBuf.with_capacity(8), b: StrBuf.with_capacity(8) };\n\
                  eat(h.a);\n\
                  0\n\
              }";
@@ -3375,12 +3375,12 @@ mod tests {
         // so scope exit is back on the whole-struct fast path — ONE Drop
         // whose operand is a whole-slot Load (covering both fields via the
         // drop glue), not a field-granular PlaceRead drop of just field b.
-        let source = "fn eat(s: String) -> i32 { 0 }\n\
-             struct H { a: String, b: String }\n\
+        let source = "fn eat(s: StrBuf) -> i32 { 0 }\n\
+             struct H { a: StrBuf, b: StrBuf }\n\
              fn main() -> i32 {\n\
-                 let mut h = H { a: String.with_capacity(8), b: String.with_capacity(8) };\n\
+                 let mut h = H { a: StrBuf.with_capacity(8), b: StrBuf.with_capacity(8) };\n\
                  eat(h.a);\n\
-                 h.a = String.with_capacity(4);\n\
+                 h.a = StrBuf.with_capacity(4);\n\
                  0\n\
              }";
         let main_cfg = build_cfg_named(source, "main");

--- a/crates/rue-cli-tests/cases/abi.toml
+++ b/crates/rue-cli-tests/cases/abi.toml
@@ -10,7 +10,7 @@
 #     registers (x86-64: 6, aarch64: 8) go on the caller's stack, and the
 #     callee prologue copies them into its frame param area.
 #   - Returns: aggregates that fit the return registers (x86-64: 6, aarch64:
-#     8) use them; larger aggregates — and String always — return via a
+#     8) use them; larger aggregates — and StrBuf always — return via a
 #     caller-allocated sret buffer whose address is a hidden first argument.
 # All sizes here (5/7/9 slots) pass and return correctly on both backends.
 
@@ -217,14 +217,14 @@ fn main() -> i32 {
 """ }]
 stdout = "8\n"
 
-# RUE-92: a user function returning String by value. The caller has always
+# RUE-92: a user function returning StrBuf by value. The caller has always
 # used the sret convention (buffer pointer as hidden first argument) for
-# String-returning calls, but the callee used to return the three slots in
+# StrBuf-returning calls, but the callee used to return the three slots in
 # registers and never write the buffer — len/cap arrived as garbage.
 [[case]]
 name = "string_return_by_value"
 files = [{ path = "main.rue", source = """
-fn make() -> String {
+fn make() -> StrBuf {
     "hello"
 }
 
@@ -245,7 +245,7 @@ hello
 [[case]]
 name = "string_return_with_args"
 files = [{ path = "main.rue", source = """
-fn pick(a: String, b: String, n: i32) -> String {
+fn pick(a: StrBuf, b: StrBuf, n: i32) -> StrBuf {
     if n > 0 { a } else { b }
 }
 

--- a/crates/rue-cli-tests/cases/aggregate_ascending_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_ascending_layout.toml
@@ -1,6 +1,6 @@
 # Ascending aggregate layout end-to-end (RUE-311 / ADR-0040).
 #
-# Every aggregate (struct/array/String) is laid out ascending-in-address:
+# Every aggregate (struct/array/StrBuf) is laid out ascending-in-address:
 # field 0 / element 0 at the LOWEST address, slot k at base + k*8. `@raw`
 # returns the low end and `@ptr_read`/`@ptr_write`/`@ptr_offset` walk slots
 # UPWARD from it, so a raw pointer behaves identically whether it points into a

--- a/crates/rue-cli-tests/cases/aggregate_slots.toml
+++ b/crates/rue-cli-tests/cases/aggregate_slots.toml
@@ -1,6 +1,6 @@
 # Multi-slot aggregate consumer sites (RUE-118).
 #
-# A multi-slot aggregate (struct, struct-with-array, or the 3-slot String fat
+# A multi-slot aggregate (struct, struct-with-array, or the 3-slot StrBuf fat
 # pointer) read from a *place* — a struct field `h.s`/`w.p` or a rebound local —
 # must materialize ALL its slots at every consumer site, not just slot 0. These
 # pin the fixed behavior after routing every consumer (call arg, return, Alloc,
@@ -75,12 +75,12 @@ fn main() -> i32 {
 """ }]
 exit_code = 30
 
-# Store of a String sourced from a struct field — previously an ICE
+# Store of a StrBuf sourced from a struct field — previously an ICE
 # ("string should have fat pointer fields in Store").
 [[case]]
 name = "store_string_from_field"
 files = [{ path = "main.rue", source = """
-struct Holder { s: String, n: i32 }
+struct Holder { s: StrBuf, n: i32 }
 fn main() -> i32 {
     let h = Holder { s: "hello", n: 7 };
     let mut s2 = "init";
@@ -90,12 +90,12 @@ fn main() -> i32 {
 """ }]
 exit_code = 5
 
-# @dbg of a String sourced from a struct field — previously an ICE
+# @dbg of a StrBuf sourced from a struct field — previously an ICE
 # ("string value should have field vregs for fat pointer"). Prints the string.
 [[case]]
 name = "dbg_string_from_field"
 files = [{ path = "main.rue", source = """
-struct Holder { s: String, n: i32 }
+struct Holder { s: StrBuf, n: i32 }
 fn main() -> i32 {
     let h = Holder { s: "hi", n: 1 };
     @dbg(h.s);
@@ -422,15 +422,15 @@ fn main() -> i32 {
 exit_code = 0
 
 # ---------------------------------------------------------------------------
-# RUE-192: [String; N] elements. All fat-pointer (ptr/len/cap) slots of a
-# String element must be materialized. Was three distinct ICEs / garbage:
+# RUE-192: [StrBuf; N] elements. All fat-pointer (ptr/len/cap) slots of a
+# StrBuf element must be materialized. Was three distinct ICEs / garbage:
 # @dbg(arr[0]) (cfg_lower 'string value should have field vregs'), a rebind
 # `let s = arr[0]`, and `arr[i].len()` (garbage len).
 [[case]]
 name = "string_array_dbg_element"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr: [String; 1] = ["hi"];
+    let arr: [StrBuf; 1] = ["hi"];
     @dbg(arr[0]);
     0
 }
@@ -441,7 +441,7 @@ stdout = "hi\n"
 name = "string_array_rebind_element"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr: [String; 1] = ["hi"];
+    let arr: [StrBuf; 1] = ["hi"];
     let s = arr[0];
     @dbg(s);
     0
@@ -452,9 +452,9 @@ stdout = "hi\n"
 [[case]]
 name = "string_array_pass_by_value"
 files = [{ path = "main.rue", source = """
-fn takes(s: String) -> u64 { s.len() }
+fn takes(s: StrBuf) -> u64 { s.len() }
 fn main() -> i32 {
-    let arr: [String; 1] = ["hello"];
+    let arr: [StrBuf; 1] = ["hello"];
     @dbg(takes(arr[0]));
     0
 }
@@ -465,7 +465,7 @@ stdout = "5\n"
 name = "string_array_element_len"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr: [String; 2] = ["hello", "xy"];
+    let arr: [StrBuf; 2] = ["hello", "xy"];
     @dbg(arr[0].len()); @dbg(arr[1].len());
     0
 }
@@ -474,7 +474,7 @@ stdout = "5\n2\n"
 
 # ---------------------------------------------------------------------------
 # RUE-193: array drop glue over a multi-slot element type. Each element's
-# slots past slot 0 were garbage (second field corrupted), and [String; 3]
+# slots past slot 0 were garbage (second field corrupted), and [StrBuf; 3]
 # (9 slots) ICE'd 'array drop with 9 element slots exceeds 6 argument
 # registers' — fixed by the flattened-slot Call helper that spills past the
 # argument registers (RUE-106 #935 pattern).
@@ -490,13 +490,13 @@ fn main() -> i32 {
 """ }]
 stdout = "10\n11\n20\n21\n30\n31\n"
 
-# [String; 3] = 9 flattened slots > 6 x86-64 arg regs / > 8 aarch64 arg regs:
+# [StrBuf; 3] = 9 flattened slots > 6 x86-64 arg regs / > 8 aarch64 arg regs:
 # the drop-glue call must spill the overflow onto the stack, not panic.
 [[case]]
 name = "array_drop_string_nine_slots"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let _arr: [String; 3] = ["aa", "bb", "cc"];
+    let _arr: [StrBuf; 3] = ["aa", "bb", "cc"];
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/array_literal_string.toml
+++ b/crates/rue-cli-tests/cases/array_literal_string.toml
@@ -1,15 +1,15 @@
 [section]
 id = "array_literal_string"
-name = "Array literals of String-producing expressions (RUE-190)"
+name = "Array literals of StrBuf-producing expressions (RUE-190)"
 description = """
 Regression tests for RUE-190: an array literal whose elements are
-String-producing expressions used to abort the compiler with
+StrBuf-producing expressions used to abort the compiler with
 E9000 "Array literal inferred as non-array type: <error>".
 
 Two flavors:
-  1. Valid String array literals must compile and run — elements are usable
+  1. Valid StrBuf array literals must compile and run — elements are usable
      (indexing, .len(), .capacity()), and each fat pointer materializes fully.
-  2. Ill-typed elements (e.g. a nonexistent `String.from`, an undefined
+  2. Ill-typed elements (e.g. a nonexistent `StrBuf.from`, an undefined
      function) must surface the element's REAL diagnostic (E0412 / E0202),
      never an internal-compiler-error about a non-array type. HM inference
      collapses an array with an error-typed element to `<error>`; the array
@@ -17,21 +17,21 @@ Two flavors:
      of ICEing on the collapsed type.
 """
 
-# --- Flavor 1: valid String array literals compile and run ----------------
+# --- Flavor 1: valid StrBuf array literals compile and run ----------------
 
-# Two String.new() elements; array indexes usable, .len() is 0.
+# Two StrBuf.new() elements; array indexes usable, .len() is 0.
 [[case]]
 name = "array_of_string_new_len"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr = [String.new(), String.new()];
+    let arr = [StrBuf.new(), StrBuf.new()];
     let n: u64 = arr[0].len();
     if n == 0 { 0 } else { 1 }
 }
 """ }]
 exit_code = 0
 
-# String literal elements; both slots readable and correct.
+# StrBuf literal elements; both slots readable and correct.
 [[case]]
 name = "array_of_string_literals_len"
 files = [{ path = "main.rue", source = """
@@ -49,7 +49,7 @@ exit_code = 0
 name = "array_of_string_with_capacity"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr = [String.with_capacity(16), String.with_capacity(16)];
+    let arr = [StrBuf.with_capacity(16), StrBuf.with_capacity(16)];
     let a: u64 = arr[0].capacity();
     let b: u64 = arr[1].capacity();
     if a >= 16 { if b >= 16 { 0 } else { 2 } } else { 1 }
@@ -57,12 +57,12 @@ fn main() -> i32 {
 """ }]
 exit_code = 0
 
-# Single-element array built from a String binding, then indexed.
+# Single-element array built from a StrBuf binding, then indexed.
 [[case]]
 name = "array_of_string_var_single"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let a = String.new();
+    let a = StrBuf.new();
     let arr = [a];
     let n: u64 = arr[0].len();
     if n == 0 { 0 } else { 1 }
@@ -72,13 +72,13 @@ exit_code = 0
 
 # --- Flavor 2: ill-typed elements surface the real error, not an ICE ------
 
-# The reported RUE-190 shape: `String.from` does not exist. Must report
+# The reported RUE-190 shape: `StrBuf.from` does not exist. Must report
 # E0412 (unknown associated function), never E9000 about a non-array type.
 [[case]]
 name = "array_of_bad_assoc_fn_reports_real_error"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr = [String.from(\"a\"), String.from(\"b\")];
+    let arr = [StrBuf.from(\"a\"), StrBuf.from(\"b\")];
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -729,10 +729,10 @@ fn main() {
 stdout = "900\n1\n2\n901\n3\n902\n4\n903\n"
 exit_code = 0
 
-# ArrayBuf(String): a list of owned, heap-backed strings. Push two, then read
+# ArrayBuf(StrBuf): a list of owned, heap-backed strings. Push two, then read
 # each back by POPPING it out (moving — the sound way for a non-Copy element;
-# `get` would return an aliasing bit-copy of the String header, a masked
-# double-free, RUE-651). String carries a destructor (it owns a heap buffer), so
+# `get` would return an aliasing bit-copy of the StrBuf header, a masked
+# double-free, RUE-651). StrBuf carries a destructor (it owns a heap buffer), so
 # this exercises the RUE-646 droppable-element path with a builtin owning type:
 # it compiles, round-trips by move-out, and drops each string exactly once. pop
 # returns last-pushed first: world!(6) then hello(5). Score = 1 (len==2) + 1000
@@ -745,12 +745,12 @@ const std = @import("std");
 const ArrayBuf = std.arraybuf.ArrayBuf;
 
 fn main() -> i32 {
-    let Buf = ArrayBuf(String);
-    let OStr = std.option.Option(String);
+    let Buf = ArrayBuf(StrBuf);
+    let OStr = std.option.Option(StrBuf);
     let mut b = Buf.new();
-    let mut s0 = String.new();
+    let mut s0 = StrBuf.new();
     s0.push_str("hello");
-    let mut s1 = String.new();
+    let mut s1 = StrBuf.new();
     s1.push_str("world!");
     b.push(s0);
     b.push(s1);
@@ -770,16 +770,16 @@ fn main() -> i32 {
 exit_code = 243
 
 # A by-copy read (`get`) of a drop-glue element is REJECTED (E0711, RUE-651).
-# Before this gate, `ArrayBuf(String)::get(0)` returned a bitwise copy of the
-# String that aliased its owned heap buffer; both the copy and the still-live
+# Before this gate, `ArrayBuf(StrBuf)::get(0)` returned a bitwise copy of the
+# StrBuf that aliased its owned heap buffer; both the copy and the still-live
 # slot ran drop glue at scope exit — a double-free that segfaulted in safe code
 # (verified: this program exited 139 before the fix). The reader now gates on its
 # element type and directs the caller to `pop` (which moves the element out,
-# leaving one owner). Storing/pushing/popping a String element stays legal — the
+# leaving one owner). Storing/pushing/popping a StrBuf element stays legal — the
 # `arraybuf_strbuf_elements` case above (which uses `pop`) still runs.
 [[case]]
 name = "arraybuf_get_on_drop_glue_element_rejected"
-description = "A by-copy `get` of a drop-glue element (String) is rejected with E0711 and pointed at `pop`, instead of a double-free segfault (RUE-651)."
+description = "A by-copy `get` of a drop-glue element (StrBuf) is rejected with E0711 and pointed at `pop`, instead of a double-free segfault (RUE-651)."
 env = { RUE_STD_PATH = "${REAL_STD}" }
 args = ["main.rue", "-o", "prog"]
 compile_fail = true
@@ -788,10 +788,10 @@ files = [{ path = "main.rue", source = """
 const std = @import("std");
 
 fn main() -> i32 {
-    let Buf = std.arraybuf.ArrayBuf(String);
-    let OStr = std.option.Option(String);
+    let Buf = std.arraybuf.ArrayBuf(StrBuf);
+    let OStr = std.option.Option(StrBuf);
     let mut b = Buf.new();
-    let mut s0 = String.new();
+    let mut s0 = StrBuf.new();
     s0.push_str("hello");
     b.push(s0);
     let n = match b.get(0) { OStr.Some(s) => 1, OStr.None => 0 };

--- a/crates/rue-cli-tests/cases/borrow_sibling_moves.toml
+++ b/crates/rue-cli-tests/cases/borrow_sibling_moves.toml
@@ -19,8 +19,8 @@ description = "By-ref receivers and borrow arguments must not erase earlier sibl
 name = "byref_method_on_sibling_keeps_move_record"
 description = "w.t.len() between two consume(w.s) calls must not resurrect w.s (double free)."
 files = [{ path = "main.rue", source = """
-struct Wrap { s: String, t: String }
-fn consume(s: String) -> i32 { 1 }
+struct Wrap { s: StrBuf, t: StrBuf }
+fn consume(s: StrBuf) -> i32 { 1 }
 fn main() -> i32 {
     let w = Wrap { s: "hello", t: "world" };
     let _a = consume(w.s);
@@ -36,9 +36,9 @@ error_contains = ["E0205", "use of moved value 'w.s'"]
 name = "borrow_call_arg_on_sibling_keeps_move_record"
 description = "Site 2 regression pin: peek(borrow w.t) must not resurrect the moved w.s."
 files = [{ path = "main.rue", source = """
-struct Wrap { s: String, t: String }
-fn consume(s: String) -> i32 { 1 }
-fn peek(borrow s: String) -> i32 { 2 }
+struct Wrap { s: StrBuf, t: StrBuf }
+fn consume(s: StrBuf) -> i32 { 1 }
+fn peek(borrow s: StrBuf) -> i32 { 2 }
 fn main() -> i32 {
     let w = Wrap { s: "hello", t: "world" };
     let _a = consume(w.s);
@@ -54,8 +54,8 @@ error_contains = ["E0205", "use of moved value 'w.s'"]
 name = "byref_method_receiver_stays_usable_control"
 description = "Control: a by-ref method does not move its receiver; sibling move alone still errors without the len() call."
 files = [{ path = "main.rue", source = """
-struct Wrap { s: String, t: String }
-fn consume(s: String) -> i32 { 20 }
+struct Wrap { s: StrBuf, t: StrBuf }
+fn consume(s: StrBuf) -> i32 { 20 }
 fn main() -> i32 {
     let w = Wrap { s: "hello", t: "world" };
     let a = consume(w.s);

--- a/crates/rue-cli-tests/cases/builtin_assocfn_infer.toml
+++ b/crates/rue-cli-tests/cases/builtin_assocfn_infer.toml
@@ -1,7 +1,7 @@
 # Builtin associated-function signatures must reach type inference (RUE-117).
 #
-# Sibling of RUE-95 (methods): builtin associated fns (`String.new`,
-# `String.with_capacity`) live only in the rue-builtins registry and weren't
+# Sibling of RUE-95 (methods): builtin associated fns (`StrBuf.new`,
+# `StrBuf.with_capacity`) live only in the rue-builtins registry and weren't
 # registered in the HM inference method map, so an untyped literal argument
 # wasn't constrained to the param type (`with_capacity(8)` -> E0206 expected u64
 # found i32) and a result feeding a literal resolved to `<error>`.
@@ -15,7 +15,7 @@ description = "Builtin associated functions must constrain literal args and anch
 name = "with_capacity_literal_arg_is_u64"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String.with_capacity(8);
+    let s = StrBuf.with_capacity(8);
     0
 }
 """ }]
@@ -25,7 +25,7 @@ exit_code = 0
 name = "string_new_result_is_empty"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String.new();
+    let s = StrBuf.new();
     if s.is_empty() { 0 } else { 1 }
 }
 """ }]
@@ -35,7 +35,7 @@ exit_code = 0
 name = "string_new_len_eq_literal"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String.new();
+    let s = StrBuf.new();
     if s.len() == 0 { 0 } else { 1 }
 }
 """ }]

--- a/crates/rue-cli-tests/cases/builtin_method_infer.toml
+++ b/crates/rue-cli-tests/cases/builtin_method_infer.toml
@@ -1,6 +1,6 @@
 # Builtin method-call return types must anchor integer-literal inference (RUE-95).
 #
-# `String.len`/`capacity` return u64, but builtin methods were registered only for
+# `StrBuf.len`/`capacity` return u64, but builtin methods were registered only for
 # sema/airgen — NOT for the HM inference `method_sigs` map — so a builtin method-call
 # result used in a binop with an untyped literal (`s.len() + 1`, `s.len() == 2`) left
 # the literal's type unconstrained, resolving to `<error>` and tripping the E0800

--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -588,13 +588,13 @@ exit_code = 42
 
 [[case]]
 name = "inout_whole_string_reassign"
-description = "Whole-value reassignment of a String (3-slot fat pointer) through inout writes back ptr, len, and cap."
+description = "Whole-value reassignment of a StrBuf (3-slot fat pointer) through inout writes back ptr, len, and cap."
 files = [{ path = "main.rue", source = """
-fn replace(inout v: String) {
+fn replace(inout v: StrBuf) {
     v = "hello rue!";
 }
 fn main() -> i32 {
-    let mut s: String = "xx";
+    let mut s: StrBuf = "xx";
     replace(inout s);
     @dbg(s.len());
     @dbg(s);

--- a/crates/rue-cli-tests/cases/comptime_array_length.toml
+++ b/crates/rue-cli-tests/cases/comptime_array_length.toml
@@ -166,7 +166,7 @@ exit_code = 42
 name = "local_annotation_drop_element_no_ice"
 files = [{ path = "main.rue", source = """
 fn f(comptime N: i32) -> i32 {
-    let y: [String; N] = ["ab", "cde"];
+    let y: [StrBuf; N] = ["ab", "cde"];
     42
 }
 

--- a/crates/rue-cli-tests/cases/divergence.toml
+++ b/crates/rue-cli-tests/cases/divergence.toml
@@ -160,7 +160,7 @@ exit_code = 6
 # ── (b) diverged statement mid-block: scope_stack stays balanced ─────────────
 
 # The original leak shape: break followed by another statement, with droppable
-# (String) locals both inside and outside the loop. Before the fix the CFG
+# (StrBuf) locals both inside and outside the loop. Before the fix the CFG
 # re-dropped `t` on the loop-exit path (after `break` had already dropped it).
 # The program must run to completion with both strings intact.
 [[case]]
@@ -168,10 +168,10 @@ name = "break_mid_block_no_double_drop"
 description = "Diverged statement mid-block must not re-drop the inner local on the exit path."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.with_capacity(8);
+    let mut s = StrBuf.with_capacity(8);
     s.push_str("outer");
     loop {
-        let mut t = String.with_capacity(8);
+        let mut t = StrBuf.with_capacity(8);
         t.push_str("inner");
         break;
         let unreachable_tail = 0;
@@ -193,7 +193,7 @@ description = "Mid-block return in an untaken branch: fall-through path must not
 files = [{ path = "main.rue", source = """
 fn check(flag: bool) -> i32 {
     if flag {
-        let mut t = String.with_capacity(8);
+        let mut t = StrBuf.with_capacity(8);
         t.push_str("taken");
         return 1;
         let unreachable_tail = 0;

--- a/crates/rue-cli-tests/cases/drop_moves.toml
+++ b/crates/rue-cli-tests/cases/drop_moves.toml
@@ -384,16 +384,16 @@ exit_code = 0
 
 [[case]]
 name = "partial_string_field_move_no_double_free"
-description = "RUE-62 with a heap type: moving one String field out of a struct must not double-free it at the struct's scope-exit drop."
+description = "RUE-62 with a heap type: moving one StrBuf field out of a struct must not double-free it at the struct's scope-exit drop."
 files = [{ path = "main.rue", source = """
-struct Holder { name: String, tag: String }
+struct Holder { name: StrBuf, tag: StrBuf }
 
-fn eat(s: String) -> i32 {
+fn eat(s: StrBuf) -> i32 {
     0
 }
 
 fn main() -> i32 {
-    let h = Holder { name: String.with_capacity(8), tag: String.with_capacity(8) };
+    let h = Holder { name: StrBuf.with_capacity(8), tag: StrBuf.with_capacity(8) };
     eat(h.name);
     @dbg(777);
     0
@@ -404,16 +404,16 @@ exit_code = 0
 
 [[case]]
 name = "branch_divergent_string_field_move_no_double_free"
-description = "RUE-156 with a heap type: a String field moved in only ONE branch must not be freed again by the struct's scope-exit drop on the moving path."
+description = "RUE-156 with a heap type: a StrBuf field moved in only ONE branch must not be freed again by the struct's scope-exit drop on the moving path."
 files = [{ path = "main.rue", source = """
-struct Holder { name: String, tag: String }
+struct Holder { name: StrBuf, tag: StrBuf }
 
-fn eat(s: String) -> i32 {
+fn eat(s: StrBuf) -> i32 {
     0
 }
 
 fn main() -> i32 {
-    let h = Holder { name: String.with_capacity(8), tag: String.with_capacity(8) };
+    let h = Holder { name: StrBuf.with_capacity(8), tag: StrBuf.with_capacity(8) };
     let c = true;
     if c {
         eat(h.name);

--- a/crates/rue-cli-tests/cases/field_type_inference.toml
+++ b/crates/rue-cli-tests/cases/field_type_inference.toml
@@ -30,7 +30,7 @@ exit_code = 1
 name = "string_field_method_receiver_anchors_literal"
 description = "RUE-126: h.s.len() resolves (field receiver is concrete) and anchors the compared literal."
 files = [{ path = "main.rue", source = """
-struct Holder { s: String }
+struct Holder { s: StrBuf }
 fn main() -> i32 {
     let h = Holder { s: "hello" };
     if h.s.len() == 5 { 5 } else { 0 }

--- a/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
+++ b/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
@@ -5,7 +5,7 @@
 #  * RUE-233: mutating the iterated place — element (`a[i]=`), whole variable
 #    (`a=`), or field — inside the body is E0428 (`MutateBorrowedValue`), like
 #    an explicit `borrow` parameter (used to be silently accepted).
-#  * RUE-257: mutating the collection through an `inout self` method (String
+#  * RUE-257: mutating the collection through an `inout self` method (StrBuf
 #    `.clear()`/`.push()`) inside the body is E0428 too — previously a runtime
 #    miscompile (a spurious `invalid UTF-8` / out-of-bounds trap).
 #  * RUE-259: a NON-Copy element type is bound by shared borrow, not moved out
@@ -170,7 +170,7 @@ fn main() -> i32 {
 
 [[case]]
 name = "mutate_via_method_in_chars_loop_is_e0428"
-description = "RUE-257: `s.clear()` inside `for c in s.chars()` mutates a shared-borrowed String (E0428), not a runtime UTF-8 trap."
+description = "RUE-257: `s.clear()` inside `for c in s.chars()` mutates a shared-borrowed StrBuf (E0428), not a runtime UTF-8 trap."
 args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0428"]

--- a/crates/rue-cli-tests/cases/for_loops.toml
+++ b/crates/rue-cli-tests/cases/for_loops.toml
@@ -3,14 +3,14 @@
 # These drive the real compiler and check exact
 # stdout / exit codes end to end. The `.chars()` cases in particular exercise
 # the `__rue_String_char_scalar` / `__rue_String_char_next` runtime ABI (a
-# String flattened to ptr/len/cap plus a byte offset, returning a scalar / next
+# StrBuf flattened to ptr/len/cap plus a byte offset, returning a scalar / next
 # offset), and the strict-UTF-8 decode trap, which the spec harness cannot fully
 # observe.
 
 [section]
 id = "cli.for_loops"
 name = "For loops (iteration layer 1)"
-description = "for over arrays, String bytes, and String .chars()."
+description = "for over arrays, StrBuf bytes, and StrBuf .chars()."
 
 [[case]]
 name = "for_array_dbg_elements"
@@ -33,7 +33,7 @@ stdout = "3\n1\n4\n1\n3\n"
 
 [[case]]
 name = "for_string_bytes_dbg"
-description = "for over a String yields each byte as u8 in ascending byte order; 'café' is 5 bytes (é = 0xC3 0xA9 = 195, 169)."
+description = "for over a StrBuf yields each byte as u8 in ascending byte order; 'café' is 5 bytes (é = 0xC3 0xA9 = 195, 169)."
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
@@ -105,11 +105,11 @@ stdout = "99\n97\n102\n233\n"
 
 [[case]]
 name = "for_chars_lossy_replaces_raw_invalid_bytes"
-description = "Lossy decode over a String holding a raw invalid byte (0xFF): the bad byte becomes U+FFFD (65533) and iteration continues without trapping — the surrounding ASCII bytes decode normally."
+description = "Lossy decode over a StrBuf holding a raw invalid byte (0xFF): the bad byte becomes U+FFFD (65533) and iteration continues without trapping — the surrounding ASCII bytes decode normally."
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push(97);
     s.push(255);
     s.push(98);

--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -2,7 +2,7 @@
 # files, the real driver, real program exit codes and stdout (RUE-1).
 #
 # These are the unchecked heap primitives a source-level ArrayBuf is built on. The
-# runtime __rue_alloc/__rue_free/__rue_realloc are already used by String, so
+# runtime __rue_alloc/__rue_free/__rue_realloc are already used by StrBuf, so
 # these cases also confirm the archive symbols resolve when referenced only
 # from user code.
 

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -93,21 +93,21 @@ exit_code = 42
 
 [[case]]
 name = "string_param_rebound_to_local_rue63"
-description = "RUE-63: rebinding a String parameter to a local ('string should have fat pointer fields in Alloc') -> SIGABRT."
+description = "RUE-63: rebinding a StrBuf parameter to a local ('string should have fat pointer fields in Alloc') -> SIGABRT."
 files = [{ path = "main.rue", source = """
-fn consume(s: String) -> i32 {
+fn consume(s: StrBuf) -> i32 {
     let held = s;
     0
 }
-fn main() -> i32 { consume(String.new()) }
+fn main() -> i32 { consume(StrBuf.new()) }
 """ }]
 exit_code = 0
 
 [[case]]
 name = "struct_field_string_eq_rue94"
-description = "RUE-94: comparing a struct-field String with == ('builtin type should have field vregs') -> SIGABRT."
+description = "RUE-94: comparing a struct-field StrBuf with == ('builtin type should have field vregs') -> SIGABRT."
 files = [{ path = "main.rue", source = """
-struct Holder { s: String }
+struct Holder { s: StrBuf }
 fn main() -> i32 {
     let h = Holder { s: "hello" };
     if h.s == "hello" { 0 } else { 1 }
@@ -117,10 +117,10 @@ exit_code = 0
 
 [[case]]
 name = "array_literal_string_element_rue96"
-description = "RUE-96: array literal with a String element inferred the element as <error> -> E9000 ICE."
+description = "RUE-96: array literal with a StrBuf element inferred the element as <error> -> E9000 ICE."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let a = String.new();
+    let a = StrBuf.new();
     let arr = [a];
     0
 }
@@ -129,10 +129,10 @@ exit_code = 0
 
 [[case]]
 name = "array_literal_string_exprs_rue190"
-description = "RUE-190: array literal of String-producing expressions used to ICE (E9000)."
+description = "RUE-190: array literal of StrBuf-producing expressions used to ICE (E9000)."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr = [String.new(), String.new()];
+    let arr = [StrBuf.new(), StrBuf.new()];
     0
 }
 """ }]
@@ -251,10 +251,10 @@ exit_code = 70
 
 [[case]]
 name = "dbg_string_array_element_rue192"
-description = "RUE-192: @dbg(arr[0]) on a [String; 1] ('string value should have field vregs for fat pointer') -> SIGABRT."
+description = "RUE-192: @dbg(arr[0]) on a [StrBuf; 1] ('string value should have field vregs for fat pointer') -> SIGABRT."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr: [String; 1] = ["hi"];
+    let arr: [StrBuf; 1] = ["hi"];
     @dbg(arr[0]);
     0
 }
@@ -278,10 +278,10 @@ exit_code = 0
 
 [[case]]
 name = "string_array_drop_register_budget_rue193"
-description = "RUE-193: [String; 3] = 9 element slots exceeded the 6 argument registers in drop glue -> SIGABRT at cfg_lower."
+description = "RUE-193: [StrBuf; 3] = 9 element slots exceeded the 6 argument registers in drop glue -> SIGABRT at cfg_lower."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let arr: [String; 3] = ["aa", "bb", "cc"];
+    let arr: [StrBuf; 3] = ["aa", "bb", "cc"];
     0
 }
 """ }]

--- a/crates/rue-cli-tests/cases/import_trailing_comma.toml
+++ b/crates/rue-cli-tests/cases/import_trailing_comma.toml
@@ -1,7 +1,7 @@
 # Trailing comma inside `@import("...",)` must still be discovered from disk
 # (RUE-536). The parser accepted `@import("x",)` as a one-argument list, but the
 # driver's import-discovery scan matched only the exact four-token shape
-# `@import ( String )`, so the trailing comma made the import silently bypass
+# `@import ( StrBuf )`, so the trailing comma made the import silently bypass
 # discovery and the module failed to load (E0704 cannot find module). The scan
 # now tolerates a comma before the close paren. Driven through the real binary
 # with the imported file resolved from disk.

--- a/crates/rue-cli-tests/cases/join_aggregates.toml
+++ b/crates/rue-cli-tests/cases/join_aggregates.toml
@@ -5,7 +5,7 @@
 # params into per-slot vregs; array-typed params got a single vreg — and an
 # array's primary vreg is just a zero placeholder — so every element was
 # dropped at the join (silent miscompile: a[i] read 0 at every opt level, both
-# backends). Structs and String (a synthetic struct) already crossed joins
+# backends). Structs and StrBuf (a synthetic struct) already crossed joins
 # intact; these cases pin them as regressions alongside the array fixes.
 #
 # Conditions go through a function call so constant folding can't delete the
@@ -175,8 +175,8 @@ fn main() -> i32 {
 stdout = "1\n2\n"
 exit_code = 3
 
-# String (3-slot fat pointer) through a join — also pinned as a regression
-# guard; String is a synthetic struct so it used the working struct path.
+# StrBuf (3-slot fat pointer) through a join — also pinned as a regression
+# guard; StrBuf is a synthetic struct so it used the working struct path.
 [[case]]
 name = "string_through_if_join"
 files = [{ path = "main.rue", source = """

--- a/crates/rue-cli-tests/cases/loop_moves.toml
+++ b/crates/rue-cli-tests/cases/loop_moves.toml
@@ -33,11 +33,11 @@ error_contains = ["E0205", "use of moved value", "previous iteration of the loop
 
 [[case]]
 name = "string_move_in_while_loop"
-description = "The String variant of the same bug double-freed at runtime before the fix."
+description = "The StrBuf variant of the same bug double-freed at runtime before the fix."
 files = [{ path = "main.rue", source = """
-fn consume(s: String) -> i32 { 1 }
+fn consume(s: StrBuf) -> i32 { 1 }
 fn main() -> i32 {
-    let s: String = "hi";
+    let s: StrBuf = "hi";
     let mut i = 0;
     while i < 2 { consume(s); i = i + 1; }
     0

--- a/crates/rue-cli-tests/cases/match_inference_fixes.toml
+++ b/crates/rue-cli-tests/cases/match_inference_fixes.toml
@@ -32,7 +32,7 @@ stdout = "42\n"
 
 [[case]]
 name = "comptime_match_selects_other_arm_type"
-description = "RUE-268: when the comptime value selects a different arm, that arm's type is the match type (the dead first arm's String is ignored)."
+description = "RUE-268: when the comptime value selects a different arm, that arm's type is the match type (the dead first arm's StrBuf is ignored)."
 files = [{ path = "main.rue", source = """
 fn f(comptime n: i32) -> i32 { match n { 0 => "wrong", _ => 7 } }
 fn main() -> i32 {

--- a/crates/rue-cli-tests/cases/partial_move_depth.toml
+++ b/crates/rue-cli-tests/cases/partial_move_depth.toml
@@ -18,9 +18,9 @@ description = "Using an aggregate whole after a nested subfield moved is E0205."
 name = "use_whole_after_subfield_move_depth2"
 files = [
     { path = "main.rue", source = """
-struct Inner { s: String, n: i32 }
+struct Inner { s: StrBuf, n: i32 }
 struct Outer { inner: Inner, tag: i32 }
-fn consume(s: String) -> i32 { @intCast(s.len()) }
+fn consume(s: StrBuf) -> i32 { @intCast(s.len()) }
 fn consume_inner(i: Inner) -> i32 { @intCast(i.s.len()) + i.n }
 fn main() -> i32 {
     let o = Outer { inner: Inner { s: "hi", n: 5 }, tag: 9 };
@@ -37,10 +37,10 @@ error_contains = ["E0205", "o.inner"]
 name = "use_whole_after_subfield_move_depth3"
 files = [
     { path = "main.rue", source = """
-struct A { s: String, k: i32 }
+struct A { s: StrBuf, k: i32 }
 struct B { a: A, k: i32 }
 struct C { b: B, k: i32 }
-fn cs(s: String) -> i32 { @intCast(s.len()) }
+fn cs(s: StrBuf) -> i32 { @intCast(s.len()) }
 fn cb(b: B) -> i32 { @intCast(b.a.s.len()) }
 fn main() -> i32 {
     let c = C { b: B { a: A { s: "hi", k: 1 }, k: 2 }, k: 3 };
@@ -57,8 +57,8 @@ error_contains = ["E0205", "c.b"]
 name = "use_whole_after_field_move_depth1"
 files = [
     { path = "main.rue", source = """
-struct Inner { s: String, n: i32 }
-fn consume(s: String) -> i32 { @intCast(s.len()) }
+struct Inner { s: StrBuf, n: i32 }
+fn consume(s: StrBuf) -> i32 { @intCast(s.len()) }
 fn consume_inner(i: Inner) -> i32 { @intCast(i.s.len()) + i.n }
 fn main() -> i32 {
     let inner = Inner { s: "hi", n: 5 };
@@ -76,8 +76,8 @@ error_contains = ["E0205", "inner"]
 name = "use_whole_element_after_subfield_move"
 files = [
     { path = "main.rue", source = """
-struct Inner { s: String, n: i32 }
-fn consume(s: String) -> i32 { @intCast(s.len()) }
+struct Inner { s: StrBuf, n: i32 }
+fn consume(s: StrBuf) -> i32 { @intCast(s.len()) }
 fn consume_inner(i: Inner) -> i32 { @intCast(i.s.len()) + i.n }
 fn main() -> i32 {
     let arr = [Inner { s: "hi", n: 5 }, Inner { s: "yo", n: 6 }];
@@ -95,9 +95,9 @@ error_contains = ["E0205", "arr[0]"]
 name = "disjoint_sibling_after_subfield_move_ok"
 files = [
     { path = "main.rue", source = """
-struct Inner { s: String, n: i32 }
+struct Inner { s: StrBuf, n: i32 }
 struct Outer { inner: Inner, tag: i32 }
-fn consume(s: String) -> i32 { @intCast(s.len()) }
+fn consume(s: StrBuf) -> i32 { @intCast(s.len()) }
 fn main() -> i32 {
     let o = Outer { inner: Inner { s: "hi", n: 5 }, tag: 9 };
     consume(o.inner.s);
@@ -113,8 +113,8 @@ exit_code = 9
 name = "disjoint_sibling_element_move_ok"
 files = [
     { path = "main.rue", source = """
-struct Inner { s: String, n: i32 }
-fn consume(s: String) -> i32 { @intCast(s.len()) }
+struct Inner { s: StrBuf, n: i32 }
+fn consume(s: StrBuf) -> i32 { @intCast(s.len()) }
 fn main() -> i32 {
     let arr = [Inner { s: "hi", n: 5 }, Inner { s: "yo", n: 6 }];
     consume(arr[0].s);

--- a/crates/rue-cli-tests/cases/print_output.toml
+++ b/crates/rue-cli-tests/cases/print_output.toml
@@ -1,8 +1,8 @@
 # `print` / `println` builtin free functions (RUE-1).
 #
-# `print(s: String)` writes the raw bytes of `s` to stdout with nothing added;
-# `println(s: String)` writes the bytes then a single `\n`. They borrow the
-# String (do not consume it), so the argument stays usable afterwards. These
+# `print(s: StrBuf)` writes the raw bytes of `s` to stdout with nothing added;
+# `println(s: StrBuf)` writes the bytes then a single `\n`. They borrow the
+# StrBuf (do not consume it), so the argument stays usable afterwards. These
 # are runtime-visible, so every case pins the exact stdout bytes (including the
 # presence or absence of a trailing newline) — the one thing the spec harness's
 # exit-code assertions can't see.
@@ -59,7 +59,7 @@ stdout = "\nend"
 name = "print_borrows_string_reusable_after_call"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("built ");
     s.push_str("string");
     print(s);

--- a/crates/rue-cli-tests/cases/programs.toml
+++ b/crates/rue-cli-tests/cases/programs.toml
@@ -94,7 +94,7 @@ stdout = """
 name = "string_builder_push_str"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("Hello");
     s.push_str(", ");
     s.push_str("Rue!");
@@ -113,7 +113,7 @@ Hello, Rue!
 name = "dbg_string_then_use"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("Hello");
     @dbg(s);
     @dbg(s.len());
@@ -130,7 +130,7 @@ name = "string_equality_branches"
 files = [
   { path = "main.rue", source = """
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(String);
+    let OptStr = @import("opt.rue").Option(StrBuf);
     match @read_line() {
         OptStr.Some(answer) => {
             if answer == "yes" {

--- a/crates/rue-cli-tests/cases/raw_ptr_and_method_name.toml
+++ b/crates/rue-cli-tests/cases/raw_ptr_and_method_name.toml
@@ -5,15 +5,15 @@
 # Previously taking a raw pointer silently suppressed the operand's destructor
 # (leak) and rejected any later use with E0205.
 #
-# RUE-223: a user struct method whose name collides with a builtin String
+# RUE-223: a user struct method whose name collides with a builtin StrBuf
 # mutation method (push/push_str/clear/reserve) must not be misclassified as a
-# String ByMutRef mutation demanding a `mut` receiver. Classification now gates
-# the name match on the receiver's resolved type actually being String.
+# StrBuf ByMutRef mutation demanding a `mut` receiver. Classification now gates
+# the name match on the receiver's resolved type actually being StrBuf.
 
 [section]
 id = "cli.raw_ptr_and_method_name"
 name = "Raw-pointer place semantics and method-name collisions"
-description = "@raw/@raw_mut borrow their operand as a place; user methods named like String mutators don't force a mut receiver."
+description = "@raw/@raw_mut borrow their operand as a place; user methods named like StrBuf mutators don't force a mut receiver."
 
 # --- RUE-222 facet A: destructor still runs exactly once after @raw ---------
 [[case]]
@@ -72,7 +72,7 @@ name = "raw_ptr_operand_usable_after"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let s = "hello";
-    let _p: ptr const String = checked { @raw(s) };
+    let _p: ptr const StrBuf = checked { @raw(s) };
     @dbg(s.len());
     0
 }
@@ -115,12 +115,12 @@ fn main() -> i32 {
 """ }]
 stdout = "5\n9\n"
 
-# --- RUE-223 guard: String's real mutation methods STILL require `mut` -------
+# --- RUE-223 guard: StrBuf's real mutation methods STILL require `mut` -------
 [[case]]
 name = "string_push_str_still_requires_mut"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String.new();
+    let s = StrBuf.new();
     s.push_str("x");
     0
 }
@@ -128,12 +128,12 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = ["E0203"]
 
-# --- RUE-223 guard: String mutation on a `mut` binding still works -----------
+# --- RUE-223 guard: StrBuf mutation on a `mut` binding still works -----------
 [[case]]
 name = "string_push_str_on_mut_ok"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("hi");
     @dbg(s.len());
     0

--- a/crates/rue-cli-tests/cases/reserved_names.toml
+++ b/crates/rue-cli-tests/cases/reserved_names.toml
@@ -24,7 +24,7 @@ name = "builtin_method_name_allowed"
 files = [{ path = "main.rue", source = """
 fn String__len() -> i32 { 7 }
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     let builtin: i32 = @intCast(s.len());
     builtin * 10 + String__len()

--- a/crates/rue-cli-tests/cases/specialization_strings.toml
+++ b/crates/rue-cli-tests/cases/specialization_strings.toml
@@ -1,11 +1,11 @@
-# String literals are interned per analyzed function and remapped into the
+# StrBuf literals are interned per analyzed function and remapped into the
 # program-global table before code generation. Generic bodies are analyzed only
 # during specialization, so their local table must be merged at that point too
 # (RUE-583).
 
 [section]
 id = "cli.specialization_strings"
-name = "String literals in specialized functions"
+name = "StrBuf literals in specialized functions"
 description = "Specialized bodies preserve and remap their local string literals."
 
 [[case]]

--- a/crates/rue-cli-tests/cases/stdin.toml
+++ b/crates/rue-cli-tests/cases/stdin.toml
@@ -1,7 +1,7 @@
 # Programs that read stdin: the @read_line / @parse_i32 loop.
 #
 # Since RUE-6 (ADR-0038) these intrinsics are fallible-by-Option, not
-# trapping: @read_line returns Option(String) (None at EOF) and @parse_* return
+# trapping: @read_line returns Option(StrBuf) (None at EOF) and @parse_* return
 # Option(int) (None on bad input). The concrete Option is imported from a small
 # local module (no prelude yet) and threaded via a `let` annotation or the
 # match arms.
@@ -16,7 +16,7 @@ name = "read_and_echo_number"
 files = [
   { path = "main.rue", source = """
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(String);
+    let OptStr = @import("opt.rue").Option(StrBuf);
     let OptInt = @import("opt.rue").Option(i32);
     let line: OptStr = @read_line();
     match line {
@@ -43,7 +43,7 @@ name = "guessing_loop_scripted"
 files = [
   { path = "main.rue", source = """
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(String);
+    let OptStr = @import("opt.rue").Option(StrBuf);
     let OptInt = @import("opt.rue").Option(i32);
     let secret = 73;
     loop {
@@ -90,7 +90,7 @@ name = "parse_error_yields_none"
 files = [
   { path = "main.rue", source = """
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(String);
+    let OptStr = @import("opt.rue").Option(StrBuf);
     let OptInt = @import("opt.rue").Option(i32);
     let line: OptStr = @read_line();
     match line {
@@ -116,7 +116,7 @@ name = "read_line_at_eof_yields_none"
 files = [
   { path = "main.rue", source = """
 fn main() -> i32 {
-    let OptStr = @import("opt.rue").Option(String);
+    let OptStr = @import("opt.rue").Option(StrBuf);
     let line: OptStr = @read_line();
     match line {
         OptStr.Some(_text) => 1,

--- a/crates/rue-cli-tests/cases/str_fixed_type.toml
+++ b/crates/rue-cli-tests/cases/str_fixed_type.toml
@@ -66,7 +66,7 @@ args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 0
 stdout = "5\n102\n195\n169\n"
 
-# An out-of-range byte index traps at runtime (exit 101), like array/String/str.
+# An out-of-range byte index traps at runtime (exit 101), like array/StrBuf/str.
 [[case]]
 name = "str_fixed_index_out_of_bounds_traps"
 files = [{ path = "main.rue", source = """

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -2,10 +2,10 @@
 # RUE-324).
 #
 # `str` is `[u8]` + the UTF-8 byte-string convention: a read-only two-word view
-# `{ptr, len}` that reuses the slice representation. String literals have type
+# `{ptr, len}` that reuses the slice representation. StrBuf literals have type
 # `str` where a `str` is expected, and are STATIC-BACKED — their bytes live in
 # `.rodata`, and the value is `{ptr -> rodata bytes, len = byte length}` (a
-# 2-word value, not the 3-word heap `String`). Because static data cannot
+# 2-word value, not the 3-word heap `StrBuf`). Because static data cannot
 # dangle, a literal `str` is FIRST-CLASS: `@copy`, storable, reassignable,
 # returnable, passable.
 #
@@ -13,7 +13,7 @@
 # PACKED byte via `__rue_str_byte_at(ptr, len, index)` (bounds-checked, traps
 # exit 101) — packed bytes, NOT the 8-byte-slotted stride an array slice uses.
 #
-# Deferred to later phases: `str` concat/comparison, `str`<->`String` interop,
+# Deferred to later phases: `str` concat/comparison, `str`<->`StrBuf` interop,
 # methods beyond `.len()`/index, and char iteration.
 
 [section]
@@ -54,7 +54,7 @@ args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 0
 stdout = "5\n102\n195\n169\n"
 
-# An out-of-bounds byte index traps at runtime (exit 101), like array/String.
+# An out-of-bounds byte index traps at runtime (exit 101), like array/StrBuf.
 [[case]]
 name = "str_index_out_of_bounds_traps"
 files = [{ path = "main.rue", source = """
@@ -163,14 +163,14 @@ args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["requires preview feature"]
 
-# A string literal with NO `str` expectation stays the 3-word heap `String`, so
-# existing String operations are unaffected by the `str` preview.
+# A string literal with NO `str` expectation stays the 3-word heap `StrBuf`, so
+# existing StrBuf operations are unaffected by the `str` preview.
 [[case]]
 name = "str_preview_does_not_change_string_default"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = "hello";        // no annotation -> String
-    let t: String = s;      // String, not str
+    let s = "hello";        // no annotation -> StrBuf
+    let t: StrBuf = s;      // StrBuf, not str
     @intCast(t.len())
 }
 """ }]

--- a/crates/rue-cli-tests/cases/strbuf_library.toml
+++ b/crates/rue-cli-tests/cases/strbuf_library.toml
@@ -1,16 +1,13 @@
 # StrBuf — the growable-string rung of ADR-0043 (RUE-325).
 #
-# ADR-0043 de-blesses `String` into `StrBuf`, the string analog of `ArrayBuf`.
-# `StrBuf` is now the canonical name for the 3-word {ptr,len,cap} heap-backed
-# growable string; `String` remains a deprecated source-level alias for one
-# migration cycle. These cases pin the runtime-visible behavior (exact stdout)
-# of the canonical `StrBuf` spelling and prove the `String` alias compiles and
-# runs identically.
+# ADR-0043 de-blesses the old `String` type into `StrBuf`, the string analog of
+# `ArrayBuf`. These cases pin the runtime-visible behavior (exact stdout) of
+# the canonical `StrBuf` spelling.
 
 [section]
 id = "cli.strbuf_library"
 name = "StrBuf growable string"
-description = "The StrBuf canonical name (ADR-0043) builds, mutates, concatenates, and prints; the deprecated String alias behaves identically."
+description = "The StrBuf name (ADR-0043) builds, mutates, concatenates, and prints."
 
 [[case]]
 name = "strbuf_new_push_str_len_print"
@@ -45,18 +42,16 @@ stdout = "n=42\n"
 exit_code = 0
 
 [[case]]
-name = "string_alias_parity"
-description = "The deprecated `String` alias resolves to the same StrBuf type: annotation, assoc fn, and equality against a StrBuf all work."
+name = "retired_string_name_is_unknown"
+description = "The retired `String` name receives the normal unknown-type diagnostic."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut a: String = String.new();
-    a.push_str("abc");
-    let mut b = StrBuf.new();
-    b.push_str("abc");
-    if a == b { 0 } else { 1 }
+    let s: String = "abc";
+    0
 }
 """ }]
-exit_code = 0
+compile_fail = true
+error_contains = ["E0204", "unknown type 'String'"]
 
 [[case]]
 name = "strbuf_reserved_name"

--- a/crates/rue-cli-tests/cases/string_alloc_failure.toml
+++ b/crates/rue-cli-tests/cases/string_alloc_failure.toml
@@ -1,4 +1,4 @@
-# String.with_capacity allocation-failure safety (RUE-255).
+# StrBuf.with_capacity allocation-failure safety (RUE-255).
 #
 # A huge requested capacity makes the heap allocation fail and return null.
 # with_capacity used to store ptr=null / cap=<huge> unconditionally, so a
@@ -9,15 +9,15 @@
 
 [section]
 id = "cli.string_alloc_failure"
-name = "String allocation-failure safety"
-description = "String.with_capacity must not poison capacity when allocation fails."
+name = "StrBuf allocation-failure safety"
+description = "StrBuf.with_capacity must not poison capacity when allocation fails."
 
 [[case]]
 name = "with_capacity_huge_no_segfault"
 description = "with_capacity(u64::MAX) fails the alloc: capacity reports 0 and a subsequent push grows fresh instead of writing through null (no SIGSEGV)."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.with_capacity(18446744073709551615);
+    let mut s = StrBuf.with_capacity(18446744073709551615);
     @dbg(s.capacity());
     s.push(65);
     @dbg(s.len());
@@ -32,7 +32,7 @@ name = "with_capacity_normal_reserves"
 description = "A satisfiable with_capacity still reserves the requested capacity and appends normally."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.with_capacity(16);
+    let mut s = StrBuf.with_capacity(16);
     @dbg(s.capacity());
     s.push(65);
     @dbg(s.len());

--- a/crates/rue-cli-tests/cases/string_byte_access.toml
+++ b/crates/rue-cli-tests/cases/string_byte_access.toml
@@ -1,17 +1,17 @@
-# String byte access (RUE-17 Phase 2, ADR-0035).
+# StrBuf byte access (RUE-17 Phase 2, ADR-0035).
 #
-# Rue's String is a byte string (conventionally UTF-8, not guaranteed valid).
+# Rue's StrBuf is a byte string (conventionally UTF-8, not guaranteed valid).
 # `s[i]` reads the i-th BYTE as u8 (O(1), out-of-range traps exit 101), and
-# `s.substring(start, len)` returns a NEW String holding bytes [start, start+len)
+# `s.substring(start, len)` returns a NEW StrBuf holding bytes [start, start+len)
 # (any byte range valid; out-of-range traps). These are exact-stdout runs of the
-# "café" demo through the real driver — the ABI (String passed as ptr/len/cap to
+# "café" demo through the real driver — the ABI (StrBuf passed as ptr/len/cap to
 # the runtime byte_at / substring calls) is exactly what a spec-harness stdout
 # check cannot exercise end to end.
 
 [section]
 id = "cli.string_byte_access"
-name = "String byte access"
-description = "Byte indexing and substring on the byte-string String type."
+name = "StrBuf byte access"
+description = "Byte indexing and substring on the byte-string StrBuf type."
 
 [[case]]
 name = "cafe_byte_indexing"
@@ -46,7 +46,7 @@ runtime_error_contains = ["index out of bounds"]
 
 [[case]]
 name = "substring_byte_range"
-description = "s.substring(3, 2) yields the two bytes of é as an independent String; source s is untouched."
+description = "s.substring(3, 2) yields the two bytes of é as an independent StrBuf; source s is untouched."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let s = "café";
@@ -63,7 +63,7 @@ stdout = "2\n195\n169\n5\n"
 
 [[case]]
 name = "substring_result_is_mutable"
-description = "The new String from substring owns a heap buffer and can be mutated further."
+description = "The new StrBuf from substring owns a heap buffer and can be mutated further."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let s = "café";

--- a/crates/rue-cli-tests/cases/string_escape_recovery.toml
+++ b/crates/rue-cli-tests/cases/string_escape_recovery.toml
@@ -1,6 +1,6 @@
 [section]
 id = "cli.string_escape_recovery"
-name = "String escape error recovery"
+name = "StrBuf escape error recovery"
 description = """
 RUE-535: an invalid escape in a properly-TERMINATED string must produce only
 the invalid-escape diagnostic (E0003). The lexer used to bail mid-string, then

--- a/crates/rue-cli-tests/cases/string_field.toml
+++ b/crates/rue-cli-tests/cases/string_field.toml
@@ -1,23 +1,23 @@
 [section]
 id = "string_field"
-name = "String fat-pointer materialization from places (RUE-111)"
+name = "StrBuf fat-pointer materialization from places (RUE-111)"
 description = """
-Regression tests for the struct-field / parameter String ICEs (RUE-63, RUE-94).
-A multi-slot aggregate (builtin String, or a struct containing one) obtained by
+Regression tests for the struct-field / parameter StrBuf ICEs (RUE-63, RUE-94).
+A multi-slot aggregate (builtin StrBuf, or a struct containing one) obtained by
 reading a place — a struct field or a rebound parameter — must materialize all of
 its fat-pointer slots, not just the first. Previously these aborted the compiler
 with "string should have fat pointer fields" / "builtin type should have field
 vregs" panics in codegen (both x86-64 and aarch64 backends).
 """
 
-# RUE-63: a String parameter rebound to a local. Lowering the Alloc of the local
+# RUE-63: a StrBuf parameter rebound to a local. Lowering the Alloc of the local
 # previously panicked "string should have fat pointer fields in Alloc" because the
-# param-sourced String had no struct_slot_vregs entry. (No call needed to repro the
+# param-sourced StrBuf had no struct_slot_vregs entry. (No call needed to repro the
 # ICE — defining the function was enough.)
 [[case]]
 name = "string_param_rebound_to_local"
 files = [{ path = "main.rue", source = """
-fn consume(s: String) -> i32 {
+fn consume(s: StrBuf) -> i32 {
     let held = s;
     0
 }
@@ -25,13 +25,13 @@ fn main() -> i32 { consume(\"hi\") }
 """ }]
 exit_code = 0
 
-# RUE-94: comparing a String read from a struct field with ==. emit_builtin_eq_call
+# RUE-94: comparing a StrBuf read from a struct field with ==. emit_builtin_eq_call
 # previously panicked "builtin type should have field vregs" because the field-read
-# String was not registered in struct_slot_vregs.
+# StrBuf was not registered in struct_slot_vregs.
 [[case]]
 name = "string_struct_field_eq_true"
 files = [{ path = "main.rue", source = """
-struct Holder { s: String }
+struct Holder { s: StrBuf }
 fn main() -> i32 {
     let h = Holder { s: \"hello\" };
     if h.s == \"hello\" { 0 } else { 1 }
@@ -42,7 +42,7 @@ exit_code = 0
 [[case]]
 name = "string_struct_field_eq_false"
 files = [{ path = "main.rue", source = """
-struct Holder { s: String }
+struct Holder { s: StrBuf }
 fn main() -> i32 {
     let h = Holder { s: \"hello\" };
     if h.s == \"world\" { 0 } else { 7 }
@@ -50,13 +50,13 @@ fn main() -> i32 {
 """ }]
 exit_code = 7
 
-# RUE-63 (field flavor): a String read from a struct field, rebound to a new local,
+# RUE-63 (field flavor): a StrBuf read from a struct field, rebound to a new local,
 # then consumed. Exercises both the field-read materialization and the re-store
 # (Alloc) of the fat pointer.
 [[case]]
 name = "string_field_rebound_then_eq"
 files = [{ path = "main.rue", source = """
-struct Holder { s: String }
+struct Holder { s: StrBuf }
 fn main() -> i32 {
     let h = Holder { s: \"hello\" };
     let s2 = h.s;
@@ -65,13 +65,13 @@ fn main() -> i32 {
 """ }]
 exit_code = 5
 
-# A struct that contains a String field, compared by value. The generic struct
-# equality path reads both operands' field vregs; with a String field this required
-# materializing the String sub-slots from the struct place-read.
+# A struct that contains a StrBuf field, compared by value. The generic struct
+# equality path reads both operands' field vregs; with a StrBuf field this required
+# materializing the StrBuf sub-slots from the struct place-read.
 [[case]]
 name = "struct_with_string_field_eq"
 files = [{ path = "main.rue", source = """
-struct P { name: String, age: i32 }
+struct P { name: StrBuf, age: i32 }
 fn main() -> i32 {
     let a = P { name: \"bob\", age: 3 };
     let b = P { name: \"bob\", age: 3 };

--- a/crates/rue-cli-tests/cases/string_growth.toml
+++ b/crates/rue-cli-tests/cases/string_growth.toml
@@ -1,4 +1,4 @@
-# String heap-growth correctness (RUE-34).
+# StrBuf heap-growth correctness (RUE-34).
 #
 # string_ensure_capacity used to realloc only `required` bytes while RECORDING
 # the doubled capacity — the next append that fit the phantom capacity wrote
@@ -7,8 +7,8 @@
 
 [section]
 id = "cli.string_growth"
-name = "String growth"
-description = "Growing a String must allocate at least the capacity it records."
+name = "StrBuf growth"
+description = "Growing a StrBuf must allocate at least the capacity it records."
 
 [[case]]
 name = "growth_does_not_corrupt_neighbor"
@@ -16,9 +16,9 @@ description = "Two interleaved strings: growing one then appending in-place must
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let cap: u64 = 16;
-    let mut s = String.with_capacity(cap);
+    let mut s = StrBuf.with_capacity(cap);
     s.push_str("AAAAAAAAAAAAAAAAA");
-    let mut s2 = String.with_capacity(cap);
+    let mut s2 = StrBuf.with_capacity(cap);
     s2.push_str("ZZZZZZZZ");
     s.push_str("XXXXXXXXXXXXXXX");
     if s2 == "ZZZZZZZZ" { 0 } else { 1 }
@@ -31,8 +31,8 @@ name = "interleaved_repeated_growth_stress"
 description = "Two strings growing in lockstep through many cap*2 doublings stay independent and reach the right lengths."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut a = String.new();
-    let mut b = String.new();
+    let mut a = StrBuf.new();
+    let mut b = StrBuf.new();
     let mut i = 0;
     while i < 50 {
         a.push_str("aaaaaaaaaa");

--- a/crates/rue-cli-tests/cases/string_mutation_receivers.toml
+++ b/crates/rue-cli-tests/cases/string_mutation_receivers.toml
@@ -1,4 +1,4 @@
-# Builtin String mutation methods on non-bare-local receivers (RUE-256).
+# Builtin StrBuf mutation methods on non-bare-local receivers (RUE-256).
 #
 # push_str/push/clear/reserve are `inout self`: they access the receiver by
 # reference and write the result back in place. They used to accept only a
@@ -9,17 +9,17 @@
 
 [section]
 id = "cli.string_mutation_receivers"
-name = "String mutation-method receivers"
-description = "String mutation methods accept struct-field, array-element, and inout-parameter receivers."
+name = "StrBuf mutation-method receivers"
+description = "StrBuf mutation methods accept struct-field, array-element, and inout-parameter receivers."
 
 # Struct-field receiver: b.data.push_str(..) mutates the field in place.
 [[case]]
 name = "field_receiver_push_str"
 description = "push_str through a struct field mutates the field (observed via its length)."
 files = [{ path = "main.rue", source = """
-struct Buf { data: String }
+struct Buf { data: StrBuf }
 fn main() -> i32 {
-    let mut b = Buf { data: String.new() };
+    let mut b = Buf { data: StrBuf.new() };
     b.data.push_str("hi");
     b.data.push_str("!!!");
     @dbg(b.data.len());
@@ -35,7 +35,7 @@ name = "array_element_const_index_push"
 description = "arr[0].push(65) mutates element 0 and leaves element 1 untouched."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut arr = [String.new(), String.new()];
+    let mut arr = [StrBuf.new(), StrBuf.new()];
     arr[0].push(65);
     @dbg(arr[0].len());
     @dbg(arr[1].len());
@@ -51,7 +51,7 @@ name = "array_element_dynamic_index_push"
 description = "arr[i].push(66) with a runtime index mutates exactly the selected element."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut arr = [String.new(), String.new()];
+    let mut arr = [StrBuf.new(), StrBuf.new()];
     let i: u64 = 1;
     arr[i].push(66);
     @dbg(arr[1].len());
@@ -65,13 +65,13 @@ stdout = "1\n0\n"
 # inout-parameter receiver: the mutation is visible in the caller's variable.
 [[case]]
 name = "inout_param_receiver_push_str"
-description = "push_str on an inout String parameter mutates the caller's variable through the borrow."
+description = "push_str on an inout StrBuf parameter mutates the caller's variable through the borrow."
 files = [{ path = "main.rue", source = """
-fn appendit(inout s: String) {
+fn appendit(inout s: StrBuf) {
     s.push_str("more");
 }
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     appendit(inout s);
     appendit(inout s);
     @dbg(s.len());
@@ -84,15 +84,15 @@ stdout = "8\n"
 # Field-of-self receiver inside an inout-self method.
 [[case]]
 name = "self_field_receiver_via_method"
-description = "self.data.push_str(..) inside an `inout self` method mutates the receiver's String field."
+description = "self.data.push_str(..) inside an `inout self` method mutates the receiver's StrBuf field."
 args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Buf {
-    data: String,
+    data: StrBuf,
     fn append(inout self) { self.data.push_str("ab"); }
 }
 fn main() -> i32 {
-    let mut b = Buf { data: String.new() };
+    let mut b = Buf { data: StrBuf.new() };
     b.append();
     b.append();
     b.append();
@@ -106,10 +106,10 @@ stdout = "6\n"
 # Control: an immutable-local receiver is still rejected (mutation needs `let mut`).
 [[case]]
 name = "immutable_local_receiver_rejected"
-description = "A String mutation method on an immutable binding is still E0203."
+description = "A StrBuf mutation method on an immutable binding is still E0203."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = String.new();
+    let s = StrBuf.new();
     s.push_str("x");
     0
 }
@@ -117,13 +117,13 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = ["E0203", "cannot assign"]
 
-# Control: a genuinely-moved String is still caught (use-after-move).
+# Control: a genuinely-moved StrBuf is still caught (use-after-move).
 [[case]]
 name = "moved_string_receiver_rejected"
-description = "Mutating a String after it was moved is still a use-after-move error."
+description = "Mutating a StrBuf after it was moved is still a use-after-move error."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     let s2 = s;
     s.push_str("x");
     @dbg(s2.len());

--- a/crates/rue-cli-tests/cases/string_mutation_value_position.toml
+++ b/crates/rue-cli-tests/cases/string_mutation_value_position.toml
@@ -1,6 +1,6 @@
-# String mutation-method result in value position no longer ICEs (RUE-224).
+# StrBuf mutation-method result in value position no longer ICEs (RUE-224).
 #
-# A String `ByMutRef` mutator (`push_str`, `clear`, `reserve`, ...) returns
+# A StrBuf `ByMutRef` mutator (`push_str`, `clear`, `reserve`, ...) returns
 # `SelfType` at the runtime ABI level so sema can store the updated value back
 # into the receiver, but the user-visible expression is Unit — the result may
 # not be used as a value. Previously sema returned the bare `Store` as the
@@ -16,16 +16,16 @@
 
 [section]
 id = "cli.string_mutation_value_position"
-name = "String mutation-method result in value position"
-description = "Using a String mutator's result as a value is a clean E0206, not an ICE (RUE-224)."
+name = "StrBuf mutation-method result in value position"
+description = "Using a StrBuf mutator's result as a value is a clean E0206, not an ICE (RUE-224)."
 
 [[case]]
 name = "mutation_result_as_arg_is_e0206_not_ice"
-description = "RUE-224 repro: `take(s.clear())` used to ICE at cfg_lower ('block has no terminator'); now a clean E0206 (Unit vs String)."
+description = "RUE-224 repro: `take(s.clear())` used to ICE at cfg_lower ('block has no terminator'); now a clean E0206 (Unit vs StrBuf)."
 files = [{ path = "main.rue", source = """
-fn take(s: String) -> i32 { 0 }
+fn take(s: StrBuf) -> i32 { 0 }
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     take(s.clear())
 }
 """ }]
@@ -34,10 +34,10 @@ error_contains = ["E0206"]
 
 [[case]]
 name = "statement_position_mutation_still_runs"
-description = "Statement-position String mutation (`push_str`/`clear`) compiles and runs (control)."
+description = "Statement-position StrBuf mutation (`push_str`/`clear`) compiles and runs (control)."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("hi");
     s.clear();
     s.push_str("done");

--- a/crates/rue-cli-tests/cases/string_phase1.toml
+++ b/crates/rue-cli-tests/cases/string_phase1.toml
@@ -1,17 +1,17 @@
-# Design-light String methods (RUE-17 Phase 1, ADR-0035).
+# Design-light StrBuf methods (RUE-17 Phase 1, ADR-0035).
 #
-# Phase 1 adds three runtime-visible String operations on top of the Phase 2
-# byte-access primitives: `@to_string(n)` (any integer -> decimal String),
-# `String + String` concatenation, and the byte-level `contains` / `starts_with`
+# Phase 1 adds three runtime-visible StrBuf operations on top of the Phase 2
+# byte-access primitives: `@to_string(n)` (any integer -> decimal StrBuf),
+# `StrBuf + StrBuf` concatenation, and the byte-level `contains` / `starts_with`
 # predicates. Every operation lowers to an `extern "C"` runtime call whose ABI
-# (String flattened to ptr/len/cap, sret return buffer for the heap results) is
+# (StrBuf flattened to ptr/len/cap, sret return buffer for the heap results) is
 # exactly what a spec-harness stdout check cannot exercise end to end — hence
 # these exact-stdout runs through the real driver.
 
 [section]
 id = "cli.string_phase1"
-name = "String Phase 1 methods"
-description = "Integer-to-String, concatenation, and byte-level search on String."
+name = "StrBuf Phase 1 methods"
+description = "Integer-to-StrBuf, concatenation, and byte-level search on StrBuf."
 
 [[case]]
 name = "to_string_demo"
@@ -128,7 +128,7 @@ stdout = "true\nfalse\ntrue\ntrue\nfalse\n5\n"
 
 [[case]]
 name = "string_plus_integer_rejected"
-description = "String + int is a type error (E0206); there is no implicit String/int conversion."
+description = "StrBuf + int is a type error (E0206); there is no implicit StrBuf/int conversion."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let a = "foo";

--- a/crates/rue-cli-tests/cases/try_intrinsic.toml
+++ b/crates/rue-cli-tests/cases/try_intrinsic.toml
@@ -2,7 +2,7 @@
 #
 # `@read_line()?` and `@parse_i64(s)?` used directly — with no annotated `let`
 # and no `match` to supply the concrete `Option` — resolve the intrinsic's own
-# fixed `Option(payload)` (read_line -> Option(String), parse_i64 -> Option(i64))
+# fixed `Option(payload)` (read_line -> Option(StrBuf), parse_i64 -> Option(i64))
 # and short-circuit the enclosing Option-returning function with None on failure
 # (EOF for read_line, unparseable string for parse_i64). Exercised end to end
 # from real stdin so a driver/ABI regression surfaces, not just a type-check.
@@ -90,7 +90,7 @@ files = [
 fn Option(comptime T: type) -> type {
     enum { Some(T), None }
 }
-fn add_one(s: String) -> Option(i64) {
+fn add_one(s: StrBuf) -> Option(i64) {
     let O = Option(i64);
     let n = @parse_i64(s)?;
     O.Some(n + 1)
@@ -117,7 +117,7 @@ files = [
 fn Option(comptime T: type) -> type {
     enum { Some(T), None }
 }
-fn add_one(s: String) -> Option(i64) {
+fn add_one(s: StrBuf) -> Option(i64) {
     let O = Option(i64);
     let n = @parse_i64(s)?;
     O.Some(n + 1)

--- a/crates/rue-cli-tests/cases/try_operator.toml
+++ b/crates/rue-cli-tests/cases/try_operator.toml
@@ -1,7 +1,7 @@
 [section]
 id = "cli.try_operator"
 name = "The `?` (try) operator on Option"
-description = "End-to-end runtime behavior of `?`: unwrap Some, short-circuit None, propagate a String payload, and the two static errors (E0503/E0504). RUE-6, ADR-0038."
+description = "End-to-end runtime behavior of `?`: unwrap Some, short-circuit None, propagate a StrBuf payload, and the two static errors (E0503/E0504). RUE-6, ADR-0038."
 
 # The `?` operator unwraps Some and short-circuits None, driven from real stdin
 # through the compiled binary. `pick` returns Some for a positive count and None
@@ -45,7 +45,7 @@ triple: none
 """
 exit_code = 0
 
-# A non-Copy (String) payload moves out through `?` correctly on the Some path
+# A non-Copy (StrBuf) payload moves out through `?` correctly on the Some path
 # and is not touched on the None path.
 [[case]]
 name = "try_string_payload"
@@ -54,17 +54,17 @@ files = [
 fn Option(comptime T: type) -> type {
     enum { Some(T), None }
 }
-fn lookup(found: bool) -> Option(String) {
-    let O = Option(String);
+fn lookup(found: bool) -> Option(StrBuf) {
+    let O = Option(StrBuf);
     if found { O.Some("world") } else { O.None }
 }
-fn greet(found: bool) -> Option(String) {
-    let O = Option(String);
+fn greet(found: bool) -> Option(StrBuf) {
+    let O = Option(StrBuf);
     let name = lookup(found)?;
     O.Some("hello " + name)
 }
 fn show(found: bool) {
-    let O = Option(String);
+    let O = Option(StrBuf);
     match greet(found) {
         O.Some(s) => println(s),
         O.None => println("(nothing)"),

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -349,7 +349,7 @@ mod tests {
                         drop fn Resource(self) { () }
 
                         @allow(unused_function)
-                        fn exercise(values: [i32; LENGTH], text: String) -> i32 {
+                        fn exercise(values: [i32; LENGTH], text: StrBuf) -> i32 {
                             let mut resource = Resource.make();
                             resource.set(1);
                             resource.value = 2;

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -606,8 +606,7 @@ mod integration_tests {
             let result = test_air(src).unwrap();
             // type_pool includes builtin types (StrBuf) plus user-defined
             // structs. There's 1 builtin (StrBuf) + 1 user-defined (Point) = 2
-            // distinct structs (the deprecated `String` alias names the same
-            // StrBuf struct, so `all_struct_ids` de-dups it away).
+            // distinct structs.
             let all_struct_ids = result.type_pool.all_struct_ids();
             assert_eq!(all_struct_ids.len(), 2);
             // Verify Point is present

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -1057,11 +1057,11 @@ mod tests {
                     &left_path,
                     r#"pub struct Payload {
                         value: i32,
-                        text: String,
+                        text: StrBuf,
                         fn score(borrow self) -> i32 { self.value }
                     }
                     drop fn Payload(self) { @dbg(self.value); }
-                    pub enum Choice { Empty, Text(String) }
+                    pub enum Choice { Empty, Text(StrBuf) }
                     pub fn entry() -> i32 {
                         let payload = Payload { value: 10, text: "left" };
                         payload.score()
@@ -1072,11 +1072,11 @@ mod tests {
                     &right_path,
                     r#"pub struct Payload {
                         value: i32,
-                        text: String,
+                        text: StrBuf,
                         fn score(borrow self) -> i32 { self.value }
                     }
                     drop fn Payload(self) { @dbg(self.value); }
-                    pub enum Choice { Empty, Text(String) }
+                    pub enum Choice { Empty, Text(StrBuf) }
                     pub fn entry() -> i32 {
                         let payload = Payload { value: 20, text: "right" };
                         payload.score()
@@ -1164,12 +1164,12 @@ mod tests {
             SourceView::new("main.rue", "fn main() -> i32 { 0 }", main_id),
             SourceView::new(
                 "left/clash.rue",
-                "pub struct Clash { text: String }",
+                "pub struct Clash { text: StrBuf }",
                 struct_id,
             ),
             SourceView::new(
                 "right/clash.rue",
-                "pub enum Clash { Text(String) }",
+                "pub enum Clash { Text(StrBuf) }",
                 enum_id,
             ),
         ];

--- a/crates/rue-oracle-diff/src/generator.rs
+++ b/crates/rue-oracle-diff/src/generator.rs
@@ -889,7 +889,7 @@ impl Program {
 
     fn snippet_string(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
         let sname = self.fresh("s");
-        body.push(format!("    let mut {sname} = String.new();"));
+        body.push(format!("    let mut {sname} = StrBuf.new();"));
         let chunks = 1 + self.rng.below(3);
         for _ in 0..chunks {
             let word = *self.rng.pick(&["foo", "bar", "baz", "hi", "x"]);
@@ -1021,7 +1021,7 @@ mod tests {
 
         for seed in 0..COMPILE_CONTRACT_SEEDS {
             let source = generate(seed);
-            saw_string_associated_call |= source.contains("String.new()");
+            saw_string_associated_call |= source.contains("StrBuf.new()");
             if let Err(errors) = validate_semantics(&source) {
                 panic!(
                     "generated seed {seed} did not compile: {errors:#?}\n\n--- source ---\n{source}"

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -840,7 +840,7 @@ impl<'a> Interp<'a> {
     fn is_owned_string_struct(&self, struct_id: rue_air::StructId) -> bool {
         matches!(
             self.state.type_pool.struct_def(struct_id).name.as_str(),
-            "String" | "StrBuf"
+            "StrBuf"
         )
     }
 

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -209,7 +209,7 @@ fn panic_and_assert_have_exact_observable_semantics() {
 #[test]
 fn assert_eagerly_evaluates_condition_then_message_even_when_true() {
     let out = run(r#"fn condition() -> bool { @dbg(1); true }
-        fn message() -> String { @dbg(2); "unused" }
+        fn message() -> StrBuf { @dbg(2); "unused" }
         fn main() -> i32 { @assert(condition(), message()); 42 }"#);
     assert_eq!(out.exit_code, 42);
     assert_eq!(out.stdout, "1\n2\n");
@@ -220,7 +220,7 @@ fn assert_eagerly_evaluates_condition_then_message_even_when_true() {
 #[test]
 fn panic_stderr_uses_raw_message_bytes_and_native_lossy_decoding() {
     let out = run("fn main() -> i32 {
-            let mut message = String.new();
+            let mut message = StrBuf.new();
             message.push(255);
             @panic(message);
             0
@@ -313,7 +313,7 @@ fn oversized_string_dbg_is_unsupported() {
 #[test]
 fn stdout_cap_counts_raw_bytes_before_lossy_rendering() {
     let src = "fn main() -> i32 {
-        let mut s = String.new();
+        let mut s = StrBuf.new();
         s.push(195);
         @dbg(s);
         0
@@ -489,7 +489,7 @@ fn only_model_gaps_are_registrable() {
 #[test]
 fn exact_string_capacity_is_implementation_defined() {
     let unsupported =
-        expect_unsupported("fn main() -> i32 { let s = String.new(); @intCast(s.capacity()) }");
+        expect_unsupported("fn main() -> i32 { let s = StrBuf.new(); @intCast(s.capacity()) }");
     assert_eq!(
         unsupported.kind(),
         UnsupportedKind::ImplementationDefined(ImplementationDefinedKind::StringCapacityValue)
@@ -867,9 +867,9 @@ fn min_mod_neg_one_traps() {
 #[test]
 fn string_equality_by_content() {
     let src = "fn main() -> i32 {
-        let mut a = String.new();
+        let mut a = StrBuf.new();
         a.push_str(\"hi\");
-        let mut b = String.new();
+        let mut b = StrBuf.new();
         b.push_str(\"hi\");
         if a == b { 7 } else { 0 }
     }";
@@ -879,7 +879,7 @@ fn string_equality_by_content() {
 #[test]
 fn string_build_and_len() {
     let src = "fn main() -> i32 {
-        let mut s = String.new();
+        let mut s = StrBuf.new();
         s.push_str(\"hi\");
         let n: u64 = s.len();
         if n == 2 { 0 } else { 1 }
@@ -890,7 +890,7 @@ fn string_build_and_len() {
 #[test]
 fn string_dbg_and_concat() {
     let src = "fn main() -> i32 {
-        let mut s = String.new();
+        let mut s = StrBuf.new();
         s.push_str(\"foo\");
         s.push_str(\"bar\");
         @dbg(s);
@@ -975,7 +975,7 @@ fn string_push_models_raw_non_utf8_byte() {
     // not valid UTF-8, but the byte-string model permits storing it; byte
     // operations must still see the raw byte.
     let src = "fn main() -> i32 {
-        let mut s = String.new();
+        let mut s = StrBuf.new();
         s.push(195);
         @dbg(s.len());
         @dbg(s[0]);
@@ -988,7 +988,7 @@ fn string_push_models_raw_non_utf8_byte() {
 fn string_chars_traps_on_raw_invalid_utf8_byte() {
     // Strict `.chars()` is the UTF-8 validation boundary for byte strings.
     let src = "fn main() -> i32 {
-        let mut s = String.new();
+        let mut s = StrBuf.new();
         s.push(195);
         for c in s.chars() {
             @dbg(c);
@@ -1005,7 +1005,7 @@ fn string_chars_lossy_replaces_raw_invalid_utf8_byte() {
     // The lossy view mirrors the runtime's replacement behavior: a lone invalid
     // lead byte becomes U+FFFD and advances by one byte.
     let src = "fn main() -> i32 {
-        let mut s = String.new();
+        let mut s = StrBuf.new();
         s.push(195);
         let mut count = 0;
         for c in s.chars_lossy() {
@@ -1060,7 +1060,7 @@ fn string_chars_lossy_matches_strict_over_valid_utf8() {
 #[test]
 fn string_is_empty_and_clear() {
     let src = "fn main() -> i32 {
-        let mut s = String.new();
+        let mut s = StrBuf.new();
         s.push_str(\"x\");
         let a: bool = s.is_empty();
         s.clear();

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -500,7 +500,7 @@ fn malformed_outer_calls_are_rejected_before_unmodeled_operands_run() {
     preview_features.insert(rue_compiler::PreviewFeature::StringTrio);
     let source = r#"fn main() -> i32 {
         let entropy: u32 = @random_u32();
-        let text = String.new();
+        let text = StrBuf.new();
         @intCast(text.capacity()) + @intCast((text + "suffix").len())
     }"#;
 
@@ -1381,7 +1381,7 @@ fn option_returning_intrinsics_require_the_exact_payload_type() {
             match @parse_i64("2") { O.Some(n) => @intCast(n), O.None => 0 }
         }
         fn line() -> i32 {
-            let O = Option(String);
+            let O = Option(StrBuf);
             match @read_line() { O.Some(_s) => 1, O.None => 0 }
         }
         fn main() -> i32 { parse32() + parse64() + line() }"#,

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -377,7 +377,7 @@ fn text_projection_gap_requires_the_complete_place_chain_to_be_well_typed() {
     let source = r#"struct Pair { value: i32 }
         fn read(p: Pair) -> i32 { p.value }
         fn main() -> i32 {
-            let text = String.new();
+            let text = StrBuf.new();
             if text.is_empty() { read(Pair { value: 1 }) } else { 0 }
         }"#;
 
@@ -400,7 +400,7 @@ fn text_projection_gap_requires_the_complete_place_chain_to_be_well_typed() {
                 }
             }
         }
-        let owned_ty = owned_ty.expect("String.new result type");
+        let owned_ty = owned_ty.expect("StrBuf.new result type");
         let TypeKind::Struct(owned_struct) = owned_ty.kind() else {
             panic!("String must be represented by a struct type")
         };

--- a/crates/rue-spec/cases/expressions/for.toml
+++ b/crates/rue-spec/cases/expressions/for.toml
@@ -4,7 +4,7 @@ spec_chapter = "4.8"
 name = "For Loop Expressions"
 description = """
 Built-in `for` loops (RUE-220, ADR-0037) iterate in read mode over an array, a
-String's bytes, or a String's `.chars()` scalar view.
+StrBuf's bytes, or a StrBuf's `.chars()` scalar view.
 """
 
 # =============================================================================
@@ -119,7 +119,7 @@ compile_fail = true
 error_contains = "cannot move out of borrowed value"
 
 # Iteration holds a shared borrow of the collection for the loop's duration, so
-# mutating it in the body — here via an `inout self` String method — is a
+# mutating it in the body — here via an `inout self` StrBuf method — is a
 # compile-time exclusivity error, not a runtime miscompile (RUE-257).
 [[case]]
 name = "for_mutate_collection_in_body_error"
@@ -137,7 +137,7 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "cannot mutate borrowed value"
 
-# The collection is borrowed for the loop, not consumed: a String iterated in a
+# The collection is borrowed for the loop, not consumed: a StrBuf iterated in a
 # `for` stays usable afterward (a second loop would be a use-after-move if the
 # first had moved it).
 [[case]]
@@ -159,7 +159,7 @@ fn main() -> i32 {
 exit_code = 8
 
 # =============================================================================
-# String byte view
+# StrBuf byte view
 # =============================================================================
 
 [[case]]
@@ -194,7 +194,7 @@ fn main() -> i32 {
 exit_code = 5
 
 # =============================================================================
-# String char (Unicode scalar) view
+# StrBuf char (Unicode scalar) view
 # =============================================================================
 
 [[case]]

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -239,7 +239,7 @@ exit_code = 0
 [[case]]
 name = "dbg_output_format_pinned"
 spec = ["4.13:8", "4.13:8a"]
-description = "The exact textual form @dbg prints: decimal integers (signed with -), true/false, raw String bytes, each newline-terminated (RUE-299)"
+description = "The exact textual form @dbg prints: decimal integers (signed with -), true/false, raw StrBuf bytes, each newline-terminated (RUE-299)"
 source = """
 fn main() -> i32 {
     @dbg(42);
@@ -274,10 +274,10 @@ exit_code = 0
 [[case]]
 name = "dbg_string_borrows_not_consumed"
 spec = ["4.13:6", "4.13:7"]
-description = "@dbg borrows a String; the value stays usable after the call (RUE-21)"
+description = "@dbg borrows a StrBuf; the value stays usable after the call (RUE-21)"
 source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     @dbg(s);
     let n: u64 = s.len();
@@ -294,14 +294,14 @@ exit_code = 0
 [[case]]
 name = "dbg_string_dropped_exactly_once"
 spec = ["4.13:6"]
-description = "A @dbg'd String is dropped exactly once by its owner, not consumed by @dbg (RUE-21)"
+description = "A @dbg'd StrBuf is dropped exactly once by its owner, not consumed by @dbg (RUE-21)"
 source = """
-struct Holder { s: String }
+struct Holder { s: StrBuf }
 drop fn Holder(self) {
     @dbg(self.s);
 }
 fn main() -> i32 {
-    let mut tmp = String.new();
+    let mut tmp = StrBuf.new();
     tmp.push_str("world");
     let h = Holder { s: tmp };
     @dbg(h.s);
@@ -851,7 +851,7 @@ runtime_error = "integer cast overflow"
 # =============================================================================
 # @read_line Intrinsic
 #
-# Since RUE-6 (ADR-0038) @read_line returns Option(String): Some(line) normally,
+# Since RUE-6 (ADR-0038) @read_line returns Option(StrBuf): Some(line) normally,
 # None at end-of-input (no trap). The concrete Option is taken from context, so
 # each case defines the ordinary comptime-generic Option enum in-file and
 # threads it via a `let` annotation or the match arms.
@@ -863,8 +863,8 @@ spec = ["4.13:33", "4.13:35"]
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    // Type checking: @read_line returns Option(String).
-    let Opt = Option(String);
+    // Type checking: @read_line returns Option(StrBuf).
+    let Opt = Option(StrBuf);
     let line: Opt = @read_line();
     match line {
         Opt.Some(s) => @dbg(s),
@@ -884,7 +884,7 @@ source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     // Verify @read_line takes no arguments.
-    let Opt = Option(String);
+    let Opt = Option(StrBuf);
     let line: Opt = @read_line();
     match line {
         Opt.Some(s) => @dbg(s),
@@ -929,7 +929,7 @@ spec = ["4.13:33", "4.13:36", "4.13:37"]
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(String);
+    let Opt = Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -947,7 +947,7 @@ spec = ["4.13:37"]
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(String);
+    let Opt = Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -965,7 +965,7 @@ spec = ["4.13:36"]
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(String);
+    let Opt = Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -990,7 +990,7 @@ spec = ["4.13:38"]
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(String);
+    let Opt = Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -1009,7 +1009,7 @@ spec = ["4.13:36", "4.13:37"]
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(String);
+    let Opt = Option(StrBuf);
     match @read_line() {
         Opt.Some(line) => @dbg(line),
         Opt.None => {},
@@ -1028,7 +1028,7 @@ spec = ["4.13:39"]
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let Opt = Option(String);
+    let Opt = Option(StrBuf);
     let line: Opt = @read_line();
     // EOF with no data is None, not a trap: this returns 0, exit success.
     match line {

--- a/crates/rue-spec/cases/expressions/try.toml
+++ b/crates/rue-spec/cases/expressions/try.toml
@@ -204,7 +204,7 @@ source = """
 fn Option(comptime T: type) -> type {
     enum { Some(T), None }
 }
-fn add_one(s: String) -> Option(i64) {
+fn add_one(s: StrBuf) -> Option(i64) {
     let O = Option(i64);
     let n = @parse_i64(s)?;
     O.Some(n + 1)
@@ -227,7 +227,7 @@ source = """
 fn Option(comptime T: type) -> type {
     enum { Some(T), None }
 }
-fn add_one(s: String) -> Option(i64) {
+fn add_one(s: StrBuf) -> Option(i64) {
     let O = Option(i64);
     let n = @parse_i64(s)?;
     O.Some(n + 1)

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -880,14 +880,14 @@ error_contains = "into a call that also passes it"
 [[case]]
 name = "move_while_loaned_string_heap"
 spec = ["6.1:36"]
-description = "The heap shape: moving a String into a call that passes it inout would double-free the buffer"
+description = "The heap shape: moving a StrBuf into a call that passes it inout would double-free the buffer"
 source = """
-fn f(inout a: String, b: String) -> u64 {
+fn f(inout a: StrBuf, b: StrBuf) -> u64 {
     a.push(120);
     b.len()
 }
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push(104);
     let r = f(inout s, s);
     if r == 1 { 0 } else { 1 }
@@ -922,14 +922,14 @@ name = "move_field_while_root_loaned"
 spec = ["6.1:36"]
 description = "Moving one field by value while loaning the whole variable shares a root and is rejected"
 source = """
-struct Inner { s: String }
+struct Inner { s: StrBuf }
 struct Outer { inner: Inner, n: i32 }
 fn f(inout a: Outer, b: Inner) -> i32 {
     a.n = 1;
     if b.s.len() == 1 { 7 } else { 8 }
 }
 fn main() -> i32 {
-    let mut st = String.new();
+    let mut st = StrBuf.new();
     st.push(120);
     let mut o = Outer { inner: Inner { s: st }, n: 0 };
     f(inout o, o.inner)

--- a/crates/rue-spec/cases/items/general.toml
+++ b/crates/rue-spec/cases/items/general.toml
@@ -9,26 +9,26 @@ description = "General rules for items, including type name uniqueness."
 # =============================================================================
 
 [[case]]
-name = "struct_reserved_string"
+name = "struct_reserved_strbuf"
 spec = ["6.0:3"]
-description = "User-defined struct cannot use reserved name 'String'"
+description = "User-defined struct cannot use reserved name 'StrBuf'"
 source = """
-struct String { data: i32 }
+struct StrBuf { data: i32 }
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = "cannot define type `String`: name is reserved for built-in type"
+error_contains = "cannot define type `StrBuf`: name is reserved for built-in type"
 
 [[case]]
-name = "enum_reserved_string"
+name = "enum_reserved_strbuf"
 spec = ["6.0:3"]
-description = "User-defined enum cannot use reserved name 'String'"
+description = "User-defined enum cannot use reserved name 'StrBuf'"
 source = """
-enum String { Empty, Full }
+enum StrBuf { Empty, Full }
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = "cannot define type `String`: name is reserved for built-in type"
+error_contains = "cannot define type `StrBuf`: name is reserved for built-in type"
 
 # =============================================================================
 # Type Name Uniqueness - Duplicate Definitions
@@ -99,7 +99,7 @@ description = "A `Type__method` name is an ordinary identifier: runtime symbols 
 source = """
 fn String__len() -> i32 { 7 }
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     let builtin: i32 = @intCast(s.len());
     builtin * 10 + String__len()

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -168,7 +168,7 @@ compile_fail = true
 error_contains = "base prefixes are lowercase"
 
 # =============================================================================
-# String Literals (syntax and legality)
+# StrBuf Literals (syntax and legality)
 # =============================================================================
 
 [[case]]

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -362,30 +362,30 @@ exit_code = 3
 expected_stdout = "2\n1\n"
 
 # =============================================================================
-# Types with Destructors (String)
+# Types with Destructors (StrBuf)
 # =============================================================================
 
-# These tests verify destructor behavior using String, which has a destructor
+# These tests verify destructor behavior using StrBuf, which has a destructor
 # that frees heap-allocated buffers when capacity > 0.
 
 [[case]]
 name = "type_with_destructor"
 spec = ["3.9:11", "3.10:29"]
-description = "A type has a destructor if dropping requires cleanup (String drops heap buffer)"
+description = "A type has a destructor if dropping requires cleanup (StrBuf drops heap buffer)"
 source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     // s has heap allocation
     0
-}  // String destructor frees heap buffer
+}  // StrBuf destructor frees heap buffer
 """
 exit_code = 0
 
 [[case]]
 name = "type_with_destructor_literal_promoted"
 spec = ["3.9:11", "3.10:29", "3.10:21"]
-description = "String promoted from literal has destructor that frees heap"
+description = "StrBuf promoted from literal has destructor that frees heap"
 source = """
 fn main() -> i32 {
     let mut s = "hello";
@@ -399,7 +399,7 @@ exit_code = 0
 [[case]]
 name = "type_with_destructor_literal_no_heap"
 spec = ["3.9:11", "3.10:29"]
-description = "String literal (cap=0) has no cleanup action"
+description = "StrBuf literal (cap=0) has no cleanup action"
 source = """
 fn main() -> i32 {
     let s = "hello";
@@ -415,16 +415,16 @@ spec = ["3.9:12"]
 description = "Struct has destructor if any field has destructor"
 source = """
 struct Container {
-    name: String,
+    name: StrBuf,
     value: i32,
 }
 
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("test");
     let c = Container { name: s, value: 42 };
     c.value
-}  // Container dropped: name field (String) is dropped, freeing heap
+}  // Container dropped: name field (StrBuf) is dropped, freeing heap
 """
 exit_code = 42
 
@@ -455,17 +455,17 @@ expected_stdout = "1\n2\n"
 [[case]]
 name = "struct_with_string_fields_dropped"
 spec = ["3.9:13"]
-description = "Struct whose String fields require cleanup drops each field (heap buffers freed)"
+description = "Struct whose StrBuf fields require cleanup drops each field (heap buffers freed)"
 source = """
 struct TwoStrings {
-    first: String,
-    second: String,
+    first: StrBuf,
+    second: StrBuf,
 }
 
 fn main() -> i32 {
-    let mut a = String.new();
+    let mut a = StrBuf.new();
     a.push_str("first");
-    let mut b = String.new();
+    let mut b = StrBuf.new();
     b.push_str("second");
     let ts = TwoStrings { first: a, second: b };
     0
@@ -677,7 +677,7 @@ spec = ["3.9:21", "3.10:29"]
 description = "Non-trivially droppable types generate destructor calls"
 source = """
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     s.push_str("hello");
     0
 }

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1604,9 +1604,9 @@ name = "borrow_method_preserves_sibling_field_move"
 spec = ["3.8:24"]
 description = "A builtin by-ref method call on a sibling field must not erase earlier move records (RUE-33)"
 source = """
-struct Wrap { s: String, t: String }
+struct Wrap { s: StrBuf, t: StrBuf }
 
-fn consume(s: String) -> i32 { 1 }
+fn consume(s: StrBuf) -> i32 { 1 }
 
 fn main() -> i32 {
     let w = Wrap { s: "hello", t: "world" };
@@ -1624,10 +1624,10 @@ name = "borrow_call_arg_preserves_sibling_field_move"
 spec = ["3.8:24"]
 description = "Passing a sibling field as a borrow argument must not erase earlier move records (RUE-33 site 2 regression pin)"
 source = """
-struct Wrap { s: String, t: String }
+struct Wrap { s: StrBuf, t: StrBuf }
 
-fn consume(s: String) -> i32 { 1 }
-fn peek(borrow s: String) -> i32 { 2 }
+fn consume(s: StrBuf) -> i32 { 1 }
+fn peek(borrow s: StrBuf) -> i32 { 2 }
 
 fn main() -> i32 {
     let w = Wrap { s: "hello", t: "world" };
@@ -1645,9 +1645,9 @@ name = "borrow_method_receiver_still_usable_after"
 spec = ["3.8:24"]
 description = "A by-ref builtin method call does not itself move its receiver: sibling and receiver stay usable"
 source = """
-struct Wrap { s: String, t: String }
+struct Wrap { s: StrBuf, t: StrBuf }
 
-fn consume(s: String) -> i32 { 21 }
+fn consume(s: StrBuf) -> i32 { 21 }
 
 fn main() -> i32 {
     let w = Wrap { s: "hello", t: "world" };

--- a/crates/rue-spec/cases/types/mutable-strings.toml
+++ b/crates/rue-spec/cases/types/mutable-strings.toml
@@ -463,7 +463,7 @@ fn main() -> i32 {
 exit_code = 0
 
 # =============================================================================
-# Byte String Semantics (3.10:32 - 3.10:33)
+# Byte StrBuf Semantics (3.10:32 - 3.10:33)
 # =============================================================================
 
 # Note: UTF-8 semantics are informative and don't have strict tests.

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -1,13 +1,13 @@
 # The `str` string type (ADR-0043 Phase 3, RUE-324).
 #
 # `str` is `[u8]` + the UTF-8 byte-string convention: a read-only two-word view
-# `{ptr, len}`. String literals have type `str` where a `str` is expected, are
+# `{ptr, len}`. StrBuf literals have type `str` where a `str` is expected, are
 # static-backed (bytes in .rodata), and are first-class (Copy, storable,
 # reassignable, returnable). `.len()` is the byte length; `s[i]` is the i-th
 # byte as `u8`, bounds-checked (an out-of-range index traps, exit 101).
 #
 # Gated behind `--preview string_trio`. Deferred to later phases: `str`
-# concatenation, ordering comparison, `str`<->`String` interop, methods beyond
+# concatenation, ordering comparison, `str`<->`StrBuf` interop, methods beyond
 # `.len()`/index, and char iteration.
 
 [section]

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -1,11 +1,11 @@
 [section]
 id = "types.strings"
 spec_chapter = "3.7"
-name = "String Type"
-description = "The String type represents immutable UTF-8 encoded string literals."
+name = "StrBuf Type"
+description = "The StrBuf type represents immutable UTF-8 encoded string literals."
 
 # =============================================================================
-# String Type Definition
+# StrBuf Type Definition
 # =============================================================================
 
 [[case]]
@@ -42,26 +42,26 @@ fn main() -> i32 {
 exit_code = 0
 
 # =============================================================================
-# String Representation and Ownership
+# StrBuf Representation and Ownership
 # =============================================================================
 
-# 3.7:2 — a String is three machine words (ptr, len, capacity), 24 bytes.
+# 3.7:2 — a StrBuf is three machine words (ptr, len, capacity), 24 bytes.
 [[case]]
 name = "string_size_is_24"
 spec = ["3.7:2"]
-description = "@size_of(String) is 24: three machine words (ptr, len, capacity)."
+description = "@size_of(StrBuf) is 24: three machine words (ptr, len, capacity)."
 source = """
 fn main() -> i32 {
-    @size_of(String)
+    @size_of(StrBuf)
 }
 """
 exit_code = 24
 
-# 3.7:39 — String is a move type: using it after a move is E0205.
+# 3.7:39 — StrBuf is a move type: using it after a move is E0205.
 [[case]]
 name = "string_is_move_type"
 spec = ["3.7:39"]
-description = "String is an affine (move) type; use after move is a compile error."
+description = "StrBuf is an affine (move) type; use after move is a compile error."
 source = """
 fn main() -> i32 {
     let a = "hello";
@@ -74,14 +74,14 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "use of moved value"
 
-# 3.7:39 — String is not a Copy type, so a @copy struct cannot hold one.
+# 3.7:39 — StrBuf is not a Copy type, so a @copy struct cannot hold one.
 [[case]]
 name = "string_not_copy_field"
 spec = ["3.7:39"]
-description = "StrBuf is not Copy: a @copy struct with a StrBuf field is rejected (via the deprecated `String` alias spelling)."
+description = "StrBuf is not Copy: a @copy struct with a StrBuf field is rejected."
 source = """
 @copy
-struct Bad { s: String }
+struct Bad { s: StrBuf }
 
 fn main() -> i32 {
     0
@@ -90,11 +90,11 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "non-Copy type 'StrBuf'"
 
-# 3.7:39 — an unused String is dropped implicitly (affine, not linear).
+# 3.7:39 — an unused StrBuf is dropped implicitly (affine, not linear).
 [[case]]
 name = "string_dropped_implicitly"
 spec = ["3.7:39"]
-description = "A String need not be explicitly consumed; an unused one drops at scope end."
+description = "A StrBuf need not be explicitly consumed; an unused one drops at scope end."
 source = """
 fn main() -> i32 {
     let _s = "foo" + "bar";   // heap-allocated, never used again
@@ -103,11 +103,11 @@ fn main() -> i32 {
 """
 exit_code = 0
 
-# 3.7:40 — a heap-owning String is freed exactly once; the program runs cleanly.
+# 3.7:40 — a heap-owning StrBuf is freed exactly once; the program runs cleanly.
 [[case]]
 name = "string_heap_freed_once"
 spec = ["3.7:40"]
-description = "A heap-allocated String is dropped once (no double free); program runs to completion."
+description = "A heap-allocated StrBuf is dropped once (no double free); program runs to completion."
 source = """
 fn main() -> i32 {
     let a = "foo" + "bar";   // heap-allocated: capacity > 0
@@ -120,7 +120,7 @@ exit_code = 0
 expected_stdout = "foobar\n"
 
 # =============================================================================
-# String Escape Sequences
+# StrBuf Escape Sequences
 # =============================================================================
 
 [[case]]
@@ -213,7 +213,7 @@ fn main() -> i32 {
 compile_fail = true
 
 # =============================================================================
-# String Equality (literal comparisons)
+# StrBuf Equality (literal comparisons)
 # =============================================================================
 
 [[case]]
@@ -311,7 +311,7 @@ fn main() -> i32 {
 compile_fail = true
 
 # =============================================================================
-# String Edge Cases
+# StrBuf Edge Cases
 # =============================================================================
 
 [[case]]
@@ -337,7 +337,7 @@ fn main() -> i32 {
 exit_code = 0
 
 # =============================================================================
-# String Type Annotation
+# StrBuf Type Annotation
 # =============================================================================
 
 [[case]]
@@ -345,7 +345,7 @@ name = "string_type_annotation"
 spec = ["3.7:1"]
 source = """
 fn main() -> i32 {
-    let s: String = "hello";
+    let s: StrBuf = "hello";
     0
 }
 """
@@ -356,14 +356,14 @@ name = "string_type_annotation_empty"
 spec = ["3.7:1"]
 source = """
 fn main() -> i32 {
-    let s: String = "";
+    let s: StrBuf = "";
     0
 }
 """
 exit_code = 0
 
 # =============================================================================
-# String Variables in Equality Comparisons
+# StrBuf Variables in Equality Comparisons
 # =============================================================================
 
 [[case]]
@@ -460,7 +460,7 @@ fn main() -> i32 {
 exit_code = 1
 
 # =============================================================================
-# String Debugging with @dbg
+# StrBuf Debugging with @dbg
 # =============================================================================
 
 [[case]]
@@ -538,7 +538,7 @@ exit_code = 0
 expected_stdout = "col1\tcol2\n"
 
 # =============================================================================
-# String in Complex Expressions
+# StrBuf in Complex Expressions
 # =============================================================================
 
 [[case]]
@@ -559,7 +559,7 @@ fn main() -> i32 {
 exit_code = 1
 
 # =============================================================================
-# Mutable String Reassignment
+# Mutable StrBuf Reassignment
 # =============================================================================
 
 [[case]]
@@ -612,7 +612,7 @@ fn main() -> i32 {
 exit_code = 1
 
 # =============================================================================
-# Mutable String Construction
+# Mutable StrBuf Construction
 # =============================================================================
 
 [[case]]
@@ -620,7 +620,7 @@ name = "string_new_basic"
 spec = ["3.10:7"]
 source = """
 fn main() -> i32 {
-    let s = String.new();
+    let s = StrBuf.new();
     0
 }
 """
@@ -631,7 +631,7 @@ name = "string_new_equality_with_empty"
 spec = ["3.10:7", "3.7:9"]
 source = """
 fn main() -> i32 {
-    let s = String.new();
+    let s = StrBuf.new();
     if s == "" { 1 } else { 0 }
 }
 """
@@ -643,7 +643,7 @@ spec = ["3.10:8"]
 source = """
 fn main() -> i32 {
     let cap: u64 = 1024;
-    let s = String.with_capacity(cap);
+    let s = StrBuf.with_capacity(cap);
     0
 }
 """
@@ -655,7 +655,7 @@ spec = ["3.10:8"]
 source = """
 fn main() -> i32 {
     let cap: u64 = 0;
-    let s = String.with_capacity(cap);
+    let s = StrBuf.with_capacity(cap);
     0
 }
 """
@@ -667,7 +667,7 @@ spec = ["3.10:8", "3.7:9"]
 source = """
 fn main() -> i32 {
     let cap: u64 = 64;
-    let s = String.with_capacity(cap);
+    let s = StrBuf.with_capacity(cap);
     if s == "" { 1 } else { 0 }
 }
 """
@@ -679,8 +679,8 @@ spec = ["3.10:7", "3.10:9"]
 source = """
 fn main() -> i32 {
     let cap: u64 = 1024;
-    let empty = String.new();
-    let prealloc = String.with_capacity(cap);
+    let empty = StrBuf.new();
+    let prealloc = StrBuf.with_capacity(cap);
     0
 }
 """
@@ -736,7 +736,7 @@ expected_stdout = "104\n5\n101\n"
 [[case]]
 name = "string_index_in_condition"
 spec = ["3.7:16"]
-description = "A String byte index reads correctly in condition position (if/while), not only when let-bound first (RUE-700: binary-op operands are analyzed in projection mode, which previously rejected a non-array base with E0900)."
+description = "A StrBuf byte index reads correctly in condition position (if/while), not only when let-bound first (RUE-700: binary-op operands are analyzed in projection mode, which previously rejected a non-array base with E0900)."
 source = """
 fn main() -> i32 {
     let s = "a1b2";

--- a/crates/rue-ui-tests/cases/diagnostics/reserved-types.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/reserved-types.toml
@@ -8,9 +8,9 @@ description = "Tests that user-defined types cannot collide with built-in type n
 # =============================================================================
 
 [[case]]
-name = "struct_named_string"
+name = "struct_named_strbuf"
 source = """
-struct String {
+struct StrBuf {
     data: i32,
 }
 
@@ -19,12 +19,12 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "cannot define type `String`: name is reserved for built-in type"
+error_contains = "cannot define type `StrBuf`: name is reserved for built-in type"
 
 [[case]]
-name = "enum_named_string"
+name = "enum_named_strbuf"
 source = """
-enum String {
+enum StrBuf {
     Empty,
     Full,
 }
@@ -34,4 +34,4 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "cannot define type `String`: name is reserved for built-in type"
+error_contains = "cannot define type `StrBuf`: name is reserved for built-in type"

--- a/crates/rue-ui-tests/cases/warnings/unused.toml
+++ b/crates/rue-ui-tests/cases/warnings/unused.toml
@@ -218,7 +218,7 @@ no_warnings = true
 name = "method_call_on_field_receiver_no_warning"
 description = "A method call on a field receiver uses the base variable (RUE-135)"
 source = """
-struct H { s: String }
+struct H { s: StrBuf }
 
 fn main() -> i32 {
     let h = H { s: "hello" };

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -93,7 +93,7 @@ extension; their whole point is to step outside the guarantees the core proves,
 so they are modeled separately rather than threaded through every rule.
 
 **Heap-backed and view types are referenced but not defined here.** A few rules
-mention `String`/`StrBuf`, `str`, `Str(N)`, slices `[T]`, or the mode-position
+mention `StrBuf`, `str`, `Str(N)`, slices `[T]`, or the mode-position
 compatibility relation `⊳` (for example the builtin-call note in §6.9, string
 content equality in §6.4, and the `⊳` examples in §5.7). None of these appears
 in the grammar above: they are **library/extension types outside the current
@@ -1068,7 +1068,7 @@ signedness (the value `n_T` already carries the sign). Only `==`/`!=` may reach 
 aggregate (ordering on aggregates is a §5 type error); there they compare
 **structurally** — a struct field-by-field, an array element-by-element, an enum
 same-tag-and-equal-payload, recursing into nested aggregates (RUE-285) — and a
-`String` by its byte content (`4.3:2`):
+`StrBuf` by its byte content (`4.3:2`):
 
 ```
   v1 ≈ v2  ⟺  v1 and v2 are structurally equal      (scalars by value; aggregates componentwise; strings by content)
@@ -1284,7 +1284,7 @@ place is unaliased for the call's duration, so copy-out is observably identical 
 the shared-cell rule above; the paper machine takes the sharing form because it is
 simpler to state and the two agree exactly on well-typed programs.
 
-A call whose callee is a builtin with no core body (e.g. a `String` method, or
+A call whose callee is a builtin with no core body (e.g. a `StrBuf` method, or
 `@dbg` / `@to_string`) reduces by the builtin's defining equation rather than by
 `(D-Call)`; these are elaboration-level primitives, and the oracle dispatches them
 directly (`string_builtin`; `@dbg` appends its argument's rendering
@@ -1341,7 +1341,7 @@ drop in `3.9` order (`run_drop`):
 where `drop*(H, [c1,…,cm])` folds `drop` over the list left-to-right, and
 `dtor_S` runs `S`'s destructor as an ordinary call (§6.9) if `S` declares one
 (skipping it, and the whole field recursion, for a **builtin** `S` such as
-`String`, whose destructor *is* its entire drop glue and has no observable effect
+`StrBuf`, whose destructor *is* its entire drop glue and has no observable effect
 in the model — `run_drop`'s builtin arm). The **enum** case reads the runtime tag `Kj` to
 recurse into the *active* variant's payload only: an inactive variant's payload
 has no storage, and a discriminant-only active variant (`a = 0`) drops nothing

--- a/docs/process/tutorial.md
+++ b/docs/process/tutorial.md
@@ -80,7 +80,7 @@ pretend future library ergonomics already exist.
   `@import("std")`, namespace-qualified access, and no prelude initially.
 - Collection and string examples should follow ADR-0043 terminology:
   fixed arrays, second-class slices, and growable `ArrayBuf` / `StrBuf`-style
-  library types. Avoid reviving deprecated `String`-as-special-type language in
+  library types. Avoid reviving `String`-as-special-type language in
   new tutorial prose.
 
 ## Child issue sequencing

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -1,39 +1,33 @@
 +++
-title = "String Type"
+title = "StrBuf Type"
 weight = 7
 template = "spec/page.html"
 +++
 
-# String Type
+# StrBuf Type
 
 {{ rule(id="3.7:1", cat="normative") }}
 
-The type `String` represents an immutable sequence of UTF-8 encoded bytes.
+The type `StrBuf` represents an immutable sequence of UTF-8 encoded bytes.
 
 {{ rule(id="3.7:57", cat="informative") }}
 
-ADR-0043 renames this growable-string type `String` → `StrBuf` (the string
-analog of the growable collection `ArrayBuf`), reframing it as the *growable
-rung* of the string trio (`str` / `Str(N)` / `StrBuf`) rather than a blessed
-built-in. During the migration, `StrBuf` is the canonical spelling and `String`
-is accepted as a deprecated alias that resolves to the same type: everywhere
-this chapter says `String`, `StrBuf` may be written instead, with identical
-representation, ownership, and semantics. The alias will be removed once the
-trio (str-as-slice, `Str(N)`) is complete; the remaining normative paragraphs
-below continue to use the `String` spelling until that migration finishes.
+ADR-0043 names this growable-string type `StrBuf` (the string analog of the
+growable collection `ArrayBuf`), framing it as the *growable rung* of the
+string trio (`str` / `Str(N)` / `StrBuf`) rather than a blessed built-in.
 
 {{ rule(id="3.7:2", cat="normative") }}
 
-A `String` value occupies three machine words — a pointer to the string data,
-the length in bytes, and the allocated capacity in bytes — so `@size_of(String)`
+A `StrBuf` value occupies three machine words — a pointer to the string data,
+the length in bytes, and the allocated capacity in bytes — so `@size_of(StrBuf)`
 is `24` on a 64-bit target. A string literal has a capacity of zero and its
-pointer refers to read-only memory (3.7:3); a `String` produced by an operation
+pointer refers to read-only memory (3.7:3); a `StrBuf` produced by an operation
 that allocates (`@to_string`, 3.7:22, or `+`, 3.7:25) has a capacity greater
 than zero and owns a heap buffer of that size.
 
 {{ rule(id="3.7:3", cat="normative") }}
 
-String literals are stored in read-only memory and have static lifetime.
+StrBuf literals are stored in read-only memory and have static lifetime.
 
 {{ rule(id="3.7:4") }}
 
@@ -48,18 +42,18 @@ fn main() -> i32 {
 
 {{ rule(id="3.7:39", cat="normative") }}
 
-`String` is a move type (an affine type), not a `Copy` type (see
-[Move Semantics](@/03-types/08-move-semantics.md)). Assigning a `String` to
+`StrBuf` is a move type (an affine type), not a `Copy` type (see
+[Move Semantics](@/03-types/08-move-semantics.md)). Assigning a `StrBuf` to
 another binding, passing it by value, or returning it moves it; the source
-binding is left invalid, and using a moved `String` is a compile-time error
-(E0205). Because `String` is not a `Copy` type, a `@copy` struct may not have a
-`String` field. Unlike a `linear` type, a `String` need not be explicitly
-consumed: an unused `String` is dropped implicitly at the end of its scope.
+binding is left invalid, and using a moved `StrBuf` is a compile-time error
+(E0205). Because `StrBuf` is not a `Copy` type, a `@copy` struct may not have a
+`StrBuf` field. Unlike a `linear` type, a `StrBuf` need not be explicitly
+consumed: an unused `StrBuf` is dropped implicitly at the end of its scope.
 
 {{ rule(id="3.7:40", cat="dynamic-semantics") }}
 
-A `String` owns its heap allocation and has a destructor (see
-[Destructors](@/03-types/09-destructors.md)). When a `String` is dropped: if its
+A `StrBuf` owns its heap allocation and has a destructor (see
+[Destructors](@/03-types/09-destructors.md)). When a `StrBuf` is dropped: if its
 capacity is zero (a literal) no action is taken; if its capacity is greater than
 zero the owned heap buffer is freed. Because a move transfers ownership, the
 buffer is freed exactly once — at the drop of the final owner — and never at a
@@ -67,9 +61,9 @@ moved-from binding.
 
 {{ rule(id="3.7:41", cat="informative") }}
 
-The capacity of a heap-allocated `String`, and the growth strategy that chooses
+The capacity of a heap-allocated `StrBuf`, and the growth strategy that chooses
 it, are implementation-defined (1.3:6): a conforming program observes only the
-length and byte content of a `String`, never its exact capacity. The
+length and byte content of a `StrBuf`, never its exact capacity. The
 mutable-string extension ([Mutable Strings](@/03-types/10-mutable-strings.md),
 section 3.10) builds on this same three-word representation.
 
@@ -85,7 +79,7 @@ fn main() -> i32 {
 }                            // 'b' is dropped: its heap buffer is freed once
 ```
 
-## String Literals
+## StrBuf Literals
 
 {{ rule(id="3.7:5", cat="normative") }}
 
@@ -93,7 +87,7 @@ A string literal is a sequence of characters enclosed in double quotes (`"`).
 
 {{ rule(id="3.7:6", cat="normative") }}
 
-String literals support the following escape sequences:
+StrBuf literals support the following escape sequences:
 
 | Escape | Meaning |
 |--------|---------|
@@ -121,7 +115,7 @@ fn main() -> i32 {
 }
 ```
 
-## String Equality
+## StrBuf Equality
 
 {{ rule(id="3.7:9", cat="normative") }}
 
@@ -146,11 +140,11 @@ fn main() -> i32 {
 }
 ```
 
-## String Debugging
+## StrBuf Debugging
 
 {{ rule(id="3.7:12", cat="normative") }}
 
-The `@dbg` intrinsic accepts a `String` argument and prints its content followed by a newline.
+The `@dbg` intrinsic accepts a `StrBuf` argument and prints its content followed by a newline.
 
 {{ rule(id="3.7:13") }}
 
@@ -166,13 +160,13 @@ fn main() -> i32 {
 
 {{ rule(id="3.7:15", cat="normative") }}
 
-A `String` is a byte string: its contents are conventionally UTF-8 but are not
+A `StrBuf` is a byte string: its contents are conventionally UTF-8 but are not
 required to be valid UTF-8 (see ADR-0035). Byte access therefore operates on the
 raw bytes and never inspects UTF-8 character boundaries.
 
 {{ rule(id="3.7:16", cat="normative") }}
 
-Indexing a `String` with an integer, `s[i]`, evaluates to the byte at byte
+Indexing a `StrBuf` with an integer, `s[i]`, evaluates to the byte at byte
 offset `i` as a value of type `u8`. The operation is `O(1)`.
 
 {{ rule(id="3.7:17", cat="dynamic-semantics") }}
@@ -195,8 +189,8 @@ fn main() -> i32 {
 
 {{ rule(id="3.7:19", cat="normative") }}
 
-The method `s.substring(start, len)` returns a new `String` containing the byte
-range `[start, start + len)` copied from `s`. Because `String` is a byte string,
+The method `s.substring(start, len)` returns a new `StrBuf` containing the byte
+range `[start, start + len)` copied from `s`. Because `StrBuf` is a byte string,
 any byte range is permitted; the range need not fall on UTF-8 character
 boundaries. The receiver `s` is borrowed, not consumed.
 
@@ -222,7 +216,7 @@ fn main() -> i32 {
 
 The intrinsic `@to_string(n)` takes an argument of any integer type (`i8`,
 `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, or `u64`) and returns a new,
-heap-allocated `String` containing the base-10 decimal representation of `n`
+heap-allocated `StrBuf` containing the base-10 decimal representation of `n`
 (see ADR-0035). The argument keeps its own type; a bare integer literal argument
 is inferred to be `i32` (the default integer type).
 
@@ -248,16 +242,16 @@ fn main() -> i32 {
 
 {{ rule(id="3.7:25", cat="normative") }}
 
-When both operands of the `+` operator are `String`, `s1 + s2` evaluates to a
-new, heap-allocated `String` whose bytes are the bytes of `s1` followed by the
+When both operands of the `+` operator are `StrBuf`, `s1 + s2` evaluates to a
+new, heap-allocated `StrBuf` whose bytes are the bytes of `s1` followed by the
 bytes of `s2` (see ADR-0035). Both operands are borrowed, not consumed, and
 remain usable afterwards.
 
 {{ rule(id="3.7:26", cat="legality-rule") }}
 
-The `+` operator requires both operands to have the same type. Mixing a `String`
+The `+` operator requires both operands to have the same type. Mixing a `StrBuf`
 and an integer (for example `s + 1`) is a type error; there is no implicit
-conversion between `String` and integers.
+conversion between `StrBuf` and integers.
 
 {{ rule(id="3.7:27") }}
 
@@ -273,7 +267,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.7:35", cat="normative") }}
 
-The free function `print(s)` takes a `String` and writes its raw bytes to
+The free function `print(s)` takes a `StrBuf` and writes its raw bytes to
 standard output, adding nothing. Unlike `@dbg`, it does not append a newline and
 does not apply any debug formatting. The argument `s` is borrowed, not consumed,
 and remains usable afterwards. This internal non-consuming access does not
@@ -282,7 +276,7 @@ change the call syntax: the source argument is unmarked (`print(s)`, not
 
 {{ rule(id="3.7:36", cat="normative") }}
 
-The free function `println(s)` takes a `String` and writes its raw bytes to
+The free function `println(s)` takes a `StrBuf` and writes its raw bytes to
 standard output followed by a single newline (`U+000A`). The argument `s` is
 borrowed, not consumed. Together with `@to_string` and `+`, `println` composes
 line-oriented output; there is no formatting or interpolation syntax. As with
@@ -292,9 +286,9 @@ argument is unmarked.
 {{ rule(id="3.7:37", cat="dynamic-semantics") }}
 
 `print(s)` and `println(s)` write exactly the bytes of `s`, in order, without
-transformation: because a `String` is a byte string, the output is byte-for-byte
+transformation: because a `StrBuf` is a byte string, the output is byte-for-byte
 identical to the string's contents (the only difference between the two is the
-single trailing newline `println` adds). Writing an empty `String` writes no
+single trailing newline `println` adds). Writing an empty `StrBuf` writes no
 bytes (for `print`) or a lone newline (for `println`).
 
 {{ rule(id="3.7:38") }}
@@ -314,7 +308,7 @@ fn main() -> i32 {
 {{ rule(id="3.7:28", cat="normative") }}
 
 The method `s.contains(needle)` returns `true` if and only if the bytes of the
-`String` `needle` occur as a contiguous subsequence of the bytes of `s`. The
+`StrBuf` `needle` occur as a contiguous subsequence of the bytes of `s`. The
 comparison is byte-level and does not inspect UTF-8 character boundaries. The
 empty needle is contained in every string. The receiver `s` is borrowed, not
 consumed.
@@ -322,7 +316,7 @@ consumed.
 {{ rule(id="3.7:29", cat="normative") }}
 
 The method `s.starts_with(prefix)` returns `true` if and only if the bytes of
-the `String` `prefix` are a prefix of the bytes of `s`. The comparison is
+the `StrBuf` `prefix` are a prefix of the bytes of `s`. The comparison is
 byte-level. The empty prefix matches every string. The receiver `s` is borrowed,
 not consumed.
 
@@ -342,7 +336,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.7:31", cat="normative") }}
 
-The character view `s.chars()` yields the Unicode scalar values of a `String`,
+The character view `s.chars()` yields the Unicode scalar values of a `StrBuf`,
 decoding its bytes as UTF-8. It is used as the iterable of a `for` loop (see
 [Loop Expressions](@/04-expressions/08-loop-expressions.md)), which binds each
 scalar value as a `u32` in ascending byte order.
@@ -351,7 +345,7 @@ scalar value as a `u32` in ascending byte order.
 
 Decoding through `s.chars()` is strict: a byte sequence that is not well-formed
 UTF-8 (an ill-formed, truncated, overlong, or surrogate sequence) traps at
-runtime when it is decoded. Because a `String` is a byte string that may hold
+runtime when it is decoded. Because a `StrBuf` is a byte string that may hold
 arbitrary bytes, this "trap, don't corrupt" behavior at the decode boundary is
 where invalidity is caught.
 
@@ -386,7 +380,7 @@ fn main() -> i32 {
 {{ rule(id="3.7:43", cat="normative") }}
 
 The type `str` is the byte-string slice type: it is `[u8]` (a read-only slice of
-bytes) carrying the same byte-string convention as `String` (§3.7:15) — its
+bytes) carrying the same byte-string convention as `StrBuf` (§3.7:15) — its
 contents are conventionally UTF-8 but are not required to be valid UTF-8. A `str`
 value is a two-word view `{ptr, len}`: a pointer to the bytes and a byte length.
 
@@ -408,7 +402,7 @@ For a `str` value `s`, `s.len()` evaluates to the length of `s` in bytes as a
 {{ rule(id="3.7:46", cat="normative") }}
 
 Indexing a `str` with an integer, `s[i]`, evaluates to the byte at byte offset
-`i` as a value of type `u8`. Like `String` byte access (§3.7:16) it operates on
+`i` as a value of type `u8`. Like `StrBuf` byte access (§3.7:16) it operates on
 the raw bytes and never inspects UTF-8 character boundaries. The operation is
 `O(1)`.
 
@@ -416,7 +410,7 @@ the raw bytes and never inspects UTF-8 character boundaries. The operation is
 
 If the index `i` is greater than or equal to `s.len()`, evaluating `s[i]` traps
 (index out of bounds), terminating the program the same way an out-of-bounds
-array or `String` index does.
+array or `StrBuf` index does.
 
 {{ rule(id="3.7:48") }}
 
@@ -481,7 +475,7 @@ exclusivity cannot see.
 
 The type `Str(N)` is the fixed-capacity string type: it is `[u8; N]` (an inline
 buffer of `N` bytes, with no heap allocation) carrying the same byte-string
-convention as `String` (§3.7:15), plus a byte length. The capacity `N` is a
+convention as `StrBuf` (§3.7:15), plus a byte length. The capacity `N` is a
 compile-time constant (an integer literal or a `const`), so `Str(N)` is a
 value type parameterized by `N`, the string analogue of the fixed array
 `[T; N]`. A `Str(N)` value stores up to `N` bytes together with its current
@@ -509,7 +503,7 @@ as a `u64`, which is at most `N`. The operation is `O(1)`.
 {{ rule(id="3.7:53", cat="normative") }}
 
 Indexing a `Str(N)` with an integer, `s[i]`, evaluates to the byte at byte
-offset `i` as a value of type `u8`. Like `String` byte access (§3.7:16) it
+offset `i` as a value of type `u8`. Like `StrBuf` byte access (§3.7:16) it
 operates on the raw bytes and never inspects UTF-8 character boundaries. The
 operation is `O(1)`.
 
@@ -517,7 +511,7 @@ operation is `O(1)`.
 
 If the index `i` is greater than or equal to `s.len()`, evaluating `s[i]` traps
 (index out of bounds), terminating the program the same way an out-of-bounds
-array, `String`, or `str` index does.
+array, `StrBuf`, or `str` index does.
 
 {{ rule(id="3.7:55", cat="normative") }}
 

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -113,9 +113,9 @@ When an array with a destructor is dropped, each element is dropped in index ord
 
 ```rue
 fn main() -> i32 {
-    let arr: [String; 3] = ["a", "b", "c"];
+    let arr: [StrBuf; 3] = ["a", "b", "c"];
     0
-}  // Each String in arr is dropped: arr[0], arr[1], arr[2]
+}  // Each StrBuf in arr is dropped: arr[0], arr[1], arr[2]
 ```
 
 {{ rule(id="3.9:17", cat="informative") }}

--- a/docs/spec/src/03-types/10-mutable-strings.md
+++ b/docs/spec/src/03-types/10-mutable-strings.md
@@ -210,12 +210,12 @@ fn main() -> i32 {
 }  // destructor frees the heap buffer
 ```
 
-## Byte String Semantics
+## Byte StrBuf Semantics
 
 {{ rule(id="3.10:32", cat="informative") }}
 
 Rue strings are *conventionally UTF-8* rather than strictly validated:
-- String literals are valid UTF-8 (validated at compile time)
+- StrBuf literals are valid UTF-8 (validated at compile time)
 - At runtime, strings are byte sequences
 - Methods like `push_str` accept any bytes
 - No runtime UTF-8 validation overhead

--- a/docs/spec/src/04-expressions/08-loop-expressions.md
+++ b/docs/spec/src/04-expressions/08-loop-expressions.md
@@ -218,8 +218,8 @@ element type and iteration order:
 
 - an array `[T; N]` — each element of type `T` is bound in ascending index
   order;
-- a `String` — each byte is bound as `u8` in ascending byte order;
-- the character view `s.chars()` of a `String` — each Unicode scalar value is
+- a `StrBuf` — each byte is bound as `u8` in ascending byte order;
+- the character view `s.chars()` of a `StrBuf` — each Unicode scalar value is
   bound as `u32`, in ascending byte order (or `s.chars_lossy()`, which decodes
   invalid UTF-8 to `U+FFFD` instead of trapping).
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -94,9 +94,9 @@ stabilized, so they are omitted from the normative inventory above, but they
 are no longer no-ops (RUE-319):
 
 - `@panic(msg?: StrBuf)` has type `!` (never): it aborts the process and never
-  returns. The optional message must have the builtin `StrBuf` type (`String`
-  is an alias for the same type); `str`, `Str(N)`, and unrelated aggregates are
-  not accepted. It writes `panic: <msg>` (or just `panic` when called with no
+  returns. The optional message must have the builtin `StrBuf` type; `str`,
+  `Str(N)`, and unrelated aggregates are not accepted. It writes
+  `panic: <msg>` (or just `panic` when called with no
   argument) to standard error and exits with status 101 — the same abort
   discipline as the `@intCast` overflow, division-by-zero, and bounds-check
   traps. As a diverging expression it participates in never coercion (3.4:2),

--- a/docs/spec/src/04-expressions/15-try-expressions.md
+++ b/docs/spec/src/04-expressions/15-try-expressions.md
@@ -93,7 +93,7 @@ fn main() -> i32 {
 When the operand of `?` is a bare call to a fallible intrinsic — `@read_line`
 or one of the `@parse_*` intrinsics (§4.13) — the intrinsic's `Option` type is
 resolved from the intrinsic itself rather than from a surrounding annotation or
-`match`. Each such intrinsic has a fixed payload (`@read_line` → `String`,
+`match`. Each such intrinsic has a fixed payload (`@read_line` → `StrBuf`,
 `@parse_i64` → `i64`, and so on), so `operand?` unwraps to that payload and
 short-circuits the enclosing function with its `None` on failure. This is what
 lets `@read_line()?` and `@parse_i64(s)?` be written directly, without first

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -46,7 +46,7 @@ User-defined type names (structs and enums) **MUST** be unique within a program.
 
 {{ rule(id="6.0:3", cat="legality-rule") }}
 
-User-defined types **MUST NOT** use names reserved for built-in types. Currently, the reserved growable-string type names are `StrBuf` and its deprecated alias `String`.
+User-defined types **MUST NOT** use names reserved for built-in types. Currently, the reserved growable-string type name is `StrBuf`.
 
 {{ rule(id="6.0:4", cat="example") }}
 
@@ -66,6 +66,6 @@ User-defined functions **MUST NOT** use names reserved for runtime and code-gene
 fn __rue_alloc() -> i32 { 0 }  // compile error: `__rue_` prefix is reserved
 
 // OK: `String__len` is an ordinary identifier, distinct from the built-in
-// `String.len` method (whose runtime symbol is `__rue_String_len`).
+// `StrBuf.len` method (whose runtime symbol is `__rue_String_len`).
 fn String__len() -> i32 { 0 }  // allowed
 ```

--- a/reproducibility/fixture/left/shared.rue
+++ b/reproducibility/fixture/left/shared.rue
@@ -1,6 +1,6 @@
 pub struct Payload {
     number: i32,
-    text: String,
+    text: StrBuf,
 
     fn score(borrow self) -> i32 {
         if self.text.len() > 0 { self.number + 11 } else { -1 }

--- a/reproducibility/fixture/main.rue
+++ b/reproducibility/fixture/main.rue
@@ -10,7 +10,7 @@ fn main() -> i32 {
     let right_score = right.compute(5);
 
     // Distinct literals force stable rodata ordering and runtime relocations.
-    let order: String = if left_score < right_score {
+    let order: StrBuf = if left_score < right_score {
         "left-before-right"
     } else {
         "right-before-left"

--- a/reproducibility/fixture/right/shared.rue
+++ b/reproducibility/fixture/right/shared.rue
@@ -1,6 +1,6 @@
 pub struct Payload {
     number: i32,
-    text: String,
+    text: StrBuf,
 
     fn score(borrow self) -> i32 {
         if self.text.len() > 0 { self.number + 17 } else { -1 }

--- a/reproducibility/fixture/semantic-order/left/types.rue
+++ b/reproducibility/fixture/semantic-order/left/types.rue
@@ -5,7 +5,7 @@ const shared = @import("shared.rue");
 
 struct Payload {
     value: i32,
-    text: String,
+    text: StrBuf,
 
     fn score(borrow self) -> i32 {
         shared.bump(self.value)
@@ -19,13 +19,13 @@ drop fn Payload(self) {
 
 enum Choice {
     Empty,
-    Text(String),
-    Many([String; 2]),
+    Text(StrBuf),
+    Many([StrBuf; 2]),
 }
 
 // Cross-kind collisions must occupy the same path-qualified glue namespace.
 struct Clash {
-    text: String,
+    text: StrBuf,
 }
 
 fn left_entry(value: i32) -> i32 {

--- a/reproducibility/fixture/semantic-order/right/types.rue
+++ b/reproducibility/fixture/semantic-order/right/types.rue
@@ -3,7 +3,7 @@ const shared = @import("shared.rue");
 struct Payload {
     value: i32,
     extra: i32,
-    text: String,
+    text: StrBuf,
 
     fn score(borrow self) -> i32 {
         shared.bump(self.value + self.extra)
@@ -17,13 +17,13 @@ drop fn Payload(self) {
 
 enum Choice {
     Empty,
-    Text(String),
-    Many([String; 3]),
+    Text(StrBuf),
+    Many([StrBuf; 3]),
 }
 
 enum Clash {
     Empty,
-    Text(String),
+    Text(StrBuf),
 }
 
 fn _right_entry(value: i32) -> i32 {

--- a/scripts/run-sanitizer.sh
+++ b/scripts/run-sanitizer.sh
@@ -34,7 +34,7 @@
 #           generated-code correctness bugs, which the fuzz job (source-level,
 #           never runs a binary) cannot see.
 #
-#   MISSED: intra-arena heap overflow / use-after-free such as RUE-34 (a String
+#   MISSED: intra-arena heap overflow / use-after-free such as RUE-34 (a StrBuf
 #           grow path recording more capacity than it allocated). The overflow
 #           write lands inside the mmap'd arena, which memcheck considers valid,
 #           so no error fires. Catching that class needs the runtime's own unit
@@ -80,9 +80,9 @@ echo "run-sanitizer: workdir $work" >&2
 #     stock examples touch only lightly. Kept here (not in examples/) so they
 #     can hammer growth loops without cluttering the user-facing examples.
 cat > "$work/san_str_grow.rue" <<'RUE'
-// Many push_str calls -> repeated String realloc (the RUE-34 grow path).
+// Many push_str calls -> repeated StrBuf realloc (the RUE-34 grow path).
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     let mut i = 0;
     while i < 500 {
         s.push_str("abcdefghij");
@@ -96,7 +96,7 @@ RUE
 cat > "$work/san_str_push_char.rue" <<'RUE'
 // Byte-at-a-time growth: exercises the smallest grow increments.
 fn main() -> i32 {
-    let mut s = String.new();
+    let mut s = StrBuf.new();
     let mut i = 0;
     while i < 300 {
         s.push(65);
@@ -110,7 +110,7 @@ RUE
 cat > "$work/san_str_mixed.rue" <<'RUE'
 // with_capacity + mixed appends: pre-sized buffer then repeated growth.
 fn main() -> i32 {
-    let mut s = String.with_capacity(4);
+    let mut s = StrBuf.with_capacity(4);
     s.push_str("hello");
     s.push_str(" world");
     let mut i = 0;

--- a/std/ascii.rue
+++ b/std/ascii.rue
@@ -4,7 +4,7 @@
 // `<ctype.h>` predicates (`isdigit`, `isalpha`, …) plus lowercase/uppercase
 // mapping, written directly against the ASCII code points. They inspect one
 // byte at a time and never look at UTF-8 boundaries, so they compose cleanly
-// with `String`'s byte indexing (`s[i] -> u8`) — see std.strings.
+// with `StrBuf`'s byte indexing (`s[i] -> u8`) — see std.strings.
 //
 //     const std = @import("std");
 //     std.ascii.is_digit(52);      // true  ('4')

--- a/std/fmt.rue
+++ b/std/fmt.rue
@@ -1,7 +1,7 @@
 // std.fmt — scalar-to-string formatting for the builtin types.
 //
 // This is the low-level formatting surface: turning individual `i*`/`u*`/`bool`
-// values into `String`. Multi-argument `format("n={}", n)` / interpolation is a
+// values into `StrBuf`. Multi-argument `format("n={}", n)` / interpolation is a
 // separate design (RUE-350) tracked in M5; this module is what it will build on.
 //
 //     const std = @import("std");
@@ -12,17 +12,17 @@ const arraybuf = @import("arraybuf.rue");
 
 // Decimal string of any integer value (wraps the `@to_string` intrinsic, which
 // already handles every integer width).
-pub fn int_to_string(comptime T: type, x: T) -> String {
+pub fn int_to_string(comptime T: type, x: T) -> StrBuf {
     @to_string(x)
 }
 
 // "true" / "false".
-pub fn bool_to_string(b: bool) -> String {
+pub fn bool_to_string(b: bool) -> StrBuf {
     if b { "true" } else { "false" }
 }
 
 // Unsigned value in an arbitrary base 2..=16, lowercase, no prefix.
-pub fn to_radix(n: u64, base: u64) -> String {
+pub fn to_radix(n: u64, base: u64) -> StrBuf {
     if n == 0 {
         return "0";
     }
@@ -36,7 +36,7 @@ pub fn to_radix(n: u64, base: u64) -> String {
         m = m / base;
     }
     // Digits were produced least-significant first; emit them reversed.
-    let mut out = String.new();
+    let mut out = StrBuf.new();
     let mut i = buf.len();
     while i > 0 {
         i = i - 1;
@@ -46,11 +46,11 @@ pub fn to_radix(n: u64, base: u64) -> String {
 }
 
 // Hexadecimal (base 16), lowercase, no `0x` prefix.
-pub fn to_hex(n: u64) -> String {
+pub fn to_hex(n: u64) -> StrBuf {
     to_radix(n, 16)
 }
 
 // Binary (base 2), no `0b` prefix.
-pub fn to_binary(n: u64) -> String {
+pub fn to_binary(n: u64) -> StrBuf {
     to_radix(n, 2)
 }

--- a/std/strings.rue
+++ b/std/strings.rue
@@ -1,7 +1,7 @@
-// std.strings — byte-oriented text helpers over `String` (RUE-677).
+// std.strings — byte-oriented text helpers over `StrBuf` (RUE-677).
 //
-// Built on the working `String` surface: byte indexing (`s[i] -> u8`), `.len()`,
-// and the mutating builders `String.new()` + `.push(byte)`. Everything here is
+// Built on the working `StrBuf` surface: byte indexing (`s[i] -> u8`), `.len()`,
+// and the mutating builders `StrBuf.new()` + `.push(byte)`. Everything here is
 // byte-level (ASCII-oriented) and never inspects UTF-8 boundaries, matching
 // std.ascii. Fallible parses/searches return `option.Option(T)`.
 //
@@ -11,14 +11,14 @@
 //     std.strings.trim("  hi  ");          // "hi"
 //     std.strings.repeat("ab", 3);         // "ababab"
 //
-// COMPILER-BUG WORKAROUND (see below): a `String` byte index `s[i]` used
+// COMPILER-BUG WORKAROUND (see below): a `StrBuf` byte index `s[i]` used
 // DIRECTLY inside an `if`/`while` condition expression is currently rejected
 // with E0900 "cannot index into non-array type 'StrBuf'" — even though the very
 // same `s[i]` works when bound to a `let` first or used in tail position.
 // Minimal repro:
 //
-//     fn f(s: String) -> u8 { if s[0] == 45 { 1 } else { 9 } }   // E0900
-//     fn f(s: String) -> u8 { let c = s[0]; if c == 45 { 1 } else { 9 } }  // OK
+//     fn f(s: StrBuf) -> u8 { if s[0] == 45 { 1 } else { 9 } }   // E0900
+//     fn f(s: StrBuf) -> u8 { let c = s[0]; if c == 45 { 1 } else { 9 } }  // OK
 //
 // So every index below reads the byte into a local in statement position first,
 // then tests the local. This is filed for the compiler team; when it is fixed
@@ -34,7 +34,7 @@ const math = @import("math.rue");
 // trap). NOTE: because magnitude is accumulated as a positive `i64` before an
 // optional negation, `i64::MIN` (-9223372036854775808) is reported as overflow
 // (`None`) — its magnitude does not fit a positive `i64`.
-pub fn parse_int(s: String) -> option.Option(i64) {
+pub fn parse_int(s: StrBuf) -> option.Option(i64) {
     let O = option.Option(i64);
     let n = s.len();
     if n == 0 {
@@ -83,7 +83,7 @@ pub fn parse_int(s: String) -> option.Option(i64) {
 }
 
 // Index of the first byte equal to `byte`, or `None`.
-pub fn find(s: String, byte: u8) -> option.Option(u64) {
+pub fn find(s: StrBuf, byte: u8) -> option.Option(u64) {
     let O = option.Option(u64);
     let n = s.len();
     let mut i: u64 = 0;
@@ -98,7 +98,7 @@ pub fn find(s: String, byte: u8) -> option.Option(u64) {
 }
 
 // Index of the last byte equal to `byte`, or `None`.
-pub fn rfind(s: String, byte: u8) -> option.Option(u64) {
+pub fn rfind(s: StrBuf, byte: u8) -> option.Option(u64) {
     let O = option.Option(u64);
     let mut i = s.len();
     while i > 0 {
@@ -112,7 +112,7 @@ pub fn rfind(s: String, byte: u8) -> option.Option(u64) {
 }
 
 // Number of bytes equal to `byte`.
-pub fn count(s: String, byte: u8) -> u64 {
+pub fn count(s: StrBuf, byte: u8) -> u64 {
     let mut c: u64 = 0;
     let n = s.len();
     let mut i: u64 = 0;
@@ -127,7 +127,7 @@ pub fn count(s: String, byte: u8) -> u64 {
 }
 
 // Whether the first byte of `s` equals `byte` (false for the empty string).
-pub fn starts_with_byte(s: String, byte: u8) -> bool {
+pub fn starts_with_byte(s: StrBuf, byte: u8) -> bool {
     if s.len() == 0 {
         false
     } else {
@@ -137,7 +137,7 @@ pub fn starts_with_byte(s: String, byte: u8) -> bool {
 }
 
 // Copy of `s` with leading ASCII whitespace removed.
-pub fn trim_start(s: String) -> String {
+pub fn trim_start(s: StrBuf) -> StrBuf {
     let n = s.len();
     let mut start: u64 = 0;
     let mut scanning = true;
@@ -149,7 +149,7 @@ pub fn trim_start(s: String) -> String {
             scanning = false;
         }
     }
-    let mut out = String.new();
+    let mut out = StrBuf.new();
     let mut i = start;
     while i < n {
         let c = s[i];
@@ -160,7 +160,7 @@ pub fn trim_start(s: String) -> String {
 }
 
 // Copy of `s` with trailing ASCII whitespace removed.
-pub fn trim_end(s: String) -> String {
+pub fn trim_end(s: StrBuf) -> StrBuf {
     let n = s.len();
     let mut end = n;
     let mut scanning = true;
@@ -172,7 +172,7 @@ pub fn trim_end(s: String) -> String {
             scanning = false;
         }
     }
-    let mut out = String.new();
+    let mut out = StrBuf.new();
     let mut i: u64 = 0;
     while i < end {
         let c = s[i];
@@ -183,7 +183,7 @@ pub fn trim_end(s: String) -> String {
 }
 
 // Copy of `s` with both leading and trailing ASCII whitespace removed.
-pub fn trim(s: String) -> String {
+pub fn trim(s: StrBuf) -> StrBuf {
     let n = s.len();
     let mut start: u64 = 0;
     let mut sc = true;
@@ -205,7 +205,7 @@ pub fn trim(s: String) -> String {
             ec = false;
         }
     }
-    let mut out = String.new();
+    let mut out = StrBuf.new();
     let mut i = start;
     while i < end {
         let c = s[i];
@@ -216,8 +216,8 @@ pub fn trim(s: String) -> String {
 }
 
 // `s` concatenated `n` times (empty string when `n == 0`).
-pub fn repeat(s: String, n: u64) -> String {
-    let mut out = String.new();
+pub fn repeat(s: StrBuf, n: u64) -> StrBuf {
+    let mut out = StrBuf.new();
     let len = s.len();
     let mut k: u64 = 0;
     while k < n {


### PR DESCRIPTION
## Summary

- remove the deprecated String alias from builtin registration, reservation, and type-pool lookup
- migrate active source, stdlib, fixtures, tests, and current documentation to StrBuf
- add regression coverage that String now receives the normal E0204 unknown-type diagnostic

## Why

RUE-757 completes the ADR-0043 migration so StrBuf is the sole growable-string type name and the obsolete alias machinery no longer remains in the current architecture.

## Validation

- formatting and unit tests
- CLI corpus: 1401 passed, 3 ignored
- spec corpus: 2049 passed, 18 ignored
- UI corpus: 178 passed
- oracle differential generated smoke: 64 of 64 agree
- focused CFG, oracle, builtin, AIR, CLI, spec, and reserved-name tests

Closes RUE-757.