### PR TITLE
[Compiler] Remove dead durable cache binding metric

### DIFF
--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -48,7 +48,6 @@ struct QueryCounts {
     ordinary_declaration_resolutions_skipped: usize,
     durable_installs: usize,
     declaration_reuse_fallbacks: usize,
-    durable_cache_population_bindings: usize,
 }
 
 impl QueryCounts {
@@ -75,7 +74,6 @@ impl QueryCounts {
             ordinary_declaration_resolutions_skipped: work.ordinary_declaration_resolutions_skipped,
             durable_installs: work.durable_installs,
             declaration_reuse_fallbacks: work.declaration_reuse_fallbacks,
-            durable_cache_population_bindings: work.durable_cache_population_bindings,
         }
     }
 
@@ -112,8 +110,6 @@ impl QueryCounts {
             durable_installs: self.durable_installs - before.durable_installs,
             declaration_reuse_fallbacks: self.declaration_reuse_fallbacks
                 - before.declaration_reuse_fallbacks,
-            durable_cache_population_bindings: self.durable_cache_population_bindings
-                - before.durable_cache_population_bindings,
         }
     }
 
@@ -140,7 +136,6 @@ impl QueryCounts {
             "ordinary_declaration_resolutions_skipped": self.ordinary_declaration_resolutions_skipped,
             "durable_installs": self.durable_installs,
             "declaration_reuse_fallbacks": self.declaration_reuse_fallbacks,
-            "durable_cache_population_bindings": self.durable_cache_population_bindings,
         })
     }
 }
@@ -714,10 +709,6 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
         cold["semantic_work"]["declaration_reuse"]["plan_executions"],
         0
     );
-    assert_eq!(
-        count(cold, &["queries", "durable_cache_population_bindings"]),
-        0
-    );
 
     let noop = get("exact_noop");
     assert_eq!(count(noop, &["parse", "modules_reused"]), modules as u64);
@@ -794,10 +785,6 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
     );
     assert_eq!(
         count(root_edit, &["semantic_work", "fallback_epochs_started"]),
-        0
-    );
-    assert_eq!(
-        count(root_edit, &["queries", "durable_cache_population_bindings"]),
         0
     );
 
