### PR TITLE
RUE-892: attribute parser subphase timing

### DIFF
--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -369,6 +369,14 @@ pub fn compile_snapshot(
     snapshot: &SourceSnapshot,
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
+    let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
+    let _span = info_span!(
+        "compile",
+        target = %options.target,
+        file_count = snapshot.len(),
+        source_bytes = total_source_bytes
+    )
+    .entered();
     compile_snapshot_impl(snapshot, options)
 }
 
@@ -379,6 +387,33 @@ pub fn compile_snapshot(
 impl CompilerSession {
     /// Produce an executable from this session's closed-valid discovery revision.
     pub fn executable(&mut self, options: &CompileOptions) -> MultiErrorResult<CompileOutput> {
+        let snapshot = self.committed_snapshot_for_executable()?;
+        let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
+        let _span = info_span!(
+            "compile",
+            target = %options.target,
+            file_count = snapshot.len(),
+            source_bytes = total_source_bytes
+        )
+        .entered();
+        compile_with_session(self, &snapshot, options)
+    }
+
+    /// Produce an executable while the caller's canonical `compile` span is
+    /// entered.
+    ///
+    /// The filesystem driver uses this after import discovery so the exact
+    /// discovery parse and the later query pipeline share one timing root.
+    /// Other callers should use [`Self::executable`], which owns that root.
+    pub fn executable_in_compile_scope(
+        &mut self,
+        options: &CompileOptions,
+    ) -> MultiErrorResult<CompileOutput> {
+        let snapshot = self.committed_snapshot_for_executable()?;
+        compile_with_session(self, &snapshot, options)
+    }
+
+    fn committed_snapshot_for_executable(&self) -> MultiErrorResult<SourceSnapshot> {
         let snapshot = self
             .committed_import_discovery()
             .ok_or_else(|| {
@@ -388,7 +423,7 @@ impl CompilerSession {
             })?
             .snapshot()
             .clone();
-        compile_with_session(self, &snapshot, options)
+        Ok(snapshot)
     }
 }
 
@@ -422,13 +457,7 @@ pub(crate) fn compile_with_session(
             )))
         })?;
     let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
-    let _span = info_span!(
-        "compile",
-        target = %options.target,
-        file_count = snapshot.len(),
-        source_bytes = total_source_bytes
-    )
-    .entered();
+    let _span = info_span!("compile_pipeline").entered();
 
     let rir = {
         let _span = info_span!("semantic_astgen").entered();

--- a/crates/rue-compiler/src/syntax.rs
+++ b/crates/rue-compiler/src/syntax.rs
@@ -84,8 +84,6 @@ pub(crate) fn parse_file(source: SourceView<'_>, interner: ThreadedRodeo) -> Fil
         }
     };
 
