### PR TITLE
RUE-872: default preview string literals to str

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -194,6 +194,14 @@ pub struct ConstraintGenerator<'a> {
     /// Type variables allocated for integer literals.
     /// These start as unbound and need to be defaulted to i32 if unconstrained.
     int_literal_vars: Vec<TypeVarId>,
+    /// Type variables allocated for string literals. Unlike integer literals,
+    /// these have a concrete, edition/preview-dependent default supplied by
+    /// semantic analysis: legacy programs default to `StrBuf`, while the
+    /// `string_trio` preview defaults to the canonical synthetic `str` type.
+    /// Contextual constraints may still bind a literal to `StrBuf` first.
+    string_literal_vars: Vec<TypeVarId>,
+    /// Concrete default for an otherwise-unconstrained string literal.
+    string_literal_default: Type,
     /// Type substitutions for Self and type parameters (used in method bodies).
     /// Maps type names (like "Self") to their concrete types.
     type_subst: Option<&'a HashMap<Spur, Type>>,
@@ -326,6 +334,10 @@ impl<'a> ConstraintGenerator<'a> {
         type_pool: &'a TypeInternPool,
         type_subst: Option<&'a HashMap<Spur, Type>>,
     ) -> Self {
+        let string_literal_default = interner
+            .get("StrBuf")
+            .and_then(|name| builtin_structs.get(&name).copied())
+            .unwrap_or(Type::ERROR);
         Self {
             rir,
             interner,
@@ -339,6 +351,8 @@ impl<'a> ConstraintGenerator<'a> {
             enums_by_file_name: None,
             methods,
             int_literal_vars: Vec::new(),
+            string_literal_vars: Vec::new(),
+            string_literal_default,
             type_subst,
             const_types: None,
             const_type_aliases: None,
@@ -355,6 +369,15 @@ impl<'a> ConstraintGenerator<'a> {
             comptime_values: None,
             type_pool,
         }
+    }
+
+    /// Override the default used for unconstrained string literals.
+    ///
+    /// Semantic analysis uses this for the `string_trio` preview after it has
+    /// registered the canonical synthetic `str` type in the shared type pool.
+    pub fn with_string_literal_default(mut self, ty: Type) -> Self {
+        self.string_literal_default = ty;
+        self
     }
 
     /// Is `ty` the synthetic slice struct `[T]` (ADR-0043, RUE-322), the `str`
@@ -685,7 +708,8 @@ impl<'a> ConstraintGenerator<'a> {
         &self.expr_types
     }
 
-    /// Consume the constraint generator and return (constraints, int_literal_vars, expr_types, type_var_count).
+    /// Consume the constraint generator and return its generated constraints,
+    /// literal variables, expression types, and allocated variable count.
     ///
     /// This is useful when you need ownership of the expression types map.
     /// The `type_var_count` can be used to pre-size the unifier's substitution for better performance.
@@ -694,12 +718,16 @@ impl<'a> ConstraintGenerator<'a> {
     ) -> (
         Vec<Constraint>,
         Vec<TypeVarId>,
+        Vec<TypeVarId>,
+        Type,
         HashMap<InstRef, InferType>,
         u32,
     ) {
         (
             self.constraints,
             self.int_literal_vars,
+            self.string_literal_vars,
+            self.string_literal_default,
             self.expr_types,
             self.type_vars.count(),
         )
@@ -780,20 +808,14 @@ impl<'a> ConstraintGenerator<'a> {
 
             InstData::BoolConst(_) => InferType::Concrete(Type::BOOL),
 
-            // String literals have the builtin growable-string type `StrBuf`
-            // (ADR-0043; formerly `String`).
+            // String literals are context-sensitive. A fresh variable lets an
+            // explicit `StrBuf` context retain the legacy owning-buffer type;
+            // otherwise semantic analysis defaults it after unification (to
+            // `str` under `string_trio`, and `StrBuf` without the preview).
             InstData::StringConst(_) => {
-                // Look up the StrBuf type from the structs map
-                if let Some(string_spur) = self.interner.get("StrBuf") {
-                    if let Some(&string_ty) = self.builtin_structs.get(&string_spur) {
-                        InferType::Concrete(string_ty)
-                    } else {
-                        // Fallback if StrBuf struct not found (shouldn't happen after builtin injection)
-                        InferType::Concrete(Type::ERROR)
-                    }
-                } else {
-                    InferType::Concrete(Type::ERROR)
-                }
+                let var = self.fresh_var();
+                self.string_literal_vars.push(var);
+                InferType::Var(var)
             }
 
             InstData::UnitConst => InferType::Concrete(Type::UNIT),
@@ -1320,7 +1342,14 @@ impl<'a> ConstraintGenerator<'a> {
                     // here — rather than leaning on the generic unit fallback —
                     // stops HM and semantic analysis from drifting apart.
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        let info = self.generate(*arg_ref, ctx);
+                        if self.is_string_literal_candidate(&info.ty) {
+                            self.add_constraint(Constraint::equal(
+                                info.ty,
+                                self.string_infer_type(),
+                                info.span,
+                            ));
+                        }
                     }
                     InferType::Concrete(Type::NEVER)
                 } else if intrinsic_name == "assert" {
@@ -1328,8 +1357,15 @@ impl<'a> ConstraintGenerator<'a> {
                     // and evaluates to `()`. It only aborts when the condition is
                     // false, so its static type is unit on both paths (spec
                     // 4.13:5b). Keep it explicit so HM and sema stay in lockstep.
-                    for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                    for (index, arg_ref) in args.iter().enumerate() {
+                        let info = self.generate(*arg_ref, ctx);
+                        if index == 1 && self.is_string_literal_candidate(&info.ty) {
+                            self.add_constraint(Constraint::equal(
+                                info.ty,
+                                self.string_infer_type(),
+                                info.span,
+                            ));
+                        }
                     }
                     InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "read_line" {
@@ -1361,7 +1397,14 @@ impl<'a> ConstraintGenerator<'a> {
                     // int type) is resolved from context, so use a fresh
                     // variable and let sema validate the resolved Option shape.
                     for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
+                        let info = self.generate(*arg_ref, ctx);
+                        if self.is_string_literal_candidate(&info.ty) {
+                            self.add_constraint(Constraint::equal(
+                                info.ty,
+                                self.string_infer_type(),
+                                info.span,
+                            ));
+                        }
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
@@ -2289,6 +2332,41 @@ impl<'a> ConstraintGenerator<'a> {
                 let receiver_info = self.generate(*receiver, ctx);
                 let args = self.rir.get_call_args(*args_start, *args_len);
 
+                // A string literal is otherwise defaulted only after solving,
+                // but method lookup needs a receiver type while constraints
+                // are still being generated. Use the StrBuf registry signature
+                // as contextual information for legacy buffer-only methods.
+                // `len` is shared by `str` and StrBuf; under the preview it may
+                // use the same result signature without forcing the receiver
+                // away from its `str` default.
+                if self.is_string_literal_candidate(&receiver_info.ty)
+                    && let InferType::Concrete(string_ty) = self.string_infer_type()
+                    && let Some(string_id) = string_ty.as_struct()
+                    && let Some(method_sig) = self.method_sig(&(string_id, *method))
+                {
+                    let shared_str_method = self.string_literal_default_is_str()
+                        && self.interner.resolve(method) == "len";
+                    if !shared_str_method {
+                        self.add_constraint(Constraint::equal(
+                            receiver_info.ty.clone(),
+                            InferType::Concrete(string_ty),
+                            receiver_info.span,
+                        ));
+                    }
+                    let param_types = method_sig.param_types.clone();
+                    let return_type = method_sig.return_type.clone();
+                    for (arg, param_type) in args.iter().zip(param_types.iter()) {
+                        let arg_info = self.generate(arg.value, ctx);
+                        self.add_constraint(Constraint::equal(
+                            arg_info.ty,
+                            param_type.clone(),
+                            arg_info.span,
+                        ));
+                    }
+                    self.record_type(inst_ref, return_type.clone());
+                    return ExprInfo::new(return_type, span);
+                }
+
                 // Resolve the call's result type from the receiver's type.
                 // When the receiver cannot yet be resolved but sema will
                 // resolve it later, yield a fresh variable rather than ERROR:
@@ -2655,7 +2733,11 @@ impl<'a> ConstraintGenerator<'a> {
             return InferType::Concrete(Type::NEVER);
         }
 
-        if self.is_string_concrete(&lhs_info.ty) || self.is_string_concrete(&rhs_info.ty) {
+        if self.is_string_concrete(&lhs_info.ty)
+            || self.is_string_concrete(&rhs_info.ty)
+            || self.is_string_literal_candidate(&lhs_info.ty)
+            || self.is_string_literal_candidate(&rhs_info.ty)
+        {
             let string_ty = self.string_infer_type();
             self.add_constraint(Constraint::equal(
                 lhs_info.ty,
@@ -2710,6 +2792,19 @@ impl<'a> ConstraintGenerator<'a> {
             }
         }
         false
+    }
+
+    /// Whether an inference type is the still-contextual type variable rooted
+    /// at a string literal. Local bindings retain the same variable, so this
+    /// also recognizes `let s = "a"; s + "b"` before defaulting runs.
+    fn is_string_literal_candidate(&self, ty: &InferType) -> bool {
+        matches!(ty, InferType::Var(var) if self.string_literal_vars.contains(var))
+    }
+
+    fn string_literal_default_is_str(&self) -> bool {
+        self.string_literal_default
+            .as_struct()
+            .is_some_and(|id| self.type_pool.struct_def(id).name == "str")
     }
 
     /// Generate constraints for a type-qualified call — an associated-function

--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -25,6 +25,9 @@ pub enum UnifyResult {
     /// Integer literal cannot unify with non-integer type.
     IntLiteralNonInteger { found: Type },
 
+    /// String literal cannot unify with a non-string type.
+    StringLiteralNonString { found: InferType },
+
     /// Occurs check failed (would create infinite type).
     OccursCheck { var: TypeVarId, ty: InferType },
 
@@ -75,6 +78,9 @@ impl UnificationError {
             UnifyResult::IntLiteralNonInteger { found } => {
                 format!("integer literal cannot be used as {found}")
             }
+            UnifyResult::StringLiteralNonString { found } => {
+                format!("string literal cannot be used as {found}")
+            }
             UnifyResult::OccursCheck { var, ty } => {
                 format!("infinite type: {var} cannot unify with {ty}")
             }
@@ -109,6 +115,10 @@ pub struct Unifier {
     /// offending match arm) instead of surfacing later at an unrelated, wider
     /// span like the whole function body (RUE-133).
     int_literal_vars: std::collections::HashSet<TypeVarId>,
+    /// Variables rooted at string literals, plus variables joined with them.
+    string_literal_vars: std::collections::HashSet<TypeVarId>,
+    /// Concrete string types that may contextualize a literal.
+    string_literal_types: std::collections::HashSet<Type>,
 }
 
 impl Default for Unifier {
@@ -123,6 +133,8 @@ impl Unifier {
         Unifier {
             substitution: Substitution::new(),
             int_literal_vars: std::collections::HashSet::new(),
+            string_literal_vars: std::collections::HashSet::new(),
+            string_literal_types: std::collections::HashSet::new(),
         }
     }
 
@@ -134,6 +146,8 @@ impl Unifier {
         Unifier {
             substitution: Substitution::with_capacity(type_var_count as usize),
             int_literal_vars: std::collections::HashSet::new(),
+            string_literal_vars: std::collections::HashSet::new(),
+            string_literal_types: std::collections::HashSet::new(),
         }
     }
 
@@ -145,6 +159,13 @@ impl Unifier {
     /// `int_literal_vars` field documentation.
     pub fn mark_int_literal_vars(&mut self, vars: &[TypeVarId]) {
         self.int_literal_vars.extend(vars.iter().copied());
+    }
+
+    /// Register string-literal variables and the concrete string types they
+    /// may acquire from context (`StrBuf`, `str`, and `Str(N)`).
+    pub fn mark_string_literal_vars(&mut self, vars: &[TypeVarId], types: &[Type]) {
+        self.string_literal_vars.extend(vars.iter().copied());
+        self.string_literal_types.extend(types.iter().copied());
     }
 
     /// Unify two types.
@@ -334,6 +355,46 @@ impl Unifier {
                 // by the Array-vs-non-array case in `unify`.
                 InferType::IntLiteral | InferType::Array { .. } => {}
             }
+        }
+
+        if self.string_literal_vars.contains(&var) {
+            match ty {
+                InferType::Var(other) => {
+                    if self.int_literal_vars.contains(other) {
+                        return UnifyResult::StringLiteralNonString {
+                            found: InferType::IntLiteral,
+                        };
+                    }
+                    self.string_literal_vars.insert(*other);
+                }
+                InferType::Concrete(t) => {
+                    if t.is_error() {
+                        return UnifyResult::Ok;
+                    }
+                    if !t.is_never() && !self.string_literal_types.contains(t) {
+                        return UnifyResult::StringLiteralNonString {
+                            found: InferType::Concrete(*t),
+                        };
+                    }
+                }
+                InferType::IntLiteral => {
+                    return UnifyResult::StringLiteralNonString {
+                        found: InferType::IntLiteral,
+                    };
+                }
+                InferType::Array { .. } => {
+                    return UnifyResult::StringLiteralNonString { found: ty.clone() };
+                }
+            }
+        } else if let InferType::Var(other) = ty
+            && self.string_literal_vars.contains(other)
+        {
+            if self.int_literal_vars.contains(&var) {
+                return UnifyResult::StringLiteralNonString {
+                    found: InferType::IntLiteral,
+                };
+            }
+            self.string_literal_vars.insert(var);
         }
 
         self.substitution.insert(var, ty.clone());
@@ -526,6 +587,20 @@ impl Unifier {
                     .insert(rep, InferType::Concrete(Type::I32));
             }
             // If it resolved to Concrete, it was already constrained - no action needed
+        }
+    }
+
+    /// Default unconstrained variables to a caller-selected concrete type.
+    ///
+    /// As with integer-literal defaulting, bind the representative at the end
+    /// of a variable chain so joined literals and expressions resolve through
+    /// one canonical default without overwriting existing contextual bindings.
+    pub fn default_unconstrained_vars(&mut self, vars: &[TypeVarId], default: Type) {
+        for &var in vars {
+            let resolved = self.substitution.apply(&InferType::Var(var));
+            if let InferType::Var(rep) = resolved {
+                self.substitution.insert(rep, InferType::Concrete(default));
+            }
         }
     }
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -677,6 +677,15 @@ fn enqueue_anonymous_destructors(
 ///
 /// This is the same trade-off Zig makes for faster builds and smaller binaries.
 fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<SemaOutput> {
+    // The preview changes the default type of an unconstrained string literal,
+    // so register the canonical synthetic `str` before freezing the shared
+    // inference context even when source never spells the type name. This keeps
+    // inference, AIR, CFG, and codegen on the single canonical type identity.
+    if sema.preview_features.contains(&PreviewFeature::StringTrio) {
+        sema.get_or_create_str_struct(Span::default())
+            .map_err(CompileErrors::from)?;
+    }
+
     // Build inference context once
     let infer_ctx = sema.build_inference_context();
 

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -264,8 +264,26 @@ impl<'a> BodySema<'a> {
 
         // Comparisons read values without consuming them (like projections).
         // This matches Rust's PartialEq trait which takes references.
-        let lhs_result = self.analyze_inst_for_projection(air, lhs, ctx)?;
-        let rhs_result = self.analyze_inst_for_projection(air, rhs, ctx)?;
+        let lhs_is_literal = matches!(self.rir.get(lhs).data, InstData::StringConst(_));
+        let (lhs_result, rhs_result) = if lhs_is_literal {
+            let rhs_result = self.analyze_inst_for_projection(air, rhs, ctx)?;
+            let expected = (self.is_builtin_string(rhs_result.ty)
+                || self.is_str_like(rhs_result.ty))
+            .then_some(rhs_result.ty);
+            let lhs_result = ctx.with_expected_type(expected, |ctx| {
+                self.analyze_inst_for_projection(air, lhs, ctx)
+            })?;
+            (lhs_result, rhs_result)
+        } else {
+            let lhs_result = self.analyze_inst_for_projection(air, lhs, ctx)?;
+            let expected = (self.is_builtin_string(lhs_result.ty)
+                || self.is_str_like(lhs_result.ty))
+            .then_some(lhs_result.ty);
+            let rhs_result = ctx.with_expected_type(expected, |ctx| {
+                self.analyze_inst_for_projection(air, rhs, ctx)
+            })?;
+            (lhs_result, rhs_result)
+        };
         let lhs_type = lhs_result.ty;
 
         // Propagate Never/Error without additional type errors

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -113,20 +113,33 @@ impl<'a> BodySema<'a> {
             &infer_ctx.method_sigs,
             &self.type_pool,
             type_subst,
-        )
-        .with_const_types(&infer_ctx.const_types)
-        .with_const_type_aliases(&infer_ctx.const_type_aliases)
-        .with_const_values(&infer_ctx.const_values)
-        .with_const_function_aliases(&infer_ctx.const_function_aliases)
-        .with_structs_by_file_name(&infer_ctx.struct_types_by_file_name)
-        .with_enums_by_file_name(&infer_ctx.enum_types_by_file_name)
-        .with_module_binding_types(&infer_ctx.module_binding_types)
-        .with_module_file_ids(&infer_ctx.module_file_ids)
-        .with_functions_by_file_name(&infer_ctx.functions_by_file_name)
-        .with_comptime_local_bindings(&comptime_local_bindings)
-        .with_inline_ctor_head_types(&inline_ctor_head_types)
-        .with_comptime_values(value_subst)
-        .with_extra_method_sigs(&extra_method_sigs);
+        );
+        if self.preview_features.contains(&PreviewFeature::StringTrio) {
+            let str_name = self
+                .interner
+                .get("str")
+                .expect("preview string default was registered before inference");
+            let str_ty = infer_ctx
+                .builtin_struct_types
+                .get(&str_name)
+                .copied()
+                .expect("canonical str type is present in the inference context");
+            cgen = cgen.with_string_literal_default(str_ty);
+        }
+        let mut cgen = cgen
+            .with_const_types(&infer_ctx.const_types)
+            .with_const_type_aliases(&infer_ctx.const_type_aliases)
+            .with_const_values(&infer_ctx.const_values)
+            .with_const_function_aliases(&infer_ctx.const_function_aliases)
+            .with_structs_by_file_name(&infer_ctx.struct_types_by_file_name)
+            .with_enums_by_file_name(&infer_ctx.enum_types_by_file_name)
+            .with_module_binding_types(&infer_ctx.module_binding_types)
+            .with_module_file_ids(&infer_ctx.module_file_ids)
+            .with_functions_by_file_name(&infer_ctx.functions_by_file_name)
+            .with_comptime_local_bindings(&comptime_local_bindings)
+            .with_inline_ctor_head_types(&inline_ctor_head_types)
+            .with_comptime_values(value_subst)
+            .with_extra_method_sigs(&extra_method_sigs);
 
         // Build parameter map for constraint context.
         // Convert Type to InferType so arrays are represented structurally.
@@ -204,12 +217,35 @@ impl<'a> BodySema<'a> {
         }
 
         // Consume the constraint generator to release borrows
-        let (constraints, int_literal_vars, expr_types, type_var_count) = cgen.into_parts();
+        let (
+            constraints,
+            int_literal_vars,
+            string_literal_vars,
+            string_literal_default,
+            expr_types,
+            type_var_count,
+        ) = cgen.into_parts();
 
         // Phase 2: Solve constraints via unification
         // Pre-size the substitution for better performance on large functions
         let mut unifier = Unifier::with_capacity(type_var_count);
         unifier.mark_int_literal_vars(&int_literal_vars);
+        // Literal contextualization is nominal. Admit only identities owned by
+        // the compiler: the injected builtin StrBuf, the selected canonical
+        // default (`str` under the preview), and synthetic fixed strings from
+        // the generated-struct registry. A user struct with a coincidental
+        // name in another module must never become literal-compatible.
+        let mut string_literal_types = vec![self.builtin_string_type(), string_literal_default];
+        string_literal_types.extend(
+            self.generated_structs
+                .values()
+                .copied()
+                .map(Type::new_struct)
+                .filter(|&ty| self.is_str_fixed_struct(ty)),
+        );
+        string_literal_types.sort_unstable_by_key(Type::as_u32);
+        string_literal_types.dedup();
+        unifier.mark_string_literal_vars(&string_literal_vars, &string_literal_types);
         let errors = unifier.solve_constraints(&constraints);
 
         // Convert unification errors to compile errors
@@ -226,6 +262,10 @@ impl<'a> BodySema<'a> {
                 UnifyResult::IntLiteralNonInteger { found } => ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
                     found: found.safe_name_with_pool(Some(&self.type_pool)),
+                },
+                UnifyResult::StringLiteralNonString { found } => ErrorKind::TypeMismatch {
+                    expected: "string type".to_string(),
+                    found: found.name_with_pool(&self.type_pool),
                 },
                 UnifyResult::OccursCheck { var, ty } => ErrorKind::TypeMismatch {
                     expected: "non-recursive type".to_string(),
@@ -265,6 +305,7 @@ impl<'a> BodySema<'a> {
 
         // Default any unconstrained integer literals to i32
         unifier.default_int_literal_vars(&int_literal_vars);
+        unifier.default_unconstrained_vars(&string_literal_vars, string_literal_default);
 
         // Pre-collect all array types from resolved InferTypes before converting them.
         // This ensures all array types are created before the conversion loop, which

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -484,11 +484,17 @@ impl<'a> BodySema<'a> {
                 // `StringConst` AIR node lowers to only the ptr+len words there
                 // (the cap word is dropped in codegen). Otherwise it is the
                 // 3-word heap `String` as before.
-                let want_str = ctx.expected_type.is_some_and(|ty| self.is_str_like(ty));
-                let ty = if want_str {
-                    ctx.expected_type.unwrap()
+                let ty = if let Some(expected) = ctx
+                    .expected_type
+                    .filter(|ty| self.is_str_like(*ty) || self.is_builtin_string(*ty))
+                {
+                    expected
                 } else {
-                    self.builtin_string_type()
+                    // HM inference carries the preview-dependent default and
+                    // any explicit `StrBuf` context. Use that resolved type as
+                    // the fallback so AIR materialization cannot drift from
+                    // the canonical inference path.
+                    Self::get_resolved_type(ctx, inst_ref, inst.span, "string literal")?
                 };
                 // Add string to the local per-function string table.
                 let string_content = self.interner.resolve(&*symbol).to_string();
@@ -2670,6 +2676,15 @@ impl<'a> BodySema<'a> {
             if annot.is_enum() || self.is_str_like(annot) {
                 ctx.expected_type = Some(annot);
             }
+        } else if let Some(inferred) = ctx.resolved_types.get(&init).copied()
+            && self.is_str_struct(inferred)
+        {
+            // Under `string_trio`, an unannotated literal-derived initializer
+            // defaults to the canonical first-class `str`. Propagate that HM
+            // result while materializing nested branch, match, aggregate, and
+            // block tails so every consumer uses the same two-slot type rather
+            // than allowing an inner literal to fall back independently.
+            ctx.expected_type = Some(inferred);
         }
 
         // Analyze the initializer. A `for`-loop element binding is a shared

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -1212,6 +1212,146 @@ mod tests {
     }
 
     #[test]
+    fn string_literal_default_tracks_preview_and_preserves_buffer_context() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let output = compile_to_air_with_preview_features(
+            r#"
+                fn main() -> i32 {
+                    let value = "hello";
+                    let first = value;
+                    let second = value;
+                    @intCast(first.len() + second.len())
+                }
+            "#,
+            preview.clone(),
+        )
+        .expect("the preview default must be Copy and reusable");
+        let literal = output
+            .functions
+            .iter()
+            .flat_map(|function| function.air.iter())
+            .find_map(|(_, inst)| matches!(inst.data, AirInstData::StringConst(_)).then_some(inst))
+            .expect("main must materialize its literal");
+        assert_eq!(
+            literal.ty.safe_name_with_pool(Some(&output.type_pool)),
+            "str"
+        );
+        assert_eq!(output.type_pool.abi_slot_count(literal.ty), 2);
+
+        let explicit = compile_to_air_with_preview_features(
+            "fn main() -> i32 { let value: StrBuf = \"hello\"; @intCast(value.len()) }",
+            preview,
+        )
+        .unwrap();
+        let literal = explicit
+            .functions
+            .iter()
+            .flat_map(|function| function.air.iter())
+            .find_map(|(_, inst)| matches!(inst.data, AirInstData::StringConst(_)).then_some(inst))
+            .unwrap();
+        assert_eq!(
+            literal.ty.safe_name_with_pool(Some(&explicit.type_pool)),
+            "StrBuf"
+        );
+        assert_eq!(explicit.type_pool.abi_slot_count(literal.ty), 3);
+
+        let legacy =
+            compile_to_air("fn main() -> i32 { let value = \"hello\"; @intCast(value.len()) }")
+                .unwrap();
+        let literal = legacy
+            .functions
+            .iter()
+            .flat_map(|function| function.air.iter())
+            .find_map(|(_, inst)| matches!(inst.data, AirInstData::StringConst(_)).then_some(inst))
+            .unwrap();
+        assert_eq!(
+            literal.ty.safe_name_with_pool(Some(&legacy.type_pool)),
+            "StrBuf"
+        );
+        assert_eq!(legacy.type_pool.abi_slot_count(literal.ty), 3);
+    }
+
+    #[test]
+    fn preview_string_default_survives_control_flow_and_aggregate_joins() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let output = compile_to_air_with_preview_features(
+            r#"
+                struct Holder { value: str }
+
+                fn main() -> i32 {
+                    let branch = if true { "a" } else { "bb" };
+                    let branch_first = branch;
+                    let branch_second = branch;
+
+                    let block = { let marker = 0; "ccc" };
+                    let block_first = block;
+                    let block_second = block;
+
+                    let matched = match true {
+                        true => "dddd",
+                        false => "eeeee",
+                    };
+                    let match_first = matched;
+                    let match_second = matched;
+
+                    let holder = Holder {
+                        value: if false { "ffffff" } else { "ggggggg" },
+                    };
+                    let field_first = holder.value;
+                    let field_second = holder.value;
+
+                    @intCast(
+                        branch_first.len() + branch_second.len()
+                            + block_first.len() + block_second.len()
+                            + match_first.len() + match_second.len()
+                            + field_first.len() + field_second.len()
+                    )
+                }
+            "#,
+            preview,
+        )
+        .expect("literal-derived joins must remain Copy first-class str values");
+
+        let literal_types: Vec<Type> = output
+            .functions
+            .iter()
+            .flat_map(|function| function.air.iter())
+            .filter_map(|(_, inst)| {
+                matches!(inst.data, AirInstData::StringConst(_)).then_some(inst.ty)
+            })
+            .collect();
+        assert_eq!(literal_types.len(), 7);
+        assert!(literal_types.iter().all(|&ty| {
+            ty.safe_name_with_pool(Some(&output.type_pool)) == "str"
+                && output.type_pool.abi_slot_count(ty) == 2
+                && ty.is_copy_in_pool(&output.type_pool)
+        }));
+    }
+
+    #[test]
+    fn string_literal_join_cannot_default_through_an_integer_literal() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let errors = compile_to_air_with_preview_features(
+            r#"
+                fn choose(cond: bool) {
+                    let mixed = if cond { 42 } else { "not an integer" };
+                }
+                fn main() -> i32 { choose(true); 0 }
+            "#,
+            preview,
+        )
+        .expect_err("integer and string literal branches must not share a default");
+        assert!(matches!(
+            &errors.iter().next().unwrap().kind,
+            ErrorKind::TypeMismatch { expected, found }
+                if expected == "string type" && found == "{integer}"
+        ));
+    }
+
+    #[test]
     fn fixed_string_call_context_stops_at_nested_call_operands() {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::StringTrio);
@@ -1343,10 +1483,11 @@ mod tests {
             .map(|(_, inst)| inst.ty.safe_name_with_pool(Some(&output.type_pool)))
             .collect();
 
-        // Comparison operands and a discarded loop-body value synthesize
-        // their own StrBuf representation. If/match-style branches and block
-        // tails remain transparent and materialize as the declared Str(8).
-        assert_eq!(literal_types.iter().filter(|ty| *ty == "StrBuf").count(), 3);
+        // Comparison operands and a discarded loop-body value have no buffer
+        // context, so under `string_trio` they use the first-class `str`
+        // default. If/match-style branches and block tails remain transparent
+        // and materialize as the declared Str(8).
+        assert_eq!(literal_types.iter().filter(|ty| *ty == "str").count(), 3);
         assert_eq!(literal_types.iter().filter(|ty| *ty == "Str(8)").count(), 4);
     }
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -289,7 +289,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// and reassignable — it is exempt from the second-class-escape rule. The
     /// struct is keyed by the name `str`, so every reference shares one
     /// `StructId`.
-    fn get_or_create_str_struct(&mut self, span: Span) -> CompileResult<Type> {
+    pub(crate) fn get_or_create_str_struct(&mut self, span: Span) -> CompileResult<Type> {
         use crate::types::{StructDef, StructField};
 
         let type_sym = self.interner.get_or_intern("str");

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -163,19 +163,50 @@ args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["requires preview feature"]
 
-# A string literal with NO `str` expectation stays the 3-word heap `StrBuf`, so
-# existing StrBuf operations are unaffected by the `str` preview.
+# A string literal with no buffer expectation defaults to the 2-word, Copy
+# first-class `str` value under the preview.
 [[case]]
-name = "str_preview_does_not_change_string_default"
+name = "str_preview_defaults_unconstrained_literal_to_copy_str"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let s = "hello";        // no annotation -> StrBuf
-    let t: StrBuf = s;      // StrBuf, not str
-    @intCast(t.len())
+    let s = if true { "hello" } else { "goodbye" };
+    let first = s;
+    let second = s;
+    @intCast(first.len() + second.len())
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 10
+
+# An explicit StrBuf context retains the legacy three-word materialization.
+[[case]]
+name = "str_preview_preserves_explicit_strbuf_literal_context"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: StrBuf = "hello";
+    @intCast(s.len())
 }
 """ }]
 args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
 exit_code = 5
+
+# A source-defined type with the same spelling in another module is a distinct
+# nominal identity and cannot contextualize a string literal.
+[[case]]
+name = "user_module_strbuf_name_does_not_gain_literal_identity"
+files = [
+  { path = "main.rue", source = """
+const other = @import("other.rue");
+fn take(value: other.StrBuf) -> i32 { 0 }
+fn main() -> i32 { take("literal") }
+""" },
+  { path = "other.rue", source = """
+pub struct StrBuf { value: i32 }
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "expected string type"]
 
 # ============================================================================
 # RUE-386 two-types model: reject buffer/view -> first-class `str` escapes.

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -4019,12 +4019,20 @@ mod tests {
     use super::*;
     use rue_air::Sema;
     use rue_cfg::CfgBuilder;
-    use rue_error::PreviewFeatures;
+    use rue_error::{PreviewFeature, PreviewFeatures};
     use rue_lexer::Lexer;
     use rue_parser::Parser;
     use rue_rir::AstGen;
 
     fn lower_function_to_mir(source: &str, function_name: &str) -> Aarch64Mir {
+        lower_function_to_mir_with_preview(source, function_name, PreviewFeatures::new())
+    }
+
+    fn lower_function_to_mir_with_preview(
+        source: &str,
+        function_name: &str,
+        preview: PreviewFeatures,
+    ) -> Aarch64Mir {
         let lexer = Lexer::new(source);
         let (tokens, interner) = lexer.tokenize().unwrap();
         let parser = Parser::new(tokens, interner);
@@ -4034,7 +4042,7 @@ mod tests {
         astgen.append_items(&ast.items);
         let rir = astgen.finish();
 
-        let sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
+        let sema = Sema::new(&rir, &mut interner, preview);
         let output = sema.analyze_all().unwrap();
 
         let func = output
@@ -4085,6 +4093,32 @@ mod tests {
     fn test_if_else() {
         let mir = lower_to_mir("fn main() -> i32 { if true { 1 } else { 2 } }");
         assert!(!mir.instructions().is_empty());
+    }
+
+    #[test]
+    fn preview_default_string_literal_lowers_only_ptr_and_len() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let mir = lower_function_to_mir_with_preview(
+            "fn main() -> i32 { let s = \"hello\"; @intCast(s.len()) }",
+            "main",
+            preview,
+        );
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::StringConstPtr { .. }))
+        );
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::StringConstLen { .. }))
+        );
+        assert!(
+            !mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::StringConstCap { .. }))
+        );
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3986,12 +3986,16 @@ mod tests {
     use super::*;
     use rue_air::Sema;
     use rue_cfg::CfgBuilder;
-    use rue_error::PreviewFeatures;
+    use rue_error::{PreviewFeature, PreviewFeatures};
     use rue_lexer::Lexer;
     use rue_parser::Parser;
     use rue_rir::AstGen;
 
     fn lower_to_mir(source: &str) -> X86Mir {
+        lower_to_mir_with_preview(source, PreviewFeatures::new())
+    }
+
+    fn lower_to_mir_with_preview(source: &str, preview: PreviewFeatures) -> X86Mir {
         let lexer = Lexer::new(source);
         let (tokens, interner) = lexer.tokenize().unwrap();
         let parser = Parser::new(tokens, interner);
@@ -4001,7 +4005,7 @@ mod tests {
         astgen.append_items(&ast.items);
         let rir = astgen.finish();
 
-        let sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
+        let sema = Sema::new(&rir, &mut interner, preview);
         let output = sema.analyze_all().unwrap();
 
         let func = &output.functions[0];
@@ -4038,5 +4042,30 @@ mod tests {
     fn test_if_else() {
         let mir = lower_to_mir("fn main() -> i32 { if true { 1 } else { 2 } }");
         assert!(!mir.instructions().is_empty());
+    }
+
+    #[test]
+    fn preview_default_string_literal_lowers_only_ptr_and_len() {
+        let mut preview = PreviewFeatures::new();
+        preview.insert(PreviewFeature::StringTrio);
+        let mir = lower_to_mir_with_preview(
+            "fn main() -> i32 { let s = \"hello\"; @intCast(s.len()) }",
+            preview,
+        );
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::StringConstPtr { .. }))
+        );
+        assert!(
+            mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::StringConstLen { .. }))
+        );
+        assert!(
+            !mir.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::StringConstCap { .. }))
+        );
     }
 }

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -567,6 +567,12 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.str_type",
+        "str_preview_defaults_unconstrained_literal_to_copy_str",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.str_type",
         "strbuf_field_borrow_str_view",
         runtime_call(UnsupportedRuntimeCallKind::StringConcat),
         &[],

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -582,6 +582,12 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "types.str_type",
+        "str_literal_unconstrained_default_is_copy_str",
+        semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
         "types.strings",
         "print_borrows_argument_string",
         runtime_call(UnsupportedRuntimeCallKind::Print),

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -44,6 +44,38 @@ fn main() -> i32 {
 """
 exit_code = 0
 
+# 3.7:44 — without an expected buffer type, a literal defaults to first-class
+# `str`; its Copy value remains reusable after assignment.
+[[case]]
+name = "str_literal_unconstrained_default_is_copy_str"
+spec = ["3.7:44"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s = if true { "hello" } else { "goodbye" };
+    let first = s;
+    let second = s;
+    @intCast(first.len() + second.len())
+}
+"""
+exit_code = 10
+
+# 3.7:44 — an explicit legacy growable-buffer expectation still
+# contextualizes the literal as StrBuf.
+[[case]]
+name = "str_literal_explicit_strbuf_context"
+spec = ["3.7:44"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: StrBuf = "hello";
+    @intCast(s.len())
+}
+"""
+exit_code = 5
+
 # 3.7:45 — `.len()` is the byte length.
 [[case]]
 name = "str_len_bytes"

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -386,8 +386,9 @@ value is a two-word view `{ptr, len}`: a pointer to the bytes and a byte length.
 
 {{ rule(id="3.7:44", cat="normative") }}
 
-Where a `str` is expected, a string literal has type `str` and is *static-backed*
-and *first-class*: its bytes reside in read-only data that cannot dangle, so the
+A string literal has type `str` unless an expected string-buffer type
+contextualizes it as `StrBuf` or `Str(N)`. A `str` literal is *static-backed* and
+*first-class*: its bytes reside in read-only data that cannot dangle, so the
 `str` value is `@copy`, storable in a binding or a struct field, reassignable,
 returnable from a function, and passable as an argument. A first-class `str`
 value originates only from a string literal or from another first-class `str`;


### PR DESCRIPTION
## Summary

- default unconstrained string literals to canonical `str` when the `string_trio` preview is enabled
- preserve contextual `StrBuf`, `Str(N)`, and `str` literal typing while propagating resolved expectations through joins and aggregate tails
- cover AIR layout, both backend lowerings, specification behavior, and CLI preview behavior

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue spec str_type`
- `scripts/rue cli str_type`
- `scripts/rue spec str_literal`
- `scripts/rue cli str_preview`

Fixes RUE-872
