### PR TITLE
RUE-897: build recent regression workspace

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -13,6 +13,7 @@ on:
       - 'scripts/generate-charts.py'
       - 'scripts/generate-site-status.py'
       - 'scripts/benchmark_annotations.py'
+      - 'scripts/benchmark_recent.py'
       - 'benchmarks/annotations.toml'
       - '.github/workflows/deploy-website.yml'
   # PRs still build (no deploy — that's trunk-only) on spec changes too, so a
@@ -25,6 +26,7 @@ on:
       - 'scripts/generate-charts.py'
       - 'scripts/generate-site-status.py'
       - 'scripts/benchmark_annotations.py'
+      - 'scripts/benchmark_recent.py'
       - 'benchmarks/annotations.toml'
       - '.github/workflows/deploy-website.yml'
   # Daily refresh so the published spec, benchmark sparkline, and status board

--- a/BUCK
+++ b/BUCK
@@ -105,11 +105,13 @@ filegroup(
         "scripts/benchmark_annotations.py",
         "scripts/benchmark_history.py",
         "scripts/benchmark_metrics.py",
+        "scripts/benchmark_recent.py",
         "scripts/benchmark_validation.py",
         "scripts/generate-charts.py",
         "scripts/generate-site-status.py",
         "scripts/perf-baseline.py",
         "scripts/validate-benchmark.py",
+        "website/templates/performance.html",
     ],
 )
 

--- a/docs/process/benchmark-recent-workspace.md
+++ b/docs/process/benchmark-recent-workspace.md
@@ -1,0 +1,22 @@
+# Recent benchmark regression workspace
+
+`scripts/benchmark_recent.py` builds the renderer-neutral model used by the
+detailed performance page. It takes durable RUE-894 runs, RUE-895 semantic
+results, and the single RUE-896 annotation stream; browser code only selects
+and renders model entries.
+
+The model retains at most 100 measured points and offers 20, 50, and 100 point
+windows. Every point carries authoritative commit metadata and links, measured
+and skipped coverage separately, relative and wall-clock freshness (stale
+after 48 hours), comparability, applicable
+annotations, raw samples, and robust uncertainty. Skipped commits are never
+represented as measurements and comparison boundaries remain explicit.
+
+Selectable comparisons are any ordered pair inside one uninterrupted canonical
+segment; gaps, regimes, workload sets, and scenarios are never crossed. Their canonical
+explanation includes per-workload robust deltas, compiler-pass contributions,
+and separate memory and binary-size changes. The default is the latest valid
+pair. Per-workload small multiples replace the overplotted seven-line chart;
+tables expose the same raw values and uncertainty to keyboard and screen-reader
+users. The page defaults to the first platform containing data, while the
+cross-platform view remains available explicitly.

--- a/scripts/benchmark_metrics.py
+++ b/scripts/benchmark_metrics.py
@@ -97,6 +97,11 @@ def _sample_summary(samples: object) -> dict | None:
     }
 
 
+def sample_summary(samples: object) -> dict | None:
+    """Return the public robust center/uncertainty summary for raw samples."""
+    return _sample_summary(samples)
+
+
 def _classification(delta_pct: float, variation_pct: float) -> str:
     if delta_pct > variation_pct:
         return "regressed"
@@ -123,7 +128,7 @@ def _headline(per_workload: dict[str, dict]) -> dict:
 
 
 def compare_runs(current: dict, reference: dict) -> dict:
-    """Compare two adjacent points without crossing semantic boundaries."""
+    """Compare two points after the caller has preserved intervening boundaries."""
     identity = require_same_identity(reference, current)
     if run_regime(reference) != run_regime(current) or comparison_break(reference, current):
         return {"status": "non_comparable", "reason": "regime_boundary", **identity}
@@ -257,6 +262,78 @@ def metric_families(run: dict) -> dict:
         if isinstance(bench.get("binary_size_bytes"), (int, float)):
             families["binary_size_bytes"][name] = bench["binary_size_bytes"]
     return families
+
+
+def comparison_explanation(current: dict, reference: dict) -> dict:
+    """Explain one valid comparison by workload, pass, memory, and binary size."""
+    comparison = compare_runs(current, reference)
+    if comparison.get("status") != "comparable":
+        return comparison
+    current_benches, reference_benches = _benches(current), _benches(reference)
+    workloads = []
+    pass_totals: dict[str, dict[str, float]] = {}
+    memory = []
+    binary = []
+    for name in workload_names(current):
+        detail = comparison["workloads"][name]
+        current_center = detail.get("current_median_ms")
+        reference_center = detail.get("reference_median_ms")
+        delta_ms = (
+            current_center - reference_center
+            if current_center is not None and reference_center is not None
+            else None
+        )
+        workloads.append({"name": name, "delta_ms": delta_ms, **detail})
+        current_passes = current_benches[name].get("passes", {})
+        reference_passes = reference_benches[name].get("passes", {})
+        if isinstance(current_passes, dict) and isinstance(reference_passes, dict):
+            # A pass observed on only one side is missing evidence, not a zero.
+            for pass_name in sorted(set(current_passes) & set(reference_passes)):
+                if pass_name in {"compile", "parse"}:
+                    continue
+                current_pass = current_passes[pass_name]
+                reference_pass = reference_passes[pass_name]
+                current_value = current_pass.get("mean_ms") if isinstance(current_pass, dict) else None
+                reference_value = reference_pass.get("mean_ms") if isinstance(reference_pass, dict) else None
+                if isinstance(current_value, (int, float)) and isinstance(reference_value, (int, float)):
+                    totals = pass_totals.setdefault(
+                        pass_name,
+                        {"before_ms": 0, "after_ms": 0, "observations": 0},
+                    )
+                    totals["before_ms"] += reference_value
+                    totals["after_ms"] += current_value
+                    totals["observations"] += 1
+        for field, target in (("peak_memory_bytes", memory), ("binary_size_bytes", binary)):
+            current_value = current_benches[name].get(field)
+            reference_value = reference_benches[name].get(field)
+            if isinstance(current_value, (int, float)) and isinstance(reference_value, (int, float)):
+                target.append({
+                    "name": name,
+                    "before": reference_value,
+                    "after": current_value,
+                    "delta": current_value - reference_value,
+                })
+    passes = [
+        {
+            "name": name,
+            "before_ms": values["before_ms"],
+            "after_ms": values["after_ms"],
+            "delta_ms": values["after_ms"] - values["before_ms"],
+        }
+        for name, values in sorted(pass_totals.items())
+        if values["observations"] == len(workloads)
+    ]
+    comparable_workloads = [item for item in workloads if item["delta_ms"] is not None]
+    return {
+        "status": "comparable",
+        "headline": comparison["headline"],
+        "workloads": workloads,
+        "passes": passes,
+        "memory_bytes": memory,
+        "binary_size_bytes": binary,
+        "dominant_workload": max(comparable_workloads, key=lambda item: abs(item["delta_ms"]), default=None),
+        "dominant_pass": max(passes, key=lambda item: abs(item["delta_ms"]), default=None),
+    }
 
 
 def derive_history_metrics(runs: list[dict]) -> dict:

