### PR TITLE
RUE-847: make safe allocation failure fail fast

### DIFF
--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -53,6 +53,34 @@ fn main() -> i32 {
 """ }]
 exit_code = 112
 
+[[case]]
+name = "realloc_failure_preserves_original"
+description = "A failed @realloc returns null while the original u8 allocation and contents remain valid."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(4);
+        @ptr_write(p, 10);
+        @ptr_write(@ptr_offset(p, 1), 20);
+        @ptr_write(@ptr_offset(p, 2), 30);
+        @ptr_write(@ptr_offset(p, 3), 40);
+        let q: ptr mut u8 = @realloc(p, 4, 2305843009213693951);
+        if @ptr_to_int(q) == 0 {
+            let sum: i32 = @intCast(@ptr_read(p))
+                + @intCast(@ptr_read(@ptr_offset(p, 1)))
+                + @intCast(@ptr_read(@ptr_offset(p, 2)))
+                + @intCast(@ptr_read(@ptr_offset(p, 3)));
+            @free(p, 4);
+            sum
+        } else {
+            @free(q, 2305843009213693951);
+            1
+        }
+    }
+}
+""" }]
+exit_code = 100
+
 # @free called from a user destructor: the whole owned-buffer-with-drop pattern
 # works on a concrete named struct (the generic-struct attachment is blocked;
 # see the meta report). Prints the live value, then the destructor's marker.

--- a/crates/rue-cli-tests/cases/string_alloc_failure.toml
+++ b/crates/rue-cli-tests/cases/string_alloc_failure.toml
@@ -1,31 +1,40 @@
-# StrBuf.with_capacity allocation-failure safety (RUE-255).
+# Safe allocation failure behavior (RUE-847).
 #
-# A huge requested capacity makes the heap allocation fail and return null.
-# with_capacity used to store ptr=null / cap=<huge> unconditionally, so a
-# later push saw "capacity sufficient" and wrote through the null pointer —
-# SIGSEGV (memory-unsafe). It must instead record cap=0 on failure so a later
-# push grows a fresh buffer (or the program traps cleanly), never a nonzero
-# capacity backed by null.
+# Huge requests are deterministic and bounded on every supported platform:
+# allocator arithmetic rejects them before entering an unbounded allocation
+# loop. Safe owners trap through the same allocation-free `@panic` diagnostic;
+# the raw heap-intrinsic cases remain separately covered as null-returning.
 
 [section]
 id = "cli.string_alloc_failure"
-name = "StrBuf allocation-failure safety"
-description = "StrBuf.with_capacity must not poison capacity when allocation fails."
+name = "Safe allocation failure behavior"
+description = "Safe infallible owners trap canonically on allocation failure and preserve zero-capacity construction."
 
 [[case]]
-name = "with_capacity_huge_no_segfault"
-description = "with_capacity(u64::MAX) fails the alloc: capacity reports 0 and a subsequent push grows fresh instead of writing through null (no SIGSEGV)."
+name = "strbuf_with_capacity_huge_traps"
+description = "StrBuf.with_capacity(u64::MAX) fails fast with the canonical allocation diagnostic."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let mut s = StrBuf.with_capacity(18446744073709551615);
+    let s = StrBuf.with_capacity(18446744073709551615);
     @dbg(s.capacity());
-    s.push(65);
-    @dbg(s.len());
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: out of memory"]
+
+[[case]]
+name = "strbuf_zero_capacity_does_not_allocate"
+description = "StrBuf.with_capacity(0) succeeds as the canonical null, zero-capacity value."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = StrBuf.with_capacity(0);
+    @dbg(s.capacity());
     0
 }
 """ }]
 exit_code = 0
-stdout = "0\n1\n"
+stdout = "0\n"
 
 [[case]]
 name = "with_capacity_normal_reserves"
@@ -41,3 +50,73 @@ fn main() -> i32 {
 """ }]
 exit_code = 0
 stdout = "16\n1\n"
+
+[[case]]
+name = "arraybuf_with_capacity_huge_traps"
+description = "Source ArrayBuf rejects an overflowing byte capacity through the same canonical trap."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let V = std.arraybuf.ArrayBuf(u64);
+    let v = V.with_capacity(18446744073709551615);
+    @dbg(v.capacity());
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: out of memory"]
+
+[[case]]
+name = "arraybuf_growth_overflow_traps"
+description = "ArrayBuf doubling overflow fails through the allocation trap instead of wrapping capacity."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let V = std.arraybuf.ArrayBuf(u8);
+    let mut v = V.new();
+    v.len = 9223372036854775808;
+    v.cap = 9223372036854775808;
+    v.push(1);
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: out of memory"]
+
+[[case]]
+name = "grid_capacity_overflow_traps"
+description = "A dependent source collection rejects row-count overflow through the canonical allocation trap."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let G = std.grid.Grid2D(u8);
+    let g = G.new(18446744073709551615, 2, 0);
+    @dbg(g.rows());
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: out of memory"]
+
+[[case]]
+name = "arraybuf_zero_capacity_does_not_allocate"
+description = "Source ArrayBuf.with_capacity(0) succeeds with null storage and zero capacity."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let V = std.arraybuf.ArrayBuf(u64);
+    let v = V.with_capacity(0);
+    @dbg(v.capacity());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "0\n"

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -207,6 +207,12 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.heap_intrinsics",
+        "realloc_failure_preserves_original",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "cli.heap_intrinsics",
         "realloc_grows_and_preserves",
         intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
