### PR TITLE
RUE-886: reuse named method and destructor bodies

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -154,8 +154,9 @@ fn import_staged_ordinary_body(
         })
     }
 
-    // Intrinsic symbols are required to pre-exist. This keeps every importer
-    // mutation inside the scratch type pool until the entire body validates.
+    // Intrinsic and declaration-derived callable symbols are required to
+    // pre-exist. This keeps importer mutation inside the scratch type pool
+    // until the entire body validates.
     if candidate.body.instructions.iter().any(|inst| matches!(&inst.data,
         crate::SemanticBodyInstData::Intrinsic { name, .. } if sema.interner.get(name.as_ref()).is_none())) {
         return Err(BF::Semantic(F::MissingFunction));
@@ -192,16 +193,42 @@ fn import_staged_ordinary_body(
                 .ok_or(BF::Semantic(F::MissingNominal))
         },
         |identity| {
-            if identity.kind != DK::FreeFunction {
-                return Err(BF::Semantic(F::MissingFunction));
-            }
             let name = sema
                 .interner
                 .get(identity.name.as_ref())
                 .ok_or(BF::Semantic(F::MissingFunction))?;
-            sema.functions_by_file_name
-                .get(&(FileId::new(identity.file_id), name))
+            if identity.kind == DK::FreeFunction {
+                return sema
+                    .functions_by_file_name
+                    .get(&(FileId::new(identity.file_id), name))
+                    .copied()
+                    .ok_or(BF::Semantic(F::MissingFunction));
+            }
+            let owner = identity
+                .owner
+                .as_deref()
+                .and_then(|owner| sema.interner.get(owner))
+                .ok_or(BF::Semantic(F::MissingFunction))?;
+            let struct_id = sema
+                .structs_by_file_name
+                .get(&(FileId::new(identity.file_id), owner))
                 .copied()
+                .ok_or(BF::Semantic(F::MissingFunction))?;
+            let info = sema
+                .method_info((struct_id, name))
+                .ok_or(BF::Semantic(F::MissingFunction))?;
+            let expected = match identity.kind {
+                DK::Method => info.has_self && identity.name.as_ref() != "__drop",
+                DK::AssociatedFunction => !info.has_self,
+                DK::Destructor => info.has_self && identity.name.as_ref() == "__drop",
+                _ => false,
+            };
+            if !expected {
+                return Err(BF::Semantic(F::MissingFunction));
+            }
+            let symbol = sema.method_symbol(struct_id, identity.name.as_ref(), info.has_self);
+            sema.interner
+                .get(&symbol)
                 .ok_or(BF::Semantic(F::MissingFunction))
         },
         |name| {
@@ -212,6 +239,31 @@ fn import_staged_ordinary_body(
     )?;
     sema.type_pool = scratch;
     Ok(imported)
+}
+
+fn imported_body_references(
+    sema: &BodySema<'_>,
+    air: &Air,
+) -> (HashSet<Spur>, HashSet<(crate::StructId, Spur)>) {
+    let mut functions = HashSet::new();
+    let mut methods = HashSet::new();
+    for instruction in air.instructions() {
+        let AirInstData::Call { name, .. } = instruction.data else {
+            continue;
+        };
+        if sema.functions.contains_key(&name) {
+            functions.insert(name);
+            continue;
+        }
+        let symbol = sema.interner.resolve(&name);
+        if let Some((key, _)) = sema.methods.iter().find(|entry| {
+            let (&(struct_id, method), info) = *entry;
+            sema.method_symbol(struct_id, sema.interner.resolve(&method), info.has_self) == symbol
+        }) {
+            methods.insert(*key);
+        }
+    }
+    (functions, methods)
 }
 
 #[cfg(test)]
@@ -233,6 +285,7 @@ fn analyze_all_function_bodies_mut(sema: &mut BodySema<'_>) -> MultiErrorResult<
     debug_assert!(sema.const_resolution_in_progress.is_empty());
     debug_assert!(sema.fn_signatures_in_flight.is_empty());
     debug_assert!(sema.source_free_function_signatures_are_complete());
+    intern_named_callable_symbols(sema);
     let bound_source_function_signature_count = sema.functions_by_file_name.len();
 
     // ADR-0045 defines reachability from `main` as the function-body analysis
@@ -260,6 +313,27 @@ fn analyze_all_function_bodies_mut(sema: &mut BodySema<'_>) -> MultiErrorResult<
     }
 
     result
+}
+
+/// Materialize every qualified named callable symbol after declaration
+/// binding, before either fresh analysis or durable import can observe the
+/// body worklist. Hash-map iteration order must not affect Spur allocation.
+fn intern_named_callable_symbols(sema: &BodySema<'_>) {
+    let mut symbols = sema
+        .methods
+        .iter()
+        .filter_map(|(&(struct_id, method), info)| {
+            let owner = sema.type_pool.struct_def(struct_id);
+            (!owner.name.starts_with("__anon_struct_")).then(|| {
+                sema.method_symbol(struct_id, sema.interner.resolve(&method), info.has_self)
+            })
+        })
+        .collect::<Vec<_>>();
+    symbols.sort();
+    symbols.dedup();
+    for symbol in symbols {
+        sema.interner.get_or_intern(&symbol);
+    }
 }
 
 /// Scan analyzed AIR for an `<error>`-typed value that survived analysis with
@@ -1000,19 +1074,8 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                         .ordinary_body_import_strings_installed += imported.strings.len();
                     sema.body_analysis_work.ordinary_bodies_reused += 1;
                     sema.body_analysis_work.ordinary_body_analyses_skipped += 1;
-                    let referenced_fns = imported
-                        .air
-                        .instructions()
-                        .iter()
-                        .filter_map(|inst| match inst.data {
-                            crate::AirInstData::Call { name, .. }
-                                if sema.functions.contains_key(&name) =>
-                            {
-                                Some(name)
-                            }
-                            _ => None,
-                        })
-                        .collect::<HashSet<_>>();
+                    let (referenced_fns, referenced_meths) =
+                        imported_body_references(sema, &imported.air);
                     let mut ordered_referenced_fns =
                         referenced_fns.iter().copied().collect::<Vec<_>>();
                     ordered_referenced_fns
@@ -1081,7 +1144,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                     enqueue_references_sorted(
                         sema.interner,
                         referenced_fns,
-                        HashSet::new(),
+                        referenced_meths,
                         &analyzed_functions,
                         &analyzed_methods,
                         &mut pending_functions,
@@ -1407,6 +1470,124 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
 
             let params = sema.rir.get_params(*params_start, *params_len);
             let full_name = sema.method_symbol(struct_id, &method_name_str, *has_self);
+            let generic = sema
+                .param_arena
+                .comptime(method_info.params)
+                .iter()
+                .copied()
+                .any(|flag| flag);
+            let owner_kind = if *has_self {
+                super::BodyOwnerKind::Method
+            } else {
+                super::BodyOwnerKind::AssociatedFunction
+            };
+            let ordinary_owner = sema.body_owner_token(
+                method_info.span.file_id,
+                &method_name_str,
+                Some(&type_name_str),
+                owner_kind,
+            );
+            if !generic
+                && let Some(candidate) = sema.reusable_ordinary_bodies.remove(&ordinary_owner)
+            {
+                sema.body_analysis_work.ordinary_body_import_attempts += 1;
+                match import_staged_ordinary_body(sema, &candidate, sema.rir.get(*body).span) {
+                    Ok(imported) => {
+                        sema.body_analysis_work.ordinary_body_import_successes += 1;
+                        sema.body_analysis_work
+                            .ordinary_body_import_instructions_installed += imported.air.len();
+                        sema.body_analysis_work
+                            .ordinary_body_import_places_installed += imported.air.places().len();
+                        sema.body_analysis_work
+                            .ordinary_body_import_strings_installed += imported.strings.len();
+                        sema.body_analysis_work.ordinary_bodies_reused += 1;
+                        sema.body_analysis_work.ordinary_body_analyses_skipped += 1;
+                        let (referenced_fns, referenced_meths) =
+                            imported_body_references(sema, &imported.air);
+                        let analyzed = AnalyzedFunction {
+                            name: full_name,
+                            ordinary_owner: Some(ordinary_owner),
+                            implicit_drop_source: Some(
+                                super::ImplicitDropDependencySourceEvent::NamedMethod {
+                                    token: ordinary_owner,
+                                    file: method_info.span.file_id.index(),
+                                    owner_name: type_name_str.clone(),
+                                    method_name: method_name_str.clone(),
+                                },
+                            ),
+                            air: imported.air,
+                            num_locals: imported.num_locals,
+                            num_param_slots: imported.num_param_slots,
+                            param_modes: imported.param_modes,
+                            allow_unreachable_code: imported.allow_unreachable_code,
+                        };
+                        sema.analyzed_body_owners.push(
+                            super::AnalyzedBodyOwnerEvent::NamedMethod {
+                                token: ordinary_owner,
+                                file: method_info.span.file_id.index(),
+                                owner_name: type_name_str.clone(),
+                                method_name: method_name_str.clone(),
+                                generic: false,
+                            },
+                        );
+                        match named_method_dependency_events(
+                            sema,
+                            struct_id,
+                            method_name,
+                            &referenced_fns,
+                            &referenced_meths,
+                        ) {
+                            Ok(events) => {
+                                sema.body_analysis_work.named_method_dependency_events +=
+                                    events.len();
+                                sema.named_method_dependencies.extend(events);
+                            }
+                            Err(error) => {
+                                errors.push(error);
+                                continue;
+                            }
+                        }
+                        sema.body_analysis_work.ordinary_body_exports_attempted += 1;
+                        match sema.export_ordinary_body(
+                            ordinary_owner,
+                            sema.rir.get(*body).span,
+                            &analyzed,
+                            &imported.strings,
+                            &[],
+                        ) {
+                            Ok(export) => {
+                                sema.body_analysis_work.ordinary_body_exports_succeeded += 1;
+                                sema.body_analysis_work
+                                    .ordinary_body_export_instructions_emitted +=
+                                    export.body.instructions.len();
+                                sema.body_analysis_work.ordinary_body_export_places_emitted +=
+                                    export.body.places.len();
+                                sema.body_analysis_work.ordinary_body_export_strings_emitted +=
+                                    export.body.strings.len();
+                                sema.ordinary_body_exports.push(export);
+                            }
+                            Err(_) => {
+                                sema.body_analysis_work.ordinary_body_exports_rejected += 1;
+                            }
+                        }
+                        functions_with_strings.push((analyzed, imported.strings));
+                        enqueue_references_sorted(
+                            sema.interner,
+                            referenced_fns,
+                            referenced_meths,
+                            &analyzed_functions,
+                            &analyzed_methods,
+                            &mut pending_functions,
+                            &mut pending_methods,
+                        );
+                        continue;
+                    }
+                    Err(_) => {
+                        sema.body_analysis_work.ordinary_body_import_failures += 1;
+                        sema.body_analysis_work.ordinary_body_import_atomic_discards += 1;
+                    }
+                }
+            }
             sema.body_analysis_work.bodies_attempted += 1;
             let previous_type_observer = sema.declaration_type_observer.replace((
                 method_info.span.file_id,
@@ -1435,12 +1616,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                         file: method_info.span.file_id.index(),
                         owner_name: type_name_str.clone(),
                         method_name: method_name_str.clone(),
-                        generic: sema
-                            .param_arena
-                            .comptime(method_info.params)
-                            .iter()
-                            .copied()
-                            .any(|flag| flag),
+                        generic,
                     });
             let analysis = sema.analyze_method_function(
                 &infer_ctx,
@@ -1476,12 +1652,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                             file: method_info.span.file_id.index(),
                             owner_name: type_name_str.clone(),
                             method_name: method_name_str.clone(),
-                            generic: sema
-                                .param_arena
-                                .comptime(method_info.params)
-                                .iter()
-                                .copied()
-                                .any(|flag| flag),
+                            generic,
                         });
                     analyzed.ordinary_owner = Some(sema.body_owner_token(
                         method_info.span.file_id,
@@ -1493,6 +1664,31 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                             super::BodyOwnerKind::AssociatedFunction
                         },
                     ));
