### PR TITLE
RUE-899: report baseline-relative homepage status

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -113,6 +113,7 @@ filegroup(
         "scripts/perf-baseline.py",
         "scripts/validate-benchmark.py",
         "website/templates/performance.html",
+        "website/templates/index.html",
     ],
 )
 

--- a/scripts/generate-site-status.py
+++ b/scripts/generate-site-status.py
@@ -5,12 +5,12 @@ Generate the homepage status-board data (website/static/status.json).
 Everything here is derived at build time from the repo itself — no services,
 no APIs:
 
-- commit / commit_date / commit_count  — from git
+- commit / commit_date / commit_count  — from git (count only when complete)
 - spec_rules      — count of normative-category {{ rule(...) }} markers in
                     docs/spec/src (categories that the traceability check in
                     ./test.sh requires 100% test coverage for)
 - spec_cases      — count of [[case]] entries in crates/rue-spec/cases
-- bench           — compile-time sparkline over the last 20 runs, from the
+- bench           — canonical 30-day comparable trend, from the
                     x86-64-linux benchmark history (fetched from the perf
                     branch by the deploy workflow; absent locally is fine)
 
@@ -26,16 +26,20 @@ import json
 import re
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import quote
 
-from benchmark_history import latest_comparable_segment, load_history
+from benchmark_history import load_history
 from benchmark_annotations import (
     DEFAULT_ANNOTATIONS,
     GitCommitResolver,
     load_annotations,
     normalized_annotations,
 )
+from benchmark_evolution import evolution_workspace
 from benchmark_metrics import derive_history_metrics
+from benchmark_recent import GitRecentResolver
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -49,7 +53,6 @@ NORMATIVE_CATS = {
     "undefined-behavior",
 }
 
-SPARKLINE_RUNS = 20
 SPARK_W, SPARK_H = 300, 52
 SPARK_Y_MIN, SPARK_Y_MAX = 8, 46  # keep the line off the edges
 
@@ -62,11 +65,14 @@ def git(*args: str) -> str:
 
 def commit_info() -> dict:
     try:
-        return {
+        result = {
             "commit": git("rev-parse", "--short", "HEAD"),
             "commit_date": git("log", "-1", "--format=%cs"),
-            "commit_count": int(git("rev-list", "--count", "HEAD")),
+            "history_complete": git("rev-parse", "--is-shallow-repository") == "false",
         }
+        if result["history_complete"]:
+            result["commit_count"] = int(git("rev-list", "--count", "HEAD"))
+        return result
     except (subprocess.CalledProcessError, FileNotFoundError):
         return {}
 
@@ -93,44 +99,155 @@ def spec_case_count() -> int:
     )
 
 
-def sparkline_data(runs: list[dict], annotations: list[dict] | None = None) -> dict | None:
-    comparable_segment = latest_comparable_segment(runs)
-    runs = comparable_segment[-SPARKLINE_RUNS:]
-    totals = []
-    for run in runs:
-        benches = run.get("benchmarks", [])
-        if benches:
-            totals.append(sum(b.get("mean_ms", 0) for b in benches))
-    if not totals:
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str):
         return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
-    lo, hi = min(totals), max(totals)
+
+def _spark_points(
+    trend_points: list[dict], window_start: datetime, window_end: datetime
+) -> tuple[str, str, str]:
+    values = [point["index"] for point in trend_points]
+    lo, hi = min(values), max(values)
     span = (hi - lo) or 1.0
+    window_seconds = max(1.0, (window_end - window_start).total_seconds())
     points = []
-    for i, total in enumerate(totals):
-        if len(totals) == 1:
-            x = SPARK_W
-        else:
-            x = SPARK_W * i / (len(totals) - 1)
-        y = SPARK_Y_MIN + (SPARK_Y_MAX - SPARK_Y_MIN) * (total - lo) / span
+    for point, value in zip(trend_points, values):
+        instant = _parse_timestamp(point.get("timestamp"))
+        x = SPARK_W * (instant - window_start).total_seconds() / window_seconds
+        x = max(0.0, min(float(SPARK_W), x))
+        # The canonical index is higher-is-better, so improvement rises.
+        y = SPARK_Y_MAX - (SPARK_Y_MAX - SPARK_Y_MIN) * (value - lo) / span
         points.append(f"{x:.0f},{y:.1f}")
