### PR TITLE
RUE-810: emit canonical dependency envelopes

### DIFF
--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -187,7 +187,7 @@ error_contains = ["undefined function", "helper"]
 
 [[case]]
 name = "emit_deps_reports_root_and_import_graph"
-description = "RUE-446: --emit deps reports the observed root/import source graph as machine-readable JSON."
+description = "RUE-810: --emit deps reports the canonical topology, complete observations, and accepted reads as a versioned envelope."
 files = [
     { path = "main.rue", source = """
 const utils = @import("utils");
@@ -218,16 +218,22 @@ args = ["--emit", "deps", "main.rue"]
 compile_only = true
 compile_stdout_contains = [
     "\"version\": 1",
-    "\"root\":",
-    "\"path\":",
+    "\"status\": \"complete\"",
+    "\"revision\": \"rue-dependency-revision-v1-sha256:",
+    "\"topology\":",
+    "\"root\": \"main.rue\"",
+    "\"records\":",
     "main.rue",
-    "\"kind\": \"root\"",
     "utils.rue",
-    "\"kind\": \"import\"",
     "leaf.rue",
     "\"specifier\": \"utils\"",
     "\"specifier\": \"leaf\"",
-    "\"resolved\":",
+    "\"status\": \"resolved\"",
+    "\"observations\":",
+    "\"status\": \"present_readable\"",
+    "\"accepted_reads\":",
+    "\"physical_identity\":",
+    "\"content_fingerprint\":",
 ]
 compile_stdout_not_contains = ["unused.rue"]
 
@@ -252,6 +258,7 @@ args = ["--emit", "deps", "main.rue"]
 compile_only = true
 compile_stdout_contains = [
     "\"version\": 1",
+    "\"status\": \"complete\"",
     "main.rue",
     "utils.rue",
     "\"specifier\": \"utils\"",
@@ -260,7 +267,7 @@ compile_stderr_not_contains = ["undefined variable", "nope", "E0201"]
 
 [[case]]
 name = "emit_deps_rejects_unresolved_import"
-description = "RUE-450: --emit deps validates the loaded root import graph before printing dependency JSON."
+description = "RUE-810: --emit deps preserves a closed unresolved graph in an incomplete envelope and exits unsuccessfully."
 files = [
     { path = "main.rue", source = """
 const missing = @import("missing");
@@ -273,7 +280,114 @@ fn main() -> i32 {
 args = ["--emit", "deps", "main.rue"]
 compile_fail = true
 error_contains = ["E0704", "missing"]
-compile_stdout_not_contains = ["\"version\": 1"]
+compile_stdout_contains = [
+    "\"version\": 1",
+    "\"status\": \"incomplete\"",
+    "\"revision\": \"rue-dependency-revision-v1-sha256:",
+    "\"specifier\": \"missing\"",
+    "\"status\": \"missing\"",
+    "\"status\": \"absent\"",
+    "\"accepted_reads\":",
+    "\"module\": \"main.rue\"",
+]
+
+[[case]]
+name = "emit_deps_reports_ambiguous_staging_reads"
+description = "RUE-810: an ambiguous closed graph emits both canonical targets and both accepted staging reads before failing."
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper");
+fn main() -> i32 { 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn file_value() -> i32 { 1 }
+""" },
+    { path = "helper/_helper.rue", source = """
+pub fn directory_value() -> i32 { 2 }
+""" },
+]
+args = ["--emit", "deps", "main.rue"]
+compile_fail = true
+error_contains = ["E0708", "ambiguous", "helper.rue", "helper/_helper.rue"]
+compile_stdout_contains = [
+    "\"status\": \"incomplete\"",
+    "\"status\": \"ambiguous\"",
+    "\"file_module\": \"helper.rue\"",
+    "\"directory_module\": \"helper/_helper.rue\"",
+    "\"module\": \"helper.rue\"",
+    "\"module\": \"helper/_helper.rue\"",
+]
+
+[[case]]
+name = "emit_deps_malformed_import_has_no_envelope"
+description = "RUE-810: malformed import shape has no canonical unresolved topology and emits diagnostics without JSON."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    @import();
+    0
+}
+""" },
+]
+args = ["--emit", "deps", "main.rue"]
+compile_fail = true
+error_contains = ["E0701", "expects 1 argument, found 0"]
+compile_stdout_not_contains = ["\"version\": 1", "\"status\":"]
+
+[[case]]
+name = "emit_deps_mixed_positional_with_missing_prefers_incomplete_graph"
+description = "RUE-810: canonical unresolved topology and diagnostics precede mixed positional/import validation."
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper");
+const missing = @import("missing");
+fn main() -> i32 { 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn value() -> i32 { 42 }
+""" },
+]
+args = ["--emit", "deps", "main.rue", "helper.rue"]
+compile_fail = true
+error_contains = ["E0704", "missing"]
+compile_stderr_not_contains = ["must not also be loaded through @import"]
+compile_stdout_contains = [
+    "\"status\": \"incomplete\"",
+    "\"specifier\": \"missing\"",
+    "\"status\": \"missing\"",
+]
+
+[[case]]
+name = "mixed_positional_with_missing_prefers_canonical_diagnostic"
+description = "RUE-810: non-dependency compilation also reports the canonical unresolved import before mixed-source validation."
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper");
+const missing = @import("missing");
+fn main() -> i32 { 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn value() -> i32 { 42 }
+""" },
+]
+args = ["main.rue", "helper.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0704", "missing"]
+compile_stderr_not_contains = ["must not also be loaded through @import"]
+
+[[case]]
+name = "missing_import_precedes_output_clobber_validation"
+description = "RUE-810: a closed attempted import revision renders its canonical diagnostic before output-path validation."
+files = [
+    { path = "main.rue", source = """
+const missing = @import("missing");
+fn main() -> i32 { 0 }
+""" },
+]
+args = ["main.rue", "-o", "main.rue"]
+compile_fail = true
+error_contains = ["E0704", "missing"]
+compile_stderr_not_contains = ["also an input source file"]
 
 [[case]]
 name = "emit_deps_rejects_mixed_emit_stages"

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -22,6 +22,7 @@ rue_crate(
         "//third-party:lasso",
         "//third-party:rayon",
         "//third-party:sha2",
+        "//third-party:serde",
         "//third-party:serde_json",
         "//third-party:tracing",
     ],

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -10,6 +10,10 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
         "definition_snapshot",
         include_str!("definition_snapshot.rs"),
     ),
