### PR TITLE
RUE-778: validate executable main signatures

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -691,6 +691,30 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
         }
     };
 
+    // The runtime invokes `main` directly using a fixed zero-argument ABI.
+    // Validate that boundary before body analysis so an invalid declaration
+    // cannot be skipped as a generic specialization or reach codegen.
+    let main_info = sema
+        .functions
+        .get(&main_sym)
+        .expect("main was found in the function table");
+    if !main_info.params.is_empty() {
+        return Err(CompileErrors::from(CompileError::new(
+            ErrorKind::InvalidMainSignature {
+                reason: "`main` must not declare parameters",
+            },
+            main_info.span,
+        )));
+    }
+    if !matches!(main_info.return_type, Type::I32 | Type::UNIT) {
+        return Err(CompileErrors::from(CompileError::new(
+            ErrorKind::InvalidMainSignature {
+                reason: "`main` must return `i32` or `()`",
+            },
+            main_info.span,
+        )));
+    }
+
     // Work queue: functions/methods to analyze
     // Start with main()
     let mut pending_functions: Vec<Spur> = vec![main_sym];

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -64,6 +64,63 @@ mod tests {
     }
 
     #[test]
+    fn main_rejects_runtime_parameters() {
+        let errors = compile_to_air("fn main(value: i32) -> i32 { value }")
+            .expect_err("a runtime parameter would violate the entry ABI");
+        assert!(errors.iter().any(|error| matches!(
+            error.kind,
+            ErrorKind::InvalidMainSignature {
+                reason: "`main` must not declare parameters"
+            }
+        )));
+        assert!(errors.iter().all(|error| error.has_span()));
+    }
+
+    #[test]
+    fn main_rejects_comptime_parameters() {
+        let errors = compile_to_air("fn main(comptime T: type) -> i32 { 0 }")
+            .expect_err("a generic main cannot be specialized by the runtime");
+        assert!(errors.iter().any(|error| matches!(
+            error.kind,
+            ErrorKind::InvalidMainSignature {
+                reason: "`main` must not declare parameters"
+            }
+        )));
+    }
+
+    #[test]
+    fn main_rejects_non_abi_return_type() {
+        let errors = compile_to_air("fn main() -> bool { true }")
+            .expect_err("the runtime cannot consume a bool return value");
+        assert!(errors.iter().any(|error| matches!(
+            error.kind,
+            ErrorKind::InvalidMainSignature {
+                reason: "`main` must return `i32` or `()`"
+            }
+        )));
+    }
+
+    #[test]
+    fn main_rejects_aggregate_return_type() {
+        let errors =
+            compile_to_air("struct Exit { code: i32 } fn main() -> Exit { Exit { code: 0 } }")
+                .expect_err("the runtime cannot consume an aggregate return value");
+        assert!(errors.iter().any(|error| matches!(
+            error.kind,
+            ErrorKind::InvalidMainSignature {
+                reason: "`main` must return `i32` or `()`"
+            }
+        )));
+    }
+
+    #[test]
+    fn main_accepts_i32_and_unit_return_types() {
+        assert!(compile_to_air("fn main() -> i32 { 0 }").is_ok());
+        assert!(compile_to_air("fn main() {}").is_ok());
+        assert!(compile_to_air("fn main() -> () {}").is_ok());
+    }
+
+    #[test]
     fn byref_arguments_reject_non_places_during_air_analysis() {
         let cases = [
             (
@@ -390,10 +447,22 @@ mod tests {
 
     #[test]
     fn strbuf_literal_body_uses_explicit_builtin_identity_and_imports_fresh() {
-        let source = "fn main() -> StrBuf { \"hello\" }";
+        let source = "fn make() -> StrBuf { \"hello\" } fn main() { make(); }";
         let output = compile_to_air(source).unwrap();
-        assert_eq!(output.ordinary_body_exports.len(), 1);
-        let body = &output.ordinary_body_exports[0].body;
+        assert_eq!(output.ordinary_body_exports.len(), 2);
+        let body = output
+            .ordinary_body_exports
+            .iter()
+            .map(|export| &export.body)
+            .find(|body| {
+                matches!(
+                    &body.return_type,
+                    crate::SemanticImportType::BuiltinNominal { name, kind }
+                        if name.as_ref() == "StrBuf"
+                            && *kind == crate::SemanticImportNominalKind::Struct
+                )
+            })
+            .expect("reachable StrBuf-returning helper export");
         assert!(matches!(
             &body.return_type,
             crate::SemanticImportType::BuiltinNominal { name, kind }
@@ -421,7 +490,13 @@ mod tests {
         assert_eq!(imported.strings, vec!["hello"]);
         assert_eq!(
             imported.air.return_type(),
-            output.functions[0].air.return_type()
+            output
+                .functions
+                .iter()
+                .find(|function| function.name == "make")
+                .unwrap()
+                .air
+                .return_type()
         );
     }
 
@@ -1669,16 +1744,22 @@ mod tests {
     fn test_variable_shadowing_different_type() {
         // Variable shadowing with a different type should work
         let output = compile_to_air(
-            "fn main() -> bool {
+            "fn shadow() -> bool {
                 let x = 10;
                 let x = true;  // Shadow x with a different type
                 x
-            }",
+            }
+            fn main() -> i32 { if shadow() { 0 } else { 1 } }",
         )
         .unwrap();
 
-        assert_eq!(output.functions[0].num_locals, 2);
-        assert_eq!(output.functions[0].air.return_type(), Type::BOOL);
+        let shadow = output
+            .functions
+            .iter()
+            .find(|function| function.name == "shadow")
+            .unwrap();
+        assert_eq!(shadow.num_locals, 2);
+        assert_eq!(shadow.air.return_type(), Type::BOOL);
     }
 
     #[test]
@@ -1946,44 +2027,73 @@ mod tests {
     fn test_string_len_method() {
         // String.len() should return u64
         let output = compile_to_air(
-            "fn main() -> u64 {
+            "fn length() -> u64 {
                 let s = \"hello\";
                 s.len()
-            }",
+            }
+            fn main() -> i32 { if length() == 5 { 0 } else { 1 } }",
         )
         .unwrap();
 
-        assert_eq!(output.functions[0].air.return_type(), Type::U64);
+        assert_eq!(
+            output
+                .functions
+                .iter()
+                .find(|function| function.name == "length")
+                .unwrap()
+                .air
+                .return_type(),
+            Type::U64
+        );
     }
 
     #[test]
     fn test_string_is_empty_method() {
         // String.is_empty() should return bool
         let output = compile_to_air(
-            "fn main() -> bool {
+            "fn empty() -> bool {
                 let s = \"hello\";
                 s.is_empty()
-            }",
+            }
+            fn main() -> i32 { if empty() { 0 } else { 1 } }",
         )
         .unwrap();
 
-        assert_eq!(output.functions[0].air.return_type(), Type::BOOL);
+        assert_eq!(
+            output
+                .functions
+                .iter()
+                .find(|function| function.name == "empty")
+                .unwrap()
+                .air
+                .return_type(),
+            Type::BOOL
+        );
     }
 
     #[test]
     fn test_string_literal_type_inference() {
         // String literal should have type String
         let output = compile_to_air(
-            "fn main() -> bool {
+            "fn has_content() -> bool {
                 let s = \"hello\";
                 let t = \"world\";
                 s.is_empty()
-            }",
+            }
+            fn main() -> i32 { if has_content() { 0 } else { 1 } }",
         )
         .unwrap();
 
         // Should have local storage for two string variables
-        assert!(output.functions[0].num_locals >= 2);
+        assert!(
+            output
+                .functions
+                .iter()
+                .find(|function| function.name == "has_content")
+                .unwrap()
+                .num_locals
+                >= 2
+        );
     }
 
     // =========================================================================
@@ -2072,36 +2182,68 @@ mod tests {
     fn test_integer_literal_infers_from_context() {
         // Integer literal should infer type from context
         let output = compile_to_air(
-            "fn main() -> i64 {
+            "fn value() -> i64 {
                 let x: i64 = 42;
                 x
-            }",
+            }
+            fn main() -> i32 { if value() == 42 { 0 } else { 1 } }",
         )
         .unwrap();
 
-        assert_eq!(output.functions[0].air.return_type(), Type::I64);
+        assert_eq!(
+            output
+                .functions
+                .iter()
+                .find(|function| function.name == "value")
+                .unwrap()
+                .air
+                .return_type(),
+            Type::I64
+        );
     }
 
     #[test]
     fn test_integer_literal_infers_from_return_type() {
         // Integer literal should infer type from function return type
-        let output = compile_to_air("fn main() -> u8 { 42 }").unwrap();
+        let output = compile_to_air(
+            "fn value() -> u8 { 42 } fn main() -> i32 { if value() == 42 { 0 } else { 1 } }",
+        )
+        .unwrap();
 
-        assert_eq!(output.functions[0].air.return_type(), Type::U8);
+        assert_eq!(
+            output
+                .functions
+                .iter()
+                .find(|function| function.name == "value")
+                .unwrap()
+                .air
+                .return_type(),
+            Type::U8
+        );
     }
 
     #[test]
     fn test_integer_literal_infers_from_binary_op() {
         // Integer literal should infer type from binary operation context
         let output = compile_to_air(
-            "fn main() -> i64 {
+            "fn value() -> i64 {
                 let x: i64 = 10;
                 x + 5  // 5 should infer to i64
-            }",
+            }
+            fn main() -> i32 { if value() == 15 { 0 } else { 1 } }",
         )
         .unwrap();
 