+    return " ".join(points), *points[-1].split(",")
+
+
+def sparkline_data(
+    runs: list[dict],
+    annotations: list[dict] | None = None,
+    platform: str = "x86-64-linux",
+    as_of: datetime | None = None,
+    resolver=None,
+) -> dict | None:
+    """Build the compact homepage view from canonical evolution semantics."""
+    if not runs or any(_parse_timestamp(run.get("timestamp")) is None for run in runs):
+        return None
+    annotations = annotations or []
+    resolver = resolver or GitRecentResolver(REPO_ROOT)
+    evolution = evolution_workspace({platform: runs}, annotations, resolver)
+    series = next(item for item in evolution["series"] if item["workload"] == "all")
+    view = series["ranges"]["30d"]
+    window_points = series["raw_points"][view["raw_start_index"]:]
+    if not window_points:
+        return None
+    latest_point = window_points[-1]
+    segment = latest_point["segment"]
+    comparable_points = [point for point in window_points if point["segment"] == segment]
+    trend_points = [point for point in view["trend_points"] if point["segment"] == segment]
+    trend_points = [
+        point for point in trend_points if isinstance(point["index"], (int, float))
+    ]
+    range_end = _parse_timestamp(evolution["range_end"])
+    range_start = range_end - timedelta(days=30)
+    endpoint = _spark_points(trend_points, range_start, range_end) if trend_points else None
+
+    derived = derive_history_metrics(runs)
+    latest_semantic = derived["points"][-1]
+    performance_index = latest_semantic["performance_index"]
+    baseline = latest_semantic["rolling_baseline"]
+    if performance_index.get("status") == "rebase":
+        state = {
+            "kind": "baseline_reset",
+            "label": "baseline reset",
+            "reason": performance_index.get("reason", "comparison boundary"),
+        }
+    elif (
+        baseline.get("status") != "comparable"
+        or baseline.get("headline", {}).get("classification") == "insufficient_data"
+    ):
+        state = {
+            "kind": "insufficient_data",
+            "label": "insufficient data",
+            "reason": baseline.get("reason", "not enough comparable baseline runs"),
+        }
+    else:
+        headline = baseline["headline"]
+        state = {
+            "kind": headline["classification"],
+            "label": headline["classification"],
+            "delta_pct": headline["delta_pct"],
+            "variation_pct": headline["variation_pct"],
+            "reference": "rolling baseline",
+        }
+
+    latest_run = runs[-1]
+    measured_at = _parse_timestamp(latest_run.get("timestamp"))
+    now = as_of or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    age_seconds = max(0, int((now.astimezone(timezone.utc) - measured_at).total_seconds()))
+    freshness = {
+        "kind": "stale" if age_seconds > 48 * 60 * 60 else "current",
+        "measured_at": latest_run["timestamp"],
+        "age_seconds": age_seconds,
+    }
+    publication = latest_run.get("publication", {})
+    coverage = publication.get("coverage", {}) if isinstance(publication, dict) else {}
+    coverage_status = {
+        "measured_commit": coverage.get("measured_commit", latest_run.get("commit")),
+        "represented_commits": coverage.get("represented_commits", []),
+        "skipped_commits": coverage.get("skipped_commits", []),
+        "gap_unknown": coverage.get("gap_unknown", True),
+    }
+
+    events_by_id = {event.get("id"): event for event in annotations}
+    relevant_annotation = None
+    for point in reversed(window_points):
+        candidates = [
+            events_by_id[event_id]
+            for event_id in point["annotation_ids"]
+            if event_id in events_by_id
+        ]
+        if candidates:
+            candidates.sort(
+                key=lambda event: (
+                    event.get("source") != "authored",
+                    event.get("id", ""),
+                )
+            )
+            relevant_annotation = dict(candidates[0])
+            annotation_id = quote(str(relevant_annotation.get("id", "")), safe="")
+            relevant_annotation["dashboard_url"] = (
+                f"/performance/?range=30d&platform={quote(platform, safe='')}&annotation={annotation_id}"
+                "#evolution-workspace"
+            )
+            break
 
     result = {
-        "latest_ms": round(totals[-1]),
-        "n_runs": len(totals),
-        "points": " ".join(points),
-        "last_x": points[-1].split(",")[0],
-        "last_y": points[-1].split(",")[1],
+        "platform": platform,
+        "window": "30d",
+        "metric": "canonical_normalized_performance_index",
+        "n_runs": len(comparable_points),
+        "n_trend_points": len(trend_points),
+        "points": endpoint[0] if endpoint else "",
+        "latest_index": performance_index.get("value"),
+        "state": state,
+        "freshness": freshness,
+        "coverage": coverage_status,
+        "dashboard_url": f"/performance/?range=30d&platform={quote(platform, safe='')}#evolution-workspace",
     }
