### PR TITLE
RUE-773: rewrite comments around present architecture

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -923,8 +923,8 @@ impl<'a> ConstraintGenerator<'a> {
                     // File-level constant: its type was resolved during
                     // declaration gathering (i32/bool/unit literals, module
                     // types for `const m = @import(...)`). Yielding it here
-                    // anchors expressions like `N + 1` and `m.go() + 1` that
-                    // previously decayed to `<error>` (RUE-142).
+                    // anchors expressions like `N + 1` and `m.go() + 1` to the
+                    // declaration's concrete type (RUE-142).
                     self.type_to_infer(*const_ty)
                 } else {
                     // Unknown variable - will be caught during semantic analysis
@@ -1035,11 +1035,9 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::Assign { name, value } => {
                 let value_info = self.generate(*value, ctx);
                 // A local shadows a same-named parameter. Otherwise, constrain
-                // assignment against the declared parameter type too: the
-                // old local-only lookup left every `inout` whole assignment
-                // unconstrained, so an integer literal defaulted to i32 and an
-                // arbitrary differently-shaped value could reach ParamStore
-                // (RUE-641).
+                // assignment against the declared parameter type too. Every
+                // `inout` whole assignment must be constrained before it can
+                // reach `ParamStore` (RUE-641).
                 let target_ty = ctx
                     .locals
                     .get(name)
@@ -2008,13 +2006,12 @@ impl<'a> ConstraintGenerator<'a> {
 
                 let base_info = self.generate(*base, ctx);
                 // When the base's struct type is already concrete, the field's
-                // declared type is known RIGHT NOW — yield it so downstream
+                // declared type is known here — yield it so downstream
                 // constraints see the real type instead of a free variable.
-                // Leaving it free mis-defaulted literals compared against i64
-                // fields to i32 (spurious E0800) and made method calls on a
-                // field receiver unresolvable (the MethodCall arm requires a
-                // Concrete receiver). When the base is still a variable, fall
-                // back to a fresh var; sema resolves and diagnoses later.
+                // This prevents literal defaulting from overriding the field
+                // width and gives method calls the concrete receiver they
+                // require. When the base is still a variable, fall back to a
+                // fresh var; sema resolves and diagnoses later.
                 // (RUE-89, RUE-126)
                 match self.known_field_type(&base_info.ty, *field) {
                     Some(field_ty) => self.type_to_infer(field_ty),
@@ -2077,8 +2074,8 @@ impl<'a> ConstraintGenerator<'a> {
                 let value_info = self.generate(*value, ctx);
                 // Constrain the assigned value against the field's declared
                 // type, so a literal RHS is range-checked at the field's width
-                // instead of silently wrapping (`s.a = 300` with a: u8 used to
-                // truncate to 44). (RUE-104)
+                // instead of wrapping (`s.a = 300` with `a: u8` must be
+                // rejected rather than truncate to 44). (RUE-104)
                 if let Some(field_ty) = self.known_field_type(&base_info.ty, *field) {
                     let expected = self.type_to_infer(field_ty);
                     self.add_constraint(Constraint::equal(value_info.ty, expected, span));
@@ -2293,7 +2290,7 @@ impl<'a> ConstraintGenerator<'a> {
                 let args = self.rir.get_call_args(*args_start, *args_len);
 
                 // Resolve the call's result type from the receiver's type.
-                // When the receiver can't be resolved RIGHT NOW but sema will
+                // When the receiver cannot yet be resolved but sema will
                 // resolve it later, yield a fresh variable rather than ERROR:
                 // a Concrete(ERROR) here flowed into sibling constraints and
                 // produced bogus "literal out of range for '<error>'" failures
@@ -2305,8 +2302,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // (RUE-576): same-named functions across files carry
                     // module-qualified internal keys in `functions`. Yielding
                     // the exact member's return type anchors uses like
-                    // `m.go() + 1` that previously decayed to `<error>`
-                    // (RUE-142).
+                    // `m.go() + 1` to the member declaration (RUE-142).
                     InferType::Concrete(ty) if ty.is_module() => {
                         let function_key = ty
                             .as_module()

--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -177,9 +177,9 @@ impl Unifier {
                     // Ret is (value, return_type), Assign is (value, variable),
                     // Alloc is (init, annotation), calls are (arg, param). So the
                     // RHS is what the context expects and the LHS is what was
-                    // found. This used to report lhs as "expected", which printed
-                    // every mismatch backwards ("expected bool, found i32" for
-                    // `fn main() -> i32 { true }`). (RUE-133)
+                    // found; diagnostics must preserve that direction
+                    // (`fn main() -> i32 { true }` expects i32 and finds bool).
+                    // (RUE-133)
                     UnifyResult::TypeMismatch {
                         expected: rhs_resolved,
                         found: lhs_resolved,

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -228,8 +228,7 @@ pub struct AirCallArg {
 }
 
 impl AirCallArg {
-    /// Returns true if this argument is passed as inout.
-    /// This is a convenience method for backwards compatibility.
+    /// Returns true when this argument requests exclusive `inout` access.
     pub fn is_inout(&self) -> bool {
         self.mode == AirArgMode::Inout
     }

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -6,7 +6,7 @@
 //! - O(1) type equality (u32 comparison)
 //! - Efficient memory usage
 //! - Clean parallel compilation (no per-function type merging)
-//! - Foundation for future generics
+//! - Canonical identities for generic instantiations
 //!
 //! # Architecture
 //!
@@ -17,17 +17,11 @@
 //! Primitive types (i8-i64, u8-u64, bool, unit, never, error) are encoded directly
 //! in the `InternedType` index using reserved indices 0-15, requiring no pool lookup.
 //!
-//! # Migration Strategy (ADR-0024)
-//!
-//! This module is part of Phase 1 of the Type Intern Pool migration:
-//! - Phase 1: Introduce pool alongside existing system (this module)
-//! - Phase 2: Migrate array types to the pool
-//! - Phase 3: Migrate struct/enum IDs to pool indices
-//! - Phase 4: Unify Type representation to `InternedType(u32)`
-//!
-//! During Phase 1, the pool coexists with the existing `Type` enum, `StructId`,
-//! `EnumId`, and `ArrayTypeId`. The pool is populated during declaration collection
-//! but not yet used for type operations.
+//! [`Type`] is the compact compiler-facing handle. Composite `StructId`,
+//! `EnumId`, `ArrayTypeId`, and pointer IDs are indices into this pool, while
+//! `InternedType` provides the pool's primitive-or-composite encoding for
+//! interning and structural lookup. Definitions and structural identities are
+//! therefore resolved through one pool (ADR-0024).
 //!
 //! # Thread Safety
 //!
@@ -195,29 +189,23 @@ pub enum TypeData {
 
 /// Data for a struct type in the intern pool.
 ///
-/// During Phase 1, this mirrors the existing `StructDef` to verify correctness.
-/// In later phases, `StructDef` will be replaced by this.
+/// The pool entry for a nominal struct and its definition.
 #[derive(Debug, Clone)]
 pub struct StructData {
     /// The name symbol (interned string).
     pub name: Spur,
-    /// Reference to the full struct definition.
-    /// During Phase 1, we keep a clone of the StructDef for verification.
-    /// In later phases, the pool will be the canonical source.
+    /// The canonical struct definition stored at this pool index.
     pub def: StructDef,
 }
 
 /// Data for an enum type in the intern pool.
 ///
-/// During Phase 1, this mirrors the existing `EnumDef` to verify correctness.
-/// In later phases, `EnumDef` will be replaced by this.
+/// The pool entry for a nominal enum and its definition.
 #[derive(Debug, Clone)]
 pub struct EnumData {
     /// The name symbol (interned string).
     pub name: Spur,
-    /// Reference to the full enum definition.
-    /// During Phase 1, we keep a clone of the EnumDef for verification.
-    /// In later phases, the pool will be the canonical source.
+    /// The canonical enum definition stored at this pool index.
     pub def: EnumDef,
 }
 
@@ -707,7 +695,7 @@ impl TypeInternPool {
     }
 
     // ========================================================================
-    // Phase 3 helpers: Direct StructId/EnumId access
+    // Direct nominal-ID access
     // ========================================================================
     //
     // These methods allow accessing struct and enum definitions directly via
@@ -1022,8 +1010,7 @@ impl TypeInternPool {
 
     /// Convert Type to InternedType recursively (handles composite types).
     ///
-    /// This is used during Phase 2B migration to convert Type to InternedType
-    /// for array interning.
+    /// Used when structural interning needs the pool encoding of a [`Type`].
     fn type_to_interned_recursive(ty: Type) -> InternedType {
         match ty.kind() {
             TypeKind::I8 => InternedType::I8,
@@ -1145,13 +1132,10 @@ impl TypeInternPool {
     }
 
     // ========================================================================
-    // Conversion helpers for migration (Phase 1)
+    // Primitive conversion helpers
     // ========================================================================
 
-    /// Convert an old-style `Type` to an `InternedType`.
-    ///
-    /// This is a temporary helper for Phase 1 migration. It converts the
-    /// existing `Type` enum to the new interned representation.
+    /// Convert a [`Type`] to an [`InternedType`] when no pool lookup is needed.
     ///
     /// # Note
     ///
@@ -1186,10 +1170,10 @@ impl TypeInternPool {
         }
     }
 
-    /// Convert an `InternedType` back to the old-style `Type`.
+    /// Convert a primitive [`InternedType`] back to [`Type`].
     ///
-    /// This is a temporary helper for Phase 1 migration to verify correctness.
-    /// Returns `None` for composite types since we need the old IDs.
+    /// Composite encodings return `None` because their concrete ID kind must be
+    /// read from the pool.
     pub fn interned_to_type(&self, ty: InternedType) -> Option<Type> {
         if !ty.is_primitive() {
             return None;
@@ -1582,12 +1566,12 @@ mod tests {
         };
         let (struct_id, _) = pool.register_struct(name, def.clone());
 
-        // Test the new Phase 3 struct_def() method that takes StructId directly
+        // Direct nominal-ID lookup returns the canonical definition.
         let retrieved = pool.struct_def(struct_id);
         assert_eq!(retrieved.name, def.name);
         assert_eq!(retrieved.is_copy, def.is_copy);
 
-        // Test the old get_struct_def() that takes InternedType
+        // The pool encoding resolves to the same definition.
         let interned = pool.struct_id_to_interned(struct_id);
         let retrieved2 = pool
             .get_struct_def(interned)
@@ -1615,12 +1599,12 @@ mod tests {
         };
         let (enum_id, _) = pool.register_enum(name, def.clone());
 
-        // Test the new Phase 3 enum_def() method that takes EnumId directly
+        // Direct nominal-ID lookup returns the canonical definition.
         let retrieved = pool.enum_def(enum_id);
         assert_eq!(retrieved.name, def.name);
         assert_eq!(retrieved.variants.len(), 2);
 
-        // Test the old get_enum_def() that takes InternedType
+        // The pool encoding resolves to the same definition.
         let interned = pool.enum_id_to_interned(enum_id);
         let retrieved2 = pool.get_enum_def(interned).expect("should get enum def");
         assert_eq!(retrieved2.name, def.name);

--- a/crates/rue-air/src/sema/analysis/anon_methods.rs
+++ b/crates/rue-air/src/sema/analysis/anon_methods.rs
@@ -1,7 +1,7 @@
 //! Anonymous-struct method registration and comptime method-signature extraction.
 //!
-//! Split out of `analysis.rs` (RUE-4); methods are part of the same
-//! `impl<'a> Sema<'a>` and behave identically.
+//! These helpers extend the canonical semantic-analysis implementation for
+//! anonymous nominal types.
 
 use super::*;
 

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -1,7 +1,7 @@
 //! Built-in arithmetic, comparison, string, and builtin method/assoc-fn analysis.
 //!
-//! Split out of `analysis.rs` (RUE-4); methods are part of the same
-//! `impl<'a> Sema<'a>` and behave identically.
+//! This category owns builtin operations within the canonical semantic-analysis
+//! implementation.
 
 use super::*;
 

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -1,7 +1,7 @@
 //! Method, module-member, and associated-function call analysis.
 //!
-//! Split out of `analysis.rs` (RUE-4); methods are part of the same
-//! `impl<'a> Sema<'a>` and behave identically.
+//! This category owns call resolution and emission within the canonical
+//! semantic-analysis implementation.
 
 use super::*;
 
@@ -214,8 +214,8 @@ impl<'a> BodySema<'a> {
             // The preview gate covers exactly what RUE-596 added: a CALL as
             // the path head (`F(args).NAME(..)`). A bare qualified member
             // that merely evaluates to a type (`m.Alias.new()`) is ordinary
-            // module-member access and must not trip the gate — it used to,
-            // with a message naming a call that doesn't exist (RUE-631).
+            // module-member access and must not trip the call-head gate
+            // (RUE-631).
             let receiver_is_call_head = matches!(
                 self.rir.get(receiver).data,
                 rue_rir::InstData::Call { .. } | rue_rir::InstData::MethodCall { .. }
@@ -634,8 +634,8 @@ impl<'a> BodySema<'a> {
         // validate here before treating any explicit marker as a loan/place.
         self.validate_explicit_call_modes(&args, param_modes.iter().copied())?;
 
-        // Check for exclusive access violation. (The old, pre-deduplication
-        // copy of this function skipped this check entirely.)
+        // Module-qualified calls enforce the same exclusive-access rule as
+        // every other call path.
         self.check_exclusive_access(&args, span)?;
 
         // Analyze arguments (the per-pipeline recursion seam). Module-qualified

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -1,7 +1,7 @@
 //! Function-level analysis orchestration: single/method/destructor/specialized function entry points and their bodies.
 //!
-//! Split out of `analysis.rs` (RUE-4); methods are part of the same
-//! `impl<'a> Sema<'a>` and behave identically.
+//! This category owns body setup, analysis, and finalization for each kind of
+//! callable.
 
 use super::*;
 

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -1,7 +1,7 @@
 //! Core per-instruction analysis dispatch and field/index assignment analysis.
 //!
-//! Split out of `analysis.rs` (RUE-4); methods are part of the same
-//! `impl<'a> Sema<'a>` and behave identically.
+//! This category is the canonical instruction dispatcher and owns assignment
+//! analysis for projected places.
 
 use super::*;
 

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -1,7 +1,7 @@
 //! Compiler intrinsic analysis (dbg/drop/cast/panic/assert/parse/import/... non-pointer intrinsics).
 //!
-//! Split out of `analysis.rs` (RUE-4); methods are part of the same
-//! `impl<'a> Sema<'a>` and behave identically.
+//! This category owns non-pointer intrinsic analysis within the canonical
+//! semantic-analysis implementation.
 
 use super::*;
 
@@ -511,10 +511,9 @@ impl<'a> BodySema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // `@cast` never had a working inference rule and is fully redundant with
-        // `@intCast` (RUE-319). Rather than silently accept it and then fail
-        // inference (the old E0206/E0702 confusion), reject it up front with a
-        // clear pointer to the working intrinsic. Inference gives `@cast` a
+        // `@cast` has no inference rule and is redundant with `@intCast`
+        // (RUE-319). Reject it up front with a clear pointer to the working
+        // intrinsic. Inference gives `@cast` a
         // fresh type variable (like `@intCast`) precisely so this diagnostic is
         // what the user sees, in every context, instead of a masking
         // type-mismatch error. Arguments are still analyzed so any error inside
@@ -714,8 +713,8 @@ impl<'a> BodySema<'a> {
                 // The target type variable decayed to `<error>` with no
                 // constraint to fix it (e.g. the result flows only into a
                 // type-polymorphic sink like `@dbg`). Report the actual problem
-                // — the cast target can't be inferred — not the array-specific
-                // "empty array" message this used to borrow (RUE-588).
+                // — the cast target can't be inferred — rather than an
+                // array-specific "empty array" diagnostic (RUE-588).
                 return Err(CompileError::new(
                     ErrorKind::CannotInferCastTarget(intrinsic_name.to_string()),
                     span,
@@ -1308,8 +1307,7 @@ impl<'a> BodySema<'a> {
         }
     }
 
-    // Note: The old analyze_inst body from here onwards is now handled by the
-    // dispatcher above and the category methods in analyze_ops.rs
+    // The dispatcher and category methods own intrinsic analysis.
 
     // ========================================================================
     // Helper methods for analysis

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1,7 +1,7 @@
 //! Linear-type / move / exclusive-access checks and call-argument analysis.
 //!
-//! Split out of `analysis.rs` (RUE-4); methods are part of the same
-//! `impl<'a> Sema<'a>` and behave identically.
+//! This category owns move and loan invariants for the canonical
+//! semantic-analysis implementation.
 
 use super::*;
 

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -1,7 +1,7 @@
 //! Pointer and low-level intrinsics: ptr read/write/offset, alloc/free/realloc, addr-of, syscall, target arch/os.
 //!
-//! Split out of `analysis.rs` (RUE-4); methods are part of the same
-//! `impl<'a> Sema<'a>` and behave identically.
+//! This category owns pointer and platform-facing intrinsic analysis within
+//! the canonical semantic-analysis implementation.
 
 use super::*;
 

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -1,7 +1,7 @@
 //! Type-inference glue: running inference, projection analysis, and resolved-type lookups.
 //!
-//! Split out of `analysis.rs` (RUE-4); methods are part of the same
-//! `impl<'a> Sema<'a>` and behave identically.
+//! This category connects the inference engine to the canonical semantic
+//! analysis and records resolved expression types.
 
 use super::*;
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -15,7 +15,7 @@
 //! - [`analyze_decl_noop`] - DropFnDecl (declarations that produce Unit)
 //!
 //! Binary operations (arithmetic, comparison, logical, bitwise) are handled
-//! by existing helper methods in `analysis.rs`:
+//! by helpers in `sema::analysis::builtin_ops`:
 //! - `analyze_binary_arith` - Add, Sub, Mul, Div, Mod, BitAnd, BitOr, BitXor, Shl, Shr
 //! - `analyze_comparison` - Eq, Ne, Lt, Gt, Le, Ge
 //! - Logical And/Or are simple enough to remain inline
@@ -111,12 +111,10 @@ impl PlaceTrace {
     ///
     /// A **dynamic** (or negative) index cannot be named, so it resets the
     /// path: segments before it are dropped and collection continues after it.
-    /// This keeps the old "you can't statically track a partial move through a
-    /// runtime index" behavior for that case (the caller falls back to the
-    /// conservative whole-array E0904 rejection), while constant indices are
-    /// now tracked precisely instead of being conflated (every `arr[K].f`
-    /// previously collapsed to `["f"]`, which both hid nested partial moves
-    /// and false-rejected sibling-element moves).
+    /// A runtime index cannot identify one statically tracked element, so the
+    /// caller uses the conservative whole-array E0904 rejection. Constant
+    /// indices remain distinct, preserving nested partial moves without
+    /// rejecting moves from sibling elements.
     pub fn field_path(&self) -> Vec<Spur> {
         let mut path = Vec::new();
         for p in &self.projections {
@@ -3304,7 +3302,7 @@ impl<'a> BodySema<'a> {
                 }
 
                 // RUE-387: reassigning an `inout` parameter whose type carries
-                // a linear value would silently drop the caller's live value.
+                // a linear value would drop the caller's live value implicitly.
                 // An `inout` binding can never be proven moved-out, so this is
                 // always ill-formed (E0494).
                 let discharged = self.place_linear_discharged(param_ty, name, &[], span, ctx);
@@ -3362,15 +3360,15 @@ impl<'a> BodySema<'a> {
         };
 
         // RUE-387: overwriting a local that still holds a live linear value
-        // would silently drop it. Legal only when the whole variable was
+        // would drop it implicitly. Legal only when the whole variable was
         // proven moved-out on every path (reinit-after-move idiom) — evaluated
         // on the post-RHS move state so `x = f(x)` counts as a discharge.
         let discharged = self.place_linear_discharged(local_ty, name, &[], span, ctx);
         self.check_linear_overwrite(local_ty, discharged, false, span)?;
         // Two-types model (ADR-0043, RUE-386): reassigning a first-class `str`
-        // local must store a first-class `str`, not a buffer or a borrowed view
-        // (`s = <buffer>` used to silently truncate a 3-word `StrBuf` into the
-        // 2-word `str` slot, leaving a dangling pointer).
+        // local must store a first-class `str`, not a buffer or a borrowed view;
+        // truncating a 3-word `StrBuf` into the 2-word slot would leave a
+        // dangling pointer.
         if self.is_str_struct(local_ty) {
             self.reject_non_first_class_str(
                 value,
@@ -3684,9 +3682,9 @@ impl<'a> BodySema<'a> {
             let field_inst = self.rir.get(*field_value);
             let field_result = if let InstData::IntConst(value) = &field_inst.data {
                 // Integer literal - use the expected field type directly, but
-                // range-check it first: this shortcut bypasses analyze_literal,
-                // and previously skipped the E0800 check entirely, so
-                // `S { a: 300 }` with a: u8 silently truncated to 44. (RUE-72)
+                // range-check it first because this shortcut bypasses
+                // `analyze_literal`; `S { a: 300 }` with `a: u8` must produce
+                // E0800 rather than truncate to 44. (RUE-72)
                 if !expected_field_type.literal_fits(*value) {
                     return Err(CompileError::new(
                         ErrorKind::LiteralOutOfRange {
@@ -4304,8 +4302,8 @@ impl<'a> BodySema<'a> {
 
     /// Analyze a field assignment.
     ///
-    /// This is a complex operation that handles VarRef and chained field access.
-    /// The full implementation is in analysis.rs as it's quite large (~200 lines).
+    /// Handles both direct and chained field access; the implementation lives
+    /// in `sema::analysis::instructions`.
     fn analyze_field_set(
         &mut self,
         air: &mut Air,
@@ -4315,9 +4313,7 @@ impl<'a> BodySema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Delegate to the main implementation in analysis.rs
-        // This is one of the larger handlers that we'll keep in the main file
-        // for now and refactor in a future pass
+        // Use the category implementation shared by instruction dispatch.
         self.analyze_field_set_impl(air, base, field, value, span, ctx)
     }
 
@@ -4755,9 +4751,8 @@ impl<'a> BodySema<'a> {
     }
 
     /// Try to resolve `module.Enum.Variant` as a module-qualified enum-variant
-    /// path (RUE-488). `.` is the sole member-access spelling; this mirrors what
-    /// the old `module.Enum::Variant` path did, including E0706 module-visibility
-    /// enforcement.
+    /// path (RUE-488). `.` is the sole member-access spelling, and the path
+    /// enforces E0706 module visibility.
     ///
     /// Returns `Ok(None)` — falling through to ordinary field access — unless
     /// `module_ref` names a module **and** `type_name` is an enum defined by that
@@ -5793,8 +5788,8 @@ impl<'a> BodySema<'a> {
 
     /// Analyze an array index write.
     ///
-    /// This is a complex operation that handles VarRef bases.
-    /// The full implementation is in analysis.rs as it's quite large.
+    /// Handles VarRef and projected place bases; the implementation lives in
+    /// `sema::analysis::instructions`.
     fn analyze_index_set(
         &mut self,
         air: &mut Air,
@@ -5804,7 +5799,6 @@ impl<'a> BodySema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Delegate to the main implementation in analysis.rs
         self.analyze_index_set_impl(air, base, index, value, span, ctx)
     }
 
@@ -6470,8 +6464,8 @@ impl<'a> BodySema<'a> {
 
     /// Analyze a method call.
     ///
-    /// This is a complex operation that handles both user-defined methods and
-    /// builtin methods. The full implementation is in analysis.rs.
+    /// Handles user-defined and builtin methods through the call-analysis
+    /// category.
     fn analyze_method_call(
         &mut self,
         air: &mut Air,
@@ -6482,7 +6476,6 @@ impl<'a> BodySema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Delegate to the main implementation in analysis.rs
         self.analyze_method_call_impl(air, receiver, method, args_start, args_len, span, ctx)
     }
 
@@ -6607,7 +6600,8 @@ impl<'a> BodySema<'a> {
 
     /// Analyze an associated function call.
     ///
-    /// This is a complex operation. The full implementation is in analysis.rs.
+    /// Resolves and analyzes an associated-function call through the
+    /// call-analysis category.
     pub(crate) fn analyze_assoc_fn_call(
         &mut self,
         air: &mut Air,
@@ -6642,7 +6636,6 @@ impl<'a> BodySema<'a> {
             }
         }
 
-        // Delegate to the main implementation in analysis.rs
         self.analyze_assoc_fn_call_impl(
             air, type_name, function, args_start, args_len, span, ctx, None,
         )
@@ -6843,10 +6836,9 @@ impl<'a> BodySema<'a> {
             return Ok(AnalysisResult::new(air_ref, Type::UNIT));
         }
 
-        // Calculate the value based on which intrinsic. Checked layout query
-        // (E0906 on oversized types, RUE-561): the old unchecked u32 math
-        // ICEd on a 2 GiB array in debug builds and truncated a 32 GiB one to
-        // size 0 / alignment 1.
+        // Calculate the value through the checked layout query. Oversized
+        // types produce E0906 rather than overflowing or truncating the slot
+        // count (RUE-561).
         let value: u64 = match intrinsic_name.as_str() {
             "size_of" => {
                 // Calculate size in bytes (slot count * 8)
@@ -6959,8 +6951,7 @@ impl<'a> BodySema<'a> {
 
     /// Analyze an intrinsic call.
     ///
-    /// This is a complex operation that handles many different intrinsics.
-    /// The full implementation is in analysis.rs.
+    /// Dispatches the intrinsic to the corresponding analysis category.
     fn analyze_intrinsic(
         &mut self,
         air: &mut Air,
@@ -6972,7 +6963,6 @@ impl<'a> BodySema<'a> {
         result_expected: Option<Type>,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Delegate to the main implementation in analysis.rs
         self.analyze_intrinsic_impl(
             air,
             inst_ref,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -918,16 +918,11 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                 // struct (it may have been created earlier without methods).
                 if *methods_len > 0 {
                     // A method that declares its own `comptime T: type`
-                    // parameter would need to be monomorphized per call over
-                    // that parameter — a generics feature not yet supported
-                    // (RUE-284). Merely *defining* such a method used to make
-                    // the enclosing `-> type` constructor non-evaluable
-                    // (registration returned None → the reduction bailed with
-                    // Ok(None)), surfacing as a misleading E1200 mis-located at
-                    // the `let` that instantiates the constructor. Detect it
-                    // here and raise a clear diagnostic pointing *at the
-                    // method* instead, without poisoning the rest of the
-                    // reduction.
+                    // parameter would need per-call monomorphization over that
+                    // parameter, which is unsupported (RUE-284). Reject it at
+                    // the method declaration so the enclosing `-> type`
+                    // reduction cannot degrade into an unrelated E1200 at the
+                    // instantiation site.
                     if let Some((method_span, method_name)) =
                         self.find_method_own_comptime_type_param(*methods_start, *methods_len)
                     {
@@ -1873,12 +1868,10 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     /// before HM inference runs (RUE-170, RUE-164).
     ///
     /// A binding like `let P = F();` (where `F` returns `type`) only gets a
-    /// concrete type during sema's analysis pass — but inference runs first,
-    /// so every use of `P` as a type name (`P { ... }`, `let p: P = ...`,
-    /// methods on a `P`-typed receiver) used to fall through to `<error>` or
-    /// an unconstrained variable. This walk finds such bindings and evaluates
-    /// their initializers eagerly so the constraint generator can route them
-    /// through the same paths as named structs.
+    /// concrete type during sema's analysis pass, but inference runs first.
+    /// This walk evaluates those initializers eagerly so uses of `P` as a type
+    /// name (`P { ... }`, `let p: P = ...`, or a method receiver) follow the
+    /// same constraint paths as named structs.
     ///
     /// The walk is opportunistic: initializers that can't be evaluated at
     /// compile time are simply skipped (sema diagnoses them later). The

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -817,8 +817,6 @@ pub enum ConstValue {
     /// as ordinary runtime values.
     Function(lasso::Spur),
     /// Unit value - the value of `()`.
-    // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
-    #[allow(dead_code)]
     Unit,
 }
 
@@ -854,8 +852,6 @@ impl ConstValue {
     }
 
     /// Try to extract a type value.
-    // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
-    #[allow(dead_code)]
     pub fn as_type(self) -> Option<Type> {
         match self {
             ConstValue::Type(ty) => Some(ty),
@@ -872,15 +868,11 @@ impl ConstValue {
     }
 
     /// Check if this is a unit value.
-    // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
-    #[allow(dead_code)]
     pub fn is_unit(self) -> bool {
         matches!(self, ConstValue::Unit)
     }
 
     /// Get the type of this constant value.
-    // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
-    #[allow(dead_code)]
     pub fn get_type(&self) -> Type {
         match self {
             ConstValue::Integer(_) => Type::I64, // Default to i64 for comptime integers

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -42,11 +42,9 @@ pub struct InferenceContext {
     /// `const N: i32 = 41`, a module type for `const m = @import(...)`). Constant
     /// types are fully resolved during declaration gathering, before any
     /// function body is inferred, so they can be consulted like params here.
-    /// Without this map a const reference inferred to `<error>` and poisoned
-    /// every expression it touched (RUE-142). Keyed by (declaring file, name):
-    /// same-named constants in sibling modules are distinct declarations, and
-    /// the old bare-name keying let one file's constant silently type another
-    /// file's code (RUE-638).
+    /// Keyed by (declaring file, name) so references receive their declared
+    /// type (RUE-142) and same-named constants in sibling modules remain
+    /// distinct declarations (RUE-638).
     pub const_types: HashMap<(FileId, Spur), Type>,
     /// File-level type aliases: name -> concrete type denoted by a
     /// type-valued constant (`const OptI = std.option.Option(i64)`). These are

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1438,11 +1438,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         let name_sym = self.interner.get_or_intern(call_name);
         // During declaration binding, the constructor may not be collected yet: struct-field and
         // enum-payload types, const initializers, and earlier function
-        // signatures all resolve before the main declaration sweep reaches
-        // the callee's `FnDecl`, so `struct S { v: Vec(i32) }` — or a
-        // signature naming `Vec(i32)` declared above `fn Vec` — used to
-        // E0204 while the same application resolved fine later (RUE-603).
-        // Collect the same-file declaration on demand, mirroring the
+        // signatures can resolve before the main declaration sweep reaches
+        // the callee's `FnDecl`. Collect the same-file declaration on demand
+        // so `struct S { v: Vec(i32) }` and signatures naming a later-collected
+        // `Vec(i32)` resolve consistently (RUE-603), mirroring the
         // declaration-time indexed const-alias resolution path.
         let mut name_key = self.resolve_function_name_local(name_sym, span.file_id);
         if name_key.is_none() && self.declaration_binding_active {
@@ -3139,9 +3138,8 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
 
     /// Checked companion to [`Self::abi_slot_count`]: `None` when the type's
     /// layout overflows or exceeds [`MAX_TYPE_SLOTS`] (RUE-561). Computed in
-    /// u64 with checked arithmetic, so a `[i32; 4294967296]` no longer
-    /// truncates to zero slots and a `[i32; 536870912]` no longer overflows
-    /// the debug-build multiply.
+    /// u64 with checked arithmetic so large array lengths cannot truncate to
+    /// zero slots or overflow the slot-count multiplication.
     pub(crate) fn checked_abi_slot_count(&self, ty: Type) -> Option<u64> {
         let slots = match ty.kind() {
             TypeKind::Array(array_type_id) => {

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -9,16 +9,16 @@
 
 /// A unique identifier for a struct definition.
 ///
-/// As of Phase 3 (ADR-0024), the inner value is a pool index into `TypeInternPool`,
-/// not a vector index into a separate struct definitions array.
+/// The inner value is a pool index into [`TypeInternPool`](crate::TypeInternPool),
+/// so the identifier and its definition use one canonical index.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StructId(pub u32);
 
 impl StructId {
     /// Create a StructId from a pool index.
     ///
-    /// This is the primary way to create StructIds during Phase 3+.
-    /// The pool index is the raw index into `TypeInternPool.types`.
+    /// The pool index is the raw index into `TypeInternPool`'s composite-type
+    /// storage.
     #[inline]
     pub fn from_pool_index(pool_index: u32) -> Self {
         StructId(pool_index)
@@ -35,16 +35,16 @@ impl StructId {
 
 /// A unique identifier for an enum definition.
 ///
-/// As of Phase 3 (ADR-0024), the inner value is a pool index into `TypeInternPool`,
-/// not a vector index into a separate enum definitions array.
+/// The inner value is a pool index into [`TypeInternPool`](crate::TypeInternPool),
+/// so the identifier and its definition use one canonical index.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct EnumId(pub u32);
 
 impl EnumId {
     /// Create an EnumId from a pool index.
     ///
-    /// This is the primary way to create EnumIds during Phase 3+.
-    /// The pool index is the raw index into `TypeInternPool.types`.
+    /// The pool index is the raw index into `TypeInternPool`'s composite-type
+    /// storage.
     #[inline]
     pub fn from_pool_index(pool_index: u32) -> Self {
         EnumId(pool_index)
@@ -67,8 +67,8 @@ pub struct ArrayTypeId(pub u32);
 impl ArrayTypeId {
     /// Create an ArrayTypeId from a pool index.
     ///
-    /// This is used during Phase 2B to create ArrayTypeIds from pool indices.
-    /// The pool index is the raw index into `TypeInternPool.types`.
+    /// The pool index is the raw index into `TypeInternPool`'s composite-type
+    /// storage.
     #[inline]
     pub fn from_pool_index(pool_index: u32) -> Self {
         ArrayTypeId(pool_index)
@@ -156,13 +156,9 @@ impl ModuleId {
 
 /// The kind of a type - used for pattern matching.
 ///
-/// This enum mirrors the structure of the `Type` enum but is designed for
-/// pattern matching. During the migration to `Type(InternedType)`, code that
-/// pattern matches on types will use `ty.kind()` to get a `TypeKind`.
-///
-/// This separation allows incremental migration: all pattern matches can be
-/// updated to use `.kind()` while `Type` is still an enum, then `Type` can be
-/// replaced with `Type(InternedType)` without breaking existing code.
+/// [`Type`] stores a compact encoded index. `TypeKind` is its decoded,
+/// pattern-matchable view; callers obtain it with [`Type::kind`]. Composite
+/// variants carry pool-backed identifiers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TypeKind {
     /// 8-bit signed integer
@@ -207,7 +203,7 @@ pub enum TypeKind {
 
 /// A type in the Rue type system.
 ///
-/// After Phase 4.1 of ADR-0024, `Type` is a newtype wrapping a u32 index.
+/// Compact encoded type handle (ADR-0024).
 /// This enables O(1) type equality via u32 comparison.
 ///
 /// # Encoding

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -178,7 +178,7 @@ impl MoveState {
 pub struct CfgBuilder<'a> {
     air: &'a Air,
     cfg: Cfg,
-    /// Type intern pool for struct/enum/array lookups (Phase 2B ADR-0024)
+    /// Canonical pool for struct, enum, array, and pointer definitions.
     type_pool: &'a TypeInternPool,
     /// Interner for resolving symbols to strings
     interner: &'a ThreadedRodeo,
@@ -1846,10 +1846,8 @@ impl<'a> CfgBuilder<'a> {
                 };
                 let val_ty = self.air.get(*value).ty;
 
-                // Only emit a Drop instruction if the type needs drop.
-                // For trivially droppable types, this is a no-op.
-                // We use self.type_needs_drop() which has access to struct/array
-                // definitions to recursively check if fields need drop.
+                // Emit Drop only when recursive type metadata says cleanup is
+                // required; trivially droppable values need no instruction.
                 if self.type_needs_drop(val_ty) {
                     self.emit(CfgInstData::Drop { value: val }, Type::UNIT, span);
                 }
@@ -2160,7 +2158,7 @@ impl<'a> CfgBuilder<'a> {
         }
     }
 
-    /// Check if a type needs to be dropped (has a destructor).
+    /// Check whether dropping a type requires cleanup.
     ///
     /// This method has access to struct and array definitions, allowing it to
     /// recursively check if struct fields or array elements need drop.
@@ -2168,8 +2166,8 @@ impl<'a> CfgBuilder<'a> {
     /// A type needs drop if dropping it requires cleanup actions:
     /// - Primitives, bool, unit, never, error: trivially droppable (no)
     /// - Enum: needs drop if any variant payload needs drop
-    /// - String: will need drop when mutable strings land (currently no)
-    /// - Struct: needs drop if any field needs drop
+    /// - Struct: needs drop when it has a destructor (including builtin
+    ///   `StrBuf`) or any field needs drop
     /// - Array: needs drop if element type needs drop
     fn type_needs_drop(&self, ty: Type) -> bool {
         match ty.kind() {
@@ -2202,19 +2200,18 @@ impl<'a> CfgBuilder<'a> {
                     .any(|&ty| self.type_needs_drop(ty))
             }
 
-            // Struct types need drop if they have a destructor (e.g., builtin String)
+            // Struct types need drop if they have a destructor (e.g. builtin
+            // StrBuf)
             // or if any field needs drop
             TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
-                // Builtins with destructors (like String) need drop
+                // Builtins with destructors (like StrBuf) need drop.
                 if struct_def.destructor.is_some() {
                     return true;
                 }
                 // Otherwise, check if any field needs drop
                 struct_def.fields.iter().any(|f| self.type_needs_drop(f.ty))
             }
-
-            // Note: String is now Type::Struct with is_builtin=true, handled above
 
             // Array types need drop if element type needs drop
             TypeKind::Array(array_id) => {

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -262,9 +262,9 @@ impl<'a> CfgLower<'a> {
     /// Call `symbol` passing `arg_vregs` as flattened by-value slot arguments
     /// per the standard convention: the first slots in ARG_REGS, the rest
     /// stored to a 16-byte-aligned stack area released after the call — the
-    /// same shape as the generic `Call` lowering. Used by the Drop paths,
-    /// whose destructor/drop-glue calls previously moved slots into argument
-    /// registers only and panicked past 8 slots (RUE-193).
+    /// same shape as generic `Call` lowering. Drop and drop-glue calls use this
+    /// path so every slot beyond the eight register arguments is passed on the
+    /// stack (RUE-193).
     fn emit_call_with_slot_args(&mut self, arg_vregs: &[VReg], symbol: &str) {
         let num_reg_args = arg_vregs.len().min(ARG_REGS.len());
         let num_stack_args = arg_vregs.len().saturating_sub(ARG_REGS.len());
@@ -667,11 +667,10 @@ impl<'a> CfgLower<'a> {
 
                 // The prologue copies every ABI arg slot — register- and
                 // stack-passed alike — into the contiguous frame param area
-                // (slots num_locals..num_locals+num_params), so all param
-                // reads are uniform frame-slot loads. Previously slots past
-                // the 8 arg registers were read from [fp+16+...], which the
-                // frame-slot-based aggregate and write paths didn't mirror,
-                // dropping slots of >8-slot aggregate args. (RUE-13/79/91)
+                // (slots num_locals..num_locals+num_params), so scalar,
+                // aggregate, and write paths all use uniform frame-slot loads,
+                // including ABI slots beyond the eight argument registers.
+                // (RUE-13/79/91)
                 if is_by_ref {
                     // For by-ref params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -439,9 +439,6 @@ pub enum Aarch64Inst {
         offset: i32,
     },
 
-    /// `add dst, src, #imm, lsl #12` - Add immediate with shift (for large offsets).
-    /// Note: Using regular AddImm for now, this is for future large offset support.
-
     /// `lsl dst, src, #imm` - Logical shift left by immediate (64-bit).
     LslImm { dst: Operand, src: Operand, imm: u8 },
 
@@ -1086,7 +1083,7 @@ impl Aarch64Mir {
 
     /// Take ownership of the symbol table.
     ///
-    /// Used during register allocation to transfer symbols to the new MIR.
+    /// Used during register allocation to transfer symbols to the rewritten MIR.
     pub fn take_symbols(&mut self) -> Vec<String> {
         self.symbol_index.clear();
         std::mem::take(&mut self.symbols)
@@ -1094,7 +1091,7 @@ impl Aarch64Mir {
 
     /// Set the symbol table.
     ///
-    /// Used during register allocation to restore symbols from the old MIR.
+    /// Used during register allocation to restore symbols from the pre-rewrite MIR.
     pub fn set_symbols(&mut self, symbols: Vec<String>) {
         // Rebuild the index from the symbol table
         self.symbol_index.clear();

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -187,11 +187,11 @@ impl RegAlloc {
     }
 
     fn rewrite_instructions(&mut self) -> CompileResult<()> {
-        // Take symbols from old MIR before taking instructions
+        // Preserve symbols from the pre-rewrite MIR before taking instructions.
         let symbols = self.mir.take_symbols();
         let old_instructions = std::mem::take(&mut self.mir).into_instructions();
         let mut new_mir = Aarch64Mir::new();
-        // Restore symbols to new MIR
+        // Restore symbols to the rewritten MIR.
         new_mir.set_symbols(symbols);
 
         for (idx, inst) in old_instructions.into_iter().enumerate() {

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -1,6 +1,6 @@
-//! Shared aggregate-slot materialization (RUE-121, phase 1).
+//! Shared aggregate-slot materialization.
 //!
-//! Multi-slot aggregates (structs, fixed-size arrays, the 3-slot `String` fat
+//! Multi-slot aggregates (structs, fixed-size arrays, the 3-slot `StrBuf` fat
 //! pointer) are tracked during CFG lowering as a list of one vreg per slot in
 //! the lowerer's `struct_slot_vregs` cache. Both backends use this module so
 //! every aggregate consumer observes the same representation.
@@ -11,17 +11,13 @@
 //! [`SlotBackend`]: vreg allocation, value lookup, and the one genuinely
 //! per-architecture instruction (load a frame slot into a vreg).
 //!
-//! Phase 1 covered the slot accessor. Phase 2 moved the StructInit/ArrayInit
-//! flattening (the eager population of the slot cache) here as
-//! [`lower_struct_init`]/[`lower_array_init`]. Phase 3 moved the consumer-side
-//! store loops here as [`store_slots`]/[`store_slots_through_ptr`] — every
-//! site that writes an aggregate's slots (Alloc, Store, PlaceWrite, inout
-//! writeback) iterates via these two primitives. Phase 4 (RUE-106) added the
-//! callee side of the sret return as [`store_slots_to_sret`]; the convention
-//! *decision* (which returns use sret) is shared in
-//! `crate::cfg_lower::type_uses_sret_return`. Remaining per-backend: the
-//! physical-register/stack marshalling of call args and sret readback (truly
-//! arch-specific: push vs str, rsp vs sp) and the scheduler/liveness tables.
+//! [`lower_struct_init`] and [`lower_array_init`] eagerly populate the slot
+//! cache. Every consumer-side aggregate write (Alloc, Store, PlaceWrite, and
+//! `inout` writeback) goes through [`store_slots`] or
+//! [`store_slots_through_ptr`]. [`store_slots_to_sret`] handles callee-side
+//! sret writes; `crate::cfg_lower::type_uses_sret_return` owns the shared
+//! convention decision. Physical-register and stack marshalling, sret
+//! readback, scheduling, and liveness remain architecture-specific.
 
 use std::collections::HashMap;
 

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -3,8 +3,8 @@
 //! This module provides common functions for calculating type sizes and
 //! field offsets, shared between x86_64 and aarch64 backends.
 //!
-//! As of Phase 3 (ADR-0024), all struct/enum lookups go through `TypeInternPool`
-//! instead of separate `&[StructDef]` slices.
+//! Struct, enum, array, and pointer definitions are resolved through the
+//! canonical `TypeInternPool` (ADR-0024).
 
 use rue_air::{ArrayTypeId, EnumId, StructId, TypeInternPool, TypeKind};
 use rue_cfg::{Cfg, CfgInstData, CfgValue, Type};

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -266,9 +266,9 @@ impl<'a> CfgLower<'a> {
     /// Call `symbol` passing `arg_vregs` as flattened by-value slot arguments
     /// per the standard convention: the first slots in ARG_REGS, the rest
     /// pushed on the stack (16-byte aligned, cleaned up after the call) —
-    /// the same shape as the generic `Call` lowering. Used by the Drop paths,
-    /// whose destructor/drop-glue calls previously moved slots into argument
-    /// registers only and panicked past 6 slots (RUE-193).
+    /// the same shape as generic `Call` lowering. Drop and drop-glue calls use
+    /// this path so every slot beyond the six register arguments is passed on
+    /// the stack (RUE-193).
     fn emit_call_with_slot_args(&mut self, arg_vregs: &[VReg], symbol: &str) {
         let num_reg_args = arg_vregs.len().min(ARG_REGS.len());
         let num_stack_args = arg_vregs.len().saturating_sub(ARG_REGS.len());
@@ -886,11 +886,10 @@ impl<'a> CfgLower<'a> {
 
                 // The prologue copies every ABI arg slot — register- and
                 // stack-passed alike — into the contiguous frame param area
-                // (slots num_locals..num_locals+num_params), so all param
-                // reads are uniform frame-slot loads. Previously slots past
-                // the 6 arg registers were read from [rbp+16+...], which the
-                // frame-slot-based aggregate and write paths didn't mirror,
-                // dropping slots of >6-slot aggregate args. (RUE-13/79/91)
+                // (slots num_locals..num_locals+num_params), so scalar,
+                // aggregate, and write paths all use uniform frame-slot loads,
+                // including ABI slots beyond the six argument registers.
+                // (RUE-13/79/91)
                 if is_by_ref {
                     // For by-ref params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.
@@ -1779,9 +1778,9 @@ impl<'a> CfgLower<'a> {
                         // (RUE-221) — regardless of how it was produced. The accessor
                         // materializes lazily-sourced values (Load/Param/PlaceRead) and
                         // cache-hits eager ones (StructInit/ArrayInit/Call/BlockParam).
-                        // The old per-source array ladder iterated array_len (element
-                        // count), not slot_count, so a multidimensional array dropped
-                        // every row after the first. (RUE-118, RUE-79)
+                        // Materialization uses the recursive slot count, so every
+                        // scalar slot of a multidimensional array is passed.
+                        // (RUE-118, RUE-79)
                         let field_vregs = self.require_aggregate_slots(arg_value);
                         // Pass a Rue callee's aggregate slots in REVERSED
                         // logical order (ADR-0040 / RUE-311). The callee

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -782,7 +782,7 @@ impl X86Mir {
 
     /// Take ownership of the symbol table.
     ///
-    /// Used during register allocation to transfer symbols to the new MIR.
+    /// Used during register allocation to transfer symbols to the rewritten MIR.
     pub fn take_symbols(&mut self) -> Vec<String> {
         self.symbol_index.clear();
         std::mem::take(&mut self.symbols)
@@ -790,7 +790,7 @@ impl X86Mir {
 
     /// Set the symbol table.
     ///
-    /// Used during register allocation to restore symbols from the old MIR.
+    /// Used during register allocation to restore symbols from the pre-rewrite MIR.
     pub fn set_symbols(&mut self, symbols: Vec<String>) {
         // Rebuild the index from the symbol table
         self.symbol_index.clear();

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -198,11 +198,11 @@ impl RegAlloc {
     fn rewrite_instructions(&mut self) -> CompileResult<()> {
         // For spilled vregs, we need to insert load/store operations.
         // This is done by building a new instruction list.
-        // Take symbols from old MIR before taking instructions
+        // Preserve symbols from the pre-rewrite MIR before taking instructions.
         let symbols = self.mir.take_symbols();
         let old_instructions = std::mem::take(&mut self.mir).into_instructions();
         let mut new_mir = X86Mir::new();
-        // Restore symbols to new MIR
+        // Restore symbols to the rewritten MIR.
         new_mir.set_symbols(symbols);
 
         for (idx, inst) in old_instructions.into_iter().enumerate() {

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -746,7 +746,7 @@ fn validate_payload_shape(
     }
 }
 
-/// Typed fail-closed reasons from the future successful-binding exporter.
+/// Typed fail-closed reasons from successful-binding export.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DurableSemanticExportFailure {
     ErrorType,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1681,11 +1681,13 @@ impl CompilerSession {
         result
     }
 
-    /// Materialize stable semantic inputs for future dependency-edge capture.
+    /// Materialize the stable semantic dependency manifest.
     ///
-    /// This tooling-only query shares the existing import and stable-definition
-    /// queries. It performs no additional RIR traversal; reference edges are not
-    /// yet claimed until every semantic reference surface can be captured.
+    /// The manifest contains the supported call, destructor, declaration-type,
+    /// type-call-head, and named-constant edge families. Per-surface completeness
+    /// flags and stable blockers make incomplete capture fail closed. The query
+    /// shares the import and stable-definition inputs and performs no additional
+    /// RIR traversal.
     pub fn semantic_dependency_inputs(
         &mut self,
         options: &CompileOptions,

--- a/crates/rue-fuzz/src/harness.rs
+++ b/crates/rue-fuzz/src/harness.rs
@@ -60,8 +60,8 @@ pub enum RunOutcome {
     /// The target panicked; carries the panic message (best-effort).
     Panic(String),
     /// The child was killed by a terminating signal (e.g. SIGSEGV=11,
-    /// SIGABRT=6, SIGFPE=8). This is the case the old in-process harness was
-    /// completely blind to.
+    /// SIGABRT=6, SIGFPE=8). Fork isolation lets the harness observe this
+    /// without dying with the target.
     Signal(i32),
     /// The child exceeded the per-input timeout and was SIGKILLed by the
     /// harness. Carries the budget in seconds. Hangs (infinite loops,
@@ -305,9 +305,9 @@ fn outcome_from_status(status: libc::c_int, panic_msg: Vec<u8>) -> RunOutcome {
     }
 
     if libc::WIFSIGNALED(status) {
-        // Signal death with no panic message: a genuine abort — stack overflow,
-        // segfault, FPE, or a direct abort() — exactly what the old harness
-        // could not see.
+        // Signal death with no panic message is a genuine abort — stack
+        // overflow, segfault, FPE, or a direct abort() — observable because
+        // the target runs in a child process.
         return RunOutcome::Signal(libc::WTERMSIG(status));
     }
     if libc::WIFEXITED(status) {

--- a/crates/rue-fuzz/src/main.rs
+++ b/crates/rue-fuzz/src/main.rs
@@ -405,8 +405,8 @@ fn print_usage(program: &str) {
         program
     );
     eprintln!();
-    // Driven from all_targets() so this list can't drift from reality again
-    // (it used to omit emitter/emitter_sequence).
+    // Drive this from all_targets() so help output and target dispatch share
+    // one authoritative inventory.
     eprintln!("Targets:");
     for target in targets::all_targets() {
         eprintln!("  {}", target.name());

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -916,10 +916,8 @@ mod tests {
     #[test]
     fn test_logos_at_import_prefixed_ident_splits() {
         // A directive whose name merely starts with "import" (@importx,
-        // @important) is an ordinary @-directive: At + Ident. It used to be a
-        // confusing "unexpected character: @" lex error because the fused
-        // @import token matched and then failed its word-boundary check
-        // without backtracking. (RUE-133)
+        // @important) is an ordinary @-directive: At + Ident. The word-boundary
+        // check must permit fallback to those two tokens (RUE-133).
         let lexer = LogosLexer::new("@importx");
         let (tokens, interner) = lexer.tokenize().unwrap();
         assert!(matches!(tokens[0].kind, TokenKind::At));

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -718,8 +718,7 @@ impl ObjectFile {
             }
 
             // Mach-O ARM64 relocation_info has no addend field. Addends come
-            // from two places, both of which used to be ignored (the parser
-            // hardcoded addend 0, RUE-131 item 5b):
+            // from two places (RUE-131 item 5b):
             // - an ARM64_RELOC_ADDEND entry immediately PRECEDING the
             //   relocation it modifies (used for BRANCH26/PAGE21/PAGEOFF12),
             // - the bytes at the patch site for ARM64_RELOC_UNSIGNED
@@ -771,8 +770,8 @@ impl ObjectFile {
                     // section. We resolve it to a symbol at the section start
                     // (offset folded into the addend below).
                     // r_symbolnum == 0 is invalid for a non-extern relocation;
-                    // the subtraction used to wrap to usize::MAX and index OOB
-                    // (a panic on malformed input). (RUE-131 item 6)
+                    // checked subtraction prevents malformed input from
+                    // wrapping into an out-of-bounds index. (RUE-131 item 6)
                     let Some(section_number) = r_symbolnum.checked_sub(1) else {
                         return Err(ParseError::InvalidSymbol(format!(
                             "non-extern relocation at 0x{:x} has r_symbolnum 0",
@@ -1535,7 +1534,7 @@ mod tests {
     }
 
     /// RUE-131 item 5b: ARM64_RELOC_UNSIGNED carries its addend in the bytes
-    /// at the patch site; the parser used to hardcode addend 0.
+    /// at the patch site, which the parser must preserve.
     #[test]
     fn test_macho_unsigned_reads_embedded_addend() {
         let mut slot = vec![0u8; 8];

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -618,8 +618,7 @@ impl ObjectBuilder {
             .collect();
         // Mach-O ARM64 relocation entries have no addend field: a non-zero
         // addend is carried by an extra ARM64_RELOC_ADDEND entry immediately
-        // preceding the relocation it modifies. (Addends used to be silently
-        // dropped here; the parser side ignored them too — RUE-131 item 5b.)
+        // preceding the relocation it modifies (RUE-131 item 5b).
         let num_addend_entries = text_relocs.iter().filter(|r| r.addend != 0).count();
         let num_text_relocs = text_relocs.len() + num_addend_entries;
 
@@ -975,9 +974,8 @@ impl ObjectBuilder {
             macho.extend_from_slice(&0_u16.to_le_bytes()); // n_desc
             // n_value is an address within the object's VM layout (section
             // addr + offset), per the Mach-O spec — the same convention
-            // rustc/clang objects use, and what our parser normalizes away.
-            // (This used to write the bare section offset, which only worked
-            // because the parser made the matching mistake.)
+            // rustc/clang objects use and the parser normalizes to a section
+            // offset.
             let value = (rodata_addr + string_offsets[i]) as u64;
             macho.extend_from_slice(&value.to_le_bytes());
             sym_name_idx += 1;
@@ -1436,9 +1434,8 @@ mod tests {
     }
 
     /// RUE-131 item 5b: non-zero addends must round-trip through the Mach-O
-    /// object format (emitted as ARM64_RELOC_ADDEND entries, re-attached by
-    /// the parser). They used to be silently dropped on emit AND hardcoded to
-    /// zero on parse.
+    /// object format: emission writes ARM64_RELOC_ADDEND entries and parsing
+    /// re-attaches them to the following relocation.
     #[test]
     fn test_macho_addend_roundtrip() {
         let obj_bytes = ObjectBuilder::new(Target::Aarch64Macos, "main")

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -15,11 +15,9 @@ use crate::util::align_up;
 
 /// Which merged output buffer a relocation's patch site lives in.
 ///
-/// Historically only `.text` relocations were collected at all — relocation
-/// records on `.rodata`/`.data` sections were silently dropped, leaving
-/// e.g. panic-Location string pointers null in every linked binary
-/// (RUE-131 item 1). Each pending relocation now carries its home so the
-/// apply loop can patch the right buffer against the right base address.
+/// Each pending relocation carries its home buffer and base address so
+/// relocations from `.text`, `.rodata`, and `.data` patch the correct merged
+/// section (RUE-131 item 1).
 #[derive(Clone, Copy, Debug)]
 enum PatchHome {
     /// Patch site is in the merged text buffer (base = code vaddr).
@@ -99,9 +97,8 @@ fn is_bss_section(name: &str) -> bool {
 /// Apply a single already-resolved relocation by patching `buf` in place.
 ///
 /// Shared by both `link_elf` and `link_macho` (RUE-335): the per-kind patch
-/// encoding is identical across object formats, so it lives here once instead
-/// of being duplicated in each linker path — a relocation fix now lands in a
-/// single place. The caller resolves the format-specific inputs first (which
+/// encoding is identical across object formats, so it lives here once. The
+/// caller resolves the format-specific inputs first (which
 /// merged buffer the patch site lives in, its base virtual address, and the
 /// symbol's resolved address) and passes them in.
 ///
@@ -747,8 +744,8 @@ impl Linker {
                         return Err(LinkError::DuplicateSymbol(sym.name.clone()));
                     }
                     // A strong definition overrides a weak one. Among weak
-                    // definitions the FIRST wins (standard linker semantics;
-                    // this used to keep the last). (RUE-131 item 9)
+                    // definitions the first wins, as required by standard
+                    // linker semantics (RUE-131 item 9).
                     if existing.binding == SymbolBinding::Weak
                         && sym.binding == SymbolBinding::Global
                     {
@@ -953,8 +950,7 @@ impl Linker {
         // Merge rodata sections directly into __TEXT (after code).
         // This keeps rodata addresses close to code for PC-relative addressing.
         // Patch sites in rodata live in the merged text buffer, so their home
-        // is Text. Rodata relocations used to not be collected at all on the
-        // Mach-O path, leaving e.g. pointer tables in rodata null.
+        // is Text and their relocations are applied against that base.
         // (RUE-131 items 8 and 11)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
@@ -1029,11 +1025,9 @@ impl Linker {
             }
         }
 
-        // Compute the final file/VM layout BEFORE placing symbols, using the
-        // same single-source-of-truth computation build_dynamic() uses. The
-        // data segment address used to be hardcoded to VM_BASE + PAGE_SIZE
-        // here, which went stale the moment __TEXT outgrew one page —
-        // the unified layout places __DATA wherever __TEXT actually ends.
+        // Compute the final file/VM layout before placing symbols, using the
+        // same single-source-of-truth computation as build_dynamic(). __DATA
+        // begins wherever the actual __TEXT layout ends.
         // (RUE-131 items 3 and 8)
         let mut layout_builder = MachOBuilder::new()
             .with_code(merged_text.clone(), 0) // only the length matters for layout
@@ -1055,10 +1049,9 @@ impl Linker {
         let text_vaddr = VM_BASE + text_file_offset;
         // __DATA segment virtual address (0 if there is no writable data)
         let data_vaddr = layout.data_vm_addr;
-        // bss begins right after the (8-aligned) initialized data within the
-        // __DATA segment. The old formula also added bss_offset_in_data —
-        // which IS merged_data.len() — double-counting the data length, so
-        // every bss symbol pointed past its real storage. (RUE-131 item 4)
+        // bss begins right after the 8-aligned initialized data within the
+        // __DATA segment; `merged_data.len()` is the complete offset and must
+        // be added exactly once. (RUE-131 item 4)
         let bss_vaddr = if bss_size > 0 {
             data_vaddr + align_up(merged_data.len() as u64, 8)
         } else {
@@ -1156,10 +1149,9 @@ impl Linker {
 
             // Resolve the symbol (locals only within their own object), with
             // the same fallbacks as the ELF path: the symbol's own section,
-            // then 0 for undefined weaks. An unresolved symbol is an ERROR —
-            // it used to be silently skipped on the theory that dyld would
-            // bind it at runtime, but we emit no binding info (nsyms = 0), so
-            // the unpatched instruction was just garbage at runtime.
+            // then 0 for undefined weaks. Any other unresolved symbol is an
+            // error because this output emits no dynamic binding information;
+            // leaving its relocation unpatched would produce invalid code.
             // (RUE-131 item 7)
             let target_vaddr =
                 if let Some(addr) = symbol_addresses.resolve(obj_idx, &sym_name, sym_binding) {

--- a/crates/rue-linker/src/macho.rs
+++ b/crates/rue-linker/src/macho.rs
@@ -35,9 +35,8 @@ pub const VM_BASE: u64 = Target::Aarch64Macos.default_base_addr();
 /// Computed file/VM layout for a dynamic executable — produced only by
 /// `compute_dynamic_layout` so relocation pre-pass and the actual build can
 /// never disagree. The linker consumes this (via [`MachOBuilder::dynamic_layout`])
-/// to place symbols *before* the binary is built; previously it hardcoded
-/// `VM_BASE + PAGE_SIZE` for the data segment, which broke as soon as
-/// __TEXT outgrew one page. (RUE-131)
+/// to place symbols before the binary is built, including a data segment whose
+/// address follows the actual extent of __TEXT. (RUE-131)
 pub(crate) struct DynamicLayout {
     pub(crate) text_file_offset: usize,
     pub(crate) text_segment_file_size: usize,
@@ -750,13 +749,9 @@ impl MachOBuilder {
 
     /// The complete dynamic-executable layout, computed in ONE place.
     ///
-    /// `calculate_text_file_offset_for_dynamic` and `build_dynamic` used to
-    /// compute this independently and had drifted: the precompute counted ONE
-    /// data section where the builder counts up to three (__const, __data,
-    /// __bss), so with more than one data section every relocation was
-    /// patched against a text offset the binary didn't actually use.
-    /// (RUE-131; the drift is the same dual-implementation disease tracked
-    /// across the codebase.)
+    /// Relocation placement and `build_dynamic` consume this same computation,
+    /// including all present __const, __data, and __bss section commands, so
+    /// their text and data offsets cannot diverge (RUE-131).
     fn compute_dynamic_layout(&self) -> DynamicLayout {
         let has_data = !self.rodata.is_empty() || !self.data.is_empty() || self.bss_size > 0;
 
@@ -1214,10 +1209,9 @@ mod tests {
         );
     }
 
-    /// RUE-131: the relocation pre-pass and the builder used to compute the
-    /// text offset independently and drifted (the pre-pass counted one data
-    /// section; the builder counts up to three). With rodata + data + bss all
-    /// present, the two must agree exactly.
+    /// The relocation pre-pass and builder share one layout computation; with
+    /// rodata, data, and bss all present their text offsets must agree exactly
+    /// (RUE-131).
     #[test]
     fn test_precompute_matches_layout_with_all_data_sections() {
         let builder = MachOBuilder::new()

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -1073,9 +1073,8 @@ fn string_is_empty_and_clear() {
 #[test]
 fn zst_param_before_scalar_does_not_shift_slots() {
     // A zero-sized argument occupies zero ABI slots (abi_slot_count), so the
-    // scalar after it lives at slot 0, not slot 1. The oracle used to force
-    // every argument to at least one slot and read 0 here — a phantom
-    // DISAGREE blaming codegen (rue-oracle component review, 2026-07-04).
+    // scalar after it lives at slot 0, not slot 1. The oracle must use that
+    // same slot contract to avoid a phantom DISAGREE blaming codegen.
     let src = "struct E {}
     fn pick(e: E, n: i32) -> i32 { n }
     fn main() -> i32 { let e = E {}; pick(e, 42) }";

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -862,8 +862,7 @@ pub struct CallArg {
 }
 
 impl CallArg {
-    /// Returns true if this argument is passed as inout.
-    /// This is a convenience method for backwards compatibility.
+    /// Returns true when this argument uses `inout` passing mode.
     pub fn is_inout(&self) -> bool {
         self.mode == ArgMode::Inout
     }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -121,8 +121,7 @@ impl ParserState {
     }
 }
 
-/// Type alias for parser extras that carries parser state.
-/// This replaces the previous thread-local approach with compile-time safe state passing.
+/// Parser extras carry symbols and file identity explicitly through parser state.
 type ParserExtras<'src> = extra::Full<Rich<'src, TokenKind>, SimpleState<ParserState>, ()>;
 
 /// Convert a `usize` offset to `u32`, asserting it fits in debug builds.
@@ -548,9 +547,8 @@ where
 /// Parser for function parameters: [comptime|inout|borrow] name: type
 ///
 /// A parameter takes at most one mode keyword. Repeated (`comptime comptime
-/// T`) or conflicting (`comptime inout x`) modifiers used to be silently
-/// accepted — the duplicate landed in a vestigial `is_comptime` flag next to
-/// `ParamMode` — and are now rejected with a targeted error. (RUE-133)
+/// T`) and conflicting (`comptime inout x`) modifiers are rejected at the
+/// second keyword with a targeted error (RUE-133).
 fn param_parser<'src, I>() -> impl Parser<'src, I, Param, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
@@ -825,11 +823,9 @@ where
         // Atom parser - primary expressions
         let atom = atom_parser(expr.clone(), block_like);
 
-        // Rust-refugee diagnostic: `expr as T` is not Rue syntax (`as` is an
-        // ordinary identifier, so `5 as i64` used to die with a generic
-        // "expected semicolon" error). An expression directly followed by the
-        // identifier `as` is never valid Rue, so consume it and report a
-        // targeted error pointing at the `as`. (RUE-133)
+        // Rust-refugee diagnostic: `expr as T` is not Rue syntax. Because `as`
+        // is otherwise an ordinary identifier, consume it in this invalid
+        // position and report a targeted error at the token (RUE-133).
         let as_misuse = select! { TokenKind::Ident(name) => name }
             .map_with(|name, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
                 (name, e.state().syms.as_kw, e.span())
@@ -1940,8 +1936,7 @@ where
         // Never type: ! — but only when the `!` is the entire argument (the
         // next token is `,` or `)`). A `!` followed by anything else is the
         // logical-not operator (e.g. `@dbg(!flag)`), which must fall through
-        // to the expression branch; committing to the never-type parse here
-        // used to reject those arguments (RUE-150). The lookahead is
+        // to the expression branch (RUE-150). The lookahead is
         // non-consuming (`rewind`) so the delimiter is still parsed normally.
         let never_type = just(TokenKind::Bang)
             .then_ignore(one_of([TokenKind::Comma, TokenKind::RParen]).rewind())
@@ -2738,16 +2733,11 @@ where
 ///    infix, so they already start a new statement without special handling.
 ///
 ///  * **Linear-time nesting (RUE-276).** Accepting `;`/`}`/end as boundaries
-///    (not just `-`) is what keeps parsing near-linear in block-nesting depth.
-///    A nested block `{ { { ... } } }` is always terminated by `}`, so this
-///    parser *succeeds* at every level and the block-like is descended exactly
-///    once. The narrow `-`-only predicate this replaced instead *failed* on
-///    every `;`/`}`-terminated block, forcing the general Pratt `expr` to
-///    re-descend the same nested input — two full descents per level, i.e.
-///    O(2^depth) (depth 20 took >30s). The general `expr` is now reached only
-///    for the rarer case of a block-like actually continued by an operator or
-///    suffix, which is shallow in practice. Producing the same block-like `Expr`
-///    the Pratt `expr` would, the AST is byte-identical either way.
+///    keeps parsing near-linear in block-nesting depth. A nested block
+///    `{ { { ... } } }` terminates with `}` at every level, so this parser
+///    succeeds and descends each level once. The general Pratt parser is used
+///    only when an operator or suffix actually continues the block-like
+///    expression, and both paths produce the same block-like AST node.
 ///
 /// It is `recursive` because the block bodies it contains hold block-items that
 /// again prefer this parser; the recursion knot lets those bodies reference the

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -42,7 +42,7 @@ pub use ast::{
     MatchExpr,
     Method,
     MethodCallExpr,
-    // SOA AST types (Phase 1)
+    // Struct-of-arrays AST types
     Param,
     ParamMode,
     ParenExpr,

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -29,9 +29,9 @@ pub const KNOWN_DIRECTIVES: &[&str] = &["allow", "copy"];
 
 /// Warning names accepted by `@allow(...)`.
 ///
-/// This validates spelling at parse time even for warnings whose emission or
-/// suppression is still pending, so typos like `@allow(unused_variabl)` fail
-/// loudly instead of becoming no-op directives (RUE-356).
+/// Parsing validates spelling so typos like `@allow(unused_variabl)` fail
+/// loudly; sema consumes these names when emitting and suppressing warnings
+/// (RUE-356).
 pub const KNOWN_WARNING_NAMES: &[&str] =
     &["unused_variable", "unused_function", "unreachable_code"];
 

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1187,8 +1187,8 @@ pub enum InstData {
     /// Anonymous enum type: an enum (sum) type used as a value expression
     /// (e.g., `enum { Some(T), None }` in comptime type construction). The
     /// enum analog of [`InstData::AnonStructType`]; enables generic sum types
-    /// like `Option`/`Result` as comptime type functions (ADR-0038, RUE-6
-    /// phase 2). Variant names and tuple-variant payloads are encoded exactly
+    /// like `Option`/`Result` as comptime type functions (ADR-0038, RUE-6).
+    /// Variant names and tuple-variant payloads are encoded exactly
     /// as in [`InstData::EnumDecl`].
     AnonEnumType {
         /// Index into extra data where variant name symbols start

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -404,15 +404,15 @@ pub fn munmap(addr: *mut u8, size: usize) -> i64 {
 
 /// Install the stack-overflow SIGSEGV handler.
 ///
-/// # TODO(RUE-645): not yet implemented on macOS
+/// # macOS limitation (RUE-707)
 ///
 /// On Linux this maps an alternate signal stack (`sigaltstack`) and installs a
 /// `SIGSEGV` handler (`rt_sigaction`) with `SA_ONSTACK`, turning a stack
 /// overflow into a clean "stack overflow" abort (exit 101) instead of a raw
 /// SIGSEGV (exit 139).
 ///
-/// Darwin's signal ABI is materially more divergent and cannot be verified on
-/// this (x86-64 Linux) host, so it is intentionally left as a no-op for now:
+/// Darwin's signal ABI requires a platform-specific implementation, so this is
+/// intentionally a no-op:
 ///
 /// - The BSD `sigaction(2)` syscall (SYS_sigaction = 46) takes a
 ///   `struct __sigaction` that, unlike Linux, includes a **caller-supplied
@@ -422,18 +422,18 @@ pub fn munmap(addr: *mut u8, size: usize) -> i64 {
 ///   A freestanding runtime would have to hand-write and correctly align that
 ///   trampoline in assembly.
 /// - The `struct __sigaction` / `stack_t` layouts and flag values differ from
-///   Linux and would need separate, untestable-locally verification.
+///   Linux and require Apple Silicon validation.
 ///
 /// Getting the trampoline subtly wrong re-crashes inside signal delivery, so
-/// shipping it unverified is worse than leaving it off. Until it can be
-/// implemented and exercised on real Apple Silicon (CI `test (macos)`), a stack
-/// overflow on macOS keeps the default SIGSEGV disposition (exit 139). The CLI
-/// regression test is marked `known_bug_on = ["aarch64-macos"]` to track this.
+/// the runtime leaves the default SIGSEGV disposition in place (exit 139).
+/// The CLI regression test is marked `known_bug_on = ["aarch64-macos"]` and
+/// RUE-707 tracks the missing trampoline and handler.
 ///
 /// The `_handler` argument matches the Linux signature so `entry::_main` can
 /// call this unconditionally.
 pub fn install_stack_overflow_handler(_handler: extern "C" fn(i32) -> !) {
-    // Intentionally a no-op on macOS; see the doc comment above (RUE-645 TODO).
+    // Deliberate no-op until the Darwin trampoline contract is implemented
+    // and validated (RUE-707).
 }
 
 /// Exit the process with the given status code.
@@ -601,7 +601,7 @@ mod tests {
     #[test]
     fn stack_overflow_handler_is_installable() {
         // Reference the installer so the unit-test build type-checks it. On
-        // macOS this is currently a no-op stub (RUE-645 TODO); taking its
+        // macOS this is a deliberate no-op (RUE-707); taking its
         // address keeps the signature in sync with the Linux backends without
         // executing anything.
         let installer: fn(extern "C" fn(i32) -> !) = install_stack_overflow_handler;

--- a/crates/rue-runtime/src/entry.rs
+++ b/crates/rue-runtime/src/entry.rs
@@ -183,7 +183,8 @@ pub unsafe extern "C" fn _main() -> ! {
     }
 
     // Install the stack-overflow SIGSEGV handler before running user code.
-    // (Currently a no-op on macOS — see the platform stub for why. RUE-645.)
+    // (A deliberate no-op on macOS; the Darwin trampoline is tracked by
+    // RUE-707.)
     platform::install_stack_overflow_handler(__rue_stack_overflow_handler);
 
     let exit_code: i32;

--- a/crates/rue-runtime/src/heap.rs
+++ b/crates/rue-runtime/src/heap.rs
@@ -29,12 +29,10 @@
 //!
 //! # Memory Efficiency
 //!
-//! Individual `free()` calls are no-ops. Memory is only reclaimed when:
-//! - The program exits (OS reclaims all memory)
-//! - A future allocator implementation adds actual freeing
-//!
-//! This is a deliberate trade-off: simplicity over memory efficiency.
-//! Rue programs are typically short-lived, so memory waste is acceptable.
+//! Individual `free()` calls are deliberately no-ops: the bump allocator
+//! retains every arena until the process exits, when the OS reclaims it. This
+//! is the runtime ABI contract for this allocator and trades memory efficiency
+//! for simple, predictable allocation.
 
 use crate::platform;
 use core::ptr;
@@ -355,15 +353,14 @@ fn alloc_from_arena(arena: *mut ArenaHeader, size: usize, align: usize) -> *mut 
 /// # Arguments
 ///
 /// * `ptr` - Pointer to the memory to free
-/// * `size` - Size of the allocation (for future compatibility)
-/// * `align` - Alignment of the allocation (for future compatibility)
+/// * `size` - Size supplied by the runtime allocation ABI
+/// * `align` - Alignment supplied by the runtime allocation ABI
 ///
-/// # Current Implementation
+/// # Bump-allocator contract
 ///
-/// This is a **no-op** in the current bump allocator. Memory is only
-/// reclaimed when the program exits. The `size` and `align` parameters
-/// are accepted for API compatibility with future allocators that may
-/// actually free memory.
+/// This is a **no-op**. Memory is reclaimed when the program exits. The
+/// `ptr`, `size`, and `align` parameters preserve the allocator ABI used by
+/// generated code, but no arena bookkeeping is changed.
 ///
 /// # Safety
 ///
@@ -371,13 +368,7 @@ fn alloc_from_arena(arena: *mut ArenaHeader, size: usize, align: usize) -> *mut 
 /// but since this is a no-op, invalid pointers are harmless.
 #[allow(unused_variables)]
 pub fn free(ptr: *mut u8, size: u64, align: u64) {
-    // No-op for bump allocator.
-    // Memory is reclaimed when the program exits.
-    //
-    // Future allocators may implement actual freeing by:
-    // 1. Finding which arena the pointer belongs to
-    // 2. Marking the region as free in a freelist
-    // 3. Potentially unmapping arenas when fully free
+    // Deliberate ABI no-op; the OS reclaims all arenas at process exit.
 }
 
 /// Reallocate memory to a new size.

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -1,6 +1,8 @@
 //! String runtime functions and methods.
 //!
-//! This module provides all runtime support for the String type:
+//! This module provides runtime support for the source-level `StrBuf` type.
+//! Exported `__rue_String_*` symbols retain their historical `String` spelling
+//! as part of the runtime ABI:
 //! - String equality comparison (`__rue_str_eq`)
 //! - Heap allocation wrappers (`__rue_alloc`, `__rue_free`, `__rue_realloc`)
 //! - String-specific allocation functions
@@ -139,14 +141,14 @@ crate::define_for_all_platforms! {
     /// # Arguments
     ///
     /// * `ptr` - Pointer to the memory to free
-    /// * `size` - Size of the allocation (for future compatibility)
-    /// * `align` - Alignment of the allocation (for future compatibility)
+    /// * `size` - Size supplied by the runtime allocation ABI
+    /// * `align` - Alignment supplied by the runtime allocation ABI
     ///
-    /// # Current Implementation
+    /// # Bump-allocator contract
     ///
-    /// This is a **no-op** in the current bump allocator. Memory is only
-    /// reclaimed when the program exits. The size and align parameters are
-    /// accepted for API compatibility with future allocators.
+    /// This is a **no-op**. Memory is reclaimed when the program exits. The
+    /// pointer, size, and alignment are retained in the generated-code ABI even
+    /// though this allocator does not use them.
     ///
     /// # ABI
     ///
@@ -362,7 +364,7 @@ pub extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_c
     }
 }
 // =============================================================================
-// String Query Methods (Phase 6: len, capacity, is_empty)
+// String query methods
 // =============================================================================
 //
 // These methods take a String (ptr, len, cap) and return a single value.
@@ -468,7 +470,7 @@ pub extern "C" fn __rue_String_is_empty(_ptr: *const u8, len: u64, _cap: u64) ->
 }
 
 // =============================================================================
-// String Byte Access (RUE-17 Phase 2, ADR-0035)
+// String byte access (ADR-0035)
 // =============================================================================
 //
 // Rue's String is a byte string (conventionally UTF-8, not guaranteed valid),
@@ -525,7 +527,7 @@ crate::define_for_all_platforms! {
 
 crate::define_for_all_platforms! {
     /// Read the byte at `index` in a `str`, returning it as `u8` (ADR-0043
-    /// Phase 3, RUE-324).
+    /// ADR-0043, RUE-324).
     ///
     /// Implements `s[i]` for the `str` string type. A `str` is `[u8]` + UTF-8:
     /// its bytes are PACKED (1 byte each, in `.rodata` for a literal), so like
@@ -692,7 +694,7 @@ crate::define_for_all_platforms! {
 /// Leniently decode one UTF-8 scalar starting at byte `offset` in the `len`-byte
 /// buffer at `ptr`, returning `(scalar, width_in_bytes)`.
 ///
-/// This backs `for c in s.chars_lossy()` (RUE-17 Phase 3, ADR-0035). Unlike the
+/// This backs `for c in s.chars_lossy()` (RUE-17, ADR-0035). Unlike the
 /// strict [`__rue_decode_utf8_at`], which traps at the decode boundary, this
 /// **never traps**: an invalid, truncated, overlong, or surrogate sequence
 /// yields the Unicode replacement scalar `U+FFFD` and advances past its
@@ -776,7 +778,7 @@ crate::define_for_all_platforms! {
     /// Decode the Unicode scalar at byte `offset`, replacing invalid UTF-8.
     ///
     /// Backs the element projection of `for c in s.chars_lossy()` (RUE-17
-    /// Phase 3). Like [`__rue_String_char_scalar`] but never traps: an invalid
+    /// RUE-17). Like [`__rue_String_char_scalar`] but never traps: an invalid
     /// sequence yields `U+FFFD` (see [`__rue_decode_utf8_lossy_at`]). Returns
     /// the scalar zero-extended into `u64` (language-level type `u32`).
     ///
@@ -807,7 +809,7 @@ crate::define_for_all_platforms! {
     /// replacing invalid UTF-8.
     ///
     /// Backs the position advance of `for c in s.chars_lossy()` (RUE-17
-    /// Phase 3). Like [`__rue_String_char_next`] but never traps: the advance
+    /// RUE-17). Like [`__rue_String_char_next`] but never traps: the advance
     /// past an invalid sequence is the width of its maximal subpart (see
     /// [`__rue_decode_utf8_lossy_at`]), guaranteeing forward progress.
     ///
@@ -912,7 +914,7 @@ crate::define_for_all_platforms! {
 }
 
 // =============================================================================
-// Byte-string search predicates (RUE-17 Phase 1, ADR-0035)
+// Byte-string search predicates (ADR-0035)
 // =============================================================================
 //
 // `s.contains(needle)` and `s.starts_with(prefix)` are byte-level: they compare
@@ -926,8 +928,8 @@ crate::define_for_all_platforms! {
 
 crate::define_for_all_platforms! {
     /// True (1) iff the bytes of `needle` occur as a contiguous run inside the
-    /// receiver's bytes. Naive O(len * needle_len) scan — adequate for the
-    /// design-light Phase 1; the empty needle is always contained.
+    /// receiver's bytes. Uses a naive O(len * needle_len) scan; the empty
+    /// needle is always contained.
     ///
     /// # Safety
     ///
@@ -1016,7 +1018,7 @@ crate::define_for_all_platforms! {
 }
 
 // =============================================================================
-// Integer-to-String formatting (RUE-17 Phase 1, ADR-0035)
+// Integer-to-String formatting (ADR-0035)
 // =============================================================================
 
 crate::define_for_all_platforms! {
@@ -1177,7 +1179,7 @@ crate::define_for_all_platforms! {
 crate::define_for_all_platforms! {
     /// Return a NEW String whose bytes are the concatenation of two Strings.
     ///
-    /// Implements `s1 + s2` (RUE-17 Phase 1, ADR-0035). Both operands are
+    /// Implements `s1 + s2` (RUE-17, ADR-0035). Both operands are
     /// borrowed (passed as their three fields each; the caps are unused but part
     /// of the ABI) and neither is consumed. The result owns a fresh heap buffer.
     ///
@@ -1256,7 +1258,7 @@ crate::define_for_all_platforms! {
 }
 
 // =============================================================================
-// String Clone Method (Phase 8)
+// String clone method
 // =============================================================================
 //
 // Clone creates a deep copy of a String. It uses `borrow self` semantics -
@@ -1386,7 +1388,7 @@ pub extern "C" fn __rue_String_clone(out: *mut StringResult, ptr: *const u8, len
 }
 
 // =============================================================================
-// String Mutation Methods (Phase 7: push_str, push, clear, reserve)
+// String mutation methods: push_str, push, clear, reserve
 // =============================================================================
 //
 // These methods take a String (ptr, len, cap) and additional arguments,
@@ -1849,11 +1851,10 @@ fn string_ensure_capacity(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> 
         }
         (new_ptr, new_cap)
     } else if required > cap {
-        // Need to grow. Compute the doubled capacity FIRST and allocate exactly
-        // that: the capacity we record must never exceed the bytes we actually
-        // own. (This previously realloc'd only `required` while recording the
-        // doubled value — the next append that fit the phantom capacity wrote
-        // past the allocation into neighboring heap memory. RUE-34)
+        // Need to grow. The recorded capacity must equal bytes actually owned,
+        // so compute the doubled capacity first and allocate exactly that
+        // amount. Otherwise a later append could trust nonexistent capacity
+        // and write past the allocation (RUE-34).
         let grown_cap = cap.saturating_mul(2);
         let new_cap = required.max(grown_cap).max(STRING_MIN_CAPACITY);
         let new_ptr = heap::realloc(ptr, cap, new_cap, 1);

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -515,9 +515,9 @@ impl TraceabilityReport {
 
 /// Extract a quoted shortcode argument (`name = "value"`), tolerating
 /// whitespace around `=`. Zola accepts `id = "x"` and renders it identically
-/// to `id="x"`, so the checker must too: a spaced `cat` used to silently
-/// demote a rule to informative, and a spaced `id` made the rule invisible —
-/// both dropped coverage enforcement without a report.
+/// to `id="x"`, so the checker must too. Otherwise a spaced `cat` can demote a
+/// rule to informative and a spaced `id` can hide it, silently weakening
+/// coverage enforcement.
 fn find_shortcode_arg(line: &str, name: &str) -> Option<String> {
     let mut search_from = 0;
     while let Some(rel) = line[search_from..].find(name) {

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -2374,22 +2374,17 @@ pub fn find_dir(env_var: &str, possible_paths: &[&str], fallback: &str) -> PathB
         })
 }
 
-/// Find the rue binary in common locations.
+/// Return the compiler path supplied through `RUE_BINARY`.
 ///
-/// When multiple Buck2 build outputs exist (each in a UUID-named directory),
-/// this function selects the most recently modified binary to avoid using
-/// stale binaries from previous builds.
+/// Test entry points set this explicitly; absence is an error because choosing
+/// among Buck output configurations is not reliable.
 pub fn find_rue_binary() -> PathBuf {
     // Explicit override — what test.sh, Buck targets, and scripts/rue set.
     if let Ok(p) = std::env::var("RUE_BINARY") {
         return PathBuf::from(p);
     }
-    // Refuse to guess. The old fallback globbed every buck-out config-hash
-    // directory and picked the NEWEST binary by mtime — with debug/release/
-    // historical configs side by side, that silently selected the wrong
-    // compiler and produced false test failures (a real incident). A repo-local
-    // bin/rue symlink had the same stale-binary and source-tree-churn risk.
-    // Guessing wrong silently is strictly worse than failing loudly.
+    // Buck output directories may contain multiple configurations, so an
+    // implicit mtime-based choice can run a compiler unrelated to this test.
     panic!(
         "cannot locate the rue compiler: set RUE_BINARY to an explicit path, \
          for example `RUE_BINARY=$(scripts/rue-bin)`"

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -757,9 +757,9 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         (positional, out)
     } else if !emit_stages.is_empty() {
         // --emit produces no executable, so there is no output positional:
-        // every positional arg is a source file. Without this, the legacy
-        // two-positional mode claimed the second FILE as the output path and
-        // `--emit air a.rue b.rue` was impossible (RUE-130).
+        // every positional arg is a source file, including the second path
+        // that legacy two-positional mode would otherwise treat as output
+        // (RUE-130).
         (positional, "a.out".to_string())
     } else if positional.len() == 1 {
         // Single source file, no -o: default output to a.out
@@ -767,9 +767,8 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     } else if positional.len() == 2 {
         // Two positional args, no -o: backwards compatible mode
         // First is source, second is output — but NEVER treat a .rue file as
-        // the output. `rue a.rue b.rue` used to silently overwrite the b.rue
-        // SOURCE FILE with the compiled binary (RUE-130); the user almost
-        // certainly meant to compile both.
+        // the output. Refusing `rue a.rue b.rue` protects the second source
+        // from being overwritten by the compiled binary (RUE-130).
         if positional[1].ends_with(".rue") {
             eprintln!(
                 "Error: refusing to use '{}' as the output path: it looks like a source file",
@@ -2173,7 +2172,7 @@ fn handle_emit_multi_file(
         None
     };
     if let Some(state) = &frontend_state {
-        // Warnings used to be silently dropped in all --emit modes (RUE-130).
+        // Every --emit mode must surface frontend warnings (RUE-130).
         diagnostics.print_warnings(state.warnings());
         let work = state.query_work();
         debug_assert_eq!(work.parsed.syntax.parser_invocations, source_snapshot.len());
@@ -2685,9 +2684,9 @@ mod tests {
 
     #[test]
     fn parse_output_equals_extensionless_input_error() {
-        // RUE-351: `-o` targeting an extensionless input source is refused. The
-        // old guard only recognized inputs by a `.rue` suffix. Paths resolve
-        // against the cwd; neither file needs to exist for the keys to match.
+        // RUE-351: `-o` targeting an extensionless input source is refused.
+        // Resolved-path identity, rather than a `.rue` suffix, protects the
+        // input; neither file needs to exist for the keys to match.
         assert!(is_error(&parse_args_from(&["prog", "-o", "prog"])));
     }
 

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -8,7 +8,7 @@
 //!
 //! The timing system is built on tracing's layer architecture:
 //!
-//! 1. **Instrumentation** (Phase 4): Compiler passes are wrapped in tracing spans
+//! 1. **Instrumentation**: Compiler passes are wrapped in tracing spans
 //!    like `info_span!("lexer")`. These are zero-cost when no subscriber collects them.
 //!
 //! 2. **Collection** (this module): `TimingLayer` implements `tracing_subscriber::Layer`


### PR DESCRIPTION
## Summary

- rewrite crate comments and doc comments around Rue's present architecture and invariants
- correct stale claims about semantic analysis, dependency manifests, `StrBuf`, runtime ABI behavior, parser warnings, and test harness lookup
- preserve current algorithm phases, ABI and safety justification, and tracked transitional behavior

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (24 targets passed)
- `scripts/rue test` (36 targets passed; generated-oracle smoke timed out under parallel load)
- `./buck2 test //:oracle-diff-generated-smoke` (isolated 64/64 pass)

Fixes RUE-773