-        assert_eq!(output.functions[0].air.return_type(), Type::I64);
+        assert_eq!(
+            output
+                .functions
+                .iter()
+                .find(|function| function.name == "value")
+                .unwrap()
+                .air
+                .return_type(),
+            Type::I64
+        );
     }
 
     // =========================================================================

--- a/crates/rue-cli-tests/cases/builtin_method_infer.toml
+++ b/crates/rue-cli-tests/cases/builtin_method_infer.toml
@@ -14,10 +14,11 @@ description = "A builtin method-call result must anchor the type of an integer l
 [[case]]
 name = "len_plus_literal"
 files = [{ path = "main.rue", source = """
-fn main() -> u64 {
+fn length_plus_one() -> u64 {
     let s = "hello";
     s.len() + 1
 }
+fn main() -> i32 { if length_plus_one() == 6 { 6 } else { 0 } }
 """ }]
 exit_code = 6
 
@@ -44,11 +45,12 @@ exit_code = 9
 [[case]]
 name = "len_mul_literal_bound_to_local"
 files = [{ path = "main.rue", source = """
-fn main() -> u64 {
+fn doubled_length() -> u64 {
     let s = "abc";
     let n = s.len() * 2;
     n
 }
+fn main() -> i32 { if doubled_length() == 6 { 6 } else { 0 } }
 """ }]
 exit_code = 6
 

--- a/crates/rue-cli-tests/cases/division.toml
+++ b/crates/rue-cli-tests/cases/division.toml
@@ -80,11 +80,12 @@ exit_code = 0
 [[case]]
 name = "i64_div_min32_neg1_no_sigfpe"
 files = [{ path = "main.rue", source = """
-fn main() -> i64 {
+fn divide() -> i64 {
     let a: i64 = 2147483648;
     let b: i64 = -1;
     a / b          // -2147483648; low byte 0
 }
+fn main() -> i32 { divide(); 0 }
 """ }]
 exit_code = 0
 

