### PR TITLE
Share Buck build work across Rue worktrees

### DIFF
--- a/.buckconfig.local.example
+++ b/.buckconfig.local.example
@@ -11,10 +11,12 @@
 # Get the key from https://app.buildbuddy.io (Settings -> API keys). CI reads the
 # same key from the BUILDBUDDY_API_KEY repo secret instead of this file.
 #
-# With this config, a normal `buck2 build` uses the remote action cache (actions
-# execute locally, cache is shared across machines + daemon restarts). Adding
-# `--prefer-remote` runs the WHOLE build on BuildBuddy's workers (verified: the
-# full compiler builds with 171/175 actions remote, 0 local). Remote execution is
+# With this config, the repository's `./buck2` wrapper adds `--prefer-local` to
+# normal execution commands: the remote action cache is queried first, then
+# misses execute locally. Adding an explicit execution-mode flag overrides the
+# wrapper, but full remote execution is not supported until RUE-320. It was
+# previously demonstrated for compilation, but complete builds still need the
+# platform-scoped linker fix. Remote execution is
 # possible because the rust toolchain ships its own tree (rustc finds its libs via
 # $ORIGIN under RE) and links via `cc`+lld; the remote_cache platform pins the
 # rbe-ubuntu22-04 container image (Python 3.10 for the prelude's rustc wrapper).
@@ -36,6 +38,7 @@ http_headers = x-buildbuddy-api-key:<YOUR_BUILDBUDDY_API_KEY>
 digest_algorithms = SHA256
 
 [build]
-# Route execution through the remote-cache/RE platform (local exec + remote cache
-# by default; full remote execution with --prefer-remote).
+# Route commands through the remote-cache platform. The repository ./buck2
+# wrapper adds --prefer-local for ordinary execution commands; RUE-320 must land
+# before full remote execution is supported.
 execution_platforms = root//platforms:remote_cache

--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -29,45 +29,69 @@ jobs:
             exit 1
           fi
 
-      - name: Write .buckconfig.local from the secret
+      - name: Provision the private cache config
         env:
-          KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
-          cat > .buckconfig.local <<EOF
-          [buck2_re_client]
-          engine_address = grpc://remote.buildbuddy.io
-          action_cache_address = grpc://remote.buildbuddy.io
-          cas_address = grpc://remote.buildbuddy.io
-          tls = true
-          http_headers = x-buildbuddy-api-key:${KEY}
-
-          [buck2]
-          digest_algorithms = SHA256
-
-          [build]
-          execution_platforms = root//platforms:remote_cache
-          EOF
-          echo "wrote .buckconfig.local (key redacted)"
+          scripts/provision-build-cache install
+          scripts/provision-build-cache apply
 
       - name: Cold build (populates the remote cache)
         run: |
-          set -o pipefail  # without it, `| tee | tail` makes a failed build exit 0
-          /usr/bin/time -v ./buck2 build //crates/rue:rue 2>&1 | tee cold.log | tail -3
+          set +e
+          /usr/bin/time -v ./buck2 build --prefer-local //crates/rue:rue >cold.log 2>&1
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "::group::Cold build failure (complete log)"
+            cat cold.log
+            echo "::endgroup::"
+            echo "::error::Cold cache-probe build failed with exit $status"
+            exit "$status"
+          fi
+          grep -E '^(Cache hits:|Commands:|Network:)' cold.log | tail -3 || tail -10 cold.log
 
       - name: Clear local buck-out, rebuild (should hit the remote cache)
         run: |
-          set -o pipefail  # without it, `| tee | tail` makes a failed build exit 0
           ./buck2 clean
-          /usr/bin/time -v ./buck2 build //crates/rue:rue 2>&1 | tee warm.log | tail -3
+          set +e
+          /usr/bin/time -v ./buck2 build --prefer-local //crates/rue:rue >warm.log 2>&1
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "::group::Warm build failure (complete log)"
+            cat warm.log
+            echo "::endgroup::"
+            echo "::error::Warm cache-probe build failed with exit $status"
+            exit "$status"
+          fi
+          grep -E '^(Cache hits:|Commands:|Network:)' warm.log | tail -3 || tail -10 warm.log
+
+      - name: Upload probe logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cache-probe-logs
+          path: |
+            cold.log
+            warm.log
+          if-no-files-found: warn
 
       - name: Cache-hit summary
         if: always()
         run: |
