### PR TITLE
RUE-801: reject partial benchmark iterations

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -102,6 +102,7 @@ filegroup(
     srcs = [
         "benchmarks/manifest.toml",
         "scripts/append-benchmark.py",
+        "scripts/benchmark_collection.py",
         "scripts/benchmark_validation.py",
         "scripts/generate-charts.py",
         "scripts/perf-baseline.py",

--- a/bench.sh
+++ b/bench.sh
@@ -93,6 +93,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [[ ! "$ITERATIONS" =~ ^[1-9][0-9]*$ ]]; then
+    log_error "--iterations must be a positive integer"
+    exit 1
+fi
+
 # Verify we're in the right directory
 if [[ ! -f "$MANIFEST" ]]; then
     log_error "Cannot find benchmarks/manifest.toml"
@@ -169,8 +174,8 @@ for i in "${!benchmark_names[@]}"; do
     full_path="$BENCHMARKS_DIR/$path"
 
     if [[ ! -f "$full_path" ]]; then
-        log_warn "Benchmark file not found: $path (skipping)"
-        continue
+        log_error "Benchmark file not found: $path"
+        exit 1
     fi
 
     log_info "Running: $name"
@@ -189,9 +194,10 @@ for i in "${!benchmark_names[@]}"; do
         if [[ "$os" == "darwin" ]]; then
             # macOS: -l gives max resident set size in bytes
             if ! timing_json=$(/usr/bin/time -l "$RUE_BIN" --benchmark-json "$full_path" -o "$output_binary" 2>"$time_output"); then
-                log_warn "  Iteration $iter failed, skipping"
+                log_error "  Iteration $iter failed"
+                cat "$time_output" >&2
                 rm -f "$time_output"
-                continue
+                exit 1
             fi
             # Extract max RSS from time output (in bytes on macOS).
             # `|| true`: a missing line is not fatal (pipefail would abort otherwise).
@@ -199,9 +205,10 @@ for i in "${!benchmark_names[@]}"; do
         else
             # Linux: -v gives max resident set size in KB
             if ! timing_json=$(/usr/bin/time -v "$RUE_BIN" --benchmark-json "$full_path" -o "$output_binary" 2>"$time_output"); then
-                log_warn "  Iteration $iter failed, skipping"
+                log_error "  Iteration $iter failed"
+                cat "$time_output" >&2
                 rm -f "$time_output"
-                continue
+                exit 1
             fi
             # Extract max RSS from time output (in KB on Linux, convert to bytes).
             # `|| true`: a missing line is not fatal (pipefail would abort otherwise);
@@ -211,20 +218,17 @@ for i in "${!benchmark_names[@]}"; do
         fi
         rm -f "$time_output"
 
-        # Extract the schema-v2 root-span total. Before RUE-642 this field
-        # summed nested spans and was inflated; historical dashboard entries
-        # retain that older meaning. `|| true`: grep may not match and
-        # `head -1` closing the pipe early can SIGPIPE grep — neither is fatal
-        # (the `-n "$total_ms"` check below handles a missing value).
-        total_ms=$(echo "$timing_json" | grep -o '"total_ms":[0-9.]*' | head -1 | cut -d: -f2 || true)
-        if [[ -n "$total_ms" ]]; then
-            iteration_results+=("$total_ms")
-            # Store full JSON for pass data extraction
-            iteration_pass_data+=("$timing_json")
-            # Store memory usage
-            if [[ -n "$peak_mem_bytes" && "$peak_mem_bytes" -gt 0 ]]; then
-                iteration_memory+=("$peak_mem_bytes")
-            fi
+        # Parse every timing payload strictly. A malformed payload invalidates
+        # the run rather than being silently omitted from the sample set.
+        total_ms=$(PYTHONPATH="$SCRIPT_DIR/scripts" python3 -c '
+import sys
+from benchmark_collection import parse_iteration_json
+print(parse_iteration_json(sys.argv[1])["total_ms"])
+' "$timing_json")
+        iteration_results+=("$total_ms")
+        iteration_pass_data+=("$timing_json")
+        if [[ -n "$peak_mem_bytes" && "$peak_mem_bytes" -gt 0 ]]; then
+            iteration_memory+=("$peak_mem_bytes")
         fi
 
         # Capture binary size from the last successful iteration
@@ -244,9 +248,9 @@ for i in "${!benchmark_names[@]}"; do
         rm -f "$output_binary"
     done
 
-    if [[ ${#iteration_results[@]} -eq 0 ]]; then
-        log_warn "  No successful iterations for $name"
-        continue
+    if [[ ${#iteration_results[@]} -ne $ITERATIONS ]]; then
+        log_error "  Collected ${#iteration_results[@]} of $ITERATIONS iterations for $name"
+        exit 1
     fi
 
     # Calculate mean and stddev for total time
@@ -299,59 +303,14 @@ for i in "${!benchmark_names[@]}"; do
 
     log_info "  $name: time=${mean}ms (±${stddev}), mem=${mem_mean_mb}MB, binary=${binary_size_kb}KB (n=$count)"
 
-    # Extract and aggregate per-pass timing data, source metrics, and memory
-    # Use Python to parse JSON and compute per-pass means
-    extra_json=$(python3 -c "
+    # Every payload is parsed again by the shared strict aggregator. Any
+    # malformed pass row or inconsistent timing schema aborts publication.
+    extra_json=$(PYTHONPATH="$SCRIPT_DIR/scripts" python3 -c '
 import json
 import sys
-
-pass_data = {}
-source_metrics = None
-peak_memory_samples = []
-timing_schema_version = None
-
-for json_str in sys.argv[1:]:
-    try:
-        data = json.loads(json_str)
-        schema_version = data.get('schema_version', 1)
-        if timing_schema_version is None:
-            timing_schema_version = schema_version
-        for p in data.get('passes', []):
-            pname = p['name']
-            # Schema v2 durations are inclusive. Persist only structural
-            # leaves so parse_file is not stacked with lexer + parser in the
-            # dashboard. V1 had no nesting metadata and parse_file was a leaf.
-            if schema_version >= 2 and p.get('leaf_invocations') != p.get('invocations'):
-                continue
-            duration = p['duration_ms']
-            if pname not in pass_data:
-                pass_data[pname] = []
-            pass_data[pname].append(duration)
-        # Get source_metrics from first run (they're constant)
-        if source_metrics is None and 'source_metrics' in data:
-            source_metrics = data['source_metrics']
-        # Collect peak memory samples
-        if 'peak_memory_bytes' in data and data['peak_memory_bytes']:
-            peak_memory_samples.append(data['peak_memory_bytes'])
-    except:
-        pass
-
-# Calculate means for passes
-passes = {}
-for pname, durations in pass_data.items():
-    mean = sum(durations) / len(durations) if durations else 0
-    passes[pname] = {'mean_ms': round(mean, 3)}
-
-result = {'passes': passes}
-if timing_schema_version is not None:
-    result['timing_schema_version'] = timing_schema_version
-if source_metrics:
-    result['source_metrics'] = source_metrics
-if peak_memory_samples:
-    result['peak_memory_bytes'] = int(sum(peak_memory_samples) / len(peak_memory_samples))
-
-print(json.dumps(result))
-" "${iteration_pass_data[@]}" 2>/dev/null || echo "{\"passes\":{}}")
+from benchmark_collection import aggregate_iterations
+print(json.dumps(aggregate_iterations(sys.argv[1:])))
+' "${iteration_pass_data[@]}")
 
     # Extract components from the JSON
     passes_json=$(echo "$extra_json" | python3 -c "import sys, json; d=json.load(sys.stdin); print(json.dumps(d.get('passes', {})))")

--- a/scripts/benchmark_collection.py
+++ b/scripts/benchmark_collection.py
@@ -1,0 +1,115 @@
+"""Strict parsing and aggregation for benchmark compiler iterations."""
+
+import json
+import math
+
+
+def _non_negative_number(value: object, description: str) -> float:
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or value < 0
+        or (isinstance(value, float) and not math.isfinite(value))
+    ):
+        raise ValueError(f"{description} must be a finite non-negative number")
+    return float(value)
+
+
+def parse_iteration_json(text: str) -> dict:
+    """Parse one compiler timing payload, rejecting malformed timing/pass data."""
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError("benchmark timing JSON must be an object")
+
+    schema_version = data.get("schema_version", 1)
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version not in (1, 2)
+    ):
+        raise ValueError("schema_version must be integer 1 or 2")
+    _non_negative_number(data.get("total_ms"), "total_ms")
+    passes = data.get("passes")
+    if not isinstance(passes, list):
+        raise ValueError("passes must be an array")
+    for index, row in enumerate(passes):
+        if not isinstance(row, dict):
+            raise ValueError(f"pass #{index + 1} must be an object")
+        name = row.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"pass #{index + 1} has no valid name")
+        _non_negative_number(row.get("duration_ms"), f"pass '{name}' duration_ms")
+        if schema_version == 2:
+            for field in ("invocations", "root_invocations", "leaf_invocations"):
+                value = row.get(field)
+                if (
+                    not isinstance(value, int)
+                    or isinstance(value, bool)
+                    or value < 0
+                ):
+                    raise ValueError(
+                        f"pass '{name}' {field} must be a non-negative integer"
+                    )
+            if row["invocations"] <= 0:
+                raise ValueError(f"pass '{name}' invocations must be greater than zero")
+            for field in ("root_invocations", "leaf_invocations"):
+                if row[field] > row["invocations"]:
+                    raise ValueError(
+                        f"pass '{name}' {field} exceeds invocations"
+                    )
+    names = [row["name"] for row in passes]
+    if len(names) != len(set(names)):
+        raise ValueError("passes must not contain duplicate names")
+    return data
+
+
+def aggregate_iterations(payloads: list[str]) -> dict:
+    """Aggregate validated compiler timing payloads without dropping rows."""
+    if not payloads:
+        raise ValueError("no benchmark iterations supplied")
+
+    pass_data: dict[str, list[float]] = {}
+    source_metrics = None
+    peak_memory_samples = []
+    timing_schema_version = None
+    expected_included_passes = None
+
+    for text in payloads:
+        data = parse_iteration_json(text)
+        schema_version = data.get("schema_version", 1)
+        if timing_schema_version is None:
+            timing_schema_version = schema_version
+        elif schema_version != timing_schema_version:
+            raise ValueError("timing schema_version changed between iterations")
+
+        included_passes = set()
+        for row in data["passes"]:
+            if schema_version >= 2 and row.get("leaf_invocations") != row.get(
+                "invocations"
+            ):
+                continue
+            included_passes.add(row["name"])
+            pass_data.setdefault(row["name"], []).append(float(row["duration_ms"]))
+        if expected_included_passes is None:
+            expected_included_passes = included_passes
+        elif included_passes != expected_included_passes:
+            raise ValueError("aggregated pass set changed between iterations")
+        if source_metrics is None and "source_metrics" in data:
+            source_metrics = data["source_metrics"]
+        if "peak_memory_bytes" in data and data["peak_memory_bytes"]:
+            peak_memory_samples.append(
+                _non_negative_number(data["peak_memory_bytes"], "peak_memory_bytes")
+            )
+
+    passes = {
+        name: {"mean_ms": round(sum(durations) / len(durations), 3)}
+        for name, durations in pass_data.items()
+    }
+    result = {"passes": passes, "timing_schema_version": timing_schema_version}
+    if source_metrics is not None:
+        result["source_metrics"] = source_metrics
+    if peak_memory_samples:
+        result["peak_memory_bytes"] = int(
+            sum(peak_memory_samples) / len(peak_memory_samples)
+        )
+    return result

--- a/scripts/benchmark_validation.py
+++ b/scripts/benchmark_validation.py
@@ -1,12 +1,22 @@
 """Shared schema and corpus validation for benchmark result publication."""
 
 from collections import Counter
+import math
 from pathlib import Path
 import tomllib
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_MANIFEST = REPO_ROOT / "benchmarks" / "manifest.toml"
+
+
+def _is_finite_non_negative_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and value >= 0
+        and (isinstance(value, int) or math.isfinite(value))
+    )
 
 
 def load_manifest_names(path: Path) -> list[str]:
@@ -39,13 +49,22 @@ def validate_results(data: object, expected_names: list[str]) -> list[str]:
     if not isinstance(data, dict):
         return ["benchmark result must be a JSON object"]
 
+    iterations = data.get("iterations")
+    if (
+        not isinstance(iterations, int)
+        or isinstance(iterations, bool)
+        or iterations <= 0
+    ):
+        errors = ["iterations must be a positive integer"]
+    else:
+        errors = []
+
     benchmarks = data.get("benchmarks")
     if not isinstance(benchmarks, list):
-        return ["benchmarks must be an array"]
+        return errors + ["benchmarks must be an array"]
     if not benchmarks:
-        return ["no benchmark results collected; all benchmarks failed"]
+        return errors + ["no benchmark results collected; all benchmarks failed"]
 
-    errors = []
     result_names = []
     for index, bench in enumerate(benchmarks):
         if not isinstance(bench, dict):
@@ -58,10 +77,48 @@ def validate_results(data: object, expected_names: list[str]) -> list[str]:
         else:
             result_names.append(name)
 
-        mean = bench.get("mean_ms")
-        if not isinstance(mean, (int, float)) or isinstance(mean, bool):
-            display_name = name if isinstance(name, str) and name else f"#{index + 1}"
-            errors.append(f"benchmark '{display_name}' has no numeric mean_ms")
+        display_name = name if isinstance(name, str) and name else f"#{index + 1}"
+        for field in ("mean_ms", "std_ms"):
+            value = bench.get(field)
+            if not _is_finite_non_negative_number(value):
+                errors.append(
+                    f"benchmark '{display_name}' has no finite non-negative {field}"
+                )
+
+        bench_iterations = bench.get("iterations")
+        if (
+            not isinstance(bench_iterations, int)
+            or isinstance(bench_iterations, bool)
+            or bench_iterations <= 0
+        ):
+            errors.append(
+                f"benchmark '{display_name}' iterations must be a positive integer"
+            )
+        elif isinstance(iterations, int) and not isinstance(iterations, bool):
+            if bench_iterations != iterations:
+                errors.append(
+                    f"benchmark '{display_name}' iterations ({bench_iterations}) "
+                    f"does not match root iterations ({iterations})"
+                )
+
+        passes = bench.get("passes")
+        if not isinstance(passes, dict):
+            errors.append(f"benchmark '{display_name}' passes must be an object")
+        else:
+            for pass_name, pass_data in passes.items():
+                if not isinstance(pass_name, str) or not pass_name:
+                    errors.append(
+                        f"benchmark '{display_name}' has an invalid pass name"
+                    )
+                    continue
+                pass_mean = (
+                    pass_data.get("mean_ms") if isinstance(pass_data, dict) else None
+                )
+                if not _is_finite_non_negative_number(pass_mean):
+                    errors.append(
+                        f"benchmark '{display_name}' pass '{pass_name}' has no "
+                        "finite non-negative mean_ms"
+                    )
 
     duplicates = sorted(
         name for name, count in Counter(result_names).items() if count > 1

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -29,6 +29,7 @@ def load_module(name: str, relative_path: str):
 
 
 validator = load_module("validate_benchmark", "scripts/validate-benchmark.py")
+collection = load_module("benchmark_collection", "scripts/benchmark_collection.py")
 charts = load_module("generate_charts", "scripts/generate-charts.py")
 perf_baseline = load_module("perf_baseline", "scripts/perf-baseline.py")
 
@@ -512,8 +513,15 @@ class BenchmarkValidationTests(unittest.TestCase):
             "version": 1,
             "timestamp": "2026-07-09T00:00:00Z",
             "commit": "probe",
+            "iterations": 5,
             "benchmarks": [
-                {"name": name, "mean_ms": index + 0.5}
+                {
+                    "name": name,
+                    "mean_ms": index + 0.5,
+                    "std_ms": 0.1,
+                    "iterations": 5,
+                    "passes": {"compile": {"mean_ms": index + 0.5}},
+                }
                 for index, name in enumerate(self.expected_names)
             ],
         }
@@ -550,16 +558,74 @@ class BenchmarkValidationTests(unittest.TestCase):
         result["benchmarks"][0]["mean_ms"] = "fast"
         errors = validator.validate_results(result, self.expected_names)
         self.assertIn(
-            f"benchmark '{self.expected_names[0]}' has no numeric mean_ms", errors
+            f"benchmark '{self.expected_names[0]}' has no finite non-negative mean_ms",
+            errors,
         )
+
+    def test_rejects_partial_and_mixed_iteration_counts(self):
+        partial = self.valid_result()
+        partial["benchmarks"][0]["iterations"] = 1
+        self.assertIn(
+            f"benchmark '{self.expected_names[0]}' iterations (1) does not match "
+            "root iterations (5)",
+            validator.validate_results(partial, self.expected_names),
+        )
+
+        mixed = self.valid_result()
+        mixed["benchmarks"][1]["iterations"] = 4
+        errors = validator.validate_results(mixed, self.expected_names)
+        self.assertTrue(any("iterations (4) does not match" in error for error in errors))
+
+    def test_rejects_malformed_counts_timing_and_pass_data(self):
+        mutations = [
+            (lambda result: result.update(iterations=True), "iterations must be"),
+            (lambda result: result.update(iterations=0), "iterations must be"),
+            (
+                lambda result: result["benchmarks"][0].update(iterations=1.0),
+                "iterations must be a positive integer",
+            ),
+            (
+                lambda result: result["benchmarks"][0].update(mean_ms=float("inf")),
+                "finite non-negative mean_ms",
+            ),
+            (
+                lambda result: result["benchmarks"][0].update(std_ms=-0.1),
+                "finite non-negative std_ms",
+            ),
+            (
+                lambda result: result["benchmarks"][0].update(passes=[]),
+                "passes must be an object",
+            ),
+            (
+                lambda result: result["benchmarks"][0]["passes"]["compile"].update(
+                    mean_ms=float("nan")
+                ),
+                "finite non-negative mean_ms",
+            ),
+        ]
+        for mutate, message in mutations:
+            with self.subTest(message=message):
+                result = self.valid_result()
+                mutate(result)
+                self.assertTrue(
+                    any(
+                        message in error
+                        for error in validator.validate_results(
+                            result, self.expected_names
+                        )
+                    )
+                )
+
 
     def test_empty_and_malformed_corpora_are_rejected(self):
         self.assertEqual(
-            validator.validate_results({"benchmarks": []}, self.expected_names),
+            validator.validate_results(
+                {"iterations": 1, "benchmarks": []}, self.expected_names
+            ),
             ["no benchmark results collected; all benchmarks failed"],
         )
         errors = validator.validate_results(
-            {"benchmarks": ["not an object"]}, self.expected_names
+            {"iterations": 1, "benchmarks": ["not an object"]}, self.expected_names
         )
         self.assertIn("benchmark #1 must be an object", errors)
         self.assertTrue(any("missing benchmark result" in error for error in errors))
@@ -644,6 +710,90 @@ class BenchmarkValidationTests(unittest.TestCase):
             self.assertEqual(published[0]["version"], 2)
             self.assertEqual(published[0]["benchmark_reason"], "push")
             self.assertEqual(published[0]["commit_range"], ["probe"])
+
+
+class BenchmarkCollectionTests(unittest.TestCase):
+    @staticmethod
+    def payload(total_ms=2.0, passes=None):
+        return json.dumps(
+            {
+                "schema_version": 2,
+                "total_ms": total_ms,
+                "passes": passes
+                if passes is not None
+                else [
+                    {
+                        "name": "lexer",
+                        "duration_ms": 1.0,
+                        "invocations": 1,
+                        "root_invocations": 0,
+                        "leaf_invocations": 1,
+                    }
+                ],
+            }
+        )
+
+    def test_valid_iterations_are_all_aggregated(self):
+        result = collection.aggregate_iterations(
+            [self.payload(2.0), self.payload(4.0)]
+        )
+        self.assertEqual(result["passes"], {"lexer": {"mean_ms": 1.0}})
+
+    def test_malformed_timing_or_pass_payload_aborts_collection(self):
+        bad_payloads = [
+            "not json",
+            self.payload(float("inf")),
+            self.payload(passes={}),
+            self.payload(passes=[{"name": "lexer", "duration_ms": "fast"}]),
+            self.payload(
+                passes=[
+                    {
+                        "name": "lexer",
+                        "duration_ms": 1.0,
+                        "invocations": 1,
+                        "leaf_invocations": 1,
+                    }
+                ]
+            ),
+            self.payload(
+                passes=[
+                    {
+                        "name": "lexer",
+                        "duration_ms": 1.0,
+                        "invocations": True,
+                        "root_invocations": 0,
+                        "leaf_invocations": 1,
+                    }
+                ]
+            ),
+            self.payload(
+                passes=[
+                    {
+                        "name": "lexer",
+                        "duration_ms": 1.0,
+                        "invocations": 1,
+                        "root_invocations": 0,
+                        "leaf_invocations": 2,
+                    }
+                ]
+            ),
+        ]
+        for payload in bad_payloads:
+            with self.subTest(payload=payload):
+                with self.assertRaises((ValueError, json.JSONDecodeError)):
+                    collection.aggregate_iterations([self.payload(), payload])
+
+    def test_rejects_unsupported_timing_schema(self):
+        payload = json.loads(self.payload())
+        payload["schema_version"] = 3
+        with self.assertRaisesRegex(ValueError, "integer 1 or 2"):
+            collection.aggregate_iterations([json.dumps(payload)])
+
+    def test_rejects_pass_set_drift_between_iterations(self):
+        changed = json.loads(self.payload())
+        changed["passes"][0]["name"] = "parser"
+        with self.assertRaisesRegex(ValueError, "pass set changed"):
+            collection.aggregate_iterations([self.payload(), json.dumps(changed)])
 
 
 class ChartAggregationTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- fail benchmark collection when any requested iteration or manifest input is missing
- validate iteration counts and finite timing/pass aggregates at both CI and history-publication boundaries
- strictly parse compiler timing payloads without silently dropping malformed samples or pass rows

## Validation

- `./buck2 test //:benchmark-tool-tests`
- `scripts/rue quick`
- `bash -n bench.sh`
- `git diff --check`

Fixes RUE-801