@@ -603,7 +609,13 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.string_alloc_failure",
-        "with_capacity_huge_no_segfault",
+        "strbuf_with_capacity_huge_traps",
+        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        &[],
+    ),
+    Entry::new(
+        "cli.string_alloc_failure",
+        "strbuf_zero_capacity_does_not_allocate",
         implementation_defined(ImplementationDefinedKind::StringCapacityValue),
         &[],
     ),

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -276,6 +276,12 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "runtime.allocation-failure",
+        "strbuf_allocation_failure_traps",
+        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
+        &[],
+    ),
+    Entry::new(
         "runtime.heap",
         "alloc_multiple_elements",
         intrinsic(UnsupportedIntrinsicKind::Allocate),
@@ -290,6 +296,12 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "runtime.heap",
         "alloc_write_read",
+        intrinsic(UnsupportedIntrinsicKind::Allocate),
+        &[],
+    ),
+    Entry::new(
+        "runtime.heap",
+        "realloc_failure_preserves_original",
         intrinsic(UnsupportedIntrinsicKind::Allocate),
         &[],
     ),
@@ -693,6 +705,12 @@ const ENTRIES: &[Entry] = &[
         "types.strings",
         "string_substring_out_of_bounds_traps",
         runtime_call(UnsupportedRuntimeCallKind::StringSubstring),
+        &[],
+    ),
+    Entry::new(
+        "types.strings",
+        "string_with_capacity_zero",
+        implementation_defined(ImplementationDefinedKind::StringCapacityValue),
         &[],
     ),
 ];

--- a/crates/rue-runtime/src/error.rs
+++ b/crates/rue-runtime/src/error.rs
@@ -10,6 +10,32 @@
 
 use crate::platform;
 
