### PR TITLE
RUE-771: align durable type import semantics

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -149,8 +149,6 @@ fn import_staged_ordinary_body(
                 Type::new_module(id)
             }
             T::GenericParameter(_) => return Err(F::GenericParameterNeedsDeclarationContext),
-            T::Tuple(_) => return Err(F::UnsupportedTuple),
-            T::Function { .. } => return Err(F::UnsupportedFunctionType),
         })
     }
 

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -12,7 +12,9 @@ use rue_span::{FileId, Span};
 
 use super::RirDeclarationIndexWork;
 use super::{ConstValue, Sema, SemaOutput};
-use crate::types::{Type, TypeKind};
+use crate::types::{
+    ArrayLen, PtrMutability, Type, TypeKind, parse_array_type_syntax, parse_pointer_type_syntax,
+};
 
 /// A nominal declaration identity valid for one successful binding request.
 /// Consumers must join this identity to their own stable definition universe
@@ -111,6 +113,7 @@ pub enum SemanticExportFailure {
     UnmappedNominalType,
     UnmappedFunction,
     UnsupportedParameterMode,
+    UnsupportedGenericSignature,
     RecursiveStructuralType,
 }
 
@@ -564,21 +567,6 @@ impl<'a> DeclarationShells<'a> {
                             return Err(DeclarationInstallFailure::CallableShapeMismatch);
                         }
                     }
