### PR TITLE
RUE-875: preserve aggregate results across cleanup

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1091,7 +1091,7 @@ impl<'a> CfgBuilder<'a> {
                 }
 
                 // Lower the final value
-                let result = self.lower_inst(*value);
+                let mut result = self.lower_inst(*value);
 
                 // Pop scope and emit StorageDead (with Drop if needed) in reverse order.
                 // BUT: if the value diverged (break/continue/return), the diverging
@@ -1101,9 +1101,54 @@ impl<'a> CfgBuilder<'a> {
                     if let Some(scope_slots) = self.scope_stack.pop() {
                         // Only emit scope cleanup if the value didn't diverge
                         if !matches!(result.continuation, Continuation::Diverged) {
+                            // Preserve a block result in frame storage before
+                            // running its scope cleanup. A multi-slot result is
+                            // not safe to keep only in backend vregs here:
+                            // destructor lowering introduces more aggregate
+                            // operands, and register coalescing can otherwise
+                            // make those cleanup values reuse a result slot.
+                            //
+                            // This scratch region is not a second owner. It is
+                            // the block expression's value crossing the cleanup
+                            // boundary, so it deliberately is not added to the
+                            // drop scope. The post-cleanup Load continues the
+                            // same value and the eventual consumer owns it.
+                            let preserved = if !scope_slots.is_empty()
+                                && let Some(value) = result.value
+                                && ty != Type::UNIT
+                                && ty != Type::NEVER
+                                && self.type_pool.abi_slot_count(ty) > 1
+                            {
+                                let width = self.type_pool.abi_slot_count(ty).max(1);
+                                let slot = self.cfg.alloc_temp_local_slots(width);
+                                self.emit(
+                                    CfgInstData::StorageLive { slot, local_ty: ty },
+                                    Type::UNIT,
+                                    span,
+                                );
+                                self.emit(
+                                    CfgInstData::Alloc { slot, init: value },
+                                    Type::UNIT,
+                                    span,
+                                );
+                                Some(slot)
+                            } else {
+                                None
+                            };
+
                             for live_slot in scope_slots.into_iter().rev() {
                                 let slot_span = live_slot.span;
                                 self.emit_drop_for_slot(&live_slot, slot_span);
+                            }
+
+                            if let Some(slot) = preserved {
+                                let value = self.emit(CfgInstData::Load { slot }, ty, span);
+                                self.emit(
+                                    CfgInstData::StorageDead { slot, local_ty: ty },
+                                    Type::UNIT,
+                                    span,
+                                );
+                                result.value = Some(value);
                             }
                         }
                     }
@@ -3119,6 +3164,55 @@ mod tests {
             cfg.get_place_projections(&place),
             [Projection::Field { field_index: 1, .. }]
         ));