-    info!(item_count = ast.items.len(), "parsing complete");
-
     FileParseOutcome {
         result: Ok(std::sync::Arc::new(ast)),
         interner,

--- a/crates/rue-parser/BUCK
+++ b/crates/rue-parser/BUCK
@@ -9,5 +9,6 @@ rue_crate(
         "//third-party:chumsky",
         "//third-party:lasso",
         "//third-party:smallvec",
+        "//third-party:tracing",
     ],
 )

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -23,6 +23,7 @@ use rue_error::{CompileError, CompileErrors, ErrorKind, MAX_NESTING_DEPTH, Multi
 use rue_lexer::TokenKind;
 use rue_span::{FileId, Span};
 use std::borrow::Cow;
+use tracing::{info, info_span};
 
 use chumsky::extra::SimpleState;
 
@@ -3536,6 +3537,7 @@ fn check_nesting_depth(
 /// Chumsky-based parser that converts tokens into an AST.
 pub struct ChumskyParser {
     tokens: Vec<(TokenKind, SimpleSpan)>,
+    input_token_count: usize,
     source_len: usize,
     interner: ThreadedRodeo,
     /// File ID for spans in this file.
@@ -3545,6 +3547,8 @@ pub struct ChumskyParser {
 impl ChumskyParser {
     /// Create a new parser from tokens and an interner produced by the lexer.
     pub fn new(tokens: Vec<rue_lexer::Token>, interner: ThreadedRodeo) -> Self {
+        let _span = info_span!("parser_token_adaptation").entered();
+        let input_token_count = tokens.len();
         let source_len = tokens.last().map(|t| t.span.end as usize).unwrap_or(0);
         // Extract file_id from the first token (all tokens in a file have the same file_id)
         let file_id = tokens
@@ -3564,6 +3568,7 @@ impl ChumskyParser {
             .collect();
         Self {
             tokens: spanned_tokens,
+            input_token_count,
             source_len,
             interner,
             file_id,
@@ -3591,13 +3596,30 @@ impl ChumskyParser {
         // parser recursion depth; rejecting deep input here means chumsky (and
         // every later pass, plus the recursive `Drop` of the AST) never sees a
         // tree deep enough to overflow the stack (RUE-42).
-        if let Some(err) = check_nesting_depth(&self.tokens, self.file_id) {
+        let nesting_error = {
+            let _span = info_span!("parser_nesting_scan").entered();
+            check_nesting_depth(&self.tokens, self.file_id)
+        };
+        if let Some(err) = nesting_error {
+            info!(
+                outcome = "nesting_error",
+                input_token_count = self.input_token_count,
+                parser_token_count = self.tokens.len(),
+                ast_item_count = 0,
+                raw_parse_error_count = 0,
+                parse_error_count = 0,
+                validation_error_count = 0,
+                "parser complete"
+            );
             return Err((CompileErrors::from(vec![err]), self.interner));
         }
 
         // Pre-intern primitive type symbols and create parser state with file ID
-        let syms = PrimitiveTypeSpurs::new(&mut self.interner);
-        let parser_state = ParserState::new(syms, self.file_id);
+        let parser_state = {
+            let _span = info_span!("parser_state_setup").entered();
+            let syms = PrimitiveTypeSpurs::new(&mut self.interner);
+            ParserState::new(syms, self.file_id)
+        };
 
         // Run chumsky on a dedicated thread with a large stack. Even at the
         // bounded `MAX_NESTING_DEPTH`, chumsky's combinator frames are heavy
@@ -3605,51 +3627,118 @@ impl ChumskyParser {
         // default thread stack. The nesting pre-scan above caps the depth; the
         // roomy stack here ensures the capped depth parses cleanly.
         let tokens = std::mem::take(&mut self.tokens);
+        let parser_token_count = tokens.len();
         let source_len = self.source_len;
         let file_id = self.file_id;
-        let result = std::thread::Builder::new()
-            .name("rue-parse".to_string())
-            .stack_size(256 * 1024 * 1024)
-            .spawn(move || {
-                let mut state = SimpleState(parser_state);
+        let worker_span = info_span!("parser_worker", parser_token_count);
+        let worker_context = worker_span.clone();
+        let dispatch = tracing::dispatcher::get_default(Clone::clone);
+        let result = {
+            // This aggregate intentionally covers spawn through join. Its
+            // worker-thread children describe the additive work, so join wait
+            // is never exposed as an overlapping leaf.
+            let _span = worker_span.enter();
+            std::thread::Builder::new()
+                .name("rue-parse".to_string())
+                .stack_size(256 * 1024 * 1024)
+                .spawn(move || {
+                    tracing::dispatcher::with_default(&dispatch, || {
+                        let _span = worker_context.enter();
+                        let mut state = SimpleState(parser_state);
 
-                // Create a stream from the token iterator
-                let token_iter = tokens.iter().cloned();
-                let stream = Stream::from_iter(token_iter);
+                        // Create a stream from the token iterator
+                        let token_iter = tokens.iter().cloned();
+                        let stream = Stream::from_iter(token_iter);
 
-                // Map the stream to split (Token, Span) tuples
-                let eoi: SimpleSpan = (source_len..source_len).into();
-                let mapped = stream.map(eoi, |(tok, span)| (tok, span));
+                        // Map the stream to split (Token, Span) tuples
+                        let eoi: SimpleSpan = (source_len..source_len).into();
+                        let mapped = stream.map(eoi, |(tok, span)| (tok, span));
 
-                ast_parser()
-                    .parse_with_state(mapped, &mut state)
-                    .into_result()
-                    .map_err(|errs| {
-                        let mut errors: Vec<CompileError> = errs
-                            .into_iter()
-                            .map(|err| convert_error(err, file_id))
-                            .collect();
-                        dedupe_parse_errors(&mut errors);
-                        CompileErrors::from(errors)
+                        let parser = {
+                            let _span = info_span!("parser_graph_construction").entered();
+                            ast_parser()
+                        };
+                        let parsed = {
+                            let _span = info_span!("parser_grammar_execution").entered();
+                            parser.parse_with_state(mapped, &mut state).into_result()
+                        };
+                        match parsed {
+                            Ok(ast) => (Ok(ast), 0, 0),
+                            Err(errs) => {
+                                let raw_error_count = errs.len();
+                                let errors = {
+                                    let _span = info_span!("parser_error_conversion").entered();
+                                    let mut errors: Vec<CompileError> = errs
+                                        .into_iter()
+                                        .map(|err| convert_error(err, file_id))
+                                        .collect();
+                                    dedupe_parse_errors(&mut errors);
+                                    errors
+                                };
+                                let error_count = errors.len();
+                                (
+                                    Err(CompileErrors::from(errors)),
+                                    raw_error_count,
+                                    error_count,
+                                )
+                            }
+                        }
                     })
-            })
-            .expect("failed to spawn parser thread")
-            .join()
-            .expect("parser thread panicked");
+                })
+                .expect("failed to spawn parser thread")
+                .join()
+                .expect("parser thread panicked")
+        };
 
+        let (result, raw_parse_error_count, parse_error_count) = result;
         let ast = match result {
             Ok(ast) => ast,
-            Err(errors) => return Err((errors, self.interner)),
+            Err(errors) => {
+                info!(
+                    outcome = "parse_error",
+                    input_token_count = self.input_token_count,
+                    parser_token_count,
+                    ast_item_count = 0,
+                    raw_parse_error_count,
+                    parse_error_count,
+                    validation_error_count = 0,
+                    "parser complete"
+                );
+                return Err((errors, self.interner));
+            }
         };
 
         // Post-parse validation that needs the interner (e.g. resolving
         // directive names so the diagnostic can say which directive is
         // unknown). See the `validate` module.
-        let validation_errors = crate::validate::check_directives(&ast, &self.interner);
+        let validation_errors = {
+            let _span = info_span!("parser_directive_validation").entered();
+            crate::validate::check_directives(&ast, &self.interner)
+        };
         if !validation_errors.is_empty() {
+            info!(
+                outcome = "validation_error",
+                input_token_count = self.input_token_count,
+                parser_token_count,
+                ast_item_count = ast.items.len(),
+                raw_parse_error_count,
+                parse_error_count,
+                validation_error_count = validation_errors.len(),
+                "parser complete"
+            );
             return Err((CompileErrors::from(validation_errors), self.interner));
         }
 
+        info!(
+            outcome = "success",
+            input_token_count = self.input_token_count,
+            parser_token_count,
+            ast_item_count = ast.items.len(),
+            raw_parse_error_count,
+            parse_error_count,
+            validation_error_count = 0,
+            "parser complete"
+        );
         Ok((ast, self.interner))
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1862,15 +1862,23 @@ fn main() {
     // Capture environment-derived resolution context exactly once for this
     // discovery epoch. Every compiler plan and identity decision receives this
     // immutable value; no discovery iteration rereads the environment.
+    // One root spans the disjoint intervals that perform canonical compiler
+    // work. RUE-890 made discovery's exact parse publishable, so leaving this
+    // boundary inside `CompilerSession::executable` would incorrectly report
+    // the discovery parse as a second timing root.
+    let compile_span = tracing::info_span!("compile", target = %options.target);
     let captured_std_root = env::var_os("RUE_STD_PATH").map(PathBuf::from);
-    let mut import_discovery = match discover_and_load_imports(
-        &sources,
-        source_manifest.as_ref(),
-        captured_std_root.as_deref(),
-        options.error_format,
-    ) {
-        Ok(result) => result,
-        Err(()) => std::process::exit(1),
+    let mut import_discovery = {
+        let _compile = compile_span.enter();
+        match discover_and_load_imports(
+            &sources,
+            source_manifest.as_ref(),
+            captured_std_root.as_deref(),
+            options.error_format,
+        ) {
+            Ok(result) => result,
+            Err(()) => std::process::exit(1),
+        }
     };
     if import_discovery.revision.status() == ImportDiscoveryRevisionStatus::ClosedValid
         && !import_discovery.mixed_imports.is_empty()
@@ -1925,6 +1933,7 @@ fn main() {
             diagnostics.print_errors(import_discovery.revision.diagnostics());
             std::process::exit(1);
         }
+        drop(compile_span);
         print_timing_output(
             &timing_data,
             options.time_passes,
@@ -1964,14 +1973,18 @@ fn main() {
 
     // Handle emit modes with multi-file support
     if !options.emit_stages.is_empty() {
-        if let Err(()) = handle_emit_multi_file(
-            &source_snapshot,
-            &mut import_discovery.session,
-            &options,
-            &diagnostics,
-        ) {
-            std::process::exit(1);
+        {
+            let _compile = compile_span.enter();
+            if let Err(()) = handle_emit_multi_file(
+                &source_snapshot,
+                &mut import_discovery.session,
+                &options,
+                &diagnostics,
+            ) {
+                std::process::exit(1);
+            }
         }
+        drop(compile_span);
         print_timing_output(
             &timing_data,
             options.time_passes,
@@ -1989,7 +2002,13 @@ fn main() {
         opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
     };
-    let compile_result = import_discovery.session.executable(&compile_options);
+    let compile_result = {
+        let _compile = compile_span.enter();
+        import_discovery
+            .session
+            .executable_in_compile_scope(&compile_options)
+    };
+    drop(compile_span);
     match compile_result {
         Ok(output) => {
             // Print warnings using the diagnostic formatter
@@ -2437,6 +2456,7 @@ fn handle_emit_multi_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing_subscriber::layer::SubscriberExt as _;
 
     fn test_snapshot(root: FileId, sources: &[(FileId, &str, &str, &str)]) -> SourceSnapshot {
         let physical_paths = sources
@@ -2478,6 +2498,56 @@ mod tests {
             }
             fs::write(&path, content).unwrap();
             path
+        }
+    }
+
+    #[test]
+    fn discovery_parse_and_pipeline_share_the_cli_compile_root() {
+        let dir = TestDir::new("timed-discovery-root");
+        let main = dir.write(
+            "main.rue",
+            "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.value() }\n",
+        );
+        dir.write("helper.rue", "pub fn value() -> i32 { 0 }\n");
+        let sources = vec![(main.to_string_lossy().into_owned(), String::new())];
+        let data = timing::TimingData::new();
+        let subscriber =
+            tracing_subscriber::registry().with(timing::TimingLayer::new(data.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let compile_span = tracing::info_span!("compile", target = "test");
+            let mut discovery = {
+                let _compile = compile_span.enter();
+                discover_and_load_imports(&sources, None, None, ErrorFormat::Text).unwrap()
+            };
+            {
+                let _compile = compile_span.enter();
+                discovery
+                    .session
+                    .executable_in_compile_scope(&CompileOptions::default())
+                    .unwrap();
+            }
+            drop(compile_span);
+        });
+
+        let edges = data.parent_edges();
+        assert!(
+            edges.contains(&("compile".to_owned(), "parse_file".to_owned())),
+            "discovery parse escaped the compile root: {edges:?}"
+        );
+        assert!(
+            edges.contains(&("compile".to_owned(), "compile_pipeline".to_owned())),
+            "post-discovery pipeline escaped the compile root: {edges:?}"
+        );
+        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None);
+        for pass in &timing.passes {
+            if pass.name == "compile" {
+                assert_eq!(pass.invocations, 1);
+                assert_eq!(pass.root_invocations, 1);
+                assert_eq!(pass.leaf_invocations, 0);
+            } else {
+                assert_eq!(pass.root_invocations, 0, "{}", pass.name);
+            }
         }
     }
 

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -232,7 +232,7 @@ impl TimingData {
 
     /// Snapshot parent-child relationships captured by the real timing layer.
     #[cfg(test)]
-    fn parent_edges(&self) -> Vec<(String, String)> {
+    pub(crate) fn parent_edges(&self) -> Vec<(String, String)> {
         self.inner
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
@@ -746,6 +746,20 @@ mod tests {
             direct_edges.contains(&("parse_file".to_owned(), "parser".to_owned())),
             "direct parse edges: {direct_edges:?}"
         );
+        for expected in [
+            ("parser", "parser_token_adaptation"),
+            ("parser", "parser_nesting_scan"),
+            ("parser", "parser_state_setup"),
+            ("parser", "parser_worker"),
+            ("parser_worker", "parser_graph_construction"),
+            ("parser_worker", "parser_grammar_execution"),
+            ("parser", "parser_directive_validation"),
+        ] {
+            assert!(
+                direct_edges.contains(&(expected.0.to_owned(), expected.1.to_owned())),
+                "missing {expected:?} in direct parse edges: {direct_edges:?}"
+            );
+        }
 
         let direct_timing =
             direct_data.to_benchmark_timing_with_metrics("test", "test", None, None);
@@ -820,10 +834,14 @@ mod tests {
         });
 
         let compile_edges = compile_data.parent_edges();
+        assert!(
+            compile_edges.contains(&("compile".to_owned(), "compile_pipeline".to_owned())),
+            "missing compile -> compile_pipeline in batch edges: {compile_edges:?}"
+        );
         for child in ["rir_declaration_index", "sema"] {
             assert!(
-                compile_edges.contains(&("compile".to_owned(), child.to_owned())),
-                "missing compile -> {child} in batch edges: {compile_edges:?}"
+                compile_edges.contains(&("compile_pipeline".to_owned(), child.to_owned())),
+                "missing compile_pipeline -> {child} in batch edges: {compile_edges:?}"
             );
         }
         assert!(
@@ -841,6 +859,29 @@ mod tests {
         assert_eq!(compile.invocations, 1);
         assert_eq!(compile.root_invocations, 1);
         assert_eq!(compile.leaf_invocations, 0);
+        let parser = compile_timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "parser")
+            .unwrap();
+        assert_eq!(parser.root_invocations, 0);
+        assert_eq!(parser.leaf_invocations, 0);
+        for phase in [
+            "parser_token_adaptation",
+            "parser_nesting_scan",
+            "parser_state_setup",
+            "parser_worker",
+            "parser_graph_construction",
+            "parser_grammar_execution",
+            "parser_directive_validation",
+        ] {
+            let timing = compile_timing
+                .passes
+                .iter()
+                .find(|pass| pass.name == phase)
+                .unwrap();
+            assert_eq!(timing.root_invocations, 0, "{phase}");
+        }
         for phase in ["rir_declaration_index", "sema"] {
             let timing = compile_timing
                 .passes
@@ -851,6 +892,49 @@ mod tests {
             assert_eq!(timing.root_invocations, 0, "{phase}");
             assert_eq!(timing.leaf_invocations, 1, "{phase}");
         }
+    }
+
+    #[test]
+    fn parser_failure_subphases_preserve_parentage() {
+        let capture = |source: &str| {
+            let snapshot = SourceSnapshot::single("main.rue", source).unwrap();
+            let data = TimingData::new();
+            let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
+            tracing::subscriber::with_default(subscriber, || {
+                parse_source_snapshot_for_ast_presentation(&snapshot).unwrap_err();
+            });
+            data.parent_edges()
+        };
+
+        let parse_error_edges = capture("fn main( {");
+        assert!(
+            parse_error_edges.contains(&(
+                "parser_worker".to_owned(),
+                "parser_error_conversion".to_owned()
+            )),
+            "parse-error edges: {parse_error_edges:?}"
+        );
+        assert!(
+            !parse_error_edges
+                .iter()
+                .any(|(_, child)| child == "parser_directive_validation"),
+            "directive validation must not run after grammar failure: {parse_error_edges:?}"
+        );
+
+        let validation_edges = capture("@important fn main() -> i32 { 0 }");
+        assert!(
+            validation_edges.contains(&(
+                "parser".to_owned(),
+                "parser_directive_validation".to_owned()
+            )),
+            "validation-error edges: {validation_edges:?}"
+        );
+        assert!(
+            !validation_edges
+                .iter()
+                .any(|(_, child)| child == "parser_error_conversion"),
+            "parse-error conversion must not run after grammar success: {validation_edges:?}"
+        );
     }
 
     #[test]

--- a/docs/process/logging.md
+++ b/docs/process/logging.md
@@ -36,6 +36,15 @@ rows. Distinct parallel leaf spans may overlap and should be interpreted as
 summed work rather than wall time. Logging filters such as `RUST_LOG=error`
 affect log output only; they do not disable timing collection.
 
+Parser timing keeps `parse_file -> parser` as the canonical aggregate and
+reports stable setup leaves plus a `parser_worker` lifecycle aggregate. The
+worker owns graph-construction and grammar-execution children; parse-error
+conversion appears only on grammar failure, while directive validation appears
+only after grammar success. The parser explicitly propagates both tracing
+dispatch and span context to its dedicated large-stack thread, so worker spans
+never become independent roots. Join wait is intentionally not an additive
+leaf because it overlaps the worker work it waits for.
+
 ### Adding Instrumentation
 
 Each compilation pass should have a tracing span wrapping the work:

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -40,17 +40,26 @@ The compiler wraps each pass in a tracing span, and some spans are **nested**,
 so the raw timing JSON contains both leaf passes and their aggregate parents:
 
 ```
-compile                 <- compiler pipeline; excludes discovery/driver startup
+compile                 <- canonical discovery parsing + compiler work
 ├─ parse_file           <- aggregate, repeated for each canonical module
 │  ├─ lexer             <- leaf
-│  └─ parser            <- leaf
-├─ semantic_astgen      <- leaf: canonical semantic AST -> RIR
-│  └─ definition_snapshot_modules <- durable module/name-candidate index
-├─ rir_declaration_index <- leaf: snapshot-local RIR declaration candidates
-├─ sema                 <- leaf: type checking / AIR
-├─ cfg_construction     <- leaf
-├─ codegen              <- leaf: MIR lower + regalloc + emit
-└─ linker               <- leaf: built-in ELF link in these baseline runs
+│  └─ parser            <- aggregate
+│     ├─ parser_token_adaptation   <- leaf
+│     ├─ parser_nesting_scan       <- leaf
+│     ├─ parser_state_setup        <- leaf
+│     ├─ parser_worker             <- thread-lifecycle aggregate
+│     │  ├─ parser_graph_construction <- leaf
+│     │  └─ parser_grammar_execution   <- leaf
+│     │     (parser_error_conversion is a failure-only sibling leaf)
+│     └─ parser_directive_validation <- leaf after grammar success
+└─ compile_pipeline     <- post-discovery query/backend aggregate
+   ├─ semantic_astgen   <- aggregate: canonical semantic AST -> RIR
+   │  └─ definition_snapshot_modules <- durable module/name-candidate index
+   ├─ rir_declaration_index <- leaf: snapshot-local RIR declaration candidates
+   ├─ sema              <- leaf: type checking / AIR
+   ├─ cfg_construction  <- leaf
+   ├─ codegen           <- leaf: MIR lower + regalloc + emit
+   └─ linker            <- leaf: built-in ELF link in these baseline runs
 ```
 
 Since RUE-642, timing JSON schema v2 labels the model as `inclusive_spans`.
@@ -76,8 +85,11 @@ overlap or residual time that occurred in no real run. Rue's current
 coordinator-level leaves are sequential, so overlapping leaf work should be
 zero today; if future parallel leaf spans overlap, their sum is work time and
 may legitimately exceed root wall time.
-`process_ms` additionally covers process startup, source loading/import
-discovery, output handling, and other driver work outside `compile`.
+`process_ms` additionally covers process startup, output handling, and other
+driver work outside `compile`. For the filesystem CLI, `compile` includes the
+stable reads, import resolution, and canonical parsing that produce the closed
+discovery revision, as well as the later query/backend interval. Output-path
+validation and output-file I/O remain outside it.
 The corpus-wide hot-pass table is likewise a descriptive ratio of summed
 per-workload medians, not the accounting for a single run.
 
@@ -88,6 +100,13 @@ per-workload medians, not the accounting for a single run.
 > workaround and can still read schema-v1 samples. Any other comparison across
 > the schema boundary must likewise use the old `compile` row rather than old
 > `total_ms`.
+
+> **Discovery-boundary discontinuity.** RUE-890 made the parser result produced
+> during import discovery the exact canonical frontend artifact. RUE-892 moves
+> that now-once-only parse under the `compile` root and introduces the
+> `compile_pipeline` post-discovery aggregate. Comparisons from before this
+> boundary omitted discovery parsing from the `compile` row even though they
+> subsequently consumed its artifact.
 
 ## Baseline (measured 2026-07-03)
 

--- a/scripts/perf-baseline.py
+++ b/scripts/perf-baseline.py
@@ -18,20 +18,17 @@ human-readable, self-contained snapshot with no history/network side effects.
 The compiler wraps each pass in a tracing span. Some spans are *nested*, so
 the raw JSON contains both leaf passes and their aggregate parents:
 
-    compile                         <- top-level compiler pipeline wall clock
-    |- parse                        <- aggregate
-    |  |- parse_file                <- aggregate, repeated for every file
-    |  |  |- lexer                  <- leaf
-    |  |  `- parser                 <- leaf
-    |  |- definition_snapshot       <- leaf
-    |  `- historical symbol merge  <- leaf
-    |- astgen                       <- leaf
-    |- semantic_astgen              <- leaf
-    |- rir_declaration_index        <- leaf
-    |- sema                         <- leaf
-    |- cfg_construction             <- leaf
-    |- codegen                      <- leaf
-    |- linker                       <- leaf
+    compile                         <- canonical discovery + compiler work
+    |- parse_file                   <- aggregate, repeated for every file
+    |  |- lexer                     <- leaf
+    |  `- parser                    <- aggregate
+    |     |- parser setup leaves
+    |     |- parser_worker          <- aggregate
+    |     |  |- graph construction  <- leaf
+    |     |  `- grammar execution   <- leaf
+    |     `- directive validation   <- leaf
+    `- compile_pipeline             <- post-discovery aggregate
+       `- semantic/codegen leaves
 
 Schema v2 marks root and leaf invocations explicitly. `total_ms` is the
 inclusive duration of root compiler spans; nested pass rows are also inclusive
@@ -85,7 +82,14 @@ WALL_CLOCK_PASS = "compile"
 CANONICAL_LEAF_ORDER = [
     "parse_file",  # schema-v1 combined lexer/parser leaf
     "lexer",
-    "parser",
+    "parser",  # pre-RUE-892 parser leaf
+    "parser_token_adaptation",
+    "parser_nesting_scan",
+    "parser_state_setup",
+    "parser_graph_construction",
+    "parser_grammar_execution",
+    "parser_error_conversion",
+    "parser_directive_validation",
     "definition_snapshot",
     "merge_" + "symbols",  # historical schema-v1 name
     "astgen",
@@ -136,9 +140,9 @@ MULTI_MAIN = """\
 const a = @import("a.rue");
 const b = @import("b.rue");
 
-fn main() -> i64 {
-    let mut total: i64 = 0;
-    let mut i: i64 = 0;
+fn main() -> i32 {
+    let mut total: i32 = 0;
+    let mut i: i32 = 0;
     while i < 100 {
         total = total + a.square(i) + b.cube(i);
         i = i + 1;
@@ -148,13 +152,13 @@ fn main() -> i64 {
 """
 
 MULTI_A = """\
-pub fn square(x: i64) -> i64 {
+pub fn square(x: i32) -> i32 {
     x * x
 }
 """
 
 MULTI_B = """\
-pub fn cube(x: i64) -> i64 {
+pub fn cube(x: i32) -> i32 {
     x * x * x
 }
 """


### PR DESCRIPTION
## Summary

- split the canonical parser span into token adaptation, nesting scan, state setup, worker lifecycle, graph construction, grammar execution, error conversion, and directive validation
- propagate tracing dispatch and span context into the dedicated parser thread without double-counting join wait
- restore one honest CLI compile root around the canonical discovery parse and post-discovery pipeline
- update timing regressions, benchmark ordering/corpus, and performance documentation

## Evidence

- `scripts/rue quick`: 25/25 targets
- parser: 115/115; compiler: 473/473; CLI/unit: 146/146
- benchmark-tool tests: 26/26
- representative baseline: 3 iterations per workload, stable leaves, one compile root
- direct `control_flow` trace: parser 350.39 ms; grammar execution 347.87 ms; graph construction 0.61 ms
- corpus hot parser leaves: grammar 1471.63 ms vs graph construction 6.39 ms

Fixes RUE-892