### PR TITLE
RUE-883: reuse unchanged ordinary bodies

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -62,11 +62,12 @@ pub use sema::{
     SpecializedFreeFunctionOrigin,
 };
 pub use semantic_body::{
-    SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg, SemanticBodyDefinitionIdentity,
-    SemanticBodyDefinitionKind, SemanticBodyExport, SemanticBodyExportFailure,
-    SemanticBodyImportFailure, SemanticBodyInst, SemanticBodyInstData, SemanticBodyMatchArm,
-    SemanticBodyPattern, SemanticBodyPlace, SemanticBodyPlaceRef, SemanticBodyProjection,
-    SemanticBodyRef, SemanticBodyWarning, SemanticImportedBody,
+    SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg, SemanticBodyCandidate,
+    SemanticBodyCandidateInstallWork, SemanticBodyDefinitionIdentity, SemanticBodyDefinitionKind,
+    SemanticBodyExport, SemanticBodyExportFailure, SemanticBodyImportFailure, SemanticBodyInst,
+    SemanticBodyInstData, SemanticBodyMatchArm, SemanticBodyModuleIdentity, SemanticBodyPattern,
+    SemanticBodyPlace, SemanticBodyPlaceRef, SemanticBodyProjection, SemanticBodyRef,
+    SemanticBodyWarning, SemanticImportedBody,
 };
 pub use semantic_import::{
     SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -58,6 +58,162 @@ pub(crate) fn analyze_all_function_bodies_with_work(
     result.map_err(|errors| super::BodyAnalysisFailure::new(errors, work))
 }
 
+fn import_staged_ordinary_body(
+    sema: &mut BodySema<'_>,
+    candidate: &crate::SemanticBodyCandidate<
+        crate::SemanticBodyDefinitionIdentity,
+        crate::SemanticBodyModuleIdentity,
+    >,
+    body_span: Span,
+) -> Result<crate::SemanticImportedBody, crate::SemanticBodyImportFailure> {
+    use crate::{SemanticBodyDefinitionKind as DK, SemanticBodyImportFailure as BF};
+    use crate::{
+        SemanticImportFailure as F, SemanticImportNominalKind as NK, SemanticImportType as T,
+    };
+
+    fn import_type(
+        sema: &BodySema<'_>,
+        pool: &crate::TypeInternPool,
+        value: &T<crate::SemanticBodyDefinitionIdentity, crate::SemanticBodyModuleIdentity>,
+    ) -> Result<Type, F> {
+        Ok(match value {
+            T::I8 => Type::I8,
+            T::I16 => Type::I16,
+            T::I32 => Type::I32,
+            T::I64 => Type::I64,
+            T::U8 => Type::U8,
+            T::U16 => Type::U16,
+            T::U32 => Type::U32,
+            T::U64 => Type::U64,
+            T::Bool => Type::BOOL,
+            T::Unit => Type::UNIT,
+            T::Never => Type::NEVER,
+            T::ComptimeType => Type::COMPTIME_TYPE,
+            T::BuiltinNominal { name, kind } => {
+                let symbol = sema
+                    .interner
+                    .get(name.as_ref())
+                    .ok_or(F::UnknownBuiltinNominal)?;
+                match kind {
+                    NK::Struct => Type::new_struct(
+                        *sema
+                            .builtin_structs
+                            .get(&symbol)
+                            .ok_or(F::UnknownBuiltinNominal)?,
+                    ),
+                    NK::Enum => Type::new_enum(
+                        *sema
+                            .builtin_enums
+                            .get(&symbol)
+                            .ok_or(F::UnknownBuiltinNominal)?,
+                    ),
+                }
+            }
+            T::Nominal(identity) => {
+                let symbol = sema
+                    .interner
+                    .get(identity.name.as_ref())
+                    .ok_or(F::MissingNominal)?;
+                match identity.kind {
+                    DK::Struct => Type::new_struct(
+                        *sema
+                            .structs_by_file_name
+                            .get(&(FileId::new(identity.file_id), symbol))
+                            .ok_or(F::MissingNominal)?,
+                    ),
+                    DK::Enum => Type::new_enum(
+                        *sema
+                            .enums_by_file_name
+                            .get(&(FileId::new(identity.file_id), symbol))
+                            .ok_or(F::MissingNominal)?,
+                    ),
+                    _ => return Err(F::NominalKindMismatch),
+                }
+            }
+            T::Array { element, len } => Type::new_array(
+                pool.intern_array_from_type(import_type(sema, pool, element)?, *len),
+            ),
+            T::PtrConst(value) => Type::new_ptr_const(
+                pool.intern_ptr_const_from_type(import_type(sema, pool, value)?),
+            ),
+            T::PtrMut(value) => {
+                Type::new_ptr_mut(pool.intern_ptr_mut_from_type(import_type(sema, pool, value)?))
+            }
+            T::Module(module) => {
+                let id = (0..sema.module_registry.len())
+                    .map(|i| ModuleId::new(i as u32))
+                    .find(|id| {
+                        sema.module_registry.get_def(*id).file_id == FileId::new(module.file_id)
+                    })
+                    .ok_or(F::MissingModule)?;
+                Type::new_module(id)
+            }
+            T::GenericParameter(_) => return Err(F::GenericParameterNeedsDeclarationContext),
+            T::Tuple(_) => return Err(F::UnsupportedTuple),
+            T::Function { .. } => return Err(F::UnsupportedFunctionType),
+        })
+    }
+
+    // Intrinsic symbols are required to pre-exist. This keeps every importer
+    // mutation inside the scratch type pool until the entire body validates.
+    if candidate.body.instructions.iter().any(|inst| matches!(&inst.data,
+        crate::SemanticBodyInstData::Intrinsic { name, .. } if sema.interner.get(name.as_ref()).is_none())) {
+        return Err(BF::Semantic(F::MissingFunction));
+    }
+    let scratch = sema.type_pool.clone();
+    let imported = crate::SemanticImportEpoch::import_body_with(
+        &candidate.body,
+        body_span,
+        |value| import_type(sema, &scratch, value),
+        |identity| {
+            if identity.kind != DK::Struct {
+                return Err(BF::WrongNominalKind);
+            }
+            let name = sema
+                .interner
+                .get(identity.name.as_ref())
+                .ok_or(BF::Semantic(F::MissingNominal))?;
+            sema.structs_by_file_name
+                .get(&(FileId::new(identity.file_id), name))
+                .copied()
+                .ok_or(BF::Semantic(F::MissingNominal))
+        },
+        |identity| {
+            if identity.kind != DK::Enum {
+                return Err(BF::WrongNominalKind);
+            }
+            let name = sema
+                .interner
+                .get(identity.name.as_ref())
+                .ok_or(BF::Semantic(F::MissingNominal))?;
+            sema.enums_by_file_name
+                .get(&(FileId::new(identity.file_id), name))
+                .copied()
+                .ok_or(BF::Semantic(F::MissingNominal))
+        },
+        |identity| {
+            if identity.kind != DK::FreeFunction {
+                return Err(BF::Semantic(F::MissingFunction));
+            }
+            let name = sema
+                .interner
+                .get(identity.name.as_ref())
+                .ok_or(BF::Semantic(F::MissingFunction))?;
+            sema.functions_by_file_name
+                .get(&(FileId::new(identity.file_id), name))
+                .copied()
+                .ok_or(BF::Semantic(F::MissingFunction))
+        },
+        |name| {
+            sema.interner
+                .get(name)
+                .expect("intrinsic symbols prevalidated")
+        },
+    )?;
+    sema.type_pool = scratch;
+    Ok(imported)
+}
+
 #[cfg(test)]
 pub(crate) fn analyze_all_function_bodies_with_namespace_probe(
     mut sema: BodySema<'_>,
@@ -823,6 +979,120 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
             debug_assert_eq!(span.file_id, fn_info.file_id);
 
             let params = sema.rir.get_params(params_start, params_len);
+
+            let ordinary_owner = sema.body_owner_token(
+                fn_info.file_id,
+                sema.interner.resolve(&source_name),
+                None,
+                super::BodyOwnerKind::FreeFunction,
+            );
+            if let Some(candidate) = sema.reusable_ordinary_bodies.remove(&ordinary_owner) {
+                sema.body_analysis_work.ordinary_body_import_attempts += 1;
+                let imported =
+                    import_staged_ordinary_body(sema, &candidate, sema.rir.get(body).span);
+                if let Ok(imported) = imported {
+                    sema.body_analysis_work.ordinary_body_import_successes += 1;
+                    sema.body_analysis_work
+                        .ordinary_body_import_instructions_installed += imported.air.len();
+                    sema.body_analysis_work
+                        .ordinary_body_import_places_installed += imported.air.places().len();
+                    sema.body_analysis_work
+                        .ordinary_body_import_strings_installed += imported.strings.len();
+                    sema.body_analysis_work.ordinary_bodies_reused += 1;
+                    sema.body_analysis_work.ordinary_body_analyses_skipped += 1;
+                    let referenced_fns = imported
+                        .air
+                        .instructions()
+                        .iter()
+                        .filter_map(|inst| match inst.data {
+                            crate::AirInstData::Call { name, .. }
+                                if sema.functions.contains_key(&name) =>
+                            {
+                                Some(name)
+                            }
+                            _ => None,
+                        })
+                        .collect::<HashSet<_>>();
+                    let mut ordered_referenced_fns =
+                        referenced_fns.iter().copied().collect::<Vec<_>>();
+                    ordered_referenced_fns
+                        .sort_by_key(|name| sema.interner.resolve(name).to_owned());
+                    let analyzed = AnalyzedFunction {
+                        name: fn_name_str,
+                        ordinary_owner: Some(ordinary_owner),
+                        implicit_drop_source: Some(
+                            super::ImplicitDropDependencySourceEvent::FreeFunction {
+                                token: ordinary_owner,
+                                file: fn_info.file_id.index(),
+                                name: sema.interner.resolve(&source_name).to_string(),
+                            },
+                        ),
+                        air: imported.air,
+                        num_locals: imported.num_locals,
+                        num_param_slots: imported.num_param_slots,
+                        param_modes: imported.param_modes,
+                        allow_unreachable_code: imported.allow_unreachable_code,
+                    };
+                    sema.analyzed_body_owners
+                        .push(super::AnalyzedBodyOwnerEvent::FreeFunction {
+                            token: ordinary_owner,
+                            file: fn_info.file_id.index(),
+                            name: sema.interner.resolve(&source_name).to_string(),
+                        });
+                    for callee in &ordered_referenced_fns {
+                        let callee_info = sema.functions[callee];
+                        sema.ordinary_free_function_dependencies.push(
+                            super::OrdinaryFreeFunctionDependencyEvent {
+                                caller_token: ordinary_owner,
+                                caller_file: fn_info.file_id.index(),
+                                caller_name: sema.interner.resolve(&source_name).to_string(),
+                                callee_file: callee_info.file_id.index(),
+                                callee_name: sema
+                                    .interner
+                                    .resolve(&sema.source_function_name(*callee))
+                                    .to_string(),
+                            },
+                        );
+                        sema.body_analysis_work
+                            .ordinary_free_function_dependency_events += 1;
+                    }
+                    sema.body_analysis_work.ordinary_body_exports_attempted += 1;
+                    match sema.export_ordinary_body(
+                        ordinary_owner,
+                        sema.rir.get(body).span,
+                        &analyzed,
+                        &imported.strings,
+                        &[],
+                    ) {
+                        Ok(export) => {
+                            sema.body_analysis_work.ordinary_body_exports_succeeded += 1;
+                            sema.body_analysis_work
+                                .ordinary_body_export_instructions_emitted +=
+                                export.body.instructions.len();
+                            sema.body_analysis_work.ordinary_body_export_places_emitted +=
+                                export.body.places.len();
+                            sema.body_analysis_work.ordinary_body_export_strings_emitted +=
+                                export.body.strings.len();
+                            sema.ordinary_body_exports.push(export);
+                        }
+                        Err(_) => sema.body_analysis_work.ordinary_body_exports_rejected += 1,
+                    }
+                    functions_with_strings.push((analyzed, imported.strings));
+                    enqueue_references_sorted(
+                        sema.interner,
+                        referenced_fns,
+                        HashSet::new(),
+                        &analyzed_functions,
+                        &analyzed_methods,
+                        &mut pending_functions,
+                        &mut pending_methods,
+                    );
+                    continue;
+                } else {
+                    sema.body_analysis_work.ordinary_body_import_failures += 1;
+                    sema.body_analysis_work.ordinary_body_import_atomic_discards += 1;
+                }
+            }
 
             sema.body_analysis_work.bodies_attempted += 1;
             let previous_type_observer = sema.declaration_type_observer.replace((

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -748,6 +748,44 @@ impl Sema<'_> {
 }
 
 impl<'a> BoundSema<'a> {
+    /// Resolve durable keys into request-independent declaration identities and
+    /// stage candidates for the canonical reachable-body worklist. No AIR type,
+    /// instruction, string, nominal, or function ID is allocated here.
+    pub fn install_ordinary_body_candidates<K, M>(
+        mut self,
+        candidates: Vec<crate::SemanticBodyCandidate<K, M>>,
+        definition: impl Fn(&K) -> Option<crate::SemanticBodyDefinitionIdentity>,
+        module: impl Fn(&M) -> Option<FileId>,
+    ) -> Self
+    where
+        K: Clone + Ord,
+        M: Clone + Ord + AsRef<str>,
+    {
+        for candidate in candidates {
+            let mapped = candidate
+                .body
+                .try_map_keys(&|key| definition(key).ok_or(()), &|key| {
+                    module(key)
+                        .map(|file| crate::SemanticBodyModuleIdentity {
+                            file_id: file.index(),
+                            path: std::sync::Arc::from(key.as_ref()),
+                        })
+                        .ok_or(())
+                });
+            if let Ok(body) = mapped {
+                self.sema.reusable_ordinary_bodies.insert(
+                    candidate.owner,
+                    crate::SemanticBodyCandidate {
+                        owner: candidate.owner,
+                        body_span: candidate.body_span,
+                        body,
+                    },
+                );
+            }
+        }
+        self
+    }
+
     #[cfg(test)]
     pub(crate) fn source_free_function_signatures_are_complete(&self) -> bool {
         self.sema.source_free_function_signatures_are_complete()

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -219,6 +219,13 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) body_analysis_work: BodyAnalysisWork,
     pub(crate) analyzed_body_owners: Vec<AnalyzedBodyOwnerEvent>,
     pub(crate) ordinary_body_exports: Vec<crate::SemanticBodyExport>,
+    pub(crate) reusable_ordinary_bodies: HashMap<
+        BodyOwnerToken,
+        crate::SemanticBodyCandidate<
+            crate::SemanticBodyDefinitionIdentity,
+            crate::SemanticBodyModuleIdentity,
+        >,
+    >,
     pub(crate) body_dependency_observer: Option<AnalyzedBodyOwnerEvent>,
     pub(crate) body_owner_tokens:
         HashMap<(u32, String, Option<String>, BodyOwnerKind), BodyOwnerToken>,
@@ -356,6 +363,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_analysis_work,
             analyzed_body_owners,
             ordinary_body_exports,
+            reusable_ordinary_bodies,
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
@@ -407,6 +415,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_analysis_work,
             analyzed_body_owners,
             ordinary_body_exports,
+            reusable_ordinary_bodies,
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
@@ -724,6 +733,7 @@ impl<'a> Sema<'a> {
             body_analysis_work: BodyAnalysisWork::default(),
             analyzed_body_owners: Vec::new(),
             ordinary_body_exports: Vec::new(),
+            reusable_ordinary_bodies: HashMap::new(),
             body_dependency_observer: None,
             body_owner_tokens: HashMap::new(),
             body_named_dependencies: Vec::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -393,6 +393,17 @@ pub struct SemaOutput {
 /// These counters deliberately expose no request-local RIR instruction handles.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BodyAnalysisWork {
+    pub ordinary_body_import_attempts: usize,
+    pub ordinary_body_import_successes: usize,
+    pub ordinary_body_import_failures: usize,
+    pub ordinary_body_import_instructions_installed: usize,
+    pub ordinary_body_import_places_installed: usize,
+    pub ordinary_body_import_strings_installed: usize,
+    pub ordinary_body_import_atomic_discards: usize,
+    /// Durable ordinary bodies actually consumed from the canonical worklist.
+    pub ordinary_bodies_reused: usize,
+    /// Ordinary source analyses avoided by those consumed reuse hits.
+    pub ordinary_body_analyses_skipped: usize,
     pub bodies_attempted: usize,
     pub bodies_succeeded: usize,
     pub bodies_failed: usize,

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -28,6 +28,18 @@ pub struct SemanticBodyDefinitionIdentity {
     pub owner: Option<Arc<str>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SemanticBodyModuleIdentity {
+    pub file_id: u32,
+    pub path: Arc<str>,
+}
+
+impl AsRef<str> for SemanticBodyModuleIdentity {
+    fn as_ref(&self) -> &str {
+        &self.path
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SemanticBodyExport {
     pub owner: BodyOwnerToken,
@@ -257,6 +269,289 @@ pub struct SemanticBody<K, M> {
     pub warnings: Arc<[SemanticBodyWarning]>,
 }
 
+impl<K, M> SemanticBody<K, M> {
+    /// Replace request-independent definition and module keys without creating
+    /// any epoch-local AIR values.
+    pub fn try_map_keys<K2, M2, E>(
+        &self,
+        key: &impl Fn(&K) -> Result<K2, E>,
+        module: &impl Fn(&M) -> Result<M2, E>,
+    ) -> Result<SemanticBody<K2, M2>, E> {
+        fn ty<K, M, K2, M2, E>(
+            value: &SemanticImportType<K, M>,
+            key: &impl Fn(&K) -> Result<K2, E>,
+            module: &impl Fn(&M) -> Result<M2, E>,
+        ) -> Result<SemanticImportType<K2, M2>, E> {
+            use SemanticImportType as T;
+            Ok(match value {
+                T::I8 => T::I8,
+                T::I16 => T::I16,
+                T::I32 => T::I32,
+                T::I64 => T::I64,
+                T::U8 => T::U8,
+                T::U16 => T::U16,
+                T::U32 => T::U32,
+                T::U64 => T::U64,
+                T::Bool => T::Bool,
+                T::Unit => T::Unit,
+                T::Never => T::Never,
+                T::ComptimeType => T::ComptimeType,
+                T::BuiltinNominal { name, kind } => T::BuiltinNominal {
+                    name: name.clone(),
+                    kind: *kind,
+                },
+                T::Nominal(value) => T::Nominal(key(value)?),
+                T::Array { element, len } => T::Array {
+                    element: Box::new(ty(element, key, module)?),
+                    len: *len,
+                },
+                T::PtrConst(value) => T::PtrConst(Box::new(ty(value, key, module)?)),
+                T::PtrMut(value) => T::PtrMut(Box::new(ty(value, key, module)?)),
+                T::Module(value) => T::Module(module(value)?),
+                T::GenericParameter(index) => T::GenericParameter(*index),
+                T::Tuple(values) => T::Tuple(
+                    values
+                        .iter()
+                        .map(|value| ty(value, key, module))
+                        .collect::<Result<Vec<_>, _>>()?
+                        .into(),
+                ),
+                T::Function { parameters, result } => T::Function {
+                    parameters: parameters
+                        .iter()
+                        .map(|value| ty(value, key, module))
+                        .collect::<Result<Vec<_>, _>>()?
+                        .into(),
+                    result: Box::new(ty(result, key, module)?),
+                },
+            })
+        }
+
+        fn pattern<K, K2, E>(
+            value: &SemanticBodyPattern<K>,
+            key: &impl Fn(&K) -> Result<K2, E>,
+        ) -> Result<SemanticBodyPattern<K2>, E> {
+            Ok(match value {
+                SemanticBodyPattern::Wildcard => SemanticBodyPattern::Wildcard,
+                SemanticBodyPattern::Int(value) => SemanticBodyPattern::Int(*value),
+                SemanticBodyPattern::Bool(value) => SemanticBodyPattern::Bool(*value),
+                SemanticBodyPattern::EnumVariant {
+                    enum_key,
+                    variant_index,
+                } => SemanticBodyPattern::EnumVariant {
+                    enum_key: key(enum_key)?,
+                    variant_index: *variant_index,
+                },
+            })
+        }
+
+        let places = self
+            .places
+            .iter()
+            .map(|place| {
+                Ok(SemanticBodyPlace {
+                    base: place.base,
+                    base_type: ty(&place.base_type, key, module)?,
+                    projections: place
+                        .projections
+                        .iter()
+                        .map(|projection| {
+                            Ok(match projection {
+                                SemanticBodyProjection::Field {
+                                    struct_key,
+                                    field_index,
+                                } => SemanticBodyProjection::Field {
+                                    struct_key: key(struct_key)?,
+                                    field_index: *field_index,
+                                },
+                                SemanticBodyProjection::Index { array_type, index } => {
+                                    SemanticBodyProjection::Index {
+                                        array_type: ty(array_type, key, module)?,
+                                        index: *index,
+                                    }
+                                }
+                            })
+                        })
+                        .collect::<Result<Vec<_>, E>>()?
+                        .into(),
+                })
+            })
+            .collect::<Result<Vec<_>, E>>()?;
+
+        use SemanticBodyInstData as D;
+        let instructions = self
+            .instructions
+            .iter()
+            .map(|inst| {
+                let data = match &inst.data {
+                    D::Const(v) => D::Const(*v),
+                    D::BoolConst(v) => D::BoolConst(*v),
+                    D::StringConst(v) => D::StringConst(*v),
+                    D::UnitConst => D::UnitConst,
+                    D::TypeConst(v) => D::TypeConst(ty(v, key, module)?),
+                    D::Add(a, b) => D::Add(*a, *b),
+                    D::Sub(a, b) => D::Sub(*a, *b),
+                    D::Mul(a, b) => D::Mul(*a, *b),
+                    D::Div(a, b) => D::Div(*a, *b),
+                    D::Mod(a, b) => D::Mod(*a, *b),
+                    D::Eq(a, b) => D::Eq(*a, *b),
+                    D::Ne(a, b) => D::Ne(*a, *b),
+                    D::Lt(a, b) => D::Lt(*a, *b),
+                    D::Gt(a, b) => D::Gt(*a, *b),
+                    D::Le(a, b) => D::Le(*a, *b),
+                    D::Ge(a, b) => D::Ge(*a, *b),
+                    D::And(a, b) => D::And(*a, *b),
+                    D::Or(a, b) => D::Or(*a, *b),
+                    D::BitAnd(a, b) => D::BitAnd(*a, *b),
+                    D::BitOr(a, b) => D::BitOr(*a, *b),
+                    D::BitXor(a, b) => D::BitXor(*a, *b),
+                    D::Shl(a, b) => D::Shl(*a, *b),
+                    D::Shr(a, b) => D::Shr(*a, *b),
+                    D::Neg(v) => D::Neg(*v),
+                    D::Not(v) => D::Not(*v),
+                    D::BitNot(v) => D::BitNot(*v),
+                    D::Branch {
+                        cond,
+                        then_value,
+                        else_value,
+                    } => D::Branch {
+                        cond: *cond,
+                        then_value: *then_value,
+                        else_value: *else_value,
+                    },
+                    D::Loop { cond, body } => D::Loop {
+                        cond: *cond,
+                        body: *body,
+                    },
+                    D::InfiniteLoop { body } => D::InfiniteLoop { body: *body },
+                    D::Match { scrutinee, arms } => D::Match {
+                        scrutinee: *scrutinee,
+                        arms: arms
+                            .iter()
+                            .map(|arm| {
+                                Ok(SemanticBodyMatchArm {
+                                    pattern: pattern(&arm.pattern, key)?,
+                                    body: arm.body,
+                                })
+                            })
+                            .collect::<Result<Vec<_>, E>>()?
+                            .into(),
+                    },
+                    D::Break => D::Break,
+                    D::Continue => D::Continue,
+                    D::Alloc { slot, init } => D::Alloc {
+                        slot: *slot,
+                        init: *init,
+                    },
+                    D::Load { slot } => D::Load { slot: *slot },
+                    D::Store { slot, value } => D::Store {
+                        slot: *slot,
+                        value: *value,
+                    },
+                    D::ParamStore { param_slot, value } => D::ParamStore {
+                        param_slot: *param_slot,
+                        value: *value,
+                    },
+                    D::Ret(v) => D::Ret(*v),
+                    D::Call { function, args } => D::Call {
+                        function: key(function)?,
+                        args: args.clone(),
+                    },
+                    D::CallGeneric => D::CallGeneric,
+                    D::Intrinsic { name, args } => D::Intrinsic {
+                        name: name.clone(),
+                        args: args.clone(),
+                    },
+                    D::Param { index } => D::Param { index: *index },
+                    D::Block { statements, value } => D::Block {
+                        statements: statements.clone(),
+                        value: *value,
+                    },
+                    D::StructInit {
+                        struct_key,
+                        fields,
+                        source_order,
+                    } => D::StructInit {
+                        struct_key: key(struct_key)?,
+                        fields: fields.clone(),
+                        source_order: source_order.clone(),
+                    },
+                    D::ArrayInit { elements } => D::ArrayInit {
+                        elements: elements.clone(),
+                    },
+                    D::PlaceRead { place } => D::PlaceRead { place: *place },
+                    D::PlaceWrite { place, value } => D::PlaceWrite {
+                        place: *place,
+                        value: *value,
+                    },
+                    D::EnumVariant {
+                        enum_key,
+                        variant_index,
+                        payload,
+                    } => D::EnumVariant {
+                        enum_key: key(enum_key)?,
+                        variant_index: *variant_index,
+                        payload: payload.clone(),
+                    },
+                    D::EnumPayloadGet {
+                        base,
+                        enum_key,
+                        variant_index,
+                        field_index,
+                    } => D::EnumPayloadGet {
+                        base: *base,
+                        enum_key: key(enum_key)?,
+                        variant_index: *variant_index,
+                        field_index: *field_index,
+                    },
+                    D::IntCast { value, from_ty } => D::IntCast {
+                        value: *value,
+                        from_ty: ty(from_ty, key, module)?,
+                    },
+                    D::Drop { value } => D::Drop { value: *value },
+                    D::StorageLive { slot } => D::StorageLive { slot: *slot },
+                    D::StorageDead { slot } => D::StorageDead { slot: *slot },
+                    D::MarkMoved {
+                        value,
+                        slot,
+                        is_param,
+                        place,
+                    } => D::MarkMoved {
+                        value: *value,
+                        slot: *slot,
+                        is_param: *is_param,
+                        place: *place,
+                    },
+                };
+                Ok(SemanticBodyInst {
+                    data,
+                    ty: ty(&inst.ty, key, module)?,
+                    anchor: inst.anchor,
+                })
+            })
+            .collect::<Result<Vec<_>, E>>()?;
+        Ok(SemanticBody {
+            return_type: ty(&self.return_type, key, module)?,
+            instructions: instructions.into(),
+            places: places.into(),
+            strings: self.strings.clone(),
+            param_drops: self
+                .param_drops
+                .iter()
+                .map(|(slot, value)| Ok((*slot, ty(value, key, module)?)))
+                .collect::<Result<Vec<_>, E>>()?
+                .into(),
+            borrow_slots: self.borrow_slots.clone(),
+            num_locals: self.num_locals,
+            num_param_slots: self.num_param_slots,
+            param_by_ref: self.param_by_ref.clone(),
+            param_writable: self.param_writable.clone(),
+            allow_unreachable_code: self.allow_unreachable_code,
+            warnings: self.warnings.clone(),
+        })
+    }
+}
+
 #[derive(Debug)]
 pub struct SemanticImportedBody {
     pub air: Air,
@@ -266,6 +561,23 @@ pub struct SemanticImportedBody {
     pub param_modes: ParamSlotModes,
     pub allow_unreachable_code: bool,
     pub warnings: Arc<[SemanticBodyWarning]>,
+}
+
+#[derive(Debug)]
+pub struct SemanticBodyCandidate<K, M> {
+    pub owner: crate::BodyOwnerToken,
+    pub body_span: rue_span::Span,
+    pub body: SemanticBody<K, M>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticBodyCandidateInstallWork {
+    pub attempts: usize,
+    pub successes: usize,
+    pub failures: usize,
+    pub instructions_installed: usize,
+    pub places_installed: usize,
+    pub strings_installed: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -163,6 +163,45 @@ where
         body: &SemanticBody<K, M>,
         body_span: Span,
     ) -> Result<SemanticImportedBody, SemanticBodyImportFailure> {
+        Self::import_body_with(
+            body,
+            body_span,
+            |ty| self.import_type_local(ty),
+            |key| match self.nominals.get(key) {
+                Some(LocalNominal::Struct(id)) => Ok(*id),
+                Some(LocalNominal::Enum(_)) => Err(SemanticBodyImportFailure::WrongNominalKind),
+                None => Err(SemanticBodyImportFailure::Semantic(
+                    SemanticImportFailure::MissingNominal,
+                )),
+            },
+            |key| match self.nominals.get(key) {
+                Some(LocalNominal::Enum(id)) => Ok(*id),
+                Some(LocalNominal::Struct(_)) => Err(SemanticBodyImportFailure::WrongNominalKind),
+                None => Err(SemanticBodyImportFailure::Semantic(
+                    SemanticImportFailure::MissingNominal,
+                )),
+            },
+            |key| {
+                self.functions
+                    .get(key)
+                    .copied()
+                    .ok_or(SemanticBodyImportFailure::Semantic(
+                        SemanticImportFailure::MissingFunction,
+                    ))
+            },
+            |name| self.interner.get_or_intern(name),
+        )
+    }
+
+    pub(crate) fn import_body_with(
+        body: &SemanticBody<K, M>,
+        body_span: Span,
+        import_type: impl Fn(&SemanticImportType<K, M>) -> Result<Type, SemanticImportFailure>,
+        struct_id: impl Fn(&K) -> Result<StructId, SemanticBodyImportFailure>,
+        enum_id: impl Fn(&K) -> Result<EnumId, SemanticBodyImportFailure>,
+        resolve_function: impl Fn(&K) -> Result<Spur, SemanticBodyImportFailure>,
+        intern: impl Fn(&str) -> Spur,
+    ) -> Result<SemanticImportedBody, SemanticBodyImportFailure> {
         use SemanticBodyImportFailure as F;
         let body_len = body_span
             .end
@@ -209,7 +248,7 @@ where
         {
             return Err(F::InvalidBorrowSlot);
         }
-        let return_type = self.import_type_local(&body.return_type)?;
+        let return_type = import_type(&body.return_type).map_err(F::Semantic)?;
         let mut air = Air::new(return_type);
         let inst_len = body.instructions.len();
         let place_len = body.places.len();
@@ -223,18 +262,8 @@ where
             }
             Ok(AirRef::from_raw(r))
         };
-        let struct_id = |key: &K| match self.nominals.get(key) {
-            Some(LocalNominal::Struct(id)) => Ok(*id),
-            Some(LocalNominal::Enum(_)) => Err(F::WrongNominalKind),
-            None => Err(F::Semantic(SemanticImportFailure::MissingNominal)),
-        };
-        let enum_id = |key: &K| match self.nominals.get(key) {
-            Some(LocalNominal::Enum(id)) => Ok(*id),
-            Some(LocalNominal::Struct(_)) => Err(F::WrongNominalKind),
-            None => Err(F::Semantic(SemanticImportFailure::MissingNominal)),
-        };
         for place in body.places.iter() {
-            let base_type = self.import_type_local(&place.base_type)?;
+            let base_type = import_type(&place.base_type).map_err(F::Semantic)?;
             let mut projections = Vec::with_capacity(place.projections.len());
             for projection in place.projections.iter() {
                 projections.push(match projection {
@@ -250,7 +279,7 @@ where
                             return Err(F::InvalidInstructionReference);
                         }
                         AirProjection::Index {
-                            array_type: self.import_type_local(array_type)?,
+                            array_type: import_type(array_type).map_err(F::Semantic)?,
                             index: AirRef::from_raw(*index),
                         }
                     }
@@ -294,7 +323,7 @@ where
                 }
                 SemanticBodyInstData::UnitConst => AirInstData::UnitConst,
                 SemanticBodyInstData::TypeConst(v) => {
-                    AirInstData::TypeConst(self.import_type_local(v)?)
+                    AirInstData::TypeConst(import_type(v).map_err(F::Semantic)?)
                 }
                 SemanticBodyInstData::Add(a, b) => binary(*a, *b, AirInstData::Add)?,
                 SemanticBodyInstData::Sub(a, b) => binary(*a, *b, AirInstData::Sub)?,
@@ -374,10 +403,7 @@ where
                 },
                 SemanticBodyInstData::Ret(v) => AirInstData::Ret(v.map(r).transpose()?),
                 SemanticBodyInstData::Call { function, args } => {
-                    let name = *self
-                        .functions
-                        .get(function)
-                        .ok_or(F::Semantic(SemanticImportFailure::MissingFunction))?;
+                    let name = resolve_function(function)?;
                     let (s, l) = call_args(&mut air, args, current)?;
                     AirInstData::Call {
                         name,
@@ -387,7 +413,7 @@ where
                 }
                 SemanticBodyInstData::CallGeneric => return Err(F::UnsupportedGenericCall),
                 SemanticBodyInstData::Intrinsic { name, args } => {
-                    let name = self.interner.get_or_intern(name.as_ref());
+                    let name = intern(name.as_ref());
                     if args.iter().any(|arg| arg.mode != crate::AirArgMode::Normal) {
                         return Err(F::InvalidParameterModes);
                     }
@@ -481,7 +507,7 @@ where
                 },
                 SemanticBodyInstData::IntCast { value, from_ty } => AirInstData::IntCast {
                     value: r(*value)?,
-                    from_ty: self.import_type_local(from_ty)?,
+                    from_ty: import_type(from_ty).map_err(F::Semantic)?,
                 },
                 SemanticBodyInstData::Drop { value } => AirInstData::Drop { value: r(*value)? },
                 SemanticBodyInstData::StorageLive { slot } => {
@@ -509,13 +535,13 @@ where
             };
             air.add_inst(AirInst {
                 data,
-                ty: self.import_type_local(&inst.ty)?,
+                ty: import_type(&inst.ty).map_err(F::Semantic)?,
                 span,
             });
         }
         let mut drops = Vec::with_capacity(body.param_drops.len());
         for (slot, ty) in body.param_drops.iter() {
-            drops.push((*slot, self.import_type_local(ty)?));
+            drops.push((*slot, import_type(ty).map_err(F::Semantic)?));
         }
         air.set_param_drops(drops);
         for slot in body.borrow_slots.iter() {

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -1009,7 +1009,7 @@ fn assert_body_cfg_work_equal(left: &Value, right: &Value) {
     ] {
         assert_eq!(
             left["semantic_work"][field], right["semantic_work"][field],
-            "body work field {field} differs before body reuse exists"
+            "body work field {field} differs in scenarios expected to take the same body path"
         );
     }
     assert_eq!(
@@ -1018,7 +1018,7 @@ fn assert_body_cfg_work_equal(left: &Value, right: &Value) {
     );
     assert_eq!(
         left["semantic_work"]["durable_bodies"], right["semantic_work"]["durable_bodies"],
-        "durable body observation work differs before body reuse exists"
+        "durable body work differs in scenarios expected to take the same body path"
     );
 }
 

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -12,6 +12,23 @@ use rue_air::{
 };
 use tracing::info_span;
 
+pub(crate) struct PreparedDurableBodyCandidate {
+    pub owner: crate::StableDefinitionKey,
+    pub body_span: rue_span::Span,
+    pub body: rue_air::SemanticBody<crate::StableDefinitionKey, Arc<str>>,
+}
+
+fn fold_body_import_work(durable: &mut crate::DurableBodyWork, body: BodyAnalysisWork) {
+    durable.import_attempts += body.ordinary_body_import_attempts;
+    durable.import_successes += body.ordinary_body_import_successes;
+    durable.import_failures += body.ordinary_body_import_failures;
+    durable.atomic_discards += body.ordinary_body_import_atomic_discards;
+    durable.candidate_fallbacks += body.ordinary_body_import_failures;
+    durable.installed_instructions += body.ordinary_body_import_instructions_installed;
+    durable.installed_places += body.ordinary_body_import_places_installed;
+    durable.installed_strings += body.ordinary_body_import_strings_installed;
+}
+
 #[cfg(test)]
 use std::cell::Cell;
 
@@ -544,6 +561,8 @@ pub(crate) fn analyze_canonical_program(
         bound,
         definitions,
         CanonicalDeclarationReuseWork::default(),
+        Vec::new(),
+        crate::DurableBodyWork::default(),
         info_span!("sema").entered(),
     )
     .map_err(|failure| failure.errors)
@@ -559,6 +578,8 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
     options: &CompileOptions,
     prepared: CanonicalPreparedDeclarations<'_>,
     reuse_plan: CanonicalDeclarationReuseWork,
+    body_candidates: Vec<PreparedDurableBodyCandidate>,
+    body_work: crate::DurableBodyWork,
 ) -> Result<CanonicalOrdinaryAnalysis, CanonicalSemanticFailure> {
     let input = CodegenInputDescriptor {
         semantic: SemanticInputDescriptor::new(
@@ -605,6 +626,8 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
             durable_cache_population_exports: usize::from(durable_declarations.is_some()),
             ..declaration_reuse
         },
+        body_candidates,
+        body_work,
         sema_span,
     )?;
     Ok(CanonicalOrdinaryAnalysis {
@@ -626,6 +649,8 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     prepared: CanonicalPreparedDeclarations<'_>,
     definitions: &BoundDefinitionSet,
     durable: &[DurableDeclarationSemantic],
+    body_candidates: Vec<PreparedDurableBodyCandidate>,
+    body_work: crate::DurableBodyWork,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
     let input = CodegenInputDescriptor {
         semantic: SemanticInputDescriptor::new(
@@ -752,6 +777,8 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
         bound,
         selected_definitions,
         reuse,
+        body_candidates,
+        body_work,
         sema_span,
     )
 }
@@ -787,6 +814,8 @@ fn finish_canonical_analysis(
     bound: rue_air::BoundSema<'_>,
     provisional_definitions: BoundDefinitionSet,
     declaration_reuse: CanonicalDeclarationReuseWork,
+    durable_body_candidates: Vec<PreparedDurableBodyCandidate>,
+    mut durable_body_reuse_work: crate::DurableBodyWork,
     sema_span: tracing::span::EnteredSpan,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
     let binding = bound.binding_work();
@@ -918,10 +947,58 @@ fn finish_canonical_analysis(
             ),
         )
     })?;
-
+    let token_by_key = authoritative_definitions
+        .body_owner_endpoints()
+        .into_iter()
+        .zip(authoritative_keys.iter())
+        .map(|(endpoint, key)| ((*key).clone(), endpoint.token))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let air_candidates = durable_body_candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            let owner = token_by_key.get(&candidate.owner).copied()?;
+            Some(rue_air::SemanticBodyCandidate {
+                owner,
+                body_span: candidate.body_span,
+                body: candidate.body,
+            })
+        })
+        .collect();
+    let modules = merged
+        .ast()
+        .modules()
+        .iter()
+        .map(|module| (module.module_id().as_str().to_owned(), module.file_id()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let bound = bound.install_ordinary_body_candidates(
+        air_candidates,
+        |key: &crate::StableDefinitionKey| {
+            let record = authoritative_definitions.definition_by_key(key)?;
+            let kind = match key.kind() {
+                crate::StableDefinitionKind::Function => {
+                    rue_air::SemanticBodyDefinitionKind::FreeFunction
+                }
+                crate::StableDefinitionKind::Struct => rue_air::SemanticBodyDefinitionKind::Struct,
+                crate::StableDefinitionKind::Enum => rue_air::SemanticBodyDefinitionKind::Enum,
+                _ => return None,
+            };
+            Some(rue_air::SemanticBodyDefinitionIdentity {
+                file_id: record.declaration_span().file_id.index(),
+                name: std::sync::Arc::from(key.name()),
+                kind,
+                owner: None,
+            })
+        },
+        |module: &std::sync::Arc<str>| modules.get(module.as_ref()).copied(),
+    );
     let sema_output = match bound.analyze_all_bodies_with_work() {
         Ok(output) => output,
         Err(failure) => {
+            let mut failed_durable_body_work = durable_body_reuse_work;
+            failed_durable_body_work.reused_bodies += failure.work().ordinary_bodies_reused;
+            failed_durable_body_work.skipped_body_analyses +=
+                failure.work().ordinary_body_analyses_skipped;
+            fold_body_import_work(&mut failed_durable_body_work, failure.work());
             let work = CanonicalSemanticWork {
                 declaration_index,
                 binding,
@@ -929,7 +1006,7 @@ fn finish_canonical_analysis(
                 bound_definitions: bound_definitions.as_ref().map(BoundDefinitionSet::work),
                 body_owner_tokens,
                 body_analysis: failure.work(),
-                durable_bodies: crate::DurableBodyWork::default(),
+                durable_bodies: failed_durable_body_work,
                 cfg: CfgConstructionWork::default(),
                 stable_ids_requested: request_stable_ids,
                 declaration_reuse,
@@ -946,6 +1023,9 @@ fn finish_canonical_analysis(
     #[cfg(test)]
     inject_cfg_failure(&mut sema_output, rir.semantic_symbols().interner());
     let body_analysis = sema_output.body_analysis_work;
+    durable_body_reuse_work.reused_bodies += body_analysis.ordinary_bodies_reused;
+    durable_body_reuse_work.skipped_body_analyses += body_analysis.ordinary_body_analyses_skipped;
+    fold_body_import_work(&mut durable_body_reuse_work, body_analysis);
     let mut durable_body_work = crate::DurableBodyWork {
         export_attempts: body_analysis.ordinary_body_exports_attempted,
         export_successes: body_analysis.ordinary_body_exports_succeeded,
@@ -953,7 +1033,7 @@ fn finish_canonical_analysis(
         instructions_exported: body_analysis.ordinary_body_export_instructions_emitted,
         places_exported: body_analysis.ordinary_body_export_places_emitted,
         strings_exported: body_analysis.ordinary_body_export_strings_emitted,
-        ..crate::DurableBodyWork::default()
+        ..durable_body_reuse_work
     };
     let durable_ordinary_body_payloads = crate::convert_semantic_body_exports(
         &sema_output.ordinary_body_exports,

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -233,6 +233,8 @@ pub struct DurableOrdinaryBody {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct DurableBodyWork {
+    pub candidate_comparisons: usize,
+    pub candidate_fallbacks: usize,
     pub export_attempts: usize,
     pub export_successes: usize,
     pub export_rejections: usize,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -819,8 +819,9 @@ impl SemanticDependencyInputManifest {
     pub fn body_dependencies(&self) -> &[StableBodyDependencyInputRecord] {
         &self.body_dependencies
     }
-    /// Observation-only durable candidates. No production body query consumes
-    /// these records in this slice.
+    /// Durable candidates published by this successful dependency manifest.
+    /// Production reuse consumes the session's last-successful canonical body
+    /// baseline; this accessor exposes the same stable artifacts to planners.
     pub fn durable_ordinary_bodies(&self) -> &[crate::DurableOrdinaryBody] {
         &self.durable_ordinary_bodies
     }
@@ -1139,6 +1140,7 @@ pub struct CompilerSession {
     dependency_manifest_cache: Vec<Arc<SemanticDependencyInputManifest>>,
     invalidation_plan_cache: VecDeque<InvalidationPlanCacheEntry>,
     durable_declaration_cache: Option<DurableDeclarationCache>,
+    last_successful_body_cache: Option<DurableOrdinaryBodyCache>,
 }
 
 #[derive(Debug)]
@@ -1148,6 +1150,12 @@ struct DurableDeclarationCache {
     preview_features: crate::PreviewFeatures,
     fingerprints: Arc<[StableDefinitionInputFingerprint]>,
     semantics: Arc<[DurableDeclarationSemantic]>,
+}
+
+#[derive(Debug, Clone)]
+struct DurableOrdinaryBodyCache {
+    manifest: Arc<SemanticDependencyInputManifest>,
+    bodies: Arc<[crate::DurableOrdinaryBody]>,
 }
 
 #[derive(Debug)]
@@ -1162,6 +1170,7 @@ struct SemanticCacheEntry {
     input: CodegenInputDescriptor,
     imports: CanonicalImportGraph,
     result: Result<Arc<CanonicalSemanticOutput>, CompileErrors>,
+    successful_body_cache: Option<DurableOrdinaryBodyCache>,
 }
 
 #[derive(Debug)]
@@ -2132,6 +2141,9 @@ impl CompilerSession {
             .find(|entry| entry.input == input && entry.imports == imports)
         {
             self.work.semantic.reuses += 1;
+            if entry.result.is_ok() {
+                self.last_successful_body_cache = entry.successful_body_cache.clone();
+            }
             let result = entry.result.clone();
             let source = self
                 .published_snapshot
@@ -2166,6 +2178,64 @@ impl CompilerSession {
                     .collect(),
                 Err(failure) => Err(failure.errors.clone()),
             };
+        let mut durable_body_work = crate::DurableBodyWork::default();
+        let mut durable_body_candidates = Vec::new();
+        if let (Some(previous), Ok(fingerprints), Ok(prepared_definitions)) = (
+            self.last_successful_body_cache.as_ref(),
+            current_fingerprints.as_ref(),
+            prepared.as_ref(),
+        ) {
+            let current = fingerprints
+                .iter()
+                .map(|fingerprint| (fingerprint.key.clone(), fingerprint))
+                .collect::<BTreeMap<_, _>>();
+            let preflight = preflight_body_invalidation_manifest(
+                &previous.manifest,
+                input.semantic.clone(),
+                imports.clone(),
+                fingerprints,
+            );
+            let invalidation = plan_semantic_invalidation(&previous.manifest, &preflight);
+            for candidate in previous.bodies.iter() {
+                durable_body_work.candidate_comparisons += 1;
+                let inputs = candidate.inputs();
+                let exact = inputs.reusable_boundary_supported()
+                    && invalidation
+                        .reusable()
+                        .binary_search(candidate.owner())
+                        .is_ok()
+                    && current
+                        .get(candidate.owner())
+                        .is_some_and(|value| *value == inputs.fingerprint())
+                    && inputs.direct_dependency_inputs().iter().all(|dependency| {
+                        current
+                            .get(&dependency.key)
+                            .is_some_and(|value| *value == dependency)
+                    });
+                let Some(record) = prepared_definitions
+                    .definitions()
+                    .definition_by_key(candidate.owner())
+                    .filter(|_| exact)
+                else {
+                    durable_body_work.candidate_fallbacks += 1;
+                    continue;
+                };
+                let Some(body_span) = record.body_span() else {
+                    durable_body_work.candidate_fallbacks += 1;
+                    continue;
+                };
+                match candidate.project_semantic_body(&mut durable_body_work) {
+                    Ok(body) => durable_body_candidates.push(
+                        crate::canonical_semantic::PreparedDurableBodyCandidate {
+                            owner: candidate.owner().clone(),
+                            body_span,
+                            body,
+                        },
+                    ),
+                    Err(_) => durable_body_work.candidate_fallbacks += 1,
+                }
+            }
+        }
         let mut reuse_plan = crate::canonical_semantic::CanonicalDeclarationReuseWork::default();
         let reusable = self.durable_declaration_cache.as_ref().and_then(|cache| {
             reuse_plan.plan_executions = 1;
@@ -2202,10 +2272,18 @@ impl CompilerSession {
                     prepared,
                     &definitions,
                     &durable,
+                    durable_body_candidates,
+                    durable_body_work,
                 )
             } else {
                 analyze_prepared_canonical_program_with_durable_export(
-                    &merged, &rir, options, prepared, reuse_plan,
+                    &merged,
+                    &rir,
+                    options,
+                    prepared,
+                    reuse_plan,
+                    durable_body_candidates,
+                    durable_body_work,
                 )
                 .map(|analysis| {
                     cold_durable = analysis
@@ -2264,11 +2342,33 @@ impl CompilerSession {
             ) {
                 cache.fingerprints = fingerprints.into();
             }
+            let bodies = build_supported_ordinary_body_cache(
+                output,
+                merged.definitions().source_snapshot(),
+                options.target,
+                &options.preview_features,
+            )
+            .unwrap_or_else(|_| Arc::from([]));
+            let manifest = body_invalidation_manifest(
+                input.semantic.clone(),
+                imports.clone(),
+                output.body_owner_issuer(),
+                merged.definitions().source_snapshot(),
+                bodies.clone(),
+            );
+            self.last_successful_body_cache = Some(DurableOrdinaryBodyCache {
+                manifest: Arc::new(manifest),
+                bodies,
+            });
         }
         self.semantic_cache.push(SemanticCacheEntry {
             input: input.clone(),
             imports,
             result: result.clone(),
+            successful_body_cache: result
+                .is_ok()
+                .then(|| self.last_successful_body_cache.clone())
+                .flatten(),
         });
         self.work.semantic_entries = self.semantic_cache.len();
         self.work.semantic_records.push(SemanticQueryRecord {
@@ -3595,6 +3695,211 @@ fn stable_kind_tag(kind: StableDefinitionKind) -> u8 {
         StableDefinitionKind::Method => 6,
         StableDefinitionKind::AssociatedFunction => 7,
     }
+}
+
+/// Build the supported ordinary-body baseline directly from the successful
+/// canonical semantic artifact. This closes the publication circularity: no
+/// current dependency manifest (and therefore no second analysis or bind) is
+/// needed before the next request can authorize reuse.
+fn build_supported_ordinary_body_cache(
+    semantic: &CanonicalSemanticOutput,
+    snapshot: &SourceSnapshot,
+    target: crate::Target,
+    preview_features: &crate::PreviewFeatures,
+) -> Result<Arc<[crate::DurableOrdinaryBody]>, CompileErrors> {
+    let definitions = semantic.body_owner_issuer();
+    // RUE-883 supports ordinary free-function call topology only. Other body
+    // dependency families are retained for their dedicated follow-up slices
+    // and fail closed here so a reuse hit never drops dependency evidence.
+    let supported = semantic.ordinary_free_function_dependencies_complete()
+        && semantic.specialized_free_function_dependencies_complete()
+        && semantic.non_generic_named_method_dependencies_complete()
+        && semantic.generic_named_method_dependencies_complete()
+        && semantic.named_destructor_dependencies_complete()
+        && semantic.implicit_named_destructor_dependencies_complete()
+        && semantic.declaration_type_dependencies_complete()
+        && semantic.declaration_type_call_head_dependencies_complete()
+        && semantic.supported_type_call_heads_complete()
+        && semantic.named_value_const_dependencies_complete()
+        && semantic.specialized_free_function_origins().is_empty()
+        && semantic.specialized_free_function_dependencies().is_empty()
+        && semantic.named_method_dependencies().is_empty()
+        && semantic.named_destructor_dependencies().is_empty()
+        && semantic.implicit_named_destructor_dependencies().is_empty()
+        && semantic.declaration_type_dependencies().is_empty()
+        && semantic
+            .declaration_type_call_head_dependencies()
+            .is_empty()
+        && semantic
+            .declaration_builtin_type_call_head_dependencies()
+            .is_empty()
+        && semantic.named_const_dependencies().is_empty()
+        && semantic.body_named_dependencies().is_empty();
+    if !supported {
+        return Ok(Arc::from([]));
+    }
+    let fingerprints = definitions
+        .definitions()
+        .iter()
+        .map(|record| {
+            stable_definition_input_fingerprint(snapshot, record)
+                .map(|fingerprint| (record.stable_key().clone(), fingerprint))
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let mut records = Vec::with_capacity(semantic.durable_ordinary_body_payloads().len());
+    for payload in semantic.durable_ordinary_body_payloads() {
+        let fingerprint = fingerprints
+            .get(&payload.owner)
+            .cloned()
+            .ok_or_else(|| invalid_dependency_manifest("durable body owner is absent"))?;
+        let mut dependency_keys = Vec::new();
+        for event in semantic.ordinary_free_function_dependencies() {
+            let caller =
+                stable_free_function_endpoint(definitions, event.caller_file, &event.caller_name)?;
+            let caller = stable_token_endpoint(semantic, event.caller_token, &caller)?;
+            if caller == payload.owner {
+                dependency_keys.push(stable_free_function_endpoint(
+                    definitions,
+                    event.callee_file,
+                    &event.callee_name,
+                )?);
+            }
+        }
+        dependency_keys.sort();
+        dependency_keys.dedup();
+        let direct_dependency_inputs = dependency_keys
+            .iter()
+            .map(|key| {
+                fingerprints
+                    .get(key)
+                    .cloned()
+                    .ok_or_else(|| invalid_dependency_manifest("durable body dependency is absent"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        records.push(StableBodyDependencyInputRecord {
+            owner: payload.owner.clone(),
+            fingerprint,
+            target,
+            preview_features: StablePreviewFeatures::new(preview_features),
+            direct_dependency_inputs: direct_dependency_inputs.into(),
+            builtin_type_call_heads: Arc::from([]),
+            blockers: Arc::from([]),
+        });
+    }
+    let mut work = crate::DurableBodyWork::default();
+    crate::finalize_durable_ordinary_bodies(
+        semantic.durable_ordinary_body_payloads(),
+        &records,
+        &mut work,
+    )
+    .map_err(|_| invalid_dependency_manifest("durable body finalization failed"))
+}
+
+fn stable_module_imports(imports: &CanonicalImportGraph) -> Arc<[StableModuleImportDependency]> {
+    imports
+        .records()
+        .iter()
+        .map(|record| match record.resolution() {
+            CanonicalImportResolution::Resolved(target) => StableModuleImportDependency::Resolved {
+                importer: record.importer().clone(),
+                normalized_specifier: Arc::from(record.normalized_specifier()),
+                target: target.clone(),
+            },
+            CanonicalImportResolution::Missing => StableModuleImportDependency::Missing {
+                importer: record.importer().clone(),
+                normalized_specifier: Arc::from(record.normalized_specifier()),
+            },
+            CanonicalImportResolution::Ambiguous {
+                file_module,
+                directory_module,
+            } => StableModuleImportDependency::Ambiguous {
+                importer: record.importer().clone(),
+                normalized_specifier: Arc::from(record.normalized_specifier()),
+                file_module: file_module.clone(),
+                directory_module: directory_module.clone(),
+            },
+        })
+        .collect::<Vec<_>>()
+        .into()
+}
+
+fn body_invalidation_manifest(
+    input: SemanticInputDescriptor,
+    imports: CanonicalImportGraph,
+    definitions: &BoundDefinitionSet,
+    snapshot: &SourceSnapshot,
+    bodies: Arc<[crate::DurableOrdinaryBody]>,
+) -> SemanticDependencyInputManifest {
+    let definition_fingerprints = definitions
+        .definitions()
+        .iter()
+        .map(|record| stable_definition_input_fingerprint(snapshot, record))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap_or_default();
+    let mut free_function_dependencies = bodies
+        .iter()
+        .flat_map(|body| {
+            body.inputs()
+                .direct_dependency_inputs()
+                .iter()
+                .map(|dependency| StableFreeFunctionDependency {
+                    caller: body.owner().clone(),
+                    callee: dependency.key.clone(),
+                })
+        })
+        .collect::<Vec<_>>();
+    free_function_dependencies.sort();
+    free_function_dependencies.dedup();
+    let body_dependencies = bodies
+        .iter()
+        .map(|body| body.inputs.clone())
+        .collect::<Vec<_>>();
+    let definition_keys = definitions
+        .definitions()
+        .iter()
+        .map(|record| record.stable_key().clone())
+        .collect::<Vec<_>>();
+    let module_imports = stable_module_imports(&imports);
+    SemanticDependencyInputManifest {
+        input,
+        imports,
+        definitions: definition_keys.into(),
+        definition_fingerprints: definition_fingerprints.into(),
+        module_imports,
+        free_function_dependencies: free_function_dependencies.into(),
+        named_method_dependencies: Arc::from([]),
+        named_destructor_dependencies: Arc::from([]),
+        implicit_named_destructor_dependencies: Arc::from([]),
+        declaration_type_dependencies: Arc::from([]),
+        declaration_type_call_head_dependencies: Arc::from([]),
+        builtin_type_call_head_inputs: Arc::from([]),
+        named_const_dependencies: Arc::from([]),
+        body_dependencies: body_dependencies.into(),
+        durable_ordinary_bodies: bodies,
+        body_dependency_blockers: Arc::from([]),
+        dependency_blockers: Arc::from([]),
+        definition_universe_complete: true,
+        work: SemanticDependencyManifestWork::default(),
+    }
+}
+
+fn preflight_body_invalidation_manifest(
+    previous: &SemanticDependencyInputManifest,
+    input: SemanticInputDescriptor,
+    imports: CanonicalImportGraph,
+    fingerprints: &[StableDefinitionInputFingerprint],
+) -> SemanticDependencyInputManifest {
+    let mut current = previous.clone();
+    current.input = input;
+    current.imports = imports.clone();
+    current.module_imports = stable_module_imports(&imports);
+    current.definitions = fingerprints
+        .iter()
+        .map(|value| value.key.clone())
+        .collect::<Vec<_>>()
+        .into();
+    current.definition_fingerprints = fingerprints.to_vec().into();
+    current
 }
 
 fn stable_free_function_endpoint(
@@ -5198,6 +5503,7 @@ mod tests {
                         "synthetic prior failed opt variant".to_string(),
                     ),
                 ))),
+                successful_body_cache: None,
             },
         );
 
@@ -6468,6 +6774,21 @@ mod tests {
             SemanticDependencyIncompleteReason::AnonymousDropOwnerUnavailable
         );
         assert!(!manifest.implicit_named_destructor_dependencies_complete());
+        assert!(manifest.durable_ordinary_bodies().is_empty());
+        assert!(
+            session
+                .last_successful_body_cache
+                .as_ref()
+                .is_some_and(|cache| cache.bodies.is_empty())
+        );
+        let warm = session
+            .semantic(&CompileOptions {
+                opt_level: OptLevel::O1,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(warm.work().durable_bodies.import_attempts, 0);
+        assert_eq!(warm.work().durable_bodies.reused_bodies, 0);
         assert!(manifest.body_dependency_blockers().iter().any(|blocker| {
             blocker.owner().is_none()
                 && blocker.surface() == SemanticDependencySurface::BodyOwner
@@ -7369,7 +7690,7 @@ mod tests {
     }
 
     #[test]
-    fn durable_ordinary_body_candidates_are_observational_and_round_trip_fresh_epoch() {
+    fn durable_ordinary_bodies_reuse_in_the_canonical_worklist_and_match_fresh_output() {
         let source = snapshot(
             &[(
                 41,
@@ -7396,7 +7717,7 @@ mod tests {
         assert_eq!(work.import_failures, 0);
         assert_eq!(work.atomic_discards, 0);
         assert!(work.installed_instructions > 0);
-        // This boundary validates candidates but never skips ordinary work.
+        // The cold request analyzes and publishes each reachable body once.
         let semantic_work = session.work().semantic_records.last().unwrap().work;
         assert_eq!(semantic_work.body_analysis.bodies_attempted, 2);
         assert_eq!(semantic_work.body_analysis.bodies_succeeded, 2);
@@ -7406,5 +7727,294 @@ mod tests {
         assert_eq!(semantic_work.durable_bodies.conversion_completions, 2);
         assert_eq!(semantic_work.durable_bodies.reused_bodies, 0);
         assert_eq!(semantic_work.durable_bodies.skipped_body_analyses, 0);
+
+        let optimized_options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let reused = session.semantic(&optimized_options).unwrap();
+        let reused_work = reused.work();
+        assert_eq!(reused_work.body_analysis.bodies_attempted, 0);
+        assert_eq!(reused_work.body_analysis.bodies_succeeded, 0);
+        assert_eq!(reused_work.durable_bodies.candidate_comparisons, 2);
+        assert_eq!(reused_work.durable_bodies.import_attempts, 2);
+        assert_eq!(reused_work.durable_bodies.import_successes, 2);
+        assert_eq!(reused_work.durable_bodies.reused_bodies, 2);
+        assert_eq!(reused_work.durable_bodies.skipped_body_analyses, 2);
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&source).into_result().unwrap();
+        let fresh = fresh.semantic(&optimized_options).unwrap();
+        assert_eq!(
+            format!("{:?}", reused.functions()),
+            format!("{:?}", fresh.functions())
+        );
+        assert_eq!(reused.strings(), fresh.strings());
+        assert_eq!(
+            format!("{:?}", reused.warnings()),
+            format!("{:?}", fresh.warnings())
+        );
+        assert_eq!(
+            format!("{:?}", reused.ordinary_free_function_dependencies()),
+            format!("{:?}", fresh.ordinary_free_function_dependencies())
+        );
+        assert_eq!(
+            format!("{:?}", reused.analyzed_body_owners()),
+            format!("{:?}", fresh.analyzed_body_owners())
+        );
+    }
+
+    #[test]
+    fn durable_ordinary_body_edit_reuses_unaffected_reachable_body_and_failure_keeps_baseline() {
+        let original = snapshot(
+            &[(
+                51,
+                "/p/main.rue",
+                "main.rue",
+                "fn a() -> i32 { 1 }\nfn b() -> i32 { 2 }\nfn main() -> i32 { a() + b() }",
+            )],
+            51,
+        );
+        let edited = snapshot(
+            &[(
+                51,
+                "/p/main.rue",
+                "main.rue",
+                "fn a() -> i32 { 3 }\nfn b() -> i32 { 2 }\nfn main() -> i32 { a() + b() }",
+            )],
+            51,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&original).into_result().unwrap();
+        session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+
+        session.update(&edited).into_result().unwrap();
+        let edited_output = session.semantic(&CompileOptions::default()).unwrap();
+        let work = edited_output.work();
+        assert_eq!(work.durable_bodies.candidate_comparisons, 3);
+        assert_eq!(work.durable_bodies.reused_bodies, 1);
+        assert_eq!(work.durable_bodies.skipped_body_analyses, 1);
+        assert_eq!(work.body_analysis.bodies_attempted, 2);
+        assert_eq!(work.body_analysis.bodies_succeeded, 2);
+        session
+            .semantic_dependency_inputs(&CompileOptions::default(), None)
+            .unwrap();
+
+        let invalid = snapshot(
+            &[(
+                51,
+                "/p/main.rue",
+                "main.rue",
+                "fn a() -> i32 { false }\nfn b() -> i32 { 2 }\nfn main() -> i32 { a() + b() }",
+            )],
+            51,
+        );
+        session.update(&invalid).into_result().unwrap();
+        assert!(session.semantic(&CompileOptions::default()).is_err());
+
+        session.update(&edited).into_result().unwrap();
+        let recovered_options = CompileOptions {
+            opt_level: OptLevel::O2,
+            ..CompileOptions::default()
+        };
+        let recovered = session.semantic(&recovered_options).unwrap();
+        assert_eq!(recovered.work().durable_bodies.reused_bodies, 3);
+        assert_eq!(recovered.work().body_analysis.bodies_attempted, 0);
+    }
+
+    #[test]
+    fn durable_ordinary_body_import_rejection_falls_back_atomically() {
+        let source = snapshot(
+            &[(
+                61,
+                "/p/main.rue",
+                "main.rue",
+                "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }",
+            )],
+            61,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+        let cache = session.last_successful_body_cache.as_mut().unwrap();
+        let mut bodies = cache.bodies.to_vec();
+        let mut instructions = bodies[0].payload.instructions.to_vec();
+        instructions[0].anchor.end = u32::MAX;
+        bodies[0].payload.instructions = instructions.into();
+        cache.bodies = bodies.into();
+
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let output = session.semantic(&options).unwrap();
+        let work = output.work();
+        assert_eq!(work.durable_bodies.candidate_comparisons, 2);
+        assert_eq!(work.durable_bodies.projection_completions, 2);
+        assert_eq!(work.durable_bodies.import_attempts, 2);
+        assert_eq!(work.durable_bodies.import_successes, 1);
+        assert_eq!(work.durable_bodies.import_failures, 1);
+        assert_eq!(work.durable_bodies.atomic_discards, 1);
+        assert_eq!(work.durable_bodies.candidate_fallbacks, 1);
+        assert_eq!(work.durable_bodies.reused_bodies, 1);
+        assert_eq!(work.body_analysis.bodies_attempted, 1);
+        assert_eq!(work.body_analysis.bodies_succeeded, 1);
+    }
+
+    #[test]
+    fn warning_producing_ordinary_body_is_not_reused_and_warning_is_recomputed() {
+        let source = snapshot(
+            &[(
+                62,
+                "/p/main.rue",
+                "main.rue",
+                "fn main() -> i32 { let unused = 1; 0 }",
+            )],
+            62,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert!(!cold.warnings().is_empty());
+        assert!(
+            session
+                .last_successful_body_cache
+                .as_ref()
+                .is_some_and(|cache| cache.bodies.is_empty())
+        );
+
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let warm = session.semantic(&options).unwrap();
+        assert_eq!(warm.work().durable_bodies.reused_bodies, 0);
+        assert_eq!(warm.work().body_analysis.bodies_attempted, 1);
+        assert_eq!(
+            format!("{:?}", warm.warnings()),
+            format!("{:?}", cold.warnings())
+        );
+    }
+
+    #[test]
+    fn unreachable_composite_body_candidate_is_never_imported() {
+        let original = snapshot(
+            &[(
+                71,
+                "/p/main.rue",
+                "main.rue",
+                "fn helper() -> [i32; 2] { [1, 2] }\nfn main() -> i32 { helper()[0] }",
+            )],
+            71,
+        );
+        let edited = snapshot(
+            &[(
+                71,
+                "/p/main.rue",
+                "main.rue",
+                "fn helper() -> [i32; 2] { [1, 2] }\nfn main() -> i32 { 0 }",
+            )],
+            71,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&original).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+        session.update(&edited).into_result().unwrap();
+        let reused = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(reused.work().durable_bodies.candidate_comparisons, 2);
+        assert_eq!(reused.work().durable_bodies.import_attempts, 0);
+        assert_eq!(reused.work().durable_bodies.reused_bodies, 0);
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&edited).into_result().unwrap();
+        let fresh = fresh.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(
+            format!("{:?}", reused.functions()),
+            format!("{:?}", fresh.functions())
+        );
+        assert_eq!(reused.type_pool().stats(), fresh.type_pool().stats());
+    }
+
+    #[test]
+    fn rejected_composite_import_does_not_mutate_the_live_type_epoch() {
+        let source = snapshot(
+            &[(72, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
+            72,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+        let cache = session.last_successful_body_cache.as_mut().unwrap();
+        let mut bodies = cache.bodies.to_vec();
+        bodies[0].payload.return_type =
+            crate::DurableType::PtrConst(Box::new(crate::DurableType::Array {
+                element: Box::new(crate::DurableType::I32),
+                len: 3,
+            }));
+        let mut instructions = bodies[0].payload.instructions.to_vec();
+        instructions[0].anchor.end = u32::MAX;
+        bodies[0].payload.instructions = instructions.into();
+        cache.bodies = bodies.into();
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let reused = session.semantic(&options).unwrap();
+        assert_eq!(reused.work().durable_bodies.import_attempts, 1);
+        assert_eq!(reused.work().durable_bodies.import_failures, 1);
+        assert_eq!(reused.work().durable_bodies.atomic_discards, 1);
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&source).into_result().unwrap();
+        let fresh = fresh.semantic(&options).unwrap();
+        assert_eq!(
+            format!("{:?}", reused.functions()),
+            format!("{:?}", fresh.functions())
+        );
+        assert_eq!(reused.type_pool().stats(), fresh.type_pool().stats());
+    }
+
+    #[test]
+    fn exact_semantic_cache_hit_restores_its_successful_body_baseline() {
+        let a = snapshot(
+            &[(
+                73,
+                "/p/main.rue",
+                "main.rue",
+                "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() }",
+            )],
+            73,
+        );
+        let b = snapshot(
+            &[(
+                73,
+                "/p/main.rue",
+                "main.rue",
+                "fn helper() -> i32 { 2 }\nfn main() -> i32 { helper() }",
+            )],
+            73,
+        );
+        let a_prime = snapshot(
+            &[(
+                73,
+                "/p/main.rue",
+                "main.rue",
+                "fn helper() -> i32 { 1 }\nfn main() -> i32 { helper() + 1 }",
+            )],
+            73,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&a).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+        session.update(&b).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+        session.update(&a).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+        session.update(&a_prime).into_result().unwrap();
+        let output = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(output.work().durable_bodies.reused_bodies, 1);
+        assert_eq!(output.work().durable_bodies.import_successes, 1);
     }
 }

--- a/docs/process/session-invalidation-benchmark.md
+++ b/docs/process/session-invalidation-benchmark.md
@@ -100,7 +100,14 @@ export attempts, successful publications and fail-closed rejections; emitted
 instructions, places and strings; compiler-owned durable conversions and
 stable-key joins; projections into AIR's neutral import DTO; atomic fresh-epoch
 imports and installed contents. `reused_bodies` and `skipped_body_analyses` are
-explicitly zero in this observational slice.
+zero on a cold request. Supported warning-free, non-generic ordinary free
+functions are retained only from the last fully successful semantic request.
+A later request uses the canonical stable-key invalidation plan plus exact
+owner and dependency fingerprints to project and atomically import candidates
+into the live AIR epoch. The counters record only bodies actually consumed by
+the existing reachability worklist; rejected or unreachable imports never
+claim avoided analysis. Warning-producing bodies and dependency surfaces owned
+by later incremental slices remain fail-closed ordinary fallbacks.
 
 Schema version 8 adds a `retention` object to every scenario. It reports current
 session-owned diagnostic entries, distinct diagnostic source attempts and


### PR DESCRIPTION
## What
- retain the last successful durable ordinary-body baseline in the compiler session
- select exact reusable free-function bodies through canonical invalidation planning
- import reusable AIR lazily and atomically through the existing reachable-body worklist
- preserve dependency evidence, warnings, failure envelopes, and honest reuse counters
- fail closed for unsupported dependency surfaces reserved for later epic slices

## Why
This activates the ordinary free-function reuse boundary prepared by RUE-721 without introducing a second analyzer, worklist, or semantic epoch.

## Validation
- scripts/rue fmt
- scripts/rue quick
- scripts/rue test
- scripts/rue test durable_ordinary_body
- adversarial architectural review

Fixes RUE-883