+    }
+
+    #[test]
+    fn aggregate_block_result_is_saved_while_scope_cleanup_runs() {
+        let cfg = build_cfg_named(
+            "struct Triple { a: u64, b: u64, c: u64 }\n\
+             struct Guard { value: i32 }\n\
+             drop fn Guard(self) { }\n\
+             fn make() -> Triple { Triple { a: 1, b: 2, c: 3 } }\n\
+             fn preserve() -> Triple { { let guard = Guard { value: 0 }; make() } }\n\
+             fn main() -> i32 { let value = preserve(); @intCast(value.a + value.b + value.c) }",
+            "preserve",
+        );
+
+        let instructions: Vec<_> = cfg
+            .blocks()
+            .iter()
+            .flat_map(|block| block.insts.iter().copied())
+            .collect();
+        let drop_index = instructions
+            .iter()
+            .position(|value| matches!(cfg.get_inst(*value).data, CfgInstData::Drop { .. }))
+            .expect("the inner Guard is cleaned up");
+        let (alloc_index, scratch_slot) = instructions[..drop_index]
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(index, value)| match cfg.get_inst(*value).data {
+                CfgInstData::Alloc { slot, .. } => Some((index, slot)),
+                _ => None,
+            })
+            .expect("the aggregate result is saved before cleanup");
+        let load_index = instructions[drop_index + 1..]
+            .iter()
+            .position(|value| {
+                matches!(
+                    cfg.get_inst(*value).data,
+                    CfgInstData::Load { slot } if slot == scratch_slot
+                )
+            })
+            .map(|index| index + drop_index + 1)
+            .expect("the aggregate result is restored after cleanup");
+
+        assert!(alloc_index < drop_index && drop_index < load_index);
+        assert_eq!(
+            cfg.num_locals(),
+            4,
+            "one Guard slot plus the complete three-slot result scratch"
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -402,6 +402,12 @@ use crate::*;
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
+
+    use rue_codegen::aarch64::{Aarch64Inst, Reg as Aarch64Reg};
+    use rue_codegen::x86_64::{Reg as X86Reg, X86Inst};
+
     use super::*;
 
     const FIRST_LITERAL: &[u8] = b"RUE784_FIRST_LITERAL";
@@ -438,6 +444,201 @@ fn main() -> i32 {
             crate::test_support::test_frontend_snapshot(&snapshot, &CompileOptions::default())
                 .unwrap();
         (rir, semantic)
+    }
+
+    fn strbuf_concat_frontend() -> (
+        std::sync::Arc<CanonicalRirOutput>,
+        std::sync::Arc<CanonicalSemanticOutput>,
+    ) {
+        let root = FileId::new(1);
+        let strbuf = FileId::new(2);
+        let metadata = SourceMetadata::new_with_trusted_standard_library(
+            root,
+            HashMap::from([
+                (root, "/project/main.rue".to_owned()),
+                (strbuf, "/project/std/strbuf.rue".to_owned()),
+            ]),
+            HashMap::from([
+                (root, "main.rue".to_owned()),
+                (strbuf, "\0rue-std/strbuf.rue".to_owned()),
+            ]),
+            HashSet::from([strbuf]),
+        )
+        .unwrap();
+        let source = r#"
+const strbuf = @import("std/strbuf.rue");
+
+fn main() -> i32 {
+    println("count: " + @to_string(3));
+    println("sum: " + @to_string(13));
+    0
+}
+"#;
+        let snapshot = SourceSnapshot::new(
+            metadata,
+            vec![
+                (root, Arc::new(source.to_owned())),
+                (
+                    strbuf,
+                    Arc::new(
+                        r#"
+pub struct StrBuf {
+    buf: ptr mut u8,
+    len: u64,
+    cap: u64,
+
+    fn concat_borrowed(borrow first: Self, borrow second: Self) -> Self {
+        Self { buf: first.buf, len: first.len + second.len, cap: 0 }
+    }
+}
+
+drop fn StrBuf(self) { }
+"#
+                        .to_owned(),
+                    ),
+                ),
+            ],
+        )
+        .unwrap();
+        let (rir, semantic, _) =
+            crate::test_support::test_frontend_snapshot(&snapshot, &CompileOptions::default())
+                .unwrap();
+        (rir, semantic)
+    }
+
+    fn assert_three_result_slots_cross_cleanup(target: Target) {
+        let (rir, semantic) = strbuf_concat_frontend();
+        let main = semantic
+            .functions()
+            .iter()
+            .find(|function| function.analyzed.name == "main")
+            .unwrap();
+        let allocated = generate_allocated_mir(
+            &main.cfg,
+            semantic.type_pool(),
+            rir.semantic_symbols().interner(),
+            target,
+        )
+        .unwrap();
+
+        let (calls, stores, loads): (Vec<(usize, String)>, Vec<(usize, i32)>, Vec<(usize, i32)>) =
+            match &allocated {
+                Mir::X86_64(mir) => (
+                    mir.instructions()
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, instruction)| match instruction {
+                            X86Inst::CallRel { symbol_id } => {
+                                Some((index, mir.get_symbol(*symbol_id).to_owned()))
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                    mir.instructions()
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, instruction)| match instruction {
+                            X86Inst::MovMR {
+                                base: X86Reg::Rbp,
+                                offset,
+                                ..
+                            } => Some((index, *offset)),
+                            _ => None,
+                        })
+                        .collect(),
+                    mir.instructions()
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, instruction)| match instruction {
+                            X86Inst::MovRM {
+                                base: X86Reg::Rbp,
+                                offset,
+                                ..
+                            } => Some((index, *offset)),
+                            _ => None,
+                        })
+                        .collect(),
+                ),
+                Mir::Aarch64(mir) => (
+                    mir.instructions()
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, instruction)| match instruction {
+                            Aarch64Inst::Bl { symbol_id } => {
+                                Some((index, mir.get_symbol(*symbol_id).to_owned()))
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                    mir.instructions()
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, instruction)| match instruction {
+                            Aarch64Inst::Str {
+                                base: Aarch64Reg::Fp,
+                                offset,
+                                ..
+                            } => Some((index, *offset)),
+                            _ => None,
+                        })
+                        .collect(),
+                    mir.instructions()
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, instruction)| match instruction {
+                            Aarch64Inst::Ldr {
+                                base: Aarch64Reg::Fp,
+                                offset,
+                                ..
+                            } => Some((index, *offset)),
+                            _ => None,
+                        })
+                        .collect(),
+                ),
+            };
+
+        let concats: Vec<_> = calls
+            .iter()
+            .filter(|(_, symbol)| symbol.contains("concat_borrowed"))
+            .collect();
+        assert_eq!(concats.len(), 2, "{target}: expected both concatenations");
+
+        for (concat_index, _) in concats {
+            let println_index = calls
+                .iter()
+                .find(|(index, symbol)| {
+                    index > concat_index && symbol.as_str() == "__rue_str_println"
+                })
+                .map(|(index, _)| *index)
+                .expect("println after concatenation");
+            let cleanups: Vec<_> = calls
+                .iter()
+                .filter(|(index, symbol)| {
+                    index > concat_index
+                        && *index < println_index
+                        && (symbol.contains(".__drop") || symbol.starts_with("__rue_drop_"))
+                })
+                .map(|(index, _)| *index)
+                .collect();
+            let first_cleanup = *cleanups.first().expect("temporary cleanup before println");
+            let last_cleanup = *cleanups.last().unwrap();
+            let saved: HashSet<_> = stores
+                .iter()
+                .filter(|(index, _)| *index > *concat_index && *index < first_cleanup)
+                .map(|(_, offset)| *offset)
+                .collect();
+            let restored: HashSet<_> = loads
+                .iter()
+                .filter(|(index, _)| *index > last_cleanup && *index < println_index)
+                .map(|(_, offset)| *offset)
+                .collect();
+            let preserved: HashSet<_> = saved.intersection(&restored).copied().collect();
+            assert_eq!(
+                preserved.len(),
+                3,
+                "{target}: StrBuf pointer, length, and capacity must all cross cleanup in frame storage"
+            );
+        }
     }
 
     #[test]