-    # The visual is deliberately bounded, but the index remains anchored to
-    # the beginning of the full comparable segment.
-    derived = derive_history_metrics(comparable_segment)
-    if derived["points"]:
-        latest = derived["points"][-1]
-        result["performance_index"] = latest["performance_index"]
-        result["previous_comparison"] = latest["previous"]
-        result["baseline_comparison"] = latest["rolling_baseline"]
-    result["annotations"] = annotations or []
+    if endpoint:
+        result["last_x"] = endpoint[1]
+        result["last_y"] = endpoint[2]
+    if relevant_annotation:
+        result["annotation"] = relevant_annotation
     return result
 
 

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -906,24 +906,25 @@ class DurableBenchmarkHistoryTests(unittest.TestCase):
         self.assertEqual(charts.generate_comparison_timeline_chart({"probe": runs}).count("<path d="), 2)
 
     def test_summary_and_homepage_use_only_latest_comparable_segment(self):
-        def run(commit, total, regime="new", gap=False):
+        def run(commit, total, day, regime="new", gap=False):
             return {
                 "commit": commit,
+                "timestamp": f"2026-07-{day:02d}T00:00:00Z",
                 "publication": {
                     "comparable": True, "regime_id": regime,
-                    "coverage": {"skipped_commits": [], "gap_unknown": gap},
+                    "coverage": {"measured_commit": commit, "represented_commits": [commit], "skipped_commits": [], "gap_unknown": gap},
                 },
-                "benchmarks": [{"name": "probe", "mean_ms": total}],
+                "benchmarks": [{"name": "probe", "mean_ms": total, "samples_ms": [total] * 3}],
             }
 
-        runs = [run("old", 1, "old"), run("new-1", 10), run("new-2", 20)]
+        runs = [run("old", 1, 1, "old"), run("new-1", 10, 2), run("new-2", 20, 3)]
         summary = charts.generate_summary_data(runs)
         self.assertEqual(summary["avg_time_ms"], 15)
         self.assertEqual(summary["best_time_ms"], 10)
         self.assertEqual(summary["comparable_run_count"], 2)
         sparkline = site_status.sparkline_data(runs)
         self.assertEqual(sparkline["n_runs"], 2)
-        self.assertEqual(sparkline["latest_ms"], 20)
+        self.assertEqual(sparkline["state"]["kind"], "insufficient_data")
 
 
 class BenchmarkMetricSemanticsTests(unittest.TestCase):
@@ -1058,20 +1059,168 @@ class BenchmarkMetricSemanticsTests(unittest.TestCase):
         self.assertAlmostEqual(summary["time_delta_pct"], 10.0)
         self.assertEqual(summary["time_delta_str"], "↑ 10.0%")
 
-    def test_status_index_uses_full_segment_when_sparkline_is_truncated(self):
+    def test_status_index_uses_full_thirty_day_segment(self):
         runs = [
-            self.sample_run(
+            {
+                **self.sample_run(
                 f"commit-{index}",
                 {"probe": [100 + index, 100 + index, 100 + index]},
-            )
+                ),
+                "timestamp": f"2026-07-{index + 1:02d}T00:00:00Z",
+            }
             for index in range(25)
         ]
         status = site_status.sparkline_data(runs)
