### PR TITLE
RUE-759: rename by-reference parameter query

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -3474,14 +3474,14 @@ mod tests {
              }";
 
         let borrow_cfg = build_cfg_named(source, "borrowed");
-        assert!(borrow_cfg.is_param_inout(0), "borrow uses the by-ref ABI");
+        assert!(borrow_cfg.is_param_by_ref(0), "borrow uses the by-ref ABI");
         assert!(
             !borrow_cfg.is_param_writable(0),
             "borrow must not carry logical write permission"
         );
 
         let inout_cfg = build_cfg_named(source, "writable");
-        assert!(inout_cfg.is_param_inout(0), "inout uses the by-ref ABI");
+        assert!(inout_cfg.is_param_by_ref(0), "inout uses the by-ref ABI");
         assert!(
             inout_cfg.is_param_writable(0),
             "inout must preserve logical write permission"

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -672,11 +672,11 @@ impl Cfg {
 
     /// Get whether a parameter slot uses the physical by-reference ABI.
     ///
-    /// This legacy name is retained for codegen callers. It is true for both
-    /// logical `borrow` and logical `inout`; use [`Cfg::is_param_writable`] for
-    /// mutation permission.
+    /// This is true for both logical `borrow` and logical `inout`. Physical
+    /// transport is independent of mutation permission; use
+    /// [`Cfg::is_param_writable`] to ask whether the callee may mutate it.
     #[inline]
-    pub fn is_param_inout(&self, slot: u32) -> bool {
+    pub fn is_param_by_ref(&self, slot: u32) -> bool {
         self.param_modes
             .by_ref()
             .get(slot as usize)

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -63,10 +63,10 @@ pub struct CfgLower<'a> {
     fn_name: &'a str,
     /// Maps StructInit CFG values to their field vregs
     struct_slot_vregs: HashMap<CfgValue, Vec<VReg>>,
-    /// Maps inout parameter indices to their pointer vregs.
-    /// For inout params, the slot contains a pointer to the caller's memory.
+    /// Maps by-reference parameter indices to their pointer vregs.
+    /// For by-ref params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
-    inout_param_ptrs: HashMap<u32, VReg>,
+    by_ref_param_ptrs: HashMap<u32, VReg>,
 }
 
 impl<'a> CfgLower<'a> {
@@ -86,8 +86,8 @@ impl<'a> CfgLower<'a> {
         let estimated_block_params = num_blocks.saturating_mul(4);
         // Estimate ~10% of values are struct inits
         let estimated_struct_inits = num_values / 10;
-        // Estimate inout params are rare, start small
-        let estimated_inout_params = num_params.min(4) as usize;
+        // Estimate by-ref params are rare, start small.
+        let estimated_by_ref_params = num_params.min(4) as usize;
 
         Self {
             ctx: CfgLowerContext::new(cfg, type_pool),
@@ -98,7 +98,7 @@ impl<'a> CfgLower<'a> {
             block_param_vregs: HashMap::with_capacity(estimated_block_params),
             fn_name: cfg.fn_name(),
             struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
-            inout_param_ptrs: HashMap::with_capacity(estimated_inout_params),
+            by_ref_param_ptrs: HashMap::with_capacity(estimated_by_ref_params),
         }
     }
 
@@ -188,9 +188,9 @@ impl<'a> CfgLower<'a> {
         })
     }
 
-    /// Ensure the inout parameter pointer vreg exists for the given param slot.
-    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
-        if let Some(ptr_vreg) = self.inout_param_ptrs.get(&param_slot).copied() {
+    /// Ensure the by-reference parameter pointer vreg exists for the given slot.
+    fn ensure_by_ref_param_ptr(&mut self, param_slot: u32) -> VReg {
+        if let Some(ptr_vreg) = self.by_ref_param_ptrs.get(&param_slot).copied() {
             return ptr_vreg;
         }
 
@@ -207,17 +207,17 @@ impl<'a> CfgLower<'a> {
         });
 
         // Cache it for future use
-        self.inout_param_ptrs.insert(param_slot, ptr_vreg);
+        self.by_ref_param_ptrs.insert(param_slot, ptr_vreg);
         ptr_vreg
     }
 
     /// Materialize every by-reference parameter pointer before CFG control
     /// flow begins, so the function-wide cache only contains definitions that
     /// dominate every block which may reuse them.
-    fn preload_inout_param_ptrs(&mut self) {
+    fn preload_by_ref_param_ptrs(&mut self) {
         for param_slot in 0..self.ctx.num_params {
-            if self.ctx.cfg.is_param_inout(param_slot) {
-                self.ensure_inout_param_ptr(param_slot);
+            if self.ctx.cfg.is_param_by_ref(param_slot) {
+                self.ensure_by_ref_param_ptr(param_slot);
             }
         }
     }
@@ -370,7 +370,7 @@ impl<'a> CfgLower<'a> {
 
     /// Lower CFG to Aarch64Mir.
     pub fn lower(mut self) -> CompileResult<Aarch64Mir> {
-        self.preload_inout_param_ptrs();
+        self.preload_by_ref_param_ptrs();
 
         // Pre-allocate vregs for block parameters
         for block in self.ctx.cfg.blocks() {
@@ -408,7 +408,7 @@ impl<'a> CfgLower<'a> {
             blocks: Vec::new(),
         };
 
-        self.preload_inout_param_ptrs();
+        self.preload_by_ref_param_ptrs();
 
         // Pre-allocate vregs for block parameters (same as lower())
         for block in self.ctx.cfg.blocks() {
@@ -540,8 +540,8 @@ impl<'a> CfgLower<'a> {
                 }
             }
             CfgInstData::Param { index } => {
-                if self.ctx.cfg.is_param_inout(*index) {
-                    Some("Inout param: load pointer then dereference".to_string())
+                if self.ctx.cfg.is_param_by_ref(*index) {
+                    Some("By-ref param: load pointer then dereference".to_string())
                 } else if (*index as usize) < ARG_REGS.len() {
                     Some(format!(
                         "From register {} (AAPCS64)",
@@ -662,8 +662,8 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Param { index } => {
-                // Check if this is an inout parameter
-                let is_inout = self.ctx.cfg.is_param_inout(*index);
+                // Check if this parameter is physically passed by reference.
+                let is_by_ref = self.ctx.cfg.is_param_by_ref(*index);
 
                 // The prologue copies every ABI arg slot — register- and
                 // stack-passed alike — into the contiguous frame param area
@@ -672,10 +672,10 @@ impl<'a> CfgLower<'a> {
                 // the 8 arg registers were read from [fp+16+...], which the
                 // frame-slot-based aggregate and write paths didn't mirror,
                 // dropping slots of >8-slot aggregate args. (RUE-13/79/91)
-                if is_inout {
-                    // For inout params, the slot contains a POINTER to the caller's memory.
+                if is_by_ref {
+                    // For by-ref params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.
-                    let ptr_vreg = self.ensure_inout_param_ptr(*index);
+                    let ptr_vreg = self.ensure_by_ref_param_ptr(*index);
                     let val_vreg = self.mir.alloc_vreg();
 
                     // Dereference the pointer to get the actual value
@@ -2288,10 +2288,10 @@ impl<'a> CfgLower<'a> {
                         // param area (slots num_locals..), so its address is the
                         // corresponding frame slot.
                         let index = *index;
-                        if self.ctx.cfg.is_param_inout(index) {
-                            // inout params hold a POINTER to the caller's storage;
+                        if self.ctx.cfg.is_param_by_ref(index) {
+                            // By-ref params hold a POINTER to the caller's storage;
                             // that pointer already IS the address of the place.
-                            let ptr_vreg = self.ensure_inout_param_ptr(index);
+                            let ptr_vreg = self.ensure_by_ref_param_ptr(index);
                             self.value_map.insert(value, ptr_vreg);
                         } else {
                             // Whole by-value param: its low end is the highest
@@ -3889,8 +3889,8 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
 }
 
 impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
-    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
-        CfgLower::ensure_inout_param_ptr(self, param_slot)
+    fn ensure_by_ref_param_ptr(&mut self, param_slot: u32) -> VReg {
+        CfgLower::ensure_by_ref_param_ptr(self, param_slot)
     }
 
     fn emit_frame_addr(&mut self, dst: VReg, slot: u32) {

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -132,7 +132,7 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
         }
         CfgInstData::Param { index } => {
             let slot_count = b.ctx().type_slot_count(ty);
-            if b.ctx().cfg.is_param_inout(index) {
+            if b.ctx().cfg.is_param_by_ref(index) {
                 // By-ref (inout/borrow) param: the frame slot holds a POINTER
                 // to the caller's storage, not the value — load the slots
                 // through it (emit_place_addr fetches the received pointer).
@@ -155,7 +155,7 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
                 .any(|p| matches!(p, Projection::Index { .. }));
             let is_by_ref_base = matches!(
                 place.base,
-                PlaceBase::Param(param_slot) if b.ctx().cfg.is_param_inout(param_slot)
+                PlaceBase::Param(param_slot) if b.ctx().cfg.is_param_by_ref(param_slot)
             );
             let slot_count = b.ctx().type_slot_count(ty);
 

--- a/crates/rue-codegen/src/byref_args.rs
+++ b/crates/rue-codegen/src/byref_args.rs
@@ -69,11 +69,11 @@ pub fn lower_byref_arg_addr<B: PlaceLowerBackend + ?Sized>(
         }
         ArgShape::Param(index) => {
             let addr_vreg = b.alloc_vreg();
-            if b.ctx().cfg.is_param_inout(index) {
+            if b.ctx().cfg.is_param_by_ref(index) {
                 // Forwarding a by-ref param: pass along the pointer we
-                // received. ensure_inout_param_ptr covers params never
+                // received. ensure_by_ref_param_ptr covers params never
                 // accessed via a Param instruction.
-                let ptr_vreg = b.ensure_inout_param_ptr(index);
+                let ptr_vreg = b.ensure_by_ref_param_ptr(index);
                 b.emit_reg_move(addr_vreg, ptr_vreg);
             } else {
                 // Normal param: it lives in a frame slot after the locals.

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -553,11 +553,11 @@ impl<'a> CfgLowerContext<'a> {
         -((slot as i32 + 1) * 8)
     }
 
-    /// Check if a slot corresponds to an inout parameter.
+    /// Check if a slot corresponds to a parameter ABI slot.
     ///
-    /// Returns `Some(param_index)` if it's an inout param slot, `None` otherwise.
-    /// Inout parameter slots are stored after local variable slots.
-    pub fn slot_to_inout_param_index(&self, slot: u32) -> Option<u32> {
+    /// Returns `Some(param_index)` if it is a parameter slot, `None` otherwise.
+    /// Parameter ABI slots are stored after local variable slots.
+    pub fn slot_to_param_index(&self, slot: u32) -> Option<u32> {
         if slot >= self.num_locals && slot < self.num_locals + self.num_params {
             Some(slot - self.num_locals)
         } else {

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -19,8 +19,8 @@ use crate::vreg::VReg;
 
 /// Per-target instruction leaves used by shared place lowering.
 pub trait PlaceLowerBackend: SlotBackend {
-    /// Get or lazily materialize a received inout/borrow parameter pointer.
-    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg;
+    /// Get or lazily materialize a received by-reference parameter pointer.
+    fn ensure_by_ref_param_ptr(&mut self, param_slot: u32) -> VReg;
 
     /// Emit `dst = address of frame slot`.
     fn emit_frame_addr(&mut self, dst: VReg, slot: u32);
@@ -87,8 +87,8 @@ pub fn lower_place_read<B: PlaceLowerBackend>(b: &mut B, dst: VReg, place: &Plac
         match place.base {
             PlaceBase::Local(slot) => b.emit_load_slot(dst, slot),
             PlaceBase::Param(param_slot) => {
-                if b.ctx().cfg.is_param_inout(param_slot) {
-                    let ptr = b.ensure_inout_param_ptr(param_slot);
+                if b.ctx().cfg.is_param_by_ref(param_slot) {
+                    let ptr = b.ensure_by_ref_param_ptr(param_slot);
                     b.emit_load_ptr_base(dst, ptr);
                 } else {
                     let slot = b.ctx().num_locals + param_slot;
@@ -124,8 +124,8 @@ pub fn lower_place_write<B: PlaceLowerBackend>(b: &mut B, place: &Place, vals: &
         match place.base {
             PlaceBase::Local(slot) => agg_slots::store_slots(b, vals, slot),
             PlaceBase::Param(param_slot) => {
-                if b.ctx().cfg.is_param_inout(param_slot) {
-                    let ptr = b.ensure_inout_param_ptr(param_slot);
+                if b.ctx().cfg.is_param_by_ref(param_slot) {
+                    let ptr = b.ensure_by_ref_param_ptr(param_slot);
                     agg_slots::store_slots_through_ptr(b, vals, ptr, 0);
                 } else {
                     let slot = b.ctx().num_locals + param_slot;
@@ -170,10 +170,10 @@ pub fn lower_place_addr<B: PlaceLowerBackend>(b: &mut B, dst: VReg, place: &Plac
             }
         }
         PlaceBase::Param(param_slot) => {
-            if b.ctx().cfg.is_param_inout(param_slot) {
+            if b.ctx().cfg.is_param_by_ref(param_slot) {
                 // A received by-ref pointer already denotes the caller place's
                 // low end. Both field and index offsets therefore add.
-                let ptr = b.ensure_inout_param_ptr(param_slot);
+                let ptr = b.ensure_by_ref_param_ptr(param_slot);
                 b.emit_reg_move(dst, ptr);
                 let static_byte_offset = offsets.static_slot_offset as i32 * 8;
                 if static_byte_offset != 0 {
@@ -249,8 +249,8 @@ fn projected_access<B: PlaceLowerBackend>(
             frame_access(b, low_slot, dynamic_offset)
         }
         PlaceBase::Param(param_slot) => {
-            if b.ctx().cfg.is_param_inout(param_slot) {
-                let ptr = b.ensure_inout_param_ptr(param_slot);
+            if b.ctx().cfg.is_param_by_ref(param_slot) {
+                let ptr = b.ensure_by_ref_param_ptr(param_slot);
                 let static_byte_offset = offsets.static_slot_offset as i32 * 8;
                 if let Some(dynamic_offset) = dynamic_offset {
                     let addr = b.alloc_vreg();
@@ -330,10 +330,12 @@ mod tests {
         let source = r#"
             struct Grid { pad: i32, cells: [[i32; 2]; 2] }
             struct Empty { unit: () }
+            fn read_borrow(borrow value: i32) -> i32 { value }
             fn read_inout(inout value: i32) -> i32 { value }
             fn read_unit(value: Empty) -> () { value.unit }
             fn main() -> i32 {
                 let mut scalar = 7;
+                let _borrow_read = read_borrow(borrow scalar);
                 let _scalar_read = read_inout(inout scalar);
                 let empty = Empty { unit: () };
                 read_unit(empty);
@@ -447,39 +449,42 @@ mod tests {
         );
 
         // Lock down the two deliberately distinct compatibility leaves. A
-        // simple by-ref read must retain AArch64's base-only LdrIndexed form,
+        // simple borrow and inout reads must retain AArch64's base-only
+        // LdrIndexed form,
         // while a projected ZST read must materialize zero without attempting
         // root-origin address arithmetic (and x86 keeps its 64-bit immediate).
-        let inout_cfg = build_cfg("read_inout");
-        let inout_x86 = X86CfgLower::new(&inout_cfg, &output.type_pool, &interner)
+        for by_ref_fn in ["read_borrow", "read_inout"] {
+            let by_ref_cfg = build_cfg(by_ref_fn);
+            let by_ref_x86 = X86CfgLower::new(&by_ref_cfg, &output.type_pool, &interner)
+                .lower()
+                .expect("x86 by-ref fixture should lower");
+            let by_ref_arm = Aarch64CfgLower::new(
+                &by_ref_cfg,
+                &output.type_pool,
+                &interner,
+                Target::Aarch64Linux,
+            )
             .lower()
-            .expect("x86 inout fixture should lower");
-        let inout_arm = Aarch64CfgLower::new(
-            &inout_cfg,
-            &output.type_pool,
-            &interner,
-            Target::Aarch64Linux,
-        )
-        .lower()
-        .expect("AArch64 inout fixture should lower");
-        assert!(matches!(
-            inout_x86.instructions(),
-            [
-                X86Inst::MovRM { .. },
-                X86Inst::MovRMIndexed { .. },
-                X86Inst::MovRR { .. },
-                X86Inst::Ret
-            ]
-        ));
-        assert!(matches!(
-            inout_arm.instructions(),
-            [
-                Aarch64Inst::Ldr { .. },
-                Aarch64Inst::LdrIndexed { .. },
-                Aarch64Inst::MovRR { .. },
-                Aarch64Inst::Ret
-            ]
-        ));
+            .expect("AArch64 by-ref fixture should lower");
+            assert!(matches!(
+                by_ref_x86.instructions(),
+                [
+                    X86Inst::MovRM { .. },
+                    X86Inst::MovRMIndexed { .. },
+                    X86Inst::MovRR { .. },
+                    X86Inst::Ret
+                ]
+            ));
+            assert!(matches!(
+                by_ref_arm.instructions(),
+                [
+                    Aarch64Inst::Ldr { .. },
+                    Aarch64Inst::LdrIndexed { .. },
+                    Aarch64Inst::MovRR { .. },
+                    Aarch64Inst::Ret
+                ]
+            ));
+        }
 
         let unit_cfg = build_cfg("read_unit");
         let unit_x86 = X86CfgLower::new(&unit_cfg, &output.type_pool, &interner)

--- a/crates/rue-codegen/src/storage_lower.rs
+++ b/crates/rue-codegen/src/storage_lower.rs
@@ -1,7 +1,7 @@
 //! Shared local and parameter storage lowering (RUE-612).
 //!
 //! CFG storage operations choose between scalar and flattened aggregate values,
-//! frame slots and received inout pointers, and eager and lazy aggregate
+//! frame slots and received by-reference pointers, and eager and lazy aggregate
 //! materialization. Those choices are target-independent. Backends retain only
 //! recursive struct flattening and the exact base-only pointer-store MIR leaf.
 
@@ -79,7 +79,7 @@ pub(crate) fn lower_load<B: StorageLowerBackend>(b: &mut B, value: CfgValue, slo
     }
 }
 
-/// Lower a store to either a local frame slot or an inout parameter's pointee.
+/// Lower a store to either a local frame slot or a by-ref parameter's pointee.
 pub(crate) fn lower_store<B: StorageLowerBackend>(b: &mut B, slot: u32, value: CfgValue) {
     let value_type = b.ctx().cfg.get_inst(value).ty;
     let aggregate_vregs = b
@@ -88,16 +88,16 @@ pub(crate) fn lower_store<B: StorageLowerBackend>(b: &mut B, slot: u32, value: C
         .then(|| agg_slots::require_aggregate_slots(b, value));
 
     if let Some(slot_vregs) = aggregate_vregs {
-        if let Some(param_slot) = inout_param_for_slot(b, slot) {
-            let ptr = b.ensure_inout_param_ptr(param_slot);
+        if let Some(param_slot) = by_ref_param_for_slot(b, slot) {
+            let ptr = b.ensure_by_ref_param_ptr(param_slot);
             agg_slots::store_slots_through_ptr(b, &slot_vregs, ptr, 0);
         } else {
             agg_slots::store_slots(b, &slot_vregs, slot);
         }
     } else {
         let value_vreg = b.get_vreg(value);
-        if let Some(param_slot) = inout_param_for_slot(b, slot) {
-            let ptr = b.ensure_inout_param_ptr(param_slot);
+        if let Some(param_slot) = by_ref_param_for_slot(b, slot) {
+            let ptr = b.ensure_by_ref_param_ptr(param_slot);
             b.emit_store_ptr_base(value_vreg, ptr);
         } else {
             b.emit_store_slot(value_vreg, slot);
@@ -105,14 +105,14 @@ pub(crate) fn lower_store<B: StorageLowerBackend>(b: &mut B, slot: u32, value: C
     }
 }
 
-/// Lower a whole-value assignment through an inout parameter pointer.
+/// Lower a whole-value assignment through a writable by-ref parameter pointer.
 pub(crate) fn lower_param_store<B: StorageLowerBackend>(
     b: &mut B,
     param_slot: u32,
     value: CfgValue,
 ) {
-    if !b.ctx().cfg.is_param_inout(param_slot) {
-        panic!("ParamStore used on non-inout param slot {}", param_slot);
+    if !b.ctx().cfg.is_param_writable(param_slot) {
+        panic!("ParamStore used on non-writable param slot {}", param_slot);
     }
 
     let value_type = b.ctx().cfg.get_inst(value).ty;
@@ -121,7 +121,7 @@ pub(crate) fn lower_param_store<B: StorageLowerBackend>(
         .is_multislot_aggregate(value_type)
         .then(|| agg_slots::require_aggregate_slots(b, value));
 
-    let ptr = b.ensure_inout_param_ptr(param_slot);
+    let ptr = b.ensure_by_ref_param_ptr(param_slot);
     if let Some(slot_vregs) = aggregate_vregs {
         agg_slots::store_slots_through_ptr(b, &slot_vregs, ptr, 0);
     } else {
@@ -130,8 +130,8 @@ pub(crate) fn lower_param_store<B: StorageLowerBackend>(
     }
 }
 
-fn inout_param_for_slot<B: SlotBackend>(b: &B, slot: u32) -> Option<u32> {
+fn by_ref_param_for_slot<B: SlotBackend>(b: &B, slot: u32) -> Option<u32> {
     b.ctx()
-        .slot_to_inout_param_index(slot)
-        .filter(|&param_slot| b.ctx().cfg.is_param_inout(param_slot))
+        .slot_to_param_index(slot)
+        .filter(|&param_slot| b.ctx().cfg.is_param_by_ref(param_slot))
 }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -71,10 +71,10 @@ pub struct CfgLower<'a> {
     fn_name: &'a str,
     /// Maps StructInit CFG values to their field vregs
     struct_slot_vregs: HashMap<CfgValue, Vec<VReg>>,
-    /// Maps inout parameter indices to their pointer vregs.
-    /// For inout params, the slot contains a pointer to the caller's memory.
+    /// Maps by-reference parameter indices to their pointer vregs.
+    /// For by-ref params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
-    inout_param_ptrs: HashMap<u32, VReg>,
+    by_ref_param_ptrs: HashMap<u32, VReg>,
 }
 
 impl<'a> CfgLower<'a> {
@@ -89,8 +89,8 @@ impl<'a> CfgLower<'a> {
         let estimated_block_params = num_blocks.saturating_mul(4);
         // Estimate ~10% of values are struct inits
         let estimated_struct_inits = num_values / 10;
-        // Estimate inout params are rare, start small
-        let estimated_inout_params = num_params.min(4) as usize;
+        // Estimate by-ref params are rare, start small.
+        let estimated_by_ref_params = num_params.min(4) as usize;
 
         Self {
             ctx: CfgLowerContext::new(cfg, type_pool),
@@ -101,7 +101,7 @@ impl<'a> CfgLower<'a> {
             next_label: 0,
             fn_name: cfg.fn_name(),
             struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
-            inout_param_ptrs: HashMap::with_capacity(estimated_inout_params),
+            by_ref_param_ptrs: HashMap::with_capacity(estimated_by_ref_params),
         }
     }
 
@@ -190,14 +190,14 @@ impl<'a> CfgLower<'a> {
         })
     }
 
-    /// Ensure the inout parameter pointer vreg exists for the given param slot.
+    /// Ensure the by-reference parameter pointer vreg exists for the given slot.
     /// If the pointer has already been loaded (via a Param instruction), returns the cached vreg.
     /// Otherwise, loads the pointer from the parameter slot and caches it.
     ///
-    /// This is needed because ParamStore and parameter-based PlaceWrite may reference an inout param
+    /// This is needed because ParamStore and parameter-based PlaceWrite may reference a by-ref param
     /// that was never accessed via a Param instruction (e.g., write-only parameter).
-    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
-        if let Some(ptr_vreg) = self.inout_param_ptrs.get(&param_slot).copied() {
+    fn ensure_by_ref_param_ptr(&mut self, param_slot: u32) -> VReg {
+        if let Some(ptr_vreg) = self.by_ref_param_ptrs.get(&param_slot).copied() {
             return ptr_vreg;
         }
 
@@ -214,17 +214,17 @@ impl<'a> CfgLower<'a> {
         });
 
         // Cache it for future use
-        self.inout_param_ptrs.insert(param_slot, ptr_vreg);
+        self.by_ref_param_ptrs.insert(param_slot, ptr_vreg);
         ptr_vreg
     }
 
     /// Materialize every by-reference parameter pointer before CFG control
     /// flow begins, so the function-wide cache only contains definitions that
     /// dominate every block which may reuse them.
-    fn preload_inout_param_ptrs(&mut self) {
+    fn preload_by_ref_param_ptrs(&mut self) {
         for param_slot in 0..self.ctx.num_params {
-            if self.ctx.cfg.is_param_inout(param_slot) {
-                self.ensure_inout_param_ptr(param_slot);
+            if self.ctx.cfg.is_param_by_ref(param_slot) {
+                self.ensure_by_ref_param_ptr(param_slot);
             }
         }
     }
@@ -543,7 +543,7 @@ impl<'a> CfgLower<'a> {
 
     /// Lower CFG to X86Mir.
     pub fn lower(mut self) -> CompileResult<X86Mir> {
-        self.preload_inout_param_ptrs();
+        self.preload_by_ref_param_ptrs();
 
         // Pre-allocate vregs for block parameters
         for block in self.ctx.cfg.blocks() {
@@ -581,7 +581,7 @@ impl<'a> CfgLower<'a> {
             blocks: Vec::new(),
         };
 
-        self.preload_inout_param_ptrs();
+        self.preload_by_ref_param_ptrs();
 
         // Pre-allocate vregs for block parameters (same as lower())
         for block in self.ctx.cfg.blocks() {
@@ -733,8 +733,8 @@ impl<'a> CfgLower<'a> {
                 }
             }
             CfgInstData::Param { index } => {
-                if self.ctx.cfg.is_param_inout(*index) {
-                    Some("Inout param: load pointer then dereference".to_string())
+                if self.ctx.cfg.is_param_by_ref(*index) {
+                    Some("By-ref param: load pointer then dereference".to_string())
                 } else {
                     // ABI slot: shifted by one when a hidden sret pointer
                     // occupies the first arg register.
@@ -881,8 +881,8 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Param { index } => {
-                // Check if this is an inout parameter
-                let is_inout = self.ctx.cfg.is_param_inout(*index);
+                // Check if this parameter is physically passed by reference.
+                let is_by_ref = self.ctx.cfg.is_param_by_ref(*index);
 
                 // The prologue copies every ABI arg slot — register- and
                 // stack-passed alike — into the contiguous frame param area
@@ -891,10 +891,10 @@ impl<'a> CfgLower<'a> {
                 // the 6 arg registers were read from [rbp+16+...], which the
                 // frame-slot-based aggregate and write paths didn't mirror,
                 // dropping slots of >6-slot aggregate args. (RUE-13/79/91)
-                if is_inout {
-                    // For inout params, the slot contains a POINTER to the caller's memory.
+                if is_by_ref {
+                    // For by-ref params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.
-                    let ptr_vreg = self.ensure_inout_param_ptr(*index);
+                    let ptr_vreg = self.ensure_by_ref_param_ptr(*index);
                     let val_vreg = self.mir.alloc_vreg();
 
                     // Dereference the pointer to get the actual value
@@ -2638,10 +2638,10 @@ impl<'a> CfgLower<'a> {
                         // param area (slots num_locals..), so its address is the
                         // corresponding frame slot.
                         let index = *index;
-                        if self.ctx.cfg.is_param_inout(index) {
-                            // inout params hold a POINTER to the caller's storage;
+                        if self.ctx.cfg.is_param_by_ref(index) {
+                            // By-ref params hold a POINTER to the caller's storage;
                             // that pointer already IS the address of the place.
-                            let ptr_vreg = self.ensure_inout_param_ptr(index);
+                            let ptr_vreg = self.ensure_by_ref_param_ptr(index);
                             self.value_map.insert(value, ptr_vreg);
                         } else {
                             // Whole by-value param: its low end is the highest
@@ -3847,8 +3847,8 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
 }
 
 impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
-    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
-        CfgLower::ensure_inout_param_ptr(self, param_slot)
+    fn ensure_by_ref_param_ptr(&mut self, param_slot: u32) -> VReg {
+        CfgLower::ensure_by_ref_param_ptr(self, param_slot)
     }
 
     fn emit_frame_addr(&mut self, dst: VReg, slot: u32) {

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -1097,7 +1097,7 @@ impl<'a> Interp<'a> {
                 // A by-reference borrow/inout parameter occupies one physical
                 // ABI slot regardless of the logical pointee width. Slices are
                 // passed by value and therefore have no by-ref bit here.
-                let width = if cfg.is_param_inout(slot) {
+                let width = if cfg.is_param_by_ref(slot) {
                     1
                 } else {
                     self.state.type_pool.abi_slot_count(place.base_type)
@@ -1546,15 +1546,17 @@ impl<'a> Interp<'a> {
 
             let mode_matches = match mode {
                 CfgArgMode::Normal => (base..end).all(|slot| {
-                    !cfg.is_param_inout(u32::try_from(slot).expect("slot is within u32 CFG bounds"))
+                    !cfg.is_param_by_ref(
+                        u32::try_from(slot).expect("slot is within u32 CFG bounds"),
+                    )
                 }),
                 CfgArgMode::Borrow => {
                     let slot = u32::try_from(base).expect("slot is within u32 CFG bounds");
-                    cfg.is_param_inout(slot) && !cfg.is_param_writable(slot)
+                    cfg.is_param_by_ref(slot) && !cfg.is_param_writable(slot)
                 }
                 CfgArgMode::Inout => {
                     let slot = u32::try_from(base).expect("slot is within u32 CFG bounds");
-                    cfg.is_param_inout(slot) && cfg.is_param_writable(slot)
+                    cfg.is_param_by_ref(slot) && cfg.is_param_writable(slot)
                 }
             };
             if !mode_matches {

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -214,7 +214,7 @@ fn logical_inout_writability_is_distinct_from_the_by_reference_abi() {
     };
 
     let (borrow_cfg, borrow_value) = place_read("borrowed");
-    assert!(borrow_cfg.is_param_inout(0), "borrow uses the by-ref ABI");
+    assert!(borrow_cfg.is_param_by_ref(0), "borrow uses the by-ref ABI");
     assert!(
         !borrow_cfg.is_param_writable(0),
         "borrow is not logically writable"
@@ -226,7 +226,7 @@ fn logical_inout_writability_is_distinct_from_the_by_reference_abi() {
     );
 
     let (inout_cfg, inout_value) = place_read("writable");
-    assert!(inout_cfg.is_param_inout(0), "inout uses the by-ref ABI");
+    assert!(inout_cfg.is_param_by_ref(0), "inout uses the by-ref ABI");
     assert!(
         inout_cfg.is_param_writable(0),
         "inout is logically writable"


### PR DESCRIPTION
## Summary

- rename `Cfg::is_param_inout` to `is_param_by_ref`
- use by-reference terminology for shared ABI transport helpers across both backends
- guard mutation-sensitive `ParamStore` lowering with `is_param_writable`
- cover borrow and inout reads explicitly on x86-64 and AArch64

## Why

The old query returned true for both logical `borrow` and logical `inout`, so its name conflated physical pointer transport with mutation permission. The new API makes those independent dimensions explicit and reduces the risk of using an ABI-layout query as an authorization check.

## Validation

- `scripts/rue quick` (24 targets)
- `scripts/rue cli abi` (49 tests)
- `//crates/rue-codegen:rue-codegen-test` (491 tests)
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-759