--- a/crates/rue-cli-tests/cases/entry_point_contract.toml
+++ b/crates/rue-cli-tests/cases/entry_point_contract.toml
@@ -1,0 +1,60 @@
+[section]
+id = "cli.entry_point_contract"
+name = "Executable entry point contract"
+description = "The source main signature must match the fixed zero-argument runtime entry ABI (RUE-778)."
+
+[[case]]
+name = "i32_main_runs"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 42 }" }]
+exit_code = 42
+
+[[case]]
+name = "unit_main_runs"
+files = [{ path = "main.rue", source = "fn main() {}" }]
+exit_code = 0
+
+[[case]]
+name = "runtime_parameter_is_rejected_before_codegen"
+files = [{ path = "main.rue", source = "fn main(value: i32) -> i32 { value }" }]
+compile_fail = true
+error_contains = ["E0211", "main.rue:", "`main` must not declare parameters"]
+
+[[case]]
+name = "comptime_parameter_is_rejected_before_specialization"
+files = [{ path = "main.rue", source = "fn main(comptime T: type) -> i32 { 0 }" }]
+compile_fail = true
+error_contains = ["E0211", "main.rue:", "`main` must not declare parameters"]
+
+[[case]]
+name = "non_abi_return_is_rejected_before_codegen"
+files = [{ path = "main.rue", source = "fn main() -> bool { true }" }]
+compile_fail = true
+error_contains = ["E0211", "main.rue:", "`main` must return `i32` or `()`"]
+
+[[case]]
+name = "unit_main_aarch64_entry_abi"
+files = [{ path = "main.rue", source = "fn main() {}" }]
+args = ["--emit", "asm", "--target", "aarch64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:", "bl __rue_exit"]
+
+[[case]]
+name = "unit_main_x86_64_entry_abi"
+files = [{ path = "main.rue", source = "fn main() {}" }]
+args = ["--emit", "asm", "--target", "x86-64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (x86-64-linux) ===", "main:", "call __rue_exit"]
+
+[[case]]
+name = "invalid_main_rejected_for_aarch64_target"
+files = [{ path = "main.rue", source = "fn main(value: i32) -> i32 { value }" }]
+args = ["--emit", "asm", "--target", "aarch64-linux", "main.rue"]
+compile_fail = true
+error_contains = ["E0211", "`main` must not declare parameters"]
+
+[[case]]
+name = "invalid_main_rejected_for_x86_64_target"
+files = [{ path = "main.rue", source = "fn main(value: i32) -> i32 { value }" }]
+args = ["--emit", "asm", "--target", "x86-64-linux", "main.rue"]
+compile_fail = true
+error_contains = ["E0211", "`main` must not declare parameters"]

--- a/crates/rue-cli-tests/cases/multifile_errors.toml
+++ b/crates/rue-cli-tests/cases/multifile_errors.toml
@@ -124,7 +124,7 @@ pub fn helper() -> i64 {
 }
 """ },
     { path = "main.rue", source = """
