### PR TITLE
RUE-659: move finalized type pool

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -460,9 +460,6 @@ fn finalize_function_body_analysis(
         functions,
         strings: global_strings,
         warnings: all_warnings,
-        // Specialization can intern new composite types, so snapshot only
-        // after its fixed point has completed.
-        type_pool: sema.type_pool.clone(),
         body_analysis_work: sema.body_analysis_work,
         ordinary_body_exports: std::mem::take(&mut sema.ordinary_body_exports),
         specialized_body_exports: std::mem::take(&mut sema.specialized_body_exports),
@@ -552,6 +549,10 @@ fn finalize_function_body_analysis(
             sema.named_const_dependencies.clone()
         },
         named_value_const_dependencies_complete: true,
+        // Body analysis and specialization can intern composite and anonymous
+        // types. Transfer the completed pool only after every finalization
+        // consumer above has finished reading semantic state.
+        type_pool: std::mem::take(&mut sema.type_pool),
     };
 
     errors.into_result_with(output)

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -582,6 +582,63 @@ mod tests {
         )));
     }
 
+    #[test]
+    fn output_type_pool_includes_composite_type_interned_by_specialization() {
+        let output = compile_to_air(
+            "fn zeros(comptime N: i32) -> [i32; N] { [0; N] }\n\
+             fn main() -> i32 { let _values = zeros(3); 0 }",
+        )
+        .unwrap();
+
+        // The generic declaration cannot intern `[i32; N]`: its length is
+        // unknown until the reachable call specializes `N` to 3.
+        assert_eq!(output.body_analysis_work.specialized_bodies_succeeded, 1);
+        assert!(
+            output.type_pool.stats().array_count >= 1,
+            "the finalized pool must retain the array interned by specialization"
+        );
+        assert!(output.functions.iter().any(|function| {
+            function.name != "main"
+                && function
+                    .air
+                    .return_type()
+                    .safe_name_with_pool(Some(&output.type_pool))
+                    == "[i32; 3]"
+        }));
+    }
+
+    #[test]
+    fn output_type_pool_includes_late_anonymous_destructor_owner() {
+        let output = compile_to_air(
+            "fn Box(comptime T: type) -> type {\n\
+                 struct { value: T, drop fn(self) {} }\n\
+             }\n\
+             fn main() { let B = Box(i32); let _value = B { value: 1 }; }",
+        )
+        .unwrap();
+
+        let anonymous = output
+            .type_pool
+            .all_struct_ids()
+            .into_iter()
+            .find(|&id| {
+                output
+                    .type_pool
+                    .struct_def(id)
+                    .name
+                    .starts_with("__anon_struct_")
+            })
+            .expect("body-time type discovery must survive in the finalized pool");
+        let destructor_name = format!("{}.__drop", output.type_pool.struct_def(anonymous).name);
+        assert!(
+            output
+                .functions
+                .iter()
+                .any(|function| function.name == destructor_name),
+            "the anonymous destructor owner and its analyzed body must agree"
+        );
+    }
+
     fn named_method_lookup_work(irrelevant: usize) -> crate::BodyAnalysisWork {
         let mut source = String::from(
             "struct Target { fn answer() -> i32 { 42 } }\n\

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -800,7 +800,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// falls back to file-level `const`s and literals like [`resolve_type`]. A
     /// length that resolves to none of these (a runtime parameter) still gets a
     /// clean E0481. The specialized array type is interned into the same pool
-    /// the CFG builder later sees (the pool is cloned *after* specialization,
+    /// the CFG builder later sees (the pool is transferred *after* specialization,
     /// RUE-282), so drop analysis of a comptime-value-length local array no
     /// longer hits an out-of-bounds `ArrayTypeId`.
     ///


### PR DESCRIPTION
## Summary

- transfer the completed semantic `TypeInternPool` into `SemaOutput` instead of deep-cloning it
- preserve the independent scratch clone required for atomic durable-body import
- cover composite types interned during specialization and late anonymous destructor owners

## Why

Semantic finalization copied every type vector and lookup map immediately before CFG construction and code generation. The semantic epoch is consumed by body analysis, so the completed pool can be moved after all finalization reads without changing type identity or downstream ownership.

## Performance

Three fresh `large_structs` samples with zero warmups measured median peak RSS falling from 53,837,824 bytes to 53,346,304 bytes (491,520 bytes, about 0.91%). Median sema time moved from 104.405 ms to 106.916 ms; that 2.4% difference is inconclusive at this sample count.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick`
- full `rue-air` tests (405 passed)
- independent adversarial review plus `scripts/rue test output_type_pool`
- full `scripts/rue test` (34 lightweight targets; 1,450 CLI; 64/64 generated oracle; reproducibility; 2,071 spec; 178 UI)

Fixes RUE-659
