### PR TITLE
RUE-887: reuse stable per-function CFGs

### DIFF
--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -532,7 +532,7 @@ impl BasicBlock {
 }
 
 /// The complete CFG for a function.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Cfg {
     /// All basic blocks
     blocks: Vec<BasicBlock>,
@@ -576,6 +576,57 @@ pub struct Cfg {
 }
 
 impl Cfg {
+    /// Clone and atomically remap every request-local payload domain embedded
+    /// in this CFG. Block and value numbers are structural within the graph;
+    /// types, nominal IDs, symbols, strings, and spans are supplied by the
+    /// caller's stable projection/import boundary.
+    pub fn try_remap_domains<E>(
+        &self,
+        mut ty: impl FnMut(Type) -> Result<Type, E>,
+        mut strukt: impl FnMut(StructId) -> Result<StructId, E>,
+        mut enm: impl FnMut(EnumId) -> Result<EnumId, E>,
+        mut symbol: impl FnMut(Spur) -> Result<Spur, E>,
+        mut string: impl FnMut(u32) -> Result<u32, E>,
+        mut span: impl FnMut(Span) -> Result<Span, E>,
+    ) -> Result<Self, E> {
+        let mut cfg = self.clone();
+        cfg.return_type = ty(cfg.return_type)?;
+        for block in &mut cfg.blocks {
+            for (_, value_ty) in &mut block.params {
+                *value_ty = ty(*value_ty)?;
+            }
+        }
+        for projection in &mut cfg.projections {
+            match projection {
+                Projection::Field { struct_id, .. } => *struct_id = strukt(*struct_id)?,
+                Projection::Index { array_type, .. } => *array_type = ty(*array_type)?,
+            }
+        }
+        for inst in &mut cfg.values {
+            inst.ty = ty(inst.ty)?;
+            inst.span = span(inst.span)?;
+            match &mut inst.data {
+                CfgInstData::StringConst(index) => *index = string(*index)?,
+                CfgInstData::Call { name, .. } | CfgInstData::Intrinsic { name, .. } => {
+                    *name = symbol(*name)?
+                }
+                CfgInstData::StructInit { struct_id, .. } => *struct_id = strukt(*struct_id)?,
+                CfgInstData::EnumVariant { enum_id, .. }
+                | CfgInstData::EnumPayloadGet { enum_id, .. } => *enum_id = enm(*enum_id)?,
+                CfgInstData::IntCast { from_ty, .. } => *from_ty = ty(*from_ty)?,
+                CfgInstData::StorageLive { local_ty, .. }
+                | CfgInstData::StorageDead { local_ty, .. } => *local_ty = ty(*local_ty)?,
+                _ => {}
+            }
+            if let CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } =
+                &mut inst.data
+            {
+                place.base_type = ty(place.base_type)?;
+            }
+        }
+        Ok(cfg)
+    }
+
     /// Create a new CFG.
     pub fn new(
         return_type: Type,

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -17,6 +17,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("diagnostic", include_str!("diagnostic.rs")),
     ("drop_glue", include_str!("drop_glue.rs")),
     ("durable_body", include_str!("durable_body.rs")),
+    ("durable_cfg", include_str!("durable_cfg.rs")),
     ("durable_semantics", include_str!("durable_semantics.rs")),
     ("import_discovery", include_str!("import_discovery.rs")),
     ("import_graph", include_str!("import_graph.rs")),

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -536,13 +536,19 @@ pub(crate) fn compare_canonical_durable_declaration_install(
             let ordinary = crate::build_functions_and_cfgs(
                 ordinary,
                 crate::OptLevel::default(),
+                crate::Target::host().unwrap(),
                 rir.semantic_symbols().interner(),
+                &[],
+                &[],
             )
             .map_err(|failure| failure.errors)?;
             let installed = crate::build_functions_and_cfgs(
                 installed,
                 crate::OptLevel::default(),
+                crate::Target::host().unwrap(),
                 rir.semantic_symbols().interner(),
+                &[],
+                &[],
             )
             .map_err(|failure| failure.errors)?;
             if format!("{:?}", ordinary.functions) != format!("{:?}", installed.functions)

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -292,6 +292,17 @@ pub struct CfgConstructionWork {
     pub optimized_level_attempts: usize,
     pub cfg_warnings_emitted: usize,
     pub implicit_destructor_targets_emitted: usize,
+    pub cfg_reuse_candidates: usize,
+    pub cfg_import_attempts: usize,
+    pub cfg_import_successes: usize,
+    pub cfg_import_failures: usize,
+    pub cfg_reuses: usize,
+    pub cfg_fallbacks: usize,
+    pub cfg_warnings_reused: usize,
+    pub implicit_destructor_targets_reused: usize,
+    pub cfg_export_attempts: usize,
+    pub cfg_export_successes: usize,
+    pub cfg_export_rejections: usize,
 }
 
 /// The semantic phase that prevented publication of request artifacts.
@@ -409,6 +420,7 @@ pub struct CanonicalSemanticOutput {
     named_value_const_dependencies_complete: bool,
     implicit_named_destructor_dependencies: Vec<rue_air::ImplicitNamedDestructorDependencyEvent>,
     implicit_named_destructor_dependencies_complete: bool,
+    durable_cfgs: Arc<[crate::queries::DurableCfgArtifact]>,
 }
 
 impl CanonicalSemanticOutput {
@@ -517,6 +529,9 @@ impl CanonicalSemanticOutput {
     pub fn implicit_named_destructor_dependencies_complete(&self) -> bool {
         self.implicit_named_destructor_dependencies_complete
     }
+    pub(crate) fn durable_cfgs(&self) -> &Arc<[crate::queries::DurableCfgArtifact]> {
+        &self.durable_cfgs
+    }
     /// Stable definition identities when requested for this run.
     pub fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
         self.bound_definitions.as_ref()
@@ -576,6 +591,7 @@ pub(crate) fn analyze_canonical_program(
         CanonicalDeclarationReuseWork::default(),
         Vec::new(),
         Vec::new(),
+        Arc::from([]),
         crate::DurableBodyWork::default(),
         info_span!("sema").entered(),
     )
@@ -594,6 +610,7 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
     reuse_plan: CanonicalDeclarationReuseWork,
     body_candidates: Vec<PreparedDurableBodyCandidate>,
     specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
+    durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
     body_work: crate::DurableBodyWork,
 ) -> Result<CanonicalOrdinaryAnalysis, CanonicalSemanticFailure> {
     let input = CodegenInputDescriptor {
@@ -643,6 +660,7 @@ pub(crate) fn analyze_prepared_canonical_program_with_durable_export(
         },
         body_candidates,
         specialized_body_candidates,
+        durable_cfg_candidates,
         body_work,
         sema_span,
     )?;
@@ -667,6 +685,7 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     durable: &[DurableDeclarationSemantic],
     body_candidates: Vec<PreparedDurableBodyCandidate>,
     specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
+    durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
     body_work: crate::DurableBodyWork,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
     let input = CodegenInputDescriptor {
@@ -796,6 +815,7 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
         reuse,
         body_candidates,
         specialized_body_candidates,
+        durable_cfg_candidates,
         body_work,
         sema_span,
     )
@@ -834,6 +854,7 @@ fn finish_canonical_analysis(
     declaration_reuse: CanonicalDeclarationReuseWork,
     durable_body_candidates: Vec<PreparedDurableBodyCandidate>,
     durable_specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
+    durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
     mut durable_body_reuse_work: crate::DurableBodyWork,
     sema_span: tracing::span::EnteredSpan,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
@@ -1154,11 +1175,98 @@ fn finish_canonical_analysis(
     let named_const_dependencies = sema_output.named_const_dependencies.clone();
     let named_value_const_dependencies_complete =
         sema_output.named_value_const_dependencies_complete;
+    let mut stable_cfg_inputs = Vec::new();
+    for function in &sema_output.functions {
+        let selected = if let Some(token) = function.ordinary_owner {
+            authoritative_definitions
+                .key_for_body_token(token)
+                .ok()
+                .and_then(|key| {
+                    durable_ordinary_body_payloads
+                        .iter()
+                        .find(|payload| &payload.owner == key)
+                        .and_then(|payload| {
+                            authoritative_definitions
+                                .definition_by_key(key)
+                                .and_then(|record| record.body_span())
+                                .map(|span| (span, payload.clone(), None))
+                        })
+                })
+        } else if let Some(rue_air::ImplicitDropDependencySourceEvent::Specialization {
+            identity,
+        }) = &function.implicit_drop_source
+        {
+            crate::durable_body::convert_specialization_identity(
+                identity,
+                merged,
+                &authoritative_definitions,
+                &mut durable_body_work,
+            )
+            .ok()
+            .and_then(|identity| {
+                durable_specialized_body_payloads
+                    .iter()
+                    .find(|payload| payload.identity == identity)
+                    .and_then(|payload| {
+                        authoritative_definitions
+                            .definition_by_key(&identity.base)
+                            .map(|record| {
+                                (
+                                    record.declaration_span(),
+                                    payload.body.clone(),
+                                    Some(identity.clone()),
+                                )
+                            })
+                    })
+            })
+        } else {
+            None
+        };
+        if let Some((body_span, body, specialization)) = selected {
+            let Ok(type_dependencies) = crate::durable_cfg::transitive_body_type_dependencies(
+                &body,
+                &sema_output.type_pool,
+                &authoritative_definitions,
+            ) else {
+                continue;
+            };
+            let type_inputs = type_dependencies
+                .into_iter()
+                .map(|key| {
+                    authoritative_definitions
+                        .definition_by_key(&key)
+                        .ok_or(())
+                        .and_then(|record| {
+                            crate::session::stable_definition_input_fingerprint(
+                                merged.definitions().source_snapshot(),
+                                record,
+                            )
+                            .map_err(|_| ())
+                        })
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .ok();
+            let Some(type_inputs) = type_inputs else {
+                continue;
+            };
+            stable_cfg_inputs.push(crate::durable_cfg::StableCfgInput {
+                identity: Arc::from(function.name.as_str()),
+                body_span,
+                body,
+                specialization,
+                type_inputs: type_inputs.into(),
+            });
+        }
+    }
+    stable_cfg_inputs.sort_by(|left, right| left.identity.cmp(&right.identity));
     drop(sema_span);
     let cfg = build_functions_and_cfgs(
         sema_output,
         options.opt_level,
+        options.target,
         rir.semantic_symbols().interner(),
+        &durable_cfg_candidates,
+        &stable_cfg_inputs,
     )
     .map_err(|failure| {
         let work = CanonicalSemanticWork {
@@ -1258,6 +1366,7 @@ fn finish_canonical_analysis(
         implicit_named_destructor_dependencies: cfg.implicit_named_destructor_dependencies,
         implicit_named_destructor_dependencies_complete: cfg
             .implicit_named_destructor_dependencies_complete,
+        durable_cfgs: cfg.durable_cfgs,
     })
 }
 

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -665,6 +665,20 @@ fn durable_specialization_identity(
     })
 }
 
+pub(crate) fn convert_specialization_identity(
+    identity: &rue_air::SemanticSpecializationIdentity<SemanticBodyDefinitionIdentity, Arc<str>>,
+    merged: &CanonicalMergedProgram,
+    definitions: &BoundDefinitionSet,
+    work: &mut DurableBodyWork,
+) -> Result<DurableSpecializationIdentity, DurableBodyConversionFailure> {
+    durable_specialization_identity(
+        identity,
+        merged,
+        &DefinitionJoinIndex::new(merged, definitions),
+        work,
+    )
+}
+
 fn durable_identity_dependency_keys(
     identity: &DurableSpecializationIdentity,
 ) -> BTreeSet<StableDefinitionKey> {

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -1,0 +1,467 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use lasso::{Key, Spur};
+use rue_air::{AirInstData, AnalyzedFunction, Type, TypeKind};
+use rue_span::Span;
+
+use crate::{DurableAirInstData, DurableOrdinaryBodyPayload, DurableType};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StableCfgInput {
+    pub identity: Arc<str>,
+    pub body_span: Span,
+    pub body: DurableOrdinaryBodyPayload,
+    pub specialization: Option<crate::DurableSpecializationIdentity>,
+    pub type_inputs: Arc<[crate::StableDefinitionInputFingerprint]>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LayoutDependencyFailure {
+    MissingDefinition,
+    AmbiguousDefinition,
+    MissingNominal,
+    AmbiguousNominal,
+}
+
+pub(crate) fn body_type_dependencies(
+    body: &DurableOrdinaryBodyPayload,
+) -> BTreeSet<crate::StableDefinitionKey> {
+    fn visit(value: &DurableType, keys: &mut BTreeSet<crate::StableDefinitionKey>) {
+        match value {
+            DurableType::Nominal(key) => {
+                keys.insert(key.clone());
+            }
+            DurableType::Array { element, .. } => visit(element, keys),
+            _ => {}
+        }
+    }
+    let mut keys = BTreeSet::new();
+    visit(&body.return_type, &mut keys);
+    for instruction in body.instructions.iter() {
+        visit(&instruction.ty, &mut keys);
+    }
+    for place in body.places.iter() {
+        visit(&place.base_type, &mut keys);
+        for projection in place.projections.iter() {
+            match projection {
+                crate::DurableProjection::Field { struct_key, .. } => {
+                    keys.insert(struct_key.clone());
+                }
+                crate::DurableProjection::Index { array_type, .. } => visit(array_type, &mut keys),
+            }
+        }
+    }
+    for (_, ty) in body.param_drops.iter() {
+        visit(ty, &mut keys);
+    }
+    for instruction in body.instructions.iter() {
+        match &instruction.data {
+            DurableAirInstData::TypeConst(ty) | DurableAirInstData::IntCast { from_ty: ty, .. } => {
+                visit(ty, &mut keys)
+            }
+            DurableAirInstData::StructInit { struct_key, .. } => {
+                keys.insert(struct_key.clone());
+            }
+            DurableAirInstData::EnumVariant { enum_key, .. }
+            | DurableAirInstData::EnumPayloadGet { enum_key, .. } => {
+                keys.insert(enum_key.clone());
+            }
+            _ => {}
+        }
+        if let DurableAirInstData::Intrinsic { name, args } = &instruction.data
+            && matches!(name.as_ref(), "ptr_read" | "ptr_write" | "ptr_offset")
+        {
+            for arg in args.iter() {
+                if let Some(argument) = body.instructions.get(arg.value as usize) {
+                    match &argument.ty {
+                        DurableType::PtrConst(pointee) | DurableType::PtrMut(pointee) => {
+                            visit(pointee, &mut keys)
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    keys
+}
+
+pub(crate) fn transitive_body_type_dependencies(
+    body: &DurableOrdinaryBodyPayload,
+    pool: &rue_air::TypeInternPool,
+    definitions: &crate::BoundDefinitionSet,
+) -> Result<BTreeSet<crate::StableDefinitionKey>, LayoutDependencyFailure> {
+    let mut keys = body_type_dependencies(body);
+    let mut pending = keys.iter().cloned().collect::<Vec<_>>();
+    let stable_key = |file: rue_span::FileId, name: &str, kind| {
+        let matches = definitions
+            .definitions()
+            .iter()
+            .filter(|record| {
+                record.stable_key().kind() == kind
+                    && record.stable_key().name() == name
+                    && record.declaration_span().file_id == file
+            })
+            .take(2)
+            .collect::<Vec<_>>();
+        match matches.as_slice() {
+            [record] => Ok(record.stable_key().clone()),
+            [] => Err(LayoutDependencyFailure::MissingDefinition),
+            _ => Err(LayoutDependencyFailure::AmbiguousDefinition),
+        }
+    };
+    while let Some(key) = pending.pop() {
+        let record = definitions
+            .definition_by_key(&key)
+            .ok_or(LayoutDependencyFailure::MissingDefinition)?;
+        let file = record.declaration_span().file_id;
+        let mut nested = Vec::new();
+        match key.kind() {
+            crate::StableDefinitionKind::Struct => {
+                let ids = pool
+                    .all_struct_ids()
+                    .into_iter()
+                    .filter(|id| {
+                        let def = pool.struct_def(*id);
+                        def.file_id == file && def.name == key.name()
+                    })
+                    .take(2)
+                    .collect::<Vec<_>>();
+                let [id] = ids.as_slice() else {
+                    return Err(if ids.is_empty() {
+                        LayoutDependencyFailure::MissingNominal
+                    } else {
+                        LayoutDependencyFailure::AmbiguousNominal
+                    });
+                };
+                nested.extend(pool.struct_def(*id).fields.iter().map(|field| field.ty));
+            }
+            crate::StableDefinitionKind::Enum => {
+                let ids = pool
+                    .all_enum_ids()
+                    .into_iter()
+                    .filter(|id| {
+                        let def = pool.enum_def(*id);
+                        def.file_id == file && def.name == key.name()
+                    })
+                    .take(2)
+                    .collect::<Vec<_>>();
+                let [id] = ids.as_slice() else {
+                    return Err(if ids.is_empty() {
+                        LayoutDependencyFailure::MissingNominal
+                    } else {
+                        LayoutDependencyFailure::AmbiguousNominal
+                    });
+                };
+                let def = pool.enum_def(*id);
+                for index in 0..def.variant_count() {
+                    nested.extend_from_slice(def.variant_payload(index));
+                }
+            }
+            _ => {}
+        }
+        while let Some(ty) = nested.pop() {
+            let found = match ty.kind() {
+                TypeKind::Struct(id) => {
+                    let def = pool.struct_def(id);
+                    (!def.is_builtin)
+                        .then(|| {
+                            stable_key(def.file_id, &def.name, crate::StableDefinitionKind::Struct)
+                        })
+                        .transpose()?
+                }
+                TypeKind::Enum(id) => {
+                    let def = pool.enum_def(id);
+                    Some(stable_key(
+                        def.file_id,
+                        &def.name,
+                        crate::StableDefinitionKind::Enum,
+                    )?)
+                }
+                TypeKind::Array(id) => {
+                    nested.push(pool.array_def(id).0);
+                    None
+                }
+                TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => None,
+                _ => None,
+            };
+            if let Some(found) = found.filter(|found| keys.insert(found.clone())) {
+                pending.push(found);
+            }
+        }
+    }
+    Ok(keys)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum StableCfgSymbol {
+    Callable(crate::StableDefinitionKey),
+    Specialization(crate::DurableSpecializationIdentity),
+    Intrinsic(Arc<str>),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CfgDomainProjection {
+    types: Vec<(Type, DurableType)>,
+    strings: Vec<(u32, Arc<str>)>,
+    spans: Vec<(Span, crate::DurableBodyAnchor)>,
+    symbols: Vec<(Spur, StableCfgSymbol)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CfgDomainFailure {
+    Shape,
+    Unsupported,
+    Missing,
+}
+
+impl CfgDomainProjection {
+    pub fn validate_cfg(&self, cfg: &rue_cfg::Cfg, span: Span) -> Result<(), CfgDomainFailure> {
+        Self::import_cfg(self, self, cfg, span).map(|_| ())
+    }
+    pub fn from_body(
+        function: &AnalyzedFunction,
+        input: &StableCfgInput,
+        strings: &[String],
+    ) -> Result<Self, CfgDomainFailure> {
+        if function.air.instructions().len() != input.body.instructions.len() {
+            return Err(CfgDomainFailure::Shape);
+        }
+        let mut types = vec![(function.air.return_type(), input.body.return_type.clone())];
+        let mut stable_strings = Vec::new();
+        let mut spans = Vec::new();
+        let mut symbols = Vec::new();
+        for ((_, current), durable) in function.air.iter().zip(input.body.instructions.iter()) {
+            types.push((current.ty, durable.ty.clone()));
+            if current.span.file_id != input.body_span.file_id
+                || current.span.start < input.body_span.start
+                || current.span.end > input.body_span.end
+            {
+                return Err(CfgDomainFailure::Unsupported);
+            }
+            spans.push((
+                current.span,
+                crate::DurableBodyAnchor {
+                    start: current.span.start - input.body_span.start,
+                    end: current.span.end - input.body_span.start,
+                },
+            ));
+            match (&current.data, &durable.data) {
+                (AirInstData::StringConst(old), DurableAirInstData::StringConst(local)) => {
+                    let value = input
+                        .body
+                        .strings
+                        .get(*local as usize)
+                        .ok_or(CfgDomainFailure::Shape)?;
+                    if strings.get(*old as usize).map(String::as_str) != Some(value) {
+                        return Err(CfgDomainFailure::Shape);
+                    }
+                    stable_strings.push((*old, value.clone()));
+                }
+                (
+                    AirInstData::IntCast { from_ty, .. },
+                    DurableAirInstData::IntCast {
+                        from_ty: stable, ..
+                    },
+                ) => types.push((*from_ty, stable.clone())),
+                (AirInstData::Call { name, .. }, DurableAirInstData::Call { function, .. }) => {
+                    symbols.push((*name, StableCfgSymbol::Callable(function.clone())))
+                }
+                (
+                    AirInstData::Call { name, .. },
+                    DurableAirInstData::CallSpecialized { identity, .. },
+                ) => symbols.push((*name, StableCfgSymbol::Specialization(identity.clone()))),
+                (
+                    AirInstData::Intrinsic { name, .. },
+                    DurableAirInstData::Intrinsic { name: stable, .. },
+                ) => symbols.push((*name, StableCfgSymbol::Intrinsic(stable.clone()))),
+                _ => {}
+            }
+        }
+        for (current, stable) in function.air.places().iter().zip(input.body.places.iter()) {
+            types.push((current.base_type, stable.base_type.clone()));
+            let current_projections = function.air.get_place_projections(current);
+            if current_projections.len() != stable.projections.len() {
+                return Err(CfgDomainFailure::Shape);
+            }
+            for (current, stable) in current_projections.iter().zip(stable.projections.iter()) {
+                if let (
+                    rue_air::AirProjection::Index { array_type, .. },
+                    crate::DurableProjection::Index {
+                        array_type: stable, ..
+                    },
+                ) = (current, stable)
+                {
+                    types.push((*array_type, stable.clone()));
+                }
+            }
+        }
+        types.sort_by_key(|(ty, _)| ty.as_u32());
+        types.dedup_by(|left, right| left.0 == right.0 && left.1 == right.1);
+        if types.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+            return Err(CfgDomainFailure::Shape);
+        }
+        stable_strings.sort_by_key(|(index, _)| *index);
+        stable_strings.dedup();
+        spans.sort_by_key(|(span, _)| (span.file_id.index(), span.start, span.end));
+        spans.dedup();
+        symbols.sort_by(|left, right| {
+            (left.0.into_usize(), &left.1).cmp(&(right.0.into_usize(), &right.1))
+        });
+        symbols.dedup_by(|left, right| left.0 == right.0 && left.1 == right.1);
+        if symbols.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+            return Err(CfgDomainFailure::Shape);
+        }
+        Ok(Self {
+            types,
+            strings: stable_strings,
+            spans,
+            symbols,
+        })
+    }
+
+    fn stable_type(&self, value: Type) -> Result<DurableType, CfgDomainFailure> {
+        self.types
+            .iter()
+            .find(|(current, _)| *current == value)
+            .map(|(_, stable)| stable.clone())
+            .ok_or(CfgDomainFailure::Missing)
+    }
+    fn current_type(&self, value: &DurableType) -> Result<Type, CfgDomainFailure> {
+        self.types
+            .iter()
+            .find(|(_, stable)| stable == value)
+            .map(|(current, _)| *current)
+            .ok_or(CfgDomainFailure::Missing)
+    }
+    fn stable_nominal(&self, value: Type) -> Result<DurableType, CfgDomainFailure> {
+        self.stable_type(value)
+    }
+    fn current_nominal(&self, value: &DurableType) -> Result<Type, CfgDomainFailure> {
+        self.current_type(value)
+    }
+
+    pub fn import_cfg(
+        old: &Self,
+        new: &Self,
+        cfg: &rue_cfg::Cfg,
+        new_span: Span,
+    ) -> Result<rue_cfg::Cfg, CfgDomainFailure> {
+        cfg.try_remap_domains(
+            |value| new.current_type(&old.stable_type(value)?),
+            |value| match new
+                .current_nominal(&old.stable_nominal(Type::new_struct(value))?)?
+                .kind()
+            {
+                TypeKind::Struct(id) => Ok(id),
+                _ => Err(CfgDomainFailure::Shape),
+            },
+            |value| match new
+                .current_nominal(&old.stable_nominal(Type::new_enum(value))?)?
+                .kind()
+            {
+                TypeKind::Enum(id) => Ok(id),
+                _ => Err(CfgDomainFailure::Shape),
+            },
+            |value: Spur| {
+                let stable = old
+                    .symbols
+                    .iter()
+                    .find(|(symbol, _)| *symbol == value)
+                    .map(|(_, value)| value)
+                    .ok_or(CfgDomainFailure::Missing)?;
+                new.symbols
+                    .iter()
+                    .find(|(_, identity)| identity == stable)
+                    .map(|(symbol, _)| *symbol)
+                    .ok_or(CfgDomainFailure::Missing)
+            },
+            |value| {
+                let stable = old
+                    .strings
+                    .iter()
+                    .find(|(index, _)| *index == value)
+                    .map(|(_, value)| value)
+                    .ok_or(CfgDomainFailure::Missing)?;
+                new.strings
+                    .iter()
+                    .find(|(_, value)| value == stable)
+                    .map(|(index, _)| *index)
+                    .ok_or(CfgDomainFailure::Missing)
+            },
+            |value| {
+                let anchor = old
+                    .spans
+                    .iter()
+                    .find(|(span, _)| *span == value)
+                    .map(|(_, anchor)| anchor)
+                    .ok_or(CfgDomainFailure::Missing)?;
+                Ok(Span {
+                    file_id: new_span.file_id,
+                    start: new_span.start + anchor.start,
+                    end: new_span.start + anchor.end,
+                })
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lasso::Key;
+    use rue_cfg::{Cfg, CfgInst, CfgInstData};
+
+    fn projection(symbol: Spur) -> CfgDomainProjection {
+        CfgDomainProjection {
+            types: vec![(Type::I32, DurableType::I32)],
+            strings: Vec::new(),
+            spans: vec![(
+                Span::new(4, 5),
+                crate::DurableBodyAnchor { start: 0, end: 1 },
+            )],
+            symbols: vec![(symbol, StableCfgSymbol::Intrinsic(Arc::from("stable")))],
+        }
+    }
+
+    #[test]
+    fn symbol_import_joins_to_existing_current_spur_and_failure_is_atomic() {
+        let old = Spur::try_from_usize(3).unwrap();
+        let new = Spur::try_from_usize(17).unwrap();
+        let mut cfg = Cfg::new(Type::I32, 0, 0, "f".into(), Vec::<bool>::new());
+        let block = cfg.new_block();
+        cfg.add_inst_to_block(
+            block,
+            CfgInst {
+                data: CfgInstData::Call {
+                    name: old,
+                    args_start: 0,
+                    args_len: 0,
+                },
+                ty: Type::I32,
+                span: Span::new(4, 5),
+            },
+        );
+        let imported = CfgDomainProjection::import_cfg(
+            &projection(old),
+            &projection(new),
+            &cfg,
+            Span::new(40, 50),
+        )
+        .unwrap();
+        assert!(
+            matches!(imported.get_inst(rue_cfg::CfgValue::from_raw(0)).data, CfgInstData::Call { name, .. } if name == new)
+        );
+
+        let mut missing = projection(new);
+        missing.symbols.clear();
+        assert!(matches!(
+            CfgDomainProjection::import_cfg(&projection(old), &missing, &cfg, Span::new(40, 50)),
+            Err(CfgDomainFailure::Missing)
+        ));
+        assert!(
+            matches!(cfg.get_inst(rue_cfg::CfgValue::from_raw(0)).data, CfgInstData::Call { name, .. } if name == old)
+        );
+    }
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -38,6 +38,7 @@ mod dependency_envelope;
 mod diagnostic;
 mod drop_glue;
 mod durable_body;
+mod durable_cfg;
 mod durable_semantics;
 mod import_discovery;
 mod import_graph;

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -126,6 +126,21 @@ pub(crate) struct CfgFrontendOutput {
         Vec<rue_air::ImplicitNamedDestructorDependencyEvent>,
     pub(crate) implicit_named_destructor_dependencies_complete: bool,
     pub(crate) work: canonical_semantic::CfgConstructionWork,
+    pub(crate) durable_cfgs: std::sync::Arc<[DurableCfgArtifact]>,
+}
+
+const DURABLE_CFG_SCHEMA_VERSION: u32 = 1;
+
+/// Last-good, fail-closed CFG candidate retained between semantic requests.
+///
+#[derive(Debug, Clone)]
+pub(crate) struct DurableCfgArtifact {
+    pub(crate) schema_version: u32,
+    pub(crate) input: crate::durable_cfg::StableCfgInput,
+    opt_level: OptLevel,
+    target: Target,
+    cfg: Cfg,
+    domains: crate::durable_cfg::CfgDomainProjection,
 }
 
 pub(crate) struct CfgConstructionFailure {
@@ -141,7 +156,10 @@ pub(crate) struct CfgConstructionFailure {
 pub(crate) fn build_functions_and_cfgs(
     sema_output: SemaOutput,
     opt_level: OptLevel,
+    target: Target,
     interner: &ThreadedRodeo,
+    durable_candidates: &[DurableCfgArtifact],
+    stable_inputs: &[crate::durable_cfg::StableCfgInput],
 ) -> Result<CfgFrontendOutput, CfgConstructionFailure> {
     let SemaOutput {
         functions,
@@ -181,11 +199,59 @@ pub(crate) fn build_functions_and_cfgs(
         .into_par_iter()
         .map(|func| {
             let dependency_source = func.implicit_drop_source.clone();
-            let mut function_work = canonical_semantic::CfgConstructionWork {
-                cfg_builds_attempted: 1,
-                air_instructions_consumed: func.air.instructions().len(),
-                ..Default::default()
-            };
+            let stable_input = stable_inputs
+                .binary_search_by(|input| input.identity.as_ref().cmp(&func.name))
+                .ok()
+                .map(|index| &stable_inputs[index]);
+            let projection = stable_input.and_then(|input| {
+                crate::durable_cfg::CfgDomainProjection::from_body(&func, input, &strings).ok()
+            });
+            let candidate = durable_candidates
+                .binary_search_by(|candidate| candidate.input.identity.as_ref().cmp(&func.name))
+                .ok()
+                .map(|index| &durable_candidates[index]);
+            let mut function_work = canonical_semantic::CfgConstructionWork::default();
+            if let Some(candidate) = candidate {
+                function_work.cfg_reuse_candidates = 1;
+                function_work.cfg_import_attempts = 1;
+                if candidate.schema_version == DURABLE_CFG_SCHEMA_VERSION
+                    && candidate.opt_level == opt_level
+                    && candidate.target == target
+                    && stable_input.is_some_and(|input| {
+                        input.body == candidate.input.body
+                            && input.specialization == candidate.input.specialization
+                            && input.type_inputs == candidate.input.type_inputs
+                    })
+                    && let Some(projection) = projection.as_ref()
+                    && let Ok(imported) = crate::durable_cfg::CfgDomainProjection::import_cfg(
+                        &candidate.domains,
+                        projection,
+                        &candidate.cfg,
+                        stable_input.unwrap().body_span,
+                    )
+                {
+                    function_work.cfg_import_successes = 1;
+                    function_work.cfg_reuses = 1;
+                    let artifact = candidate.clone();
+                    return Ok((
+                        (
+                            FunctionWithCfg {
+                                analyzed: func,
+                                cfg: imported,
+                            },
+                            Vec::new(),
+                            Vec::new(),
+                            true,
+                            Some(artifact),
+                        ),
+                        function_work,
+                    ));
+                }
+                function_work.cfg_import_failures = 1;
+                function_work.cfg_fallbacks = 1;
+            }
+            function_work.cfg_builds_attempted = 1;
+            function_work.air_instructions_consumed = func.air.instructions().len();
             let cfg_output = CfgBuilder::build(
                 &func.air,
                 func.num_locals,
@@ -260,6 +326,24 @@ pub(crate) fn build_functions_and_cfgs(
                 }
             }
 
+            function_work.cfg_export_attempts = usize::from(stable_input.is_some());
+            let artifact = stable_input.zip(projection).and_then(|(input, domains)| {
+                (cfg_output.warnings.is_empty()
+                    && implicit_edges.is_empty()
+                    && complete
+                    && domains.validate_cfg(&cfg, input.body_span).is_ok())
+                .then(|| DurableCfgArtifact {
+                    schema_version: DURABLE_CFG_SCHEMA_VERSION,
+                    input: input.clone(),
+                    opt_level,
+                    target,
+                    cfg: cfg.clone(),
+                    domains,
+                })
+            });
+            function_work.cfg_export_successes = usize::from(artifact.is_some());
+            function_work.cfg_export_rejections =
+                function_work.cfg_export_attempts - function_work.cfg_export_successes;
             Ok((
                 (
                     FunctionWithCfg {
@@ -269,6 +353,7 @@ pub(crate) fn build_functions_and_cfgs(
                     cfg_output.warnings,
                     implicit_edges,
                     complete,
+                    artifact,
                 ),
                 function_work,
             ))
@@ -278,6 +363,7 @@ pub(crate) fn build_functions_and_cfgs(
     let mut functions = Vec::with_capacity(results.len());
     let mut implicit_named_destructor_dependencies = Vec::new();
     let mut implicit_named_destructor_dependencies_complete = true;
+    let mut durable_cfgs = Vec::new();
     let mut first_errors = None;
     for result in results {
         let (output, function_work) = match result {
@@ -299,11 +385,23 @@ pub(crate) fn build_functions_and_cfgs(
         work.cfg_warnings_emitted += function_work.cfg_warnings_emitted;
         work.implicit_destructor_targets_emitted +=
             function_work.implicit_destructor_targets_emitted;
-        if let Some((func, func_warnings, mut implicit_edges, complete)) = output {
+        work.cfg_reuse_candidates += function_work.cfg_reuse_candidates;
+        work.cfg_import_attempts += function_work.cfg_import_attempts;
+        work.cfg_import_successes += function_work.cfg_import_successes;
+        work.cfg_import_failures += function_work.cfg_import_failures;
+        work.cfg_reuses += function_work.cfg_reuses;
+        work.cfg_fallbacks += function_work.cfg_fallbacks;
+        work.cfg_warnings_reused += function_work.cfg_warnings_reused;
+        work.implicit_destructor_targets_reused += function_work.implicit_destructor_targets_reused;
+        work.cfg_export_attempts += function_work.cfg_export_attempts;
+        work.cfg_export_successes += function_work.cfg_export_successes;
+        work.cfg_export_rejections += function_work.cfg_export_rejections;
+        if let Some((func, func_warnings, mut implicit_edges, complete, artifact)) = output {
             functions.push(func);
             warnings.extend(func_warnings);
             implicit_named_destructor_dependencies.append(&mut implicit_edges);
             implicit_named_destructor_dependencies_complete &= complete;
+            durable_cfgs.extend(artifact);
         }
     }
     if let Some(errors) = first_errors {
@@ -325,6 +423,7 @@ pub(crate) fn build_functions_and_cfgs(
         implicit_named_destructor_dependencies,
         implicit_named_destructor_dependencies_complete,
         work,
+        durable_cfgs: durable_cfgs.into(),
     })
 }
 
@@ -551,7 +650,14 @@ mod failure_work_tests {
     fn malformed_air_retains_deterministic_work_from_every_cfg_builder() {
         let run = || {
             let (output, interner) = malformed_cfg_input();
-            match build_functions_and_cfgs(output, OptLevel::O1, &interner) {
+            match build_functions_and_cfgs(
+                output,
+                OptLevel::O1,
+                Target::host().unwrap(),
+                &interner,
+                &[],
+                &[],
+            ) {
                 Ok(_) => panic!("malformed AIR unexpectedly built a CFG"),
                 Err(failure) => failure,
             }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1150,6 +1150,7 @@ pub struct CompilerSession {
     invalidation_plan_cache: VecDeque<InvalidationPlanCacheEntry>,
     durable_declaration_cache: Option<DurableDeclarationCache>,
     last_successful_body_cache: Option<DurableOrdinaryBodyCache>,
+    last_successful_cfg_cache: Option<Arc<[crate::queries::DurableCfgArtifact]>>,
 }
 
 #[derive(Debug)]
@@ -2197,6 +2198,8 @@ impl CompilerSession {
             self.work.semantic.reuses += 1;
             if entry.result.is_ok() {
                 self.last_successful_body_cache = entry.successful_body_cache.clone();
+                self.last_successful_cfg_cache =
+                    Some(entry.result.as_ref().unwrap().durable_cfgs().clone());
             }
             let result = entry.result.clone();
             let source = self
@@ -2370,6 +2373,9 @@ impl CompilerSession {
                     &durable,
                     durable_body_candidates,
                     durable_specialized_body_candidates,
+                    self.last_successful_cfg_cache
+                        .clone()
+                        .unwrap_or_else(|| Arc::from([])),
                     durable_body_work,
                 )
             } else {
@@ -2381,6 +2387,9 @@ impl CompilerSession {
                     reuse_plan,
                     durable_body_candidates,
                     durable_specialized_body_candidates,
+                    self.last_successful_cfg_cache
+                        .clone()
+                        .unwrap_or_else(|| Arc::from([])),
                     durable_body_work,
                 )
                 .map(|analysis| {
@@ -2398,6 +2407,7 @@ impl CompilerSession {
             .unwrap_or_else(|failure| failure.failure.work);
         let result = analysis.map(Arc::new).map_err(|failure| failure.errors);
         if let Ok(output) = &result {
+            self.last_successful_cfg_cache = Some(output.durable_cfgs().clone());
             debug_assert_eq!(output.input(), &input);
             debug_assert_eq!(semantic_work.binding.bind_invocations, 1);
             debug_assert_eq!(semantic_work.manifest.build_invocations, 1);
@@ -4904,6 +4914,276 @@ mod tests {
         assert_eq!(
             format!("{:?}", reused.warnings()),
             format!("{:?}", ordinary.warnings())
+        );
+    }
+
+    #[test]
+    fn cfg_reuse_is_per_function_and_preserves_exact_build_work() {
+        let first = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn a() -> i32 { 1 }\nfn b() -> i32 { 2 }\nfn main() -> i32 { a() + b() }",
+            )],
+            1,
+        );
+        let second = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn a() -> i32 { 1 }\nfn b() -> i32 { 3 }\nfn main() -> i32 { a() + b() }",
+            )],
+            1,
+        );
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        let cold = session.semantic(&options).unwrap();
+        assert_eq!(cold.work().cfg.cfg_builds_attempted, 3);
+        assert_eq!(cold.work().cfg.optimization_attempts, 3);
+        session.update(&second).into_result().unwrap();
+        let warm = session.semantic(&options).unwrap();
+        assert_eq!(warm.work().cfg.cfg_reuses, 2);
+        assert_eq!(warm.work().cfg.cfg_import_successes, 2);
+        assert_eq!(warm.work().cfg.cfg_builds_attempted, 1);
+        assert_eq!(warm.work().cfg.optimization_attempts, 1);
+        assert_eq!(warm.work().cfg.optimized_level_attempts, 1);
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&second).into_result().unwrap();
+        let fresh = fresh.semantic(&options).unwrap();
+        assert_eq!(
+            format!("{:?}", warm.functions()),
+            format!("{:?}", fresh.functions())
+        );
+        assert_eq!(
+            format!("{:?}", warm.warnings()),
+            format!("{:?}", fresh.warnings())
+        );
+    }
+
+    #[test]
+    fn specialized_cfg_reuse_is_stable_and_malformed_import_falls_back_atomically() {
+        let first = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn choose(comptime n: i32) -> i32 { n }\nfn b() -> i32 { 2 }\nfn main() -> i32 { choose(40) + b() }",
+            )],
+            1,
+        );
+        let second = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn choose(comptime n: i32) -> i32 { n }\nfn b() -> i32 { 3 }\nfn main() -> i32 { choose(40) + b() }",
+            )],
+            1,
+        );
+        let third = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn choose(comptime n: i32) -> i32 { n }\nfn b() -> i32 { 4 }\nfn main() -> i32 { choose(40) + b() }",
+            )],
+            1,
+        );
+        let options = CompileOptions {
+            opt_level: OptLevel::O0,
+            ..CompileOptions::default()
+        };
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.semantic(&options).unwrap();
+        let cache = Arc::make_mut(session.last_successful_cfg_cache.as_mut().unwrap());
+        let specialization = cache
+            .iter_mut()
+            .find(|candidate| candidate.input.specialization.is_some())
+            .unwrap();
+        specialization.schema_version = u32::MAX;
+        session.update(&second).into_result().unwrap();
+        let warm = session.semantic(&options).unwrap();
+        assert_eq!(warm.work().cfg.cfg_import_failures, 2);
+        assert_eq!(warm.work().cfg.cfg_fallbacks, 2);
+        assert_eq!(warm.work().cfg.cfg_reuses, 0);
+        assert_eq!(warm.work().cfg.cfg_builds_attempted, 3);
+        assert_eq!(warm.work().cfg.optimization_attempts, 3);
+        assert_eq!(warm.work().cfg.optimized_level_attempts, 0);
+        session.update(&third).into_result().unwrap();
+        let repaired = session.semantic(&options).unwrap();
+        assert_eq!(repaired.work().cfg.cfg_reuses, 1);
+        assert_eq!(repaired.work().cfg.cfg_builds_attempted, 2);
+    }
+
+    #[test]
+    fn cfg_reuse_rejects_target_and_callable_identity_changes() {
+        let first = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn old() -> i32 { 1 }\nfn stable() -> i32 { 2 }\nfn main() -> i32 { old() + stable() }",
+            )],
+            1,
+        );
+        let renamed = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn new() -> i32 { 1 }\nfn stable() -> i32 { 2 }\nfn main() -> i32 { new() + stable() }",
+            )],
+            1,
+        );
+        let host = Target::host().unwrap();
+        let other = if host == Target::Aarch64Linux {
+            Target::X86_64Linux
+        } else {
+            Target::Aarch64Linux
+        };
+        let first_options = CompileOptions {
+            target: host,
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let other_options = CompileOptions {
+            target: other,
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.semantic(&first_options).unwrap();
+        let cross_target = session.semantic(&other_options).unwrap();
+        assert_eq!(cross_target.work().cfg.cfg_reuses, 0);
+        assert_eq!(cross_target.work().cfg.cfg_builds_attempted, 3);
+        assert!(cross_target.work().cfg.cfg_import_failures >= 2);
+        session.update(&renamed).into_result().unwrap();
+        let changed = session.semantic(&other_options).unwrap();
+        assert_eq!(changed.work().cfg.cfg_reuses, 1);
+        assert_eq!(changed.work().cfg.cfg_builds_attempted, 2);
+        assert_eq!(changed.work().cfg.cfg_import_failures, 1);
+        let mut fresh = CompilerSession::new();
+        fresh.update(&renamed).into_result().unwrap();
+        let fresh = fresh.semantic(&other_options).unwrap();
+        assert_eq!(
+            format!("{:?}", changed.functions()),
+            format!("{:?}", fresh.functions())
+        );
+    }
+
+    #[test]
+    fn nested_layout_change_invalidates_only_layout_consumers() {
+        let first = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "struct Inner { a: i32 }\nstruct Outer { inner: Inner }\nfn consume(value: Outer) -> i32 { value.inner.a }\nfn unaffected() -> i32 { 7 }\nfn main() -> i32 { consume(Outer { inner: Inner { a: 1 } }) + unaffected() }",
+            )],
+            1,
+        );
+        let second = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "struct Inner { a: i32, b: i32 }\nstruct Outer { inner: Inner }\nfn consume(value: Outer) -> i32 { value.inner.a }\nfn unaffected() -> i32 { 7 }\nfn main() -> i32 { consume(Outer { inner: Inner { a: 1, b: 2 } }) + unaffected() }",
+            )],
+            1,
+        );
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.semantic(&options).unwrap();
+        session.update(&second).into_result().unwrap();
+        let warm = session.semantic(&options).unwrap();
+        assert_eq!(warm.work().cfg.cfg_reuses, 1);
+        assert!(warm.work().cfg.cfg_import_failures >= 1);
+        let mut fresh = CompilerSession::new();
+        fresh.update(&second).into_result().unwrap();
+        let fresh = fresh.semantic(&options).unwrap();
+        assert_eq!(
+            format!("{:?}", warm.functions()),
+            format!("{:?}", fresh.functions())
+        );
+    }
+
+    #[test]
+    fn pointer_only_consumer_ignores_pointee_layout_but_field_consumer_rebuilds() {
+        let first = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "struct Foo { a: i32 }\nfn pointer_only(value: ptr const Foo) -> i32 { 7 }\nfn field(value: Foo) -> i32 { value.a }\nfn main() -> i32 { let value = Foo { a: 1 }; checked { pointer_only(@raw(value)) + field(value) } }",
+            )],
+            1,
+        );
+        let second = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "struct Foo { a: i32, b: i32 }\nfn pointer_only(value: ptr const Foo) -> i32 { 7 }\nfn field(value: Foo) -> i32 { value.a }\nfn main() -> i32 { let value = Foo { a: 1, b: 2 }; checked { pointer_only(@raw(value)) + field(value) } }",
+            )],
+            1,
+        );
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.semantic(&options).unwrap();
+        session.update(&second).into_result().unwrap();
+        let warm = session.semantic(&options).unwrap();
+        assert_eq!(warm.work().cfg.cfg_reuses, 1);
+        assert!(warm.work().cfg.cfg_import_failures >= 1);
+        let mut fresh = CompilerSession::new();
+        fresh.update(&second).into_result().unwrap();
+        let fresh = fresh.semantic(&options).unwrap();
+        assert_eq!(
+            format!("{:?}", warm.functions()),
+            format!("{:?}", fresh.functions())
+        );
+    }
+
+    #[test]
+    fn incomplete_optimized_cfg_projection_is_rejected_at_export() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn choose(value: bool) -> i32 { if value { 1 } else { 2 } }\nfn main() -> i32 { choose(true) }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let output = session
+            .semantic(&CompileOptions {
+                opt_level: OptLevel::O0,
+                ..CompileOptions::default()
+            })
+            .unwrap();
+        assert_eq!(output.work().cfg.cfg_export_attempts, 2);
+        assert!(output.work().cfg.cfg_export_rejections >= 1);
+        assert_eq!(
+            output.work().cfg.cfg_export_attempts,
+            output.work().cfg.cfg_export_successes + output.work().cfg.cfg_export_rejections
         );
     }
 


### PR DESCRIPTION
## Summary

- add stable per-function CFG artifacts with atomic type, symbol, string, span, nominal, block, and value remapping
- retain last-good CFG candidates and reuse eligible ordinary and specialized functions with exact target, optimization, body, and transitive layout provenance
- fail closed for unsupported warning, destructor, glue, malformed, or incomplete artifacts and record deterministic build/import/export work
- cover per-function reuse, target and symbol changes, nested and pointer layout invalidation, specialization, atomic fallback, parity, and O0/O1 counters

## Validation

- `scripts/rue test`

Fixes RUE-887