### PR TITLE
RUE-896: add benchmark timeline annotations

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -12,6 +12,8 @@ on:
       - 'website/**'
       - 'scripts/generate-charts.py'
       - 'scripts/generate-site-status.py'
+      - 'scripts/benchmark_annotations.py'
+      - 'benchmarks/annotations.toml'
       - '.github/workflows/deploy-website.yml'
   # PRs still build (no deploy — that's trunk-only) on spec changes too, so a
   # spec edit that breaks the website build is caught before merge.
@@ -22,6 +24,8 @@ on:
       - 'docs/spec/**'
       - 'scripts/generate-charts.py'
       - 'scripts/generate-site-status.py'
+      - 'scripts/benchmark_annotations.py'
+      - 'benchmarks/annotations.toml'
       - '.github/workflows/deploy-website.yml'
   # Daily refresh so the published spec, benchmark sparkline, and status board
   # don't drift more than ~24 hours behind trunk.
@@ -47,6 +51,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Annotation commit/range validation needs the authoritative history.
+          fetch-depth: 0
 
       - name: Setup dotslash
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18

--- a/BUCK
+++ b/BUCK
@@ -102,6 +102,7 @@ filegroup(
     srcs = glob(["benchmarks/**"]) + [
         "scripts/append-benchmark.py",
         "scripts/benchmark_collection.py",
+        "scripts/benchmark_annotations.py",
         "scripts/benchmark_history.py",
         "scripts/benchmark_metrics.py",
         "scripts/benchmark_validation.py",

--- a/benchmarks/annotations.toml
+++ b/benchmarks/annotations.toml
@@ -1,0 +1,25 @@
+version = 1
+
+[[annotation]]
+commit = "2de9f67a23bed406ab85302c1045c00cfb138011"
+category = "optimization"
+title = "Recursive parser alternatives made linear"
+explanation = "Parser alternative construction was reworked to avoid recursive growth and improve scaling on deeply nested input."
+link = "https://github.com/rue-language/rue/pull/1638"
+
+[annotation.scope]
+metrics = ["latency", "throughput"]
+workloads = ["deep_nesting"]
+platforms = ["*"]
+
+[[annotation]]
+commit = "c5971e2586c983885e0fa703fc70821b8775207b"
+category = "optimization"
+title = "Stable per-function CFGs reused"
+explanation = "CompilerSession can reuse stable per-function control-flow graphs instead of rebuilding unchanged work."
+link = "https://github.com/rue-language/rue/pull/1644"
+
+[annotation.scope]
+metrics = ["latency", "throughput"]
+workloads = ["*"]
+platforms = ["*"]

--- a/docs/process/benchmark-annotations.md
+++ b/docs/process/benchmark-annotations.md
@@ -1,0 +1,29 @@
+# Benchmark annotations
+
+Curated performance events live in `benchmarks/annotations.toml`. The file is
+version controlled and validated by `scripts/benchmark_annotations.py`; chart,
+comparison, and homepage-status metadata all consume its one normalized event
+stream.
+
+Each `[[annotation]]` identifies either `commit`, or an inclusive
+`start_commit`/`end_commit` range. It includes one of these categories:
+`capability`, `optimization`, `benchmark_corpus`,
+`measurement_infrastructure`, `known_regression`, or `repair`. A title, concise
+explanation, Rue issue or pull-request link, and exact metric/workload/platform
+scope are required. `comparability_note` is optional. Use `"*"` alone for an
+unrestricted scope dimension.
+
+Commits must resolve in the Rue repository, ranges must follow ancestry, and
+duplicate or conflicting events fail the build. Multiple distinct events at a
+commit are valid and normalized deterministically.
+
+The normalizer also compares every pair of durable-history publication
+regimes. Any corpus, timing schema, build mode, iteration policy, runner,
+platform, scenario, or future regime-dimension change automatically creates a
+`measurement_infrastructure` event containing its before/after values. This
+makes comparability-boundary annotations structural rather than an authoring
+convention. Missing annotation files and old histories without publication
+regimes remain valid; an entirely legacy history has no derived events, while
+either transition between unknown legacy identity and an explicit regime is
+annotated as a comparability boundary with the absent identity shown as
+`unknown`.

--- a/scripts/benchmark_annotations.py
+++ b/scripts/benchmark_annotations.py
@@ -1,0 +1,281 @@
+"""Versioned benchmark annotations and derived measurement-boundary events."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+CATEGORIES = {
+    "capability",
+    "optimization",
+    "benchmark_corpus",
+    "measurement_infrastructure",
+    "known_regression",
+    "repair",
+}
+METRICS = {"latency", "throughput", "memory", "binary_size", "*"}
+REPOSITORY = "https://github.com/rue-language/rue"
+LINK_RE = re.compile(rf"{re.escape(REPOSITORY)}/(?:issues|pull)/[1-9][0-9]*$")
+COMMIT_RE = re.compile(r"[0-9a-f]{7,40}$")
+SCOPE_IDENTIFIER_RE = re.compile(r"[a-z0-9]+(?:[._-][a-z0-9]+)*$")
+DEFAULT_ANNOTATIONS = Path(__file__).resolve().parent.parent / "benchmarks" / "annotations.toml"
+
+
+class GitCommitResolver:
+    """Resolve and order annotation commits against the authoritative repository."""
+
+    def __init__(self, repository: Path):
+        self.repository = repository
+
+    def canonical(self, commit: str) -> str:
+        process = subprocess.run(
+            ["git", "rev-parse", "--verify", f"{commit}^{{commit}}"],
+            cwd=self.repository,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        value = process.stdout.strip()
+        if process.returncode != 0 or not re.fullmatch(r"[0-9a-f]{40}", value):
+            raise ValueError(f"unknown annotation commit: {commit}")
+        return value
+
+    def is_ancestor(self, start: str, end: str) -> bool:
+        return subprocess.run(
+            ["git", "merge-base", "--is-ancestor", start, end],
+            cwd=self.repository,
+            capture_output=True,
+            check=False,
+        ).returncode == 0
+
+    def timestamp(self, commit: str) -> int:
+        process = subprocess.run(
+            ["git", "show", "-s", "--format=%ct", commit],
+            cwd=self.repository,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if process.returncode != 0 or not process.stdout.strip().isdigit():
+            raise ValueError(f"unknown annotation commit: {commit}")
+        return int(process.stdout.strip())
+
+
+def load_annotations(path: Path = DEFAULT_ANNOTATIONS) -> list[dict]:
+    """Load authored annotations; a missing file is valid legacy input."""
+    if not path.exists():
+        return []
+    value = tomllib.loads(path.read_text())
+    if value.get("version") != SCHEMA_VERSION:
+        raise ValueError(f"benchmark annotation schema version must be {SCHEMA_VERSION}")
+    unknown = set(value) - {"version", "annotation"}
+    if unknown:
+        raise ValueError(f"unknown benchmark annotation document fields: {', '.join(sorted(unknown))}")
+    annotations = value.get("annotation", [])
+    if not isinstance(annotations, list) or any(not isinstance(item, dict) for item in annotations):
+        raise ValueError("benchmark annotations must be an array of tables")
+    return annotations
+
+
+def _text(item: dict, field: str, maximum: int) -> str:
+    value = item.get(field)
+    if not isinstance(value, str) or not value.strip() or value != value.strip() or len(value) > maximum:
+        raise ValueError(f"annotation {field} must be non-empty, trimmed, and at most {maximum} characters")
+    return value
+
+
+def _scope(value: object) -> dict:
+    if not isinstance(value, dict) or set(value) != {"metrics", "workloads", "platforms"}:
+        raise ValueError("annotation scope must contain only metrics, workloads, and platforms")
+    result = {}
+    for field in ("metrics", "workloads", "platforms"):
+        entries = value.get(field)
+        if (
+            not isinstance(entries, list)
+            or not entries
+            or any(
+                not isinstance(entry, str)
+                or not entry
+                or entry != entry.strip()
+                or (entry != "*" and not SCOPE_IDENTIFIER_RE.fullmatch(entry))
+                for entry in entries
+            )
+            or len(entries) != len(set(entries))
+        ):
+            raise ValueError(f"annotation scope {field} must be a non-empty unique string list")
+        result[field] = sorted(entries)
+        if "*" in result[field] and len(result[field]) != 1:
+            raise ValueError(f"annotation scope {field} cannot combine * with named values")
+    if any(metric not in METRICS for metric in result["metrics"]):
+        raise ValueError("annotation scope contains an invalid metric family")
+    return result
+
+
+def _location(item: dict, resolver) -> dict:
+    has_commit = "commit" in item
+    has_range = "start_commit" in item or "end_commit" in item
+    if has_commit == has_range:
+        raise ValueError("annotation must specify exactly one commit or one commit range")
+    fields = ["commit"] if has_commit else ["start_commit", "end_commit"]
+    if any(not isinstance(item.get(field), str) or not COMMIT_RE.fullmatch(item[field]) for field in fields):
+        raise ValueError("annotation commit keys must be 7-40 lowercase hexadecimal characters")
+    commits = [resolver.canonical(item[field]) for field in fields]
+    if has_commit:
+        return {"kind": "commit", "commit": commits[0]}
+    if not resolver.is_ancestor(commits[0], commits[1]):
+        raise ValueError("annotation range start must be an ancestor of its end")
+    return {"kind": "range", "start_commit": commits[0], "end_commit": commits[1]}
+
+
+def _event_id(event: dict) -> str:
+    encoded = json.dumps(event, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_authored_annotations(annotations: list[dict], resolver) -> list[dict]:
+    """Validate and normalize checked-in annotations or raise ValueError."""
+    normalized = []
+    identities = {}
+    allowed = {
+        "commit", "start_commit", "end_commit", "category", "title",
+        "explanation", "link", "scope", "comparability_note",
+    }
+    for index, item in enumerate(annotations, 1):
+        unknown = set(item) - allowed
+        if unknown:
+            raise ValueError(f"annotation #{index} has unknown fields: {', '.join(sorted(unknown))}")
+        category = item.get("category")
+        if category not in CATEGORIES:
+            raise ValueError(f"annotation #{index} has invalid category: {category}")
+        title = _text(item, "title", 100)
+        explanation = _text(item, "explanation", 500)
+        link = item.get("link")
+        if not isinstance(link, str) or not LINK_RE.fullmatch(link):
+            raise ValueError(f"annotation #{index} must link to a Rue issue or pull request")
+        event = {
+            "source": "authored",
+            "location": _location(item, resolver),
+            "category": category,
+            "title": title,
+            "explanation": explanation,
+            "link": link,
+            "scope": _scope(item.get("scope")),
+        }
+        if "comparability_note" in item:
+            event["comparability_note"] = _text(item, "comparability_note", 300)
+        identity = (
+            json.dumps(event["location"], sort_keys=True),
+            event["category"],
+            event["title"],
+        )
+        serialized = json.dumps(event, sort_keys=True, separators=(",", ":"))
+        if identity in identities:
+            kind = "duplicate" if identities[identity] == serialized else "conflicting"
+            raise ValueError(f"{kind} benchmark annotation event: {title}")
+        identities[identity] = serialized
+        event["id"] = _event_id(event)
+        normalized.append(event)
+    return normalized
+
+
+def _regime(run: dict) -> dict | None:
+    publication = run.get("publication")
+    regime = publication.get("regime") if isinstance(publication, dict) else None
+    return regime if isinstance(regime, dict) else None
+
+
+def derived_identity_annotations(runs: list[dict], resolver) -> list[dict]:
+    """Derive an event for every durable measurement-identity transition."""
+    events = []
+    for previous, current in zip(runs, runs[1:]):
+        before, after = _regime(previous), _regime(current)
+        if before is None and after is None:
+            continue
+        if before == after:
+            continue
+        before_dimensions = before or {}
+        after_dimensions = after or {}
+        changed = sorted(set(before_dimensions) | set(after_dimensions), key=str)
+        changed = [
+            field
+            for field in changed
+            if before_dimensions.get(field) != after_dimensions.get(field)
+        ]
+        raw_commit = current.get("commit")
+        if not isinstance(raw_commit, str) or not raw_commit:
+            raise ValueError("measurement identity change has no commit")
+        commit = resolver.canonical(raw_commit)
+        platform = after_dimensions.get("platform", before_dimensions.get("platform", "*"))
+        before_state = "explicit" if before is not None else "unknown"
+        after_state = "explicit" if after is not None else "unknown"
+        explanation = (
+            f"Durable measurement identity changed from {before_state} to {after_state}: "
+            + ", ".join(changed)
+            + "."
+        )
+        event = {
+            "source": "derived",
+            "location": {"kind": "commit", "commit": commit},
+            "category": "measurement_infrastructure",
+            "title": "Benchmark measurement identity changed",
+            "explanation": explanation,
+            "link": f"{REPOSITORY}/commit/{commit}",
+            "scope": _scope({
+                "metrics": ["*"],
+                "workloads": ["*"],
+                "platforms": [platform],
+            }),
+            "comparability_note": "A comparability boundary occurs at this measurement.",
+            "changed_dimensions": changed,
+            "identity_change": {
+                "before": {"status": before_state, "dimensions": before},
+                "after": {"status": after_state, "dimensions": after},
+            },
+            "dimension_changes": {
+                field: {
+                    "before": before_dimensions.get(field),
+                    "after": after_dimensions.get(field),
+                }
+                for field in changed
+            },
+        }
+        event["id"] = _event_id(event)
+        events.append(event)
+    return events
+
+
+def normalized_annotation_stream(
+    histories: list[list[dict]], authored: list[dict], resolver
+) -> list[dict]:
+    """Return one deterministic stream shared by every benchmark data product."""
+    events = validate_authored_annotations(authored, resolver)
+    for runs in histories:
+        events.extend(derived_identity_annotations(runs, resolver))
+
+    # The same automatic transition can appear in multiple products. Event IDs
+    # make their union stable without hiding distinct platform-scoped changes.
+    events = list({event["id"]: event for event in events}.values())
+
+    def sort_key(event: dict) -> tuple:
+        location = event["location"]
+        commit = location.get("commit", location.get("start_commit"))
+        return (
+            resolver.timestamp(commit),
+            commit,
+            event["category"],
+            event["title"],
+            event["source"],
+            event["id"],
+        )
+
+    return sorted(events, key=sort_key)
+
+
+def normalized_annotations(runs: list[dict], authored: list[dict], resolver) -> list[dict]:
+    return normalized_annotation_stream([runs], authored, resolver)

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -38,7 +38,16 @@ from benchmark_history import (
     load_history,
     run_regime,
 )
+from benchmark_annotations import (
+    DEFAULT_ANNOTATIONS,
+    GitCommitResolver,
+    load_annotations,
+    normalized_annotation_stream,
+    normalized_annotations,
+)
 from benchmark_metrics import derive_history_metrics
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Chart dimensions
 TIMELINE_WIDTH = 800
@@ -1229,6 +1238,11 @@ def generate_platform_charts(history_path: Path, output_dir: Path, platform: Opt
         "coverage": coverage,
         "regimes": regime_summary(runs),
         "metric_semantics": derive_history_metrics(runs),
+        "annotations": normalized_annotations(
+            runs,
+            load_annotations(DEFAULT_ANNOTATIONS),
+            GitCommitResolver(REPO_ROOT),
+        ),
     }
     if platform:
         metadata["platform"] = platform
@@ -1294,7 +1308,12 @@ def generate_comparison_charts(history_files: list[Path], output_dir: Path):
     # Generate comparison metadata
     metadata = {
         "platforms": platform_info_list,
-        "default_platform": platform_info_list[0]["id"] if platform_info_list else None
+        "default_platform": platform_info_list[0]["id"] if platform_info_list else None,
+        "annotations": normalized_annotation_stream(
+            list(platform_data.values()),
+            load_annotations(DEFAULT_ANNOTATIONS),
+            GitCommitResolver(REPO_ROOT),
+        ),
     }
     metadata_path = output_dir / "metadata.json"
     with open(metadata_path, "w") as f:

--- a/scripts/generate-site-status.py
+++ b/scripts/generate-site-status.py
@@ -29,6 +29,12 @@ import sys
 from pathlib import Path
 
 from benchmark_history import latest_comparable_segment, load_history
+from benchmark_annotations import (
+    DEFAULT_ANNOTATIONS,
+    GitCommitResolver,
+    load_annotations,
+    normalized_annotations,
+)
 from benchmark_metrics import derive_history_metrics
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -87,7 +93,7 @@ def spec_case_count() -> int:
     )
 
 
-def sparkline_data(runs: list[dict]) -> dict | None:
+def sparkline_data(runs: list[dict], annotations: list[dict] | None = None) -> dict | None:
     comparable_segment = latest_comparable_segment(runs)
     runs = comparable_segment[-SPARKLINE_RUNS:]
     totals = []
@@ -124,6 +130,7 @@ def sparkline_data(runs: list[dict]) -> dict | None:
         result["performance_index"] = latest["performance_index"]
         result["previous_comparison"] = latest["previous"]
         result["baseline_comparison"] = latest["rolling_baseline"]
+    result["annotations"] = annotations or []
     return result
 
 
@@ -138,7 +145,13 @@ def bench_sparkline() -> dict | None:
     except (OSError, json.JSONDecodeError, ValueError):
         return None
 
-    return sparkline_data(history.get("runs", []))
+    runs = history.get("runs", [])
+    annotations = normalized_annotations(
+        runs,
+        load_annotations(DEFAULT_ANNOTATIONS),
+        GitCommitResolver(REPO_ROOT),
+    )
+    return sparkline_data(runs, annotations)
 
 
 def main() -> int:

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -30,6 +30,7 @@ def load_module(name: str, relative_path: str):
 
 validator = load_module("validate_benchmark", "scripts/validate-benchmark.py")
 collection = load_module("benchmark_collection", "scripts/benchmark_collection.py")
+annotations = load_module("benchmark_annotations", "scripts/benchmark_annotations.py")
 charts = load_module("generate_charts", "scripts/generate-charts.py")
 site_status = load_module("generate_site_status", "scripts/generate-site-status.py")
 history_tools = load_module("benchmark_history", "scripts/benchmark_history.py")
@@ -1068,6 +1069,218 @@ class BenchmarkMetricSemanticsTests(unittest.TestCase):
             status["performance_index"]["value"],
             100 * 100 / 124,
         )
+
+
+class TestBenchmarkAnnotations(unittest.TestCase):
+    class Resolver:
+        def __init__(self, commits=("aaaaaaa", "bbbbbbb", "ccccccc")):
+            self.commits = {commit: commit[0] * 40 for commit in commits}
+
+        def canonical(self, commit):
+            if commit not in self.commits and commit not in self.commits.values():
+                raise ValueError(f"unknown annotation commit: {commit}")
+            return self.commits.get(commit, commit)
+
+        def is_ancestor(self, start, end):
+            order = list(self.commits.values())
+            return order.index(start) <= order.index(end)
+
+        def timestamp(self, commit):
+            values = list(self.commits.values())
+            if commit not in values:
+                raise ValueError("unknown")
+            return values.index(commit) + 1
+
+    @staticmethod
+    def authored(commit="aaaaaaa", category="optimization", title="Useful optimization"):
+        return {
+            "commit": commit,
+            "category": category,
+            "title": title,
+            "explanation": "This is a concise explanation of the benchmark event.",
+            "link": "https://github.com/rue-language/rue/pull/123",
+            "scope": {
+                "metrics": ["latency"],
+                "workloads": ["probe"],
+                "platforms": ["x86-64-linux"],
+            },
+        }
+
+    @staticmethod
+    def sample_run(commit, regime=None):
+        publication = {"comparable": True, "regime_id": "regime"}
+        if regime is not None:
+            publication["regime"] = regime
+        return {"commit": commit, "publication": publication, "benchmarks": []}
+
+    def test_commit_ranges_and_same_commit_events_normalize_deterministically(self):
+        resolver = self.Resolver()
+        first = self.authored("bbbbbbb", title="Zulu")
+        second = self.authored("bbbbbbb", category="repair", title="Alpha")
+        ranged = {
+            **self.authored(title="Range"),
+            "start_commit": "aaaaaaa",
+            "end_commit": "ccccccc",
+        }
+        del ranged["commit"]
+        stream = annotations.normalized_annotations([], [first, ranged, second], resolver)
+        self.assertEqual([event["title"] for event in stream], ["Range", "Zulu", "Alpha"])
+        self.assertEqual(stream[0]["location"]["kind"], "range")
+        self.assertEqual(len({event["id"] for event in stream}), 3)
+
+    def test_invalid_categories_commits_links_scopes_and_fields_are_rejected(self):
+        resolver = self.Resolver()
+        mutations = [
+            (lambda event: event.update(category="invalid"), "invalid category"),
+            (lambda event: event.update(commit="ddddddd"), "unknown annotation commit"),
+            (lambda event: event.update(link="https://example.com/123"), "must link"),
+            (lambda event: event["scope"].update(metrics=["seconds_plus_bytes"]), "invalid metric"),
+            (lambda event: event["scope"].update(workloads=[" probe"]), "unique string list"),
+            (lambda event: event["scope"].update(platforms=["linux/x86"]), "unique string list"),
+            (lambda event: event["scope"].update(workloads=["*", "probe"]), "cannot combine"),
+            (lambda event: event["scope"].update(metrics=["*", "latency"]), "cannot combine"),
+            (lambda event: event.update(typo=True), "unknown fields"),
+            (lambda event: event.update(title=""), "title must be"),
+        ]
+        for mutate, message in mutations:
+            with self.subTest(message=message):
+                event = self.authored()
+                mutate(event)
+                with self.assertRaisesRegex(ValueError, message):
+                    annotations.normalized_annotations([], [event], resolver)
+
+    def test_duplicate_and_conflicting_events_are_rejected(self):
+        resolver = self.Resolver()
+        event = self.authored()
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            annotations.normalized_annotations([], [event, dict(event)], resolver)
+        conflict = {**event, "explanation": "A different explanation."}
+        with self.assertRaisesRegex(ValueError, "conflicting"):
+            annotations.normalized_annotations([], [event, conflict], resolver)
+
+    def test_invalid_or_incomplete_ranges_are_rejected(self):
+        resolver = self.Resolver()
+        reversed_range = {
+            **self.authored(),
+            "start_commit": "ccccccc",
+            "end_commit": "aaaaaaa",
+        }
+        del reversed_range["commit"]
+        with self.assertRaisesRegex(ValueError, "ancestor"):
+            annotations.normalized_annotations([], [reversed_range], resolver)
+        incomplete = {**self.authored(), "start_commit": "aaaaaaa"}
+        del incomplete["commit"]
+        with self.assertRaisesRegex(ValueError, "commit keys"):
+            annotations.normalized_annotations([], [incomplete], resolver)
+
+    def test_every_measurement_identity_change_is_derived_with_all_dimensions(self):
+        before = {
+            "platform": "x86-64-linux",
+            "corpus_sha256": "old",
+            "timing_schema_versions": [1],
+            "build_mode": "release",
+            "iteration_policy": {"kind": "fixed", "iterations": 5},
+            "runner_image": "old-image",
+            "scenario_family": "cold_compilation",
+        }
+        after = {
+            **before,
+            "corpus_sha256": "new",
+            "timing_schema_versions": [2],
+            "runner_image": "new-image",
+        }
+        events = annotations.derived_identity_annotations(
+            [
+                self.sample_run("a" * 40, before),
+                self.sample_run("b" * 40, after),
+            ],
+            self.Resolver(),
+        )
+        self.assertEqual(len(events), 1)
+        self.assertEqual(
+            events[0]["changed_dimensions"],
+            ["corpus_sha256", "runner_image", "timing_schema_versions"],
+        )
+        self.assertEqual(events[0]["dimension_changes"]["corpus_sha256"], {
+            "before": "old", "after": "new"
+        })
+        self.assertEqual(events[0]["identity_change"]["before"]["status"], "explicit")
+        self.assertEqual(events[0]["identity_change"]["after"]["status"], "explicit")
+        self.assertEqual(events[0]["category"], "measurement_infrastructure")
+
+    def test_legacy_to_explicit_transition_is_automatically_annotated(self):
+        regime = {"platform": "x86-64-linux", "runner_image": "image"}
+        events = annotations.derived_identity_annotations(
+            [
+                self.sample_run("a" * 40),
+                self.sample_run("b" * 40, regime),
+            ],
+            self.Resolver(),
+        )
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["location"]["commit"], "b" * 40)
+        self.assertEqual(events[0]["identity_change"]["before"], {
+            "status": "unknown", "dimensions": None
+        })
+        self.assertEqual(events[0]["identity_change"]["after"], {
+            "status": "explicit", "dimensions": regime
+        })
+
+    def test_explicit_to_legacy_transition_is_automatically_annotated(self):
+        regime = {"platform": "x86-64-linux", "runner_image": "image"}
+        events = annotations.derived_identity_annotations(
+            [
+                self.sample_run("a" * 40, regime),
+                self.sample_run("b" * 40),
+            ],
+            self.Resolver(),
+        )
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["identity_change"]["before"]["status"], "explicit")
+        self.assertEqual(events[0]["identity_change"]["after"], {
+            "status": "unknown", "dimensions": None
+        })
+
+    def test_derived_transition_rejects_unknown_run_commit(self):
+        with self.assertRaisesRegex(ValueError, "unknown annotation commit"):
+            annotations.derived_identity_annotations(
+                [
+                    self.sample_run("a" * 40, {"platform": "one"}),
+                    self.sample_run("d" * 40, {"platform": "two"}),
+                ],
+                self.Resolver(),
+            )
+
+    def test_commit_order_resolution_errors_are_not_silenced(self):
+        resolver = self.Resolver()
+        with mock.patch.object(
+            resolver, "timestamp", side_effect=ValueError("timestamp failure")
+        ):
+            with self.assertRaisesRegex(ValueError, "timestamp failure"):
+                annotations.normalized_annotations(
+                    [], [self.authored()], resolver
+                )
+
+    def test_legacy_history_and_missing_annotation_file_are_supported(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.assertEqual(
+                annotations.load_annotations(Path(temp_dir) / "missing.toml"), []
+            )
+        self.assertEqual(
+            annotations.normalized_annotations(
+                [self.sample_run("legacy")], [], self.Resolver()
+            ),
+            [],
+        )
+
+    def test_recent_status_receives_the_canonical_stream_unchanged(self):
+        run = BenchmarkMetricSemanticsTests.sample_run(
+            "a" * 40, {"probe": [10, 10, 10]}
+        )
+        stream = annotations.normalized_annotations(
+            [run], [self.authored()], self.Resolver()
+        )
+        self.assertEqual(site_status.sparkline_data([run], stream)["annotations"], stream)
 
 
 class BenchmarkCollectionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a version-controlled schema for benchmark milestone and regime annotations
- derive unavoidable events for every durable measurement-identity boundary
- publish one normalized deterministic stream to platform, comparison, and homepage status data
- backfill queryable compiler and parser scaling milestones

## Validation

- `./buck2 test //:benchmark-tool-tests` (63 tests)
- `scripts/rue quick` (25 targets)
- `website/build.sh`
- `git diff --check`

Fixes RUE-896