-                    let names = pending
-                        .shell
-                        .parameter_names
-                        .iter()
-                        .map(|name| self.sema.interner.get_or_intern(name.as_ref()));
-                    let types = parameters
-                        .iter()
-                        .map(|parameter| self.sema.import_export_type(&parameter.ty))
-                        .collect::<Result<Vec<_>, _>>()?;
-                    let range = self.sema.param_arena.alloc(
-                        names,
-                        types,
-                        pending.shell.parameter_modes.iter().copied(),
-                        pending.shell.parameter_comptime.iter().copied(),
-                    );
                     let InstData::FnDecl {
                         name,
                         return_type,
@@ -592,7 +580,47 @@ impl<'a> DeclarationShells<'a> {
                     else {
                         return Err(DeclarationInstallFailure::KindMismatch);
                     };
-                    let return_type_value = self.sema.import_export_type(result)?;
+                    let type_name = self.sema.interner.get_or_intern("type");
+                    let rir_parameters = self.sema.rir.get_params(*params_start, *params_len);
+                    if parameters
+                        .iter()
+                        .zip(rir_parameters.iter())
+                        .any(|(parameter, rir)| {
+                            rir.is_comptime
+                                && rir.ty == type_name
+                                && parameter.ty != SemanticExportType::ComptimeType
+                        })
+                    {
+                        return Err(DeclarationInstallFailure::CallableShapeMismatch);
+                    }
+                    let names = pending
+                        .shell
+                        .parameter_names
+                        .iter()
+                        .map(|name| self.sema.interner.get_or_intern(name.as_ref()));
+                    let generic_parameters = rir_parameters
+                        .iter()
+                        .filter(|parameter| parameter.is_comptime && parameter.ty == type_name)
+                        .map(|_| Type::COMPTIME_TYPE)
+                        .collect::<Vec<_>>();
+                    let types = parameters
+                        .iter()
+                        .map(|parameter| {
+                            self.sema.import_export_type_with_generics(
+                                &parameter.ty,
+                                Some(&generic_parameters),
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    let range = self.sema.param_arena.alloc(
+                        names,
+                        types,
+                        pending.shell.parameter_modes.iter().copied(),
+                        pending.shell.parameter_comptime.iter().copied(),
+                    );
+                    let return_type_value = self
+                        .sema
+                        .import_export_type_with_generics(result, Some(&generic_parameters))?;
                     if let Some(owner) = &pending.shell.identity.owner {
                         let owner = self.sema.interner.get_or_intern(owner.as_ref());
                         let id = *self
@@ -695,6 +723,23 @@ impl Sema<'_> {
         &self,
         value: &SemanticExportType,
     ) -> Result<Type, DeclarationInstallFailure> {
+        self.import_export_type_with_generics(value, None)
+    }
+
+    fn import_export_type_with_generics(
+        &self,
+        value: &SemanticExportType,
+        generic_parameters: Option<&[Type]>,
+    ) -> Result<Type, DeclarationInstallFailure> {
+        if let Some(generic_parameters) = generic_parameters
+            && Self::validate_generic_references(value, generic_parameters.len())?
+        {
+            // Ordinary declaration binding represents every generic-dependent
+            // signature type, including composites, as one top-level
+            // placeholder until specialization. Preserve the recursive DTO for
+            // durable identity, but reconstruct that exact AIR representation.
+            return Ok(Type::COMPTIME_TYPE);
+        }
         Ok(match value {
             SemanticExportType::I8 => Type::I8,
             SemanticExportType::I16 => Type::I16,
@@ -707,9 +752,10 @@ impl Sema<'_> {
             SemanticExportType::Bool => Type::BOOL,
             SemanticExportType::Unit => Type::UNIT,
             SemanticExportType::Never => Type::NEVER,
-            SemanticExportType::ComptimeType | SemanticExportType::GenericParameter(_) => {
-                Type::COMPTIME_TYPE
-            }
+            SemanticExportType::ComptimeType => Type::COMPTIME_TYPE,
+            SemanticExportType::GenericParameter(index) => *generic_parameters
+                .and_then(|parameters| parameters.get(*index as usize))
+                .ok_or(DeclarationInstallFailure::UnsupportedType)?,
             SemanticExportType::Nominal(nominal) => {
                 let name = self.interner.get_or_intern(nominal.name.as_ref());
                 match nominal.kind {
@@ -728,21 +774,45 @@ impl Sema<'_> {
                     _ => return Err(DeclarationInstallFailure::KindMismatch),
                 }
             }
-            SemanticExportType::Array { element, len } => Type::new_array(
-                self.type_pool
-                    .intern_array_from_type(self.import_export_type(element)?, *len),
-            ),
-            SemanticExportType::PtrConst(value) => Type::new_ptr_const(
-                self.type_pool
-                    .intern_ptr_const_from_type(self.import_export_type(value)?),
-            ),
-            SemanticExportType::PtrMut(value) => Type::new_ptr_mut(
-                self.type_pool
-                    .intern_ptr_mut_from_type(self.import_export_type(value)?),
-            ),
+            SemanticExportType::Array { element, len } => {
+                Type::new_array(self.type_pool.intern_array_from_type(
+                    self.import_export_type_with_generics(element, generic_parameters)?,
+                    *len,
+                ))
+            }
+            SemanticExportType::PtrConst(value) => {
+                Type::new_ptr_const(self.type_pool.intern_ptr_const_from_type(
+                    self.import_export_type_with_generics(value, generic_parameters)?,
+                ))
+            }
+            SemanticExportType::PtrMut(value) => {
+                Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(
+                    self.import_export_type_with_generics(value, generic_parameters)?,
+                ))
+            }
             SemanticExportType::Module(_) => {
                 return Err(DeclarationInstallFailure::UnsupportedType);
             }
+        })
+    }
+
+    fn validate_generic_references(
+        value: &SemanticExportType,
+        generic_parameter_count: usize,
+    ) -> Result<bool, DeclarationInstallFailure> {
+        Ok(match value {
+            SemanticExportType::GenericParameter(index) => {
+                if *index as usize >= generic_parameter_count {
+                    return Err(DeclarationInstallFailure::UnsupportedType);
+                }
+                true
+            }
+            SemanticExportType::Array { element, .. }
+            | SemanticExportType::PtrConst(element)
+            | SemanticExportType::PtrMut(element) => {
+                Self::validate_generic_references(element, generic_parameter_count)?
+            }
+            _ => false,
         })
     }
 }
@@ -1226,8 +1296,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
             .collect::<Vec<_>>();
         let convert = |ty: Type, symbol: Spur| {
             if ty == Type::COMPTIME_TYPE {
-                if let Some(index) = generic_names.iter().position(|name| *name == symbol) {
-                    return Ok(SemanticExportType::GenericParameter(index as u32));
+                let syntax = self.interner.resolve(&symbol);
+                if syntax != "type" {
+                    return self.export_deferred_signature_type(syntax, &generic_names);
                 }
             }
             self.export_type(ty, &mut Vec::new())
@@ -1254,6 +1325,36 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok((parameters.into(), convert(return_type, return_type_sym)?))
+    }
+
+    fn export_deferred_signature_type(
+        &self,
+        syntax: &str,
+        generic_names: &[Spur],
+    ) -> Result<SemanticExportType, SemanticExportFailure> {
+        if let Some(index) = generic_names
+            .iter()
+            .position(|name| self.interner.resolve(name) == syntax)
+        {
+            return Ok(SemanticExportType::GenericParameter(index as u32));
+        }
+        if let Some((element, len)) = parse_array_type_syntax(syntax) {
+            let ArrayLen::Literal(len) = len else {
+                return Err(SemanticExportFailure::UnsupportedGenericSignature);
+            };
+            return Ok(SemanticExportType::Array {
+                element: Box::new(self.export_deferred_signature_type(&element, generic_names)?),
+                len,
+            });
+        }
+        if let Some((pointee, mutability)) = parse_pointer_type_syntax(syntax) {
+            let pointee = Box::new(self.export_deferred_signature_type(&pointee, generic_names)?);
+            return Ok(match mutability {
+                PtrMutability::Const => SemanticExportType::PtrConst(pointee),
+                PtrMutability::Mut => SemanticExportType::PtrMut(pointee),
+            });
+        }
+        Err(SemanticExportFailure::UnsupportedGenericSignature)
     }
 
     fn build_declaration_semantics(
@@ -1709,6 +1810,9 @@ mod tests {
             enum Maybe { None, Some(Leaf) }
             const LIMIT: i32 = 7;
             fn id(comptime T: type, value: T) -> T { value }
+            fn nested(comptime T: type, value: [[T; 2]; 2]) -> [[T; 2]; 2] { value }
+            fn pointed(comptime T: type, value: ptr const T) -> ptr const T { value }
+            fn ordered(comptime T: type, comptime U: type, left: [T; 2], right: ptr const U) -> ptr const U { right }
             fn helper(value: ptr const Leaf) -> bool { true }
             const alias = helper;
             drop fn Boxed(self) {}
@@ -1727,6 +1831,45 @@ mod tests {
                     && parameters[1].ty == SemanticExportType::GenericParameter(0)
                     && *result == SemanticExportType::GenericParameter(0)
         )));
+        let nested = SemanticExportType::Array {
+            element: Box::new(SemanticExportType::Array {
+                element: Box::new(SemanticExportType::GenericParameter(0)),
+                len: 2,
+            }),
+            len: 2,
+        };
+        assert!(records.iter().any(|record| matches!(
+            &record.payload,
+            SemanticDeclarationPayload::Callable { parameters, result, .. }
+                if record.identity.name.as_ref() == "nested"
+                    && parameters[1].ty == nested
+                    && *result == nested
+        )));
+        assert!(records.iter().any(|record| matches!(
+            &record.payload,
+            SemanticDeclarationPayload::Callable { parameters, result, .. }
+                if record.identity.name.as_ref() == "pointed"
+                    && parameters[1].ty
+                        == SemanticExportType::PtrConst(Box::new(
+                            SemanticExportType::GenericParameter(0)
+                        ))
+                    && *result == parameters[1].ty
+        )));
+        assert!(records.iter().any(|record| matches!(
+            &record.payload,
+            SemanticDeclarationPayload::Callable { parameters, result, .. }
+                if record.identity.name.as_ref() == "ordered"
+                    && parameters[2].ty
+                        == SemanticExportType::Array {
+                            element: Box::new(SemanticExportType::GenericParameter(0)),
+                            len: 2,
+                        }
+                    && parameters[3].ty
+                        == SemanticExportType::PtrConst(Box::new(
+                            SemanticExportType::GenericParameter(1)
+                        ))
+                    && *result == parameters[3].ty
+        )));
         assert!(records.iter().any(|record| matches!(
             &record.payload,
             SemanticDeclarationPayload::Const { value: SemanticExportConstValue::Function { name, .. }, .. }
@@ -1741,6 +1884,14 @@ mod tests {
     }
 
     #[test]
+    fn value_dependent_composite_signature_export_fails_closed() {
+        assert!(matches!(
+            export("fn sized(comptime N: i32, values: [i32; N]) -> i32 { values[0] } fn main() {}"),
+            Err(SemanticExportFailure::UnsupportedGenericSignature)
+        ));
+    }
+
+    #[test]
     fn durable_payload_install_matches_ordinary_binding_in_a_fresh_epoch() {
         let source = r#"
             struct Resource {
@@ -1751,6 +1902,9 @@ mod tests {
             enum Choice { None, Some(Resource) }
             drop fn Resource(self) {}
             fn helper(value: ptr const Resource) -> i32 { value.value }
+            fn id(comptime T: type, value: T) -> T { value }
+            fn nested(comptime T: type, value: [[T; 2]; 2]) -> [[T; 2]; 2] { value }
+            fn pointed(comptime T: type, value: ptr const T) -> ptr const T { value }
             fn main() -> i32 { 0 }
         "#;
         let exports = export(source).unwrap().0;

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -309,21 +309,6 @@ impl<K, M> SemanticBody<K, M> {
                 T::PtrMut(value) => T::PtrMut(Box::new(ty(value, key, module)?)),
                 T::Module(value) => T::Module(module(value)?),
                 T::GenericParameter(index) => T::GenericParameter(*index),
-                T::Tuple(values) => T::Tuple(
-                    values
-                        .iter()
-                        .map(|value| ty(value, key, module))
-                        .collect::<Result<Vec<_>, _>>()?
-                        .into(),
-                ),
-                T::Function { parameters, result } => T::Function {
-                    parameters: parameters
-                        .iter()
-                        .map(|value| ty(value, key, module))
-                        .collect::<Result<Vec<_>, _>>()?
-                        .into(),
-                    result: Box::new(ty(result, key, module)?),
-                },
             })
         }
 

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -63,11 +63,6 @@ pub enum SemanticImportType<K, M> {
     PtrMut(Box<Self>),
     Module(M),
     GenericParameter(u32),
-    Tuple(Arc<[Self]>),
-    Function {
-        parameters: Arc<[Self]>,
-        result: Box<Self>,
-    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -93,8 +88,7 @@ pub enum SemanticImportFailure {
     UnknownBuiltinNominal,
     BuiltinNominalKindMismatch,
     GenericParameterNeedsDeclarationContext,
-    UnsupportedTuple,
-    UnsupportedFunctionType,
+    GenericParameterOutOfRange,
     ForeignLocalType,
     ForeignLocalValue,
 }
@@ -753,6 +747,15 @@ where
         &self,
         value: &SemanticImportType<K, M>,
     ) -> Result<Type, SemanticImportFailure> {
+        self.import_type_local_with(value, &self.type_pool, None)
+    }
+
+    fn import_type_local_with(
+        &self,
+        value: &SemanticImportType<K, M>,
+        type_pool: &TypeInternPool,
+        generic_parameters: Option<&[Type]>,
+    ) -> Result<Type, SemanticImportFailure> {
         Ok(match value {
             SemanticImportType::I8 => Type::I8,
             SemanticImportType::I16 => Type::I16,
@@ -788,17 +791,23 @@ where
                 Some(LocalNominal::Enum(id)) => Type::new_enum(*id),
                 None => return Err(SemanticImportFailure::MissingNominal),
             },
-            SemanticImportType::Array { element, len } => Type::new_array(
-                self.type_pool
-                    .intern_array_from_type(self.import_type_local(element)?, *len),
-            ),
-            SemanticImportType::PtrConst(value) => Type::new_ptr_const(
-                self.type_pool
-                    .intern_ptr_const_from_type(self.import_type_local(value)?),
-            ),
+            SemanticImportType::Array { element, len } => {
+                Type::new_array(type_pool.intern_array_from_type(
+                    self.import_type_local_with(element, type_pool, generic_parameters)?,
+                    *len,
+                ))
+            }
+            SemanticImportType::PtrConst(value) => {
+                Type::new_ptr_const(type_pool.intern_ptr_const_from_type(
+                    self.import_type_local_with(value, type_pool, generic_parameters)?,
+                ))
+            }
             SemanticImportType::PtrMut(value) => Type::new_ptr_mut(
-                self.type_pool
-                    .intern_ptr_mut_from_type(self.import_type_local(value)?),
+                type_pool.intern_ptr_mut_from_type(self.import_type_local_with(
+                    value,
+                    type_pool,
+                    generic_parameters,
+                )?),
             ),
             SemanticImportType::Module(key) => Type::new_module(
                 *self
@@ -806,14 +815,37 @@ where
                     .get(key)
                     .ok_or(SemanticImportFailure::MissingModule)?,
             ),
-            SemanticImportType::GenericParameter(_) => {
-                return Err(SemanticImportFailure::GenericParameterNeedsDeclarationContext);
-            }
-            SemanticImportType::Tuple(_) => return Err(SemanticImportFailure::UnsupportedTuple),
-            SemanticImportType::Function { .. } => {
-                return Err(SemanticImportFailure::UnsupportedFunctionType);
-            }
+            SemanticImportType::GenericParameter(index) => *generic_parameters
+                .ok_or(SemanticImportFailure::GenericParameterNeedsDeclarationContext)?
+                .get(*index as usize)
+                .ok_or(SemanticImportFailure::GenericParameterOutOfRange)?,
         })
+    }
+
+    /// Validate one callable signature in an isolated type epoch.
+    ///
+    /// The ordered generic environment is derived only from comptime `type`
+    /// parameters. A generic reference outside that environment is rejected,
+    /// and structural types interned before a later failure remain confined to
+    /// the scratch pool.
+    pub fn validate_callable_signature(
+        &self,
+        parameters: &[(SemanticImportType<K, M>, bool)],
+        result: &SemanticImportType<K, M>,
+    ) -> Result<(), SemanticImportFailure> {
+        let type_pool = self.type_pool.clone();
+        let generic_parameters = parameters
+            .iter()
+            .filter(|(ty, is_comptime)| {
+                *is_comptime && matches!(ty, SemanticImportType::ComptimeType)
+            })
+            .map(|_| Type::COMPTIME_TYPE)
+            .collect::<Vec<_>>();
+        for (ty, _) in parameters {
+            self.import_type_local_with(ty, &type_pool, Some(&generic_parameters))?;
+        }
+        self.import_type_local_with(result, &type_pool, Some(&generic_parameters))?;
+        Ok(())
     }
 
     /// Import an ordered declaration parameter or payload sequence.
@@ -1170,7 +1202,7 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_and_foreign_values_fail_closed() {
+    fn missing_context_and_foreign_values_fail_closed() {
         let epoch = Epoch::new(vec![], vec![], vec![]).unwrap();
         assert_eq!(
             epoch.import_type(&ImportType::Nominal("missing")),
@@ -1185,13 +1217,47 @@ mod tests {
             Err(SemanticImportFailure::GenericParameterNeedsDeclarationContext)
         );
         assert_eq!(
-            epoch.import_type(&ImportType::Tuple(Arc::from([]))),
-            Err(SemanticImportFailure::UnsupportedTuple)
-        );
-        assert_eq!(
             epoch.import_const_value(&SemanticImportConstValue::Function("missing")),
             Err(SemanticImportFailure::MissingFunction)
         );
+    }
+
+    #[test]
+    fn callable_generic_environment_is_ordered_bounded_and_atomic() {
+        let epoch = Epoch::new(vec![], vec![], vec![]).unwrap();
+        let valid = [
+            (ImportType::ComptimeType, true),
+            (ImportType::GenericParameter(0), false),
+        ];
+        epoch
+            .validate_callable_signature(&valid, &ImportType::GenericParameter(0))
+            .unwrap();
+
+        let before = epoch.type_pool().stats();
+        let invalid = [
+            (ImportType::ComptimeType, true),
+            (
+                ImportType::Array {
+                    element: Box::new(ImportType::U8),
+                    len: 4,
+                },
+                false,
+            ),
+            (
+                ImportType::Array {
+                    element: Box::new(ImportType::PtrConst(Box::new(
+                        ImportType::GenericParameter(1),
+                    ))),
+                    len: 2,
+                },
+                false,
+            ),
+        ];
+        assert_eq!(
+            epoch.validate_callable_signature(&invalid, &ImportType::GenericParameter(0)),
+            Err(SemanticImportFailure::GenericParameterOutOfRange)
+        );
+        assert_eq!(epoch.type_pool().stats(), before);
     }
 
     #[test]

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -20,7 +20,7 @@ use crate::{
     StableDefinitionKey, StableDefinitionKind,
 };
 
-pub const DURABLE_ORDINARY_BODY_SCHEMA_VERSION: u32 = 2;
+pub const DURABLE_ORDINARY_BODY_SCHEMA_VERSION: u32 = 3;
 
 pub type DurableAirRef = u32;
 pub type DurablePlaceRef = u32;
@@ -458,21 +458,6 @@ fn durable_type(
                 .ok_or(DurableBodyConversionFailure::UnresolvedModule)?,
         ),
         SemanticImportType::GenericParameter(index) => DurableType::GenericParameter(*index),
-        SemanticImportType::Tuple(elements) => DurableType::Tuple(
-            elements
-                .iter()
-                .map(|element| durable_type(element, merged, index, work))
-                .collect::<Result<Vec<_>, _>>()?
-                .into(),
-        ),
-        SemanticImportType::Function { parameters, result } => DurableType::Function {
-            parameters: parameters
-                .iter()
-                .map(|parameter| durable_type(parameter, merged, index, work))
-                .collect::<Result<Vec<_>, _>>()?
-                .into(),
-            result: Box::new(durable_type(result, merged, index, work)?),
-        },
     })
 }
 
@@ -898,17 +883,6 @@ impl DurableOrdinaryBodyPayload {
                 DurableType::Array { element, .. }
                 | DurableType::PtrConst(element)
                 | DurableType::PtrMut(element) => visit_type(element, keys),
-                DurableType::Tuple(values) => {
-                    for value in values.iter() {
-                        visit_type(value, keys);
-                    }
-                }
-                DurableType::Function { parameters, result } => {
-                    for value in parameters.iter() {
-                        visit_type(value, keys);
-                    }
-                    visit_type(result, keys);
-                }
                 _ => {}
             }
         }

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -44,21 +44,6 @@ impl DurableType {
             },
             Self::PtrConst(value) => SemanticImportType::PtrConst(Box::new(value.import_dto())),
             Self::PtrMut(value) => SemanticImportType::PtrMut(Box::new(value.import_dto())),
-            Self::Tuple(values) => SemanticImportType::Tuple(
-                values
-                    .iter()
-                    .map(Self::import_dto)
-                    .collect::<Vec<_>>()
-                    .into(),
-            ),
-            Self::Function { parameters, result } => SemanticImportType::Function {
-                parameters: parameters
-                    .iter()
-                    .map(Self::import_dto)
-                    .collect::<Vec<_>>()
-                    .into(),
-                result: Box::new(result.import_dto()),
-            },
             Self::Module(module) => SemanticImportType::Module(Arc::from(module.as_str())),
             Self::GenericParameter(index) => SemanticImportType::GenericParameter(*index),
         }
@@ -124,17 +109,6 @@ pub fn import_durable_declaration_semantics(
             DurableType::Array { element, .. }
             | DurableType::PtrConst(element)
             | DurableType::PtrMut(element) => collect_modules(element, modules),
-            DurableType::Tuple(elements) => {
-                for element in elements.iter() {
-                    collect_modules(element, modules);
-                }
-            }
-            DurableType::Function { parameters, result } => {
-                for parameter in parameters.iter() {
-                    collect_modules(parameter, modules);
-                }
-                collect_modules(result, modules);
-            }
             _ => {}
         }
     }
@@ -260,10 +234,11 @@ pub fn import_durable_declaration_semantics(
             DurableDeclarationPayload::Callable {
                 parameters, result, ..
             } => {
-                for parameter in parameters.iter() {
-                    epoch.import_type(&parameter.ty.import_dto())?;
-                }
-                epoch.import_type(&result.import_dto())?;
+                let parameters = parameters
+                    .iter()
+                    .map(|parameter| (parameter.ty.import_dto(), parameter.is_comptime))
+                    .collect::<Vec<_>>();
+                epoch.validate_callable_signature(&parameters, &result.import_dto())?;
             }
             DurableDeclarationPayload::Destructor => {}
         }
@@ -276,7 +251,7 @@ use crate::{
 };
 
 /// Version of the canonical durable type/value encoding.
-pub const DURABLE_SEMANTIC_SCHEMA_VERSION: u32 = 2;
+pub const DURABLE_SEMANTIC_SCHEMA_VERSION: u32 = 3;
 
 pub(crate) fn builtin_nominal_kind(name: &str) -> Option<SemanticImportNominalKind> {
     if rue_builtins::get_builtin_type(name).is_some() {
@@ -317,13 +292,6 @@ pub enum DurableType {
     },
     PtrConst(Box<DurableType>),
     PtrMut(Box<DurableType>),
-    /// Reserved for the source-level tuple surface once binding supports it.
-    Tuple(Arc<[DurableType]>),
-    /// Reserved for first-class function types. Parameter order is semantic.
-    Function {
-        parameters: Arc<[DurableType]>,
-        result: Box<DurableType>,
-    },
     /// A module value's resolved logical module identity.
     Module(ModuleId),
     /// A declaration-scoped generic parameter, indexed in source order.
@@ -499,11 +467,6 @@ pub fn project_durable_declaration_semantics(
 
     let mut shell_by_key = BTreeMap::new();
     for shell in shells {
-        // The AIR installer does not yet reconstruct the declaration-scoped
-        // type-parameter environment needed by generic callable bodies.
-        if shell.is_generic {
-            return Err(DurableSemanticProjectionFailure::UnsupportedDeclaration);
-        }
         let join_key = ProjectionJoinKey::from_shell(shell)
             .ok_or(DurableSemanticProjectionFailure::UnsupportedDeclaration)?;
         let key = definition_by_join_key
@@ -658,7 +621,7 @@ fn project_type(
         DurableType::PtrMut(value) => {
             SemanticExportType::PtrMut(Box::new(project_type(value, definitions, module_files)?))
         }
-        DurableType::Module(_) | DurableType::Tuple(_) | DurableType::Function { .. } => {
+        DurableType::Module(_) => {
             return Err(DurableSemanticProjectionFailure::UnsupportedType);
         }
     })
@@ -1018,7 +981,8 @@ impl From<SemanticExportFailure> for DurableSemanticExportFailure {
             SemanticExportFailure::AnonymousNominalType => Self::AnonymousNominalType,
             SemanticExportFailure::UnmappedNominalType => Self::MissingStableNominalDefinition,
             SemanticExportFailure::UnmappedFunction => Self::MissingStableFunctionDefinition,
-            SemanticExportFailure::UnsupportedParameterMode => Self::UnsupportedTypeForm,
+            SemanticExportFailure::UnsupportedParameterMode
+            | SemanticExportFailure::UnsupportedGenericSignature => Self::UnsupportedTypeForm,
             SemanticExportFailure::RecursiveStructuralType => Self::RecursiveStructuralType,
         }
     }
@@ -1085,9 +1049,24 @@ mod tests {
     }
 
     #[test]
-    fn structural_order_is_canonical_and_parameter_order_is_semantic() {
-        let a = DurableType::Tuple(Arc::from([DurableType::Bool, DurableType::I32]));
-        let b = DurableType::Tuple(Arc::from([DurableType::I32, DurableType::Bool]));
+    fn callable_parameter_order_is_semantic() {
+        let parameter = |ty| DurableSemanticParameter {
+            ty,
+            mode: DurableParameterMode::Value,
+            is_comptime: false,
+        };
+        let a = DurableDeclarationPayload::Callable {
+            parameters: Arc::from([parameter(DurableType::Bool), parameter(DurableType::I32)]),
+            result: DurableType::Unit,
+            has_self: false,
+            is_unchecked: false,
+        };
+        let b = DurableDeclarationPayload::Callable {
+            parameters: Arc::from([parameter(DurableType::I32), parameter(DurableType::Bool)]),
+            result: DurableType::Unit,
+            has_self: false,
+            is_unchecked: false,
+        };
         assert_ne!(a, b);
 
         let first = DurableConstValue::Type(DurableType::Array {
@@ -1127,6 +1106,35 @@ mod tests {
                 is_unchecked: false,
             },
         }
+    }
+
+    #[test]
+    fn durable_callable_rejects_generic_indices_outside_its_type_parameters() {
+        let declaration = DurableDeclarationSemantic {
+            key: test_key(StableDefinitionKind::Function, "invalid", None),
+            is_public: true,
+            payload: DurableDeclarationPayload::Callable {
+                parameters: Arc::from([
+                    DurableSemanticParameter {
+                        ty: DurableType::ComptimeType,
+                        mode: DurableParameterMode::Value,
+                        is_comptime: true,
+                    },
+                    DurableSemanticParameter {
+                        ty: DurableType::GenericParameter(1),
+                        mode: DurableParameterMode::Value,
+                        is_comptime: false,
+                    },
+                ]),
+                result: DurableType::GenericParameter(0),
+                has_self: false,
+                is_unchecked: false,
+            },
+        };
+        assert!(matches!(
+            import_durable_declaration_semantics(&[declaration]),
+            Err(SemanticImportFailure::GenericParameterOutOfRange)
+        ));
     }
 
     #[test]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -4695,7 +4695,142 @@ mod tests {
     }
 
     #[test]
-    fn generic_named_method_reuse_fails_closed_without_poisoning_recovery() {
+    fn generic_callable_signature_round_trips_through_durable_declaration_reuse() {
+        let source = |value| {
+            snapshot(
+                &[(
+                    1,
+                    "/p/main.rue",
+                    "main.rue",
+                    &format!(
+                        "fn id(comptime T: type, value: T) -> T {{ value }} fn main() -> i32 {{ {value} }}"
+                    ),
+                )],
+                1,
+            )
+        };
+        let first = source(1);
+        let edited = source(2);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.semantic(&options).unwrap();
+
+        session.update(&edited).into_result().unwrap();
+        let reused = session.semantic(&options).unwrap();
+        assert_eq!(reused.work().binding.declaration_resolution_invocations, 0);
+        assert_eq!(reused.work().binding.durable_payloads_installed, 2);
+        assert_eq!(reused.work().declaration_reuse.durable_records_reused, 2);
+        assert_eq!(reused.work().declaration_reuse.fallback_epochs_started, 0);
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&edited).into_result().unwrap();
+        let ordinary = fresh.semantic(&options).unwrap();
+        assert_semantic_artifact_parity(&session, &reused, &ordinary);
+        assert_diagnostic_parity(&session, &fresh);
+    }
+
+    #[test]
+    fn composite_generic_signature_reuses_across_relocation_and_specialization_edit() {
+        let source = |file, physical: &str, value| {
+            snapshot(
+                &[(
+                    file,
+                    physical,
+                    "main.rue",
+                    &format!(
+                        "fn first(comptime T: type, values: [[T; 2]; 2]) -> T {{ values[0][0] }} fn main() -> i32 {{ first(i32, [[1, 2], [3, {value}]]) }}"
+                    ),
+                )],
+                file,
+            )
+        };
+        let first = source(1, "/old/main.rue", 4);
+        let relocated_edit = source(99, "/new/main.rue", 5);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.semantic(&options).unwrap();
+
+        session.update(&relocated_edit).into_result().unwrap();
+        let reused = session.semantic(&options).unwrap();
+        assert_eq!(reused.work().binding.declaration_resolution_invocations, 0);
+        assert_eq!(reused.work().binding.durable_payloads_installed, 2);
+        assert_eq!(reused.work().declaration_reuse.durable_records_reused, 2);
+        assert_eq!(reused.work().declaration_reuse.fallback_epochs_started, 0);
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&relocated_edit).into_result().unwrap();
+        let ordinary = fresh.semantic(&options).unwrap();
+        assert_semantic_artifact_parity(&session, &reused, &ordinary);
+        assert_diagnostic_parity(&session, &fresh);
+    }
+
+    #[test]
+    fn nested_generic_index_corruption_falls_back_without_partial_install() {
+        let source = |value| {
+            snapshot(
+                &[(
+                    1,
+                    "/p/main.rue",
+                    "main.rue",
+                    &format!(
+                        "fn first(comptime T: type, values: [[T; 2]; 2]) -> T {{ values[0][0] }} fn main() -> i32 {{ first(i32, [[1, 2], [3, {value}]]) }}"
+                    ),
+                )],
+                1,
+            )
+        };
+        let first = source(4);
+        let edited = source(5);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.semantic(&options).unwrap();
+
+        let cache = session.durable_declaration_cache.as_mut().unwrap();
+        let mut declarations = cache.semantics.to_vec();
+        let declaration = declarations
+            .iter_mut()
+            .find(|declaration| declaration.key.name() == "first")
+            .unwrap();
+        let crate::DurableDeclarationPayload::Callable { parameters, .. } =
+            &mut declaration.payload
+        else {
+            unreachable!();
+        };
+        let mut corrupted = parameters.to_vec();
+        corrupted[1].ty = crate::DurableType::Array {
+            element: Box::new(crate::DurableType::PtrConst(Box::new(
+                crate::DurableType::GenericParameter(9),
+            ))),
+            len: 2,
+        };
+        *parameters = corrupted.into();
+        cache.semantics = declarations.into();
+
+        session.update(&edited).into_result().unwrap();
+        let fallback = session.semantic(&options).unwrap();
+        assert_eq!(
+            fallback.work().binding.declaration_resolution_invocations,
+            1
+        );
+        assert_eq!(fallback.work().declaration_reuse.install_invocations, 1);
+        assert_eq!(fallback.work().declaration_reuse.durable_records_reused, 0);
+        assert_eq!(fallback.work().declaration_reuse.fallbacks, 1);
+        assert_eq!(fallback.work().declaration_reuse.fallback_epochs_started, 1);
+        assert_eq!(fallback.work().declaration_reuse.semantic_epochs_started, 2);
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&edited).into_result().unwrap();
+        let ordinary = fresh.semantic(&options).unwrap();
+        assert_semantic_artifact_parity(&session, &fallback, &ordinary);
+        assert_eq!(fallback.type_pool().stats(), ordinary.type_pool().stats());
+        assert_diagnostic_parity(&session, &fresh);
+    }
+
+    #[test]
+    fn comptime_named_method_reuses_declarations_while_body_reuse_fails_closed() {
         let source = |body: &str| snapshot(&[(1, "/p/main.rue", "main.rue", body)], 1);
         let first = source(
             "struct Value { fn choose(borrow self, comptime n: i32) -> i32 { n } } fn main() -> i32 { let value = Value {}; value.choose(1) }",
@@ -4716,17 +4851,19 @@ mod tests {
         let ordinary = session.semantic(&options).unwrap();
         assert_eq!(
             ordinary.work().binding.declaration_resolution_invocations,
-            1
+            0
         );
-        assert_eq!(ordinary.work().binding.durable_install_invocations, 0);
-        assert_eq!(ordinary.work().declaration_reuse.durable_records_reused, 0);
+        assert_eq!(ordinary.work().binding.durable_install_invocations, 1);
+        assert_eq!(ordinary.work().binding.durable_payloads_installed, 3);
+        assert_eq!(ordinary.work().declaration_reuse.durable_records_reused, 3);
+        assert_eq!(ordinary.work().declaration_reuse.fallback_epochs_started, 0);
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
         let expected = fresh.semantic(&options).unwrap();
         assert_semantic_artifact_parity(&session, &ordinary, &expected);
 
-        // Unsupported revisions did not leave a partial baseline: a supported
-        // revision seeds normally, and its next body edit can reuse normally.
+        // Moving to a different declaration universe seeds a new baseline, and
+        // its next body edit can reuse normally.
         session.update(&supported).into_result().unwrap();
         let seeded = session.semantic(&options).unwrap();
         assert_eq!(seeded.work().binding.declaration_resolution_invocations, 1);
@@ -4741,7 +4878,7 @@ mod tests {
     }
 
     #[test]
-    fn anonymous_structural_reuse_fails_closed_without_partial_install() {
+    fn anonymous_structural_body_reuse_fails_closed_after_declaration_reuse() {
         let first = snapshot(
             &[(
                 1,
@@ -4771,10 +4908,12 @@ mod tests {
         let ordinary = session.semantic(&options).unwrap();
         assert_eq!(
             ordinary.work().binding.declaration_resolution_invocations,
-            1
+            0
         );
-        assert_eq!(ordinary.work().binding.durable_install_invocations, 0);
-        assert_eq!(ordinary.work().declaration_reuse.durable_records_reused, 0);
+        assert_eq!(ordinary.work().binding.durable_install_invocations, 1);
+        assert_eq!(ordinary.work().binding.durable_payloads_installed, 2);
+        assert_eq!(ordinary.work().declaration_reuse.durable_records_reused, 2);
+        assert_eq!(ordinary.work().declaration_reuse.fallback_epochs_started, 0);
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
         let expected = fresh.semantic(&options).unwrap();


### PR DESCRIPTION
## Summary

- remove tuple and first-class-function forms that current AIR cannot produce or import
- retain generic parameter forms and validate them against authoritative callable parameter environments
- preserve exact recursive durable identity for generic arrays and pointers while matching ordinary AIR placeholder semantics
- reject unsupported or corrupted signatures atomically with exact fallback accounting

## Testing

- full `rue-air` suite (403/403)
- full `rue-compiler` suite (465/465)
- `scripts/rue quick` (25/25 targets)
- `scripts/rue test`
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-771
