### PR TITLE
RUE-797: harden CFG verification

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -721,6 +721,15 @@ impl TypeInternPool {
         }
     }
 
+    /// Get a struct definition without panicking on an invalid or wrong-kind ID.
+    pub fn try_struct_def(&self, struct_id: StructId) -> Option<StructDef> {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        match inner.types.get(struct_id.0 as usize)? {
+            TypeData::Struct(data) => Some(data.def.clone()),
+            _ => None,
+        }
+    }
+
     /// Get an enum definition by EnumId.
     ///
     /// The EnumId contains a pool index. This method looks up the enum
@@ -738,6 +747,15 @@ impl TypeInternPool {
                 "Expected enum at pool index {}, got {:?}",
                 pool_index, other
             ),
+        }
+    }
+
+    /// Get an enum definition without panicking on an invalid or wrong-kind ID.
+    pub fn try_enum_def(&self, enum_id: EnumId) -> Option<EnumDef> {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        match inner.types.get(enum_id.0 as usize)? {
+            TypeData::Enum(data) => Some(data.def.clone()),
+            _ => None,
         }
     }
 
@@ -883,6 +901,17 @@ impl TypeInternPool {
                 "Expected array at pool index {}, got {:?}",
                 pool_index, other
             ),
+        }
+    }
+
+    /// Get an array definition without panicking on an invalid or wrong-kind ID.
+    pub fn try_array_def(&self, array_id: ArrayTypeId) -> Option<(Type, u64)> {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        match inner.types.get(array_id.0 as usize)? {
+            TypeData::Array { element, len } => {
+                Some((Self::interned_to_type_recursive(*element, &inner), *len))
+            }
+            _ => None,
         }
     }
 

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1580,6 +1580,15 @@ impl<'a> CfgBuilder<'a> {
                     None => None,
                 };
 
+                // Unit has no runtime value. Keeping a path-local synthetic
+                // unit value on Return makes that operand appear to cross a
+                // join without a block parameter and violates SSA dominance.
+                let val = if self.cfg.return_type() == Type::UNIT {
+                    None
+                } else {
+                    val
+                };
+
                 // Emit drops for all live slots before returning
                 self.emit_drops_for_all_scopes(span);
 