@@ -487,5 +688,11 @@ fn main() -> i32 {
 
         let repeated = compile_snapshot(&snapshot, &CompileOptions::default()).unwrap();
         assert_eq!(output.elf, repeated.elf);
+    }
+
+    #[test]
+    fn strbuf_concat_result_survives_cleanup_after_register_allocation() {
+        assert_three_result_slots_cross_cleanup(Target::X86_64Linux);
+        assert_three_result_slots_cross_cleanup(Target::Aarch64Linux);
     }
 }


### PR DESCRIPTION
## Summary

- preserve multi-slot block results in complete-width frame scratch while destructor cleanup runs
- reload the same non-owning value after cleanup so register coalescing cannot overwrite aggregate slots
- add CFG and post-register-allocation x86-64/AArch64 coverage for the exact canonical StrBuf concat, formatting, cleanup, and println path

This is the immediate sanitizer follow-up to #1628. Its merge-group Valgrind run exposed the register-allocation aliasing after that PR merged.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- Rue CFG 101/101
- Rue compiler 444/444
- focused stats 3/3 and string concatenation 7/7
- full serialized suite: light 34/34; CLI 1451 passed/3 ignored; generated oracle 64/64; reproducibility passed; spec 2071 passed/18 ignored; UI 178/178

Follow-up to RUE-875.