### PR TITLE
RUE-800: fail closed on corpus omissions

### DIFF
--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -959,9 +959,13 @@ fn unknown_only_on_targets(case: &Case) -> Vec<&str> {
 }
 
 fn load_cases(cases_dir: &Path) -> Vec<(String, TestFile)> {
-    let mut toml_files = Vec::new();
-    rue_test_runner::collect_toml_files(cases_dir, &mut toml_files);
-    toml_files.sort();
+    let toml_files = rue_test_runner::discover_files(cases_dir, "toml").unwrap_or_else(|error| {
+        eprintln!(
+            "error: failed to discover CLI test files under {}: {error}",
+            cases_dir.display()
+        );
+        std::process::exit(1);
+    });
 
     let mut out = Vec::new();
     for path in toml_files {

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -57,7 +57,7 @@ use rue_oracle::{
     run_source_with_preview_features,
 };
 use serde::Deserialize;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -573,7 +573,14 @@ fn spec_mode(raw_args: Vec<String>) -> ExitCode {
         // `load_test_files` expands `params` templates and validates preview
         // feature names exactly as the spec runner does; it needs only the
         // cases dir (no spec markdown).
-        let files = rue_test_runner::load_test_files(dir);
+        let files = match rue_test_runner::load_test_files(dir) {
+            Ok(files) => files,
+            Err(error) => {
+                inventory_complete = false;
+                report.harness_failures.push(error);
+                continue;
+            }
+        };
         if files.is_empty() {
             inventory_complete = false;
             report.harness_failures.push(format!(
@@ -1252,119 +1259,22 @@ fn discover_toml(dirs: &[PathBuf]) -> (Vec<PathBuf>, Vec<String>) {
     let mut files = Vec::new();
     let mut failures = Vec::new();
     for dir in dirs {
-        let before = files.len();
-        match collect_toml(dir, &mut files) {
-            Ok(()) if files.len() == before => failures.push(format!(
+        match rue_test_runner::discover_files(dir, "toml") {
+            Ok(discovered) if discovered.is_empty() => failures.push(format!(
                 "no .toml case files found under requested root {}",
                 dir.display()
             )),
-            Ok(()) => {}
-            Err(mut errors) => failures.append(&mut errors),
+            Ok(mut discovered) => files.append(&mut discovered),
+            Err(error) => failures.push(format!(
+                "could not discover case files under {}: {error}",
+                dir.display()
+            )),
         }
     }
     files.sort();
     files.dedup();
     failures.sort();
     (files, failures)
-}
-
-/// Recursively collect TOML files, reporting rather than hiding filesystem errors.
-fn collect_toml(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Vec<String>> {
-    let mut failures = Vec::new();
-    let mut visited_dirs = BTreeSet::new();
-    collect_toml_inner(dir, out, &mut failures, &mut visited_dirs);
-    if failures.is_empty() {
-        Ok(())
-    } else {
-        failures.sort();
-        Err(failures)
-    }
-}
-
-fn collect_toml_inner(
-    dir: &Path,
-    out: &mut Vec<PathBuf>,
-    failures: &mut Vec<String>,
-    visited_dirs: &mut BTreeSet<PathBuf>,
-) {
-    let canonical_dir = match std::fs::canonicalize(dir) {
-        Ok(path) => path,
-        Err(error) => {
-            failures.push(format!(
-                "could not resolve cases directory {}: {error}",
-                dir.display()
-            ));
-            return;
-        }
-    };
-    if !visited_dirs.insert(canonical_dir) {
-        return;
-    }
-
-    let entries = match std::fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(error) => {
-            failures.push(format!(
-                "could not read cases directory {}: {error}",
-                dir.display()
-            ));
-            return;
-        }
-    };
-
-    for entry in entries {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(error) => {
-                failures.push(format!(
-                    "could not read a directory entry under {}: {error}",
-                    dir.display()
-                ));
-                continue;
-            }
-        };
-        let path = entry.path();
-        let file_type = match entry.file_type() {
-            Ok(file_type) => file_type,
-            Err(error) => {
-                failures.push(format!(
-                    "could not determine file type for {}: {error}",
-                    path.display()
-                ));
-                continue;
-            }
-        };
-
-        if file_type.is_dir() {
-            collect_toml_inner(&path, out, failures, visited_dirs);
-        } else if file_type.is_file() {
-            collect_toml_file(&path, out);
-        } else if file_type.is_symlink() {
-            // Buck inputs and user-provided case roots may contain symlinks.
-            // Follow them explicitly, but surface a broken link as discovery
-            // failure instead of silently treating it as an absent case.
-            match std::fs::metadata(&path) {
-                Ok(metadata) if metadata.is_dir() => {
-                    collect_toml_inner(&path, out, failures, visited_dirs);
-                }
-                Ok(metadata) if metadata.is_file() => collect_toml_file(&path, out),
-                Ok(_) => {}
-                Err(error) => failures.push(format!(
-                    "could not determine symlink target type for {}: {error}",
-                    path.display()
-                )),
-            }
-        }
-    }
-}
-
-fn collect_toml_file(path: &Path, out: &mut Vec<PathBuf>) {
-    if path
-        .extension()
-        .is_some_and(|extension| extension == "toml")
-    {
-        out.push(path.to_path_buf());
-    }
 }
 
 #[cfg(test)]

--- a/crates/rue-spec/BUCK
+++ b/crates/rue-spec/BUCK
@@ -6,7 +6,6 @@ rue_binary(
         "//crates/rue-test-runner:rue-test-runner",
         "//third-party:libtest2-mimic",
         "//third-party:tempfile",
-        "//third-party:toml",
     ],
 )
 

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -69,7 +69,10 @@ fn run_traceability(detailed: bool) {
         std::process::exit(1);
     }
 
-    let report = traceability::generate_report(&spec_dir, &cases_dir);
+    let report = traceability::generate_report(&spec_dir, &cases_dir).unwrap_or_else(|error| {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    });
 
     if detailed {
         report.print_detailed();
@@ -172,7 +175,10 @@ fn main() {
     let cases_dir = find_dir("RUE_SPEC_CASES", CASES_DIR_PATHS, "cases");
 
     // Load all test files
-    let specs = load_test_files(&cases_dir);
+    let specs = load_test_files(&cases_dir).unwrap_or_else(|error| {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    });
 
     // Build test trials, separating stable and preview tests
     // Pre-allocate based on total case count across all specs

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -54,7 +54,7 @@
 //! }
 //! ```
 
-use rue_test_runner::collect_files_by_ext;
+use rue_test_runner::{discover_files, load_test_files};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
@@ -513,53 +513,90 @@ impl TraceabilityReport {
     }
 }
 
-/// Extract a quoted shortcode argument (`name = "value"`), tolerating
-/// whitespace around `=`. Zola accepts `id = "x"` and renders it identically
-/// to `id="x"`, so the checker must too. Otherwise a spaced `cat` can demote a
-/// rule to informative and a spaced `id` can hide it, silently weakening
-/// coverage enforcement.
-fn find_shortcode_arg(line: &str, name: &str) -> Option<String> {
-    let mut search_from = 0;
-    while let Some(rel) = line[search_from..].find(name) {
-        let pos = search_from + rel;
-        let after = line[pos + name.len()..].trim_start();
-        if let Some(rest) = after.strip_prefix('=') {
-            let rest = rest.trim_start();
-            if let Some(rest) = rest.strip_prefix('"') {
-                if let Some(end) = rest.find('"') {
-                    return Some(rest[..end].to_string());
-                }
-            }
-        }
-        search_from = pos + name.len();
-    }
-    None
-}
-
 /// Parse a spec marker from a line.
 /// Format: {{ rule(id="X.Y:Z") }} or {{ rule(id="X.Y:Z", cat="category") }} (Zola shortcode)
 /// Category can be: normative, informative, syntax, example
 /// Default category (no cat) is informative.
 /// Returns (id, category) if found.
-fn parse_spec_comment(line: &str) -> Option<(String, String)> {
+fn parse_spec_comment(line: &str) -> Result<Option<(String, String)>, String> {
     let line = line.trim();
 
-    // Zola shortcode format: {{ rule(id="X.Y:Z") }} or {{ rule(id="X.Y:Z", cat="category") }}
-    if !(line.starts_with("{{") && line.contains("rule(")) {
-        return None;
+    if !line
+        .strip_prefix("{{")
+        .is_some_and(|body| body.trim_start().starts_with("rule"))
+    {
+        return Ok(None);
     }
-    let id = find_shortcode_arg(line, "id")?;
-    // Validate that the ID contains a colon (required format: X.Y:Z)
-    if !id.contains(':') {
-        return None;
+    let body = line
+        .strip_prefix("{{")
+        .and_then(|body| body.strip_suffix("}}"))
+        .map(str::trim)
+        .and_then(|body| body.strip_prefix("rule("))
+        .and_then(|body| body.strip_suffix(')'))
+        .ok_or_else(|| "malformed rule marker".to_string())?;
+
+    let mut id = None;
+    let mut category = None;
+    for argument in body.split(',') {
+        let (name, value) = argument
+            .trim()
+            .split_once('=')
+            .ok_or_else(|| "malformed rule marker argument".to_string())?;
+        let value = value.trim();
+        let value = value
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .filter(|value| !value.contains('"'))
+            .ok_or_else(|| {
+                format!(
+                    "rule marker argument `{}` must be a quoted string",
+                    name.trim()
+                )
+            })?
+            .to_string();
+        let slot = match name.trim() {
+            "id" => &mut id,
+            "cat" => &mut category,
+            other => return Err(format!("unknown rule marker argument `{other}`")),
+        };
+        if slot.replace(value).is_some() {
+            return Err(format!("duplicate rule marker argument `{}`", name.trim()));
+        }
     }
-    let category = find_shortcode_arg(line, "cat").unwrap_or_else(|| "informative".to_string());
-    Some((id, category))
+
+    let id = id.ok_or_else(|| "rule marker is missing `id`".to_string())?;
+    let valid_id = id.split_once(':').is_some_and(|(section, paragraph)| {
+        section.contains('.')
+            && section
+                .split('.')
+                .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_alphanumeric()))
+            && !paragraph.is_empty()
+            && paragraph.chars().all(|c| c.is_ascii_alphanumeric())
+    });
+    if !valid_id {
+        return Err(format!("invalid rule id `{id}` (expected X.Y:Z)"));
+    }
+    let category = category.unwrap_or_else(|| "informative".to_string());
+    const CATEGORIES: &[&str] = &[
+        "normative",
+        "legality-rule",
+        "dynamic-semantics",
+        "syntax",
+        "undefined-behavior",
+        "example",
+        "informative",
+    ];
+    if !CATEGORIES.contains(&category.as_str()) {
+        return Err(format!("unknown rule category `{category}`"));
+    }
+    Ok(Some((id, category)))
 }
 
 /// Check if a line is a spec marker (Zola shortcode format).
 fn is_spec_marker(line: &str) -> bool {
-    line.starts_with("{{") && line.contains("rule(")
+    line.trim()
+        .strip_prefix("{{")
+        .is_some_and(|body| body.trim_start().starts_with("rule"))
 }
 
 /// Parse spec paragraphs from a markdown file. A rule id that was already
@@ -571,19 +608,16 @@ fn parse_spec_file(
     path: &Path,
     paragraphs: &mut BTreeMap<String, SpecParagraph>,
     duplicates: &mut Vec<String>,
-) {
-    let content = match fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("Error reading spec file {}: {}", path.display(), e);
-            return;
-        }
-    };
+) -> Result<(), String> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read spec file {}: {error}", path.display()))?;
 
     let lines: Vec<&str> = content.lines().collect();
 
     for (i, line) in lines.iter().enumerate() {
-        if let Some((id, category)) = parse_spec_comment(line) {
+        let marker = parse_spec_comment(line)
+            .map_err(|error| format!("{}:{}: {error}", path.display(), i + 1))?;
+        if let Some((id, category)) = marker {
             // Get the next non-empty line as the paragraph text
             let mut text = String::new();
             for j in (i + 1)..lines.len() {
@@ -620,6 +654,7 @@ fn parse_spec_file(
             }
         }
     }
+    Ok(())
 }
 
 /// Parses all specification paragraphs from markdown files in a directory.
@@ -637,217 +672,24 @@ fn parse_spec_file(
 /// list of DUPLICATE rule ids (an id defined more than once across the spec).
 /// Duplicates fail the traceability gate: with last-writer-wins insertion, a
 /// duplicate can silently replace a normative rule with an informative one.
-pub fn parse_spec_paragraphs(spec_dir: &Path) -> (BTreeMap<String, SpecParagraph>, Vec<String>) {
+pub fn parse_spec_paragraphs(
+    spec_dir: &Path,
+) -> Result<(BTreeMap<String, SpecParagraph>, Vec<String>), String> {
     let mut paragraphs = BTreeMap::new();
     let mut duplicates = Vec::new();
 
-    let mut md_files = Vec::new();
-    collect_files_by_ext(spec_dir, "md", &mut md_files);
+    let md_files = discover_files(spec_dir, "md").map_err(|error| {
+        format!(
+            "failed to discover specification files under {}: {error}",
+            spec_dir.display()
+        )
+    })?;
 
     for path in md_files {
-        parse_spec_file(&path, &mut paragraphs, &mut duplicates);
+        parse_spec_file(&path, &mut paragraphs, &mut duplicates)?;
     }
 
-    (paragraphs, duplicates)
-}
-
-/// A parsed test specification file.
-///
-/// Each TOML file in the test cases directory represents a section of tests.
-/// This struct holds the parsed metadata and test cases from one such file.
-pub struct TestFile {
-    /// The section identifier from the TOML file (e.g., "expressions.arithmetic").
-    pub section_id: String,
-    /// All test cases defined in this file.
-    pub cases: Vec<TestCase>,
-}
-
-/// A single test case with its specification references.
-///
-/// For parameterized tests, this represents one expanded instance with
-/// any `spec_extra` references merged into the base `spec` references.
-pub struct TestCase {
-    /// The test case name (expanded with parameter values for parameterized tests).
-    pub name: String,
-    /// Specification paragraph IDs that this test covers (e.g., ["3.1:5", "3.1:6"]).
-    pub spec_refs: Vec<String>,
-    /// Whether this case actually *runs* and so can satisfy coverage.
-    ///
-    /// A rule's behavior is only exercised by a test that runs and is required
-    /// to pass. A case does **not** count as coverage if it is `skip = true`, or
-    /// if it is a preview-feature test that is allowed to fail (`preview` set
-    /// without `preview_should_pass`). Such a case's spec references still count
-    /// for orphan detection — a dangling reference is broken whether or not the
-    /// case runs — but they do not mark a normative paragraph as covered
-    /// (RUE-132).
-    pub counts_as_coverage: bool,
-}
-
-/// Parses test files and extracts specification references.
-///
-/// Recursively searches for `.toml` files in the cases directory and parses
-/// each one to extract test cases and their spec references.
-///
-/// # Parameterized Tests
-///
-/// For parameterized tests (those with a `params` array), this function expands
-/// each parameter set into a separate [`TestCase`], substituting placeholders
-/// in the test name and merging any `spec_extra` references with the base `spec` array.
-///
-/// # Arguments
-///
-/// * `cases_dir` - Path to the test cases directory (e.g., `crates/rue-spec/cases`)
-///
-/// # Returns
-///
-/// A list of [`TestFile`] structs, one per TOML file found.
-pub fn parse_test_files(cases_dir: &Path) -> Vec<TestFile> {
-    let mut test_files = Vec::new();
-
-    let mut toml_files = Vec::new();
-    collect_files_by_ext(cases_dir, "toml", &mut toml_files);
-
-    for path in toml_files {
-        let content = match fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("Error reading test file {}: {}", path.display(), e);
-                continue;
-            }
-        };
-
-        // Parse the TOML file
-        let table: toml::Table = match toml::from_str(&content) {
-            Ok(t) => t,
-            Err(e) => {
-                eprintln!("Error parsing test file {}: {}", path.display(), e);
-                continue;
-            }
-        };
-
-        // Get section ID
-        let section_id = table
-            .get("section")
-            .and_then(|s| s.get("id"))
-            .and_then(|id| id.as_str())
-            .unwrap_or("unknown")
-            .to_string();
-
-        // Get cases
-        let case_array_opt = table.get("case").and_then(|c| c.as_array());
-        let mut cases = Vec::new();
-        if let Some(case_array) = case_array_opt {
-            for case in case_array {
-                let base_name = case
-                    .get("name")
-                    .and_then(|n| n.as_str())
-                    .unwrap_or("unnamed")
-                    .to_string();
-
-                let base_spec_refs: Vec<String> = case
-                    .get("spec")
-                    .and_then(|s| s.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-
-                // A case only counts as coverage if it actually runs and is
-                // required to pass (RUE-132): a `skip = true` case never runs,
-                // and a preview-feature test without `preview_should_pass` is
-                // allowed to fail, so neither exercises the rule it references.
-                let base_skip = case.get("skip").and_then(|s| s.as_bool()).unwrap_or(false);
-                let is_preview = case
-                    .get("preview")
-                    .and_then(|p| p.as_str())
-                    .is_some_and(|s| !s.is_empty());
-                let preview_should_pass = case
-                    .get("preview_should_pass")
-                    .and_then(|p| p.as_bool())
-                    .unwrap_or(false);
-                let preview_allowed_to_fail = is_preview && !preview_should_pass;
-
-                // Check if this is a parameterized test
-                if let Some(params_array) = case.get("params").and_then(|p| p.as_array()) {
-                    // Expand parameterized test - each param set becomes a test case
-                    for param_set in params_array {
-                        let param_table = match param_set.as_table() {
-                            Some(t) => t,
-                            None => continue,
-                        };
-
-                        // Substitute placeholders in name
-                        let mut expanded_name = base_name.clone();
-                        for (key, value) in param_table {
-                            let placeholder = format!("{{{}}}", key);
-                            let replacement = match value {
-                                toml::Value::String(s) => s.clone(),
-                                toml::Value::Integer(i) => i.to_string(),
-                                other => other.to_string(),
-                            };
-                            expanded_name = expanded_name.replace(&placeholder, &replacement);
-                        }
-
-                        // Merge base spec refs with spec_extra from params
-                        let mut spec_refs = base_spec_refs.clone();
-                        if let Some(spec_extra) = param_table.get("spec_extra") {
-                            if let Some(arr) = spec_extra.as_array() {
-                                for item in arr {
-                                    if let Some(s) = item.as_str() {
-                                        spec_refs.push(s.to_string());
-                                    }
-                                }
-                            }
-                        }
-
-                        // A per-param `skip = true` override also disqualifies
-                        // just that instance from counting as coverage.
-                        let param_skip = param_table
-                            .get("skip")
-                            .and_then(|s| s.as_bool())
-                            .unwrap_or(false);
-                        // Per-param `preview`/`preview_should_pass` overrides
-                        // mirror the runner's expand_case: an instance the
-                        // runner allows to fail must not count as coverage,
-                        // even when the BASE case has no preview (RUE-132).
-                        let param_is_preview = param_table
-                            .get("preview")
-                            .and_then(|p| p.as_str())
-                            .map(|s| !s.is_empty());
-                        let param_should_pass = param_table
-                            .get("preview_should_pass")
-                            .and_then(|p| p.as_bool());
-                        let effective_preview = param_is_preview.unwrap_or(is_preview);
-                        let effective_should_pass =
-                            param_should_pass.unwrap_or(preview_should_pass);
-                        let param_preview_allowed_to_fail =
-                            effective_preview && !effective_should_pass;
-                        let counts_as_coverage =
-                            !base_skip && !param_skip && !param_preview_allowed_to_fail;
-
-                        cases.push(TestCase {
-                            name: expanded_name,
-                            spec_refs,
-                            counts_as_coverage,
-                        });
-                    }
-                } else {
-                    // Non-parameterized test
-                    cases.push(TestCase {
-                        name: base_name,
-                        spec_refs: base_spec_refs,
-                        counts_as_coverage: !base_skip && !preview_allowed_to_fail,
-                    });
-                }
-            }
-        }
-
-        test_files.push(TestFile { section_id, cases });
-    }
-
-    test_files
+    Ok((paragraphs, duplicates))
 }
 
 /// Generates a complete traceability report linking specification to tests.
@@ -874,12 +716,13 @@ pub fn parse_test_files(cases_dir: &Path) -> Vec<TestFile> {
 /// let report = generate_report(Path::new("docs/spec/src"), Path::new("crates/rue-spec/cases"));
 /// report.print_summary();
 /// ```
-pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> TraceabilityReport {
+pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> Result<TraceabilityReport, String> {
     // Parse spec paragraphs
-    let (paragraphs, duplicate_rule_ids) = parse_spec_paragraphs(spec_dir);
+    let (paragraphs, duplicate_rule_ids) = parse_spec_paragraphs(spec_dir)?;
 
-    // Parse test files
-    let test_files = parse_test_files(cases_dir);
+    // Use the runner's typed deserialization and parameter expansion so the
+    // traceability view cannot accept metadata the executable suite rejects.
+    let test_files = load_test_files(cases_dir)?;
 
     // Build coverage map
     let mut coverage: BTreeMap<String, Vec<TestReference>> = BTreeMap::new();
@@ -891,17 +734,19 @@ pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> TraceabilityReport 
     }
 
     // Process test files
-    for test_file in &test_files {
-        for case in &test_file.cases {
-            let test_name = format!("{}::{}", test_file.section_id, case.name);
+    for (_, test_file) in &test_files {
+        for case in &test_file.case {
+            let test_name = format!("{}::{}", test_file.section.id, case.name);
+            let counts_as_coverage =
+                !case.skip && (case.preview.is_none() || case.preview_should_pass);
 
-            for spec_ref in &case.spec_refs {
+            for spec_ref in &case.spec {
                 if let Some(tests) = coverage.get_mut(spec_ref) {
                     // A skipped or preview-allowed-to-fail case never exercises
                     // the rule, so it must not mark the paragraph as covered
                     // (RUE-132). Its reference is still valid, so it is not an
                     // orphan — it simply doesn't contribute coverage.
-                    if case.counts_as_coverage {
+                    if counts_as_coverage {
                         tests.push(TestReference {
                             test_name: test_name.clone(),
                         });
@@ -913,12 +758,12 @@ pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> TraceabilityReport 
         }
     }
 
-    TraceabilityReport {
+    Ok(TraceabilityReport {
         paragraphs,
         coverage,
         orphan_references,
         duplicate_rule_ids,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -928,26 +773,131 @@ mod tests {
     #[test]
     fn test_parse_spec_comment() {
         // Simple shortcode without category defaults to informative
-        let (id, cat) = parse_spec_comment("{{ rule(id=\"3.1:1\") }}").unwrap();
+        let (id, cat) = parse_spec_comment("{{ rule(id=\"3.1:1\") }}")
+            .unwrap()
+            .unwrap();
         assert_eq!(id, "3.1:1");
         assert_eq!(cat, "informative");
 
         // Shortcode with explicit normative category
-        let (id, cat) = parse_spec_comment("{{ rule(id=\"4.2:3\", cat=\"normative\") }}").unwrap();
+        let (id, cat) = parse_spec_comment("{{ rule(id=\"4.2:3\", cat=\"normative\") }}")
+            .unwrap()
+            .unwrap();
         assert_eq!(id, "4.2:3");
         assert_eq!(cat, "normative");
 
         // Shortcode with explicit syntax category
-        let (id, cat) = parse_spec_comment("{{ rule(id=\"2.1:1\", cat=\"syntax\") }}").unwrap();
+        let (id, cat) = parse_spec_comment("{{ rule(id=\"2.1:1\", cat=\"syntax\") }}")
+            .unwrap()
+            .unwrap();
         assert_eq!(id, "2.1:1");
         assert_eq!(cat, "syntax");
 
         // Invalid: no colon in ID
-        assert!(parse_spec_comment("{{ rule(id=\"3.1.1\") }}").is_none());
+        assert!(parse_spec_comment("{{ rule(id=\"3.1.1\") }}").is_err());
 
         // Invalid formats
-        assert!(parse_spec_comment("not a spec comment").is_none());
-        assert!(parse_spec_comment("<!-- not spec -->").is_none());
+        assert!(parse_spec_comment("not a spec comment").unwrap().is_none());
+        assert!(parse_spec_comment("<!-- not spec -->").unwrap().is_none());
+        assert!(
+            parse_spec_comment("{{ note(text=\"rule\") }}")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn malformed_markers_and_unknown_categories_are_rejected() {
+        assert!(parse_spec_comment("{{ rule(id=\"1.1:1\" }}").is_err());
+        assert!(parse_spec_comment("{{ rule(cat=\"normative\") }}").is_err());
+        assert!(
+            parse_spec_comment("{{ rule(id=\"1.1:1\", cat=\"typo\") }}")
+                .unwrap_err()
+                .contains("unknown rule category")
+        );
+    }
+
+    #[test]
+    fn malformed_test_file_fails_report_even_with_valid_sibling() {
+        let spec_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            spec_dir.path().join("spec.md"),
+            "{{ rule(id=\"1.1:1\", cat=\"normative\") }}\nRule.",
+        )
+        .unwrap();
+        let cases_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            cases_dir.path().join("valid.toml"),
+            r#"
+[section]
+id = "test.section"
+name = "Test"
+[[case]]
+name = "valid"
+source = "fn main() -> i32 { 0 }"
+spec = ["1.1:1"]
+exit_code = 0
+"#,
+        )
+        .unwrap();
+        fs::write(cases_dir.path().join("malformed.toml"), "case = [").unwrap();
+
+        let error = generate_report(spec_dir.path(), cases_dir.path()).unwrap_err();
+        assert!(error.contains("malformed.toml"), "{error}");
+    }
+
+    #[test]
+    fn traceability_uses_runner_parameter_expansion() {
+        let spec_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            spec_dir.path().join("spec.md"),
+            concat!(
+                "{{ rule(id=\"1.1:1\", cat=\"normative\") }}\nBase.\n",
+                "{{ rule(id=\"1.1:2\", cat=\"normative\") }}\nExtra.\n"
+            ),
+        )
+        .unwrap();
+        let cases_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            cases_dir.path().join("params.toml"),
+            r#"
+[section]
+id = "test.section"
+name = "Test"
+[[case]]
+name = "case_{kind}"
+source = "fn main() -> i32 { 0 }"
+spec = ["1.1:1"]
+exit_code = 0
+params = [{ kind = "expanded", spec_extra = ["1.1:2"] }]
+"#,
+        )
+        .unwrap();
+
+        let report = generate_report(spec_dir.path(), cases_dir.path()).unwrap();
+        assert_eq!(
+            report.coverage["1.1:1"][0].test_name,
+            "test.section::case_expanded"
+        );
+        assert_eq!(
+            report.coverage["1.1:2"][0].test_name,
+            "test.section::case_expanded"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_spec_file_fails_report() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let spec_dir = tempfile::tempdir().unwrap();
+        let spec = spec_dir.path().join("unreadable.md");
+        fs::write(&spec, "{{ rule(id=\"1.1:1\") }}\nRule.").unwrap();
+        fs::set_permissions(&spec, fs::Permissions::from_mode(0o000)).unwrap();
+        let cases_dir = tempfile::tempdir().unwrap();
+        let result = generate_report(spec_dir.path(), cases_dir.path());
+        fs::set_permissions(&spec, fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(result.is_err());
     }
 
     #[test]
@@ -971,7 +921,7 @@ Another paragraph.
 
         let mut paragraphs = BTreeMap::new();
         let mut duplicates = Vec::new();
-        parse_spec_file(&file_path, &mut paragraphs, &mut duplicates);
+        parse_spec_file(&file_path, &mut paragraphs, &mut duplicates).unwrap();
         assert!(duplicates.is_empty());
 
         assert_eq!(paragraphs.len(), 2);
@@ -985,7 +935,9 @@ Another paragraph.
     #[test]
     fn test_default_category_is_informative() {
         // Rules without explicit category default to informative
-        let (id, cat) = parse_spec_comment("{{ rule(id=\"1.1:1\") }}").unwrap();
+        let (id, cat) = parse_spec_comment("{{ rule(id=\"1.1:1\") }}")
+            .unwrap()
+            .unwrap();
         assert_eq!(id, "1.1:1");
         assert_eq!(cat, "informative");
     }
@@ -1005,7 +957,7 @@ fn main() { }
 
         let mut paragraphs = BTreeMap::new();
         let mut duplicates = Vec::new();
-        parse_spec_file(&file_path, &mut paragraphs, &mut duplicates);
+        parse_spec_file(&file_path, &mut paragraphs, &mut duplicates).unwrap();
         assert!(duplicates.is_empty());
 
         assert_eq!(paragraphs.len(), 1);
@@ -1096,14 +1048,14 @@ exit_code = 0
 [[case]]
 name = "preview_may_fail"
 spec = ["1.1:3"]
-preview = "some_feature"
+preview = "raw_bytes"
 source = "fn main() -> i32 { 0 }"
 exit_code = 0
 
 [[case]]
 name = "preview_must_pass"
 spec = ["1.1:4"]
-preview = "some_feature"
+preview = "raw_bytes"
 preview_should_pass = true
 source = "fn main() -> i32 { 0 }"
 exit_code = 0
@@ -1113,7 +1065,7 @@ exit_code = 0
         let cases_dir = tempfile::tempdir().unwrap();
         fs::write(cases_dir.path().join("c.toml"), cases).unwrap();
 
-        let report = generate_report(spec_dir.path(), cases_dir.path());
+        let report = generate_report(spec_dir.path(), cases_dir.path()).unwrap();
 
         // Only 1.1:1 and 1.1:4 are exercised by a running, must-pass test.
         assert!(!report.coverage["1.1:1"].is_empty(), "normal test covers");

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 10_000;
 /// This matches the convention used by Rust's test harness and the Rue runtime.
 /// When a Rue program encounters a runtime error, it exits with this code.
 pub const RUNTIME_ERROR_EXIT_CODE: i32 = 101;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::io::{Read as IoRead, Write};
 use std::path::{Path, PathBuf};
@@ -1371,38 +1371,92 @@ pub fn validate_nonempty_case_corpus(
     ))
 }
 
-/// Recursively collect all files with the given extension from a directory.
-pub fn collect_files_by_ext(dir: &Path, ext: &str, files: &mut Vec<PathBuf>) {
-    if let Ok(entries) = fs::read_dir(dir) {
-        for entry in entries.flatten() {
+/// Recursively discover files with the given extension.
+///
+/// The result is sorted by path. Every filesystem error is returned: callers
+/// must never run a partial corpus merely because one directory entry could
+/// not be inspected.
+pub fn discover_files(dir: &Path, ext: &str) -> std::io::Result<Vec<PathBuf>> {
+    fn visit(
+        dir: &Path,
+        ext: &str,
+        files: &mut Vec<PathBuf>,
+        visited_dirs: &mut BTreeSet<PathBuf>,
+    ) -> std::io::Result<()> {
+        let canonical_dir = fs::canonicalize(dir).map_err(|error| {
+            std::io::Error::new(
+                error.kind(),
+                format!("failed to resolve directory {}: {error}", dir.display()),
+            )
+        })?;
+        if !visited_dirs.insert(canonical_dir) {
+            return Ok(());
+        }
+        let read_dir = fs::read_dir(dir).map_err(|error| {
+            std::io::Error::new(
+                error.kind(),
+                format!("failed to read directory {}: {error}", dir.display()),
+            )
+        })?;
+        let mut entries = Vec::new();
+        for entry in read_dir {
+            let entry = entry.map_err(|error| {
+                std::io::Error::new(
+                    error.kind(),
+                    format!("failed to read an entry in {}: {error}", dir.display()),
+                )
+            })?;
             let path = entry.path();
-            if path.is_dir() {
-                collect_files_by_ext(&path, ext, files);
-            } else if path.extension().is_some_and(|e| e == ext) {
+            let file_type = entry.file_type().map_err(|error| {
+                std::io::Error::new(
+                    error.kind(),
+                    format!("failed to inspect {}: {error}", path.display()),
+                )
+            })?;
+            entries.push((path, file_type));
+        }
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        for (path, file_type) in entries {
+            if file_type.is_dir() {
+                visit(&path, ext, files, visited_dirs)?;
+            } else if file_type.is_symlink() {
+                let target = fs::metadata(&path).map_err(|error| {
+                    std::io::Error::new(
+                        error.kind(),
+                        format!(
+                            "failed to inspect symlink target {}: {error}",
+                            path.display()
+                        ),
+                    )
+                })?;
+                if target.is_dir() {
+                    visit(&path, ext, files, visited_dirs)?;
+                } else if target.is_file()
+                    && path.extension().is_some_and(|candidate| candidate == ext)
+                {
+                    files.push(path);
+                }
+            } else if file_type.is_file()
+                && path.extension().is_some_and(|candidate| candidate == ext)
+            {
                 files.push(path);
             }
         }
+        Ok(())
     }
-}
 
-/// Recursively collect all TOML files from a directory.
-///
-/// This is a convenience wrapper around [`collect_files_by_ext`].
-pub fn collect_toml_files(dir: &Path, files: &mut Vec<PathBuf>) {
-    collect_files_by_ext(dir, "toml", files);
+    let mut files = Vec::new();
+    let mut visited_dirs = BTreeSet::new();
+    visit(dir, ext, &mut files, &mut visited_dirs)?;
+    Ok(files)
 }
 
 /// Load all test files from a directory (including subdirectories).
 ///
-/// This function validates that all preview feature names in tests are known.
-/// If any unknown preview features are found, an error is printed for each
-/// invalid feature and the function panics with a summary.
-///
-/// # Panics
-///
-/// Panics if any test uses an unknown preview feature name. This prevents
-/// tests from being silently skipped due to typos in feature names.
-pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
+/// This function validates test metadata and returns every discovery, read,
+/// parse, or validation failure instead of silently running a partial corpus.
+pub fn load_test_files(cases_dir: &Path) -> Result<Vec<(String, TestFile)>, String> {
     let mut specs = Vec::new();
     let mut preview_errors: Vec<UnknownPreviewFeatureError> = Vec::new();
     let mut platform_errors: Vec<UnknownPlatformError> = Vec::new();
@@ -1410,17 +1464,12 @@ pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
     let mut bare_compile_fail: Vec<BareCompileFailError> = Vec::new();
     let mut compile_fail_exit_codes: Vec<CompileFailExitCodeError> = Vec::new();
 
-    if !cases_dir.exists() {
-        eprintln!(
-            "Warning: cases directory not found: {}",
+    let toml_files = discover_files(cases_dir, "toml").map_err(|error| {
+        format!(
+            "failed to discover test files under {}: {error}",
             cases_dir.display()
-        );
-        return specs;
-    }
-
-    // Collect all TOML files recursively
-    let mut toml_files = Vec::new();
-    collect_toml_files(cases_dir, &mut toml_files);
+        )
+    })?;
 
     let mut load_errors: Vec<String> = Vec::new();
     for path in toml_files {
@@ -1474,107 +1523,81 @@ pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
     // A case file that fails to load must fail the suite: silently skipping it
     // would silently remove every test it contains. (RUE-132)
     if !load_errors.is_empty() {
-        eprintln!(
-            "
-Error: {} test file(s) failed to load:",
-            load_errors.len()
-        );
-        for error in &load_errors {
-            eprintln!("  - {}", error);
-        }
-        panic!(
-            "Test loading failed: {} file(s) unreadable or unparsable.              See errors above for details.",
-            load_errors.len()
-        );
+        return Err(format!(
+            "{} test file(s) failed to load:\n  - {}",
+            load_errors.len(),
+            load_errors.join("\n  - ")
+        ));
     }
 
     // Report all preview feature errors and fail if any were found
     if !preview_errors.is_empty() {
-        eprintln!(
-            "\nError: Found {} unknown preview feature name(s):",
-            preview_errors.len()
-        );
-        for error in &preview_errors {
-            eprintln!("  - {}", error);
-        }
-        panic!(
-            "Test loading failed: {} test(s) use unknown preview feature names. \
-             See errors above for details.",
-            preview_errors.len()
-        );
+        return Err(format!(
+            "{} test(s) use unknown preview feature names:\n  - {}",
+            preview_errors.len(),
+            preview_errors
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n  - ")
+        ));
     }
 
     // Report unknown only_on platform names and fail if any were found
     if !platform_errors.is_empty() {
-        eprintln!(
-            "\nError: Found {} unknown only_on platform name(s):",
-            platform_errors.len()
-        );
-        for error in &platform_errors {
-            eprintln!("  - {}", error);
-        }
-        panic!(
-            "Test loading failed: {} case(s) use unknown only_on platform names \
-             (the case would run on NO platform). See errors above for details.",
-            platform_errors.len()
-        );
+        return Err(format!(
+            "{} case(s) use unknown only_on platform names:\n  - {}",
+            platform_errors.len(),
+            platform_errors
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n  - ")
+        ));
     }
 
     // Report stray compile-error assertions and fail if any were found
     if !stray_error_assertions.is_empty() {
-        eprintln!(
-            "\nError: Found {} case(s) with a compile-error assertion but no `compile_fail`:",
-            stray_error_assertions.len()
-        );
-        for error in &stray_error_assertions {
-            eprintln!("  - {}", error);
-        }
-        panic!(
-            "Test loading failed: {} case(s) set `error_contains`/`expected_error` without \
-             `compile_fail`. See errors above for details.",
-            stray_error_assertions.len()
-        );
+        return Err(format!(
+            "{} case(s) set a compile-error assertion without `compile_fail`:\n  - {}",
+            stray_error_assertions.len(),
+            stray_error_assertions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n  - ")
+        ));
     }
 
     // Report bare compile_fail cases and fail if any were found
     if !bare_compile_fail.is_empty() {
-        eprintln!(
-            "\nError: Found {} `compile_fail` case(s) with no error assertion:",
-            bare_compile_fail.len()
-        );
-        for error in &bare_compile_fail {
-            eprintln!("  - {}", error);
-        }
-        panic!(
-            "Test loading failed: {} `compile_fail` case(s) declare neither \
-             `error_contains` nor `expected_error`, so they pass on any rejection. \
-             See errors above for details.",
-            bare_compile_fail.len()
-        );
+        return Err(format!(
+            "{} `compile_fail` case(s) have no error assertion:\n  - {}",
+            bare_compile_fail.len(),
+            bare_compile_fail
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n  - ")
+        ));
     }
 
     // Report runtime exit-code assertions that compile-fail cases cannot check.
     if !compile_fail_exit_codes.is_empty() {
-        eprintln!(
-            "\nError: Found {} `compile_fail` case(s) with an ignored `exit_code`:",
-            compile_fail_exit_codes.len()
-        );
-        for error in &compile_fail_exit_codes {
-            eprintln!("  - {}", error);
-        }
-        panic!(
-            concat!(
-                "Test loading failed: {} `compile_fail` case(s) declare `exit_code`, ",
-                "which is only checked after successful compilation. ",
-                "See errors above for details."
-            ),
-            compile_fail_exit_codes.len()
-        );
+        return Err(format!(
+            "{} `compile_fail` case(s) declare an ignored `exit_code`:\n  - {}",
+            compile_fail_exit_codes.len(),
+            compile_fail_exit_codes
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n  - ")
+        ));
     }
 
     // Sort by identifier for deterministic ordering
     specs.sort_by(|a, b| a.0.cmp(&b.0));
-    specs
+    Ok(specs)
 }
 
 /// Normalize a string for golden test comparison.
@@ -2404,6 +2427,97 @@ pub fn find_rue_binary() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const VALID_TEST_FILE: &str = r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "valid"
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+"#;
+
+    #[test]
+    fn discovery_is_recursive_and_deterministic() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::create_dir(directory.path().join("b")).unwrap();
+        fs::create_dir(directory.path().join("a")).unwrap();
+        fs::write(directory.path().join("b/z.toml"), "").unwrap();
+        fs::write(directory.path().join("a/y.toml"), "").unwrap();
+        fs::write(directory.path().join("a/ignored.md"), "").unwrap();
+
+        let discovered = discover_files(directory.path(), "toml").unwrap();
+        assert_eq!(
+            discovered,
+            vec![
+                directory.path().join("a/y.toml"),
+                directory.path().join("b/z.toml")
+            ]
+        );
+    }
+
+    #[test]
+    fn discovery_rejects_a_missing_root() {
+        let directory = tempfile::tempdir().unwrap();
+        let missing = directory.path().join("missing");
+        assert!(discover_files(&missing, "toml").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovery_rejects_an_unreadable_root() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("root");
+        fs::create_dir(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o000)).unwrap();
+        let result = discover_files(&root, "toml");
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn malformed_file_cannot_hide_behind_a_valid_sibling() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(directory.path().join("a-valid.toml"), VALID_TEST_FILE).unwrap();
+        fs::write(directory.path().join("b-malformed.toml"), "not = [valid").unwrap();
+
+        let error = load_test_files(directory.path()).unwrap_err();
+        assert!(error.contains("b-malformed.toml"), "{error}");
+        assert!(error.contains("failed to load"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_subdirectory_fails_discovery() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let unreadable = directory.path().join("unreadable");
+        fs::create_dir(&unreadable).unwrap();
+        fs::write(unreadable.join("hidden.toml"), VALID_TEST_FILE).unwrap();
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+        let result = discover_files(directory.path(), "toml");
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_test_file_fails_loading() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let unreadable = directory.path().join("unreadable.toml");
+        fs::write(&unreadable, VALID_TEST_FILE).unwrap();
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+        let result = load_test_files(directory.path());
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(result.is_err());
+    }
 
     #[cfg(unix)]
     fn fake_compiler(script: &str) -> (tempfile::TempDir, PathBuf) {

--- a/crates/rue-ui-tests/src/main.rs
+++ b/crates/rue-ui-tests/src/main.rs
@@ -41,7 +41,10 @@ fn main() {
     let cases_dir = find_dir("RUE_UI_CASES", CASES_DIR_PATHS, "cases");
 
     // Load all test files
-    let test_files = load_test_files(&cases_dir);
+    let test_files = load_test_files(&cases_dir).unwrap_or_else(|error| {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    });
     let total_cases: usize = test_files
         .iter()
         .map(|(_, test_file)| test_file.case.len())


### PR DESCRIPTION
## Summary

- replace silent recursive corpus scanning with one deterministic, fallible discovery API
- make spec, UI, CLI, traceability, and oracle consumers fail closed on partial discovery or invalid input
- make traceability consume the canonical typed and parameter-expanded test corpus
- reject malformed specification rule markers and unknown rule categories
- add adversarial coverage for missing permissions, malformed files, valid siblings, marker validation, and parameter expansion

## Root cause

Corpus discovery and traceability had multiple permissive paths that printed or dropped filesystem and parse errors. A valid sibling could therefore leave the corpus nonempty and preserve a false-green result while inputs were omitted.

## Validation

- `scripts/rue test`
- `scripts/rue quick` after rebasing onto current upstream trunk
- focused runner, spec, CLI, oracle, and traceability targets
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-800