+                    if !generic {
+                        sema.body_analysis_work.ordinary_body_exports_attempted += 1;
+                        match sema.export_ordinary_body(
+                            ordinary_owner,
+                            sema.rir.get(*body).span,
+                            &analyzed,
+                            &local_strings,
+                            &warnings,
+                        ) {
+                            Ok(export) => {
+                                sema.body_analysis_work.ordinary_body_exports_succeeded += 1;
+                                sema.body_analysis_work
+                                    .ordinary_body_export_instructions_emitted +=
+                                    export.body.instructions.len();
+                                sema.body_analysis_work.ordinary_body_export_places_emitted +=
+                                    export.body.places.len();
+                                sema.body_analysis_work.ordinary_body_export_strings_emitted +=
+                                    export.body.strings.len();
+                                sema.ordinary_body_exports.push(export);
+                            }
+                            Err(_) => {
+                                sema.body_analysis_work.ordinary_body_exports_rejected += 1;
+                            }
+                        }
+                    }
                     analyzed.implicit_drop_source =
                         Some(super::ImplicitDropDependencySourceEvent::NamedMethod {
                             token: sema.body_owner_token(
@@ -1585,8 +1781,116 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 let struct_type = Type::new_struct(struct_id);
                 let full_name = sema.destructor_symbol(struct_id);
 
-                sema.body_analysis_work.bodies_attempted += 1;
                 let owner_name = sema.type_pool.struct_def(struct_id).name.clone();
+                let ordinary_owner = sema.body_owner_token(
+                    destructor.span.file_id,
+                    &owner_name,
+                    Some(&owner_name),
+                    super::BodyOwnerKind::Destructor,
+                );
+                if let Some(candidate) = sema.reusable_ordinary_bodies.remove(&ordinary_owner) {
+                    sema.body_analysis_work.ordinary_body_import_attempts += 1;
+                    match import_staged_ordinary_body(
+                        sema,
+                        &candidate,
+                        sema.rir.get(destructor.body).span,
+                    ) {
+                        Ok(imported) => {
+                            sema.body_analysis_work.ordinary_body_import_successes += 1;
+                            sema.body_analysis_work
+                                .ordinary_body_import_instructions_installed += imported.air.len();
+                            sema.body_analysis_work
+                                .ordinary_body_import_places_installed +=
+                                imported.air.places().len();
+                            sema.body_analysis_work
+                                .ordinary_body_import_strings_installed += imported.strings.len();
+                            sema.body_analysis_work.ordinary_bodies_reused += 1;
+                            sema.body_analysis_work.ordinary_body_analyses_skipped += 1;
+                            let (referenced_fns, referenced_meths) =
+                                imported_body_references(sema, &imported.air);
+                            let analyzed = AnalyzedFunction {
+                                name: full_name,
+                                ordinary_owner: Some(ordinary_owner),
+                                implicit_drop_source: Some(
+                                    super::ImplicitDropDependencySourceEvent::NamedDestructor {
+                                        token: ordinary_owner,
+                                        file: destructor.span.file_id.index(),
+                                        owner_name: owner_name.clone(),
+                                    },
+                                ),
+                                air: imported.air,
+                                num_locals: imported.num_locals,
+                                num_param_slots: imported.num_param_slots,
+                                param_modes: imported.param_modes,
+                                allow_unreachable_code: imported.allow_unreachable_code,
+                            };
+                            sema.analyzed_body_owners.push(
+                                super::AnalyzedBodyOwnerEvent::NamedDestructor {
+                                    token: ordinary_owner,
+                                    file: destructor.span.file_id.index(),
+                                    owner_name: owner_name.clone(),
+                                },
+                            );
+                            match named_destructor_dependency_events(
+                                sema,
+                                struct_id,
+                                destructor.span,
+                                &referenced_fns,
+                                &referenced_meths,
+                            ) {
+                                Ok(events) => {
+                                    sema.body_analysis_work.named_destructor_dependency_events +=
+                                        events.len();
+                                    sema.named_destructor_dependencies.extend(events);
+                                }
+                                Err(error) => {
+                                    errors.push(error);
+                                    continue;
+                                }
+                            }
+                            sema.body_analysis_work.ordinary_body_exports_attempted += 1;
+                            match sema.export_ordinary_body(
+                                ordinary_owner,
+                                sema.rir.get(destructor.body).span,
+                                &analyzed,
+                                &imported.strings,
+                                &[],
+                            ) {
+                                Ok(export) => {
+                                    sema.body_analysis_work.ordinary_body_exports_succeeded += 1;
+                                    sema.body_analysis_work
+                                        .ordinary_body_export_instructions_emitted +=
+                                        export.body.instructions.len();
+                                    sema.body_analysis_work.ordinary_body_export_places_emitted +=
+                                        export.body.places.len();
+                                    sema.body_analysis_work.ordinary_body_export_strings_emitted +=
+                                        export.body.strings.len();
+                                    sema.ordinary_body_exports.push(export);
+                                }
+                                Err(_) => {
+                                    sema.body_analysis_work.ordinary_body_exports_rejected += 1;
+                                }
+                            }
+                            functions_with_strings.push((analyzed, imported.strings));
+                            enqueue_references_sorted(
+                                sema.interner,
+                                referenced_fns,
+                                referenced_meths,
+                                &analyzed_functions,
+                                &analyzed_methods,
+                                &mut pending_functions,
+                                &mut pending_methods,
+                            );
+                            continue;
+                        }
+                        Err(_) => {
+                            sema.body_analysis_work.ordinary_body_import_failures += 1;
+                            sema.body_analysis_work.ordinary_body_import_atomic_discards += 1;
+                        }
+                    }
+                }
+
+                sema.body_analysis_work.bodies_attempted += 1;
                 let previous_type_observer = sema.declaration_type_observer.replace((
                     destructor.span.file_id,
                     owner_name.clone(),
@@ -1645,6 +1949,29 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                             Some(&sema.type_pool.struct_def(struct_id).name),
                             super::BodyOwnerKind::Destructor,
                         ));
+                        sema.body_analysis_work.ordinary_body_exports_attempted += 1;
+                        match sema.export_ordinary_body(
+                            ordinary_owner,
+                            sema.rir.get(destructor.body).span,
+                            &analyzed,
+                            &local_strings,
+                            &warnings,
+                        ) {
+                            Ok(export) => {
+                                sema.body_analysis_work.ordinary_body_exports_succeeded += 1;
+                                sema.body_analysis_work
+                                    .ordinary_body_export_instructions_emitted +=
+                                    export.body.instructions.len();
+                                sema.body_analysis_work.ordinary_body_export_places_emitted +=
+                                    export.body.places.len();
+                                sema.body_analysis_work.ordinary_body_export_strings_emitted +=
+                                    export.body.strings.len();
+                                sema.ordinary_body_exports.push(export);
+                            }
+                            Err(_) => {
+                                sema.body_analysis_work.ordinary_body_exports_rejected += 1;
+                            }
+                        }
                         analyzed.implicit_drop_source =
                             Some(super::ImplicitDropDependencySourceEvent::NamedDestructor {
                                 token: sema.body_owner_token(

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -978,6 +978,13 @@ fn finish_canonical_analysis(
                 crate::StableDefinitionKind::Function => {
                     rue_air::SemanticBodyDefinitionKind::FreeFunction
                 }
+                crate::StableDefinitionKind::Method => rue_air::SemanticBodyDefinitionKind::Method,
+                crate::StableDefinitionKind::AssociatedFunction => {
+                    rue_air::SemanticBodyDefinitionKind::AssociatedFunction
+                }
+                crate::StableDefinitionKind::Destructor => {
+                    rue_air::SemanticBodyDefinitionKind::Destructor
+                }
                 crate::StableDefinitionKind::Struct => rue_air::SemanticBodyDefinitionKind::Struct,
                 crate::StableDefinitionKind::Enum => rue_air::SemanticBodyDefinitionKind::Enum,
                 _ => return None,
@@ -986,7 +993,7 @@ fn finish_canonical_analysis(
                 file_id: record.declaration_span().file_id.index(),
                 name: std::sync::Arc::from(key.name()),
                 kind,
-                owner: None,
+                owner: key.owner().map(|owner| std::sync::Arc::from(owner.name())),
             })
         },
         |module: &std::sync::Arc<str>| modules.get(module.as_ref()).copied(),

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -5,7 +5,10 @@
 //! in this module are the only representation eligible for retention between
 //! frontend revisions.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use rue_air::{
     AirArgMode, AirPlaceBase, SemanticBodyDefinitionIdentity, SemanticBodyDefinitionKind,
@@ -509,10 +512,13 @@ pub fn convert_semantic_body_exports(
             .definition_for_body_token(export.owner)
             .map_err(|_| DurableBodyConversionFailure::ForeignOwnerToken)?;
         let owner = owner_record.stable_key().clone();
-        // This first retained schema intentionally admits ordinary free
-        // functions only. Methods and synthesized/specialized bodies remain
-        // fail-closed until their complete identity boundary is designed.
-        if owner.kind() != StableDefinitionKind::Function {
+        if !matches!(
+            owner.kind(),
+            StableDefinitionKind::Function
+                | StableDefinitionKind::Method
+                | StableDefinitionKind::AssociatedFunction
+                | StableDefinitionKind::Destructor
+        ) {
             return Err(DurableBodyConversionFailure::WrongDefinitionKind);
         }
         let expected_inputs = crate::session::stable_definition_input_fingerprint(
@@ -883,6 +889,78 @@ impl DurableOrdinaryBody {
 }
 
 impl DurableOrdinaryBodyPayload {
+    pub(crate) fn referenced_definition_keys(&self) -> BTreeSet<StableDefinitionKey> {
+        fn visit_type(value: &DurableType, keys: &mut BTreeSet<StableDefinitionKey>) {
+            match value {
+                DurableType::Nominal(key) => {
+                    keys.insert(key.clone());
+                }
+                DurableType::Array { element, .. }
+                | DurableType::PtrConst(element)
+                | DurableType::PtrMut(element) => visit_type(element, keys),
+                DurableType::Tuple(values) => {
+                    for value in values.iter() {
+                        visit_type(value, keys);
+                    }
+                }
+                DurableType::Function { parameters, result } => {
+                    for value in parameters.iter() {
+                        visit_type(value, keys);
+                    }
+                    visit_type(result, keys);
+                }
+                _ => {}
+            }
+        }
+
+        let mut keys = BTreeSet::new();
+        visit_type(&self.return_type, &mut keys);
+        for instruction in self.instructions.iter() {
+            visit_type(&instruction.ty, &mut keys);
+            match &instruction.data {
+                DurableAirInstData::TypeConst(value)
+                | DurableAirInstData::IntCast { from_ty: value, .. } => {
+                    visit_type(value, &mut keys);
+                }
+                DurableAirInstData::Call { function, .. } => {
+                    keys.insert(function.clone());
+                }
+                DurableAirInstData::StructInit { struct_key, .. } => {
+                    keys.insert(struct_key.clone());
+                }
+                DurableAirInstData::EnumVariant { enum_key, .. }
+                | DurableAirInstData::EnumPayloadGet { enum_key, .. } => {
+                    keys.insert(enum_key.clone());
+                }
+                DurableAirInstData::Match { arms, .. } => {
+                    for arm in arms.iter() {
+                        if let DurablePattern::EnumVariant { enum_key, .. } = &arm.pattern {
+                            keys.insert(enum_key.clone());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        for place in self.places.iter() {
+            visit_type(&place.base_type, &mut keys);
+            for projection in place.projections.iter() {
+                match projection {
+                    DurableProjection::Field { struct_key, .. } => {
+                        keys.insert(struct_key.clone());
+                    }
+                    DurableProjection::Index { array_type, .. } => {
+                        visit_type(array_type, &mut keys);
+                    }
+                }
+            }
+        }
+        for (_, value) in self.param_drops.iter() {
+            visit_type(value, &mut keys);
+        }
+        keys
+    }
+
     /// Project the durable algebra into AIR's neutral import DTO. This does not
     /// allocate any AIR instruction, type, string, nominal, or function ID.
     pub fn project_semantic_body(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -2342,24 +2342,26 @@ impl CompilerSession {
             ) {
                 cache.fingerprints = fingerprints.into();
             }
-            let bodies = build_supported_ordinary_body_cache(
+            self.last_successful_body_cache = build_supported_ordinary_body_cache(
                 output,
                 merged.definitions().source_snapshot(),
                 options.target,
                 &options.preview_features,
             )
-            .unwrap_or_else(|_| Arc::from([]));
-            let manifest = body_invalidation_manifest(
-                input.semantic.clone(),
-                imports.clone(),
-                output.body_owner_issuer(),
-                merged.definitions().source_snapshot(),
-                bodies.clone(),
-            );
-            self.last_successful_body_cache = Some(DurableOrdinaryBodyCache {
-                manifest: Arc::new(manifest),
-                bodies,
-            });
+            .and_then(|bodies| {
+                body_invalidation_manifest(
+                    input.semantic.clone(),
+                    imports.clone(),
+                    output,
+                    merged.definitions().source_snapshot(),
+                    bodies.clone(),
+                )
+                .map(|manifest| DurableOrdinaryBodyCache {
+                    manifest: Arc::new(manifest),
+                    bodies,
+                })
+            })
+            .ok();
         }
         self.semantic_cache.push(SemanticCacheEntry {
             input: input.clone(),
@@ -3008,6 +3010,18 @@ impl CompilerSession {
                     )
                 })?;
             let mut direct_dependencies = Vec::new();
+            if let Some(payload) = semantic.as_ref().ok().and_then(|semantic| {
+                semantic
+                    .durable_ordinary_body_payloads()
+                    .iter()
+                    .find(|payload| &payload.owner == owner)
+            }) {
+                // Imported bodies intentionally skip source analysis and its
+                // declaration-type observers. The durable AIR is already
+                // joined to the same authoritative definition universe, so
+                // retain every named type/callable it embeds as direct input.
+                direct_dependencies.extend(payload.referenced_definition_keys());
+            }
             direct_dependencies.extend(
                 free_function_dependencies
                     .iter()
@@ -3708,9 +3722,6 @@ fn build_supported_ordinary_body_cache(
     preview_features: &crate::PreviewFeatures,
 ) -> Result<Arc<[crate::DurableOrdinaryBody]>, CompileErrors> {
     let definitions = semantic.body_owner_issuer();
-    // RUE-883 supports ordinary free-function call topology only. Other body
-    // dependency families are retained for their dedicated follow-up slices
-    // and fail closed here so a reuse hit never drops dependency evidence.
     let supported = semantic.ordinary_free_function_dependencies_complete()
         && semantic.specialized_free_function_dependencies_complete()
         && semantic.non_generic_named_method_dependencies_complete()
@@ -3723,10 +3734,6 @@ fn build_supported_ordinary_body_cache(
         && semantic.named_value_const_dependencies_complete()
         && semantic.specialized_free_function_origins().is_empty()
         && semantic.specialized_free_function_dependencies().is_empty()
-        && semantic.named_method_dependencies().is_empty()
-        && semantic.named_destructor_dependencies().is_empty()
-        && semantic.implicit_named_destructor_dependencies().is_empty()
-        && semantic.declaration_type_dependencies().is_empty()
         && semantic
             .declaration_type_call_head_dependencies()
             .is_empty()
@@ -3753,6 +3760,7 @@ fn build_supported_ordinary_body_cache(
             .cloned()
             .ok_or_else(|| invalid_dependency_manifest("durable body owner is absent"))?;
         let mut dependency_keys = Vec::new();
+        dependency_keys.extend(payload.referenced_definition_keys());
         for event in semantic.ordinary_free_function_dependencies() {
             let caller =
                 stable_free_function_endpoint(definitions, event.caller_file, &event.caller_name)?;
@@ -3763,6 +3771,70 @@ fn build_supported_ordinary_body_cache(
                     event.callee_file,
                     &event.callee_name,
                 )?);
+            }
+        }
+        for event in semantic.named_method_dependencies() {
+            let caller = stable_named_method_endpoint(
+                definitions,
+                event.caller_file,
+                &event.caller_owner_name,
+                &event.caller_method_name,
+            )?;
+            let caller = stable_token_endpoint(semantic, event.caller_token, &caller)?;
+            if caller != payload.owner {
+                continue;
+            }
+            dependency_keys.push(match &event.target {
+                rue_air::NamedMethodDependencyTargetEvent::FreeFunction { file, name } => {
+                    stable_free_function_endpoint(definitions, *file, name)?
+                }
+                rue_air::NamedMethodDependencyTargetEvent::NamedMethod {
+                    file,
+                    owner_name,
+                    method_name,
+                } => stable_named_method_endpoint(definitions, *file, owner_name, method_name)?,
+            });
+        }
+        for event in semantic.named_destructor_dependencies() {
+            let caller = stable_named_destructor_endpoint(
+                definitions,
+                event.caller_file,
+                &event.caller_owner_name,
+            )?;
+            let caller = stable_token_endpoint(semantic, event.caller_token, &caller)?;
+            if caller != payload.owner {
+                continue;
+            }
+            dependency_keys.push(match &event.target {
+                rue_air::NamedMethodDependencyTargetEvent::FreeFunction { file, name } => {
+                    stable_free_function_endpoint(definitions, *file, name)?
+                }
+                rue_air::NamedMethodDependencyTargetEvent::NamedMethod {
+                    file,
+                    owner_name,
+                    method_name,
+                } => stable_named_method_endpoint(definitions, *file, owner_name, method_name)?,
+            });
+        }
+        for event in semantic.implicit_named_destructor_dependencies() {
+            let source =
+                stable_implicit_drop_source_endpoint(semantic, definitions, &event.source)?;
+            if source == payload.owner {
+                dependency_keys.push(stable_named_destructor_endpoint(
+                    definitions,
+                    event.target_file,
+                    &event.target_owner_name,
+                )?);
+            }
+        }
+        for event in semantic.declaration_type_dependencies() {
+            let provenance = stable_declaration_source_endpoint(definitions, event)?;
+            let source = match event.source_token {
+                Some(token) => stable_token_endpoint(semantic, token, &provenance)?,
+                None => provenance,
+            };
+            if source == payload.owner {
+                dependency_keys.push(stable_named_type_endpoint(definitions, event)?);
             }
         }
         dependency_keys.sort();
@@ -3826,16 +3898,16 @@ fn stable_module_imports(imports: &CanonicalImportGraph) -> Arc<[StableModuleImp
 fn body_invalidation_manifest(
     input: SemanticInputDescriptor,
     imports: CanonicalImportGraph,
-    definitions: &BoundDefinitionSet,
+    semantic: &CanonicalSemanticOutput,
     snapshot: &SourceSnapshot,
     bodies: Arc<[crate::DurableOrdinaryBody]>,
-) -> SemanticDependencyInputManifest {
+) -> Result<SemanticDependencyInputManifest, CompileErrors> {
+    let definitions = semantic.body_owner_issuer();
     let definition_fingerprints = definitions
         .definitions()
         .iter()
         .map(|record| stable_definition_input_fingerprint(snapshot, record))
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap_or_default();
+        .collect::<Result<Vec<_>, _>>()?;
     let mut free_function_dependencies = bodies
         .iter()
         .flat_map(|body| {
@@ -3850,6 +3922,100 @@ fn body_invalidation_manifest(
         .collect::<Vec<_>>();
     free_function_dependencies.sort();
     free_function_dependencies.dedup();
+    let mut named_method_dependencies = semantic
+        .named_method_dependencies()
+        .iter()
+        .map(|event| {
+            let provenance = stable_named_method_endpoint(
+                definitions,
+                event.caller_file,
+                &event.caller_owner_name,
+                &event.caller_method_name,
+            )?;
+            let caller = stable_token_endpoint(semantic, event.caller_token, &provenance)?;
+            let target =
+                match &event.target {
+                    rue_air::NamedMethodDependencyTargetEvent::FreeFunction { file, name } => {
+                        StableNamedMethodDependencyTarget::FreeFunction(
+                            stable_free_function_endpoint(definitions, *file, name)?,
+                        )
+                    }
+                    rue_air::NamedMethodDependencyTargetEvent::NamedMethod {
+                        file,
+                        owner_name,
+                        method_name,
+                    } => StableNamedMethodDependencyTarget::NamedMethod(
+                        stable_named_method_endpoint(definitions, *file, owner_name, method_name)?,
+                    ),
+                };
+            Ok(StableNamedMethodDependency { caller, target })
+        })
+        .collect::<Result<Vec<_>, CompileErrors>>()?;
+    named_method_dependencies.sort();
+    named_method_dependencies.dedup();
+    let mut named_destructor_dependencies = semantic
+        .named_destructor_dependencies()
+        .iter()
+        .map(|event| {
+            let provenance = stable_named_destructor_endpoint(
+                definitions,
+                event.caller_file,
+                &event.caller_owner_name,
+            )?;
+            let caller = stable_token_endpoint(semantic, event.caller_token, &provenance)?;
+            let target =
+                match &event.target {
+                    rue_air::NamedMethodDependencyTargetEvent::FreeFunction { file, name } => {
+                        StableNamedMethodDependencyTarget::FreeFunction(
+                            stable_free_function_endpoint(definitions, *file, name)?,
+                        )
+                    }
+                    rue_air::NamedMethodDependencyTargetEvent::NamedMethod {
+                        file,
+                        owner_name,
+                        method_name,
+                    } => StableNamedMethodDependencyTarget::NamedMethod(
+                        stable_named_method_endpoint(definitions, *file, owner_name, method_name)?,
+                    ),
+                };
+            Ok(StableNamedDestructorDependency { caller, target })
+        })
+        .collect::<Result<Vec<_>, CompileErrors>>()?;
+    named_destructor_dependencies.sort();
+    named_destructor_dependencies.dedup();
+    let mut implicit_named_destructor_dependencies = semantic
+        .implicit_named_destructor_dependencies()
+        .iter()
+        .map(|event| {
+            Ok(StableImplicitNamedDestructorDependency {
+                source: stable_implicit_drop_source_endpoint(semantic, definitions, &event.source)?,
+                target: stable_named_destructor_endpoint(
+                    definitions,
+                    event.target_file,
+                    &event.target_owner_name,
+                )?,
+            })
+        })
+        .collect::<Result<Vec<_>, CompileErrors>>()?;
+    implicit_named_destructor_dependencies.sort();
+    implicit_named_destructor_dependencies.dedup();
+    let mut declaration_type_dependencies = semantic
+        .declaration_type_dependencies()
+        .iter()
+        .map(|event| {
+            let provenance = stable_declaration_source_endpoint(definitions, event)?;
+            Ok(StableDeclarationTypeDependency {
+                source: match event.source_token {
+                    Some(token) => stable_token_endpoint(semantic, token, &provenance)?,
+                    None => provenance,
+                },
+                target: stable_named_type_endpoint(definitions, event)?,
+                kind: event.dependency_kind,
+            })
+        })
+        .collect::<Result<Vec<_>, CompileErrors>>()?;
+    declaration_type_dependencies.sort();
+    declaration_type_dependencies.dedup();
     let body_dependencies = bodies
         .iter()
         .map(|body| body.inputs.clone())
@@ -3860,17 +4026,17 @@ fn body_invalidation_manifest(
         .map(|record| record.stable_key().clone())
         .collect::<Vec<_>>();
     let module_imports = stable_module_imports(&imports);
-    SemanticDependencyInputManifest {
+    Ok(SemanticDependencyInputManifest {
         input,
         imports,
         definitions: definition_keys.into(),
         definition_fingerprints: definition_fingerprints.into(),
         module_imports,
         free_function_dependencies: free_function_dependencies.into(),
-        named_method_dependencies: Arc::from([]),
-        named_destructor_dependencies: Arc::from([]),
-        implicit_named_destructor_dependencies: Arc::from([]),
-        declaration_type_dependencies: Arc::from([]),
+        named_method_dependencies: named_method_dependencies.into(),
+        named_destructor_dependencies: named_destructor_dependencies.into(),
+        implicit_named_destructor_dependencies: implicit_named_destructor_dependencies.into(),
+        declaration_type_dependencies: declaration_type_dependencies.into(),
         declaration_type_call_head_dependencies: Arc::from([]),
         builtin_type_call_head_inputs: Arc::from([]),
         named_const_dependencies: Arc::from([]),
@@ -3880,7 +4046,7 @@ fn body_invalidation_manifest(
         dependency_blockers: Arc::from([]),
         definition_universe_complete: true,
         work: SemanticDependencyManifestWork::default(),
-    }
+    })
 }
 
 fn preflight_body_invalidation_manifest(
@@ -7806,6 +7972,160 @@ mod tests {
     }
 
     #[test]
+    fn durable_named_methods_associated_functions_and_destructors_reuse_canonically() {
+        let source = snapshot(
+            &[(
+                45,
+                "/p/main.rue",
+                "main.rue",
+                "fn method_helper(value: i32) -> i32 { value } fn cleanup() {} struct Resource { value: i32, fn make(value: i32) -> Resource { Resource { value: value } } fn get(borrow self) -> i32 { method_helper(self.value) } } drop fn Resource(self) { cleanup(); } fn main() -> i32 { let resource = Resource.make(42); resource.get() }",
+            )],
+            45,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.work().body_analysis.bodies_attempted, 6);
+        assert_eq!(
+            session
+                .last_successful_body_cache
+                .as_ref()
+                .unwrap()
+                .bodies
+                .len(),
+            6
+        );
+
+        let relocated = snapshot(
+            &[(
+                145,
+                "/relocated/main.rue",
+                "main.rue",
+                "fn method_helper(value: i32) -> i32 { value } fn cleanup() {} struct Resource { value: i32, fn make(value: i32) -> Resource { Resource { value: value } } fn get(borrow self) -> i32 { method_helper(self.value) } } drop fn Resource(self) { cleanup(); } fn main() -> i32 { let resource = Resource.make(42); resource.get() }",
+            )],
+            145,
+        );
+        session.update(&relocated).into_result().unwrap();
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let reused = session.semantic(&options).unwrap();
+        assert_eq!(reused.work().durable_bodies.candidate_comparisons, 6);
+        assert_eq!(reused.work().durable_bodies.import_attempts, 6);
+        assert_eq!(reused.work().durable_bodies.import_successes, 6);
+        assert_eq!(reused.work().durable_bodies.reused_bodies, 6);
+        assert_eq!(reused.work().body_analysis.bodies_attempted, 0);
+
+        let mut fresh_session = CompilerSession::new();
+        fresh_session.update(&relocated).into_result().unwrap();
+        let fresh = fresh_session.semantic(&options).unwrap();
+        assert_body_artifact_parity(&reused, &fresh);
+        assert_diagnostic_parity(&session, &fresh_session);
+
+        let edited = snapshot(
+            &[(
+                145,
+                "/relocated/main.rue",
+                "main.rue",
+                "fn method_helper(value: i32) -> i32 { value } fn cleanup() {} struct Resource { value: i32, fn make(value: i32) -> Resource { Resource { value: value } } fn get(borrow self) -> i32 { method_helper(self.value) + 1 } } drop fn Resource(self) { cleanup(); } fn main() -> i32 { let resource = Resource.make(42); resource.get() }",
+            )],
+            145,
+        );
+        session.update(&edited).into_result().unwrap();
+        let edited_output = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(edited_output.work().durable_bodies.candidate_comparisons, 6);
+        assert_eq!(edited_output.work().durable_bodies.reused_bodies, 4);
+        assert_eq!(edited_output.work().body_analysis.bodies_attempted, 2);
+        let mut edited_fresh_session = CompilerSession::new();
+        edited_fresh_session.update(&edited).into_result().unwrap();
+        let edited_fresh = edited_fresh_session
+            .semantic(&CompileOptions::default())
+            .unwrap();
+        assert_body_artifact_parity(&edited_output, &edited_fresh);
+        assert_diagnostic_parity(&session, &edited_fresh_session);
+
+        let destructor_edit = snapshot(
+            &[(
+                145,
+                "/relocated/main.rue",
+                "main.rue",
+                "fn method_helper(value: i32) -> i32 { value } fn cleanup() {} struct Resource { value: i32, fn make(value: i32) -> Resource { Resource { value: value } } fn get(borrow self) -> i32 { method_helper(self.value) + 1 } } drop fn Resource(self) { cleanup(); let _marker = 0; } fn main() -> i32 { let resource = Resource.make(42); resource.get() }",
+            )],
+            145,
+        );
+        session.update(&destructor_edit).into_result().unwrap();
+        let destructor_output = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(destructor_output.work().durable_bodies.reused_bodies, 2);
+        assert_eq!(destructor_output.work().body_analysis.bodies_attempted, 4);
+
+        let helper_edit = snapshot(
+            &[(
+                145,
+                "/relocated/main.rue",
+                "main.rue",
+                "fn method_helper(value: i32) -> i32 { value + 1 } fn cleanup() {} struct Resource { value: i32, fn make(value: i32) -> Resource { Resource { value: value } } fn get(borrow self) -> i32 { method_helper(self.value) + 1 } } drop fn Resource(self) { cleanup(); let _marker = 0; } fn main() -> i32 { let resource = Resource.make(42); resource.get() }",
+            )],
+            145,
+        );
+        session.update(&helper_edit).into_result().unwrap();
+        let helper_output = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(helper_output.work().durable_bodies.reused_bodies, 3);
+        assert_eq!(helper_output.work().body_analysis.bodies_attempted, 3);
+        let mut helper_fresh_session = CompilerSession::new();
+        helper_fresh_session
+            .update(&helper_edit)
+            .into_result()
+            .unwrap();
+        let helper_fresh = helper_fresh_session
+            .semantic(&CompileOptions::default())
+            .unwrap();
+        assert_body_artifact_parity(&helper_output, &helper_fresh);
+        assert_diagnostic_parity(&session, &helper_fresh_session);
+    }
+
+    #[test]
+    fn nested_layout_change_invalidates_receiver_destructor_and_callers_only() {
+        let source = |inner_type: &str| {
+            let program = if inner_type == "i32" {
+                "struct Inner { value: i32 } struct Outer { inner: Inner, fn consume(self) -> i32 { 0 } } drop fn Outer(self) {} fn unrelated() -> i32 { 7 } fn main() -> i32 { let outer = Outer { inner: Inner { value: 1 } }; outer.consume() + unrelated() }"
+            } else {
+                "struct Inner { value: i64 } struct Outer { inner: Inner, fn consume(self) -> i32 { 0 } } drop fn Outer(self) {} fn unrelated() -> i32 { 7 } fn main() -> i32 { let outer = Outer { inner: Inner { value: 1 } }; outer.consume() + unrelated() }"
+            };
+            snapshot(&[(46, "/p/main.rue", "main.rue", program)], 46)
+        };
+        let original = source("i32");
+        let edited = source("i64");
+        let mut session = CompilerSession::new();
+        session.update(&original).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.work().body_analysis.bodies_attempted, 4);
+        let retained = session.last_successful_body_cache.as_ref().unwrap();
+        assert_eq!(retained.bodies.len(), 4);
+        assert!(
+            retained
+                .manifest
+                .declaration_type_dependencies()
+                .iter()
+                .any(|edge| edge.source.name() == "Outer" && edge.target.name() == "Inner")
+        );
+
+        session.update(&edited).into_result().unwrap();
+        let actual = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(actual.work().durable_bodies.candidate_comparisons, 4);
+        assert_eq!(actual.work().durable_bodies.reused_bodies, 1);
+        assert_eq!(actual.work().durable_bodies.skipped_body_analyses, 1);
+        assert_eq!(actual.work().body_analysis.bodies_attempted, 3);
+        assert_eq!(actual.work().body_analysis.bodies_succeeded, 3);
+
+        let mut fresh_session = CompilerSession::new();
+        fresh_session.update(&edited).into_result().unwrap();
+        let fresh = fresh_session.semantic(&CompileOptions::default()).unwrap();
+        assert_body_artifact_parity(&actual, &fresh);
+        assert_diagnostic_parity(&session, &fresh_session);
+    }
+
+    #[test]
     fn durable_ordinary_body_edit_reuses_unaffected_reachable_body_and_failure_keeps_baseline() {
         let original = snapshot(
             &[(
@@ -7906,6 +8226,127 @@ mod tests {
         fresh_session.update(&source).into_result().unwrap();
         let fresh = fresh_session.semantic(&options).unwrap();
         assert_body_artifact_parity(&output, &fresh);
+        assert_diagnostic_parity(&session, &fresh_session);
+    }
+
+    #[test]
+    fn rejected_named_call_import_leaves_symbol_and_type_epochs_unchanged() {
+        let source = snapshot(
+            &[(
+                63,
+                "/p/main.rue",
+                "main.rue",
+                "struct Value { fn helper() -> i32 { 1 } fn spare() -> i32 { 99 } fn compute(borrow self) -> i32 { Value.helper() + 1 } } fn main() -> i32 { let value = Value {}; value.compute() }",
+            )],
+            63,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+        assert!(
+            session
+                .last_successful_body_cache
+                .as_ref()
+                .unwrap()
+                .bodies
+                .iter()
+                .all(|body| body.owner().name() != "spare"),
+            "the cold body analysis must not observe the spare callable"
+        );
+        assert!(
+            session
+                .rir_cache
+                .as_ref()
+                .unwrap()
+                .semantic_symbols()
+                .interner()
+                .get("Value::spare")
+                .is_some(),
+            "declaration completion must pre-intern unreachable callable symbols"
+        );
+        let symbols_before = session
+            .rir_cache
+            .as_ref()
+            .unwrap()
+            .semantic_symbols()
+            .interner()
+            .len();
+        let cache = session.last_successful_body_cache.as_mut().unwrap();
+        let mut bodies = cache.bodies.to_vec();
+        let method = bodies
+            .iter_mut()
+            .find(|body| body.owner().kind() == StableDefinitionKind::Method)
+            .unwrap();
+        let mut instructions = method.payload.instructions.to_vec();
+        let call = instructions
+            .iter()
+            .position(|instruction| {
+                matches!(instruction.data, crate::DurableAirInstData::Call { .. })
+            })
+            .unwrap();
+        let crate::DurableAirInstData::Call {
+            function: helper, ..
+        } = &instructions[call].data
+        else {
+            unreachable!();
+        };
+        assert_eq!(helper.name(), "helper");
+        let helper_owner = helper.owner().unwrap();
+        let spare = StableDefinitionKey::for_test(
+            helper.module().clone(),
+            helper.namespace(),
+            StableDefinitionKind::AssociatedFunction,
+            "spare",
+            Some((helper_owner.kind(), Arc::from(helper_owner.name()))),
+        );
+        let crate::DurableAirInstData::Call { function, .. } = &mut instructions[call].data else {
+            unreachable!();
+        };
+        *function = spare;
+        let later = instructions.len() - 1;
+        assert!(later > call);
+        instructions[later].anchor.end = u32::MAX;
+        method.payload.instructions = instructions.into();
+        cache.bodies = bodies.into();
+
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let actual = session.semantic(&options).unwrap();
+        assert_eq!(actual.work().durable_bodies.candidate_comparisons, 3);
+        assert_eq!(actual.work().durable_bodies.import_attempts, 3);
+        assert_eq!(actual.work().durable_bodies.import_successes, 2);
+        assert_eq!(actual.work().durable_bodies.import_failures, 1);
+        assert_eq!(actual.work().durable_bodies.atomic_discards, 1);
+        assert_eq!(actual.work().durable_bodies.reused_bodies, 2);
+        assert_eq!(actual.work().body_analysis.bodies_attempted, 1);
+        assert_eq!(
+            session
+                .rir_cache
+                .as_ref()
+                .unwrap()
+                .semantic_symbols()
+                .interner()
+                .len(),
+            symbols_before
+        );
+
+        let mut fresh_session = CompilerSession::new();
+        fresh_session.update(&source).into_result().unwrap();
+        let fresh = fresh_session.semantic(&options).unwrap();
+        assert_eq!(
+            symbols_before,
+            fresh_session
+                .rir_cache
+                .as_ref()
+                .unwrap()
+                .semantic_symbols()
+                .interner()
+                .len()
+        );
+        assert_body_artifact_parity(&actual, &fresh);
+        assert_eq!(actual.type_pool().stats(), fresh.type_pool().stats());
         assert_diagnostic_parity(&session, &fresh_session);
     }
 
@@ -8405,12 +8846,8 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_constant_nominal_and_destructor_provenance_fails_closed() {
-        let cases = [
-            "const n: i32 = 1; fn main() -> i32 { n }",
-            "struct Point { x: i32 } fn make() -> Point { Point { x: 1 } } fn main() -> i32 { make().x }",
-            "struct Loud { x: i32 } drop fn Loud(self) {} fn main() -> i32 { let value = Loud { x: 1 }; value.x }",
-        ];
+    fn unsupported_constant_provenance_fails_closed() {
+        let cases = ["const n: i32 = 1; fn main() -> i32 { n }"];
         for (index, program) in cases.into_iter().enumerate() {
             let id = u32::try_from(120 + index).unwrap();
             let source = snapshot(&[(id, "/p/main.rue", "main.rue", program)], id);


### PR DESCRIPTION
## Summary
- extend durable ordinary-body reuse to named methods, associated functions, and named destructors
- retain canonical method, destructor, implicit-drop, and declaration-layout dependency graphs across warm revisions
- keep named-call import transactional with deterministic declaration-derived symbols and exact fail-closed accounting
- prove relocation, nested layout invalidation, call-chain closure, fresh parity, and rejected-import recovery

## Testing
- `scripts/rue quick`
- `scripts/rue test`
- focused RUE-886 regression tests

Fixes RUE-886