+          command_summary() {
+            if [ -f "$1" ]; then
+              grep -oE 'Commands: .*' "$1" | tail -1 || echo "unavailable (build failed before Buck summary)"
+            else
+              echo "unavailable (step did not run)"
+            fi
+          }
           {
             echo "### Remote cache probe"
             echo '```'
-            echo "COLD: $(grep -oE 'Commands: .*' cold.log | tail -1)"
-            echo "WARM: $(grep -oE 'Commands: .*' warm.log | tail -1)"
+            echo "COLD: $(command_summary cold.log)"
+            echo "WARM: $(command_summary warm.log)"
             echo '```'
             echo "A non-zero 'cached'/'remote' count on WARM means the remote cache is working."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ scripts/rue cli abi                  # filtered CLI integration tests
 scripts/rue test [pattern]           # broad/full suite
 scripts/rue fmt                      # format changed Rust files
 scripts/rue gc                       # reclaim stale Buck2 artifacts
+scripts/rue cache install            # securely install the shared cache config
+scripts/rue cache apply --all        # provision current Git/Codex worktrees
 ```
 
 Use `scripts/rue-bin` to obtain an absolute compiler path. Do not reconstruct
@@ -157,6 +159,15 @@ are timeout-only and unrelated tests are competing for the machine, rerun that
 target once in isolation. A clean isolated 64/64 run is sufficient local
 evidence; do not repeatedly rerun the entire suite. A semantic disagreement,
 compiler error, or isolated timeout remains a real failure.
+
+An unfiltered `scripts/rue test` is host-serialized across Rue worktrees and
+runs the opaque spec, UI, CLI, oracle, and reproducibility harnesses one at a
+time. Do not bypass that coordination with a direct `buck2 test //...` when a
+full local run is intended. Quick, filtered, and targeted checks do not take the
+host lock. The optional BuildBuddy action cache uses one private user config and
+ignored per-worktree symlinks; see `docs/process/build-cache.md`. Never commit or
+print its credential, and do not use `--prefer-remote` while RUE-320 remains
+open.
 
 Testing conventions:
 

--- a/BUCK
+++ b/BUCK
@@ -109,6 +109,7 @@ filegroup(
 
 sh_test(
     name = "spec-tests",
+    labels = ["rue_heavy_suite"],
     test = "//crates/rue-spec:rue-spec",
     args = ["--quiet"],
     env = {
@@ -129,6 +130,7 @@ sh_test(
 
 sh_test(
     name = "ui-tests",
+    labels = ["rue_heavy_suite"],
     test = "//crates/rue-ui-tests:rue-ui-tests",
     args = ["--quiet"],
     env = {
@@ -139,6 +141,7 @@ sh_test(
 
 sh_test(
     name = "cli-tests",
+    labels = ["rue_heavy_suite"],
     test = "//crates/rue-cli-tests:rue-cli-tests",
     args = ["--quiet"],
     env = {
@@ -152,6 +155,7 @@ sh_test(
 
 sh_test(
     name = "reproducible-programs",
+    labels = ["rue_heavy_suite"],
     test = "scripts/test-reproducible-output.sh",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
@@ -166,6 +170,7 @@ sh_test(
 # `test.sh` and CI include it while `quick-test.sh` remains unit-only.
 sh_test(
     name = "oracle-diff-generated-smoke",
+    labels = ["rue_heavy_suite"],
     test = "scripts/oracle-diff-generated-smoke.sh",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
@@ -250,6 +255,8 @@ filegroup(
         "fmt.sh",
         "scripts/rue",
         "scripts/rue-bin",
+        "scripts/provision-build-cache",
+        "scripts/with-full-suite-lock",
         "scripts/run-sanitizer.sh",
         "test.sh",
     ],
@@ -260,5 +267,24 @@ sh_test(
     test = "scripts/test-wrapper-scripts.sh",
     env = {
         "RUE_WRAPPER_ROOT": "$(location :wrapper-script-inputs)",
+    },
+)
+
+filegroup(
+    name = "build-sharing-test-inputs",
+    srcs = [
+        "buck2",
+        "buck2-bin",
+        "scripts/provision-build-cache",
+        "scripts/with-full-suite-lock",
+        "test.sh",
+    ],
+)
+
+sh_test(
+    name = "build-sharing-tests",
+    test = "scripts/test-build-sharing.sh",
+    env = {
+        "RUE_BUILD_SHARING_ROOT": "$(location :build-sharing-test-inputs)",
     },
 )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,12 @@ just forwards to `./buck2 build //crates/rue:rue`, so you can drive Buck2
 directly if you prefer. macOS also requires Xcode Command Line Tools for linking
 Rue executables.
 
+On development machines with several Rue worktrees, unfiltered full suites are
+serialized automatically to avoid oversubscribing the host. Quick and filtered
+checks remain concurrent. Maintainers can opt into the shared action cache as
+documented in [docs/process/build-cache.md](docs/process/build-cache.md); no
+BuildBuddy account is required to build or test Rue.
+
 For IDE support, rust-analyzer reads the checked-in `rust-project.json` (Rue has
 no Cargo workspace). Regenerate it with `./gen-rust-project.sh` when crates or
 dependencies change — see [docs/development.md](docs/development.md#editor--ide-support).

--- a/buck2
+++ b/buck2
@@ -1,91 +1,48 @@
-#!/usr/bin/env dotslash
+#!/usr/bin/env bash
+# Rue's Buck2 entry point. The pinned DotSlash manifest lives in buck2-bin.
+set -euo pipefail
 
-{
-  "name": "buck2",
-  "platforms": {
-    "macos-aarch64": {
-      "size": 33728207,
-      "hash": "blake3",
-      "digest": "3bbd7cfe1b51d17124f5634812ae904254e01da429a61f62fe9c3d7c45e12dd9",
-      "format": "zst",
-      "path": "buck2-aarch64-apple-darwin",
-      "providers": [
-        {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-aarch64-apple-darwin.zst"
-        }
-      ]
-    },
-    "windows-aarch64": {
-      "size": 29333382,
-      "hash": "blake3",
-      "digest": "34417c30bd88b2110e00044f619aae791ec4e2d7f982aeb0fa43f01c0c2b06ac",
-      "format": "zst",
-      "path": "buck2-aarch64-pc-windows-msvc.exe",
-      "providers": [
-        {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-aarch64-pc-windows-msvc.exe.zst"
-        }
-      ]
-    },
-    "linux-aarch64": {
-      "size": 36896909,
-      "hash": "blake3",
-      "digest": "889091fae4410776de12ddc1ec676f019a0b9bd9bacf69298e5d0b16482f9ae6",
-      "format": "zst",
-      "path": "buck2-aarch64-unknown-linux-musl",
-      "providers": [
-        {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-aarch64-unknown-linux-musl.zst"
-        }
-      ]
-    },
-    "linux-riscv64": {
-      "size": 39062685,
-      "hash": "blake3",
-      "digest": "4c6275d204a22fe5920bbf6fadf41a04580ec79b713c2447fcc264534f78e221",
-      "format": "zst",
-      "path": "buck2-riscv64gc-unknown-linux-gnu",
-      "providers": [
-        {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-riscv64gc-unknown-linux-gnu.zst"
-        }
-      ]
-    },
-    "macos-x86_64": {
-      "size": 35999107,
-      "hash": "blake3",
-      "digest": "688c7d5da371fcb0dc8d337c37a55963e3001688e0942473c0f9897cb11170d9",
-      "format": "zst",
-      "path": "buck2-x86_64-apple-darwin",
-      "providers": [
-        {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-x86_64-apple-darwin.zst"
-        }
-      ]
-    },
-    "windows-x86_64": {
-      "size": 31097651,
-      "hash": "blake3",
-      "digest": "fae94eafc83a7e780c66775760e3ca2e92f499047299968ae7847ee3300f2970",
-      "format": "zst",
-      "path": "buck2-x86_64-pc-windows-msvc.exe",
-      "providers": [
-        {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-x86_64-pc-windows-msvc.exe.zst"
-        }
-      ]
-    },
-    "linux-x86_64": {
-      "size": 38600655,
-      "hash": "blake3",
-      "digest": "807fe2ba2c7aaf3a3a312de4220cee2abba9f37940c45b5a5f42ff1fd33dc089",
-      "format": "zst",
-      "path": "buck2-x86_64-unknown-linux-musl",
-      "providers": [
-        {
-          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-x86_64-unknown-linux-musl.zst"
-        }
-      ]
-    }
-  }
-}
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+args=("$@")
+
+# A previously installed private config follows newly created worktrees on
+# their first direct Buck invocation as well as through scripts/rue.
+if [[ -x "$repo_root/scripts/provision-build-cache" ]]; then
+    (cd "$repo_root" && scripts/provision-build-cache auto)
+fi
+
+# The remote-cache execution platform must set remote_enabled for OSS Buck2 to
+# connect to the action cache. Its limited-hybrid default otherwise prefers
+# remote execution, which Rue cannot rely on until RUE-320 fixes remote linking.
+# Force cache lookup followed by local execution unless the caller explicitly
+# selected an execution mode.
+uses_remote_cache=0
+if [[ -r "$repo_root/.buckconfig.local" ]] &&
+   grep -Eq '^[[:space:]]*execution_platforms[[:space:]]*=[[:space:]]*root//platforms:remote_cache([[:space:]]|$)' "$repo_root/.buckconfig.local"; then
+    uses_remote_cache=1
+fi
+
+execution_command=0
+explicit_preference=0
+for arg in "${args[@]}"; do
+    case "$arg" in
+        build|test|run|install) execution_command=1 ;;
+        --prefer-local|--prefer-remote|--local-only|--remote-only) explicit_preference=1 ;;
+    esac
+done
+
+if [[ "$uses_remote_cache" -eq 1 ]] && [[ "$execution_command" -eq 1 ]] && [[ "$explicit_preference" -eq 0 ]]; then
+    original_args=("${args[@]}")
+    args=()
+    inserted=0
+    for arg in "${original_args[@]}"; do
+        if [[ "$arg" == "--" ]] && [[ "$inserted" -eq 0 ]]; then
+            args+=(--prefer-local)
+            inserted=1
+        fi
+        args+=("$arg")
+    done
+    [[ "$inserted" -eq 1 ]] || args+=(--prefer-local)
+fi
+
+exec dotslash "$repo_root/buck2-bin" "${args[@]}"

--- a/buck2-bin
+++ b/buck2-bin
@@ -1,0 +1,91 @@
+#!/usr/bin/env dotslash
+
+{
+  "name": "buck2",
+  "platforms": {
+    "macos-aarch64": {
+      "size": 33728207,
+      "hash": "blake3",
+      "digest": "3bbd7cfe1b51d17124f5634812ae904254e01da429a61f62fe9c3d7c45e12dd9",
+      "format": "zst",
+      "path": "buck2-aarch64-apple-darwin",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-aarch64-apple-darwin.zst"
+        }
+      ]
+    },
+    "windows-aarch64": {
+      "size": 29333382,
+      "hash": "blake3",
+      "digest": "34417c30bd88b2110e00044f619aae791ec4e2d7f982aeb0fa43f01c0c2b06ac",
+      "format": "zst",
+      "path": "buck2-aarch64-pc-windows-msvc.exe",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-aarch64-pc-windows-msvc.exe.zst"
+        }
+      ]
+    },
+    "linux-aarch64": {
+      "size": 36896909,
+      "hash": "blake3",
+      "digest": "889091fae4410776de12ddc1ec676f019a0b9bd9bacf69298e5d0b16482f9ae6",
+      "format": "zst",
+      "path": "buck2-aarch64-unknown-linux-musl",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-aarch64-unknown-linux-musl.zst"
+        }
+      ]
+    },
+    "linux-riscv64": {
+      "size": 39062685,
+      "hash": "blake3",
+      "digest": "4c6275d204a22fe5920bbf6fadf41a04580ec79b713c2447fcc264534f78e221",
+      "format": "zst",
+      "path": "buck2-riscv64gc-unknown-linux-gnu",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-riscv64gc-unknown-linux-gnu.zst"
+        }
+      ]
+    },
+    "macos-x86_64": {
+      "size": 35999107,
+      "hash": "blake3",
+      "digest": "688c7d5da371fcb0dc8d337c37a55963e3001688e0942473c0f9897cb11170d9",
+      "format": "zst",
+      "path": "buck2-x86_64-apple-darwin",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-x86_64-apple-darwin.zst"
+        }
+      ]
+    },
+    "windows-x86_64": {
+      "size": 31097651,
+      "hash": "blake3",
+      "digest": "fae94eafc83a7e780c66775760e3ca2e92f499047299968ae7847ee3300f2970",
+      "format": "zst",
+      "path": "buck2-x86_64-pc-windows-msvc.exe",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-x86_64-pc-windows-msvc.exe.zst"
+        }
+      ]
+    },
+    "linux-x86_64": {
+      "size": 38600655,
+      "hash": "blake3",
+      "digest": "807fe2ba2c7aaf3a3a312de4220cee2abba9f37940c45b5a5f42ff1fd33dc089",
+      "format": "zst",
+      "path": "buck2-x86_64-unknown-linux-musl",
+      "providers": [
+        {
+          "url": "https://github.com/facebook/buck2/releases/download/2026-07-01/buck2-x86_64-unknown-linux-musl.zst"
+        }
+      ]
+    }
+  }
+}

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -3,9 +3,9 @@
 Buck2 rebuilds everything from scratch in each `buck-out`, and OSS buck2 has **no
 persistent action cache across daemon restarts** (noted in `ci.yml`). Every CI run
 and every isolated worktree rebuilds unchanged crates. We use **BuildBuddy** (free
-tier) for a shared remote action cache — and full remote **execution** was proven
-to work locally: with the config below, the entire compiler built on BuildBuddy's
-workers (171/175 actions remote, 0 local, ~103s cold).
+tier) for a shared remote action cache. Remote execution experiments established
+the remaining toolchain requirements, but complete remote builds are not a
+supported workflow while RUE-320 remains open.
 
 > **Status (RUE-316 landed the groundwork; RUE-320 finishes it).** The remote
 > platform + the `$ORIGIN` toolchain-tree fix are in place, but full RE is **not
