### PR TITLE
RUE-874: implement StrBuf owned byte algorithms in Rue

### DIFF
--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -485,7 +485,14 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         what: &str,
         span: Span,
     ) -> rue_error::CompileResult<()> {
-        if self.preview_features.contains(&feature) {
+        // The repository standard library is trusted compiler input and may
+        // use the packed-byte substrate that implements its safe StrBuf
+        // surface. Authorization comes from canonical import provenance, not
+        // a path spelling, and deliberately applies only to RawBytes: every
+        // other preview feature remains subject to the consumer's flags.
+        let trusted_std_raw_bytes = feature == rue_error::PreviewFeature::RawBytes
+            && self.trusted_standard_library_files.contains(&span.file_id);
+        if self.preview_features.contains(&feature) || trusted_std_raw_bytes {
             Ok(())
         } else {
             Err(rue_error::CompileError::new(

--- a/crates/rue-cli-tests/cases/std_internal_raw_bytes.toml
+++ b/crates/rue-cli-tests/cases/std_internal_raw_bytes.toml
@@ -1,0 +1,56 @@
+# The trusted repository standard library may use the preview raw-byte
+# substrate internally without imposing that preview flag on its consumers.
+# User source remains gated, including files whose names resemble std modules.
+
+[section]
+id = "cli.std_internal_raw_bytes"
+name = "Trusted standard-library raw-byte substrate"
+description = "Canonical std provenance authorizes internal raw bytes without globally enabling their preview feature."
+
+[[case]]
+name = "ordinary_std_import_needs_no_raw_bytes_preview"
+description = "Importing the real std bundle does not expose its internal StrBuf implementation preview to consumers."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    std.exit(0);
+    1
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "user_raw_bytes_still_require_preview"
+description = "Trusting imported std source does not globally enable raw-byte intrinsics in the root module."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    checked {
+        let p = @alloc_bytes(1);
+        @free_bytes(p, 1);
+    };
+    std.exit(0);
+    1
+}
+""" }]
+compile_fail = true
+error_contains = ["--preview raw_bytes"]
+
+[[case]]
+name = "stdlib_like_filename_is_not_trusted_provenance"
+description = "A user root named like a std module cannot bypass the raw-byte preview gate."
+files = [{ path = "strbuf.rue", source = """
+fn main() -> i32 {
+    checked {
+        let p = @alloc_bytes(1);
+        @free_bytes(p, 1);
+    };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["--preview raw_bytes"]

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -29,6 +29,264 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
+name = "source_owned_algorithms_use_packed_bytes"
+description = "The qualified source type allocates, grows, appends, clones, slices, and concatenates packed bytes."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mut bytes = S.allocate(2);
+    bytes.append_byte(1);
+    bytes.append_byte(2);
+    bytes.append_byte(3);
+    bytes.append_byte(4);
+    bytes.append_byte(5);
+    bytes.append_byte(6);
+    bytes.append_byte(7);
+    bytes.append_byte(8);
+    bytes.append_byte(9);
+    bytes.append_byte(10);
+    bytes.append_byte(11);
+    bytes.append_byte(12);
+    bytes.append_byte(13);
+    bytes.append_byte(14);
+    bytes.append_byte(15);
+    bytes.append_byte(16);
+    bytes.append_byte(17);
+    if bytes.len() != 17 || bytes.capacity() < 17 { return 1; }
+    bytes.reserve_source(20);
+    if bytes.len() != 17 || bytes.capacity() < 37 { return 2; }
+    checked {
+        if @byte_read(bytes.buf, 0) != 1 { return 3; }
+        if @byte_read(bytes.buf, 7) != 8 { return 4; }
+        if @byte_read(bytes.buf, 8) != 9 { return 5; }
+        if @byte_read(bytes.buf, 15) != 16 { return 6; }
+        if @byte_read(bytes.buf, 16) != 17 { return 7; }
+    };
+
+    let value: S = "abcdefghijklmnopq";
+    let copied = value.copy();
+    if value != "abcdefghijklmnopq" || copied != value { return 8; }
+
+    let empty = S.new();
+    let empty_copy = empty.copy();
+    if empty_copy.len() != 0 || empty_copy.capacity() < 16 { return 9; }
+
+    let mut appended: S = "ab";
+    let suffix: S = "cdefghijk";
+    S.append_owned(suffix, inout appended);
+    if appended != "abcdefghijk" { return 10; }
+
+    let middle = value.byte_range(2, 10);
+    if middle != "cdefghijkl" { return 11; }
+    let right: S = "XY";
+    let joined = S.concat_borrowed(borrow middle, borrow right);
+    if joined != "cdefghijklXY" { return 12; }
+    if middle != "cdefghijkl" || right != "XY" { return 13; }
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "raw_bytes", "--preview", "string_trio", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "source_literal_promotion_self_append_and_adjacent_bytes"
+description = "Literal promotion and a reallocating self append preserve every adjacent packed byte."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mut value: S = "abcdefghijk";
+    value.duplicate();
+    if value != "abcdefghijkabcdefghijk" { return 1; }
+    if value.capacity() < value.len() { return 2; }
+    checked {
+        if @byte_read(value.buf, 7) != 104 { return 3; }
+        if @byte_read(value.buf, 8) != 105 { return 4; }
+        if @byte_read(value.buf, 10) != 107 { return 5; }
+        if @byte_read(value.buf, 11) != 97 { return 6; }
+        if @byte_read(value.buf, 21) != 107 { return 7; }
+    };
+
+    let mut reserved: S = "stay";
+    reserved.reserve_source(0);
+    if reserved != "stay" || reserved.capacity() == 0 { return 8; }
+
+    let mut appended_empty: S = "put";
+    let empty = S.new();
+    S.append_owned(empty, inout appended_empty);
+    if appended_empty != "put" || appended_empty.capacity() == 0 { return 9; }
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "raw_bytes", "--preview", "string_trio", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "source_zero_capacity_empty_ranges_and_early_free"
+description = "Zero-sized construction and ranges remain unallocated, while early free resets an owner."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let zero = S.allocate(0);
+    if zero.capacity() != 0 { return 1; }
+    let source: S = "abc";
+    let empty = source.byte_range(3, 0);
+    if empty.len() != 0 || empty.capacity() != 0 { return 2; }
+
+    let mut owned = S.allocate(4);
+    owned.append_byte(65);
+    owned.free();
+    if owned.len() != 0 || owned.capacity() != 0 { return 3; }
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "source_capacity_overflow_fails_fast"
+description = "Reserve overflow follows the canonical allocation-failure contract before touching the owner."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let zero: u64 = 0;
+    let p: ptr mut u8 = checked { @int_to_ptr(zero) };
+    let mut impossible = S { buf: p, len: 18446744073709551615, cap: 0 };
+    impossible.grow(1);
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: out of memory"]
+
+[[case]]
+name = "source_allocation_failure_fails_fast"
+description = "A failed source allocation never publishes a null-backed nonzero capacity."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let impossible = S.allocate(18446744073709551615);
+    @intCast(impossible.len())
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["panic: out of memory"]
+
+[[case]]
+name = "source_byte_range_out_of_bounds"
+description = "Source byte-range copying rejects an overflowing or out-of-bounds range."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let value: S = "abc";
+    let impossible = value.byte_range(2, 18446744073709551615);
+    @intCast(impossible.len())
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 101
+runtime_error_contains = ["index out of bounds"]
+
+[[case]]
+name = "source_emit_avoids_transitional_runtime_methods"
+description = "MIR for qualified source algorithms has no transitional String allocation or mutation calls."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mut value: S = "ab";
+    value.duplicate();
+    let copied = value.copy();
+    let prefix = copied.byte_range(1, 2);
+    let suffix: S = "z";
+    let joined = S.concat_borrowed(borrow prefix, borrow suffix);
+    @intCast(joined.len())
+}
+""" }]
+args = ["--emit", "mir", "main.rue", "--preview", "string_trio"]
+compile_only = true
+compile_stdout_contains = ["duplicate", "byte_range", "concat_borrowed", "read_packed_byte", "write_packed_byte"]
+compile_stdout_not_contains = [
+  "__rue_String_with_capacity",
+  "__rue_String_reserve",
+  "__rue_String_push",
+  "__rue_String_push_str",
+  "__rue_String_clone",
+  "__rue_String_substring",
+  "__rue_String_concat",
+]
+
+[[case]]
+name = "raw_pointer_helpers_are_not_associated_surface"
+description = "The source StrBuf type exposes no associated function that accepts arbitrary raw pointers."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let zero: u64 = 0;
+    let p: ptr mut u8 = checked { @int_to_ptr(zero) };
+    @intCast(S.read_byte(p, 0))
+}
+""" }]
+compile_fail = true
+error_contains = ["read_byte"]
+
+[[case]]
+name = "module_raw_pointer_helpers_are_private"
+description = "Packed-byte implementation functions cannot be called through the imported std.strbuf module."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let zero: u64 = 0;
+    let p: ptr mut u8 = checked { @int_to_ptr(zero) };
+    @intCast(std.strbuf.read_packed_byte(p, 0))
+}
+""" }]
+compile_fail = true
+error_contains = ["private"]
+
+[[case]]
+name = "append_owned_rejects_same_owner_alias"
+description = "The supported self-append path is duplicate; a consumed source cannot alias its inout target."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const S = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mut value: S = "abc";
+    S.append_owned(value, inout value);
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+compile_fail = true
+error_contains = ["into a call that also passes it"]
+
+[[case]]
 name = "canonical_identity_drives_string_semantics"
 description = "Qualified and aliased std StrBuf values use view coercions, indexing, iteration, equality, and transitional runtime helpers."
 env = { RUE_STD_PATH = "${REAL_STD}" }
@@ -68,8 +326,8 @@ const std = @import("std");
 const S = std.strbuf.StrBuf;
 
 fn owned(byte: u8) -> S {
-    let p: ptr mut u8 = checked { @alloc(4) };
-    checked { @ptr_write(p, byte); };
+    let p: ptr mut u8 = checked { @alloc_bytes(4) };
+    checked { @byte_write(p, 0, byte); };
     std.strbuf.StrBuf { buf: p, len: 1, cap: 4 }
 }
 
@@ -92,6 +350,7 @@ fn main() -> i32 {
     0
 }
 """ }]
