### PR TITLE
RUE-871: add source-defined std StrBuf shell

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -384,8 +384,14 @@ impl<'a> Sema<'a> {
                 } => {
                     let enum_name = self.interner.resolve(&*name).to_string();
 
-                    // Check for collision with built-in type names
-                    if is_reserved_type_name(&enum_name) {
+                    // Builtins occupy the root source namespace. An imported
+                    // module has its own nominal namespace, so the same short
+                    // name there does not collide with the builtin.
+                    if is_reserved_type_name(&enum_name)
+                        && self
+                            .root_file_id
+                            .is_none_or(|root| root == inst.span.file_id)
+                    {
                         return Err(CompileError::new(
                             ErrorKind::ReservedTypeName {
                                 type_name: enum_name,
@@ -447,8 +453,14 @@ impl<'a> Sema<'a> {
                 } => {
                     let struct_name = self.interner.resolve(&*name).to_string();
 
-                    // Check for collision with built-in type names
-                    if is_reserved_type_name(&struct_name) {
+                    // Builtins occupy the root source namespace. An imported
+                    // module has its own nominal namespace, so the same short
+                    // name there does not collide with the builtin.
+                    if is_reserved_type_name(&struct_name)
+                        && self
+                            .root_file_id
+                            .is_none_or(|root| root == inst.span.file_id)
+                    {
                         return Err(CompileError::new(
                             ErrorKind::ReservedTypeName {
                                 type_name: struct_name,

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -1,0 +1,95 @@
+# Source-defined std.strbuf.StrBuf (RUE-871), exercised through the real std
+# bundle. These cases intentionally use only the qualified or aliased library
+# type so the synthetic builtin `StrBuf` cannot satisfy the coverage.
+
+[section]
+id = "cli.std_strbuf"
+name = "Source-defined std.strbuf.StrBuf"
+description = "The named std.strbuf.StrBuf header has its source-defined methods, layout, and drop behavior."
+
+[[case]]
+name = "qualified_nonallocating_surface"
+description = "Qualified construction and nonallocating methods operate on the source-defined type."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut s = std.strbuf.StrBuf.new();
+    if s.len() != 0 { return 1; }
+    if s.capacity() != 0 { return 2; }
+    if !s.is_empty() { return 3; }
+    s.clear();
+    if !s.is_empty() { return 4; }
+    s.free();
+    if s.capacity() != 0 { return 5; }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "owned_allocation_drop_and_early_free"
+description = "cap > 0 owns an allocation; moved scope-drop and explicit early free each leave one teardown path."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn owned(byte: u8) -> S {
+    let p: ptr mut u8 = checked { @alloc(4) };
+    checked { @ptr_write(p, byte); };
+    std.strbuf.StrBuf { buf: p, len: 1, cap: 4 }
+}
+
+fn consume(s: S) -> i32 {
+    // The moved parameter is the sole owner and is dropped on return.
+    if s.len() == 1 && s.capacity() == 4 { 0 } else { 1 }
+}
+
+fn main() -> i32 {
+    let automatic = owned(65);
+    if consume(automatic) != 0 { return 1; }
+
+    let mut early = owned(66);
+    early.clear();
+    if !early.is_empty() { return 2; }
+    if early.capacity() != 4 { return 3; }
+    early.free();
+    // The later source-defined destructor observes cap == 0 and is a no-op.
+    if early.capacity() != 0 { return 4; }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "aliased_three_word_layout_and_scope_drop"
+description = "An alias preserves the ptr/len/cap three-word layout and source-defined scope-exit destructor."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn make() -> S {
+    S.new()
+}
+
+fn main() -> i32 {
+    let size = @size_of(S);
+    let buf_offset: u64 = @offset_of(S, buf);
+    let len_offset: u64 = @offset_of(S, len);
+    let cap_offset: u64 = @offset_of(S, cap);
+    if size != 24 { return 1; }
+    if buf_offset != 0 { return 2; }
+    if len_offset != 8 { return 3; }
+    if cap_offset != 16 { return 4; }
+
+    // Moving the value returned by make leaves one final owner. Its named,
+    // source-defined destructor runs exactly once at this scope exit; cap == 0
+    // ensures that teardown does not call @free.
+    let s = make();
+    if s.is_empty() { 0 } else { 5 }
+}
+""" }]
+exit_code = 0

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -11,6 +11,7 @@
 // - std.fmt: scalar-to-string formatting (int/bool, hex/binary)
 // - std.option.Option: Optional values
 // - std.result.Result: Fallible values (Ok/Err), propagated with `?`
+// - std.strbuf.StrBuf: Source-defined growable string buffer header
 // - std.arraybuf.ArrayBuf: Growable heap-backed collections
 
 // Re-export library modules.
@@ -21,6 +22,7 @@ pub const tuple = @import("tuple.rue");
 pub const fmt = @import("fmt.rue");
 pub const option = @import("option.rue");
 pub const result = @import("result.rue");
+pub const strbuf = @import("strbuf.rue");
 pub const arraybuf = @import("arraybuf.rue");
 
 // Collections (Standard library v1, M2).

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -1,0 +1,55 @@
+// std.strbuf — the source-defined growable string buffer header (RUE-871).
+//
+// This module deliberately provides only construction, observation, clearing,
+// and teardown. Allocation and growth remain out of scope: `new()` creates a
+// null, zero-capacity buffer without allocating.
+//
+// The ownership invariant is encoded by `cap`: a value with `cap == 0` owns no
+// allocation and must not call `@free`; a value with `cap > 0` owns its `buf`
+// allocation. `free()` supports early release and resets all three fields, so
+// the ordinary scope-exit destructor is then a safe no-op.
+
+pub struct StrBuf {
+    buf: ptr mut u8,
+    len: u64,
+    cap: u64,
+
+    // Construct an empty buffer without allocating.
+    fn new() -> Self {
+        let zero: u64 = 0;
+        Self {
+            buf: checked { @int_to_ptr(zero) },
+            len: 0,
+            cap: 0,
+        }
+    }
+
+    fn len(borrow self) -> u64 { self.len }
+    fn capacity(borrow self) -> u64 { self.cap }
+    fn is_empty(borrow self) -> bool { self.len == 0 }
+
+    // Remove all bytes while retaining any owned allocation.
+    fn clear(inout self) {
+        self.len = 0;
+    }
+
+    // Release an owned allocation early. Resetting the header transfers this
+    // value to the non-owning empty state before its eventual scope-exit drop.
+    fn free(inout self) {
+        if self.cap > 0 {
+            checked { @free(self.buf, self.cap); };
+        }
+        let zero: u64 = 0;
+        self.buf = checked { @int_to_ptr(zero) };
+        self.len = 0;
+        self.cap = 0;
+    }
+}
+
+// Source-defined drop glue owns teardown for `std.strbuf.StrBuf`. In
+// particular, the null header from `new()` never reaches `@free`.
+drop fn StrBuf(self) {
+    if self.cap > 0 {
+        checked { @free(self.buf, self.cap); };
+    }
+}


### PR DESCRIPTION
## Summary

- add the source-defined `std.strbuf.StrBuf` header with its nonallocating API
- give it source-level ownership teardown and early-free behavior
- allow reserved builtin spellings inside imported module namespaces while retaining root-level rejection
- cover qualified and aliased use, layout, ownership, moves, and drop behavior through the real CLI/std bundle

## Validation

- `scripts/rue fmt`
- `scripts/rue cli std_strbuf` (3/3)
- `scripts/rue cli strbuf_reserved_name` (1/1)
- `scripts/rue quick`
- `git diff --check`

Fixes RUE-871
