### PR TITLE
RUE-721: preserve failed semantic work

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -43,10 +43,11 @@ pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
 pub use sema::{
-    AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyAnalysisWork, BodyNamedDependencyEvent,
-    BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken, BoundSema, BuiltinTypeCallHead, ConstValue,
-    DeclarationBindingWork, DeclarationBuiltinTypeCallHeadDependencyEvent,
-    DeclarationInstallFailure, DeclarationShells, DeclarationTypeCallHeadDependencyEvent,
+    AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyAnalysisFailure, BodyAnalysisWork,
+    BodyNamedDependencyEvent, BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken, BoundSema,
+    BuiltinTypeCallHead, ConstValue, DeclarationBindingWork,
+    DeclarationBuiltinTypeCallHeadDependencyEvent, DeclarationInstallFailure,
+    DeclarationResolutionFailure, DeclarationShells, DeclarationTypeCallHeadDependencyEvent,
     DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,
     DeclarationTypeDependencySourceKind, DeclarationTypeDependencyTargetKind, FunctionInfo,
     ImplicitDropDependencySourceEvent, ImplicitNamedDestructorDependencyEvent, MethodInfo,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -43,8 +43,19 @@ use crate::types::{
 ///
 /// Called from Sema::analyze_all after declarations are collected.
 /// Uses the demand-driven driver for every program shape.
-pub(crate) fn analyze_all_function_bodies(mut sema: BodySema<'_>) -> MultiErrorResult<SemaOutput> {
-    analyze_all_function_bodies_mut(&mut sema)
+pub(crate) fn analyze_all_function_bodies(sema: BodySema<'_>) -> MultiErrorResult<SemaOutput> {
+    analyze_all_function_bodies_with_work(sema).map_err(super::BodyAnalysisFailure::into_errors)
+}
+
+pub(crate) fn analyze_all_function_bodies_with_work(
+    mut sema: BodySema<'_>,
+) -> Result<SemaOutput, super::BodyAnalysisFailure> {
+    let result = analyze_all_function_bodies_mut(&mut sema);
+    let work = result
+        .as_ref()
+        .map(|output| output.body_analysis_work)
+        .unwrap_or(sema.body_analysis_work);
+    result.map_err(|errors| super::BodyAnalysisFailure::new(errors, work))
 }
 
 #[cfg(test)]

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -138,6 +138,9 @@ pub struct DeclarationBindingWork {
     pub indexed_declaration_records_visited: usize,
     /// Resolution of declaration payloads, constants, and cycles.
     pub declaration_resolution_invocations: usize,
+    /// Declaration-resolution invocations that returned diagnostics before a
+    /// body-analysis-ready binder could be finalized.
+    pub declaration_resolution_failures: usize,
     /// Construction of the body-analysis-ready state.
     pub body_readiness_finalization_invocations: usize,
     /// Durable payload installation attempts at the declaration-shell seam.
@@ -151,6 +154,28 @@ pub struct DeclarationBindingWork {
     pub indexed_anonymous_methods: usize,
     pub indexed_destructors: usize,
     pub indexed_const_candidates: usize,
+}
+
+/// Diagnostics and value-only structural work from failed declaration
+/// resolution. Partially resolved semantic state remains private.
+#[derive(Debug, Clone)]
+pub struct DeclarationResolutionFailure {
+    errors: CompileErrors,
+    work: DeclarationBindingWork,
+}
+
+impl DeclarationResolutionFailure {
+    fn new(errors: CompileErrors, work: DeclarationBindingWork) -> Self {
+        Self { errors, work }
+    }
+
+    pub fn work(&self) -> DeclarationBindingWork {
+        self.work
+    }
+
+    pub fn into_errors(self) -> CompileErrors {
+        self.errors
+    }
 }
 
 /// Stable-joinable identity of a declaration whose semantic payload is not yet
@@ -330,7 +355,15 @@ impl<'a> DeclarationShells<'a> {
     }
 
     /// Resolve declaration payloads and finalize a body-analysis-ready binder.
-    pub fn resolve_declarations(mut self) -> MultiErrorResult<BoundSema<'a>> {
+    pub fn resolve_declarations(self) -> MultiErrorResult<BoundSema<'a>> {
+        self.resolve_declarations_with_work()
+            .map_err(DeclarationResolutionFailure::into_errors)
+    }
+
+    /// Resolve declaration payloads while retaining exact work on failure.
+    pub fn resolve_declarations_with_work(
+        mut self,
+    ) -> Result<BoundSema<'a>, DeclarationResolutionFailure> {
         // This is the explicit payload-install boundary. The ordinary adapter
         // deliberately resolves from the authoritative current-revision RIR in
         // historical order. A future importer may validate durable payloads
@@ -354,10 +387,14 @@ impl<'a> DeclarationShells<'a> {
                 .iter()
                 .all(|pending| pending.declaration.as_u32() < self.sema.rir.len() as u32)
         );
-        self.sema
-            .resolve_declarations()
-            .map_err(CompileErrors::from)?;
         self.binding_work.declaration_resolution_invocations += 1;
+        if let Err(error) = self.sema.resolve_declarations() {
+            self.binding_work.declaration_resolution_failures += 1;
+            return Err(DeclarationResolutionFailure::new(
+                CompileErrors::from(error),
+                self.binding_work,
+            ));
+        }
         self.binding_work.body_readiness_finalization_invocations += 1;
         Ok(self.sema.into_bound_with_work(self.binding_work))
     }
@@ -856,6 +893,12 @@ impl<'a> BoundSema<'a> {
 
     pub fn analyze_all_bodies(self) -> MultiErrorResult<SemaOutput> {
         self.sema.analyze_all_bodies()
+    }
+
+    /// Analyze bodies while retaining value-only work counters if diagnostics
+    /// prevent AIR publication.
+    pub fn analyze_all_bodies_with_work(self) -> Result<SemaOutput, super::BodyAnalysisFailure> {
+        self.sema.analyze_all_bodies_with_work()
     }
 }
 
@@ -1542,6 +1585,7 @@ impl DeclarationBindingWork {
             callable_value_shells_predeclared: 0,
             indexed_declaration_records_visited: 0,
             declaration_resolution_invocations: 0,
+            declaration_resolution_failures: 0,
             body_readiness_finalization_invocations: 0,
             durable_install_invocations: 0,
             durable_payloads_installed: 0,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -46,12 +46,12 @@ mod visibility;
 
 // Public re-exports
 pub use binding_manifest::{
-    BoundSema, DeclarationBindingWork, DeclarationInstallFailure, DeclarationShells,
-    SemanticBinding, SemanticBindingKind, SemanticBindingManifest, SemanticBindingManifestWork,
-    SemanticBindingNamespace, SemanticDeclarationExport, SemanticDeclarationExportWork,
-    SemanticDeclarationPayload, SemanticDeclarationShell, SemanticDeclarationShellIdentity,
-    SemanticExportConstValue, SemanticExportFailure, SemanticExportParameter, SemanticExportType,
-    SemanticNominalIdentity, SemanticParameterMode,
+    BoundSema, DeclarationBindingWork, DeclarationInstallFailure, DeclarationResolutionFailure,
+    DeclarationShells, SemanticBinding, SemanticBindingKind, SemanticBindingManifest,
+    SemanticBindingManifestWork, SemanticBindingNamespace, SemanticDeclarationExport,
+    SemanticDeclarationExportWork, SemanticDeclarationPayload, SemanticDeclarationShell,
+    SemanticDeclarationShellIdentity, SemanticExportConstValue, SemanticExportFailure,
+    SemanticExportParameter, SemanticExportType, SemanticNominalIdentity, SemanticParameterMode,
 };
 pub use context::ConstValue;
 pub use declaration_index::RirDeclarationIndexWork;
@@ -59,16 +59,16 @@ pub use inference_ctx::InferenceContext;
 pub use info::{AnonMethodSig, ConstInfo, FunctionInfo, MethodInfo};
 pub use known_symbols::KnownSymbols;
 pub use output::{
-    AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyAnalysisWork, BodyNamedDependencyEvent,
-    BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken, BuiltinTypeCallHead,
-    DeclarationBuiltinTypeCallHeadDependencyEvent, DeclarationTypeCallHeadDependencyEvent,
-    DeclarationTypeDependencyEvent, DeclarationTypeDependencyKind,
-    DeclarationTypeDependencySourceKind, DeclarationTypeDependencyTargetKind,
-    ImplicitDropDependencySourceEvent, ImplicitNamedDestructorDependencyEvent,
-    NamedConstDependencyEvent, NamedConstDependencyTargetEvent, NamedDestructorDependencyEvent,
-    NamedMethodDependencyEvent, NamedMethodDependencyTargetEvent,
-    OrdinaryFreeFunctionDependencyEvent, ParamSlotModes, SemaOutput,
-    SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
+    AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyAnalysisFailure, BodyAnalysisWork,
+    BodyNamedDependencyEvent, BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken,
+    BuiltinTypeCallHead, DeclarationBuiltinTypeCallHeadDependencyEvent,
+    DeclarationTypeCallHeadDependencyEvent, DeclarationTypeDependencyEvent,
+    DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
+    DeclarationTypeDependencyTargetKind, ImplicitDropDependencySourceEvent,
+    ImplicitNamedDestructorDependencyEvent, NamedConstDependencyEvent,
+    NamedConstDependencyTargetEvent, NamedDestructorDependencyEvent, NamedMethodDependencyEvent,
+    NamedMethodDependencyTargetEvent, OrdinaryFreeFunctionDependencyEvent, ParamSlotModes,
+    SemaOutput, SpecializedFreeFunctionDependencyEvent, SpecializedFreeFunctionOrigin,
 };
 
 use std::collections::{HashMap, HashSet};
@@ -830,6 +830,10 @@ impl BodySema<'_> {
     /// Analyze all function bodies using a structurally frozen source namespace.
     fn analyze_all_bodies(self) -> MultiErrorResult<SemaOutput> {
         analysis::analyze_all_function_bodies(self)
+    }
+
+    fn analyze_all_bodies_with_work(self) -> Result<SemaOutput, BodyAnalysisFailure> {
+        analysis::analyze_all_function_bodies_with_work(self)
     }
 }
 

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -412,6 +412,8 @@ pub struct BodyAnalysisWork {
     pub specialization_requests_duplicate: usize,
     pub specialization_rewrites: usize,
     pub specialization_rounds: usize,
+    /// Failures in specialization orchestration before a specialized body is attempted.
+    pub specialization_driver_failures: usize,
     pub specialized_bodies_attempted: usize,
     pub specialized_bodies_succeeded: usize,
     pub specialized_bodies_failed: usize,
@@ -440,4 +442,26 @@ pub struct BodyAnalysisWork {
     /// This excludes one-time implicit-root scans, unused-reference scans, and
     /// comptime evaluation. Indexed dispatch keeps this value at zero.
     pub reachable_declaration_rir_visits: usize,
+}
+
+/// Diagnostics and value-only structural work from a failed body-analysis
+/// request. Failed AIR artifacts remain private and are never published.
+#[derive(Debug, Clone)]
+pub struct BodyAnalysisFailure {
+    errors: rue_error::CompileErrors,
+    work: BodyAnalysisWork,
+}
+
+impl BodyAnalysisFailure {
+    pub(crate) fn new(errors: rue_error::CompileErrors, work: BodyAnalysisWork) -> Self {
+        Self { errors, work }
+    }
+
+    pub fn work(&self) -> BodyAnalysisWork {
+        self.work
+    }
+
+    pub fn into_errors(self) -> rue_error::CompileErrors {
+        self.errors
+    }
 }

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -250,6 +250,7 @@ impl Specializer {
             sema.body_analysis_work.specialization_rounds += 1;
             if self.rounds > MAX_SPECIALIZATION_ROUNDS {
                 let key = &pending[0];
+                sema.body_analysis_work.specialization_driver_failures += 1;
                 return Err(CompileError::new(
                     ErrorKind::ComptimeEvaluationFailed {
                         reason: format!(

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -146,6 +146,7 @@ struct Fixture {
     reachable_root_body_edit: SourceSnapshot,
     identity_edit: SourceSnapshot,
     syntax_error: SourceSnapshot,
+    semantic_error: SourceSnapshot,
 }
 
 impl Fixture {
@@ -157,6 +158,7 @@ impl Fixture {
             reachable_root_body_edit: snapshot(modules, Variant::ReachableRootBodyEdit),
             identity_edit: snapshot(modules, Variant::IdentityEdit),
             syntax_error: snapshot(modules, Variant::SyntaxError),
+            semantic_error: snapshot(modules, Variant::SemanticError),
         }
     }
 }
@@ -167,6 +169,7 @@ enum Variant {
     ReachableRootBodyEdit,
     IdentityEdit,
     SyntaxError,
+    SemanticError,
 }
 
 fn snapshot(modules: usize, variant: Variant) -> SourceSnapshot {
@@ -188,10 +191,14 @@ fn snapshot(modules: usize, variant: Variant) -> SourceSnapshot {
     let sources = (0..modules)
         .map(|index| {
             let source = if index == 0 {
-                format!(
-                    "fn main() -> i32 {{ {} }}",
-                    usize::from(!matches!(variant, Variant::Base))
-                )
+                if matches!(variant, Variant::SemanticError) {
+                    "fn main() -> i32 { missing_name }".to_string()
+                } else {
+                    format!(
+                        "fn main() -> i32 {{ {} }}",
+                        usize::from(!matches!(variant, Variant::Base))
+                    )
+                }
             } else if index == changed && matches!(variant, Variant::SyntaxError) {
                 format!("fn leaf{index}( {{")
             } else {
@@ -221,7 +228,16 @@ fn parse_json(work: ParsedModulesWork) -> Value {
 fn semantic_work_json(work: &CompilerSessionWork, from: usize) -> Value {
     let records = &work.semantic_records[from..];
     json!({
+        "failed_requests": records.iter().filter(|record| record.failure.is_some()).count(),
+        "failure_phases": {
+            "declaration": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(rue_compiler::CanonicalSemanticFailurePhase::Declaration))).count(),
+            "body_analysis": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(rue_compiler::CanonicalSemanticFailurePhase::BodyAnalysis))).count(),
+            "cfg_construction": records.iter().filter(|record| matches!(record.failure.map(|failure| failure.phase), Some(rue_compiler::CanonicalSemanticFailurePhase::CfgConstruction))).count(),
+        },
         "bind_invocations": records.iter().map(|record| record.work.binding.bind_invocations).sum::<usize>(),
+        "declaration_resolution_invocations": records.iter().map(|record| record.work.binding.declaration_resolution_invocations).sum::<usize>(),
+        "declaration_resolution_failures": records.iter().map(|record| record.work.binding.declaration_resolution_failures).sum::<usize>(),
+        "body_readiness_finalization_invocations": records.iter().map(|record| record.work.binding.body_readiness_finalization_invocations).sum::<usize>(),
         "body_free_function_lookups": records.iter().map(|record| record.work.body_analysis.free_function_record_lookups).sum::<usize>(),
         "bodies_attempted": records.iter().map(|record| record.work.body_analysis.bodies_attempted).sum::<usize>(),
         "bodies_succeeded": records.iter().map(|record| record.work.body_analysis.bodies_succeeded).sum::<usize>(),
@@ -236,6 +252,7 @@ fn semantic_work_json(work: &CompilerSessionWork, from: usize) -> Value {
         "specialization_requests_duplicate": records.iter().map(|record| record.work.body_analysis.specialization_requests_duplicate).sum::<usize>(),
         "specialization_rewrites": records.iter().map(|record| record.work.body_analysis.specialization_rewrites).sum::<usize>(),
         "specialization_rounds": records.iter().map(|record| record.work.body_analysis.specialization_rounds).sum::<usize>(),
+        "specialization_driver_failures": records.iter().map(|record| record.work.body_analysis.specialization_driver_failures).sum::<usize>(),
         "specialized_bodies_attempted": records.iter().map(|record| record.work.body_analysis.specialized_bodies_attempted).sum::<usize>(),
         "specialized_bodies_succeeded": records.iter().map(|record| record.work.body_analysis.specialized_bodies_succeeded).sum::<usize>(),
         "specialized_bodies_failed": records.iter().map(|record| record.work.body_analysis.specialized_bodies_failed).sum::<usize>(),
@@ -614,6 +631,25 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
             parse
         }),
     ));
+    scenarios.push(named(
+        "failed_semantic_edit",
+        measure(&mut session, |session| {
+            let update = session.update(&fixture.semantic_error);
+            assert!(update.downstream_invalidated());
+            let parse = update.work();
+            update.into_result().unwrap();
+            session.semantic(&options).unwrap_err();
+            parse
+        }),
+    ));
+    scenarios.push(named(
+        "semantic_recovery",
+        measure(&mut session, |session| {
+            let parse = session.update(&fixture.identity_edit).work();
+            session.semantic(&options).unwrap();
+            parse
+        }),
+    ));
 
     let mut stable = CompilerSession::new();
     scenarios.push(named(
@@ -821,6 +857,47 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
     assert_query_executions(recovery, 0, 0, 0, 0);
     assert_eq!(count(recovery, &["queries", "semantic_reuses"]), 1);
 
+    let failed_semantic = get("failed_semantic_edit");
+    assert_query_executions(failed_semantic, 1, 1, 1, 0);
+    assert_eq!(
+        count(failed_semantic, &["semantic_work", "failed_requests"]),
+        1
+    );
+    assert_eq!(
+        count(
+            failed_semantic,
+            &["semantic_work", "failure_phases", "body_analysis"]
+        ),
+        1
+    );
+    assert_eq!(
+        count(failed_semantic, &["semantic_work", "bodies_attempted"]),
+        1
+    );
+    assert_eq!(
+        count(failed_semantic, &["semantic_work", "bodies_succeeded"]),
+        0
+    );
+    assert_eq!(
+        count(failed_semantic, &["semantic_work", "bodies_failed"]),
+        1
+    );
+
+    let semantic_recovery = get("semantic_recovery");
+    assert_query_executions(semantic_recovery, 1, 1, 1, 0);
+    assert_eq!(
+        count(
+            semantic_recovery,
+            &[
+                "semantic_work",
+                "declaration_reuse",
+                "ordinary_declaration_resolutions_skipped"
+            ]
+        ),
+        1,
+        "failed semantic requests must not replace the last-good durable baseline"
+    );
+
     let stable_cold = get("stable_definitions_cold");
     assert_query_executions(stable_cold, 1, 1, 1, 1);
     assert_semantic_work(stable_cold, 1, 1, 1);
@@ -925,6 +1002,7 @@ fn assert_body_cfg_work_equal(left: &Value, right: &Value) {
         "specialization_requests_duplicate",
         "specialization_rewrites",
         "specialization_rounds",
+        "specialization_driver_failures",
         "specialized_bodies_attempted",
         "specialized_bodies_succeeded",
         "specialized_bodies_failed",
@@ -1095,7 +1173,7 @@ fn main() {
     println!(
         "{}",
         json!({
-            "schema_version": 9,
+            "schema_version": 10,
             "workload": "compiler_session_invalidation",
             "configuration": {
                 "modules": config.modules,
@@ -1116,7 +1194,7 @@ mod tests {
     #[test]
     fn small_workload_is_a_structural_smoke_test() {
         let scenarios = run_iteration(&Fixture::new(4));
-        assert_eq!(scenarios.len(), 12);
+        assert_eq!(scenarios.len(), 14);
         assert!(
             scenarios
                 .iter()

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -537,12 +537,14 @@ pub(crate) fn compare_canonical_durable_declaration_install(
                 ordinary,
                 crate::OptLevel::default(),
                 rir.semantic_symbols().interner(),
-            )?;
+            )
+            .map_err(|failure| failure.errors)?;
             let installed = crate::build_functions_and_cfgs(
                 installed,
                 crate::OptLevel::default(),
                 rir.semantic_symbols().interner(),
-            )?;
+            )
+            .map_err(|failure| failure.errors)?;
             if format!("{:?}", ordinary.functions) != format!("{:?}", installed.functions)
                 || format!("{:?}", ordinary.warnings) != format!("{:?}", installed.warnings)
                 || ordinary.strings != installed.strings

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -12,6 +12,9 @@ use rue_air::{
 };
 use tracing::info_span;
 
+#[cfg(test)]
+use std::cell::Cell;
+
 use crate::{
     BoundDefinitionSet, BoundDefinitionWork, CanonicalImportGraph, CanonicalMergedProgram,
     CanonicalRirOutput, CodegenInputDescriptor, CompileOptions, CompileWarning,
@@ -22,6 +25,105 @@ use crate::{
     },
     build_functions_and_cfgs,
 };
+
+#[cfg(test)]
+thread_local! {
+    static INJECT_CFG_FAILURE: Cell<bool> = const { Cell::new(false) };
+    static INJECT_DECLARATION_FAILURE: Cell<bool> = const { Cell::new(false) };
+    static INJECT_AUTHORITATIVE_KEY_MISMATCH: Cell<bool> = const { Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(crate) fn with_test_cfg_failure_injection<T>(run: impl FnOnce() -> T) -> T {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            INJECT_CFG_FAILURE.with(|enabled| enabled.set(false));
+        }
+    }
+
+    INJECT_CFG_FAILURE.with(|enabled| {
+        assert!(
+            !enabled.replace(true),
+            "CFG failure injection is not nestable"
+        );
+    });
+    let _reset = Reset;
+    run()
+}
+
+#[cfg(test)]
+pub(crate) fn with_test_declaration_failure_injection<T>(run: impl FnOnce() -> T) -> T {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            INJECT_DECLARATION_FAILURE.with(|enabled| enabled.set(false));
+        }
+    }
+
+    INJECT_DECLARATION_FAILURE.with(|enabled| {
+        assert!(
+            !enabled.replace(true),
+            "declaration failure injection is not nestable"
+        );
+    });
+    let _reset = Reset;
+    run()
+}
+
+#[cfg(test)]
+pub(crate) fn with_test_authoritative_key_mismatch<T>(run: impl FnOnce() -> T) -> T {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            INJECT_AUTHORITATIVE_KEY_MISMATCH.with(|enabled| enabled.set(false));
+        }
+    }
+
+    INJECT_AUTHORITATIVE_KEY_MISMATCH.with(|enabled| {
+        assert!(
+            !enabled.replace(true),
+            "authoritative-key mismatch injection is not nestable"
+        );
+    });
+    let _reset = Reset;
+    run()
+}
+
+#[cfg(test)]
+fn inject_cfg_failure(sema_output: &mut rue_air::SemaOutput, interner: &crate::ThreadedRodeo) {
+    use rue_air::{Air, AirInst, AirInstData, Type};
+    use rue_span::Span;
+
+    if !INJECT_CFG_FAILURE.with(Cell::get) {
+        return;
+    }
+    let function = sema_output
+        .functions
+        .iter_mut()
+        .find(|function| function.name == "main")
+        .expect("test CFG injection requires main");
+    let mut air = Air::new(Type::I32);
+    let call = air.add_inst(AirInst {
+        data: AirInstData::CallGeneric {
+            name: interner.get_or_intern("test_unrewritten_generic"),
+            type_args_start: 0,
+            type_args_len: 0,
+            value_args_start: 0,
+            value_args_len: 0,
+            args_start: 0,
+            args_len: 0,
+        },
+        ty: Type::I32,
+        span: Span::new(0, 1),
+    });
+    air.add_inst(AirInst {
+        data: AirInstData::Ret(Some(call)),
+        ty: Type::I32,
+        span: Span::new(0, 1),
+    });
+    function.air = air;
+}
 
 pub(crate) struct CanonicalOrdinaryAnalysis {
     pub output: CanonicalSemanticOutput,
@@ -61,17 +163,47 @@ pub(crate) fn prepare_canonical_declarations<'a>(
     rir: &'a CanonicalRirOutput,
     options: &CompileOptions,
     imports: &CanonicalImportGraph,
-) -> MultiErrorResult<CanonicalPreparedDeclarations<'a>> {
-    let sema = configure_timed_canonical_sema(merged, rir, options, imports)?;
+) -> Result<CanonicalPreparedDeclarations<'a>, CanonicalSemanticFailure> {
+    let sema = configure_timed_canonical_sema(merged, rir, options, imports).map_err(|errors| {
+        CanonicalSemanticFailure::declaration(errors, CanonicalSemanticWork::default())
+    })?;
     let declaration_index = sema.rir_declaration_index_work();
-    let shells = sema.predeclare_declaration_shells()?;
+    let declaration_reuse = CanonicalDeclarationReuseWork {
+        semantic_epochs_started: 1,
+        declaration_indexes_built: declaration_index.build_invocations,
+        shell_predeclaration_epochs: 1,
+        ..CanonicalDeclarationReuseWork::default()
+    };
+    let shells = sema.predeclare_declaration_shells().map_err(|errors| {
+        CanonicalSemanticFailure::declaration(
+            errors,
+            declaration_stage_work(
+                declaration_index,
+                DeclarationBindingWork::default(),
+                SemanticBindingManifestWork::default(),
+                BodyOwnerTokenWork::default(),
+                BodyAnalysisWork::default(),
+                false,
+                declaration_reuse,
+            ),
+        )
+    })?;
     let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
     let definitions = match issue_shell_definitions(merged, rir.source_revision(), &shell_records) {
         Ok(definitions) => definitions,
         Err(preparation_error) => {
             let preparation_error = crate::CompileErrors::from(preparation_error);
-            let bound = shells.resolve_declarations()?;
-            return recover_body_diagnostics(bound, preparation_error);
+            let bound = shells.resolve_declarations_with_work().map_err(|failure| {
+                declaration_resolution_failure(failure, declaration_index, false, declaration_reuse)
+            })?;
+            return Err(recover_declaration_failure(
+                bound,
+                preparation_error,
+                declaration_index,
+                false,
+                declaration_reuse,
+                BodyOwnerTokenWork::default(),
+            ));
         }
     };
     Ok(CanonicalPreparedDeclarations {
@@ -135,6 +267,85 @@ pub struct CfgConstructionWork {
     pub optimized_level_attempts: usize,
     pub cfg_warnings_emitted: usize,
     pub implicit_destructor_targets_emitted: usize,
+}
+
+/// The semantic phase that prevented publication of request artifacts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CanonicalSemanticFailurePhase {
+    Declaration,
+    BodyAnalysis,
+    CfgConstruction,
+}
+
+/// Value-only structural work retained for a failed semantic request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CanonicalSemanticFailureWork {
+    pub phase: CanonicalSemanticFailurePhase,
+    pub work: CanonicalSemanticWork,
+}
+
+pub(crate) struct CanonicalSemanticFailure {
+    pub(crate) errors: crate::CompileErrors,
+    pub(crate) failure: CanonicalSemanticFailureWork,
+}
+
+impl CanonicalSemanticFailure {
+    fn new(
+        phase: CanonicalSemanticFailurePhase,
+        errors: crate::CompileErrors,
+        work: CanonicalSemanticWork,
+    ) -> Self {
+        Self {
+            errors,
+            failure: CanonicalSemanticFailureWork { phase, work },
+        }
+    }
+
+    pub(crate) fn declaration(errors: crate::CompileErrors, work: CanonicalSemanticWork) -> Self {
+        Self::new(CanonicalSemanticFailurePhase::Declaration, errors, work)
+    }
+}
+
+fn declaration_stage_work(
+    declaration_index: RirDeclarationIndexWork,
+    binding: DeclarationBindingWork,
+    manifest: SemanticBindingManifestWork,
+    body_owner_tokens: BodyOwnerTokenWork,
+    body_analysis: BodyAnalysisWork,
+    stable_ids_requested: bool,
+    declaration_reuse: CanonicalDeclarationReuseWork,
+) -> CanonicalSemanticWork {
+    CanonicalSemanticWork {
+        declaration_index,
+        binding,
+        manifest,
+        body_owner_tokens,
+        body_analysis,
+        stable_ids_requested,
+        declaration_reuse,
+        ..CanonicalSemanticWork::default()
+    }
+}
+
+fn declaration_resolution_failure(
+    failure: rue_air::DeclarationResolutionFailure,
+    declaration_index: RirDeclarationIndexWork,
+    stable_ids_requested: bool,
+    declaration_reuse: CanonicalDeclarationReuseWork,
+) -> CanonicalSemanticFailure {
+    let binding = failure.work();
+    CanonicalSemanticFailure::declaration(
+        failure.into_errors(),
+        declaration_stage_work(
+            declaration_index,
+            binding,
+            SemanticBindingManifestWork::default(),
+            BodyOwnerTokenWork::default(),
+            BodyAnalysisWork::default(),
+            stable_ids_requested,
+            declaration_reuse,
+        ),
+    )
 }
 
 /// Owned semantic and optimized CFG artifacts returned by `CompilerSession`.
@@ -314,7 +525,8 @@ pub(crate) fn analyze_canonical_program(
         ),
         opt_level: options.opt_level.into(),
     };
-    let prepared = prepare_canonical_declarations(merged, rir, options, imports)?;
+    let prepared = prepare_canonical_declarations(merged, rir, options, imports)
+        .map_err(|failure| failure.errors)?;
     let CanonicalPreparedDeclarations {
         shells,
         shell_records: _,
@@ -334,6 +546,7 @@ pub(crate) fn analyze_canonical_program(
         CanonicalDeclarationReuseWork::default(),
         info_span!("sema").entered(),
     )
+    .map_err(|failure| failure.errors)
 }
 
 /// Run the ordinary canonical path once and opportunistically export its
@@ -345,7 +558,8 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
     rir: &CanonicalRirOutput,
     options: &CompileOptions,
     prepared: CanonicalPreparedDeclarations<'_>,
-) -> MultiErrorResult<CanonicalOrdinaryAnalysis> {
+    reuse_plan: CanonicalDeclarationReuseWork,
+) -> Result<CanonicalOrdinaryAnalysis, CanonicalSemanticFailure> {
     let input = CodegenInputDescriptor {
         semantic: SemanticInputDescriptor::new(
             merged.definitions().source_snapshot(),
@@ -361,7 +575,15 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
         definitions,
         declaration_index,
     } = prepared;
-    let bound = shells.resolve_declarations()?;
+    let declaration_reuse = CanonicalDeclarationReuseWork {
+        semantic_epochs_started: 1,
+        declaration_indexes_built: declaration_index.build_invocations,
+        shell_predeclaration_epochs: 1,
+        ..reuse_plan
+    };
+    let bound = shells.resolve_declarations_with_work().map_err(|failure| {
+        declaration_resolution_failure(failure, declaration_index, false, declaration_reuse)
+    })?;
 
     let durable_declarations = bound
         .with_declaration_semantics_from_shells(&shell_records, |records, _work| {
@@ -380,11 +602,8 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
         bound,
         definitions.clone(),
         CanonicalDeclarationReuseWork {
-            semantic_epochs_started: 1,
-            declaration_indexes_built: declaration_index.build_invocations,
-            shell_predeclaration_epochs: 1,
             durable_cache_population_exports: usize::from(durable_declarations.is_some()),
-            ..CanonicalDeclarationReuseWork::default()
+            ..declaration_reuse
         },
         sema_span,
     )?;
@@ -407,7 +626,7 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     prepared: CanonicalPreparedDeclarations<'_>,
     definitions: &BoundDefinitionSet,
     durable: &[DurableDeclarationSemantic],
-) -> MultiErrorResult<CanonicalSemanticOutput> {
+) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
     let input = CodegenInputDescriptor {
         semantic: SemanticInputDescriptor::new(
             merged.definitions().source_snapshot(),
@@ -441,7 +660,9 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
             reuse.fallbacks = 1;
             // Projection is read-only, so ordinary resolution consumes the
             // exact same unmutated shells and does not create a hidden epoch.
-            shells.resolve_declarations()?
+            shells.resolve_declarations_with_work().map_err(|failure| {
+                declaration_resolution_failure(failure, declaration_index, false, reuse)
+            })?
         }
         Ok((projected, _)) => {
             reuse.install_invocations += 1;
@@ -455,20 +676,67 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
                     // Installation consumes potentially mutated shells. Only
                     // this failure requires a wholly fresh ordinary epoch.
                     reuse.fallbacks = 1;
+                    let fallback = configure_timed_canonical_sema(merged, rir, options, imports)
+                        .map_err(|errors| {
+                            CanonicalSemanticFailure::declaration(
+                                errors,
+                                declaration_stage_work(
+                                    declaration_index,
+                                    DeclarationBindingWork::default(),
+                                    SemanticBindingManifestWork::default(),
+                                    BodyOwnerTokenWork::default(),
+                                    BodyAnalysisWork::default(),
+                                    false,
+                                    reuse,
+                                ),
+                            )
+                        })?;
                     reuse.fallback_epochs_started = 1;
                     reuse.semantic_epochs_started += 1;
-                    let fallback = configure_timed_canonical_sema(merged, rir, options, imports)?;
                     reuse.declaration_indexes_built +=
                         fallback.rir_declaration_index_work().build_invocations;
-                    let fallback_shells = fallback.predeclare_declaration_shells()?;
+                    reuse.shell_predeclaration_epochs += 1;
+                    let fallback_shells =
+                        fallback.predeclare_declaration_shells().map_err(|errors| {
+                            CanonicalSemanticFailure::declaration(
+                                errors,
+                                declaration_stage_work(
+                                    declaration_index,
+                                    DeclarationBindingWork::default(),
+                                    SemanticBindingManifestWork::default(),
+                                    BodyOwnerTokenWork::default(),
+                                    BodyAnalysisWork::default(),
+                                    false,
+                                    reuse,
+                                ),
+                            )
+                        })?;
                     let fallback_records = fallback_shells
                         .declaration_shells()
                         .cloned()
                         .collect::<Vec<_>>();
                     selected_definitions =
                         issue_shell_definitions(merged, rir.source_revision(), &fallback_records)
-                            .map_err(crate::CompileErrors::from)?;
-                    fallback_shells.resolve_declarations()?
+                            .map_err(crate::CompileErrors::from)
+                            .map_err(|errors| {
+                                CanonicalSemanticFailure::declaration(
+                                    errors,
+                                    declaration_stage_work(
+                                        declaration_index,
+                                        DeclarationBindingWork::default(),
+                                        SemanticBindingManifestWork::default(),
+                                        BodyOwnerTokenWork::default(),
+                                        BodyAnalysisWork::default(),
+                                        false,
+                                        reuse,
+                                    ),
+                                )
+                            })?;
+                    fallback_shells
+                        .resolve_declarations_with_work()
+                        .map_err(|failure| {
+                            declaration_resolution_failure(failure, declaration_index, false, reuse)
+                        })?
                 }
             }
         }
@@ -520,8 +788,21 @@ fn finish_canonical_analysis(
     provisional_definitions: BoundDefinitionSet,
     declaration_reuse: CanonicalDeclarationReuseWork,
     sema_span: tracing::span::EnteredSpan,
-) -> MultiErrorResult<CanonicalSemanticOutput> {
+) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
     let binding = bound.binding_work();
+    #[cfg(test)]
+    if INJECT_DECLARATION_FAILURE.with(Cell::get) {
+        return Err(recover_declaration_failure(
+            bound,
+            crate::CompileErrors::from(crate::CompileError::without_span(
+                rue_error::ErrorKind::InternalError("test declaration failure injection".into()),
+            )),
+            declaration_index,
+            request_stable_ids,
+            declaration_reuse,
+            BodyOwnerTokenWork::default(),
+        ));
+    }
     let manifest = bound.binding_manifest();
     let authoritative_definitions = match issue_bound_definitions(
         merged,
@@ -531,7 +812,14 @@ fn finish_canonical_analysis(
     ) {
         Ok(definitions) => definitions,
         Err(preparation_error) => {
-            return recover_body_diagnostics(bound, crate::CompileErrors::from(preparation_error));
+            return Err(recover_declaration_failure(
+                bound,
+                crate::CompileErrors::from(preparation_error),
+                declaration_index,
+                request_stable_ids,
+                declaration_reuse,
+                BodyOwnerTokenWork::default(),
+            ));
         }
     };
     let provisional_keys = provisional_definitions
@@ -562,6 +850,12 @@ fn finish_canonical_analysis(
         })
         .map(|r| r.stable_key())
         .collect::<Vec<_>>();
+    #[cfg(test)]
+    let mut authoritative_keys = authoritative_keys;
+    #[cfg(test)]
+    if INJECT_AUTHORITATIVE_KEY_MISMATCH.with(Cell::get) {
+        authoritative_keys.pop();
+    }
     if provisional_keys != authoritative_keys {
         let first_difference = provisional_keys
             .iter()
@@ -577,7 +871,21 @@ fn finish_canonical_analysis(
                 first_difference.and_then(|index| authoritative_keys.get(index)),
             )),
         ));
-        return recover_body_diagnostics(bound, preparation_error);
+        return Err(recover_declaration_failure(
+            bound,
+            preparation_error,
+            declaration_index,
+            request_stable_ids,
+            declaration_reuse,
+            BodyOwnerTokenWork {
+                provisional_slots: provisional_keys.len(),
+                authoritative_slots: authoritative_keys.len(),
+                slots_validated: first_difference
+                    .unwrap_or_else(|| provisional_keys.len().min(authoritative_keys.len())),
+                tokens_installed: 0,
+                validation_failures: 1,
+            },
+        ));
     }
     let manifest_work = manifest.work();
     let bound_definitions = request_stable_ids.then(|| authoritative_definitions.clone());
@@ -590,14 +898,53 @@ fn finish_canonical_analysis(
         validation_failures: 0,
     };
     let bound = bound.install_body_owner_tokens(&endpoints).map_err(|_| {
-        crate::CompileErrors::from(crate::CompileError::without_span(
-            rue_error::ErrorKind::InternalError(
-                "failed to install authoritative body-owner tokens".into(),
+        let mut failed_tokens = body_owner_tokens;
+        failed_tokens.tokens_installed = 0;
+        failed_tokens.validation_failures = 1;
+        CanonicalSemanticFailure::declaration(
+            crate::CompileErrors::from(crate::CompileError::without_span(
+                rue_error::ErrorKind::InternalError(
+                    "failed to install authoritative body-owner tokens".into(),
+                ),
+            )),
+            declaration_stage_work(
+                declaration_index,
+                binding,
+                manifest_work,
+                failed_tokens,
+                BodyAnalysisWork::default(),
+                request_stable_ids,
+                declaration_reuse,
             ),
-        ))
+        )
     })?;
 
-    let sema_output = bound.analyze_all_bodies()?;
+    let sema_output = match bound.analyze_all_bodies_with_work() {
+        Ok(output) => output,
+        Err(failure) => {
+            let work = CanonicalSemanticWork {
+                declaration_index,
+                binding,
+                manifest: manifest_work,
+                bound_definitions: bound_definitions.as_ref().map(BoundDefinitionSet::work),
+                body_owner_tokens,
+                body_analysis: failure.work(),
+                durable_bodies: crate::DurableBodyWork::default(),
+                cfg: CfgConstructionWork::default(),
+                stable_ids_requested: request_stable_ids,
+                declaration_reuse,
+            };
+            return Err(CanonicalSemanticFailure::new(
+                CanonicalSemanticFailurePhase::BodyAnalysis,
+                failure.into_errors(),
+                work,
+            ));
+        }
+    };
+    #[cfg(test)]
+    let mut sema_output = sema_output;
+    #[cfg(test)]
+    inject_cfg_failure(&mut sema_output, rir.semantic_symbols().interner());
     let body_analysis = sema_output.body_analysis_work;
     let mut durable_body_work = crate::DurableBodyWork {
         export_attempts: body_analysis.ordinary_body_exports_attempted,
@@ -651,7 +998,26 @@ fn finish_canonical_analysis(
         sema_output,
         options.opt_level,
         rir.semantic_symbols().interner(),
-    )?;
+    )
+    .map_err(|failure| {
+        let work = CanonicalSemanticWork {
+            declaration_index,
+            binding,
+            manifest: manifest_work,
+            bound_definitions: bound_definitions.as_ref().map(BoundDefinitionSet::work),
+            body_owner_tokens,
+            body_analysis,
+            durable_bodies: durable_body_work,
+            cfg: failure.work,
+            stable_ids_requested: request_stable_ids,
+            declaration_reuse,
+        };
+        CanonicalSemanticFailure::new(
+            CanonicalSemanticFailurePhase::CfgConstruction,
+            failure.errors,
+            work,
+        )
+    })?;
     let mut warnings = cfg.warnings;
     warnings.sort_by(|left, right| {
         let key = |warning: &CompileWarning| {
@@ -727,14 +1093,35 @@ fn finish_canonical_analysis(
 /// Preserve ordinary source diagnostics when strict token preparation rejects
 /// an already-bound epoch. The semantic result is consumed and discarded: it
 /// can recover diagnostics, but can never publish a partially prepared output.
-fn recover_body_diagnostics<T>(
+fn recover_declaration_failure(
     bound: rue_air::BoundSema<'_>,
     preparation_error: crate::CompileErrors,
-) -> MultiErrorResult<T> {
-    match bound.analyze_all_bodies() {
-        Err(source_errors) => Err(source_errors),
-        Ok(_) => Err(preparation_error),
-    }
+    declaration_index: RirDeclarationIndexWork,
+    stable_ids_requested: bool,
+    declaration_reuse: CanonicalDeclarationReuseWork,
+    body_owner_tokens: BodyOwnerTokenWork,
+) -> CanonicalSemanticFailure {
+    let binding = bound.binding_work();
+    let manifest = bound.binding_manifest().work();
+    let (errors, body_analysis) = match bound.analyze_all_bodies_with_work() {
+        Err(failure) => {
+            let work = failure.work();
+            (failure.into_errors(), work)
+        }
+        Ok(output) => (preparation_error, output.body_analysis_work),
+    };
+    CanonicalSemanticFailure::declaration(
+        errors,
+        declaration_stage_work(
+            declaration_index,
+            binding,
+            manifest,
+            body_owner_tokens,
+            body_analysis,
+            stable_ids_requested,
+            declaration_reuse,
+        ),
+    )
 }
 
 #[cfg(test)]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -127,7 +127,10 @@ pub use bound_definitions::{
 };
 pub use canonical_lower::{CanonicalRirOutput, CanonicalRirWork};
 pub use canonical_merge::{CanonicalMergeWork, CanonicalMergedAst, CanonicalMergedProgram};
-pub use canonical_semantic::{CanonicalSemanticOutput, CanonicalSemanticWork};
+pub use canonical_semantic::{
+    CanonicalSemanticFailurePhase, CanonicalSemanticFailureWork, CanonicalSemanticOutput,
+    CanonicalSemanticWork,
+};
 pub use definition_snapshot::{
     DefinitionId, DefinitionKind, DefinitionNameKey, DefinitionNamespace, DefinitionOccurrenceId,
     DefinitionRecord, DefinitionShard, DefinitionShardWork, DefinitionSnapshot, ModuleDefinition,

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -128,6 +128,11 @@ pub(crate) struct CfgFrontendOutput {
     pub(crate) work: canonical_semantic::CfgConstructionWork,
 }
 
+pub(crate) struct CfgConstructionFailure {
+    pub(crate) errors: CompileErrors,
+    pub(crate) work: canonical_semantic::CfgConstructionWork,
+}
+
 /// Lower semantic-analysis output through drop-glue synthesis, comptime filtering,
 /// CFG construction, and CFG optimization.
 ///
@@ -137,7 +142,7 @@ pub(crate) fn build_functions_and_cfgs(
     sema_output: SemaOutput,
     opt_level: OptLevel,
     interner: &ThreadedRodeo,
-) -> MultiErrorResult<CfgFrontendOutput> {
+) -> Result<CfgFrontendOutput, CfgConstructionFailure> {
     let SemaOutput {
         functions,
         strings,
@@ -273,10 +278,16 @@ pub(crate) fn build_functions_and_cfgs(
     let mut functions = Vec::with_capacity(results.len());
     let mut implicit_named_destructor_dependencies = Vec::new();
     let mut implicit_named_destructor_dependencies_complete = true;
+    let mut first_errors = None;
     for result in results {
-        let ((func, func_warnings, mut implicit_edges, complete), function_work) = match result {
-            Ok(value) => value,
-            Err((errors, _discarded_work)) => return Err(errors),
+        let (output, function_work) = match result {
+            Ok((output, function_work)) => (Some(output), function_work),
+            Err((errors, function_work)) => {
+                if first_errors.is_none() {
+                    first_errors = Some(errors);
+                }
+                (None, function_work)
+            }
         };
         work.cfg_builds_attempted += function_work.cfg_builds_attempted;
         work.cfg_builds_succeeded += function_work.cfg_builds_succeeded;
@@ -288,10 +299,15 @@ pub(crate) fn build_functions_and_cfgs(
         work.cfg_warnings_emitted += function_work.cfg_warnings_emitted;
         work.implicit_destructor_targets_emitted +=
             function_work.implicit_destructor_targets_emitted;
-        functions.push(func);
-        warnings.extend(func_warnings);
-        implicit_named_destructor_dependencies.append(&mut implicit_edges);
-        implicit_named_destructor_dependencies_complete &= complete;
+        if let Some((func, func_warnings, mut implicit_edges, complete)) = output {
+            functions.push(func);
+            warnings.extend(func_warnings);
+            implicit_named_destructor_dependencies.append(&mut implicit_edges);
+            implicit_named_destructor_dependencies_complete &= complete;
+        }
+    }
+    if let Some(errors) = first_errors {
+        return Err(CfgConstructionFailure { errors, work });
     }
     implicit_named_destructor_dependencies.sort();
     implicit_named_destructor_dependencies.dedup();
@@ -435,4 +451,91 @@ pub(crate) fn compile_with_session(
         semantic: semantic.work(),
     };
     Ok(output)
+}
+
+#[cfg(test)]
+mod failure_work_tests {
+    use lasso::ThreadedRodeo;
+    use rue_air::{Air, AirInst, AirInstData, Sema, Type};
+    use rue_error::PreviewFeatures;
+    use rue_lexer::Lexer;
+    use rue_parser::Parser;
+    use rue_rir::AstGen;
+    use rue_span::Span;
+
+    use super::*;
+
+    fn malformed_cfg_input() -> (SemaOutput, ThreadedRodeo) {
+        let source = "fn alpha() -> i32 { 1 }\nfn broken() -> i32 { 2 }\nfn main() -> i32 { alpha() + broken() + zeta() }\nfn zeta() -> i32 { 3 }";
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        let parser = Parser::new(tokens, interner);
+        let (ast, interner) = parser.parse().unwrap();
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = astgen.finish();
+        let mut output = Sema::new(&rir, &interner, PreviewFeatures::new())
+            .analyze_all()
+            .unwrap();
+
+        for (name, start) in [("broken", 10), ("zeta", 20)] {
+            let generic = interner.get_or_intern(format!("unrewritten_{name}"));
+            let function = output
+                .functions
+                .iter_mut()
+                .find(|function| function.name == name)
+                .unwrap();
+            let mut air = Air::new(Type::I32);
+            let call = air.add_inst(AirInst {
+                data: AirInstData::CallGeneric {
+                    name: generic,
+                    type_args_start: 0,
+                    type_args_len: 0,
+                    value_args_start: 0,
+                    value_args_len: 0,
+                    args_start: 0,
+                    args_len: 0,
+                },
+                ty: Type::I32,
+                span: Span::new(start, start + 1),
+            });
+            air.add_inst(AirInst {
+                data: AirInstData::Ret(Some(call)),
+                ty: Type::I32,
+                span: Span::new(start, start + 1),
+            });
+            function.air = air;
+        }
+        (output, interner)
+    }
+
+    #[test]
+    fn malformed_air_retains_deterministic_work_from_every_cfg_builder() {
+        let run = || {
+            let (output, interner) = malformed_cfg_input();
+            match build_functions_and_cfgs(output, OptLevel::O1, &interner) {
+                Ok(_) => panic!("malformed AIR unexpectedly built a CFG"),
+                Err(failure) => failure,
+            }
+        };
+        let first = run();
+        let second = run();
+        assert_eq!(first.work, second.work);
+        assert_eq!(first.work.functions_considered, 4);
+        assert_eq!(first.work.cfg_builds_attempted, 4);
+        assert_eq!(first.work.cfg_builds_succeeded, 2);
+        assert_eq!(first.work.cfg_builds_failed, 2);
+        assert_eq!(first.work.optimization_attempts, 2);
+        assert_eq!(first.work.optimization_completions, 2);
+        assert_eq!(first.work.optimized_level_attempts, 2);
+        assert_eq!(
+            format!("{:?}", first.errors),
+            format!("{:?}", second.errors)
+        );
+        assert_eq!(
+            first.errors.iter().next().unwrap().span().unwrap().start,
+            10,
+            "the first sorted failing function supplies the published diagnostic"
+        );
+    }
 }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1013,6 +1013,7 @@ impl CanonicalImportGraphOutput {
 pub struct SemanticQueryRecord {
     pub input: CodegenInputDescriptor,
     pub work: CanonicalSemanticWork,
+    pub failure: Option<crate::CanonicalSemanticFailureWork>,
     pub failed: bool,
 }
 
@@ -2149,7 +2150,7 @@ impl CompilerSession {
         }
 
         self.work.semantic.executions += 1;
-        let prepared = prepare_canonical_declarations(&merged, &rir, options, &imports);
+        let mut prepared = prepare_canonical_declarations(&merged, &rir, options, &imports);
         let current_fingerprints: Result<Vec<StableDefinitionInputFingerprint>, CompileErrors> =
             match &prepared {
                 Ok(definitions) => definitions
@@ -2163,9 +2164,11 @@ impl CompilerSession {
                         )
                     })
                     .collect(),
-                Err(errors) => Err(errors.clone()),
+                Err(failure) => Err(failure.errors.clone()),
             };
+        let mut reuse_plan = crate::canonical_semantic::CanonicalDeclarationReuseWork::default();
         let reusable = self.durable_declaration_cache.as_ref().and_then(|cache| {
+            reuse_plan.plan_executions = 1;
             self.work.declaration_reuse_plans += 1;
             if cache.root != *merged.ast().root()
                 || cache.target != options.target
@@ -2175,40 +2178,49 @@ impl CompilerSession {
             }
             let fingerprints = current_fingerprints.as_ref().ok()?;
             let (matches, compared) = declaration_surfaces_match(&cache.fingerprints, fingerprints);
+            reuse_plan.durable_records_compared = compared;
             self.work.durable_records_compared += compared;
             matches.then(|| cache.semantics.clone())
         });
+        if let Err(failure) = &mut prepared {
+            failure.failure.work.declaration_reuse.plan_executions += reuse_plan.plan_executions;
+            failure
+                .failure
+                .work
+                .declaration_reuse
+                .durable_records_compared += reuse_plan.durable_records_compared;
+        }
         let mut cold_durable = None;
-        let result = prepared
-            .and_then(|prepared| {
-                if let Some(durable) = reusable {
-                    let definitions = prepared.definitions().clone();
-                    analyze_prepared_canonical_program_reusing_declarations(
-                        &merged,
-                        &rir,
-                        options,
-                        &imports,
-                        prepared,
-                        &definitions,
-                        &durable,
-                    )
-                } else {
-                    analyze_prepared_canonical_program_with_durable_export(
-                        &merged, &rir, options, prepared,
-                    )
-                    .map(|analysis| {
-                        cold_durable = analysis
-                            .durable_declarations
-                            .map(|semantics| (analysis.definitions, semantics));
-                        analysis.output
-                    })
-                }
-            })
-            .map(Arc::new);
-        let semantic_work = result
+        let analysis = prepared.and_then(|prepared| {
+            if let Some(durable) = reusable {
+                let definitions = prepared.definitions().clone();
+                analyze_prepared_canonical_program_reusing_declarations(
+                    &merged,
+                    &rir,
+                    options,
+                    &imports,
+                    prepared,
+                    &definitions,
+                    &durable,
+                )
+            } else {
+                analyze_prepared_canonical_program_with_durable_export(
+                    &merged, &rir, options, prepared, reuse_plan,
+                )
+                .map(|analysis| {
+                    cold_durable = analysis
+                        .durable_declarations
+                        .map(|semantics| (analysis.definitions, semantics));
+                    analysis.output
+                })
+            }
+        });
+        let failure = analysis.as_ref().err().map(|failure| failure.failure);
+        let semantic_work = analysis
             .as_ref()
             .map(|output| output.work())
-            .unwrap_or_default();
+            .unwrap_or_else(|failure| failure.failure.work);
+        let result = analysis.map(Arc::new).map_err(|failure| failure.errors);
         if let Ok(output) = &result {
             debug_assert_eq!(output.input(), &input);
             debug_assert_eq!(semantic_work.binding.bind_invocations, 1);
@@ -2262,6 +2274,7 @@ impl CompilerSession {
         self.work.semantic_records.push(SemanticQueryRecord {
             input: input.clone(),
             work: semantic_work,
+            failure,
             failed: result.is_err(),
         });
         let source = self
@@ -3964,8 +3977,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        LinkerMode, ModuleId, OptLevel, PreviewFeature, PreviewFeatures, SourceMetadata,
-        SourceSnapshot, Target,
+        CanonicalSemanticFailurePhase, LinkerMode, ModuleId, OptLevel, PreviewFeature,
+        PreviewFeatures, SourceMetadata, SourceSnapshot, Target,
     };
 
     fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
@@ -4768,6 +4781,219 @@ mod tests {
         assert_eq!(session.work().semantic.executions, 2);
         assert_eq!(session.work().semantic_entries, 1);
         assert_eq!(session.work().semantic_entries_invalidated, 1);
+    }
+
+    #[test]
+    fn failed_body_work_is_retained_without_replacing_the_last_good_baseline() {
+        let valid = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 0 }")],
+            1,
+        );
+        let invalid = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn main() -> i32 { missing_name }",
+            )],
+            1,
+        );
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&valid).into_result().unwrap();
+        session.semantic(&options).unwrap();
+
+        session.update(&invalid).into_result().unwrap();
+        let first = session.semantic(&options).unwrap_err();
+        let second = session.semantic(&options).unwrap_err();
+        assert_eq!(format!("{first:?}"), format!("{second:?}"));
+        let record = session.work().semantic_records.last().unwrap();
+        assert_eq!(
+            record.failure.unwrap().phase,
+            CanonicalSemanticFailurePhase::BodyAnalysis
+        );
+        assert_eq!(record.work.body_analysis.bodies_attempted, 1);
+        assert_eq!(record.work.body_analysis.bodies_succeeded, 0);
+        assert_eq!(record.work.body_analysis.bodies_failed, 1);
+        assert_eq!(record.work.cfg.cfg_builds_attempted, 0);
+
+        session.update(&valid).into_result().unwrap();
+        session.semantic(&options).unwrap();
+        let recovered = session.work().semantic_records.last().unwrap();
+        assert!(recovered.failure.is_none());
+        assert_eq!(
+            recovered
+                .work
+                .declaration_reuse
+                .ordinary_declaration_resolutions_skipped,
+            1,
+            "the failed request must not replace the last-good durable baseline"
+        );
+    }
+
+    #[test]
+    fn specialization_failure_work_is_retained() {
+        let invalid = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn runaway(comptime n: i32) -> i32 { runaway(n + 1) }\nfn main() -> i32 { runaway(0) }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&invalid).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap_err();
+        let record = session.work().semantic_records.last().unwrap();
+        assert_eq!(
+            record.failure.unwrap().phase,
+            CanonicalSemanticFailurePhase::BodyAnalysis
+        );
+        assert_eq!(record.work.body_analysis.specialization_driver_failures, 1);
+        assert_eq!(record.work.body_analysis.specialized_bodies_attempted, 64);
+        assert_eq!(record.work.body_analysis.specialized_bodies_succeeded, 64);
+        assert_eq!(record.work.body_analysis.specialized_bodies_failed, 0);
+        assert_eq!(record.work.body_analysis.specialization_rounds, 65);
+    }
+
+    #[test]
+    fn declaration_failure_retains_completed_declaration_work() {
+        let valid = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 0 }")],
+            1,
+        );
+        let changed = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&valid).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+        session.update(&changed).into_result().unwrap();
+        crate::canonical_semantic::with_test_declaration_failure_injection(|| {
+            session.semantic(&CompileOptions::default()).unwrap_err();
+        });
+
+        let record = session.work().semantic_records.last().unwrap();
+        assert_eq!(
+            record.failure.unwrap().phase,
+            CanonicalSemanticFailurePhase::Declaration
+        );
+        assert_eq!(record.work.declaration_index.build_invocations, 1);
+        assert_eq!(record.work.binding.bind_invocations, 1);
+        assert_eq!(record.work.manifest.build_invocations, 1);
+        assert_eq!(record.work.body_analysis.bodies_attempted, 1);
+        assert_eq!(record.work.body_analysis.bodies_succeeded, 1);
+        assert_eq!(record.work.declaration_reuse.plan_executions, 1);
+        assert_eq!(record.work.declaration_reuse.durable_records_compared, 1);
+        assert_eq!(record.work.declaration_reuse.semantic_epochs_started, 1);
+    }
+
+    #[test]
+    fn declaration_resolution_failure_retains_exact_attempt_work() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "struct Recursive { next: Recursive } fn main() -> i32 { 0 }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap_err();
+
+        let record = session.work().semantic_records.last().unwrap();
+        assert_eq!(
+            record.failure.unwrap().phase,
+            CanonicalSemanticFailurePhase::Declaration
+        );
+        assert_eq!(record.work.declaration_index.build_invocations, 1);
+        assert_eq!(record.work.binding.bind_invocations, 1);
+        assert_eq!(record.work.binding.namespace_setup_invocations, 1);
+        assert_eq!(record.work.binding.declaration_resolution_invocations, 1);
+        assert_eq!(record.work.binding.declaration_resolution_failures, 1);
+        assert_eq!(
+            record.work.binding.body_readiness_finalization_invocations,
+            0
+        );
+        assert_eq!(record.work.manifest.build_invocations, 0);
+        assert_eq!(record.work.body_analysis.bodies_attempted, 0);
+    }
+
+    #[test]
+    fn authoritative_key_mismatch_retains_failed_token_validation_work() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn helper() -> i32 { 0 } fn main() -> i32 { helper() }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        crate::canonical_semantic::with_test_authoritative_key_mismatch(|| {
+            session.semantic(&CompileOptions::default()).unwrap_err();
+        });
+
+        let record = session.work().semantic_records.last().unwrap();
+        assert_eq!(
+            record.failure.unwrap().phase,
+            CanonicalSemanticFailurePhase::Declaration
+        );
+        assert_eq!(record.work.body_owner_tokens.provisional_slots, 2);
+        assert_eq!(record.work.body_owner_tokens.authoritative_slots, 1);
+        assert_eq!(record.work.body_owner_tokens.slots_validated, 1);
+        assert_eq!(record.work.body_owner_tokens.tokens_installed, 0);
+        assert_eq!(record.work.body_owner_tokens.validation_failures, 1);
+    }
+
+    #[test]
+    fn cfg_failure_retains_work_without_replacing_the_last_good_baseline() {
+        let valid = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 0 }")],
+            1,
+        );
+        let changed = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
+            1,
+        );
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&valid).into_result().unwrap();
+        session.semantic(&options).unwrap();
+
+        session.update(&changed).into_result().unwrap();
+        crate::canonical_semantic::with_test_cfg_failure_injection(|| {
+            session.semantic(&options).unwrap_err();
+        });
+        let failed = session.work().semantic_records.last().unwrap();
+        assert_eq!(
+            failed.failure.unwrap().phase,
+            CanonicalSemanticFailurePhase::CfgConstruction
+        );
+        assert_eq!(failed.work.body_analysis.bodies_succeeded, 1);
+        assert_eq!(failed.work.cfg.functions_considered, 1);
+        assert_eq!(failed.work.cfg.cfg_builds_attempted, 1);
+        assert_eq!(failed.work.cfg.cfg_builds_failed, 1);
+        assert_eq!(failed.work.cfg.optimization_attempts, 0);
+
+        session.update(&valid).into_result().unwrap();
+        session.semantic(&options).unwrap();
+        let recovered = session.work().semantic_records.last().unwrap();
+        assert!(recovered.failure.is_none());
+        assert_eq!(
+            recovered
+                .work
+                .declaration_reuse
+                .ordinary_declaration_resolutions_skipped,
+            1,
+            "the CFG failure must not replace the last-good durable baseline"
+        );
     }
 
     #[test]

--- a/docs/process/session-invalidation-benchmark.md
+++ b/docs/process/session-invalidation-benchmark.md
@@ -74,12 +74,12 @@ values rather than timing-dependent shared state.
 Schema version 4 adds value-only body and CFG work. Top-level
 `semantic_work` records body attempts/successes/failures, AIR and local-string
 production, string remapping, specialization scans/calls/unique and duplicate
-requests/rewrites/rounds, and specialized-body attempts/successes/failures.
+requests/rewrites/rounds, specialization-driver failures, and specialized-body
+attempts/successes/failures.
 `semantic_work.cfg` records synthesized glue, functions considered and
 filtered, CFG attempts/successes/failures, AIR consumed, optimization attempts
 and completions (including non-O0 attempts), warnings, and implicit destructor
-targets. Counts describe completed semantic records; failed requests cannot yet
-be retained by the session record API and are tested at their owning phase.
+targets. Counts describe both successful and failed semantic executions.
 
 Schema version 5 adds `manifest_work.body_owner_events_translated`,
 `body_named_events_translated`, and `body_dependency_records_built`. The
@@ -117,3 +117,18 @@ Schema version 9 removes the obsolete population-binding query field. The
 authoritative `semantic_work.bind_invocations` and
 `semantic_work.declaration_reuse.durable_cache_population_exports` counters
 continue to gate the single-bind export path directly.
+
+Schema version 10 adds explicit failed semantic-request accounting.
+`semantic_work.failed_requests` counts retained failure envelopes and
+`semantic_work.failure_phases` splits declaration, body-analysis, and CFG
+construction failures. All ordinary body, specialization, and CFG fields now
+include deterministic work performed before a failed request was discarded.
+Declaration failures likewise retain each counter completed before their exact
+fallible boundary, including declaration-index, binding, manifest, recovery
+body, and durable-reuse work when those stages were reached.
+Declaration binding distinguishes resolution invocations, resolution failures,
+and successful body-readiness finalizations, so a rejected declaration epoch
+does not masquerade as an unattempted or completed one.
+The `failed_semantic_edit` scenario hard-gates attempted/failed body work, and
+`semantic_recovery` proves that a failure did not replace the last-good durable
+declaration baseline.


### PR DESCRIPTION
## What

- preserve exact declaration, body-analysis, specialization, and CFG work when semantic requests fail
- retain failure-phase evidence in canonical semantic query records
- extend benchmark schema and recovery scenarios to report failed work honestly
- add deterministic multi-function CFG failure aggregation and focused failure/recovery coverage

## Why

The canonical session previously discarded structural work performed by failed requests, making failed and fallback analysis invisible to the invalidation benchmark. This establishes the exact accounting boundary required before production body reuse.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- `scripts/rue test` (full serialized suite)

Fixes RUE-721