-        self.assertEqual(status["n_runs"], site_status.SPARKLINE_RUNS)
+        self.assertEqual(status["n_runs"], 25)
         self.assertAlmostEqual(
-            status["performance_index"]["value"],
+            status["latest_index"],
             100 * 100 / 124,
         )
+
+
+class HomepageBenchmarkStatusTests(unittest.TestCase):
+    class Resolver:
+        def is_ancestor(self, start, end):
+            return start == end
+
+    @staticmethod
+    def sample_run(index, center, regime="same", workloads=None, day=None):
+        values = workloads or {"probe": center}
+        run = BenchmarkMetricSemanticsTests.sample_run(
+            f"{index:040x}",
+            {name: [value - 0.1, value, value + 0.1] for name, value in values.items()},
+            regime=regime,
+        )
+        run["timestamp"] = f"2026-07-{day or index:02d}T00:00:00Z"
+        run["publication"]["coverage"] = {
+            "measured_commit": run["commit"],
+            "represented_commits": [run["commit"]],
+            "skipped_commits": [],
+            "gap_unknown": False,
+        }
+        return run
+
+    def status(self, runs, annotations=None, as_of=None):
+        return site_status.sparkline_data(
+            runs,
+            annotations or [],
+            resolver=self.Resolver(),
+            as_of=as_of or datetime(2026, 7, 10, tzinfo=timezone.utc),
+        )
+
+    def test_stable_improved_regressed_and_insufficient_states(self):
+        preceding = [self.sample_run(1, 100), self.sample_run(2, 101), self.sample_run(3, 99)]
+        self.assertEqual(self.status(preceding + [self.sample_run(4, 100)])["state"]["kind"], "stable")
+        self.assertEqual(self.status(preceding + [self.sample_run(4, 80)])["state"]["kind"], "improved")
+        regressed = self.status(preceding + [self.sample_run(4, 120)])
+        self.assertEqual(regressed["state"]["kind"], "regressed")
+        self.assertGreater(regressed["state"]["delta_pct"], regressed["state"]["variation_pct"])
+        self.assertEqual(self.status(preceding[:2])["state"]["kind"], "insufficient_data")
+
+    def test_regime_and_corpus_changes_are_explicit_resets_without_percentage(self):
+        runs = [self.sample_run(1, 100), self.sample_run(2, 100), self.sample_run(3, 100)]
+        regime = self.status(runs + [self.sample_run(4, 120, regime="runner-b")])
+        self.assertEqual(regime["state"]["kind"], "baseline_reset")
+        self.assertNotIn("delta_pct", regime["state"])
+
+        corpus_a = self.status(runs + [self.sample_run(4, 120, workloads={"probe": 120, "new": 1})])
+        corpus_b = self.status(runs + [self.sample_run(4, 120, workloads={"probe": 120, "new": 10000})])
+        self.assertEqual(corpus_a["state"], corpus_b["state"])
+        self.assertEqual(corpus_a["state"]["kind"], "baseline_reset")
+
+    def test_capability_annotation_freshness_coverage_and_deep_link(self):
+        runs = [self.sample_run(1, 100), self.sample_run(2, 100), self.sample_run(3, 100), self.sample_run(4, 120)]
+        event = {
+            "id": "capability-cost",
+            "source": "authored",
+            "location": {"kind": "commit", "commit": runs[-1]["commit"]},
+            "category": "capability",
+            "title": "Intentional capability cost",
+            "explanation": "Accepted cost for a language feature.",
+            "link": "https://github.com/rue-language/rue/pull/1",
+            "scope": {"metrics": ["latency"], "workloads": ["*"], "platforms": ["*"]},
+        }
+        status = self.status(
+            runs, [event], as_of=datetime(2026, 7, 7, 1, tzinfo=timezone.utc)
+        )
+        self.assertEqual(status["state"]["kind"], "regressed")
+        self.assertEqual(status["freshness"]["kind"], "stale")
+        self.assertEqual(status["annotation"]["title"], "Intentional capability cost")
+        self.assertIn("range=30d", status["annotation"]["dashboard_url"])
+        self.assertIn("annotation=capability-cost", status["annotation"]["dashboard_url"])
+        self.assertFalse(status["coverage"]["gap_unknown"])
+        self.assertEqual(status["coverage"]["represented_commits"], [runs[-1]["commit"]])
+
+    def test_missing_or_malformed_time_data_is_not_presented(self):
+        self.assertIsNone(self.status([]))
+        run = self.sample_run(1, 100)
+        del run["timestamp"]
+        self.assertIsNone(self.status([run]))
+
+    def test_insufficient_legacy_samples_do_not_fabricate_endpoint(self):
+        run = self.sample_run(1, 100)
+        run["benchmarks"][0]["samples_ms"] = [100, 100]
+        status = self.status([run])
+        self.assertEqual(status["state"]["kind"], "insufficient_data")
+        self.assertEqual(status["n_trend_points"], 0)
+        self.assertEqual(status["points"], "")
+        self.assertNotIn("last_x", status)
+        self.assertNotIn("last_y", status)
+
+    def test_thirty_day_window_uses_calendar_time_and_latest_segment(self):
+        runs = [
+            self.sample_run(1, 100, day=1),
+            self.sample_run(2, 100, day=2),
+            self.sample_run(3, 100, day=3),
+            self.sample_run(4, 100, day=4),
+        ]
+        runs[0]["timestamp"] = "2026-05-01T00:00:00Z"
+        status = self.status(runs)
+        self.assertEqual(status["window"], "30d")
+        self.assertEqual(status["n_runs"], 3)
+
+    def test_sparkline_x_coordinates_use_calendar_spacing(self):
+        runs = [
+            self.sample_run(1, 100, day=1),
+            self.sample_run(2, 90, day=2),
+            self.sample_run(3, 80, day=30),
+        ]
+        status = self.status(runs)
+        coordinates = [point.split(",") for point in status["points"].split()]
+        self.assertEqual([int(point[0]) for point in coordinates], [10, 20, 300])
+
+    def test_shallow_checkout_omits_misleading_commit_count(self):
+        def fake_git(*args):
+            responses = {
+                ("rev-parse", "--short", "HEAD"): "abc123",
+                ("log", "-1", "--format=%cs"): "2026-07-01",
+                ("rev-parse", "--is-shallow-repository"): "true",
+            }
+            if args == ("rev-list", "--count", "HEAD"):
+                self.fail("shallow checkout must not count the truncated history")
+            return responses[args]
+        with mock.patch.object(site_status, "git", side_effect=fake_git):
+            status = site_status.commit_info()
+        self.assertFalse(status["history_complete"])
+        self.assertNotIn("commit_count", status)
+
+    def test_homepage_template_reports_honest_states(self):
+        template = (INPUT_ROOT / "website" / "templates" / "index.html").read_text()
+        self.assertIn("30-day comparable trend", template)
+        self.assertIn("no trustworthy percentage", template)
+        self.assertIn("history count unavailable", template)
+        self.assertIn("commit coverage is unknown", template)
+        self.assertIn("benchmark data unavailable", template)
+        self.assertIn("{% if status.bench.n_trend_points > 0 %}", template)
+        self.assertNotIn("measurements taken on every commit", template)
+        performance = (INPUT_ROOT / "website" / "templates" / "performance.html").read_text()
+        self.assertIn("deepLink.get('range')", performance)
+        self.assertIn("evolution-deep-linked-annotation", performance)
+        self.assertIn("annotationTargetId(requestedAnnotation)", performance)
+        self.assertIn("target.scrollIntoView", performance)
+        self.assertIn("target.focus", performance)
+        self.assertIn("item.dataset.deepLinked = 'true'", performance)
+        self.assertIn("item.style.outline", performance)
 
 
 class TestBenchmarkAnnotations(unittest.TestCase):
