### PR TITLE
RUE-799: make sanitizer verdicts fail closed

### DIFF
--- a/scripts/run-sanitizer.sh
+++ b/scripts/run-sanitizer.sh
@@ -7,7 +7,7 @@
 # This is the local driver for the `sanitizer.yml` CI job (RUE-49). Run it from
 # anywhere in the repo:
 #
-#   scripts/run-sanitizer.sh                 # examples/*.rue + curated corpus
+#   scripts/run-sanitizer.sh                 # recursive examples + curated corpus
 #   scripts/run-sanitizer.sh path/to/x.rue   # ...plus extra programs
 #
 # Requirements: `valgrind` on PATH (CI installs it via apt-get). The rue
@@ -135,67 +135,170 @@ fn main() -> i32 {
         sum = sum + p.x + p.y;
         i = i + 1;
     }
-    sum % 256
+    if sum == 10000 { 0 } else { 1 }
 }
 RUE
 
-# --- Assemble the program list: examples/ + curated + any CLI args.
+# --- Assemble the program list. Match the CLI smoke-test's root-module rule:
+#     a directory containing main.rue contributes that root and is not searched
+#     further; elsewhere, every .rue file is a standalone example. This keeps
+#     helper modules from being compiled as programs while still finding nested
+#     root-module and ordinary examples.
 programs=()