-fn main() -> i64 {
+fn main() -> i32 {
     if 1 + 2 {
         return 1;
     }
@@ -150,7 +150,7 @@ pub fn helper() -> i64 {
 }
 """ },
     { path = "main.rue", source = """
-fn main() -> i64 {
+fn main() -> i32 {
     if 1 + 2 {
         return 1;
     }
@@ -177,7 +177,7 @@ pub fn helper() -> i64 {
 }
 """ },
     { path = "main.rue", source = """
-fn main() -> i64 {
+fn main() -> i32 {
     if -1 {
         return 1;
     }
@@ -204,10 +204,10 @@ pub fn helper() -> i64 {
 """ },
     { path = "main.rue", source = """
 struct P { x: i64 }
-fn main() -> i64 {
+fn main() -> i32 {
     let mut p = P { x: 1 };
     p.x = true;
-    return p.x;
+    return 0;
 }
 """ },
 ]
@@ -230,7 +230,7 @@ pub fn helper() -> i64 {
 }
 """ },
     { path = "main.rue", source = """
-fn main() -> i64 {
+fn main() -> i32 {
     let mut a = [1, 2, 3];
     let i = a[0] && true;
     return 0;

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -27,18 +27,18 @@ mod integration_tests {
 
         #[test]
         fn signed_integer_return() {
-            assert!(test_air("fn main() -> i8 { 42 }").is_ok());
-            assert!(test_air("fn main() -> i16 { 42 }").is_ok());
+            assert!(test_air("fn value() -> i8 { 42 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> i16 { 42 } fn main() { value(); }").is_ok());
             assert!(test_air("fn main() -> i32 { 42 }").is_ok());
-            assert!(test_air("fn main() -> i64 { 42 }").is_ok());
+            assert!(test_air("fn value() -> i64 { 42 } fn main() { value(); }").is_ok());
         }
 
         #[test]
         fn unsigned_integer_return() {
-            assert!(test_air("fn main() -> u8 { 42 }").is_ok());
-            assert!(test_air("fn main() -> u16 { 42 }").is_ok());
-            assert!(test_air("fn main() -> u32 { 42 }").is_ok());
-            assert!(test_air("fn main() -> u64 { 42 }").is_ok());
+            assert!(test_air("fn value() -> u8 { 42 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> u16 { 42 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> u32 { 42 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> u64 { 42 } fn main() { value(); }").is_ok());
         }
 
         #[test]
@@ -52,7 +52,7 @@ mod integration_tests {
         #[test]
         fn integer_literal_type_inference() {
             // Type inferred from return type
-            assert!(test_air("fn main() -> i64 { 100 }").is_ok());
+            assert!(test_air("fn value() -> i64 { 100 } fn main() { value(); }").is_ok());
             // Type inferred from annotation
             assert!(test_air("fn main() -> i32 { let x: i64 = 100; 0 }").is_ok());
         }
@@ -67,8 +67,8 @@ mod integration_tests {
 
         #[test]
         fn boolean_literals() {
-            assert!(test_air("fn main() -> bool { true }").is_ok());
-            assert!(test_air("fn main() -> bool { false }").is_ok());
+            assert!(test_air("fn value() -> bool { true } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> bool { false } fn main() { value(); }").is_ok());
         }
 
         #[test]
@@ -163,9 +163,9 @@ mod integration_tests {
 
         #[test]
         fn unsigned_arithmetic() {
-            assert!(test_air("fn main() -> u32 { 10 + 5 }").is_ok());
-            assert!(test_air("fn main() -> u32 { 10 - 5 }").is_ok());
-            assert!(test_air("fn main() -> u32 { 10 * 5 }").is_ok());
+            assert!(test_air("fn value() -> u32 { 10 + 5 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> u32 { 10 - 5 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> u32 { 10 * 5 } fn main() { value(); }").is_ok());
         }
     }
 
@@ -178,22 +178,24 @@ mod integration_tests {
 
         #[test]
         fn equality_comparison() {
-            assert!(test_air("fn main() -> bool { 1 == 1 }").is_ok());
-            assert!(test_air("fn main() -> bool { 1 != 2 }").is_ok());
+            assert!(test_air("fn value() -> bool { 1 == 1 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> bool { 1 != 2 } fn main() { value(); }").is_ok());
         }
 
         #[test]
         fn ordering_comparison() {
-            assert!(test_air("fn main() -> bool { 1 < 2 }").is_ok());
-            assert!(test_air("fn main() -> bool { 2 > 1 }").is_ok());
-            assert!(test_air("fn main() -> bool { 1 <= 2 }").is_ok());
-            assert!(test_air("fn main() -> bool { 2 >= 1 }").is_ok());
+            assert!(test_air("fn value() -> bool { 1 < 2 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> bool { 2 > 1 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> bool { 1 <= 2 } fn main() { value(); }").is_ok());
+            assert!(test_air("fn value() -> bool { 2 >= 1 } fn main() { value(); }").is_ok());
         }
 
         #[test]
         fn boolean_equality() {
-            assert!(test_air("fn main() -> bool { true == true }").is_ok());
-            assert!(test_air("fn main() -> bool { true != false }").is_ok());
+            assert!(test_air("fn value() -> bool { true == true } fn main() { value(); }").is_ok());
+            assert!(
+                test_air("fn value() -> bool { true != false } fn main() { value(); }").is_ok()
+            );
         }
 
         #[test]
@@ -204,7 +206,7 @@ mod integration_tests {
 
         #[test]
         fn mixed_type_comparison_rejected() {
-            let result = test_air("fn main() -> bool { 1 == true }");
+            let result = test_air("fn value() -> bool { 1 == true } fn main() { value(); }");
             assert!(result.is_err());
         }
     }
@@ -218,27 +220,34 @@ mod integration_tests {
 
         #[test]
         fn logical_and() {
-            assert!(test_cfg("fn main() -> bool { true && false }").is_ok());
+            assert!(
+                test_cfg("fn value() -> bool { true && false } fn main() { value(); }").is_ok()
+            );
         }
 
         #[test]
         fn logical_or() {
-            assert!(test_cfg("fn main() -> bool { true || false }").is_ok());
+            assert!(
+                test_cfg("fn value() -> bool { true || false } fn main() { value(); }").is_ok()
+            );
         }
 
         #[test]
         fn logical_not() {
-            assert!(test_air("fn main() -> bool { !true }").is_ok());
+            assert!(test_air("fn value() -> bool { !true } fn main() { value(); }").is_ok());
         }
 
         #[test]
         fn chained_logical() {
-            assert!(test_cfg("fn main() -> bool { true && false || true }").is_ok());
+            assert!(
+                test_cfg("fn value() -> bool { true && false || true } fn main() { value(); }")
+                    .is_ok()
+            );
         }
 
         #[test]
         fn logical_with_non_bool_rejected() {
-            let result = test_air("fn main() -> bool { 1 && true }");
+            let result = test_air("fn value() -> bool { 1 && true } fn main() { value(); }");
             assert!(result.is_err());
         }
     }
@@ -282,7 +291,7 @@ mod integration_tests {
 
         #[test]
         fn bitwise_on_bool_rejected() {
-            let result = test_air("fn main() -> bool { true & false }");
+            let result = test_air("fn value() -> bool { true & false } fn main() { value(); }");
             assert!(result.is_err());
         }
     }
@@ -318,7 +327,8 @@ mod integration_tests {
 
         #[test]
         fn if_result_type_checked() {
-            let result = test_air("fn main() -> bool { if true { 1 } else { 0 } }");
+            let result =
+                test_air("fn value() -> bool { if true { 1 } else { 0 } } fn main() { value(); }");
             assert!(result.is_err());
         }
     }
@@ -496,7 +506,7 @@ mod integration_tests {
 
         #[test]
         fn shadowing_can_change_type() {
-            let src = "fn main() -> bool { let x = 1; let x = true; x }";
+            let src = "fn value() -> bool { let x = 1; let x = true; x } fn main() { value(); }";
             assert!(test_air(src).is_ok());
         }
 
@@ -673,11 +683,12 @@ mod integration_tests {
         fn struct_equality() {
             let src = r#"
                 struct Point { x: i32, y: i32 }
-                fn main() -> bool {
+                fn equal() -> bool {
                     let a = Point { x: 1, y: 2 };
                     let b = Point { x: 1, y: 2 };
                     a == b
                 }
+                fn main() { equal(); }
             "#;
             assert!(test_air(src).is_ok());
         }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -3536,19 +3536,39 @@ mod tests {
     #[test]
     fn signature_target_and_failed_body_changes_fail_closed_and_recovery_reuses() {
         let base = snapshot(
-            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn value() -> i32 { 1 } fn main() { value(); }",
+            )],
             1,
         );
         let signature = snapshot(
-            &[(1, "/p/main.rue", "main.rue", "fn main() -> i64 { 1 }")],
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn value() -> i64 { 1 } fn main() { value(); }",
+            )],
             1,
         );
         let broken_body = snapshot(
-            &[(1, "/p/main.rue", "main.rue", "fn main() -> i64 { missing }")],
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn value() -> i64 { missing } fn main() { value(); }",
+            )],
             1,
         );
         let recovered = snapshot(
-            &[(1, "/p/main.rue", "main.rue", "fn main() -> i64 { 2 }")],
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn value() -> i64 { 2 } fn main() { value(); }",
+            )],
             1,
         );
         let options = CompileOptions::default();
@@ -3568,7 +3588,7 @@ mod tests {
             recovered.work().binding.declaration_resolution_invocations,
             0
         );
-        assert_eq!(recovered.work().declaration_reuse.durable_records_reused, 1);
+        assert_eq!(recovered.work().declaration_reuse.durable_records_reused, 2);
 
         let mut other_target = options.clone();
         other_target.target = *Target::all()
@@ -4363,12 +4383,15 @@ mod tests {
             session
                 .semantic_dependency_inputs(&CompileOptions::default(), None)
                 .unwrap()
-                .definition_fingerprints()[0]
+                .definition_fingerprints()
+                .iter()
+                .find(|fingerprint| fingerprint.key.name() == "value")
+                .expect("value definition fingerprint")
                 .clone()
         }
 
-        let original = fingerprints("fn main() -> i32 { 0 }");
-        let body_changed = fingerprints("fn main() -> i32 { 1 }");
+        let original = fingerprints("fn value() -> i32 { 0 } fn main() { value(); }");
+        let body_changed = fingerprints("fn value() -> i32 { 1 } fn main() { value(); }");
         assert_eq!(original.key, body_changed.key);
         assert_eq!(original.declaration, body_changed.declaration);
         assert_eq!(original.signature, body_changed.signature);
@@ -4381,7 +4404,7 @@ mod tests {
             StableDefinitionFingerprintPrecision::SignatureAndBody
         );
 
-        let visibility_changed = fingerprints("pub fn main() -> i32 { 0 }");
+        let visibility_changed = fingerprints("pub fn value() -> i32 { 0 } fn main() { value(); }");
         assert_eq!(original.key, visibility_changed.key);
         assert_ne!(original.declaration, visibility_changed.declaration);
         assert_ne!(original.signature, visibility_changed.signature);
@@ -4390,7 +4413,7 @@ mod tests {
             visibility_changed.body_or_initializer
         );
 
-        let signature_changed = fingerprints("fn main() -> i64 { 0 }");
+        let signature_changed = fingerprints("fn value() -> i64 { 0 } fn main() { value(); }");
         assert_eq!(original.declaration, signature_changed.declaration);
         assert_ne!(original.signature, signature_changed.signature);
         assert_eq!(

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -117,6 +117,11 @@ impl ErrorCode {
     /// grants exclusive access to the caller's bytes; it is not a first-class
     /// string header that may be rebound (RUE-641).
     pub const STR_VIEW_REASSIGNMENT: Self = Self(210);
+    /// The executable entry point has parameters or a return type other than
+    /// `i32` or `()` (spec 6.1:8, RUE-778). The runtime calls `main` with no
+    /// arguments and consumes either its status code or the unit value, so a
+    /// different source signature would violate the entry ABI.
+    pub const INVALID_MAIN_SIGNATURE: Self = Self(211);
 
     // ========================================================================
     // Struct/enum errors (E0400-E0499)
@@ -1094,6 +1099,9 @@ pub enum ErrorKind {
     // Semantic errors
     #[error("no main function found")]
     NoMainFunction,
+    /// The `main` declaration does not match the runtime entry ABI (RUE-778).
+    #[error("invalid main function signature: {reason}")]
+    InvalidMainSignature { reason: &'static str },
     #[error("undefined variable '{0}'")]
     UndefinedVariable(String),
     #[error("undefined function '{0}'")]
@@ -1620,6 +1628,7 @@ impl ErrorKind {
 
             // Semantic errors (E0200-E0399)
             ErrorKind::NoMainFunction => ErrorCode::NO_MAIN_FUNCTION,
+            ErrorKind::InvalidMainSignature { .. } => ErrorCode::INVALID_MAIN_SIGNATURE,
             ErrorKind::UndefinedVariable(_) => ErrorCode::UNDEFINED_VARIABLE,
             ErrorKind::UndefinedFunction(_) => ErrorCode::UNDEFINED_FUNCTION,
             ErrorKind::AssignToImmutable(_) => ErrorCode::ASSIGN_TO_IMMUTABLE,

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1722,7 +1722,9 @@ files = [{ path = "probe.rue", source = "not Rue" }]
         };
         assert!(message.contains("KNOWN_ORACLE_GAPS entry is stale"));
 
-        case.source = "fn main() -> u32 { let value: u32 = @random_u32(); value }".to_string();
+        case.source =
+            "fn probe() -> u32 { let value: u32 = @random_u32(); value } fn main() { probe(); }"
+                .to_string();
         assert_eq!(
             check_spec_case_with_known_gap("test:1", &case, true),
             CaseOutcome::Unmodeled(UnmodeledReason::ModelGap(ModelGapKind::ExternalDependency(
@@ -2057,7 +2059,8 @@ files = [{ path = "probe.rue", source = "not Rue" }]
             CaseOutcome::Agree
         ));
 
-        let unsupported_source = "fn main() -> u32 { let value: u32 = @random_u32(); value }";
+        let unsupported_source =
+            "fn probe() -> u32 { let value: u32 = @random_u32(); value } fn main() { probe(); }";
         let unsupported_cli = corpus_case(unsupported_source, false);
         assert!(matches!(
             check_case(Path::new("unsupported.toml"), &unsupported_cli),
@@ -2162,9 +2165,10 @@ files = [{ path = "probe.rue", source = "not Rue" }]
 
     #[test]
     fn exact_model_gap_kind_survives_case_classification() {
-        let error =
-            rue_oracle::run_source("fn main() -> u32 { let value: u32 = @random_u32(); value }")
-                .expect_err("randomness must remain outside the deterministic oracle");
+        let error = rue_oracle::run_source(
+            "fn probe() -> u32 { let value: u32 = @random_u32(); value } fn main() { probe(); }",
+        )
+        .expect_err("randomness must remain outside the deterministic oracle");
 
         assert_eq!(
             record_oracle_error("typed gap probe", error),
@@ -2216,7 +2220,7 @@ files = [{ path = "probe.rue", source = "not Rue" }]
     #[test]
     fn active_unknown_trap_contract_cannot_hide_behind_a_typed_model_gap() {
         let mut case = corpus_case(
-            "fn main() -> u32 { let value: u32 = @random_u32(); value }",
+            "fn probe() -> u32 { let value: u32 = @random_u32(); value } fn main() { probe(); }",
             false,
         );
         case.runtime_error_contains = vec!["custom trap wording".to_string()];

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -476,7 +476,7 @@ fn place_write_contracts_precede_rhs_model_gaps() {
             outer.inner.value = @random_u32();
             outer.inner.value
         }
-        fn main() -> u32 { write() }";
+        fn main() { write(); }";
 
     let gap = expect_unsupported(SOURCE);
     assert_eq!(
@@ -589,7 +589,7 @@ fn place_read_base_contract_precedes_index_model_gap() {
             let values: [u32; 2] = [1, 2];
             values[@random_u32()]
         }
-        fn main() -> u32 { read() }";
+        fn main() { read(); }";
 
     let gap = expect_unsupported(SOURCE);
     assert_eq!(
@@ -748,7 +748,7 @@ fn whole_place_write_requires_exact_type_and_writable_storage() {
             value = @random_u32();
             value
         }
-        fn main() -> u32 { write(1) }";
+        fn main() { write(1); }";
 
     let gap = expect_unsupported(SOURCE);
     assert_eq!(
@@ -834,33 +834,34 @@ fn whole_place_write_requires_exact_type_and_writable_storage() {
 #[test]
 fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
     const SOURCE: &str = "fn take(borrow value: str) -> u64 { value.len() }
-        fn main() -> u64 {
+        fn probe() -> u64 {
             let value: Str(2) = \"hi\";
             let other: Str(3) = \"hey\";
             take(borrow value) + other.len()
-        }";
+        }
+        fn main() { probe(); }";
     let mut preview_features = PreviewFeatures::new();
     preview_features.insert(rue_compiler::PreviewFeature::StringTrio);
     let mut state = query_cfg_state_with_preview_features(SOURCE, &preview_features)
         .expect("whole PlaceRead probe must compile");
-    let main_index = state
+    let probe_index = state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "main")
-        .expect("main CFG");
-    let other_fixed_type = state.functions[main_index]
+        .position(|function| function.cfg.fn_name() == "probe")
+        .expect("probe CFG");
+    let other_fixed_type = state.functions[probe_index]
         .cfg
         .blocks()
         .iter()
         .flat_map(|block| block.insts.iter().copied())
-        .map(|value| state.functions[main_index].cfg.get_inst(value).ty)
+        .map(|value| state.functions[probe_index].cfg.get_inst(value).ty)
         .find(|ty| {
             ty.as_struct()
                 .is_some_and(|struct_id| state.type_pool.struct_def(struct_id).name == "Str(3)")
         })
         .expect("Str(3) parameter type");
     let (read_value, original_place, read_type) = {
-        let cfg = &state.functions[main_index].cfg;
+        let cfg = &state.functions[probe_index].cfg;
         cfg.blocks()
             .iter()
             .flat_map(|block| block.insts.iter().copied())
@@ -875,7 +876,7 @@ fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
             .expect("Str(N)-to-str whole PlaceRead")
     };
     {
-        let cfg = &state.functions[main_index].cfg;
+        let cfg = &state.functions[probe_index].cfg;
         let interp = Interp {
             state: &state,
             stdout: String::new(),
@@ -904,7 +905,7 @@ fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
         ));
     }
 
-    state.functions[main_index]
+    state.functions[probe_index]
         .cfg
         .get_inst_mut(read_value)
         .data = CfgInstData::PlaceRead {
@@ -913,7 +914,7 @@ fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
             ..original_place
         },
     };
-    let cfg = &state.functions[main_index].cfg;
+    let cfg = &state.functions[probe_index].cfg;
     let mut interp = Interp {
         state: &state,
         stdout: String::new(),

--- a/crates/rue-spec/cases/appendices/implementation-limits.toml
+++ b/crates/rue-spec/cases/appendices/implementation-limits.toml
@@ -11,25 +11,25 @@ description = "Tests for implementation-defined limits and boundaries."
 [[case]]
 name = "u64_max_literal"
 spec = ["C.2:1"]
-source = "fn main() -> u64 { 18446744073709551615 }"
+source = "fn value() -> u64 { 18446744073709551615 } fn main() -> i32 { if value() == 18446744073709551615 { 255 } else { 0 } }"
 exit_code = 255
 
 [[case]]
 name = "i8_min"
 spec = ["C.2:2"]
-source = "fn main() -> i8 { -128 }"
+source = "fn value() -> i8 { -128 } fn main() -> i32 { if value() == -128 { 128 } else { 0 } }"
 exit_code = 128
 
 [[case]]
 name = "i8_max"
 spec = ["C.2:2"]
-source = "fn main() -> i8 { 127 }"
+source = "fn value() -> i8 { 127 } fn main() -> i32 { if value() == 127 { 127 } else { 0 } }"
 exit_code = 127
 
 [[case]]
 name = "u8_max"
 spec = ["C.2:2"]
-source = "fn main() -> u8 { 255 }"
+source = "fn value() -> u8 { 255 } fn main() -> i32 { if value() == 255 { 255 } else { 0 } }"
 exit_code = 255
 
 [[case]]
@@ -53,10 +53,11 @@ exit_code = 1
 name = "u32_max"
 spec = ["C.2:2"]
 source = """
-fn main() -> u32 {
+fn value() -> u32 {
     let x: u32 = 4294967295;
     if x > 0 { 1 } else { 0 }
 }
+fn main() -> i32 { if value() == 1 { 1 } else { 0 } }
 """
 exit_code = 1
 

--- a/crates/rue-spec/cases/expressions/literals.toml
+++ b/crates/rue-spec/cases/expressions/literals.toml
@@ -81,10 +81,11 @@ exit_code = 42
 name = "literal_inferred_i64"
 spec = ["4.1:3"]
 source = """
-fn main() -> i64 {
+fn inferred() -> i64 {
     let x: i64 = 42;
     x
 }
+fn main() -> i32 { if inferred() == 42 { 42 } else { 0 } }
 """
 exit_code = 42
 

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -10,9 +10,36 @@ description = "Function declarations with the fn keyword, including parameters a
 
 [[case]]
 name = "simple_main"
-spec = ["6.1:1", "6.1:7"]
+spec = ["6.1:1", "6.1:7", "6.1:8"]
 source = "fn main() -> i32 { 0 }"
 exit_code = 0
+
+[[case]]
+name = "main_unit_return"
+spec = ["6.1:8"]
+source = "fn main() {}"
+exit_code = 0
+
+[[case]]
+name = "main_runtime_parameter_rejected"
+spec = ["6.1:8"]
+source = "fn main(value: i32) -> i32 { value }"
+compile_fail = true
+error_contains = ["E0211", "`main` must not declare parameters"]
+
+[[case]]
+name = "main_comptime_parameter_rejected"
+spec = ["6.1:8"]
+source = "fn main(comptime T: type) -> i32 { 0 }"
+compile_fail = true
+error_contains = ["E0211", "`main` must not declare parameters"]
+
+[[case]]
+name = "main_non_abi_return_rejected"
+spec = ["6.1:8"]
+source = "fn main() -> bool { true }"
+compile_fail = true
+error_contains = ["E0211", "`main` must return `i32` or `()`"]
 
 [[case]]
 name = "main_basic_{variant}"

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -628,9 +628,9 @@ cfg main (return_type: i32) {
 name = "cfg_early_return_drops"
 description = "CFG shows StorageDead before early return"
 source = """
-fn main(cond: bool) -> i32 {
+fn main() -> i32 {
     let a = 1;
-    if cond {
+    if true {
         return 42;
     }
     a
@@ -642,7 +642,7 @@ cfg main (return_type: i32) {
     v0 : () = storage_live $0
     v1 : i32 = const 1
     v2 : () = alloc $0 = v1
-    v3 : bool = param 0
+    v3 : bool = const true
     branch v3, bb1, bb2
 
   bb1:

--- a/crates/rue-spec/cases/types/integers.toml
+++ b/crates/rue-spec/cases/types/integers.toml
@@ -12,7 +12,7 @@ description = "Signed and unsigned integer types: i8, i16, i32, i64, u8, u16, u3
 [[case]]
 name = "{type}_return"
 spec = ["3.1:1"]
-source = "fn main() -> {type} { {value} }"
+source = "fn value() -> {type} { {value} } fn main() -> i32 { if value() == {value} { {value} } else { 0 } }"
 params = [
   { type = "i8", value = "42", exit_code = 42, spec_extra = ["3.1:2"] },
   { type = "i16", value = "100", exit_code = 100, spec_extra = ["3.1:3"] },
@@ -27,7 +27,7 @@ params = [
 [[case]]
 name = "{type}_zero"
 spec = ["3.1:1"]
-source = "fn main() -> {type} { 0 }"
+source = "fn value() -> {type} { 0 } fn main() -> i32 { value(); 0 }"
 exit_code = 0
 params = [
   { type = "i8", spec_extra = ["3.1:2"] },
@@ -44,10 +44,11 @@ params = [
 name = "{type}_variable"
 spec = ["3.1:1"]
 source = """
-fn main() -> {type} {
+fn value() -> {type} {
     let x: {type} = {value};
     x
 }
+fn main() -> i32 { if value() == {value} { {value} } else { 0 } }
 """
 params = [
   { type = "i8", value = "50", exit_code = 50, spec_extra = ["3.1:2"] },
@@ -58,25 +59,26 @@ params = [
 [[case]]
 name = "i8_max_positive"
 spec = ["3.1:2"]
-source = "fn main() -> i8 { 127 }"
+source = "fn value() -> i8 { 127 } fn main() -> i32 { if value() == 127 { 127 } else { 0 } }"
 exit_code = 127
 
 [[case]]
 name = "i8_arithmetic"
 spec = ["3.1:1", "3.1:2"]
 source = """
-fn main() -> i8 {
+fn value() -> i8 {
     let a: i8 = 10;
     let b: i8 = 5;
     a + b
 }
+fn main() -> i32 { if value() == 15 { 15 } else { 0 } }
 """
 exit_code = 15
 
 [[case]]
 name = "u8_max"
 spec = ["3.1:9"]
-source = "fn main() -> u8 { 255 }"
+source = "fn value() -> u8 { 255 } fn main() -> i32 { if value() == 255 { 255 } else { 0 } }"
 exit_code = 255
 
 # =============================================================================
@@ -176,10 +178,11 @@ error_contains = "[E0206]"
 spec = ["3.1:1"]
 compile_fail = true
 source = """
-fn main() -> {to} {
+fn mismatch() -> {to} {
     let x: {from} = 42;
     x
 }
+fn main() { mismatch(); }
 """
 params = [
   { from = "i8", to = "i32" },
@@ -195,10 +198,11 @@ name = "{type}_overflow_addition"
 spec = ["3.1:6"]
 runtime_error = "integer overflow"
 source = """
-fn main() -> {type} {
+fn overflow() -> {type} {
     let x: {type} = {max};
     x + 1
 }
+fn main() { overflow(); }
 """
 params = [
   { type = "i8", max = "127" },
@@ -210,10 +214,11 @@ name = "{type}_overflow_subtraction"
 spec = ["3.1:6"]
 runtime_error = "integer overflow"
 source = """
-fn main() -> {type} {
+fn overflow() -> {type} {
     let x: {type} = {min};
     x - 1
 }
+fn main() { overflow(); }
 """
 params = [
   { type = "i8", min = "-128" },
@@ -224,10 +229,11 @@ params = [
 name = "i8_overflow_multiplication"
 spec = ["3.1:6"]
 source = """
-fn main() -> i8 {
+fn overflow() -> i8 {
     let x: i8 = 16;
     x * 16
 }
+fn main() -> i32 { overflow(); 0 }
 """
 runtime_error = "integer overflow"
 
@@ -246,11 +252,12 @@ runtime_error = "integer overflow"
 name = "i64_overflow_addition"
 spec = ["3.1:6"]
 source = """
-fn main() -> i64 {
+fn overflow() -> i64 {
     let x: i64 = 4611686018427387903;
     let y: i64 = x + x;
     y + x
 }
+fn main() -> i32 { overflow(); 0 }
 """
 runtime_error = "integer overflow"
 
@@ -258,11 +265,12 @@ runtime_error = "integer overflow"
 name = "i64_overflow_subtraction"
 spec = ["3.1:6"]
 source = """
-fn main() -> i64 {
+fn overflow() -> i64 {
     let x: i64 = -4611686018427387903;
     let y: i64 = x + x;
     y + x
 }
+fn main() -> i32 { overflow(); 0 }
 """
 runtime_error = "integer overflow"
 
@@ -270,10 +278,11 @@ runtime_error = "integer overflow"
 name = "i64_overflow_multiplication"
 spec = ["3.1:6"]
 source = """
-fn main() -> i64 {
+fn overflow() -> i64 {
     let x: i64 = 3037000500;
     x * x
 }
+fn main() -> i32 { overflow(); 0 }
 """
 runtime_error = "integer overflow"
 
@@ -286,10 +295,11 @@ name = "{type}_overflow_addition"
 spec = ["3.1:13"]
 runtime_error = "integer overflow"
 source = """
-fn main() -> {type} {
+fn overflow() -> {type} {
     let x: {type} = {max};
     x + 1
 }
+fn main() { overflow(); }
 """
 params = [
   { type = "u8", max = "255" },
@@ -301,11 +311,12 @@ params = [
 name = "u8_overflow_addition_rhs"
 spec = ["3.1:13"]
 source = """
-fn main() -> u8 {
+fn overflow() -> u8 {
     let x: u8 = 200;
     let y: u8 = 100;
     x + y
 }
+fn main() -> i32 { overflow(); 0 }
 """
 runtime_error = "integer overflow"
 
@@ -314,10 +325,11 @@ name = "{type}_overflow_subtraction"
 spec = ["3.1:13"]
 runtime_error = "integer overflow"
 source = """
-fn main() -> {type} {
+fn overflow() -> {type} {
     let x: {type} = 0;
     x - 1
 }
+fn main() { overflow(); }
 """
 params = [
   { type = "u8" },
@@ -331,10 +343,11 @@ name = "{type}_overflow_multiplication"
 spec = ["3.1:13"]
 runtime_error = "integer overflow"
 source = """
-fn main() -> {type} {
+fn overflow() -> {type} {
     let x: {type} = {value};
     x * {value}
 }
+fn main() { overflow(); }
 """
 params = [
   { type = "u8", value = "16" },
@@ -345,11 +358,12 @@ params = [
 name = "u64_overflow_addition"
 spec = ["3.1:13"]
 source = """
-fn main() -> u64 {
+fn overflow() -> u64 {
     let x: u64 = 9223372036854775807;
     let y: u64 = x + x;
     y + x
 }
+fn main() -> i32 { overflow(); 0 }
 """
 runtime_error = "integer overflow"
 
@@ -361,10 +375,11 @@ runtime_error = "integer overflow"
 name = "{type}_near_max_no_overflow"
 spec = ["3.1:6"]
 source = """
-fn main() -> {type} {
+fn value() -> {type} {
     let x: {type} = {near_max};
     x + 1
 }
+fn main() -> i32 { if value() == {near_max} + 1 { {near_max} + 1 } else { 0 } }
 """
 params = [
   { type = "i8", near_max = "126", exit_code = 127 },
@@ -398,10 +413,11 @@ exit_code = 42
 name = "{type}_near_max_no_overflow"
 spec = ["3.1:13"]
 source = """
-fn main() -> {type} {
+fn value() -> {type} {
     let x: {type} = {near_max};
     x + 1
 }
+fn main() -> i32 { if value() == {near_max} + 1 { {near_max} + 1 } else { 0 } }
 """
 params = [
   { type = "u8", near_max = "254", exit_code = 255 },
@@ -567,9 +583,10 @@ spec = ["3.1:17"]
 compile_fail = true
 error_contains = "out of range"
 source = """
-fn main() -> {type} {
+fn out_of_range() -> {type} {
     {value}
 }
+fn main() { out_of_range(); }
 """
 params = [
   { type = "i8", value = "128" },

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -257,7 +257,11 @@ A program **MUST** have a function named `main`.
 
 {{ rule(id="6.1:8", cat="legality-rule") }}
 
-The `main` function **MUST** return either `i32` or `()`. When it returns `i32`, that value becomes the program's exit code. When it returns `()`, the exit code is 0.
+The `main` function **MUST** declare no parameters, including `comptime`
+parameters, and **MUST** return either `i32` or `()`. Thus `main` is never a
+generic function and the runtime can invoke it using the executable entry ABI
+without supplying source-level arguments. When it returns `i32`, that value
+becomes the program's exit code. When it returns `()`, the exit code is 0.
 
 Programs can also terminate explicitly through the standard library:
 `std.exit(code)` terminates the process immediately with the provided `u64`


### PR DESCRIPTION
## Summary

- define the executable `main` contract as zero parameters with an `i32` or unit return
- reject runtime parameters, comptime parameters, scalar non-ABI returns, and aggregate returns in semantic analysis with source-located E0211 diagnostics
- add semantic, specification, native CLI, x86-64, and AArch64 coverage
- update older fixtures to exercise their original behavior through legal reachable helper functions

## Root cause

Semantic analysis selected `main` only by name, while every runtime entry point invoked the emitted symbol through a fixed zero-argument ABI. Invalid source signatures could therefore reach code generation and read unspecified argument registers or use an unsupported return convention.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue cli entry_point_contract`
- `scripts/rue spec items.functions`
- `scripts/rue test`

Fixes RUE-778