@@ -1280,10 +1429,15 @@ class TestBenchmarkAnnotations(unittest.TestCase):
         run = BenchmarkMetricSemanticsTests.sample_run(
             "a" * 40, {"probe": [10, 10, 10]}
         )
+        run["timestamp"] = "2026-07-01T00:00:00Z"
         stream = annotations.normalized_annotations(
             [run], [self.authored()], self.Resolver()
         )
-        self.assertEqual(site_status.sparkline_data([run], stream)["annotations"], stream)
+        status = site_status.sparkline_data(
+            [run], stream, resolver=self.Resolver(),
+            as_of=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        )
+        self.assertEqual(status["annotation"]["id"], stream[0]["id"])
 
 
 class TestRecentRegressionWorkspace(unittest.TestCase):

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -35,7 +35,7 @@
         <p class="observed">as of trunk, {{ status.commit_date | default(value="today") | date(format="%-d %B %Y") }}</p>
         <ul class="report-rows">
             <li><span class="k">trunk</span><span class="leader"></span>
-                <span class="v">{{ status.commit | default(value="—") }} · commit {{ status.commit_count | default(value="—") }}</span></li>
+                <span class="v">{{ status.commit | default(value="—") }}{% if status.history_complete and status.commit_count %} · commit {{ status.commit_count }}{% else %} · history count unavailable{% endif %}</span></li>
             {% if status.spec_rules %}
             <li><span class="k">spec rules traced</span><span class="leader"></span>
                 <span class="v"><span class="ok">{{ status.spec_rules }} / {{ status.spec_rules }}</span></span></li>