@@ -18,24 +18,55 @@ workers (171/175 actions remote, 0 local, ~103s cold).
 > **RUE-320**. Until then the `remote_cache` platform is opt-in/experimental and
 > its remote-execution actions require that linker override locally.
 
-- **Remote action cache**: actions execute locally; the cache is shared across
-  machines + daemon restarts. Can only affect *speed*, never correctness.
+- **Remote action cache**: the repository `./buck2` wrapper supplies
+  `--prefer-local`, so cache misses execute locally while hits are shared across
+  machines + daemon restarts. The cache can only affect *speed*, never
+  correctness.
 - **`--prefer-remote`**: full remote **execution** — compiles + links on
   BuildBuddy's container (~80 free-tier cores). Blocked on RUE-320.
 
 Tracking: RUE-316 (groundwork), RUE-320 (platform-scoped linker to finish RE).
 
-## Local dev
+## Local development across worktrees
 
 ```bash
-cp .buckconfig.local.example .buckconfig.local
-# paste your key (https://app.buildbuddy.io -> Settings -> API keys) into the
-# x-buildbuddy-api-key line
+scripts/rue cache install       # prompts without echo for the BuildBuddy key
+scripts/rue cache apply --all   # primary checkout + current Git/Codex worktrees
 ```
 
-`.buckconfig.local` is gitignored (holds the key) and buck2 layers it over
-`.buckconfig` automatically. Without the file, nothing changes — the shared config
-stays cache-agnostic.
+`install` writes one user-owned configuration at
+`${XDG_CONFIG_HOME:-~/.config}/rue/buildbuddy.buckconfig`, with mode `0600`.
+`apply` places only an ignored `.buckconfig.local` symlink in each checkout, so
+the credential is neither copied between worktrees nor stored in Git. It refuses
+to replace an existing local config and refuses a central config readable by
+another account. Commands never print the key.
+
+Once installed, direct `./buck2`, `scripts/rue ...`, and `test.sh` runs
+automatically link a new worktree on first use. If the central config is absent,
+Rue simply uses its ordinary local Buck configuration. If it is malformed or
+insecure, Rue warns and continues without provisioning it. Existing local paths,
+including broken or unrelated symlinks, are left untouched. This keeps cache
+setup opt-in and prevents a credential problem from making local builds unusable.
+
+The setup is for the shared **action cache**. Do not add `--prefer-remote` to
+normal commands: full remote execution remains blocked on RUE-320. The checked-in
+`.buckconfig.local.example` remains a reference for the generated configuration,
+not the recommended per-worktree setup.
+
+## Full-suite host coordination
+
+`scripts/rue test` with no filter takes a user-scoped lock under `/tmp`, shared by
+independent Rue project roots. Only one full suite runs on the host at once;
+`scripts/rue quick`, filtered tests, and direct targeted Buck commands remain
+available concurrently. A waiter reports the current holder once and then at
+most once per minute. Owner PID metadata and atomic stale-lock recovery handle
+normal exit, interruption, and a process that died while acquiring the lock.
+
+Within the full suite, Buck first discovers and runs all non-heavy tests with
+`//...`. The spec, UI, CLI, generated-oracle, and program-reproducibility targets
+carry the `rue_heavy_suite` label. `test.sh` queries that label from Buck's live
+target graph and runs every result one at a time, preserving independent cache
+entries without a hand-maintained inventory that can omit a new suite.
 
 ## What it took (the non-obvious bits)
 
