### PR TITLE
RUE-873: give std StrBuf a stable language identity

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -202,6 +202,9 @@ pub struct ConstraintGenerator<'a> {
     string_literal_vars: Vec<TypeVarId>,
     /// Concrete default for an otherwise-unconstrained string literal.
     string_literal_default: Type,
+    /// Explicit compiler-provided identity for the transitional growable
+    /// string type used by intrinsic signatures and StrBuf-only contexts.
+    strbuf_type: Type,
     /// Type substitutions for Self and type parameters (used in method bodies).
     /// Maps type names (like "Self") to their concrete types.
     type_subst: Option<&'a HashMap<Spur, Type>>,
@@ -334,10 +337,8 @@ impl<'a> ConstraintGenerator<'a> {
         type_pool: &'a TypeInternPool,
         type_subst: Option<&'a HashMap<Spur, Type>>,
     ) -> Self {
-        let string_literal_default = interner
-            .get("StrBuf")
-            .and_then(|name| builtin_structs.get(&name).copied())
-            .unwrap_or(Type::ERROR);
+        let strbuf_type = type_pool.builtin_strbuf_type().unwrap_or(Type::ERROR);
+        let string_literal_default = strbuf_type;
         Self {
             rir,
             interner,
@@ -353,6 +354,7 @@ impl<'a> ConstraintGenerator<'a> {
             int_literal_vars: Vec::new(),
             string_literal_vars: Vec::new(),
             string_literal_default,
+            strbuf_type,
             type_subst,
             const_types: None,
             const_type_aliases: None,
@@ -377,6 +379,13 @@ impl<'a> ConstraintGenerator<'a> {
     /// registered the canonical synthetic `str` type in the shared type pool.
     pub fn with_string_literal_default(mut self, ty: Type) -> Self {
         self.string_literal_default = ty;
+        self
+    }
+
+    /// Supply the transitional StrBuf nominal through an already-resolved
+    /// semantic identity instead of rediscovering it from a source spelling.
+    pub fn with_strbuf_type(mut self, ty: Type) -> Self {
+        self.strbuf_type = ty;
         self
     }
 
@@ -2738,7 +2747,11 @@ impl<'a> ConstraintGenerator<'a> {
             || self.is_string_literal_candidate(&lhs_info.ty)
             || self.is_string_literal_candidate(&rhs_info.ty)
         {
-            let string_ty = self.string_infer_type();
+            let string_ty = [&lhs_info.ty, &rhs_info.ty]
+                .into_iter()
+                .find(|ty| self.is_string_concrete(ty))
+                .cloned()
+                .unwrap_or_else(|| self.string_infer_type());
             self.add_constraint(Constraint::equal(
                 lhs_info.ty,
                 string_ty.clone(),
@@ -2773,25 +2786,12 @@ impl<'a> ConstraintGenerator<'a> {
     /// as an [`InferType::Concrete`], or `Concrete(ERROR)` if it hasn't been
     /// injected (should not happen once builtin types are registered).
     fn string_infer_type(&self) -> InferType {
-        if let Some(string_spur) = self.interner.get("StrBuf") {
-            if let Some(&string_ty) = self.builtin_structs.get(&string_spur) {
-                return InferType::Concrete(string_ty);
-            }
-        }
-        InferType::Concrete(Type::ERROR)
+        InferType::Concrete(self.strbuf_type)
     }
 
-    /// Whether `ty` is *concretely* the builtin `StrBuf` struct (not a type
-    /// variable that might later resolve to it).
+    /// Whether `ty` is concretely either canonical or transitional StrBuf.
     fn is_string_concrete(&self, ty: &InferType) -> bool {
-        if let InferType::Concrete(t) = ty {
-            if let Some(string_spur) = self.interner.get("StrBuf") {
-                if let Some(&string_ty) = self.builtin_structs.get(&string_spur) {
-                    return *t == string_ty;
-                }
-            }
-        }
-        false
+        matches!(ty, InferType::Concrete(t) if t.as_struct().is_some_and(|id| self.type_pool.is_strbuf(id)))
     }
 
     /// Whether an inference type is the still-contextual type variable rooted

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -37,7 +37,8 @@ use rue_span::FileId;
 
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::types::{
-    ArrayTypeId, EnumDef, EnumId, PtrConstTypeId, PtrMutTypeId, StructDef, StructId, Type, TypeKind,
+    ArrayTypeId, EnumDef, EnumId, LangItem, PtrConstTypeId, PtrMutTypeId, StructDef, StructId,
+    Type, TypeKind,
 };
 
 /// Interned type index - 32 bits, Copy, cheap comparison.
@@ -267,6 +268,14 @@ struct TypeInternPoolInner {
 
     /// Relocation-stable logical identity for each defining source file.
     symbol_paths: HashMap<FileId, String>,
+
+    /// Explicit language-item assignments issued by a trusted frontend or
+    /// durable semantic import boundary.
+    struct_lang_items: HashMap<StructId, LangItem>,
+
+    /// Transitional compiler-injected StrBuf identity, recorded when its
+    /// runtime-backed nominal is registered rather than rediscovered by name.
+    builtin_strbuf: Option<StructId>,
 }
 
 impl TypeInternPool {
@@ -281,6 +290,8 @@ impl TypeInternPool {
                 struct_by_file_name: HashMap::new(),
                 enum_by_file_name: HashMap::new(),
                 symbol_paths: HashMap::new(),
+                struct_lang_items: HashMap::new(),
+                builtin_strbuf: None,
             }),
         }
     }
@@ -390,11 +401,16 @@ impl TypeInternPool {
         // Create new struct type
         let pool_index = inner.types.len() as u32;
         let interned = InternedType::from_pool_index(pool_index);
+        let struct_id = StructId::from_pool_index(pool_index);
+
+        if def.is_builtin && def.destructor.as_deref() == Some("__rue_drop_String") {
+            inner.builtin_strbuf = Some(struct_id);
+        }
 
         inner.types.push(TypeData::Struct(StructData { name, def }));
         inner.struct_by_file_name.insert(key, interned);
 
-        (StructId::from_pool_index(pool_index), true)
+        (struct_id, true)
     }
 
     /// Reserve a struct ID without registering the full definition yet.
@@ -728,6 +744,41 @@ impl TypeInternPool {
             TypeData::Struct(data) => Some(data.def.clone()),
             _ => None,
         }
+    }
+
+    /// Return the stable standard-library identity carried by a nominal type.
+    pub fn struct_lang_item(&self, struct_id: StructId) -> Option<LangItem> {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        inner.struct_lang_items.get(&struct_id).copied()
+    }
+
+    /// Assign an explicitly authorized language item to a registered nominal.
+    pub fn set_struct_lang_item(&self, struct_id: StructId, lang_item: LangItem) {
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        assert!(
+            matches!(
+                inner.types.get(struct_id.0 as usize),
+                Some(TypeData::Struct(_))
+            ),
+            "language items can only be assigned to registered structs"
+        );
+        inner.struct_lang_items.insert(struct_id, lang_item);
+    }
+
+    /// Whether a nominal is the canonical source StrBuf or the transitional
+    /// synthetic StrBuf. The two remain distinct nominal types.
+    pub fn is_strbuf(&self, struct_id: StructId) -> bool {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        if inner.builtin_strbuf == Some(struct_id) {
+            return true;
+        }
+        inner.struct_lang_items.get(&struct_id) == Some(&LangItem::StrBuf)
+    }
+
+    /// The transitional compiler-injected StrBuf type, if registered.
+    pub fn builtin_strbuf_type(&self) -> Option<Type> {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        inner.builtin_strbuf.map(Type::new_struct)
     }
 
     /// Get an enum definition by EnumId.
@@ -1248,6 +1299,8 @@ impl Clone for TypeInternPool {
                 struct_by_file_name: inner.struct_by_file_name.clone(),
                 enum_by_file_name: inner.enum_by_file_name.clone(),
                 symbol_paths: inner.symbol_paths.clone(),
+                struct_lang_items: inner.struct_lang_items.clone(),
+                builtin_strbuf: inner.builtin_strbuf,
             }),
         }
     }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -71,8 +71,8 @@ pub use semantic_import::{
     SemanticImportedType,
 };
 pub use types::{
-    ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId, StructDef,
-    StructField, StructId, Type, TypeKind, parse_array_type_syntax,
+    ArrayTypeId, EnumDef, EnumId, LangItem, ModuleDef, ModuleId, PtrConstTypeId, PtrMutTypeId,
+    StructDef, StructField, StructId, Type, TypeKind, parse_array_type_syntax,
 };
 
 /// Sentinel value used to encode parameter slots in AIR instructions.

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -289,8 +289,12 @@ impl<'a> BodySema<'a> {
             }
         };
 
-        // Check if this is a builtin type and handle its methods
-        if let Some(builtin_def) = self.get_builtin_type_def(struct_id) {
+        // Source-defined methods on a language item are authoritative. The
+        // builtin registry remains a transitional fallback for operations the
+        // source module has not migrated yet.
+        if self.method_info((struct_id, method)).is_none()
+            && let Some(builtin_def) = self.get_builtin_type_def(struct_id)
+        {
             let method_ctx = BuiltinMethodContext {
                 struct_id,
                 builtin_def,
@@ -774,8 +778,11 @@ impl<'a> BodySema<'a> {
             )?;
         }
 
-        // Handle builtin type associated functions
-        if let Some(builtin_def) = self.get_builtin_type_def(struct_id) {
+        // Prefer the canonical source implementation, retaining registry
+        // lowering only for associated functions not yet defined in source.
+        if self.method_info((struct_id, function)).is_none()
+            && let Some(builtin_def) = self.get_builtin_type_def(struct_id)
+        {
             return self.analyze_builtin_assoc_fn(
                 air,
                 ctx,

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -114,6 +114,11 @@ impl<'a> BodySema<'a> {
             &self.type_pool,
             type_subst,
         );
+        let strbuf_ty = self
+            .builtin_string_id
+            .map(Type::new_struct)
+            .expect("transitional StrBuf was registered before inference");
+        cgen = cgen.with_strbuf_type(strbuf_ty);
         if self.preview_features.contains(&PreviewFeature::StringTrio) {
             let str_name = self
                 .interner
@@ -125,6 +130,8 @@ impl<'a> BodySema<'a> {
                 .copied()
                 .expect("canonical str type is present in the inference context");
             cgen = cgen.with_string_literal_default(str_ty);
+        } else {
+            cgen = cgen.with_string_literal_default(strbuf_ty);
         }
         let mut cgen = cgen
             .with_const_types(&infer_ctx.const_types)
@@ -236,6 +243,13 @@ impl<'a> BodySema<'a> {
         // the generated-struct registry. A user struct with a coincidental
         // name in another module must never become literal-compatible.
         let mut string_literal_types = vec![self.builtin_string_type(), string_literal_default];
+        string_literal_types.extend(
+            self.type_pool
+                .all_struct_ids()
+                .into_iter()
+                .filter(|id| self.type_pool.is_strbuf(*id))
+                .map(Type::new_struct),
+        );
         string_literal_types.extend(
             self.generated_structs
                 .values()

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -159,6 +159,7 @@ pub struct DeclarationBindingWork {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SemanticDeclarationShellIdentity {
     pub module_path: Arc<str>,
+    pub is_trusted_standard_library: bool,
     pub namespace: SemanticBindingNamespace,
     pub kind: SemanticBindingKind,
     pub name: Arc<str>,
@@ -383,6 +384,10 @@ impl<'a> DeclarationShells<'a> {
                 .unwrap_or_else(|| format!("file{}", export.identity.file_id.index()));
             let identity = SemanticDeclarationShellIdentity {
                 module_path: Arc::from(module_path),
+                is_trusted_standard_library: self
+                    .sema
+                    .trusted_standard_library_files
+                    .contains(&export.identity.file_id),
                 namespace: export.identity.namespace,
                 kind: export.identity.kind,
                 name: export.identity.name.clone(),
@@ -883,6 +888,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     shell: SemanticDeclarationShell {
                         identity: SemanticDeclarationShellIdentity {
                             module_path: module_path(inst.span.file_id),
+                            is_trusted_standard_library: self
+                                .trusted_standard_library_files
+                                .contains(&inst.span.file_id),
                             namespace: SemanticBindingNamespace::Type,
                             kind,
                             name: Arc::from(self.interner.resolve(name)),
@@ -940,6 +948,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         .collect::<Vec<_>>();
                     let identity = SemanticDeclarationShellIdentity {
                         module_path: module_path(inst.span.file_id),
+                        is_trusted_standard_library: self
+                            .trusted_standard_library_files
+                            .contains(&inst.span.file_id),
                         namespace: if owner.is_some() {
                             SemanticBindingNamespace::Method
                         } else {
@@ -966,6 +977,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 } => (
                     SemanticDeclarationShellIdentity {
                         module_path: module_path(inst.span.file_id),
+                        is_trusted_standard_library: self
+                            .trusted_standard_library_files
+                            .contains(&inst.span.file_id),
                         namespace: SemanticBindingNamespace::Value,
                         // Function aliases are classified only after evaluating
                         // the initializer; their stable value identity is already
@@ -986,6 +1000,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 InstData::DropFnDecl { type_name, body } => (
                     SemanticDeclarationShellIdentity {
                         module_path: module_path(inst.span.file_id),
+                        is_trusted_standard_library: self
+                            .trusted_standard_library_files
+                            .contains(&inst.span.file_id),
                         namespace: SemanticBindingNamespace::Destructor,
                         kind: SemanticBindingKind::Destructor,
                         name: Arc::from(self.interner.resolve(type_name)),

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -63,7 +63,7 @@ impl<'a> Sema<'a> {
                 .insert((file_id, name_spur), struct_id);
 
             // Store special IDs for quick access
-            if builtin.name == "StrBuf" {
+            if builtin.drop_fn == Some("__rue_drop_String") {
                 self.builtin_string_id = Some(struct_id);
             }
 
@@ -114,12 +114,11 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     // Builtin type helper methods
     // ========================================================================
 
-    /// Check if a type is the builtin String type.
-    ///
-    /// Uses the stored `builtin_string_id` for fast comparison.
+    /// Check if a type is either the canonical source StrBuf or its
+    /// transitional synthetic predecessor.
     pub(crate) fn is_builtin_string(&self, ty: Type) -> bool {
         match ty.kind() {
-            TypeKind::Struct(struct_id) => Some(struct_id) == self.builtin_string_id,
+            TypeKind::Struct(struct_id) => self.type_pool.is_strbuf(struct_id),
             _ => false,
         }
     }
@@ -133,7 +132,9 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         struct_id: StructId,
     ) -> Option<&'static BuiltinTypeDef> {
         let struct_def = self.type_pool.struct_def(struct_id);
-        if struct_def.is_builtin {
+        if self.type_pool.is_strbuf(struct_id) {
+            Some(&rue_builtins::STRING_TYPE)
+        } else if struct_def.is_builtin {
             rue_builtins::get_builtin_type(&struct_def.name)
         } else {
             None

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -495,6 +495,17 @@ impl<'a> Sema<'a> {
 
                     // Register in type pool and get pool-based StructId
                     let (struct_id, _) = self.type_pool.register_struct(*name, struct_def);
+                    if self
+                        .trusted_standard_library_files
+                        .contains(&inst.span.file_id)
+                        && let Some(module_path) = self.symbol_paths.get(&inst.span.file_id)
+                        && let Some(lang_item) = crate::LangItem::from_standard_library_nominal(
+                            module_path,
+                            &self.type_pool.struct_def(struct_id).name,
+                        )
+                    {
+                        self.type_pool.set_struct_lang_item(struct_id, lang_item);
+                    }
 
                     // Source declarations are always keyed by their defining file.
                     self.structs_by_file_name.insert(key, struct_id);

--- a/crates/rue-air/src/sema/file_paths.rs
+++ b/crates/rue-air/src/sema/file_paths.rs
@@ -4,7 +4,7 @@
 //! relocation-stable identities used in generated symbols. Import resolution
 //! is supplied separately as canonical compiler records.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::{FileId, Span};
@@ -64,6 +64,12 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
     pub fn set_symbol_paths(&mut self, symbol_paths: HashMap<FileId, String>) {
         self.symbol_paths = symbol_paths;
         self.refresh_type_symbol_paths();
+    }
+
+    /// Install standard-library provenance established by import discovery.
+    /// Path spelling alone never grants this authority.
+    pub fn set_trusted_standard_library_files(&mut self, file_ids: HashSet<FileId>) {
+        self.trusted_standard_library_files = file_ids;
     }
 
     fn refresh_type_symbol_paths(&self) {

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -275,6 +275,9 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) file_paths: HashMap<FileId, String>,
     /// Maps FileId to relocation-stable paths used in generated symbols.
     pub(crate) symbol_paths: HashMap<FileId, String>,
+    /// FileIds whose standard-library provenance was established by the
+    /// frontend's import resolver, rather than inferred from path spelling.
+    pub(crate) trusted_standard_library_files: HashSet<FileId>,
     /// Explicit semantic root module for root-relative import fallback.
     pub(crate) root_file_id: Option<FileId>,
     /// Arena storage for function/method parameter data.
@@ -383,6 +386,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             canonical_imports,
             file_paths,
             symbol_paths,
+            trusted_standard_library_files,
             root_file_id,
             param_arena,
             anon_struct_method_sigs,
@@ -433,6 +437,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             canonical_imports,
             file_paths,
             symbol_paths,
+            trusted_standard_library_files,
             root_file_id,
             param_arena,
             anon_struct_method_sigs,
@@ -742,6 +747,7 @@ impl<'a> Sema<'a> {
             canonical_imports: None,
             file_paths: HashMap::new(),
             symbol_paths: HashMap::new(),
+            trusted_standard_library_files: HashSet::new(),
             root_file_id: None,
             param_arena: ParamArena::new(),
             anon_struct_method_sigs: HashMap::new(),

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -33,6 +33,7 @@ pub struct SemanticImportNominal<K> {
     pub name: Arc<str>,
     pub kind: SemanticImportNominalKind,
     pub is_public: bool,
+    pub lang_item: Option<crate::LangItem>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -641,6 +642,12 @@ where
                 .entry(nominal.module_path.clone())
                 .or_insert(FileId::new(next));
         }
+        type_pool.set_symbol_paths(
+            module_files
+                .iter()
+                .map(|(path, file_id)| (*file_id, path.to_string()))
+                .collect(),
+        );
         let mut local = BTreeMap::new();
         let mut local_identities = std::collections::BTreeSet::new();
         for nominal in nominals {
@@ -672,6 +679,9 @@ where
                             file_id,
                         },
                     );
+                    if let Some(lang_item) = nominal.lang_item {
+                        type_pool.set_struct_lang_item(id, lang_item);
+                    }
                     LocalNominal::Struct(id)
                 }
                 SemanticImportNominalKind::Enum => {
@@ -1025,6 +1035,7 @@ mod tests {
             name: Arc::from(name),
             kind,
             is_public: true,
+            lang_item: None,
         }
     }
 

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -349,6 +349,27 @@ impl Type {
     }
 }
 
+/// Compiler-recognized identity of a canonical standard-library nominal type.
+///
+/// This is derived from the nominal's relocation-stable module identity, not
+/// its unqualified spelling, so imports and aliases preserve it while an
+/// unrelated user declaration with the same name never acquires it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LangItem {
+    /// `std.strbuf.StrBuf`.
+    StrBuf,
+}
+
+impl LangItem {
+    /// Classify a nominal only after its module has crossed a trusted
+    /// standard-library provenance boundary.
+    pub fn from_standard_library_nominal(module_path: &str, name: &str) -> Option<Self> {
+        (name == "StrBuf"
+            && crate::path_norm::normalize_module_path(module_path) == "\0rue-std/strbuf.rue")
+            .then_some(Self::StrBuf)
+    }
+}
+
 /// Definition of a struct type.
 #[derive(Debug, Clone)]
 pub struct StructDef {

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -29,6 +29,37 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
+name = "canonical_identity_drives_string_semantics"
+description = "Qualified and aliased std StrBuf values use view coercions, indexing, iteration, equality, and transitional runtime helpers."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn read_len(borrow value: str) -> u64 { value.len() }
+fn exclusive_len(inout value: str) -> u64 { value.len() }
+
+fn main() -> i32 {
+    let mut value: S = "abc";
+    if read_len(borrow value) != 3 { return 1; }
+    if exclusive_len(inout value) != 3 { return 2; }
+    if value[1] != 98 { return 3; }
+    if value != "abc" { return 4; }
+
+    let mut bytes = 0;
+    for _byte in value { bytes = bytes + 1; }
+    if bytes != 3 { return 5; }
+
+    let mut chars = 0;
+    for _char in value.chars() { chars = chars + 1; }
+    if chars != 3 { return 6; }
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 0
+
+[[case]]
 name = "owned_allocation_drop_and_early_free"
 description = "cap > 0 owns an allocation; moved scope-drop and explicit early free each leave one teardown path."
 env = { RUE_STD_PATH = "${REAL_STD}" }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2481,7 +2481,7 @@ impl<'a> CfgLower<'a> {
                 let dropped_ty = self.ctx.cfg.get_inst(*dropped_value).ty;
 
                 // Handle String specially - it's a fat pointer (ptr, len, cap)
-                if self.ctx.is_builtin_string(dropped_ty) {
+                if self.ctx.is_legacy_builtin_string(dropped_ty) {
                     // String requires all 3 slots as arguments to __rue_drop_String.
                     // The accessor handles every source (cache for StructInit/Call/
                     // BlockParam; materialize for Load/Param/PlaceRead). (RUE-118)

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -364,8 +364,7 @@ pub fn format_terminator(cfg: &rue_cfg::Cfg, terminator: &rue_cfg::Terminator) -
 pub fn type_uses_sret_return(type_pool: &TypeInternPool, ty: Type, ret_reg_budget: u32) -> bool {
     match ty.kind() {
         TypeKind::Struct(struct_id) => {
-            let struct_def = type_pool.struct_def(struct_id);
-            if struct_def.is_builtin && struct_def.name == "StrBuf" {
+            if type_pool.is_strbuf(struct_id) {
                 return true;
             }
             types::type_slot_count(type_pool, ty) > ret_reg_budget
@@ -469,18 +468,20 @@ impl<'a> CfgLowerContext<'a> {
     // Builtin type helpers
     // ========================================================================
 
-    /// Check if a type is the builtin growable-string struct (`StrBuf`).
-    ///
-    /// Returns true if the type is a struct marked as builtin with name
-    /// "StrBuf" (ADR-0043; formerly "String").
+    /// Check if a type is the canonical or transitional growable-string struct.
     pub fn is_builtin_string(&self, ty: Type) -> bool {
         match ty.kind() {
-            TypeKind::Struct(struct_id) => {
-                let struct_def = self.type_pool.struct_def(struct_id);
-                struct_def.is_builtin && struct_def.name == "StrBuf"
-            }
+            TypeKind::Struct(struct_id) => self.type_pool.is_strbuf(struct_id),
             _ => false,
         }
+    }
+
+    /// Whether `ty` is the transitional compiler-injected StrBuf whose drop
+    /// implementation is supplied directly by the runtime.
+    pub fn is_legacy_builtin_string(&self, ty: Type) -> bool {
+        ty.as_struct().is_some_and(|id| {
+            self.type_pool.struct_def(id).is_builtin && self.type_pool.is_strbuf(id)
+        })
     }
 
     /// Check if a type has string byte-content equality semantics.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2836,7 +2836,7 @@ impl<'a> CfgLower<'a> {
                 let dropped_ty = self.ctx.cfg.get_inst(*dropped_value).ty;
 
                 // Handle builtin String specially - it's a fat pointer (ptr, len, cap)
-                if self.ctx.is_builtin_string(dropped_ty) {
+                if self.ctx.is_legacy_builtin_string(dropped_ty) {
                     // String requires all 3 slots as arguments to __rue_drop_String.
                     // The accessor handles every source (cache for StructInit/Call/
                     // BlockParam; materialize for Load/Param/PlaceRead). (RUE-118)

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -625,6 +625,19 @@ pub(crate) fn configure_canonical_sema<'a>(
         .collect();
     sema.set_canonical_imports(modules, imports)
         .map_err(CompileErrors::from)?;
+    sema.set_trusted_standard_library_files(
+        merged
+            .ast()
+            .modules()
+            .iter()
+            .filter_map(|module| {
+                module
+                    .module_id()
+                    .is_trusted_standard_library()
+                    .then_some(module.file_id())
+            })
+            .collect(),
+    );
     Ok(sema)
 }
 

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -179,6 +179,14 @@ pub fn import_durable_declaration_semantics(
                 name: Arc::from(declaration.key.name()),
                 kind: SemanticImportNominalKind::Struct,
                 is_public: declaration.is_public,
+                lang_item: if declaration.key.module().is_trusted_standard_library() {
+                    rue_air::LangItem::from_standard_library_nominal(
+                        declaration.key.module().as_str(),
+                        declaration.key.name(),
+                    )
+                } else {
+                    None
+                },
             }),
             DurableDeclarationPayload::Enum { .. } => nominals.push(SemanticImportNominal {
                 key: declaration.key.clone(),
@@ -186,6 +194,7 @@ pub fn import_durable_declaration_semantics(
                 name: Arc::from(declaration.key.name()),
                 kind: SemanticImportNominalKind::Enum,
                 is_public: declaration.is_public,
+                lang_item: None,
             }),
             DurableDeclarationPayload::Callable { .. } => {
                 // Length-prefix every component. Unlike a source-like name this
@@ -412,7 +421,11 @@ impl ProjectionJoinKey {
 
     fn from_shell(shell: &SemanticDeclarationShell) -> Option<Self> {
         Some(Self {
-            module: ModuleId::from_validated_canonical(&shell.identity.module_path),
+            module: if shell.identity.is_trusted_standard_library {
+                ModuleId::from_trusted_validated_canonical(&shell.identity.module_path)
+            } else {
+                ModuleId::from_validated_canonical(&shell.identity.module_path)
+            },
             namespace: stable_namespace(shell.identity.namespace),
             kind: stable_kind(shell.identity.kind)?,
             name: shell.identity.name.clone(),
@@ -1026,6 +1039,49 @@ mod tests {
         assert_query_value::<DurableDeclarationPayload>();
         assert_query_value::<DurableDeclarationSemantic>();
         assert_query_value::<DurableSemanticExportFailure>();
+    }
+
+    #[test]
+    fn trusted_std_strbuf_survives_durable_import_with_aarch64_sret_identity() {
+        let key = StableDefinitionKey::for_test(
+            ModuleId::from_trusted_standard_library_path("\0rue-std/strbuf.rue").unwrap(),
+            StableDefinitionNamespace::Type,
+            StableDefinitionKind::Struct,
+            "StrBuf",
+            None,
+        );
+        let epoch = import_durable_declaration_semantics(&[DurableDeclarationSemantic {
+            key,
+            is_public: true,
+            payload: DurableDeclarationPayload::Struct {
+                fields: Arc::from([
+                    (
+                        Arc::from("buf"),
+                        DurableType::PtrMut(Box::new(DurableType::U8)),
+                    ),
+                    (Arc::from("len"), DurableType::U64),
+                    (Arc::from("cap"), DurableType::U64),
+                ]),
+                is_copy: false,
+                is_linear: false,
+            },
+        }])
+        .unwrap();
+        let strbuf = epoch
+            .type_pool()
+            .all_struct_ids()
+            .into_iter()
+            .find(|id| epoch.type_pool().struct_lang_item(*id) == Some(rue_air::LangItem::StrBuf))
+            .expect("durable import should restore StrBuf language-item identity");
+        assert_eq!(
+            epoch.type_pool().struct_symbol_name(strbuf),
+            "StrBuf$_00rue_2dstd_2fstrbuf_2erue"
+        );
+        assert!(rue_codegen::cfg_lower::type_uses_sret_return(
+            epoch.type_pool(),
+            rue_air::Type::new_struct(strbuf),
+            8,
+        ));
     }
 
     #[test]

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1003,7 +1003,21 @@ impl DiscoverySourceAssembler {
                 (FileId::new((index + 1) as u32), module.as_str().to_owned())
             })
             .collect();
-        let metadata = SourceMetadata::new(FileId::new(1), physical_paths, logical_paths)?;
+        let trusted_standard_library_files = ordered
+            .iter()
+            .enumerate()
+            .filter_map(|(index, (module, _))| {
+                module
+                    .is_trusted_standard_library()
+                    .then_some(FileId::new((index + 1) as u32))
+            })
+            .collect();
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            FileId::new(1),
+            physical_paths,
+            logical_paths,
+            trusted_standard_library_files,
+        )?;
         let contents = ordered
             .into_iter()
             .enumerate()
@@ -1116,7 +1130,7 @@ fn classify_module(
                     requested, std_root
                 )));
             }
-            return ModuleId::from_logical_path(
+            return ModuleId::from_trusted_standard_library_path(
                 Path::new("\0rue-std").join(relative).to_string_lossy(),
             );
         }

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -6,6 +6,188 @@ mod tests {
     use super::*;
 
     #[test]
+    fn canonical_std_strbuf_identity_survives_qualified_and_aliased_lookup() {
+        let context = ImportDiscoveryContext::new(1, "/project", Some("/sdk"), "test")
+            .expect("discovery context should be valid");
+        let mut assembler = DiscoverySourceAssembler::new(
+            context,
+            "/project/main.rue",
+            "/project/main.rue",
+            PhysicalFileIdentity::new(1, 1),
+            FileMetadataFingerprint::new(1, 1, 1),
+            Arc::new(
+                r#"
+                    const std = @import("/sdk/_std.rue");
+                    const other = @import("other.rue");
+                    const Qualified = std.strbuf.StrBuf;
+                    const Alias = Qualified;
+                    fn qualified(value: std.strbuf.StrBuf) -> std.strbuf.StrBuf { value }
+                    fn aliased(value: Alias) -> Alias { value }
+                    fn ordinary(value: other.StrBuf) -> i32 { value.value }
+                    fn main() -> i32 {
+                        let qualified_value: Qualified = "q";
+                        let _qualified_result = qualified(qualified_value);
+                        let aliased_value: Alias = "a";
+                        let _aliased_result = aliased(aliased_value);
+                        0
+                    }
+                "#
+                .to_owned(),
+            ),
+        )
+        .unwrap();
+        assembler
+            .add_explicit(
+                "/sdk/_std.rue",
+                "/sdk/_std.rue",
+                PhysicalFileIdentity::new(2, 2),
+                FileMetadataFingerprint::new(2, 2, 2),
+                Arc::new("pub const strbuf = @import(\"strbuf.rue\");".to_owned()),
+            )
+            .unwrap();
+        assembler
+            .add_explicit(
+                "/sdk/strbuf.rue",
+                "/sdk/strbuf.rue",
+                PhysicalFileIdentity::new(3, 3),
+                FileMetadataFingerprint::new(3, 3, 3),
+                Arc::new(
+                    r#"
+                    pub struct StrBuf {
+                        buf: ptr mut u8,
+                        len: u64,
+                        cap: u64,
+                        fn len(borrow self) -> u64 { self.len }
+                    }
+                    drop fn StrBuf(self) {}
+                "#
+                    .to_owned(),
+                ),
+            )
+            .unwrap();
+        assembler
+            .add_explicit(
+                "/project/other.rue",
+                "/project/other.rue",
+                PhysicalFileIdentity::new(4, 4),
+                FileMetadataFingerprint::new(4, 4, 4),
+                Arc::new("pub struct StrBuf { value: i32 }".to_owned()),
+            )
+            .unwrap();
+        let snapshot = assembler.snapshot().unwrap();
+
+        let mut options = CompileOptions::default();
+        options
+            .preview_features
+            .insert("string_trio".parse().unwrap());
+        let (rir, semantic, _) = test_frontend_snapshot(&snapshot, &options)
+            .expect("qualified and aliased canonical StrBuf references should compile");
+        let pool = semantic.type_pool();
+        let named_strbufs = pool
+            .all_struct_ids()
+            .into_iter()
+            .filter(|id| pool.struct_def(*id).name == "StrBuf")
+            .collect::<Vec<_>>();
+        let canonical = named_strbufs
+            .iter()
+            .copied()
+            .filter(|id| pool.struct_lang_item(*id) == Some(rue_air::LangItem::StrBuf))
+            .collect::<Vec<_>>();
+        assert_eq!(canonical.len(), 1, "std StrBuf has one canonical identity");
+        let canonical_id = canonical[0];
+        assert_eq!(
+            named_strbufs
+                .iter()
+                .filter(|id| { **id != canonical_id && !pool.struct_def(**id).is_builtin })
+                .count(),
+            1,
+            "the same spelling in user source remains an ordinary nominal"
+        );
+        assert!(
+            named_strbufs
+                .iter()
+                .find(|id| { **id != canonical_id && !pool.struct_def(**id).is_builtin })
+                .is_some_and(|id| pool.struct_lang_item(*id).is_none())
+        );
+
+        let parameter_type = |name: &str| {
+            semantic
+                .functions()
+                .iter()
+                .find(|function| {
+                    function.analyzed.name == name
+                        || function.analyzed.name.ends_with(&format!("__{name}"))
+                })
+                .map(|function| function.analyzed.air.return_type())
+                .expect("function should retain its source parameter type")
+        };
+        assert_eq!(parameter_type("qualified"), Type::new_struct(canonical_id));
+        assert_eq!(parameter_type("aliased"), Type::new_struct(canonical_id));
+
+        for &target in Target::all() {
+            for function in semantic.functions() {
+                generate_mir(
+                    &function.cfg,
+                    pool,
+                    rir.semantic_symbols().interner(),
+                    target,
+                )
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "canonical source StrBuf function {} should lower for {target}: {error}",
+                        function.analyzed.name
+                    )
+                });
+            }
+        }
+    }
+
+    #[test]
+    fn caller_logical_std_spelling_cannot_spoof_strbuf_language_item() {
+        let root = FileId::new(1);
+        let spoof_file = FileId::new(2);
+        let metadata = SourceMetadata::new(
+            root,
+            [
+                (root, "main.rue".to_owned()),
+                (spoof_file, "spoof.rue".to_owned()),
+            ]
+            .into(),
+            [
+                (root, "main.rue".to_owned()),
+                (spoof_file, "\0rue-std/strbuf.rue".to_owned()),
+            ]
+            .into(),
+        )
+        .unwrap();
+        let snapshot = SourceSnapshot::from_sources(
+            &[
+                SourceView::new(
+                    "main.rue",
+                    "const spoof = @import(\"spoof.rue\"); fn main() -> i32 { 0 }",
+                    root,
+                ),
+                SourceView::new("spoof.rue", "pub struct StrBuf { value: i32 }", spoof_file),
+            ],
+            metadata,
+        )
+        .unwrap();
+        let (_, semantic, _) = test_frontend_snapshot(&snapshot, &CompileOptions::default())
+            .expect("caller-authored sentinel spelling remains an ordinary module");
+        let spoof = semantic
+            .type_pool()
+            .all_struct_ids()
+            .into_iter()
+            .find(|id| {
+                let def = semantic.type_pool().struct_def(*id);
+                def.name == "StrBuf" && def.file_id == spoof_file
+            })
+            .unwrap();
+        assert_eq!(semantic.type_pool().struct_lang_item(spoof), None);
+        assert!(!semantic.type_pool().is_strbuf(spoof));
+    }
+
+    #[test]
     fn canonical_single_source_adapter_executes_each_frontend_phase_once() {
         let snapshot = SourceSnapshot::single("<test>", "fn main() -> i32 { 42 }").unwrap();
         let (_rir, semantic, session) =

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -235,6 +235,13 @@ impl fmt::Display for SourceId {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModuleId {
     logical_path: Arc<str>,
+    origin: ModuleOrigin,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum ModuleOrigin {
+    Caller,
+    StandardLibrary,
 }
 
 impl ModuleId {
@@ -247,6 +254,7 @@ impl ModuleId {
         }
         Ok(Self {
             logical_path: path.into(),
+            origin: ModuleOrigin::Caller,
         })
     }
     pub(crate) fn from_validated_canonical(path: &str) -> Self {
@@ -254,7 +262,31 @@ impl ModuleId {
         debug_assert_eq!(normalize_module_path(path), path);
         Self {
             logical_path: Arc::from(path),
+            origin: ModuleOrigin::Caller,
         }
+    }
+    pub(crate) fn from_trusted_standard_library_path(path: impl AsRef<str>) -> CompileResult<Self> {
+        let path = normalize_module_path(path.as_ref());
+        if !path.starts_with("\0rue-std/") {
+            return Err(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "trusted standard-library module is outside the standard-library namespace".into(),
+            )));
+        }
+        Ok(Self {
+            logical_path: path.into(),
+            origin: ModuleOrigin::StandardLibrary,
+        })
+    }
+    pub(crate) fn from_trusted_validated_canonical(path: &str) -> Self {
+        debug_assert!(path.starts_with("\0rue-std/"));
+        debug_assert_eq!(normalize_module_path(path), path);
+        Self {
+            logical_path: Arc::from(path),
+            origin: ModuleOrigin::StandardLibrary,
+        }
+    }
+    pub fn is_trusted_standard_library(&self) -> bool {
+        self.origin == ModuleOrigin::StandardLibrary
     }
     pub fn logical_path(&self) -> &str {
         &self.logical_path
@@ -395,13 +427,11 @@ impl ModuleResolutionInputs {
     }
 
     pub fn from_metadata(metadata: &SourceMetadata) -> Self {
-        let root = ModuleId::from_validated_canonical(
-            metadata.logical_path(metadata.root_file_id()).unwrap(),
-        );
+        let root = metadata.root_module_id();
         let modules: Vec<_> = metadata
             .file_ids()
             .map(|id| ModuleResolutionInput {
-                module: ModuleId::from_validated_canonical(metadata.logical_path(id).unwrap()),
+                module: metadata.module_id(id).unwrap(),
                 physical_path: Arc::from(metadata.physical_path(id).unwrap()),
             })
             .collect();

--- a/crates/rue-compiler/src/source_metadata.rs
+++ b/crates/rue-compiler/src/source_metadata.rs
@@ -6,9 +6,7 @@
 //! of the checkout location. Keeping both maps together with an explicit root
 //! makes it impossible for those coupled inputs to drift after construction.
 
-use std::collections::HashMap;
-#[cfg(test)]
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use rue_air::normalize_module_path;
 use rue_error::{CompileError, CompileResult, ErrorKind};
@@ -29,6 +27,7 @@ pub struct SourceMetadata {
     sorted_ids: Vec<FileId>,
     physical_paths: HashMap<FileId, String>,
     logical_paths: HashMap<FileId, String>,
+    trusted_standard_library_files: HashSet<FileId>,
 }
 
 impl SourceMetadata {
@@ -96,7 +95,31 @@ impl SourceMetadata {
             sorted_ids: file_ids,
             physical_paths,
             logical_paths,
+            trusted_standard_library_files: HashSet::new(),
         })
+    }
+
+    pub(crate) fn new_with_trusted_standard_library(
+        root_file_id: FileId,
+        physical_paths: HashMap<FileId, String>,
+        logical_paths: HashMap<FileId, String>,
+        trusted_standard_library_files: HashSet<FileId>,
+    ) -> CompileResult<Self> {
+        let mut metadata = Self::new(root_file_id, physical_paths, logical_paths)?;
+        for file_id in &trusted_standard_library_files {
+            let Some(path) = metadata.logical_path(*file_id) else {
+                return Err(invalid_input(
+                    "trusted standard-library file is absent from metadata",
+                ));
+            };
+            if !path.starts_with("\0rue-std/") {
+                return Err(invalid_input(
+                    "trusted standard-library file has a non-standard logical path",
+                ));
+            }
+        }
+        metadata.trusted_standard_library_files = trusted_standard_library_files;
+        Ok(metadata)
     }
 
     #[cfg(test)]
@@ -206,8 +229,12 @@ impl SourceMetadata {
 
     /// Canonical logical module identity for a request-local file ID.
     pub fn module_id(&self, file_id: FileId) -> Option<ModuleId> {
-        self.logical_path(file_id)
-            .map(ModuleId::from_validated_canonical)
+        let path = self.logical_path(file_id)?;
+        Some(if self.trusted_standard_library_files.contains(&file_id) {
+            ModuleId::from_trusted_validated_canonical(path)
+        } else {
+            ModuleId::from_validated_canonical(path)
+        })
     }
 
     /// Canonical logical identity of the explicitly designated root module.

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -78,7 +78,22 @@ impl SourceSnapshot {
             .iter()
             .map(|module| (module.file_id(), module.module_id().as_str().to_owned()))
             .collect();
-        let metadata = SourceMetadata::new(root_file_id, physical_paths, logical_paths)?;
+        let trusted_standard_library_files = program
+            .modules()
+            .iter()
+            .filter_map(|module| {
+                module
+                    .module_id()
+                    .is_trusted_standard_library()
+                    .then_some(module.file_id())
+            })
+            .collect();
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            root_file_id,
+            physical_paths,
+            logical_paths,
+            trusted_standard_library_files,
+        )?;
         validate_source_lengths(
             program
                 .modules()
@@ -199,11 +214,7 @@ impl SourceSnapshot {
         let candidates: Vec<_> = contents
             .into_iter()
             .map(|(file_id, text)| {
-                let module_id = ModuleId::from_validated_canonical(
-                    metadata
-                        .logical_path(file_id)
-                        .expect("validated membership"),
-                );
+                let module_id = metadata.module_id(file_id).expect("validated membership");
                 let source_id = SourceId::from_shared_text(text);
                 (file_id, module_id, source_id)
             })
@@ -241,11 +252,7 @@ impl SourceSnapshot {
             .enumerate()
             .map(|(index, record)| (record.file_id, index))
             .collect();
-        let root_module = ModuleId::from_validated_canonical(
-            metadata
-                .logical_path(metadata.root_file_id())
-                .expect("validated root"),
-        );
+        let root_module = metadata.root_module_id();
         let revision = SourceRevision::new(
             root_module,
             contents
@@ -647,6 +654,59 @@ mod tests {
                 .map(|m| m.module.as_str())
                 .collect::<Vec<_>>(),
             ["app/helper.rue", "app/main.rue"]
+        );
+    }
+
+    #[test]
+    fn parsed_module_reassembly_preserves_typed_module_origin() {
+        let root = FileId::new(7);
+        let standard_library = FileId::new(11);
+        let physical = HashMap::from([
+            (root, "/project/main.rue".to_owned()),
+            (standard_library, "/sdk/strbuf.rue".to_owned()),
+        ]);
+        let logical = HashMap::from([
+            (root, "app/main.rue".to_owned()),
+            (standard_library, "\0rue-std/strbuf.rue".to_owned()),
+        ]);
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            root,
+            physical,
+            logical,
+            HashSet::from([standard_library]),
+        )
+        .unwrap();
+        let original = SourceSnapshot::new(
+            metadata,
+            vec![
+                (root, Arc::new("fn main() {}".to_owned())),
+                (
+                    standard_library,
+                    Arc::new("pub struct StrBuf {}".to_owned()),
+                ),
+            ],
+        )
+        .unwrap();
+        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&original).unwrap();
+
+        let reconstructed = SourceSnapshot::from_parsed_modules(&parsed).unwrap();
+        for module in parsed.modules() {
+            assert_eq!(
+                reconstructed.metadata().module_id(module.file_id()),
+                Some(module.module_id().clone())
+            );
+        }
+        assert!(
+            reconstructed
+                .module_id(standard_library)
+                .unwrap()
+                .is_trusted_standard_library()
+        );
+        assert!(
+            !reconstructed
+                .module_id(root)
+                .unwrap()
+                .is_trusted_standard_library()
         );
     }
 


### PR DESCRIPTION
## Summary

- give canonical `std.strbuf.StrBuf` a trusted, relocation-stable language-item identity established by std-root-validated import discovery
- carry that identity through source revisions, semantic declaration shells, durable reconstruction, type-pool cloning, semantic analysis, ABI classification, and both codegen backends
- keep source-defined methods and drop glue authoritative while retaining the synthetic runtime-backed StrBuf as an explicitly separate transition
- prove aliases preserve nominal identity and same-spelled user structs receive no string behavior

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue cli std_strbuf`
- AIR tests: 427/427
- compiler tests: 443/443
- x86-64 and AArch64 MIR lowering coverage
- `git diff --check`

Fixes RUE-873