@@ -49,23 +49,50 @@
         </ul>
         {% if status.bench %}
         <div class="sparkline-block">
-            <div class="spark-label"><b>compile time</b><span>benchmark suite · total ms{% if status.bench.n_runs > 1 %} · last {{ status.bench.n_runs }} runs{% endif %}</span></div>
+            <div class="spark-label"><b>compiler performance</b><span>{{ status.bench.platform }} · 30-day comparable trend</span></div>
             <svg viewBox="0 0 300 52" preserveAspectRatio="none" role="img"
-                 aria-label="Compile time trend; latest total {{ status.bench.latest_ms }} milliseconds">
+                 aria-label="Thirty-day normalized compiler performance trend; {{ status.bench.state.label }}">
                 <polyline fill="none" stroke="var(--color-border-dark)" stroke-width="1" points="0,46 300,46"/>
-                {% if status.bench.n_runs > 1 %}
+                {% if status.bench.points and status.bench.n_trend_points > 1 %}
                 <polyline fill="none" stroke="var(--color-olive)" stroke-width="1.6"
                           stroke-linejoin="round" points="{{ status.bench.points }}"/>
                 {% endif %}
+                {% if status.bench.n_trend_points > 0 %}
                 <circle cx="{{ status.bench.last_x }}" cy="{{ status.bench.last_y }}" r="3" fill="var(--color-gold)"/>
+                {% endif %}
             </svg>
-            <div class="spark-label"><span></span><span>latest: <b style="color: var(--color-fg);">{{ status.bench.latest_ms }} ms</b></span></div>
+            <div class="spark-label"><span>{{ status.bench.state.label }}</span><span>
+                {% if status.bench.state.kind == "baseline_reset" %}
+                    comparison reset · {{ status.bench.state.reason }}
+                {% elif status.bench.state.kind == "insufficient_data" %}
+                    no trustworthy percentage · {{ status.bench.state.reason }}
+                {% else %}
+                    rolling baseline Δ {{ status.bench.state.delta_pct | round(precision=2) }}% · variation {{ status.bench.state.variation_pct | round(precision=2) }}%
+                {% endif %}
+                {% if status.bench.latest_index %} · index {{ status.bench.latest_index | round(precision=2) }}{% endif %}
+            </span></div>
+            <div class="spark-label"><span>freshness</span><span>{{ status.bench.freshness.kind }} · measured {{ status.bench.freshness.measured_at }}</span></div>
+            <div class="spark-label"><span>coverage</span><span>
+                {% if status.bench.coverage.gap_unknown %}
+                    commit coverage is unknown
+                {% elif status.bench.coverage.skipped_commits | length > 0 %}
+                    measured {{ status.bench.coverage.measured_commit }} · {{ status.bench.coverage.skipped_commits | length }} known skipped commit(s)
+                {% else %}
+                    measured {{ status.bench.coverage.measured_commit }} · no known skipped commits
+                {% endif %}
+            </span></div>
+            {% if status.bench.annotation %}
+            <div class="spark-label"><span>recent event</span><span><a href="{{ status.bench.annotation.dashboard_url }}">{{ status.bench.annotation.title }} →</a></span></div>
+            {% endif %}
+            <div class="spark-label"><span></span><span><a href="{{ status.bench.dashboard_url }}">open this 30-day dashboard range →</a></span></div>
         </div>
