### PR TITLE
Refresh performance dashboard daily

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,8 +7,8 @@ name: Benchmarks
 #
 # Results flow: each platform job runs bench.sh and uploads results.json as
 # an artifact; the collect job appends them to per-platform history files on
-# the `perf` branch; the Website workflow (workflow_run trigger) then
-# redeploys the performance dashboard with the new data.
+# the `perf` branch; the daily Website workflow then redeploys the performance
+# dashboard with the latest collected data.
 
 on:
   push:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,7 +4,7 @@ on:
   # Deploy (post-merge on trunk) only on real website changes. The spec is
   # published from docs/spec, but re-deploying on every spec commit rolls the
   # dice against the flaky GitHub Pages backend far too often; spec, benchmark,
-  # and status-board changes are picked up by the weekly schedule (or a manual
+  # and status-board changes are picked up by the daily schedule (or a manual
   # run) instead.
   push:
     branches: [trunk]
@@ -23,10 +23,10 @@ on:
       - 'scripts/generate-charts.py'
       - 'scripts/generate-site-status.py'
       - '.github/workflows/deploy-website.yml'
-  # Weekly refresh so the published spec, benchmark sparkline, and status board
-  # don't drift more than ~7 days behind trunk. Switch to '0 6 1 * *' for monthly.
+  # Daily refresh so the published spec, benchmark sparkline, and status board
+  # don't drift more than ~24 hours behind trunk.
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- refresh the published website daily at 06:00 UTC instead of weekly
- keep benchmark collection per trunk commit while publishing the latest collected history within 24 hours
- align the benchmark workflow's data-flow documentation with the deployment schedule

## Why

Rue now changes regularly enough that a weekly website deployment can leave the performance dashboard showing obsolete results for several days. A daily refresh improves freshness without deploying GitHub Pages after every benchmark run.

## Validation

- parsed both changed workflow files with Ruby's YAML parser
- `git diff --check`