+args = ["main.rue", "--preview", "raw_bytes", "-o", "prog"]
 exit_code = 0
 
 [[case]]

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -1,43 +1,224 @@
-// std.strbuf — the source-defined growable string buffer header (RUE-871).
+// std.strbuf — the source-defined growable byte-string buffer.
 //
-// This module deliberately provides only construction, observation, clearing,
-// and teardown. Allocation and growth remain out of scope: `new()` creates a
-// null, zero-capacity buffer without allocating.
-//
-// The ownership invariant is encoded by `cap`: a value with `cap == 0` owns no
-// allocation and must not call `@free`; a value with `cap > 0` owns its `buf`
-// allocation. `free()` supports early release and resets all three fields, so
-// the ordinary scope-exit destructor is then a safe no-op.
+// `cap == 0` is the non-owning representation used by literals and `new()`.
+// A value with `cap > 0` owns exactly `cap` packed bytes at alignment one.
+// Allocation failure is fail-fast, and an owner header is changed only after
+// its replacement allocation has succeeded.
+
+// Raw-pointer operations are private module implementation details. Keeping
+// them outside the public struct prevents callers from laundering unchecked
+// arbitrary pointers through safe-looking associated functions.
+fn read_packed_byte(source: ptr mut u8, index: u64) -> u8 {
+    checked { @byte_read(source, index) }
+}
+
+fn write_packed_byte(destination: ptr mut u8, index: u64, byte: u8) {
+    checked { @byte_write(destination, index, byte); };
+}
+
+fn copy_packed_bytes(
+    source: ptr mut u8,
+    source_start: u64,
+    destination: ptr mut u8,
+    destination_start: u64,
+    count: u64,
+) {
+    let mut i: u64 = 0;
+    while i < count {
+        let byte = read_packed_byte(source, source_start + i);
+        write_packed_byte(destination, destination_start + i, byte);
+        i = i + 1;
+    }
+}
 
 pub struct StrBuf {
     buf: ptr mut u8,
     len: u64,
     cap: u64,
 
-    // Construct an empty buffer without allocating.
     fn new() -> Self {
         let zero: u64 = 0;
-        Self {
-            buf: checked { @int_to_ptr(zero) },
-            len: 0,
-            cap: 0,
+        Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+    }
+
+    fn with_capacity(requested: u64) -> Self {
+        Self.allocate(requested)
+    }
+
+    // Ordinary entry point used to exercise the source implementation until
+    // RUE-875 removes the compiler's special handling of `with_capacity`.
+    fn allocate(requested: u64) -> Self {
+        if requested == 0 {
+            return Self.new();
         }
+        let cap = Self.initial_capacity(requested);
+        let allocation: ptr mut u8 = checked { @alloc_bytes(cap) };
+        if checked { @ptr_to_int(allocation) } == 0 {
+            @panic("out of memory");
+        }
+        Self { buf: allocation, len: 0, cap: cap }
     }
 
     fn len(borrow self) -> u64 { self.len }
     fn capacity(borrow self) -> u64 { self.cap }
     fn is_empty(borrow self) -> bool { self.len == 0 }
 
-    // Remove all bytes while retaining any owned allocation.
+    fn initial_capacity(required: u64) -> u64 {
+        if required < 16 { 16 } else { required }
+    }
+
+    // Shared checked growth policy: required capacity is `len + additional`,
+    // with a minimum of 16 and doubling when that remains representable.
+    fn growth_capacity(current: u64, required: u64) -> u64 {
+        let mut candidate = Self.initial_capacity(current);
+        while candidate < required {
+            if candidate > 9223372036854775807 {
+                candidate = required;
+            } else {
+                candidate = candidate * 2;
+            }
+        }
+        candidate
+    }
+
+    fn reserve(inout self, additional: u64) {
+        self.grow(additional);
+    }
+
+    // Ordinary entry point for direct source testing before RUE-875 routes the
+    // public `reserve` spelling to the body above.
+    fn reserve_source(inout self, additional: u64) {
+        self.grow(additional);
+    }
+
+    // Literal promotion allocates before copying. Owned growth uses realloc;
+    // on failure, @realloc_bytes leaves the old allocation valid, and this
+    // method leaves the header unchanged before taking the fail-fast path.
+    fn grow(inout self, additional: u64) {
+        if additional > 18446744073709551615 - self.len {
+            @panic("out of memory");
+        }
+        let required = self.len + additional;
+        if required <= self.cap {
+            return;
+        }
+
+        let new_cap = Self.growth_capacity(self.cap, required);
+        if self.cap == 0 {
+            let replacement: ptr mut u8 = checked { @alloc_bytes(new_cap) };
+            if checked { @ptr_to_int(replacement) } == 0 {
+                @panic("out of memory");
+            }
+            copy_packed_bytes(self.buf, 0, replacement, 0, self.len);
+            self.buf = replacement;
+        } else {
+            let replacement = checked { @realloc_bytes(self.buf, self.cap, new_cap) };
+            if checked { @ptr_to_int(replacement) } == 0 {
+                @panic("out of memory");
+            }
+            self.buf = replacement;
+        }
+        self.cap = new_cap;
+    }
+
+    fn push(inout self, byte: u8) {
+        self.append_byte(byte);
+    }
+
+    fn append_byte(inout self, byte: u8) {
+        self.grow(1);
+        write_packed_byte(self.buf, self.len, byte);
+        self.len = self.len + 1;
+    }
+
+    fn push_str(inout self, other: Self) {
+        Self.append_owned(other, inout self);
+    }
+
+    // The normal source append path consumes a separate owner. Literal inputs
+    // may share static storage safely because the destination is promoted to a
+    // fresh allocation before any writes.
+    fn append_owned(other: Self, inout target: Self) {
+        let source_len = other.len;
+        let destination_start = target.len;
+        target.grow(source_len);
+        if source_len == 0 {
+            return;
+        }
+        copy_packed_bytes(other.buf, 0, target.buf, destination_start, source_len);
+        target.len = destination_start + source_len;
+    }
+
+    // Directly exercise the alias-sensitive case before RUE-875 routes the
+    // public spelling here. Growth happens first; reads then use the current
+    // pointer, so reallocating a self append never reads a stale allocation.
+    fn duplicate(inout self) {
+        let old_len = self.len;
+        self.grow(old_len);
+        copy_packed_bytes(self.buf, 0, self.buf, old_len, old_len);
+        self.len = old_len + old_len;
+    }
+
     fn clear(inout self) {
         self.len = 0;
     }
 
-    // Release an owned allocation early. Resetting the header transfers this
-    // value to the non-owning empty state before its eventual scope-exit drop.
+    fn clone(borrow self) -> Self {
+        self.copy()
+    }
+
+    // Clone always allocates, including for an empty or literal-backed value.
+    fn copy(borrow self) -> Self {
+        let mut result = Self.allocate(Self.initial_capacity(self.len));
+        copy_packed_bytes(self.buf, 0, result.buf, 0, self.len);
+        result.len = self.len;
+        result
+    }
+
+    fn substring(borrow self, start: u64, count: u64) -> Self {
+        self.byte_range(start, count)
+    }
+
+    fn byte_range(borrow self, start: u64, count: u64) -> Self {
+        if start > self.len || count > self.len - start {
+            // Preserve the canonical user-visible diagnostic until Rue has a
+            // source-accessible bounds-trap primitive.
+            @panic("index out of bounds");
+        }
+        if count == 0 {
+            return Self.new();
+        }
+        let mut result = Self.allocate(count);
+        copy_packed_bytes(self.buf, start, result.buf, 0, count);
+        result.len = count;
+        result
+    }
+
+    fn concat(borrow self, borrow other: Self) -> Self {
+        Self.concat_borrowed(borrow self, borrow other)
+    }
+
+    // Ordinary entry point for the source concatenation algorithm until the
+    // operator's compiler cutover in RUE-875.
+    fn concat_borrowed(borrow first: Self, borrow second: Self) -> Self {
+        if second.len > 18446744073709551615 - first.len {
+            @panic("out of memory");
+        }
+        let total = first.len + second.len;
+        if total == 0 {
+            return Self.new();
+        }
+        let mut result = Self.allocate(total);
+        copy_packed_bytes(first.buf, 0, result.buf, 0, first.len);
+        copy_packed_bytes(second.buf, 0, result.buf, first.len, second.len);
+        result.len = total;
+        result
+    }
+
+    // Reset after freeing so the later destructor is a no-op.
     fn free(inout self) {
         if self.cap > 0 {
-            checked { @free(self.buf, self.cap); };
+            checked { @free_bytes(self.buf, self.cap); };
         }
         let zero: u64 = 0;
         self.buf = checked { @int_to_ptr(zero) };
@@ -46,10 +227,8 @@ pub struct StrBuf {
     }
 }
 
-// Source-defined drop glue owns teardown for `std.strbuf.StrBuf`. In
-// particular, the null header from `new()` never reaches `@free`.
 drop fn StrBuf(self) {
     if self.cap > 0 {
-        checked { @free(self.buf, self.cap); };
+        checked { @free_bytes(self.buf, self.cap); };
     }
 }


### PR DESCRIPTION
Implements source-defined StrBuf allocation and owned byte algorithms on the checked packed-byte substrate.

- centralizes capacity growth, literal promotion, copying, concatenation, substring, cloning, and teardown in Rue source
- restricts raw-byte helpers to trusted standard-library implementation files while preserving the user preview gate
- adds regression coverage for allocation, growth, aliasing, bounds, overflow, OOM, ownership, and transitional runtime-helper absence

Fixes RUE-874