### PR TITLE
RUE-782: mark raw-pointer runtime exports unsafe

### DIFF
--- a/crates/rue-runtime/src/debug.rs
+++ b/crates/rue-runtime/src/debug.rs
@@ -80,9 +80,10 @@ crate::define_for_all_platforms! {
     /// # Safety
     ///
     /// The caller must ensure:
-    /// - `ptr` points to a valid UTF-8 string of `len` bytes
+    /// - `ptr` is non-null and points to a valid UTF-8 string of `len` bytes
+    ///   when `len > 0`; it may be null when `len == 0`
     /// - The memory region remains valid for the duration of the call
-    pub extern "C" fn __rue_dbg_str(ptr: *const u8, len: u64) {
+    pub unsafe extern "C" fn __rue_dbg_str(ptr: *const u8, len: u64) {
         // SAFETY: Creating a slice from the raw pointer is safe because:
         // - The caller (Rue-generated code) guarantees `ptr` points to valid UTF-8
         //   string data of exactly `len` bytes
@@ -91,8 +92,12 @@ crate::define_for_all_platforms! {
         // - `ptr` is properly aligned (u8 requires only byte alignment)
         // - The pointed-to memory is initialized (Rue initializes all memory)
         // - We only read from the slice, never write
-        let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
-        platform::write_stdout(bytes);
+        if len > 0 {
+            // SAFETY: the caller guarantees a non-null pointer valid for `len`
+            // initialized bytes when the length is positive.
+            let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+            platform::write_stdout(bytes);
+        }
         // Write newline using byte char literal (b"..." has issues with macOS linker)
         let newline = [b'\n'];
         platform::write_stdout(&newline);

--- a/crates/rue-runtime/src/entry.rs
+++ b/crates/rue-runtime/src/entry.rs
@@ -145,6 +145,11 @@ extern "C" fn __rue_x86_64_linux_start() -> ! {
 /// On macOS, the entry point is `_main` (or `start` for dyld). The kernel
 /// starts execution with SP 16-byte aligned. The AAPCS64 ABI expects SP
 /// to be 16-byte aligned at function entry.
+///
+/// # Safety
+///
+/// This must only be entered by the macOS process loader with the initial
+/// stack and register state required by AAPCS64.
 #[cfg(all(not(test), target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn _main() -> ! {
@@ -185,6 +190,11 @@ pub unsafe extern "C" fn _main() -> ! {
 /// On Linux, the entry point is `_start`. The kernel starts execution
 /// with SP 16-byte aligned. The AAPCS64 ABI expects SP to be 16-byte
 /// aligned at function entry.
+///
+/// # Safety
+///
+/// This must only be entered by the Linux process loader with the initial
+/// stack and register state required by AAPCS64.
 #[cfg(all(not(test), target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn _start() -> ! {

--- a/crates/rue-runtime/src/error.rs
+++ b/crates/rue-runtime/src/error.rs
@@ -304,9 +304,10 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// The caller (Rue-generated code) guarantees `ptr` points to `len` valid,
-    /// initialized, byte-aligned bytes that stay valid for the call.
-    pub extern "C" fn __rue_panic(ptr: *const u8, len: u64) -> ! {
+    /// When `len > 0`, `ptr` must be non-null and point to `len` valid,
+    /// initialized bytes that stay valid for the call. `ptr` may be null when
+    /// `len == 0`.
+    pub unsafe extern "C" fn __rue_panic(ptr: *const u8, len: u64) -> ! {
         // "panic: " built byte-by-byte to avoid the macOS byte-string linker bug.
         let mut prefix = [0u8; 7];
         prefix[0] = b'p';
@@ -318,8 +319,12 @@ crate::define_for_all_platforms! {
         prefix[6] = b' ';
         platform::write_stderr(&prefix);
         // SAFETY: the caller guarantees `ptr`/`len` describe a valid byte range.
-        let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
-        platform::write_stderr(bytes);
+        if len > 0 {
+            // SAFETY: the caller guarantees a non-null pointer valid for `len`
+            // initialized bytes when the length is positive.
+            let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+            platform::write_stderr(bytes);
+        }
         let newline = [b'\n'];
         platform::write_stderr(&newline);
         platform::exit(101)

--- a/crates/rue-runtime/src/io.rs
+++ b/crates/rue-runtime/src/io.rs
@@ -42,15 +42,20 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// The caller must ensure `ptr` points to `len` valid, initialized bytes
-    /// that remain valid for the duration of the call. The borrow ABI
-    /// guarantees this: the String is not consumed and outlives the call.
+    /// When `len > 0`, `ptr` must be non-null and point to `len` valid,
+    /// initialized bytes that remain valid for the duration of the call. It
+    /// may be null when `len == 0`. The borrow ABI guarantees the live-buffer
+    /// requirement: the String is not consumed and outlives the call.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_print(ptr: *const u8, len: u64, _cap: u64) {
+    pub unsafe extern "C" fn __rue_print(ptr: *const u8, len: u64, _cap: u64) {
         // SAFETY: `ptr` points to `len` valid bytes owned by the caller's
         // String (borrowed, not consumed), and we only read from the slice.
-        let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
-        platform::write_stdout(bytes);
+        if len > 0 {
+            // SAFETY: the caller guarantees a non-null pointer valid for `len`
+            // initialized bytes when the length is positive.
+            let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+            platform::write_stdout(bytes);
+        }
     }
 }
 
@@ -74,10 +79,13 @@ crate::define_for_all_platforms! {
     ///
     /// See [`__rue_print`].
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_println(ptr: *const u8, len: u64, _cap: u64) {
+    pub unsafe extern "C" fn __rue_println(ptr: *const u8, len: u64, _cap: u64) {
         // SAFETY: see `__rue_print` — `ptr` is valid for `len` borrowed bytes.
-        let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
-        platform::write_stdout(bytes);
+        if len > 0 {
+            // SAFETY: see `__rue_print`.
+            let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+            platform::write_stdout(bytes);
+        }
         // Byte-array literal (not `b"\n"`) to avoid a macOS linker quirk seen
         // with `b"..."` in `__rue_dbg_str`.
         let newline = [b'\n'];
@@ -137,24 +145,49 @@ pub struct OptionStringResult {
 /// ```
 ///
 /// Caller allocates space for the return value and passes pointer.
+///
+/// # Safety
+///
+/// `out` must be valid, aligned, writable storage for one
+/// [`OptionStringResult`] and must remain exclusively accessible for the call.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_read_line(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) {
+pub unsafe extern "C" fn __rue_read_line(
+    out: *mut OptionStringResult,
+    some_disc: u64,
+    none_disc: u64,
+) {
     read_line_impl(out, some_disc, none_disc);
 }
 
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_read_line(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) {
+/// # Safety
+///
+/// `out` must be valid, aligned, writable storage for one
+/// [`OptionStringResult`] and must remain exclusively accessible for the call.
+pub unsafe extern "C" fn __rue_read_line(
+    out: *mut OptionStringResult,
+    some_disc: u64,
+    none_disc: u64,
+) {
     read_line_impl(out, some_disc, none_disc);
 }
 
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_read_line(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) {
+/// # Safety
+///
+/// `out` must be valid, aligned, writable storage for one
+/// [`OptionStringResult`] and must remain exclusively accessible for the call.
+pub unsafe extern "C" fn __rue_read_line(
+    out: *mut OptionStringResult,
+    some_disc: u64,
+    none_disc: u64,
+) {
     read_line_impl(out, some_disc, none_disc);
 }
 

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -134,6 +134,25 @@ compile_error!(
 macro_rules! define_for_all_platforms {
     (
         $(#[$meta:meta])*
+        pub unsafe extern "C" fn $name:ident($($arg:ident : $arg_ty:ty),* $(,)?) $(-> $ret:ty)? $body:block
+    ) => {
+        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+        $(#[$meta])*
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
+
+        #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+        $(#[$meta])*
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
+
+        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+        $(#[$meta])*
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
+    };
+    (
+        $(#[$meta:meta])*
         pub extern "C" fn $name:ident($($arg:ident : $arg_ty:ty),* $(,)?) $(-> $ret:ty)? $body:block
     ) => {
         #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
@@ -178,3 +197,234 @@ pub use aarch64_macos::{exit, write, write_all, write_stderr};
 
 #[cfg(all(test, target_arch = "aarch64", target_os = "linux"))]
 pub use aarch64_linux::{exit, write, write_all, write_stderr};
+
+#[cfg(test)]
+mod export_safety_tests {
+    extern crate std;
+
+    use self::std::{string::String, vec::Vec};
+    const MODULE_SOURCES: &[(&str, &str)] = &[
+        ("aarch64_linux", include_str!("aarch64_linux.rs")),
+        ("aarch64_macos", include_str!("aarch64_macos.rs")),
+        ("debug", include_str!("debug.rs")),
+        ("entry", include_str!("entry.rs")),
+        ("error", include_str!("error.rs")),
+        ("heap", include_str!("heap.rs")),
+        ("io", include_str!("io.rs")),
+        ("memory", include_str!("memory.rs")),
+        ("parse", include_str!("parse.rs")),
+        ("random", include_str!("random.rs")),
+        ("string", include_str!("string.rs")),
+        ("x86_64_linux", include_str!("x86_64_linux.rs")),
+    ];
+
+    /// Every extern function declaration whose signature contains a raw
+    /// pointer: symbol, whether it is unsafe, and declaration count. Counts are
+    /// one for macro-defined exports and three for hand-written platform copies.
+    /// This is intentionally checked against the
+    /// source declaration rather than by assigning function pointers: Rust
+    /// permits a safe function pointer to coerce to an unsafe one, which would
+    /// let an accidentally-safe export pass a type-only test.
+    const POINTER_EXPORTS: &[(&str, bool, usize)] = &[
+        ("__rue_String_byte_at", true, 1),
+        ("__rue_String_capacity", false, 3),
+        ("__rue_String_char_next", true, 1),
+        ("__rue_String_char_next_lossy", true, 1),
+        ("__rue_String_char_scalar", true, 1),
+        ("__rue_String_char_scalar_lossy", true, 1),
+        ("__rue_String_clear", true, 3),
+        ("__rue_String_clone", true, 3),
+        ("__rue_String_concat", true, 1),
+        ("__rue_String_contains", true, 1),
+        ("__rue_String_is_empty", false, 3),
+        ("__rue_String_len", false, 3),
+        ("__rue_String_new", true, 3),
+        ("__rue_String_push", true, 3),
+        ("__rue_String_push_str", true, 3),
+        ("__rue_String_reserve", true, 3),
+        ("__rue_String_starts_with", true, 1),
+        ("__rue_String_substring", true, 1),
+        ("__rue_String_with_capacity", true, 3),
+        ("__rue_alloc", false, 1),
+        ("__rue_dbg_str", true, 1),
+        ("__rue_drop_String", false, 1),
+        ("__rue_free", false, 1),
+        ("__rue_panic", true, 1),
+        ("__rue_parse_i32", true, 1),
+        ("__rue_parse_i64", true, 1),
+        ("__rue_parse_u32", true, 1),
+        ("__rue_parse_u64", true, 1),
+        ("__rue_print", true, 1),
+        ("__rue_println", true, 1),
+        ("__rue_read_line", true, 3),
+        ("__rue_realloc", true, 1),
+        ("__rue_str_byte_at", true, 1),
+        ("__rue_str_eq", true, 1),
+        ("__rue_to_string", true, 1),
+        ("__rue_to_string_unsigned", true, 1),
+        ("bcmp", true, 1),
+        ("memcmp", true, 1),
+        ("memcpy", true, 1),
+        ("memmove", true, 1),
+        ("memset", true, 1),
+    ];
+
+    fn pointer_exports(source: &str) -> Vec<(&str, bool)> {
+        let lines: Vec<_> = source.lines().collect();
+        let mut exports = Vec::new();
+        let mut line_index = 0;
+
+        while line_index < lines.len() {
+            let line = lines[line_index].trim_start();
+            let has_c_abi = line.contains("extern \"C\" fn ");
+            let has_export_attr = lines[line_index.saturating_sub(8)..line_index]
+                .iter()
+                .any(|line| line.contains("no_mangle"));
+            let looks_like_function =
+                line.contains(" fn ") || line.starts_with("fn ") || line.starts_with("unsafe fn ");
+            if line.starts_with("///") || !looks_like_function || (!has_c_abi && !has_export_attr) {
+                line_index += 1;
+                continue;
+            }
+            let declaration_prefix = line
+                .split_once(" fn ")
+                .map(|(prefix, _)| prefix)
+                .unwrap_or(line);
+            let is_unsafe = declaration_prefix
+                .split_whitespace()
+                .any(|word| word == "unsafe");
+
+            let mut signature = String::from(line);
+            while !signature.contains('{') {
+                line_index += 1;
+                signature.push(' ');
+                signature.push_str(lines[line_index].trim());
+            }
+
+            if signature.contains("*const ") || signature.contains("*mut ") {
+                let after_fn = line
+                    .split_once(" fn ")
+                    .map(|(_, rest)| rest)
+                    .or_else(|| line.strip_prefix("fn "))
+                    .or_else(|| line.strip_prefix("unsafe fn "))
+                    .expect("export declaration has fn keyword");
+                let name = after_fn
+                    .split_once('(')
+                    .expect("export declaration has arguments")
+                    .0;
+                exports.push((name, is_unsafe));
+            }
+            line_index += 1;
+        }
+
+        exports
+    }
+
+    #[test]
+    fn raw_pointer_export_safety_is_explicit_and_complete() {
+        let mut actual = Vec::new();
+        for &(_, source) in MODULE_SOURCES {
+            actual.extend(pointer_exports(source));
+        }
+        actual.extend(pointer_exports(include_str!("lib.rs")));
+        actual.sort_unstable();
+
+        let mut counted = Vec::new();
+        for &(name, is_unsafe) in &actual {
+            match counted.last_mut() {
+                Some((last_name, last_unsafe, count))
+                    if *last_name == name && *last_unsafe == is_unsafe =>
+                {
+                    *count += 1;
+                }
+                _ => counted.push((name, is_unsafe, 1)),
+            }
+        }
+
+        assert_eq!(counted, POINTER_EXPORTS);
+    }
+
+    #[test]
+    fn every_declared_runtime_module_is_in_the_export_inventory() {
+        let lib_source = include_str!("lib.rs");
+        let mut declared = Vec::new();
+        for line in lib_source.lines().map(str::trim) {
+            let declaration = line
+                .strip_prefix("pub mod ")
+                .or_else(|| line.strip_prefix("mod "));
+            if let Some(name) = declaration.and_then(|rest| rest.strip_suffix(';')) {
+                declared.push(name);
+            }
+        }
+        declared.sort_unstable();
+
+        let mut inventoried: Vec<_> = MODULE_SOURCES.iter().map(|(name, _)| *name).collect();
+        inventoried.sort_unstable();
+        assert_eq!(inventoried, declared);
+    }
+
+    #[test]
+    fn pointer_taking_safe_exports_have_no_pointer_precondition() {
+        // These exports never inspect their pointer argument. The String query
+        // functions return another ABI field, while free/drop are deliberate
+        // bump-allocator no-ops. Calling any of them with an arbitrary pointer
+        // therefore cannot violate a Rust memory-safety invariant.
+        let arbitrary = core::ptr::dangling_mut::<u8>();
+        assert_eq!(crate::string::__rue_String_len(arbitrary, 7, 11), 7);
+        assert_eq!(crate::string::__rue_String_capacity(arbitrary, 7, 11), 11);
+        assert_eq!(crate::string::__rue_String_is_empty(arbitrary, 7, 11), 0);
+        crate::string::__rue_free(arbitrary, u64::MAX, 3);
+        crate::string::__rue_drop_String(arbitrary, u64::MAX, u64::MAX);
+    }
+
+    #[test]
+    fn null_pointer_is_valid_at_zero_length_boundaries() {
+        let null = core::ptr::null();
+
+        // SAFETY: each boundary explicitly permits null for a zero-length
+        // input, and every out-pointer below names valid exclusive storage.
+        unsafe {
+            crate::debug::__rue_dbg_str(null, 0);
+            crate::io::__rue_print(null, 0, 0);
+            crate::io::__rue_println(null, 0, 0);
+            assert!(crate::memory::memcpy(core::ptr::null_mut(), null, 0).is_null());
+            assert!(crate::memory::memmove(core::ptr::null_mut(), null, 0).is_null());
+            assert!(crate::memory::memset(core::ptr::null_mut(), 0, 0).is_null());
+            assert_eq!(crate::memory::memcmp(null, null, 0), 0);
+            assert_eq!(crate::memory::bcmp(null, null, 0), 0);
+            assert_eq!(crate::string::__rue_str_eq(null, 0, null, 0), 1);
+
+            let mut parsed = crate::parse::OptionIntResult { disc: 0, value: 1 };
+            crate::parse::__rue_parse_i32(&mut parsed, null, 0, 7, 9);
+            assert_eq!(parsed.disc, 9);
+            assert_eq!(parsed.value, 0);
+
+            let mut substring = crate::string::StringResult {
+                ptr: core::ptr::dangling_mut(),
+                len: u64::MAX,
+                cap: u64::MAX,
+            };
+            crate::string::__rue_String_substring(&mut substring, null, 0, 0, 0, 0);
+            assert!(substring.ptr.is_null());
+            assert_eq!((substring.len, substring.cap), (0, 0));
+
+            assert_eq!(
+                crate::string::__rue_String_contains(null, 0, 0, null, 0, 0),
+                1
+            );
+            assert_eq!(
+                crate::string::__rue_String_starts_with(null, 0, 0, null, 0, 0),
+                1
+            );
+
+            let mut concatenated = crate::string::StringResult {
+                ptr: core::ptr::dangling_mut(),
+                len: u64::MAX,
+                cap: u64::MAX,
+            };
+            crate::string::__rue_String_concat(&mut concatenated, null, 0, 0, null, 0, 0);
+            assert!(concatenated.ptr.is_null());
+            assert_eq!((concatenated.len, concatenated.cap), (0, 0));
+        }
+    }
+}

--- a/crates/rue-runtime/src/memory.rs
+++ b/crates/rue-runtime/src/memory.rs
@@ -7,8 +7,9 @@
 ///
 /// # Safety
 ///
-/// - `dst` must be valid for writes of `n` bytes
-/// - `src` must be valid for reads of `n` bytes
+/// - When `n > 0`, `dst` must be non-null and valid for writes of `n` bytes
+/// - When `n > 0`, `src` must be non-null and valid for reads of `n` bytes
+/// - Either pointer may be null when `n == 0`
 /// - The memory regions must not overlap
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn memcpy(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
@@ -30,8 +31,9 @@ pub unsafe extern "C" fn memcpy(dst: *mut u8, src: *const u8, n: usize) -> *mut 
 ///
 /// # Safety
 ///
-/// - `dst` must be valid for writes of `n` bytes
-/// - `src` must be valid for reads of `n` bytes
+/// - When `n > 0`, `dst` must be non-null and valid for writes of `n` bytes
+/// - When `n > 0`, `src` must be non-null and valid for reads of `n` bytes
+/// - Either pointer may be null when `n == 0`
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn memmove(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
     if (dst as usize) < (src as usize) {
@@ -68,7 +70,8 @@ pub unsafe extern "C" fn memmove(dst: *mut u8, src: *const u8, n: usize) -> *mut
 ///
 /// # Safety
 ///
-/// - `dst` must be valid for writes of `n` bytes
+/// - When `n > 0`, `dst` must be non-null and valid for writes of `n` bytes
+/// - `dst` may be null when `n == 0`
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn memset(dst: *mut u8, c: i32, n: usize) -> *mut u8 {
     let byte = c as u8;
@@ -90,8 +93,8 @@ pub unsafe extern "C" fn memset(dst: *mut u8, c: i32, n: usize) -> *mut u8 {
 ///
 /// # Safety
 ///
-/// - `s1` must be valid for reads of `n` bytes
-/// - `s2` must be valid for reads of `n` bytes
+/// - When `n > 0`, both pointers must be non-null and valid for reads of `n` bytes
+/// - Either pointer may be null when `n == 0`
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     let mut i = 0;
@@ -121,8 +124,8 @@ pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
 ///
 /// # Safety
 ///
-/// - `s1` must be valid for reads of `n` bytes
-/// - `s2` must be valid for reads of `n` bytes
+/// - When `n > 0`, both pointers must be non-null and valid for reads of `n` bytes
+/// - Either pointer may be null when `n == 0`
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     let mut i = 0;

--- a/crates/rue-runtime/src/parse.rs
+++ b/crates/rue-runtime/src/parse.rs
@@ -24,14 +24,10 @@ pub struct OptionIntResult {
 
 /// Parse decimal ASCII into an `i64`, returning `None` on empty input, an
 /// invalid character, or overflow. Shared core for the signed parsers.
-fn parse_i64_checked(ptr: *const u8, len: u64) -> Option<i64> {
-    if len == 0 {
+fn parse_i64_checked(bytes: &[u8]) -> Option<i64> {
+    if bytes.is_empty() {
         return None;
     }
-
-    // SAFETY: the caller (an `@parse_*` intrinsic) passes the ptr/len of a
-    // live borrowed String; we only read `len` bytes.
-    let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
     let mut idx = 0;
     let is_negative = bytes[0] == b'-';
 
@@ -82,13 +78,10 @@ fn parse_i64_checked(ptr: *const u8, len: u64) -> Option<i64> {
 /// Parse decimal ASCII into a `u64`, returning `None` on empty input, a leading
 /// minus, an invalid character, or overflow. Shared core for the unsigned
 /// parsers.
-fn parse_u64_checked(ptr: *const u8, len: u64) -> Option<u64> {
-    if len == 0 {
+fn parse_u64_checked(bytes: &[u8]) -> Option<u64> {
+    if bytes.is_empty() {
         return None;
     }
-
-    // SAFETY: see `parse_i64_checked`.
-    let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
 
     // A leading minus is invalid for unsigned types.
     if bytes[0] == b'-' {
@@ -117,8 +110,8 @@ fn parse_u64_checked(ptr: *const u8, len: u64) -> Option<u64> {
 }
 
 /// Parse decimal ASCII into an `i32` (range-checked), `None` on failure.
-fn parse_i32_checked(ptr: *const u8, len: u64) -> Option<i32> {
-    let v = parse_i64_checked(ptr, len)?;
+fn parse_i32_checked(bytes: &[u8]) -> Option<i32> {
+    let v = parse_i64_checked(bytes)?;
     if v < i32::MIN as i64 || v > i32::MAX as i64 {
         return None;
     }
@@ -126,8 +119,8 @@ fn parse_i32_checked(ptr: *const u8, len: u64) -> Option<i32> {
 }
 
 /// Parse decimal ASCII into a `u32` (range-checked), `None` on failure.
-fn parse_u32_checked(ptr: *const u8, len: u64) -> Option<u32> {
-    let v = parse_u64_checked(ptr, len)?;
+fn parse_u32_checked(bytes: &[u8]) -> Option<u32> {
+    let v = parse_u64_checked(bytes)?;
     if v > u32::MAX as u64 {
         return None;
     }
@@ -166,8 +159,21 @@ unsafe fn write_parse_result(
 
 crate::define_for_all_platforms! {
     /// extern "C" fn __rue_parse_i32(out, ptr, len, some_disc, none_disc)
-    pub extern "C" fn __rue_parse_i32(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
-        let parsed = parse_i32_checked(ptr, len).map(|v| v as u64);
+    ///
+    /// # Safety
+    ///
+    /// `out` must be valid, aligned, writable storage for one
+    /// [`OptionIntResult`]. When `len > 0`, `ptr` must be non-null and valid for
+    /// reads of `len` bytes; it may be null when `len == 0`.
+    pub unsafe extern "C" fn __rue_parse_i32(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
+        let bytes = if len == 0 {
+            &[][..]
+        } else {
+            // SAFETY: the caller guarantees a non-null pointer valid for `len`
+            // bytes when the length is positive.
+            unsafe { core::slice::from_raw_parts(ptr, len as usize) }
+        };
+        let parsed = parse_i32_checked(bytes).map(|v| v as u64);
         // SAFETY: `out` is the caller-allocated sret buffer for the result.
         unsafe { write_parse_result(out, parsed, some_disc, none_disc) };
     }
@@ -175,8 +181,20 @@ crate::define_for_all_platforms! {
 
 define_for_all_platforms! {
     /// extern "C" fn __rue_parse_i64(out, ptr, len, some_disc, none_disc)
-    pub extern "C" fn __rue_parse_i64(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
-        let parsed = parse_i64_checked(ptr, len).map(|v| v as u64);
+    ///
+    /// # Safety
+    ///
+    /// `out` must be valid, aligned, writable storage for one
+    /// [`OptionIntResult`]. When `len > 0`, `ptr` must be non-null and valid for
+    /// reads of `len` bytes; it may be null when `len == 0`.
+    pub unsafe extern "C" fn __rue_parse_i64(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
+        let bytes = if len == 0 {
+            &[][..]
+        } else {
+            // SAFETY: see `__rue_parse_i32`.
+            unsafe { core::slice::from_raw_parts(ptr, len as usize) }
+        };
+        let parsed = parse_i64_checked(bytes).map(|v| v as u64);
         // SAFETY: `out` is the caller-allocated sret buffer for the result.
         unsafe { write_parse_result(out, parsed, some_disc, none_disc) };
     }
@@ -184,8 +202,20 @@ define_for_all_platforms! {
 
 define_for_all_platforms! {
     /// extern "C" fn __rue_parse_u32(out, ptr, len, some_disc, none_disc)
-    pub extern "C" fn __rue_parse_u32(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
-        let parsed = parse_u32_checked(ptr, len).map(|v| v as u64);
+    ///
+    /// # Safety
+    ///
+    /// `out` must be valid, aligned, writable storage for one
+    /// [`OptionIntResult`]. When `len > 0`, `ptr` must be non-null and valid for
+    /// reads of `len` bytes; it may be null when `len == 0`.
+    pub unsafe extern "C" fn __rue_parse_u32(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
+        let bytes = if len == 0 {
+            &[][..]
+        } else {
+            // SAFETY: see `__rue_parse_i32`.
+            unsafe { core::slice::from_raw_parts(ptr, len as usize) }
+        };
+        let parsed = parse_u32_checked(bytes).map(|v| v as u64);
         // SAFETY: `out` is the caller-allocated sret buffer for the result.
         unsafe { write_parse_result(out, parsed, some_disc, none_disc) };
     }
@@ -193,8 +223,20 @@ define_for_all_platforms! {
 
 define_for_all_platforms! {
     /// extern "C" fn __rue_parse_u64(out, ptr, len, some_disc, none_disc)
-    pub extern "C" fn __rue_parse_u64(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
-        let parsed = parse_u64_checked(ptr, len);
+    ///
+    /// # Safety
+    ///
+    /// `out` must be valid, aligned, writable storage for one
+    /// [`OptionIntResult`]. When `len > 0`, `ptr` must be non-null and valid for
+    /// reads of `len` bytes; it may be null when `len == 0`.
+    pub unsafe extern "C" fn __rue_parse_u64(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
+        let bytes = if len == 0 {
+            &[][..]
+        } else {
+            // SAFETY: see `__rue_parse_i32`.
+            unsafe { core::slice::from_raw_parts(ptr, len as usize) }
+        };
+        let parsed = parse_u64_checked(bytes);
         // SAFETY: `out` is the caller-allocated sret buffer for the result.
         unsafe { write_parse_result(out, parsed, some_disc, none_disc) };
     }
@@ -209,46 +251,37 @@ mod tests {
 
     #[test]
     fn test_parse_i32_basic() {
-        assert_eq!(parse_i32_checked(b"42".as_ptr(), 2), Some(42));
-        assert_eq!(parse_i32_checked(b"0".as_ptr(), 1), Some(0));
-        assert_eq!(
-            parse_i32_checked(b"2147483647".as_ptr(), 10),
-            Some(2147483647)
-        );
+        assert_eq!(parse_i32_checked(b"42"), Some(42));
+        assert_eq!(parse_i32_checked(b"0"), Some(0));
+        assert_eq!(parse_i32_checked(b"2147483647"), Some(2147483647));
     }
 
     #[test]
     fn test_parse_i32_negative() {
-        assert_eq!(parse_i32_checked(b"-17".as_ptr(), 3), Some(-17));
-        assert_eq!(
-            parse_i32_checked(b"-2147483648".as_ptr(), 11),
-            Some(-2147483648)
-        );
+        assert_eq!(parse_i32_checked(b"-17"), Some(-17));
+        assert_eq!(parse_i32_checked(b"-2147483648"), Some(-2147483648));
     }
 
     #[test]
     fn test_parse_i64_basic() {
-        assert_eq!(parse_i64_checked(b"42".as_ptr(), 2), Some(42));
+        assert_eq!(parse_i64_checked(b"42"), Some(42));
         assert_eq!(
-            parse_i64_checked(b"9223372036854775807".as_ptr(), 19),
+            parse_i64_checked(b"9223372036854775807"),
             Some(9223372036854775807)
         );
     }
 
     #[test]
     fn test_parse_u32_basic() {
-        assert_eq!(parse_u32_checked(b"42".as_ptr(), 2), Some(42));
-        assert_eq!(
-            parse_u32_checked(b"4294967295".as_ptr(), 10),
-            Some(4294967295)
-        );
+        assert_eq!(parse_u32_checked(b"42"), Some(42));
+        assert_eq!(parse_u32_checked(b"4294967295"), Some(4294967295));
     }
 
     #[test]
     fn test_parse_u64_basic() {
-        assert_eq!(parse_u64_checked(b"42".as_ptr(), 2), Some(42));
+        assert_eq!(parse_u64_checked(b"42"), Some(42));
         assert_eq!(
-            parse_u64_checked(b"18446744073709551615".as_ptr(), 20),
+            parse_u64_checked(b"18446744073709551615"),
             Some(18446744073709551615)
         );
     }
@@ -256,20 +289,33 @@ mod tests {
     #[test]
     fn test_parse_failure_returns_none() {
         // Empty, invalid character, and lone-minus all fail to `None`.
-        assert_eq!(parse_i64_checked(b"".as_ptr(), 0), None);
-        assert_eq!(parse_i64_checked(b"12abc".as_ptr(), 5), None);
-        assert_eq!(parse_i64_checked(b"-".as_ptr(), 1), None);
+        assert_eq!(parse_i64_checked(b""), None);
+        assert_eq!(parse_i64_checked(b"12abc"), None);
+        assert_eq!(parse_i64_checked(b"-"), None);
         // Overflow past i64 range.
-        assert_eq!(parse_i64_checked(b"9223372036854775808".as_ptr(), 19), None);
+        assert_eq!(parse_i64_checked(b"9223372036854775808"), None);
         // i32 range check.
-        assert_eq!(parse_i32_checked(b"2147483648".as_ptr(), 10), None);
+        assert_eq!(parse_i32_checked(b"2147483648"), None);
     }
 
     #[test]
     fn test_parse_unsigned_rejects_negative() {
-        assert_eq!(parse_u32_checked(b"-17".as_ptr(), 3), None);
-        assert_eq!(parse_u64_checked(b"-1".as_ptr(), 2), None);
+        assert_eq!(parse_u32_checked(b"-17"), None);
+        assert_eq!(parse_u64_checked(b"-1"), None);
         // u32 range check.
-        assert_eq!(parse_u32_checked(b"4294967296".as_ptr(), 10), None);
+        assert_eq!(parse_u32_checked(b"4294967296"), None);
+    }
+
+    #[test]
+    fn extern_parse_boundary_writes_sret_layout() {
+        let input = b"-42";
+        let mut out = OptionIntResult { disc: 0, value: 0 };
+
+        // SAFETY: `out` is valid, aligned, exclusive result storage and
+        // `input` remains live for all three reported bytes.
+        unsafe { __rue_parse_i64(&mut out, input.as_ptr(), input.len() as u64, 7, 9) };
+
+        assert_eq!(out.disc, 7);
+        assert_eq!(out.value, (-42_i64) as u64);
     }
 }

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -66,10 +66,12 @@ crate::define_for_all_platforms! {
     /// # Safety
     ///
     /// The caller must ensure that:
-    /// - `ptr1` points to a valid buffer of at least `len1` bytes
-    /// - `ptr2` points to a valid buffer of at least `len2` bytes
+    /// - When `len1 > 0`, `ptr1` is non-null and points to a valid buffer of at
+    ///   least `len1` bytes; it may be null when `len1 == 0`
+    /// - When `len2 > 0`, `ptr2` is non-null and points to a valid buffer of at
+    ///   least `len2` bytes; it may be null when `len2 == 0`
     /// - Both pointers remain valid for the duration of the call
-    pub extern "C" fn __rue_str_eq(ptr1: *const u8, len1: u64, ptr2: *const u8, len2: u64) -> u64 {
+    pub unsafe extern "C" fn __rue_str_eq(ptr1: *const u8, len1: u64, ptr2: *const u8, len2: u64) -> u64 {
         // Fast path 1: different lengths means not equal
         if len1 != len2 {
             return 0;
@@ -186,7 +188,13 @@ crate::define_for_all_platforms! {
     /// ```text
     /// extern "C" fn __rue_realloc(ptr: *mut u8, old_size: u64, new_size: u64, align: u64) -> *mut u8
     /// ```
-    pub extern "C" fn __rue_realloc(ptr: *mut u8, old_size: u64, new_size: u64, align: u64) -> *mut u8 {
+    ///
+    /// # Safety
+    ///
+    /// If `ptr` is non-null and `new_size > old_size`, it must be valid for
+    /// reads of `old_size` bytes. It must be either null or a pointer returned
+    /// by this runtime allocator with the supplied allocation layout.
+    pub unsafe extern "C" fn __rue_realloc(ptr: *mut u8, old_size: u64, new_size: u64, align: u64) -> *mut u8 {
         heap::realloc(ptr, old_size, new_size, align)
     }
 }
@@ -236,10 +244,15 @@ crate::define_for_all_platforms! {
 ///
 /// Caller allocates space for the return value and passes pointer.
 /// Callee writes (ptr=0, len=0, cap=0) to that pointer.
+///
+/// # Safety
+///
+/// `out` must be valid, aligned, writable storage for one [`StringResult`]
+/// and must remain exclusively accessible for the call.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_new(out: *mut StringResult) {
+pub unsafe extern "C" fn __rue_String_new(out: *mut StringResult) {
     // SAFETY: Writing to `out` is safe because:
     // - Caller (Rue-generated code) allocates stack space and passes a valid pointer
     // - The sret convention guarantees `out` points to properly sized/aligned memory
@@ -254,7 +267,10 @@ pub extern "C" fn __rue_String_new(out: *mut StringResult) {
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_new(out: *mut StringResult) {
+/// # Safety
+///
+/// `out` must be valid, aligned, exclusively writable [`StringResult`] storage.
+pub unsafe extern "C" fn __rue_String_new(out: *mut StringResult) {
     unsafe {
         (*out).ptr = core::ptr::null_mut();
         (*out).len = 0;
@@ -265,7 +281,10 @@ pub extern "C" fn __rue_String_new(out: *mut StringResult) {
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_new(out: *mut StringResult) {
+/// # Safety
+///
+/// `out` must be valid, aligned, exclusively writable [`StringResult`] storage.
+pub unsafe extern "C" fn __rue_String_new(out: *mut StringResult) {
     unsafe {
         (*out).ptr = core::ptr::null_mut();
         (*out).len = 0;
@@ -283,10 +302,15 @@ pub extern "C" fn __rue_String_new(out: *mut StringResult) {
 /// ```text
 /// extern "C" fn __rue_String_with_capacity(out: *mut StringResult, cap: u64)
 /// ```
+///
+/// # Safety
+///
+/// `out` must be valid, aligned, writable storage for one [`StringResult`]
+/// and must remain exclusively accessible for the call.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_cap: u64) {
+pub unsafe extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_cap: u64) {
     let actual_cap = if requested_cap < STRING_MIN_CAPACITY {
         STRING_MIN_CAPACITY
     } else {
@@ -313,7 +337,10 @@ pub extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_c
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_cap: u64) {
+/// # Safety
+///
+/// `out` must be valid, aligned, exclusively writable [`StringResult`] storage.
+pub unsafe extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_cap: u64) {
     let actual_cap = if requested_cap < STRING_MIN_CAPACITY {
         STRING_MIN_CAPACITY
     } else {
@@ -340,7 +367,10 @@ pub extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_c
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_cap: u64) {
+/// # Safety
+///
+/// `out` must be valid, aligned, exclusively writable [`StringResult`] storage.
+pub unsafe extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_cap: u64) {
     let actual_cap = if requested_cap < STRING_MIN_CAPACITY {
         STRING_MIN_CAPACITY
     } else {
@@ -508,11 +538,11 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// The caller must ensure `ptr` points to a valid buffer of at least `len`
-    /// bytes. The in-range read below is then sound because the bounds check
-    /// guarantees `index < len`.
+    /// When `len > 0`, `ptr` must be non-null and point to a valid buffer of at
+    /// least `len` bytes; it may be null when `len == 0`. The in-range read
+    /// below is then sound because the bounds check guarantees `index < len`.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_String_byte_at(ptr: *const u8, len: u64, _cap: u64, index: u64) -> u64 {
+    pub unsafe extern "C" fn __rue_String_byte_at(ptr: *const u8, len: u64, _cap: u64, index: u64) -> u64 {
         if index >= len {
             // Never returns: prints "error: index out of bounds" and exits 101.
             crate::error::__rue_bounds_check();
@@ -548,11 +578,11 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// The caller must ensure `ptr` points to a valid buffer of at least `len`
-    /// bytes. The in-range read below is then sound because the bounds check
-    /// guarantees `index < len`.
+    /// When `len > 0`, `ptr` must be non-null and point to a valid buffer of at
+    /// least `len` bytes; it may be null when `len == 0`. The in-range read
+    /// below is then sound because the bounds check guarantees `index < len`.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_str_byte_at(ptr: *const u8, len: u64, index: u64) -> u64 {
+    pub unsafe extern "C" fn __rue_str_byte_at(ptr: *const u8, len: u64, index: u64) -> u64 {
         if index >= len {
             // Never returns: prints "error: index out of bounds" and exits 101.
             crate::error::__rue_bounds_check();
@@ -578,7 +608,8 @@ crate::define_for_all_platforms! {
 ///
 /// # Safety
 ///
-/// `ptr` must point to a valid buffer of at least `len` bytes.
+/// When `len > 0`, `ptr` must be non-null and valid for `len` bytes; it may be
+/// null when `len == 0`.
 unsafe fn __rue_decode_utf8_at(ptr: *const u8, len: u64, offset: u64) -> (u32, u64) {
     let len = len as usize;
     let i = offset as usize;
@@ -649,9 +680,10 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// `ptr` must point to a valid buffer of at least `len` bytes.
+    /// When `len > 0`, `ptr` must be non-null and valid for `len` bytes; it may
+    /// be null when `len == 0`.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_String_char_scalar(
+    pub unsafe extern "C" fn __rue_String_char_scalar(
         ptr: *const u8,
         len: u64,
         _cap: u64,
@@ -677,9 +709,10 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// `ptr` must point to a valid buffer of at least `len` bytes.
+    /// When `len > 0`, `ptr` must be non-null and valid for `len` bytes; it may
+    /// be null when `len == 0`.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_String_char_next(
+    pub unsafe extern "C" fn __rue_String_char_next(
         ptr: *const u8,
         len: u64,
         _cap: u64,
@@ -707,7 +740,8 @@ crate::define_for_all_platforms! {
 ///
 /// # Safety
 ///
-/// `ptr` must point to a valid buffer of at least `len` bytes.
+/// When `len > 0`, `ptr` must be non-null and valid for `len` bytes; it may be
+/// null when `len == 0`.
 unsafe fn __rue_decode_utf8_lossy_at(ptr: *const u8, len: u64, offset: u64) -> (u32, u64) {
     const FFFD: u32 = 0xFFFD;
     let len = len as usize;
@@ -790,9 +824,10 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// `ptr` must point to a valid buffer of at least `len` bytes.
+    /// When `len > 0`, `ptr` must be non-null and valid for `len` bytes; it may
+    /// be null when `len == 0`.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_String_char_scalar_lossy(
+    pub unsafe extern "C" fn __rue_String_char_scalar_lossy(
         ptr: *const u8,
         len: u64,
         _cap: u64,
@@ -821,9 +856,10 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// `ptr` must point to a valid buffer of at least `len` bytes.
+    /// When `len > 0`, `ptr` must be non-null and valid for `len` bytes; it may
+    /// be null when `len == 0`.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_String_char_next_lossy(
+    pub unsafe extern "C" fn __rue_String_char_next_lossy(
         ptr: *const u8,
         len: u64,
         _cap: u64,
@@ -855,8 +891,15 @@ crate::define_for_all_platforms! {
     ///
     /// `out` (the sret pointer) comes first, then the source String's fields
     /// (`cap` unused), then the range arguments.
+    ///
+    /// # Safety
+    ///
+    /// `out` must be valid, aligned, exclusively writable storage for one
+    /// [`StringResult`]. When `len > 0`, `ptr` must be non-null and valid for
+    /// reads of `len` bytes; it may be null when `len == 0`. It must not overlap
+    /// `out`.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_String_substring(
+    pub unsafe extern "C" fn __rue_String_substring(
         out: *mut StringResult,
         ptr: *const u8,
         len: u64,
@@ -933,10 +976,11 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// `ptr` must be valid for `len` bytes and `needle_ptr` for `needle_len`
-    /// bytes; every read below is bounded by those lengths.
+    /// Each pointer must be non-null and valid for its associated length when
+    /// that length is positive; either pointer may be null when its length is
+    /// zero. Every read below is bounded by those lengths.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_String_contains(
+    pub unsafe extern "C" fn __rue_String_contains(
         ptr: *const u8,
         len: u64,
         _cap: u64,
@@ -983,10 +1027,11 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// `ptr` must be valid for `len` bytes and `prefix_ptr` for `prefix_len`
-    /// bytes; every read below is bounded by those lengths.
+    /// Each pointer must be non-null and valid for its associated length when
+    /// that length is positive; either pointer may be null when its length is
+    /// zero. Every read below is bounded by those lengths.
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_String_starts_with(
+    pub unsafe extern "C" fn __rue_String_starts_with(
         ptr: *const u8,
         len: u64,
         _cap: u64,
@@ -1041,7 +1086,7 @@ crate::define_for_all_platforms! {
     /// # Safety
     ///
     /// `out` must be a valid sret pointer — see `__rue_String_new`.
-    pub extern "C" fn __rue_to_string(out: *mut StringResult, n: i64) {
+    pub unsafe extern "C" fn __rue_to_string(out: *mut StringResult, n: i64) {
         // "-9223372036854775808" (i64::MIN) is the longest result: 20 bytes.
         let mut buf = [0u8; 20];
         let negative = n < 0;
@@ -1125,7 +1170,7 @@ crate::define_for_all_platforms! {
     /// # Safety
     ///
     /// `out` must be a valid sret pointer — see `__rue_String_new`.
-    pub extern "C" fn __rue_to_string_unsigned(out: *mut StringResult, n: u64) {
+    pub unsafe extern "C" fn __rue_to_string_unsigned(out: *mut StringResult, n: u64) {
         // "18446744073709551615" (u64::MAX) is the longest result: 20 bytes.
         let mut buf = [0u8; 20];
         let mut mag = n;
@@ -1194,10 +1239,11 @@ crate::define_for_all_platforms! {
     ///
     /// # Safety
     ///
-    /// `ptr1`/`ptr2` must be valid for `len1`/`len2` bytes respectively, and
+    /// Each input pointer must be non-null and valid for its associated length
+    /// when that length is positive; it may be null when its length is zero.
     /// `out` must be a valid sret pointer (see `__rue_String_new`).
     #[allow(non_snake_case)]
-    pub extern "C" fn __rue_String_concat(
+    pub unsafe extern "C" fn __rue_String_concat(
         out: *mut StringResult,
         ptr1: *const u8,
         len1: u64,
@@ -1279,10 +1325,21 @@ crate::define_for_all_platforms! {
 ///
 /// Always allocates a new heap buffer, even for literals (cap == 0).
 /// The clone is always heap-allocated so it can be mutated.
+///
+/// # Safety
+///
+/// `out` must be valid, aligned, exclusively writable storage for one
+/// [`StringResult`]. When `len > 0`, `ptr` must be non-null and valid for reads
+/// of `len` bytes; it may be null when `len == 0`. It must not overlap `out`.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_clone(out: *mut StringResult, ptr: *const u8, len: u64, _cap: u64) {
+pub unsafe extern "C" fn __rue_String_clone(
+    out: *mut StringResult,
+    ptr: *const u8,
+    len: u64,
+    _cap: u64,
+) {
     let new_cap = len.max(STRING_MIN_CAPACITY);
     let new_ptr = heap::alloc(new_cap, 1);
 
@@ -1318,7 +1375,17 @@ pub extern "C" fn __rue_String_clone(out: *mut StringResult, ptr: *const u8, len
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_clone(out: *mut StringResult, ptr: *const u8, len: u64, _cap: u64) {
+/// # Safety
+///
+/// `out` must be valid result storage. When `len > 0`, `ptr` must be non-null
+/// and readable for `len` bytes; it may be null when `len == 0`. Their storage
+/// must not overlap.
+pub unsafe extern "C" fn __rue_String_clone(
+    out: *mut StringResult,
+    ptr: *const u8,
+    len: u64,
+    _cap: u64,
+) {
     let new_cap = len.max(STRING_MIN_CAPACITY);
     let new_ptr = heap::alloc(new_cap, 1);
 
@@ -1354,7 +1421,17 @@ pub extern "C" fn __rue_String_clone(out: *mut StringResult, ptr: *const u8, len
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_clone(out: *mut StringResult, ptr: *const u8, len: u64, _cap: u64) {
+/// # Safety
+///
+/// `out` must be valid result storage. When `len > 0`, `ptr` must be non-null
+/// and readable for `len` bytes; it may be null when `len == 0`. Their storage
+/// must not overlap.
+pub unsafe extern "C" fn __rue_String_clone(
+    out: *mut StringResult,
+    ptr: *const u8,
+    len: u64,
+    _cap: u64,
+) {
     let new_cap = len.max(STRING_MIN_CAPACITY);
     let new_ptr = heap::alloc(new_cap, 1);
 
@@ -1411,10 +1488,17 @@ pub extern "C" fn __rue_String_clone(out: *mut StringResult, ptr: *const u8, len
 /// * `other_ptr` - Pointer to the other string's data
 /// * `other_len` - Length of the other string
 /// * `_other_cap` - Capacity of the other string (unused, but part of ABI)
+///
+/// # Safety
+///
+/// `out` must be valid, aligned, exclusively writable storage for one
+/// [`StringResult`]. The receiver fields must describe a live String allocation
+/// (or a `cap == 0` literal), and `other_ptr` must be readable for `other_len`
+/// bytes. The source ranges and `out` must not overlap writes performed here.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_push_str(
+pub unsafe extern "C" fn __rue_String_push_str(
     out: *mut StringResult,
     ptr: *mut u8,
     len: u64,
@@ -1466,7 +1550,12 @@ pub extern "C" fn __rue_String_push_str(
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_push_str(
+/// # Safety
+///
+/// `out` must be valid result storage; both String field triples must describe
+/// live storage for their lengths/capacities and must not overlap writes. A
+/// pointer may be null only for the canonical empty `(null, 0, 0)` String.
+pub unsafe extern "C" fn __rue_String_push_str(
     out: *mut StringResult,
     ptr: *mut u8,
     len: u64,
@@ -1518,7 +1607,12 @@ pub extern "C" fn __rue_String_push_str(
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_push_str(
+/// # Safety
+///
+/// `out` must be valid result storage; both String field triples must describe
+/// live storage for their lengths/capacities and must not overlap writes. A
+/// pointer may be null only for the canonical empty `(null, 0, 0)` String.
+pub unsafe extern "C" fn __rue_String_push_str(
     out: *mut StringResult,
     ptr: *mut u8,
     len: u64,
@@ -1576,10 +1670,16 @@ pub extern "C" fn __rue_String_push_str(
 /// * `len` - Current length in bytes
 /// * `cap` - Current capacity (0 for literals)
 /// * `byte` - The byte to append
+///
+/// # Safety
+///
+/// `out` must be valid, aligned, exclusively writable storage for one
+/// [`StringResult`]. The receiver fields must describe a live String allocation
+/// (or a `cap == 0` literal), and `out` must not overlap that allocation.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_push(
+pub unsafe extern "C" fn __rue_String_push(
     out: *mut StringResult,
     ptr: *mut u8,
     len: u64,
@@ -1620,7 +1720,12 @@ pub extern "C" fn __rue_String_push(
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_push(
+/// # Safety
+///
+/// `out` must be valid result storage; `ptr`/`len`/`cap` must describe a live
+/// String and must not overlap `out`. `ptr` may be null only for the canonical
+/// empty `(null, 0, 0)` String.
+pub unsafe extern "C" fn __rue_String_push(
     out: *mut StringResult,
     ptr: *mut u8,
     len: u64,
@@ -1661,7 +1766,12 @@ pub extern "C" fn __rue_String_push(
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_push(
+/// # Safety
+///
+/// `out` must be valid result storage; `ptr`/`len`/`cap` must describe a live
+/// String and must not overlap `out`. `ptr` may be null only for the canonical
+/// empty `(null, 0, 0)` String.
+pub unsafe extern "C" fn __rue_String_push(
     out: *mut StringResult,
     ptr: *mut u8,
     len: u64,
@@ -1707,10 +1817,21 @@ pub extern "C" fn __rue_String_push(
 /// * `ptr` - Pointer to the string data
 /// * `_len` - Current length in bytes (unused)
 /// * `cap` - Current capacity
+///
+/// # Safety
+///
+/// `out` must be valid, aligned, exclusively writable storage for one
+/// [`StringResult`] and must not overlap the live String described by
+/// `ptr`/`cap`.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_clear(out: *mut StringResult, ptr: *mut u8, _len: u64, cap: u64) {
+pub unsafe extern "C" fn __rue_String_clear(
+    out: *mut StringResult,
+    ptr: *mut u8,
+    _len: u64,
+    cap: u64,
+) {
     // SAFETY: Writing to `out` is safe - see __rue_String_new for rationale
     unsafe {
         (*out).ptr = ptr;
@@ -1722,7 +1843,17 @@ pub extern "C" fn __rue_String_clear(out: *mut StringResult, ptr: *mut u8, _len:
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_clear(out: *mut StringResult, ptr: *mut u8, _len: u64, cap: u64) {
+/// # Safety
+///
+/// `out` must be valid result storage and must not overlap the live String
+/// described by `ptr`/`cap`. `ptr` may be null for the canonical empty
+/// `(null, 0, 0)` String.
+pub unsafe extern "C" fn __rue_String_clear(
+    out: *mut StringResult,
+    ptr: *mut u8,
+    _len: u64,
+    cap: u64,
+) {
     // SAFETY: Writing to `out` is safe - see __rue_String_new for rationale
     unsafe {
         (*out).ptr = ptr;
@@ -1734,7 +1865,17 @@ pub extern "C" fn __rue_String_clear(out: *mut StringResult, ptr: *mut u8, _len:
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_clear(out: *mut StringResult, ptr: *mut u8, _len: u64, cap: u64) {
+/// # Safety
+///
+/// `out` must be valid result storage and must not overlap the live String
+/// described by `ptr`/`cap`. `ptr` may be null for the canonical empty
+/// `(null, 0, 0)` String.
+pub unsafe extern "C" fn __rue_String_clear(
+    out: *mut StringResult,
+    ptr: *mut u8,
+    _len: u64,
+    cap: u64,
+) {
     // SAFETY: Writing to `out` is safe - see __rue_String_new for rationale
     unsafe {
         (*out).ptr = ptr;
@@ -1752,10 +1893,16 @@ pub extern "C" fn __rue_String_clear(out: *mut StringResult, ptr: *mut u8, _len:
 /// * `len` - Current length in bytes
 /// * `cap` - Current capacity (0 for literals)
 /// * `additional` - Number of additional bytes to reserve
+///
+/// # Safety
+///
+/// `out` must be valid, aligned, exclusively writable storage for one
+/// [`StringResult`]. The receiver fields must describe a live String allocation
+/// (or a `cap == 0` literal), and `out` must not overlap that allocation.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_reserve(
+pub unsafe extern "C" fn __rue_String_reserve(
     out: *mut StringResult,
     ptr: *mut u8,
     len: u64,
@@ -1775,7 +1922,12 @@ pub extern "C" fn __rue_String_reserve(
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_reserve(
+/// # Safety
+///
+/// `out` must be valid result storage; `ptr`/`len`/`cap` must describe a live
+/// String and must not overlap `out`. `ptr` may be null only for the canonical
+/// empty `(null, 0, 0)` String.
+pub unsafe extern "C" fn __rue_String_reserve(
     out: *mut StringResult,
     ptr: *mut u8,
     len: u64,
@@ -1795,7 +1947,12 @@ pub extern "C" fn __rue_String_reserve(
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_String_reserve(
+/// # Safety
+///
+/// `out` must be valid result storage; `ptr`/`len`/`cap` must describe a live
+/// String and must not overlap `out`. `ptr` may be null only for the canonical
+/// empty `(null, 0, 0)` String.
+pub unsafe extern "C" fn __rue_String_reserve(
     out: *mut StringResult,
     ptr: *mut u8,
     len: u64,
@@ -1905,31 +2062,36 @@ mod tests {
 
     #[test]
     fn test_str_eq_compares_content_and_length() {
-        let a = b"same";
-        let b = b"same";
-        let c = b"same!";
-        let d = b"diff";
+        // SAFETY: every pointer/length pair below comes from the live byte
+        // arrays declared in this scope.
+        unsafe {
+            let a = b"same";
+            let b = b"same";
+            let c = b"same!";
+            let d = b"diff";
 
-        assert_eq!(
-            __rue_str_eq(a.as_ptr(), a.len() as u64, b.as_ptr(), b.len() as u64),
-            1
-        );
-        assert_eq!(
-            __rue_str_eq(a.as_ptr(), a.len() as u64, c.as_ptr(), c.len() as u64),
-            0
-        );
-        assert_eq!(
-            __rue_str_eq(a.as_ptr(), a.len() as u64, d.as_ptr(), d.len() as u64),
-            0
-        );
-        assert_eq!(__rue_str_eq(a.as_ptr(), 0, d.as_ptr(), 0), 1);
+            assert_eq!(
+                __rue_str_eq(a.as_ptr(), a.len() as u64, b.as_ptr(), b.len() as u64),
+                1
+            );
+            assert_eq!(
+                __rue_str_eq(a.as_ptr(), a.len() as u64, c.as_ptr(), c.len() as u64),
+                0
+            );
+            assert_eq!(
+                __rue_str_eq(a.as_ptr(), a.len() as u64, d.as_ptr(), d.len() as u64),
+                0
+            );
+            assert_eq!(__rue_str_eq(a.as_ptr(), 0, d.as_ptr(), 0), 1);
+        }
     }
 
     #[test]
     fn test_string_new_and_query_methods() {
         let mut out = blank_result();
 
-        __rue_String_new(&mut out);
+        // SAFETY: `out` is valid, aligned, exclusively borrowed result storage.
+        unsafe { __rue_String_new(&mut out) };
 
         assert!(out.ptr.is_null());
         assert_eq!(out.len, 0);
@@ -1954,7 +2116,8 @@ mod tests {
     fn test_string_with_capacity_allocates_at_least_minimum() {
         let mut out = blank_result();
 
-        __rue_String_with_capacity(&mut out, 3);
+        // SAFETY: `out` is valid, aligned, exclusively borrowed result storage.
+        unsafe { __rue_String_with_capacity(&mut out, 3) };
 
         assert!(!out.ptr.is_null());
         assert_eq!(out.len, 0);
@@ -2007,48 +2170,54 @@ mod tests {
     fn test_byte_access_returns_zero_extended_bytes() {
         let bytes = [0x00, 0x7f, 0x80, 0xff];
 
-        assert_eq!(
-            __rue_String_byte_at(bytes.as_ptr(), bytes.len() as u64, 0, 0),
-            0
-        );
-        assert_eq!(
-            __rue_String_byte_at(bytes.as_ptr(), bytes.len() as u64, 0, 2),
-            0x80
-        );
-        assert_eq!(
-            __rue_str_byte_at(bytes.as_ptr(), bytes.len() as u64, 3),
-            0xff
-        );
+        // SAFETY: all accesses are within the live `bytes` array.
+        unsafe {
+            assert_eq!(
+                __rue_String_byte_at(bytes.as_ptr(), bytes.len() as u64, 0, 0),
+                0
+            );
+            assert_eq!(
+                __rue_String_byte_at(bytes.as_ptr(), bytes.len() as u64, 0, 2),
+                0x80
+            );
+            assert_eq!(
+                __rue_str_byte_at(bytes.as_ptr(), bytes.len() as u64, 3),
+                0xff
+            );
+        }
     }
 
     #[test]
     fn test_utf8_char_scalar_and_next_decode_multibyte_scalars() {
         let bytes = "aé🙂".as_bytes();
 
-        assert_eq!(
-            __rue_String_char_scalar(bytes.as_ptr(), bytes.len() as u64, 0, 0),
-            'a' as u64
-        );
-        assert_eq!(
-            __rue_String_char_next(bytes.as_ptr(), bytes.len() as u64, 0, 0),
-            1
-        );
-        assert_eq!(
-            __rue_String_char_scalar(bytes.as_ptr(), bytes.len() as u64, 0, 1),
-            'é' as u64
-        );
-        assert_eq!(
-            __rue_String_char_next(bytes.as_ptr(), bytes.len() as u64, 0, 1),
-            3
-        );
-        assert_eq!(
-            __rue_String_char_scalar(bytes.as_ptr(), bytes.len() as u64, 0, 3),
-            '🙂' as u64
-        );
-        assert_eq!(
-            __rue_String_char_next(bytes.as_ptr(), bytes.len() as u64, 0, 3),
-            bytes.len() as u64
-        );
+        // SAFETY: all offsets are scalar boundaries within the live UTF-8 buffer.
+        unsafe {
+            assert_eq!(
+                __rue_String_char_scalar(bytes.as_ptr(), bytes.len() as u64, 0, 0),
+                'a' as u64
+            );
+            assert_eq!(
+                __rue_String_char_next(bytes.as_ptr(), bytes.len() as u64, 0, 0),
+                1
+            );
+            assert_eq!(
+                __rue_String_char_scalar(bytes.as_ptr(), bytes.len() as u64, 0, 1),
+                'é' as u64
+            );
+            assert_eq!(
+                __rue_String_char_next(bytes.as_ptr(), bytes.len() as u64, 0, 1),
+                3
+            );
+            assert_eq!(
+                __rue_String_char_scalar(bytes.as_ptr(), bytes.len() as u64, 0, 3),
+                '🙂' as u64
+            );
+            assert_eq!(
+                __rue_String_char_next(bytes.as_ptr(), bytes.len() as u64, 0, 3),
+                bytes.len() as u64
+            );
+        }
     }
 
     #[test]
@@ -2056,30 +2225,34 @@ mod tests {
         const FFFD: u64 = 0xfffd;
         let bytes = [b'a', 0xf0, 0x9f, b'!', 0xff, b'z'];
 
-        assert_eq!(
-            __rue_String_char_scalar_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 0),
-            b'a' as u64
-        );
-        assert_eq!(
-            __rue_String_char_next_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 0),
-            1
-        );
-        assert_eq!(
-            __rue_String_char_scalar_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 1),
-            FFFD
-        );
-        assert_eq!(
-            __rue_String_char_next_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 1),
-            3
-        );
-        assert_eq!(
-            __rue_String_char_scalar_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 4),
-            FFFD
-        );
-        assert_eq!(
-            __rue_String_char_next_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 4),
-            5
-        );
+        // SAFETY: all offsets are within the live `bytes` array; the lossy
+        // functions do not require valid UTF-8.
+        unsafe {
+            assert_eq!(
+                __rue_String_char_scalar_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 0),
+                b'a' as u64
+            );
+            assert_eq!(
+                __rue_String_char_next_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 0),
+                1
+            );
+            assert_eq!(
+                __rue_String_char_scalar_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 1),
+                FFFD
+            );
+            assert_eq!(
+                __rue_String_char_next_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 1),
+                3
+            );
+            assert_eq!(
+                __rue_String_char_scalar_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 4),
+                FFFD
+            );
+            assert_eq!(
+                __rue_String_char_next_lossy(bytes.as_ptr(), bytes.len() as u64, 0, 4),
+                5
+            );
+        }
     }
 
     #[test]
@@ -2087,7 +2260,9 @@ mod tests {
         let bytes = b"abcdef";
         let mut out = blank_result();
 
-        __rue_String_substring(&mut out, bytes.as_ptr(), bytes.len() as u64, 0, 2, 3);
+        // SAFETY: `out` is valid result storage and `bytes` is live for its
+        // reported length; the requested range is in bounds.
+        unsafe { __rue_String_substring(&mut out, bytes.as_ptr(), bytes.len() as u64, 0, 2, 3) };
 
         assert_string_result(&out, b"cde");
         assert_ne!(out.ptr as *const u8, bytes.as_ptr());
@@ -2098,7 +2273,9 @@ mod tests {
         let bytes = b"abcdef";
         let mut out = blank_result();
 
-        __rue_String_substring(&mut out, bytes.as_ptr(), bytes.len() as u64, 0, 3, 0);
+        // SAFETY: `out` is valid result storage and the empty range is within
+        // the live `bytes` buffer.
+        unsafe { __rue_String_substring(&mut out, bytes.as_ptr(), bytes.len() as u64, 0, 3, 0) };
 
         assert!(out.ptr.is_null());
         assert_eq!(out.len, 0);
@@ -2109,85 +2286,89 @@ mod tests {
     fn test_contains_and_starts_with_are_byte_based() {
         let haystack = b"bananas";
 
-        assert_eq!(
-            __rue_String_contains(
-                haystack.as_ptr(),
-                haystack.len() as u64,
-                0,
-                b"nan".as_ptr(),
-                3,
-                0,
-            ),
-            1
-        );
-        assert_eq!(
-            __rue_String_contains(
-                haystack.as_ptr(),
-                haystack.len() as u64,
-                0,
-                b"nab".as_ptr(),
-                3,
-                0,
-            ),
-            0
-        );
-        assert_eq!(
-            __rue_String_starts_with(
-                haystack.as_ptr(),
-                haystack.len() as u64,
-                0,
-                b"ban".as_ptr(),
-                3,
-                0,
-            ),
-            1
-        );
-        assert_eq!(
-            __rue_String_starts_with(
-                haystack.as_ptr(),
-                haystack.len() as u64,
-                0,
-                b"nan".as_ptr(),
-                3,
-                0,
-            ),
-            0
-        );
-        assert_eq!(
-            __rue_String_contains(
-                haystack.as_ptr(),
-                haystack.len() as u64,
-                0,
-                b"".as_ptr(),
-                0,
+        // SAFETY: every pointer/length pair below names a live byte array.
+        unsafe {
+            assert_eq!(
+                __rue_String_contains(
+                    haystack.as_ptr(),
+                    haystack.len() as u64,
+                    0,
+                    b"nan".as_ptr(),
+                    3,
+                    0,
+                ),
+                1
+            );
+            assert_eq!(
+                __rue_String_contains(
+                    haystack.as_ptr(),
+                    haystack.len() as u64,
+                    0,
+                    b"nab".as_ptr(),
+                    3,
+                    0,
+                ),
                 0
-            ),
-            1
-        );
-        assert_eq!(
-            __rue_String_starts_with(
-                haystack.as_ptr(),
-                haystack.len() as u64,
-                0,
-                b"".as_ptr(),
-                0,
-                0,
-            ),
-            1
-        );
+            );
+            assert_eq!(
+                __rue_String_starts_with(
+                    haystack.as_ptr(),
+                    haystack.len() as u64,
+                    0,
+                    b"ban".as_ptr(),
+                    3,
+                    0,
+                ),
+                1
+            );
+            assert_eq!(
+                __rue_String_starts_with(
+                    haystack.as_ptr(),
+                    haystack.len() as u64,
+                    0,
+                    b"nan".as_ptr(),
+                    3,
+                    0,
+                ),
+                0
+            );
+            assert_eq!(
+                __rue_String_contains(
+                    haystack.as_ptr(),
+                    haystack.len() as u64,
+                    0,
+                    b"".as_ptr(),
+                    0,
+                    0
+                ),
+                1
+            );
+            assert_eq!(
+                __rue_String_starts_with(
+                    haystack.as_ptr(),
+                    haystack.len() as u64,
+                    0,
+                    b"".as_ptr(),
+                    0,
+                    0,
+                ),
+                1
+            );
+        }
     }
 
     #[test]
     fn test_to_string_formats_signed_extremes() {
         let mut out = blank_result();
 
-        __rue_to_string(&mut out, 0);
+        // SAFETY: `out` is valid, aligned, exclusively borrowed result storage.
+        unsafe { __rue_to_string(&mut out, 0) };
         assert_string_result(&out, b"0");
 
-        __rue_to_string(&mut out, -42);
+        unsafe { __rue_to_string(&mut out, -42) };
         assert_string_result(&out, b"-42");
 
-        __rue_to_string(&mut out, i64::MIN);
+        unsafe { __rue_to_string(&mut out, i64::MIN) };
         assert_string_result(&out, b"-9223372036854775808");
     }
 
@@ -2195,10 +2376,11 @@ mod tests {
     fn test_to_string_unsigned_formats_full_u64_range() {
         let mut out = blank_result();
 
-        __rue_to_string_unsigned(&mut out, 0);
+        // SAFETY: `out` is valid, aligned, exclusively borrowed result storage.
+        unsafe { __rue_to_string_unsigned(&mut out, 0) };
         assert_string_result(&out, b"0");
 
-        __rue_to_string_unsigned(&mut out, u64::MAX);
+        unsafe { __rue_to_string_unsigned(&mut out, u64::MAX) };
         assert_string_result(&out, b"18446744073709551615");
     }
 
@@ -2208,15 +2390,19 @@ mod tests {
         let right = b"world";
         let mut out = blank_result();
 
-        __rue_String_concat(
-            &mut out,
-            left.as_ptr(),
-            left.len() as u64,
-            0,
-            right.as_ptr(),
-            right.len() as u64,
-            0,
-        );
+        // SAFETY: `out` is valid result storage and both input buffers are
+        // live for their reported lengths.
+        unsafe {
+            __rue_String_concat(
+                &mut out,
+                left.as_ptr(),
+                left.len() as u64,
+                0,
+                right.as_ptr(),
+                right.len() as u64,
+                0,
+            )
+        };
 
         assert_string_result(&out, b"hello, world");
     }
@@ -2226,7 +2412,9 @@ mod tests {
         let source = b"literal";
         let mut out = blank_result();
 
-        __rue_String_clone(&mut out, source.as_ptr(), source.len() as u64, 0);
+        // SAFETY: `out` is valid result storage and `source` is live for its
+        // reported length.
+        unsafe { __rue_String_clone(&mut out, source.as_ptr(), source.len() as u64, 0) };
 
         assert_string_result(&out, source);
         assert_ne!(out.ptr as *const u8, source.as_ptr());
@@ -2237,13 +2425,17 @@ mod tests {
         let source = b"abc";
         let mut out = blank_result();
 
-        __rue_String_push(
-            &mut out,
-            source.as_ptr() as *mut u8,
-            source.len() as u64,
-            0,
-            b'd',
-        );
+        // SAFETY: `out` is valid result storage and `source` is live for its
+        // reported length. `cap == 0` identifies borrowed literal storage.
+        unsafe {
+            __rue_String_push(
+                &mut out,
+                source.as_ptr() as *mut u8,
+                source.len() as u64,
+                0,
+                b'd',
+            )
+        };
 
         assert_string_result(&out, b"abcd");
         assert_ne!(out.ptr as *const u8, source.as_ptr());
@@ -2252,7 +2444,8 @@ mod tests {
     #[test]
     fn test_push_str_appends_without_reallocation_when_capacity_suffices() {
         let mut base = blank_result();
-        __rue_String_with_capacity(&mut base, STRING_MIN_CAPACITY);
+        // SAFETY: `base` is valid, aligned, exclusively borrowed result storage.
+        unsafe { __rue_String_with_capacity(&mut base, STRING_MIN_CAPACITY) };
         let start = base.ptr;
         unsafe {
             *base.ptr.add(0) = b'a';
@@ -2261,7 +2454,11 @@ mod tests {
         base.len = 2;
 
         let mut out = blank_result();
-        __rue_String_push_str(&mut out, base.ptr, base.len, base.cap, b"cd".as_ptr(), 2, 0);
+        // SAFETY: `out` is valid result storage; both input buffers are live
+        // for their reported lengths and the mutable buffer matches its cap.
+        unsafe {
+            __rue_String_push_str(&mut out, base.ptr, base.len, base.cap, b"cd".as_ptr(), 2, 0)
+        };
 
         assert_eq!(out.ptr, start);
         assert_string_result(&out, b"abcd");
@@ -2270,16 +2467,18 @@ mod tests {
     #[test]
     fn test_clear_preserves_capacity_and_reserve_grows() {
         let mut base = blank_result();
-        __rue_String_with_capacity(&mut base, 2);
+        // SAFETY: each out-pointer is valid result storage; the carried String
+        // pointer, length, and capacity come from the preceding runtime call.
+        unsafe { __rue_String_with_capacity(&mut base, 2) };
         let original_cap = base.cap;
 
         let mut reserved = blank_result();
-        __rue_String_reserve(&mut reserved, base.ptr, 0, base.cap, original_cap + 1);
+        unsafe { __rue_String_reserve(&mut reserved, base.ptr, 0, base.cap, original_cap + 1) };
         assert_eq!(reserved.len, 0);
         assert!(reserved.cap > original_cap);
 
         let mut cleared = blank_result();
-        __rue_String_clear(&mut cleared, reserved.ptr, 7, reserved.cap);
+        unsafe { __rue_String_clear(&mut cleared, reserved.ptr, 7, reserved.cap) };
         assert_eq!(cleared.ptr, reserved.ptr);
         assert_eq!(cleared.len, 0);
         assert_eq!(cleared.cap, reserved.cap);


### PR DESCRIPTION
Summary

- mark runtime ABI functions with caller pointer invariants as unsafe extern C
- document every unsafe boundary and preserve justified safe pointer exceptions
- inventory raw-pointer export safety across all runtime modules and platform copies
- make canonical null-plus-zero String boundaries avoid zero-length pointer UB

Validation

- ./buck2 test //crates/rue-runtime:rue-runtime-test (79 passed)
- scripts/rue quick (24 targets passed)
- scripts/rue fmt
- git diff --check

Fixes RUE-782