@@ -46,10 +77,13 @@ they're recorded here so a future config change doesn't silently regress:
    scheme (buck2 rejects `grpcs://`; `tls = true` upgrades the transport), and
    **`[buck2] digest_algorithms = SHA256`** (BuildBuddy's CAS digest). Without
    these the RE client silently never connects (`remote: 0`, no error).
-2. **`remote_enabled = True`** in `platforms/remote_cache.bzl`: OSS buck2 only
-   opens the RE connection when remote is enabled — *even for cache-only use*. A
-   pure `remote_enabled = False` cache config connects to nothing. So the platform
-   enables remote but leans local (limited hybrid + fallback) for cache-mostly use.
+2. **`remote_enabled = True` plus `--prefer-local`**: OSS buck2 only opens the RE
+   connection when remote is enabled — *even for cache-only use*. A pure
+   `remote_enabled = False` cache config connects to nothing. Buck's limited
+   hybrid mode otherwise prefers remote execution, so the repository `./buck2`
+   wrapper adds `--prefer-local` to ordinary build/test/run/install commands.
+   Remote cache lookup still happens before a local miss executes. An explicit
+   execution-mode flag overrides the wrapper.
 3. **rustc under RE** (`toolchains/rust/defs.bzl`): rustc finds `librustc_driver.so`
    via its native `$ORIGIN/../lib` RPATH, which only resolves if the whole toolchain
    tree is materialized on the remote worker. The `compiler`/`rustdoc` RunInfo carry

--- a/platforms/remote_cache.bzl
+++ b/platforms/remote_cache.bzl
@@ -1,8 +1,8 @@
 # Remote execution + cache platform (RUE-316). remote_enabled=True opens the RE
-# connection (required for the cache in OSS buck2); limited hybrid + local
-# fallback keeps most execution local. rustc's shared libs resolve on the remote
-# worker via the $ORIGIN RPATH now that the toolchain carries its full tree
-# (toolchains/rust/defs.bzl).
+# connection (required even for cache-only use in OSS buck2). Limited hybrid
+# prefers remote execution; the repository's ./buck2 wrapper therefore adds
+# --prefer-local for ordinary execution commands. Explicit execution-mode flags
+# still override it. Full remote execution remains blocked on RUE-320.
 def _remote_cache_platform_impl(ctx):
     base = ctx.attrs.base[ExecutionPlatformRegistrationInfo]
     platforms = [

--- a/scripts/provision-build-cache
+++ b/scripts/provision-build-cache
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Install one private BuildBuddy Buck config and share it with Rue worktrees.
+set -euo pipefail
+
+config_home="${XDG_CONFIG_HOME:-${HOME:?HOME must be set}/.config}"
+central_config="${RUE_BUILDBUDDY_CONFIG:-$config_home/rue/buildbuddy.buckconfig}"
+
+usage() {
+    cat <<'EOF'
+usage: scripts/provision-build-cache install
+       scripts/provision-build-cache apply [--all] [RUE_ROOT ...]
+       scripts/provision-build-cache status [RUE_ROOT ...]
+
+install reads BUILDBUDDY_API_KEY, or prompts without echo on a terminal, and
+writes the central config with mode 0600. apply links .buckconfig.local in the
+current checkout (or named roots) to that config. --all also discovers Git and
+Codex worktrees. No credential is printed.
+EOF
+}
+
+validate_config() {
+    if [[ ! -f "$central_config" ]] || [[ ! -r "$central_config" ]]; then
+        echo "error: BuildBuddy config is unavailable; run scripts/provision-build-cache install" >&2
+        return 1
+    fi
+    if [[ ! -O "$central_config" ]]; then
+        echo "error: BuildBuddy config is not owned by the current user" >&2
+        return 1
+    fi
+    local mode
+    # Try GNU stat first. GNU accepts -f with unrelated filesystem-reporting
+    # semantics, so probing the BSD form first can succeed with unusable output.
+    mode="$(stat -c '%a' "$central_config" 2>/dev/null || stat -f '%Lp' "$central_config" 2>/dev/null || true)"
+    if [[ -z "$mode" ]] || (( (8#$mode & 077) != 0 )); then
+        echo "error: BuildBuddy config permissions must deny group and other access (use chmod 600)" >&2
+        return 1
+    fi
+    if grep -q '<YOUR_BUILDBUDDY_API_KEY>' "$central_config" ||
+       ! grep -Eq '^[[:space:]]*http_headers[[:space:]]*=[[:space:]]*x-buildbuddy-api-key:.+' "$central_config"; then
+        echo "error: BuildBuddy config does not contain a configured API key" >&2
+        return 1
+    fi
+}
+
+install_config() {
+    local key="${BUILDBUDDY_API_KEY:-}"
+    if [[ -z "$key" ]] && [[ -t 0 ]]; then
+        read -r -s -p 'BuildBuddy API key: ' key
+        echo >&2
+    fi
+    if [[ -z "$key" ]] || [[ "$key" == *$'\n'* ]] || [[ "$key" == *$'\r'* ]]; then
+        echo "error: set BUILDBUDDY_API_KEY or run interactively with a non-empty single-line key" >&2
+        exit 1
+    fi
+
+    umask 077
+    mkdir -p "$(dirname "$central_config")"
+    local tmp="${central_config}.tmp.$$"
+    trap 'rm -f "$tmp"' EXIT
+    {
+        cat <<'EOF'
+[buck2_re_client]
+engine_address = grpc://remote.buildbuddy.io
+action_cache_address = grpc://remote.buildbuddy.io
+cas_address = grpc://remote.buildbuddy.io
+tls = true
+EOF
+        printf 'http_headers = x-buildbuddy-api-key:%s\n' "$key"
+        cat <<'EOF'
+
+[buck2]
+digest_algorithms = SHA256
+
+[build]
+execution_platforms = root//platforms:remote_cache
+EOF
+    } >"$tmp"
+    chmod 600 "$tmp"
+    mv "$tmp" "$central_config"
+    trap - EXIT
+    echo "Installed private BuildBuddy config at $central_config"
+}
+
+is_rue_root() {
+    [[ -f "$1/.buckconfig" ]] && [[ -x "$1/buck2" ]] && [[ -f "$1/platforms/remote_cache.bzl" ]]
+}
+
+apply_root() {
+    local root="$1" destination="$1/.buckconfig.local"
+    if ! is_rue_root "$root"; then
+        echo "error: not a Rue checkout: $root" >&2
+        return 1
+    fi
+    if [[ -L "$destination" ]]; then
+        if [[ "$(cd "$(dirname "$destination")" && readlink "$destination")" == "$central_config" ]]; then
+            echo "BuildBuddy cache already configured: $root"
+            return 0
+        fi
+        echo "error: refusing to replace an unrelated symlink: $destination" >&2
+        return 1
+    fi
+    if [[ -e "$destination" ]]; then
+        echo "error: refusing to replace existing config: $destination" >&2
+        return 1
+    fi
+    ln -s "$central_config" "$destination"
+    echo "Configured BuildBuddy cache: $root"
+}
+
+auto_apply() {
+    # Recommended wrappers call this so newly created worktrees adopt an
+    # already-installed central config on first use. Absence is an intentional
+    # cache-off state; an invalid config is ignored with a credential-free
+    # warning so local builds remain usable.
+    # Any existing path, including a broken symlink, belongs to the user. Do
+    # not replace it and do not let an opt-in cache feature break local builds.
+    [[ -e "$PWD/.buckconfig.local" || -L "$PWD/.buckconfig.local" ]] && return 0
+    [[ -f "$central_config" ]] || return 0
+    if ! validate_config; then
+        echo "warning: BuildBuddy cache config is invalid; continuing without remote cache" >&2
+        return 0
+    fi
+    if ! apply_root "$PWD" >/dev/null; then
+        echo "warning: could not provision BuildBuddy cache; continuing without changing local config" >&2
+    fi
+    return 0
+}
+
+collect_all_roots() {
+    printf '%s\n' "$PWD"
+    if command -v git >/dev/null 2>&1; then
+        git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' || true
+    fi
+    local codex_home="${CODEX_HOME:-${HOME:-}/.codex}" root
+    for root in "$codex_home"/worktrees/*/rue; do
+        [[ -d "$root" ]] && printf '%s\n' "$root"
+    done
+}
+
+command="${1:-}"
+shift || true
+case "$command" in
+    install)
+        [[ $# -eq 0 ]] || { usage >&2; exit 2; }
+        install_config
+        ;;
+    apply)
+        validate_config
+        all=0
+        if [[ "${1:-}" == "--all" ]]; then all=1; shift; fi
+        roots=("$@")
+        if [[ "$all" -eq 1 ]]; then
+            while IFS= read -r root; do roots+=("$root"); done < <(collect_all_roots)
+        elif [[ ${#roots[@]} -eq 0 ]]; then
+            roots=("$PWD")
+        fi
+        # Sort/unique avoids duplicate output when the current checkout also
+        # appears in Git's worktree inventory.
+        failed=0
+        while IFS= read -r root; do
+            [[ -n "$root" ]] || continue
+            if ! apply_root "$root"; then failed=1; fi
+        done < <(printf '%s\n' "${roots[@]}" | sort -u)
+        [[ "$failed" -eq 0 ]]
+        ;;
+    auto)
+        [[ $# -eq 0 ]] || { usage >&2; exit 2; }
+        auto_apply
+        ;;
+    status)
+        validate_config
+        roots=("$@")
+        [[ ${#roots[@]} -gt 0 ]] || roots=("$PWD")
+        for root in "${roots[@]}"; do
+            if [[ -L "$root/.buckconfig.local" ]] && [[ "$(readlink "$root/.buckconfig.local")" == "$central_config" ]]; then
+                echo "BuildBuddy cache configured: $root"
+            else
+                echo "BuildBuddy cache not configured: $root" >&2
+                exit 1
+            fi
+        done
+        ;;
+    *)
+        usage >&2
+        exit 2
+        ;;
+esac

--- a/scripts/rue
+++ b/scripts/rue
@@ -14,6 +14,7 @@
 #   scripts/rue perf [args...]     Per-pass compiler perf baseline (scripts/perf-baseline.py)
 #   scripts/rue fmt                Format the code (./fmt.sh)
 #   scripts/rue gc                 Reclaim disk: drop buck-out artifacts unused for 1+ week
+#   scripts/rue cache [args...]    Provision the shared BuildBuddy action cache
 #   scripts/rue path               Print the absolute binary path (build if needed)
 #
 set -euo pipefail
@@ -26,6 +27,13 @@ set -euo pipefail
 caller_pwd="$PWD"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
+
+# Once a private central cache config has been installed, make new worktrees
+# adopt it on first use. Missing/invalid credentials never enter the repository
+# and never prevent a local build.
+if [[ -x scripts/provision-build-cache ]]; then
+    scripts/provision-build-cache auto
+fi
 
 cmd="${1:-}"
 shift || true
@@ -109,6 +117,9 @@ case "$cmd" in
         # buck-out grows without bound; drop artifacts not used in the last
         # week. An optional argument overrides the window: scripts/rue gc 1d
         ./buck2 clean --stale "${1:-1w}"
+        ;;
+    cache)
+        scripts/provision-build-cache "$@"
         ;;
     ""|-h|--help|help)
         # Print the header comment block (everything between the shebang and

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Hermetic regression tests for cache provisioning and full-suite scheduling.
+set -uo pipefail
+
+if [[ -n "${RUE_BUILD_SHARING_ROOT:-}" ]]; then
+    SRC_ROOT="$RUE_BUILD_SHARING_ROOT"
+else
+    SRC_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
+FAILURES=0
+TESTS=0
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAILURES=$((FAILURES + 1)); }
+pass() { printf 'ok: %s\n' "$1"; }
+check() {
+    TESTS=$((TESTS + 1))
+    if [[ "$2" -eq 0 ]]; then pass "$1"; else fail "$1"; fi
+}
+
+make_rue_root() {
+    local root="$1"
+    mkdir -p "$root/platforms"
+    : >"$root/.buckconfig"
+    : >"$root/platforms/remote_cache.bzl"
+    printf '#!/bin/sh\nexit 0\n' >"$root/buck2"
+    chmod +x "$root/buck2"
+}
+
+test_cache_provisioning() {
+    local sb key config out rc mode
+    sb="$(mktemp -d)"
+    key='test-secret-that-must-not-be-printed'
+    config="$sb/config/rue/buildbuddy.buckconfig"
+    make_rue_root "$sb/primary"
+    make_rue_root "$sb/worktree"
+
+    rc=0
+    out="$(HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
+        "$SRC_ROOT/scripts/provision-build-cache" install 2>&1)" || rc=$?
+    check "cache: install succeeds" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+    check "cache: install never prints the key" "$([[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
+    mode="$(stat -c '%a' "$config" 2>/dev/null || stat -f '%Lp' "$config")"
+    check "cache: central config is private" "$([ $((8#$mode & 077)) -eq 0 ] && echo 0 || echo 1)"
+
+    rc=0
+    out="$(HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/primary" "$sb/worktree" 2>&1)" || rc=$?
+    check "cache: one command provisions multiple worktrees" \
+        "$([ "$rc" -eq 0 ] && [[ -L "$sb/primary/.buckconfig.local" ]] && [[ -L "$sb/worktree/.buckconfig.local" ]] && echo 0 || echo 1)"
+    check "cache: worktrees share the central config" \
+        "$([ "$(readlink "$sb/primary/.buckconfig.local")" = "$config" ] && [ "$(readlink "$sb/worktree/.buckconfig.local")" = "$config" ] && echo 0 || echo 1)"
+    check "cache: provisioning never prints the key" "$([[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
+
+    make_rue_root "$sb/future-worktree"
+    rc=0
+    (cd "$sb/future-worktree" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        "$SRC_ROOT/scripts/provision-build-cache" auto) >/dev/null 2>&1 || rc=$?
+    check "cache: a future worktree adopts the installed config on first use" \
+        "$([ "$rc" -eq 0 ] && [[ -L "$sb/future-worktree/.buckconfig.local" ]] && echo 0 || echo 1)"
+
+    rm -f "$sb/worktree/.buckconfig.local"
+    printf 'local config that must survive\n' >"$sb/worktree/.buckconfig.local"
+    rc=0
+    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/worktree" >/dev/null 2>&1 || rc=$?
+    check "cache: existing per-worktree config is preserved" \
+        "$([ "$rc" -ne 0 ] && grep -q 'must survive' "$sb/worktree/.buckconfig.local" && echo 0 || echo 1)"
+
+    chmod 644 "$config"
+    rc=0
+    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/primary" >/dev/null 2>&1 || rc=$?
+    check "cache: insecure central permissions fail closed" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+test_buck_wrapper_prefers_local_cache_misses() {
+    local sb
+    sb="$(mktemp -d)"
+    mkdir -p "$sb/fakebin"
+    cp "$SRC_ROOT/buck2" "$sb/buck2"
+    cp "$SRC_ROOT/buck2-bin" "$sb/buck2-bin"
+    chmod +x "$sb/buck2"
+    cat >"$sb/.buckconfig.local" <<'EOF'
+[build]
+execution_platforms = root//platforms:remote_cache
+EOF
+    cat >"$sb/fakebin/dotslash" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$DOTSLASH_ARGS"
+EOF
+    chmod +x "$sb/fakebin/dotslash"
+
+    DOTSLASH_ARGS="$sb/build.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" build //:probe
+    check "buck wrapper: cache misses prefer local execution" \
+        "$(grep -Fxq -- '--prefer-local' "$sb/build.args" && echo 0 || echo 1)"
+
+    DOTSLASH_ARGS="$sb/remote.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" build --prefer-remote //:probe
+    check "buck wrapper: explicit execution preference is preserved" \
+        "$(! grep -Fxq -- '--prefer-local' "$sb/remote.args" && grep -Fxq -- '--prefer-remote' "$sb/remote.args" && echo 0 || echo 1)"
+
+    DOTSLASH_ARGS="$sb/run.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" run //:probe -- program-arg
+    local local_line separator_line
+    local_line="$(grep -nFx -- '--prefer-local' "$sb/run.args" | cut -d: -f1)"
+    separator_line="$(grep -nFx -- '--' "$sb/run.args" | cut -d: -f1)"
+    check "buck wrapper: preference stays before executable arguments" \
+        "$([ "$local_line" -lt "$separator_line" ] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+test_buck_wrapper_auto_provisions() {
+    local sb config
+    sb="$(mktemp -d)"
+    config="$sb/config/rue/buildbuddy.buckconfig"
+    mkdir -p "$sb/scripts" "$sb/platforms" "$sb/fakebin" "$(dirname "$config")"
+    cp "$SRC_ROOT/buck2" "$sb/buck2"
+    cp "$SRC_ROOT/buck2-bin" "$sb/buck2-bin"
+    cp "$SRC_ROOT/scripts/provision-build-cache" "$sb/scripts/provision-build-cache"
+    : >"$sb/.buckconfig"
+    : >"$sb/platforms/remote_cache.bzl"
+    chmod +x "$sb/buck2" "$sb/scripts/provision-build-cache"
+    cat >"$config" <<'EOF'
+[buck2_re_client]
+http_headers = x-buildbuddy-api-key:test-secret
+[build]
+execution_platforms = root//platforms:remote_cache
+EOF
+    chmod 600 "$config"
+    cat >"$sb/fakebin/dotslash" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$DOTSLASH_ARGS"
+EOF
+    chmod +x "$sb/fakebin/dotslash"
+
+    (cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        DOTSLASH_ARGS="$sb/args" PATH="$sb/fakebin:$PATH" ./buck2 build //:probe)
+    check "buck wrapper: direct use provisions a future worktree" \
+        "$([[ -L "$sb/.buckconfig.local" ]] && [ "$(readlink "$sb/.buckconfig.local")" = "$config" ] && echo 0 || echo 1)"
+    check "buck wrapper: newly adopted cache prefers local misses" \
+        "$(grep -Fxq -- '--prefer-local' "$sb/args" && echo 0 || echo 1)"
+
+    rm "$sb/.buckconfig.local"
+    ln -s "$sb/missing-user-config" "$sb/.buckconfig.local"
+    (cd "$sb" && HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        DOTSLASH_ARGS="$sb/broken.args" PATH="$sb/fakebin:$PATH" ./buck2 build //:probe)
+    check "buck wrapper: a broken user symlink never blocks local builds" \
+        "$([[ -L "$sb/.buckconfig.local" ]] && [ "$(readlink "$sb/.buckconfig.local")" = "$sb/missing-user-config" ] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+test_lock_recovers_stale_holder() {
+    local sb lock rc=0
+    sb="$(mktemp -d)"; lock="$sb/full.lock"
+    mkdir -m 700 "$lock"
+    printf 'pid=99999999\ntoken=dead\nrepo=gone\n' >"$lock/owner"
+    RUE_FULL_SUITE_LOCK_DIR="$lock" RUE_FULL_SUITE_LOCK_POLL_SECONDS=1 \
+        "$SRC_ROOT/scripts/with-full-suite-lock" sh -c ": >'$sb/ran'" >/dev/null 2>&1 || rc=$?
+    check "lock: a dead holder is recovered" \
+        "$([ "$rc" -eq 0 ] && [[ -f "$sb/ran" ]] && [[ ! -e "$lock" ]] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+test_lock_recovers_uninitialized_orphan() {
+    local sb lock rc=0
+    sb="$(mktemp -d)"; lock="$sb/full.lock"
+    mkdir -m 700 "$lock"
+    RUE_FULL_SUITE_LOCK_DIR="$lock" RUE_FULL_SUITE_LOCK_INIT_GRACE_SECONDS=0 \
+        "$SRC_ROOT/scripts/with-full-suite-lock" sh -c ": >'$sb/ran'" >/dev/null 2>&1 || rc=$?
+    check "lock: an orphan without owner metadata is recovered" \
+        "$([ "$rc" -eq 0 ] && [[ -f "$sb/ran" ]] && [[ ! -e "$lock" ]] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+test_lock_interrupt_releases() {
+    local sb lock holder
+    sb="$(mktemp -d)"; lock="$sb/full.lock"
+    cat >"$sb/wait" <<'EOF'
+#!/usr/bin/env bash
+trap 'exit 0' TERM INT
+: >"$READY"
+while true; do sleep 1; done
+EOF
+    chmod +x "$sb/wait"
+    READY="$sb/ready" RUE_FULL_SUITE_LOCK_DIR="$lock" \
+        "$SRC_ROOT/scripts/with-full-suite-lock" "$sb/wait" >/dev/null 2>&1 &
+    holder=$!
+    for _ in {1..100}; do [[ -e "$sb/ready" ]] && break; sleep 0.02; done
+    kill -TERM "$holder"
+    wait "$holder" 2>/dev/null || true
+    check "lock: interruption releases ownership" "$([[ ! -e "$lock" ]] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+test_lock_serializes_and_reports_once() {
+    local sb lock first second
+    sb="$(mktemp -d)"; lock="$sb/full.lock"
+    cat >"$sb/hold" <<'EOF'
+#!/usr/bin/env bash
+: >"$READY"
+while [[ ! -e "$RELEASE" ]]; do sleep 0.05; done
+EOF
+    chmod +x "$sb/hold"
+    READY="$sb/ready" RELEASE="$sb/release" RUE_FULL_SUITE_LOCK_DIR="$lock" \
+        "$SRC_ROOT/scripts/with-full-suite-lock" "$sb/hold" >"$sb/first.out" 2>&1 &
+    first=$!
+    for _ in {1..100}; do [[ -e "$sb/ready" ]] && break; sleep 0.02; done
+
+    RUE_FULL_SUITE_LOCK_DIR="$lock" RUE_FULL_SUITE_LOCK_POLL_SECONDS=1 \
+        RUE_FULL_SUITE_LOCK_NOTICE_SECONDS=60 \
+        "$SRC_ROOT/scripts/with-full-suite-lock" sh -c ": >'$sb/second-ran'" >"$sb/second.out" 2>&1 &
+    second=$!
+    sleep 0.1
+    check "lock: a second full suite cannot overlap" "$([[ ! -e "$sb/second-ran" ]] && echo 0 || echo 1)"
+    : >"$sb/release"
+    wait "$first" || true
+    wait "$second" || true
+    check "lock: waiter runs after release" "$([[ -e "$sb/second-ran" ]] && echo 0 || echo 1)"
+    check "lock: waiting is observable without noisy polling" \
+        "$([ "$(grep -c 'waiting...' "$sb/second.out" 2>/dev/null || true)" -eq 1 ] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+test_full_suite_orchestration() {
+    local sb rc=0
+    sb="$(mktemp -d)"
+    mkdir -p "$sb/scripts"
+    cp "$SRC_ROOT/test.sh" "$sb/test.sh"
+    cp "$SRC_ROOT/scripts/with-full-suite-lock" "$sb/scripts/with-full-suite-lock"
+    chmod +x "$sb/test.sh" "$sb/scripts/with-full-suite-lock"
+    cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BUCK_LOG"
+if [[ "${1:-}" == "uquery" ]]; then
+    printf '%s\n' \
+        root//:cli-tests \
+        root//:oracle-diff-generated-smoke \
+        root//:reproducible-programs \
+        root//:spec-tests \
+        root//:ui-tests
+fi
+EOF
+    chmod +x "$sb/buck2"
+    BUCK_LOG="$sb/calls" RUE_FULL_SUITE_LOCK_DIR="$sb/lock" "$sb/test.sh" >/dev/null 2>&1 || rc=$?
+    check "suite: unfiltered orchestration succeeds" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+    check "suite: broad discovery excludes opaque heavy tests" \
+        "$(grep -Fxq 'test //... --exclude rue_heavy_suite --always-exclude' "$sb/calls" && echo 0 || echo 1)"
+    check "suite: heavy targets are discovered from the live graph" \
+        "$(grep -Fxq 'uquery attrfilter(labels, rue_heavy_suite, //...)' "$sb/calls" && echo 0 || echo 1)"
+    check "suite: every discovered heavy target runs independently" \
+        "$([ "$(grep -Ec '^test root//:(spec-tests|ui-tests|cli-tests|oracle-diff-generated-smoke|reproducible-programs)$' "$sb/calls")" -eq 5 ] && echo 0 || echo 1)"
+    check "suite: no concurrent heavy label sweep occurs" \
+        "$(! grep -Fq -- '--include rue_heavy_suite' "$sb/calls" && echo 0 || echo 1)"
+    check "suite: host lock is released" "$([[ ! -e "$sb/lock" ]] && echo 0 || echo 1)"
+    rm -rf "$sb"
+}
+
+test_cache_provisioning
+test_buck_wrapper_prefers_local_cache_misses
+test_buck_wrapper_auto_provisions
+test_lock_recovers_stale_holder
+test_lock_recovers_uninitialized_orphan
+test_lock_interrupt_releases
+test_lock_serializes_and_reports_once
+test_full_suite_orchestration
+
+echo "--------------------------------------------------"
+if [[ "$FAILURES" -eq 0 ]]; then
+    echo "build-sharing tests: all $TESTS checks passed"
+    exit 0
+fi
+echo "build-sharing tests: $FAILURES of $TESTS checks FAILED"
+exit 1

--- a/scripts/with-full-suite-lock
+++ b/scripts/with-full-suite-lock
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Serialize Rue's full suite across independent Buck project roots on one host.
+# Focused and quick checks do not use this wrapper and remain concurrent.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: scripts/with-full-suite-lock <command> [args...]" >&2
+    exit 2
+fi
+
+uid="$(id -u)"
+lock_dir="${RUE_FULL_SUITE_LOCK_DIR:-/tmp/rue-full-suite-${uid}.lock}"
+poll_seconds="${RUE_FULL_SUITE_LOCK_POLL_SECONDS:-1}"
+notice_seconds="${RUE_FULL_SUITE_LOCK_NOTICE_SECONDS:-60}"
+init_grace_seconds="${RUE_FULL_SUITE_LOCK_INIT_GRACE_SECONDS:-5}"
+token="$$.$RANDOM.$RANDOM"
+child_pid=""
+owns_lock=0
+
+owner_value() {
+    local key="$1"
+    [[ -r "$lock_dir/owner" ]] || return 1
+    sed -n "s/^${key}=//p" "$lock_dir/owner" | head -n 1
+}
+
+release_lock() {
+    if [[ "$owns_lock" -eq 1 ]] && [[ "$(owner_value token 2>/dev/null || true)" == "$token" ]]; then
+        rm -rf "$lock_dir"
+    fi
+    owns_lock=0
+}
+
+handle_signal() {
+    local signal="$1" status="$2"
+    trap - "$signal"
+    if [[ -n "$child_pid" ]]; then
+        kill -"$signal" "$child_pid" 2>/dev/null || true
+        wait "$child_pid" 2>/dev/null || true
+    fi
+    release_lock
+    exit "$status"
+}
+
+trap 'handle_signal INT 130' INT
+trap 'handle_signal TERM 143' TERM
+trap release_lock EXIT
+
+waited=0
+next_notice=0
+while ! mkdir -m 700 "$lock_dir" 2>/dev/null; do
+    # Never remove a directory owned by another account. This also makes a
+    # malicious or accidental collision in /tmp fail closed.
+    if [[ -e "$lock_dir" ]] && [[ ! -O "$lock_dir" ]]; then
+        echo "error: full-suite lock is not owned by the current user: $lock_dir" >&2
+        exit 1
+    fi
+
+    holder_pid="$(owner_value pid 2>/dev/null || true)"
+    holder_repo="$(owner_value repo 2>/dev/null || true)"
+    if [[ "$holder_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$holder_pid" 2>/dev/null; then
+        # Rename is atomic: only one waiter can claim a stale lock, and nobody
+        # can delete a freshly acquired replacement at the original path.
+        stale="${lock_dir}.stale.$$.$RANDOM"
+        if mv "$lock_dir" "$stale" 2>/dev/null; then
+            rm -rf "$stale"
+        fi
+        continue
+    fi
+    if [[ -z "$holder_pid" ]]; then
+        # A process can die between mkdir and publishing owner metadata. After
+        # a short grace period, recover that otherwise permanent orphan.
+        # GNU stat accepts -f with different semantics, so try its -c form
+        # before falling back to BSD/macOS stat.
+        lock_mtime="$(stat -c '%Y' "$lock_dir" 2>/dev/null || stat -f '%m' "$lock_dir" 2>/dev/null || true)"
+        now="$(date +%s)"
+        if [[ "$lock_mtime" =~ ^[0-9]+$ ]] && (( now - lock_mtime >= init_grace_seconds )); then
+            stale="${lock_dir}.stale.$$.$RANDOM"
+            if mv "$lock_dir" "$stale" 2>/dev/null; then
+                rm -rf "$stale"
+            fi
+            continue
+        fi
+    fi
+
+    if [[ "$waited" -ge "$next_notice" ]]; then
+        if [[ -n "$holder_pid" ]]; then
+            echo "Rue full suite is already running (pid $holder_pid${holder_repo:+ in $holder_repo}); waiting..." >&2
+        else
+            echo "Rue full suite lock is being initialized; waiting..." >&2
+        fi
+        next_notice=$((waited + notice_seconds))
+    fi
+    sleep "$poll_seconds"
+    waited=$((waited + poll_seconds))
+done
+
+owns_lock=1
+owner_tmp="$lock_dir/owner.tmp"
+{
+    printf 'pid=%s\n' "$$"
+    printf 'token=%s\n' "$token"
+    printf 'repo=%s\n' "$PWD"
+    printf 'started=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$owner_tmp"
+mv "$owner_tmp" "$lock_dir/owner"
+
+"$@" &
+child_pid=$!
+status=0
+wait "$child_pid" || status=$?
+child_pid=""
+exit "$status"

--- a/test.sh
+++ b/test.sh
@@ -33,6 +33,20 @@ set -euo pipefail
 cd "$(dirname "$0")"
 repo_root="$PWD"
 
+# Direct full-suite invocations also bootstrap an already-installed private
+# cache config. This is a no-op when the user has not opted in.
+if [[ -x scripts/provision-build-cache ]]; then
+    scripts/provision-build-cache auto
+fi
+
+# A no-filter run is the host-wide full suite. Serialize it across independent
+# Buck project roots before starting any build work; filtered runs stay free to
+# run concurrently. The environment marker prevents recursion after the lock
+# wrapper re-enters this script.
+if [[ $# -eq 0 ]] && [[ "${RUE_FULL_SUITE_LOCK_HELD:-}" != 1 ]]; then
+    exec ./scripts/with-full-suite-lock env RUE_FULL_SUITE_LOCK_HELD=1 "$0"
+fi
+
 # Always print the result sentinel, even on an early `set -e` exit, so a piped
 # or captured run is self-describing (RUE-579).
 print_test_suite_result() {
@@ -54,8 +68,26 @@ REPOSITORY_QUALITY_GATES=(
 )
 
 if [[ $# -eq 0 ]]; then
-    echo "Running unit tests and spec/UI/CLI suites..."
-    ./buck2 test //...
+    # Keep discovery broad so new crate and repository tests cannot disappear
+    # behind a hand-maintained list. Heavy opaque harnesses are labeled in BUCK:
+    # query that label from the live graph, exclude it from the broad pass, then
+    # run every returned target alone. A newly labeled target is automatically
+    # included without ever putting the whole heavy set in one test invocation.
+    HEAVY_SUITES=()
+    while IFS= read -r suite; do
+        [[ -n "$suite" ]] && HEAVY_SUITES+=("$suite")
+    done < <(./buck2 uquery 'attrfilter(labels, rue_heavy_suite, //...)')
+    if [[ ${#HEAVY_SUITES[@]} -eq 0 ]]; then
+        echo "error: Buck query found no rue_heavy_suite targets" >&2
+        exit 1
+    fi
+
+    echo "Running unit tests and lightweight repository checks..."
+    ./buck2 test //... --exclude rue_heavy_suite --always-exclude
+    for suite in "${HEAVY_SUITES[@]}"; do
+        echo "Running heavy suite $suite..."
+        ./buck2 test "$suite"
+    done
 else
     # Unit tests live under //crates/...; the suite sh_tests are at the repo
     # root, so this scope keeps them out of the unfiltered step below.


### PR DESCRIPTION
## What changed

- provision one private BuildBuddy action-cache config and safely link it into primary, Git, and Codex worktrees
- make new worktrees adopt that config on first direct Buck or Rue-wrapper use, while preserving user-owned local configs and failing open
- force cache lookup followed by local execution until RUE-320 makes full remote execution safe
- serialize unfiltered full suites across Rue worktrees and run the five opaque heavy harnesses one at a time
- add hermetic regression tests, contributor/agent guidance, and a diagnostic cold/warm cache-probe workflow

## Why

Buck's daemon and local `buck-out` state are scoped to a project root, so several worktrees rebuild the same actions independently and can collectively oversubscribe the host. Rue already had dormant BuildBuddy groundwork, but the documented limited-hybrid behavior was backwards: it prefers remote execution, while Rue's linker still requires local execution.

This change shares cacheable actions without putting credentials in Git, coordinates the genuinely expensive whole-suite work, and preserves broad test discovery and independent Buck test results.

## Validation

- `scripts/test-build-sharing.sh` — 27/27
- `scripts/test-wrapper-scripts.sh` — 26/26
- `./buck2 test //:build-sharing-tests //:wrapper-script-tests`
- `scripts/rue quick` — 24 targets, 0 failures
- `scripts/rue fmt`
- `scripts/rue test` — full suite passed; CLI 1401 passed/3 ignored, spec 2049 passed/18 ignored, UI 178 passed, generated oracle 64/64 with zero timeouts

After opening this PR, the manual cache-probe workflow will be run on this branch using the existing repository secret to validate real cold/warm remote cache hits.
