### PR TITLE
RUE-885: reuse specialized semantic bodies

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -67,7 +67,9 @@ pub use semantic_body::{
     SemanticBodyExport, SemanticBodyExportFailure, SemanticBodyImportFailure, SemanticBodyInst,
     SemanticBodyInstData, SemanticBodyMatchArm, SemanticBodyModuleIdentity, SemanticBodyPattern,
     SemanticBodyPlace, SemanticBodyPlaceRef, SemanticBodyProjection, SemanticBodyRef,
-    SemanticBodyWarning, SemanticImportedBody,
+    SemanticBodyWarning, SemanticImportedBody, SemanticSpecializationIdentity,
+    SemanticSpecializedBodyCandidate, SemanticSpecializedBodyExport,
+    SemanticSpecializedCandidateInstallWork,
 };
 pub use semantic_import::{
     SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -54,9 +54,9 @@ pub(crate) fn analyze_all_function_bodies_with_work(
     result.map_err(|errors| super::BodyAnalysisFailure::new(errors, work))
 }
 
-fn import_staged_ordinary_body(
+pub(crate) fn import_staged_body(
     sema: &mut BodySema<'_>,
-    candidate: &crate::SemanticBodyCandidate<
+    body: &crate::SemanticBody<
         crate::SemanticBodyDefinitionIdentity,
         crate::SemanticBodyModuleIdentity,
     >,
@@ -95,6 +95,11 @@ fn import_staged_ordinary_body(
                         *sema
                             .builtin_structs
                             .get(&symbol)
+                            .or_else(|| {
+                                (name.as_ref() == "str")
+                                    .then(|| sema.generated_structs.get(&symbol))
+                                    .flatten()
+                            })
                             .ok_or(F::UnknownBuiltinNominal)?,
                     ),
                     NK::Enum => Type::new_enum(
@@ -148,16 +153,59 @@ fn import_staged_ordinary_body(
         })
     }
 
+    fn resolve_body_function(
+        sema: &BodySema<'_>,
+        identity: &crate::SemanticBodyDefinitionIdentity,
+    ) -> Result<Spur, BF> {
+        let name = sema
+            .interner
+            .get(identity.name.as_ref())
+            .ok_or(BF::Semantic(F::MissingFunction))?;
+        if identity.kind == DK::FreeFunction {
+            return sema
+                .functions_by_file_name
+                .get(&(FileId::new(identity.file_id), name))
+                .copied()
+                .ok_or(BF::Semantic(F::MissingFunction));
+        }
+        let owner = identity
+            .owner
+            .as_deref()
+            .and_then(|owner| sema.interner.get(owner))
+            .ok_or(BF::Semantic(F::MissingFunction))?;
+        let struct_id = sema
+            .structs_by_file_name
+            .get(&(FileId::new(identity.file_id), owner))
+            .copied()
+            .ok_or(BF::Semantic(F::MissingFunction))?;
+        let info = sema
+            .method_info((struct_id, name))
+            .ok_or(BF::Semantic(F::MissingFunction))?;
+        let expected = match identity.kind {
+            DK::Method => info.has_self && identity.name.as_ref() != "__drop",
+            DK::AssociatedFunction => !info.has_self,
+            DK::Destructor => info.has_self && identity.name.as_ref() == "__drop",
+            _ => false,
+        };
+        if !expected {
+            return Err(BF::Semantic(F::MissingFunction));
+        }
+        let symbol = sema.method_symbol(struct_id, identity.name.as_ref(), info.has_self);
+        sema.interner
+            .get(&symbol)
+            .ok_or(BF::Semantic(F::MissingFunction))
+    }
+
     // Intrinsic and declaration-derived callable symbols are required to
     // pre-exist. This keeps importer mutation inside the scratch type pool
     // until the entire body validates.
-    if candidate.body.instructions.iter().any(|inst| matches!(&inst.data,
+    if body.instructions.iter().any(|inst| matches!(&inst.data,
         crate::SemanticBodyInstData::Intrinsic { name, .. } if sema.interner.get(name.as_ref()).is_none())) {
         return Err(BF::Semantic(F::MissingFunction));
     }
     let scratch = sema.type_pool.clone();
     let imported = crate::SemanticImportEpoch::import_body_with(
-        &candidate.body,
+        body,
         body_span,
         |value| import_type(sema, &scratch, value),
         |identity| {
@@ -186,44 +234,36 @@ fn import_staged_ordinary_body(
                 .copied()
                 .ok_or(BF::Semantic(F::MissingNominal))
         },
+        |identity| resolve_body_function(sema, identity),
         |identity| {
-            let name = sema
-                .interner
-                .get(identity.name.as_ref())
-                .ok_or(BF::Semantic(F::MissingFunction))?;
-            if identity.kind == DK::FreeFunction {
-                return sema
-                    .functions_by_file_name
-                    .get(&(FileId::new(identity.file_id), name))
-                    .copied()
-                    .ok_or(BF::Semantic(F::MissingFunction));
-            }
-            let owner = identity
-                .owner
-                .as_deref()
-                .and_then(|owner| sema.interner.get(owner))
-                .ok_or(BF::Semantic(F::MissingFunction))?;
-            let struct_id = sema
-                .structs_by_file_name
-                .get(&(FileId::new(identity.file_id), owner))
-                .copied()
-                .ok_or(BF::Semantic(F::MissingFunction))?;
-            let info = sema
-                .method_info((struct_id, name))
-                .ok_or(BF::Semantic(F::MissingFunction))?;
-            let expected = match identity.kind {
-                DK::Method => info.has_self && identity.name.as_ref() != "__drop",
-                DK::AssociatedFunction => !info.has_self,
-                DK::Destructor => info.has_self && identity.name.as_ref() == "__drop",
-                _ => false,
-            };
-            if !expected {
-                return Err(BF::Semantic(F::MissingFunction));
-            }
-            let symbol = sema.method_symbol(struct_id, identity.name.as_ref(), info.has_self);
-            sema.interner
-                .get(&symbol)
-                .ok_or(BF::Semantic(F::MissingFunction))
+            let base = resolve_body_function(sema, &identity.base)?;
+            let type_arguments = identity
+                .type_arguments
+                .iter()
+                .map(|value| import_type(sema, &scratch, value))
+                .collect::<Result<Vec<_>, _>>()?;
+            let value_arguments = identity
+                .value_arguments
+                .iter()
+                .map(|value| {
+                    Ok(match value {
+                        crate::SemanticImportConstValue::Integer(value) => {
+                            crate::sema::ConstValue::Integer(*value)
+                        }
+                        crate::SemanticImportConstValue::Bool(value) => {
+                            crate::sema::ConstValue::Bool(*value)
+                        }
+                        crate::SemanticImportConstValue::Type(value) => {
+                            crate::sema::ConstValue::Type(import_type(sema, &scratch, value)?)
+                        }
+                        crate::SemanticImportConstValue::Function(value) => {
+                            crate::sema::ConstValue::Function(resolve_body_function(sema, value)?)
+                        }
+                        crate::SemanticImportConstValue::Unit => crate::sema::ConstValue::Unit,
+                    })
+                })
+                .collect::<Result<Vec<_>, BF>>()?;
+            Ok((base, type_arguments, value_arguments))
         },
         |name| {
             sema.interner
@@ -235,7 +275,7 @@ fn import_staged_ordinary_body(
     Ok(imported)
 }
 
-fn imported_body_references(
+pub(crate) fn imported_body_references(
     sema: &BodySema<'_>,
     air: &Air,
 ) -> (HashSet<Spur>, HashSet<(crate::StructId, Spur)>) {
@@ -425,6 +465,7 @@ fn finalize_function_body_analysis(
         type_pool: sema.type_pool.clone(),
         body_analysis_work: sema.body_analysis_work,
         ordinary_body_exports: std::mem::take(&mut sema.ordinary_body_exports),
+        specialized_body_exports: std::mem::take(&mut sema.specialized_body_exports),
         analyzed_body_owners: {
             sema.analyzed_body_owners.sort();
             sema.analyzed_body_owners.dedup();
@@ -1053,8 +1094,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
             );
             if let Some(candidate) = sema.reusable_ordinary_bodies.remove(&ordinary_owner) {
                 sema.body_analysis_work.ordinary_body_import_attempts += 1;
-                let imported =
-                    import_staged_ordinary_body(sema, &candidate, sema.rir.get(body).span);
+                let imported = import_staged_body(sema, &candidate.body, sema.rir.get(body).span);
                 if let Ok(imported) = imported {
                     sema.body_analysis_work.ordinary_body_import_successes += 1;
                     sema.body_analysis_work
@@ -1482,7 +1522,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 && let Some(candidate) = sema.reusable_ordinary_bodies.remove(&ordinary_owner)
             {
                 sema.body_analysis_work.ordinary_body_import_attempts += 1;
-                match import_staged_ordinary_body(sema, &candidate, sema.rir.get(*body).span) {
+                match import_staged_body(sema, &candidate.body, sema.rir.get(*body).span) {
                     Ok(imported) => {
                         sema.body_analysis_work.ordinary_body_import_successes += 1;
                         sema.body_analysis_work
@@ -1781,9 +1821,9 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 );
                 if let Some(candidate) = sema.reusable_ordinary_bodies.remove(&ordinary_owner) {
                     sema.body_analysis_work.ordinary_body_import_attempts += 1;
-                    match import_staged_ordinary_body(
+                    match import_staged_body(
                         sema,
-                        &candidate,
+                        &candidate.body,
                         sema.rir.get(destructor.body).span,
                     ) {
                         Ok(imported) => {
@@ -2587,6 +2627,7 @@ mod error_invariant_tests {
             type_pool: TypeInternPool::new(),
             body_analysis_work: crate::BodyAnalysisWork::default(),
             ordinary_body_exports: Vec::new(),
+            specialized_body_exports: Vec::new(),
             analyzed_body_owners: Vec::new(),
             body_named_dependencies: Vec::new(),
             ordinary_free_function_dependencies: Vec::new(),

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -818,6 +818,57 @@ impl Sema<'_> {
 }
 
 impl<'a> BoundSema<'a> {
+    pub fn install_specialized_body_candidates<K, M>(
+        mut self,
+        candidates: Vec<crate::SemanticSpecializedBodyCandidate<K, M>>,
+        definition: impl Fn(&K) -> Option<crate::SemanticBodyDefinitionIdentity>,
+        module: impl Fn(&M) -> Option<FileId>,
+    ) -> (Self, crate::SemanticSpecializedCandidateInstallWork)
+    where
+        K: Clone + Ord,
+        M: Clone + Ord + AsRef<str>,
+    {
+        let mut work = crate::SemanticSpecializedCandidateInstallWork::default();
+        for candidate in candidates {
+            work.attempts += 1;
+            let map_module = |key: &M| {
+                module(key)
+                    .map(|file| crate::SemanticBodyModuleIdentity {
+                        file_id: file.index(),
+                        path: std::sync::Arc::from(key.as_ref()),
+                    })
+                    .ok_or(())
+            };
+            let map_definition = |key: &K| definition(key).ok_or(());
+            let identity = candidate
+                .identity
+                .try_map_keys(&map_definition, &|key: &M| {
+                    Ok::<_, ()>(std::sync::Arc::from(key.as_ref()))
+                });
+            let body = candidate.body.try_map_keys(&map_definition, &map_module);
+            let dependencies = candidate
+                .dependencies
+                .iter()
+                .map(&map_definition)
+                .collect::<Result<Vec<_>, _>>();
+            if let (Ok(identity), Ok(body), Ok(dependencies)) = (identity, body, dependencies) {
+                self.sema.reusable_specialized_bodies.push(
+                    crate::SemanticSpecializedBodyCandidate {
+                        identity,
+                        body_span: candidate.body_span,
+                        body,
+                        dependencies: dependencies.into(),
+                        dependency_boundary_complete: candidate.dependency_boundary_complete,
+                    },
+                );
+                work.successes += 1;
+            } else {
+                work.mapping_failures += 1;
+            }
+        }
+        (self, work)
+    }
+
     /// Resolve durable keys into request-independent declaration identities and
     /// stage candidates for the canonical reachable-body worklist. No AIR type,
     /// instruction, string, nominal, or function ID is allocated here.

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -25,7 +25,7 @@
 //! - [`Sema::analyze_all`] - Perform full semantic analysis
 //! - [`Sema::analyze_all_bodies`] - Analyze function bodies after declarations
 
-mod analysis;
+pub(crate) mod analysis;
 mod analyze_ops;
 mod anon_structs;
 mod binding_manifest;
@@ -218,10 +218,18 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) body_analysis_work: BodyAnalysisWork,
     pub(crate) analyzed_body_owners: Vec<AnalyzedBodyOwnerEvent>,
     pub(crate) ordinary_body_exports: Vec<crate::SemanticBodyExport>,
+    pub(crate) specialized_body_exports: Vec<crate::SemanticSpecializedBodyExport>,
     pub(crate) reusable_ordinary_bodies: HashMap<
         BodyOwnerToken,
         crate::SemanticBodyCandidate<
             crate::SemanticBodyDefinitionIdentity,
+            crate::SemanticBodyModuleIdentity,
+        >,
+    >,
+    pub(crate) reusable_specialized_bodies: Vec<
+        crate::SemanticSpecializedBodyCandidate<
+            crate::SemanticBodyDefinitionIdentity,
+            std::sync::Arc<str>,
             crate::SemanticBodyModuleIdentity,
         >,
     >,
@@ -360,7 +368,9 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_analysis_work,
             analyzed_body_owners,
             ordinary_body_exports,
+            specialized_body_exports,
             reusable_ordinary_bodies,
+            reusable_specialized_bodies,
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
@@ -411,7 +421,9 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_analysis_work,
             analyzed_body_owners,
             ordinary_body_exports,
+            specialized_body_exports,
             reusable_ordinary_bodies,
+            reusable_specialized_bodies,
             body_dependency_observer,
             body_owner_tokens,
             body_named_dependencies,
@@ -728,7 +740,9 @@ impl<'a> Sema<'a> {
             body_analysis_work: BodyAnalysisWork::default(),
             analyzed_body_owners: Vec::new(),
             ordinary_body_exports: Vec::new(),
+            specialized_body_exports: Vec::new(),
             reusable_ordinary_bodies: HashMap::new(),
+            reusable_specialized_bodies: Vec::new(),
             body_dependency_observer: None,
             body_owner_tokens: HashMap::new(),
             body_named_dependencies: Vec::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -4,9 +4,9 @@
 //! - [`AnalyzedFunction`] - A single analyzed function with typed IR
 //! - [`SemaOutput`] - Complete output from analyzing a program
 
-use crate::SemanticBodyExport;
 use crate::inst::Air;
 use crate::intern_pool::TypeInternPool;
+use crate::{SemanticBodyExport, SemanticSpecializedBodyExport};
 use rue_error::CompileWarning;
 /// Opaque identity issued by the compiler for one supported ordinary body.
 ///
@@ -247,6 +247,12 @@ pub struct BodyNamedDependencyEvent {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ImplicitDropDependencySourceEvent {
     Anonymous,
+    Specialization {
+        identity: crate::SemanticSpecializationIdentity<
+            crate::SemanticBodyDefinitionIdentity,
+            std::sync::Arc<str>,
+        >,
+    },
     FreeFunction {
         token: BodyOwnerToken,
         file: u32,
@@ -364,6 +370,8 @@ pub struct SemaOutput {
     pub body_analysis_work: BodyAnalysisWork,
     /// Pre-specialization durable candidates for supported ordinary bodies.
     pub ordinary_body_exports: Vec<SemanticBodyExport>,
+    /// Completed post-fixed-point generic instances eligible for durable reuse.
+    pub specialized_body_exports: Vec<SemanticSpecializedBodyExport>,
     /// Stable-capable provenance for every successfully analyzed source body.
     pub analyzed_body_owners: Vec<AnalyzedBodyOwnerEvent>,
     pub body_named_dependencies: Vec<BodyNamedDependencyEvent>,
@@ -416,6 +424,20 @@ pub struct BodyAnalysisWork {
     pub ordinary_body_export_instructions_emitted: usize,
     pub ordinary_body_export_places_emitted: usize,
     pub ordinary_body_export_strings_emitted: usize,
+    pub specialized_body_exports_attempted: usize,
+    pub specialized_body_exports_succeeded: usize,
+    pub specialized_body_exports_rejected: usize,
+    pub specialized_body_export_instructions_emitted: usize,
+    pub specialized_body_export_places_emitted: usize,
+    pub specialized_body_export_strings_emitted: usize,
+    pub specialized_body_import_attempts: usize,
+    pub specialized_body_import_successes: usize,
+    pub specialized_body_import_failures: usize,
+    pub specialized_body_import_instructions_installed: usize,
+    pub specialized_body_import_places_installed: usize,
+    pub specialized_body_import_strings_installed: usize,
+    pub specialized_bodies_reused: usize,
+    pub specialized_body_analyses_skipped: usize,
     pub string_ids_remapped: usize,
     pub specialization_air_instructions_scanned: usize,
     pub generic_calls_observed: usize,

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use lasso::Spur;
 use rue_error::CompileWarning;
@@ -9,11 +9,78 @@ use crate::{
     AirInstData, AirPattern, AirProjection, SemanticBody, SemanticBodyAnchor, SemanticBodyCallArg,
     SemanticBodyDefinitionIdentity, SemanticBodyDefinitionKind, SemanticBodyExport,
     SemanticBodyExportFailure as F, SemanticBodyInst, SemanticBodyInstData, SemanticBodyMatchArm,
-    SemanticBodyPattern, SemanticBodyPlace, SemanticBodyProjection, SemanticImportType, Type,
+    SemanticBodyPattern, SemanticBodyPlace, SemanticBodyProjection, SemanticImportConstValue,
+    SemanticImportType, SemanticSpecializationIdentity, SemanticSpecializedBodyExport, Type,
     TypeKind,
 };
 
 impl BodySema<'_> {
+    pub(crate) fn export_specialized_body(
+        &self,
+        base_name: Spur,
+        base_info: &super::FunctionInfo,
+        type_arguments: &[Type],
+        value_arguments: &[super::ConstValue],
+        analyzed: &AnalyzedFunction,
+        strings: &[String],
+        warnings: &[CompileWarning],
+        specialized_calls: &HashMap<
+            Spur,
+            SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
+        >,
+        dependencies: &[SemanticBodyDefinitionIdentity],
+        dependency_boundary_complete: bool,
+    ) -> Result<SemanticSpecializedBodyExport, F> {
+        let source_name = self.source_function_name(base_name);
+        let source_name_str = self.interner.resolve(&source_name);
+        let owner = self.body_owner_token(
+            base_info.file_id,
+            source_name_str,
+            None,
+            super::BodyOwnerKind::FreeFunction,
+        );
+        let body = self
+            .export_body(
+                owner,
+                base_info.span,
+                analyzed,
+                strings,
+                warnings,
+                Some(specialized_calls),
+            )?
+            .body;
+        let type_arguments = type_arguments
+            .iter()
+            .map(|value| self.export_body_type(*value))
+            .collect::<Result<Vec<_>, _>>()?;
+        let value_arguments = value_arguments
+            .iter()
+            .map(|value| {
+                Ok(match value {
+                    super::ConstValue::Integer(value) => SemanticImportConstValue::Integer(*value),
+                    super::ConstValue::Bool(value) => SemanticImportConstValue::Bool(*value),
+                    super::ConstValue::Type(value) => {
+                        SemanticImportConstValue::Type(self.export_body_type(*value)?)
+                    }
+                    super::ConstValue::Function(value) => {
+                        SemanticImportConstValue::Function(self.function_identity(*value)?)
+                    }
+                    super::ConstValue::Unit => SemanticImportConstValue::Unit,
+                })
+            })
+            .collect::<Result<Vec<_>, F>>()?;
+        Ok(SemanticSpecializedBodyExport {
+            identity: SemanticSpecializationIdentity {
+                base: self.function_identity(base_name)?,
+                type_arguments: type_arguments.into(),
+                value_arguments: value_arguments.into(),
+            },
+            body,
+            dependencies: dependencies.into(),
+            dependency_boundary_complete,
+        })
+    }
+
     pub(crate) fn export_ordinary_body(
         &self,
         owner: BodyOwnerToken,
@@ -21,6 +88,23 @@ impl BodySema<'_> {
         analyzed: &AnalyzedFunction,
         strings: &[String],
         warnings: &[CompileWarning],
+    ) -> Result<SemanticBodyExport, F> {
+        self.export_body(owner, body_span, analyzed, strings, warnings, None)
+    }
+
+    fn export_body(
+        &self,
+        owner: BodyOwnerToken,
+        body_span: Span,
+        analyzed: &AnalyzedFunction,
+        strings: &[String],
+        warnings: &[CompileWarning],
+        specialized_calls: Option<
+            &HashMap<
+                Spur,
+                SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
+            >,
+        >,
     ) -> Result<SemanticBodyExport, F> {
         // CompileWarning carries structured labels, notes, help, and suggestions
         // which the first durable DTO intentionally does not model. Publishing a
@@ -271,9 +355,15 @@ impl BodySema<'_> {
                     name,
                     args_start,
                     args_len,
-                } => SemanticBodyInstData::Call {
-                    function: self.function_identity(*name)?,
-                    args: call_args(*args_start, *args_len)?,
+                } => match specialized_calls.and_then(|calls| calls.get(name)) {
+                    Some(identity) => SemanticBodyInstData::CallSpecialized {
+                        identity: identity.clone(),
+                        args: call_args(*args_start, *args_len)?,
+                    },
+                    None => SemanticBodyInstData::Call {
+                        function: self.function_identity(*name)?,
+                        args: call_args(*args_start, *args_len)?,
+                    },
                 },
                 AirInstData::CallGeneric { .. } => return Err(F::UnsupportedGenericCall),
                 AirInstData::Intrinsic {
@@ -412,7 +502,10 @@ impl BodySema<'_> {
         })
     }
 
-    fn function_identity(&self, symbol: Spur) -> Result<SemanticBodyDefinitionIdentity, F> {
+    pub(crate) fn function_identity(
+        &self,
+        symbol: Spur,
+    ) -> Result<SemanticBodyDefinitionIdentity, F> {
         if let Some(info) = self.functions.get(&symbol) {
             return Ok(SemanticBodyDefinitionIdentity {
                 file_id: info.file_id.index(),
@@ -473,7 +566,7 @@ impl BodySema<'_> {
         })
     }
 
-    fn export_body_type(
+    pub(crate) fn export_body_type(
         &self,
         ty: Type,
     ) -> Result<SemanticImportType<SemanticBodyDefinitionIdentity, Arc<str>>, F> {

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -548,6 +548,40 @@ mod tests {
         assert_eq!(work.specialized_bodies_failed, 0);
     }
 
+    #[test]
+    fn completed_specializations_export_stable_identity_and_exact_work() {
+        let output = compile_to_air(
+            "fn id(comptime T: type, value: T) -> T { value }\nfn main() -> i32 { id(i32, 1) + id(i32, 2) }",
+        )
+        .unwrap();
+        let work = output.body_analysis_work;
+        assert_eq!(work.specialized_body_exports_attempted, 1);
+        assert_eq!(work.specialized_body_exports_succeeded, 1);
+        assert_eq!(work.specialized_body_exports_rejected, 0);
+        let [export] = output.specialized_body_exports.as_slice() else {
+            panic!("one deduplicated specialization export expected");
+        };
+        assert_eq!(export.identity.base.name.as_ref(), "id");
+        assert_eq!(export.identity.type_arguments.len(), 1);
+        assert!(export.identity.value_arguments.is_empty());
+        assert_eq!(
+            work.specialized_body_export_instructions_emitted,
+            export.body.instructions.len()
+        );
+        assert_eq!(
+            work.specialized_body_export_places_emitted,
+            export.body.places.len()
+        );
+        assert_eq!(
+            work.specialized_body_export_strings_emitted,
+            export.body.strings.len()
+        );
+        assert!(export.body.instructions.iter().all(|instruction| !matches!(
+            instruction.data,
+            crate::SemanticBodyInstData::CallGeneric
+        )));
+    }
+
     fn named_method_lookup_work(irrelevant: usize) -> crate::BodyAnalysisWork {
         let mut source = String::from(
             "struct Target { fn answer() -> i32 { 42 } }\n\

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -6,7 +6,9 @@
 use std::sync::Arc;
 
 use crate::{Air, ParamSlotModes};
-use crate::{AirArgMode, AirPlaceBase, BodyOwnerToken, SemanticImportType};
+use crate::{
+    AirArgMode, AirPlaceBase, BodyOwnerToken, SemanticImportConstValue, SemanticImportType,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SemanticBodyDefinitionKind {
@@ -16,6 +18,8 @@ pub enum SemanticBodyDefinitionKind {
     Destructor,
     Struct,
     Enum,
+    ValueConst,
+    ModuleBinding,
 }
 
 /// Request-independent textual identity used only until the compiler joins it
@@ -44,6 +48,118 @@ impl AsRef<str> for SemanticBodyModuleIdentity {
 pub struct SemanticBodyExport {
     pub owner: BodyOwnerToken,
     pub body: SemanticBody<SemanticBodyDefinitionIdentity, Arc<str>>,
+}
+
+/// Request-independent identity of one completed generic specialization.
+///
+/// The base and every nested nominal/function value are declaration identities;
+/// no request-local symbol, type-pool, file, or AIR identifier crosses this seam.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SemanticSpecializationIdentity<K, M> {
+    pub base: K,
+    pub type_arguments: Arc<[SemanticImportType<K, M>]>,
+    pub value_arguments: Arc<[SemanticImportConstValue<K, M>]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticSpecializedBodyExport {
+    pub identity: SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
+    pub body: SemanticBody<SemanticBodyDefinitionIdentity, Arc<str>>,
+    pub dependencies: Arc<[SemanticBodyDefinitionIdentity]>,
+    pub dependency_boundary_complete: bool,
+}
+
+#[derive(Debug)]
+pub struct SemanticSpecializedBodyCandidate<K, IM, BM = IM> {
+    pub identity: SemanticSpecializationIdentity<K, IM>,
+    pub body_span: rue_span::Span,
+    pub body: SemanticBody<K, BM>,
+    pub dependencies: Arc<[K]>,
+    pub dependency_boundary_complete: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticSpecializedCandidateInstallWork {
+    pub attempts: usize,
+    pub successes: usize,
+    pub mapping_failures: usize,
+}
+
+impl<K, M> SemanticSpecializationIdentity<K, M> {
+    pub fn try_map_keys<K2, M2, E>(
+        &self,
+        key: &impl Fn(&K) -> Result<K2, E>,
+        module: &impl Fn(&M) -> Result<M2, E>,
+    ) -> Result<SemanticSpecializationIdentity<K2, M2>, E> {
+        fn ty<K, M, K2, M2, E>(
+            value: &SemanticImportType<K, M>,
+            key: &impl Fn(&K) -> Result<K2, E>,
+            module: &impl Fn(&M) -> Result<M2, E>,
+        ) -> Result<SemanticImportType<K2, M2>, E> {
+            use SemanticImportType as T;
+            Ok(match value {
+                T::I8 => T::I8,
+                T::I16 => T::I16,
+                T::I32 => T::I32,
+                T::I64 => T::I64,
+                T::U8 => T::U8,
+                T::U16 => T::U16,
+                T::U32 => T::U32,
+                T::U64 => T::U64,
+                T::Bool => T::Bool,
+                T::Unit => T::Unit,
+                T::Never => T::Never,
+                T::ComptimeType => T::ComptimeType,
+                T::BuiltinNominal { name, kind } => T::BuiltinNominal {
+                    name: name.clone(),
+                    kind: *kind,
+                },
+                T::Nominal(value) => T::Nominal(key(value)?),
+                T::Array { element, len } => T::Array {
+                    element: Box::new(ty(element, key, module)?),
+                    len: *len,
+                },
+                T::PtrConst(value) => T::PtrConst(Box::new(ty(value, key, module)?)),
+                T::PtrMut(value) => T::PtrMut(Box::new(ty(value, key, module)?)),
+                T::Module(value) => T::Module(module(value)?),
+                T::GenericParameter(index) => T::GenericParameter(*index),
+            })
+        }
+        fn value<K, M, K2, M2, E>(
+            value: &SemanticImportConstValue<K, M>,
+            key: &impl Fn(&K) -> Result<K2, E>,
+            module: &impl Fn(&M) -> Result<M2, E>,
+        ) -> Result<SemanticImportConstValue<K2, M2>, E> {
+            Ok(match value {
+                SemanticImportConstValue::Integer(value) => {
+                    SemanticImportConstValue::Integer(*value)
+                }
+                SemanticImportConstValue::Bool(value) => SemanticImportConstValue::Bool(*value),
+                SemanticImportConstValue::Type(value) => {
+                    SemanticImportConstValue::Type(ty(value, key, module)?)
+                }
+                SemanticImportConstValue::Function(value) => {
+                    SemanticImportConstValue::Function(key(value)?)
+                }
+                SemanticImportConstValue::Unit => SemanticImportConstValue::Unit,
+            })
+        }
+        Ok(SemanticSpecializationIdentity {
+            base: key(&self.base)?,
+            type_arguments: self
+                .type_arguments
+                .iter()
+                .map(|value| ty(value, key, module))
+                .collect::<Result<Vec<_>, _>>()?
+                .into(),
+            value_arguments: self
+                .value_arguments
+                .iter()
+                .map(|item| value(item, key, module))
+                .collect::<Result<Vec<_>, _>>()?
+                .into(),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -185,6 +301,12 @@ pub enum SemanticBodyInstData<K, M> {
     Ret(Option<SemanticBodyRef>),
     Call {
         function: K,
+        args: Arc<[SemanticBodyCallArg]>,
+    },
+    /// A call to another concrete specialization. Its stable generic origin
+    /// and ordered canonical arguments replace the request-local mangled name.
+    CallSpecialized {
+        identity: SemanticSpecializationIdentity<K, M>,
         args: Arc<[SemanticBodyCallArg]>,
     },
     CallGeneric,
@@ -440,6 +562,10 @@ impl<K, M> SemanticBody<K, M> {
                     D::Ret(v) => D::Ret(*v),
                     D::Call { function, args } => D::Call {
                         function: key(function)?,
+                        args: args.clone(),
+                    },
+                    D::CallSpecialized { identity, args } => D::CallSpecialized {
+                        identity: identity.try_map_keys(key, module)?,
                         args: args.clone(),
                     },
                     D::CallGeneric => D::CallGeneric,

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -183,6 +183,7 @@ where
                         SemanticImportFailure::MissingFunction,
                     ))
             },
+            |_| Err(SemanticBodyImportFailure::UnsupportedGenericCall),
             |name| self.interner.get_or_intern(name),
         )
     }
@@ -194,6 +195,12 @@ where
         struct_id: impl Fn(&K) -> Result<StructId, SemanticBodyImportFailure>,
         enum_id: impl Fn(&K) -> Result<EnumId, SemanticBodyImportFailure>,
         resolve_function: impl Fn(&K) -> Result<Spur, SemanticBodyImportFailure>,
+        resolve_specialization: impl Fn(
+            &crate::SemanticSpecializationIdentity<K, M>,
+        ) -> Result<
+            (Spur, Vec<Type>, Vec<crate::sema::ConstValue>),
+            SemanticBodyImportFailure,
+        >,
         intern: impl Fn(&str) -> Spur,
     ) -> Result<SemanticImportedBody, SemanticBodyImportFailure> {
         use SemanticBodyImportFailure as F;
@@ -403,6 +410,25 @@ where
                         name,
                         args_start: s,
                         args_len: l,
+                    }
+                }
+                SemanticBodyInstData::CallSpecialized { identity, args } => {
+                    let (name, type_args, value_args) = resolve_specialization(identity)?;
+                    let type_args = type_args.iter().map(|ty| ty.as_u32()).collect::<Vec<_>>();
+                    let type_args_start = air.add_extra(&type_args);
+                    let type_args_len = type_args.len() as u32;
+                    let value_args = crate::specialize::encode_const_values(&value_args);
+                    let value_args_start = air.add_extra(&value_args);
+                    let value_args_len = value_args.len() as u32;
+                    let (args_start, args_len) = call_args(&mut air, args, current)?;
+                    AirInstData::CallGeneric {
+                        name,
+                        type_args_start,
+                        type_args_len,
+                        value_args_start,
+                        value_args_len,
+                        args_start,
+                        args_len,
                     }
                 }
                 SemanticBodyInstData::CallGeneric => return Err(F::UnsupportedGenericCall),

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -172,6 +172,17 @@ pub(crate) struct Specializer {
     seen_warnings: HashSet<(std::mem::Discriminant<WarningKind>, Span)>,
     /// Expansion waves consumed across the entire joint sema fixed point.
     rounds: usize,
+    completed_exports: Vec<CompletedExport>,
+    next_unexported: usize,
+}
+
+struct CompletedExport {
+    key: SpecializationKey,
+    base_info: FunctionInfo,
+    function_index: usize,
+    warning_free: bool,
+    dependencies: Vec<crate::SemanticBodyDefinitionIdentity>,
+    dependency_boundary_complete: bool,
 }
 
 struct SpecializedBody {
@@ -180,6 +191,8 @@ struct SpecializedBody {
     local_strings: Vec<String>,
     referenced_functions: HashSet<Spur>,
     referenced_methods: HashSet<(StructId, Spur)>,
+    dependencies: Vec<crate::SemanticBodyDefinitionIdentity>,
+    dependency_boundary_complete: bool,
 }
 
 /// Maximum number of specialization rounds before giving up.
@@ -200,6 +213,65 @@ struct SpecializedBody {
 pub(crate) const MAX_SPECIALIZATION_ROUNDS: usize = 64;
 
 impl Specializer {
+    fn stable_identity(
+        key: &SpecializationKey,
+        sema: &crate::sema::BodySema<'_>,
+    ) -> Result<
+        crate::SemanticSpecializationIdentity<
+            crate::SemanticBodyDefinitionIdentity,
+            std::sync::Arc<str>,
+        >,
+        crate::SemanticBodyExportFailure,
+    > {
+        let base = sema.function_identity(key.base_name)?;
+        let type_arguments = key
+            .type_args
+            .iter()
+            .map(|value| sema.export_body_type(*value))
+            .collect::<Result<Vec<_>, _>>()?;
+        let value_arguments = key
+            .value_args
+            .iter()
+            .map(|value| {
+                Ok(match value {
+                    ConstValue::Integer(value) => crate::SemanticImportConstValue::Integer(*value),
+                    ConstValue::Bool(value) => crate::SemanticImportConstValue::Bool(*value),
+                    ConstValue::Type(value) => {
+                        crate::SemanticImportConstValue::Type(sema.export_body_type(*value)?)
+                    }
+                    ConstValue::Function(value) => {
+                        crate::SemanticImportConstValue::Function(sema.function_identity(*value)?)
+                    }
+                    ConstValue::Unit => crate::SemanticImportConstValue::Unit,
+                })
+            })
+            .collect::<Result<Vec<_>, crate::SemanticBodyExportFailure>>()?;
+        Ok(crate::SemanticSpecializationIdentity {
+            base,
+            type_arguments: type_arguments.into(),
+            value_arguments: value_arguments.into(),
+        })
+    }
+
+    fn take_reusable_body(
+        &self,
+        key: &SpecializationKey,
+        sema: &mut crate::sema::BodySema<'_>,
+    ) -> Option<
+        crate::SemanticSpecializedBodyCandidate<
+            crate::SemanticBodyDefinitionIdentity,
+            std::sync::Arc<str>,
+            crate::SemanticBodyModuleIdentity,
+        >,
+    > {
+        let identity = Self::stable_identity(key, sema).ok()?;
+        let index = sema
+            .reusable_specialized_bodies
+            .iter()
+            .position(|candidate| candidate.identity == identity)?;
+        Some(sema.reusable_specialized_bodies.remove(index))
+    }
+
     /// Analyze and rewrite every specialization reachable from newly appended
     /// bodies, returning ordinary references that must re-enter sema's worklist.
     ///
@@ -243,14 +315,66 @@ impl Specializer {
             self.next_unscanned = scan_end;
 
             if pending.is_empty() {
+                let specialized_calls = self
+                    .specializations
+                    .iter()
+                    .filter_map(|(key, info)| {
+                        Self::stable_identity(key, sema)
+                            .ok()
+                            .map(|identity| (info.mangled_name, identity))
+                    })
+                    .collect::<HashMap<_, _>>();
+                for candidate in &self.completed_exports[self.next_unexported..] {
+                    sema.body_analysis_work.specialized_body_exports_attempted += 1;
+                    let (function, strings) = &functions_with_strings[candidate.function_index];
+                    let warnings = if candidate.warning_free {
+                        &[][..]
+                    } else {
+                        // The durable warning algebra is intentionally lossless;
+                        // passing a marker preserves fail-closed behavior.
+                        sema.body_analysis_work.specialized_body_exports_rejected += 1;
+                        continue;
+                    };
+                    match sema.export_specialized_body(
+                        candidate.key.base_name,
+                        &candidate.base_info,
+                        &candidate.key.type_args,
+                        &candidate.key.value_args,
+                        function,
+                        strings,
+                        warnings,
+                        &specialized_calls,
+                        &candidate.dependencies,
+                        candidate.dependency_boundary_complete,
+                    ) {
+                        Ok(export) => {
+                            sema.body_analysis_work.specialized_body_exports_succeeded += 1;
+                            sema.body_analysis_work
+                                .specialized_body_export_instructions_emitted +=
+                                export.body.instructions.len();
+                            sema.body_analysis_work
+                                .specialized_body_export_places_emitted += export.body.places.len();
+                            sema.body_analysis_work
+                                .specialized_body_export_strings_emitted +=
+                                export.body.strings.len();
+                            sema.specialized_body_exports.push(export);
+                        }
+                        Err(_) => {
+                            sema.body_analysis_work.specialized_body_exports_rejected += 1;
+                        }
+                    }
+                }
+                self.next_unexported = self.completed_exports.len();
                 return Ok(discovered);
             }
 
+            // Every non-empty expansion wave consumes the persistent
+            // fixed-point budget. Reuse skips analysis, not expansion depth.
             self.rounds += 1;
             sema.body_analysis_work.specialization_rounds += 1;
             if self.rounds > MAX_SPECIALIZATION_ROUNDS {
-                let key = &pending[0];
                 sema.body_analysis_work.specialization_driver_failures += 1;
+                let key = &pending[0];
                 return Err(CompileError::new(
                     ErrorKind::ComptimeEvaluationFailed {
                         reason: format!(
@@ -269,7 +393,6 @@ impl Specializer {
             // Create specialized function bodies by re-analyzing with type
             // substitution. Newly created bodies are scanned next round.
             for key in &pending {
-                sema.body_analysis_work.specialized_bodies_attempted += 1;
                 let info = &self.specializations[key];
                 let base_info = match sema.function_info(key.base_name) {
                     Some(info) => info.clone(),
@@ -281,21 +404,78 @@ impl Specializer {
                         ));
                     }
                 };
-                let specialized = match create_specialized_function(
-                    sema,
-                    infer_ctx,
-                    key,
-                    info.mangled_name,
-                    &base_info,
-                    interner,
-                ) {
+                let reusable = self.take_reusable_body(key, sema).and_then(|candidate| {
+                    sema.body_analysis_work.specialized_body_import_attempts += 1;
+                    match crate::sema::analysis::import_staged_body(
+                        sema,
+                        &candidate.body,
+                        candidate.body_span,
+                    ) {
+                        Ok(imported) if imported.warnings.is_empty() => {
+                            sema.body_analysis_work.specialized_body_import_successes += 1;
+                            sema.body_analysis_work.specialized_body_import_instructions_installed +=
+                                imported.air.len();
+                            sema.body_analysis_work.specialized_body_import_places_installed +=
+                                imported.air.places().len();
+                            sema.body_analysis_work.specialized_body_import_strings_installed +=
+                                imported.strings.len();
+                            sema.body_analysis_work.specialized_bodies_reused += 1;
+                            sema.body_analysis_work.specialized_body_analyses_skipped += 1;
+                            let (referenced_functions, referenced_methods) =
+                                crate::sema::analysis::imported_body_references(sema, &imported.air);
+                            Some(SpecializedBody {
+                                function: AnalyzedFunction {
+                                    ordinary_owner: None,
+                                    name: interner.resolve(&info.mangled_name).to_string(),
+                                    implicit_drop_source: Some(
+                                        crate::sema::ImplicitDropDependencySourceEvent::Specialization {
+                                            identity: candidate.identity.clone(),
+                                        },
+                                    ),
+                                    air: imported.air,
+                                    num_locals: imported.num_locals,
+                                    num_param_slots: imported.num_param_slots,
+                                    param_modes: imported.param_modes,
+                                    allow_unreachable_code: imported.allow_unreachable_code,
+                                },
+                                warnings: Vec::new(),
+                                local_strings: imported.strings,
+                                referenced_functions,
+                                referenced_methods,
+                                dependencies: candidate.dependencies.to_vec(),
+                                dependency_boundary_complete: candidate
+                                    .dependency_boundary_complete,
+                            })
+                        }
+                        _ => {
+                            sema.body_analysis_work.specialized_body_import_failures += 1;
+                            None
+                        }
+                    }
+                });
+                let was_reused = reusable.is_some();
+                if !was_reused {
+                    sema.body_analysis_work.specialized_bodies_attempted += 1;
+                }
+                let specialized = match reusable.map(Ok).unwrap_or_else(|| {
+                    create_specialized_function(
+                        sema,
+                        infer_ctx,
+                        key,
+                        info.mangled_name,
+                        &base_info,
+                        interner,
+                    )
+                }) {
                     Ok(body) => body,
                     Err(error) => {
                         sema.body_analysis_work.specialized_bodies_failed += 1;
                         return Err(error);
                     }
                 };
-                sema.body_analysis_work.specialized_bodies_succeeded += 1;
+                if !was_reused {
+                    sema.body_analysis_work.specialized_bodies_succeeded += 1;
+                }
                 sema.body_analysis_work.air_instructions_produced +=
                     specialized.function.air.instructions().len();
                 sema.body_analysis_work.local_strings_produced += specialized.local_strings.len();
@@ -346,6 +526,20 @@ impl Specializer {
                         .specialized_free_function_dependency_events += 1;
                 }
 
+                let mut dependencies = specialized.dependencies;
+                let mut dependency_boundary_complete = specialized.dependency_boundary_complete;
+                for function in &specialized.referenced_functions {
+                    match sema.function_identity(*function) {
+                        Ok(identity) => dependencies.push(identity),
+                        Err(_) => dependency_boundary_complete = false,
+                    }
+                }
+                if !specialized.referenced_methods.is_empty() {
+                    dependency_boundary_complete = false;
+                }
+                dependencies.sort();
+                dependencies.dedup();
+
                 discovered
                     .functions
                     .extend(specialized.referenced_functions);
@@ -358,6 +552,7 @@ impl Specializer {
                 // function was non-generic). A warning that fires in ANY
                 // specialization is surfaced: with comptime-pruned branches
                 // the body that triggers it is really compiled.
+                let warning_free = specialized.warnings.is_empty();
                 for warning in specialized.warnings {
                     if let Some(span) = warning.span()
                         && self
@@ -367,7 +562,16 @@ impl Specializer {
                         all_warnings.push(warning);
                     }
                 }
+                let function_index = functions_with_strings.len();
                 functions_with_strings.push((specialized.function, specialized.local_strings));
+                self.completed_exports.push(CompletedExport {
+                    key: key.clone(),
+                    base_info,
+                    function_index,
+                    warning_free,
+                    dependencies,
+                    dependency_boundary_complete,
+                });
             }
         }
     }
@@ -656,6 +860,41 @@ fn create_specialized_function(
         specialized_params.push((name, concrete_ty, mode, is_comptime));
     }
 
+    let source_name = sema.source_function_name(key.base_name);
+    let source_name_text = sema.interner.resolve(&source_name).to_string();
+    let owner = crate::sema::AnalyzedBodyOwnerEvent::FreeFunction {
+        token: sema.body_owner_token(
+            base_info.file_id,
+            &source_name_text,
+            None,
+            crate::sema::BodyOwnerKind::FreeFunction,
+        ),
+        file: base_info.file_id.index(),
+        name: source_name_text.clone(),
+    };
+    let body_dependency_start = sema.body_named_dependencies.len();
+    let type_dependency_start = sema.declaration_type_dependencies.len();
+    let type_call_head_start = sema.declaration_type_call_head_dependencies.len();
+    let builtin_call_head_start = sema.declaration_builtin_type_call_head_dependencies.len();
+    let previous_body_observer = sema.body_dependency_observer.replace(owner);
+    let previous_type_observer = sema.declaration_type_observer.replace((
+        base_info.file_id,
+        source_name_text.clone(),
+        None,
+        crate::sema::DeclarationTypeDependencySourceKind::Function,
+        crate::sema::DeclarationTypeDependencyKind::Body,
+    ));
+
+    let analysis = sema.analyze_specialized_function(
+        infer_ctx,
+        return_type,
+        &specialized_params,
+        base_info.body,
+        &type_subst,
+        &value_subst,
+    );
+    sema.body_dependency_observer = previous_body_observer;
+    sema.declaration_type_observer = previous_type_observer;
     let (
         air,
         num_locals,
@@ -665,35 +904,99 @@ fn create_specialized_function(
         local_strings,
         referenced_functions,
         referenced_methods,
-    ) = sema.analyze_specialized_function(
-        infer_ctx,
-        return_type,
-        &specialized_params,
-        base_info.body,
-        &type_subst,
-        &value_subst,
-    )?;
+    ) = analysis?;
+
+    let mut dependencies = Vec::new();
+    for event in &sema.body_named_dependencies[body_dependency_start..] {
+        let (file_id, name, kind) = match &event.target {
+            crate::sema::NamedConstDependencyTargetEvent::ValueConst { file, name } => (
+                *file,
+                name.as_str(),
+                crate::SemanticBodyDefinitionKind::ValueConst,
+            ),
+            crate::sema::NamedConstDependencyTargetEvent::FreeFunction { file, name } => (
+                *file,
+                name.as_str(),
+                crate::SemanticBodyDefinitionKind::FreeFunction,
+            ),
+            crate::sema::NamedConstDependencyTargetEvent::NamedType { file, name, kind } => (
+                *file,
+                name.as_str(),
+                match kind {
+                    crate::sema::DeclarationTypeDependencyTargetKind::Struct => {
+                        crate::SemanticBodyDefinitionKind::Struct
+                    }
+                    crate::sema::DeclarationTypeDependencyTargetKind::Enum => {
+                        crate::SemanticBodyDefinitionKind::Enum
+                    }
+                    crate::sema::DeclarationTypeDependencyTargetKind::ValueConst => {
+                        crate::SemanticBodyDefinitionKind::ValueConst
+                    }
+                },
+            ),
+            crate::sema::NamedConstDependencyTargetEvent::ModuleBinding { file, name } => (
+                *file,
+                name.as_str(),
+                crate::SemanticBodyDefinitionKind::ModuleBinding,
+            ),
+        };
+        dependencies.push(crate::SemanticBodyDefinitionIdentity {
+            file_id,
+            name: std::sync::Arc::from(name),
+            kind,
+            owner: None,
+        });
+    }
+    for event in &sema.declaration_type_dependencies[type_dependency_start..] {
+        dependencies.push(crate::SemanticBodyDefinitionIdentity {
+            file_id: event.target_file,
+            name: std::sync::Arc::from(event.target_name.as_str()),
+            kind: match event.target_kind {
+                crate::sema::DeclarationTypeDependencyTargetKind::Struct => {
+                    crate::SemanticBodyDefinitionKind::Struct
+                }
+                crate::sema::DeclarationTypeDependencyTargetKind::Enum => {
+                    crate::SemanticBodyDefinitionKind::Enum
+                }
+                crate::sema::DeclarationTypeDependencyTargetKind::ValueConst => {
+                    crate::SemanticBodyDefinitionKind::ValueConst
+                }
+            },
+            owner: None,
+        });
+    }
+    for event in &sema.declaration_type_call_head_dependencies[type_call_head_start..] {
+        dependencies.push(crate::SemanticBodyDefinitionIdentity {
+            file_id: event.callable_file,
+            name: std::sync::Arc::from(event.callable_name.as_str()),
+            kind: crate::SemanticBodyDefinitionKind::FreeFunction,
+            owner: None,
+        });
+    }
+    // Builtin type call heads are compiler-schema inputs rather than source
+    // definitions; their meaning is covered by the durable schema version.
+    let dependency_boundary_complete = sema.declaration_builtin_type_call_head_dependencies
+        [builtin_call_head_start..]
+        .iter()
+        .all(|event| {
+            matches!(
+                event.builtin,
+                crate::sema::BuiltinTypeCallHead::FixedCapacityString
+            )
+        });
+    dependencies.sort();
+    dependencies.dedup();
 
     Ok(SpecializedBody {
         function: AnalyzedFunction {
             ordinary_owner: None,
             name: specialized_name_str,
-            implicit_drop_source: Some(
-                crate::sema::ImplicitDropDependencySourceEvent::FreeFunction {
-                    token: sema.body_owner_token(
-                        base_info.file_id,
-                        sema.interner
-                            .resolve(&sema.source_function_name(key.base_name)),
-                        None,
-                        crate::sema::BodyOwnerKind::FreeFunction,
-                    ),
-                    file: base_info.file_id.index(),
-                    name: sema
-                        .interner
-                        .resolve(&sema.source_function_name(key.base_name))
-                        .to_string(),
+            implicit_drop_source: Some(Specializer::stable_identity(key, sema).map_or(
+                crate::sema::ImplicitDropDependencySourceEvent::Anonymous,
+                |identity| crate::sema::ImplicitDropDependencySourceEvent::Specialization {
+                    identity,
                 },
-            ),
+            )),
             air,
             num_locals,
             num_param_slots,
@@ -704,5 +1007,7 @@ fn create_specialized_function(
         local_strings,
         referenced_functions,
         referenced_methods,
+        dependencies,
+        dependency_boundary_complete,
     })
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -18,6 +18,14 @@ pub(crate) struct PreparedDurableBodyCandidate {
     pub body: rue_air::SemanticBody<crate::StableDefinitionKey, Arc<str>>,
 }
 
+pub(crate) struct PreparedDurableSpecializedBodyCandidate {
+    pub identity: rue_air::SemanticSpecializationIdentity<crate::StableDefinitionKey, Arc<str>>,
+    pub body_span: rue_span::Span,
+    pub body: rue_air::SemanticBody<crate::StableDefinitionKey, Arc<str>>,
+    pub dependencies: Arc<[crate::StableDefinitionKey]>,
+    pub dependency_boundary_complete: bool,
+}
+
 fn fold_body_import_work(durable: &mut crate::DurableBodyWork, body: BodyAnalysisWork) {
     durable.import_attempts += body.ordinary_body_import_attempts;
     durable.import_successes += body.ordinary_body_import_successes;
@@ -376,6 +384,7 @@ pub struct CanonicalSemanticOutput {
     bound_definitions: Option<BoundDefinitionSet>,
     body_owner_issuer: BoundDefinitionSet,
     durable_ordinary_body_payloads: Arc<[crate::DurableOrdinaryBodyPayload]>,
+    durable_specialized_body_payloads: Arc<[crate::DurableSpecializedBodyPayload]>,
     work: CanonicalSemanticWork,
     analyzed_body_owners: Vec<AnalyzedBodyOwnerEvent>,
     body_named_dependencies: Vec<BodyNamedDependencyEvent>,
@@ -518,6 +527,10 @@ impl CanonicalSemanticOutput {
     pub(crate) fn durable_ordinary_body_payloads(&self) -> &[crate::DurableOrdinaryBodyPayload] {
         &self.durable_ordinary_body_payloads
     }
+
+    pub fn durable_specialized_body_payloads(&self) -> &[crate::DurableSpecializedBodyPayload] {
+        &self.durable_specialized_body_payloads
+    }
     /// Structural work performed by this request.
     pub fn work(&self) -> CanonicalSemanticWork {
         self.work
@@ -562,6 +575,7 @@ pub(crate) fn analyze_canonical_program(
         definitions,
         CanonicalDeclarationReuseWork::default(),
         Vec::new(),
+        Vec::new(),
         crate::DurableBodyWork::default(),
         info_span!("sema").entered(),
     )
@@ -579,6 +593,7 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
     prepared: CanonicalPreparedDeclarations<'_>,
     reuse_plan: CanonicalDeclarationReuseWork,
     body_candidates: Vec<PreparedDurableBodyCandidate>,
+    specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     body_work: crate::DurableBodyWork,
 ) -> Result<CanonicalOrdinaryAnalysis, CanonicalSemanticFailure> {
     let input = CodegenInputDescriptor {
@@ -627,6 +642,7 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
             ..declaration_reuse
         },
         body_candidates,
+        specialized_body_candidates,
         body_work,
         sema_span,
     )?;
@@ -650,6 +666,7 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     definitions: &BoundDefinitionSet,
     durable: &[DurableDeclarationSemantic],
     body_candidates: Vec<PreparedDurableBodyCandidate>,
+    specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     body_work: crate::DurableBodyWork,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
     let input = CodegenInputDescriptor {
@@ -778,6 +795,7 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
         selected_definitions,
         reuse,
         body_candidates,
+        specialized_body_candidates,
         body_work,
         sema_span,
     )
@@ -815,6 +833,7 @@ fn finish_canonical_analysis(
     provisional_definitions: BoundDefinitionSet,
     declaration_reuse: CanonicalDeclarationReuseWork,
     durable_body_candidates: Vec<PreparedDurableBodyCandidate>,
+    durable_specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     mut durable_body_reuse_work: crate::DurableBodyWork,
     sema_span: tracing::span::EnteredSpan,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
@@ -998,6 +1017,54 @@ fn finish_canonical_analysis(
         },
         |module: &std::sync::Arc<str>| modules.get(module.as_ref()).copied(),
     );
+    let specialized_air_candidates = durable_specialized_body_candidates
+        .into_iter()
+        .map(|candidate| rue_air::SemanticSpecializedBodyCandidate {
+            identity: candidate.identity,
+            body_span: candidate.body_span,
+            body: candidate.body,
+            dependencies: candidate.dependencies,
+            dependency_boundary_complete: candidate.dependency_boundary_complete,
+        })
+        .collect();
+    let (bound, specialized_install_work) = bound.install_specialized_body_candidates(
+        specialized_air_candidates,
+        |key: &crate::StableDefinitionKey| {
+            let record = authoritative_definitions.definition_by_key(key)?;
+            let kind = match key.kind() {
+                crate::StableDefinitionKind::Function => {
+                    rue_air::SemanticBodyDefinitionKind::FreeFunction
+                }
+                crate::StableDefinitionKind::Method => rue_air::SemanticBodyDefinitionKind::Method,
+                crate::StableDefinitionKind::AssociatedFunction => {
+                    rue_air::SemanticBodyDefinitionKind::AssociatedFunction
+                }
+                crate::StableDefinitionKind::Destructor => {
+                    rue_air::SemanticBodyDefinitionKind::Destructor
+                }
+                crate::StableDefinitionKind::Struct => rue_air::SemanticBodyDefinitionKind::Struct,
+                crate::StableDefinitionKind::Enum => rue_air::SemanticBodyDefinitionKind::Enum,
+                crate::StableDefinitionKind::ValueConst => {
+                    rue_air::SemanticBodyDefinitionKind::ValueConst
+                }
+                crate::StableDefinitionKind::ModuleBinding => {
+                    rue_air::SemanticBodyDefinitionKind::ModuleBinding
+                }
+            };
+            Some(rue_air::SemanticBodyDefinitionIdentity {
+                file_id: record.declaration_span().file_id.index(),
+                name: Arc::from(key.name()),
+                kind,
+                owner: key.owner().map(|owner| Arc::from(owner.name())),
+            })
+        },
+        |module: &Arc<str>| modules.get(module.as_ref()).copied(),
+    );
+    durable_body_reuse_work.specialized_mapping_attempts += specialized_install_work.attempts;
+    durable_body_reuse_work.specialized_mapping_successes += specialized_install_work.successes;
+    durable_body_reuse_work.specialized_mapping_failures +=
+        specialized_install_work.mapping_failures;
+    durable_body_reuse_work.candidate_fallbacks += specialized_install_work.mapping_failures;
     let sema_output = match bound.analyze_all_bodies_with_work() {
         Ok(output) => output,
         Err(failure) => {
@@ -1044,6 +1111,13 @@ fn finish_canonical_analysis(
     };
     let durable_ordinary_body_payloads = crate::convert_semantic_body_exports(
         &sema_output.ordinary_body_exports,
+        merged,
+        &authoritative_definitions,
+        &mut durable_body_work,
+    )
+    .unwrap_or_else(|_| Arc::from([]));
+    let durable_specialized_body_payloads = crate::convert_semantic_specialized_body_exports(
+        &sema_output.specialized_body_exports,
         merged,
         &authoritative_definitions,
         &mut durable_body_work,
@@ -1105,6 +1179,15 @@ fn finish_canonical_analysis(
             work,
         )
     })?;
+    let durable_specialized_body_payloads =
+        crate::durable_body::attach_specialized_implicit_drop_dependencies(
+            durable_specialized_body_payloads,
+            &cfg.implicit_named_destructor_dependencies,
+            merged,
+            &authoritative_definitions,
+            &mut durable_body_work,
+        )
+        .unwrap_or_else(|_| Arc::from([]));
     let mut warnings = cfg.warnings;
     warnings.sort_by(|left, right| {
         let key = |warning: &CompileWarning| {
@@ -1150,6 +1233,7 @@ fn finish_canonical_analysis(
         bound_definitions,
         body_owner_issuer: authoritative_definitions,
         durable_ordinary_body_payloads,
+        durable_specialized_body_payloads,
         work,
         analyzed_body_owners,
         body_named_dependencies,

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -12,7 +12,8 @@ use std::{
 
 use rue_air::{
     AirArgMode, AirPlaceBase, SemanticBodyDefinitionIdentity, SemanticBodyDefinitionKind,
-    SemanticBodyInstData, SemanticBodyPattern, SemanticBodyProjection, SemanticImportType,
+    SemanticBodyInstData, SemanticBodyPattern, SemanticBodyProjection, SemanticImportConstValue,
+    SemanticImportType,
 };
 
 use crate::{
@@ -20,7 +21,8 @@ use crate::{
     StableDefinitionKey, StableDefinitionKind,
 };
 
-pub const DURABLE_ORDINARY_BODY_SCHEMA_VERSION: u32 = 3;
+pub const DURABLE_ORDINARY_BODY_SCHEMA_VERSION: u32 = 4;
+pub const DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION: u32 = 2;
 
 pub type DurableAirRef = u32;
 pub type DurablePlaceRef = u32;
@@ -146,6 +148,10 @@ pub enum DurableAirInstData {
         function: StableDefinitionKey,
         args: Arc<[DurableCallArg]>,
     },
+    CallSpecialized {
+        identity: DurableSpecializationIdentity,
+        args: Arc<[DurableCallArg]>,
+    },
     Intrinsic {
         name: Arc<str>,
         args: Arc<[DurableCallArg]>,
@@ -234,10 +240,139 @@ pub struct DurableOrdinaryBody {
     pub inputs: StableBodyDependencyInputRecord,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DurableSpecializationIdentity {
+    pub base: StableDefinitionKey,
+    pub type_arguments: Arc<[DurableType]>,
+    pub value_arguments: Arc<[crate::DurableConstValue]>,
+}
+
+impl DurableSpecializationIdentity {
+    fn import_dto(&self) -> rue_air::SemanticSpecializationIdentity<StableDefinitionKey, Arc<str>> {
+        rue_air::SemanticSpecializationIdentity {
+            base: self.base.clone(),
+            type_arguments: self
+                .type_arguments
+                .iter()
+                .map(DurableType::import_dto)
+                .collect::<Vec<_>>()
+                .into(),
+            value_arguments: self
+                .value_arguments
+                .iter()
+                .map(crate::DurableConstValue::import_dto)
+                .collect::<Vec<_>>()
+                .into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DurableSpecializedBodyPayload {
+    pub schema_version: u32,
+    pub identity: DurableSpecializationIdentity,
+    /// The completed body uses the same durable AIR algebra as ordinary bodies.
+    pub body: DurableOrdinaryBodyPayload,
+    pub dependencies: Arc<[StableDefinitionKey]>,
+    pub dependency_boundary_complete: bool,
+}
+
+/// A completed specialized body together with the exact stable inputs that
+/// authorize reusing this particular specialization in a later revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DurableSpecializedBody {
+    pub payload: DurableSpecializedBodyPayload,
+    pub inputs: StableBodyDependencyInputRecord,
+}
+
+impl DurableSpecializedBody {
+    pub fn identity(&self) -> &DurableSpecializationIdentity {
+        &self.payload.identity
+    }
+
+    pub fn inputs(&self) -> &StableBodyDependencyInputRecord {
+        &self.inputs
+    }
+
+    pub fn project_semantic_candidate(
+        &self,
+        body_span: rue_span::Span,
+        work: &mut DurableBodyWork,
+    ) -> Result<
+        rue_air::SemanticSpecializedBodyCandidate<StableDefinitionKey, Arc<str>>,
+        DurableBodyProjectionFailure,
+    > {
+        if self.inputs.owner() != &self.payload.identity.base
+            || self.inputs.fingerprint() != &self.payload.body.expected_inputs
+        {
+            work.projection_attempts += 1;
+            work.projection_failures += 1;
+            return Err(DurableBodyProjectionFailure::InputFingerprintMismatch);
+        }
+        self.payload.project_semantic_candidate(body_span, work)
+    }
+}
+
+impl DurableSpecializedBodyPayload {
+    pub fn project_semantic_candidate(
+        &self,
+        body_span: rue_span::Span,
+        work: &mut DurableBodyWork,
+    ) -> Result<
+        rue_air::SemanticSpecializedBodyCandidate<StableDefinitionKey, Arc<str>>,
+        DurableBodyProjectionFailure,
+    > {
+        if self.schema_version != DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION
+            || self.body.owner != self.identity.base
+        {
+            work.projection_attempts += 1;
+            work.projection_failures += 1;
+            return Err(DurableBodyProjectionFailure::SchemaVersionMismatch);
+        }
+        let value = |value: &crate::DurableConstValue| match value {
+            crate::DurableConstValue::Integer(value) => SemanticImportConstValue::Integer(*value),
+            crate::DurableConstValue::Bool(value) => SemanticImportConstValue::Bool(*value),
+            crate::DurableConstValue::Type(value) => {
+                SemanticImportConstValue::Type(value.import_dto())
+            }
+            crate::DurableConstValue::Function(value) => {
+                SemanticImportConstValue::Function(value.clone())
+            }
+            crate::DurableConstValue::Unit => SemanticImportConstValue::Unit,
+        };
+        Ok(rue_air::SemanticSpecializedBodyCandidate {
+            identity: rue_air::SemanticSpecializationIdentity {
+                base: self.identity.base.clone(),
+                type_arguments: self
+                    .identity
+                    .type_arguments
+                    .iter()
+                    .map(DurableType::import_dto)
+                    .collect::<Vec<_>>()
+                    .into(),
+                value_arguments: self
+                    .identity
+                    .value_arguments
+                    .iter()
+                    .map(value)
+                    .collect::<Vec<_>>()
+                    .into(),
+            },
+            body_span,
+            body: self.body.project_semantic_body(work)?,
+            dependencies: self.dependencies.clone(),
+            dependency_boundary_complete: self.dependency_boundary_complete,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct DurableBodyWork {
     pub candidate_comparisons: usize,
     pub candidate_fallbacks: usize,
+    pub specialized_mapping_attempts: usize,
+    pub specialized_mapping_successes: usize,
+    pub specialized_mapping_failures: usize,
     pub export_attempts: usize,
     pub export_successes: usize,
     pub export_rejections: usize,
@@ -312,7 +447,8 @@ fn semantic_kind(kind: StableDefinitionKind) -> Option<SemanticBodyDefinitionKin
         StableDefinitionKind::Destructor => Some(SemanticBodyDefinitionKind::Destructor),
         StableDefinitionKind::Struct => Some(SemanticBodyDefinitionKind::Struct),
         StableDefinitionKind::Enum => Some(SemanticBodyDefinitionKind::Enum),
-        StableDefinitionKind::ValueConst | StableDefinitionKind::ModuleBinding => None,
+        StableDefinitionKind::ValueConst => Some(SemanticBodyDefinitionKind::ValueConst),
+        StableDefinitionKind::ModuleBinding => Some(SemanticBodyDefinitionKind::ModuleBinding),
     }
 }
 
@@ -472,6 +608,185 @@ fn durable_builtin_nominal(
         name: name.clone(),
         kind,
     })
+}
+
+fn durable_const_value(
+    value: &SemanticImportConstValue<SemanticBodyDefinitionIdentity, Arc<str>>,
+    merged: &CanonicalMergedProgram,
+    index: &DefinitionJoinIndex<'_>,
+    work: &mut DurableBodyWork,
+) -> Result<crate::DurableConstValue, DurableBodyConversionFailure> {
+    Ok(match value {
+        SemanticImportConstValue::Integer(value) => crate::DurableConstValue::Integer(*value),
+        SemanticImportConstValue::Bool(value) => crate::DurableConstValue::Bool(*value),
+        SemanticImportConstValue::Type(value) => {
+            crate::DurableConstValue::Type(durable_type(value, merged, index, work)?)
+        }
+        SemanticImportConstValue::Function(value) => {
+            let key = join_definition(value, index, work)?;
+            if !matches!(
+                key.kind(),
+                StableDefinitionKind::Function
+                    | StableDefinitionKind::Method
+                    | StableDefinitionKind::AssociatedFunction
+            ) {
+                return Err(DurableBodyConversionFailure::WrongDefinitionKind);
+            }
+            crate::DurableConstValue::Function(key.clone())
+        }
+        SemanticImportConstValue::Unit => crate::DurableConstValue::Unit,
+    })
+}
+
+fn durable_specialization_identity(
+    identity: &rue_air::SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
+    merged: &CanonicalMergedProgram,
+    index: &DefinitionJoinIndex<'_>,
+    work: &mut DurableBodyWork,
+) -> Result<DurableSpecializationIdentity, DurableBodyConversionFailure> {
+    let base = join_definition(&identity.base, index, work)?.clone();
+    if base.kind() != StableDefinitionKind::Function {
+        return Err(DurableBodyConversionFailure::WrongDefinitionKind);
+    }
+    Ok(DurableSpecializationIdentity {
+        base,
+        type_arguments: identity
+            .type_arguments
+            .iter()
+            .map(|value| durable_type(value, merged, index, work))
+            .collect::<Result<Vec<_>, _>>()?
+            .into(),
+        value_arguments: identity
+            .value_arguments
+            .iter()
+            .map(|value| durable_const_value(value, merged, index, work))
+            .collect::<Result<Vec<_>, _>>()?
+            .into(),
+    })
+}
+
+fn durable_identity_dependency_keys(
+    identity: &DurableSpecializationIdentity,
+) -> BTreeSet<StableDefinitionKey> {
+    fn visit_type(value: &DurableType, keys: &mut BTreeSet<StableDefinitionKey>) {
+        match value {
+            DurableType::Nominal(key) => {
+                keys.insert(key.clone());
+            }
+            DurableType::Array { element, .. }
+            | DurableType::PtrConst(element)
+            | DurableType::PtrMut(element) => visit_type(element, keys),
+            _ => {}
+        }
+    }
+    let mut keys = BTreeSet::new();
+    for value in identity.type_arguments.iter() {
+        visit_type(value, &mut keys);
+    }
+    for value in identity.value_arguments.iter() {
+        match value {
+            crate::DurableConstValue::Type(value) => visit_type(value, &mut keys),
+            crate::DurableConstValue::Function(key) => {
+                keys.insert(key.clone());
+            }
+            _ => {}
+        }
+    }
+    keys
+}
+
+/// Atomically joins completed specialization identities and bodies to stable
+/// compiler-owned values. A failed identity, argument, or body conversion
+/// discards the whole export set, never a partially stable artifact.
+pub fn convert_semantic_specialized_body_exports(
+    exports: &[rue_air::SemanticSpecializedBodyExport],
+    merged: &CanonicalMergedProgram,
+    definitions: &BoundDefinitionSet,
+    work: &mut DurableBodyWork,
+) -> Result<Arc<[DurableSpecializedBodyPayload]>, DurableBodyConversionFailure> {
+    if definitions.source_revision() != merged.ast().source_revision() {
+        work.atomic_discards += usize::from(!exports.is_empty());
+        return Err(DurableBodyConversionFailure::ForeignRevision);
+    }
+    let index = DefinitionJoinIndex::new(merged, definitions);
+    let mut converted = Vec::with_capacity(exports.len());
+    for export in exports {
+        let identity = durable_specialization_identity(&export.identity, merged, &index, work)?;
+        let base = identity.base.clone();
+        let token = definitions
+            .body_owner_endpoints()
+            .into_iter()
+            .find(|endpoint| definitions.key_for_body_token(endpoint.token).ok() == Some(&base))
+            .map(|endpoint| endpoint.token)
+            .ok_or(DurableBodyConversionFailure::MissingStableDefinition)?;
+        let ordinary = rue_air::SemanticBodyExport {
+            owner: token,
+            body: export.body.clone(),
+        };
+        let bodies = convert_semantic_body_exports(&[ordinary], merged, definitions, work)?;
+        let [body] = bodies.as_ref() else {
+            work.atomic_discards += 1;
+            return Err(DurableBodyConversionFailure::MissingStableDefinition);
+        };
+        let mut dependencies = export
+            .dependencies
+            .iter()
+            .map(|dependency| join_definition(dependency, &index, work).cloned())
+            .collect::<Result<BTreeSet<_>, _>>()?;
+        dependencies.extend(durable_identity_dependency_keys(&identity));
+        converted.push(DurableSpecializedBodyPayload {
+            schema_version: DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION,
+            identity,
+            body: body.clone(),
+            dependencies: dependencies.into_iter().collect::<Vec<_>>().into(),
+            dependency_boundary_complete: export.dependency_boundary_complete,
+        });
+    }
+    Ok(converted.into())
+}
+
+/// Attach destructor inputs observed by CFG lowering to the exact completed
+/// specialization that owned the drop. No dependency is inferred from types
+/// merely mentioned or borrowed by the body.
+pub fn attach_specialized_implicit_drop_dependencies(
+    payloads: Arc<[DurableSpecializedBodyPayload]>,
+    events: &[rue_air::ImplicitNamedDestructorDependencyEvent],
+    merged: &CanonicalMergedProgram,
+    definitions: &BoundDefinitionSet,
+    work: &mut DurableBodyWork,
+) -> Result<Arc<[DurableSpecializedBodyPayload]>, DurableBodyConversionFailure> {
+    let index = DefinitionJoinIndex::new(merged, definitions);
+    let mut payloads = payloads.to_vec();
+    for event in events {
+        let rue_air::ImplicitDropDependencySourceEvent::Specialization { identity } = &event.source
+        else {
+            continue;
+        };
+        let identity = durable_specialization_identity(identity, merged, &index, work)?;
+        let Some(payload) = payloads
+            .iter_mut()
+            .find(|payload| payload.identity == identity)
+        else {
+            // Warning-producing and otherwise rejected exports have no durable
+            // payload to enrich.
+            continue;
+        };
+        let destructor = rue_air::SemanticBodyDefinitionIdentity {
+            file_id: event.target_file,
+            name: Arc::from(event.target_owner_name.as_str()),
+            kind: rue_air::SemanticBodyDefinitionKind::Destructor,
+            owner: Some(Arc::from(event.target_owner_name.as_str())),
+        };
+        let destructor = join_definition(&destructor, &index, work)?.clone();
+        let mut dependencies = payload
+            .dependencies
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        dependencies.insert(destructor);
+        payload.dependencies = dependencies.into_iter().collect::<Vec<_>>().into();
+    }
+    Ok(payloads.into())
 }
 
 /// Atomically join AIR's neutral ordinary-body exports to the authoritative
@@ -634,6 +949,17 @@ pub fn convert_semantic_body_exports(
                     function: key(function, work)?,
                     args: args.iter().map(arg).collect::<Vec<_>>().into(),
                 },
+                SemanticBodyInstData::CallSpecialized { identity, args } => {
+                    DurableAirInstData::CallSpecialized {
+                        identity: durable_specialization_identity(
+                            identity,
+                            merged,
+                            &join_index,
+                            work,
+                        )?,
+                        args: args.iter().map(arg).collect::<Vec<_>>().into(),
+                    }
+                }
                 SemanticBodyInstData::CallGeneric => {
                     return Err(DurableBodyConversionFailure::UnsupportedGenericCall);
                 }
@@ -899,6 +1225,21 @@ impl DurableOrdinaryBodyPayload {
                 DurableAirInstData::Call { function, .. } => {
                     keys.insert(function.clone());
                 }
+                DurableAirInstData::CallSpecialized { identity, .. } => {
+                    keys.insert(identity.base.clone());
+                    for ty in identity.type_arguments.iter() {
+                        visit_type(ty, &mut keys);
+                    }
+                    for value in identity.value_arguments.iter() {
+                        match value {
+                            crate::DurableConstValue::Type(ty) => visit_type(ty, &mut keys),
+                            crate::DurableConstValue::Function(key) => {
+                                keys.insert(key.clone());
+                            }
+                            _ => {}
+                        }
+                    }
+                }
                 DurableAirInstData::StructInit { struct_key, .. } => {
                     keys.insert(struct_key.clone());
                 }
@@ -1062,9 +1403,9 @@ impl DurableOrdinaryBodyPayload {
                 D::Alloc { init, .. } => check(*init),
                 D::Store { value, .. } | D::ParamStore { value, .. } => check(*value),
                 D::Ret(value) => value.map_or(Ok(()), &check),
-                D::Call { args, .. } | D::Intrinsic { args, .. } => {
-                    args.iter().try_for_each(|arg| check(arg.value))
-                }
+                D::Call { args, .. }
+                | D::CallSpecialized { args, .. }
+                | D::Intrinsic { args, .. } => args.iter().try_for_each(|arg| check(arg.value)),
                 D::Block { statements, value } => {
                     check_all(statements).and_then(|()| check(*value))
                 }
@@ -1209,6 +1550,10 @@ impl DurableOrdinaryBodyPayload {
                 DurableAirInstData::Ret(v) => S::Ret(*v),
                 DurableAirInstData::Call { function, args } => S::Call {
                     function: function.clone(),
+                    args: args.iter().map(arg).collect::<Vec<_>>().into(),
+                },
+                DurableAirInstData::CallSpecialized { identity, args } => S::CallSpecialized {
+                    identity: identity.import_dto(),
                     args: args.iter().map(arg).collect::<Vec<_>>().into(),
                 },
                 DurableAirInstData::Intrinsic { name, args } => S::Intrinsic {
@@ -1395,6 +1740,43 @@ mod tests {
     }
 
     #[test]
+    fn specialization_identity_preserves_all_durable_argument_kinds() {
+        let function = StableDefinitionKey::for_test(
+            ModuleId::from_logical_path("helpers.rue").unwrap(),
+            StableDefinitionNamespace::Value,
+            StableDefinitionKind::Function,
+            "helper",
+            None,
+        );
+        let identity = DurableSpecializationIdentity {
+            base: owner(),
+            type_arguments: Arc::from([DurableType::I32]),
+            value_arguments: Arc::from([
+                crate::DurableConstValue::Bool(true),
+                crate::DurableConstValue::Type(DurableType::I64),
+                crate::DurableConstValue::Function(function.clone()),
+                crate::DurableConstValue::Unit,
+            ]),
+        };
+
+        let projected = identity.import_dto();
+        assert_eq!(projected.base, owner());
+        assert_eq!(
+            projected.type_arguments.as_ref(),
+            &[SemanticImportType::I32]
+        );
+        assert_eq!(
+            projected.value_arguments.as_ref(),
+            &[
+                SemanticImportConstValue::Bool(true),
+                SemanticImportConstValue::Type(SemanticImportType::I64),
+                SemanticImportConstValue::Function(function),
+                SemanticImportConstValue::Unit,
+            ]
+        );
+    }
+
+    #[test]
     fn projection_rejects_forward_instruction_references() {
         let candidate = payload(vec![instruction(DurableAirInstData::Ret(Some(0)))]);
         let mut work = DurableBodyWork::default();
@@ -1459,6 +1841,10 @@ mod tests {
                 name: Arc::from("Arch"),
                 kind: Enum,
             })
+        );
+        assert_eq!(
+            durable_builtin_nominal(&Arc::from("str"), Enum),
+            Err(DurableBodyConversionFailure::WrongDefinitionKind)
         );
     }
 

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -51,7 +51,7 @@ impl DurableType {
 }
 
 impl DurableConstValue {
-    fn import_dto(&self) -> SemanticImportConstValue<StableDefinitionKey, Arc<str>> {
+    pub(crate) fn import_dto(&self) -> SemanticImportConstValue<StableDefinitionKey, Arc<str>> {
         match self {
             Self::Integer(value) => SemanticImportConstValue::Integer(*value),
             Self::Bool(value) => SemanticImportConstValue::Bool(*value),

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -136,10 +136,12 @@ pub use definition_snapshot::{
     DefinitionRecord, DefinitionShard, DefinitionShardWork, DefinitionSnapshot, ModuleDefinition,
 };
 pub use durable_body::{
-    DURABLE_ORDINARY_BODY_SCHEMA_VERSION, DurableAirInst, DurableAirInstData, DurableAirRef,
-    DurableBodyAnchor, DurableBodyConversionFailure, DurableBodyProjectionFailure, DurableBodyWork,
-    DurableCallArg, DurableMatchArm, DurableOrdinaryBody, DurableOrdinaryBodyPayload,
-    DurablePattern, DurablePlace, DurablePlaceRef, DurableProjection,
+    DURABLE_ORDINARY_BODY_SCHEMA_VERSION, DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION, DurableAirInst,
+    DurableAirInstData, DurableAirRef, DurableBodyAnchor, DurableBodyConversionFailure,
+    DurableBodyProjectionFailure, DurableBodyWork, DurableCallArg, DurableMatchArm,
+    DurableOrdinaryBody, DurableOrdinaryBodyPayload, DurablePattern, DurablePlace, DurablePlaceRef,
+    DurableProjection, DurableSpecializationIdentity, DurableSpecializedBody,
+    DurableSpecializedBodyPayload, convert_semantic_specialized_body_exports,
 };
 pub use durable_semantics::{
     DURABLE_SEMANTIC_SCHEMA_VERSION, DurableConstValue, DurableDeclarationPayload,

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -5,6 +5,161 @@ use std::sync::Arc;
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn execute_compiled_output(output: &CompileOutput, label: &str) -> std::process::Output {
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static NEXT_EXECUTABLE: AtomicU64 = AtomicU64::new(0);
+        let unique = NEXT_EXECUTABLE.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "rue-compiler-specialization-{label}-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::write(&path, &output.elf).expect("write linked Rue executable");
+        let mut permissions = std::fs::metadata(&path)
+            .expect("read linked Rue executable metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions).expect("make linked Rue executable runnable");
+        #[cfg(target_os = "macos")]
+        {
+            let signing = std::process::Command::new("codesign")
+                .args([
+                    "-f",
+                    "-s",
+                    "-",
+                    "--identifier",
+                    "dev.rue-lang.compiler-test",
+                    "--timestamp=none",
+                ])
+                .arg(&path)
+                .output()
+                .expect("run ad-hoc codesign for linked Rue executable");
+            assert!(
+                signing.status.success(),
+                "codesign linked Rue executable: {}",
+                String::from_utf8_lossy(&signing.stderr)
+            );
+        }
+        let result = std::process::Command::new(&path).output();
+        let cleanup = std::fs::remove_file(&path);
+        cleanup.expect("remove linked Rue executable after execution");
+        result.expect("execute linked Rue program")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn warm_specialization_with_strings_matches_fresh_link_and_execution() {
+        let snapshot = SourceSnapshot::single(
+            "<specialization-strings>",
+            r#"
+                fn choose(comptime result: i32) -> i32 {
+                    let message: str = "hello";
+                    @dbg(message);
+                    result
+                }
+
+                fn main() -> i32 { choose(42) }
+            "#,
+        )
+        .unwrap();
+        let cold_options = CompileOptions::default();
+        let optimized = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+
+        let mut warm_session = CompilerSession::new();
+        warm_session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let cold = warm_session.semantic(&cold_options).unwrap();
+        assert_eq!(cold.work().body_analysis.specialized_bodies_attempted, 1);
+        assert_eq!(
+            cold.work().body_analysis.specialized_body_exports_succeeded,
+            1,
+            "specialized body work: {:?}",
+            cold.work().body_analysis
+        );
+        assert_eq!(cold.durable_specialized_body_payloads().len(), 1);
+        assert_eq!(
+            cold.durable_specialized_body_payloads()[0]
+                .body
+                .strings
+                .len(),
+            1
+        );
+        assert!(cold.durable_specialized_body_payloads()[0].dependency_boundary_complete);
+        let warm = warm_session.semantic(&optimized).unwrap();
+        assert_eq!(warm.work().body_analysis.specialized_bodies_reused, 1);
+        assert_eq!(warm.work().body_analysis.specialized_bodies_attempted, 0);
+        assert_eq!(
+            warm.work()
+                .body_analysis
+                .specialized_body_import_strings_installed,
+            1
+        );
+        assert!(!warm.strings().is_empty());
+
+        let mut fresh_session = CompilerSession::new();
+        fresh_session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let fresh = fresh_session.semantic(&optimized).unwrap();
+        assert_eq!(
+            format!("{:?}", warm.functions()),
+            format!("{:?}", fresh.functions())
+        );
+        assert_eq!(warm.type_pool().stats(), fresh.type_pool().stats());
+        let named_types = |pool: &TypeInternPool| {
+            (
+                pool.all_struct_ids()
+                    .into_iter()
+                    .map(|id| format!("{:?}", pool.struct_def(id)))
+                    .collect::<Vec<_>>(),
+                pool.all_enum_ids()
+                    .into_iter()
+                    .map(|id| format!("{:?}", pool.enum_def(id)))
+                    .collect::<Vec<_>>(),
+            )
+        };
+        assert_eq!(
+            named_types(warm.type_pool()),
+            named_types(fresh.type_pool())
+        );
+        assert_eq!(warm.strings(), fresh.strings());
+        assert_eq!(
+            format!("{:?}", warm.warnings()),
+            format!("{:?}", fresh.warnings())
+        );
+
+        let warm_output =
+            crate::queries::compile_with_session(&mut warm_session, &snapshot, &optimized).unwrap();
+        let fresh_output =
+            crate::queries::compile_with_session(&mut fresh_session, &snapshot, &optimized)
+                .unwrap();
+        assert_eq!(
+            format!("{:?}", warm_output.warnings),
+            format!("{:?}", fresh_output.warnings)
+        );
+
+        let warm_execution = execute_compiled_output(&warm_output, "warm");
+        let fresh_execution = execute_compiled_output(&fresh_output, "fresh");
+        assert_eq!(
+            warm_execution.status.code(),
+            Some(42),
+            "warm execution failed: {warm_execution:?}"
+        );
+        assert_eq!(warm_execution.stdout, b"hello\n");
+        assert!(warm_execution.stderr.is_empty());
+        assert_eq!(warm_execution.status.code(), fresh_execution.status.code());
+        assert_eq!(warm_execution.stdout, fresh_execution.stdout);
+        assert_eq!(warm_execution.stderr, fresh_execution.stderr);
+    }
+
     #[test]
     fn source_token_volume_survives_an_exact_zero_parse_update() {
         let snapshot =

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1165,6 +1165,7 @@ struct DurableDeclarationCache {
 struct DurableOrdinaryBodyCache {
     manifest: Arc<SemanticDependencyInputManifest>,
     bodies: Arc<[crate::DurableOrdinaryBody]>,
+    specialized_bodies: Arc<[crate::DurableSpecializedBody]>,
 }
 
 #[derive(Debug)]
@@ -2233,6 +2234,7 @@ impl CompilerSession {
             };
         let mut durable_body_work = crate::DurableBodyWork::default();
         let mut durable_body_candidates = Vec::new();
+        let mut durable_specialized_body_candidates = Vec::new();
         if let (Some(previous), Ok(fingerprints), Ok(prepared_definitions)) = (
             self.last_successful_body_cache.as_ref(),
             current_fingerprints.as_ref(),
@@ -2288,6 +2290,47 @@ impl CompilerSession {
                     Err(_) => durable_body_work.candidate_fallbacks += 1,
                 }
             }
+            for candidate in previous.specialized_bodies.iter() {
+                durable_body_work.candidate_comparisons += 1;
+                let base = &candidate.identity().base;
+                let inputs = candidate.inputs();
+                let exact = inputs.reusable_boundary_supported()
+                    && inputs.target() == options.target
+                    && inputs.preview_features()
+                        == &StablePreviewFeatures::new(&options.preview_features)
+                    && current
+                        .get(base)
+                        .is_some_and(|value| *value == inputs.fingerprint())
+                    && inputs.direct_dependency_inputs().iter().all(|dependency| {
+                        current
+                            .get(&dependency.key)
+                            .is_some_and(|value| *value == dependency)
+                    });
+                let Some(record) = prepared_definitions
+                    .definitions()
+                    .definition_by_key(base)
+                    .filter(|_| exact)
+                else {
+                    durable_body_work.candidate_fallbacks += 1;
+                    continue;
+                };
+                // Specialized exports are anchored to FunctionInfo::span,
+                // which is the full declaration span (ordinary exports use
+                // the AST body span).
+                let body_span = record.declaration_span();
+                match candidate.project_semantic_candidate(body_span, &mut durable_body_work) {
+                    Ok(candidate) => durable_specialized_body_candidates.push(
+                        crate::canonical_semantic::PreparedDurableSpecializedBodyCandidate {
+                            identity: candidate.identity,
+                            body_span: candidate.body_span,
+                            body: candidate.body,
+                            dependencies: candidate.dependencies,
+                            dependency_boundary_complete: candidate.dependency_boundary_complete,
+                        },
+                    ),
+                    Err(_) => durable_body_work.candidate_fallbacks += 1,
+                }
+            }
         }
         let mut reuse_plan = crate::canonical_semantic::CanonicalDeclarationReuseWork::default();
         let reusable = self.durable_declaration_cache.as_ref().and_then(|cache| {
@@ -2326,6 +2369,7 @@ impl CompilerSession {
                     &definitions,
                     &durable,
                     durable_body_candidates,
+                    durable_specialized_body_candidates,
                     durable_body_work,
                 )
             } else {
@@ -2336,6 +2380,7 @@ impl CompilerSession {
                     prepared,
                     reuse_plan,
                     durable_body_candidates,
+                    durable_specialized_body_candidates,
                     durable_body_work,
                 )
                 .map(|analysis| {
@@ -2402,6 +2447,12 @@ impl CompilerSession {
                 &options.preview_features,
             )
             .and_then(|bodies| {
+                let specialized_bodies = build_supported_specialized_body_cache(
+                    output,
+                    merged.definitions().source_snapshot(),
+                    options.target,
+                    &options.preview_features,
+                )?;
                 body_invalidation_manifest(
                     input.semantic.clone(),
                     imports.clone(),
@@ -2412,6 +2463,7 @@ impl CompilerSession {
                 .map(|manifest| DurableOrdinaryBodyCache {
                     manifest: Arc::new(manifest),
                     bodies,
+                    specialized_bodies,
                 })
             })
             .ok();
@@ -2836,6 +2888,12 @@ impl CompilerSession {
                 }
                 let mut implicit_destructor_edges = Vec::new();
                 for event in semantic.implicit_named_destructor_dependencies() {
+                    if matches!(
+                        event.source,
+                        rue_air::ImplicitDropDependencySourceEvent::Specialization { .. }
+                    ) {
+                        continue;
+                    }
                     implicit_destructor_edges.push(StableImplicitNamedDestructorDependency {
                         source: stable_implicit_drop_source_endpoint(
                             semantic,
@@ -3870,6 +3928,12 @@ fn build_supported_ordinary_body_cache(
             });
         }
         for event in semantic.implicit_named_destructor_dependencies() {
+            if matches!(
+                event.source,
+                rue_air::ImplicitDropDependencySourceEvent::Specialization { .. }
+            ) {
+                continue;
+            }
             let source =
                 stable_implicit_drop_source_endpoint(semantic, definitions, &event.source)?;
             if source == payload.owner {
@@ -3918,6 +3982,154 @@ fn build_supported_ordinary_body_cache(
         &mut work,
     )
     .map_err(|_| invalid_dependency_manifest("durable body finalization failed"))
+}
+
+/// Finalize each completed specialization against its own exact stable input
+/// boundary. Generic declarations are intentionally blocked from ordinary-body
+/// reuse, but a concrete specialization has no unresolved substitution
+/// identity: its ordered durable arguments are part of the cache key.
+fn build_supported_specialized_body_cache(
+    semantic: &CanonicalSemanticOutput,
+    snapshot: &SourceSnapshot,
+    target: crate::Target,
+    preview_features: &crate::PreviewFeatures,
+) -> Result<Arc<[crate::DurableSpecializedBody]>, CompileErrors> {
+    if !semantic.specialized_free_function_dependencies_complete()
+        || !semantic.declaration_type_dependencies_complete()
+        || !semantic.declaration_type_call_head_dependencies_complete()
+        || !semantic.supported_type_call_heads_complete()
+        || !semantic.named_value_const_dependencies_complete()
+        || !semantic.implicit_named_destructor_dependencies_complete()
+    {
+        return Ok(Arc::from([]));
+    }
+    let definitions = semantic.body_owner_issuer();
+    let fingerprints = definitions
+        .definitions()
+        .iter()
+        .map(|record| {
+            stable_definition_input_fingerprint(snapshot, record)
+                .map(|fingerprint| (record.stable_key().clone(), fingerprint))
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let mut named_const_edges = BTreeMap::<StableDefinitionKey, Vec<StableDefinitionKey>>::new();
+    for event in semantic.named_const_dependencies() {
+        let source = stable_top_level_endpoint(
+            definitions,
+            event.source_file,
+            &event.source_name,
+            StableDefinitionNamespace::Value,
+            StableDefinitionKind::ValueConst,
+        )?;
+        let target = match &event.target {
+            rue_air::NamedConstDependencyTargetEvent::ValueConst { file, name } => {
+                stable_top_level_endpoint(
+                    definitions,
+                    *file,
+                    name,
+                    StableDefinitionNamespace::Value,
+                    StableDefinitionKind::ValueConst,
+                )?
+            }
+            rue_air::NamedConstDependencyTargetEvent::FreeFunction { file, name } => {
+                stable_free_function_endpoint(definitions, *file, name)?
+            }
+            rue_air::NamedConstDependencyTargetEvent::NamedType { file, name, kind } => {
+                let kind = match kind {
+                    rue_air::DeclarationTypeDependencyTargetKind::Struct => {
+                        StableDefinitionKind::Struct
+                    }
+                    rue_air::DeclarationTypeDependencyTargetKind::Enum => {
+                        StableDefinitionKind::Enum
+                    }
+                    rue_air::DeclarationTypeDependencyTargetKind::ValueConst => {
+                        StableDefinitionKind::ValueConst
+                    }
+                };
+                stable_top_level_endpoint(
+                    definitions,
+                    *file,
+                    name,
+                    if kind == StableDefinitionKind::ValueConst {
+                        StableDefinitionNamespace::Value
+                    } else {
+                        StableDefinitionNamespace::Type
+                    },
+                    kind,
+                )?
+            }
+            rue_air::NamedConstDependencyTargetEvent::ModuleBinding { file, name } => {
+                stable_top_level_endpoint(
+                    definitions,
+                    *file,
+                    name,
+                    StableDefinitionNamespace::Value,
+                    StableDefinitionKind::ModuleBinding,
+                )?
+            }
+        };
+        named_const_edges.entry(source).or_default().push(target);
+    }
+    let mut result = Vec::with_capacity(semantic.durable_specialized_body_payloads().len());
+    for payload in semantic.durable_specialized_body_payloads() {
+        if payload.schema_version != crate::DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION
+            || payload.body.owner != payload.identity.base
+            || payload.body.schema_version != crate::DURABLE_ORDINARY_BODY_SCHEMA_VERSION
+        {
+            return Err(invalid_dependency_manifest(
+                "durable specialized body has an incompatible schema or owner",
+            ));
+        }
+        if !payload.dependency_boundary_complete {
+            continue;
+        }
+        let fingerprint = fingerprints
+            .get(&payload.identity.base)
+            .cloned()
+            .filter(|value| value == &payload.body.expected_inputs)
+            .ok_or_else(|| {
+                invalid_dependency_manifest("durable specialized body base is absent or stale")
+            })?;
+        let mut dependency_keys = payload
+            .dependencies
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let mut pending = dependency_keys.iter().cloned().collect::<Vec<_>>();
+        while let Some(key) = pending.pop() {
+            if let Some(targets) = named_const_edges.get(&key) {
+                for target in targets {
+                    if dependency_keys.insert(target.clone()) {
+                        pending.push(target.clone());
+                    }
+                }
+            }
+        }
+        dependency_keys.remove(&payload.identity.base);
+        let direct_dependency_inputs = dependency_keys
+            .into_iter()
+            .map(|key| {
+                fingerprints.get(&key).cloned().ok_or_else(|| {
+                    invalid_dependency_manifest(
+                        "durable specialized body dependency is absent from fingerprints",
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        result.push(crate::DurableSpecializedBody {
+            payload: payload.clone(),
+            inputs: StableBodyDependencyInputRecord {
+                owner: payload.identity.base.clone(),
+                fingerprint,
+                target,
+                preview_features: StablePreviewFeatures::new(preview_features),
+                direct_dependency_inputs: direct_dependency_inputs.into(),
+                builtin_type_call_heads: Arc::from([]),
+                blockers: Arc::from([]),
+            },
+        });
+    }
+    Ok(result.into())
 }
 
 fn stable_module_imports(imports: &CanonicalImportGraph) -> Arc<[StableModuleImportDependency]> {
@@ -4039,6 +4251,12 @@ fn body_invalidation_manifest(
     let mut implicit_named_destructor_dependencies = semantic
         .implicit_named_destructor_dependencies()
         .iter()
+        .filter(|event| {
+            !matches!(
+                event.source,
+                rue_air::ImplicitDropDependencySourceEvent::Specialization { .. }
+            )
+        })
         .map(|event| {
             Ok(StableImplicitNamedDestructorDependency {
                 source: stable_implicit_drop_source_endpoint(semantic, definitions, &event.source)?,
@@ -4215,6 +4433,11 @@ fn stable_implicit_drop_source_endpoint(
         rue_air::ImplicitDropDependencySourceEvent::Anonymous => Err(invalid_dependency_manifest(
             "anonymous drop-dependency source has no stable endpoint",
         )),
+        rue_air::ImplicitDropDependencySourceEvent::Specialization { .. } => {
+            Err(invalid_dependency_manifest(
+                "specialized drop-dependency source requires specialization identity",
+            ))
+        }
         rue_air::ImplicitDropDependencySourceEvent::FreeFunction { token, file, name } => {
             let provenance = stable_free_function_endpoint(definitions, *file, name)?;
             stable_token_endpoint(semantic, *token, &provenance)
@@ -5601,19 +5824,83 @@ mod tests {
     }
 
     #[test]
+    fn reused_specializations_consume_the_persistent_round_budget() {
+        let source = |requested: i32| {
+            let program = format!(
+                "fn chain(comptime n: i32) -> i32 {{\n\
+                     if n == 0 {{ 0 }} else {{ chain(n - 1) }}\n\
+                 }}\n\
+                 fn main() -> i32 {{ chain({requested}) }}"
+            );
+            snapshot(&[(1, "/p/main.rue", "main.rue", program.as_str())], 1)
+        };
+        let baseline = source(63);
+        let overflowing = source(64);
+        let mut session = CompilerSession::new();
+        session.update(&baseline).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.durable_specialized_body_payloads().len(), 64);
+        assert_eq!(cold.work().body_analysis.specialization_rounds, 64);
+
+        session.update(&overflowing).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap_err();
+        let failure = session.work().semantic_records.last().unwrap();
+        assert_eq!(
+            failure.failure.unwrap().phase,
+            CanonicalSemanticFailurePhase::BodyAnalysis
+        );
+        let work = failure.work.body_analysis;
+        assert_eq!(work.specialization_rounds, 65);
+        assert_eq!(work.specialized_bodies_attempted, 1);
+        assert_eq!(work.specialized_bodies_succeeded, 1);
+        assert_eq!(work.specialized_bodies_reused, 63);
+        assert_eq!(work.specialization_driver_failures, 1);
+
+        session.update(&baseline).into_result().unwrap();
+        let recovered = session
+            .semantic(&CompileOptions {
+                opt_level: OptLevel::O2,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(recovered.work().body_analysis.specialization_rounds, 64);
+        assert_eq!(recovered.work().body_analysis.specialized_bodies_reused, 64);
+        assert_eq!(
+            recovered.work().body_analysis.specialized_bodies_attempted,
+            0
+        );
+
+        let third_warm = session
+            .semantic(&CompileOptions {
+                opt_level: OptLevel::O3,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(third_warm.work().body_analysis.specialization_rounds, 64);
+        assert_eq!(
+            third_warm.work().body_analysis.specialized_bodies_reused,
+            64
+        );
+        assert_eq!(
+            third_warm.work().body_analysis.specialized_bodies_attempted,
+            0
+        );
+    }
+
+    #[test]
     fn declaration_failure_retains_completed_declaration_work() {
         let valid = snapshot(
             &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 0 }")],
             1,
         );
-        let changed = snapshot(
+        let changed_source = snapshot(
             &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
             1,
         );
         let mut session = CompilerSession::new();
         session.update(&valid).into_result().unwrap();
         session.semantic(&CompileOptions::default()).unwrap();
-        session.update(&changed).into_result().unwrap();
+        session.update(&changed_source).into_result().unwrap();
         crate::canonical_semantic::with_test_declaration_failure_injection(|| {
             session.semantic(&CompileOptions::default()).unwrap_err();
         });
@@ -8197,6 +8484,572 @@ mod tests {
             format!("{:?}", reused.analyzed_body_owners()),
             format!("{:?}", fresh.analyzed_body_owners())
         );
+    }
+
+    #[test]
+    fn durable_specialized_body_reuses_in_existing_fixed_point_and_matches_fresh_output() {
+        let source = snapshot(
+            &[(
+                42,
+                "/p/main.rue",
+                "main.rue",
+                "fn id(comptime T: type, value: T) -> T { value }\nfn main() -> i32 { id(i32, 42) }",
+            )],
+            42,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.durable_specialized_body_payloads().len(), 1);
+        assert_eq!(
+            session
+                .last_successful_body_cache
+                .as_ref()
+                .map(|cache| cache.specialized_bodies.len()),
+            Some(1)
+        );
+        assert_eq!(cold.work().body_analysis.specialized_bodies_attempted, 1);
+        assert_eq!(cold.work().body_analysis.specialized_bodies_reused, 0);
+
+        let optimized = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let reused = session.semantic(&optimized).unwrap();
+        let work = reused.work().body_analysis;
+        assert_eq!(work.specialized_body_import_attempts, 1);
+        assert_eq!(work.specialized_body_import_successes, 1);
+        assert_eq!(work.specialized_body_import_failures, 0);
+        assert_eq!(work.specialized_bodies_reused, 1);
+        assert_eq!(work.specialized_body_analyses_skipped, 1);
+        assert_eq!(work.specialized_bodies_attempted, 0);
+        assert_eq!(work.specialization_rounds, 1);
+
+        let mut fresh_session = CompilerSession::new();
+        fresh_session.update(&source).into_result().unwrap();
+        let fresh = fresh_session.semantic(&optimized).unwrap();
+        assert_eq!(
+            format!("{:?}", reused.functions()),
+            format!("{:?}", fresh.functions())
+        );
+        assert_eq!(reused.strings(), fresh.strings());
+        assert_eq!(
+            format!("{:?}", reused.warnings()),
+            format!("{:?}", fresh.warnings())
+        );
+
+        let reused_executable =
+            crate::queries::compile_with_session(&mut session, &source, &optimized).unwrap();
+        let fresh_executable =
+            crate::queries::compile_with_session(&mut fresh_session, &source, &optimized).unwrap();
+        assert_eq!(reused_executable.elf, fresh_executable.elf);
+        assert_eq!(
+            format!("{:?}", reused_executable.warnings),
+            format!("{:?}", fresh_executable.warnings)
+        );
+    }
+
+    #[test]
+    fn specialized_reuse_survives_relocation_file_ids_and_input_order() {
+        let original = snapshot(
+            &[
+                (
+                    71,
+                    "/old/main.rue",
+                    "main.rue",
+                    "const lib = @import(\"lib.rue\"); fn main() -> i32 { lib.id(i32, 42) }",
+                ),
+                (
+                    72,
+                    "/old/lib.rue",
+                    "lib.rue",
+                    "pub fn id(comptime T: type, value: T) -> T { value }",
+                ),
+            ],
+            71,
+        );
+        let relocated = snapshot(
+            &[
+                (
+                    4,
+                    "/new/lib.rue",
+                    "lib.rue",
+                    "pub fn id(comptime T: type, value: T) -> T { value }",
+                ),
+                (
+                    9,
+                    "/new/main.rue",
+                    "main.rue",
+                    "const lib = @import(\"lib.rue\"); fn main() -> i32 { lib.id(i32, 42) }",
+                ),
+            ],
+            9,
+        );
+        let mut session = CompilerSession::new();
+        publish_with_test_imports(&mut session, &original);
+        session.semantic(&CompileOptions::default()).unwrap();
+        publish_with_test_imports(&mut session, &relocated);
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let reused = session.semantic(&options).unwrap();
+        assert_eq!(reused.work().durable_bodies.candidate_comparisons, 1);
+        assert_eq!(reused.work().durable_bodies.candidate_fallbacks, 0);
+        assert_eq!(reused.work().body_analysis.specialized_bodies_reused, 1);
+        assert_eq!(reused.work().body_analysis.specialized_bodies_attempted, 0);
+
+        let mut fresh_session = CompilerSession::new();
+        publish_with_test_imports(&mut fresh_session, &relocated);
+        let fresh = fresh_session.semantic(&options).unwrap();
+        assert_body_artifact_parity(&reused, &fresh);
+        assert_diagnostic_parity(&session, &fresh_session);
+    }
+
+    #[test]
+    fn specialized_target_and_preview_boundaries_fail_closed_exactly() {
+        let source = snapshot(
+            &[(
+                42,
+                "/p/main.rue",
+                "main.rue",
+                "fn id(comptime T: type, value: T) -> T { value } fn main() -> i32 { id(i32, 42) }",
+            )],
+            42,
+        );
+        let run = |options: CompileOptions| {
+            let mut session = CompilerSession::new();
+            session.update(&source).into_result().unwrap();
+            session.semantic(&CompileOptions::default()).unwrap();
+            session.semantic(&options).unwrap()
+        };
+        let other_target = *Target::all()
+            .iter()
+            .find(|target| **target != CompileOptions::default().target)
+            .unwrap();
+        let target = run(CompileOptions {
+            target: other_target,
+            ..CompileOptions::default()
+        });
+        assert_eq!(target.work().durable_bodies.candidate_comparisons, 1);
+        assert_eq!(target.work().durable_bodies.candidate_fallbacks, 1);
+        assert_eq!(
+            target.work().body_analysis.specialized_body_import_attempts,
+            0
+        );
+        assert_eq!(target.work().body_analysis.specialized_bodies_attempted, 1);
+
+        let preview = run(CompileOptions {
+            preview_features: PreviewFeatures::from([PreviewFeature::TestInfra]),
+            ..CompileOptions::default()
+        });
+        assert_eq!(preview.work().durable_bodies.candidate_comparisons, 1);
+        assert_eq!(preview.work().durable_bodies.candidate_fallbacks, 1);
+        assert_eq!(
+            preview
+                .work()
+                .body_analysis
+                .specialized_body_import_attempts,
+            0
+        );
+        assert_eq!(preview.work().body_analysis.specialized_bodies_attempted, 1);
+    }
+
+    #[test]
+    fn warning_specializations_recompute_once_and_are_never_published() {
+        let source = snapshot(
+            &[(
+                42,
+                "/p/main.rue",
+                "main.rue",
+                "fn noisy(comptime n: i32) -> i32 { let unused = 0; n } fn main() -> i32 { noisy(1) + noisy(1) }",
+            )],
+            42,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.durable_specialized_body_payloads().len(), 0);
+        assert_eq!(cold.work().body_analysis.specialized_bodies_attempted, 1);
+        assert!(cold.work().body_analysis.specialization_requests_duplicate >= 1);
+        assert_eq!(cold.warnings().len(), 1);
+
+        let warm = session
+            .semantic(&CompileOptions {
+                opt_level: OptLevel::O1,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(warm.work().durable_bodies.candidate_comparisons, 0);
+        assert_eq!(warm.work().body_analysis.specialized_bodies_reused, 0);
+        assert_eq!(warm.work().body_analysis.specialized_bodies_attempted, 1);
+        assert!(warm.work().body_analysis.specialization_requests_duplicate >= 1);
+        assert_eq!(warm.warnings().len(), 1);
+        assert_eq!(
+            format!("{:?}", warm.warnings()),
+            format!("{:?}", cold.warnings())
+        );
+    }
+
+    #[test]
+    fn method_referencing_specialization_is_explicitly_fail_closed() {
+        let source = snapshot(
+            &[(
+                42,
+                "/p/main.rue",
+                "main.rue",
+                "struct Value { value: i32, fn get(borrow self) -> i32 { self.value } } fn use(comptime n: i32, value: Value) -> i32 { value.get() + n } fn main() -> i32 { use(1, Value { value: 41 }) }",
+            )],
+            42,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.durable_specialized_body_payloads().len(), 1);
+        assert!(
+            !cold.durable_specialized_body_payloads()[0].dependency_boundary_complete,
+            "method provenance is unsupported and must be marked incomplete"
+        );
+        assert!(
+            session
+                .last_successful_body_cache
+                .as_ref()
+                .unwrap()
+                .specialized_bodies
+                .is_empty()
+        );
+        let warm = session
+            .semantic(&CompileOptions {
+                opt_level: OptLevel::O1,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(warm.work().durable_bodies.candidate_comparisons, 0);
+        assert_eq!(warm.work().body_analysis.specialized_bodies_reused, 0);
+        assert_eq!(warm.work().body_analysis.specialized_bodies_attempted, 1);
+    }
+
+    #[test]
+    fn unsupported_callable_alias_is_rejected_before_specialization() {
+        let source = snapshot(
+            &[(
+                42,
+                "/p/main.rue",
+                "main.rue",
+                "fn helper() -> i32 { 1 } const F = helper; fn Witness(comptime T: type, comptime value: T) -> type { struct { marker: i32 } } fn bad(value: Witness(type, F)) -> i32 { value.marker } fn main() -> i32 { 0 }",
+            )],
+            42,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap_err();
+        let failure = session.work().semantic_records.last().unwrap();
+        assert!(failure.failure.is_some());
+        assert_eq!(failure.work.durable_bodies.import_attempts, 0);
+        assert_eq!(
+            failure.work.body_analysis.specialized_body_import_attempts,
+            0
+        );
+        assert_eq!(failure.work.body_analysis.specialized_bodies_attempted, 0);
+        assert!(session.last_successful_body_cache.is_none());
+    }
+
+    #[test]
+    fn nested_specialized_bodies_reuse_and_close_over_changed_callees() {
+        let source_text = "fn inner(comptime T: type, value: T) -> T { value }\n\
+             fn outer(comptime T: type, value: T) -> T { inner(T, value) }\n\
+             fn main() -> i32 { outer(i32, 41) + outer(i32, 1) }";
+        let source = snapshot(&[(42, "/p/main.rue", "main.rue", source_text)], 42);
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.durable_specialized_body_payloads().len(), 2);
+        assert_eq!(cold.work().body_analysis.specialized_bodies_attempted, 2);
+        assert!(cold.work().body_analysis.specialization_requests_duplicate >= 1);
+
+        let optimized = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let warm = session.semantic(&optimized).unwrap();
+        let work = warm.work().body_analysis;
+        assert_eq!(work.specialized_body_import_attempts, 2);
+        assert_eq!(work.specialized_body_import_successes, 2);
+        assert_eq!(work.specialized_bodies_reused, 2);
+        assert_eq!(work.specialized_body_analyses_skipped, 2);
+        assert_eq!(work.specialized_bodies_attempted, 0);
+        assert_eq!(work.specialization_rounds, 2);
+
+        let unrelated_text = format!("{source_text}\nfn unrelated() -> i32 {{ 7 }}");
+        let unrelated = snapshot(
+            &[(42, "/p/main.rue", "main.rue", unrelated_text.as_str())],
+            42,
+        );
+        session.update(&unrelated).into_result().unwrap();
+        let unrelated = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(unrelated.work().body_analysis.specialized_bodies_reused, 2);
+        assert_eq!(
+            unrelated.work().body_analysis.specialized_bodies_attempted,
+            0
+        );
+
+        let changed_text = "fn inner(comptime T: type, value: T) -> T { let copy = value; copy }\n\
+             fn outer(comptime T: type, value: T) -> T { inner(T, value) }\n\
+             fn main() -> i32 { outer(i32, 41) + outer(i32, 1) }\n\
+             fn unrelated() -> i32 { 7 }";
+        let changed = snapshot(&[(42, "/p/main.rue", "main.rue", changed_text)], 42);
+        session.update(&changed).into_result().unwrap();
+        let changed = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(changed.work().body_analysis.specialized_bodies_reused, 0);
+        assert_eq!(changed.work().body_analysis.specialized_bodies_attempted, 2);
+    }
+
+    #[test]
+    fn missing_nested_specialized_callee_discards_only_that_candidate() {
+        let source_text = "fn inner(comptime T: type, value: T) -> T { value }\n\
+             fn outer(comptime T: type, value: T) -> T { inner(T, value) }\n\
+             fn main() -> i32 { outer(i32, 42) }";
+        let source = snapshot(&[(42, "/p/main.rue", "main.rue", source_text)], 42);
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+
+        let cache = session.last_successful_body_cache.as_mut().unwrap();
+        let outer = Arc::make_mut(&mut cache.specialized_bodies)
+            .iter_mut()
+            .find(|candidate| candidate.identity().base.name() == "outer")
+            .unwrap();
+        let call = Arc::make_mut(&mut outer.payload.body.instructions)
+            .iter_mut()
+            .find_map(|instruction| match &mut instruction.data {
+                crate::DurableAirInstData::CallSpecialized { identity, .. } => Some(identity),
+                _ => None,
+            })
+            .unwrap();
+        call.base = StableDefinitionKey::for_test(
+            call.base.module().clone(),
+            call.base.namespace(),
+            call.base.kind(),
+            "missing_inner",
+            None,
+        );
+
+        let optimized = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let recovered = session.semantic(&optimized).unwrap();
+        assert_eq!(recovered.work().durable_bodies.candidate_fallbacks, 1);
+        assert_eq!(
+            recovered.work().durable_bodies.specialized_mapping_attempts,
+            2
+        );
+        assert_eq!(
+            recovered
+                .work()
+                .durable_bodies
+                .specialized_mapping_successes,
+            1
+        );
+        assert_eq!(
+            recovered.work().durable_bodies.specialized_mapping_failures,
+            1
+        );
+        assert_eq!(
+            recovered
+                .work()
+                .body_analysis
+                .specialized_body_import_attempts,
+            1
+        );
+        assert_eq!(
+            recovered
+                .work()
+                .body_analysis
+                .specialized_body_import_successes,
+            1
+        );
+        assert_eq!(
+            recovered
+                .work()
+                .body_analysis
+                .specialized_body_import_failures,
+            0
+        );
+        assert_eq!(recovered.work().body_analysis.specialized_bodies_reused, 1);
+        assert_eq!(
+            recovered.work().body_analysis.specialized_bodies_attempted,
+            1
+        );
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&source).into_result().unwrap();
+        let fresh = fresh.semantic(&optimized).unwrap();
+        assert_eq!(
+            format!("{:?}", recovered.functions()),
+            format!("{:?}", fresh.functions())
+        );
+        assert_eq!(recovered.strings(), fresh.strings());
+    }
+
+    #[test]
+    fn malformed_nested_specialized_import_falls_back_atomically() {
+        let source_text = "fn inner(comptime T: type, value: T) -> T { value }\n\
+             fn outer(comptime T: type, value: T) -> T { inner(T, value) }\n\
+             fn main() -> i32 { outer(i32, 42) }";
+        let source = snapshot(&[(42, "/p/main.rue", "main.rue", source_text)], 42);
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.semantic(&CompileOptions::default()).unwrap();
+
+        let cache = session.last_successful_body_cache.as_mut().unwrap();
+        let outer = Arc::make_mut(&mut cache.specialized_bodies)
+            .iter_mut()
+            .find(|candidate| candidate.identity().base.name() == "outer")
+            .unwrap();
+        let call = Arc::make_mut(&mut outer.payload.body.instructions)
+            .iter_mut()
+            .find_map(|instruction| match &mut instruction.data {
+                crate::DurableAirInstData::CallSpecialized { identity, .. } => Some(identity),
+                _ => None,
+            })
+            .unwrap();
+        // Projection and stable-key mapping accept this durable shape, but an
+        // imported completed specialization has no declaration-scoped generic
+        // context in which this type can be resolved.
+        call.type_arguments = Arc::from([crate::DurableType::GenericParameter(0)]);
+
+        let optimized = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let recovered = session.semantic(&optimized).unwrap();
+        let work = recovered.work().body_analysis;
+        assert_eq!(recovered.work().durable_bodies.candidate_fallbacks, 0);
+        assert_eq!(work.specialized_body_import_attempts, 2);
+        assert_eq!(work.specialized_body_import_successes, 1);
+        assert_eq!(work.specialized_body_import_failures, 1);
+        assert_eq!(work.specialized_bodies_reused, 1);
+        assert_eq!(work.specialized_bodies_attempted, 1);
+        assert_eq!(work.specialized_bodies_succeeded, 1);
+
+        let mut fresh_session = CompilerSession::new();
+        fresh_session.update(&source).into_result().unwrap();
+        let fresh = fresh_session.semantic(&optimized).unwrap();
+        assert_body_artifact_parity(&recovered, &fresh);
+        assert_diagnostic_parity(&session, &fresh_session);
+    }
+
+    #[test]
+    fn recursive_specialized_candidates_reenter_the_fixed_point_once_each() {
+        let source = snapshot(
+            &[(
+                42,
+                "/p/main.rue",
+                "main.rue",
+                r#"fn fib(comptime n: i32) -> i32 {
+                       if n < 2 { n } else { fib(n - 1) + fib(n - 2) }
+                   }
+                   fn main() -> i32 { fib(5) + fib(5) }"#,
+            )],
+            42,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.durable_specialized_body_payloads().len(), 6);
+
+        let optimized = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let warm = session.semantic(&optimized).unwrap();
+        let work = warm.work().body_analysis;
+        assert_eq!(work.specialized_body_import_attempts, 6);
+        assert_eq!(work.specialized_body_import_successes, 6);
+        assert_eq!(work.specialized_bodies_reused, 6);
+        assert_eq!(work.specialized_bodies_attempted, 0);
+        assert_eq!(work.specialization_rounds, 4);
+        assert!(work.specialization_requests_duplicate >= 1);
+        assert_eq!(warm.specialized_free_function_origins().len(), 6);
+    }
+
+    #[test]
+    fn evaluated_away_named_const_provenance_invalidates_only_affected_instance() {
+        let first_text = "const answer: i32 = 41;\n\
+             fn choose(comptime use_answer: bool) -> i32 {\n\
+                 if use_answer { answer } else { 1 }\n\
+             }\n\
+             fn main() -> i32 { choose(true) + choose(false) }";
+        let first = snapshot(&[(42, "/p/main.rue", "main.rue", first_text)], 42);
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.durable_specialized_body_payloads().len(), 2);
+        let bool_identities = cold
+            .durable_specialized_body_payloads()
+            .iter()
+            .map(|payload| payload.identity.value_arguments.as_ref())
+            .collect::<Vec<_>>();
+        assert!(bool_identities.contains(&[crate::DurableConstValue::Bool(true)].as_slice()));
+        assert!(bool_identities.contains(&[crate::DurableConstValue::Bool(false)].as_slice()));
+
+        let changed_text = first_text.replace("41", "42");
+        let changed_source = snapshot(
+            &[(42, "/p/main.rue", "main.rue", changed_text.as_str())],
+            42,
+        );
+        session.update(&changed_source).into_result().unwrap();
+        let changed = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(changed.work().body_analysis.specialized_bodies_reused, 1);
+        assert_eq!(changed.work().body_analysis.specialized_bodies_attempted, 1);
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&changed_source).into_result().unwrap();
+        let fresh = fresh.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(
+            format!("{:?}", changed.functions()),
+            format!("{:?}", fresh.functions())
+        );
+    }
+
+    #[test]
+    fn specialized_drop_provenance_invalidates_only_the_owning_instance() {
+        let first_text = "fn cleanup() {}\n\
+             struct Resource { value: i32 }\n\
+             drop fn Resource(self) { cleanup(); }\n\
+             fn borrowed(comptime n: i32, borrow resource: Resource) -> i32 {\n\
+                 resource.value + n\n\
+             }\n\
+             fn owned(comptime n: i32, resource: Resource) -> i32 {\n\
+                 resource.value + n\n\
+             }\n\
+             fn main() -> i32 {\n\
+                 let left = Resource { value: 20 };\n\
+                 let right = Resource { value: 20 };\n\
+                 borrowed(1, borrow left) + owned(1, right)\n\
+             }";
+        let first = snapshot(&[(43, "/p/main.rue", "main.rue", first_text)], 43);
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        let cold = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(cold.durable_specialized_body_payloads().len(), 2);
+
+        let changed_text = first_text.replace("cleanup();", "cleanup(); let marker = 0;");
+        let changed_source = snapshot(
+            &[(43, "/p/main.rue", "main.rue", changed_text.as_str())],
+            43,
+        );
+        session.update(&changed_source).into_result().unwrap();
+        let changed = session.semantic(&CompileOptions::default()).unwrap();
+        assert_eq!(changed.work().body_analysis.specialized_bodies_reused, 1);
+        assert_eq!(changed.work().body_analysis.specialized_bodies_attempted, 1);
+
+        let mut fresh_session = CompilerSession::new();
+        fresh_session.update(&changed_source).into_result().unwrap();
+        let fresh = fresh_session.semantic(&CompileOptions::default()).unwrap();
+        assert_body_artifact_parity(&changed, &fresh);
+        assert_diagnostic_parity(&session, &fresh_session);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- give completed generic specializations stable durable identities and payloads
- reuse cached specializations through the existing specialization fixed point with exact dependency and round accounting
- preserve strings, type structure, diagnostics, and implicit destructor dependencies across warm imports
- add fail-closed mapping/work ledgers and warm/fresh artifact plus execution regressions

## Validation

- `scripts/rue test`
- AIR: 404/404
- compiler: 481/481
- `scripts/rue quick`

Fixes RUE-885