+    (
+        "dependency_envelope",
+        include_str!("dependency_envelope.rs"),
+    ),
     ("diagnostic", include_str!("diagnostic.rs")),
     ("drop_glue", include_str!("drop_glue.rs")),
     ("durable_body", include_str!("durable_body.rs")),

--- a/crates/rue-compiler/src/dependency_envelope.rs
+++ b/crates/rue-compiler/src/dependency_envelope.rs
@@ -1,0 +1,535 @@
+//! Deterministic presentation of one closed canonical import revision.
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::{
+    AcceptedReadManifestEntry, CanonicalImportGraphProblem, CanonicalImportResolution,
+    ImportCandidateRole, ImportDiscoveryRevisionArtifact, ImportDiscoveryRevisionStatus,
+    ImportObservationStatus, SourceRevision,
+};
+
+pub const DEPENDENCY_ENVELOPE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyEnvelopeStatus {
+    Complete,
+    Incomplete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DependencyEnvelope {
+    pub version: u32,
+    pub status: DependencyEnvelopeStatus,
+    pub revision: String,
+    pub context: DependencyContext,
+    pub topology: DependencyTopology,
+    pub observations: Vec<DependencyObservation>,
+    pub accepted_reads: Vec<DependencyAcceptedRead>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DependencyContext {
+    pub import_policy_version: u32,
+    pub epoch: String,
+    pub project_root: String,
+    pub std_root: Option<String>,
+    pub read_policy_revision: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DependencyTopology {
+    pub root: String,
+    pub records: Vec<DependencyTopologyRecord>,
+    pub cycles: Vec<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DependencyTopologyRecord {
+    pub importer: String,
+    pub specifier: String,
+    pub outcome: DependencyResolutionOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DependencyResolutionOutcome {
+    Resolved {
+        module: String,
+    },
+    Missing,
+    Ambiguous {
+        file_module: String,
+        directory_module: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DependencyObservation {
+    pub request: DependencyRequest,
+    pub outcome: DependencyObservationOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DependencyRequest {
+    pub policy_version: u32,
+    pub epoch: String,
+    pub read_policy_revision: String,
+    pub importer: String,
+    pub source_offset: u32,
+    pub source_end: u32,
+    pub exact_specifier: String,
+    pub normalized_specifier: String,
+    pub importer_anchor: String,
+    pub root_anchor: String,
+    pub group: u32,
+    pub position: u32,
+    pub requested_path: String,
+    pub role: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DependencyObservationOutcome {
+    Absent,
+    PresentReadable {
+        canonical_path: String,
+        physical_identity: String,
+        metadata_fingerprint: String,
+        content_fingerprint: String,
+    },
+    PresentUnreadable {
+        message: String,
+    },
+    DeniedLexical,
+    DeniedCanonical {
+        canonical_path: String,
+    },
+    InvalidPhysicalType {
+        canonical_path: String,
+    },
+    UnstableRead {
+        message: String,
+    },
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DependencyAcceptedRead {
+    pub module: String,
+    pub requested_path: String,
+    pub canonical_path: String,
+    pub physical_identity: String,
+    pub metadata_fingerprint: String,
+    pub content_fingerprint: String,
+}
+
+impl DependencyEnvelope {
+    /// Project the compiler-owned graph and ledgers without rediscovering an
+    /// import edge or consulting semantic analysis.
+    pub fn from_closed_revision(artifact: &ImportDiscoveryRevisionArtifact) -> Option<Self> {
+        let graph = artifact.graph()?;
+        let status = match artifact.status() {
+            ImportDiscoveryRevisionStatus::ClosedValid if graph.validation().is_valid() => {
+                DependencyEnvelopeStatus::Complete
+            }
+            ImportDiscoveryRevisionStatus::ClosedAttempted
+                if !graph.validation().problems().is_empty()
+                    && graph.validation().problems().iter().all(|problem| {
+                        matches!(
+                            problem,
+                            CanonicalImportGraphProblem::MissingResolution { .. }
+                                | CanonicalImportGraphProblem::AmbiguousResolution { .. }
+                        )
+                    }) =>
+            {
+                DependencyEnvelopeStatus::Incomplete
+            }
+            ImportDiscoveryRevisionStatus::Open
+            | ImportDiscoveryRevisionStatus::ClosedAttempted
+            | ImportDiscoveryRevisionStatus::ClosedValid => return None,
+        };
+        let context = DependencyContext {
+            import_policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
+            epoch: artifact.context().epoch().to_string(),
+            project_root: artifact.context().project_root().to_owned(),
+            std_root: artifact.context().std_root().map(str::to_owned),
+            read_policy_revision: artifact.context().read_policy_revision().to_owned(),
+        };
+        let topology = DependencyTopology {
+            root: graph.graph().root().as_str().to_owned(),
+            records: graph
+                .graph()
+                .records()
+                .iter()
+                .map(|record| DependencyTopologyRecord {
+                    importer: record.importer().as_str().to_owned(),
+                    specifier: record.normalized_specifier().to_owned(),
+                    outcome: match record.resolution() {
+                        CanonicalImportResolution::Resolved(module) => {
+                            DependencyResolutionOutcome::Resolved {
+                                module: module.as_str().to_owned(),
+                            }
+                        }
+                        CanonicalImportResolution::Missing => DependencyResolutionOutcome::Missing,
+                        CanonicalImportResolution::Ambiguous {
+                            file_module,
+                            directory_module,
+                        } => DependencyResolutionOutcome::Ambiguous {
+                            file_module: file_module.as_str().to_owned(),
+                            directory_module: directory_module.as_str().to_owned(),
+                        },
+                    },
+                })
+                .collect(),
+            cycles: graph
+                .validation()
+                .cycles()
+                .iter()
+                .map(|cycle| {
+                    cycle
+                        .modules()
+                        .iter()
+                        .map(|module| module.as_str().to_owned())
+                        .collect()
+                })
+                .collect(),
+        };
+        let observations: Vec<DependencyObservation> = artifact
+            .ledger()
+            .iter()
+            .map(|observation| {
+                let request = observation.request();
+                let context = request.context();
+                DependencyObservation {
+                    request: DependencyRequest {
+                        policy_version: crate::IMPORT_DISCOVERY_POLICY_VERSION,
+                        epoch: context.epoch().to_string(),
+                        read_policy_revision: context.read_policy_revision().to_owned(),
+                        importer: request.occurrence().importer().as_str().to_owned(),
+                        source_offset: request.occurrence().source_offset(),
+                        source_end: request.occurrence().source_end(),
+                        exact_specifier: request.exact_specifier().to_owned(),
+                        normalized_specifier: request.normalized_specifier().to_owned(),
+                        importer_anchor: request.importer_anchor().to_owned(),
+                        root_anchor: request.root_anchor().to_owned(),
+                        group: request.group() as u32,
+                        position: request.position() as u32,
+                        requested_path: request.requested_path().to_owned(),
+                        role: candidate_role(request.role()),
+                    },
+                    outcome: observation_outcome(observation.status()),
+                }
+            })
+            .collect();
+        let accepted_reads: Vec<DependencyAcceptedRead> = artifact
+            .accepted_read_manifest()
+            .iter()
+            .map(accepted_read)
+            .collect();
+        let revision = revision_label(
+            artifact.source_revision(),
+            status,
+            &context,
+            &topology,
+            &observations,
+            &accepted_reads,
+        );
+        Some(Self {
+            version: DEPENDENCY_ENVELOPE_VERSION,
+            status,
+            revision,
+            context,
+            topology,
+            observations,
+            accepted_reads,
+        })
+    }
+}
+
+fn candidate_role(role: ImportCandidateRole) -> &'static str {
+    match role {
+        ImportCandidateRole::ExactFile => "exact_file",
+        ImportCandidateRole::FileModule => "file_module",
+        ImportCandidateRole::DirectoryFacade => "directory_facade",
+        ImportCandidateRole::StandardLibraryFacade => "standard_library_facade",
+    }
+}
+
+fn observation_outcome(status: &ImportObservationStatus) -> DependencyObservationOutcome {
+    match status {
+        ImportObservationStatus::Absent => DependencyObservationOutcome::Absent,
+        ImportObservationStatus::PresentReadable {
+            canonical_path,
+            metadata_identity,
+            metadata_fingerprint,
+            content_fingerprint,
+        } => DependencyObservationOutcome::PresentReadable {
+            canonical_path: canonical_path.to_string(),
+            physical_identity: physical_identity(*metadata_identity),
+            metadata_fingerprint: metadata_fingerprint_string(*metadata_fingerprint),
+            content_fingerprint: fingerprint(*content_fingerprint),
+        },
+        ImportObservationStatus::PresentUnreadable(message) => {
+            DependencyObservationOutcome::PresentUnreadable {
+                message: message.to_string(),
+            }
+        }
+        ImportObservationStatus::DeniedLexical => DependencyObservationOutcome::DeniedLexical,
+        ImportObservationStatus::DeniedCanonical { canonical_path } => {
+            DependencyObservationOutcome::DeniedCanonical {
+                canonical_path: canonical_path.to_string(),
+            }
+        }
+        ImportObservationStatus::InvalidPhysicalType { canonical_path } => {
+            DependencyObservationOutcome::InvalidPhysicalType {
+                canonical_path: canonical_path.to_string(),
+            }
+        }
+        ImportObservationStatus::UnstableRead(message) => {
+            DependencyObservationOutcome::UnstableRead {
+                message: message.to_string(),
+            }
+        }
+        ImportObservationStatus::Cancelled => DependencyObservationOutcome::Cancelled,
+    }
+}
+
+fn accepted_read(entry: &AcceptedReadManifestEntry) -> DependencyAcceptedRead {
+    DependencyAcceptedRead {
+        module: entry.module().as_str().to_owned(),
+        requested_path: entry.requested_path().to_owned(),
+        canonical_path: entry.canonical_path().to_owned(),
+        physical_identity: physical_identity(entry.metadata_identity()),
+        metadata_fingerprint: metadata_fingerprint_string(entry.metadata_fingerprint()),
+        content_fingerprint: fingerprint(entry.content_fingerprint()),
+    }
+}
+
+fn physical_identity(identity: crate::PhysicalFileIdentity) -> String {
+    format!("{:016x}:{:016x}", identity.volume(), identity.file())
+}
+
+fn metadata_fingerprint_string(fingerprint: crate::FileMetadataFingerprint) -> String {
+    format!(
+        "{:016x}:{:016x}:{:016x}",
+        fingerprint.length(),
+        fingerprint.modified(),
+        fingerprint.changed()
+    )
+}
+
+fn fingerprint(value: u64) -> String {
+    format!("{value:016x}")
+}
+
+fn revision_label(
+    revision: &SourceRevision,
+    status: DependencyEnvelopeStatus,
+    context: &DependencyContext,
+    topology: &DependencyTopology,
+    observations: &[DependencyObservation],
+    accepted_reads: &[DependencyAcceptedRead],
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"rue-dependency-revision-v1\0");
+    update_digest(&mut digest, revision.root().as_str().as_bytes());
+    for module in revision.modules() {
+        update_digest(&mut digest, module.module.as_str().as_bytes());
+        update_digest(&mut digest, module.source.to_string().as_bytes());
+    }
+    let presentation =
+        serde_json::to_vec(&(status, context, topology, observations, accepted_reads))
+            .expect("dependency envelope values have infallible JSON serialization");
+    update_digest(&mut digest, &presentation);
+    format!("rue-dependency-revision-v1-sha256:{:x}", digest.finalize())
+}
+
+fn update_digest(digest: &mut Sha256, bytes: &[u8]) {
+    digest.update((bytes.len() as u64).to_be_bytes());
+    digest.update(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{
+        AcceptedImportSource, CompilerSession, DiscoverySourceAssembler, FileMetadataFingerprint,
+        ImportDiscoveryContext, ImportObservation, ImportObservationLedger, PhysicalFileIdentity,
+    };
+
+    fn context(epoch: u64) -> ImportDiscoveryContext {
+        ImportDiscoveryContext::new(epoch, "/project", Some("/sdk"), "test-policy").unwrap()
+    }
+
+    fn metadata() -> FileMetadataFingerprint {
+        FileMetadataFingerprint::new(10, 20, 30)
+    }
+
+    fn assembler(source: &str) -> DiscoverySourceAssembler {
+        DiscoverySourceAssembler::new(
+            context(1),
+            "/project/main.rue",
+            "/project/main.rue",
+            PhysicalFileIdentity::new(1, 1),
+            metadata(),
+            Arc::new(source.into()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn complete_envelope_uses_canonical_graph_and_separate_ledgers() {
+        let source = "const a = @import(\"a\"); fn main() -> i32 { 0 }";
+        let imported = "pub fn answer() -> i32 { 42 }";
+        let mut assembler = assembler(source);
+        assembler
+            .add_explicit(
+                "/project/a.rue",
+                "/project/a.rue",
+                PhysicalFileIdentity::new(1, 2),
+                metadata(),
+                Arc::new(imported.into()),
+            )
+            .unwrap();
+        let snapshot = assembler.snapshot().unwrap();
+        let mut session = CompilerSession::new();
+        let plan = session
+            .stage_import_discovery(
+                &snapshot,
+                context(1),
+                assembler.accepted_read_manifest(),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        loop {
+            let pending = plan.pending_requests(&ledger);
+            if pending.is_empty() {
+                break;
+            }
+            for request in pending {
+                let observation = if request.requested_path() == "/project/a.rue" {
+                    ImportObservation::accepted(
+                        request.clone(),
+                        AcceptedImportSource::new(
+                            request.requested_path(),
+                            "/project/a.rue",
+                            PhysicalFileIdentity::new(1, 2),
+                            metadata(),
+                            Arc::new(imported.into()),
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap()
+                } else {
+                    ImportObservation::absent(request)
+                };
+                ledger.record(observation).unwrap();
+            }
+        }
+        let closed = session.close_import_discovery(ledger).unwrap();
+        let envelope = DependencyEnvelope::from_closed_revision(&closed).unwrap();
+
+        assert_eq!(envelope.status, DependencyEnvelopeStatus::Complete);
+        assert_eq!(envelope.topology.root, "main.rue");
+        assert!(matches!(
+            envelope.topology.records[0].outcome,
+            DependencyResolutionOutcome::Resolved { ref module } if module == "a.rue"
+        ));
+        assert!(envelope.observations.iter().any(|observation| matches!(
+            observation.outcome,
+            DependencyObservationOutcome::Absent
+        )));
+        assert!(envelope.observations.iter().any(|observation| matches!(
+            observation.outcome,
+            DependencyObservationOutcome::PresentReadable { .. }
+        )));
+        assert_eq!(envelope.accepted_reads.len(), 2);
+        assert!(
+            envelope
+                .revision
+                .starts_with("rue-dependency-revision-v1-sha256:")
+        );
+    }
+
+    #[test]
+    fn missing_envelope_is_revision_labeled_and_incomplete() {
+        let assembler = assembler("const x = @import(\"missing\"); fn main() -> i32 { 0 }");
+        let snapshot = assembler.snapshot().unwrap();
+        let mut session = CompilerSession::new();
+        let plan = session
+            .stage_import_discovery(
+                &snapshot,
+                context(1),
+                assembler.accepted_read_manifest(),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        loop {
+            let pending = plan.pending_requests(&ledger);
+            if pending.is_empty() {
+                break;
+            }
+            for request in pending {
+                ledger.record(ImportObservation::absent(request)).unwrap();
+            }
+        }
+        session.close_import_discovery(ledger).unwrap_err();
+        let envelope =
+            DependencyEnvelope::from_closed_revision(session.discovery_attempt().unwrap()).unwrap();
+
+        assert_eq!(envelope.status, DependencyEnvelopeStatus::Incomplete);
+        assert!(matches!(
+            envelope.topology.records[0].outcome,
+            DependencyResolutionOutcome::Missing
+        ));
+        assert_eq!(envelope.accepted_reads.len(), 1);
+        assert!(envelope.observations.iter().all(|observation| matches!(
+            observation.outcome,
+            DependencyObservationOutcome::Absent
+        )));
+    }
+
+    #[test]
+    fn policy_denial_is_not_serialized_as_a_probe_or_read() {
+        assert!(matches!(
+            observation_outcome(&ImportObservationStatus::DeniedLexical),
+            DependencyObservationOutcome::DeniedLexical
+        ));
+        assert!(matches!(
+            observation_outcome(&ImportObservationStatus::Absent),
+            DependencyObservationOutcome::Absent
+        ));
+    }
+
+    #[test]
+    fn malformed_import_shape_is_not_an_incomplete_envelope() {
+        let assembler = assembler("fn main() -> i32 { @import(); 0 }");
+        let snapshot = assembler.snapshot().unwrap();
+        let mut session = CompilerSession::new();
+        let plan = session
+            .stage_import_discovery(
+                &snapshot,
+                context(1),
+                assembler.accepted_read_manifest(),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        assert!(
+            plan.pending_requests(&ImportObservationLedger::default())
+                .is_empty()
+        );
+        session
+            .close_import_discovery(ImportObservationLedger::default())
+            .unwrap_err();
+        let attempted = session.discovery_attempt().unwrap();
+        assert!(attempted.graph().is_some());
+        assert!(attempted.graph().unwrap().validation().is_valid());
+        assert!(DependencyEnvelope::from_closed_revision(attempted).is_none());
+    }
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -34,6 +34,7 @@ mod canonical_lower;
 mod canonical_merge;
 mod canonical_semantic;
 mod definition_snapshot;
+mod dependency_envelope;
 mod diagnostic;
 mod drop_glue;
 mod durable_body;
@@ -64,6 +65,11 @@ mod api_inventory;
 mod integration_tests;
 
 // Supported source, identity, option, session, and diagnostic surface.
+pub use dependency_envelope::{
+    DependencyAcceptedRead, DependencyContext, DependencyEnvelope, DependencyEnvelopeStatus,
+    DependencyObservation, DependencyObservationOutcome, DependencyRequest,
+    DependencyResolutionOutcome, DependencyTopology, DependencyTopologyRecord,
+};
 pub use diagnostic::{
     ColorChoice, DiagnosticFormatter, JsonDiagnostic, JsonDiagnosticFormatter, JsonSpan,
     JsonSuggestion, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::Read;
@@ -19,18 +19,18 @@ mod timing;
 use rue_compiler::CompilerSessionWork;
 use rue_compiler::{
     AcceptedImportSource, Ast, CanonicalRirOutput, CanonicalSemanticOutput, CompileError,
-    CompileErrors, CompileOptions, CompileWarning, CompilerSession, DiscoverySourceAssembler,
-    ErrorKind, FileId, FileMetadataFingerprint, ImportDiscoveryContext,
-    ImportDiscoveryRevisionArtifact, ImportObservation, ImportObservationLedger,
-    ImportObservationStatus, Lexer, LinkerMode, MultiFileFormatter, MultiFileJsonFormatter,
-    OptLevel, PhysicalFileIdentity, PipelineWork, PreviewFeature, PreviewFeatures, SourceInfo,
-    SourceMetadata, SourceSnapshot, Token, TypeInternPool, configure_thread_pool,
-    generate_emitted_asm, generate_liveness_info, generate_lowering_info, generate_mir,
-    generate_regalloc_info, generate_stack_frame_info, parse_source_snapshot_for_ast_presentation,
+    CompileErrors, CompileOptions, CompileWarning, CompilerSession, DependencyEnvelope,
+    DependencyEnvelopeStatus, DiscoverySourceAssembler, ErrorKind, FileId, FileMetadataFingerprint,
+    ImportDiscoveryContext, ImportDiscoveryRevisionArtifact, ImportDiscoveryRevisionStatus,
+    ImportObservation, ImportObservationLedger, ImportObservationStatus, Lexer, LinkerMode,
+    MultiFileFormatter, MultiFileJsonFormatter, OptLevel, PhysicalFileIdentity, PipelineWork,
+    PreviewFeature, PreviewFeatures, SourceInfo, SourceMetadata, SourceSnapshot, Token,
+    TypeInternPool, configure_thread_pool, generate_emitted_asm, generate_liveness_info,
+    generate_lowering_info, generate_mir, generate_regalloc_info, generate_stack_frame_info,
+    parse_source_snapshot_for_ast_presentation,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
-use serde::Serialize;
 
 /// Compilation stages that can be emitted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -815,21 +815,6 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         if explicit_output {
             eprintln!("Warning: -o is ignored with --emit; IR goes to stdout");
         }
-    } else {
-        // In every executable-producing mode: the output must not clobber an
-        // input. Compare RESOLVED filesystem paths, not raw strings, so
-        // different spellings of the same file are all caught — `rue a.rue -o
-        // a.rue`, `rue ./prog -o prog`, or an extensionless source `rue prog
-        // -o prog`. The earlier guard keyed off a `.rue` suffix, so
-        // extensionless sources slipped through and the compiled output
-        // silently overwrote the source (RUE-351). Hard links are caught by
-        // inode, and the guard re-runs after @import discovery for sources
-        // that are not known yet at parse time (RUE-527).
-        if check_output_clobbers_source(&final_output_path, source_paths.iter().map(|s| s.as_str()))
-            .is_err()
-        {
-            return ParseResult::Error;
-        }
     }
 
     if log_format.is_some() && log_level.is_none() {
@@ -1501,99 +1486,12 @@ fn validate_manifest_allows_source(
     Err(())
 }
 
-#[derive(Debug, Clone, Serialize)]
-struct DependencySource {
-    path: String,
-    kind: &'static str,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct DependencyImport {
-    from: String,
-    specifier: String,
-    resolved: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct DependencyOutput {
-    version: u32,
-    root: String,
-    sources: Vec<DependencySource>,
-    imports: Vec<DependencyImport>,
-}
-
 #[derive(Debug)]
 struct ImportDiscoveryResult {
     mixed_imports: Vec<PathBuf>,
     source_snapshot: SourceSnapshot,
     revision: Arc<ImportDiscoveryRevisionArtifact>,
     session: CompilerSession,
-}
-
-fn dependency_output_from_canonical_graph(
-    snapshot: &SourceSnapshot,
-    graph: &rue_compiler::CanonicalImportGraph,
-    positional_sources: &HashSet<PathBuf>,
-) -> DependencyOutput {
-    let physical_for = |module: &rue_compiler::ModuleId| {
-        snapshot
-            .metadata()
-            .logical_paths()
-            .find_map(|(file_id, logical)| {
-                (logical == module.as_str())
-                    .then(|| snapshot.metadata().physical_path(file_id))
-                    .flatten()
-            })
-            .and_then(|path| fs::canonicalize(path).ok())
-    };
-    let root = physical_for(graph.root()).unwrap_or_default();
-    let sources = snapshot
-        .files()
-        .filter_map(|source| {
-            fs::canonicalize(source.path).ok().map(|path| {
-                let kind = if source.file_id == snapshot.metadata().root_file_id() {
-                    "root"
-                } else if positional_sources.contains(&path) {
-                    "positional"
-                } else {
-                    "import"
-                };
-                DependencySource {
-                    path: path.display().to_string(),
-                    kind,
-                }
-            })
-        })
-        .collect();
-    let mut imports = Vec::new();
-    for record in graph.records() {
-        let Some(from) = physical_for(record.importer()) else {
-            continue;
-        };
-        let targets: Vec<_> = match record.resolution() {
-            rue_compiler::CanonicalImportResolution::Resolved(target) => vec![target],
-            rue_compiler::CanonicalImportResolution::Ambiguous {
-                file_module,
-                directory_module,
-            } => vec![file_module, directory_module],
-            rue_compiler::CanonicalImportResolution::Missing => Vec::new(),
-        };
-        for target in targets {
-            if let Some(resolved) = physical_for(target) {
-                imports.push(DependencyImport {
-                    from: from.display().to_string(),
-                    specifier: record.normalized_specifier().to_owned(),
-                    resolved: resolved.display().to_string(),
-                });
-            }
-        }
-    }
-    DependencyOutput {
-        version: 1,
-        root: root.display().to_string(),
-        sources,
-        imports,
-    }
 }
 
 /// Reject a source before discovery lexing if Rue's span representation cannot
@@ -1851,17 +1749,33 @@ fn discover_and_load_imports(
         eprintln!("Error: {error}");
     })?;
     debug_assert_eq!(final_plan.source_revision(), snapshot.source_revision());
-    let closed = staging.close_import_discovery(ledger).map_err(|_| {
-        let diagnostics = staging
-            .import_diagnostics()
-            .expect("failed closure publishes canonical import diagnostics");
-        let errors = CompileErrors::from(diagnostics.errors().to_vec());
-        let infos = snapshot
-            .files()
-            .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
-            .collect();
-        DiagnosticOutput::new(error_format, infos).print_errors(&errors);
-    })?;
+    let closed = match staging.close_import_discovery(ledger) {
+        Ok(closed) => closed,
+        Err(_) => {
+            let attempted = staging
+                .discovery_attempt()
+                .expect("failed closure publishes an attempted import revision")
+                .clone();
+            if DependencyEnvelope::from_closed_revision(&attempted).is_some() {
+                // Missing and ambiguous resolution are structurally closed and
+                // therefore have canonical topology for `--emit deps`. The
+                // caller owns their one diagnostic rendering so the envelope
+                // can be written first. All other failures have no topology.
+                attempted
+            } else {
+                let diagnostics = staging
+                    .import_diagnostics()
+                    .expect("failed closure publishes canonical import diagnostics");
+                let errors = CompileErrors::from(diagnostics.errors().to_vec());
+                let infos = snapshot
+                    .files()
+                    .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+                    .collect();
+                DiagnosticOutput::new(error_format, infos).print_errors(&errors);
+                return Err(());
+            }
+        }
+    };
     Ok(ImportDiscoveryResult {
         mixed_imports,
         source_snapshot: snapshot,
@@ -1958,7 +1872,9 @@ fn main() {
         Ok(result) => result,
         Err(()) => std::process::exit(1),
     };
-    if !import_discovery.mixed_imports.is_empty() {
+    if import_discovery.revision.status() == ImportDiscoveryRevisionStatus::ClosedValid
+        && !import_discovery.mixed_imports.is_empty()
+    {
         eprintln!(
             "Error: source files listed after the root must not also be loaded through @import"
         );
@@ -1974,21 +1890,6 @@ fn main() {
         std::process::exit(1);
     }
     let source_snapshot = import_discovery.source_snapshot.clone();
-
-    // Re-run the output-clobber guard now that @import discovery has appended
-    // the full source set: the parse-time guard only saw positional paths, so
-    // `rue main.rue -o helper.rue` (helper loaded via @import) silently
-    // replaced helper.rue with the executable (RUE-527). --emit never writes
-    // the output path, so it is exempt, matching the parse-time guard.
-    if options.emit_stages.is_empty()
-        && check_output_clobbers_source(
-            &options.output_path,
-            source_snapshot.files().map(|source| source.path),
-        )
-        .is_err()
-    {
-        std::process::exit(1);
-    }
 
     // Create multi-file diagnostic formatters from the snapshot's borrowed
     // views so diagnostics and compilation necessarily observe the same input.
@@ -2009,27 +1910,20 @@ fn main() {
             );
             std::process::exit(1);
         }
-        let positional_sources = options
-            .source_paths
-            .iter()
-            .skip(1)
-            .filter_map(|path| fs::canonicalize(path).ok())
-            .collect();
-        let dependency_output = dependency_output_from_canonical_graph(
-            &source_snapshot,
-            import_discovery
-                .revision
-                .graph()
-                .expect("closed valid discovery has graph")
-                .graph(),
-            &positional_sources,
-        );
-        match serde_json::to_string_pretty(&dependency_output) {
+        let dependency_envelope =
+            DependencyEnvelope::from_closed_revision(&import_discovery.revision)
+                .expect("closed valid or resolution-incomplete discovery has dependency topology");
+        let incomplete = dependency_envelope.status == DependencyEnvelopeStatus::Incomplete;
+        match serde_json::to_string_pretty(&dependency_envelope) {
             Ok(json) => println!("{json}"),
             Err(e) => {
-                eprintln!("Error emitting dependency graph: {e}");
+                eprintln!("Error emitting dependency envelope: {e}");
                 std::process::exit(1);
             }
+        }
+        if incomplete {
+            diagnostics.print_errors(import_discovery.revision.diagnostics());
+            std::process::exit(1);
         }
         print_timing_output(
             &timing_data,
@@ -2039,6 +1933,26 @@ fn main() {
             None,
         );
         return;
+    }
+
+    if import_discovery.revision.status() != ImportDiscoveryRevisionStatus::ClosedValid {
+        diagnostics.print_errors(import_discovery.revision.diagnostics());
+        std::process::exit(1);
+    }
+
+    // Only a closed-valid revision may reach output validation. Canonical
+    // attempted-revision diagnostics take precedence over an output-path
+    // conflict, matching discovery failure ordering. Run the guard only now,
+    // once @import discovery has appended the full source set. --emit never
+    // writes the output path.
+    if options.emit_stages.is_empty()
+        && check_output_clobbers_source(
+            &options.output_path,
+            source_snapshot.files().map(|source| source.path),
+        )
+        .is_err()
+    {
+        std::process::exit(1);
     }
 
     // --emit and --benchmark-json both own stdout, so combining them would
@@ -2794,18 +2708,22 @@ mod tests {
     }
 
     #[test]
-    fn parse_output_equals_extensionless_input_error() {
-        // RUE-351: `-o` targeting an extensionless input source is refused.
-        // Resolved-path identity, rather than a `.rue` suffix, protects the
-        // input; neither file needs to exist for the keys to match.
-        assert!(is_error(&parse_args_from(&["prog", "-o", "prog"])));
+    fn parse_defers_extensionless_output_identity_check() {
+        // RUE-351 remains enforced after closed discovery, when canonical
+        // import diagnostics have already received precedence.
+        assert!(matches!(
+            parse_args_from(&["prog", "-o", "prog"]),
+            ParseResult::Options(_)
+        ));
     }
 
     #[test]
-    fn parse_output_equals_input_different_spelling_error() {
-        // RUE-351: resolved-path comparison catches `./prog` vs `prog` — the
-        // same file spelled two ways — not just a byte-for-byte string match.
-        assert!(is_error(&parse_args_from(&["./prog", "-o", "prog"])));
+    fn parse_defers_different_spelling_output_identity_check() {
+        // The post-discovery guard still compares resolved path spellings.
+        assert!(matches!(
+            parse_args_from(&["./prog", "-o", "prog"]),
+            ParseResult::Options(_)
+        ));
     }
 
     #[test]
@@ -3004,10 +2922,13 @@ mod tests {
     fn emit_mode_skips_output_clobber_guard() {
         // --emit writes nothing to the output path, so -o naming a source
         // file is NOT a clobber (it is merely ignored, with a warning); the
-        // same spelling without --emit is still refused.
+        // executable mode defers the guard until import discovery has closed.
         let opts = unwrap_options(parse_args_from(&["--emit", "ast", "x.rue", "-o", "x.rue"]));
         assert_eq!(opts.emit_stages, vec![EmitStage::Ast]);
-        assert!(is_error(&parse_args_from(&["x.rue", "-o", "x.rue"])));
+        assert!(matches!(
+            parse_args_from(&["x.rue", "-o", "x.rue"]),
+            ParseResult::Options(_)
+        ));
     }
 
     #[test]

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,10 +56,24 @@ discovering the root import graph:
 "$RUE" --emit deps main.rue
 ```
 
-This prints JSON containing the canonical root source, all observed
-root/positional/imported source files, and resolved `@import` edges. It is the
-observed dependency graph; a source manifest is still the declared allowed-read
-set.
+This prints a deterministic version-1 JSON envelope with a revision label and
+three separately ordered components:
+
+- `topology`: the compiler's canonical root and import outcomes (`resolved`,
+  `missing`, or `ambiguous`), plus legal import cycles;
+- `observations`: every compiler-generated candidate request and its physical or
+  policy outcome; and
+- `accepted_reads`: only regular source contents actually read and accepted,
+  with their logical module, physical identity, metadata fingerprint, and
+  content fingerprint.
+
+The top-level `status` is `complete` for a closed valid graph. A structurally
+closed graph containing a missing or ambiguous import is still emitted with
+`status: "incomplete"`; Rue also renders the canonical diagnostics and exits
+unsuccessfully. Parse, discovery-I/O, identity, and non-closure failures have no
+canonical topology and therefore emit no dependency envelope. A denied request
+is not an executed probe, an absent probe is not an accepted read, and the
+source manifest remains the separately declared allowed-read set.
 
 Run `"$RUE" --help` for targets, preview features, optimization levels,
 logging, timing, manifests, and all emit stages.


### PR DESCRIPTION
## Summary

- replace the CLI dependency graph projection with a compiler-owned, deterministic versioned envelope
- serialize canonical topology/outcomes, the complete observation ledger, and accepted reads from one closed import revision
- emit explicit incomplete envelopes for missing or ambiguous imports while preserving canonical diagnostics and nonzero exit status
- keep malformed, I/O, identity, and non-closure failures from inventing dependency topology
- preserve import-diagnostic precedence over mixed-input and output-clobber validation

## Why

Dependency presentation previously rebuilt physical edges in the CLI, so it could diverge from the canonical import graph used by compilation. ADR-0051 requires build integrations and `--emit deps` to consume the same revision-aligned compiler artifacts without requiring semantic analysis.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue cli emit_deps`
- `scripts/rue test`

Fixes RUE-810
