### PR TITLE
RUE-784: compact per-function string tables

### DIFF
--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -65,21 +65,42 @@ fn generate_inner<T, Emit>(
     interner: &ThreadedRodeo,
     target: Target,
     emit: Emit,
-) -> CompileResult<T>
+) -> CompileResult<(T, Vec<String>)>
 where
     Emit: for<'a> FnOnce(Emitter<'a>) -> CompileResult<T>,
 {
-    let prepared = prepare_backend(cfg, type_pool, interner, target)?;
+    let mut prepared = prepare_backend(cfg, type_pool, interner, target)?;
+    let referenced_strings = prepared
+        .mir
+        .instructions()
+        .iter()
+        .filter_map(|inst| match inst {
+            Aarch64Inst::StringConstPtr { string_id, .. }
+            | Aarch64Inst::StringConstLen { string_id, .. }
+            | Aarch64Inst::StringConstCap { string_id, .. } => Some(*string_id),
+            _ => None,
+        });
+    let (local_strings, string_id_remap) = crate::compact_string_table(strings, referenced_strings);
+    for inst in prepared.mir.instructions_vec_mut() {
+        let string_id = match inst {
+            Aarch64Inst::StringConstPtr { string_id, .. }
+            | Aarch64Inst::StringConstLen { string_id, .. }
+            | Aarch64Inst::StringConstCap { string_id, .. } => string_id,
+            _ => continue,
+        };
+        *string_id = string_id_remap[string_id];
+    }
     let emitter = Emitter::new(
         &prepared.mir,
         prepared.total_locals,
         prepared.num_locals_original,
         prepared.num_params,
         &prepared.used_callee_saved,
-        strings,
+        &local_strings,
     )
     .with_sret(prepared.has_sret);
-    emit(emitter)
+    let emitted = emit(emitter)?;
+    Ok((emitted, local_strings))
 }
 
 /// Generate machine code from CFG.
