### PR TITLE
RUE-807: centralize import discovery protocol

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -75,6 +75,7 @@ files = [
     { path = "sources.manifest", source = """
 main.rue
 with\\#hash.rue # comment after an escaped path character
+with\\#hash/_with\\#hash.rue # declared absent ambiguity arm
 """ },
     { path = "main.rue", source = """
 const helper = @import("with#hash");
@@ -101,6 +102,7 @@ files = [
 # One source path per line, relative to this manifest file.
 main.rue
 utils.rue
+utils/_utils.rue # declared absent ambiguity arm
 """ },
     { path = "main.rue", source = """
 const utils = @import("utils");

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -14,6 +14,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("drop_glue", include_str!("drop_glue.rs")),
     ("durable_body", include_str!("durable_body.rs")),
     ("durable_semantics", include_str!("durable_semantics.rs")),
+    ("import_discovery", include_str!("import_discovery.rs")),
     ("import_graph", include_str!("import_graph.rs")),
     ("linking", include_str!("linking.rs")),
     ("parsed_modules", include_str!("parsed_modules.rs")),

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1118,8 +1118,7 @@ fn classify_module(
             }
             return ModuleId::from_logical_path(
                 Path::new("\0rue-std").join(relative).to_string_lossy(),
-            )
-            .map_err(|e| e);
+            );
         }
     }
     let project_root = Path::new(context.project_root());
@@ -1921,7 +1920,7 @@ mod tests {
         let errors = session.close_import_discovery(ledger).unwrap_err();
         assert!(matches!(
             &errors.first().unwrap().kind,
-            ErrorKind::StdLibNotFound { .. }
+            ErrorKind::StdLibNotFound
         ));
         assert_eq!(
             session.discovery_attempt().unwrap().status(),

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1,0 +1,1974 @@
+//! Compiler-owned import discovery protocol.
+//!
+//! Candidate policy is pure compiler state. Hosts execute only requests returned
+//! by [`ImportDiscoveryPlan::pending_requests`] and report typed observations;
+//! they never recognize imports or choose resolution precedence.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use rue_error::{AmbiguousModuleData, CompileError, CompileErrors, CompileResult, ErrorKind};
+use rue_span::FileId;
+
+use crate::{
+    ImportDirective, ModuleId, ParsedProgram, SourceMetadata, SourceRevision, SourceSnapshot,
+};
+
+/// Version of the target-independent candidate policy represented by plans.
+pub const IMPORT_DISCOVERY_POLICY_VERSION: u32 = 1;
+
+/// Immutable invocation inputs captured once for a discovery epoch.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ImportDiscoveryContext {
+    epoch: u64,
+    project_root: Arc<str>,
+    std_root: Option<Arc<str>>,
+    read_policy_revision: Arc<str>,
+}
+
+impl ImportDiscoveryContext {
+    pub fn new(
+        epoch: u64,
+        project_root: impl AsRef<str>,
+        std_root: Option<&str>,
+        read_policy_revision: impl Into<Arc<str>>,
+    ) -> CompileResult<Self> {
+        let project_root = normalize_absolute(project_root.as_ref())?;
+        let std_root = std_root.map(normalize_absolute).transpose()?.map(Arc::from);
+        Ok(Self {
+            epoch,
+            project_root: Arc::from(project_root),
+            std_root,
+            read_policy_revision: read_policy_revision.into(),
+        })
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+    pub fn project_root(&self) -> &str {
+        &self.project_root
+    }
+    pub fn std_root(&self) -> Option<&str> {
+        self.std_root.as_deref()
+    }
+    pub fn read_policy_revision(&self) -> &str {
+        &self.read_policy_revision
+    }
+}
+
+/// Stable key for one parser-owned import occurrence.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ImportOccurrenceKey {
+    importer: ModuleId,
+    source_offset: u32,
+    source_end: u32,
+    specifier: Arc<str>,
+}
+
+impl ImportOccurrenceKey {
+    fn from_directive(site: &ImportDirective) -> Self {
+        Self {
+            importer: site.importer().clone(),
+            source_offset: site.source_offset(),
+            source_end: site.source_end(),
+            specifier: Arc::from(site.specifier()),
+        }
+    }
+    pub fn importer(&self) -> &ModuleId {
+        &self.importer
+    }
+    pub fn source_offset(&self) -> u32 {
+        self.source_offset
+    }
+    pub fn source_end(&self) -> u32 {
+        self.source_end
+    }
+    pub fn specifier(&self) -> &str {
+        &self.specifier
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ImportCandidateRole {
+    ExactFile,
+    FileModule,
+    DirectoryFacade,
+    StandardLibraryFacade,
+}
+
+/// One physical operation selected by compiler policy.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ImportDiscoveryRequest {
+    context: ImportDiscoveryContext,
+    occurrence: ImportOccurrenceKey,
+    exact_specifier: Arc<str>,
+    normalized_specifier: Arc<str>,
+    importer_anchor: Arc<str>,
+    root_anchor: Arc<str>,
+    group: u32,
+    position: u32,
+    requested_path: Arc<str>,
+    role: ImportCandidateRole,
+}
+
+impl ImportDiscoveryRequest {
+    pub fn context(&self) -> &ImportDiscoveryContext {
+        &self.context
+    }
+    pub fn occurrence(&self) -> &ImportOccurrenceKey {
+        &self.occurrence
+    }
+    pub fn group(&self) -> usize {
+        self.group as usize
+    }
+    pub fn exact_specifier(&self) -> &str {
+        &self.exact_specifier
+    }
+    pub fn normalized_specifier(&self) -> &str {
+        &self.normalized_specifier
+    }
+    pub fn importer_anchor(&self) -> &str {
+        &self.importer_anchor
+    }
+    pub fn root_anchor(&self) -> &str {
+        &self.root_anchor
+    }
+    pub fn position(&self) -> usize {
+        self.position as usize
+    }
+    pub fn requested_path(&self) -> &str {
+        &self.requested_path
+    }
+    pub fn role(&self) -> ImportCandidateRole {
+        self.role
+    }
+}
+
+/// Result of one host transaction. Denial and absence are intentionally
+/// distinct from an accepted source read.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ImportObservationStatus {
+    Absent,
+    PresentReadable {
+        canonical_path: Arc<str>,
+        metadata_identity: PhysicalFileIdentity,
+        metadata_fingerprint: FileMetadataFingerprint,
+        content_fingerprint: u64,
+    },
+    PresentUnreadable(Arc<str>),
+    DeniedLexical,
+    DeniedCanonical {
+        canonical_path: Arc<str>,
+    },
+    InvalidPhysicalType {
+        canonical_path: Arc<str>,
+    },
+    UnstableRead(Arc<str>),
+    Cancelled,
+}
+
+/// Host-observed identity of one physical file, separate from its mutable metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PhysicalFileIdentity {
+    volume: u64,
+    file: u64,
+}
+
+impl PhysicalFileIdentity {
+    pub fn new(volume: u64, file: u64) -> Self {
+        Self { volume, file }
+    }
+    pub fn volume(self) -> u64 {
+        self.volume
+    }
+    pub fn file(self) -> u64 {
+        self.file
+    }
+}
+
+/// Metadata fingerprint captured around an accepted stable read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FileMetadataFingerprint {
+    length: u64,
+    modified: u64,
+    changed: u64,
+}
+
+impl FileMetadataFingerprint {
+    pub fn new(length: u64, modified: u64, changed: u64) -> Self {
+        Self {
+            length,
+            modified,
+            changed,
+        }
+    }
+    pub fn length(self) -> u64 {
+        self.length
+    }
+    pub fn modified(self) -> u64 {
+        self.modified
+    }
+    pub fn changed(self) -> u64 {
+        self.changed
+    }
+}
+
+impl ImportObservationStatus {
+    fn is_present(&self) -> bool {
+        matches!(self, Self::PresentReadable { .. })
+    }
+    pub fn is_failure(&self) -> bool {
+        !matches!(self, Self::Absent | Self::PresentReadable { .. })
+    }
+}
+
+/// Accepted source bytes paired with their transaction observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcceptedImportSource {
+    requested_path: Arc<str>,
+    canonical_path: Arc<str>,
+    metadata_identity: PhysicalFileIdentity,
+    metadata_fingerprint: FileMetadataFingerprint,
+    content_fingerprint: u64,
+    source: Arc<String>,
+}
+
+impl AcceptedImportSource {
+    pub fn new(
+        requested_path: impl Into<Arc<str>>,
+        canonical_path: impl Into<Arc<str>>,
+        metadata_identity: PhysicalFileIdentity,
+        metadata_fingerprint: FileMetadataFingerprint,
+        source: Arc<String>,
+    ) -> CompileResult<Self> {
+        let requested_path = Arc::from(normalize_absolute(&requested_path.into())?);
+        let canonical_path = Arc::from(normalize_absolute(&canonical_path.into())?);
+        let content_fingerprint = source_fingerprint(&source);
+        Ok(Self {
+            requested_path,
+            canonical_path,
+            metadata_identity,
+            metadata_fingerprint,
+            content_fingerprint,
+            source,
+        })
+    }
+    pub fn requested_path(&self) -> &str {
+        &self.requested_path
+    }
+    pub fn canonical_path(&self) -> &str {
+        &self.canonical_path
+    }
+    pub fn content_fingerprint(&self) -> u64 {
+        self.content_fingerprint
+    }
+    pub fn metadata_identity(&self) -> PhysicalFileIdentity {
+        self.metadata_identity
+    }
+    pub fn metadata_fingerprint(&self) -> FileMetadataFingerprint {
+        self.metadata_fingerprint
+    }
+    pub fn source(&self) -> &Arc<String> {
+        &self.source
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportObservation {
+    request: ImportDiscoveryRequest,
+    status: ImportObservationStatus,
+    accepted_source: Option<AcceptedImportSource>,
+}
+
+impl ImportObservation {
+    pub fn absent(request: ImportDiscoveryRequest) -> Self {
+        Self {
+            request,
+            status: ImportObservationStatus::Absent,
+            accepted_source: None,
+        }
+    }
+    pub fn accepted(
+        request: ImportDiscoveryRequest,
+        source: AcceptedImportSource,
+    ) -> CompileResult<Self> {
+        if request.requested_path() != source.requested_path() {
+            return Err(invalid_input(
+                "accepted source requested path does not match its request",
+            ));
+        }
+        Ok(Self {
+            request,
+            status: ImportObservationStatus::PresentReadable {
+                canonical_path: source.canonical_path.clone(),
+                metadata_identity: source.metadata_identity,
+                metadata_fingerprint: source.metadata_fingerprint,
+                content_fingerprint: source.content_fingerprint,
+            },
+            accepted_source: Some(source),
+        })
+    }
+    pub fn failure(
+        request: ImportDiscoveryRequest,
+        status: ImportObservationStatus,
+    ) -> CompileResult<Self> {
+        if matches!(
+            status,
+            ImportObservationStatus::Absent | ImportObservationStatus::PresentReadable { .. }
+        ) {
+            return Err(invalid_input(
+                "failure observation must carry a failure status",
+            ));
+        }
+        Ok(Self {
+            request,
+            status,
+            accepted_source: None,
+        })
+    }
+    pub fn request(&self) -> &ImportDiscoveryRequest {
+        &self.request
+    }
+    pub fn status(&self) -> &ImportObservationStatus {
+        &self.status
+    }
+    pub fn accepted_source(&self) -> Option<&AcceptedImportSource> {
+        self.accepted_source.as_ref()
+    }
+}
+
+/// Deterministically ordered observations from one immutable epoch.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImportObservationLedger(BTreeMap<ImportDiscoveryRequest, ImportObservation>);
+
+impl ImportObservationLedger {
+    pub fn record(&mut self, observation: ImportObservation) -> CompileResult<()> {
+        let request = observation.request.clone();
+        if let Some(previous) = self.0.get(&request) {
+            if previous == &observation {
+                return Ok(());
+            }
+            return Err(invalid_input(
+                "one discovery request received conflicting observations",
+            ));
+        }
+        self.0.insert(request, observation);
+        Ok(())
+    }
+    pub fn get(&self, request: &ImportDiscoveryRequest) -> Option<&ImportObservation> {
+        self.0.get(request)
+    }
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &ImportObservation> {
+        self.0.values()
+    }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ImportDiscoveryPlan {
+    source_revision: SourceRevision,
+    context: ImportDiscoveryContext,
+    groups: Arc<[Arc<[ImportDiscoveryRequest]>]>,
+}
+
+impl ImportDiscoveryPlan {
+    pub(crate) fn new(
+        program: &ParsedProgram,
+        context: ImportDiscoveryContext,
+    ) -> CompileResult<Self> {
+        let root_dir = context.project_root().to_owned();
+        let mut groups = Vec::new();
+        for site in program.import_directives().iter() {
+            let importer_path = requested_path_for_module(&context, site.importer())?;
+            let importer_dir = parent_dir(&importer_path);
+            let mut bases = vec![importer_dir];
+            if !bases.contains(&root_dir) {
+                bases.push(root_dir.clone());
+            }
+            let candidate_groups =
+                discovery_candidate_groups(site.specifier(), &bases, context.std_root());
+            let occurrence = ImportOccurrenceKey::from_directive(site);
+            let normalized_specifier = normalize_path(site.specifier());
+            for (group_index, candidates) in candidate_groups.into_iter().enumerate() {
+                let group_index = u32::try_from(group_index)
+                    .map_err(|_| invalid_input("import candidate group count exceeds u32::MAX"))?;
+                let requests = candidates
+                    .into_iter()
+                    .enumerate()
+                    .map(|(position, candidate)| {
+                        let position = u32::try_from(position)
+                            .expect("candidate group size is bounded by policy");
+                        let role = candidate_role(site.specifier(), group_index, position);
+                        ImportDiscoveryRequest {
+                            context: context.clone(),
+                            occurrence: occurrence.clone(),
+                            exact_specifier: Arc::from(site.specifier()),
+                            normalized_specifier: Arc::from(normalized_specifier.as_str()),
+                            importer_anchor: Arc::from(importer_path.as_str()),
+                            root_anchor: Arc::from(context.project_root()),
+                            group: group_index,
+                            position,
+                            requested_path: Arc::from(normalize_path(&candidate)),
+                            role,
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                groups.push(requests.into());
+            }
+        }
+        groups.sort_by(|left: &Arc<[ImportDiscoveryRequest]>, right| left[0].cmp(&right[0]));
+        Ok(Self {
+            source_revision: program.source_revision().clone(),
+            context,
+            groups: groups.into(),
+        })
+    }
+
+    pub fn source_revision(&self) -> &SourceRevision {
+        &self.source_revision
+    }
+    pub fn context(&self) -> &ImportDiscoveryContext {
+        &self.context
+    }
+    pub fn groups(&self) -> &[Arc<[ImportDiscoveryRequest]>] {
+        &self.groups
+    }
+
+    pub(crate) fn validate_ledger(&self, ledger: &ImportObservationLedger) -> CompileResult<()> {
+        let requests = self
+            .groups
+            .iter()
+            .flat_map(|group| group.iter())
+            .collect::<BTreeSet<_>>();
+        if ledger.iter().any(|observation| {
+            observation.request().context() != &self.context
+                || !requests.contains(observation.request())
+        }) {
+            return Err(invalid_input(
+                "observation ledger contains a request outside the current discovery plan and epoch",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn reduce_graph(
+        &self,
+        root: ModuleId,
+        ledger: &ImportObservationLedger,
+        accepted_reads: &[AcceptedReadManifestEntry],
+    ) -> CompileResult<crate::CanonicalImportGraph> {
+        self.validate_ledger(ledger)?;
+        let manifest = accepted_reads
+            .iter()
+            .map(|entry| (entry.metadata_identity(), entry))
+            .collect::<BTreeMap<_, _>>();
+        if manifest.len() != accepted_reads.len() {
+            return Err(invalid_input(
+                "accepted read manifest contains duplicate physical identities",
+            ));
+        }
+        let mut by_site: BTreeMap<&ImportOccurrenceKey, Vec<&Arc<[ImportDiscoveryRequest]>>> =
+            BTreeMap::new();
+        for group in self.groups.iter() {
+            by_site.entry(&group[0].occurrence).or_default().push(group);
+        }
+        let mut records = Vec::with_capacity(by_site.len());
+        for (site, groups) in by_site {
+            let winning = groups.iter().find_map(|group| {
+                let present = group
+                    .iter()
+                    .filter_map(|request| ledger.get(request))
+                    .filter_map(ImportObservation::accepted_source)
+                    .collect::<Vec<_>>();
+                (!present.is_empty()).then_some(present)
+            });
+            let module_for = |source: &AcceptedImportSource| -> CompileResult<ModuleId> {
+                let entry = manifest.get(&source.metadata_identity()).ok_or_else(|| {
+                    invalid_input(format!(
+                        "accepted observation for physical identity {:?} is absent from the accepted read manifest",
+                        source.metadata_identity()
+                    ))
+                })?;
+                if entry.metadata_identity() != source.metadata_identity()
+                    || entry.metadata_fingerprint() != source.metadata_fingerprint()
+                    || entry.content_fingerprint() != source.content_fingerprint()
+                {
+                    return Err(invalid_input(
+                        "accepted observation does not match its accepted read provenance",
+                    ));
+                }
+                Ok(entry.module().clone())
+            };
+            let resolution = match winning.as_deref() {
+                Some([source]) => crate::CanonicalImportResolution::Resolved(module_for(source)?),
+                Some([file, directory, ..]) => crate::CanonicalImportResolution::Ambiguous {
+                    file_module: module_for(file)?,
+                    directory_module: module_for(directory)?,
+                },
+                Some([]) => unreachable!(),
+                None => crate::CanonicalImportResolution::Missing,
+            };
+            records.push(crate::CanonicalImportRecord::new(
+                site.importer().clone(),
+                site.specifier(),
+                resolution,
+            ));
+        }
+        Ok(crate::CanonicalImportGraph::from_discovery_records(
+            root, records,
+        ))
+    }
+
+    /// Return exactly the next operations allowed by candidate precedence.
+    pub fn pending_requests(
+        &self,
+        ledger: &ImportObservationLedger,
+    ) -> Vec<ImportDiscoveryRequest> {
+        let mut by_site: BTreeMap<&ImportOccurrenceKey, Vec<&Arc<[ImportDiscoveryRequest]>>> =
+            BTreeMap::new();
+        for group in self.groups.iter() {
+            by_site.entry(&group[0].occurrence).or_default().push(group);
+        }
+        let mut pending = Vec::new();
+        for groups in by_site.values() {
+            for group in groups {
+                let observations = group
+                    .iter()
+                    .map(|request| ledger.get(request))
+                    .collect::<Vec<_>>();
+                if observations
+                    .iter()
+                    .any(|observation| observation.is_some_and(|o| o.status.is_failure()))
+                {
+                    break;
+                }
+                let missing = group
+                    .iter()
+                    .zip(&observations)
+                    .filter_map(|(request, observation)| {
+                        observation.is_none().then_some(request.clone())
+                    })
+                    .collect::<Vec<_>>();
+                if !missing.is_empty() {
+                    pending.extend(missing);
+                    break;
+                }
+                if observations
+                    .iter()
+                    .any(|observation| observation.is_some_and(|o| o.status.is_present()))
+                {
+                    break;
+                }
+            }
+        }
+        pending
+    }
+
+    pub fn failures<'a>(
+        &'a self,
+        ledger: &'a ImportObservationLedger,
+    ) -> impl Iterator<Item = &'a ImportObservation> {
+        self.groups
+            .iter()
+            .flat_map(move |group| group.iter().filter_map(|request| ledger.get(request)))
+            .filter(|observation| observation.status.is_failure())
+    }
+
+    /// Accepted reads in winning groups only. Later candidate groups are never
+    /// requested, so policy cannot be reconstructed from this value by a host.
+    pub fn accepted_sources<'a>(
+        &'a self,
+        ledger: &'a ImportObservationLedger,
+    ) -> Vec<&'a AcceptedImportSource> {
+        let mut by_site: BTreeMap<&ImportOccurrenceKey, Vec<&Arc<[ImportDiscoveryRequest]>>> =
+            BTreeMap::new();
+        for group in self.groups.iter() {
+            by_site.entry(&group[0].occurrence).or_default().push(group);
+        }
+        let mut accepted = Vec::new();
+        for groups in by_site.values() {
+            for group in groups {
+                if group
+                    .iter()
+                    .any(|request| ledger.get(request).is_some_and(|o| o.status.is_failure()))
+                {
+                    break;
+                }
+                let present = group
+                    .iter()
+                    .filter_map(|request| ledger.get(request))
+                    .filter_map(ImportObservation::accepted_source)
+                    .collect::<Vec<_>>();
+                if !present.is_empty() {
+                    accepted.extend(present);
+                    break;
+                }
+            }
+        }
+        accepted.sort_by(|left, right| {
+            left.requested_path
+                .cmp(&right.requested_path)
+                .then(left.canonical_path.cmp(&right.canonical_path))
+        });
+        accepted.dedup_by(|left, right| {
+            left.canonical_path == right.canonical_path
+                && left.content_fingerprint == right.content_fingerprint
+        });
+        accepted
+    }
+
+    pub(crate) fn diagnostics(
+        &self,
+        program: &ParsedProgram,
+        ledger: &ImportObservationLedger,
+    ) -> CompileErrors {
+        let mut errors = CompileErrors::new();
+        for invalid in program.invalid_imports() {
+            let kind = match invalid.shape() {
+                crate::InvalidImportShape::WrongArity { actual } => {
+                    ErrorKind::IntrinsicWrongArgCount {
+                        name: "import".into(),
+                        expected: 1,
+                        found: *actual as usize,
+                    }
+                }
+                crate::InvalidImportShape::NonStringArgument => {
+                    ErrorKind::ImportRequiresStringLiteral
+                }
+            };
+            errors.push(CompileError::new(kind, invalid.span()));
+        }
+
+        let mut groups_by_site: BTreeMap<
+            &ImportOccurrenceKey,
+            Vec<&Arc<[ImportDiscoveryRequest]>>,
+        > = BTreeMap::new();
+        for group in self.groups.iter() {
+            groups_by_site
+                .entry(group[0].occurrence())
+                .or_default()
+                .push(group);
+        }
+        for (site, groups) in groups_by_site {
+            let file_id = program
+                .module(site.importer())
+                .expect("plan importer belongs to parsed program")
+                .file_id();
+            let span = rue_span::Span::with_file(file_id, site.source_offset(), site.source_end());
+            if let Some(failure) = groups
+                .iter()
+                .flat_map(|group| group.iter())
+                .filter_map(|request| ledger.get(request))
+                .find(|observation| observation.status().is_failure())
+            {
+                let candidate = failure.request().requested_path();
+                let message = match failure.status() {
+                    ImportObservationStatus::PresentUnreadable(reason) => {
+                        format!("could not read import candidate '{candidate}': {reason}")
+                    }
+                    ImportObservationStatus::DeniedLexical => format!(
+                        "import candidate '{candidate}' is not listed in the source manifest read policy"
+                    ),
+                    ImportObservationStatus::DeniedCanonical { canonical_path } => format!(
+                        "import candidate '{candidate}' resolves to '{canonical_path}', which is not listed in the source manifest read policy"
+                    ),
+                    ImportObservationStatus::InvalidPhysicalType { canonical_path } => format!(
+                        "import candidate '{candidate}' resolves to '{canonical_path}', which is not a regular source file"
+                    ),
+                    ImportObservationStatus::UnstableRead(reason) => format!(
+                        "import candidate '{candidate}' changed during its stable read transaction: {reason}"
+                    ),
+                    ImportObservationStatus::Cancelled => {
+                        format!("import discovery was cancelled while reading '{candidate}'")
+                    }
+                    ImportObservationStatus::Absent
+                    | ImportObservationStatus::PresentReadable { .. } => {
+                        unreachable!("only failure observations reach diagnostic projection")
+                    }
+                };
+                errors.push(CompileError::new(
+                    ErrorKind::InvalidCompilerInput(message),
+                    span,
+                ));
+                continue;
+            }
+
+            let winning = groups.iter().find_map(|group| {
+                let present = group
+                    .iter()
+                    .filter_map(|request| ledger.get(request))
+                    .filter_map(ImportObservation::accepted_source)
+                    .collect::<Vec<_>>();
+                (!present.is_empty()).then_some(present)
+            });
+            match winning.as_deref() {
+                Some([_]) => {}
+                Some([file, directory, ..]) => errors.push(CompileError::new(
+                    ErrorKind::AmbiguousModule(Box::new(AmbiguousModuleData {
+                        path: site.specifier().into(),
+                        file_module: file.requested_path().into(),
+                        dir_module: directory.requested_path().into(),
+                    })),
+                    span,
+                )),
+                Some([]) => unreachable!(),
+                None if site.specifier() == "std" => {
+                    errors.push(CompileError::new(ErrorKind::StdLibNotFound, span));
+                }
+                None => errors.push(CompileError::new(
+                    ErrorKind::ModuleNotFound {
+                        path: site.specifier().into(),
+                        candidates: groups
+                            .iter()
+                            .flat_map(|group| group.iter())
+                            .map(|request| request.requested_path().into())
+                            .collect(),
+                    },
+                    span,
+                )),
+            }
+        }
+        errors
+    }
+}
+
+/// Compiler-owned durable identity assembly for a discovery epoch.
+#[derive(Debug, Clone)]
+pub struct DiscoverySourceAssembler {
+    context: ImportDiscoveryContext,
+    root_module: ModuleId,
+    entries: BTreeMap<ModuleId, AssembledSource>,
+    physical: BTreeMap<PhysicalFileIdentity, PhysicalSourceOwner>,
+    canonical_identities: BTreeMap<Arc<str>, PhysicalFileIdentity>,
+    accepted_reads: BTreeMap<ModuleId, AcceptedReadManifestEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct PhysicalSourceOwner {
+    module: ModuleId,
+    canonical_path: Arc<str>,
+}
+
+#[derive(Debug, Clone)]
+struct AssembledSource {
+    requested_path: Arc<str>,
+    canonical_path: Arc<str>,
+    source: Arc<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcceptedReadManifestEntry {
+    module: ModuleId,
+    requested_path: Arc<str>,
+    canonical_path: Arc<str>,
+    metadata_identity: PhysicalFileIdentity,
+    metadata_fingerprint: FileMetadataFingerprint,
+    content_fingerprint: u64,
+}
+
+impl AcceptedReadManifestEntry {
+    pub fn module(&self) -> &ModuleId {
+        &self.module
+    }
+    pub fn requested_path(&self) -> &str {
+        &self.requested_path
+    }
+    pub fn canonical_path(&self) -> &str {
+        &self.canonical_path
+    }
+    pub fn content_fingerprint(&self) -> u64 {
+        self.content_fingerprint
+    }
+    pub fn metadata_identity(&self) -> PhysicalFileIdentity {
+        self.metadata_identity
+    }
+    pub fn metadata_fingerprint(&self) -> FileMetadataFingerprint {
+        self.metadata_fingerprint
+    }
+}
+
+impl DiscoverySourceAssembler {
+    pub fn new(
+        context: ImportDiscoveryContext,
+        root_requested_path: impl Into<Arc<str>>,
+        root_canonical_path: impl Into<Arc<str>>,
+        metadata_identity: PhysicalFileIdentity,
+        metadata_fingerprint: FileMetadataFingerprint,
+        root_source: Arc<String>,
+    ) -> CompileResult<Self> {
+        let requested_path = Arc::from(normalize_absolute(&root_requested_path.into())?);
+        let canonical_path = Arc::from(normalize_absolute(&root_canonical_path.into())?);
+        let module = classify_module(&context, &requested_path, &canonical_path)?;
+        let assembled = AssembledSource {
+            requested_path: requested_path.clone(),
+            canonical_path: canonical_path.clone(),
+            source: root_source.clone(),
+        };
+        let mut entries = BTreeMap::new();
+        entries.insert(module.clone(), assembled);
+        let mut physical = BTreeMap::new();
+        physical.insert(
+            metadata_identity,
+            PhysicalSourceOwner {
+                module: module.clone(),
+                canonical_path: canonical_path.clone(),
+            },
+        );
+        let canonical_identities = BTreeMap::from([(canonical_path.clone(), metadata_identity)]);
+        let mut accepted_reads = BTreeMap::new();
+        accepted_reads.insert(
+            module.clone(),
+            AcceptedReadManifestEntry {
+                module: module.clone(),
+                requested_path,
+                canonical_path: canonical_path.clone(),
+                metadata_identity,
+                metadata_fingerprint,
+                content_fingerprint: source_fingerprint(&root_source),
+            },
+        );
+        Ok(Self {
+            context,
+            root_module: module,
+            entries,
+            physical,
+            canonical_identities,
+            accepted_reads,
+        })
+    }
+
+    pub fn add_explicit(
+        &mut self,
+        requested_path: &str,
+        canonical_path: &str,
+        metadata_identity: PhysicalFileIdentity,
+        metadata_fingerprint: FileMetadataFingerprint,
+        source: Arc<String>,
+    ) -> CompileResult<bool> {
+        self.add_source(&AcceptedImportSource::new(
+            Arc::from(normalize_absolute(requested_path)?),
+            Arc::from(canonical_path),
+            metadata_identity,
+            metadata_fingerprint,
+            source,
+        )?)
+    }
+
+    pub fn add_plan_reads(
+        &mut self,
+        plan: &ImportDiscoveryPlan,
+        ledger: &ImportObservationLedger,
+    ) -> CompileResult<usize> {
+        if plan.context != self.context {
+            return Err(invalid_input(
+                "discovery plan belongs to a different epoch or captured context",
+            ));
+        }
+        let mut added = 0;
+        for source in plan.accepted_sources(ledger) {
+            added += usize::from(self.add_source(source)?);
+        }
+        Ok(added)
+    }
+
+    fn add_source(&mut self, source: &AcceptedImportSource) -> CompileResult<bool> {
+        let module = classify_module(
+            &self.context,
+            source.requested_path(),
+            source.canonical_path(),
+        )?;
+        if let Some(previous_identity) = self.canonical_identities.get(source.canonical_path())
+            && previous_identity != &source.metadata_identity
+        {
+            return Err(invalid_input(format!(
+                "canonical source {:?} changed physical identity during discovery epoch",
+                source.canonical_path()
+            )));
+        }
+        if let Some(owner) = self.physical.get(&source.metadata_identity).cloned() {
+            if owner.module != module {
+                return Err(invalid_input(format!(
+                    "physical source identity for {:?} is claimed by incompatible logical IDs {} and {}",
+                    source.canonical_path(),
+                    owner.module,
+                    module
+                )));
+            }
+            let existing = self
+                .entries
+                .get(&owner.module)
+                .expect("physical map references entry");
+            if source_fingerprint(&existing.source) != source.content_fingerprint {
+                return Err(invalid_input(format!(
+                    "physical source {:?} changed during discovery epoch",
+                    source.canonical_path()
+                )));
+            }
+            let provenance = self
+                .accepted_reads
+                .get(&owner.module)
+                .expect("accepted source retains provenance");
+            if provenance.metadata_identity != source.metadata_identity
+                || provenance.metadata_fingerprint != source.metadata_fingerprint
+            {
+                return Err(invalid_input(format!(
+                    "physical source {:?} metadata changed during discovery epoch",
+                    source.canonical_path()
+                )));
+            }
+            if source.canonical_path() < owner.canonical_path.as_ref() {
+                self.entries.get_mut(&owner.module).unwrap().canonical_path =
+                    source.canonical_path.clone();
+                self.accepted_reads
+                    .get_mut(&owner.module)
+                    .unwrap()
+                    .canonical_path = source.canonical_path.clone();
+                self.physical
+                    .get_mut(&source.metadata_identity)
+                    .unwrap()
+                    .canonical_path = source.canonical_path.clone();
+            }
+            self.canonical_identities
+                .insert(source.canonical_path.clone(), source.metadata_identity);
+            return Ok(false);
+        }
+        if let Some(existing) = self.entries.get(&module) {
+            return Err(invalid_input(format!(
+                "logical module {} names distinct physical sources {:?} and {:?}",
+                module,
+                existing.canonical_path,
+                source.canonical_path()
+            )));
+        }
+        self.physical.insert(
+            source.metadata_identity,
+            PhysicalSourceOwner {
+                module: module.clone(),
+                canonical_path: source.canonical_path.clone(),
+            },
+        );
+        self.canonical_identities
+            .insert(source.canonical_path.clone(), source.metadata_identity);
+        self.entries.insert(
+            module.clone(),
+            AssembledSource {
+                requested_path: source.requested_path.clone(),
+                canonical_path: source.canonical_path.clone(),
+                source: source.source.clone(),
+            },
+        );
+        self.accepted_reads.insert(
+            module.clone(),
+            AcceptedReadManifestEntry {
+                module,
+                requested_path: source.requested_path.clone(),
+                canonical_path: source.canonical_path.clone(),
+                metadata_identity: source.metadata_identity,
+                metadata_fingerprint: source.metadata_fingerprint,
+                content_fingerprint: source.content_fingerprint,
+            },
+        );
+        Ok(true)
+    }
+
+    pub fn snapshot(&self) -> CompileResult<SourceSnapshot> {
+        let root_module = &self.root_module;
+        let ordered = std::iter::once((root_module, self.entries.get(root_module).unwrap())).chain(
+            self.entries
+                .iter()
+                .filter(|(module, _)| *module != root_module),
+        );
+        let ordered = ordered.collect::<Vec<_>>();
+        let physical_paths = ordered
+            .iter()
+            .enumerate()
+            .map(|(index, (module, entry))| {
+                (
+                    FileId::new((index + 1) as u32),
+                    display_path_for_module(module, entry),
+                )
+            })
+            .collect();
+        let logical_paths = ordered
+            .iter()
+            .enumerate()
+            .map(|(index, (module, _))| {
+                (FileId::new((index + 1) as u32), module.as_str().to_owned())
+            })
+            .collect();
+        let metadata = SourceMetadata::new(FileId::new(1), physical_paths, logical_paths)?;
+        let contents = ordered
+            .into_iter()
+            .enumerate()
+            .map(|(index, (_, entry))| (FileId::new((index + 1) as u32), entry.source.clone()))
+            .collect();
+        SourceSnapshot::new(metadata, contents)
+    }
+
+    pub fn accepted_read_manifest(&self) -> Arc<[AcceptedReadManifestEntry]> {
+        self.accepted_reads.values().cloned().collect()
+    }
+}
+
+fn candidate_role(specifier: &str, group: u32, position: u32) -> ImportCandidateRole {
+    if specifier == "std" && group == 0 {
+        ImportCandidateRole::StandardLibraryFacade
+    } else if specifier.ends_with(".rue") {
+        ImportCandidateRole::ExactFile
+    } else if position == 0 {
+        ImportCandidateRole::FileModule
+    } else {
+        ImportCandidateRole::DirectoryFacade
+    }
+}
+
+fn discovery_candidate_groups(
+    specifier: &str,
+    base_dirs: &[String],
+    std_root: Option<&str>,
+) -> Vec<Vec<String>> {
+    let join = |base: &str, relative: &str| {
+        Path::new(base)
+            .join(relative)
+            .to_string_lossy()
+            .into_owned()
+    };
+    if specifier == "std" {
+        return std_root
+            .into_iter()
+            .map(|root| vec![join(root, "_std.rue")])
+            .chain(
+                base_dirs
+                    .iter()
+                    .map(|base| vec![join(base, "std/_std.rue")]),
+            )
+            .collect();
+    }
+    if specifier.ends_with(".rue") {
+        return base_dirs
+            .iter()
+            .map(|base| vec![join(base, specifier)])
+            .collect();
+    }
+    let basename = Path::new(specifier)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(specifier);
+    base_dirs
+        .iter()
+        .map(|base| {
+            vec![
+                join(base, &format!("{specifier}.rue")),
+                join(base, &format!("{specifier}/_{basename}.rue")),
+            ]
+        })
+        .collect()
+}
+
+fn requested_path_for_module(
+    context: &ImportDiscoveryContext,
+    module: &ModuleId,
+) -> CompileResult<String> {
+    const STD_PREFIX: &str = "\0rue-std/";
+    if let Some(relative) = module.as_str().strip_prefix(STD_PREFIX) {
+        let std_root = context
+            .std_root()
+            .ok_or_else(|| invalid_input("standard-library module has no captured std root"))?;
+        return Ok(normalize_path(
+            &Path::new(std_root).join(relative).to_string_lossy(),
+        ));
+    }
+    Ok(normalize_path(
+        &Path::new(context.project_root())
+            .join(module.as_str())
+            .to_string_lossy(),
+    ))
+}
+
+fn display_path_for_module(module: &ModuleId, entry: &AssembledSource) -> String {
+    if module.as_str().starts_with("\0rue-std/") {
+        entry.requested_path.to_string()
+    } else {
+        module.as_str().to_owned()
+    }
+}
+
+fn classify_module(
+    context: &ImportDiscoveryContext,
+    requested: &str,
+    canonical: &str,
+) -> CompileResult<ModuleId> {
+    let requested = Path::new(requested);
+    let canonical = Path::new(canonical);
+    if let Some(std_root) = context.std_root() {
+        let std_root = Path::new(std_root);
+        if let Ok(relative) = requested.strip_prefix(std_root) {
+            if !canonical.starts_with(std_root) {
+                return Err(invalid_input(format!(
+                    "standard-library candidate {:?} escapes captured std root {:?}",
+                    requested, std_root
+                )));
+            }
+            return ModuleId::from_logical_path(
+                Path::new("\0rue-std").join(relative).to_string_lossy(),
+            )
+            .map_err(|e| e);
+        }
+    }
+    let project_root = Path::new(context.project_root());
+    let logical = lexical_relative_path(project_root, requested).ok_or_else(|| {
+        invalid_input(format!(
+            "source {:?} cannot receive a project-relative durable identity",
+            requested
+        ))
+    })?;
+    ModuleId::from_logical_path(logical.to_string_lossy())
+}
+
+fn parent_dir(path: &str) -> String {
+    Path::new(path)
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+fn normalize_path(path: &str) -> String {
+    let mut result = PathBuf::new();
+    let absolute = Path::new(path).is_absolute();
+    for component in Path::new(path).components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let can_pop = result
+                    .components()
+                    .next_back()
+                    .is_some_and(|component| matches!(component, Component::Normal(_)));
+                if can_pop {
+                    result.pop();
+                } else if !absolute {
+                    result.push("..");
+                }
+            }
+            _ => result.push(component.as_os_str()),
+        }
+    }
+    result.to_string_lossy().into_owned()
+}
+fn normalize_absolute(path: &str) -> CompileResult<String> {
+    let path = Path::new(path);
+    if !path.is_absolute() {
+        return Err(invalid_input(format!(
+            "discovery identity path {path:?} is not absolute"
+        )));
+    }
+    Ok(normalize_path(path.to_string_lossy().as_ref()))
+}
+fn lexical_relative_path(base: &Path, target: &Path) -> Option<PathBuf> {
+    let base: Vec<_> = base.components().collect();
+    let target: Vec<_> = target.components().collect();
+    if base.first() != target.first() {
+        return None;
+    }
+    let common = base.iter().zip(&target).take_while(|(a, b)| a == b).count();
+    let mut result = PathBuf::new();
+    for component in &base[common..] {
+        if matches!(component, Component::Normal(_)) {
+            result.push("..");
+        }
+    }
+    for component in &target[common..] {
+        if let Component::Normal(part) = component {
+            result.push(part);
+        }
+    }
+    Some(result)
+}
+pub(crate) fn source_fingerprint(source: &str) -> u64 {
+    source.bytes().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
+    })
+}
+fn invalid_input(message: impl Into<String>) -> CompileError {
+    CompileError::without_span(ErrorKind::InvalidCompilerInput(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn context(epoch: u64) -> ImportDiscoveryContext {
+        ImportDiscoveryContext::new(epoch, "/project", Some("/sdk"), "all").unwrap()
+    }
+
+    fn identity() -> PhysicalFileIdentity {
+        PhysicalFileIdentity::new(1, 2)
+    }
+
+    fn metadata_fingerprint() -> FileMetadataFingerprint {
+        FileMetadataFingerprint::new(3, 4, 5)
+    }
+
+    #[test]
+    fn absolute_normalization_never_pops_above_root() {
+        assert_eq!(normalize_path("/project/../../../x"), "/x");
+        assert_eq!(normalize_path("/../../x"), "/x");
+        assert_eq!(normalize_absolute("/../../../x").unwrap(), "/x");
+        assert!(
+            AcceptedImportSource::new(
+                "relative.rue",
+                "/physical/relative.rue",
+                identity(),
+                metadata_fingerprint(),
+                Arc::new(String::new()),
+            )
+            .is_err()
+        );
+        assert!(
+            DiscoverySourceAssembler::new(
+                context(1),
+                "/project/main.rue",
+                "relative-physical-main.rue",
+                identity(),
+                metadata_fingerprint(),
+                Arc::new(String::new()),
+            )
+            .is_err()
+        );
+    }
+
+    fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
+        SourceSnapshot::new(
+            SourceMetadata::new(
+                FileId::new(root),
+                entries
+                    .iter()
+                    .map(|(id, path, _, _)| (FileId::new(*id), (*path).into()))
+                    .collect::<HashMap<_, _>>(),
+                entries
+                    .iter()
+                    .map(|(id, _, logical, _)| (FileId::new(*id), (*logical).into()))
+                    .collect::<HashMap<_, _>>(),
+            )
+            .unwrap(),
+            entries
+                .iter()
+                .map(|(id, _, _, source)| (FileId::new(*id), Arc::new((*source).into())))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    fn accepted_reads(snapshot: &SourceSnapshot) -> Arc<[AcceptedReadManifestEntry]> {
+        snapshot
+            .files()
+            .map(|source| AcceptedReadManifestEntry {
+                module: snapshot.module_id(source.file_id).unwrap().clone(),
+                requested_path: Arc::from(source.path),
+                canonical_path: Arc::from(source.path),
+                metadata_identity: PhysicalFileIdentity::new(1, source.file_id.index() as u64),
+                metadata_fingerprint: metadata_fingerprint(),
+                content_fingerprint: source_fingerprint(source.source),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn assembler_is_order_independent_and_rejects_alias_conflicts() {
+        let mut a = DiscoverySourceAssembler::new(
+            context(1),
+            "/project/main.rue",
+            "/real/main",
+            PhysicalFileIdentity::new(1, 1),
+            metadata_fingerprint(),
+            Arc::new(String::new()),
+        )
+        .unwrap();
+        a.add_explicit(
+            "/project/b.rue",
+            "/real/b",
+            PhysicalFileIdentity::new(2, 2),
+            metadata_fingerprint(),
+            Arc::new("b".into()),
+        )
+        .unwrap();
+        a.add_explicit(
+            "/project/a.rue",
+            "/real/a",
+            PhysicalFileIdentity::new(3, 3),
+            metadata_fingerprint(),
+            Arc::new("a".into()),
+        )
+        .unwrap();
+        let snapshot = a.snapshot().unwrap();
+        assert_eq!(
+            snapshot
+                .metadata()
+                .logical_paths()
+                .map(|(_, p)| p)
+                .collect::<Vec<_>>(),
+            vec!["main.rue", "a.rue", "b.rue"]
+        );
+        let error = a
+            .add_explicit(
+                "/project/alias.rue",
+                "/real/a",
+                PhysicalFileIdentity::new(3, 3),
+                metadata_fingerprint(),
+                Arc::new("a".into()),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("incompatible logical IDs"));
+    }
+
+    fn assembler_for_physical_identity_test() -> DiscoverySourceAssembler {
+        DiscoverySourceAssembler::new(
+            context(1),
+            "/project/main.rue",
+            "/real/main",
+            PhysicalFileIdentity::new(1, 1),
+            metadata_fingerprint(),
+            Arc::new(String::new()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn hard_link_identity_rejects_incompatible_modules_in_either_order() {
+        for reverse in [false, true] {
+            let mut assembler = assembler_for_physical_identity_test();
+            let (first, second) = if reverse {
+                (
+                    ("/project/b.rue", "/real/hard-b"),
+                    ("/project/a.rue", "/real/hard-a"),
+                )
+            } else {
+                (
+                    ("/project/a.rue", "/real/hard-a"),
+                    ("/project/b.rue", "/real/hard-b"),
+                )
+            };
+            assembler
+                .add_explicit(
+                    first.0,
+                    first.1,
+                    PhysicalFileIdentity::new(9, 9),
+                    metadata_fingerprint(),
+                    Arc::new("same inode".into()),
+                )
+                .unwrap();
+            let error = assembler
+                .add_explicit(
+                    second.0,
+                    second.1,
+                    PhysicalFileIdentity::new(9, 9),
+                    metadata_fingerprint(),
+                    Arc::new("same inode".into()),
+                )
+                .unwrap_err();
+            assert!(error.to_string().contains("incompatible logical IDs"));
+        }
+    }
+
+    #[test]
+    fn hard_link_alias_reuse_is_insertion_order_independent() {
+        let build = |paths: [&str; 2]| {
+            let mut assembler = assembler_for_physical_identity_test();
+            for path in paths {
+                assembler
+                    .add_explicit(
+                        "/project/a.rue",
+                        path,
+                        PhysicalFileIdentity::new(9, 9),
+                        metadata_fingerprint(),
+                        Arc::new("same inode".into()),
+                    )
+                    .unwrap();
+            }
+            (
+                assembler.snapshot().unwrap(),
+                assembler.accepted_read_manifest(),
+            )
+        };
+        let forward = build(["/real/z-hard-a", "/real/a-hard-a"]);
+        let reverse = build(["/real/a-hard-a", "/real/z-hard-a"]);
+        assert_eq!(forward.0.metadata(), reverse.0.metadata());
+        assert_eq!(forward.0.source_revision(), reverse.0.source_revision());
+        assert_eq!(forward.1, reverse.1);
+        assert!(
+            forward
+                .1
+                .iter()
+                .any(|entry| entry.canonical_path() == "/real/a-hard-a")
+        );
+    }
+
+    #[test]
+    fn close_joins_hard_link_alias_observation_by_physical_identity() {
+        let source = snapshot(
+            &[
+                (
+                    1,
+                    "/project/main.rue",
+                    "main.rue",
+                    "const a = @import(\"a\"); fn main() -> i32 { 0 }",
+                ),
+                (2, "/project/a.rue", "a.rue", "pub fn value() -> i32 { 1 }"),
+            ],
+            1,
+        );
+        let mut manifest = accepted_reads(&source).to_vec();
+        manifest
+            .iter_mut()
+            .find(|entry| entry.module().as_str() == "a.rue")
+            .unwrap()
+            .canonical_path = Arc::from("/real/a-hard-link");
+
+        let mut session = crate::CompilerSession::new();
+        let plan = session
+            .stage_import_discovery(
+                &source,
+                context(50),
+                manifest.into(),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        for request in plan.pending_requests(&ledger) {
+            let observation = if request.requested_path().ends_with("/a.rue") {
+                ImportObservation::accepted(
+                    request.clone(),
+                    AcceptedImportSource::new(
+                        request.requested_path(),
+                        "/real/z-hard-link",
+                        PhysicalFileIdentity::new(1, 2),
+                        metadata_fingerprint(),
+                        Arc::new("pub fn value() -> i32 { 1 }".into()),
+                    )
+                    .unwrap(),
+                )
+                .unwrap()
+            } else {
+                ImportObservation::absent(request.clone())
+            };
+            ledger.record(observation).unwrap();
+        }
+        let closed = session.close_import_discovery(ledger).unwrap();
+        assert_eq!(
+            closed.status(),
+            crate::ImportDiscoveryRevisionStatus::ClosedValid
+        );
+        assert!(matches!(
+            closed.graph().unwrap().graph().records()[0].resolution(),
+            crate::CanonicalImportResolution::Resolved(module) if module.as_str() == "a.rue"
+        ));
+    }
+
+    #[test]
+    fn epoch_is_part_of_plan_identity() {
+        let snapshot =
+            SourceSnapshot::single("/project/main.rue", "fn main() -> i32 { 0 }").unwrap();
+        let mut session = crate::CompilerSession::new();
+        session.update(&snapshot).into_result().unwrap();
+        let one = session.import_discovery_plan(context(1)).unwrap();
+        let two = session.import_discovery_plan(context(2)).unwrap();
+        assert_ne!(one, two);
+    }
+
+    #[test]
+    fn malformed_import_is_retained_but_never_requests_discovery() {
+        let snapshot =
+            SourceSnapshot::single("/project/main.rue", "fn main() { @import(1); }").unwrap();
+        let mut session = crate::CompilerSession::new();
+        let parsed = session.update(&snapshot).into_result().unwrap();
+        assert_eq!(parsed.invalid_imports().len(), 1);
+        assert!(matches!(
+            parsed.invalid_imports()[0].shape(),
+            crate::InvalidImportShape::NonStringArgument
+        ));
+        let plan = session.import_discovery_plan(context(1)).unwrap();
+        assert!(
+            plan.pending_requests(&ImportObservationLedger::default())
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn cancellation_is_non_closure_and_accepted_ambiguity_reads_both_candidates() {
+        let snapshot = SourceSnapshot::single(
+            "/project/main.rue",
+            "const m = @import(\"thing\"); fn main() -> i32 { 0 }",
+        )
+        .unwrap();
+        let mut session = crate::CompilerSession::new();
+        session.update(&snapshot).into_result().unwrap();
+        let plan = session.import_discovery_plan(context(7)).unwrap();
+        let pending = plan.pending_requests(&ImportObservationLedger::default());
+        assert_eq!(pending.len(), 2);
+
+        let mut cancelled = ImportObservationLedger::default();
+        cancelled
+            .record(
+                ImportObservation::failure(pending[0].clone(), ImportObservationStatus::Cancelled)
+                    .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(plan.failures(&cancelled).count(), 1);
+        assert!(plan.accepted_sources(&cancelled).is_empty());
+
+        let mut complete = ImportObservationLedger::default();
+        for (request, canonical) in pending.into_iter().zip(["/real/file", "/real/facade"]) {
+            let source = AcceptedImportSource::new(
+                Arc::from(request.requested_path()),
+                Arc::from(canonical),
+                identity(),
+                metadata_fingerprint(),
+                Arc::new("pub fn answer() -> i32 { 42 }".into()),
+            )
+            .unwrap();
+            complete
+                .record(ImportObservation::accepted(request, source).unwrap())
+                .unwrap();
+        }
+        assert_eq!(plan.accepted_sources(&complete).len(), 2);
+        assert!(plan.pending_requests(&complete).is_empty());
+
+        let pending = plan.pending_requests(&ImportObservationLedger::default());
+        let mut denied_arm = ImportObservationLedger::default();
+        let accepted = AcceptedImportSource::new(
+            Arc::from(pending[0].requested_path()),
+            Arc::from("/real/file"),
+            identity(),
+            metadata_fingerprint(),
+            Arc::new("pub fn answer() -> i32 { 42 }".into()),
+        )
+        .unwrap();
+        denied_arm
+            .record(ImportObservation::accepted(pending[0].clone(), accepted).unwrap())
+            .unwrap();
+        denied_arm
+            .record(
+                ImportObservation::failure(
+                    pending[1].clone(),
+                    ImportObservationStatus::DeniedLexical,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(plan.failures(&denied_arm).count(), 1);
+        assert!(matches!(
+            plan.failures(&denied_arm).next().unwrap().status(),
+            ImportObservationStatus::DeniedLexical
+        ));
+        assert!(plan.accepted_sources(&denied_arm).is_empty());
+    }
+
+    #[test]
+    fn discovery_state_preserves_last_good_and_distinguishes_attempted_from_nonclosure() {
+        let valid = snapshot(
+            &[(1, "/project/main.rue", "main.rue", "fn main() -> i32 { 0 }")],
+            1,
+        );
+        let mut session = crate::CompilerSession::new();
+        session
+            .stage_import_discovery(
+                &valid,
+                context(1),
+                accepted_reads(&valid),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let committed = session
+            .close_import_discovery(ImportObservationLedger::default())
+            .unwrap();
+        assert_eq!(
+            committed.status(),
+            crate::ImportDiscoveryRevisionStatus::ClosedValid
+        );
+        assert!(Arc::ptr_eq(
+            committed
+                .graph()
+                .expect("closed-valid revision retains graph"),
+            &session.committed_import_graph().unwrap()
+        ));
+        assert!(Arc::ptr_eq(
+            committed
+                .graph()
+                .expect("closed-valid revision retains graph"),
+            &session.import_graph(Some("/sdk")).unwrap()
+        ));
+        let last_good = session
+            .last_good_discovery()
+            .unwrap()
+            .source_revision()
+            .clone();
+
+        let importing = snapshot(
+            &[(
+                1,
+                "/project/main.rue",
+                "main.rue",
+                "const h = @import(\"helper\"); fn main() -> i32 { 0 }",
+            )],
+            1,
+        );
+        let plan = session
+            .stage_import_discovery(
+                &importing,
+                context(2),
+                accepted_reads(&importing),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let request = plan.pending_requests(&ImportObservationLedger::default())[0].clone();
+        let mut carried = ImportObservationLedger::default();
+        carried
+            .record(
+                ImportObservation::accepted(
+                    request.clone(),
+                    AcceptedImportSource::new(
+                        request.requested_path(),
+                        request.requested_path(),
+                        PhysicalFileIdentity::new(9, 9),
+                        FileMetadataFingerprint::new(9, 9, 9),
+                        Arc::new("fn broken( {".into()),
+                    )
+                    .unwrap(),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let parse_failed = snapshot(
+            &[
+                (
+                    1,
+                    "/project/main.rue",
+                    "main.rue",
+                    "const h = @import(\"helper\"); fn main() -> i32 { 0 }",
+                ),
+                (2, "/project/helper.rue", "helper.rue", "fn broken( {"),
+            ],
+            1,
+        );
+        assert!(
+            session
+                .stage_import_discovery(
+                    &parse_failed,
+                    context(2),
+                    accepted_reads(&parse_failed),
+                    carried.clone(),
+                )
+                .is_err()
+        );
+        let attempted = session.discovery_attempt().unwrap();
+        assert_eq!(
+            attempted.status(),
+            crate::ImportDiscoveryRevisionStatus::ClosedAttempted
+        );
+        assert_eq!(attempted.source_revision(), parse_failed.source_revision());
+        assert_eq!(attempted.ledger(), &carried);
+        assert!(attempted.plan().is_none());
+        assert!(attempted.graph().is_none());
+        assert!(!attempted.diagnostics().is_empty());
+        assert_eq!(
+            session.last_good_discovery().unwrap().source_revision(),
+            &last_good
+        );
+        assert!(session.merge().is_err());
+
+        let missing = snapshot(
+            &[(
+                (1),
+                "/project/main.rue",
+                "main.rue",
+                "const x = @import(\"missing\"); fn main() -> i32 { 0 }",
+            )],
+            1,
+        );
+        let plan = session
+            .stage_import_discovery(
+                &missing,
+                context(3),
+                accepted_reads(&missing),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        loop {
+            let pending = plan.pending_requests(&ledger);
+            if pending.is_empty() {
+                break;
+            }
+            for request in pending {
+                ledger.record(ImportObservation::absent(request)).unwrap();
+            }
+        }
+        let errors = session.close_import_discovery(ledger).unwrap_err();
+        assert!(matches!(
+            &errors.first().unwrap().kind,
+            ErrorKind::ModuleNotFound { .. }
+        ));
+        assert_eq!(
+            session.discovery_attempt().unwrap().status(),
+            crate::ImportDiscoveryRevisionStatus::ClosedAttempted
+        );
+        assert_eq!(
+            session.last_good_discovery().unwrap().source_revision(),
+            &last_good
+        );
+        assert!(session.merge().is_err());
+
+        let plan = session
+            .stage_import_discovery(
+                &missing,
+                context(4),
+                accepted_reads(&missing),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut cancelled = ImportObservationLedger::default();
+        cancelled
+            .record(
+                ImportObservation::failure(
+                    plan.pending_requests(&cancelled)[0].clone(),
+                    ImportObservationStatus::Cancelled,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        session.close_import_discovery(cancelled).unwrap_err();
+        let attempt = session.discovery_attempt().unwrap();
+        assert_eq!(attempt.status(), crate::ImportDiscoveryRevisionStatus::Open);
+        assert!(attempt.graph().is_none());
+        assert_eq!(
+            session.last_good_discovery().unwrap().source_revision(),
+            &last_good
+        );
+    }
+
+    #[test]
+    fn incomplete_plain_ledger_stays_open_without_resolution_diagnostics() {
+        let source = snapshot(
+            &[(
+                1,
+                "/project/main.rue",
+                "main.rue",
+                "const x = @import(\"missing\"); fn main() -> i32 { 0 }",
+            )],
+            1,
+        );
+        let mut session = crate::CompilerSession::new();
+        session
+            .stage_import_discovery(
+                &source,
+                context(40),
+                accepted_reads(&source),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let errors = session
+            .close_import_discovery(ImportObservationLedger::default())
+            .unwrap_err();
+        assert!(matches!(
+            &errors.first().unwrap().kind,
+            ErrorKind::InvalidCompilerInput(_)
+        ));
+        let attempt = session.discovery_attempt().unwrap();
+        assert_eq!(attempt.status(), crate::ImportDiscoveryRevisionStatus::Open);
+        assert!(attempt.graph().is_none());
+        assert!(!attempt.diagnostics().iter().any(|error| matches!(
+            error.kind,
+            ErrorKind::ModuleNotFound { .. } | ErrorKind::StdLibNotFound
+        )));
+    }
+
+    #[test]
+    fn minimum_diagnostics_put_malformed_shape_before_graph_outcomes() {
+        let source = snapshot(
+            &[(
+                (1),
+                "/project/main.rue",
+                "main.rue",
+                "fn main() { @import(1); @import(\"missing\"); }",
+            )],
+            1,
+        );
+        let mut session = crate::CompilerSession::new();
+        let plan = session
+            .stage_import_discovery(
+                &source,
+                context(9),
+                accepted_reads(&source),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        loop {
+            let pending = plan.pending_requests(&ledger);
+            if pending.is_empty() {
+                break;
+            }
+            for request in pending {
+                ledger.record(ImportObservation::absent(request)).unwrap();
+            }
+        }
+        let errors = session.close_import_discovery(ledger).unwrap_err();
+        let errors = errors.iter().collect::<Vec<_>>();
+        assert!(matches!(
+            &errors[0].kind,
+            ErrorKind::ImportRequiresStringLiteral
+        ));
+        assert!(matches!(&errors[1].kind, ErrorKind::ModuleNotFound { .. }));
+        assert_eq!(
+            session.discovery_attempt().unwrap().status(),
+            crate::ImportDiscoveryRevisionStatus::ClosedAttempted
+        );
+    }
+
+    #[test]
+    fn ambiguous_and_std_missing_close_as_attempted_with_typed_diagnostics() {
+        let ambiguous = snapshot(
+            &[
+                (
+                    1,
+                    "/project/main.rue",
+                    "main.rue",
+                    "const x = @import(\"thing\"); fn main() -> i32 { 0 }",
+                ),
+                (2, "/project/thing.rue", "thing.rue", "const x = 1;"),
+                (
+                    3,
+                    "/project/thing/_thing.rue",
+                    "thing/_thing.rue",
+                    "const x = 2;",
+                ),
+            ],
+            1,
+        );
+        let mut session = crate::CompilerSession::new();
+        let plan = session
+            .stage_import_discovery(
+                &ambiguous,
+                context(10),
+                accepted_reads(&ambiguous),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        for request in plan.pending_requests(&ledger) {
+            let (contents, identity) = if request.requested_path().ends_with("/_thing.rue") {
+                ("const x = 2;", PhysicalFileIdentity::new(1, 3))
+            } else {
+                ("const x = 1;", PhysicalFileIdentity::new(1, 2))
+            };
+            let source = AcceptedImportSource::new(
+                Arc::from(request.requested_path()),
+                Arc::from(request.requested_path()),
+                identity,
+                metadata_fingerprint(),
+                Arc::new(contents.into()),
+            )
+            .unwrap();
+            ledger
+                .record(ImportObservation::accepted(request, source).unwrap())
+                .unwrap();
+        }
+        let errors = session.close_import_discovery(ledger).unwrap_err();
+        assert!(matches!(
+            &errors.first().unwrap().kind,
+            ErrorKind::AmbiguousModule(_)
+        ));
+        let attempted = session.discovery_attempt().unwrap();
+        assert_eq!(
+            attempted.status(),
+            crate::ImportDiscoveryRevisionStatus::ClosedAttempted
+        );
+        assert!(attempted.graph().is_some());
+
+        let std_missing = snapshot(
+            &[(
+                1,
+                "/project/main.rue",
+                "main.rue",
+                "const x = @import(\"std\"); fn main() -> i32 { 0 }",
+            )],
+            1,
+        );
+        let plan = session
+            .stage_import_discovery(
+                &std_missing,
+                context(11),
+                accepted_reads(&std_missing),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        loop {
+            let pending = plan.pending_requests(&ledger);
+            if pending.is_empty() {
+                break;
+            }
+            for request in pending {
+                ledger.record(ImportObservation::absent(request)).unwrap();
+            }
+        }
+        let errors = session.close_import_discovery(ledger).unwrap_err();
+        assert!(matches!(
+            &errors.first().unwrap().kind,
+            ErrorKind::StdLibNotFound { .. }
+        ));
+        assert_eq!(
+            session.discovery_attempt().unwrap().status(),
+            crate::ImportDiscoveryRevisionStatus::ClosedAttempted
+        );
+    }
+
+    #[test]
+    fn foreign_epoch_observations_cannot_close_a_staging_revision() {
+        let source = snapshot(
+            &[(
+                1,
+                "/project/main.rue",
+                "main.rue",
+                "const x = @import(\"missing\"); fn main() -> i32 { 0 }",
+            )],
+            1,
+        );
+        let mut current = crate::CompilerSession::new();
+        current
+            .stage_import_discovery(
+                &source,
+                context(30),
+                accepted_reads(&source),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut foreign = crate::CompilerSession::new();
+        let foreign_plan = foreign
+            .stage_import_discovery(
+                &source,
+                context(31),
+                accepted_reads(&source),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        ledger
+            .record(ImportObservation::absent(
+                foreign_plan.pending_requests(&ledger)[0].clone(),
+            ))
+            .unwrap();
+        let errors = current.close_import_discovery(ledger).unwrap_err();
+        assert!(matches!(
+            &errors.first().unwrap().kind,
+            ErrorKind::InvalidCompilerInput(_)
+        ));
+        assert!(current.merge().is_err());
+    }
+}

--- a/crates/rue-compiler/src/import_graph.rs
+++ b/crates/rue-compiler/src/import_graph.rs
@@ -28,14 +28,21 @@ use crate::{
 pub struct ImportDirective {
     importer: ModuleId,
     source_offset: u32,
+    source_end: u32,
     specifier: Arc<str>,
 }
 
 impl ImportDirective {
-    pub(crate) fn new(importer: ModuleId, source_offset: u32, specifier: Arc<str>) -> Self {
+    pub(crate) fn new(
+        importer: ModuleId,
+        source_offset: u32,
+        source_end: u32,
+        specifier: Arc<str>,
+    ) -> Self {
         Self {
             importer,
             source_offset,
+            source_end,
             specifier,
         }
     }
@@ -47,6 +54,9 @@ impl ImportDirective {
     /// Byte offset of the `@import` call in its source module.
     pub fn source_offset(&self) -> u32 {
         self.source_offset
+    }
+    pub fn source_end(&self) -> u32 {
+        self.source_end
     }
 
     /// Exact decoded string-literal value passed to `@import`.
@@ -177,6 +187,18 @@ pub struct CanonicalImportGraph {
 }
 
 impl CanonicalImportGraph {
+    pub(crate) fn from_discovery_records(
+        root: ModuleId,
+        mut records: Vec<CanonicalImportRecord>,
+    ) -> Self {
+        records.sort();
+        records.dedup();
+        Self {
+            root,
+            records: records.into(),
+        }
+    }
+
     pub fn root(&self) -> &ModuleId {
         &self.root
     }
@@ -446,6 +468,7 @@ pub(crate) fn extract_import_directives(
         directives.push(ImportDirective {
             importer,
             source_offset: inst.span.start,
+            source_end: inst.span.end,
             specifier: Arc::from(interner.resolve(specifier)),
         });
     }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -38,6 +38,7 @@ mod diagnostic;
 mod drop_glue;
 mod durable_body;
 mod durable_semantics;
+mod import_discovery;
 mod import_graph;
 mod linking;
 mod parsed_modules;
@@ -67,6 +68,12 @@ pub use diagnostic::{
     ColorChoice, DiagnosticFormatter, JsonDiagnostic, JsonDiagnosticFormatter, JsonSpan,
     JsonSuggestion, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
 };
+pub use import_discovery::{
+    AcceptedImportSource, AcceptedReadManifestEntry, DiscoverySourceAssembler,
+    FileMetadataFingerprint, IMPORT_DISCOVERY_POLICY_VERSION, ImportCandidateRole,
+    ImportDiscoveryContext, ImportDiscoveryPlan, ImportDiscoveryRequest, ImportObservation,
+    ImportObservationLedger, ImportObservationStatus, ImportOccurrenceKey, PhysicalFileIdentity,
+};
 pub use import_graph::{
     CanonicalImportCycle, CanonicalImportGraph, CanonicalImportGraphProblem,
     CanonicalImportGraphValidation, CanonicalImportRecord, CanonicalImportResolution,
@@ -74,8 +81,9 @@ pub use import_graph::{
     ResolvedLinkRevision, ResolvedProgramRevision,
 };
 pub use parsed_modules::{
-    ParseInvalidationSummary, ParsedAstPresentation, ParsedAstPresentationWork, ParsedModulesWork,
-    ParsedProgram, parse_source_snapshot_for_ast_presentation,
+    InvalidImportShape, ParseInvalidationSummary, ParsedAstPresentation, ParsedAstPresentationWork,
+    ParsedInvalidImport, ParsedModulesWork, ParsedProgram,
+    parse_source_snapshot_for_ast_presentation,
 };
 pub use queries::{
     CompileOptions, CompileOutput, FunctionWithCfg, LinkerMode, PipelineWork, SourceStats,
@@ -86,16 +94,16 @@ pub use session::{
     DefinitionQueryRecord, FRONTEND_DIAGNOSTIC_RETENTION_LIMIT,
     FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT, FrontendDiagnosticSnapshot,
     FrontendDiagnosticStage, FrontendQueryWork, FrontendRetentionMetrics,
-    ImportGraphInputDescriptor, SemanticDependencyBlocker, SemanticDependencyIncompleteReason,
-    SemanticDependencyInputManifest, SemanticDependencyManifestWork, SemanticDependencySurface,
-    SemanticFullInvalidationReason, SemanticInvalidationPlan, SemanticInvalidationScope,
-    SemanticInvalidationWork, SemanticQueryRecord, StableBodyDependencyInputRecord,
-    StableBuiltinTypeCallHeadInput, StableDeclarationTypeCallHeadDependency,
-    StableDeclarationTypeDependency, StableDefinitionFingerprint,
-    StableDefinitionFingerprintPrecision, StableDefinitionInputFingerprint,
-    StableFreeFunctionDependency, StableModuleImportDependency, StableNamedConstDependency,
-    StableNamedConstDependencyTarget, StableNamedDestructorDependency, StableNamedMethodDependency,
-    StableNamedMethodDependencyTarget,
+    ImportDiscoveryRevisionArtifact, ImportDiscoveryRevisionStatus, ImportGraphInputDescriptor,
+    SemanticDependencyBlocker, SemanticDependencyIncompleteReason, SemanticDependencyInputManifest,
+    SemanticDependencyManifestWork, SemanticDependencySurface, SemanticFullInvalidationReason,
+    SemanticInvalidationPlan, SemanticInvalidationScope, SemanticInvalidationWork,
+    SemanticQueryRecord, StableBodyDependencyInputRecord, StableBuiltinTypeCallHeadInput,
+    StableDeclarationTypeCallHeadDependency, StableDeclarationTypeDependency,
+    StableDefinitionFingerprint, StableDefinitionFingerprintPrecision,
+    StableDefinitionInputFingerprint, StableFreeFunctionDependency, StableModuleImportDependency,
+    StableNamedConstDependency, StableNamedConstDependencyTarget, StableNamedDestructorDependency,
+    StableNamedMethodDependency, StableNamedMethodDependencyTarget,
 };
 pub use source_identity::{
     CodegenInputDescriptor, LinkInputDescriptor, ModuleId, ModuleResolutionInput,
@@ -137,7 +145,7 @@ pub use backend::{
 };
 
 // Small foundational types callers need to configure or inspect the facade.
-pub use rue_air::{TypeInternPool, import_candidate_groups};
+pub use rue_air::TypeInternPool;
 pub use rue_cfg::OptLevel;
 pub use rue_codegen::{
     LoweringDebugInfo, RegAllocDebugInfo, StackFrameInfo, generate_stack_frame_info,

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -158,13 +158,52 @@ impl ParsedDefinitionIndex {
 pub struct ParsedImportDirective {
     importer: ModuleId,
     source_offset: u32,
+    source_end: u32,
     specifier: Arc<str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ParsedInvalidImport {
+    importer: ModuleId,
+    span: Span,
+    shape: InvalidImportShape,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum InvalidImportShape {
+    WrongArity { actual: u32 },
+    NonStringArgument,
+}
+
+impl ParsedInvalidImport {
+    pub fn importer(&self) -> &ModuleId {
+        &self.importer
+    }
+    pub fn span(&self) -> Span {
+        self.span
+    }
+    pub fn shape(&self) -> &InvalidImportShape {
+        &self.shape
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct ParsedImportSite {
     source_offset: u32,
+    source_end: u32,
     specifier: Arc<str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedInvalidImportSite {
+    span: Span,
+    shape: InvalidImportShape,
+}
+
+#[derive(Default)]
+struct ImportSiteCollector {
+    valid: Vec<ParsedImportSite>,
+    invalid: Vec<ParsedInvalidImportSite>,
 }
 
 /// Immutable parsed syntax whose spans and symbols belong to one FileId epoch.
@@ -177,6 +216,7 @@ struct ParsedSyntaxPayload {
     resolver: FrozenSymbolResolver,
     definitions: ParsedDefinitionIndex,
     import_sites: Arc<[ParsedImportSite]>,
+    invalid_import_sites: Arc<[ParsedInvalidImportSite]>,
 }
 
 impl ParsedImportDirective {
@@ -198,6 +238,7 @@ pub struct ParsedModule {
     physical_path: Arc<str>,
     payload: Arc<ParsedSyntaxPayload>,
     imports: Arc<[ParsedImportDirective]>,
+    invalid_imports: Arc<[ParsedInvalidImport]>,
 }
 
 /// An AST paired with the exact parsed module that owns all of its symbols.
@@ -311,6 +352,9 @@ impl ParsedModule {
     pub fn imports(&self) -> &[ParsedImportDirective] {
         &self.imports
     }
+    pub fn invalid_imports(&self) -> &[ParsedInvalidImport] {
+        &self.invalid_imports
+    }
 
     pub fn resolve(&self, symbol: &ParsedSymbol) -> CompileResult<&str> {
         self.payload.resolver.resolve(symbol)
@@ -355,6 +399,7 @@ pub struct ParsedProgram {
     source_revision: SourceRevision,
     modules: Arc<[Arc<ParsedModule>]>,
     imports: ImportDirectives,
+    invalid_imports: Arc<[ParsedInvalidImport]>,
 }
 
 impl ParsedProgram {
@@ -388,15 +433,27 @@ impl ParsedProgram {
                     ImportDirective::new(
                         directive.importer.clone(),
                         directive.source_offset,
+                        directive.source_end,
                         directive.specifier.clone(),
                     )
                 })
                 .collect(),
         );
+        let mut invalid_imports = modules
+            .iter()
+            .flat_map(|module| module.invalid_imports().iter().cloned())
+            .collect::<Vec<_>>();
+        invalid_imports.sort_by(|left, right| {
+            left.importer
+                .cmp(&right.importer)
+                .then(left.span.file_id.index().cmp(&right.span.file_id.index()))
+                .then(left.span.start.cmp(&right.span.start))
+        });
         Ok(Self {
             source_revision,
             modules: modules.into(),
             imports,
+            invalid_imports: invalid_imports.into(),
         })
     }
 
@@ -429,6 +486,9 @@ impl ParsedProgram {
     /// Canonical program-wide import occurrences, ready for graph resolution.
     pub fn import_directives(&self) -> &ImportDirectives {
         &self.imports
+    }
+    pub fn invalid_imports(&self) -> &[ParsedInvalidImport] {
+        &self.invalid_imports
     }
 
     pub(crate) fn shared_symbol_strings(&self) -> Option<Vec<&str>> {
@@ -861,7 +921,7 @@ fn build_module_with_resolver(
     ast: Arc<Ast>,
     resolver: Arc<RodeoResolver<Spur>>,
     token: Arc<SymbolProvenance>,
-    import_sites: Vec<ParsedImportSite>,
+    import_sites: ImportSiteCollector,
 ) -> CompileResult<Arc<ParsedModule>> {
     let module = snapshot
         .module_id(file_id)
@@ -897,7 +957,8 @@ fn build_module_with_resolver(
         ast: provenanced_ast,
         resolver,
         definitions,
-        import_sites: import_sites.into(),
+        import_sites: import_sites.valid.into(),
+        invalid_import_sites: import_sites.invalid.into(),
     });
     Ok(bind_payload(snapshot, file_id, payload))
 }
@@ -923,7 +984,17 @@ fn bind_payload(
         .map(|site| ParsedImportDirective {
             importer: module.clone(),
             source_offset: site.source_offset,
+            source_end: site.source_end,
             specifier: site.specifier.clone(),
+        })
+        .collect::<Vec<_>>();
+    let invalid_imports = payload
+        .invalid_import_sites
+        .iter()
+        .map(|site| ParsedInvalidImport {
+            importer: module.clone(),
+            span: site.span,
+            shape: site.shape.clone(),
         })
         .collect::<Vec<_>>();
     Arc::new(ParsedModule {
@@ -931,6 +1002,7 @@ fn bind_payload(
         physical_path: Arc::from(snapshot.metadata().physical_path(file_id).unwrap()),
         payload,
         imports: imports.into(),
+        invalid_imports: invalid_imports.into(),
     })
 }
 
@@ -938,8 +1010,8 @@ fn collect_imports(
     ast: &Ast,
     module: &ModuleId,
     resolver: &ThreadedRodeo,
-) -> CompileResult<Vec<ParsedImportSite>> {
-    let mut imports = Vec::new();
+) -> CompileResult<ImportSiteCollector> {
+    let mut imports = ImportSiteCollector::default();
     for item in &ast.items {
         match item {
             Item::Function(value) => {
@@ -984,7 +1056,10 @@ fn collect_imports(
             Item::Error(_) => {}
         }
     }
-    imports.sort();
+    imports.valid.sort();
+    imports
+        .invalid
+        .sort_by_key(|site| (site.span.file_id.index(), site.span.start));
     Ok(imports)
 }
 
@@ -993,7 +1068,7 @@ fn walk_signature(
     return_type: Option<&TypeExpr>,
     module: &ModuleId,
     resolver: &ThreadedRodeo,
-    imports: &mut Vec<ParsedImportSite>,
+    imports: &mut ImportSiteCollector,
 ) -> CompileResult<()> {
     for param in params {
         walk_type_expr(&param.ty, module, resolver, imports)?;
@@ -1008,7 +1083,7 @@ fn walk_type_expr(
     ty: &TypeExpr,
     module: &ModuleId,
     resolver: &ThreadedRodeo,
-    imports: &mut Vec<ParsedImportSite>,
+    imports: &mut ImportSiteCollector,
 ) -> CompileResult<()> {
     match ty {
         TypeExpr::Named(_)
@@ -1060,7 +1135,7 @@ fn walk_args(
     args: &[rue_parser::ast::CallArg],
     module: &ModuleId,
     resolver: &ThreadedRodeo,
-    imports: &mut Vec<ParsedImportSite>,
+    imports: &mut ImportSiteCollector,
 ) -> CompileResult<()> {
     for arg in args {
         walk_expr(&arg.expr, module, resolver, imports)?;
@@ -1072,7 +1147,7 @@ fn walk_block(
     block: &rue_parser::ast::BlockExpr,
     module: &ModuleId,
     resolver: &ThreadedRodeo,
-    imports: &mut Vec<ParsedImportSite>,
+    imports: &mut ImportSiteCollector,
 ) -> CompileResult<()> {
     for statement in &block.statements {
         match statement {
@@ -1100,7 +1175,7 @@ fn walk_expr(
     expr: &Expr,
     module: &ModuleId,
     resolver: &ThreadedRodeo,
-    imports: &mut Vec<ParsedImportSite>,
+    imports: &mut ImportSiteCollector,
 ) -> CompileResult<()> {
     match expr {
         Expr::Int(_)
@@ -1183,16 +1258,29 @@ fn walk_expr(
             let name = resolver.try_resolve(&value.name.name).ok_or_else(|| {
                 invalid_input("intrinsic name is absent from the module symbol universe")
             })?;
-            if name == "import"
-                && let [IntrinsicArg::Expr(Expr::String(literal))] = value.args.as_slice()
-            {
-                let specifier = resolver.try_resolve(&literal.value).ok_or_else(|| {
-                    invalid_input("import literal is absent from the module symbol universe")
-                })?;
-                imports.push(ParsedImportSite {
-                    source_offset: value.span.start,
-                    specifier: Arc::from(specifier),
-                });
+            if name == "import" {
+                if let [IntrinsicArg::Expr(Expr::String(literal))] = value.args.as_slice() {
+                    let specifier = resolver.try_resolve(&literal.value).ok_or_else(|| {
+                        invalid_input("import literal is absent from the module symbol universe")
+                    })?;
+                    imports.valid.push(ParsedImportSite {
+                        source_offset: value.span.start,
+                        source_end: value.span.end,
+                        specifier: Arc::from(specifier),
+                    });
+                } else {
+                    let shape = if value.args.len() != 1 {
+                        InvalidImportShape::WrongArity {
+                            actual: u32::try_from(value.args.len()).unwrap_or(u32::MAX),
+                        }
+                    } else {
+                        InvalidImportShape::NonStringArgument
+                    };
+                    imports.invalid.push(ParsedInvalidImportSite {
+                        span: value.span,
+                        shape,
+                    });
+                }
             }
             for arg in &value.args {
                 if let IntrinsicArg::Expr(expr) = arg {

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -356,6 +356,26 @@ pub fn compile_snapshot(
     compile_snapshot_impl(snapshot, options)
 }
 
+/// Compile the closed-valid discovery revision already adopted by `session`.
+///
+/// This preserves the compiler-owned import graph and captured discovery
+/// context instead of reconstructing a peer frontend from source bytes.
+impl CompilerSession {
+    /// Produce an executable from this session's closed-valid discovery revision.
+    pub fn executable(&mut self, options: &CompileOptions) -> MultiErrorResult<CompileOutput> {
+        let snapshot = self
+            .committed_import_discovery()
+            .ok_or_else(|| {
+                CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                    "compilation requires a closed-valid import discovery revision".into(),
+                )))
+            })?
+            .snapshot()
+            .clone();
+        compile_with_session(self, &snapshot, options)
+    }
+}
+
 fn compile_snapshot_impl(
     snapshot: &SourceSnapshot,
     options: &CompileOptions,
@@ -366,6 +386,16 @@ fn compile_snapshot_impl(
     // (RUE-352). The jobs setting is now applied once in the driver's `main()`
     // via `configure_thread_pool` before dispatching to any path.
 
+    let mut session = CompilerSession::new();
+    session.update_for_presentation(snapshot).into_result()?;
+    compile_with_session(&mut session, snapshot, options)
+}
+
+fn compile_with_session(
+    session: &mut CompilerSession,
+    snapshot: &SourceSnapshot,
+    options: &CompileOptions,
+) -> MultiErrorResult<CompileOutput> {
     let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
     let _span = info_span!(
         "compile",
@@ -375,8 +405,6 @@ fn compile_snapshot_impl(
     )
     .entered();
 
-    let mut session = CompilerSession::new();
-    session.update_for_presentation(snapshot).into_result()?;
     let rir = {
         let _span = info_span!("semantic_astgen").entered();
         session.rir()?

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -995,6 +995,57 @@ pub struct CompilerSessionUpdate {
     diagnostics: Arc<FrontendDiagnosticSnapshot>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportDiscoveryRevisionStatus {
+    Open,
+    ClosedAttempted,
+    ClosedValid,
+}
+
+#[derive(Debug, Clone)]
+pub struct ImportDiscoveryRevisionArtifact {
+    status: ImportDiscoveryRevisionStatus,
+    source_revision: SourceRevision,
+    context: crate::ImportDiscoveryContext,
+    snapshot: SourceSnapshot,
+    program: Option<Arc<ParsedProgram>>,
+    plan: Option<crate::ImportDiscoveryPlan>,
+    ledger: crate::ImportObservationLedger,
+    accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+    graph: Option<Arc<CanonicalImportGraphOutput>>,
+    diagnostics: CompileErrors,
+}
+
+impl ImportDiscoveryRevisionArtifact {
+    pub fn status(&self) -> ImportDiscoveryRevisionStatus {
+        self.status
+    }
+    pub fn source_revision(&self) -> &SourceRevision {
+        &self.source_revision
+    }
+    pub fn context(&self) -> &crate::ImportDiscoveryContext {
+        &self.context
+    }
+    pub fn snapshot(&self) -> &SourceSnapshot {
+        &self.snapshot
+    }
+    pub fn plan(&self) -> Option<&crate::ImportDiscoveryPlan> {
+        self.plan.as_ref()
+    }
+    pub fn ledger(&self) -> &crate::ImportObservationLedger {
+        &self.ledger
+    }
+    pub fn accepted_read_manifest(&self) -> &[crate::AcceptedReadManifestEntry] {
+        &self.accepted_reads
+    }
+    pub fn graph(&self) -> Option<&Arc<CanonicalImportGraphOutput>> {
+        self.graph.as_ref()
+    }
+    pub fn diagnostics(&self) -> &CompileErrors {
+        &self.diagnostics
+    }
+}
+
 impl CompilerSessionUpdate {
     pub fn result(&self) -> Result<&Arc<ParsedProgram>, &CompileErrors> {
         self.result.as_ref()
@@ -1019,6 +1070,10 @@ impl CompilerSessionUpdate {
 #[derive(Debug, Default)]
 pub struct CompilerSession {
     parse: CanonicalParseSession,
+    discovery_parse: CanonicalParseSession,
+    discovery_staging_active: bool,
+    discovery_attempt: Option<Arc<ImportDiscoveryRevisionArtifact>>,
+    committed_discovery: Option<Arc<ImportDiscoveryRevisionArtifact>>,
     published: Option<Arc<ParsedProgram>>,
     published_snapshot: Option<SourceSnapshot>,
     batch_diagnostic_order: Option<Vec<crate::ModuleId>>,
@@ -1078,6 +1133,234 @@ impl CompilerSession {
     }
     pub fn published(&self) -> Option<&Arc<ParsedProgram>> {
         self.published.as_ref()
+    }
+    /// Derive the pre-closure import plan for the session's current parsed
+    /// revision. Hosts may execute only the requests carried by this query.
+    pub fn import_discovery_plan(
+        &self,
+        context: crate::ImportDiscoveryContext,
+    ) -> crate::CompileResult<crate::ImportDiscoveryPlan> {
+        let program = self.published.as_ref().ok_or_else(|| {
+            CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "import discovery requires a successfully parsed staging revision".into(),
+            ))
+        })?;
+        crate::ImportDiscoveryPlan::new(program, context)
+    }
+    pub fn discovery_attempt(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
+        self.discovery_attempt.as_ref()
+    }
+    pub fn last_good_discovery(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
+        self.committed_import_discovery()
+    }
+
+    /// The exact closed-valid discovery revision adopted by this session.
+    ///
+    /// Downstream compilation must consume this artifact (or queries that
+    /// delegate to it), rather than reconstructing import or standard-library
+    /// resolution from the source snapshot alone.
+    pub fn committed_import_discovery(&self) -> Option<&Arc<ImportDiscoveryRevisionArtifact>> {
+        self.committed_discovery.as_ref()
+    }
+
+    /// Return the canonical graph and captured resolution context adopted for
+    /// the current compiler revision.
+    pub fn committed_import_graph(&self) -> Result<Arc<CanonicalImportGraphOutput>, CompileErrors> {
+        let committed = self.committed_discovery.as_ref().ok_or_else(|| {
+            CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "no closed-valid import discovery revision is committed".into(),
+            )))
+        })?;
+        Ok(committed
+            .graph()
+            .expect("closed-valid discovery revisions retain their canonical graph")
+            .clone())
+    }
+
+    /// Parse an immutable staging snapshot without publishing it to semantic
+    /// or dependency queries.
+    pub fn stage_import_discovery(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        context: crate::ImportDiscoveryContext,
+        accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
+        carried_ledger: crate::ImportObservationLedger,
+    ) -> Result<crate::ImportDiscoveryPlan, CompileErrors> {
+        self.discovery_staging_active = true;
+        let source_revision = snapshot.source_revision().clone();
+        let publish_failed_attempt = |errors: CompileErrors| ImportDiscoveryRevisionArtifact {
+            status: ImportDiscoveryRevisionStatus::ClosedAttempted,
+            source_revision: source_revision.clone(),
+            context: context.clone(),
+            snapshot: snapshot.clone(),
+            program: None,
+            plan: None,
+            ledger: carried_ledger.clone(),
+            accepted_reads: accepted_reads.clone(),
+            graph: None,
+            diagnostics: errors,
+        };
+        if let Err(errors) = validate_accepted_read_manifest(snapshot, &accepted_reads) {
+            self.discovery_attempt = Some(Arc::new(publish_failed_attempt(errors.clone())));
+            return Err(errors);
+        }
+        let program = match self.discovery_parse.update(snapshot).into_result() {
+            Ok(program) => program,
+            Err(errors) => {
+                self.discovery_attempt = Some(Arc::new(publish_failed_attempt(errors.clone())));
+                return Err(errors);
+            }
+        };
+        let plan = match crate::ImportDiscoveryPlan::new(&program, context.clone()) {
+            Ok(plan) => plan,
+            Err(error) => {
+                let errors = CompileErrors::from(error);
+                self.discovery_attempt = Some(Arc::new(publish_failed_attempt(errors.clone())));
+                return Err(errors);
+            }
+        };
+        self.discovery_attempt = Some(Arc::new(ImportDiscoveryRevisionArtifact {
+            status: ImportDiscoveryRevisionStatus::Open,
+            source_revision: program.source_revision().clone(),
+            context,
+            snapshot: snapshot.clone(),
+            program: Some(program),
+            plan: Some(plan.clone()),
+            ledger: carried_ledger,
+            accepted_reads,
+            graph: None,
+            diagnostics: CompileErrors::new(),
+        }));
+        Ok(plan)
+    }
+
+    /// Close the current staging revision. Missing, ambiguous, and malformed
+    /// imports retain a closed attempted artifact; only a diagnostic-free graph
+    /// is atomically adopted as the committed compiler revision.
+    pub fn close_import_discovery(
+        &mut self,
+        ledger: crate::ImportObservationLedger,
+    ) -> Result<Arc<ImportDiscoveryRevisionArtifact>, CompileErrors> {
+        let open = self
+            .discovery_attempt
+            .as_deref()
+            .filter(|artifact| artifact.status == ImportDiscoveryRevisionStatus::Open)
+            .ok_or_else(|| CompileErrors::from(no_published_program()))?
+            .clone();
+        let plan = open
+            .plan
+            .as_ref()
+            .expect("open discovery attempt retains its plan")
+            .clone();
+        let program = open
+            .program
+            .as_ref()
+            .expect("open discovery attempt retains its program")
+            .clone();
+        plan.validate_ledger(&ledger).map_err(CompileErrors::from)?;
+        if !plan.pending_requests(&ledger).is_empty() {
+            let errors =
+                CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                    "import discovery ledger is incomplete; the revision remains open".into(),
+                )));
+            let artifact = Arc::new(ImportDiscoveryRevisionArtifact {
+                ledger,
+                diagnostics: errors.clone(),
+                ..open
+            });
+            self.discovery_attempt = Some(artifact);
+            return Err(errors);
+        }
+        let diagnostics = plan.diagnostics(&program, &ledger);
+        if plan.failures(&ledger).next().is_some() {
+            let artifact = Arc::new(ImportDiscoveryRevisionArtifact {
+                ledger,
+                diagnostics: diagnostics.clone(),
+                ..open
+            });
+            self.discovery_attempt = Some(artifact);
+            return Err(diagnostics);
+        }
+
+        let resolution = ModuleResolutionInputs::new(
+            program.root().clone(),
+            program
+                .modules()
+                .iter()
+                .map(|module| crate::ModuleResolutionInput {
+                    module: module.module_id().clone(),
+                    physical_path: Arc::from(module.physical_path()),
+                })
+                .collect(),
+        )?;
+        let input = ImportGraphInputDescriptor {
+            sources: program.source_revision().clone(),
+            resolution,
+            std_dir: open.context.std_root().map(Arc::from),
+        };
+        let graph = plan.reduce_graph(program.root().clone(), &ledger, &open.accepted_reads)?;
+        let validation = validate_canonical_import_graph(&graph, &input.resolution);
+        let graph = Arc::new(CanonicalImportGraphOutput {
+            input,
+            graph,
+            validation,
+        });
+        let resolution_only = graph.validation().problems().iter().all(|problem| {
+            matches!(
+                problem,
+                crate::CanonicalImportGraphProblem::MissingResolution { .. }
+                    | crate::CanonicalImportGraphProblem::AmbiguousResolution { .. }
+            )
+        });
+        if !resolution_only {
+            let mut errors = diagnostics;
+            errors.push(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "import discovery produced a structurally invalid canonical graph".into(),
+            )));
+            let artifact = Arc::new(ImportDiscoveryRevisionArtifact {
+                ledger,
+                diagnostics: errors.clone(),
+                ..open
+            });
+            self.discovery_attempt = Some(artifact);
+            return Err(errors);
+        }
+        if !graph.validation().is_valid() || !diagnostics.is_empty() {
+            let artifact = Arc::new(ImportDiscoveryRevisionArtifact {
+                status: ImportDiscoveryRevisionStatus::ClosedAttempted,
+                ledger,
+                graph: Some(graph),
+                diagnostics: diagnostics.clone(),
+                ..open
+            });
+            self.discovery_attempt = Some(artifact);
+            return Err(diagnostics);
+        }
+
+        self.update_for_presentation(&open.snapshot).into_result()?;
+        let artifact = Arc::new(ImportDiscoveryRevisionArtifact {
+            status: ImportDiscoveryRevisionStatus::ClosedValid,
+            ledger,
+            graph: Some(graph),
+            diagnostics,
+            ..open
+        });
+        self.discovery_attempt = Some(artifact.clone());
+        self.committed_discovery = Some(artifact.clone());
+        self.discovery_staging_active = false;
+        Ok(artifact)
+    }
+
+    fn require_closed_discovery(&self) -> Result<(), CompileErrors> {
+        if self.discovery_staging_active {
+            return Err(CompileErrors::from(CompileError::without_span(
+                ErrorKind::InvalidCompilerInput(
+                    "semantic and dependency queries require a closed valid discovery revision"
+                        .into(),
+                ),
+            )));
+        }
+        Ok(())
     }
     pub fn work(&self) -> &CompilerSessionWork {
         &self.work
@@ -1265,6 +1548,16 @@ impl CompilerSession {
         );
         match result {
             Ok(candidate) => {
+                if self.discovery_attempt.as_deref().is_some_and(|artifact| {
+                    artifact.source_revision != *candidate.source_revision()
+                }) {
+                    self.discovery_attempt = None;
+                }
+                if self.committed_discovery.as_deref().is_some_and(|artifact| {
+                    artifact.source_revision != *candidate.source_revision()
+                }) {
+                    self.committed_discovery = None;
+                }
                 let exact = self.published.as_deref().is_some_and(|published| {
                     programs_are_pointer_equivalent(published, &candidate)
                 });
@@ -1324,7 +1617,23 @@ impl CompilerSession {
         &mut self,
         std_dir: Option<&str>,
     ) -> Result<Arc<CanonicalImportGraphOutput>, CompileErrors> {
+        self.require_closed_discovery()?;
         self.work.imports.calls += 1;
+        if let Some(committed) = self.committed_discovery.as_ref() {
+            let graph = committed
+                .graph()
+                .expect("closed-valid discovery revisions retain their canonical graph");
+            if graph.input().std_dir.as_deref() != std_dir {
+                return Err(CompileErrors::from(CompileError::without_span(
+                    ErrorKind::InvalidCompilerInput(
+                        "the requested standard-library context differs from the committed import discovery revision"
+                            .into(),
+                    ),
+                )));
+            }
+            self.work.imports.reuses += 1;
+            return Ok(graph.clone());
+        }
         let parsed = self.published.as_deref().ok_or_else(no_published_program)?;
         let resolution = ModuleResolutionInputs::new(
             parsed.root().clone(),
@@ -1368,6 +1677,7 @@ impl CompilerSession {
     }
 
     pub fn merge(&mut self) -> Result<Arc<CanonicalMergedProgram>, CompileErrors> {
+        self.require_closed_discovery()?;
         self.work.merge.calls += 1;
         if let Some(cached) = &self.merge_cache {
             self.work.merge.reuses += 1;
@@ -3219,6 +3529,51 @@ fn programs_are_pointer_equivalent(left: &ParsedProgram, right: &ParsedProgram) 
             .iter()
             .zip(right.modules())
             .all(|(left, right)| Arc::ptr_eq(left, right))
+}
+
+fn validate_accepted_read_manifest(
+    snapshot: &SourceSnapshot,
+    accepted_reads: &[crate::AcceptedReadManifestEntry],
+) -> Result<(), CompileErrors> {
+    if accepted_reads.len() != snapshot.len() {
+        return Err(CompileErrors::from(CompileError::without_span(
+            ErrorKind::InvalidCompilerInput(
+                "accepted read manifest does not cover the staging source snapshot".into(),
+            ),
+        )));
+    }
+    let entries = accepted_reads
+        .iter()
+        .map(|entry| (entry.module(), entry))
+        .collect::<BTreeMap<_, _>>();
+    if entries.len() != accepted_reads.len() {
+        return Err(CompileErrors::from(CompileError::without_span(
+            ErrorKind::InvalidCompilerInput(
+                "accepted read manifest contains duplicate logical modules".into(),
+            ),
+        )));
+    }
+    for source in snapshot.files() {
+        let module = snapshot
+            .module_id(source.file_id)
+            .expect("snapshot files have logical module IDs");
+        let Some(entry) = entries.get(module) else {
+            return Err(CompileErrors::from(CompileError::without_span(
+                ErrorKind::InvalidCompilerInput(format!(
+                    "accepted read manifest is missing logical module {module}"
+                )),
+            )));
+        };
+        if entry.content_fingerprint() != crate::import_discovery::source_fingerprint(source.source)
+        {
+            return Err(CompileErrors::from(CompileError::without_span(
+                ErrorKind::InvalidCompilerInput(format!(
+                    "accepted read manifest content does not match logical module {module}"
+                )),
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn no_published_program() -> CompileErrors {

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
 use std::env;
 use std::fs;
+use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
@@ -13,17 +15,19 @@ use tracing_subscriber::{EnvFilter, Layer as _, fmt};
 
 mod timing;
 
-#[cfg(test)]
-use rue_compiler::CompilerSessionWork;
 use rue_compiler::{
-    Ast, CanonicalRirOutput, CanonicalSemanticOutput, CompileError, CompileErrors, CompileOptions,
-    CompileWarning, CompilerSession, ErrorKind, FileId, Lexer, LinkerMode, MAX_SOURCE_BYTES,
-    MultiFileFormatter, MultiFileJsonFormatter, OptLevel, PipelineWork, PreviewFeature,
-    PreviewFeatures, SourceInfo, SourceMetadata, SourceSnapshot, Span, Token, TokenKind,
-    TypeInternPool, compile_snapshot, configure_thread_pool, generate_emitted_asm,
+    AcceptedImportSource, Ast, CanonicalRirOutput, CanonicalSemanticOutput, CompileError,
+    CompileErrors, CompileOptions, CompileWarning, CompilerSession, DiscoverySourceAssembler,
+    ErrorKind, FileId, FileMetadataFingerprint, ImportDiscoveryContext,
+    ImportDiscoveryRevisionArtifact, ImportObservation, ImportObservationLedger,
+    ImportObservationStatus, Lexer, LinkerMode, MultiFileFormatter, MultiFileJsonFormatter,
+    OptLevel, PhysicalFileIdentity, PipelineWork, PreviewFeature, PreviewFeatures, SourceInfo,
+    SourceSnapshot, Token, TypeInternPool, configure_thread_pool, generate_emitted_asm,
     generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
-    generate_stack_frame_info, import_candidate_groups, parse_source_snapshot_for_ast_presentation,
+    generate_stack_frame_info, parse_source_snapshot_for_ast_presentation,
 };
+#[cfg(test)]
+use rue_compiler::{CompilerSessionWork, SourceMetadata};
 use rue_rir::RirPrinter;
 use rue_target::Target;
 use serde::Serialize;
@@ -96,14 +100,15 @@ fn emit_frontend_route(stages: &[EmitStage]) -> EmitFrontendRoute {
     }
 }
 
-fn build_emit_frontend(
-    source_snapshot: &SourceSnapshot,
+fn build_emit_frontend_in_session(
+    session: &mut CompilerSession,
     options: CompileOptions,
 ) -> Result<EmitFrontend, CompileErrors> {
-    let mut session = CompilerSession::new();
-    let parsed = session
-        .update_for_presentation(source_snapshot)
-        .into_result()?;
+    let parsed = session.published().cloned().ok_or_else(|| {
+        CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+            "emit requires a published closed discovery revision".into(),
+        )))
+    })?;
     let rir = {
         let _span = info_span!("semantic_astgen").entered();
         session.rir()?
@@ -123,6 +128,18 @@ fn build_emit_frontend(
         #[cfg(test)]
         session_work,
     })
+}
+
+#[cfg(test)]
+fn build_emit_frontend(
+    source_snapshot: &SourceSnapshot,
+    options: CompileOptions,
+) -> Result<EmitFrontend, CompileErrors> {
+    let mut session = CompilerSession::new();
+    session
+        .update_for_presentation(source_snapshot)
+        .into_result()?;
+    build_emit_frontend_in_session(&mut session, options)
 }
 
 impl EmitFrontend {
@@ -1149,19 +1166,28 @@ impl SourceManifest {
                 base_dir.join(entry_path)
             };
             declared_paths.insert(normalize_lexical_path(&resolved));
-            let canonical = fs::canonicalize(&resolved).map_err(|e| {
-                format!(
-                    "Error reading source manifest '{}': line {} entry '{}' cannot be resolved: {}",
-                    path, line_number, entry, e
-                )
-            })?;
-            if !canonical.is_file() {
-                return Err(format!(
-                    "Error reading source manifest '{}': line {} entry '{}' is not a file",
-                    path, line_number, entry
-                ));
+            match fs::canonicalize(&resolved) {
+                Ok(canonical) if canonical.is_file() => {
+                    allowed.insert(canonical);
+                }
+                Ok(_) => {
+                    return Err(format!(
+                        "Error reading source manifest '{}': line {} entry '{}' is not a file",
+                        path, line_number, entry
+                    ));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    // A manifest grants an operation, not a claim that the
+                    // candidate exists. Declared absent ambiguity arms must be
+                    // observable without probing paths the policy did not name.
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "Error reading source manifest '{}': line {} entry '{}' cannot be resolved: {}",
+                        path, line_number, entry, error
+                    ));
+                }
             }
-            allowed.insert(canonical);
         }
 
         Ok(Self {
@@ -1181,6 +1207,26 @@ impl SourceManifest {
 
     fn display_path(&self) -> String {
         self.path.display().to_string()
+    }
+
+    fn policy_revision(&self) -> String {
+        let mut declared = self
+            .declared_paths
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        declared.sort();
+        let mut allowed = self
+            .allowed
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        allowed.sort();
+        format!(
+            "manifest-v1\ndeclared={}\nallowed={}",
+            declared.join("\0"),
+            allowed.join("\0")
+        )
     }
 }
 
@@ -1206,11 +1252,98 @@ fn normalize_lexical_path(path: &Path) -> PathBuf {
     normalized
 }
 
+enum StableReadError {
+    Io(std::io::Error),
+    Changed,
+}
+
+struct StableRead {
+    source: String,
+    identity: PhysicalFileIdentity,
+    fingerprint: FileMetadataFingerprint,
+}
+
+fn stable_read_to_string(path: &Path) -> Result<StableRead, StableReadError> {
+    let before = fs::metadata(path).map_err(StableReadError::Io)?;
+    let mut file = fs::File::open(path).map_err(StableReadError::Io)?;
+    let opened = file.metadata().map_err(StableReadError::Io)?;
+    if !same_file_observation(&before, &opened) {
+        return Err(StableReadError::Changed);
+    }
+    let mut source = String::new();
+    file.read_to_string(&mut source)
+        .map_err(StableReadError::Io)?;
+    let after = file.metadata().map_err(StableReadError::Io)?;
+    if !same_file_observation(&opened, &after) {
+        return Err(StableReadError::Changed);
+    }
+    Ok(StableRead {
+        source,
+        identity: physical_file_identity(&opened),
+        fingerprint: file_metadata_fingerprint(&opened),
+    })
+}
+
+#[cfg(unix)]
+fn physical_file_identity(metadata: &fs::Metadata) -> PhysicalFileIdentity {
+    use std::os::unix::fs::MetadataExt;
+    PhysicalFileIdentity::new(metadata.dev(), metadata.ino())
+}
+
+#[cfg(unix)]
+fn file_metadata_fingerprint(metadata: &fs::Metadata) -> FileMetadataFingerprint {
+    use std::os::unix::fs::MetadataExt;
+    let modified = (metadata.mtime() as u64)
+        .wrapping_mul(1_000_000_000)
+        .wrapping_add(metadata.mtime_nsec() as u64);
+    let changed = (metadata.ctime() as u64)
+        .wrapping_mul(1_000_000_000)
+        .wrapping_add(metadata.ctime_nsec() as u64);
+    FileMetadataFingerprint::new(metadata.len(), modified, changed)
+}
+
+#[cfg(not(unix))]
+fn physical_file_identity(_metadata: &fs::Metadata) -> PhysicalFileIdentity {
+    PhysicalFileIdentity::new(0, 0)
+}
+
+#[cfg(not(unix))]
+fn file_metadata_fingerprint(metadata: &fs::Metadata) -> FileMetadataFingerprint {
+    use std::time::UNIX_EPOCH;
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos() as u64)
+        .unwrap_or(0);
+    FileMetadataFingerprint::new(metadata.len(), modified, 0)
+}
+
+#[cfg(unix)]
+fn same_file_observation(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    left.dev() == right.dev()
+        && left.ino() == right.ino()
+        && left.len() == right.len()
+        && left.mtime() == right.mtime()
+        && left.mtime_nsec() == right.mtime_nsec()
+        && left.ctime() == right.ctime()
+        && left.ctime_nsec() == right.ctime_nsec()
+}
+
+#[cfg(not(unix))]
+fn same_file_observation(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    left.len() == right.len()
+        && left.modified().ok() == right.modified().ok()
+        && left.is_file() == right.is_file()
+}
+
 /// Compute `target` relative to `base` without consulting the filesystem.
 ///
 /// Both inputs are expected to be absolute and lexically normalized. Keeping
 /// this lexical is important: following symlinks would turn source identity
 /// back into a property of the machine's physical directory layout.
+#[cfg(test)]
 fn lexical_relative_path(base: &Path, target: &Path) -> Option<PathBuf> {
     let base_components: Vec<_> = base.components().collect();
     let target_components: Vec<_> = target.components().collect();
@@ -1249,6 +1382,7 @@ fn lexical_relative_path(base: &Path, target: &Path) -> Option<PathBuf> {
     Some(relative)
 }
 
+#[cfg(test)]
 const STD_SYMBOL_NAMESPACE: &str = "\0rue-std";
 
 /// Derive relocation-stable source identities for generated symbol names.
@@ -1258,11 +1392,7 @@ const STD_SYMBOL_NAMESPACE: &str = "\0rue-std";
 /// remain stable when the whole source layout moves. The standard library has
 /// its own namespace because `$RUE_STD_PATH` may live outside (and at a
 /// different depth from) the relocated project root.
-fn derive_symbol_paths(sources: &[(String, String)]) -> Result<Vec<String>, String> {
-    let std_root = env::var_os("RUE_STD_PATH").map(PathBuf::from);
-    derive_symbol_paths_with_std_root(sources, std_root.as_deref())
-}
-
+#[cfg(test)]
 fn derive_symbol_paths_with_std_root(
     sources: &[(String, String)],
     std_root: Option<&Path>,
@@ -1379,317 +1509,320 @@ struct DependencyOutput {
     imports: Vec<DependencyImport>,
 }
 
-#[derive(Debug, Default)]
-struct DependencyGraph {
-    root: Option<PathBuf>,
-    sources: std::collections::BTreeMap<PathBuf, &'static str>,
-    imports: Vec<(PathBuf, String, PathBuf)>,
-    import_seen: std::collections::HashSet<(PathBuf, String, PathBuf)>,
-}
-
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct ImportDiscoveryResult {
     mixed_imports: Vec<PathBuf>,
-    unresolved_imports: Vec<UnresolvedImport>,
+    source_snapshot: SourceSnapshot,
+    revision: Arc<ImportDiscoveryRevisionArtifact>,
+    session: CompilerSession,
 }
 
-#[derive(Debug)]
-struct UnresolvedImport {
-    path: String,
-    candidates: Vec<String>,
-    span: Span,
-}
-
-impl DependencyGraph {
-    fn record_source(&mut self, path: PathBuf, kind: &'static str) {
-        if kind == "root" {
-            self.root = Some(path.clone());
-        }
-        self.sources.entry(path).or_insert(kind);
-    }
-
-    fn record_import(&mut self, from: PathBuf, specifier: &str, resolved: PathBuf) {
-        let key = (from.clone(), specifier.to_string(), resolved.clone());
-        if self.import_seen.insert(key.clone()) {
-            self.imports.push(key);
-        }
-    }
-
-    fn to_output(&self) -> DependencyOutput {
-        let sources = self
-            .sources
-            .iter()
-            .map(|(path, kind)| DependencySource {
-                path: path.display().to_string(),
-                kind,
+fn dependency_output_from_canonical_graph(
+    snapshot: &SourceSnapshot,
+    graph: &rue_compiler::CanonicalImportGraph,
+    positional_sources: &HashSet<PathBuf>,
+) -> DependencyOutput {
+    let physical_for = |module: &rue_compiler::ModuleId| {
+        snapshot
+            .metadata()
+            .logical_paths()
+            .find_map(|(file_id, logical)| {
+                (logical == module.as_str())
+                    .then(|| snapshot.metadata().physical_path(file_id))
+                    .flatten()
             })
-            .collect();
-        let imports = self
-            .imports
-            .iter()
-            .map(|(from, specifier, resolved)| DependencyImport {
-                from: from.display().to_string(),
-                specifier: specifier.clone(),
-                resolved: resolved.display().to_string(),
+            .and_then(|path| fs::canonicalize(path).ok())
+    };
+    let root = physical_for(graph.root()).unwrap_or_default();
+    let sources = snapshot
+        .files()
+        .filter_map(|source| {
+            fs::canonicalize(source.path).ok().map(|path| {
+                let kind = if source.file_id == snapshot.metadata().root_file_id() {
+                    "root"
+                } else if positional_sources.contains(&path) {
+                    "positional"
+                } else {
+                    "import"
+                };
+                DependencySource {
+                    path: path.display().to_string(),
+                    kind,
+                }
             })
-            .collect();
-
-        DependencyOutput {
-            version: 1,
-            root: self
-                .root
-                .as_ref()
-                .map(|path| path.display().to_string())
-                .unwrap_or_default(),
-            sources,
-            imports,
+        })
+        .collect();
+    let mut imports = Vec::new();
+    for record in graph.records() {
+        let Some(from) = physical_for(record.importer()) else {
+            continue;
+        };
+        let targets: Vec<_> = match record.resolution() {
+            rue_compiler::CanonicalImportResolution::Resolved(target) => vec![target],
+            rue_compiler::CanonicalImportResolution::Ambiguous {
+                file_module,
+                directory_module,
+            } => vec![file_module, directory_module],
+            rue_compiler::CanonicalImportResolution::Missing => Vec::new(),
+        };
+        for target in targets {
+            if let Some(resolved) = physical_for(target) {
+                imports.push(DependencyImport {
+                    from: from.display().to_string(),
+                    specifier: record.normalized_specifier().to_owned(),
+                    resolved: resolved.display().to_string(),
+                });
+            }
         }
+    }
+    DependencyOutput {
+        version: 1,
+        root: root.display().to_string(),
+        sources,
+        imports,
     }
 }
 
 /// Reject a source before discovery lexing if Rue's span representation cannot
 /// describe its byte offsets.
-fn validate_source_len_before_discovery(
-    file_id: FileId,
-    path: &str,
-    source: &str,
-    error_format: ErrorFormat,
-) -> Result<(), ()> {
-    if source.len() <= MAX_SOURCE_BYTES {
-        return Ok(());
-    }
-
-    let error = CompileError::without_span(ErrorKind::InvalidCompilerInput(format!(
-        "source text for file ID {} ({path:?}) is {} bytes, exceeding the maximum supported length of {} bytes",
-        file_id.index(),
-        source.len(),
-        MAX_SOURCE_BYTES
-    )));
-    let diagnostics =
-        DiagnosticOutput::new(error_format, vec![(file_id, SourceInfo::new(source, path))]);
-    diagnostics.print_error(&error);
-    Err(())
-}
-
-/// Discover `@import("...")` references in the given sources and load the
-/// referenced module files from disk, transitively, appending them to
-/// `sources`.
-///
-/// Sema resolves import paths only against loaded files (see
-/// `resolve_import_path` in rue-air), so this is the step that makes
-/// `@import` work without hand-listing every module (RUE-14).
-///
-/// Imports are found by scanning the token stream (so comments and string
-/// contents are handled correctly) for the `@import ( "<path>" )` shape.
-/// Resolution mirrors sema's `ModulePath` order, probing the filesystem:
-///
-/// - `"std"`: `$RUE_STD_PATH/_std.rue`, then `std/_std.rue` relative to the
-///   importing file, then relative to the first (root) source file
-/// - `"foo.rue"`: exact path relative to the importing file, then the root
-/// - `"foo"` / `"a/b"`: `{path}.rue` then the directory-module facade
-///   `{path}/_{basename}.rue` (the facade lives INSIDE the directory, like
-///   `std/_std.rue` — ratified in RUE-137), relative to the importing file,
-///   then the root
-///
-/// Unresolvable imports are recorded for modes like `--emit deps` that need
-/// the import graph but should not run full semantic validation. Normal
-/// compilation still lets sema report those errors from the typed import use.
+/// Reach the parser-owned import fixed point by executing compiler-generated
+/// filesystem requests. This driver owns only the read-policy checks and
+/// physical observation transactions; the compiler owns recognition,
+/// candidate order, identity assembly, closure, and canonical outcomes.
 ///
 /// Returns non-root positional sources that were also reached through an
 /// import. That mixed mode is rejected by the CLI after discovery (RUE-434),
 /// because the file should be part of the root import graph, not also an
 /// additional flat positional input.
 fn discover_and_load_imports(
-    sources: &mut Vec<(String, String)>,
+    sources: &[(String, String)],
     source_manifest: Option<&SourceManifest>,
-    dependency_graph: &mut DependencyGraph,
+    std_root: Option<&Path>,
     error_format: ErrorFormat,
 ) -> Result<ImportDiscoveryResult, ()> {
     use std::collections::HashSet;
 
-    let root_dir = Path::new(&sources[0].0)
+    let root_path = normalize_lexical_path(Path::new(&sources[0].0));
+    let root_dir = root_path
         .parent()
-        .map(PathBuf::from)
-        .unwrap_or_default();
-
-    // Canonical paths of everything already loaded (for dedupe and cycles).
-    let mut loaded: HashSet<PathBuf> = sources
-        .iter()
-        .filter_map(|(p, _)| fs::canonicalize(p).ok())
-        .collect();
+        .unwrap_or_else(|| Path::new("/"))
+        .to_path_buf();
+    let std_root = std_root.map(normalize_lexical_path);
+    let policy_revision = source_manifest
+        .map(SourceManifest::policy_revision)
+        .unwrap_or_else(|| "unrestricted".into());
+    let context = ImportDiscoveryContext::new(
+        1,
+        root_dir.to_string_lossy(),
+        std_root
+            .as_deref()
+            .map(|path| path.to_string_lossy())
+            .as_deref(),
+        policy_revision,
+    )
+    .map_err(|error| {
+        eprintln!("Error: {error}");
+    })?;
+    let root_canonical = fs::canonicalize(&root_path).map_err(|error| {
+        eprintln!("Error reading {}: {error}", root_path.display());
+    })?;
+    if source_manifest.is_some_and(|manifest| !manifest.allows_canonical(&root_canonical)) {
+        eprintln!("Error: root source escapes the source manifest after canonicalization");
+        return Err(());
+    }
+    let root_read = stable_read_to_string(&root_canonical).map_err(|error| match error {
+        StableReadError::Io(error) => eprintln!("Error reading {}: {error}", root_path.display()),
+        StableReadError::Changed => eprintln!(
+            "Error reading {}: source changed during read",
+            root_path.display()
+        ),
+    })?;
+    let mut assembler = DiscoverySourceAssembler::new(
+        context.clone(),
+        root_path.to_string_lossy(),
+        root_canonical.to_string_lossy(),
+        root_read.identity,
+        root_read.fingerprint,
+        Arc::new(root_read.source),
+    )
+    .map_err(|error| {
+        eprintln!("Error: {error}");
+    })?;
     let explicit_non_root: HashSet<PathBuf> = sources
         .iter()
         .skip(1)
-        .filter_map(|(p, _)| fs::canonicalize(p).ok())
+        .filter_map(|(path, _)| fs::canonicalize(path).ok())
         .collect();
-    let mut result = ImportDiscoveryResult::default();
+    for (path, _) in sources.iter().skip(1) {
+        let canonical = fs::canonicalize(path).map_err(|error| {
+            eprintln!("Error reading {path}: {error}");
+        })?;
+        if source_manifest.is_some_and(|manifest| !manifest.allows_canonical(&canonical)) {
+            eprintln!(
+                "Error: positional source escapes the source manifest after canonicalization: {path}"
+            );
+            return Err(());
+        }
+        let read = stable_read_to_string(&canonical).map_err(|error| match error {
+            StableReadError::Io(error) => eprintln!("Error reading {path}: {error}"),
+            StableReadError::Changed => {
+                eprintln!("Error reading {path}: source changed during read")
+            }
+        })?;
+        let requested = normalize_lexical_path(Path::new(path));
+        assembler
+            .add_explicit(
+                requested.to_string_lossy().as_ref(),
+                canonical.to_string_lossy().as_ref(),
+                read.identity,
+                read.fingerprint,
+                Arc::new(read.source),
+            )
+            .map_err(|error| {
+                eprintln!("Error: {error}");
+            })?;
+    }
+
+    let mut ledger = ImportObservationLedger::default();
+    let mut staging = CompilerSession::new();
+    let mut mixed_imports = Vec::new();
     let mut mixed_seen = HashSet::new();
-
-    let mut i = 0;
-    while i < sources.len() {
-        let source_index = i;
-        let importer_file_id = FileId::new((i + 1) as u32);
-        let importer_path = sources[source_index].0.clone();
-        let importer_canonical = fs::canonicalize(&importer_path).ok();
-        i += 1;
-
-        let tokenized = {
-            let content = &sources[source_index].1;
-            validate_source_len_before_discovery(
-                importer_file_id,
-                &importer_path,
-                content,
-                error_format,
-            )?;
-            Lexer::new(content).tokenize()
-        };
-        let Ok((tokens, interner)) = tokenized else {
-            // Lex errors will be reported properly during compilation.
-            continue;
-        };
-
-        for w in tokens.windows(5) {
-            // Match `@import ( "<path>" )`, tolerating a trailing comma before
-            // the close paren (RUE-536): `@import("x",)` is a valid one-argument
-            // list and must still be discovered. The 5-token window lets us peek
-            // past the string at either `)` or `, )`.
-            let (TokenKind::AtImport(_), TokenKind::LParen, TokenKind::String(s)) =
-                (&w[0].kind, &w[1].kind, &w[2].kind)
-            else {
-                continue;
-            };
-            match (&w[3].kind, &w[4].kind) {
-                (TokenKind::RParen, _) => {}
-                (TokenKind::Comma, TokenKind::RParen) => {}
-                _ => continue,
-            }
-            let import_str = interner.resolve(s);
-
-            let importer_dir = Path::new(&importer_path)
-                .parent()
-                .map(PathBuf::from)
-                .unwrap_or_default();
-
-            // Candidate GROUPS, nearest base directory first. Within a group,
-            // EVERY existing candidate is loaded — if both `foo.rue` and
-            // `foo/_foo.rue` exist, loading both lets sema report the
-            // dual-entity ambiguity (E0708) instead of the driver silently
-            // picking one. Later groups are only probed when the nearer group
-            // had nothing.
-            let base_dirs = vec![
-                importer_dir.to_string_lossy().into_owned(),
-                root_dir.to_string_lossy().into_owned(),
-            ];
-            let std_dir = (import_str == "std")
-                .then(|| env::var("RUE_STD_PATH").ok())
-                .flatten();
-            let groups: Vec<Vec<PathBuf>> =
-                import_candidate_groups(import_str, &base_dirs, std_dir.as_deref())
-                    .into_iter()
-                    .map(|group| group.into_iter().map(PathBuf::from).collect())
+    let final_plan;
+    loop {
+        let snapshot = assembler.snapshot().map_err(|error| {
+            eprintln!("Error: {error}");
+        })?;
+        let plan = match staging.stage_import_discovery(
+            &snapshot,
+            context.clone(),
+            assembler.accepted_read_manifest(),
+            ledger.clone(),
+        ) {
+            Ok(plan) => plan,
+            Err(errors) => {
+                let infos = snapshot
+                    .files()
+                    .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
                     .collect();
-
-            let mut undeclared_candidate = None;
-            let mut candidate_paths = Vec::new();
-            let mut resolved_import = false;
-            'groups: for group in groups {
-                let mut group_hit = false;
-                for candidate in group {
-                    candidate_paths.push(candidate.display().to_string());
-                    if let Some(manifest) = source_manifest
-                        && !manifest.declares_path_without_probe(&candidate)
-                    {
-                        undeclared_candidate.get_or_insert(candidate.clone());
-                        continue;
-                    }
-                    let Ok(canonical) = fs::canonicalize(&candidate) else {
-                        continue;
-                    };
-                    if !canonical.is_file() {
-                        continue;
-                    }
-                    if let Some(importer_canonical) = &importer_canonical {
-                        dependency_graph.record_import(
-                            importer_canonical.clone(),
-                            import_str,
-                            canonical.clone(),
-                        );
-                    }
-                    if let Some(manifest) = source_manifest
-                        && !manifest.allows_canonical(&canonical)
-                    {
-                        eprintln!(
-                            "Error: import '{}' resolved to '{}' which is not listed in source manifest '{}'",
-                            import_str,
-                            candidate.display(),
-                            manifest.display_path()
-                        );
-                        eprintln!(
-                            "Source manifests constrain allowed reads; add the file to the manifest or remove the import."
-                        );
-                        return Err(());
-                    }
-                    if loaded.contains(&canonical) {
-                        if explicit_non_root.contains(&canonical)
-                            && mixed_seen.insert(canonical.clone())
-                        {
-                            result.mixed_imports.push(canonical);
-                        }
-                        group_hit = true; // already loaded (or a cycle)
-                        resolved_import = true;
-                        continue;
-                    }
-                    // The candidate EXISTS at this point (canonicalize +
-                    // is_file above), so a read failure is present-but-
-                    // unreadable (I/O error, invalid UTF-8) — a hard error,
-                    // not absence. Treating it as absence misreported an
-                    // existing import as E0704 "cannot find module", and
-                    // silently erased one arm of a file-vs-directory
-                    // ambiguity so the other candidate was picked without the
-                    // required E0708 (RUE-529).
-                    let module_content = match fs::read_to_string(&candidate) {
-                        Ok(content) => content,
-                        Err(e) => {
-                            eprintln!("Error reading {}: {}", candidate.display(), e);
-                            eprintln!("note: resolved from import '{import_str}'");
-                            return Err(());
-                        }
-                    };
-                    loaded.insert(canonical.clone());
-                    dependency_graph.record_source(canonical, "import");
-                    sources.push((candidate.to_string_lossy().into_owned(), module_content));
-                    group_hit = true;
-                    resolved_import = true;
-                }
-                if group_hit {
-                    resolved_import = true;
-                    break 'groups;
-                }
-            }
-            if !resolved_import
-                && let (Some(manifest), Some(candidate)) = (source_manifest, undeclared_candidate)
-            {
-                eprintln!(
-                    "Error: import '{}' resolved to '{}' which is not listed in source manifest '{}'",
-                    import_str,
-                    candidate.display(),
-                    manifest.display_path()
-                );
-                eprintln!(
-                    "Source manifests constrain allowed reads; add the file to the manifest or remove the import."
-                );
+                DiagnosticOutput::new(error_format, infos).print_errors(&errors);
                 return Err(());
             }
-            if !resolved_import {
-                result.unresolved_imports.push(UnresolvedImport {
-                    path: import_str.to_string(),
-                    candidates: candidate_paths,
-                    span: Span::with_file(importer_file_id, w[0].span.start, w[3].span.end),
-                });
+        };
+        loop {
+            let pending = plan.pending_requests(&ledger);
+            if pending.is_empty() {
+                break;
+            }
+            for request in pending {
+                let candidate = Path::new(request.requested_path());
+                let observation = if let Some(manifest) = source_manifest
+                    && !manifest.declares_path_without_probe(candidate)
+                {
+                    ImportObservation::failure(request, ImportObservationStatus::DeniedLexical)
+                        .unwrap()
+                } else {
+                    match fs::canonicalize(candidate) {
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                            ImportObservation::absent(request)
+                        }
+                        Err(error) => ImportObservation::failure(
+                            request,
+                            ImportObservationStatus::PresentUnreadable(Arc::from(
+                                error.to_string(),
+                            )),
+                        )
+                        .unwrap(),
+                        Ok(canonical)
+                            if source_manifest
+                                .is_some_and(|manifest| !manifest.allows_canonical(&canonical)) =>
+                        {
+                            ImportObservation::failure(
+                                request,
+                                ImportObservationStatus::DeniedCanonical {
+                                    canonical_path: Arc::from(
+                                        canonical.to_string_lossy().into_owned(),
+                                    ),
+                                },
+                            )
+                            .unwrap()
+                        }
+                        Ok(canonical) if !canonical.is_file() => ImportObservation::failure(
+                            request,
+                            ImportObservationStatus::InvalidPhysicalType {
+                                canonical_path: Arc::from(canonical.to_string_lossy().into_owned()),
+                            },
+                        )
+                        .unwrap(),
+                        Ok(canonical) => match stable_read_to_string(&canonical) {
+                            Ok(read) => {
+                                let accepted = AcceptedImportSource::new(
+                                    Arc::from(request.requested_path()),
+                                    Arc::from(canonical.to_string_lossy().into_owned()),
+                                    read.identity,
+                                    read.fingerprint,
+                                    Arc::new(read.source),
+                                )
+                                .unwrap();
+                                ImportObservation::accepted(request, accepted).unwrap()
+                            }
+                            Err(StableReadError::Io(error)) => ImportObservation::failure(
+                                request,
+                                ImportObservationStatus::PresentUnreadable(Arc::from(
+                                    error.to_string(),
+                                )),
+                            )
+                            .unwrap(),
+                            Err(StableReadError::Changed) => ImportObservation::failure(
+                                request,
+                                ImportObservationStatus::UnstableRead(Arc::from(
+                                    "candidate metadata changed during read",
+                                )),
+                            )
+                            .unwrap(),
+                        },
+                    }
+                };
+                ledger.record(observation).map_err(|error| {
+                    eprintln!("Error: {error}");
+                })?;
             }
         }
+        if plan.failures(&ledger).next().is_some() {
+            final_plan = plan;
+            break;
+        }
+        for accepted in plan.accepted_sources(&ledger) {
+            let canonical = PathBuf::from(accepted.canonical_path());
+            if explicit_non_root.contains(&canonical) && mixed_seen.insert(canonical.clone()) {
+                mixed_imports.push(canonical);
+            }
+        }
+        let added = assembler.add_plan_reads(&plan, &ledger).map_err(|error| {
+            eprintln!("Error: {error}");
+        })?;
+        if added == 0 {
+            final_plan = plan;
+            break;
+        }
     }
-    Ok(result)
+
+    let snapshot = assembler.snapshot().map_err(|error| {
+        eprintln!("Error: {error}");
+    })?;
+    debug_assert_eq!(final_plan.source_revision(), snapshot.source_revision());
+    let closed = staging.close_import_discovery(ledger).map_err(|errors| {
+        let infos = snapshot
+            .files()
+            .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+            .collect();
+        DiagnosticOutput::new(error_format, infos).print_errors(&errors);
+    })?;
+    Ok(ImportDiscoveryResult {
+        mixed_imports,
+        source_snapshot: snapshot,
+        revision: closed,
+        session: staging,
+    })
 }
 
 fn main() {
@@ -1755,35 +1888,26 @@ fn main() {
         }
     }
 
-    // Read all source files into memory
-    let mut sources: Vec<(String, String)> = options
+    // Discovery performs the accepted stable-read transaction for every root
+    // and positional source; keep only the requested spellings here.
+    let sources: Vec<(String, String)> = options
         .source_paths
         .iter()
-        .map(|path| {
-            let content = fs::read_to_string(path).unwrap_or_else(|e| {
-                eprintln!("Error reading {}: {}", path, e);
-                std::process::exit(1);
-            });
-            (path.clone(), content)
-        })
+        .map(|path| (path.clone(), String::new()))
         .collect();
 
     // Discover and load @import-ed modules from disk, transitively. Sema
     // resolves imports only against already-loaded files, so without this
     // step `const utils = @import("utils")` fails with E0704 unless the
     // user hand-lists every module on the command line (RUE-14).
-    let mut dependency_graph = DependencyGraph::default();
-    for (index, (path, _content)) in sources.iter().enumerate() {
-        if let Ok(canonical) = fs::canonicalize(path) {
-            let kind = if index == 0 { "root" } else { "positional" };
-            dependency_graph.record_source(canonical, kind);
-        }
-    }
-
-    let import_discovery = match discover_and_load_imports(
-        &mut sources,
+    // Capture environment-derived resolution context exactly once for this
+    // discovery epoch. Every compiler plan and identity decision receives this
+    // immutable value; no discovery iteration rereads the environment.
+    let captured_std_root = env::var_os("RUE_STD_PATH").map(PathBuf::from);
+    let mut import_discovery = match discover_and_load_imports(
+        &sources,
         source_manifest.as_ref(),
-        &mut dependency_graph,
+        captured_std_root.as_deref(),
         options.error_format,
     ) {
         Ok(result) => result,
@@ -1804,7 +1928,7 @@ fn main() {
         eprintln!("Build-system source manifests are tracked separately from positional inputs.");
         std::process::exit(1);
     }
-    let sources = sources;
+    let source_snapshot = import_discovery.source_snapshot.clone();
 
     // Re-run the output-clobber guard now that @import discovery has appended
     // the full source set: the parse-time guard only saw positional paths, so
@@ -1814,78 +1938,13 @@ fn main() {
     if options.emit_stages.is_empty()
         && check_output_clobbers_source(
             &options.output_path,
-            sources.iter().map(|(path, _)| path.as_str()),
+            source_snapshot.files().map(|source| source.path),
         )
         .is_err()
     {
         std::process::exit(1);
     }
 
-    // Give every loaded source a stable ID in caller order. Physical paths stay
-    // available for imports and diagnostics; generated symbols use a separate,
-    // relocation-stable identity (RUE-618).
-    let file_ids: Vec<_> = (1..=sources.len())
-        .map(|index| FileId::new(index as u32))
-        .collect();
-    let symbol_paths = match derive_symbol_paths(&sources) {
-        Ok(paths) => paths,
-        Err(message) => {
-            let source_infos = sources
-                .iter()
-                .zip(file_ids.iter().copied())
-                .map(|((path, content), file_id)| {
-                    (file_id, SourceInfo::new(content.as_str(), path.as_str()))
-                })
-                .collect();
-            let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
-            diagnostics.print_error(&CompileError::without_span(
-                ErrorKind::InvalidCompilerInput(message),
-            ));
-            std::process::exit(1);
-        }
-    };
-    let physical_path_map = sources
-        .iter()
-        .zip(file_ids.iter().copied())
-        .map(|((path, _), file_id)| (file_id, path.clone()))
-        .collect();
-    let logical_path_map = file_ids.iter().copied().zip(symbol_paths).collect();
-    let source_metadata =
-        match SourceMetadata::new(file_ids[0], physical_path_map, logical_path_map) {
-            Ok(source_metadata) => source_metadata,
-            Err(error) => {
-                let source_infos = sources
-                    .iter()
-                    .zip(file_ids.iter().copied())
-                    .map(|((path, content), file_id)| {
-                        (file_id, SourceInfo::new(content.as_str(), path.as_str()))
-                    })
-                    .collect();
-                let diagnostics = DiagnosticOutput::new(options.error_format, source_infos);
-                diagnostics.print_error(&error);
-                std::process::exit(1);
-            }
-        };
-
-    // Move each loaded String directly behind an Arc: this transfers its
-    // allocation without copying the source bytes. The snapshot now owns the
-    // complete, immutable compiler input used by every compilation path.
-    let source_contents = sources
-        .into_iter()
-        .zip(file_ids)
-        .map(|((_path, content), file_id)| (file_id, Arc::new(content)))
-        .collect();
-    let source_snapshot = match SourceSnapshot::new(source_metadata, source_contents) {
-        Ok(source_snapshot) => source_snapshot,
-        Err(error) => {
-            // Snapshot validation errors are unspanned. At this point the
-            // snapshot constructor owns the source buffers on both paths, so
-            // no borrowed source view remains available for formatting.
-            let diagnostics = DiagnosticOutput::new(options.error_format, Vec::new());
-            diagnostics.print_error(&error);
-            std::process::exit(1);
-        }
-    };
     // Create multi-file diagnostic formatters from the snapshot's borrowed
     // views so diagnostics and compilation necessarily observe the same input.
     let source_infos = source_snapshot
@@ -1905,21 +1964,22 @@ fn main() {
             );
             std::process::exit(1);
         }
-        if !import_discovery.unresolved_imports.is_empty() {
-            let mut errors = CompileErrors::new();
-            for import in &import_discovery.unresolved_imports {
-                errors.push(CompileError::new(
-                    ErrorKind::ModuleNotFound {
-                        path: import.path.clone(),
-                        candidates: import.candidates.clone(),
-                    },
-                    import.span,
-                ));
-            }
-            diagnostics.print_errors(&errors);
-            std::process::exit(1);
-        }
-        match serde_json::to_string_pretty(&dependency_graph.to_output()) {
+        let positional_sources = options
+            .source_paths
+            .iter()
+            .skip(1)
+            .filter_map(|path| fs::canonicalize(path).ok())
+            .collect();
+        let dependency_output = dependency_output_from_canonical_graph(
+            &source_snapshot,
+            import_discovery
+                .revision
+                .graph()
+                .expect("closed valid discovery has graph")
+                .graph(),
+            &positional_sources,
+        );
+        match serde_json::to_string_pretty(&dependency_output) {
             Ok(json) => println!("{json}"),
             Err(e) => {
                 eprintln!("Error emitting dependency graph: {e}");
@@ -1945,7 +2005,12 @@ fn main() {
 
     // Handle emit modes with multi-file support
     if !options.emit_stages.is_empty() {
-        if let Err(()) = handle_emit_multi_file(&source_snapshot, &options, &diagnostics) {
+        if let Err(()) = handle_emit_multi_file(
+            &source_snapshot,
+            &mut import_discovery.session,
+            &options,
+            &diagnostics,
+        ) {
             std::process::exit(1);
         }
         print_timing_output(
@@ -1965,7 +2030,7 @@ fn main() {
         opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
     };
-    let compile_result = compile_snapshot(&source_snapshot, &compile_options);
+    let compile_result = import_discovery.session.executable(&compile_options);
     match compile_result {
         Ok(output) => {
             // Print warnings using the diagnostic formatter
@@ -2085,6 +2150,7 @@ fn main() {
 /// For later stages (rir, air, cfg, etc.), the merged program is used.
 fn handle_emit_multi_file(
     source_snapshot: &SourceSnapshot,
+    session: &mut CompilerSession,
     options: &Options,
     diagnostics: &DiagnosticOutput<'_>,
 ) -> Result<(), ()> {
@@ -2144,7 +2210,7 @@ fn handle_emit_multi_file(
             opt_level: options.opt_level,
             preview_features: options.preview_features.clone(),
         };
-        let frontend = match build_emit_frontend(source_snapshot, compile_options) {
+        let frontend = match build_emit_frontend_in_session(session, compile_options) {
             Ok(frontend) => frontend,
             Err(errors) => {
                 diagnostics.print_errors(&errors);
@@ -2918,12 +2984,11 @@ mod tests {
         .unwrap();
         fs::write(dir.join("helper.rue"), [0xFFu8]).unwrap();
 
-        let mut sources = vec![(
+        let sources = vec![(
             main_path.to_string_lossy().into_owned(),
             fs::read_to_string(&main_path).unwrap(),
         )];
-        let mut graph = DependencyGraph::default();
-        let result = discover_and_load_imports(&mut sources, None, &mut graph, ErrorFormat::Text);
+        let result = discover_and_load_imports(&sources, None, None, ErrorFormat::Text);
         assert!(
             result.is_err(),
             "unreadable existing candidate must error, not resolve or vanish"
@@ -2931,14 +2996,16 @@ mod tests {
 
         // Control: once the candidate is valid text, discovery loads it.
         fs::write(dir.join("helper.rue"), "pub fn h() -> i32 {{ 1 }}\n").unwrap();
-        let mut sources = vec![(
+        let sources = vec![(
             main_path.to_string_lossy().into_owned(),
             fs::read_to_string(&main_path).unwrap(),
         )];
-        let mut graph = DependencyGraph::default();
-        let result = discover_and_load_imports(&mut sources, None, &mut graph, ErrorFormat::Text);
-        assert!(result.is_ok());
-        assert_eq!(sources.len(), 2, "helper must be discovered and loaded");
+        let result = discover_and_load_imports(&sources, None, None, ErrorFormat::Text).unwrap();
+        assert_eq!(
+            result.source_snapshot.len(),
+            2,
+            "helper must be discovered and loaded"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1149,6 +1149,19 @@ impl SourceManifest {
             .parent()
             .filter(|parent| !parent.as_os_str().is_empty())
             .unwrap_or_else(|| Path::new("."));
+        let base_dir = if base_dir.is_absolute() {
+            normalize_lexical_path(base_dir)
+        } else {
+            normalize_lexical_path(
+                &env::current_dir().map_err(|error| {
+                    format!(
+                        "Error reading source manifest '{}': cannot resolve current directory: {}",
+                        path, error
+                    )
+                })?
+                .join(base_dir),
+            )
+        };
 
         let mut allowed = std::collections::HashSet::new();
         let mut declared_paths = std::collections::HashSet::new();

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::io::Read;
@@ -15,6 +15,8 @@ use tracing_subscriber::{EnvFilter, Layer as _, fmt};
 
 mod timing;
 
+#[cfg(test)]
+use rue_compiler::CompilerSessionWork;
 use rue_compiler::{
     AcceptedImportSource, Ast, CanonicalRirOutput, CanonicalSemanticOutput, CompileError,
     CompileErrors, CompileOptions, CompileWarning, CompilerSession, DiscoverySourceAssembler,
@@ -22,12 +24,10 @@ use rue_compiler::{
     ImportDiscoveryRevisionArtifact, ImportObservation, ImportObservationLedger,
     ImportObservationStatus, Lexer, LinkerMode, MultiFileFormatter, MultiFileJsonFormatter,
     OptLevel, PhysicalFileIdentity, PipelineWork, PreviewFeature, PreviewFeatures, SourceInfo,
-    SourceSnapshot, Token, TypeInternPool, configure_thread_pool, generate_emitted_asm,
-    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
-    generate_stack_frame_info, parse_source_snapshot_for_ast_presentation,
+    SourceMetadata, SourceSnapshot, Token, TypeInternPool, configure_thread_pool,
+    generate_emitted_asm, generate_liveness_info, generate_lowering_info, generate_mir,
+    generate_regalloc_info, generate_stack_frame_info, parse_source_snapshot_for_ast_presentation,
 };
-#[cfg(test)]
-use rue_compiler::{CompilerSessionWork, SourceMetadata};
 use rue_rir::RirPrinter;
 use rue_target::Target;
 use serde::Serialize;
@@ -1601,6 +1601,30 @@ fn discover_and_load_imports(
     error_format: ErrorFormat,
 ) -> Result<ImportDiscoveryResult, ()> {
     use std::collections::HashSet;
+
+    // Preserve the compiler API boundary's positional-source validation before
+    // discovery aliases physical identities. In particular, `main.rue` and
+    // `./main.rue` are duplicate CLI inputs even though discovery would
+    // correctly recognize them as the same physical source.
+    let physical_paths: HashMap<_, _> = sources
+        .iter()
+        .enumerate()
+        .map(|(index, (path, _))| (FileId::new((index + 1) as u32), path.clone()))
+        .collect();
+    let logical_paths: HashMap<_, _> = sources
+        .iter()
+        .enumerate()
+        .map(|(index, _)| {
+            (
+                FileId::new((index + 1) as u32),
+                format!("positional-{}", index + 1),
+            )
+        })
+        .collect();
+    if let Err(error) = SourceMetadata::new(FileId::new(1), physical_paths, logical_paths) {
+        DiagnosticOutput::new(error_format, Vec::new()).print_errors(&CompileErrors::from(error));
+        return Err(());
+    }
 
     let root_path = normalize_lexical_path(Path::new(&sources[0].0));
     let root_dir = root_path

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -31,11 +31,23 @@ find "$root_a/project" -type f -name '*.rue' -exec touch -t 200001010000 {} +
 find "$root_b/project" -type f -name '*.rue' -exec touch -t 203001010000 {} +
 (
     cd "$root_a/project"
-    find . -type f -name '*.rue' -print | sed 's#^\./##' | LC_ALL=C sort > sources.manifest
+    {
+        find . -type f -name '*.rue' -print | sed 's#^\./##'
+        # ADR-0051 read policy: resolution observes these absent
+        # importer-relative arms before the root-relative shared module.
+        printf '%s\n' \
+            semantic-order/left/shared.rue \
+            semantic-order/right/shared.rue
+    } | LC_ALL=C sort > sources.manifest
 )
 (
     cd "$root_b/project"
-    find . -type f -name '*.rue' -print | sed 's#^\./##' | LC_ALL=C sort -r > sources.manifest
+    {
+        find . -type f -name '*.rue' -print | sed 's#^\./##'
+        printf '%s\n' \
+            semantic-order/left/shared.rue \
+            semantic-order/right/shared.rue
+    } | LC_ALL=C sort -r > sources.manifest
 )
 
 sha256() {


### PR DESCRIPTION
## Summary

- move import-site discovery into parser-owned AST collection
- add the compiler-owned discovery request/observation protocol and closed-valid graph artifacts
- make the CLI a stable filesystem transaction executor while retaining the accepted discovery session through compilation and emit routes
- add coverage for invalid imports, read manifests, hard-link identities, deterministic aliases, and discovery closure

## Tests

- `scripts/rue quick`
- `scripts/rue cli import`
- `scripts/rue cli modules`

Fixes RUE-807