@@ -1861,7 +1870,14 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::StorageLive { slot } => {
                 // Emit StorageLive to CFG
-                self.emit(CfgInstData::StorageLive { slot: *slot }, Type::UNIT, span);
+                self.emit(
+                    CfgInstData::StorageLive {
+                        slot: *slot,
+                        local_ty: ty,
+                    },
+                    Type::UNIT,
+                    span,
+                );
 
                 // Fresh storage holds a fresh (not-moved-out) value.
                 // Slots are not currently reused, so this is a no-op today,
@@ -1886,7 +1902,14 @@ impl<'a> CfgBuilder<'a> {
             AirInstData::StorageDead { slot } => {
                 // StorageDead in AIR is a hint; CFG builder emits these at scope exit
                 // This case handles explicit StorageDead if any (currently unused)
-                self.emit(CfgInstData::StorageDead { slot: *slot }, Type::UNIT, span);
+                self.emit(
+                    CfgInstData::StorageDead {
+                        slot: *slot,
+                        local_ty: ty,
+                    },
+                    Type::UNIT,
+                    span,
+                );
                 ExprResult {
                     value: None,
                     continuation: Continuation::Continues,
@@ -2515,6 +2538,7 @@ impl<'a> CfgBuilder<'a> {
         self.emit(
             CfgInstData::StorageDead {
                 slot: live_slot.slot,
+                local_ty: live_slot.ty,
             },
             Type::UNIT,
             span,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -434,6 +434,7 @@ pub enum CfgInstData {
     /// The slot is now valid to write to.
     StorageLive {
         slot: u32,
+        local_ty: Type,
     },
 
     /// Marks that a local slot becomes dead (storage can be deallocated).
@@ -441,6 +442,7 @@ pub enum CfgInstData {
     /// Drop elaboration inserts Drop before this if the type needs drop.
     StorageDead {
         slot: u32,
+        local_ty: Type,
     },
 }
 
@@ -742,6 +744,26 @@ impl Cfg {
     #[inline]
     pub fn value_count(&self) -> usize {
         self.values.len()
+    }
+
+    #[inline]
+    pub(crate) fn extra_len(&self) -> usize {
+        self.extra.len()
+    }
+
+    #[inline]
+    pub(crate) fn call_args_len(&self) -> usize {
+        self.call_args.len()
+    }
+
+    #[inline]
+    pub(crate) fn switch_cases_len(&self) -> usize {
+        self.switch_cases.len()
+    }
+
+    #[inline]
+    pub(crate) fn projections_len(&self) -> usize {
+        self.projections.len()
     }
 
     /// Add values to the extra array and return (start, len).
@@ -1307,10 +1329,10 @@ impl Cfg {
             CfgInstData::Drop { value } => {
                 write!(f, "drop {}", value)
             }
-            CfgInstData::StorageLive { slot } => {
+            CfgInstData::StorageLive { slot, .. } => {
                 write!(f, "storage_live ${}", slot)
             }
-            CfgInstData::StorageDead { slot } => {
+            CfgInstData::StorageDead { slot, .. } => {
                 write!(f, "storage_dead ${}", slot)
             }
         }

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -25,6 +25,7 @@ mod constprop;
 mod dce;
 
 use crate::Cfg;
+use rue_air::TypeInternPool;
 
 /// Optimization level, following standard compiler conventions.
 ///
@@ -126,10 +127,14 @@ impl std::fmt::Display for OptLevel {
 ///
 /// ```ignore
 /// let mut cfg = CfgBuilder::build(...);
-/// optimize(&mut cfg, OptLevel::O1);
+/// optimize(&mut cfg, OptLevel::O1, &type_pool);
 /// // cfg is now optimized
 /// ```
-pub fn optimize(cfg: &mut Cfg, level: OptLevel) {
+pub fn optimize(cfg: &mut Cfg, level: OptLevel, type_pool: &TypeInternPool) {
+    // Verify construction output before any pass can detach dead values or
+    // erase unreachable blocks and thereby hide a malformed definition/use.
+    cfg.verify_with_type_pool(type_pool);
+
     match level {
         OptLevel::O0 => {
             // No optimization
@@ -154,16 +159,11 @@ pub fn optimize(cfg: &mut Cfg, level: OptLevel) {
         }
     }
 
-    // Structural verification (RUE-227). This runs at EVERY opt level (O0
-    // included) so the CFG handed to codegen is always checked — the AIR→CFG
-    // "block has no terminator" bug class becomes a loud, localized panic here
-    // instead of a mysterious SIGABRT deep in cfg_lower. `optimize` is the
-    // single choke point every build site funnels through right before
-    // lowering, so verifying here covers both construction and optimization
-    // output. Malformed-AIR cases that populate `CfgOutput.errors` (e.g. an
-    // un-specialized CallGeneric) abort before this is reached, so they are
-    // never verified. See `crate::verify`.
-    cfg.verify();
+    // Recheck the graph handed to codegen. DCE deliberately leaves detached
+    // dead values in the arena, so attachment completeness was established by
+    // the strict pre-pass check above; all live attachments and uses are still
+    // checked here. See `crate::verify`.
+    cfg.verify_after_optimization_with_type_pool(type_pool);
 }
 
 #[cfg(test)]

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -15,44 +15,30 @@
 //! Per RUE-45 the guard must fire in **release** builds too, so this uses
 //! `panic!`/`assert!`, never `debug_assert!`.
 //!
-//! # Invariants checked (for every *reachable* block)
+//! # Invariants checked
 //!
-//! 1. **Termination** — the block ends in a real terminator (`Goto`, `Branch`,
-//!    `Switch`, `Return`, or `Unreachable`), never the `None` placeholder that a
-//!    mid-block `diverged()` bail leaves behind.
-//! 2. **Value definition** — every `CfgValue` referenced by an instruction or a
-//!    terminator indexes a value that actually exists in the CFG.
-//! 3. **Block-param arity** — the number of block-arguments passed along each
-//!    edge equals the arity of the successor block's parameter list.
-//! 4. **Block-param types** (RUE-347) — each block-argument's type equals the
-//!    corresponding successor parameter's type. This is the block-parameter
-//!    type invariant SSA passes and codegen rely on; a divergence-handling bug
-//!    in lowering (e.g. wiring a unit "result" of a `!`-typed arm into a join)
-//!    trips it here instead of miscompiling later.
-//! 5. **Place-root types** (RUE-589) — the first field/index projection consumes
-//!    the logical base type recorded on the place. Physical slot indices alone
-//!    cannot recover that type for flattened or zero-sized parameters, so a
-//!    projection that names a different root is malformed CFG.
+//! Every arena value has exactly one legal attachment, block parameters agree
+//! with their attachment metadata, and every operand is defined before use and
+//! dominated by its definition. Targets, variable-length storage slices,
+//! local/parameter slots, places, projections, edge arguments, conditions, and
+//! returns are validated before any getter or graph traversal can index them.
 //!
-//! Unreachable blocks skip the termination check only: an orphan block created
-//! but never wired in (or one left behind before DCE) may legitimately carry a
-//! `None` terminator, and it never reaches codegen. But an unreachable block
-//! that *does* carry a terminator still has its edges arity- and type-checked
-//! (invariants 3 and 4): such blocks are exactly where divergence-handling
-//! bugs park ill-typed edges "harmlessly" (RUE-347), and a pass or backend
-//! change that consults edge types before checking reachability would turn
-//! one into a real miscompile.
+//! These checks apply to unreachable blocks too. The sole reachability-based
+//! exemption is an unreachable block's `None` terminator: construction can
+//! leave an orphan block unfinished, but all of its existing contents still
+//! have to be structurally valid. Optimization runs strict verification before
+//! DCE can detach dead arena values, then verifies the remaining live graph
+//! again after all passes.
 
-use crate::inst::{Cfg, CfgInstData, CfgValue, Projection, Terminator};
-use rue_air::{Type, TypeKind};
+use crate::inst::{BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
+use rue_air::{Type, TypeInternPool, TypeKind};
 
 impl Cfg {
     /// Count every operand use of `needle` across instructions and
     /// terminators.
     ///
-    /// This is derived from the verifier's exhaustive operand walk so
-    /// provenance-sensitive consumers do not need a second, drift-prone list
-    /// of [`CfgInstData`] variants.
+    /// The instruction walk mirrors the verifier's exhaustive operand list so
+    /// provenance-sensitive consumers retain the established counting behavior.
     pub fn value_use_count(&self, needle: CfgValue) -> usize {
         let mut count = 0;
         for block in self.blocks() {
@@ -113,269 +99,24 @@ impl Cfg {
     ///
     /// See the module docs for the invariants and the rationale for the hard
     /// panic. This is a compiler-bug guard: a well-formed pipeline never trips
-    /// it, so the cost (one linear walk of reachable blocks) is paid only to
-    /// pin future lowering regressions to their source.
+    /// it; the check is paid to pin future lowering regressions to their source.
     pub fn verify(&self) {
-        let reachable = self.reachable_blocks();
-        let value_count = self.value_count() as u32;
-
-        for block in self.blocks() {
-            if !reachable[block.id.as_u32() as usize] {
-                // Unreachable blocks may legitimately be unterminated (module
-                // docs), but if one carries a real terminator its edges must
-                // still be well-formed: arity- and type-check them (RUE-347).
-                if !matches!(block.terminator, Terminator::None) {
-                    self.verify_terminator(block.id, &block.terminator, value_count);
-                }
-                continue;
-            }
-
-            // (1) Termination.
-            if matches!(block.terminator, Terminator::None) {
-                panic!(
-                    "internal compiler error: CFG verification failed in function \
-                     `{}`: reachable block {} has no terminator (an AIR→CFG lowering \
-                     path left the block unterminated — likely an expression used in \
-                     value position that produced no CFG value). This is a compiler \
-                     bug (RUE-227).",
-                    self.fn_name(),
-                    block.id,
-                );
-            }
-
-            // (2) Value definition — block params and instruction operands.
-            for &(param_val, _) in &block.params {
-                self.check_value_defined(param_val, value_count, block.id, "block parameter");
-            }
-            for &inst_val in &block.insts {
-                self.check_value_defined(inst_val, value_count, block.id, "instruction result");
-                let inst = self.get_inst(inst_val);
-                let mut operands = Vec::new();
-                self.collect_inst_operands(&inst.data, &mut operands);
-                for op in operands {
-                    self.check_value_defined(op, value_count, block.id, "instruction operand");
-                }
-                if matches!(
-                    &inst.data,
-                    CfgInstData::PlaceRead { .. } | CfgInstData::PlaceWrite { .. }
-                ) {
-                    self.verify_place_root_type(block.id, inst_val, inst);
-                }
-            }
-
-            // (2) + (3) Terminator operands and edge arities.
-            self.verify_terminator(block.id, &block.terminator, value_count);
-        }
+        Verifier::new(self, None, true).verify();
     }
 
-    /// Panic if `value` does not index a defined value in this CFG.
-    #[inline]
-    fn check_value_defined(
-        &self,
-        value: CfgValue,
-        value_count: u32,
-        block: crate::inst::BlockId,
-        role: &str,
-    ) {
-        assert!(
-            value.as_u32() < value_count,
-            "internal compiler error: CFG verification failed in function `{}`: {} \
-             {} in block {} references an undefined value (only {} values exist). \
-             This is a compiler bug (RUE-227).",
-            self.fn_name(),
-            role,
-            value,
-            block,
-            value_count,
-        );
+    /// Verify with the active semantic type pool, enabling exact aggregate
+    /// layouts and projection-chain validation. Production callers must use
+    /// this entry point.
+    pub fn verify_with_type_pool(&self, type_pool: &TypeInternPool) {
+        Verifier::new(self, Some(type_pool), true).verify();
     }
 
-    /// Verify that the first projection consumes the logical type carried by
-    /// the place base. Later projection links need the type pool to validate,
-    /// but this first link is fully described by the CFG itself and must not
-    /// be inferred from the projection under test.
-    fn verify_place_root_type(
-        &self,
-        block: crate::inst::BlockId,
-        value: CfgValue,
-        inst: &crate::inst::CfgInst,
-    ) {
-        let place = match &inst.data {
-            CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } => place,
-            _ => unreachable!("verify_place_root_type called on a non-place instruction"),
-        };
-        let Some(first) = self.get_place_projections(place).first() else {
-            return;
-        };
-        let required_base_type = match first {
-            Projection::Field { struct_id, .. } => Type::new_struct(*struct_id),
-            Projection::Index { array_type, .. } => {
-                assert!(
-                    matches!(array_type.kind(), TypeKind::Array(_)),
-                    "internal compiler error: CFG verification failed in function `{}`: place in \
-                     instruction {} in block {} has an Index projection whose declared \
-                     container type {:?} is not an array. This is a compiler bug (RUE-589).",
-                    self.fn_name(),
-                    value,
-                    block,
-                    array_type,
-                );
-                *array_type
-            }
-        };
-        assert!(
-            place.base_type == required_base_type,
-            "internal compiler error: CFG verification failed in function `{}`: place in \
-             instruction {} in block {} has logical base type {:?}, but its first \
-             projection requires base type {:?}. This is a compiler bug (RUE-589).",
-            self.fn_name(),
-            value,
-            block,
-            place.base_type,
-            required_base_type,
-        );
-    }
-
-    /// Verify a block's terminator: operand definedness and successor arities.
-    fn verify_terminator(&self, block: crate::inst::BlockId, term: &Terminator, value_count: u32) {
-        match term {
-            Terminator::Goto {
-                target,
-                args_start,
-                args_len,
-            } => {
-                let args = self.get_extra(*args_start, *args_len);
-                for &arg in args {
-                    self.check_value_defined(arg, value_count, block, "goto argument");
-                }
-                self.check_edge_args(block, *target, args);
-            }
-            Terminator::Branch {
-                cond,
-                then_block,
-                then_args_start,
-                then_args_len,
-                else_block,
-                else_args_start,
-                else_args_len,
-            } => {
-                self.check_value_defined(*cond, value_count, block, "branch condition");
-                let then_args = self.get_extra(*then_args_start, *then_args_len);
-                for &arg in then_args {
-                    self.check_value_defined(arg, value_count, block, "branch-then argument");
-                }
-                self.check_edge_args(block, *then_block, then_args);
-                let else_args = self.get_extra(*else_args_start, *else_args_len);
-                for &arg in else_args {
-                    self.check_value_defined(arg, value_count, block, "branch-else argument");
-                }
-                self.check_edge_args(block, *else_block, else_args);
-            }
-            Terminator::Switch {
-                scrutinee,
-                cases_start,
-                cases_len,
-                default,
-            } => {
-                self.check_value_defined(*scrutinee, value_count, block, "switch scrutinee");
-                // Switch edges carry no block-arguments, so every successor
-                // must have an empty parameter list.
-                for (_, target) in self.get_switch_cases(*cases_start, *cases_len) {
-                    self.check_edge_args(block, *target, &[]);
-                }
-                self.check_edge_args(block, *default, &[]);
-            }
-            Terminator::Return { value } => {
-                if let Some(v) = value {
-                    self.check_value_defined(*v, value_count, block, "return value");
-                }
-            }
-            Terminator::Unreachable | Terminator::None => {}
-        }
-    }
-
-    /// Panic if the block-arguments on an edge do not match the successor
-    /// block's parameter list — in count (RUE-227) or, position by position,
-    /// in type (RUE-347).
-    fn check_edge_args(
-        &self,
-        from: crate::inst::BlockId,
-        to: crate::inst::BlockId,
-        args: &[CfgValue],
-    ) {
-        let params = &self.get_block(to).params;
-        assert!(
-            params.len() == args.len(),
-            "internal compiler error: CFG verification failed in function `{}`: edge \
-             {} -> {} passes {} block-argument(s) but the target expects {} block \
-             parameter(s). This is a compiler bug (RUE-227).",
-            self.fn_name(),
-            from,
-            to,
-            args.len(),
-            params.len(),
-        );
-        for (i, (&arg, &(_, param_ty))) in args.iter().zip(params.iter()).enumerate() {
-            let arg_ty = self.get_inst(arg).ty;
-            assert!(
-                arg_ty == param_ty,
-                "internal compiler error: CFG verification failed in function `{}`: edge \
-                 {} -> {} passes block-argument {} ({}) with type {:?} but the target \
-                 parameter has type {:?} — an ill-typed edge, usually a divergence-handling \
-                 bug in lowering. This is a compiler bug (RUE-347).",
-                self.fn_name(),
-                from,
-                to,
-                i,
-                arg,
-                arg_ty,
-                param_ty,
-            );
-        }
-    }
-
-    /// Compute which blocks are reachable from the entry block by following
-    /// terminator successors.
-    fn reachable_blocks(&self) -> Vec<bool> {
-        let mut reachable = vec![false; self.block_count()];
-        if self.block_count() == 0 {
-            return reachable;
-        }
-        let mut stack = vec![self.entry];
-        reachable[self.entry.as_u32() as usize] = true;
-        while let Some(id) = stack.pop() {
-            let mut push = |succ: crate::inst::BlockId| {
-                let idx = succ.as_u32() as usize;
-                if !reachable[idx] {
-                    reachable[idx] = true;
-                    stack.push(succ);
-                }
-            };
-            match &self.get_block(id).terminator {
-                Terminator::Goto { target, .. } => push(*target),
-                Terminator::Branch {
-                    then_block,
-                    else_block,
-                    ..
-                } => {
-                    push(*then_block);
-                    push(*else_block);
-                }
-                Terminator::Switch {
-                    cases_start,
-                    cases_len,
-                    default,
-                    ..
-                } => {
-                    for (_, target) in self.get_switch_cases(*cases_start, *cases_len) {
-                        push(*target);
-                    }
-                    push(*default);
-                }
-                Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
-            }
-        }
-        reachable
+    /// Verify the optimized live graph. DCE intentionally retains dead values
+    /// in the arena after detaching them from blocks, so attachment completeness
+    /// is checked before optimization while every remaining attachment and use
+    /// is checked again afterward.
+    pub(crate) fn verify_after_optimization_with_type_pool(&self, type_pool: &TypeInternPool) {
+        Verifier::new(self, Some(type_pool), false).verify();
     }
 
     /// Collect every `CfgValue` operand referenced by an instruction into
@@ -474,14 +215,1082 @@ impl Cfg {
     }
 }
 
+#[derive(Clone, Copy)]
+enum Attachment {
+    Param { block: BlockId },
+    Inst { block: BlockId, position: usize },
+}
+
+struct Verifier<'a> {
+    cfg: &'a Cfg,
+    type_pool: Option<&'a TypeInternPool>,
+    require_complete_attachments: bool,
+    attachments: Vec<Option<Attachment>>,
+    reachable: Vec<bool>,
+    dominators: Vec<Vec<bool>>,
+}
+
+impl<'a> Verifier<'a> {
+    fn new(
+        cfg: &'a Cfg,
+        type_pool: Option<&'a TypeInternPool>,
+        require_complete_attachments: bool,
+    ) -> Self {
+        Self {
+            cfg,
+            type_pool,
+            require_complete_attachments,
+            attachments: vec![None; cfg.value_count()],
+            reachable: vec![false; cfg.block_count()],
+            dominators: Vec::new(),
+        }
+    }
+
+    fn fail(&self, message: impl std::fmt::Display) -> ! {
+        panic!(
+            "internal compiler error: CFG verification failed in function `{}`: {}. This is a compiler bug (RUE-797).",
+            self.cfg.fn_name(),
+            message
+        )
+    }
+
+    fn verify(mut self) {
+        self.verify_block_table_and_attachments();
+        self.verify_targets_and_slices();
+        self.compute_reachability();
+        self.compute_dominators();
+
+        for block in self.cfg.blocks() {
+            let block_index = block.id.as_u32() as usize;
+            if self.reachable[block_index] && matches!(block.terminator, Terminator::None) {
+                self.fail(format_args!(
+                    "reachable block {} has no terminator",
+                    block.id
+                ));
+            }
+
+            for (position, &value) in block.insts.iter().enumerate() {
+                self.verify_inst(block.id, position, value);
+            }
+            if !matches!(block.terminator, Terminator::None) {
+                self.verify_terminator_use(block.id, &block.terminator);
+            }
+        }
+    }
+
+    fn verify_block_table_and_attachments(&mut self) {
+        let block_count = self.cfg.block_count();
+        if self.cfg.entry.as_u32() as usize >= block_count {
+            self.fail(format_args!(
+                "entry block {} is out of bounds (only {} blocks exist)",
+                self.cfg.entry, block_count
+            ));
+        }
+
+        for (expected, block) in self.cfg.blocks().iter().enumerate() {
+            if block.id.as_u32() as usize != expected {
+                self.fail(format_args!(
+                    "block table slot {} contains mismatched id {}",
+                    expected, block.id
+                ));
+            }
+            for (index, &(value, stored_ty)) in block.params.iter().enumerate() {
+                self.attach(
+                    value,
+                    Attachment::Param { block: block.id },
+                    "block parameter",
+                );
+                let inst = self.inst(value, block.id, "block parameter");
+                match inst.data {
+                    CfgInstData::BlockParam { index: actual } if actual == index as u32 => {}
+                    CfgInstData::BlockParam { index: actual } => self.fail(format_args!(
+                        "block parameter {} in block {} is stored at index {} but declares index {}",
+                        value, block.id, index, actual
+                    )),
+                    ref other => self.fail(format_args!(
+                        "block parameter {} in block {} has non-BlockParam data {:?}",
+                        value, block.id, other
+                    )),
+                }
+                if inst.ty != stored_ty {
+                    self.fail(format_args!(
+                        "block parameter {} in block {} stores type {:?} but its value has type {:?}",
+                        value, block.id, stored_ty, inst.ty
+                    ));
+                }
+            }
+            for (position, &value) in block.insts.iter().enumerate() {
+                self.attach(
+                    value,
+                    Attachment::Inst {
+                        block: block.id,
+                        position,
+                    },
+                    "instruction",
+                );
+                if matches!(
+                    self.inst(value, block.id, "instruction").data,
+                    CfgInstData::BlockParam { .. }
+                ) {
+                    self.fail(format_args!(
+                        "ordinary instruction {} in block {} has BlockParam data",
+                        value, block.id
+                    ));
+                }
+            }
+        }
+
+        if self.require_complete_attachments {
+            for (index, attachment) in self.attachments.iter().enumerate() {
+                if attachment.is_none() {
+                    self.fail(format_args!(
+                        "value v{} is unattached (every value must be exactly one block parameter or ordinary instruction)",
+                        index
+                    ));
+                }
+            }
+        }
+    }
+
+    fn attach(&mut self, value: CfgValue, attachment: Attachment, role: &str) {
+        let index = value.as_u32() as usize;
+        if index >= self.attachments.len() {
+            self.fail(format_args!(
+                "{} {} references an undefined value (only {} values exist)",
+                role,
+                value,
+                self.attachments.len()
+            ));
+        }
+        if let Some(previous) = self.attachments[index] {
+            self.fail(format_args!(
+                "value {} has duplicate attachments ({}, then {})",
+                value,
+                Self::attachment_name(previous),
+                Self::attachment_name(attachment)
+            ));
+        }
+        self.attachments[index] = Some(attachment);
+    }
+
+    fn attachment_name(attachment: Attachment) -> String {
+        match attachment {
+            Attachment::Param { block } => format!("parameter in {block}"),
+            Attachment::Inst { block, position } => {
+                format!("instruction {position} in {block}")
+            }
+        }
+    }
+
+    fn inst(&self, value: CfgValue, block: BlockId, role: &str) -> &crate::inst::CfgInst {
+        if value.as_u32() as usize >= self.cfg.value_count() {
+            self.fail(format_args!(
+                "{} {} in block {} is undefined (only {} values exist)",
+                role,
+                value,
+                block,
+                self.cfg.value_count()
+            ));
+        }
+        self.cfg.get_inst(value)
+    }
+
+    fn verify_targets_and_slices(&self) {
+        for block in self.cfg.blocks() {
+            for &value in &block.insts {
+                let data = &self.inst(value, block.id, "instruction").data;
+                match data {
+                    CfgInstData::Call {
+                        args_start,
+                        args_len,
+                        ..
+                    } => self.check_range(
+                        *args_start,
+                        *args_len,
+                        self.cfg.call_args_len(),
+                        block.id,
+                        value,
+                        "call-argument",
+                    ),
+                    CfgInstData::Intrinsic {
+                        args_start,
+                        args_len,
+                        ..
+                    } => self.check_extra(*args_start, *args_len, block.id, value, "intrinsic"),
+                    CfgInstData::StructInit {
+                        fields_start,
+                        fields_len,
+                        ..
+                    } => self.check_extra(
+                        *fields_start,
+                        *fields_len,
+                        block.id,
+                        value,
+                        "struct fields",
+                    ),
+                    CfgInstData::ArrayInit {
+                        elements_start,
+                        elements_len,
+                    } => self.check_extra(
+                        *elements_start,
+                        *elements_len,
+                        block.id,
+                        value,
+                        "array elements",
+                    ),
+                    CfgInstData::EnumVariant {
+                        payload_start,
+                        payload_len,
+                        ..
+                    } => self.check_extra(
+                        *payload_start,
+                        *payload_len,
+                        block.id,
+                        value,
+                        "enum payload",
+                    ),
+                    CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } => {
+                        self.check_range(
+                            place.proj_start,
+                            place.proj_len,
+                            self.cfg.projections_len(),
+                            block.id,
+                            value,
+                            "projection",
+                        )
+                    }
+                    _ => {}
+                }
+            }
+            match &block.terminator {
+                Terminator::Goto {
+                    target,
+                    args_start,
+                    args_len,
+                } => {
+                    self.check_target(block.id, *target, "goto");
+                    self.check_term_extra(*args_start, *args_len, block.id, "goto arguments");
+                }
+                Terminator::Branch {
+                    then_block,
+                    then_args_start,
+                    then_args_len,
+                    else_block,
+                    else_args_start,
+                    else_args_len,
+                    ..
+                } => {
+                    self.check_target(block.id, *then_block, "branch then");
+                    self.check_target(block.id, *else_block, "branch else");
+                    self.check_term_extra(
+                        *then_args_start,
+                        *then_args_len,
+                        block.id,
+                        "branch then arguments",
+                    );
+                    self.check_term_extra(
+                        *else_args_start,
+                        *else_args_len,
+                        block.id,
+                        "branch else arguments",
+                    );
+                }
+                Terminator::Switch {
+                    cases_start,
+                    cases_len,
+                    default,
+                    ..
+                } => {
+                    self.check_range(
+                        *cases_start,
+                        *cases_len,
+                        self.cfg.switch_cases_len(),
+                        block.id,
+                        CfgValue::from_raw(0),
+                        "switch-case",
+                    );
+                    for &(_, target) in self.cfg.get_switch_cases(*cases_start, *cases_len) {
+                        self.check_target(block.id, target, "switch case");
+                    }
+                    self.check_target(block.id, *default, "switch default");
+                }
+                Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
+            }
+        }
+    }
+
+    fn check_target(&self, from: BlockId, target: BlockId, role: &str) {
+        if target.as_u32() as usize >= self.cfg.block_count() {
+            self.fail(format_args!(
+                "{} target {} from block {} is out of bounds (only {} blocks exist)",
+                role,
+                target,
+                from,
+                self.cfg.block_count()
+            ));
+        }
+    }
+
+    fn check_extra(&self, start: u32, len: u32, block: BlockId, value: CfgValue, role: &str) {
+        self.check_range(start, len, self.cfg.extra_len(), block, value, role);
+    }
+
+    fn check_term_extra(&self, start: u32, len: u32, block: BlockId, role: &str) {
+        let end = start.checked_add(len).map(|v| v as usize);
+        if end.is_none_or(|end| start as usize > end || end > self.cfg.extra_len()) {
+            self.fail(format_args!(
+                "{} in terminator of block {} uses out-of-bounds slice {}..{} (storage length {})",
+                role,
+                block,
+                start,
+                end.map_or_else(|| "overflow".to_string(), |v| v.to_string()),
+                self.cfg.extra_len()
+            ));
+        }
+    }
+
+    fn check_range(
+        &self,
+        start: u32,
+        len: u32,
+        storage_len: usize,
+        block: BlockId,
+        value: CfgValue,
+        role: &str,
+    ) {
+        let end = start.checked_add(len).map(|v| v as usize);
+        if end.is_none_or(|end| start as usize > end || end > storage_len) {
+            self.fail(format_args!(
+                "{} slice for instruction {} in block {} is out of bounds: {}..{} (storage length {})",
+                role,
+                value,
+                block,
+                start,
+                end.map_or_else(|| "overflow".to_string(), |v| v.to_string()),
+                storage_len
+            ));
+        }
+    }
+
+    fn compute_reachability(&mut self) {
+        let mut stack = vec![self.cfg.entry];
+        while let Some(id) = stack.pop() {
+            let index = id.as_u32() as usize;
+            if self.reachable[index] {
+                continue;
+            }
+            self.reachable[index] = true;
+            self.for_each_successor(id, |successor| stack.push(successor));
+        }
+    }
+
+    fn for_each_successor(&self, block: BlockId, mut f: impl FnMut(BlockId)) {
+        match &self.cfg.get_block(block).terminator {
+            Terminator::Goto { target, .. } => f(*target),
+            Terminator::Branch {
+                then_block,
+                else_block,
+                ..
+            } => {
+                f(*then_block);
+                f(*else_block);
+            }
+            Terminator::Switch {
+                cases_start,
+                cases_len,
+                default,
+                ..
+            } => {
+                for &(_, target) in self.cfg.get_switch_cases(*cases_start, *cases_len) {
+                    f(target);
+                }
+                f(*default);
+            }
+            Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
+        }
+    }
+
+    fn compute_dominators(&mut self) {
+        let count = self.cfg.block_count();
+        let mut predecessors = vec![Vec::new(); count];
+        for block in self.cfg.blocks() {
+            if self.reachable[block.id.as_u32() as usize] {
+                self.for_each_successor(block.id, |successor| {
+                    predecessors[successor.as_u32() as usize].push(block.id)
+                });
+            }
+        }
+        self.dominators = vec![vec![false; count]; count];
+        for block in self.cfg.blocks() {
+            let index = block.id.as_u32() as usize;
+            if !self.reachable[index] {
+                continue;
+            }
+            if block.id == self.cfg.entry {
+                self.dominators[index][index] = true;
+            } else {
+                for candidate in 0..count {
+                    self.dominators[index][candidate] = self.reachable[candidate];
+                }
+            }
+        }
+        loop {
+            let mut changed = false;
+            for block in self.cfg.blocks() {
+                let index = block.id.as_u32() as usize;
+                if !self.reachable[index] || block.id == self.cfg.entry {
+                    continue;
+                }
+                let mut next = vec![true; count];
+                if predecessors[index].is_empty() {
+                    next.fill(false);
+                } else {
+                    for pred in &predecessors[index] {
+                        for (candidate, present) in next.iter_mut().enumerate() {
+                            *present &= self.dominators[pred.as_u32() as usize][candidate];
+                        }
+                    }
+                }
+                next[index] = true;
+                if next != self.dominators[index] {
+                    self.dominators[index] = next;
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    fn verify_inst(&self, block: BlockId, position: usize, value: CfgValue) {
+        let inst = self.inst(value, block, "instruction");
+        match &inst.data {
+            CfgInstData::Param { index } => {
+                self.check_param_slot(*index, inst.ty, block, value, "Param")
+            }
+            CfgInstData::Alloc { slot, init } => self.check_local_slot(
+                *slot,
+                self.inst(*init, block, "allocation initializer").ty,
+                block,
+                value,
+                "Alloc",
+            ),
+            CfgInstData::Load { slot } => {
+                self.check_local_slot(*slot, inst.ty, block, value, "Load")
+            }
+            CfgInstData::Store {
+                slot,
+                value: stored,
+            } => self.check_local_slot(
+                *slot,
+                self.inst(*stored, block, "stored value").ty,
+                block,
+                value,
+                "Store",
+            ),
+            CfgInstData::StorageLive { slot, local_ty } => {
+                self.check_local_slot(*slot, *local_ty, block, value, "StorageLive")
+            }
+            CfgInstData::StorageDead { slot, local_ty } => {
+                self.check_local_slot(*slot, *local_ty, block, value, "StorageDead")
+            }
+            CfgInstData::ParamStore {
+                param_slot,
+                value: stored,
+            } => self.check_param_slot(
+                *param_slot,
+                self.inst(*stored, block, "stored parameter value").ty,
+                block,
+                value,
+                "ParamStore",
+            ),
+            CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } => {
+                self.verify_place(block, value, place)
+            }
+            CfgInstData::BlockParam { .. } => unreachable!(),
+            _ => {}
+        }
+        self.for_each_inst_operand(block, value, &inst.data, |operand, role| {
+            self.verify_use(block, Some(position), operand, role)
+        });
+    }
+
+    fn check_local_slot(&self, slot: u32, ty: Type, block: BlockId, value: CfgValue, role: &str) {
+        let width = self.abi_slot_count(ty, block, value, role);
+        let end = slot.checked_add(width);
+        if end.is_none_or(|end| end > self.cfg.num_locals()) {
+            self.fail(format_args!(
+                "{} instruction {} in block {} uses local slot range {}..{} for type {:?}, but only {} local slots exist",
+                role,
+                value,
+                block,
+                slot,
+                end.map_or_else(|| "overflow".to_string(), |end| end.to_string()),
+                ty,
+                self.cfg.num_locals()
+            ));
+        }
+    }
+
+    fn check_param_slot(&self, slot: u32, ty: Type, block: BlockId, value: CfgValue, role: &str) {
+        // Borrowed and inout parameters carry one physical pointer slot even
+        // when their logical type is a multi-slot aggregate. Places retain the
+        // logical type so projection validation can follow the pointee shape.
+        let width = if self.cfg.is_param_by_ref(slot) {
+            1
+        } else {
+            self.abi_slot_count(ty, block, value, role)
+        };
+        let end = slot.checked_add(width);
+        if end.is_none_or(|end| end > self.cfg.num_params()) {
+            self.fail(format_args!(
+                "{} instruction {} in block {} uses parameter slot range {}..{} for type {:?}, but only {} parameter slots exist",
+                role,
+                value,
+                block,
+                slot,
+                end.map_or_else(|| "overflow".to_string(), |end| end.to_string()),
+                ty,
+                self.cfg.num_params()
+            ));
+        }
+    }
+
+    fn abi_slot_count(&self, ty: Type, block: BlockId, value: CfgValue, role: &str) -> u32 {
+        match ty.kind() {
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Error
+            | TypeKind::PtrConst(_)
+            | TypeKind::PtrMut(_) => 1,
+            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => 0,
+            TypeKind::Struct(struct_id) => {
+                let Some(pool) = self.type_pool else {
+                    return 0;
+                };
+                let Some(def) = pool.try_struct_def(struct_id) else {
+                    self.fail(format_args!(
+                        "{} instruction {} in block {} references invalid struct type {:?}",
+                        role, value, block, struct_id
+                    ));
+                };
+                def.fields.iter().fold(0u32, |total, field| {
+                    total.saturating_add(self.abi_slot_count(field.ty, block, value, role))
+                })
+            }
+            TypeKind::Array(array_id) => {
+                let Some(pool) = self.type_pool else {
+                    return 0;
+                };
+                let Some((element, len)) = pool.try_array_def(array_id) else {
+                    self.fail(format_args!(
+                        "{} instruction {} in block {} references invalid array type {:?}",
+                        role, value, block, array_id
+                    ));
+                };
+                let element_width = u64::from(self.abi_slot_count(element, block, value, role));
+                u32::try_from(element_width.saturating_mul(len)).unwrap_or(u32::MAX)
+            }
+            TypeKind::Enum(enum_id) => {
+                let Some(pool) = self.type_pool else {
+                    return 0;
+                };
+                let Some(def) = pool.try_enum_def(enum_id) else {
+                    self.fail(format_args!(
+                        "{} instruction {} in block {} references invalid enum type {:?}",
+                        role, value, block, enum_id
+                    ));
+                };
+                let payload_width = (0..def.variant_count())
+                    .map(|index| {
+                        def.variant_payload(index).iter().fold(0u32, |total, &ty| {
+                            total.saturating_add(self.abi_slot_count(ty, block, value, role))
+                        })
+                    })
+                    .max()
+                    .unwrap_or(0);
+                1u32.saturating_add(payload_width)
+            }
+        }
+    }
+
+    fn is_fixed_str_to_view_coercion(&self, source: Type, result: Type) -> bool {
+        let Some(pool) = self.type_pool else {
+            return false;
+        };
+        let (TypeKind::Struct(source_id), TypeKind::Struct(result_id)) =
+            (source.kind(), result.kind())
+        else {
+            return false;
+        };
+        let (Some(source_def), Some(result_def)) = (
+            pool.try_struct_def(source_id),
+            pool.try_struct_def(result_id),
+        ) else {
+            return false;
+        };
+        let is_fixed_str = source_def
+            .name
+            .strip_prefix("Str(")
+            .and_then(|rest| rest.strip_suffix(')'))
+            .is_some_and(|capacity| capacity.parse::<u64>().is_ok());
+        is_fixed_str
+            && result_def.name == "str"
+            && source_def.fields.len() == result_def.fields.len()
+            && source_def
+                .fields
+                .iter()
+                .zip(&result_def.fields)
+                .all(|(source, result)| source.ty == result.ty)
+    }
+
+    fn verify_place(&self, block: BlockId, value: CfgValue, place: &Place) {
+        match place.base {
+            PlaceBase::Local(slot) => {
+                self.check_local_slot(slot, place.base_type, block, value, "place")
+            }
+            PlaceBase::Param(slot) => {
+                self.check_param_slot(slot, place.base_type, block, value, "place")
+            }
+        }
+        let projections = self.cfg.get_place_projections(place);
+        if let Some(pool) = self.type_pool {
+            let mut current_ty = place.base_type;
+            for (projection_index, projection) in projections.iter().enumerate() {
+                current_ty = match projection {
+                    Projection::Field {
+                        struct_id,
+                        field_index,
+                    } => {
+                        let Some(def) = pool.try_struct_def(*struct_id) else {
+                            self.fail(format_args!(
+                                "projection {} in place instruction {} in block {} references invalid struct id {:?}",
+                                projection_index, value, block, struct_id
+                            ));
+                        };
+                        let expected = Type::new_struct(*struct_id);
+                        if current_ty != expected {
+                            self.fail(format_args!(
+                                "projection {} in place instruction {} in block {} expects container type {:?}, but previous link produced {:?}",
+                                projection_index, value, block, expected, current_ty
+                            ));
+                        }
+                        let Some(field) = def.fields.get(*field_index as usize) else {
+                            self.fail(format_args!(
+                                "projection {} in place instruction {} in block {} references field {} of struct {:?}, which has {} fields",
+                                projection_index,
+                                value,
+                                block,
+                                field_index,
+                                struct_id,
+                                def.fields.len()
+                            ));
+                        };
+                        field.ty
+                    }
+                    Projection::Index { array_type, .. } => {
+                        let TypeKind::Array(array_id) = array_type.kind() else {
+                            self.fail(format_args!(
+                                "projection {} in place instruction {} in block {} has non-array container type {:?}",
+                                projection_index, value, block, array_type
+                            ));
+                        };
+                        let Some((element_ty, _)) = pool.try_array_def(array_id) else {
+                            self.fail(format_args!(
+                                "projection {} in place instruction {} in block {} references invalid array id {:?}",
+                                projection_index, value, block, array_id
+                            ));
+                        };
+                        if current_ty != *array_type {
+                            self.fail(format_args!(
+                                "projection {} in place instruction {} in block {} expects container type {:?}, but previous link produced {:?}",
+                                projection_index, value, block, array_type, current_ty
+                            ));
+                        }
+                        element_ty
+                    }
+                };
+            }
+
+            let inst = self.cfg.get_inst(value);
+            match &inst.data {
+                CfgInstData::PlaceRead { .. }
+                    if inst.ty != current_ty
+                        && !self.is_fixed_str_to_view_coercion(current_ty, inst.ty) =>
+                {
+                    self.fail(format_args!(
+                        "place-read instruction {} in block {} has result type {:?}, but its projection chain produces {:?}",
+                        value, block, inst.ty, current_ty
+                    ));
+                }
+                CfgInstData::PlaceWrite { value: stored, .. } => {
+                    let stored_ty = self.inst(*stored, block, "place-write value").ty;
+                    if stored_ty != current_ty {
+                        self.fail(format_args!(
+                            "place-write instruction {} in block {} stores type {:?}, but its projection chain produces {:?}",
+                            value, block, stored_ty, current_ty
+                        ));
+                    }
+                    if inst.ty != Type::UNIT {
+                        self.fail(format_args!(
+                            "place-write instruction {} in block {} has result type {:?}, expected unit",
+                            value, block, inst.ty
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(first) = projections.first() {
+            let required = match first {
+                Projection::Field { struct_id, .. } => Type::new_struct(*struct_id),
+                Projection::Index { array_type, .. } => {
+                    if !matches!(array_type.kind(), TypeKind::Array(_)) {
+                        self.fail(format_args!(
+                            "place in instruction {} in block {} has Index projection with non-array container type {:?}",
+                            value, block, array_type
+                        ));
+                    }
+                    *array_type
+                }
+            };
+            if place.base_type != required {
+                self.fail(format_args!(
+                    "place in instruction {} in block {} has logical base type {:?}, but its first projection requires base type {:?}",
+                    value, block, place.base_type, required
+                ));
+            }
+        }
+        for projection in projections {
+            if let Projection::Index { array_type, index } = projection {
+                if !matches!(array_type.kind(), TypeKind::Array(_)) {
+                    self.fail(format_args!(
+                        "place in instruction {} in block {} has Index projection with non-array container type {:?}",
+                        value, block, array_type
+                    ));
+                }
+                let index_ty = self.inst(*index, block, "projection index").ty;
+                if !matches!(
+                    index_ty.kind(),
+                    TypeKind::I8
+                        | TypeKind::I16
+                        | TypeKind::I32
+                        | TypeKind::I64
+                        | TypeKind::U8
+                        | TypeKind::U16
+                        | TypeKind::U32
+                        | TypeKind::U64
+                ) {
+                    self.fail(format_args!(
+                        "projection index {} used by instruction {} in block {} has non-integer type {:?}",
+                        index, value, block, index_ty
+                    ));
+                }
+            }
+        }
+    }
+
+    fn verify_terminator_use(&self, block: BlockId, term: &Terminator) {
+        match term {
+            Terminator::Goto {
+                target,
+                args_start,
+                args_len,
+            } => {
+                let args = self.cfg.get_extra(*args_start, *args_len);
+                for &arg in args {
+                    self.verify_use(block, None, arg, "goto argument");
+                }
+                self.verify_edge(block, *target, args);
+            }
+            Terminator::Branch {
+                cond,
+                then_block,
+                then_args_start,
+                then_args_len,
+                else_block,
+                else_args_start,
+                else_args_len,
+            } => {
+                self.verify_use(block, None, *cond, "branch condition");
+                if self.inst(*cond, block, "branch condition").ty != Type::BOOL {
+                    self.fail(format_args!(
+                        "branch condition {} in block {} has type {:?}, expected bool",
+                        cond,
+                        block,
+                        self.cfg.get_inst(*cond).ty
+                    ));
+                }
+                let then_args = self.cfg.get_extra(*then_args_start, *then_args_len);
+                for &arg in then_args {
+                    self.verify_use(block, None, arg, "branch-then argument");
+                }
+                self.verify_edge(block, *then_block, then_args);
+                let else_args = self.cfg.get_extra(*else_args_start, *else_args_len);
+                for &arg in else_args {
+                    self.verify_use(block, None, arg, "branch-else argument");
+                }
+                self.verify_edge(block, *else_block, else_args);
+            }
+            Terminator::Switch {
+                scrutinee,
+                cases_start,
+                cases_len,
+                default,
+            } => {
+                self.verify_use(block, None, *scrutinee, "switch scrutinee");
+                for &(_, target) in self.cfg.get_switch_cases(*cases_start, *cases_len) {
+                    self.verify_edge(block, target, &[]);
+                }
+                self.verify_edge(block, *default, &[]);
+            }
+            Terminator::Return { value } => match (self.cfg.return_type(), value) {
+                (Type::UNIT, None) => {}
+                (Type::UNIT, Some(value)) => self.fail(format_args!(
+                    "return in block {} supplies unit value {}; unit-returning functions must use Return {{ value: None }}",
+                    block, value
+                )),
+                (return_ty, None) => self.fail(format_args!(
+                    "return in block {} has no value but function return type is {:?}",
+                    block, return_ty
+                )),
+                (return_ty, Some(value)) => {
+                    self.verify_use(block, None, *value, "return value");
+                    let value_ty = self.cfg.get_inst(*value).ty;
+                    if value_ty != return_ty {
+                        self.fail(format_args!(
+                            "return value {} in block {} has type {:?}, expected {:?}",
+                            value, block, value_ty, return_ty
+                        ));
+                    }
+                }
+            },
+            Terminator::Unreachable | Terminator::None => {}
+        }
+    }
+
+    fn verify_edge(&self, from: BlockId, to: BlockId, args: &[CfgValue]) {
+        let params = &self.cfg.get_block(to).params;
+        if params.len() != args.len() {
+            self.fail(format_args!(
+                "edge {} -> {} passes {} block arguments but target expects {}",
+                from,
+                to,
+                args.len(),
+                params.len()
+            ));
+        }
+        for (index, (&arg, &(_, param_ty))) in args.iter().zip(params).enumerate() {
+            let arg_ty = self.cfg.get_inst(arg).ty;
+            if arg_ty != param_ty {
+                self.fail(format_args!(
+                    "edge {} -> {} argument {} ({}) has type {:?}, target parameter has type {:?} (ill-typed edge)",
+                    from, to, index, arg, arg_ty, param_ty
+                ));
+            }
+        }
+    }
+
+    fn verify_use(
+        &self,
+        use_block: BlockId,
+        use_position: Option<usize>,
+        value: CfgValue,
+        role: &str,
+    ) {
+        let _ = self.inst(value, use_block, role);
+        let Some(attachment) = self.attachments[value.as_u32() as usize] else {
+            self.fail(format_args!(
+                "{} {} in block {} refers to an unattached value",
+                role, value, use_block
+            ));
+        };
+        match attachment {
+            Attachment::Param { block } if block == use_block => {}
+            Attachment::Inst { block, position } if block == use_block => {
+                if use_position.is_some_and(|use_position| position >= use_position) {
+                    self.fail(format_args!(
+                        "{} {} in block {} is used before its definition at instruction position {}",
+                        role, value, use_block, position
+                    ));
+                }
+            }
+            Attachment::Param { block: def_block }
+            | Attachment::Inst {
+                block: def_block, ..
+            } => {
+                let use_index = use_block.as_u32() as usize;
+                if self.reachable[use_index]
+                    && !self.dominators[use_index][def_block.as_u32() as usize]
+                {
+                    self.fail(format_args!(
+                        "{} {} in reachable block {} is defined in block {}, which does not dominate the use",
+                        role, value, use_block, def_block
+                    ));
+                }
+            }
+        }
+    }
+
+    fn for_each_inst_operand(
+        &self,
+        block: BlockId,
+        value: CfgValue,
+        data: &CfgInstData,
+        mut f: impl FnMut(CfgValue, &'static str),
+    ) {
+        match data {
+            CfgInstData::Const(_)
+            | CfgInstData::BoolConst(_)
+            | CfgInstData::StringConst(_)
+            | CfgInstData::Param { .. }
+            | CfgInstData::BlockParam { .. }
+            | CfgInstData::Load { .. }
+            | CfgInstData::StorageLive { .. }
+            | CfgInstData::StorageDead { .. } => {}
+            CfgInstData::Add(a, b)
+            | CfgInstData::Sub(a, b)
+            | CfgInstData::Mul(a, b)
+            | CfgInstData::Div(a, b)
+            | CfgInstData::Mod(a, b)
+            | CfgInstData::Eq(a, b)
+            | CfgInstData::Ne(a, b)
+            | CfgInstData::Lt(a, b)
+            | CfgInstData::Gt(a, b)
+            | CfgInstData::Le(a, b)
+            | CfgInstData::Ge(a, b)
+            | CfgInstData::BitAnd(a, b)
+            | CfgInstData::BitOr(a, b)
+            | CfgInstData::BitXor(a, b)
+            | CfgInstData::Shl(a, b)
+            | CfgInstData::Shr(a, b) => {
+                f(*a, "left operand");
+                f(*b, "right operand");
+            }
+            CfgInstData::Neg(v) | CfgInstData::Not(v) | CfgInstData::BitNot(v) => {
+                f(*v, "unary operand")
+            }
+            CfgInstData::Alloc { init, .. } => f(*init, "allocation initializer"),
+            CfgInstData::Store { value, .. } | CfgInstData::ParamStore { value, .. } => {
+                f(*value, "stored value")
+            }
+            CfgInstData::PlaceRead { place } => {
+                for projection in self.cfg.get_place_projections(place) {
+                    if let Projection::Index { index, .. } = projection {
+                        f(*index, "projection index");
+                    }
+                }
+            }
+            CfgInstData::PlaceWrite { place, value } => {
+                for projection in self.cfg.get_place_projections(place) {
+                    if let Projection::Index { index, .. } = projection {
+                        f(*index, "projection index");
+                    }
+                }
+                f(*value, "place-write value");
+            }
+            CfgInstData::Call {
+                args_start,
+                args_len,
+                ..
+            } => {
+                for arg in self.cfg.get_call_args(*args_start, *args_len) {
+                    f(arg.value, "call argument");
+                }
+            }
+            CfgInstData::Intrinsic {
+                args_start,
+                args_len,
+                ..
+            } => {
+                for &operand in self.cfg.get_extra(*args_start, *args_len) {
+                    f(operand, "intrinsic argument");
+                }
+            }
+            CfgInstData::StructInit {
+                fields_start,
+                fields_len,
+                ..
+            } => {
+                for &operand in self.cfg.get_extra(*fields_start, *fields_len) {
+                    f(operand, "struct field");
+                }
+            }
+            CfgInstData::ArrayInit {
+                elements_start,
+                elements_len,
+            } => {
+                for &operand in self.cfg.get_extra(*elements_start, *elements_len) {
+                    f(operand, "array element");
+                }
+            }
+            CfgInstData::EnumVariant {
+                payload_start,
+                payload_len,
+                ..
+            } => {
+                for &operand in self.cfg.get_extra(*payload_start, *payload_len) {
+                    f(operand, "enum payload");
+                }
+            }
+            CfgInstData::EnumPayloadGet { base, .. } => f(*base, "enum base"),
+            CfgInstData::IntCast { value, .. } => f(*value, "cast operand"),
+            CfgInstData::Drop { value } => f(*value, "drop operand"),
+        }
+        let _ = (block, value);
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::inst::{Cfg, CfgInst, CfgInstData, PlaceBase, Projection, Terminator};
-    use rue_air::{ArrayTypeId, StructId, Type};
+    use crate::inst::{
+        BlockId, Cfg, CfgInst, CfgInstData, Place, PlaceBase, Projection, Terminator,
+    };
+    use crate::{OptLevel, opt};
+    use lasso::ThreadedRodeo;
+    use rue_air::{ArrayTypeId, StructDef, StructField, StructId, Type, TypeInternPool};
     use rue_span::Span;
 
     fn unit_cfg() -> Cfg {
         Cfg::new(Type::I32, 0, 0, "test".to_string(), vec![])
+    }
+
+    fn register_struct(
+        pool: &TypeInternPool,
+        interner: &ThreadedRodeo,
+        name: &str,
+        field_types: &[Type],
+    ) -> StructId {
+        pool.register_struct(
+            interner.get_or_intern(name),
+            StructDef {
+                name: name.to_string(),
+                fields: field_types
+                    .iter()
+                    .enumerate()
+                    .map(|(index, &ty)| StructField {
+                        name: format!("field{index}"),
+                        ty,
+                    })
+                    .collect(),
+                is_copy: false,
+                is_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: rue_span::FileId::DEFAULT,
+            },
+        )
+        .0
     }
 
     #[test]
@@ -580,7 +1389,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "declared container type Type::I32 is not an array")]
+    #[should_panic(expected = "Index projection with non-array container type Type::I32")]
     fn verify_rejects_non_array_index_projection_type() {
         let mut cfg = Cfg::new(Type::I32, 1, 0, "index_type".to_string(), vec![]);
         let entry = cfg.new_block();
@@ -637,22 +1446,30 @@ mod tests {
         let mut cfg = unit_cfg();
         let entry = cfg.new_block();
         cfg.entry = entry;
-        cfg.set_terminator(entry, Terminator::Return { value: None });
+        let value = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
         // An orphan block, never wired in, with no terminator: must be skipped.
         let _orphan = cfg.new_block();
         cfg.verify();
     }
 
     #[test]
-    #[should_panic(expected = "block-argument")]
+    #[should_panic(expected = "block arguments")]
     fn verify_catches_arity_mismatch() {
         let mut cfg = unit_cfg();
         let entry = cfg.new_block();
         cfg.entry = entry;
         let target = cfg.new_block();
         // Target expects one block parameter...
-        cfg.add_block_param(target, Type::I32);
-        cfg.set_terminator(target, Terminator::Return { value: None });
+        let param = cfg.add_block_param(target, Type::I32);
+        cfg.set_terminator(target, Terminator::Return { value: Some(param) });
         // ...but the goto edge passes zero arguments.
         cfg.set_terminator(
             entry,
@@ -671,8 +1488,8 @@ mod tests {
         let entry = cfg.new_block();
         cfg.entry = entry;
         let target = cfg.new_block();
-        cfg.add_block_param(target, Type::I32);
-        cfg.set_terminator(target, Terminator::Return { value: None });
+        let param = cfg.add_block_param(target, Type::I32);
+        cfg.set_terminator(target, Terminator::Return { value: Some(param) });
         let arg = cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -713,12 +1530,25 @@ mod tests {
         let mut cfg = unit_cfg();
         let entry = cfg.new_block();
         cfg.entry = entry;
-        cfg.set_terminator(entry, Terminator::Return { value: None });
+        let entry_value = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(
+            entry,
+            Terminator::Return {
+                value: Some(entry_value),
+            },
+        );
         // Unreachable-but-terminated pair with a unit→i32 edge.
         let orphan_from = cfg.new_block();
         let orphan_to = cfg.new_block();
-        cfg.add_block_param(orphan_to, Type::I32);
-        cfg.set_terminator(orphan_to, Terminator::Return { value: None });
+        let param = cfg.add_block_param(orphan_to, Type::I32);
+        cfg.set_terminator(orphan_to, Terminator::Return { value: Some(param) });
         let arg = cfg.add_inst_to_block(
             orphan_from,
             CfgInst {
@@ -737,5 +1567,670 @@ mod tests {
             },
         );
         cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "value v0 is unattached")]
+    fn verify_rejects_unattached_value() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst(CfgInst {
+            data: CfgInstData::Const(0),
+            ty: Type::I32,
+            span: Span::new(0, 0),
+        });
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate attachments")]
+    fn verify_rejects_duplicate_attachment() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let value = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.get_block_mut(entry).insts.push(value);
+        cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "declares index 1")]
+    fn verify_rejects_wrong_block_param_index() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let param = cfg.add_block_param(entry, Type::I32);
+        cfg.get_inst_mut(param).data = CfgInstData::BlockParam { index: 1 };
+        cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "has non-BlockParam data")]
+    fn verify_rejects_wrong_block_param_data() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let param = cfg.add_block_param(entry, Type::I32);
+        cfg.get_inst_mut(param).data = CfgInstData::Const(0);
+        cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "stores type Type::U64")]
+    fn verify_rejects_wrong_block_param_stored_type() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let param = cfg.add_block_param(entry, Type::I32);
+        cfg.get_block_mut(entry).params[0].1 = Type::U64;
+        cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "used before its definition")]
+    fn verify_rejects_use_before_definition() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let later = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(1),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        let earlier = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Neg(later),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.get_block_mut(entry).insts.swap(0, 1);
+        cfg.set_terminator(
+            entry,
+            Terminator::Return {
+                value: Some(earlier),
+            },
+        );
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "does not dominate the use")]
+    fn verify_rejects_cross_block_non_dominating_use() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let left = cfg.new_block();
+        let right = cfg.new_block();
+        let cond = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::BoolConst(true),
+                ty: Type::BOOL,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(
+            entry,
+            Terminator::Branch {
+                cond,
+                then_block: left,
+                then_args_start: 0,
+                then_args_len: 0,
+                else_block: right,
+                else_args_start: 0,
+                else_args_len: 0,
+            },
+        );
+        let value = cfg.add_inst_to_block(
+            left,
+            CfgInst {
+                data: CfgInstData::Const(1),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(left, Terminator::Return { value: Some(value) });
+        cfg.set_terminator(right, Terminator::Return { value: Some(value) });
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "branch condition")]
+    fn verify_rejects_non_bool_branch_condition() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let target = cfg.new_block();
+        let cond = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(1),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(
+            entry,
+            Terminator::Branch {
+                cond,
+                then_block: target,
+                then_args_start: 0,
+                then_args_len: 0,
+                else_block: target,
+                else_args_start: 0,
+                else_args_len: 0,
+            },
+        );
+        cfg.set_terminator(target, Terminator::Unreachable);
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "has no value but function return type")]
+    fn verify_rejects_missing_nonunit_return_value() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.set_terminator(entry, Terminator::Return { value: None });
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "unit-returning functions must use")]
+    fn verify_rejects_explicit_unit_return_value() {
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "unit_return".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let value = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::UNIT,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "entry block bb7 is out of bounds")]
+    fn verify_rejects_invalid_entry_before_indexing() {
+        let mut cfg = unit_cfg();
+        cfg.new_block();
+        cfg.entry = BlockId::from_raw(7);
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "goto target bb9")]
+    fn verify_rejects_invalid_target_before_indexing() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.set_terminator(
+            entry,
+            Terminator::Goto {
+                target: BlockId::from_raw(9),
+                args_start: 0,
+                args_len: 0,
+            },
+        );
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "local slot range 0..1")]
+    fn verify_checks_slots_in_unreachable_blocks() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let value = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
+        let orphan = cfg.new_block();
+        cfg.add_inst_to_block(
+            orphan,
+            CfgInst {
+                data: CfgInstData::Load { slot: 0 },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.verify_with_type_pool(&TypeInternPool::new());
+    }
+
+    #[test]
+    #[should_panic(expected = "parameter slot range 0..1")]
+    fn verify_rejects_invalid_parameter_slot() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Param { index: 0 },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify_with_type_pool(&TypeInternPool::new());
+    }
+
+    #[test]
+    #[should_panic(expected = "local slot range 0..2")]
+    fn verify_rejects_multi_slot_local_overflow() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let pair = register_struct(&pool, &interner, "Pair", &[Type::I32, Type::I32]);
+        let mut cfg = Cfg::new(Type::UNIT, 1, 0, "wide_local".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Load { slot: 0 },
+                ty: Type::new_struct(pair),
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify_with_type_pool(&pool);
+    }
+
+    #[test]
+    fn verify_accepts_multi_slot_logical_type_in_one_by_ref_parameter_slot() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let pair = register_struct(&pool, &interner, "BorrowedPair", &[Type::I32, Type::I32]);
+        let pair_ty = Type::new_struct(pair);
+        let mut cfg = Cfg::new(Type::UNIT, 0, 1, "borrowed_pair".to_string(), vec![true]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let place = cfg.make_place(
+            PlaceBase::Param(0),
+            pair_ty,
+            [Projection::Field {
+                struct_id: pair,
+                field_index: 1,
+            }],
+        );
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: None });
+        cfg.verify_with_type_pool(&pool);
+    }
+
+    #[test]
+    #[should_panic(expected = "references invalid struct id")]
+    fn verify_rejects_invalid_struct_projection_id() {
+        let pool = TypeInternPool::new();
+        let mut cfg = Cfg::new(Type::UNIT, 1, 0, "invalid_struct".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            Type::I32,
+            [Projection::Field {
+                struct_id: StructId::from_pool_index(99),
+                field_index: 0,
+            }],
+        );
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify_with_type_pool(&pool);
+    }
+
+    #[test]
+    #[should_panic(expected = "references invalid array id")]
+    fn verify_rejects_invalid_array_projection_id() {
+        let pool = TypeInternPool::new();
+        let mut cfg = Cfg::new(Type::UNIT, 1, 0, "invalid_array".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let index = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::U64,
+                span: Span::new(0, 0),
+            },
+        );
+        let array_type = Type::new_array(ArrayTypeId::from_pool_index(99));
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            Type::I32,
+            [Projection::Index { array_type, index }],
+        );
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify_with_type_pool(&pool);
+    }
+
+    #[test]
+    #[should_panic(expected = "references field 1")]
+    fn verify_rejects_out_of_bounds_field_projection() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let record = register_struct(&pool, &interner, "Record", &[Type::I32]);
+        let record_ty = Type::new_struct(record);
+        let mut cfg = Cfg::new(Type::UNIT, 1, 0, "bad_field".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            record_ty,
+            [Projection::Field {
+                struct_id: record,
+                field_index: 1,
+            }],
+        );
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify_with_type_pool(&pool);
+    }
+
+    #[test]
+    #[should_panic(expected = "previous link produced")]
+    fn verify_rejects_broken_nested_projection_continuity() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let inner = register_struct(&pool, &interner, "Inner", &[Type::I32]);
+        let wrong = register_struct(&pool, &interner, "Wrong", &[Type::I32]);
+        let outer = register_struct(&pool, &interner, "Outer", &[Type::new_struct(inner)]);
+        let mut cfg = Cfg::new(Type::UNIT, 1, 0, "broken_chain".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            Type::new_struct(outer),
+            [
+                Projection::Field {
+                    struct_id: outer,
+                    field_index: 0,
+                },
+                Projection::Field {
+                    struct_id: wrong,
+                    field_index: 0,
+                },
+            ],
+        );
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify_with_type_pool(&pool);
+    }
+
+    #[test]
+    #[should_panic(expected = "projection chain produces Type::I32")]
+    fn verify_rejects_place_read_result_type_mismatch() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let record = register_struct(&pool, &interner, "ResultRecord", &[Type::I32]);
+        let mut cfg = Cfg::new(Type::UNIT, 1, 0, "bad_result".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            Type::new_struct(record),
+            [Projection::Field {
+                struct_id: record,
+                field_index: 0,
+            }],
+        );
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty: Type::BOOL,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify_with_type_pool(&pool);
+    }
+
+    #[test]
+    #[should_panic(expected = "array elements slice")]
+    fn verify_rejects_invalid_extra_slice_before_slicing() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::ArrayInit {
+                    elements_start: u32::MAX,
+                    elements_len: 2,
+                },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "call-argument slice")]
+    fn verify_rejects_invalid_call_argument_slice_before_slicing() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Call {
+                    name: lasso::Spur::default(),
+                    args_start: 1,
+                    args_len: 1,
+                },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "switch-case slice")]
+    fn verify_rejects_invalid_switch_case_slice_before_slicing() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let value = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(0),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(
+            entry,
+            Terminator::Switch {
+                scrutinee: value,
+                cases_start: 1,
+                cases_len: 1,
+                default: entry,
+            },
+        );
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "projection slice")]
+    fn verify_rejects_invalid_projection_slice_before_slicing() {
+        let mut cfg = Cfg::new(Type::I32, 1, 0, "projection_slice".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead {
+                    place: Place {
+                        base: PlaceBase::Local(0),
+                        base_type: Type::I32,
+                        proj_start: 1,
+                        proj_len: 1,
+                    },
+                },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "projection index v0")]
+    fn verify_rejects_non_integer_projection_index() {
+        let mut cfg = Cfg::new(Type::I32, 1, 0, "projection_index".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let index = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::BoolConst(false),
+                ty: Type::BOOL,
+                span: Span::new(0, 0),
+            },
+        );
+        let array_type = Type::new_array(ArrayTypeId::from_pool_index(1));
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            array_type,
+            [Projection::Index { array_type, index }],
+        );
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.verify();
+    }
+
+    #[test]
+    fn optimize_verifies_before_and_after_dce() {
+        for level in [OptLevel::O0, OptLevel::O1] {
+            let mut cfg = unit_cfg();
+            let entry = cfg.new_block();
+            cfg.entry = entry;
+            cfg.add_inst_to_block(
+                entry,
+                CfgInst {
+                    data: CfgInstData::Const(99),
+                    ty: Type::I32,
+                    span: Span::new(0, 0),
+                },
+            );
+            let result = cfg.add_inst_to_block(
+                entry,
+                CfgInst {
+                    data: CfgInstData::Const(42),
+                    ty: Type::I32,
+                    span: Span::new(0, 0),
+                },
+            );
+            cfg.set_terminator(
+                entry,
+                Terminator::Return {
+                    value: Some(result),
+                },
+            );
+            opt::optimize(&mut cfg, level, &TypeInternPool::new());
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "is unattached")]
+    fn o1_cannot_hide_unattached_value_with_dce() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst(CfgInst {
+            data: CfgInstData::Const(99),
+            ty: Type::I32,
+            span: Span::new(0, 0),
+        });
+        let result = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(42),
+                ty: Type::I32,
+                span: Span::new(0, 0),
+            },
+        );
+        cfg.set_terminator(
+            entry,
+            Terminator::Return {
+                value: Some(result),
+            },
+        );
+        opt::optimize(&mut cfg, OptLevel::O1, &TypeInternPool::new());
     }
 }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2610,13 +2610,13 @@ impl<'a> CfgLower<'a> {
                 );
             }
 
