### PR TITLE
RUE-890: publish discovery parse without reparsing

### DIFF
--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1803,6 +1803,242 @@ mod tests {
     }
 
     #[test]
+    fn closed_import_free_discovery_publishes_the_exact_parse_without_reparsing() {
+        let source = snapshot(
+            &[(1, "/project/main.rue", "main.rue", "fn main() -> i32 { 0 }")],
+            1,
+        );
+        let mut session = crate::CompilerSession::new();
+        session
+            .stage_import_discovery(
+                &source,
+                context(10),
+                accepted_reads(&source),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let staged = session
+            .discovery_attempt()
+            .unwrap()
+            .program()
+            .unwrap()
+            .clone();
+        let closed = session
+            .close_import_discovery(ImportObservationLedger::default())
+            .unwrap();
+
+        assert!(Arc::ptr_eq(closed.program().unwrap(), &staged));
+        assert!(Arc::ptr_eq(session.published().unwrap(), &staged));
+        assert_eq!(closed.parse_work().syntax.lexer_invocations, 1);
+        assert_eq!(closed.parse_work().syntax.parser_invocations, 1);
+        assert_eq!(session.work().last_parse, closed.parse_work());
+
+        let exact = session.update_for_presentation(&source);
+        assert_eq!(exact.work().syntax.lexer_invocations, 0);
+        assert_eq!(exact.work().syntax.parser_invocations, 0);
+        assert!(Arc::ptr_eq(exact.result().unwrap(), &staged));
+    }
+
+    #[test]
+    fn open_and_failed_discovery_attempts_never_seed_the_published_parse() {
+        let source = snapshot(
+            &[(
+                1,
+                "/project/main.rue",
+                "main.rue",
+                "fn main() { @import(\"missing\"); }",
+            )],
+            1,
+        );
+        let mut session = crate::CompilerSession::new();
+        session
+            .stage_import_discovery(
+                &source,
+                context(12),
+                accepted_reads(&source),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        assert!(session.published().is_none());
+        session
+            .close_import_discovery(ImportObservationLedger::default())
+            .unwrap_err();
+        assert!(session.published().is_none());
+
+        let direct = session.update_for_presentation(&source);
+        assert_eq!(direct.work().syntax.parser_invocations, 1);
+        direct.into_result().unwrap();
+    }
+
+    #[test]
+    fn discovery_work_resets_for_context_changes_and_superseding_edits() {
+        let original = snapshot(
+            &[(1, "/project/main.rue", "main.rue", "fn main() -> i32 { 0 }")],
+            1,
+        );
+        let edited = snapshot(
+            &[(1, "/project/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
+            1,
+        );
+        let mut session = crate::CompilerSession::new();
+        session
+            .stage_import_discovery(
+                &original,
+                context(20),
+                accepted_reads(&original),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        assert_eq!(
+            session
+                .discovery_attempt()
+                .unwrap()
+                .parse_work()
+                .syntax
+                .parser_invocations,
+            1
+        );
+
+        session
+            .stage_import_discovery(
+                &original,
+                context(21),
+                accepted_reads(&original),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let changed_context = session.discovery_attempt().unwrap().parse_work();
+        assert_eq!(changed_context.syntax.parser_invocations, 0);
+        assert_eq!(changed_context.modules_considered, 1);
+        assert_eq!(changed_context.modules_reused, 1);
+
+        session
+            .stage_import_discovery(
+                &edited,
+                context(21),
+                accepted_reads(&edited),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let superseded = session.discovery_attempt().unwrap().parse_work();
+        assert_eq!(superseded.syntax.parser_invocations, 1);
+        assert_eq!(superseded.modules_considered, 1);
+        assert_eq!(superseded.modules_reparsed, 1);
+    }
+
+    #[test]
+    fn fixed_point_discovery_accumulates_exact_work_and_seeds_incremental_parse() {
+        let main_text = "const h = @import(\"helper\"); fn main() -> i32 { h.answer() }";
+        let helper_text = "pub fn answer() -> i32 { 42 }";
+        let root_only = snapshot(&[(1, "/project/main.rue", "main.rue", main_text)], 1);
+        let complete = snapshot(
+            &[
+                (1, "/project/main.rue", "main.rue", main_text),
+                (2, "/project/helper.rue", "helper.rue", helper_text),
+            ],
+            1,
+        );
+        let discovery_context = context(11);
+        let mut session = crate::CompilerSession::new();
+        let first = session
+            .stage_import_discovery(
+                &root_only,
+                discovery_context.clone(),
+                accepted_reads(&root_only),
+                ImportObservationLedger::default(),
+            )
+            .unwrap();
+        let mut ledger = ImportObservationLedger::default();
+        for request in first.pending_requests(&ledger) {
+            let observation = if request.requested_path() == "/project/helper.rue" {
+                ImportObservation::accepted(
+                    request,
+                    AcceptedImportSource::new(
+                        "/project/helper.rue",
+                        "/project/helper.rue",
+                        PhysicalFileIdentity::new(1, 2),
+                        metadata_fingerprint(),
+                        Arc::new(helper_text.into()),
+                    )
+                    .unwrap(),
+                )
+                .unwrap()
+            } else {
+                ImportObservation::absent(request)
+            };
+            ledger.record(observation).unwrap();
+        }
+        let final_plan = session
+            .stage_import_discovery(
+                &complete,
+                discovery_context,
+                accepted_reads(&complete),
+                ledger.clone(),
+            )
+            .unwrap();
+        assert!(final_plan.pending_requests(&ledger).is_empty());
+        let staged = session
+            .discovery_attempt()
+            .unwrap()
+            .program()
+            .unwrap()
+            .clone();
+        let closed = session.close_import_discovery(ledger).unwrap();
+        let work = closed.parse_work();
+
+        assert!(Arc::ptr_eq(closed.program().unwrap(), &staged));
+        assert!(Arc::ptr_eq(session.published().unwrap(), &staged));
+        assert_eq!(work.syntax.lexer_invocations, 2);
+        assert_eq!(work.syntax.parser_invocations, 2);
+        assert_eq!(work.syntax.tokens, staged.token_count());
+        assert_eq!(work.modules_considered, 3);
+        assert_eq!(work.modules_reparsed, 2);
+        assert_eq!(work.modules_reused, 1);
+
+        let exact = session.update_for_presentation(&complete);
+        assert_eq!(exact.work().syntax.parser_invocations, 0);
+        assert_eq!(exact.work().modules_reused, 2);
+        assert!(Arc::ptr_eq(exact.result().unwrap(), &staged));
+
+        let broken_in_presentation_order = snapshot(
+            &[
+                (2, "/project/helper.rue", "helper.rue", "fn helper( {"),
+                (1, "/project/main.rue", "main.rue", "fn main( {"),
+            ],
+            1,
+        );
+        let errors = session
+            .update_for_presentation(&broken_in_presentation_order)
+            .into_result()
+            .unwrap_err();
+        assert_eq!(
+            errors
+                .iter()
+                .map(|error| error.span().unwrap().file_id)
+                .collect::<Vec<_>>(),
+            [FileId::new(2), FileId::new(1)]
+        );
+
+        let edited = snapshot(
+            &[
+                (1, "/project/main.rue", "main.rue", main_text),
+                (
+                    2,
+                    "/project/helper.rue",
+                    "helper.rue",
+                    "pub fn answer() -> i32 { 43 }",
+                ),
+            ],
+            1,
+        );
+        let edited_update = session.update_for_presentation(&edited);
+        assert_eq!(edited_update.work().syntax.parser_invocations, 1);
+        assert_eq!(edited_update.work().modules_reparsed, 1);
+        assert_eq!(edited_update.work().modules_reused, 1);
+        edited_update.into_result().unwrap();
+    }
+
+    #[test]
     fn incomplete_plain_ledger_closes_attempt_without_resolution_diagnostics() {
         let source = snapshot(
             &[(

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -196,6 +196,7 @@ struct ParsedSyntaxPayload {
     source: SourceId,
     file_id: FileId,
     source_text: Arc<String>,
+    token_count: usize,
     ast: ProvenancedAst,
     resolver: FrozenSymbolResolver,
     definitions: ParsedDefinitionIndex,
@@ -307,6 +308,9 @@ impl ParsedModule {
     pub fn source_text(&self) -> &str {
         &self.payload.source_text
     }
+    pub(crate) fn token_count(&self) -> usize {
+        self.payload.token_count
+    }
     pub(crate) fn shared_source_text(&self) -> Arc<String> {
         self.payload.source_text.clone()
     }
@@ -363,6 +367,24 @@ pub struct ParsedModulesWork {
     pub source_text_clones: usize,
     /// Source bytes rehashed while classifying reusable modules.
     pub source_bytes_rehashed: usize,
+}
+
+impl ParsedModulesWork {
+    /// Add the work from another update in the same bounded parse lifecycle.
+    pub(crate) fn accumulate(&mut self, other: Self) {
+        self.syntax.lexer_invocations += other.syntax.lexer_invocations;
+        self.syntax.parser_invocations += other.syntax.parser_invocations;
+        self.syntax.lexed_bytes += other.syntax.lexed_bytes;
+        self.syntax.tokens += other.syntax.tokens;
+        self.previous_modules_indexed += other.previous_modules_indexed;
+        self.modules_considered += other.modules_considered;
+        self.previous_module_lookups += other.previous_module_lookups;
+        self.modules_reused += other.modules_reused;
+        self.modules_rebound += other.modules_rebound;
+        self.modules_reparsed += other.modules_reparsed;
+        self.source_text_clones += other.source_text_clones;
+        self.source_bytes_rehashed += other.source_bytes_rehashed;
+    }
 }
 
 /// Deterministically ordered collection of independently parsed modules.
@@ -456,6 +478,23 @@ impl ParsedProgram {
         &self.invalid_imports
     }
 
+    /// Token volume of this immutable program, including one EOF token per module.
+    pub(crate) fn token_count(&self) -> usize {
+        self.modules.iter().map(|module| module.token_count()).sum()
+    }
+
+    pub(crate) fn belongs_to_exact_snapshot(&self, snapshot: &SourceSnapshot) -> bool {
+        self.source_revision() == snapshot.source_revision()
+            && self.modules.len() == snapshot.len()
+            && self.modules.iter().all(|module| {
+                let file_id = module.file_id();
+                snapshot.module_id(file_id) == Some(module.module_id())
+                    && snapshot.source_id(file_id) == Some(module.source_id())
+                    && snapshot.metadata().physical_path(file_id) == Some(module.physical_path())
+                    && snapshot.source_text(file_id) == Some(module.source_text())
+            })
+    }
+
     pub(crate) fn shared_symbol_strings(&self) -> Option<Vec<&str>> {
         let first = self.modules.first()?;
         if self.modules.iter().all(|module| {
@@ -541,14 +580,45 @@ impl CanonicalParseSession {
         snapshot: &SourceSnapshot,
         baseline: Arc<ParsedProgram>,
     ) -> CompileResult<Self> {
-        if baseline.source_revision() != snapshot.source_revision() {
+        if !baseline.belongs_to_exact_snapshot(snapshot) {
             return Err(invalid_input(
-                "parse-session baseline belongs to a foreign source revision",
+                "parse-session baseline belongs to a foreign source snapshot",
             ));
         }
         Ok(Self {
             baseline: Some(baseline),
         })
+    }
+
+    /// Adopt an already parsed exact-snapshot program as this session's baseline.
+    ///
+    /// This performs no syntax work. The caller supplies work already performed
+    /// by the bounded operation that produced `program`; foreign revisions are
+    /// rejected without advancing the baseline.
+    pub(crate) fn adopt_exact(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        program: Arc<ParsedProgram>,
+        work: ParsedModulesWork,
+    ) -> CanonicalParseUpdate {
+        let invalidation = classify_invalidation(snapshot, self.baseline.as_deref());
+        if !program.belongs_to_exact_snapshot(snapshot) {
+            return CanonicalParseUpdate {
+                result: Err(CompileErrors::from(invalid_input(
+                    "adopted parsed program belongs to a foreign source snapshot",
+                ))),
+                work,
+                invalidation,
+                baseline_advanced: false,
+            };
+        }
+        self.baseline = Some(program.clone());
+        CanonicalParseUpdate {
+            result: Ok(program),
+            work,
+            invalidation,
+            baseline_advanced: true,
+        }
     }
 
     #[cfg(test)]
@@ -775,7 +845,8 @@ fn parse_snapshot_file(
     let outcome = crate::syntax::parse_file(source, ThreadedRodeo::new());
     let work = outcome.work;
     let result = outcome.result.and_then(|ast| {
-        build_module(snapshot, file_id, ast, outcome.interner).map_err(CompileErrors::from)
+        build_module(snapshot, file_id, ast, outcome.interner, work.tokens)
+            .map_err(CompileErrors::from)
     });
     (result, work)
 }
@@ -872,12 +943,21 @@ fn build_module(
     file_id: FileId,
     ast: Arc<Ast>,
     interner: ThreadedRodeo,
+    token_count: usize,
 ) -> CompileResult<Arc<ParsedModule>> {
     let token = Arc::new(SymbolProvenance);
     let module = snapshot.module_id(file_id).expect("snapshot membership");
     let import_sites = collect_imports(&ast, module, &interner)?;
     let resolver = Arc::new(interner.into_resolver());
-    build_module_with_resolver(snapshot, file_id, ast, resolver, token, import_sites)
+    build_module_with_resolver(
+        snapshot,
+        file_id,
+        ast,
+        resolver,
+        token,
+        import_sites,
+        token_count,
+    )
 }
 
 fn build_module_with_resolver(
@@ -887,6 +967,7 @@ fn build_module_with_resolver(
     resolver: Arc<RodeoResolver<Spur>>,
     token: Arc<SymbolProvenance>,
     import_sites: ImportSiteCollector,
+    token_count: usize,
 ) -> CompileResult<Arc<ParsedModule>> {
     let module = snapshot
         .module_id(file_id)
@@ -919,6 +1000,7 @@ fn build_module_with_resolver(
         source,
         file_id,
         source_text,
+        token_count,
         ast: provenanced_ast,
         resolver,
         definitions,
@@ -2099,7 +2181,7 @@ fn main() -> i32 {
             CanonicalParseSession::from_baseline(&foreign, parsed)
                 .unwrap_err()
                 .to_string(),
-            "invalid compiler input: parse-session baseline belongs to a foreign source revision"
+            "invalid compiler input: parse-session baseline belongs to a foreign source snapshot"
         );
 
         let broken = snapshot(
@@ -2116,5 +2198,24 @@ fn main() -> i32 {
             error_fingerprint(update.result().unwrap_err()),
             error_fingerprint(&direct)
         );
+    }
+
+    #[test]
+    fn exact_adoption_rejects_relocated_snapshot_without_advancing_baseline() {
+        let original = snapshot(&[(1, "/a.rue", "a.rue", "fn a() {}")], 1);
+        let relocated = snapshot(&[(9, "/moved/a.rue", "a.rue", "fn a() {}")], 9);
+        assert_eq!(original.source_revision(), relocated.source_revision());
+        let parsed = Arc::new(parse_source_snapshot_modules(&original).unwrap());
+        let work = ParsedModulesWork {
+            modules_considered: 1,
+            modules_reparsed: 1,
+            ..ParsedModulesWork::default()
+        };
+        let mut session = CanonicalParseSession::new();
+        let update = session.adopt_exact(&relocated, parsed, work);
+        assert!(update.result().is_err());
+        assert_eq!(update.work(), work);
+        assert!(!update.baseline_advanced());
+        assert!(session.baseline().is_none());
     }
 }

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -6,6 +6,28 @@ mod tests {
     use super::*;
 
     #[test]
+    fn source_token_volume_survives_an_exact_zero_parse_update() {
+        let snapshot =
+            SourceSnapshot::single("/project/main.rue", "fn main() -> i32 { 42 }").unwrap();
+        let mut session = CompilerSession::new();
+        let first = session.update_for_presentation(&snapshot);
+        let expected_tokens = first.work().syntax.tokens;
+        first.into_result().unwrap();
+        let exact = session.update_for_presentation(&snapshot);
+        assert_eq!(exact.work().syntax.parser_invocations, 0);
+        exact.into_result().unwrap();
+
+        let output = crate::queries::compile_with_session(
+            &mut session,
+            &snapshot,
+            &CompileOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(output.work.parsed.syntax.parser_invocations, 0);
+        assert_eq!(output.source_stats.tokens, expected_tokens);
+    }
+
+    #[test]
     fn canonical_std_strbuf_identity_survives_qualified_and_aliased_lookup() {
         let context = ImportDiscoveryContext::new(1, "/project", Some("/sdk"), "test")
             .expect("discovery context should be valid");

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -412,6 +412,15 @@ pub(crate) fn compile_with_session(
     snapshot: &SourceSnapshot,
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
+    let source_tokens = session
+        .published()
+        .filter(|program| program.belongs_to_exact_snapshot(snapshot))
+        .map(|program| program.token_count())
+        .ok_or_else(|| {
+            CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
+                "compilation snapshot differs from the published parsed program".into(),
+            )))
+        })?;
     let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
     let _span = info_span!(
         "compile",
@@ -442,7 +451,7 @@ pub(crate) fn compile_with_session(
             .files()
             .map(|source| source.source.lines().count())
             .sum(),
-        tokens: session_work.last_parse.syntax.tokens,
+        tokens: source_tokens,
     };
     output.work = PipelineWork {
         parsed: session_work.last_parse,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1050,6 +1050,7 @@ pub struct ImportDiscoveryRevisionArtifact {
     context: crate::ImportDiscoveryContext,
     snapshot: SourceSnapshot,
     program: Option<Arc<ParsedProgram>>,
+    parse_work: ParsedModulesWork,
     plan: Option<crate::ImportDiscoveryPlan>,
     ledger: crate::ImportObservationLedger,
     accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
@@ -1070,6 +1071,14 @@ impl ImportDiscoveryRevisionArtifact {
     }
     pub fn snapshot(&self) -> &SourceSnapshot {
         &self.snapshot
+    }
+    #[cfg(test)]
+    pub(crate) fn program(&self) -> Option<&Arc<ParsedProgram>> {
+        self.program.as_ref()
+    }
+    /// Exact parse work performed by this bounded discovery lifecycle.
+    pub fn parse_work(&self) -> ParsedModulesWork {
+        self.parse_work
     }
     pub fn plan(&self) -> Option<&crate::ImportDiscoveryPlan> {
         self.plan.as_ref()
@@ -1348,6 +1357,19 @@ impl CompilerSession {
         accepted_reads: Arc<[crate::AcceptedReadManifestEntry]>,
         carried_ledger: crate::ImportObservationLedger,
     ) -> Result<crate::ImportDiscoveryPlan, CompileErrors> {
+        let mut parse_work = self
+            .discovery_attempt
+            .as_deref()
+            .filter(|attempt| {
+                continues_discovery_lifecycle(
+                    attempt,
+                    snapshot,
+                    &context,
+                    &accepted_reads,
+                    &carried_ledger,
+                )
+            })
+            .map_or_else(ParsedModulesWork::default, |attempt| attempt.parse_work);
         self.discovery_staging_active = true;
         let source_revision = snapshot.source_revision().clone();
         if let Err(errors) = validate_accepted_read_manifest(snapshot, &accepted_reads) {
@@ -1365,6 +1387,7 @@ impl CompilerSession {
                 context: context.clone(),
                 snapshot: snapshot.clone(),
                 program: None,
+                parse_work,
                 plan: None,
                 ledger: carried_ledger.clone(),
                 accepted_reads: accepted_reads.clone(),
@@ -1374,7 +1397,9 @@ impl CompilerSession {
             }));
             return Err(errors);
         }
-        let program = match self.discovery_parse.update(snapshot).into_result() {
+        let parse_update = self.discovery_parse.update(snapshot);
+        parse_work.accumulate(parse_update.work());
+        let program = match parse_update.into_result() {
             Ok(program) => program,
             Err(errors) => {
                 let diagnostic_snapshot = self.publish_import_diagnostics(
@@ -1391,6 +1416,7 @@ impl CompilerSession {
                     context: context.clone(),
                     snapshot: snapshot.clone(),
                     program: None,
+                    parse_work,
                     plan: None,
                     ledger: carried_ledger.clone(),
                     accepted_reads: accepted_reads.clone(),
@@ -1419,6 +1445,7 @@ impl CompilerSession {
                     context: context.clone(),
                     snapshot: snapshot.clone(),
                     program: Some(program),
+                    parse_work,
                     plan: None,
                     ledger: carried_ledger.clone(),
                     accepted_reads: accepted_reads.clone(),
@@ -1435,6 +1462,7 @@ impl CompilerSession {
             context,
             snapshot: snapshot.clone(),
             program: Some(program),
+            parse_work,
             plan: Some(plan.clone()),
             ledger: carried_ledger,
             accepted_reads,
@@ -1595,7 +1623,12 @@ impl CompilerSession {
             return Err(diagnostics);
         }
 
-        if let Err(errors) = self.update_for_presentation(&open.snapshot).into_result() {
+        let adoption = self.adopt_discovery_program_for_presentation(
+            &open.snapshot,
+            program.clone(),
+            open.parse_work,
+        );
+        if let Err(errors) = adoption.into_result() {
             self.publish_failed_import_attempt(
                 open,
                 plan,
@@ -1871,6 +1904,26 @@ impl CompilerSession {
                 .collect(),
         );
         let update = self.parse.update_for_batch(snapshot);
+        self.finish_update(snapshot, update)
+    }
+
+    fn adopt_discovery_program_for_presentation(
+        &mut self,
+        snapshot: &SourceSnapshot,
+        program: Arc<ParsedProgram>,
+        work: ParsedModulesWork,
+    ) -> CompilerSessionUpdate {
+        #[cfg(test)]
+        {
+            self.supplied_test_import_graph = None;
+        }
+        self.batch_diagnostic_order = Some(
+            snapshot
+                .files()
+                .map(|source| snapshot.module_id(source.file_id).unwrap().clone())
+                .collect(),
+        );
+        let update = self.parse.adopt_exact(snapshot, program, work);
         self.finish_update(snapshot, update)
     }
 
@@ -4438,6 +4491,45 @@ fn no_published_program() -> CompileErrors {
     CompileErrors::from(CompileError::without_span(ErrorKind::InvalidCompilerInput(
         "frontend query session has no successful parsed program".to_string(),
     )))
+}
+
+/// Successive fixed-point snapshots belong to one bounded discovery parse run
+/// only when they preserve all prior source, manifest, context, and ledger
+/// provenance. Any failed/closed/superseding attempt starts fresh accounting.
+fn continues_discovery_lifecycle(
+    previous: &ImportDiscoveryRevisionArtifact,
+    snapshot: &SourceSnapshot,
+    context: &crate::ImportDiscoveryContext,
+    accepted_reads: &[crate::AcceptedReadManifestEntry],
+    carried_ledger: &crate::ImportObservationLedger,
+) -> bool {
+    if previous.status != ImportDiscoveryRevisionStatus::Open || previous.context != *context {
+        return false;
+    }
+    let Some(program) = previous.program.as_deref() else {
+        return false;
+    };
+    if program.root() != snapshot.source_revision().root()
+        || !program.modules().iter().all(|module| {
+            let file_id = module.file_id();
+            snapshot.module_id(file_id) == Some(module.module_id())
+                && snapshot.source_id(file_id) == Some(module.source_id())
+                && snapshot.metadata().physical_path(file_id) == Some(module.physical_path())
+        })
+    {
+        return false;
+    }
+    if !previous
+        .accepted_reads
+        .iter()
+        .all(|entry| accepted_reads.iter().any(|candidate| candidate == entry))
+    {
+        return false;
+    }
+    previous
+        .ledger
+        .iter()
+        .all(|observation| carried_ledger.get(observation.request()) == Some(observation))
 }
 
 #[cfg(test)]

--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -14,8 +14,11 @@ use crate::{
 /// Token counts include the EOF token emitted by the lexer. A file contributes
 /// tokens only when lexing succeeds and produces the token vector passed to the
 /// parser. Source bytes use UTF-8 byte lengths, matching Rue's byte-based spans.
-/// Values describe one syntax run; they are neither process-global totals nor
-/// metadata attached to a reusable parsed artifact.
+/// Values describe one bounded syntax run; they are neither process-global
+/// totals nor metadata attached to a reusable parsed artifact. Import discovery
+/// treats one provenance-preserving fixed-point lifecycle as a bounded run, so
+/// its values sum only the actual calls made across that lifecycle's snapshot
+/// expansions.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SyntaxWork {
     /// Number of lexer invocations.

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -2200,7 +2200,8 @@ fn handle_emit_multi_file(
         // Every --emit mode must surface frontend warnings (RUE-130).
         diagnostics.print_warnings(state.warnings());
         let work = state.query_work();
-        debug_assert_eq!(work.parsed.syntax.parser_invocations, source_snapshot.len());
+        debug_assert_eq!(state.parsed.modules().len(), source_snapshot.len());
+        debug_assert!(work.parsed.syntax.parser_invocations <= source_snapshot.len());
         debug_assert_eq!(work.lowered.parser_invocations, 0);
         debug_assert_eq!(work.semantic.binding.bind_invocations, 1);
         debug_assert_eq!(work.semantic.manifest.build_invocations, 1);


### PR DESCRIPTION
## Summary

- publish the exact `ParsedProgram` produced by closed-valid import discovery instead of lexing and parsing the same snapshot again
- accumulate actual parse work across provenance-preserving fixed-point discovery iterations
- retain immutable per-module token volume so source statistics remain correct when a published program is reused with zero syntax work
- reject adoption from foreign snapshots and preserve presentation-order diagnostics and incremental reuse

## Why

Normal CLI compilation parsed every source twice: once to discover imports and again to publish the canonical frontend program. Parsing has become a visible compilation bottleneck, so the duplicate work inflated both latency and trace counts without producing a distinct artifact.

## Impact

A one-file normal compilation now performs one lexer invocation and one parser invocation. Multi-file fixed-point discovery parses each newly discovered module once, then adopts the exact resulting program into the canonical session.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (25 targets passed)
- `rue-compiler` unit suite (467 tests passed)
- `rue --benchmark-json examples/hello.rue` (1 lexer, 1 parser, 10 source tokens)

Fixes RUE-890
