### PR TITLE
RUE-888: complete incremental reuse evidence

### DIFF
--- a/crates/rue-compiler-session-bench/BUCK
+++ b/crates/rue-compiler-session-bench/BUCK
@@ -3,6 +3,7 @@ load("//crates:defs.bzl", "rue_binary")
 rue_binary(
     name = "rue-compiler-session-bench",
     deps = [
+        "//crates/rue-air:rue-air",
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-span:rue-span",
         "//third-party:serde_json",

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -4,9 +4,13 @@
 
 use std::{collections::HashMap, env, process, sync::Arc, time::Instant};
 
+use rue_air::{InternedType, TypeInternPool};
 use rue_compiler::{
-    CompileOptions, CompilerSession, CompilerSessionWork, FRONTEND_DIAGNOSTIC_RETENTION_LIMIT,
-    FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT, ParsedModulesWork,
+    AcceptedReadManifestEntry, CanonicalSemanticOutput, CompileOptions, CompilerSession,
+    CompilerSessionWork, DiscoverySourceAssembler, DurableBodyWork,
+    FRONTEND_DIAGNOSTIC_RETENTION_LIMIT, FRONTEND_INVALIDATION_PLAN_RETENTION_LIMIT,
+    FileMetadataFingerprint, FrontendDiagnosticSnapshot, ImportDiscoveryContext,
+    ImportObservationLedger, OptLevel, ParsedModulesWork, PhysicalFileIdentity,
     SemanticDependencyIncompleteReason, SemanticDependencyInputManifest, SemanticDependencySurface,
     SemanticFullInvalidationReason, SemanticInvalidationPlan, SemanticInvalidationScope,
     SourceMetadata, SourceSnapshot,
@@ -18,7 +22,7 @@ const DEFAULT_MODULES: usize = 128;
 const DEFAULT_WARMUP: usize = 3;
 const DEFAULT_ITERATIONS: usize = 10;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Config {
     modules: usize,
     warmup: usize,
@@ -172,6 +176,174 @@ enum Variant {
     SemanticError,
 }
 
+struct CompletionFixture {
+    direct: SourceSnapshot,
+    direct_unrelated_edit: SourceSnapshot,
+    direct_reachable_edit: SourceSnapshot,
+    chain: SourceSnapshot,
+    chain_reachable_edit: SourceSnapshot,
+    semantic_error: SourceSnapshot,
+    specialization: SourceSnapshot,
+    specialization_unrelated_edit: SourceSnapshot,
+}
+
+#[derive(Clone, Copy)]
+enum CompletionGraph {
+    Direct,
+    Chain,
+}
+
+impl CompletionFixture {
+    fn new(functions: usize) -> Self {
+        assert!(
+            functions >= 4,
+            "completion workload requires at least four functions"
+        );
+        Self {
+            direct: completion_snapshot(functions, CompletionGraph::Direct, 0, false),
+            direct_unrelated_edit: completion_snapshot(
+                functions,
+                CompletionGraph::Direct,
+                1,
+                false,
+            ),
+            direct_reachable_edit: completion_snapshot(
+                functions,
+                CompletionGraph::Direct,
+                0,
+                true,
+            ),
+            chain: completion_snapshot(functions, CompletionGraph::Chain, 0, false),
+            chain_reachable_edit: completion_snapshot(
+                functions,
+                CompletionGraph::Chain,
+                0,
+                true,
+            ),
+            semantic_error: single_root_snapshot(completion_source(
+                functions,
+                CompletionGraph::Direct,
+                0,
+                false,
+                true,
+            )),
+            specialization: single_root_snapshot(
+                "fn choose(comptime n: i32) -> i32 { n }\nfn stable() -> i32 { 2 }\nfn dead() -> i32 { 0 }\nfn main() -> i32 { choose(40) + stable() }".to_owned(),
+            ),
+            specialization_unrelated_edit: single_root_snapshot(
+                "fn choose(comptime n: i32) -> i32 { n }\nfn stable() -> i32 { 2 }\nfn dead() -> i32 { 1 }\nfn main() -> i32 { choose(40) + stable() }".to_owned(),
+            ),
+        }
+    }
+}
+
+fn completion_snapshot(
+    functions: usize,
+    graph: CompletionGraph,
+    dead_value: i32,
+    reachable_edit: bool,
+) -> SourceSnapshot {
+    single_root_snapshot(completion_source(
+        functions,
+        graph,
+        dead_value,
+        reachable_edit,
+        false,
+    ))
+}
+
+fn completion_source(
+    functions: usize,
+    graph: CompletionGraph,
+    dead_value: i32,
+    reachable_edit: bool,
+    semantic_error: bool,
+) -> String {
+    let leaves = functions - 1;
+    let chain_len = leaves / 2 + leaves % 2;
+    let mut source = String::new();
+    for index in 0..leaves {
+        let body = if index == 0 {
+            usize::from(reachable_edit).to_string()
+        } else if matches!(graph, CompletionGraph::Chain) && index < chain_len {
+            format!("f{:03}() + 1", index - 1)
+        } else {
+            index.to_string()
+        };
+        source.push_str(&format!("fn f{index:03}() -> i32 {{ {body} }}\n"));
+    }
+    source.push_str(&format!("fn dead() -> i32 {{ {dead_value} }}\n"));
+    if semantic_error {
+        source.push_str("fn main() -> i32 { missing_name }\n");
+    } else {
+        let calls = match graph {
+            CompletionGraph::Direct => (0..leaves).collect::<Vec<_>>(),
+            CompletionGraph::Chain => {
+                let mut calls = vec![chain_len - 1];
+                calls.extend(chain_len..leaves);
+                calls
+            }
+        };
+        source.push_str("fn main() -> i32 { ");
+        source.push_str(
+            &calls
+                .into_iter()
+                .map(|index| format!("f{index:03}()"))
+                .collect::<Vec<_>>()
+                .join(" + "),
+        );
+        source.push_str(" }\n");
+    }
+    source
+}
+
+fn single_root_snapshot(source: String) -> SourceSnapshot {
+    completion_discovery(Arc::new(source)).0
+}
+
+fn completion_discovery(
+    source: Arc<String>,
+) -> (
+    SourceSnapshot,
+    ImportDiscoveryContext,
+    Arc<[AcceptedReadManifestEntry]>,
+) {
+    let context = ImportDiscoveryContext::new(1, "/bench", None, "rue-888-benchmark").unwrap();
+    let source_len = source.len() as u64;
+    let assembler = DiscoverySourceAssembler::new(
+        context.clone(),
+        "/bench/main.rue",
+        "/bench/main.rue",
+        PhysicalFileIdentity::new(1, 1),
+        FileMetadataFingerprint::new(source_len, 0, 0),
+        source,
+    )
+    .unwrap();
+    (
+        assembler.snapshot().unwrap(),
+        context,
+        assembler.accepted_read_manifest(),
+    )
+}
+
+fn close_completion_discovery(session: &mut CompilerSession, source: &SourceSnapshot) {
+    let expected_revision = source.source_revision().clone();
+    let source_text = Arc::new(source.files().next().unwrap().source.to_owned());
+    let (discovered, context, accepted_reads) = completion_discovery(source_text);
+    assert_eq!(discovered.source_revision(), &expected_revision);
+    session
+        .stage_import_discovery(
+            &discovered,
+            context,
+            accepted_reads,
+            ImportObservationLedger::default(),
+        )
+        .unwrap();
+    session
+        .close_import_discovery(ImportObservationLedger::default())
+        .unwrap();
+}
+
 fn snapshot(modules: usize, variant: Variant) -> SourceSnapshot {
     let changed = modules - 1;
     let physical = (0..modules)
@@ -225,6 +397,44 @@ fn parse_json(work: ParsedModulesWork) -> Value {
     })
 }
 
+fn durable_body_work_json(work: DurableBodyWork) -> Value {
+    json!({
+        "candidate_comparisons": work.candidate_comparisons,
+        "candidate_fallbacks": work.candidate_fallbacks,
+        "specialized_mapping_attempts": work.specialized_mapping_attempts,
+        "specialized_mapping_successes": work.specialized_mapping_successes,
+        "specialized_mapping_failures": work.specialized_mapping_failures,
+        "export_attempts": work.export_attempts,
+        "export_successes": work.export_successes,
+        "export_rejections": work.export_rejections,
+        "instructions_exported": work.instructions_exported,
+        "places_exported": work.places_exported,
+        "strings_exported": work.strings_exported,
+        "conversion_attempts": work.conversion_attempts,
+        "conversion_completions": work.conversion_completions,
+        "conversion_failures": work.conversion_failures,
+        "stable_key_joins": work.stable_key_joins,
+        "finalization_attempts": work.finalization_attempts,
+        "finalization_completions": work.finalization_completions,
+        "finalization_failures": work.finalization_failures,
+        "projection_attempts": work.projection_attempts,
+        "projection_completions": work.projection_completions,
+        "projection_failures": work.projection_failures,
+        "instructions_projected": work.instructions_projected,
+        "places_projected": work.places_projected,
+        "strings_projected": work.strings_projected,
+        "import_attempts": work.import_attempts,
+        "import_successes": work.import_successes,
+        "import_failures": work.import_failures,
+        "installed_instructions": work.installed_instructions,
+        "installed_places": work.installed_places,
+        "installed_strings": work.installed_strings,
+        "atomic_discards": work.atomic_discards,
+        "reused_bodies": work.reused_bodies,
+        "skipped_body_analyses": work.skipped_body_analyses,
+    })
+}
+
 fn semantic_work_json(work: &CompilerSessionWork, from: usize) -> Value {
     let records = &work.semantic_records[from..];
     json!({
@@ -257,6 +467,11 @@ fn semantic_work_json(work: &CompilerSessionWork, from: usize) -> Value {
         "specialized_bodies_succeeded": records.iter().map(|record| record.work.body_analysis.specialized_bodies_succeeded).sum::<usize>(),
         "specialized_bodies_failed": records.iter().map(|record| record.work.body_analysis.specialized_bodies_failed).sum::<usize>(),
         "durable_bodies": {
+            "candidate_comparisons": records.iter().map(|record| record.work.durable_bodies.candidate_comparisons).sum::<usize>(),
+            "candidate_fallbacks": records.iter().map(|record| record.work.durable_bodies.candidate_fallbacks).sum::<usize>(),
+            "specialized_mapping_attempts": records.iter().map(|record| record.work.durable_bodies.specialized_mapping_attempts).sum::<usize>(),
+            "specialized_mapping_successes": records.iter().map(|record| record.work.durable_bodies.specialized_mapping_successes).sum::<usize>(),
+            "specialized_mapping_failures": records.iter().map(|record| record.work.durable_bodies.specialized_mapping_failures).sum::<usize>(),
             "export_attempts": records.iter().map(|record| record.work.durable_bodies.export_attempts).sum::<usize>(),
             "export_successes": records.iter().map(|record| record.work.durable_bodies.export_successes).sum::<usize>(),
             "export_rejections": records.iter().map(|record| record.work.durable_bodies.export_rejections).sum::<usize>(),
@@ -299,6 +514,17 @@ fn semantic_work_json(work: &CompilerSessionWork, from: usize) -> Value {
             "optimized_level_attempts": records.iter().map(|record| record.work.cfg.optimized_level_attempts).sum::<usize>(),
             "warnings_emitted": records.iter().map(|record| record.work.cfg.cfg_warnings_emitted).sum::<usize>(),
             "implicit_destructor_targets_emitted": records.iter().map(|record| record.work.cfg.implicit_destructor_targets_emitted).sum::<usize>(),
+            "reuse_candidates": records.iter().map(|record| record.work.cfg.cfg_reuse_candidates).sum::<usize>(),
+            "import_attempts": records.iter().map(|record| record.work.cfg.cfg_import_attempts).sum::<usize>(),
+            "import_successes": records.iter().map(|record| record.work.cfg.cfg_import_successes).sum::<usize>(),
+            "import_failures": records.iter().map(|record| record.work.cfg.cfg_import_failures).sum::<usize>(),
+            "reuses": records.iter().map(|record| record.work.cfg.cfg_reuses).sum::<usize>(),
+            "fallbacks": records.iter().map(|record| record.work.cfg.cfg_fallbacks).sum::<usize>(),
+            "warnings_reused": records.iter().map(|record| record.work.cfg.cfg_warnings_reused).sum::<usize>(),
+            "implicit_destructor_targets_reused": records.iter().map(|record| record.work.cfg.implicit_destructor_targets_reused).sum::<usize>(),
+            "export_attempts": records.iter().map(|record| record.work.cfg.cfg_export_attempts).sum::<usize>(),
+            "export_successes": records.iter().map(|record| record.work.cfg.cfg_export_successes).sum::<usize>(),
+            "export_rejections": records.iter().map(|record| record.work.cfg.cfg_export_rejections).sum::<usize>(),
         },
         "ordinary_free_function_dependency_events": records.iter().map(|record| record.work.body_analysis.ordinary_free_function_dependency_events).sum::<usize>(),
         "specialized_origin_records": records.iter().map(|record| record.work.body_analysis.specialized_origin_records).sum::<usize>(),
@@ -518,6 +744,7 @@ fn measure_manifest_plan(
     let plan = session.semantic_invalidation_plan(previous.unwrap_or(&current), &current);
     let plan_elapsed = plan_started.elapsed();
     let after_plan = QueryCounts::from(session.work());
+    let durable_body_work = durable_body_work_json(manifest_work.durable_bodies);
     (
         json!({
             "manifest_wall_time_ns": manifest_elapsed.as_nanos(),
@@ -529,26 +756,7 @@ fn measure_manifest_plan(
                 "body_named_events_translated": manifest_work.body_named_events_translated,
                 "body_dependency_records_built": manifest_work.body_dependency_records_built,
                 "extra_rir_instructions_visited": manifest_work.extra_rir_instructions_visited,
-                "durable_bodies": {
-                    "finalization_attempts": manifest_work.durable_bodies.finalization_attempts,
-                    "finalization_completions": manifest_work.durable_bodies.finalization_completions,
-                    "finalization_failures": manifest_work.durable_bodies.finalization_failures,
-                    "projection_attempts": manifest_work.durable_bodies.projection_attempts,
-                    "projection_completions": manifest_work.durable_bodies.projection_completions,
-                    "projection_failures": manifest_work.durable_bodies.projection_failures,
-                    "instructions_projected": manifest_work.durable_bodies.instructions_projected,
-                    "places_projected": manifest_work.durable_bodies.places_projected,
-                    "strings_projected": manifest_work.durable_bodies.strings_projected,
-                    "import_attempts": manifest_work.durable_bodies.import_attempts,
-                    "import_successes": manifest_work.durable_bodies.import_successes,
-                    "import_failures": manifest_work.durable_bodies.import_failures,
-                    "installed_instructions": manifest_work.durable_bodies.installed_instructions,
-                    "installed_places": manifest_work.durable_bodies.installed_places,
-                    "installed_strings": manifest_work.durable_bodies.installed_strings,
-                    "atomic_discards": manifest_work.durable_bodies.atomic_discards,
-                    "reused_bodies": manifest_work.durable_bodies.reused_bodies,
-                    "skipped_body_analyses": manifest_work.durable_bodies.skipped_body_analyses,
-                },
+                "durable_bodies": durable_body_work,
             },
             "planner_queries": after_plan.delta(after_manifest).json(),
             "plan": invalidation_plan_json(&plan),
@@ -556,6 +764,476 @@ fn measure_manifest_plan(
         }),
         current,
     )
+}
+
+fn measured_semantic(
+    session: &mut CompilerSession,
+    source: &SourceSnapshot,
+    options: &CompileOptions,
+) -> (Value, Arc<CanonicalSemanticOutput>) {
+    let mut output = None;
+    let value = measure(session, |session| {
+        let update = session.update(source);
+        let parse = update.work();
+        update.into_result().unwrap();
+        output = Some(session.semantic(options).unwrap());
+        parse
+    });
+    (value, output.unwrap())
+}
+
+fn type_pool_snapshot(pool: &TypeInternPool) -> Vec<String> {
+    // InternedType reserves raw indices 0..16 for primitives. Composite values
+    // are stored densely after that prefix, so this captures the exact ordered
+    // public type universe without relying on HashMap iteration in Debug output.
+    (0..pool.len())
+        .map(|index| {
+            format!(
+                "{:?}",
+                pool.get(InternedType::from_raw(16 + index as u32))
+                    .expect("dense type-pool entry")
+            )
+        })
+        .collect()
+}
+
+fn assert_diagnostic_parity(
+    reused: Option<&Arc<FrontendDiagnosticSnapshot>>,
+    cold: Option<&Arc<FrontendDiagnosticSnapshot>>,
+) {
+    assert_eq!(reused.is_some(), cold.is_some());
+    let (Some(reused), Some(cold)) = (reused, cold) else {
+        return;
+    };
+    assert_eq!(reused.source_revision(), cold.source_revision());
+    assert_eq!(
+        format!("{:?}", reused.stage()),
+        format!("{:?}", cold.stage())
+    );
+    assert_eq!(
+        format!("{:?}", reused.errors()),
+        format!("{:?}", cold.errors())
+    );
+    assert_eq!(
+        format!("{:?}", reused.warnings()),
+        format!("{:?}", cold.warnings())
+    );
+    assert_eq!(reused.is_success(), cold.is_success());
+}
+
+fn assert_cold_reused_parity(
+    reused_session: &mut CompilerSession,
+    reused: &CanonicalSemanticOutput,
+    source: &SourceSnapshot,
+    options: &CompileOptions,
+) -> Value {
+    let mut cold_session = CompilerSession::new();
+    cold_session.update(source).into_result().unwrap();
+    let cold = cold_session.semantic(options).unwrap();
+    let cold_semantic_work = semantic_work_json(cold_session.work(), 0);
+    let cold_count = |path: &[&str]| count(&cold_semantic_work, path);
+    assert!(cold_count(&["bodies_attempted"]) > 0);
+    assert_eq!(
+        cold_count(&["bodies_attempted"]),
+        cold_count(&["bodies_succeeded"])
+    );
+    assert_eq!(cold_count(&["durable_bodies", "candidate_comparisons"]), 0);
+    assert_eq!(cold_count(&["durable_bodies", "reused_bodies"]), 0);
+    assert_eq!(cold_count(&["cfg", "reuse_candidates"]), 0);
+    assert_eq!(cold_count(&["cfg", "reuses"]), 0);
+    assert_eq!(
+        cold_count(&["cfg", "builds_attempted"]),
+        cold_count(&["cfg", "builds_succeeded"])
+    );
+    assert_eq!(
+        cold_count(&["declaration_reuse", "durable_cache_population_exports"]),
+        1
+    );
+    assert_eq!(
+        format!("{:?}", reused.functions()),
+        format!("{:?}", cold.functions())
+    );
+    assert_eq!(reused.input(), cold.input());
+    assert_eq!(reused.type_pool().stats(), cold.type_pool().stats());
+    assert_eq!(
+        type_pool_snapshot(reused.type_pool()),
+        type_pool_snapshot(cold.type_pool())
+    );
+    let bound_definition_snapshot = |output: &CanonicalSemanticOutput| {
+        output.bound_definitions().map(|definitions| {
+            definitions
+                .definitions()
+                .iter()
+                .map(|definition| {
+                    format!(
+                        "{:?}|{:?}|{:?}|{:?}",
+                        definition.stable_key(),
+                        definition.occurrence(),
+                        definition.declaration_span(),
+                        definition.visibility()
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+    };
+    assert_eq!(
+        bound_definition_snapshot(reused),
+        bound_definition_snapshot(&cold)
+    );
+    assert_eq!(reused.strings(), cold.strings());
+    assert_eq!(
+        format!("{:?}", reused.warnings()),
+        format!("{:?}", cold.warnings())
+    );
+    assert_eq!(
+        format!("{:?}", reused.analyzed_body_owners()),
+        format!("{:?}", cold.analyzed_body_owners())
+    );
+    assert_eq!(
+        format!("{:?}", reused.body_named_dependencies()),
+        format!("{:?}", cold.body_named_dependencies())
+    );
+    assert_eq!(
+        format!("{:?}", reused.ordinary_free_function_dependencies()),
+        format!("{:?}", cold.ordinary_free_function_dependencies())
+    );
+    assert_eq!(
+        format!("{:?}", reused.specialized_free_function_origins()),
+        format!("{:?}", cold.specialized_free_function_origins())
+    );
+    assert_eq!(
+        format!("{:?}", reused.specialized_free_function_dependencies()),
+        format!("{:?}", cold.specialized_free_function_dependencies())
+    );
+    assert_eq!(
+        reused.durable_specialized_body_payloads(),
+        cold.durable_specialized_body_payloads()
+    );
+    assert_eq!(
+        reused.ordinary_free_function_dependencies_complete(),
+        cold.ordinary_free_function_dependencies_complete()
+    );
+    assert_eq!(
+        reused.specialized_free_function_dependencies_complete(),
+        cold.specialized_free_function_dependencies_complete()
+    );
+    assert_eq!(
+        reused.non_generic_named_method_dependencies_complete(),
+        cold.non_generic_named_method_dependencies_complete()
+    );
+    assert_eq!(
+        reused.generic_named_method_dependencies_complete(),
+        cold.generic_named_method_dependencies_complete()
+    );
+    assert_eq!(
+        reused.named_destructor_dependencies_complete(),
+        cold.named_destructor_dependencies_complete()
+    );
+    assert_eq!(
+        reused.declaration_type_dependencies_complete(),
+        cold.declaration_type_dependencies_complete()
+    );
+    assert_eq!(
+        reused.declaration_type_call_head_dependencies_complete(),
+        cold.declaration_type_call_head_dependencies_complete()
+    );
+    assert_eq!(
+        reused.supported_type_call_heads_complete(),
+        cold.supported_type_call_heads_complete()
+    );
+    assert_eq!(
+        reused.named_value_const_dependencies_complete(),
+        cold.named_value_const_dependencies_complete()
+    );
+    assert_eq!(
+        reused.implicit_named_destructor_dependencies_complete(),
+        cold.implicit_named_destructor_dependencies_complete()
+    );
+
+    assert_diagnostic_parity(
+        reused_session.latest_diagnostics(),
+        cold_session.latest_diagnostics(),
+    );
+    assert_diagnostic_parity(
+        reused_session.latest_successful_diagnostics(),
+        cold_session.latest_successful_diagnostics(),
+    );
+    assert_diagnostic_parity(
+        reused_session.last_good_semantic_diagnostics(),
+        cold_session.last_good_semantic_diagnostics(),
+    );
+
+    let reused_manifest = reused_session
+        .semantic_dependency_inputs(options, None)
+        .unwrap();
+    let cold_manifest = cold_session
+        .semantic_dependency_inputs(options, None)
+        .unwrap();
+    assert_eq!(reused_manifest.input(), cold_manifest.input());
+    assert_eq!(reused_manifest.imports(), cold_manifest.imports());
+    macro_rules! assert_manifest_field {
+        ($field:ident) => {
+            assert_eq!(
+                format!("{:?}", reused_manifest.$field()),
+                format!("{:?}", cold_manifest.$field()),
+                "stable manifest field {} differs",
+                stringify!($field)
+            );
+        };
+    }
+    assert_manifest_field!(definitions);
+    assert_manifest_field!(definition_fingerprints);
+    assert_manifest_field!(module_imports);
+    assert_manifest_field!(free_function_dependencies);
+    assert_manifest_field!(named_method_dependencies);
+    assert_manifest_field!(named_destructor_dependencies);
+    assert_manifest_field!(implicit_named_destructor_dependencies);
+    assert_manifest_field!(declaration_type_dependencies);
+    assert_manifest_field!(declaration_type_call_head_dependencies);
+    assert_manifest_field!(builtin_type_call_head_inputs);
+    assert_manifest_field!(named_const_dependencies);
+    assert_manifest_field!(body_dependencies);
+    assert_manifest_field!(body_dependency_blockers);
+    assert_manifest_field!(dependency_blockers);
+    assert_eq!(
+        reused_manifest.durable_ordinary_bodies(),
+        cold_manifest.durable_ordinary_bodies()
+    );
+    assert_eq!(
+        reused_manifest.free_function_caller_dependencies_complete(),
+        cold_manifest.free_function_caller_dependencies_complete()
+    );
+    assert_eq!(
+        reused_manifest.non_generic_named_method_dependencies_complete(),
+        cold_manifest.non_generic_named_method_dependencies_complete()
+    );
+    assert_eq!(
+        reused_manifest.generic_named_method_dependencies_complete(),
+        cold_manifest.generic_named_method_dependencies_complete()
+    );
+    assert_eq!(
+        reused_manifest.named_destructor_dependencies_complete(),
+        cold_manifest.named_destructor_dependencies_complete()
+    );
+    assert_eq!(
+        reused_manifest.implicit_named_destructor_dependencies_complete(),
+        cold_manifest.implicit_named_destructor_dependencies_complete()
+    );
+    assert_eq!(
+        reused_manifest.declaration_type_dependencies_complete(),
+        cold_manifest.declaration_type_dependencies_complete()
+    );
+    assert_eq!(
+        reused_manifest.declaration_type_call_head_dependencies_complete(),
+        cold_manifest.declaration_type_call_head_dependencies_complete()
+    );
+    assert_eq!(
+        reused_manifest.supported_type_call_heads_complete(),
+        cold_manifest.supported_type_call_heads_complete()
+    );
+    assert_eq!(
+        reused_manifest.named_value_const_dependencies_complete(),
+        cold_manifest.named_value_const_dependencies_complete()
+    );
+    assert_eq!(
+        reused_manifest.semantic_dependency_graph_complete(),
+        cold_manifest.semantic_dependency_graph_complete()
+    );
+    assert_eq!(
+        reused_manifest.definition_universe_complete(),
+        cold_manifest.definition_universe_complete()
+    );
+
+    assert_eq!(
+        format!("{:?}", reused.named_method_dependencies()),
+        format!("{:?}", cold.named_method_dependencies())
+    );
+    assert_eq!(
+        format!("{:?}", reused.named_destructor_dependencies()),
+        format!("{:?}", cold.named_destructor_dependencies())
+    );
+    assert_eq!(
+        format!("{:?}", reused.declaration_type_dependencies()),
+        format!("{:?}", cold.declaration_type_dependencies())
+    );
+    assert_eq!(
+        format!("{:?}", reused.declaration_type_call_head_dependencies()),
+        format!("{:?}", cold.declaration_type_call_head_dependencies())
+    );
+    assert_eq!(
+        format!(
+            "{:?}",
+            reused.declaration_builtin_type_call_head_dependencies()
+        ),
+        format!(
+            "{:?}",
+            cold.declaration_builtin_type_call_head_dependencies()
+        )
+    );
+    assert_eq!(
+        format!("{:?}", reused.named_const_dependencies()),
+        format!("{:?}", cold.named_const_dependencies())
+    );
+    assert_eq!(
+        format!("{:?}", reused.implicit_named_destructor_dependencies()),
+        format!("{:?}", cold.implicit_named_destructor_dependencies())
+    );
+
+    close_completion_discovery(reused_session, source);
+    close_completion_discovery(&mut cold_session, source);
+    let reused_executable = reused_session.executable(options).unwrap();
+    let cold_executable = cold_session.executable(options).unwrap();
+    assert_eq!(reused_executable.elf, cold_executable.elf);
+    assert_eq!(
+        format!("{:?}", reused_executable.warnings),
+        format!("{:?}", cold_executable.warnings)
+    );
+
+    json!({
+        "public_semantic_cfg_artifacts": "exact",
+        "public_type_universe": "exact_ordered_entries",
+        "durable_specialized_body_payloads": "exact",
+        "durable_ordinary_body_manifest_artifacts": "exact",
+        "session_private_durable_cfg_cache": "not_exposed_compared_via_public_cfgs_and_emitted_output",
+        "diagnostics": "exact",
+        "warnings": "exact",
+        "stable_identities": "exact",
+        "dependency_records": "exact",
+        "emitted_output": "byte_exact",
+        "work_counters": "reused_and_cold_serialized_with_structural_assertions",
+        "cold_semantic_work": cold_semantic_work,
+    })
+}
+
+fn with_parity(mut scenario: Value, evidence: Value) -> Value {
+    scenario["differential_parity"] = evidence;
+    scenario
+}
+
+fn completion_workloads(functions: usize) -> Vec<Value> {
+    let fixture = CompletionFixture::new(functions);
+    let o0 = CompileOptions {
+        opt_level: OptLevel::O0,
+        ..CompileOptions::default()
+    };
+    let o1 = CompileOptions {
+        opt_level: OptLevel::O1,
+        ..CompileOptions::default()
+    };
+    let mut scenarios = Vec::new();
+
+    let mut noop = CompilerSession::new();
+    let (cold_value, _) = measured_semantic(&mut noop, &fixture.direct, &o1);
+    scenarios.push(named("completion_cold_n", cold_value));
+    let (noop_value, noop_output) = measured_semantic(&mut noop, &fixture.direct, &o1);
+    let parity = assert_cold_reused_parity(&mut noop, &noop_output, &fixture.direct, &o1);
+    scenarios.push(with_parity(
+        named("completion_exact_noop", noop_value),
+        parity,
+    ));
+
+    let mut unrelated = CompilerSession::new();
+    measured_semantic(&mut unrelated, &fixture.direct, &o1);
+    let (unrelated_value, unrelated_output) =
+        measured_semantic(&mut unrelated, &fixture.direct_unrelated_edit, &o1);
+    let parity = assert_cold_reused_parity(
+        &mut unrelated,
+        &unrelated_output,
+        &fixture.direct_unrelated_edit,
+        &o1,
+    );
+    scenarios.push(with_parity(
+        named("completion_unrelated_edit", unrelated_value),
+        parity,
+    ));
+
+    let mut changed = CompilerSession::new();
+    measured_semantic(&mut changed, &fixture.direct, &o1);
+    let (changed_value, changed_output) =
+        measured_semantic(&mut changed, &fixture.direct_reachable_edit, &o1);
+    let parity = assert_cold_reused_parity(
+        &mut changed,
+        &changed_output,
+        &fixture.direct_reachable_edit,
+        &o1,
+    );
+    scenarios.push(with_parity(
+        named("completion_changed_reachable_body", changed_value),
+        parity,
+    ));
+
+    let mut closure = CompilerSession::new();
+    measured_semantic(&mut closure, &fixture.chain, &o1);
+    let (closure_value, closure_output) =
+        measured_semantic(&mut closure, &fixture.chain_reachable_edit, &o1);
+    let parity = assert_cold_reused_parity(
+        &mut closure,
+        &closure_output,
+        &fixture.chain_reachable_edit,
+        &o1,
+    );
+    scenarios.push(with_parity(
+        named("completion_reverse_closure", closure_value),
+        parity,
+    ));
+
+    for (name, options) in [("completion_cfg_o0", o0), ("completion_cfg_o1", o1.clone())] {
+        let mut session = CompilerSession::new();
+        measured_semantic(&mut session, &fixture.direct, &options);
+        let (value, output) =
+            measured_semantic(&mut session, &fixture.direct_unrelated_edit, &options);
+        let parity = assert_cold_reused_parity(
+            &mut session,
+            &output,
+            &fixture.direct_unrelated_edit,
+            &options,
+        );
+        scenarios.push(with_parity(named(name, value), parity));
+    }
+
+    let mut specialization = CompilerSession::new();
+    measured_semantic(&mut specialization, &fixture.specialization, &o1);
+    let (specialization_value, specialization_output) = measured_semantic(
+        &mut specialization,
+        &fixture.specialization_unrelated_edit,
+        &o1,
+    );
+    let parity = assert_cold_reused_parity(
+        &mut specialization,
+        &specialization_output,
+        &fixture.specialization_unrelated_edit,
+        &o1,
+    );
+    scenarios.push(with_parity(
+        named("completion_specialization_reuse", specialization_value),
+        parity,
+    ));
+
+    let mut recovery = CompilerSession::new();
+    measured_semantic(&mut recovery, &fixture.direct, &o1);
+    let failed = measure(&mut recovery, |session| {
+        let update = session.update(&fixture.semantic_error);
+        let parse = update.work();
+        update.into_result().unwrap();
+        session.semantic(&o1).unwrap_err();
+        parse
+    });
+    scenarios.push(named("completion_failed_semantic", failed));
+    let (recovery_value, recovery_output) =
+        measured_semantic(&mut recovery, &fixture.direct_unrelated_edit, &o1);
+    let parity = assert_cold_reused_parity(
+        &mut recovery,
+        &recovery_output,
+        &fixture.direct_unrelated_edit,
+        &o1,
+    );
+    scenarios.push(with_parity(
+        named("completion_failure_recovery", recovery_value),
+        parity,
+    ));
+
+    assert_completion_structure(&scenarios, functions);
+    scenarios
 }
 
 fn run_iteration(fixture: &Fixture) -> Vec<Value> {
@@ -694,6 +1372,7 @@ fn run_iteration(fixture: &Fixture) -> Vec<Value> {
         "invalidation_plan_module_identity_change",
         identity_plan,
     ));
+    scenarios.extend(completion_workloads(fixture.modules));
     assert_structure(&scenarios, fixture.modules);
     scenarios
 }
@@ -987,6 +1666,237 @@ fn assert_structure(scenarios: &[Value], modules: usize) {
     assert_production_incremental_plan(plan_identity, 1, 0, 2, modules - 1, modules - 1, 2);
 }
 
+fn assert_completion_structure(scenarios: &[Value], functions: usize) {
+    let get = |name: &str| {
+        scenarios
+            .iter()
+            .find(|value| value["name"] == name)
+            .unwrap()
+    };
+    let body = |scenario: &Value, field: &str| {
+        count(scenario, &["semantic_work", "durable_bodies", field])
+    };
+    let cfg = |scenario: &Value, field: &str| count(scenario, &["semantic_work", "cfg", field]);
+
+    let cold = get("completion_cold_n");
+    assert_eq!(
+        count(cold, &["semantic_work", "bodies_attempted"]),
+        functions as u64
+    );
+    assert_eq!(body(cold, "export_attempts"), functions as u64);
+    assert_eq!(body(cold, "export_successes"), functions as u64);
+    assert_eq!(body(cold, "export_rejections"), 0);
+    assert_eq!(body(cold, "conversion_attempts"), functions as u64);
+    assert_eq!(body(cold, "conversion_completions"), functions as u64);
+    assert_eq!(body(cold, "conversion_failures"), 0);
+    assert_eq!(body(cold, "candidate_comparisons"), 0);
+    assert_eq!(body(cold, "candidate_fallbacks"), 0);
+    assert_eq!(body(cold, "projection_attempts"), 0);
+    assert_eq!(body(cold, "import_attempts"), 0);
+    assert_eq!(body(cold, "atomic_discards"), 0);
+    assert_eq!(body(cold, "reused_bodies"), 0);
+    assert_eq!(body(cold, "skipped_body_analyses"), 0);
+    assert_eq!(count(cold, &["semantic_work", "bind_invocations"]), 1);
+    assert_eq!(
+        count(
+            cold,
+            &["semantic_work", "declaration_resolution_invocations"]
+        ),
+        1
+    );
+    assert_eq!(
+        count(cold, &["semantic_work", "declaration_resolution_failures"]),
+        0
+    );
+    assert_eq!(
+        count(
+            cold,
+            &["semantic_work", "body_readiness_finalization_invocations"]
+        ),
+        1
+    );
+    assert_eq!(
+        count(cold, &["semantic_work", "bodies_succeeded"]),
+        functions as u64
+    );
+    assert_eq!(count(cold, &["semantic_work", "bodies_failed"]), 0);
+    assert_eq!(cfg(cold, "builds_attempted"), functions as u64);
+    assert_eq!(cfg(cold, "builds_succeeded"), functions as u64);
+    assert_eq!(cfg(cold, "builds_failed"), 0);
+    assert_eq!(cfg(cold, "optimization_attempts"), functions as u64);
+    assert_eq!(cfg(cold, "optimization_completions"), functions as u64);
+    assert_eq!(cfg(cold, "optimized_level_attempts"), functions as u64);
+    assert_eq!(cfg(cold, "reuse_candidates"), 0);
+    assert_eq!(cfg(cold, "fallbacks"), 0);
+    assert_eq!(cfg(cold, "export_attempts"), functions as u64);
+    assert_eq!(cfg(cold, "export_successes"), functions as u64);
+    assert_eq!(cfg(cold, "export_rejections"), 0);
+    assert_eq!(
+        count(
+            cold,
+            &[
+                "semantic_work",
+                "declaration_reuse",
+                "durable_cache_population_exports"
+            ]
+        ),
+        1,
+        "cold cache population must export from the one analysis epoch"
+    );
+    assert_declaration_epoch_work(cold, 1, 1, 1, 1, 0);
+
+    let noop = get("completion_exact_noop");
+    assert_eq!(count(noop, &["queries", "semantic_executions"]), 0);
+    assert_eq!(count(noop, &["queries", "semantic_reuses"]), 1);
+
+    let unrelated = get("completion_unrelated_edit");
+    assert_eq!(body(unrelated, "candidate_comparisons"), functions as u64);
+    assert_eq!(body(unrelated, "reused_bodies"), functions as u64);
+    assert_eq!(body(unrelated, "skipped_body_analyses"), functions as u64);
+    assert_eq!(body(unrelated, "candidate_fallbacks"), 0);
+    assert_eq!(count(unrelated, &["semantic_work", "bodies_attempted"]), 0);
+    assert_eq!(cfg(unrelated, "reuses"), functions as u64);
+    assert_eq!(cfg(unrelated, "builds_attempted"), 0);
+    assert_eq!(cfg(unrelated, "optimization_attempts"), 0);
+
+    let changed = get("completion_changed_reachable_body");
+    assert_eq!(body(changed, "candidate_comparisons"), functions as u64);
+    assert_eq!(body(changed, "reused_bodies"), (functions - 2) as u64);
+    assert_eq!(body(changed, "candidate_fallbacks"), 2);
+    assert_eq!(count(changed, &["semantic_work", "bodies_attempted"]), 2);
+    assert_eq!(cfg(changed, "reuses"), (functions - 1) as u64);
+    assert_eq!(cfg(changed, "builds_attempted"), 1);
+    assert_eq!(cfg(changed, "optimization_attempts"), 1);
+
+    let chain_len = (functions - 1) / 2 + (functions - 1) % 2;
+    let invalidated = chain_len + 1;
+    let closure = get("completion_reverse_closure");
+    assert_eq!(body(closure, "candidate_comparisons"), functions as u64);
+    assert_eq!(
+        body(closure, "reused_bodies"),
+        (functions - invalidated) as u64
+    );
+    assert_eq!(body(closure, "candidate_fallbacks"), invalidated as u64);
+    assert_eq!(
+        count(closure, &["semantic_work", "bodies_attempted"]),
+        invalidated as u64
+    );
+    assert_eq!(cfg(closure, "reuses"), (functions - 1) as u64);
+    assert_eq!(cfg(closure, "builds_attempted"), 1);
+
+    for name in ["completion_cfg_o0", "completion_cfg_o1"] {
+        let scenario = get(name);
+        assert_eq!(cfg(scenario, "reuse_candidates"), functions as u64);
+        assert_eq!(cfg(scenario, "import_attempts"), functions as u64);
+        assert_eq!(cfg(scenario, "import_successes"), functions as u64);
+        assert_eq!(cfg(scenario, "reuses"), functions as u64);
+        assert_eq!(cfg(scenario, "fallbacks"), 0);
+        assert_eq!(cfg(scenario, "builds_attempted"), 0);
+        assert_eq!(cfg(scenario, "optimization_attempts"), 0);
+    }
+
+    let specialized = get("completion_specialization_reuse");
+    assert_eq!(body(specialized, "candidate_comparisons"), 1);
+    assert_eq!(body(specialized, "candidate_fallbacks"), 0);
+    assert_eq!(body(specialized, "specialized_mapping_attempts"), 1);
+    assert_eq!(body(specialized, "specialized_mapping_successes"), 1);
+    assert_eq!(body(specialized, "specialized_mapping_failures"), 0);
+    assert_eq!(body(specialized, "projection_attempts"), 1);
+    assert_eq!(body(specialized, "projection_completions"), 1);
+    assert_eq!(body(specialized, "projection_failures"), 0);
+    assert_eq!(body(specialized, "import_attempts"), 0);
+    assert_eq!(body(specialized, "import_successes"), 0);
+    assert_eq!(body(specialized, "import_failures"), 0);
+    assert_eq!(body(specialized, "atomic_discards"), 0);
+    assert_eq!(body(specialized, "reused_bodies"), 0);
+    assert_eq!(body(specialized, "skipped_body_analyses"), 0);
+    assert_eq!(
+        count(specialized, &["semantic_work", "bodies_attempted"]),
+        2
+    );
+    assert_eq!(
+        count(specialized, &["semantic_work", "bodies_succeeded"]),
+        2
+    );
+    assert_eq!(count(specialized, &["semantic_work", "bodies_failed"]), 0);
+    assert_eq!(
+        count(
+            specialized,
+            &["semantic_work", "specialized_bodies_attempted"]
+        ),
+        0
+    );
+    assert_eq!(cfg(specialized, "reuse_candidates"), 2);
+    assert_eq!(cfg(specialized, "import_attempts"), 2);
+    assert_eq!(cfg(specialized, "import_successes"), 2);
+    assert_eq!(cfg(specialized, "import_failures"), 0);
+    assert_eq!(cfg(specialized, "reuses"), 2);
+    assert_eq!(cfg(specialized, "fallbacks"), 0);
+    assert_eq!(cfg(specialized, "builds_attempted"), 1);
+    assert_eq!(cfg(specialized, "builds_succeeded"), 1);
+    assert_eq!(cfg(specialized, "builds_failed"), 0);
+    assert_eq!(cfg(specialized, "optimization_attempts"), 1);
+    assert_eq!(cfg(specialized, "optimization_completions"), 1);
+    assert_eq!(cfg(specialized, "optimized_level_attempts"), 1);
+
+    let failed = get("completion_failed_semantic");
+    assert_eq!(count(failed, &["semantic_work", "failed_requests"]), 1);
+    assert_eq!(
+        count(
+            failed,
+            &["semantic_work", "failure_phases", "body_analysis"]
+        ),
+        1
+    );
+    assert_eq!(
+        count(failed, &["semantic_work", "failure_phases", "declaration"]),
+        0
+    );
+    assert_eq!(
+        count(
+            failed,
+            &["semantic_work", "failure_phases", "cfg_construction"]
+        ),
+        0
+    );
+    assert_eq!(body(failed, "candidate_comparisons"), functions as u64);
+    assert_eq!(body(failed, "candidate_fallbacks"), 1);
+    assert_eq!(body(failed, "projection_attempts"), (functions - 1) as u64);
+    assert_eq!(
+        body(failed, "projection_completions"),
+        (functions - 1) as u64
+    );
+    assert_eq!(body(failed, "projection_failures"), 0);
+    assert_eq!(body(failed, "import_attempts"), 0);
+    assert_eq!(body(failed, "reused_bodies"), 0);
+    assert_eq!(body(failed, "skipped_body_analyses"), 0);
+    assert_eq!(body(failed, "atomic_discards"), 0);
+    assert_eq!(body(failed, "export_attempts"), 0);
+    assert_eq!(count(failed, &["semantic_work", "bodies_attempted"]), 1);
+    assert_eq!(count(failed, &["semantic_work", "bodies_succeeded"]), 0);
+    assert_eq!(count(failed, &["semantic_work", "bodies_failed"]), 1);
+    assert_eq!(cfg(failed, "reuse_candidates"), 0);
+    assert_eq!(cfg(failed, "builds_attempted"), 0);
+    assert_eq!(
+        count(
+            failed,
+            &[
+                "semantic_work",
+                "declaration_reuse",
+                "durable_cache_population_exports"
+            ]
+        ),
+        0
+    );
+    assert_declaration_epoch_work(failed, 1, 1, 1, 0, 0);
+    let recovery = get("completion_failure_recovery");
+    assert_eq!(body(recovery, "reused_bodies"), functions as u64);
+    assert_eq!(body(recovery, "candidate_fallbacks"), 0);
+    assert_eq!(count(recovery, &["semantic_work", "bodies_attempted"]), 0);
+    assert_eq!(cfg(recovery, "reuses"), functions as u64);
+    assert_eq!(cfg(recovery, "builds_attempted"), 0);
+}
+
 fn assert_body_cfg_work_equal(left: &Value, right: &Value) {
     for field in [
         "bodies_attempted",
@@ -1012,14 +1922,28 @@ fn assert_body_cfg_work_equal(left: &Value, right: &Value) {
             "body work field {field} differs in scenarios expected to take the same body path"
         );
     }
-    assert_eq!(
-        left["semantic_work"]["cfg"], right["semantic_work"]["cfg"],
-        "CFG work differs before CFG reuse exists"
-    );
-    assert_eq!(
-        left["semantic_work"]["durable_bodies"], right["semantic_work"]["durable_bodies"],
-        "durable body work differs in scenarios expected to take the same body path"
-    );
+    for field in [
+        "drop_glue_functions_synthesized",
+        "functions_considered",
+        "comptime_functions_filtered",
+        "builds_attempted",
+        "builds_succeeded",
+        "builds_failed",
+        "air_instructions_consumed",
+        "optimization_attempts",
+        "optimization_completions",
+        "optimized_level_attempts",
+        "warnings_emitted",
+        "implicit_destructor_targets_emitted",
+        "export_attempts",
+        "export_successes",
+        "export_rejections",
+    ] {
+        assert_eq!(
+            left["semantic_work"]["cfg"][field], right["semantic_work"]["cfg"][field],
+            "CFG construction field {field} differs in scenarios expected to rebuild equally"
+        );
+    }
 }
 
 fn assert_production_incremental_plan(
@@ -1132,32 +2056,38 @@ fn assert_declaration_epoch_work(
 }
 
 fn parse_config() -> Config {
+    parse_config_args(env::args().skip(1)).unwrap_or_else(|message| usage(&message))
+}
+
+fn parse_config_args(args: impl IntoIterator<Item = String>) -> Result<Config, String> {
     let mut config = Config {
         modules: DEFAULT_MODULES,
         warmup: DEFAULT_WARMUP,
         iterations: DEFAULT_ITERATIONS,
     };
-    let mut args = env::args().skip(1);
+    let mut args = args.into_iter();
     while let Some(arg) = args.next() {
         let value = args
             .next()
-            .unwrap_or_else(|| usage(&format!("missing value for {arg}")));
+            .ok_or_else(|| format!("missing value for {arg}"))?;
         let value = value
             .parse::<usize>()
-            .unwrap_or_else(|_| usage(&format!("invalid value for {arg}")));
+            .map_err(|_| format!("invalid value for {arg}"))?;
         match arg.as_str() {
-            "--modules" if value >= 2 => config.modules = value,
+            "--modules" if value >= 4 => config.modules = value,
             "--warmup" => config.warmup = value,
             "--iterations" if value > 0 => config.iterations = value,
-            _ => usage(&format!("unknown option or invalid value: {arg}")),
+            _ => return Err(format!("unknown option or invalid value: {arg}")),
         }
     }
-    config
+    Ok(config)
 }
 
 fn usage(message: &str) -> ! {
     eprintln!("error: {message}");
-    eprintln!("usage: rue-compiler-session-bench [--modules N] [--warmup N] [--iterations N]");
+    eprintln!(
+        "usage: rue-compiler-session-bench [--modules N>=4] [--warmup N] [--iterations N>=1]"
+    );
     process::exit(2)
 }
 
@@ -1173,14 +2103,15 @@ fn main() {
     println!(
         "{}",
         json!({
-            "schema_version": 10,
+            "schema_version": 11,
             "workload": "compiler_session_invalidation",
             "configuration": {
                 "modules": config.modules,
                 "warmup_iterations": config.warmup,
                 "measured_iterations": config.iterations,
                 "filesystem_discovery_during_updates": false,
-                "backend_or_link": false,
+                "backend_or_link_during_measured_scenarios": false,
+                "differential_parity_backend_and_link": true,
             },
             "iterations": iterations,
         })
@@ -1194,13 +2125,31 @@ mod tests {
     #[test]
     fn small_workload_is_a_structural_smoke_test() {
         let scenarios = run_iteration(&Fixture::new(4));
-        assert_eq!(scenarios.len(), 14);
+        assert_eq!(scenarios.len(), 24);
         assert!(
             scenarios
                 .iter()
                 .all(|scenario| scenario["wall_time_ns"].is_u64()
                     || (scenario["manifest_wall_time_ns"].is_u64()
                         && scenario["plan_wall_time_ns"].is_u64()))
+        );
+    }
+
+    #[test]
+    fn completion_workload_rejects_fewer_than_four_modules_at_config_boundary() {
+        for modules in ["2", "3"] {
+            assert!(
+                parse_config_args(["--modules".to_owned(), modules.to_owned()]).is_err(),
+                "--modules {modules} must be rejected before fixture construction"
+            );
+        }
+        assert_eq!(
+            parse_config_args(["--modules".to_owned(), "4".to_owned()]).unwrap(),
+            Config {
+                modules: 4,
+                warmup: DEFAULT_WARMUP,
+                iterations: DEFAULT_ITERATIONS,
+            }
         );
     }
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -260,7 +260,7 @@ pub struct CanonicalSemanticWork {
     pub body_owner_tokens: BodyOwnerTokenWork,
     /// Demand-driven function-body analysis work.
     pub body_analysis: BodyAnalysisWork,
-    /// Observational durable ordinary-body boundary work. Reuse remains zero.
+    /// Durable body comparison, import, export, reuse, and fallback work.
     pub durable_bodies: crate::DurableBodyWork,
     /// Drop-glue, CFG construction, and optimization work.
     pub cfg: CfgConstructionWork,

--- a/docs/designs/0050-semantic-dependency-manifest.md
+++ b/docs/designs/0050-semantic-dependency-manifest.md
@@ -6,445 +6,206 @@ tags: [compiler, incremental, tooling]
 feature-flag: null
 created: 2026-07-12
 accepted: 2026-07-13
-implemented:
+implemented: 2026-07-14
 spec-sections: []
 superseded-by:
 ---
 
 # Stable semantic dependency manifests
 
-## Goal
+## Decision
 
-Permit sound declaration and body invalidation without retaining request-local
-`Spur`, `InstRef`, `FileId`, `StructId`, specialization order, or CFG identity.
-This proposal does not authorize CFG reuse until every dependency surface below
-is captured and closure tests prove it.
+`CompilerSession` represents reusable declaration, body, specialization, and CFG
+inputs with compiler-owned stable identities and exact ordered dependency
+records. Request-local `Spur`, `InstRef`, `FileId`, raw `Span`, `Type`, nominal
+ID, AIR offset, string-pool index, specialization discovery order, and CFG-local
+identity never serve as durable keys.
 
-## Stable model
-
-Each manifest is keyed by `SemanticInputDescriptor`, canonical import graph, and
-an ordered definition universe of `StableDefinitionKey`. A future record has:
-
-- `owner: StableDefinitionKey`;
-- separate declaration/signature and body fingerprints;
-- ordered direct `declaration_dependencies` and `body_dependencies`;
-- explicit non-definition dependencies: root, canonical imports, target and
-  preview features; optimization belongs only to CFG/codegen reuse;
-- specialization descriptors made from stable callee key plus canonical type and
-  comptime-value arguments, never discovery order.
-
-Consumers compute deterministic reverse edges and transitive closure from sorted
-direct edges. Missing owners or unresolved targets fail closed by invalidating
-the requesting record, never by silently dropping an edge.
-
-## Durable recursive type and value algebra
-
-The query boundary uses the versioned `DurableType` and `DurableConstValue`
-algebra in `rue-compiler`; schema version 2 is part of every future persistent
-key. Version 2 adds a closed builtin nominal tag validated against
-`rue-builtins` name and kind, rather than inventing source definition keys for
-synthetic types. The algebra otherwise contains only scalar data, `ModuleId`, `StableDefinitionKey`, owned
-structural children, and source-order generic-parameter indices. It is
-`Send + Sync + Eq + Ord + Hash`. It never contains `FileId`, `Span`, `Spur`,
-`InstRef`, request-local `Type`, `StructId`, `EnumId`, or type-pool indices.
-
-The current bound declaration inventory is: signed and unsigned integer widths,
-bool, unit, never, comptime `type`, named structs/enums, arrays, const/mut raw
-pointers, and modules. Constants additionally contain integers, booleans, type
-values, function aliases, and unit. Function/method/destructor signatures use
-the same type forms plus ordered parameter modes and comptime flags at the
-declaration-record layer. Struct fields and enum payloads preserve source order.
-Generic/comptime parameters preserve declaration order; concrete comptime
-arguments use the value algebra. Tuples and first-class function types are
-reserved algebra variants but are not presently emitted by AIR binding.
-
-Named structs and enums are encoded as a single nominal stable-key edge, never
-expanded. This makes self and mutual recursion finite without traversal-order
-backreferences. Structural children are recursively encoded; encountering a
-structural pool cycle is a typed failure. Ordered language constructs retain
-source order. Sets and maps in declaration records must be sorted by stable key
-before construction. No interner number, debug string, physical path, source
-offset, or discovery order participates in equality or hashing.
-
-Export is fail closed. Error types, unresolved modules, missing pool entries,
-anonymous/local nominal types, unjoinable function aliases, and unknown future
-type/value forms produce `DurableSemanticExportFailure`; they are never
-stringified. Adding or changing a variant increments the schema version.
-
-### Producer, projection, and installation seams
-
-The one-way AIR export and stable compiler algebra are implemented. A compiler
-projection adapter now performs the inverse stable-key/current-revision join:
-it validates the exact `BoundDefinitionSet`, current declaration shells, and
-durable record universe before producing AIR `SemanticDeclarationExport` DTOs.
-It supplies current `FileId`s, spans, owners, names, kinds, and visibility while
-leaving authoritative body handles and parameter metadata in the shells.
-Records are projected in stable-key order; missing, duplicate, extra,
-ambiguous, namespace/kind/owner/module/visibility, and unsupported cases are
-typed failures. Work counters pin zero RIR traversal.
-
-The result now feeds AIR's atomic installer from the canonical in-process
-session for a deliberately narrow production subset. The session issues the
-current stable universe directly from pre-resolution shells, compares
-parser-authored declaration/signature fingerprints, projects retained durable
-payloads, and then runs current-revision body analysis and CFG construction.
-Function, method, associated-function, and destructor bodies are never cached.
-Constants, module values, function aliases, generics, and anonymous owners
-remain explicit clean fallbacks.
-
-## Current capture audit
-
-The existing compiler does not yet expose a complete sound graph:
-
-- declaration binding resolves types, constants, functions, methods, associated
-  functions, module bindings and destructors, but retains results under
-  request-local IDs;
-- constant initialization recursively discovers const dependencies inside
-  `declarations.rs`; those edges are not returned;
-- reachable body analysis returns `HashSet<Spur>` and
-  `HashSet<(StructId, Spur)>` from function/method/destructor analysis, sorts them
-  only for worklist scheduling, then discards the owner-to-target edges;
-- type syntax and struct/enum payload resolution can reference constructors,
-  constants and types without appearing as ordinary call edges;
-- implicit drop glue and anonymous destructors add roots after type/comptime
-  evaluation;
-- generic specialization creates concrete callees from type/comptime values and
-  may discover more bodies; specialization identity is not durable;
-- import resolution is already a stable separate query and must be included as
-  an explicit input rather than rediscovered from RIR;
-- CFG construction consumes typed AIR and optimization level. Reusing it before
-  stable AIR/type/string identity exists would be unsound.
-
-Adding a second RIR scan would still miss semantic choices made during binding
-and specialization, so extraction must occur at the points above.
-
-## First implemented slice
-
-`CompilerSession::semantic_dependency_inputs` is tooling-only and
-shares `import_graph` plus `stable_definitions`. It publishes an immutable,
-ordered stable definition universe with semantic and import inputs. It also
-contains the first complete edge surface: ordered module import dependencies
-from importer to resolved target, with missing and ambiguous outcomes retained
-as fail-closed records. Work records visited definition/import records and
-asserts zero extra RIR visits. This is the destination index required to
-translate future definition-level edges; it makes no body or CFG reuse claim.
-
-## Required next slices
-
-The [body-analysis and CFG incrementality audit](../notes/body-analysis-cfg-incrementality-audit.md)
-records the post-RUE-719 live phase ownership, request-local identity inventory,
-and missing work counters. Its first implementation gate is observational:
-complete the body, specialization, remapping, fallback, and CFG structural
-ledger before retaining semantic artifacts.
-
-1. During declaration binding, translate winning bindings to stable keys and
-   capture signature/type/const/module/destructor direct edges.
-2. ~~Thread stable-capable owner provenance through body analysis and translate
-   each supported ordinary free-function/method/destructor body into an ordered
-   per-owner input record.~~ Generic named methods carry a local fail-closed
-   blocker; anonymous bodies publish no reusable record. Durable AIR remains
-   unimplemented. Each record explicitly retains target and preview-feature
-   inputs, and inherits any whole-graph dependency-completeness blocker until
-   that evidence can be localized safely to individual owners. Owner-scoped
-   observers at the existing analysis seams retain body-only nominal types,
-   type-call heads, value constants, module bindings, callable aliases, calls,
-   and implicit destructor obligations; an AIR-type observation pass covers
-   already-resolved inferred/comptime paths without revisiting RIR.
-
-`StableDefinitionKey` is compiler-owned: `rue-compiler` depends on `rue-air`,
-and reversing that dependency or duplicating the stable-key implementation in
-AIR would violate the phase boundary. The compiler now issues an opaque
-`(issuer, slot)` body-owner token after declaration resolution, exact-compares
-the supported callable/destructor slots against the authoritative binding
-manifest, and installs the finalized token endpoints before body dispatch.
-AIR attaches the token to every body-owner and body-local dependency source;
-`FileId`, name, kind, and optional named owner remain checked provenance only.
-The canonical output retains the exact issuer map, and dependency translation
-accepts a source only by resolving its token through that map after validating
-the same `SourceRevision`. Missing, duplicate, foreign, stale, or wrong-kind
-tokens fail the entire manifest before publication.
-Tests cover duplicate member names in sibling modules, reordered inputs,
-physical relocation, reassigned FileIds, foreign issuers, and fresh durable
-fallback epochs. AIR and CFG are still not retained or reused.
-
-The next observational boundary is implemented for supported ordinary
-non-generic free functions. Before specialization, AIR exhaustively decodes a
-body into a neutral structured exchange DTO. `CallGeneric`, anonymous or
-unmapped identity, foreign spans, warning-producing bodies, and malformed
-payloads reject only the candidate. Anchors are relative to the authoritative
-source body, so relocation and unrelated surrounding edits do not change the
+Consumers compute deterministic reverse edges and transitive invalidation
+closure from sorted direct records. A missing owner, unresolved target,
+incomplete observation, projection failure, or unsupported artifact invalidates
+that candidate. It never silently drops an edge or partially installs an
 artifact.
 
-The compiler converts that DTO into its own versioned `DurableOrdinaryBody`
-algebra using `StableDefinitionKey`, `DurableType`, `ModuleId`, owned strings,
-structured places/projections and relative anchors. Conversion validates the
-owner token, current source revision, exact body-input fingerprint and complete
-dependency record. Projection and atomic fresh-epoch installation prove
-remapping without retaining AIR IDs or packed extras. This slice installs no
-production cache entry, skips no analysis, retains no CFG, and recomputes
-global unused and CFG warnings.
+This model is an in-process, last-successful cache boundary. Persistent storage
+and cross-process schema compatibility are not implied by this ADR.
 
-The body algebra is independently versioned; schema version 2 admits the same
-closed builtin nominal identity used by durable declaration semantics. Unknown
-or wrong-kind builtin tags reject before AIR installation.
-3. Define durable canonical type/comptime specialization arguments and record
-   generic-origin edges.
-4. ~~Split declaration/signature and body fingerprints at parsed syntax boundaries.~~
-5. Gate deterministic closure on recursion, mutual recursion, methods,
-   destructors, constants, imports, generics, relocation/FileId/input order, and
-   target/feature/root changes.
-6. Only then retain typed AIR or CFG results; CFG keys additionally include
-   optimization inputs and any global string/type remapping identity.
+## Stable definition and input model
 
-Acceptance requires one existing semantic execution to emit the complete
-manifest with no second whole-RIR traversal and unchanged diagnostic bytes/order.
-The tooling query still materializes the stable-definition view through its
-existing separately measured binding boundary. That is not a second body pass
-or RIR traversal, and consolidating it with semantic binding is deferred until
-the production body query consumes these records.
+The ordered definition universe uses `StableDefinitionKey`, consisting of
+logical `ModuleId`, namespace, declaration kind, source name, and optional named
+owner. Each named declaration has independently domain-separated declaration,
+signature, and body/initializer fingerprints. Parser-authored boundaries, not
+token or brace searches, define those partitions.
 
-## Invalidation planning seam
+Semantic dependency manifests are keyed by:
 
-`CompilerSession::semantic_invalidation_plan` now memoizes an immutable
-comparison of two manifests. It computes exact stable-key additions, removals,
-and fingerprint changes, and contains a deterministic reverse-dependency closure
-whose work counters explicitly pin zero RIR traversal. Root, canonical import,
-target, and preview-feature changes are unconditional full invalidations;
-physical relocation, FileId assignment, and input order are absent from its
-definition comparison.
+- `SemanticInputDescriptor` (source revision, module-resolution inputs, target,
+  and preview features);
+- the canonical import graph;
+- the ordered stable definition universe;
+- direct declaration and per-body dependency records;
+- explicit evidence-based blockers for unsupported successful surfaces.
 
-This is intentionally a safety seam, not yet retained semantic artifacts. A
-production manifest carries an immutable sorted set of
-`SemanticDependencyBlocker` records instead of a hard-coded global completeness
-bit. Each record identifies the dependency surface, the precise missing
-semantic identity, and a stable owner when one exists. Compatibility
-`*_complete` accessors and whole-graph completeness are derived from that set.
-The planner unions both revisions' blockers into its
-`IncompleteDependencyGraph` reason, so endpoint loss fails closed and cannot be
-hidden by a boolean toggle. Supported production programs now have an empty
-blocker set and produce `Incremental` plans for exact no-ops and body-only
-changes, including deterministic reverse-dependency closure and reusable-key
-cardinality. That plan is evidence for a later retained-artifact query; it does
-not itself reuse AIR or CFG results.
+Physical paths, FileId assignment, input order, offsets, interner values, and
+discovery order do not participate in stable definition comparison. Canonical
+module resolution remains an explicit input because relocation can change a
+relative import's result. Optimization does not affect body identity; it is an
+explicit CFG/codegen input. Linker choice is not a semantic input.
 
-There are no unconditional production blockers. Individual programs can still
-add evidence-based blockers, including anonymous drop owners and any future
-unsupported dynamic or unnameable type-call heads. Such programs continue to
-return `Full` with the exact blocker union and no reusable candidates. The
-records are sorted/deduplicated, independent of FileId and physical location,
-and require no second RIR scan.
+## Durable type, value, and specialization algebra
 
-## Definition fingerprint partition
+The versioned `DurableType` and `DurableConstValue` algebra contains scalar
+data, stable module/definition keys, owned structural children, source-order
+generic parameter indices, and closed builtin nominal tags. It is
+`Send + Sync + Eq + Ord + Hash` and contains no request-local compiler or AIR
+identity.
 
-Stable definition inputs now use schema v2 with independently domain-separated
-declaration, signature, and body-or-initializer digests. Declaration hashes only
-the stable key and visibility. Function, named method, associated-function, and
-named-destructor signatures end at the parser-authored body start; const
-signatures end at the parser-authored initializer start. Their exact payload
-span is hashed separately. Struct signatures are framed source fragments that
-exclude every parser-authored named-method body, so editing a method body does
-not spuriously change its owner type; enum and body-free struct declarations are
-exact signature-only inputs.
+Named structs/enums encode one nominal stable-key edge rather than recursively
+expanding their definitions. Structural arrays and pointers recursively encode
+children. Source-ordered fields, variants, parameter modes, comptime flags, and
+arguments retain source order; sets and maps are sorted before construction.
 
-No token or brace search reconstructs these boundaries. Bound definition
-records join semantic winners back to the canonical AST and reject missing,
-foreign, reversed, overlapping, or out-of-range spans. Syntax and semantic
-rejection still publish no manifest. The public precision enum includes a
-conservative full-declaration fallback for future syntax whose authoritative
-partition is unavailable, but every currently issued named definition kind has
-an exact partition. Hashes exclude FileId, offsets, physical paths, and input
-order; tests cover relocation, visibility, parameters/returns, fields, enum
-variants, function/method/destructor bodies, and const initializers without an
-extra parser, binder, or RIR traversal.
+Export is fail closed. Error types, unresolved modules, anonymous/local nominal
+types, ambiguous function aliases, malformed structural cycles, unknown builtin
+tags, and unrecognized future variants produce typed failures rather than debug
+strings or partial values.
 
-Implicit drop obligations are now observed where AIR is elaborated into CFG,
-including scope/parameter/overwrite drops, recursive struct/enum/array glue,
-and partial-drop destructor calls. Each analyzed body carries a neutral,
-stable-capable owner (ordinary or specialized-base function, named method, or
-named destructor); synthesized named struct/enum glue is owned by the named
-type definition. The compiler joins those owners and named destructor targets
-to exact-revision `StableDefinitionKey`s without rescanning RIR. Anonymous
-owners or destructor targets explicitly make this surface incomplete. This is
-separate from the current unconditional named-destructor analysis roots: roots
-ensure code exists, while these edges record which definitions actually require
-the destructor or its transitive glue.
+Stable free-function specialization identity combines the generic base
+`StableDefinitionKey` with canonical type and comptime-value arguments. The
+session joins that identity to the current specialized machine symbol before an
+imported caller becomes visible. Named methods with comptime parameters
+currently produce one runtime body and therefore use the named method identity;
+future method instantiation must add stable substitution identity before reuse
+may cover it.
 
-### Free-function capture progress
+## Dependency capture
 
-The first request-local capture seam now records free-function references from
-ordinary reachable free-function bodies at the existing worklist boundary. Its
-caller identity is the authoritative opaque body-owner token; the defining
-FileId epoch and owned source name are checked provenance, while callees retain
-their checked declaration endpoints. Methods, constructors and intrinsics
-remain excluded by their separate channels. The
-ordinary-caller output reports this surface complete; method and destructor
-callers remain separate, explicitly incomplete surfaces.
+Dependencies are observed at the semantic operation that selects them, not by
+a second RIR scan. Current successful manifests include:
 
-Specialized free-function bodies now retain a neutral origin record containing
-their mangled analyzed name, exact generic base FileId/source name, and
-request-local type/value specialization argument words. This survives fixpoint
-discovery without claiming that the argument encoding is a durable
-cross-request key.
+- canonical module-import edges;
+- declaration nominal-type edges for fields, enum payloads, signatures, const
+  value types, method owners, and destructor owners;
+- type-call heads, including stable free-function endpoints and tagged builtin
+  inputs;
+- named value-constant and module-binding dependencies;
+- ordinary and specialized free-function calls;
+- named method/associated-function calls;
+- named destructor calls;
+- implicit named-destructor obligations discovered during CFG elaboration;
+- per-body owner, target/feature, warning policy, and exact dependency-input
+  fingerprints.
 
-Specialized-body free-function references are now captured alongside that
-origin at the existing specialization-analysis seam, including later fixpoint
-rounds and recursion. `semantic_dependency_inputs` joins every ordinary and
-specialized endpoint against the exact-revision `BoundDefinitionSet` by FileId,
-owned source name, value namespace, and function kind. Missing, ambiguous, or
-non-function endpoints fail closed. The resulting sorted stable edges use only
-the generic base caller and callee `StableDefinitionKey`; specialization
-argument words remain request-local evidence and distinct instances deduplicate
-to one stable edge. Work counters pin zero additional RIR visits.
+AIR carries an opaque `(issuer, slot)` owner token only within one semantic
+epoch. The compiler validates it against the exact `BoundDefinitionSet` and
+translates it to stable identity before publishing a manifest or durable body.
+Foreign, stale, duplicate, missing, or wrong-kind tokens reject publication.
 
-The narrow `free_function_caller_dependencies_complete` flag covers ordinary
-and specialized free-function callers to free-function callees. The overall
-semantic graph remains incomplete until method/destructor callers, declaration
-and type/constant/drop dependencies are captured, so these edges still do not
-authorize AIR or CFG reuse.
+Anonymous/dynamic owners and any future successful form without an authoritative
+stable endpoint emit a sorted `SemanticDependencyBlocker`. The invalidation
+planner unions blockers from both revisions and selects full invalidation for
+the affected graph. Successful supported programs have no unconditional global
+blocker.
 
-Named methods on stable named structs now have a second neutral capture seam.
-The caller is `(FileId, owned owner name, owned method name)` and each target is
-tagged as a free function or another named method. Compiler translation joins
-methods by exact revision, FileId, owner, method namespace and
-method/associated-function kind; anonymous owners and invalid endpoints never
-silently enter the stable graph. Stable named-method edges are sorted and
-deduplicated without another RIR traversal.
+## Invalidation planning
 
-`non_generic_named_method_dependencies_complete` covers reachable named methods
-without comptime parameters calling free functions (including generic free
-function bases) or other named methods. The same authoritative reference sets
-now retain edges for named methods with comptime parameters. Anonymous methods,
-destructors, constructors and intrinsics remain outside this surface and keep
-the overall semantic graph incomplete.
+`CompilerSession::semantic_invalidation_plan` memoizes comparison of two stable
+manifests. It computes exact additions, removals, declaration/signature/body
+changes, and deterministic reverse dependency closure. Root, canonical-import,
+target, and preview-feature changes select conservative full invalidation.
+Planning performs no RIR query or instruction traversal.
 
-Audit of comptime-parameter named methods found no specialization mechanism:
-receiver resolution records only `(StructId, method)`, coerces every explicit
-argument as a runtime argument, emits one direct `Call` symbol, and the lazy
-driver analyzes the declaration once. `MethodInfo` has no specialization key or
-substitution/origin fields. Tests pin two distinct comptime arguments producing
-one analyzed method body and no specialization origins. The declaration is
-therefore the exact stable caller identity, and
-`generic_named_method_dependencies_complete` is production-derived from the
-same successful named-method traversal. Future method instantiation support
-must add substitution identity before this flag may remain true; rejected or
-endpoint-incomplete traversals still publish no manifest.
+The plan selects candidates; it is not itself proof that a retained artifact
+can import. Each declaration, body, specialization, and CFG projection still
+validates its complete current inputs atomically.
 
-Named destructor bodies now use the same existing reference sets to capture
-tagged free-function and named-method targets. Their caller handle is the exact
-named owner declaration FileId/name and compiler translation joins the
-Destructor namespace/kind and owner in the exact `BoundDefinitionSet`.
-`named_destructor_dependencies_complete` covers named destructors; anonymous
-destructors remain a separate incomplete surface.
+## Fresh-epoch declaration import
 
-Resolved declaration tables now publish a conservative nominal-type edge slice
-for struct fields, enum payloads, ordinary function signatures, named
-method/associated-function signatures and owners, constant value types, and
-named destructor owners. Arrays and pointers are traversed to their nominal
-leaf; builtins and anonymous/structural types do not invent definition keys.
-Compiler translation joins both endpoints against the exact bound-definition
-revision and retains the field/payload/signature/declared-type/owner edge kind,
-with zero additional RIR traversal.
+The compiler predeclares current shells in stable-key order and projects
+retained declaration payloads onto exact current identities. AIR's installer
+completes structs, enums, free functions, named methods/associated functions,
+and named destructors while retaining current bodies, spans, parameter names,
+and source order.
 
-Declaration-type capture is complete for successful named declarations.
-Resolver-time observation retains nominal leaves before deferred generic
-signatures become `COMPTIME_TYPE`, recursively including arrays and pointers;
-the resolved declaration-table sweep remains a parity backstop. Type aliases
-retain both the exact value-constant declaration endpoint and the resolved
-nominal target. All endpoints join the same bound-definition revision, and no
-RIR rescan or source-text inference is involved. Type-call heads remain a
-separate, independently fail-closed surface.
+Projection is read-only. Installation validates the complete identity set,
+visibility, nominal shape, callable arity, parameter modes/comptime flags,
+receiver, and unchecked state before publication. A failed installation
+consumes the candidate epoch and falls back through a wholly fresh ordinary
+binder, preventing observation of partial state.
 
-The pre-substitution observer now classifies every type-call head accepted by
-the current resolver. User-defined free and module-qualified free comptime
-functions retain exact declaration endpoints. The stable `Str(N)` head
-is a `FixedCapacityString` language-builtin input, not a fabricated source
-definition; its target identity is already part of the semantic input
-descriptor. No intrinsic currently returns a type. Dotted heads
-are exclusively module paths: `Owner.Make()` where `Owner` is a named type is
-rejected, so associated type constructors, dynamic heads, and unnameable heads
-are not successful language forms and emit no partial dependency edge.
-Both type-call-head completeness surfaces are true for successful programs:
-named heads retain their exact stable function endpoint, while `Str(N)` retains
-its tagged builtin input. Unsupported syntax is rejected before a manifest is
-published; if a successful dynamic/unnameable form is introduced later, its
-producer must emit an evidence-based blocker rather than silently broadening
-this claim. Supported programs can therefore have whole-graph completeness.
+Cold compilation exports the declaration baseline from its primary ordinary
+binder. It does not run a population binder or second RIR/body pass. A new
+baseline is published only after the whole semantic/CFG request succeeds.
 
-Named value-constant initializers record direct dependencies while the existing
-dependency-ordered constant collector and comptime evaluator resolve them.
-Targets are tagged as value constants, free comptime functions/type
-constructors, named struct/enum types, or module bindings. Recursive collection
-temporarily changes and then restores the exact `(FileId, name)` source, so
-chains and diamonds retain direct edges rather than a transitive approximation.
-Compiler translation joins every source and target against the exact bound
-definition revision; module-binding targets are real binding identities whose
-resolved import topology remains in the existing module-import edge channel.
-Module bindings are not value-constant sources and are filtered from this
-surface. Cyclic or otherwise rejected initializers publish no partial manifest.
-`named_value_const_dependencies_complete=true` covers successful named value
-constants; anonymous/dynamic values and the overall semantic graph remain
-explicitly incomplete. Capture is sorted/deduplicated and adds no RIR scan.
+## Per-definition body import
 
-## Fresh-epoch semantic import boundary
+Supported ordinary free functions, named methods, associated functions, named
+destructors, and stable free-function specializations export compiler-owned
+durable bodies. Each record contains:
 
-Durable declaration values can now be remapped into a fresh AIR-owned epoch
-without retaining an exporting request's `Type`, `StructId`, `EnumId`,
-`ModuleId`, or `Spur`. AIR exposes a neutral, generic stable-key import DTO and
-`SemanticImportEpoch`; the compiler alone translates `StableDefinitionKey` and
-logical `ModuleId` values into it. Nominal shells are predeclared in stable-key
-order and completed in a second phase, allowing recursive pointer graphs.
-Primitive, nominal, array, pointer and module types plus scalar/type/function
-constant values round-trip through the epoch's stable join.
+- stable owner/specialization identity and exact input fingerprints;
+- canonical durable types and comptime values;
+- owned symbols and strings;
+- record-local instruction and place references;
+- source-relative anchors and ABI metadata;
+- exact dependency and completeness provenance.
 
-AIR now also has a comparison-only declaration-install boundary. Given a
-durable payload already projected onto the exact current-revision identities,
-fresh predeclared shells can be completed for structs, enums, free functions,
-named methods and associated functions, and named destructors. The installer
-retains current RIR bodies, spans, parameter names and source order; it imports
-only resolved signature/aggregate payloads. It validates the complete identity
-set and visibility before mutation, then validates nominal field/variant shape
-and callable arity, modes, comptime flags, receiver and unchecked state. A
-typed failure consumes the candidate binder, ensuring that fallback creates a
-fresh binder and runs ordinary resolution rather than observing partial state.
-Installation and installed-payload counters distinguish this path from ordinary
-declaration resolution, and installation performs no additional RIR scan.
+Projection resolves all current stable endpoints and anchors before mutation.
+Atomic import remaps the complete body into the fresh AIR epoch. Imported bodies
+remain part of the canonical reachability/specialization fixed point and return
+the same dependency observations as ordinary analysis. A rejected candidate is
+scheduled through the ordinary worklist; no partial AIR survives.
 
-`CompilerSession` now retains a successful stable-keyed durable baseline
-across source updates. Exact no-op/relocation and body-only edits of the
-supported universe install that baseline into current shells; a 128-module
-workload pins 128 records installed and zero ordinary declaration-resolution
-invocations while exact fresh-batch functions, strings, and canonically ordered
-warnings remain equal. Signature/declaration/root/target/feature changes fail
-closed before installation. Module types and constants (including function
-aliases) still fail closed because module/value classification is not
-authoritative until dependency-ordered initializer evaluation. AIR's reserved
-tuple/function forms also remain unsupported.
+Warning-producing bodies, anonymous structural owners, unresolved generic
+calls, untranslatable comptime/function values, and incomplete dependency
+surfaces currently compile through ordinary analysis and make no reuse claim.
 
-Cold population exports stable-keyed declaration payloads from the primary
-ordinary binder before body analysis consumes it. The exporter uses the
-already captured declaration shells, so it neither materializes the optional
-binding manifest nor traverses RIR. The session publishes the semantic result
-and its durable baseline only after the whole ordinary request succeeds;
-failed requests leave the last-good baseline untouched. The ordinary binding
-and population-export counters directly enforce that cold requests bind once
-and export once. Cold and successful reuse requests each construct exactly one
-semantic epoch, one declaration index, and one shell predeclaration epoch. Cold
-requests report one population export; reuse reports none. Projection failure
-is read-only and resolves the same unmutated shells. Only an installation
-failure, which consumes candidate shells to preserve atomicity, may report a
-second semantic/index epoch and one fallback epoch. These values, together with
-the exact plan/comparison/install/reuse counters, are serialized under
-`semantic_work.declaration_reuse` by the session benchmark and are treated as a
-checked schema rather than inferred timing data.
+## Per-function CFG import
 
-The split-binding seam now predeclares free-callable, named-method/associated,
-named-const, and named-destructor identities in logical-path order. It retains
-exact-revision bodies/initializers, spans, parameter names/modes/comptime flags,
-source order, and generic context in private pending records, apart from any
-resolved payload. The ordinary adapter crosses the explicit install/finalize
-boundary using current resolution and preserves historical diagnostic and
-constant-evaluation order. Anonymous structural methods remain deferred because
-they lack a durable structural-owner identity. Module bindings and value
-constants also cannot be distinguished before dependency-ordered initializer
-evaluation, though their value-namespace identity is already fixed. Cached AIR
-bodies, CFGs, and RIR fragments are never imported by this boundary.
+CFG artifacts are keyed by exact stable body provenance, optimization level,
+target, and the transitive nominal layouts consumed by CFG operations. The
+durable projection owns current-independent representations of types,
+struct/enum identities, callable/intrinsic symbols, strings, relative spans,
+warnings, and implicit destructor targets.
+
+Import clones the retained CFG and atomically remaps every external domain.
+Block, value, and instruction references stay local to that clone. The remapped
+artifact is exhaustively validated before publication. Pointer pointees are
+layout dependencies only for operations that consume pointee layout; nominal
+field/payload closure remains transitive.
+
+Target/optimization mismatch, missing or ambiguous symbols/layouts, malformed
+schema, unsupported drop-glue/synthetic provenance, unreproducible
+warning/destructor data, or any remap failure rebuilds only that CFG. Body
+analysis and CFG reuse are independent: a conservatively reanalyzed body may
+still yield an exactly reusable CFG.
+
+## Atomic publication and evidence
+
+The session retains last-successful declaration, body, and CFG candidates.
+Syntax, declaration, body, specialization, CFG, diagnostic, or output failure
+does not replace them. Work counters record every comparison, conversion,
+projection, import, remap, reuse, fallback, rejection, atomic discard, skipped
+body analysis, avoided CFG build, and avoided optimization. Attempts increment
+before fallible work; parallel CFG counters are value-owned and reduced in
+deterministic function order.
+
+The schema-11 session benchmark provides the completion evidence: supported
+N=128 exact-noop, unrelated-edit, changed-reachable-body, reverse-closure,
+specialization, O0/O1 CFG, failure, and recovery scenarios have exact structural
+assertions. Reused scenarios are compared with fresh sessions for semantic/CFG
+artifacts, warnings, diagnostics, stable identities, dependency records,
+manifests, and byte-identical executables. Cold compilation is asserted to
+populate all caches from its one canonical analysis.
+
+## Consequences and remaining work
+
+Rue has one canonical semantic/CFG computation path with stable, atomic
+per-definition reuse consumers. Unsupported artifacts fail closed without
+weakening compilation or introducing a peer frontend.
+
+Persistent serialization, filesystem watchers, editor protocols, and stable
+position/reference indexes remain separate work. RUE-813 tracks a general
+reusable differential oracle beyond the bounded completion workload. RUE-901
+tracks realistic multi-module cold/reused projects and performance baselines.

--- a/docs/notes/body-analysis-cfg-incrementality-audit.md
+++ b/docs/notes/body-analysis-cfg-incrementality-audit.md
@@ -1,342 +1,141 @@
 # Body analysis and CFG incrementality audit
 
-Status: RUE-720 trunk audit after RUE-719. This note records the live ownership
-and identity boundaries before any body or CFG artifact is retained. It does
-not authorize reuse.
+Status: RUE-720 completion audit. `CompilerSession` retains and reuses supported
+per-definition body and CFG artifacts through the canonical semantic query.
+Unsupported surfaces fail closed to the existing analysis/build path.
 
-## Durable ordinary-body observation boundary
+## Canonical ownership
 
-Ordinary non-generic free-function AIR is decoded before specialization mutates
-`CallGeneric`. AIR publishes only a neutral structured DTO keyed by the
-authoritative opaque owner token. The compiler joins callable and nominal
-identity to `StableDefinitionKey`, converts types to `DurableType`, owns
-strings, stores body-relative anchors, and links the artifact to the exact
-per-owner semantic dependency input record. Warning-producing and unsupported
-bodies fail closed without changing ordinary artifacts or diagnostics.
+The live pipeline remains singular:
 
-The compiler schema is distinct from AIR's DTO and contains no `FileId`,
-`Span`, `Spur`, `Type`, nominal ID, `AirRef`, packed `extra`, string-pool ID, or
-discovery-order identity. Projection and atomic fresh-epoch import are
-observational validation only. No AIR/CFG is cached, no body analysis is
-skipped, global unused and CFG warnings are not imported, and reuse counters
-remain zero.
+1. parse, import validation, merge, and RIR create the current revision;
+2. canonical declaration preparation creates one fresh AIR semantic epoch;
+3. durable declaration payloads install atomically when their exact inputs
+   match, otherwise the ordinary binder runs;
+4. the existing reachability/specialization fixed point imports eligible
+   durable bodies or analyzes current source bodies;
+5. finalization assembles current strings, warnings, dependencies, and the type
+   pool;
+6. `build_functions_and_cfgs` imports eligible CFGs or invokes `CfgBuilder`,
+   then returns canonical `FunctionWithCfg` values.
 
-## Conclusion
+There is no peer parser, binder, body analyzer, phase machine, or CFG builder.
+Durable records are compiler-owned exchange artifacts projected into the same
+current-revision AIR and CFG types consumed by cold compilation.
 
-`CompilerSession` has one semantic path, but its body-analysis result is
-not a per-definition query result. `BoundSema::analyze_all_bodies` consumes one
-request-local semantic epoch and runs a joint, program-wide reachability and
-specialization fixed point. `build_functions_and_cfgs` then consumes the whole
-`SemaOutput`, synthesizes glue, remaps function-local strings into one global
-table, sorts every emitted function, builds every CFG in parallel, and
-optimizes every successful CFG.
+## Durable body boundary
 
-The first independently gated RUE-720 implementation PR should therefore add
-structural work accounting at the existing seams. The present counters record
-selected declaration lookups and dependency events, but cannot prove how many
-bodies, specialization candidates, string entries, glue functions, or CFGs
-were attempted, completed, discarded, or optimized. Retaining AIR before that
-ledger exists would make apparent reuse indistinguishable from hidden work.
+Supported ordinary free functions, named methods, associated functions, named
+destructors, and stable free-function specializations use a durable input made
+from:
 
-Stable ordinary-body identity can build on `StableDefinitionKey` plus the
-already separated declaration, signature, and body fingerprints. A reusable
-body output cannot be today's `AnalyzedFunction`: it contains request-local
-AIR symbol, type, string, span/FileId, and global-pool identities. Durable
-specialization and CFG representations remain later design steps.
+- the owner's `StableDefinitionKey` (or stable specialization identity);
+- exact signature and body fingerprints;
+- target and preview-feature inputs;
+- sorted direct dependency records and their exact current fingerprints;
+- source-relative body anchors and warning/dependency completeness evidence.
 
-## Live phase and ownership map
+The output owns canonical `DurableType` and comptime values, symbols and
+strings, record-local instruction/place references, parameter ABI data, and
+stable dependency observations. It contains no request-local `Spur`, `InstRef`,
+`FileId`, raw `Span`, `Type`, nominal ID, AIR offset, or string-pool index.
 
-The production session reaches this path through `CompilerSession`:
+Candidate comparison happens before ordinary dispatch. Projection resolves all
+stable endpoints and anchors without mutation. Atomic import then remaps the
+complete body into the fresh AIR epoch; any missing, ambiguous, stale,
+wrong-kind, malformed, unsupported, or fingerprint-mismatched value discards
+the candidate and schedules the ordinary body. Reused bodies still participate
+in the same reachability and specialization fixed point, so root selection and
+reverse dependency closure remain authoritative.
 
-1. Canonical parse and merge create `CanonicalMergedProgram`, its
-   `DefinitionSnapshot`, and parser-authored signature/body partitions.
-2. Canonical RIR construction creates one revision-local `Rir` and
-   `SourceRevision`.
-3. `prepare_canonical_declarations` creates one `Sema`, its RIR declaration
-   index, declaration shells, and stable definition records.
-4. The ordinary path resolves the shells. The reuse path atomically installs
-   projected durable declaration payloads or falls back to an entirely
-   ordinary binder. Both produce one `BoundSema` that owns the mutable semantic
-   epoch consumed below.
-5. `finish_canonical_analysis` calls `BoundSema::analyze_all_bodies` exactly
-   once. `rue_air::sema::analysis::analyze_function_bodies_lazy` owns the
-   reachable-body worklists and the outer fixed point.
-6. The driver roots `main`, named destructors, and dynamically registered
-   anonymous destructors. It analyzes reachable ordinary free functions,
-   anonymous methods, named methods, and named destructors into
-   `AnalyzedFunction` values. Calls discovered by each body feed the same
-   deterministic worklists.
-7. One `Specializer` persists across the outer fixed point. It scans newly
-   appended AIR, deduplicates request-local `SpecializationKey` values, rewrites
-   `CallGeneric` instructions in place, reanalyzes generic source bodies for
-   pending substitutions, and returns newly discovered ordinary callees to the
-   outer worklists. Its 64-round budget is program-wide.
-8. Finalization concatenates function-local strings into one request-global
-   table and rewrites AIR string indices. It also orders warnings and dependency
-   observations and returns one `SemaOutput` with the request-global type pool.
-9. `build_functions_and_cfgs` consumes that entire output. It synthesizes drop
-   glue from the complete type pool, removes comptime-only functions, combines
-   and sorts all machine symbols, then uses `CfgBuilder::build` for every
-   function. Malformed AIR fails before optimization; otherwise the CFG is
-   optimized with the request's `OptLevel`.
-10. CFG lowering also discovers implicit named-destructor dependencies. The
-    driver joins request-local `StructId` targets through the global type pool,
-    merges CFG warnings in sorted function order, and returns
-    `FunctionWithCfg` values coupled to the same type pool and string table.
+Specialized free functions are keyed by the stable generic base plus canonical
+type and comptime-value arguments. Imported ordinary callers receive the
+current specialized symbol mapping before installation. Named methods with
+comptime parameters currently have one runtime body rather than a method
+specialization mechanism, so the named declaration is their stable identity.
 
-There is no second parser, lowerer, binder, or body-analysis entry point in this
-path. The declaration-import parity helper deliberately runs ordinary and
-installed binders separately in tests; it is not a production reuse path.
+Anonymous structural methods/destructors, incomplete dependency evidence,
+warning-producing bodies, unresolved generic calls, and untranslatable
+comptime/function values remain ordinary fallbacks. These are supported
+compilation paths, but they do not claim incremental reuse.
 
-## Current prospective query owners
+The session publishes a new body baseline only after the full semantic request
+succeeds. Syntax, declaration, body, specialization, or CFG failure leaves the
+previous successful baseline intact.
 
-| Body class | Current selection identity | Current analysis owner | Reuse disposition |
-| --- | --- | --- | --- |
-| Non-generic free function | request-local `Spur`, then indexed `InstRef` | outer sema worklist | first supported candidate after durable projection exists |
-| Generic free function | `SpecializationKey { Spur, Vec<Type>, Vec<ConstValue> }` | persistent program-wide `Specializer` | unsupported until specialization arguments and output are durable |
-| Named method/associated function | request-local `(StructId, Spur)` and private `InstRef` | outer sema worklist | possible only after owner/method stable keys are threaded through dispatch |
-| Anonymous method/destructor | request-local `StructId`, captured substitution maps | outer sema worklist | fail closed; no stable definition endpoint |
-| Named destructor | declaration-index record plus request-local `StructId` | implicit-root pass | later supported candidate; it needs explicit root and drop-dependency provenance |
-| Synthesized drop glue | request-local type-pool traversal | CFG frontend tail | not a source body; later artifact keyed by durable nominal type and destructor/layout inputs |
+## Durable CFG boundary
 
-Named methods with comptime parameters currently still produce one runtime
-body; they do not have a method-specialization table. That surface must fail
-closed rather than being described as specialized reuse.
+A durable CFG artifact is keyed by its exact stable body provenance,
+optimization level, target, and every nominal layout actually consumed by CFG
+operations. It retains a cloned CFG plus an explicit projection of all domains
+that must be remapped into the current semantic output:
 
-## Request-local identity inventory
+- types and named struct/enum identities;
+- callable and intrinsic symbols;
+- string-table entries;
+- source-relative spans;
+- implicit destructor targets and warning provenance.
 
-### Body dispatch and semantic inputs
+Block and value IDs stay local to the cloned CFG and are remapped atomically as
+one internally consistent record. Layout dependency closure is transitive for
+nominal fields/payloads. Pointer pointees are not layout dependencies unless an
+operation such as pointer read/write/offset consumes the pointee layout.
 
-- `InstRef` identifies RIR declarations and bodies only inside the current RIR.
-- `Spur` identifies functions, methods, parameters, calls, and function-valued
-  constants only inside the current interner.
-- `FileId` and raw `Span` values appear in lookup records, diagnostics,
-  warnings, specialization call sites, and dependency observations. They are
-  useful for projecting a current result, but are not durable identity.
-- `StructId`, `EnumId`, array/pointer intern IDs, and `Type::as_u32` values are
-  indices into one `TypeInternPool`. Even primitive-looking `Type` values must
-  be treated as belonging to the representation that produced them.
-- `InferenceContext`, `ParamArena`, captured comptime maps, method tables,
-  declaration tables, module registry state, and named-declaration indices are
-  owned by the consumed `Sema` epoch.
-- `ConstValue::Type` embeds `Type`; `ConstValue::Function` embeds `Spur`.
+Import requires an exact join for every domain and validates the remapped CFG
+before publication. Target or optimization changes select a different key.
+Missing symbols/layouts, malformed schemas, unsupported synthetic/drop-glue
+provenance, warning/destructor surfaces that cannot be reproduced, or any
+remap failure rebuild that function's CFG. A body may be reanalyzed while its
+unchanged resulting CFG is reused; the durable CFG key is based on artifact
+provenance, not merely on whether body analysis ran.
 
-### Current body output
+The session publishes CFG candidates only after the complete semantic/CFG
+request succeeds. Failed requests cannot poison the last-good CFG baseline.
 
-`AnalyzedFunction` is not durable:
+## Structural evidence
 
-- `name` is a display/machine symbol, not sufficient source identity;
-- `Air` instructions contain interned symbols, pool-local types, AIR-local
-  instruction/extra-array offsets, string indices, and source spans;
-- `implicit_drop_source` has stable-capable names but still uses FileId indices
-  that require exact-revision translation;
-- parameter slot counts/modes and allow flags are values and can be retained
-  only alongside their complete semantic provenance;
-- warnings retain current spans and their final order is program-wide;
-- local strings are rewritten into a request-global string table only during
-  body-analysis finalization.
+`CanonicalSemanticWork` records each body candidate comparison, stable
+specialization-map operation, export/conversion/finalization/projection/import,
+installed entity, reuse, fallback, atomic discard, and skipped ordinary body
+analysis. `CfgConstructionWork` records construction/optimization plus each CFG
+candidate, import, reuse, fallback, reused warning/destructor target, and
+durable export. Attempts are counted before fallible work; parallel CFG values
+are reduced deterministically rather than mutated through shared timing state.
 
-The returned `SemaOutput` further couples all bodies to one `TypeInternPool`,
-one global string table, program-wide dependency completeness flags, and the
-fixed-point result set.
+The schema-11 session benchmark hard-gates supported N=128 workloads:
 
-### Specialization
+- exact no-op performs whole-query reuse;
+- an unrelated edit imports all 128 bodies and CFGs and performs zero body
+  analyses, CFG builds, or optimizations;
+- a reachable leaf edit reanalyzes exactly the leaf and its direct reverse
+  caller while rebuilding only the changed CFG;
+- a chain edit invalidates the exact transitive reverse closure;
+- O0 and O1 both import all eligible CFGs with zero construction/optimization;
+- stable specialization imports avoid specialized reanalysis;
+- semantic failure records discarded work and recovery imports from the prior
+  successful baseline;
+- cold analysis populates declaration, body, and CFG caches from its one
+  canonical pass, without duplicate cache-population analysis.
 
-`SpecializationKey` is wholly request-local: its base is a `Spur`, type
-arguments are pool-local `Type` values, and value arguments can contain either.
-The specialized machine name is derived from those values and interned again.
-The specializer also owns a request-global scan frontier, warning-dedup set,
-round counter, and first-call-site span. Consequently an ordinary body result
-that still contains `CallGeneric` cannot be imported independently, and a
-post-rewrite body cannot be imported without the exact specialization map that
-performed the rewrite.
+Every reused scenario is compared against a fresh session for exact public
+semantic/CFG artifacts, ordered type-pool entries, strings, warnings, stable
+identities, specialized durable-body payloads, durable ordinary bodies exposed
+by the manifest, dependency/completeness records, diagnostics, and
+byte-identical emitted output. The private retained durable-CFG cache has no
+comparison accessor, so its parity is asserted through imported public CFGs,
+exact work counters, and emitted bytes. See
+[`session-invalidation-benchmark.md`](../process/session-invalidation-benchmark.md)
+for the field-level contract.
 
-The existing `SpecializedFreeFunctionOrigin` is an observation, not a durable
-identity. Its FileId index and encoded `Type::as_u32`, `ConstValue::Type`, and
-`ConstValue::Function` words are revision-local.
+## Remaining boundaries
 
-### CFG
+The current implementation is intentionally in-process and last-successful
+only. Persistent cache serialization, cross-process compatibility, filesystem
+watching, editor protocols, and stable position/reference indexes are separate
+projects. Programs containing unsupported reusable body/CFG surfaces compile
+normally and fail closed per artifact.
 
-`Cfg` contains block/value/instruction identities local to one build. Its
-instructions retain pool-local `Type`, `StructId`, symbols/string provenance,
-and source spans. `CfgOutput` additionally exposes request-local `StructId`
-destructor targets. Final warning and function order is assembled outside the
-builder. CFG reuse therefore requires an atomic import that remaps every type,
-symbol, string, span, and destructor target before any artifact becomes
-visible.
-
-## Exact dependency and invalidation inputs
-
-An ordinary per-definition body query must conservatively include or depend on:
-
-- the owner's `StableDefinitionKey`;
-- its body fingerprint and exact signature fingerprint;
-- target and preview-feature semantic inputs;
-- stable declaration semantics for the owner;
-- every resolved value, type, const, module, method, destructor, and callable
-  type-head dependency selected during analysis, including negative or
-  ambiguous resolution where relevant;
-- inferred nominal layouts and function signatures used by type checking;
-- function-level warning allowances and all diagnostic-producing source spans;
-- for methods, the stable nominal owner and receiver mode;
-- implicit destructor obligations discovered during later CFG elaboration.
-
-Optimization level is not a body-analysis input today and must not reduce body
-reuse. It is a CFG key. A future CFG query additionally needs the durable body
-artifact identity, optimization level, complete type/layout inputs, global
-string remapping provenance, machine-symbol order/identity, drop-glue inputs,
-and warning policy.
-
-Compilation root and reverse dependency closure determine which cached body
-requests may be considered. They are not by themselves artifact keys or proof
-that a retained result can be projected. If root choice changes a body-local
-observable, that specific provenance must become an explicit input. A missing
-stable endpoint, incomplete dependency surface, failed projection, or
-unsupported body class must select the ordinary path with zero partial
-installation.
-
-## Current fallback and failure boundaries
-
-- Declaration projection is read-only and can fall back using the same shells.
-- Declaration installation consumes shells; a failure starts a wholly fresh
-  semantic epoch before ordinary binding.
-- Body analysis has no import attempt or body-level fallback yet. Any body
-  error fails the single request after other queued work may already have run.
-- Specialization failure occurs inside the joint fixed point. The partially
-  rewritten and appended AIR is discarded with the failed `SemaOutput`.
-- CFG builders run in parallel. Each malformed-AIR result records errors and
-  skips optimization, but other parallel builders may already have completed.
-  Collection returns the first ordered failure and discards the request output.
-- There is no persistent body/CFG baseline to poison. A future session must
-  publish a new baseline only after body projection, specialization,
-  string/type remapping, CFG construction, warning assembly, and parity checks
-  have all succeeded.
-
-## Structural work ledger audit
-
-`BodyAnalysisWork` currently exposes dependency-event counts; free-function,
-named-method, and anonymous-method record lookups; named-destructor records
-visited; and two expected-zero RIR scan counters. The session benchmark exports
-only part of that structure. Declaration reuse has a substantially more exact
-attempt/fallback/epoch ledger.
-
-Missing body-analysis counters:
-
-- roots selected and queue items popped, deduplicated, absent, attempted,
-  succeeded, and failed, split by ordinary function, named method, anonymous
-  method/destructor, and named destructor;
-- AIR instructions and local strings produced or remapped;
-- specialization AIR instructions scanned, generic calls observed, unique and
-  duplicate requests, rewrite attempts, outer waves, internal rounds,
-  specialized bodies attempted/succeeded/failed, and ordinary references
-  returned;
-- warning candidates produced and specialization-warning deduplications;
-- comptime-only bodies filtered after analysis;
-- body import comparisons, projection attempts, remapped entities, reuse,
-  rejection reasons, fallbacks, and ordinary analyses skipped once reuse exists.
-
-Missing CFG-tail counters:
-
-- drop-glue candidates visited and functions synthesized;
-- functions considered and comptime-only functions filtered;
-- CFG builds attempted/succeeded/failed and AIR instructions consumed;
-- optimization attempts/completions, split by level if the benchmark aggregates
-  unlike requests;
-- warnings and implicit destructor targets emitted;
-- type, string, symbol, span, and destructor-target remaps attempted/completed;
-- CFG import comparisons, reuse, rejection reasons, fallbacks, and builds
-  skipped once reuse exists.
-
-Every attempt must be counted before the fallible operation. Parallel CFG work
-must use per-result value counters reduced in deterministic function order, not
-a shared timing-dependent atomic. Failed requests must return their work record
-to the benchmark harness where the API permits; otherwise failure scenarios
-cannot prove that discarded work occurred.
-
-## Proposed ordinary body-query boundary
-
-The first reusable semantic unit should be a supported, non-generic named
-definition, not a whole `SemaOutput` and not a CFG. The conceptual durable
-input is:
-
-```text
-StableBodyInput {
-    owner: StableDefinitionKey,
-    signature: StableDefinitionFingerprint,
-    body: StableDefinitionFingerprint,
-    semantic_input: { target, preview_features },
-    dependencies: ordered stable keys plus exact input fingerprints,
-}
-```
-
-The root and reverse closure select which inputs are requested; root membership
-need not be duplicated in an artifact that is otherwise semantically identical.
-If root choice changes observable warning policy or another body-local result,
-that fact must instead become an explicit input.
-
-The conceptual durable output is an owned, request-independent typed-body
-record containing a stable owner, canonical types, owned symbol/string values,
-source-relative diagnostic anchors, parameter ABI metadata, warning records,
-direct stable dependency observations, and an instruction graph whose references
-are record-local rather than AIR-epoch offsets. Projection into fresh AIR must
-be atomic and return either a complete current-epoch `AnalyzedFunction` plus
-local strings and dependencies, or no mutation.
-
-This shape is a design constraint, not approval to introduce a second IR now.
-The implementation should first test whether existing AIR can gain an explicit
-export/import representation without becoming a parallel analyzer or lowerer.
-
-Initial support must exclude generic free functions, named methods with an
-unresolved generic surface, anonymous owners, bodies with untranslatable
-function-valued comptime data, and any dependency observation lacking a stable
-endpoint. Those bodies run the ordinary worklist.
-
-## Smallest independently gated first PR
-
-Add value-only body, specialization, and CFG structural counters at the live
-operations above, thread them through `SemaOutput`, `CanonicalSemanticWork`, and
-the session benchmark JSON, and hard-gate cold, exact-noop, body-edit, failure,
-and recovery scenarios. Do not add a cache, durable AIR, or CFG reuse.
-
-Required tests for that PR:
-
-1. A small non-generic call graph pins exact body attempts and completions.
-2. Recursion and duplicate references pin queue deduplication separately from
-   analysis attempts.
-3. A generic chain pins specialization scans, unique/duplicate requests,
-   rounds, bodies, and rewrites.
-4. A semantic body failure counts the attempt and no completion.
-5. Malformed AIR in a focused CFG test counts a build failure and zero
-   optimization attempts for that function.
-6. O0 and optimized CFG tests count the same builds and the appropriate
-   optimization work.
-7. The N=4 benchmark smoke asserts cold and declaration-reuse revisions still
-   perform identical body/CFG work today; this is the pre-reuse baseline.
-8. The benchmark schema and process document enumerate every new field and do
-   not infer work from elapsed time.
-
-At the time of this audit, the next planned PR was to thread `StableDefinitionKey` through
-ordinary body dispatch and translate direct dependency observations at the
-point they are produced. That second PR should still retain no AIR: its gate is
-an exact, complete per-owner dependency/input manifest with unsupported owners
-failing closed. Durable body export/import was planned as the following slice;
-the observational export/import slice described below has since been
-implemented, without enabling production reuse.
-
-## Later sequence
-
-1. Land the complete structural ledger.
-2. Thread stable owners through ordinary body analysis and emit exact per-owner
-   dependency/input records without a second RIR scan.
-3. Define and test atomic durable ordinary-body export/import.
-4. Demonstrate unchanged-body reuse and exact fresh-session parity, including
-   changed reachable bodies and reverse caller closure.
-5. Define canonical specialization type/value/function arguments and a durable
-   specialization identity before retaining specialized bodies.
-6. Extend the body boundary to supported named methods and destructors.
-7. Define stable CFG artifacts and atomic remapping only after semantic body
-   reuse is sound; include optimization, layout, string, symbol, and drop
-   provenance in the key.
-
-Persistent storage, watchers, an LSP, parallel compiler entry points, and weaker
-semantic keys remain out of scope.
+RUE-813 tracks a general reusable cold-versus-reused differential oracle beyond
+the bounded completion workload. RUE-901 tracks representative multi-module
+projects, wall-time baselines, and longer-running performance analysis. Neither
+is required to establish the sound per-function boundary implemented here.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -1,65 +1,44 @@
 # Compiler session architecture completion audit
 
-This is the RUE-730 completion audit after the RUE-728–RUE-736 migration. It
-records the supported boundary, the compatibility surface removed from the
-compiler crate, and the responsibilities that remain deliberately separate.
+This audit records the canonical compiler boundary after RUE-720.
 
 ## Supported boundary
 
 | Requirement | Evidence |
 | --- | --- |
-| Owned source identity | `SourceSnapshot::new` owns text and validated `SourceMetadata`; metadata identifies an explicit root and stable logical modules. `SourceView` is a read-only record returned by snapshots for diagnostics and presentation, not a borrowed assembly input. Filesystem discovery is a caller responsibility. |
-| One semantic graph | `CompilerSession` publishes snapshots and owns parse, import, merge, RIR, semantic, invalidation, diagnostic, and durable-reuse queries. Returned artifacts are immutable `Arc` values. |
-| One batch adapter | `compile_snapshot` is the only public `compile_*` entry point. It creates a session, issues the same RIR and semantic queries as long-lived consumers, then performs backend emission and linking. |
-| Explicit options | `CompileOptions` carries target, linker, optimization, and preview features. Query descriptors own the subset that affects their identity. |
-| Diagnostics | Session snapshots preserve attempted and last-good query identity with bounded retention. Batch mode preserves caller-selected source ordering where diagnostics require it. |
-| Work accounting | `PipelineWork` and `CompilerSessionWork` distinguish executions from reuse. The N=4 test workload and opt-in N=128 session benchmark hard-gate structural counters. |
-| Public API control | `api_inventory` limits facade size, requires the supported source/session/query names, rejects retired peers, and permits exactly one public `compile_*` function. |
+| Owned source identity | `SourceSnapshot` owns validated source text and metadata with an explicit root and stable logical modules. Filesystem discovery remains a caller responsibility. |
+| One semantic graph | `CompilerSession` owns parse, import, merge, RIR, semantic, diagnostics, invalidation, stable dependency, durable body, and durable CFG state. Returned query artifacts are immutable `Arc` values. |
+| One batch adapter | `compile_snapshot` is the only public `compile_*` entry point. It uses the same session queries as long-lived consumers before backend emission and linking. |
+| Explicit inputs | `CompileOptions` carries target, linker, optimization, and preview features. Semantic, CFG, and link descriptors own only their relevant subsets. |
+| Diagnostics | Attempted and last-good diagnostics have bounded retention. Failed semantic requests retain value-only work while leaving successful artifact baselines intact. |
+| Per-definition reuse | Supported declarations, bodies, stable free-function specializations, and CFGs cross versioned stable projection/import boundaries. Unsupported artifacts fail closed individually to the ordinary path. |
+| Work accounting | Schema-11 N=4/N=128 workloads hard-gate exact body/CFG comparisons, imports, fallbacks, skipped analyses, avoided builds/optimization, recovery, and cold/fresh parity. |
+| Public API control | `api_inventory` requires the supported snapshot/session/query surface, rejects retired peers, and permits exactly one public `compile_*` function. |
 
-## Removed compatibility surface
+## Architectural invariants
 
-The following names are written with a soft line-break so repository searches
-for a retired identifier remain clean while the audit still records the exact
-human-readable spelling.
+Syntax-only AST presentation is not a semantic path. Backend presentation
+accepts session-produced CFG artifacts. The CLI owns filesystem/project and
+standard-library discovery plus user-facing rendering. `rue-oracle` owns its
+evaluator state but obtains compiler semantics and CFGs through
+`CompilerSession`.
 
-| Removed symbol family | Exact retired names |
-| --- | --- |
-| Peer driver | <code>Compilation<wbr>Unit</code> |
-| Shared-interner parse records | <code>Parsed<wbr>File</code>, the compatibility form of <code>Parsed<wbr>Program</code> |
-| Concatenated merge records | <code>Merged<wbr>Ast</code>, <code>Merged<wbr>Program</code> |
-| Duplicate parse/merge functions | <code>parse_<wbr>all_files</code> and variants, <code>merge_<wbr>symbols</code> |
-| Aggregate frontend adapters | <code>compile_<wbr>frontend</code>, <code>compile_<wbr>frontend_with_options</code>, <code>query_<wbr>canonical_frontend</code>, <code>query_<wbr>canonical_frontend_source</code>, <code>Canonical<wbr>FrontendArtifacts</code>, and <code>Canonical<wbr>PipelineWork</code> |
-| Raw-AST semantic adapters | <code>compile_<wbr>frontend_from_ast</code>, <code>compile_<wbr>frontend_from_ast_with_options</code>, <code>compile_<wbr>frontend_from_ast_with_file_paths</code>, <code>compile_<wbr>frontend_from_ast_with_file_paths_and_target</code>, <code>compile_<wbr>frontend_from_ast_with_file_paths_and_symbol_paths_and_target</code>, <code>compile_<wbr>frontend_from_ast_with_source_metadata_and_target</code>, and <code>compile_<wbr>frontend_from_merged_ast_with_source_metadata_and_target</code> |
-| Test/fuzz semantic adapters | <code>compile_<wbr>to_air</code>, <code>compile_<wbr>to_cfg</code>, and <code>compile_<wbr>to_cfg_with_preview_features</code> |
-| Parallel batch adapters | <code>compile_<wbr>with_options</code>, <code>compile_<wbr>multi_file_with_options</code>, <code>compile_<wbr>multi_file_with_symbol_paths_and_options</code>, <code>compile_<wbr>multi_file_with_symbol_paths_and_options_and_stats</code>, <code>compile_<wbr>multi_file_with_source_metadata_and_options</code>, <code>compile_<wbr>multi_file_with_source_metadata_and_options_and_stats</code>, <code>compile_<wbr>source_snapshot_with_options</code>, <code>compile_<wbr>source_snapshot_with_options_and_work</code>, and <code>compile_<wbr>source_snapshot_with_options_and_stats</code> |
+Durable declaration, body, specialization, and CFG artifacts are projections
+of the canonical query graph, not peer phase machines. They use stable logical
+identity and atomically remap into fresh request-local domains. Raw interners,
+FileIds, spans, type-pool indices, AIR references, and CFG-local identities do
+not cross the durable boundary. Exact missing provenance selects ordinary
+computation.
 
-No compatibility type aliases or forwarding wrappers remain. Syntax-only AST
-presentation is not a compatibility semantic path: it cannot lower, analyze,
-generate code, or link.
+## Deliberately separate work
 
-## Intentionally separate responsibilities
-
-- The CLI owns project discovery, physical paths, standard-library discovery,
-  user-facing emit selection, and diagnostic rendering.
-- `ParsedAstPresentation` preserves token/AST inspection in caller order. It is
-  deliberately syntax-only and does not compete with session semantics.
-- Backend presentation functions accept session-produced CFG artifacts for
-  `--emit` views. Machine lowering and linking live in dedicated implementation
-  modules, while the public one-shot adapter controls their sequencing.
-- Import-graph validation is independently keyed because tooling may request it
-  without semantic analysis. It still consumes the session's parsed modules.
-- `rue-oracle` owns its evaluator state projection, but obtains all compiler
-  semantics and CFGs through `CompilerSession`.
-
-## Deliberate future work
-
-Body and CFG reuse remains revision-wide even though declaration payload reuse
-is supported. Persistent caching, filesystem watching, editor protocols, and
-stable position/reference indexes remain separate projects. Any such work must
-extend session query artifacts rather than introduce another parser, lowerer,
-binder, or compiler driver.
+Persistent caches, filesystem watching, editor protocols, and stable
+position/reference indexes remain separate projects and must extend the session
+artifact graph rather than add another parser, lowerer, binder, or driver.
+RUE-813 generalizes differential testing beyond RUE-720's bounded oracle;
+RUE-901 adds realistic project/performance scenarios.
 
 Physical relocation remains part of `ModuleResolutionInputs` because relative
-imports can resolve differently when source text is unchanged. Linker mode is
-excluded from semantic identity; optimization is included in codegen identity
-but excluded from stable-definition identity.
+imports may resolve differently when text is unchanged. Linker mode is excluded
+from semantic identity. Optimization is excluded from body identity and is an
+explicit CFG/codegen key.

--- a/docs/process/session-invalidation-benchmark.md
+++ b/docs/process/session-invalidation-benchmark.md
@@ -1,141 +1,126 @@
 # Compiler session invalidation benchmark
 
-This opt-in benchmark characterizes `CompilerSession` without starting
-a compiler process per query. It uses generated source held in memory, performs
-no filesystem discovery during measured updates, and stops before backend code
-generation or linking.
+This opt-in benchmark is the canonical structural workload for
+`CompilerSession`. It runs entirely in process over owned `SourceSnapshot`
+values. Its measured semantic scenarios stop before backend emission; bounded
+cold-versus-reused parity checks additionally run the canonical backend and
+linker and require byte-identical executables.
 
-Run the full deterministic workload with:
+Run the deterministic N=128 workload with:
 
 ```sh
 ./buck2 run //crates/rue-compiler-session-bench:rue-compiler-session-bench -- \
   --modules 128 --warmup 3 --iterations 10 > session-invalidation.json
 ```
 
-The defaults are the values shown above. Setup constructs every `SourceSnapshot`
-before warmup starts. Each measured iteration creates fresh sessions and runs
-cold parse through semantic analysis, an exact no-op, a reachable root body edit,
-a module identity change, a failed syntax edit and recovery, then cold and reused
-stable definition queries. The semantic cold path performs one declaration bind
-and exports its durable baseline from that same bind. For supported named
-declarations, the reachable root body edit installs durable declaration payloads
-into a fresh AIR epoch, then analyzes current bodies and builds current CFGs. A
-second persistent session measures cold, exact-noop, reachable-root-body-edit,
-and module-identity-change dependency-manifest and semantic-invalidation-plan
-workloads.
+The historical `--modules` spelling is retained for command compatibility. In
+the RUE-720 completion scenarios N is the exact number of reachable analyzed
+bodies: `main` plus N-1 generated functions. One additional unreachable
+function is present solely to make an unrelated source edit execute the
+semantic query without changing the reachable program.
 
-The JSON contains nanosecond wall-time observations and structural work for each
-scenario. Treat structural counters as correctness gates: the driver aborts if
-reuse and invalidation do not match the scenario. Wall time is observational;
-compare repeated runs on the same otherwise-idle machine and do not impose a
-regression threshold without collecting a stable baseline first. The existing
-`bench.sh` history schema describes whole compiler invocations and binary output,
-so these stateful session samples intentionally use a separate schema rather
-than silently changing dashboard meaning.
+## Contract
 
-Schema version 2 added dependency-manifest and invalidation-plan query counters,
-separate manifest/plan timings, fingerprint comparisons, dependency/closure
-visits, and result cardinalities. At that historical stage production graphs
-were incomplete and plans conservatively reported full invalidation. Schema
-version 3 exercises complete supported graphs: exact no-op and reachable-root
-edits produce incremental plans with reusable declarations, while unsupported
-surfaces and global semantic-input changes still fail closed. Planning itself
-must run no RIR query or RIR instruction scan.
+Every iteration runs the original parse, declaration, diagnostic-retention,
+dependency-manifest, and invalidation-plan scenarios, followed by these
+supported body/CFG scenarios:
 
-At N=128 the structural gates require the supported reachable-root-body-edit
-workload to reuse and atomically install all 128 durable declaration records,
-skip ordinary declaration resolution, and perform no population export. Cold
-compilation performs one ordinary bind and exports the durable baseline from
-that bind. This is a measured declaration-resolution saving, not whole-pipeline
-incremental compilation: program merge/RIR and current body/CFG work still run.
-Constants, module values, function aliases, generic named methods, and anonymous
-structural owners currently fail closed to ordinary declaration resolution with
-zero partial installs. Persistent cache formats and LSP consumers remain
-deliberately out of scope.
+- `completion_cold_n`: one cold analysis of exactly N reachable bodies;
+- `completion_exact_noop`: whole-query reuse with no semantic execution;
+- `completion_unrelated_edit`: all N body and CFG artifacts import;
+- `completion_changed_reachable_body`: the edited leaf and its direct reverse
+  caller are reanalyzed while the other N-2 bodies import;
+- `completion_reverse_closure`: an N-dependent call chain proves exact
+  transitive reverse invalidation;
+- `completion_cfg_o0` and `completion_cfg_o1`: all N CFGs import and perform no
+  construction or optimization at either optimization level;
+- `completion_specialization_reuse`: stable specialization identity imports a
+  specialized body and its CFG after an unrelated edit;
+- `completion_failed_semantic` and `completion_failure_recovery`: a failed
+  request is retained as work evidence but cannot replace the last-good body or
+  CFG baseline.
 
-Schema version 3 adds the exact declaration-reuse ledger under
-`semantic_work.declaration_reuse`: plans, durable comparisons and reuse,
-skipped ordinary resolution, installs, fallbacks, semantic/index/shell epochs,
-population exports, and fallback epochs. Cold and successful declaration-reuse
-scenarios are hard-gated to one epoch/index/shell-predeclaration each. Cold
-reports one export; reuse reports none and no fallback epoch.
+The executable aborts on any structural mismatch. Wall time is observational;
+compare it only across repeated runs on an otherwise idle machine. The
+structural counters, not elapsed time, are the correctness gates.
 
-The ordinary test suite runs only a four-module, single-iteration structural
-smoke test through
-`//crates/rue-compiler-session-bench:rue-compiler-session-bench-test`; the
-128-module timing workload remains opt-in.
+For every reused completion scenario, a fresh session compiles the same source.
+The benchmark exact-compares the public canonical semantic/CFG artifacts,
+ordered type-pool entries, strings, warnings, stable definition keys,
+specialized durable-body payloads, body-owner and dependency records, retained
+diagnostics, and every non-work field exposed by the stable dependency manifest,
+including its durable ordinary bodies. The session-private retained CFG cache
+is not exposed as a comparison API; parity for it is established through the
+public remapped CFGs, exact import counters, and emitted output rather than an
+inaccessible cache-object claim. The benchmark closes the same canonical
+import-discovery revision in each session and requires byte-identical emitted
+executables and equal backend warnings. Successful comparisons are recorded as
+`differential_parity`; counter expectations remain scenario-specific because
+reuse is supposed to perform less work than cold compilation. Each parity
+record also serializes the fresh session's complete `cold_semantic_work` beside
+the scenario's reused `semantic_work`, and both sides are covered by exact
+structural gates. Exact no-op runs the same differential parity check even
+though its semantic output is a whole-query reuse.
 
-The
-[body-analysis and CFG incrementality audit](../notes/body-analysis-cfg-incrementality-audit.md)
-requires this ledger before body or CFG reuse is introduced. Counters describe
-actual operations, and parallel CFG counters reduce deterministic per-function
-values rather than timing-dependent shared state.
+## Work ledger
 
-Schema version 4 adds value-only body and CFG work. Top-level
-`semantic_work` records body attempts/successes/failures, AIR and local-string
-production, string remapping, specialization scans/calls/unique and duplicate
-requests/rewrites/rounds, specialization-driver failures, and specialized-body
-attempts/successes/failures.
-`semantic_work.cfg` records synthesized glue, functions considered and
-filtered, CFG attempts/successes/failures, AIR consumed, optimization attempts
-and completions (including non-O0 attempts), warnings, and implicit destructor
-targets. Counts describe both successful and failed semantic executions.
+Schema version 11 contains the complete body and CFG ledgers. Every field is a
+direct operation count reduced deterministically from value-owned records;
+none is inferred from timing.
 
-Schema version 5 adds `manifest_work.body_owner_events_translated`,
-`body_named_events_translated`, and `body_dependency_records_built`. The
-manifest now publishes one ordered stable input record for each supported
-ordinary body analyzed in the existing semantic pass, and the benchmark
-hard-gates zero extra RIR traversal.
-`semantic_work.body_dependency_air_instructions_observed` records the explicit
-post-emission type observation needed for already-resolved inferred/comptime
-nominal types; it is bounded by produced AIR and is not a second RIR pass.
+`semantic_work.durable_bodies` contains:
 
-Schema version 6 adds `semantic_work.body_owner_tokens`, with exact provisional,
-authoritative, validated, installed, and failed-validation counts. Ordinary and
-durable-fallback semantic epochs each receive a fresh issuer; the benchmark
-continues to claim no AIR or CFG retention or reuse.
+- candidate comparisons and fallbacks;
+- stable specialization-map attempts, successes, and failures;
+- export attempts, successes, rejections, and exported instruction/place/string
+  counts;
+- durable conversions, completions, failures, and stable-key joins;
+- finalization and projection attempts, completions, failures, and projected
+  instruction/place/string counts;
+- atomic import attempts, successes, failures, installed entities, and atomic
+  discards;
+- bodies reused and ordinary body analyses skipped.
 
-Schema version 7 adds `semantic_work.durable_bodies`. It counts ordinary-body
-export attempts, successful publications and fail-closed rejections; emitted
-instructions, places and strings; compiler-owned durable conversions and
-stable-key joins; projections into AIR's neutral import DTO; atomic fresh-epoch
-imports and installed contents. `reused_bodies` and `skipped_body_analyses` are
-zero on a cold request. Supported warning-free, non-generic ordinary free
-functions are retained only from the last fully successful semantic request.
-A later request uses the canonical stable-key invalidation plan plus exact
-owner and dependency fingerprints to project and atomically import candidates
-into the live AIR epoch. The counters record only bodies actually consumed by
-the existing reachability worklist; rejected or unreachable imports never
-claim avoided analysis. Warning-producing bodies and dependency surfaces owned
-by later incremental slices remain fail-closed ordinary fallbacks.
+`semantic_work.cfg` contains:
 
-Schema version 8 adds a `retention` object to every scenario. It reports current
-session-owned diagnostic entries, distinct diagnostic source attempts and
-bytes, unique dependency manifests, and invalidation plans. Structural gates
-enforce the production caps (16 diagnostics and eight plans, with no more than
-two plan-owned manifests per plan plus the current manifest). These gauges do
-not count diagnostic `Arc`s pinned by benchmark callers: ownership of those
-artifacts has intentionally left the session. Compiler unit stress tests run a
-32-round syntax-failure, semantic-failure, recovery, and edit sequence and a
-plan workload beyond the eviction cap, pinning bounded bytes, deterministic
-FIFO recomputation, last-good recovery, and clean-session parity.
+- drop-glue synthesis, functions considered and comptime functions filtered;
+- CFG builds attempted/succeeded/failed and AIR instructions consumed;
+- optimization attempts/completions and non-O0 level attempts;
+- warnings and implicit destructor targets emitted;
+- reuse candidates, import attempts/successes/failures, reuses, and fallbacks;
+- warnings and implicit destructor targets reused;
+- durable CFG export attempts/successes/rejections.
 
-Schema version 9 removes the obsolete population-binding query field. The
-authoritative `semantic_work.bind_invocations` and
-`semantic_work.declaration_reuse.durable_cache_population_exports` counters
-continue to gate the single-bind export path directly.
+All body, specialization, and CFG fields include work performed by failed
+semantic requests. Attempts are incremented before their fallible operation.
+Parallel CFG builders return per-function values which are reduced in canonical
+machine-symbol order.
 
-Schema version 10 adds explicit failed semantic-request accounting.
-`semantic_work.failed_requests` counts retained failure envelopes and
-`semantic_work.failure_phases` splits declaration, body-analysis, and CFG
-construction failures. All ordinary body, specialization, and CFG fields now
-include deterministic work performed before a failed request was discarded.
-Declaration failures likewise retain each counter completed before their exact
-fallible boundary, including declaration-index, binding, manifest, recovery
-body, and durable-reuse work when those stages were reached.
-Declaration binding distinguishes resolution invocations, resolution failures,
-and successful body-readiness finalizations, so a rejected declaration epoch
-does not masquerade as an unattempted or completed one.
-The `failed_semantic_edit` scenario hard-gates attempted/failed body work, and
-`semantic_recovery` proves that a failure did not replace the last-good durable
-declaration baseline.
+The cold N scenario requires exactly N body analyses, N durable body exports,
+and N CFG builds. It also requires exactly one declaration-cache population
+export from that same semantic epoch, proving that cold cache population does
+not run a duplicate binder or body-analysis pass. Exact no-op requires query
+reuse and zero semantic execution. Unrelated edit requires N imported bodies,
+N skipped analyses, N imported CFGs, zero body fallback, zero CFG build, and
+zero optimization.
+
+## Schema history and test coverage
+
+Schemas 2-3 introduced manifest/planner work and declaration reuse. Schema 4
+added body, specialization, and CFG work. Schemas 5-7 added body dependency
+records, stable owner tokens, and durable-body conversion/import accounting.
+Schema 8 added bounded diagnostic/manifest/plan retention. Schema 9 removed an
+obsolete population-binding field. Schema 10 added failed-request phase and
+partial-work accounting. Schema 11 adds the RUE-720 completion workloads, the
+remaining body and CFG counters, exact structural reuse gates, and bounded
+cold-versus-reused artifact/diagnostic/executable parity.
+
+The ordinary suite runs an N=4 structural smoke test through
+`//crates/rue-compiler-session-bench:rue-compiler-session-bench-test`. The full
+N=128 timing workload remains opt-in, but it executes the same assertions.
+
+This benchmark is deliberately bounded to synthetic, supported programs.
+[RUE-813](https://linear.app/steve-klabnik/issue/RUE-813) tracks a reusable,
+broader differential oracle. [RUE-901](https://linear.app/steve-klabnik/issue/RUE-901)
+tracks realistic multi-module cold/reused projects and performance baselines.
+Neither gap weakens the exact structural completion evidence recorded here.


### PR DESCRIPTION
Completes the RUE-720 release evidence for durable body and CFG reuse.

- extends the session benchmark to schema 11 with exact N=128 body/CFG reuse, specialization, invalidation, and recovery counters
- differentially checks public semantic/CFG artifacts, dependency manifests, diagnostics, and byte-identical emitted output against fresh sessions
- updates ADR 0050 and the incrementality audits to the implemented architecture and explicit remaining RUE-813/RUE-901 scope

Validation:
- focused compiler-session benchmark tests (2/2)
- schema-11 N=128 workload (24 scenarios, 8 parity scenarios)
- scripts/rue quick (25 targets)
- scripts/rue test (full suite passed)

Fixes RUE-888