--- a/scripts/benchmark_recent.py
+++ b/scripts/benchmark_recent.py
@@ -1,0 +1,236 @@
+"""Renderer-neutral recent benchmark regression workspace."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from benchmark_history import run_regime
+from benchmark_metrics import (
+    comparison_explanation,
+    derive_history_metrics,
+    sample_summary,
+)
+
+
+WINDOWS = (20, 50, 100)
+STALE_AFTER_SECONDS = 48 * 60 * 60
+ISSUE_RE = re.compile(r"\bRUE-[0-9]+\b")
+PR_RE = re.compile(r"#([1-9][0-9]*)\b")
+REPOSITORY = "https://github.com/rue-language/rue"
+
+
+class GitRecentResolver:
+    def __init__(self, repository: Path):
+        self.repository = repository
+
+    def metadata(self, commit: str) -> dict:
+        process = subprocess.run(
+            ["git", "show", "-s", "--format=%H%x00%s%x00%cs%x00%B", commit],
+            cwd=self.repository,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        fields = process.stdout.rstrip("\n").split("\0")
+        if process.returncode != 0 or len(fields) != 4:
+            raise ValueError(f"unknown benchmark commit: {commit}")
+        canonical, subject, date, body = fields
+        issues = sorted(set(ISSUE_RE.findall(subject + "\n" + body)))
+        pulls = sorted({int(value) for value in PR_RE.findall(subject + "\n" + body)})
+        return {
+            "commit": canonical,
+            "metadata_status": "available",
+            "subject": subject,
+            "date": date,
+            "links": {
+                "commit": f"{REPOSITORY}/commit/{canonical}",
+                "issues": [
+                    {"id": issue, "url": f"https://linear.app/steve-klabnik/issue/{issue}"}
+                    for issue in issues
+                ],
+                "pull_requests": [
+                    {"id": f"PR #{number}", "url": f"{REPOSITORY}/pull/{number}"}
+                    for number in pulls
+                ],
+            },
+        }
+
+    def is_ancestor(self, start: str, end: str) -> bool:
+        return subprocess.run(
+            ["git", "merge-base", "--is-ancestor", start, end],
+            cwd=self.repository,
+            capture_output=True,
+            check=False,
+        ).returncode == 0
+
+
+def _annotation_applies(event: dict, commit: str, resolver) -> bool:
+    location = event.get("location", {})
+    if location.get("kind") == "commit":
+        return location.get("commit") == commit
+    if location.get("kind") == "range":
+        return resolver.is_ancestor(location["start_commit"], commit) and resolver.is_ancestor(
+            commit, location["end_commit"]
+        )
+    return False
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def recent_workspace(
+    runs: list[dict],
+    annotations: list[dict],
+    resolver,
+    platform: str,
+    as_of: datetime | None = None,
+) -> dict:
+    """Build the only model consumed by the recent-workspace UI."""
+    selected_runs = runs[-max(WINDOWS):]
+    derived = derive_history_metrics(selected_runs)
+    timestamps = [
+        value for run in selected_runs
+        if (value := _parse_timestamp(run.get("timestamp"))) is not None
+    ]
+    newest = max(timestamps, default=None)
+    as_of = as_of or datetime.now(timezone.utc)
+    if as_of.tzinfo is None:
+        as_of = as_of.replace(tzinfo=timezone.utc)
+    else:
+        as_of = as_of.astimezone(timezone.utc)
+    points = []
+    for run, semantic in zip(selected_runs, derived["points"]):
+        commit = run.get("commit")
+        try:
+            metadata = resolver.metadata(commit)
+        except ValueError:
+            # Old checked-in history can name revisions no longer present in
+            # the repository graph. Preserve the measurement while making the
+            # missing authority explicit instead of inventing metadata.
+            measured = run.get("timestamp")
+            metadata = {
+                "commit": commit,
+                "metadata_status": "unavailable",
+                "subject": "Commit metadata unavailable",
+                "date": measured[:10] if isinstance(measured, str) else None,
+                "links": {
+                    "commit": f"{REPOSITORY}/commit/{commit}",
+                    "issues": [],
+                    "pull_requests": [],
+                },
+            }
+        measured_at = _parse_timestamp(run.get("timestamp"))
+        publication = run.get("publication", {})
+        coverage = publication.get("coverage", {}) if isinstance(publication, dict) else {}
+        point_annotations = [
+            event for event in annotations
+            if _annotation_applies(event, metadata["commit"], resolver)
+        ]
+        links = dict(metadata["links"])
+        links["annotations"] = sorted({event["link"] for event in point_annotations})
+        wall_age = (
+            max(0, int((as_of - measured_at).total_seconds()))
+            if measured_at is not None else None
+        )
+        points.append({
+            **metadata,
+            "links": links,
+            "measured_at": run.get("timestamp"),
+            "freshness": {
+                "age_from_latest_seconds": (
+                    int((newest - measured_at).total_seconds())
+                    if newest is not None and measured_at is not None else None
+                ),
+                "latest": measured_at == newest if measured_at is not None else False,
+                "wall_clock_age_seconds": wall_age,
+                "stale": wall_age is None or wall_age > STALE_AFTER_SECONDS,
+                "as_of": as_of.isoformat().replace("+00:00", "Z"),
+            },
+            "coverage": {
+                "measured_commit": coverage.get("measured_commit"),
+                "represented_commits": coverage.get("represented_commits", []),
+                "skipped_commits": coverage.get("skipped_commits", []),
+                "gap_unknown": coverage.get("gap_unknown", True),
+            },
+            "regime_id": run_regime(run),
+            "comparability": semantic["previous"],
+            "annotations": point_annotations,
+            "workloads": [
+                {
+                    "name": bench.get("name"),
+                    "raw_samples_ms": bench.get("samples_ms", []),
+                    "uncertainty": sample_summary(bench.get("samples_ms")),
+                }
+                for bench in run.get("benchmarks", [])
+            ],
+        })
+
+    segments: list[list[int]] = []
+    for index, point in enumerate(points):
+        if index == 0 or point["comparability"].get("status") != "comparable":
+            segments.append([])
+        segments[-1].append(index)
+
+    comparisons = []
+    for segment in segments:
+        for offset, before_index in enumerate(segment):
+            for after_index in segment[offset + 1:]:
+                explanation = comparison_explanation(
+                    selected_runs[after_index], selected_runs[before_index]
+                )
+                if explanation.get("status") != "comparable":
+                    raise ValueError("canonical segment unexpectedly produced a non-comparable pair")
+                comparisons.append({
+                    "before": points[before_index]["commit"],
+                    "after": points[after_index]["commit"],
+                    "explanation": explanation,
+                })
+
+    default_comparison = next(
+        (
+            item for item in reversed(comparisons)
+            if item["explanation"].get("headline", {}).get("classification")
+            != "insufficient_data"
+        ),
+        comparisons[-1] if comparisons else None,
+    )
+
+    small_multiples = {}
+    for point in points:
+        for workload in point["workloads"]:
+            summary = workload["uncertainty"]
+            if summary is None:
+                continue
+            small_multiples.setdefault(workload["name"], []).append({
+                "commit": point["commit"],
+                "median_ms": summary["center"],
+                "variation_pct": summary["relative_variation_pct"],
+                "comparison_boundary": point["comparability"].get("status") != "comparable",
+            })
+
+    return {
+        "schema_version": 1,
+        "platform": platform,
+        "window_options": list(WINDOWS),
+        "default_window": WINDOWS[0],
+        "points": points,
+        "comparisons": comparisons,
+        "default_selection": (
+            {"before": default_comparison["before"], "after": default_comparison["after"]}
+            if default_comparison else None
+        ),
+        "small_multiples": [
+            {"workload": name, "points": values}
+            for name, values in sorted(small_multiples.items())
+        ],
+        "annotations": annotations,
+    }

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -46,6 +46,7 @@ from benchmark_annotations import (
     normalized_annotations,
 )
 from benchmark_metrics import derive_history_metrics
+from benchmark_recent import GitRecentResolver, recent_workspace
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -1229,6 +1230,11 @@ def generate_platform_charts(history_path: Path, output_dir: Path, platform: Opt
     coverage = calculate_coverage_metrics(runs)
 
     # Write metadata JSON for the website to consume (includes summary and detailed metrics)
+    annotation_stream = normalized_annotations(
+        runs,
+        load_annotations(DEFAULT_ANNOTATIONS),
+        GitCommitResolver(REPO_ROOT),
+    )
     metadata = {
         "benchmarks": benchmark_names,
         "run_count": len(runs),
@@ -1238,10 +1244,12 @@ def generate_platform_charts(history_path: Path, output_dir: Path, platform: Opt
         "coverage": coverage,
         "regimes": regime_summary(runs),
         "metric_semantics": derive_history_metrics(runs),
-        "annotations": normalized_annotations(
+        "annotations": annotation_stream,
+        "recent_workspace": recent_workspace(
             runs,
-            load_annotations(DEFAULT_ANNOTATIONS),
-            GitCommitResolver(REPO_ROOT),
+            annotation_stream,
+            GitRecentResolver(REPO_ROOT),
+            platform or "unknown",
         ),
     }
     if platform:

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -4,6 +4,7 @@
 import importlib.util
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 import subprocess
 import sys
@@ -35,6 +36,7 @@ charts = load_module("generate_charts", "scripts/generate-charts.py")
 site_status = load_module("generate_site_status", "scripts/generate-site-status.py")
 history_tools = load_module("benchmark_history", "scripts/benchmark_history.py")
 metrics = load_module("benchmark_metrics", "scripts/benchmark_metrics.py")
+recent = load_module("benchmark_recent", "scripts/benchmark_recent.py")
 perf_baseline = load_module("perf_baseline", "scripts/perf-baseline.py")
 
 
@@ -1281,6 +1283,205 @@ class TestBenchmarkAnnotations(unittest.TestCase):
             [run], [self.authored()], self.Resolver()
         )
         self.assertEqual(site_status.sparkline_data([run], stream)["annotations"], stream)
+
+
+class TestRecentRegressionWorkspace(unittest.TestCase):
+    class Resolver:
+        def metadata(self, commit):
+            index = int(commit[0], 16)
+            return {
+                "commit": commit,
+                "subject": f"RUE-{900 + index}: measured change {index}",
+                "date": f"2026-07-{index + 1:02d}",
+                "links": {
+                    "commit": f"https://github.com/rue-language/rue/commit/{commit}",
+                    "issues": [{
+                        "id": f"RUE-{900 + index}",
+                        "url": f"https://linear.app/steve-klabnik/issue/RUE-{900 + index}",
+                    }],
+                    "pull_requests": [],
+                },
+            }
+
+        def is_ancestor(self, start, end):
+            return int(start[0], 16) <= int(end[0], 16)
+
+    @staticmethod
+    def sample_run(index, probe_samples, other_samples, skipped=()):
+        commit = f"{index:x}" * 40
+        def bench(name, samples, parser):
+            return {
+                "name": name,
+                "mean_ms": sum(samples) / len(samples),
+                "samples_ms": samples,
+                "passes": {
+                    "parser": {"mean_ms": parser},
+                    "codegen": {"mean_ms": 2.0},
+                },
+                "peak_memory_bytes": 1000 + index * 10,
+                "binary_size_bytes": 2000 + index * 5,
+            }
+        return {
+            "commit": commit,
+            "timestamp": f"2026-07-{index + 1:02d}T00:00:00Z",
+            "publication": {
+                "comparable": True,
+                "regime_id": "same",
+                "regime": {"platform": "x86-64-linux"},
+                "coverage": {
+                    "measured_commit": commit,
+                    "represented_commits": [commit],
+                    "skipped_commits": list(skipped),
+                    "gap_unknown": False,
+                },
+            },
+            "benchmarks": [
+                bench("probe", probe_samples, 5.0 if index < 4 else 20.0),
+                bench("other", other_samples, 3.0 if index < 4 else 4.0),
+            ],
+        }
+
+    def test_fixture_distinguishes_noise_regression_annotation_and_gap(self):
+        skipped = "a" * 40
+        runs = [
+            self.sample_run(1, [99.9, 100, 100.1], [49.9, 50, 50.1]),
+            self.sample_run(2, [90, 100, 110], [49.9, 50, 50.1]),
+            self.sample_run(3, [99.9, 100, 100.1], [49.9, 50, 50.1], [skipped]),
+            self.sample_run(4, [119.9, 120, 120.1], [50.9, 51, 51.1]),
+        ]
+        capability = {
+            "id": "capability",
+            "source": "authored",
+            "location": {"kind": "commit", "commit": "4" * 40},
+            "category": "capability",
+            "title": "Queryable compiler",
+            "explanation": "Compiler queries are now available.",
+            "link": "https://github.com/rue-language/rue/pull/1",
+            "scope": {"metrics": ["latency"], "workloads": ["*"], "platforms": ["*"]},
+        }
+        model = recent.recent_workspace(
+            runs,
+            [capability],
+            self.Resolver(),
+            "x86-64-linux",
+            as_of=datetime(2026, 7, 5, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(model["window_options"], [20, 50, 100])
+        self.assertEqual(model["points"][1]["comparability"]["headline"]["classification"], "stable")
+        self.assertGreater(model["points"][1]["comparability"]["headline"]["variation_pct"], 0)
+        self.assertEqual(model["points"][2]["comparability"]["status"], "non_comparable")
+        self.assertEqual(model["points"][2]["coverage"]["represented_commits"], ["3" * 40])
+        self.assertEqual(model["points"][2]["coverage"]["skipped_commits"], [skipped])
+        self.assertEqual(model["points"][3]["comparability"]["headline"]["classification"], "regressed")
+        self.assertEqual(model["points"][3]["annotations"][0]["category"], "capability")
+        self.assertFalse(model["points"][3]["freshness"]["stale"])
+        self.assertTrue(model["points"][0]["freshness"]["stale"])
+        self.assertGreater(model["points"][0]["freshness"]["wall_clock_age_seconds"], 0)
+        self.assertGreater(model["points"][0]["freshness"]["age_from_latest_seconds"], 0)
+        self.assertEqual(model["default_selection"], {"before": "3" * 40, "after": "4" * 40})
+        self.assertFalse(any(
+            item["before"] == "2" * 40 and item["after"] == "4" * 40
+            for item in model["comparisons"]
+        ))
+
+        explanation = model["comparisons"][-1]["explanation"]
+        self.assertEqual(explanation["dominant_workload"]["name"], "probe")
+        self.assertEqual(explanation["dominant_pass"]["name"], "parser")
+        parser = next(item for item in explanation["passes"] if item["name"] == "parser")
+        self.assertEqual(parser["delta_ms"], parser["after_ms"] - parser["before_ms"])
+        self.assertTrue(explanation["memory_bytes"])
+        self.assertTrue(explanation["binary_size_bytes"])
+        probe = next(item for item in model["small_multiples"] if item["workload"] == "probe")
+        self.assertTrue(probe["points"][2]["comparison_boundary"])
+
+    def test_workspace_caps_payload_at_one_hundred_points(self):
+        runs = [self.sample_run(index % 15 + 1, [10, 10, 10], [5, 5, 5]) for index in range(105)]
+        model = recent.recent_workspace(
+            runs, [], self.Resolver(), "x86-64-linux",
+            as_of=datetime(2026, 8, 1, tzinfo=timezone.utc),
+        )
+        self.assertEqual(len(model["points"]), 100)
+
+    def test_every_ordered_pair_inside_one_segment_is_selectable(self):
+        runs = [
+            self.sample_run(index, [10 + index] * 3, [5 + index] * 3)
+            for index in (1, 2, 3)
+        ]
+        model = recent.recent_workspace(
+            runs, [], self.Resolver(), "x86-64-linux",
+            as_of=datetime(2026, 7, 4, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            {(item["before"], item["after"]) for item in model["comparisons"]},
+            {
+                ("1" * 40, "2" * 40),
+                ("1" * 40, "3" * 40),
+                ("2" * 40, "3" * 40),
+            },
+        )
+
+    def test_insufficient_pair_is_explicit_but_not_preferred_over_evidence(self):
+        runs = [
+            self.sample_run(1, [10, 10], [5, 5]),
+            self.sample_run(2, [11, 11, 11], [6, 6, 6]),
+            self.sample_run(3, [12, 12, 12], [7, 7, 7]),
+        ]
+        model = recent.recent_workspace(
+            runs, [], self.Resolver(), "x86-64-linux",
+            as_of=datetime(2026, 7, 4, tzinfo=timezone.utc),
+        )
+        insufficient = next(item for item in model["comparisons"] if item["before"] == "1" * 40)
+        self.assertEqual(
+            insufficient["explanation"]["headline"]["classification"],
+            "insufficient_data",
+        )
+        self.assertEqual(model["default_selection"], {
+            "before": "2" * 40, "after": "3" * 40
+        })
+
+    def test_missing_pass_is_not_treated_as_zero_measurement(self):
+        before = self.sample_run(1, [10, 10, 10], [5, 5, 5])
+        after = self.sample_run(2, [11, 11, 11], [6, 6, 6])
+        del after["benchmarks"][0]["passes"]["codegen"]
+        explanation = metrics.comparison_explanation(after, before)
+        self.assertNotIn(
+            "codegen",
+            {item["name"] for item in explanation["passes"]},
+        )
+
+    def test_git_metadata_uses_real_linear_form_and_only_discovered_prs(self):
+        completed = subprocess.CompletedProcess(
+            [], 0,
+            "a" * 40 + "\0RUE-897: workspace (#1648)\0" + "2026-07-14\0body\n",
+            "",
+        )
+        with mock.patch.object(recent.subprocess, "run", return_value=completed):
+            metadata = recent.GitRecentResolver(Path(".")).metadata("a" * 40)
+        self.assertEqual(
+            metadata["links"]["issues"],
+            [{
+                "id": "RUE-897",
+                "url": "https://linear.app/steve-klabnik/issue/RUE-897",
+            }],
+        )
+        self.assertEqual(
+            metadata["links"]["pull_requests"],
+            [{
+                "id": "PR #1648",
+                "url": "https://github.com/rue-language/rue/pull/1648",
+            }],
+        )
+
+    def test_recent_template_keeps_semantics_server_side_and_guards_insufficient_data(self):
+        template = (INPUT_ROOT / "website" / "templates" / "performance.html").read_text()
+        self.assertIn("insufficient data for a delta", template)
+        self.assertIn("point.coverage.skipped_commits.join", template)
+        self.assertIn("annotationLink.href = item.link", template)
+        self.assertIn("value.before_ms.toFixed", template)
+        self.assertIn("headline.classification === 'insufficient_data'", template)
+        self.assertIn("populateComparisons(points)", template)
+        self.assertNotIn("function calculateDelta", template)
 
 
 class BenchmarkCollectionTests(unittest.TestCase):

--- a/website/build.sh
+++ b/website/build.sh
@@ -128,7 +128,7 @@ platforms.sort(key=lambda p: p['id'])
 
 metadata = {
     'platforms': platforms,
-    'default_platform': platforms[0]['id'] if platforms else None
+    'default_platform': next((p['id'] for p in platforms if p['has_data']), None)
 }
 
 with open(benchmarks_dir / 'metadata.json', 'w') as f:

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -24,6 +24,23 @@
             </div>
         </section>
 
+        <section id="recent-workspace" class="mb-12" aria-labelledby="recent-workspace-title">
+            <h2 id="recent-workspace-title" class="section-title">Recent regression workspace</h2>
+            <div class="flex flex-wrap items-center gap-3 mb-4">
+                <span class="text-sm font-medium">Recent window:</span>
+                <div id="recent-window-controls" class="flex gap-2" role="group" aria-label="Recent benchmark window"></div>
+                <label for="recent-before" class="text-sm font-medium">Before:</label>
+                <select id="recent-before" class="bg-surface border border-themed rounded px-2 py-1 text-sm"></select>
+                <label for="recent-after" class="text-sm font-medium">After:</label>
+                <select id="recent-after" class="bg-surface border border-themed rounded px-2 py-1 text-sm"></select>
+            </div>
+            <div id="recent-comparison" class="bg-surface border border-themed rounded-lg p-4 mb-6" aria-live="polite"></div>
+            <h3>Per-workload recent measurements</h3>
+            <div id="recent-small-multiples" class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6"></div>
+            <h3>Measured commits</h3>
+            <div id="recent-points" class="overflow-x-auto"></div>
+        </section>
+
         <!-- Summary Stats: single-platform mode shows latest/avg/best + delta;
              comparison mode shows one row per platform (populated by JS) -->
         <section id="summary-stats" class="mb-12">
@@ -50,17 +67,6 @@
                 Total compilation time across the last 20 commits. Lower is better.
             </p>
             <div id="timeline-chart-container" class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
-                <p class="text-muted text-center py-8">Loading chart...</p>
-            </div>
-        </section>
-
-        <!-- Timeline Chart (Per-Program) - Only shown for single platform -->
-        <section id="timeline-by-program-section" class="mb-12">
-            <h2 class="section-title">Compilation Time by Program</h2>
-            <p class="text-muted mb-4">
-                Each benchmark program shown as a separate line to identify which programs regress.
-            </p>
-            <div id="timeline-by-program-container" class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
                 <p class="text-muted text-center py-8">Loading chart...</p>
             </div>
         </section>
@@ -124,8 +130,13 @@
             const platformInfo = document.getElementById('platform-info');
             const benchmarkSelect = document.getElementById('benchmark-select');
             const timelineContainer = document.getElementById('timeline-chart-container');
-            const timelineByProgramSection = document.getElementById('timeline-by-program-section');
-            const timelineByProgramContainer = document.getElementById('timeline-by-program-container');
+            const recentSection = document.getElementById('recent-workspace');
+            const recentWindowControls = document.getElementById('recent-window-controls');
+            const recentBefore = document.getElementById('recent-before');
+            const recentAfter = document.getElementById('recent-after');
+            const recentComparison = document.getElementById('recent-comparison');
+            const recentSmallMultiples = document.getElementById('recent-small-multiples');
+            const recentPoints = document.getElementById('recent-points');
             const breakdownSection = document.getElementById('breakdown-section');
             const breakdownContainer = document.getElementById('breakdown-chart-container');
             const memorySection = document.getElementById('memory-section');
@@ -137,6 +148,151 @@
 
             let currentPlatform = 'comparison';
             let platformMetadata = null;
+
+            function node(tag, text, className) {
+                const value = document.createElement(tag);
+                if (text !== undefined) value.textContent = text;
+                if (className) value.className = className;
+                return value;
+            }
+
+            function escapeHtml(value) {
+                return String(value).replace(/[&<>"']/g, character => ({
+                    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+                })[character]);
+            }
+
+            function renderRecentWorkspace(model) {
+                recentWindowControls.replaceChildren();
+                const renderWindow = (size) => {
+                    const points = model.points.slice(-size);
+                    recentPoints.replaceChildren();
+                    const table = node('table', undefined, 'w-full text-sm');
+                    const caption = node('caption', `Last ${points.length} measured points on ${model.platform}`, 'sr-only');
+                    table.appendChild(caption);
+                    const head = node('thead');
+                    const headRow = node('tr');
+                    ['Commit', 'Subject / date', 'Result', 'Coverage', 'Annotations', 'Raw values and uncertainty'].forEach(label => {
+                        const th = node('th', label, 'text-left p-2'); th.scope = 'col'; headRow.appendChild(th);
+                    });
+                    head.appendChild(headRow); table.appendChild(head);
+                    const body = node('tbody');
+                    points.forEach(point => {
+                        const row = node('tr', undefined, 'border-b border-themed');
+                        const commitCell = node('td', undefined, 'p-2');
+                        const link = node('a', point.commit.slice(0, 8)); link.href = point.links.commit; commitCell.appendChild(link);
+                        point.links.issues.forEach(item => {
+                            commitCell.appendChild(document.createTextNode(' '));
+                            const issue = node('a', item.id); issue.href = item.url; commitCell.appendChild(issue);
+                        });
+                        (point.links.pull_requests || []).forEach(item => {
+                            commitCell.appendChild(document.createTextNode(' '));
+                            const pull = node('a', item.id); pull.href = item.url; commitCell.appendChild(pull);
+                        });
+                        const relativeFreshness = point.freshness.latest ? 'latest measurement' : `${point.freshness.age_from_latest_seconds}s older than latest`;
+                        const wallFreshness = point.freshness.stale ? `stale (${point.freshness.wall_clock_age_seconds ?? 'unknown'}s old)` : `current (${point.freshness.wall_clock_age_seconds}s old)`;
+                        const subject = node('td', `${point.subject} (${point.date}); measured ${point.measured_at || 'unknown'}; ${relativeFreshness}; ${wallFreshness}`, 'p-2');
+                        const headline = point.comparability.headline;
+                        const resultText = !headline ? point.comparability.reason
+                            : headline.classification === 'insufficient_data' ? 'insufficient data'
+                            : `${headline.classification}; Δ ${headline.delta_pct.toFixed(2)}%, variation ${headline.variation_pct.toFixed(2)}%`;
+                        const result = node('td', resultText, 'p-2');
+                        const represented = point.coverage.represented_commits.length ? point.coverage.represented_commits.join(', ') : 'none';
+                        const skipped = point.coverage.skipped_commits.length ? point.coverage.skipped_commits.join(', ') : 'none';
+                        const coverage = node('td', `Measured: ${point.coverage.measured_commit || 'unknown'}; represented: ${represented}; skipped: ${skipped}; unknown gap: ${point.coverage.gap_unknown}`, 'p-2');
+                        const annotation = node('td', undefined, 'p-2');
+                        if (point.annotations.length === 0) {
+                            annotation.textContent = 'None';
+                        } else {
+                            point.annotations.forEach((item, index) => {
+                                if (index) annotation.appendChild(document.createTextNode('; '));
+                                const annotationLink = node('a', `${item.category}: ${item.title}`);
+                                annotationLink.href = item.link;
+                                annotation.appendChild(annotationLink);
+                                annotation.appendChild(document.createTextNode(` — ${item.explanation}`));
+                            });
+                        }
+                        const raw = node('td', point.workloads.map(item => item.uncertainty ? `${item.name}: ${item.uncertainty.center.toFixed(2)}ms, ±${item.uncertainty.relative_variation_pct.toFixed(2)}%, samples [${item.raw_samples_ms.join(', ')}]` : `${item.name}: insufficient data`).join('; '), 'p-2');
+                        [commitCell, subject, result, coverage, annotation, raw].forEach(cell => row.appendChild(cell));
+                        body.appendChild(row);
+                    });
+                    table.appendChild(body); recentPoints.appendChild(table);
+
+                    recentSmallMultiples.replaceChildren();
+                    model.small_multiples.forEach(multiple => {
+                        const visible = multiple.points.filter(point => points.some(item => item.commit === point.commit));
+                        const card = node('div', undefined, 'bg-surface border border-themed rounded-lg p-3');
+                        const smallTable = node('table', undefined, 'w-full text-xs');
+                        smallTable.appendChild(node('caption', multiple.workload, 'font-medium text-left mb-2'));
+                        visible.forEach(point => {
+                            const row = node('tr');
+                            row.appendChild(node('th', point.commit.slice(0, 8) + (point.comparison_boundary ? ' (boundary)' : ''), 'text-left p-1'));
+                            row.appendChild(node('td', `${point.median_ms.toFixed(2)}ms ±${point.variation_pct.toFixed(2)}%`, 'text-right p-1'));
+                            smallTable.appendChild(row);
+                        });
+                        card.appendChild(smallTable); recentSmallMultiples.appendChild(card);
+                    });
+                    populateComparisons(points);
+                };
+
+                model.window_options.forEach(size => {
+                    const button = node('button', String(size), 'border border-themed rounded px-2 py-1 text-sm');
+                    button.type = 'button'; button.setAttribute('aria-pressed', size === model.default_window ? 'true' : 'false');
+                    button.addEventListener('click', () => {
+                        recentWindowControls.querySelectorAll('button').forEach(item => item.setAttribute('aria-pressed', item === button ? 'true' : 'false'));
+                        renderWindow(size);
+                    });
+                    recentWindowControls.appendChild(button);
+                });
+
+                let activeByBefore = new Map();
+                const renderComparison = () => {
+                    const item = model.comparisons.find(value => value.before === recentBefore.value && value.after === recentAfter.value);
+                    recentComparison.replaceChildren();
+                    if (!item) { recentComparison.appendChild(node('p', 'Select exactly two comparable measured commits.')); return; }
+                    const explanation = item.explanation;
+                    if (explanation.headline.classification === 'insufficient_data') {
+                        recentComparison.appendChild(node('p', `Before ${item.before.slice(0, 8)} → after ${item.after.slice(0, 8)}: insufficient data for a delta or uncertainty classification.`));
+                    } else {
+                        recentComparison.appendChild(node('p', `Before ${item.before.slice(0, 8)} → after ${item.after.slice(0, 8)}: ${explanation.headline.classification}; Δ ${explanation.headline.delta_pct.toFixed(2)}%, observed variation ${explanation.headline.variation_pct.toFixed(2)}%.`));
+                    }
+                    recentComparison.appendChild(node('p', `Dominant workload: ${explanation.dominant_workload?.name || 'none'} (${explanation.dominant_workload?.delta_ms?.toFixed(2) || '0'}ms). Dominant pass: ${explanation.dominant_pass?.name || 'none'} (${explanation.dominant_pass?.delta_ms?.toFixed(2) || '0'}ms).`));
+                    const list = node('ul');
+                    explanation.workloads.forEach(value => list.appendChild(node('li', `${value.name}: ${value.reference_median_ms?.toFixed(2)}ms → ${value.current_median_ms?.toFixed(2)}ms (${value.classification}, ±${value.variation_pct?.toFixed(2)}%)`)));
+                    explanation.passes.forEach(value => list.appendChild(node('li', `${value.name} pass: ${value.before_ms.toFixed(2)}ms → ${value.after_ms.toFixed(2)}ms; contribution ${value.delta_ms >= 0 ? '+' : ''}${value.delta_ms.toFixed(2)}ms`)));
+                    explanation.memory_bytes.forEach(value => list.appendChild(node('li', `${value.name} memory: ${value.before} → ${value.after} bytes (${value.delta >= 0 ? '+' : ''}${value.delta})`)));
+                    explanation.binary_size_bytes.forEach(value => list.appendChild(node('li', `${value.name} binary: ${value.before} → ${value.after} bytes (${value.delta >= 0 ? '+' : ''}${value.delta})`)));
+                    recentComparison.appendChild(list);
+                };
+                const updateAfter = () => {
+                    const previousAfter = recentAfter.value;
+                    recentAfter.replaceChildren();
+                    (activeByBefore.get(recentBefore.value) || []).forEach(item => { const option = node('option', item.after.slice(0, 8)); option.value = item.after; recentAfter.appendChild(option); });
+                    if ([...recentAfter.options].some(option => option.value === previousAfter)) recentAfter.value = previousAfter;
+                    renderComparison();
+                };
+                function populateComparisons(points) {
+                    const visible = new Set(points.map(point => point.commit));
+                    const comparisons = model.comparisons.filter(item => visible.has(item.before) && visible.has(item.after));
+                    activeByBefore = new Map();
+                    comparisons.forEach(item => {
+                        if (!activeByBefore.has(item.before)) activeByBefore.set(item.before, []);
+                        activeByBefore.get(item.before).push(item);
+                    });
+                    const preferred = comparisons.find(item => model.default_selection && item.before === model.default_selection.before && item.after === model.default_selection.after)
+                        || [...comparisons].reverse().find(item => item.explanation.headline.classification !== 'insufficient_data')
+                        || comparisons[comparisons.length - 1];
+                    recentBefore.replaceChildren();
+                    activeByBefore.forEach((_, commit) => { const option = node('option', commit.slice(0, 8)); option.value = commit; recentBefore.appendChild(option); });
+                    if (preferred) recentBefore.value = preferred.before;
+                    updateAfter();
+                    if (preferred) recentAfter.value = preferred.after;
+                    renderComparison();
+                }
+                recentBefore.onchange = updateAfter;
+                recentAfter.onchange = renderComparison;
+                renderWindow(model.default_window);
+            }
 
             // Fetch an SVG and insert it into a container
             function loadSvg(container, path) {
@@ -163,7 +319,7 @@
 
             function fmtDelta(str, pct) {
                 if (!str) return '';
-                return ` <span class="text-sm" style="color: ${pct > 0 ? WORSE : BETTER}">${str}</span>`;
+                return ` <span class="text-sm" style="color: ${pct > 0 ? WORSE : BETTER}">${escapeHtml(str)}</span>`;
             }
 
             // Single-platform mode: big latest value + delta + sub-line
@@ -184,7 +340,7 @@
                     `<div class="text-xs text-muted mt-1">Avg: ${s.avg_memory_mb ? s.avg_memory_mb.toFixed(1) + 'MB' : '--'}</div>`;
                 statBodies.binary.innerHTML =
                     `<div class="flex items-baseline gap-2"><span class="text-2xl font-semibold">${s.latest_binary_kb ? s.latest_binary_kb.toFixed(1) + 'KB' : '--'}</span>${fmtDelta(s.binary_delta_str, s.binary_delta_pct)}</div>` +
-                    `<div class="text-xs text-muted mt-1">Commit: ${s.latest_commit || '--'}</div>`;
+                    `<div class="text-xs text-muted mt-1">Commit: ${escapeHtml(s.latest_commit || '--')}</div>`;
             }
 
             // Comparison mode: one compact row per platform in each card
@@ -195,8 +351,8 @@
                 }
                 const row = (name, val) =>
                     `<div class="flex justify-between items-baseline py-0.5 text-sm">` +
-                    `<span class="text-muted">${name}</span>` +
-                    `<span style="font-family: var(--font-mono); font-size: 0.82rem; font-variant-numeric: tabular-nums;">${val}</span></div>`;
+                    `<span class="text-muted">${escapeHtml(name)}</span>` +
+                    `<span style="font-family: var(--font-mono); font-size: 0.82rem; font-variant-numeric: tabular-nums;">${escapeHtml(val)}</span></div>`;
                 statBodies.time.innerHTML = metas.map(m =>
                     row(m.name, m.summary?.latest_time_ms ? m.summary.latest_time_ms.toFixed(1) + 'ms' : '--')).join('');
                 statBodies.memory.innerHTML = metas.map(m =>
@@ -227,7 +383,7 @@
 
                 benchmarks.forEach(b => {
                     html += '<tr class="border-b border-themed">';
-                    html += `<td class="p-2 font-medium">${b.name}</td>`;
+                    html += `<td class="p-2 font-medium">${escapeHtml(b.name)}</td>`;
                     html += `<td class="p-2 text-right">${b.mean_ms?.toFixed(2) || '-'}</td>`;
                     html += `<td class="p-2 text-right">${b.source_metrics?.lines?.toLocaleString() || '-'}</td>`;
                     html += `<td class="p-2 text-right">${b.source_metrics?.tokens?.toLocaleString() || '-'}</td>`;
@@ -249,7 +405,7 @@
                 if (platform === 'comparison') {
                     // Comparison mode: show cross-platform timeline, hide per-program charts
                     platformInfo.textContent = 'Showing all platforms';
-                    timelineByProgramSection.style.display = 'none';
+                    recentSection.style.display = 'none';
                     breakdownSection.style.display = 'none';
                     memorySection.style.display = 'none';
                     binarySection.style.display = 'none';
@@ -269,7 +425,7 @@
                     // Single platform mode: show all charts
                     const platformName = platformMetadata?.platforms?.find(p => p.id === platform)?.name || platform;
                     platformInfo.textContent = `${platformName}`;
-                    timelineByProgramSection.style.display = 'block';
+                    recentSection.style.display = 'block';
                     breakdownSection.style.display = 'block';
                     memorySection.style.display = 'block';
                     binarySection.style.display = 'block';
@@ -278,7 +434,6 @@
                     const basePath = `/benchmarks/platforms/${platform}`;
 
                     loadSvg(timelineContainer, `${basePath}/timeline.svg`);
-                    loadSvg(timelineByProgramContainer, `${basePath}/timeline_by_program.svg`);
                     loadSvg(breakdownContainer, `${basePath}/breakdown.svg`);
                     loadSvg(memoryContainer, `${basePath}/memory.svg`);
                     loadSvg(binaryContainer, `${basePath}/binary_size.svg`);
@@ -289,6 +444,7 @@
                         .then(data => {
                             updateStats(data.summary);
                             updateMetricsTable(data.latest_benchmarks);
+                            renderRecentWorkspace(data.recent_workspace);
 
                             // Populate benchmark dropdown
                             benchmarkSelect.innerHTML = '<option value="">All (aggregate)</option>';
@@ -327,10 +483,11 @@
                         });
                     }
 
-                    // Load comparison view by default, or first platform with data
+                    // Detailed performance defaults to the first platform with data.
                     const defaultPlatform = data.default_platform || 'comparison';
                     if (data.platforms?.some(p => p.has_data)) {
-                        loadPlatformData('comparison');
+                        platformSelect.value = defaultPlatform;
+                        loadPlatformData(defaultPlatform);
                     } else {
                         platformInfo.textContent = 'No benchmark data available yet';
                         timelineContainer.innerHTML = '<p class="text-muted text-center py-8">No benchmark data available</p>';
@@ -339,14 +496,13 @@
                 .catch(() => {
                     // Fallback to legacy mode (single history.json)
                     platformSelect.parentElement.parentElement.style.display = 'none';
-                    timelineByProgramSection.style.display = 'block';
+                    recentSection.style.display = 'none';
                     breakdownSection.style.display = 'block';
                     memorySection.style.display = 'block';
                     binarySection.style.display = 'block';
                     metricsSection.style.display = 'block';
 
                     loadSvg(timelineContainer, '/benchmarks/timeline.svg');
-                    loadSvg(timelineByProgramContainer, '/benchmarks/timeline_by_program.svg');
                     loadSvg(breakdownContainer, '/benchmarks/breakdown.svg');
                     loadSvg(memoryContainer, '/benchmarks/memory.svg');
                     loadSvg(binaryContainer, '/benchmarks/binary_size.svg');


### PR DESCRIPTION
Build the default per-platform recent regression workspace with canonical comparison semantics, 20/50/100 measured-point windows, exact coverage and freshness, annotations and source links, comparable commit selection, before/after contribution analysis, and accessible per-workload detail.

Validation:
- `./buck2 test //:benchmark-tool-tests`
- `scripts/rue quick`
- `website/build.sh`
- inline JavaScript syntax check

Fixes RUE-897