+/// Abort a safe, infallible allocation operation after it fails.
+///
+/// This deliberately routes through the same `@panic` implementation used by
+/// source-level owners such as `ArrayBuf`, so every safe allocation failure has
+/// one stable, allocation-free diagnostic and exit status.
+#[inline]
+pub(crate) fn allocation_failure() -> ! {
+    let mut msg = [0u8; 13];
+    msg[0] = b'o';
+    msg[1] = b'u';
+    msg[2] = b't';
+    msg[3] = b' ';
+    msg[4] = b'o';
+    msg[5] = b'f';
+    msg[6] = b' ';
+    msg[7] = b'm';
+    msg[8] = b'e';
+    msg[9] = b'm';
+    msg[10] = b'o';
+    msg[11] = b'r';
+    msg[12] = b'y';
+    // SAFETY: `msg` is live for the non-returning call and describes exactly
+    // 13 initialized bytes.
+    unsafe { __rue_panic(msg.as_ptr(), msg.len() as u64) }
+}
+
 crate::define_for_all_platforms! {
     /// Runtime error: division by zero.
     ///
@@ -416,6 +442,7 @@ mod tests {
         assert_eq!(b"panic: ".len(), 7);
         assert_eq!(b"panic\n".len(), 6);
         assert_eq!(b"assertion failed\n".len(), 17);
+        assert_eq!(b"out of memory".len(), 13);
     }
 
     #[test]

--- a/crates/rue-runtime/src/heap.rs
+++ b/crates/rue-runtime/src/heap.rs
@@ -38,6 +38,41 @@ use crate::platform;
 use core::ptr;
 use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+std::thread_local! {
+    /// Test-only fault seam at the raw allocator boundary. Production builds
+    /// contain no counter or alternate allocation path; native CI on each
+    /// supported platform uses this to exercise safe consumers deterministically.
+    static ALLOCATIONS_BEFORE_FAILURE: core::cell::Cell<Option<usize>> = const {
+        core::cell::Cell::new(None)
+    };
+}
+
+#[cfg(test)]
+pub(crate) fn fail_allocations_after_for_test(successful_allocations: usize) {
+    ALLOCATIONS_BEFORE_FAILURE.set(Some(successful_allocations));
+}
+
+#[cfg(test)]
+pub(crate) fn disable_allocation_failure_for_test() {
+    ALLOCATIONS_BEFORE_FAILURE.set(None);
+}
+
+#[cfg(test)]
+fn injected_allocation_failure() -> bool {
+    ALLOCATIONS_BEFORE_FAILURE.get().is_some_and(|remaining| {
+        if remaining == 0 {
+            true
+        } else {
+            ALLOCATIONS_BEFORE_FAILURE.set(Some(remaining - 1));
+            false
+        }
+    })
+}
+
 /// Default arena size: 64 KiB
 ///
 /// This is chosen to be:
@@ -187,6 +222,11 @@ fn alloc_arena(min_size: usize, align: usize) -> *mut ArenaHeader {
 /// The returned pointer (if non-null) is valid and properly aligned.
 /// The memory remains valid until the program exits.
 pub fn alloc(size: u64, align: u64) -> *mut u8 {
+    #[cfg(test)]
+    if injected_allocation_failure() {
+        return ptr::null_mut();
+    }
+
     // Validate arguments. `align` is also capped at the page size: the arena
     // base is only page-aligned (mmap), and blocks are placed at an offset
     // aligned relative to that base, so an `align` greater than a page could
@@ -502,6 +542,26 @@ mod tests {
         // must now return null instead.
         let ptr = alloc((usize::MAX as u64) - 124, 1);
         assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn failed_realloc_preserves_old_allocation() {
+        let old_ptr = alloc(4, 1);
+        assert!(!old_ptr.is_null());
+        unsafe {
+            old_ptr.write(11);
+            old_ptr.add(1).write(22);
+            old_ptr.add(2).write(33);
+            old_ptr.add(3).write(44);
+        }
+
+        fail_allocations_after_for_test(0);
+        let grown = realloc(old_ptr, 4, 8, 1);
+        disable_allocation_failure_for_test();
+
+        assert!(grown.is_null());
+        let bytes = unsafe { core::slice::from_raw_parts(old_ptr, 4) };
+        assert_eq!(bytes, &[11, 22, 33, 44]);
     }
 
     #[test]

--- a/crates/rue-runtime/src/io.rs
+++ b/crates/rue-runtime/src/io.rs
@@ -204,31 +204,7 @@ fn read_line_impl(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) 
     let mut cap = READ_LINE_INITIAL_CAPACITY;
     let mut ptr = heap::alloc(cap, 1);
     if ptr.is_null() {
-        // Allocation failed - panic
-        let mut msg = [0u8; 21];
-        msg[0] = b'e';
-        msg[1] = b'r';
-        msg[2] = b'r';
-        msg[3] = b'o';
-        msg[4] = b'r';
-        msg[5] = b':';
-        msg[6] = b' ';
-        msg[7] = b'o';
-        msg[8] = b'u';
-        msg[9] = b't';
-        msg[10] = b' ';
-        msg[11] = b'o';
-        msg[12] = b'f';
-        msg[13] = b' ';
-        msg[14] = b'm';
-        msg[15] = b'e';
-        msg[16] = b'm';
-        msg[17] = b'o';
-        msg[18] = b'r';
-        msg[19] = b'y';
-        msg[20] = b'\n';
-        platform::write_stderr(&msg);
-        platform::exit(101);
+        crate::error::allocation_failure();
     }
 
     let mut len: u64 = 0;
@@ -299,13 +275,14 @@ fn read_line_impl(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) 
         // Need to store this byte - ensure we have capacity
         if len >= cap {
             // Grow the buffer (2x strategy)
-            let new_cap = cap.saturating_mul(2).max(STRING_MIN_CAPACITY);
+            let Some(new_cap) = cap.checked_mul(2) else {
+                crate::error::allocation_failure();
+            };
+            let new_cap = new_cap.max(STRING_MIN_CAPACITY);
             let new_ptr = heap::realloc(ptr, cap, new_cap, 1);
             if new_ptr.is_null() {
-                // Realloc failed - free old buffer and panic
-                heap::free(ptr, cap, 1);
-                platform::write_stderr(b"error: out of memory\n");
-                platform::exit(101);
+                // Keep the old allocation intact until the canonical trap.
+                crate::error::allocation_failure();
             }
             ptr = new_ptr;
             cap = new_cap;
@@ -329,5 +306,41 @@ fn read_line_impl(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) 
         (*out).ptr = ptr;
         (*out).len = len;
         (*out).cap = cap;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use self::std::process::Command;
+
+    #[test]
+    fn read_line_allocation_failure_uses_canonical_trap() {
+        const CHILD_ENV: &str = "RUE_READ_LINE_OOM_CHILD";
+        if self::std::env::var_os(CHILD_ENV).is_some() {
+            crate::heap::fail_allocations_after_for_test(0);
+            let mut out = super::OptionStringResult {
+                disc: 0,
+                ptr: core::ptr::null_mut(),
+                len: 0,
+                cap: 0,
+            };
+            super::read_line_impl(&mut out, 1, 0);
+            unreachable!();
+        }
+
+        let output = Command::new(self::std::env::current_exe().expect("current test binary"))
+            .args([
+                "--exact",
+                "io::tests::read_line_allocation_failure_uses_canonical_trap",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("spawn allocation-failure child");
+
+        assert_eq!(output.status.code(), Some(101));
+        assert_eq!(output.stderr, b"panic: out of memory\n");
     }
 }

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -311,22 +311,19 @@ pub unsafe extern "C" fn __rue_String_new(out: *mut StringResult) {
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 pub unsafe extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_cap: u64) {
+    if requested_cap == 0 {
+        unsafe { __rue_String_new(out) };
+        return;
+    }
     let actual_cap = if requested_cap < STRING_MIN_CAPACITY {
         STRING_MIN_CAPACITY
     } else {
         requested_cap
     };
     let ptr = heap::alloc(actual_cap, 1);
-    // On allocation failure `heap::alloc` returns null. Store cap=0 (not the
-    // requested capacity) so a later `push` sees "no room", grows fresh from
-    // the null buffer (or traps cleanly), rather than believing it may write
-    // `actual_cap` bytes through a null pointer (RUE-255). Mirrors the null
-    // handling in `__rue_String_clone` and `string_ensure_capacity`.
-    let (ptr, actual_cap) = if ptr.is_null() {
-        (core::ptr::null_mut(), 0)
-    } else {
-        (ptr, actual_cap)
-    };
+    if ptr.is_null() {
+        crate::error::allocation_failure();
+    }
     unsafe {
         (*out).ptr = ptr;
         (*out).len = 0;
@@ -341,22 +338,19 @@ pub unsafe extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requ
 ///
 /// `out` must be valid, aligned, exclusively writable [`StringResult`] storage.
 pub unsafe extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_cap: u64) {
+    if requested_cap == 0 {
+        unsafe { __rue_String_new(out) };
+        return;
+    }
     let actual_cap = if requested_cap < STRING_MIN_CAPACITY {
         STRING_MIN_CAPACITY
     } else {
         requested_cap
     };
     let ptr = heap::alloc(actual_cap, 1);
-    // On allocation failure `heap::alloc` returns null. Store cap=0 (not the
-    // requested capacity) so a later `push` sees "no room", grows fresh from
-    // the null buffer (or traps cleanly), rather than believing it may write
-    // `actual_cap` bytes through a null pointer (RUE-255). Mirrors the null
-    // handling in `__rue_String_clone` and `string_ensure_capacity`.
-    let (ptr, actual_cap) = if ptr.is_null() {
-        (core::ptr::null_mut(), 0)
-    } else {
-        (ptr, actual_cap)
-    };
+    if ptr.is_null() {
+        crate::error::allocation_failure();
+    }
     unsafe {
         (*out).ptr = ptr;
         (*out).len = 0;
@@ -371,22 +365,19 @@ pub unsafe extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requ
 ///
 /// `out` must be valid, aligned, exclusively writable [`StringResult`] storage.
 pub unsafe extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_cap: u64) {
+    if requested_cap == 0 {
+        unsafe { __rue_String_new(out) };
+        return;
+    }
     let actual_cap = if requested_cap < STRING_MIN_CAPACITY {
         STRING_MIN_CAPACITY
     } else {
         requested_cap
     };
     let ptr = heap::alloc(actual_cap, 1);
-    // On allocation failure `heap::alloc` returns null. Store cap=0 (not the
-    // requested capacity) so a later `push` sees "no room", grows fresh from
-    // the null buffer (or traps cleanly), rather than believing it may write
-    // `actual_cap` bytes through a null pointer (RUE-255). Mirrors the null
-    // handling in `__rue_String_clone` and `string_ensure_capacity`.
-    let (ptr, actual_cap) = if ptr.is_null() {
-        (core::ptr::null_mut(), 0)
-    } else {
-        (ptr, actual_cap)
-    };
+    if ptr.is_null() {
+        crate::error::allocation_failure();
+    }
     unsafe {
         (*out).ptr = ptr;
         (*out).len = 0;
@@ -932,16 +923,8 @@ crate::define_for_all_platforms! {
         };
         let new_ptr = heap::alloc(new_cap, 1);
 
-        // Check for allocation failure before the copy to avoid UB (mirrors
-        // __rue_String_clone): on OOM, publish an empty String and return.
         if new_ptr.is_null() {
-            // SAFETY: writing to `out` is valid — see __rue_String_new.
-            unsafe {
-                (*out).ptr = core::ptr::null_mut();
-                (*out).len = 0;
-                (*out).cap = 0;
-            }
-            return;
+            crate::error::allocation_failure();
         }
 
         // SAFETY: `start + sub_len <= len` (checked above) so the source range
@@ -1122,16 +1105,8 @@ crate::define_for_all_platforms! {
         };
         let new_ptr = heap::alloc(new_cap, 1);
 
-        // Check for allocation failure before the copy to avoid UB (mirrors
-        // __rue_String_clone): on OOM, publish an empty String and return.
         if new_ptr.is_null() {
-            // SAFETY: writing to `out` is valid — see __rue_String_new.
-            unsafe {
-                (*out).ptr = core::ptr::null_mut();
-                (*out).len = 0;
-                (*out).cap = 0;
-            }
-            return;
+            crate::error::allocation_failure();
         }
 
         // SAFETY: `new_ptr` was just allocated with `new_cap >= len` bytes; the
@@ -1196,16 +1171,8 @@ crate::define_for_all_platforms! {
         };
         let new_ptr = heap::alloc(new_cap, 1);
 
-        // Check for allocation failure before the copy to avoid UB (mirrors
-        // __rue_String_clone): on OOM, publish an empty String and return.
         if new_ptr.is_null() {
-            // SAFETY: writing to `out` is valid — see __rue_String_new.
-            unsafe {
-                (*out).ptr = core::ptr::null_mut();
-                (*out).len = 0;
-                (*out).cap = 0;
-            }
-            return;
+            crate::error::allocation_failure();
         }
 
         // SAFETY: `new_ptr` was just allocated with `new_cap >= len` bytes; the
@@ -1252,7 +1219,9 @@ crate::define_for_all_platforms! {
         len2: u64,
         _cap2: u64,
     ) {
-        let total = len1 + len2;
+        let Some(total) = len1.checked_add(len2) else {
+            crate::error::allocation_failure();
+        };
 
         if total == 0 {
             // Empty result: a valid literal-like String (cap == 0, ptr null)
@@ -1273,16 +1242,8 @@ crate::define_for_all_platforms! {
         };
         let new_ptr = heap::alloc(new_cap, 1);
 
-        // Check for allocation failure before the copy to avoid UB (mirrors
-        // __rue_String_clone): on OOM, publish an empty String and return.
         if new_ptr.is_null() {
-            // SAFETY: writing to `out` is valid — see __rue_String_new.
-            unsafe {
-                (*out).ptr = core::ptr::null_mut();
-                (*out).len = 0;
-                (*out).cap = 0;
-            }
-            return;
+            crate::error::allocation_failure();
         }
 
         // SAFETY: `new_ptr` has `new_cap >= total = len1 + len2` bytes. The two
@@ -1343,15 +1304,8 @@ pub unsafe extern "C" fn __rue_String_clone(
     let new_cap = len.max(STRING_MIN_CAPACITY);
     let new_ptr = heap::alloc(new_cap, 1);
 
-    // Check for allocation failure before copy to avoid UB
     if new_ptr.is_null() {
-        // SAFETY: Writing to `out` is safe - see __rue_String_new for rationale
-        unsafe {
-            (*out).ptr = core::ptr::null_mut();
-            (*out).len = 0;
-            (*out).cap = 0;
-        }
-        return;
+        crate::error::allocation_failure();
     }
 
     if len > 0 && !ptr.is_null() {
@@ -1389,15 +1343,8 @@ pub unsafe extern "C" fn __rue_String_clone(
     let new_cap = len.max(STRING_MIN_CAPACITY);
     let new_ptr = heap::alloc(new_cap, 1);
 
-    // Check for allocation failure before copy to avoid UB
     if new_ptr.is_null() {
-        // SAFETY: Writing to `out` is safe - see __rue_String_new for rationale
-        unsafe {
-            (*out).ptr = core::ptr::null_mut();
-            (*out).len = 0;
-            (*out).cap = 0;
-        }
-        return;
+        crate::error::allocation_failure();
     }
 
     if len > 0 && !ptr.is_null() {
@@ -1435,15 +1382,8 @@ pub unsafe extern "C" fn __rue_String_clone(
     let new_cap = len.max(STRING_MIN_CAPACITY);
     let new_ptr = heap::alloc(new_cap, 1);
 
-    // Check for allocation failure before copy to avoid UB
     if new_ptr.is_null() {
-        // SAFETY: Writing to `out` is safe - see __rue_String_new for rationale
-        unsafe {
-            (*out).ptr = core::ptr::null_mut();
-            (*out).len = 0;
-            (*out).cap = 0;
-        }
-        return;
+        crate::error::allocation_failure();
     }
 
     if len > 0 && !ptr.is_null() {
@@ -1509,19 +1449,6 @@ pub unsafe extern "C" fn __rue_String_push_str(
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, other_len);
 
-    // On allocation failure `string_ensure_capacity` returns a null pointer;
-    // writing to `new_ptr.add(len)` would be a wild write. Republish the
-    // original string unchanged instead (matching the null-guard every sibling
-    // allocator uses).
-    if new_ptr.is_null() {
-        unsafe {
-            (*out).ptr = ptr;
-            (*out).len = len;
-            (*out).cap = cap;
-        }
-        return;
-    }
-
     if other_len > 0 && !other_ptr.is_null() {
         // SAFETY: Copying is safe because:
         // - Caller guarantees `other_ptr` is valid for reads of `other_len` bytes
@@ -1566,19 +1493,6 @@ pub unsafe extern "C" fn __rue_String_push_str(
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, other_len);
 
-    // On allocation failure `string_ensure_capacity` returns a null pointer;
-    // writing to `new_ptr.add(len)` would be a wild write. Republish the
-    // original string unchanged instead (matching the null-guard every sibling
-    // allocator uses).
-    if new_ptr.is_null() {
-        unsafe {
-            (*out).ptr = ptr;
-            (*out).len = len;
-            (*out).cap = cap;
-        }
-        return;
-    }
-
     if other_len > 0 && !other_ptr.is_null() {
         // SAFETY: Copying is safe because:
         // - Caller guarantees `other_ptr` is valid for reads of `other_len` bytes
@@ -1622,19 +1536,6 @@ pub unsafe extern "C" fn __rue_String_push_str(
     _other_cap: u64,
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, other_len);
-
-    // On allocation failure `string_ensure_capacity` returns a null pointer;
-    // writing to `new_ptr.add(len)` would be a wild write. Republish the
-    // original string unchanged instead (matching the null-guard every sibling
-    // allocator uses).
-    if new_ptr.is_null() {
-        unsafe {
-            (*out).ptr = ptr;
-            (*out).len = len;
-            (*out).cap = cap;
-        }
-        return;
-    }
 
     if other_len > 0 && !other_ptr.is_null() {
         // SAFETY: Copying is safe because:
@@ -1688,17 +1589,6 @@ pub unsafe extern "C" fn __rue_String_push(
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, 1);
 
-    // On allocation failure `new_ptr` is null; republish the original string
-    // unchanged rather than write through null + len.
-    if new_ptr.is_null() {
-        unsafe {
-            (*out).ptr = ptr;
-            (*out).len = len;
-            (*out).cap = cap;
-        }
-        return;
-    }
-
     // SAFETY: Writing the byte is safe because:
     // - `string_ensure_capacity` guarantees `new_ptr` has room for `len + 1` bytes
     // - `new_ptr.add(len)` points to the first unused byte after existing content
@@ -1734,17 +1624,6 @@ pub unsafe extern "C" fn __rue_String_push(
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, 1);
 
-    // On allocation failure `new_ptr` is null; republish the original string
-    // unchanged rather than write through null + len.
-    if new_ptr.is_null() {
-        unsafe {
-            (*out).ptr = ptr;
-            (*out).len = len;
-            (*out).cap = cap;
-        }
-        return;
-    }
-
     // SAFETY: Writing the byte is safe because:
     // - `string_ensure_capacity` guarantees `new_ptr` has room for `len + 1` bytes
     // - `new_ptr.add(len)` points to the first unused byte after existing content
@@ -1779,17 +1658,6 @@ pub unsafe extern "C" fn __rue_String_push(
     byte: u8,
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, 1);
-
-    // On allocation failure `new_ptr` is null; republish the original string
-    // unchanged rather than write through null + len.
-    if new_ptr.is_null() {
-        unsafe {
-            (*out).ptr = ptr;
-            (*out).len = len;
-            (*out).cap = cap;
-        }
-        return;
-    }
 
     // SAFETY: Writing the byte is safe because:
     // - `string_ensure_capacity` guarantees `new_ptr` has room for `len + 1` bytes
@@ -1983,18 +1851,24 @@ pub unsafe extern "C" fn __rue_String_reserve(
 /// # Returns
 ///
 /// (new_ptr, new_cap) with capacity >= len + additional.
-/// Returns (null, 0) if allocation fails.
+/// Allocation or capacity overflow aborts through the canonical allocation
+/// failure path. A zero-sized request preserves the original empty value.
 #[inline]
 fn string_ensure_capacity(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> (*mut u8, u64) {
-    let required = len.saturating_add(additional);
+    let Some(required) = len.checked_add(additional) else {
+        crate::error::allocation_failure();
+    };
+
+    if required == 0 {
+        return (ptr, cap);
+    }
 
     if cap == 0 {
         // Heap promotion: allocate new buffer and copy existing content
         let new_cap = required.max(STRING_MIN_CAPACITY);
         let new_ptr = heap::alloc(new_cap, 1);
-        // Check for allocation failure before copy to avoid UB
         if new_ptr.is_null() {
-            return (core::ptr::null_mut(), 0);
+            crate::error::allocation_failure();
         }
         if len > 0 && !ptr.is_null() {
             // SAFETY: Copying is safe because:
@@ -2012,12 +1886,16 @@ fn string_ensure_capacity(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> 
         // so compute the doubled capacity first and allocate exactly that
         // amount. Otherwise a later append could trust nonexistent capacity
         // and write past the allocation (RUE-34).
-        let grown_cap = cap.saturating_mul(2);
+        let Some(grown_cap) = cap.checked_mul(2) else {
+            crate::error::allocation_failure();
+        };
         let new_cap = required.max(grown_cap).max(STRING_MIN_CAPACITY);
         let new_ptr = heap::realloc(ptr, cap, new_cap, 1);
-        // Check for allocation failure
         if new_ptr.is_null() {
-            return (core::ptr::null_mut(), 0);
+            // `realloc` leaves the old allocation valid on failure. Do not
+            // publish a null replacement or release the original before the
+            // canonical trap.
+            crate::error::allocation_failure();
         }
         (new_ptr, new_cap)
     } else {
@@ -2028,6 +1906,9 @@ fn string_ensure_capacity(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> 
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
+    use self::std::process::Command;
     use super::*;
 
     fn blank_result() -> StringResult {
@@ -2125,6 +2006,18 @@ mod tests {
     }
 
     #[test]
+    fn test_string_with_zero_capacity_does_not_allocate() {
+        let mut out = blank_result();
+
+        // SAFETY: `out` is valid, aligned, exclusively borrowed result storage.
+        unsafe { __rue_String_with_capacity(&mut out, 0) };
+
+        assert!(out.ptr.is_null());
+        assert_eq!(out.len, 0);
+        assert_eq!(out.cap, 0);
+    }
+
+    #[test]
     fn test_ensure_capacity_promotes_literals_and_preserves_bytes() {
         let source = b"abc";
 
@@ -2159,11 +2052,81 @@ mod tests {
     }
 
     #[test]
-    fn test_ensure_capacity_returns_null_on_unrepresentable_growth() {
-        let (ptr, cap) = string_ensure_capacity(core::ptr::null_mut(), 0, 0, u64::MAX);
+    fn safe_allocating_paths_use_canonical_trap() {
+        const CHILD_ENV: &str = "RUE_STRING_OOM_CHILD";
+        if let Some(mode) = self::std::env::var_os(CHILD_ENV) {
+            let mode = mode.to_string_lossy();
+            crate::heap::fail_allocations_after_for_test(0);
+            let mut out = blank_result();
+            let one = b"x";
+            unsafe {
+                match mode.as_ref() {
+                    "with_capacity" => __rue_String_with_capacity(&mut out, 8),
+                    "substring" => __rue_String_substring(&mut out, one.as_ptr(), 1, 0, 0, 1),
+                    "to_string" => __rue_to_string(&mut out, 1),
+                    "to_string_unsigned" => __rue_to_string_unsigned(&mut out, 1),
+                    "concat" => {
+                        __rue_String_concat(&mut out, one.as_ptr(), 1, 0, one.as_ptr(), 1, 0)
+                    }
+                    "clone" => __rue_String_clone(&mut out, one.as_ptr(), 1, 0),
+                    "clone_empty" => __rue_String_clone(&mut out, core::ptr::null(), 0, 0),
+                    "push_str" => __rue_String_push_str(
+                        &mut out,
+                        core::ptr::null_mut(),
+                        0,
+                        0,
+                        one.as_ptr(),
+                        1,
+                        0,
+                    ),
+                    "push" => __rue_String_push(&mut out, core::ptr::null_mut(), 0, 0, b'x'),
+                    "reserve" => __rue_String_reserve(&mut out, core::ptr::null_mut(), 0, 0, 1),
+                    "concat_overflow" => __rue_String_concat(
+                        &mut out,
+                        core::ptr::null(),
+                        u64::MAX,
+                        0,
+                        core::ptr::null(),
+                        1,
+                        0,
+                    ),
+                    "growth_overflow" => {
+                        let cap = (u64::MAX / 2) + 1;
+                        let _ = string_ensure_capacity(core::ptr::null_mut(), cap, cap, 1);
+                    }
+                    other => panic!("unknown allocation failure mode: {other}"),
+                }
+            }
+            unreachable!();
+        }
 
-        assert!(ptr.is_null());
-        assert_eq!(cap, 0);
+        for mode in [
+            "with_capacity",
+            "substring",
+            "to_string",
+            "to_string_unsigned",
+            "concat",
+            "clone",
+            "clone_empty",
+            "push_str",
+            "push",
+            "reserve",
+            "concat_overflow",
+            "growth_overflow",
+        ] {
+            let output = Command::new(self::std::env::current_exe().expect("current test binary"))
+                .args([
+                    "--exact",
+                    "string::tests::safe_allocating_paths_use_canonical_trap",
+                    "--nocapture",
+                ])
+                .env(CHILD_ENV, mode)
+                .output()
+                .expect("spawn allocation-failure child");
+
+            assert_eq!(output.status.code(), Some(101), "mode {mode}");
+            assert_eq!(output.stderr, b"panic: out of memory\n", "mode {mode}");
+        }
     }
 
     #[test]
@@ -2418,6 +2381,19 @@ mod tests {
 
         assert_string_result(&out, source);
         assert_ne!(out.ptr as *const u8, source.as_ptr());
+    }
+
+    #[test]
+    fn test_clone_empty_allocates_mutable_storage() {
+        let mut out = blank_result();
+
+        // SAFETY: `out` is valid result storage; a null source pointer is
+        // permitted when the source length is zero.
+        unsafe { __rue_String_clone(&mut out, core::ptr::null(), 0, 0) };
+
+        assert!(!out.ptr.is_null());
+        assert_eq!(out.len, 0);
+        assert!(out.cap >= STRING_MIN_CAPACITY);
     }
 
     #[test]

--- a/crates/rue-spec/cases/runtime/allocation-failure.toml
+++ b/crates/rue-spec/cases/runtime/allocation-failure.toml
@@ -1,0 +1,20 @@
+# Safe allocation failure behavior (RUE-847).
+
+[section]
+id = "runtime.allocation-failure"
+spec_chapter = "8.6"
+name = "Allocation Failure"
+description = "Safe infallible allocation APIs trap with a stable, allocation-free diagnostic."
+
+[[case]]
+name = "strbuf_allocation_failure_traps"
+spec = ["8.6:1", "8.6:2"]
+source = """
+fn main() -> i32 {
+    let s = StrBuf.with_capacity(18446744073709551615);
+    @dbg(s.capacity());
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "panic: out of memory"

--- a/crates/rue-spec/cases/runtime/heap.toml
+++ b/crates/rue-spec/cases/runtime/heap.toml
@@ -87,6 +87,36 @@ fn main() -> i32 {
 """
 exit_code = 12
 
+# A failed reallocation returns null without consuming or modifying the old
+# allocation. The caller can still read and free the original pointer.
+[[case]]
+name = "realloc_failure_preserves_original"
+spec = ["9.2:12", "8.6:3", "8.6:4"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(4);
+        @ptr_write(p, 10);
+        @ptr_write(@ptr_offset(p, 1), 20);
+        @ptr_write(@ptr_offset(p, 2), 30);
+        @ptr_write(@ptr_offset(p, 3), 40);
+        let q: ptr mut u8 = @realloc(p, 4, 2305843009213693951);
+        if @ptr_to_int(q) == 0 {
+            let sum: i32 = @intCast(@ptr_read(p))
+                + @intCast(@ptr_read(@ptr_offset(p, 1)))
+                + @intCast(@ptr_read(@ptr_offset(p, 2)))
+                + @intCast(@ptr_read(@ptr_offset(p, 3)));
+            @free(p, 4);
+            sum
+        } else {
+            @free(q, 2305843009213693951);
+            1
+        }
+    }
+}
+"""
+exit_code = 100
+
 # @realloc of a null pointer behaves like a fresh @alloc.
 [[case]]
 name = "realloc_null_is_alloc"

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -656,7 +656,7 @@ source = """
 fn main() -> i32 {
     let cap: u64 = 0;
     let s = StrBuf.with_capacity(cap);
-    0
+    @intCast(s.capacity())
 }
 """
 exit_code = 0

--- a/docs/spec/src/03-types/10-mutable-strings.md
+++ b/docs/spec/src/03-types/10-mutable-strings.md
@@ -55,7 +55,9 @@ fn main() -> i32 {
 
 {{ rule(id="3.10:8", cat="normative") }}
 
-`StrBuf.with_capacity(cap: u64)` returns an empty string with pre-allocated capacity for `cap` bytes.
+`StrBuf.with_capacity(cap: u64)` returns an empty string with pre-allocated
+capacity for `cap` bytes. When `cap` is zero, it performs no allocation and
+returns a string whose capacity is zero.
 
 {{ rule(id="3.10:9", cat="example") }}
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -387,7 +387,11 @@ If end-of-file is reached with no data read, the result is `None` (this is not a
 
 {{ rule(id="4.13:40", cat="informative") }}
 
-If a read error occurs, a runtime panic occurs with the message "input error". (This behavior is documented but not tested, as I/O errors cannot be reliably simulated in portable test environments.)
+If a read error occurs, a runtime panic occurs with the message "input error".
+If allocation or capacity growth fails while constructing the returned
+`StrBuf`, the allocation-failure rules of §8.6 apply. (These behaviors are
+documented but not tested here, as the failures cannot be reliably simulated
+through portable source-level input.)
 
 {{ rule(id="4.13:41") }}
 

--- a/docs/spec/src/08-runtime-behavior/06-allocation-failure.md
+++ b/docs/spec/src/08-runtime-behavior/06-allocation-failure.md
@@ -1,0 +1,36 @@
++++
+title = "Allocation Failure"
+weight = 6
+template = "spec/page.html"
++++
+
+# Allocation Failure
+
+{{ rule(id="8.6:1", cat="dynamic-semantics") }}
+
+Any safe, infallible operation that allocates or grows owned storage traps on
+allocation failure rather than returning a null pointer or publishing an
+invalid owner. This includes constructors; unit-returning `StrBuf` operations
+such as `push`, `push_str`, and `reserve`; `@read_line`; and safe standard
+library owners such as `ArrayBuf` and collections built on it. Capacity
+arithmetic that cannot be represented is treated as allocation failure.
+
+{{ rule(id="8.6:2", cat="dynamic-semantics") }}
+
+The allocation-failure trap writes exactly `panic: out of memory` followed by
+a newline to standard error and terminates the program with exit code 101. The
+trap path itself performs no heap allocation.
+
+{{ rule(id="8.6:3", cat="dynamic-semantics") }}
+
+When a safe owner attempts to grow using reallocation, it does not replace its
+stored pointer or capacity until reallocation succeeds. On failure, the
+original allocation and its initialized contents remain valid until the
+allocation-failure trap terminates the program.
+
+{{ rule(id="8.6:4", cat="normative") }}
+
+The raw `@alloc` and `@realloc` intrinsics are not safe, infallible allocation
+APIs. Allocator failure returns null as specified by §9.2, and does not itself
+produce the safe allocation-failure trap; checked code using these raw
+intrinsics is responsible for handling a null result.

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -119,7 +119,9 @@ pointer is permitted and has no effect.
 to the resized block, which may differ from `p`. The first
 `min(old_count, new_count)` elements are preserved. If `p` is null it behaves
 like `@alloc(new_count)`. `old_count` and `new_count` must have type `u64`. The
-result type is the same pointer type as `p`.
+result type is the same pointer type as `p`. On allocation failure it returns
+null and leaves the original block allocated, with its contents unchanged; the
+caller remains responsible for freeing that original block.
 
 {{ rule(id="9.2:13", cat="legality-rule") }}
 

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -112,13 +112,22 @@ pub fn ArrayBuf(comptime T: type) -> type {
             let zero: u64 = 0;
             let mut v = Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 };
             if n > 0 {
-                // `@realloc` of the null buffer allocates a fresh block; its
-                // result type is inferred from `v.buf` (a `ptr mut T` field),
-                // so no `T` annotation is needed in the method body.
-                checked {
-                    let grown = @realloc(v.buf, v.cap, n);
-                    v.buf = grown;
-                };
+                let element_size: u64 = @intCast(@size_of(T));
+                if element_size > 0 {
+                    if n > 18446744073709551615 / element_size {
+                        @panic("out of memory");
+                    }
+                    // `@realloc` of the null buffer allocates a fresh block;
+                    // install the result only after checking it so the owner
+                    // never publishes nonzero capacity backed by null.
+                    checked {
+                        let grown = @realloc(v.buf, v.cap, n);
+                        if @ptr_to_int(grown) == 0 {
+                            @panic("out of memory");
+                        }
+                        v.buf = grown;
+                    };
+                }
                 v.cap = n;
             }
             v
@@ -175,11 +184,27 @@ pub fn ArrayBuf(comptime T: type) -> type {
         // buffer (amortized 2x) when full. Internal helper.
         fn reserve(inout self) {
             if self.len == self.cap {
-                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
-                checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
-                    self.buf = grown;
+                let new_cap: u64 = if self.cap == 0 {
+                    4
+                } else {
+                    if self.cap > 9223372036854775807 {
+                        @panic("out of memory");
+                    }
+                    self.cap * 2
                 };
+                let element_size: u64 = @intCast(@size_of(T));
+                if element_size > 0 {
+                    if new_cap > 18446744073709551615 / element_size {
+                        @panic("out of memory");
+                    }
+                    checked {
+                        let grown = @realloc(self.buf, self.cap, new_cap);
+                        if @ptr_to_int(grown) == 0 {
+                            @panic("out of memory");
+                        }
+                        self.buf = grown;
+                    };
+                }
                 self.cap = new_cap;
             }
         }

--- a/std/deque.rue
+++ b/std/deque.rue
@@ -66,6 +66,9 @@ pub fn Deque(comptime T: type) -> type {
 
         fn _ensure_room(inout self) {
             if self.count == self.cap {
+                if self.cap > 9223372036854775807 {
+                    @panic("out of memory");
+                }
                 self._grow_to(self.cap * 2);
             }
         }

--- a/std/grid.rue
+++ b/std/grid.rue
@@ -22,6 +22,9 @@ pub fn Grid2D(comptime T: type) -> type {
         fn new(rows: u64, cols: u64, fill: T) -> Self {
             let b = arraybuf.ArrayBuf(T);
             let mut cells = b.new();
+            if cols > 0 && rows > 18446744073709551615 / cols {
+                @panic("out of memory");
+            }
             let total = rows * cols;
             let mut i: u64 = 0;
             while i < total {

--- a/std/intmap.rue
+++ b/std/intmap.rue
@@ -125,8 +125,16 @@ pub fn IntMap(comptime V: type) -> type {
 
         // Insert or overwrite `k -> v`.
         fn insert(inout self, k: i64, v: V) {
-            // Grow at 70% load (count+1 > cap*7/10).
-            if (self.count + 1) * 10 > self.cap * 7 {
+            // Grow above 70% load without overflowing intermediate products.
+            if self.count == 18446744073709551615 {
+                @panic("out of memory");
+            }
+            let next_count = self.count + 1;
+            let threshold = (self.cap / 10) * 7 + ((self.cap % 10) * 7) / 10;
+            if next_count > threshold {
+                if self.cap > 9223372036854775807 {
+                    @panic("out of memory");
+                }
                 self._grow_to(self.cap * 2);
             }
             let mut idx = self._slot(k);


### PR DESCRIPTION
## Summary

- route safe infallible allocation failures through one allocation-free `panic: out of memory` trap with exit 101
- preserve raw null-returning `@alloc`/`@realloc`, old allocations on failed growth, and zero-capacity allocation-free construction
- harden StrBuf, ArrayBuf, owned input, and dependent collection capacity arithmetic and add deterministic runtime, CLI, and specification coverage

## Validation

- `scripts/rue test`
- `scripts/rue quick`
- `scripts/rue spec allocation_failure`
- `scripts/rue cli heap_intrinsics`
- `scripts/rue cli string_alloc_failure`
- isolated oracle-diff spec audit

Fixes RUE-847