+        {% else %}
+        <p class="observed">benchmark data unavailable</p>
         {% endif %}
         {% else %}
         <p class="observed">status data is generated at build time</p>
         {% endif %}
-        <p class="report-foot">measurements taken on every commit — <a href="{{ get_url(path='performance') }}">full dashboard →</a></p>
+        <p class="report-foot">coverage and freshness are reported from durable measurements — <a href="{{ get_url(path='performance') }}">full dashboard →</a></p>
     </aside>
 </section>
 

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -193,6 +193,9 @@
             }
 
             function renderEvolutionWorkspace(model, allPlatforms) {
+                const deepLink = new URLSearchParams(window.location.search);
+                const annotationTargetId = id => 'evolution-annotation-' + encodeURIComponent(String(id))
+                    .replace(/%/g, '-').replace(/[^A-Za-z0-9_.:-]/g, '_');
                 evolutionSection.style.display = 'block';
                 evolutionRangeControls.replaceChildren();
                 evolutionPlatformSelect.replaceChildren();
@@ -204,6 +207,8 @@
                     evolutionPlatformSelect.appendChild(option);
                 });
                 evolutionPlatformSelect.value = allPlatforms ? '*' : model.platform_options[0];
+                const requestedPlatform = deepLink.get('platform');
+                if (model.platform_options.includes(requestedPlatform)) evolutionPlatformSelect.value = requestedPlatform;
                 model.workload_options.forEach(workload => {
                     const option = node('option', workload === 'all' ? 'All workloads (canonical index)' : `Workload: ${workload}`);
                     option.value = `workload:${workload}`; evolutionWorkloadSelect.appendChild(option);
@@ -213,7 +218,8 @@
                     option.value = `family:${family.id}`; evolutionWorkloadSelect.appendChild(option);
                 });
 
-                let activeRange = model.default_range;
+                const requestedRange = deepLink.get('range');
+                let activeRange = model.range_options.includes(requestedRange) ? requestedRange : model.default_range;
                 const render = () => {
                     const platform = evolutionPlatformSelect.value;
                     const filter = evolutionWorkloadSelect.value;
@@ -329,10 +335,26 @@
                         const list = node('ul');
                         events.forEach(event => {
                             const item = node('li'); const link = node('a', `${event.category}: ${event.title}`);
+                            item.id = annotationTargetId(event.id);
+                            if (event.id === deepLink.get('annotation')) {
+                                item.className = 'evolution-deep-linked-annotation';
+                                item.tabIndex = -1;
+                                item.dataset.deepLinked = 'true';
+                                item.style.outline = '2px solid var(--color-accent)';
+                                item.style.outlineOffset = '3px';
+                            }
                             link.href = event.link; item.appendChild(link);
                             item.appendChild(document.createTextNode(` — ${event.explanation}; ${JSON.stringify(event.location)}`));
                             list.appendChild(item);
                         }); evolutionAnnotations.appendChild(list);
+                        const requestedAnnotation = deepLink.get('annotation');
+                        const target = requestedAnnotation
+                            ? document.getElementById(annotationTargetId(requestedAnnotation))
+                            : null;
+                        if (target) {
+                            target.scrollIntoView({ block: 'center' });
+                            target.focus({ preventScroll: true });
+                        }
                     }
                     const table = node('table', undefined, 'w-full text-sm');
                     table.appendChild(node('caption', 'Authoritative raw benchmark history for the selected calendar range', 'sr-only'));


### PR DESCRIPTION
## Summary
- replace the homepage raw-total sparkline with the canonical 30-day comparable performance index
- report honest baseline, freshness, coverage, reset, and annotation states with functional dashboard deep links
- suppress misleading shallow-history counts and non-comparable percentages

## Validation
- `python3 scripts/test-benchmark-tools.py` (86/86)
- `website/build.sh`
- performance template inline JavaScript syntax check
- `scripts/rue quick` (25 targets, before conflict-free rebase)

Fixes RUE-899