-for f in "$repo_root"/examples/*.rue; do
-    [[ -e "$f" ]] && programs+=("$f")
-done
-for f in "$work"/san_*.rue; do
-    programs+=("$f")
-done
-for f in "$@"; do
-    programs+=("$f")
+contracts=()
+labels=()
+
+add_program() {
+    programs+=("$1")
+    contracts+=("$2")
+    labels+=("$3")
+}
+
+discover_examples() {
+    local dir="$1"
+    local entry
+    if [[ -f "$dir/main.rue" ]]; then
+        add_program "$dir/main.rue" "memory-only" "${dir#"$repo_root/"}/main.rue"
+        return
+    fi
+
+    # Include hidden entries just as std::fs::read_dir does in the CLI harness.
+    # nullglob keeps unmatched patterns from becoming literal path strings.
+    for entry in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
+        if [[ -d "$entry" ]]; then
+            discover_examples "$entry"
+        elif [[ -f "$entry" && "$entry" == *.rue ]]; then
+            add_program "$entry" "memory-only" "${entry#"$repo_root/"}"
+        fi
+    done
+}
+
+shopt -s nullglob
+if [[ ! -d "$repo_root/examples" ]]; then
+    echo "run-sanitizer: examples directory is missing: $repo_root/examples" >&2
+    exit 1
+fi
+discover_examples "$repo_root/examples"
+example_count=${#programs[@]}
+if [[ "$example_count" -eq 0 ]]; then
+    echo "run-sanitizer: no .rue examples discovered under $repo_root/examples" >&2
+    exit 1
+fi
+
+# These nested examples are coverage canaries for both discovery branches: a
+# dogfood root-module tree and an ordinary source under the std examples tree.
+required_examples=(
+    "$repo_root/examples/calculator/main.rue"
+    "$repo_root/examples/std/arraybuf_demo.rue"
+)
+for required in "${required_examples[@]}"; do
+    found=0
+    for src in "${programs[@]}"; do
+        if [[ "$src" == "$required" ]]; then
+            found=1
+            break
+        fi
+    done
+    if [[ "$found" -eq 0 ]]; then
+        echo "run-sanitizer: required example sentinel was not discovered: ${required#"$repo_root/"}" >&2
+        exit 1
+    fi
 done
 
-# --- Verdict from a valgrind log (NOT from the program's own exit code: Rue
-#     programs legitimately exit with codes up to 255, e.g. examples/arrays.rue
-#     exits 157). A fatal signal under valgrind still prints
-#     "ERROR SUMMARY: 0 errors", so we must check for it separately.
-verdict_ok() {
-    local log="$1"
-    if grep -q "Process terminating with default action of signal" "$log"; then
-        return 1
-    fi
-    if grep -qE "ERROR SUMMARY: [1-9][0-9]* errors" "$log"; then
-        return 1
-    fi
-    grep -q "ERROR SUMMARY: 0 errors" "$log"
-}
+# Curated self-checks must return zero. Repository examples and caller-supplied
+# programs use the memory-only contract: any normal exit code is accepted once
+# Memcheck reports clean, because many examples intentionally return nonzero.
+for f in "$work"/san_*.rue; do
+    add_program "$f" "exit:0" "curated/$(basename "$f")"
+done
+for f in "$@"; do
+    add_program "$f" "memory-only" "$f"
+done
+
+# GNU timeout's status 124 is also a valid program exit. Run Valgrind through a
+# tiny completion recorder so an actual timeout (no marker) is distinguishable
+# from a child that completed normally with status 124 (marker contains 124).
+cat > "$work/run-and-record-status.sh" <<'SH'
+#!/usr/bin/env bash
+status_file="$1"
+shift
+set +e
+"$@"
+status=$?
+printf '%s\n' "$status" > "$status_file"
+exit "$status"
+SH
+chmod +x "$work/run-and-record-status.sh"
 
 failures=0
 checked=0
-for src in "${programs[@]}"; do
-    name="$(basename "$src" .rue)"
-    bin="$work/$name.bin"
-    log="$work/$name.vglog"
+for ((i = 0; i < ${#programs[@]}; i++)); do
+    src="${programs[$i]}"
+    contract="${contracts[$i]}"
+    label="${labels[$i]}"
+    artifact="$(printf '%04d' "$i")"
+    bin="$work/$artifact.bin"
+    log="$work/$artifact.vglog"
+    compile_log="$work/$artifact.compile"
+    status_file="$work/$artifact.status"
 
-    if ! "$rue" "$src" -o "$bin" > "$work/$name.compile" 2>&1; then
-        echo "FAIL(compile) $name"
-        sed 's/^/    /' "$work/$name.compile"
+    if ! "$rue" "$src" -o "$bin" > "$compile_log" 2>&1; then
+        echo "FAIL(compile) $label"
+        sed 's/^/    /' "$compile_log"
         failures=$((failures + 1))
         continue
     fi
 
     # Cap runtime: valgrind adds heavy slowdown and a codegen bug could loop.
-    timeout 120 valgrind \
-        --error-exitcode=1 \
+    # Capture timeout/Valgrind's status explicitly; `set -e` is suspended only
+    # around this expected-to-be-nonzero probe.
+    set +e
+    timeout 120 "$work/run-and-record-status.sh" "$status_file" valgrind \
+        --error-exitcode=125 \
         --leak-check=full \
         --show-leak-kinds=all \
         --track-origins=yes \
         --log-file="$log" \
-        "$bin" > /dev/null 2>&1 || true
+        "$bin" > /dev/null 2>&1
+    timeout_status=$?
+    set -e
 
     checked=$((checked + 1))
-    if verdict_ok "$log"; then
-        echo "PASS $name"
-    else
-        echo "FAIL(memcheck) $name"
+
+    if [[ ! -f "$status_file" && "$timeout_status" -eq 124 ]]; then
+        echo "FAIL(timeout) $label (status $timeout_status; no completion marker)"
+        failures=$((failures + 1))
+        continue
+    elif [[ ! -f "$status_file" ]]; then
+        echo "FAIL(valgrind) $label (wrapper status $timeout_status; no completion marker)"
+        failures=$((failures + 1))
+        continue
+    fi
+
+    status="$(sed -n '1p' "$status_file")"
+    if [[ ! "$status" =~ ^[0-9]+$ ]]; then
+        echo "FAIL(valgrind) $label (invalid recorded status: $status)"
+        failures=$((failures + 1))
+    elif [[ ! -f "$log" ]]; then
+        echo "FAIL(valgrind) $label (status $status; no Memcheck log)"
+        failures=$((failures + 1))
+    elif grep -q "Process terminating with default action of signal" "$log"; then
+        echo "FAIL(signal) $label (status $status)"
         sed 's/^/    /' "$log"
         failures=$((failures + 1))
+    elif grep -qE "ERROR SUMMARY: [1-9][0-9]* errors" "$log"; then
+        echo "FAIL(memcheck) $label (Valgrind status $status)"
+        sed 's/^/    /' "$log"
+        failures=$((failures + 1))
+    elif ! grep -q "ERROR SUMMARY: 0 errors" "$log"; then
+        echo "FAIL(valgrind) $label (status $status; missing clean summary)"
+        sed 's/^/    /' "$log"
+        failures=$((failures + 1))
+    elif [[ "$contract" == exit:* && "$status" -ne "${contract#exit:}" ]]; then
+        echo "FAIL(program) $label (expected exit ${contract#exit:}, got $status)"
+        failures=$((failures + 1))
+    else
+        echo "PASS $label (program status $status; contract $contract)"
     fi
 done
 

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -22,6 +22,11 @@
 #     bundled standard-library path, so a top-level example using @import("std")
 #     failed before Valgrind ever ran.
 #
+#   * RUE-799: the Valgrind driver only discovered top-level examples and
+#     discarded execution status. Nested roots, helper-module boundaries,
+#     timeouts, signals, and failing curated self-checks therefore escaped its
+#     contract.
+#
 # Each test runs a COPY of the real script in a throwaway sandbox with a fake
 # `./buck2` (and, for scripts/rue, a fake scripts/rue-bin + fake compiler), so
 # no real build runs. The fakes log their cwd/argv; we assert on exit status,
@@ -296,10 +301,13 @@ test_testsh_cli_examples_survive_case_chdir() {
 # every compiler invocation without needing a real compiler or Valgrind.
 test_sanitizer_defaults_std_path() {
   local sb; sb="$(mktemp -d)"
-  mkdir -p "$sb/scripts" "$sb/examples" "$sb/std" "$sb/fakebin" "$sb/tmp"
+  mkdir -p "$sb/scripts" "$sb/examples/calculator" "$sb/examples/std" \
+    "$sb/std" "$sb/fakebin" "$sb/tmp"
   cp "$SRC_ROOT/scripts/run-sanitizer.sh" "$sb/scripts/run-sanitizer.sh"
   chmod +x "$sb/scripts/run-sanitizer.sh"
   printf 'const std = @import("std");\nfn main() -> i32 { 0 }\n' >"$sb/examples/std_probe.rue"
+  printf 'fn main() -> i32 { 0 }\n' >"$sb/examples/calculator/main.rue"
+  printf 'fn main() -> i32 { 0 }\n' >"$sb/examples/std/arraybuf_demo.rue"
   echo '// fake bundled standard library' >"$sb/std/_std.rue"
 
   cat >"$sb/compiler" <<'EOF'
@@ -373,6 +381,155 @@ EOF
   rm -rf "$sb"
 }
 
+# Build a representative sanitizer sandbox. Its nested calculator directory
+# has a root plus a helper that must never be compiled independently, while the
+# std directory supplies the required nested ordinary-file sentinel.
+make_sanitizer_sandbox() {
+  local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/scripts" "$sb/examples/calculator/lib" "$sb/examples/std" \
+    "$sb/std" "$sb/fakebin" "$sb/tmp"
+  cp "$SRC_ROOT/scripts/run-sanitizer.sh" "$sb/scripts/run-sanitizer.sh"
+  chmod +x "$sb/scripts/run-sanitizer.sh"
+  printf 'fn main() -> i32 { 0 }\n' >"$sb/examples/top.rue"
+  printf 'fn main() -> i32 { 0 }\n' >"$sb/examples/calculator/main.rue"
+  printf 'pub fn helper() -> i32 { 0 }\n' >"$sb/examples/calculator/lib/helper.rue"
+  printf 'fn main() -> i32 { 0 }\n' >"$sb/examples/std/arraybuf_demo.rue"
+  echo '// fake bundled standard library' >"$sb/std/_std.rue"
+
+  cat >"$sb/compiler" <<'EOF'
+#!/usr/bin/env bash
+src="$1"
+printf '%s\n' "$src" >>"$COMPILE_LOG"
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    out="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[ -n "$out" ] || exit 89
+case "$src" in
+  */san_*.rue) status="${FAKE_CURATED_EXIT:-0}" ;;
+  *) status="${FAKE_EXAMPLE_EXIT:-0}" ;;
+esac
+printf '#!/bin/sh\nexit %s\n' "$status" >"$out"
+chmod +x "$out"
+EOF
+  chmod +x "$sb/compiler"
+
+  cat >"$sb/fakebin/valgrind" <<'EOF'
+#!/usr/bin/env bash
+log=""
+for arg in "$@"; do
+  case "$arg" in
+    --log-file=*) log="${arg#--log-file=}" ;;
+  esac
+done
+[ -n "$log" ] || exit 90
+case "${FAKE_VG_MODE:-clean}" in
+  clean)
+    printf 'ERROR SUMMARY: 0 errors\n' >"$log"
+    "${!#}"
+    ;;
+  error)
+    printf 'Invalid write of size 8\nERROR SUMMARY: 1 errors\n' >"$log"
+    exit 125
+    ;;
+  signal)
+    printf 'Process terminating with default action of signal 11 (SIGSEGV)\nERROR SUMMARY: 0 errors\n' >"$log"
+    exit 139
+    ;;
+  *) exit 91 ;;
+esac
+EOF
+  chmod +x "$sb/fakebin/valgrind"
+
+  cat >"$sb/fakebin/timeout" <<'EOF'
+#!/usr/bin/env bash
+if [ "${FAKE_TIMEOUT:-0}" -ne 0 ]; then
+  exit 124
+fi
+shift
+exec "$@"
+EOF
+  chmod +x "$sb/fakebin/timeout"
+  printf '%s\n' "$sb"
+}
+
+run_sanitizer_sandbox() {
+  local sb="$1"
+  PATH="$sb/fakebin:$PATH" \
+    RUE_BINARY="$sb/compiler" \
+    COMPILE_LOG="$sb/compile.log" \
+    TMPDIR="$sb/tmp" \
+    "$sb/scripts/run-sanitizer.sh"
+}
+
+test_sanitizer_recursive_discovery_contract() {
+  local sb; sb="$(make_sanitizer_sandbox)"
+  local rc=0
+  run_sanitizer_sandbox "$sb" >/dev/null 2>&1 || rc=$?
+  check "run-sanitizer: recursive representative corpus succeeds" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  check "run-sanitizer: discovers a nested root module" \
+    "$(grep -Fxq "$sb/examples/calculator/main.rue" "$sb/compile.log" 2>/dev/null && echo 0 || echo 1)"
+  check "run-sanitizer: discovers the nested std/ArrayBuf example" \
+    "$(grep -Fxq "$sb/examples/std/arraybuf_demo.rue" "$sb/compile.log" 2>/dev/null && echo 0 || echo 1)"
+  check "run-sanitizer: does not compile a root's helper module independently" \
+    "$(! grep -Fxq "$sb/examples/calculator/lib/helper.rue" "$sb/compile.log" 2>/dev/null && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_sanitizer_status_contracts() {
+  local sb rc out
+
+  sb="$(make_sanitizer_sandbox)"; rc=0
+  FAKE_EXAMPLE_EXIT=124 run_sanitizer_sandbox "$sb" >/dev/null 2>&1 || rc=$?
+  check "run-sanitizer: completed ordinary exit 124 is not mistaken for timeout" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+
+  sb="$(make_sanitizer_sandbox)"; rc=0
+  out="$(FAKE_CURATED_EXIT=7 run_sanitizer_sandbox "$sb" 2>&1)" || rc=$?
+  check "run-sanitizer: clean Memcheck plus nonzero curated self-check fails" \
+    "$([ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'FAIL(program)' && echo 0 || echo 1)"
+  rm -rf "$sb"
+
+  sb="$(make_sanitizer_sandbox)"; rc=0
+  out="$(FAKE_TIMEOUT=1 run_sanitizer_sandbox "$sb" 2>&1)" || rc=$?
+  check "run-sanitizer: timeout status fails" \
+    "$([ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'FAIL(timeout)' && echo 0 || echo 1)"
+  rm -rf "$sb"
+
+  sb="$(make_sanitizer_sandbox)"; rc=0
+  out="$(FAKE_VG_MODE=signal run_sanitizer_sandbox "$sb" 2>&1)" || rc=$?
+  check "run-sanitizer: fatal signal with a clean Memcheck summary fails" \
+    "$([ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'FAIL(signal)' && echo 0 || echo 1)"
+  rm -rf "$sb"
+
+  sb="$(make_sanitizer_sandbox)"; rc=0
+  out="$(FAKE_VG_MODE=error run_sanitizer_sandbox "$sb" 2>&1)" || rc=$?
+  check "run-sanitizer: real Memcheck error fails" \
+    "$([ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'FAIL(memcheck).*Valgrind status 125' && echo 0 || echo 1)"
+  rm -rf "$sb"
+
+  sb="$(make_sanitizer_sandbox)"
+  rm -f "$sb/examples/calculator/main.rue"
+  rc=0; out="$(run_sanitizer_sandbox "$sb" 2>&1)" || rc=$?
+  check "run-sanitizer: missing nested root sentinel fails" \
+    "$([ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'calculator/main.rue' && echo 0 || echo 1)"
+  rm -rf "$sb"
+
+  sb="$(make_sanitizer_sandbox)"
+  rm -rf "$sb/examples"; mkdir "$sb/examples"
+  rc=0; out="$(run_sanitizer_sandbox "$sb" 2>&1)" || rc=$?
+  check "run-sanitizer: empty example corpus fails loudly" \
+    "$([ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'no .rue examples discovered' && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
 # --- run everything ---------------------------------------------------------
 
 test_ruebin_build_failure_is_loud
@@ -384,6 +541,8 @@ test_rue_run_resolves_relative_output
 test_rue_cli_examples_survive_case_chdir
 test_testsh_cli_examples_survive_case_chdir
 test_sanitizer_defaults_std_path
+test_sanitizer_recursive_discovery_contract
+test_sanitizer_status_contracts
 
 echo "--------------------------------------------------"
 if [ "$FAILURES" -eq 0 ]; then


### PR DESCRIPTION
## Summary

- discover sanitizer example roots recursively with the CLI smoke-test root-module rule
- require nested dogfood and std/ArrayBuf sentinels and fail when example coverage is empty
- model curated self-checks as `exit:0` and ordinary examples as memory-only programs
- classify timeout, fatal signal, Memcheck, Valgrind, and program failures independently
- add portable wrapper regressions for discovery and every false-green verdict path

## Root cause

The sanitizer enumerated only `examples/*.rue`, so nested root modules were absent and helper-module boundaries were never exercised. It also discarded the timeout/Valgrind status and trusted only the Memcheck summary, allowing a clean log from a failing self-check to pass.

## Validation

- `bash -n scripts/run-sanitizer.sh scripts/test-wrapper-scripts.sh`
- `scripts/test-wrapper-scripts.sh` (37 checks)
- `scripts/rue quick` (24 suites)
- `git diff --check`

Fixes RUE-799
