### PR TITLE
RUE-895: define comparable benchmark metrics

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -103,6 +103,7 @@ filegroup(
         "scripts/append-benchmark.py",
         "scripts/benchmark_collection.py",
         "scripts/benchmark_history.py",
+        "scripts/benchmark_metrics.py",
         "scripts/benchmark_validation.py",
         "scripts/generate-charts.py",
         "scripts/generate-site-status.py",

--- a/bench.sh
+++ b/bench.sh
@@ -358,6 +358,8 @@ runner_image="${RUE_BENCH_RUNNER_IMAGE:-local:${host}}"
 # Build final JSON
 cat > "$RESULTS_FILE" << EOF
 {
+  "measurement_family": "compiler",
+  "scenario_family": "cold_compilation",
   "version": 1,
   "timestamp": "$timestamp",
   "commit": "$commit",

--- a/docs/process/benchmark-metrics.md
+++ b/docs/process/benchmark-metrics.md
@@ -1,0 +1,30 @@
+# Benchmark metric semantics
+
+`scripts/benchmark_metrics.py` is the canonical, renderer-independent policy
+for interpreting durable benchmark history. Charts and status data consume its
+derived JSON; they do not define regression thresholds themselves.
+
+Each latency point is the median of at least three raw `samples_ms`. Observed
+variation is `1.4826 * median(abs(sample - median)) / median`. A comparison's
+variation band is the root-sum-square of current and reference relative
+variation. Lower latency outside that band is `improved`, higher latency is
+`regressed`, and movement inside it is `stable`. Missing evidence is
+`insufficient_data`; there is no fixed absolute or percentage threshold.
+The multi-workload headline delta is the geometric mean of workload ratios;
+its variation band is the root-mean-square of workload variation bands.
+
+The rolling baseline is the median of per-run medians from the preceding three
+to seven points. Its variation includes both median within-run variation and
+scaled MAD between run medians. Comparisons never cross a durable-history
+regime or gap and require identical workload composition.
+
+The latency performance index is the geometric mean of each workload's
+`baseline median / current median`, multiplied by 100. The baseline is exactly
+100 and higher is better. Regime, scenario, or workload changes explicitly
+rebase instead of moving the headline. Latency, source throughput, peak memory,
+and binary size are emitted as separate metric families and are never combined.
+
+Historical `bench.sh` data is identified as `compiler/cold_compilation`; new
+runs record that identity explicitly. Comparison APIs reject a different
+measurement or scenario family, reserving distinct reused-session/query
+scenarios for RUE-901 without conflating them with cold compilation.

--- a/scripts/append-benchmark.py
+++ b/scripts/append-benchmark.py
@@ -86,6 +86,10 @@ def main() -> int:
             "iteration_policy": {"kind": "fixed", "iterations": result.get("iterations")},
             "platform": args.platform,
             "runner": {"image": runner_image, "host": result.get("host")},
+            "metric_semantics": {
+                "measurement_family": result.get("measurement_family", "compiler"),
+                "scenario_family": result.get("scenario_family", "cold_compilation"),
+            },
             "trigger_reason": args.reason,
             "coverage": coverage,
         }

--- a/scripts/benchmark_history.py
+++ b/scripts/benchmark_history.py
@@ -208,6 +208,8 @@ def regime_metadata(result: dict, platform: str, runner_image: str, corpus: dict
         "build_mode": result.get("build_mode"),
         "iteration_policy": {"kind": "fixed", "iterations": result.get("iterations")},
         "runner_image": runner_image,
+        "measurement_family": result.get("measurement_family", "compiler"),
+        "scenario_family": result.get("scenario_family", "cold_compilation"),
     }
     encoded = json.dumps(regime, sort_keys=True, separators=(",", ":")).encode()
     return {"id": hashlib.sha256(encoded).hexdigest(), "dimensions": regime}
@@ -245,7 +247,7 @@ def validate_publication(run: dict) -> list[str]:
     publication = run.get("publication")
     if not isinstance(publication, dict):
         return ["publication metadata must be an object"]
-    required = ("schema_version", "comparable", "regime_id", "regime", "corpus", "timing_schema_versions", "build_mode", "compiler", "iteration_policy", "platform", "runner", "trigger_reason", "coverage")
+    required = ("schema_version", "comparable", "regime_id", "regime", "corpus", "timing_schema_versions", "build_mode", "compiler", "iteration_policy", "platform", "runner", "trigger_reason", "coverage", "metric_semantics")
     for name in required:
         if name not in publication:
             errors.append(f"publication metadata missing {name}")
@@ -289,6 +291,12 @@ def validate_publication(run: dict) -> list[str]:
     timing_versions = publication.get("timing_schema_versions")
     if not isinstance(timing_versions, list) or not timing_versions or any(not isinstance(value, int) or isinstance(value, bool) or value <= 0 for value in timing_versions):
         errors.append("publication timing schema metadata is malformed")
+    semantics = publication.get("metric_semantics")
+    if not isinstance(semantics, dict) or semantics != {
+        "measurement_family": run.get("measurement_family", "compiler"),
+        "scenario_family": run.get("scenario_family", "cold_compilation"),
+    } or any(not isinstance(value, str) or not value for value in semantics.values()):
+        errors.append("publication metric semantics are malformed")
     if isinstance(regime, dict):
         expected_dimensions = {
             "platform": publication.get("platform"),
@@ -298,6 +306,8 @@ def validate_publication(run: dict) -> list[str]:
             "build_mode": publication.get("build_mode"),
             "iteration_policy": publication.get("iteration_policy"),
             "runner_image": runner.get("image") if isinstance(runner, dict) else None,
+            "measurement_family": semantics.get("measurement_family") if isinstance(semantics, dict) else None,
+            "scenario_family": semantics.get("scenario_family") if isinstance(semantics, dict) else None,
         }
         if regime != expected_dimensions:
             errors.append("publication fields do not match regime dimensions")

--- a/scripts/benchmark_metrics.py
+++ b/scripts/benchmark_metrics.py
@@ -1,0 +1,317 @@
+"""Canonical benchmark comparison and performance-index semantics.
+
+The policy is intentionally independent of chart rendering.  A run is a
+``compiler/cold_compilation`` measurement unless it carries an explicit
+identity; this default describes the historical ``bench.sh`` data.
+
+Latency uses the median of each benchmark's raw samples.  Variation is the
+scaled median absolute deviation (1.4826 * MAD), expressed relative to the
+median.  A comparison combines current and reference variation by root-sum-
+square.  A delta is stable inside that observed-variation band, improved below
+it, and regressed above it (compilation latency is lower-is-better).  At least
+three samples are required for each run.  The rolling baseline is the median
+of per-run medians from the preceding three to seven comparable runs; its
+variation combines within-run sample variation with variation between run
+medians.  There is no fixed absolute or percentage threshold.
+
+The latency performance index is the geometric mean of per-workload
+``baseline / current`` ratios times 100, so 100 is the baseline and higher is
+better.  Regime, scenario, or workload-composition changes explicitly rebase
+the index instead of producing a misleading movement.  Latency, throughput,
+memory, and binary size remain separate metric families.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+
+from benchmark_history import comparison_break, run_regime
+
+
+POLICY_VERSION = 1
+BASELINE_MIN_RUNS = 3
+BASELINE_WINDOW = 7
+MIN_SAMPLES = 3
+DEFAULT_MEASUREMENT_FAMILY = "compiler"
+DEFAULT_SCENARIO_FAMILY = "cold_compilation"
+
+
+def measurement_identity(run: dict) -> dict[str, str]:
+    """Return the semantic identity of a run, including historical defaults."""
+    publication = run.get("publication", {})
+    semantics = publication.get("metric_semantics", {}) if isinstance(publication, dict) else {}
+    measurement = semantics.get("measurement_family", run.get("measurement_family"))
+    scenario = semantics.get("scenario_family", run.get("scenario_family"))
+    return {
+        "measurement_family": measurement or DEFAULT_MEASUREMENT_FAMILY,
+        "scenario_family": scenario or DEFAULT_SCENARIO_FAMILY,
+    }
+
+
+def require_same_identity(left: dict, right: dict) -> dict[str, str]:
+    """Reject comparisons that mix measurement or execution scenarios."""
+    left_identity = measurement_identity(left)
+    right_identity = measurement_identity(right)
+    if left_identity != right_identity:
+        raise ValueError(
+            "cannot mix benchmark measurement/scenario families: "
+            f"{left_identity} != {right_identity}"
+        )
+    return left_identity
+
+
+def workload_names(run: dict) -> tuple[str, ...]:
+    names = [bench.get("name") for bench in run.get("benchmarks", []) if isinstance(bench, dict)]
+    if any(not isinstance(name, str) or not name for name in names) or len(names) != len(set(names)):
+        raise ValueError("benchmark workload names must be non-empty and unique")
+    return tuple(sorted(names))
+
+
+def _benches(run: dict) -> dict[str, dict]:
+    return {
+        bench["name"]: bench
+        for bench in run.get("benchmarks", [])
+        if isinstance(bench, dict) and isinstance(bench.get("name"), str)
+    }
+
+
+def _sample_summary(samples: object) -> dict | None:
+    if not isinstance(samples, list) or len(samples) < MIN_SAMPLES:
+        return None
+    if any(
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+        for value in samples
+    ):
+        return None
+    values = [float(value) for value in samples]
+    center = statistics.median(values)
+    mad = statistics.median(abs(value - center) for value in values)
+    return {
+        "center": center,
+        "relative_variation_pct": 100.0 * 1.4826 * mad / center,
+        "sample_count": len(values),
+    }
+
+
+def _classification(delta_pct: float, variation_pct: float) -> str:
+    if delta_pct > variation_pct:
+        return "regressed"
+    if delta_pct < -variation_pct:
+        return "improved"
+    return "stable"
+
+
+def _headline(per_workload: dict[str, dict]) -> dict:
+    if not per_workload or any(value["classification"] == "insufficient_data" for value in per_workload.values()):
+        return {"classification": "insufficient_data"}
+    ratios = [1.0 + value["delta_pct"] / 100.0 for value in per_workload.values()]
+    delta = 100.0 * (math.exp(sum(math.log(value) for value in ratios) / len(ratios)) - 1.0)
+    variation = math.sqrt(
+        sum(value["variation_pct"] ** 2 for value in per_workload.values())
+        / len(per_workload)
+    )
+    return {
+        "delta_pct": delta,
+        "variation_pct": variation,
+        "classification": _classification(delta, variation),
+        "direction": "lower_is_better",
+    }
+
+
+def compare_runs(current: dict, reference: dict) -> dict:
+    """Compare two adjacent points without crossing semantic boundaries."""
+    identity = require_same_identity(reference, current)
+    if run_regime(reference) != run_regime(current) or comparison_break(reference, current):
+        return {"status": "non_comparable", "reason": "regime_boundary", **identity}
+    names = workload_names(current)
+    if names != workload_names(reference):
+        return {"status": "non_comparable", "reason": "workload_composition_changed", **identity}
+    current_benches, reference_benches = _benches(current), _benches(reference)
+    comparisons = {}
+    for name in names:
+        current_sample = _sample_summary(current_benches[name].get("samples_ms"))
+        reference_sample = _sample_summary(reference_benches[name].get("samples_ms"))
+        if current_sample is None or reference_sample is None:
+            comparisons[name] = {"classification": "insufficient_data"}
+            continue
+        delta = 100.0 * (current_sample["center"] / reference_sample["center"] - 1.0)
+        variation = math.hypot(
+            current_sample["relative_variation_pct"],
+            reference_sample["relative_variation_pct"],
+        )
+        comparisons[name] = {
+            "delta_pct": delta,
+            "variation_pct": variation,
+            "classification": _classification(delta, variation),
+            "current_median_ms": current_sample["center"],
+            "reference_median_ms": reference_sample["center"],
+        }
+    return {
+        "status": "comparable",
+        "reference": "previous",
+        **identity,
+        "headline": _headline(comparisons),
+        "workloads": comparisons,
+    }
+
+
+def compare_to_rolling_baseline(current: dict, preceding: list[dict]) -> dict:
+    """Compare against up to seven preceding points in one contiguous segment."""
+    identity = measurement_identity(current)
+    names = workload_names(current)
+    candidates = preceding[-BASELINE_WINDOW:]
+    if len(candidates) < BASELINE_MIN_RUNS:
+        return {"status": "insufficient_data", "reason": "baseline_requires_three_runs", **identity}
+    chain = candidates + [current]
+    for index, run in enumerate(candidates):
+        require_same_identity(run, current)
+        if run_regime(run) != run_regime(current) or workload_names(run) != names:
+            return {"status": "non_comparable", "reason": "baseline_boundary", **identity}
+        if comparison_break(chain[index], chain[index + 1]):
+            return {"status": "non_comparable", "reason": "baseline_boundary", **identity}
+    current_benches = _benches(current)
+    prior_benches = [_benches(run) for run in candidates]
+    comparisons = {}
+    for name in names:
+        current_sample = _sample_summary(current_benches[name].get("samples_ms"))
+        prior_samples = [_sample_summary(benches[name].get("samples_ms")) for benches in prior_benches]
+        if current_sample is None or any(sample is None for sample in prior_samples):
+            comparisons[name] = {"classification": "insufficient_data"}
+            continue
+        samples = [sample for sample in prior_samples if sample is not None]
+        centers = [sample["center"] for sample in samples]
+        baseline = statistics.median(centers)
+        between_mad = statistics.median(abs(center - baseline) for center in centers)
+        between_variation = 100.0 * 1.4826 * between_mad / baseline
+        within_variation = statistics.median(sample["relative_variation_pct"] for sample in samples)
+        reference_variation = math.hypot(between_variation, within_variation)
+        variation = math.hypot(current_sample["relative_variation_pct"], reference_variation)
+        delta = 100.0 * (current_sample["center"] / baseline - 1.0)
+        comparisons[name] = {
+            "delta_pct": delta,
+            "variation_pct": variation,
+            "classification": _classification(delta, variation),
+            "current_median_ms": current_sample["center"],
+            "reference_median_ms": baseline,
+            "baseline_run_count": len(samples),
+        }
+    return {
+        "status": "comparable",
+        "reference": "rolling_baseline",
+        **identity,
+        "headline": _headline(comparisons),
+        "workloads": comparisons,
+    }
+
+
+def performance_index(current: dict, baseline: dict) -> dict:
+    """Return a composition-safe latency index whose baseline is exactly 100."""
+    identity = require_same_identity(baseline, current)
+    if run_regime(current) != run_regime(baseline):
+        return {"status": "rebase", "reason": "regime_changed", **identity}
+    if comparison_break(baseline, current):
+        return {"status": "rebase", "reason": "comparison_boundary", **identity}
+    names = workload_names(current)
+    if names != workload_names(baseline):
+        return {"status": "rebase", "reason": "workload_composition_changed", **identity}
+    current_benches, baseline_benches = _benches(current), _benches(baseline)
+    ratios = []
+    for name in names:
+        current_sample = _sample_summary(current_benches[name].get("samples_ms"))
+        baseline_sample = _sample_summary(baseline_benches[name].get("samples_ms"))
+        if current_sample is None or baseline_sample is None:
+            return {"status": "insufficient_data", **identity}
+        ratios.append(baseline_sample["center"] / current_sample["center"])
+    if not ratios:
+        return {"status": "insufficient_data", **identity}
+    return {
+        "status": "comparable",
+        "value": 100.0 * math.exp(sum(math.log(value) for value in ratios) / len(ratios)),
+        "baseline": 100.0,
+        "direction": "higher_is_better",
+        **identity,
+    }
+
+
+def metric_families(run: dict) -> dict:
+    """Expose absolute products without combining unlike metric families."""
+    families = {"latency_ms": {}, "throughput": {}, "memory_bytes": {}, "binary_size_bytes": {}}
+    for name, bench in _benches(run).items():
+        sample = _sample_summary(bench.get("samples_ms"))
+        if sample:
+            families["latency_ms"][name] = sample["center"]
+        source = bench.get("source_metrics", {})
+        mean_ms = bench.get("mean_ms")
+        if isinstance(source, dict) and isinstance(mean_ms, (int, float)) and mean_ms > 0:
+            families["throughput"][name] = {
+                key: source[key] * 1000.0 / mean_ms
+                for key in ("lines", "tokens")
+                if isinstance(source.get(key), (int, float))
+            }
+        if isinstance(bench.get("peak_memory_bytes"), (int, float)):
+            families["memory_bytes"][name] = bench["peak_memory_bytes"]
+        if isinstance(bench.get("binary_size_bytes"), (int, float)):
+            families["binary_size_bytes"][name] = bench["binary_size_bytes"]
+    return families
+
+
+def derive_history_metrics(runs: list[dict]) -> dict:
+    """Derive renderer-neutral point metadata for regression/evolution consumers."""
+    points = []
+    segment: list[dict] = []
+    anchor = None
+    for run in runs:
+        reason = None
+        if not segment:
+            reason = "history_start"
+        else:
+            try:
+                same_identity = measurement_identity(segment[-1]) == measurement_identity(run)
+                same_workloads = workload_names(segment[-1]) == workload_names(run)
+            except ValueError:
+                same_identity = same_workloads = False
+            if comparison_break(segment[-1], run):
+                reason = "regime_boundary"
+            elif not same_identity:
+                reason = "scenario_changed"
+            elif not same_workloads:
+                reason = "workload_composition_changed"
+        if reason:
+            segment = []
+            anchor = run
+        previous = compare_runs(run, segment[-1]) if segment else {
+            "status": "non_comparable", "reason": reason, **measurement_identity(run)
+        }
+        rolling = compare_to_rolling_baseline(run, segment)
+        index = performance_index(run, anchor) if anchor is not None else {"status": "insufficient_data"}
+        if run is anchor and index.get("status") == "comparable":
+            index["status"] = "rebase"
+            index["reason"] = reason
+        points.append({
+            "commit": run.get("commit"),
+            "regime_id": run_regime(run),
+            "workloads": list(workload_names(run)),
+            "identity": measurement_identity(run),
+            "previous": previous,
+            "rolling_baseline": rolling,
+            "performance_index": index,
+            "metric_families": metric_families(run),
+        })
+        segment.append(run)
+    return {
+        "schema_version": POLICY_VERSION,
+        "policy": {
+            "estimator": "median_and_scaled_mad",
+            "minimum_samples": MIN_SAMPLES,
+            "baseline_min_runs": BASELINE_MIN_RUNS,
+            "baseline_window": BASELINE_WINDOW,
+            "threshold": "root_sum_square_observed_relative_variation",
+            "latency_direction": "lower_is_better",
+            "index_direction": "higher_is_better",
+        },
+        "points": points,
+    }

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -38,6 +38,7 @@ from benchmark_history import (
     load_history,
     run_regime,
 )
+from benchmark_metrics import derive_history_metrics
 
 # Chart dimensions
 TIMELINE_WIDTH = 800
@@ -217,6 +218,13 @@ def calculate_delta(current: float, previous: float) -> tuple[float, str]:
         return pct, "→ 0%"
     arrow = "↑" if pct > 0 else "↓"
     return pct, f"{arrow} {abs(pct):.1f}%"
+
+
+def format_delta_pct(pct: float) -> str:
+    """Format an already-computed canonical percentage without reclassifying it."""
+    if pct == 0:
+        return "→ 0%"
+    return f"{'↑' if pct > 0 else '↓'} {abs(pct):.1f}%"
 
 
 def escape_xml(s: str) -> str:
@@ -1067,11 +1075,19 @@ def generate_summary_data(runs: list[dict], platform: Optional[str] = None) -> d
     latest_commit = short_commit(latest.get("commit", "")) if latest else ""
 
     # Calculate deltas
-    prev_time = get_total_time(previous) if previous else 0
     prev_memory = get_peak_memory(previous) if previous else 0
     prev_binary = get_binary_size(previous) if previous else 0
 
-    time_delta_pct, time_delta_str = calculate_delta(latest_time, prev_time)
+    derived = derive_history_metrics(runs)
+    time_comparison = derived["points"][-1]["previous"]
+    canonical_headline = time_comparison.get("headline", {})
+    time_delta_pct = canonical_headline.get("delta_pct", 0)
+    time_delta_str = (
+        format_delta_pct(time_delta_pct)
+        if time_comparison.get("status") == "comparable"
+        and canonical_headline.get("classification") != "insufficient_data"
+        else ""
+    )
     memory_delta_pct, memory_delta_str = calculate_delta(latest_memory, prev_memory)
     binary_delta_pct, binary_delta_str = calculate_delta(latest_binary, prev_binary)
 
@@ -1091,6 +1107,7 @@ def generate_summary_data(runs: list[dict], platform: Optional[str] = None) -> d
         "latest_binary_kb": round(latest_binary, 2),
         "time_delta_pct": round(time_delta_pct, 2),
         "time_delta_str": time_delta_str,
+        "time_comparison": time_comparison,
         "memory_delta_pct": round(memory_delta_pct, 2),
         "memory_delta_str": memory_delta_str,
         "binary_delta_pct": round(binary_delta_pct, 2),
@@ -1211,6 +1228,7 @@ def generate_platform_charts(history_path: Path, output_dir: Path, platform: Opt
         "latest_benchmarks": latest_benchmarks,
         "coverage": coverage,
         "regimes": regime_summary(runs),
+        "metric_semantics": derive_history_metrics(runs),
     }
     if platform:
         metadata["platform"] = platform

--- a/scripts/generate-site-status.py
+++ b/scripts/generate-site-status.py
@@ -29,6 +29,7 @@ import sys
 from pathlib import Path
 
 from benchmark_history import latest_comparable_segment, load_history
+from benchmark_metrics import derive_history_metrics
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -87,7 +88,8 @@ def spec_case_count() -> int:
 
 
 def sparkline_data(runs: list[dict]) -> dict | None:
-    runs = latest_comparable_segment(runs)[-SPARKLINE_RUNS:]
+    comparable_segment = latest_comparable_segment(runs)
+    runs = comparable_segment[-SPARKLINE_RUNS:]
     totals = []
     for run in runs:
         benches = run.get("benchmarks", [])
@@ -107,13 +109,22 @@ def sparkline_data(runs: list[dict]) -> dict | None:
         y = SPARK_Y_MIN + (SPARK_Y_MAX - SPARK_Y_MIN) * (total - lo) / span
         points.append(f"{x:.0f},{y:.1f}")
 
-    return {
+    result = {
         "latest_ms": round(totals[-1]),
         "n_runs": len(totals),
         "points": " ".join(points),
         "last_x": points[-1].split(",")[0],
         "last_y": points[-1].split(",")[1],
     }
+    # The visual is deliberately bounded, but the index remains anchored to
+    # the beginning of the full comparable segment.
+    derived = derive_history_metrics(comparable_segment)
+    if derived["points"]:
+        latest = derived["points"][-1]
+        result["performance_index"] = latest["performance_index"]
+        result["previous_comparison"] = latest["previous"]
+        result["baseline_comparison"] = latest["rolling_baseline"]
+    return result
 
 
 def bench_sparkline() -> dict | None:

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -33,6 +33,7 @@ collection = load_module("benchmark_collection", "scripts/benchmark_collection.p
 charts = load_module("generate_charts", "scripts/generate-charts.py")
 site_status = load_module("generate_site_status", "scripts/generate-site-status.py")
 history_tools = load_module("benchmark_history", "scripts/benchmark_history.py")
+metrics = load_module("benchmark_metrics", "scripts/benchmark_metrics.py")
 perf_baseline = load_module("perf_baseline", "scripts/perf-baseline.py")
 
 
@@ -722,6 +723,13 @@ class BenchmarkValidationTests(unittest.TestCase):
             self.assertEqual(published[0]["version"], 3)
             self.assertEqual(published[0]["publication"]["trigger_reason"], "push")
             self.assertEqual(published[0]["publication"]["coverage"]["represented_commits"], ["probe"])
+            self.assertEqual(
+                published[0]["publication"]["metric_semantics"],
+                {
+                    "measurement_family": "compiler",
+                    "scenario_family": "cold_compilation",
+                },
+            )
 
 
 class DurableBenchmarkHistoryTests(unittest.TestCase):
@@ -912,6 +920,154 @@ class DurableBenchmarkHistoryTests(unittest.TestCase):
         sparkline = site_status.sparkline_data(runs)
         self.assertEqual(sparkline["n_runs"], 2)
         self.assertEqual(sparkline["latest_ms"], 20)
+
+
+class BenchmarkMetricSemanticsTests(unittest.TestCase):
+    @staticmethod
+    def sample_run(commit, values, regime="same", scenario="cold_compilation"):
+        benchmarks = []
+        for name, samples in values.items():
+            benchmarks.append({
+                "name": name,
+                "samples_ms": samples,
+                "mean_ms": sum(samples) / len(samples),
+                "source_metrics": {"lines": 100, "tokens": 200},
+                "peak_memory_bytes": 1024,
+                "binary_size_bytes": 2048,
+            })
+        return {
+            "commit": commit,
+            "measurement_family": "compiler",
+            "scenario_family": scenario,
+            "publication": {
+                "comparable": True,
+                "regime_id": regime,
+                "coverage": {"skipped_commits": [], "gap_unknown": False},
+                "metric_semantics": {
+                    "measurement_family": "compiler",
+                    "scenario_family": scenario,
+                },
+            },
+            "benchmarks": benchmarks,
+        }
+
+    def test_previous_delta_variation_and_classification_use_samples(self):
+        reference = self.sample_run("a", {"probe": [99, 100, 101]})
+        stable = self.sample_run("b", {"probe": [100, 101, 102]})
+        regression = self.sample_run("c", {"probe": [109.9, 110, 110.1]})
+        improvement = self.sample_run("d", {"probe": [89.9, 90, 90.1]})
+
+        stable_result = metrics.compare_runs(stable, reference)
+        self.assertEqual(stable_result["status"], "comparable")
+        self.assertEqual(stable_result["headline"]["classification"], "stable")
+        self.assertAlmostEqual(stable_result["workloads"]["probe"]["delta_pct"], 1.0)
+        self.assertGreater(stable_result["workloads"]["probe"]["variation_pct"], 1.0)
+        self.assertEqual(
+            metrics.compare_runs(regression, reference)["headline"]["classification"],
+            "regressed",
+        )
+        self.assertEqual(
+            metrics.compare_runs(improvement, reference)["headline"]["classification"],
+            "improved",
+        )
+
+    def test_rolling_baseline_is_robust_and_requires_three_runs(self):
+        current = self.sample_run("d", {"probe": [109.9, 110, 110.1]})
+        preceding = [
+            self.sample_run("a", {"probe": [99.9, 100, 100.1]}),
+            self.sample_run("b", {"probe": [100.9, 101, 101.1]}),
+            self.sample_run("c", {"probe": [98.9, 99, 99.1]}),
+        ]
+        self.assertEqual(
+            metrics.compare_to_rolling_baseline(current, preceding[:2])["status"],
+            "insufficient_data",
+        )
+        result = metrics.compare_to_rolling_baseline(current, preceding)
+        self.assertEqual(result["headline"]["classification"], "regressed")
+        self.assertEqual(result["workloads"]["probe"]["reference_median_ms"], 100)
+        self.assertEqual(result["workloads"]["probe"]["baseline_run_count"], 3)
+
+    def test_missing_samples_are_insufficient_data(self):
+        result = metrics.compare_runs(
+            self.sample_run("b", {"probe": [100, 101]}),
+            self.sample_run("a", {"probe": [100, 100, 100]}),
+        )
+        self.assertEqual(result["headline"]["classification"], "insufficient_data")
+
+    def test_workload_and_regime_changes_are_non_comparable_rebases(self):
+        baseline = self.sample_run("a", {"one": [100, 100, 100]})
+        composition = self.sample_run("b", {"one": [100, 100, 100], "two": [50, 50, 50]})
+        regime = self.sample_run("c", {"one": [100, 100, 100]}, regime="new")
+        self.assertEqual(metrics.compare_runs(composition, baseline)["reason"], "workload_composition_changed")
+        self.assertEqual(metrics.performance_index(composition, baseline)["status"], "rebase")
+        self.assertEqual(metrics.compare_runs(regime, baseline)["reason"], "regime_boundary")
+        self.assertEqual(metrics.performance_index(regime, baseline)["reason"], "regime_changed")
+
+        derived = metrics.derive_history_metrics([baseline, composition])
+        self.assertEqual(derived["points"][1]["performance_index"]["status"], "rebase")
+        self.assertEqual(
+            derived["points"][1]["performance_index"]["reason"],
+            "workload_composition_changed",
+        )
+
+    def test_performance_index_is_geometric_mean_with_baseline_one_hundred(self):
+        baseline = self.sample_run("a", {
+            "one": [100, 100, 100],
+            "two": [400, 400, 400],
+        })
+        current = self.sample_run("b", {
+            "one": [50, 50, 50],
+            "two": [800, 800, 800],
+        })
+        result = metrics.performance_index(current, baseline)
+        self.assertEqual(result["status"], "comparable")
+        self.assertAlmostEqual(result["value"], 100.0)
+        self.assertEqual(metrics.performance_index(baseline, baseline)["value"], 100.0)
+
+    def test_scenario_mixing_is_rejected(self):
+        cold = self.sample_run("a", {"probe": [100, 100, 100]})
+        reused = self.sample_run(
+            "b", {"probe": [50, 50, 50]}, scenario="reused_session_query"
+        )
+        with self.assertRaisesRegex(ValueError, "cannot mix"):
+            metrics.compare_runs(reused, cold)
+        with self.assertRaisesRegex(ValueError, "cannot mix"):
+            metrics.performance_index(reused, cold)
+
+    def test_metric_products_remain_separate_families(self):
+        run = self.sample_run("a", {"probe": [10, 10, 10]})
+        families = metrics.metric_families(run)
+        self.assertEqual(
+            set(families),
+            {"latency_ms", "throughput", "memory_bytes", "binary_size_bytes"},
+        )
+        self.assertEqual(families["latency_ms"]["probe"], 10)
+        self.assertEqual(families["throughput"]["probe"]["lines"], 10000)
+        self.assertEqual(families["memory_bytes"]["probe"], 1024)
+        self.assertEqual(families["binary_size_bytes"]["probe"], 2048)
+
+    def test_dashboard_summary_routes_latency_through_canonical_policy(self):
+        reference = self.sample_run("a", {"probe": [99.9, 100, 100.1]})
+        current = self.sample_run("b", {"probe": [109.9, 110, 110.1]})
+        summary = charts.generate_summary_data([reference, current])
+        self.assertEqual(summary["time_comparison"]["headline"]["classification"], "regressed")
+        self.assertAlmostEqual(summary["time_delta_pct"], 10.0)
+        self.assertEqual(summary["time_delta_str"], "↑ 10.0%")
+
+    def test_status_index_uses_full_segment_when_sparkline_is_truncated(self):
+        runs = [
+            self.sample_run(
+                f"commit-{index}",
+                {"probe": [100 + index, 100 + index, 100 + index]},
+            )
+            for index in range(25)
+        ]
+        status = site_status.sparkline_data(runs)
+        self.assertEqual(status["n_runs"], site_status.SPARKLINE_RUNS)
+        self.assertAlmostEqual(
+            status["performance_index"]["value"],
+            100 * 100 / 124,
+        )
 
 
 class BenchmarkCollectionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a canonical renderer-independent policy for benchmark comparisons
- derive previous/rolling baselines, observed-variation classifications, and a long-term geometric performance index
- enforce workload, regime, and scenario boundaries while keeping metric families separate
- expose canonical metrics to chart and homepage status consumers

## Validation

- `./buck2 test //:benchmark-tool-tests` (52 tests)
- `scripts/rue quick` (25 targets)
- `website/build.sh`
- `git diff --check`

Fixes RUE-895