@@ -92,14 +113,15 @@ pub fn generate(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<MachineCode> {
-    generate_inner(cfg, type_pool, strings, interner, target, |emitter| {
-        // Keep the normal path allocation-free with respect to assembly text.
-        let (code, relocations) = emitter.emit()?;
-        Ok(MachineCode {
-            code,
-            relocations,
-            strings: strings.to_vec(),
-        })
+    let ((code, relocations), strings) =
+        generate_inner(cfg, type_pool, strings, interner, target, |emitter| {
+            // Keep the normal path allocation-free with respect to assembly text.
+            emitter.emit()
+        })?;
+    Ok(MachineCode {
+        code,
+        relocations,
+        strings,
     })
 }
 
@@ -114,16 +136,17 @@ pub fn generate_with_asm(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<(MachineCode, String)> {
-    generate_inner(cfg, type_pool, strings, interner, target, |emitter| {
-        let emitted = emitter.emit_all()?;
-        let asm = emitted.to_asm();
-        let machine_code = MachineCode {
-            code: emitted.to_bytes(),
-            relocations: emitted.relocations,
-            strings: strings.to_vec(),
-        };
-        Ok((machine_code, asm))
-    })
+    let (emitted, strings) =
+        generate_inner(cfg, type_pool, strings, interner, target, |emitter| {
+            emitter.emit_all()
+        })?;
+    let asm = emitted.to_asm();
+    let machine_code = MachineCode {
+        code: emitted.to_bytes(),
+        relocations: emitted.relocations,
+        strings,
+    };
+    Ok((machine_code, asm))
 }
 
 /// Generate register allocation debug info from CFG.

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -190,6 +190,32 @@ pub struct MachineCode {
     pub strings: Vec<String>,
 }
 
+/// Build a function-local string table and remap MIR string IDs to it.
+///
+/// Semantic analysis assigns IDs in the program-wide string table. Object files
+/// are emitted per function, so retaining that whole table in every object is
+/// both unnecessary and quadratic in programs with many functions. Ordering
+/// local strings by their global ID keeps the object bytes deterministic.
+fn compact_string_table(
+    strings: &[String],
+    referenced_ids: impl IntoIterator<Item = u32>,
+) -> (Vec<String>, std::collections::BTreeMap<u32, u32>) {
+    let referenced_ids: std::collections::BTreeSet<_> = referenced_ids.into_iter().collect();
+    let mut remap = std::collections::BTreeMap::new();
+    let mut local_strings = Vec::with_capacity(referenced_ids.len());
+
+    for global_id in referenced_ids {
+        let local_id = local_strings.len() as u32;
+        let string = strings
+            .get(global_id as usize)
+            .unwrap_or_else(|| panic!("string ID {global_id} is absent from the global table"));
+        local_strings.push(string.clone());
+        remap.insert(global_id, local_id);
+    }
+
+    (local_strings, remap)
+}
+
 /// A single emitted machine instruction.
 ///
 /// This captures both the machine code bytes and the human-readable assembly text

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -61,21 +61,42 @@ fn generate_inner<T, Emit>(
     strings: &[String],
     interner: &ThreadedRodeo,
     emit: Emit,
-) -> CompileResult<T>
+) -> CompileResult<(T, Vec<String>)>
 where
     Emit: for<'a> FnOnce(Emitter<'a>) -> CompileResult<T>,
 {
-    let prepared = prepare_backend(cfg, type_pool, interner)?;
+    let mut prepared = prepare_backend(cfg, type_pool, interner)?;
+    let referenced_strings = prepared
+        .mir
+        .instructions()
+        .iter()
+        .filter_map(|inst| match inst {
+            X86Inst::StringConstPtr { string_id, .. }
+            | X86Inst::StringConstLen { string_id, .. }
+            | X86Inst::StringConstCap { string_id, .. } => Some(*string_id),
+            _ => None,
+        });
+    let (local_strings, string_id_remap) = crate::compact_string_table(strings, referenced_strings);
+    for inst in prepared.mir.instructions_vec_mut() {
+        let string_id = match inst {
+            X86Inst::StringConstPtr { string_id, .. }
+            | X86Inst::StringConstLen { string_id, .. }
+            | X86Inst::StringConstCap { string_id, .. } => string_id,
+            _ => continue,
+        };
+        *string_id = string_id_remap[string_id];
+    }
     let emitter = Emitter::new(
         &prepared.mir,
         prepared.total_locals,
         prepared.num_locals_original,
         prepared.num_params,
         &prepared.used_callee_saved,
-        strings,
+        &local_strings,
     )
     .with_sret(prepared.has_sret);
-    emit(emitter)
+    let emitted = emit(emitter)?;
+    Ok((emitted, local_strings))
 }
 
 /// Generate machine code from CFG.
@@ -88,14 +109,15 @@ pub fn generate(
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<MachineCode> {
-    generate_inner(cfg, type_pool, strings, interner, |emitter| {
-        // Keep the normal path allocation-free with respect to assembly text.
-        let (code, relocations) = emitter.emit()?;
-        Ok(MachineCode {
-            code,
-            relocations,
-            strings: strings.to_vec(),
-        })
+    let ((code, relocations), strings) =
+        generate_inner(cfg, type_pool, strings, interner, |emitter| {
+            // Keep the normal path allocation-free with respect to assembly text.
+            emitter.emit()
+        })?;
+    Ok(MachineCode {
+        code,
+        relocations,
+        strings,
     })
 }
 
@@ -109,16 +131,16 @@ pub fn generate_with_asm(
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<(MachineCode, String)> {
-    generate_inner(cfg, type_pool, strings, interner, |emitter| {
-        let emitted = emitter.emit_all()?;
-        let asm = emitted.to_asm();
-        let machine_code = MachineCode {
-            code: emitted.to_bytes(),
-            relocations: emitted.relocations,
-            strings: strings.to_vec(),
-        };
-        Ok((machine_code, asm))
-    })
+    let (emitted, strings) = generate_inner(cfg, type_pool, strings, interner, |emitter| {
+        emitter.emit_all()
+    })?;
+    let asm = emitted.to_asm();
+    let machine_code = MachineCode {
+        code: emitted.to_bytes(),
+        relocations: emitted.relocations,
+        strings,
+    };
+    Ok((machine_code, asm))
 }
 
 /// Generate register allocation debug info from CFG.

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -145,17 +145,17 @@ fn collect_codegen_results(
     function_count: usize,
 ) -> MultiErrorResult<Vec<Vec<u8>>> {
     let mut object_files = Vec::with_capacity(results.len());
-    let mut total_code_bytes = 0usize;
+    let mut total_object_bytes = 0usize;
 
     for result in results {
         let obj = result.map_err(CompileErrors::from)?;
-        total_code_bytes += obj.len();
+        total_object_bytes += obj.len();
         object_files.push(obj);
     }
 
     info!(
         function_count,
-        code_bytes = total_code_bytes,
+        object_bytes = total_object_bytes,
         "codegen complete"
     );
     Ok(object_files)
@@ -399,3 +399,93 @@ use tracing::{info, info_span};
 
 use crate::linking::{link_internal_with_warnings, link_system_with_warnings};
 use crate::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIRST_LITERAL: &[u8] = b"RUE784_FIRST_LITERAL";
+    const SECOND_LITERAL: &[u8] = b"RUE784_SECOND_LITERAL";
+    const SOURCE: &str = r#"
+fn first() -> i32 {
+    println("RUE784_FIRST_LITERAL");
+    0
+}
+
+fn second() -> i32 {
+    println("RUE784_SECOND_LITERAL");
+    0
+}
+
+fn main() -> i32 {
+    first() + second()
+}
+"#;
+
+    fn count(haystack: &[u8], needle: &[u8]) -> usize {
+        haystack
+            .windows(needle.len())
+            .filter(|window| *window == needle)
+            .count()
+    }
+
+    fn frontend() -> (
+        std::sync::Arc<CanonicalRirOutput>,
+        std::sync::Arc<CanonicalSemanticOutput>,
+    ) {
+        let snapshot = SourceSnapshot::single("<rue-784>", SOURCE).unwrap();
+        let (rir, semantic, _) =
+            crate::test_support::test_frontend_snapshot(&snapshot, &CompileOptions::default())
+                .unwrap();
+        (rir, semantic)
+    }
+
+    #[test]
+    fn function_objects_only_contain_their_referenced_strings() {
+        let (rir, semantic) = frontend();
+        let interner = rir.semantic_symbols().interner();
+
+        for target in [
+            Target::X86_64Linux,
+            Target::Aarch64Linux,
+            Target::Aarch64Macos,
+        ] {
+            let options = CompileOptions {
+                target,
+                ..CompileOptions::default()
+            };
+            let objects = match target.arch() {
+                Arch::X86_64 => generate_x86_64_objects(
+                    semantic.functions(),
+                    semantic.type_pool(),
+                    semantic.strings(),
+                    interner,
+                    &options,
+                ),
+                Arch::Aarch64 => generate_aarch64_objects(
+                    semantic.functions(),
+                    semantic.type_pool(),
+                    semantic.strings(),
+                    interner,
+                    &options,
+                ),
+            }
+            .unwrap();
+
+            let all_object_bytes: Vec<_> = objects.into_iter().flatten().collect();
+            assert_eq!(count(&all_object_bytes, FIRST_LITERAL), 1, "{target}");
+            assert_eq!(count(&all_object_bytes, SECOND_LITERAL), 1, "{target}");
+        }
+    }
+
+    #[test]
+    fn final_binary_contains_each_function_literal_once() {
+        let snapshot = SourceSnapshot::single("<rue-784>", SOURCE).unwrap();
+        let output = compile_snapshot(&snapshot, &CompileOptions::default()).unwrap();
+        assert_eq!(count(&output.elf, FIRST_LITERAL), 1);
+        assert_eq!(count(&output.elf, SECOND_LITERAL), 1);
+
+        let repeated = compile_snapshot(&snapshot, &CompileOptions::default()).unwrap();
+        assert_eq!(output.elf, repeated.elf);
+    }
+}

--- a/docs/process/string-table-benchmark.md
+++ b/docs/process/string-table-benchmark.md
@@ -1,0 +1,62 @@
+# Per-function string table benchmark
+
+This benchmark isolates the cost of retaining the program-wide string table in
+every function object. It was added for RUE-784 and is intentionally generated
+outside the normal benchmark manifest because its intermediate-object metric
+comes from the compiler's structured `codegen complete` event.
+
+## Workload
+
+The workload has 400 functions. Each function passes a distinct 1,024-byte
+literal to `println`, and `main` calls every function. The generated source is
+428,023 bytes:
+
+```python
+from pathlib import Path
+
+functions = 400
+payload = 1024
+parts = []
+for index in range(functions):
+    marker = f"RUE784_{index:04}_"
+    literal = marker + chr(ord("a") + index % 26) * (payload - len(marker))
+    parts.append(f'fn f{index:04}() -> i32 {{ println("{literal}"); 0 }}\n')
+
+calls = " ".join(f"f{index:04}();" for index in range(functions))
+parts.append(f"fn main() -> i32 {{ {calls} 0 }}\n")
+Path("/tmp/rue-784-string-heavy.rue").write_text("".join(parts))
+```
+
+Build the compiler with `scripts/rue build`, resolve its path with
+`scripts/rue-bin`, and warm it with one compilation. Intermediate object bytes
+come from this command (the pre-RUE-784 field was named `code_bytes`):
+
+```bash
+RUST_LOG=info "$RUE" /tmp/rue-784-string-heavy.rue -o /tmp/rue-784-out
+```
+
+Measure wall time and peak RSS with three alternating warmed runs, using the
+median:
+
+```bash
+/usr/bin/time -l "$RUE" /tmp/rue-784-string-heavy.rue -o /tmp/rue-784-out
+stat -f '%z' /tmp/rue-784-out
+```
+
+## RUE-784 result
+
+Measured on arm64 macOS 26.5.1. The baseline was commit
+`24646460b38f2266897f75ecab04929a9d82f332`; both compilers were built with the
+repository's Buck2 release target. Timing and RSS are medians of three warmed,
+alternating runs. Byte counts are deterministic single-run results.
+
+| Metric | Baseline | Per-function tables | Reduction |
+| --- | ---: | ---: | ---: |
+| Compile wall time | 0.43 s | 0.13 s | 69.77% |
+| Peak RSS | 914,046,976 B | 30,523,392 B | 96.66% |
+| Intermediate object bytes | 169,574,765 B | 657,995 B | 99.61% |
+| Final binary size | 164,637,936 B | 477,936 B | 99.71% |
+
+The final binary size is the post-write file size reported by `stat`; it can be
+slightly larger than the linker's `output_bytes` event on macOS because the CLI
+performs the final platform-specific file preparation after linking.


### PR DESCRIPTION
## Summary

- compact the program-wide string table into a deterministic referenced subset for each function
- remap x86-64 and AArch64 MIR string IDs before normal and assembly emission
- add ELF, Mach-O, final-binary, and deterministic-output regression coverage
- document a reproducible 400-function benchmark and its before/after results

## Impact

On the documented string-heavy workload, intermediate object bytes fall by 99.61% and final binary size by 99.71%. Median compile wall time falls from 0.43 s to 0.13 s, and median peak RSS falls from 914,046,976 B to 30,523,392 B.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue test` (full serialized suite)
- focused backend regression tests across x86-64 ELF, AArch64 ELF, and AArch64 Mach-O

Fixes RUE-784