-            CfgInstData::StorageLive { slot: _ } => {
+            CfgInstData::StorageLive { .. } => {
                 // StorageLive marks a slot as valid for use.
                 // Currently a no-op in codegen. In the future, this could be used
                 // for stack slot optimization (LLVM lifetime intrinsics).
             }
 
-            CfgInstData::StorageDead { slot: _ } => {
+            CfgInstData::StorageDead { .. } => {
                 // StorageDead marks a slot as no longer in use.
                 // Currently a no-op in codegen. In the future, this could be used
                 // for stack slot optimization (LLVM lifetime intrinsics).
@@ -3734,7 +3734,19 @@ impl<'a> CfgLower<'a> {
             Terminator::Return { value } => {
                 // Handle `return;` without expression (unit-returning functions)
                 let Some(value) = value else {
-                    self.mir.push(Aarch64Inst::Ret);
+                    if self.fn_name == "main" {
+                        // Linux enters Rue's `main` directly. Unit has no CFG
+                        // value, so pass the language-defined success status to
+                        // the non-returning runtime exit shim explicitly.
+                        self.mir.push(Aarch64Inst::MovImm {
+                            dst: Operand::Physical(Reg::X0),
+                            imm: 0,
+                        });
+                        let symbol_id = self.intern_symbol("__rue_exit");
+                        self.mir.push(Aarch64Inst::Bl { symbol_id });
+                    } else {
+                        self.mir.push(Aarch64Inst::Ret);
+                    }
                     return;
                 };
 
@@ -4073,6 +4085,23 @@ mod tests {
     fn test_simple_return() {
         let mir = lower_to_mir("fn main() -> i32 { 42 }");
         assert!(!mir.instructions().is_empty());
+    }
+
+    #[test]
+    fn unit_main_exits_with_zero_status() {
+        let mir = lower_to_mir("fn main() {}");
+        assert!(mir.instructions().windows(2).any(|pair| {
+            matches!(
+                pair,
+                [
+                    Aarch64Inst::MovImm {
+                        dst: Operand::Physical(Reg::X0),
+                        imm: 0,
+                    },
+                    Aarch64Inst::Bl { .. },
+                ]
+            )
+        }));
     }
 
     #[test]

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -243,8 +243,8 @@ fn format_cfg_inst_data_impl(
             format!("int_cast {} : {}", value, from_ty.name())
         }
         CfgInstData::Drop { value } => format!("drop {}", value),
-        CfgInstData::StorageLive { slot } => format!("storage_live ${}", slot),
-        CfgInstData::StorageDead { slot } => format!("storage_dead ${}", slot),
+        CfgInstData::StorageLive { slot, .. } => format!("storage_live ${}", slot),
+        CfgInstData::StorageDead { slot, .. } => format!("storage_dead ${}", slot),
         // Place operations
         CfgInstData::PlaceRead { place } => {
             format!("place_read {}", cfg.place_to_string(place))

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -500,19 +500,11 @@ mod tests {
         .expect("AArch64 ZST fixture should lower");
         assert!(matches!(
             unit_x86.instructions(),
-            [
-                X86Inst::MovRI64 { imm: 0, .. },
-                X86Inst::MovRR { .. },
-                X86Inst::Ret
-            ]
+            [X86Inst::MovRI64 { imm: 0, .. }, X86Inst::Ret]
         ));
         assert!(matches!(
             unit_arm.instructions(),
-            [
-                Aarch64Inst::MovImm { imm: 0, .. },
-                Aarch64Inst::MovRR { .. },
-                Aarch64Inst::Ret
-            ]
+            [Aarch64Inst::MovImm { imm: 0, .. }, Aarch64Inst::Ret]
         ));
     }
 }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2972,13 +2972,13 @@ impl<'a> CfgLower<'a> {
                 );
             }
 
-            CfgInstData::StorageLive { slot: _ } => {
+            CfgInstData::StorageLive { .. } => {
                 // StorageLive marks a slot as valid for use.
                 // Currently a no-op in codegen. In the future, this could be used
                 // for stack slot optimization (LLVM lifetime intrinsics).
             }
 
-            CfgInstData::StorageDead { slot: _ } => {
+            CfgInstData::StorageDead { .. } => {
                 // StorageDead marks a slot as no longer in use.
                 // Currently a no-op in codegen. In the future, this could be used
                 // for stack slot optimization (LLVM lifetime intrinsics).
@@ -3684,7 +3684,19 @@ impl<'a> CfgLower<'a> {
             Terminator::Return { value } => {
                 // Handle `return;` without expression (unit-returning functions)
                 let Some(value) = value else {
-                    self.mir.push(X86Inst::Ret);
+                    if self.fn_name == "main" {
+                        // Linux enters Rue's `main` directly. Unit has no CFG
+                        // value, so pass the language-defined success status to
+                        // the non-returning runtime exit shim explicitly.
+                        self.mir.push(X86Inst::MovRI32 {
+                            dst: Operand::Physical(Reg::Rdi),
+                            imm: 0,
+                        });
+                        let symbol_id = self.intern_symbol("__rue_exit");
+                        self.mir.push(X86Inst::CallRel { symbol_id });
+                    } else {
+                        self.mir.push(X86Inst::Ret);
+                    }
                     return;
                 };
 
@@ -4026,6 +4038,23 @@ mod tests {
     fn test_simple_return() {
         let mir = lower_to_mir("fn main() -> i32 { 42 }");
         assert!(!mir.instructions().is_empty());
+    }
+
+    #[test]
+    fn unit_main_exits_with_zero_status() {
+        let mir = lower_to_mir("fn main() {}");
+        assert!(mir.instructions().windows(2).any(|pair| {
+            matches!(
+                pair,
+                [
+                    X86Inst::MovRI32 {
+                        dst: Operand::Physical(Reg::Rdi),
+                        imm: 0,
+                    },
+                    X86Inst::CallRel { .. },
+                ]
+            )
+        }));
     }
 
     #[test]

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -858,6 +858,25 @@ mod integration_tests {
             let src = r#"fn main() -> i32 { let _s = "hello\\world"; 0 }"#;
             assert!(test_air(src).is_ok());
         }
+
+        #[test]
+        fn projected_fixed_string_borrow_coerces_to_str_view() {
+            let src = r#"
+                struct Holder { s: Str(8) }
+                fn take(borrow s: str) -> u64 { s.len() }
+                fn main() -> i32 {
+                    let h = Holder { s: "hi" };
+                    @intCast(take(borrow h.s))
+                }
+            "#;
+            let snapshot = SourceSnapshot::single("<test>", src).unwrap();
+            let mut options = CompileOptions::default();
+            options
+                .preview_features
+                .insert("string_trio".parse().unwrap());
+
+            assert!(test_frontend_snapshot(&snapshot, &options).is_ok());
+        }
     }
 
     // ========================================================================
@@ -1036,12 +1055,9 @@ mod integration_tests {
                     })
                     .collect();
                 assert_eq!(return_values.len(), 1, "{name} must have one return");
-                let return_value = return_values[0].expect("unit return must use a dummy value");
-                let return_inst = cfg.get_inst(return_value);
-                assert_eq!(return_inst.ty, Type::UNIT, "{name} return value type");
                 assert!(
-                    matches!(return_inst.data, rue_cfg::CfgInstData::Const(0)),
-                    "{name} must return the established dummy unit value, not a side-effect-only intrinsic"
+                    return_values[0].is_none(),
+                    "{name} must use the canonical valueless unit return"
                 );
 
                 for &target in Target::all() {

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -208,7 +208,7 @@ pub(crate) fn build_functions_and_cfgs(
             function_work.optimization_attempts = 1;
             function_work.optimized_level_attempts = usize::from(opt_level != OptLevel::O0);
             let mut cfg = cfg_output.cfg;
-            rue_cfg::opt::optimize(&mut cfg, opt_level);
+            rue_cfg::opt::optimize(&mut cfg, opt_level, &type_pool);
             function_work.optimization_completions = 1;
             function_work.cfg_warnings_emitted = cfg_output.warnings.len();
             function_work.implicit_destructor_targets_emitted =

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -569,7 +569,11 @@ mod durable_body_integration_tests {
                 imported.allow_unreachable_code,
             );
             assert!(cfg_output.errors.is_empty());
-            rue_cfg::opt::optimize(&mut cfg_output.cfg, rue_cfg::OptLevel::O0);
+            rue_cfg::opt::optimize(
+                &mut cfg_output.cfg,
+                rue_cfg::OptLevel::O0,
+                epoch.type_pool(),
+            );
             assert_eq!(
                 normalize_epoch_symbols(&cfg_output.cfg.to_string()),
                 normalize_epoch_symbols(&ordinary.cfg.to_string())

--- a/crates/rue-spec/cases/golden/ir-dumps.toml
+++ b/crates/rue-spec/cases/golden/ir-dumps.toml
@@ -190,7 +190,6 @@ function set:
     mov v1, 42
     mov [v0], v1
     mov v2, 0
-    mov rax, v2
     ret
 """
 
@@ -229,7 +228,6 @@ function set:
     mov v1, #42
     str v1, [v0]
     mov v2, #0
-    mov x0, v2
     ret
 """
 


### PR DESCRIPTION
## Summary

- make CFG verification establish unique value attachment, block-parameter ownership, definition order, and reachable dominance
- validate targets, arena slices, branch/return types, slot extents, and complete projection chains with the active type pool
- verify construction output before optimization and the live graph again after DCE
- canonicalize unit CFG returns while preserving a deterministic zero ABI result on both backends

## Why

The release-build CFG guard previously allowed malformed definitions, non-dominating uses, invalid storage references, and ill-typed terminators to reach later passes. DCE could also erase the evidence before verification. The verifier now fails at the CFG boundary with function, block, and value context.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (24/24 targets)
- CFG tests (99/99)
- compiler tests (422/422)
- codegen tests (493/493)
- CLI tests (1401 passed, 3 ignored)
- specification tests (2049 passed, 18 ignored)
- UI tests (178/178)
- generated oracle smoke in isolation (64/64)
- reproducibility suite

Fixes RUE-797