@@ -1108,7 +1095,7 @@ fn main() {
     println!(
         "{}",
         json!({
-            "schema_version": 8,
+            "schema_version": 9,
             "workload": "compiler_session_invalidation",
             "configuration": {
                 "modules": config.modules,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -87,10 +87,6 @@ pub struct CompilerSessionWork {
     pub ordinary_declaration_resolutions_skipped: usize,
     pub durable_installs: usize,
     pub declaration_reuse_fallbacks: usize,
-    /// Extra ordinary declaration binds currently used to populate the
-    /// successful durable baseline. Kept explicit until export is folded into
-    /// the primary ordinary bind.
-    pub durable_cache_population_bindings: usize,
     /// Current bounded-retention gauges for long-lived service integrations.
     pub retention: FrontendRetentionMetrics,
 }
@@ -3320,8 +3316,13 @@ mod tests {
         let cold = session.semantic(&options).unwrap();
         assert_eq!(cold.work().binding.bind_invocations, 1);
         assert_eq!(cold.work().binding.declaration_resolution_invocations, 1);
+        assert_eq!(
+            cold.work()
+                .declaration_reuse
+                .durable_cache_population_exports,
+            1
+        );
         assert_eq!(cold.work().manifest.rir_instructions_visited, 256);
-        assert_eq!(session.work().durable_cache_population_bindings, 0);
         session.update(&second).into_result().unwrap();
         let reused = session.semantic(&options).unwrap();
 

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -425,17 +425,17 @@ ordinary binder before body analysis consumes it. The exporter uses the
 already captured declaration shells, so it neither materializes the optional
 binding manifest nor traverses RIR. The session publishes the semantic result
 and its durable baseline only after the whole ordinary request succeeds;
-failed requests leave the last-good baseline untouched. The legacy
-`durable_cache_population_bindings` work counter is hard-gated at zero to make
-an accidental second bind visible. Cold and successful reuse requests each
-construct exactly one semantic epoch, one declaration index, and one shell
-predeclaration epoch. Cold requests report one population export; reuse reports
-none. Projection failure is read-only and resolves the same unmutated shells.
-Only an installation failure, which consumes candidate shells to preserve
-atomicity, may report a second semantic/index epoch and one fallback epoch.
-These values, together with the exact plan/comparison/install/reuse counters,
-are serialized under `semantic_work.declaration_reuse` by the session benchmark
-and are treated as a checked schema rather than inferred timing data.
+failed requests leave the last-good baseline untouched. The ordinary binding
+and population-export counters directly enforce that cold requests bind once
+and export once. Cold and successful reuse requests each construct exactly one
+semantic epoch, one declaration index, and one shell predeclaration epoch. Cold
+requests report one population export; reuse reports none. Projection failure
+is read-only and resolves the same unmutated shells. Only an installation
+failure, which consumes candidate shells to preserve atomicity, may report a
+second semantic/index epoch and one fallback epoch. These values, together with
+the exact plan/comparison/install/reuse counters, are serialized under
+`semantic_work.declaration_reuse` by the session benchmark and are treated as a
+checked schema rather than inferred timing data.
 
 The split-binding seam now predeclares free-callable, named-method/associated,
 named-const, and named-destructor identities in logical-path order. It retains

--- a/docs/process/session-invalidation-benchmark.md
+++ b/docs/process/session-invalidation-benchmark.md
@@ -44,22 +44,21 @@ must run no RIR query or RIR instruction scan.
 
 At N=128 the structural gates require the supported reachable-root-body-edit
 workload to reuse and atomically install all 128 durable declaration records,
-skip ordinary declaration resolution, and perform zero cache-population binds.
-Cold compilation remains one bind. This is a measured declaration-resolution
-saving, not whole-pipeline incremental compilation: program merge/RIR and
-current body/CFG work still run. Constants, module values, function aliases,
-generic named methods, and anonymous structural owners currently fail closed to
-ordinary declaration resolution with zero partial installs. Persistent cache
-formats and LSP consumers remain deliberately out of scope.
+skip ordinary declaration resolution, and perform no population export. Cold
+compilation performs one ordinary bind and exports the durable baseline from
+that bind. This is a measured declaration-resolution saving, not whole-pipeline
+incremental compilation: program merge/RIR and current body/CFG work still run.
+Constants, module values, function aliases, generic named methods, and anonymous
+structural owners currently fail closed to ordinary declaration resolution with
+zero partial installs. Persistent cache formats and LSP consumers remain
+deliberately out of scope.
 
 Schema version 3 adds the exact declaration-reuse ledger under
 `semantic_work.declaration_reuse`: plans, durable comparisons and reuse,
 skipped ordinary resolution, installs, fallbacks, semantic/index/shell epochs,
 population exports, and fallback epochs. Cold and successful declaration-reuse
 scenarios are hard-gated to one epoch/index/shell-predeclaration each. Cold
-reports one export; reuse reports none and no fallback epoch. The legacy
-`queries.durable_cache_population_bindings` value remains present and must be
-zero.
+reports one export; reuse reports none and no fallback epoch.
 
 The ordinary test suite runs only a four-module, single-iteration structural
 smoke test through
@@ -113,3 +112,8 @@ artifacts has intentionally left the session. Compiler unit stress tests run a
 32-round syntax-failure, semantic-failure, recovery, and edit sequence and a
 plan workload beyond the eviction cap, pinning bounded bytes, deterministic
 FIFO recomputation, last-good recovery, and clean-session parity.
+
+Schema version 9 removes the obsolete population-binding query field. The
+authoritative `semantic_work.bind_invocations` and
+`semantic_work.declaration_reuse.durable_cache_population_exports` counters
+continue to gate the single-bind export path directly.


### PR DESCRIPTION
## Summary

- remove the dead `durable_cache_population_bindings` compiler work metric
- remove its benchmark JSON/schema plumbing and zero-only assertions
- keep the ordinary bind and durable population-export counters as the authoritative accounting
- update the benchmark schema and documentation for the current single-bind export path

## Validation

- `scripts/rue fmt`
- `scripts/rue test leaf_body_edit_reuses_128_durable_declarations_and_skips_ordinary_resolution`
- `scripts/rue quick`
- `git diff --check`

Fixes RUE-764
