### PR TITLE
RUE-787: restore deep nesting baseline coverage

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -229,6 +229,7 @@ sh_test(
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_BENCHMARK_TEST_ROOT": "$(location :benchmark-tool-inputs)",
+        "RUE_DEEP_NESTING_CASE": "$(location //crates/rue-cli-tests:deep-nesting-case)/cases/deep_nesting.toml",
     },
 )
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,8 +9,8 @@ benchmarks/
 ├── manifest.toml       # Benchmark metadata
 ├── README.md           # This file
 └── stress/             # Stress test programs
-    ├── many_functions.rue    # 100+ functions
-    ├── deep_nesting.rue      # Deeply nested blocks
+    ├── many_functions.rue    # 1,000 functions
+    ├── deep_nesting.rue      # 12,198-line nesting stress corpus
     ├── large_structs.rue     # Many struct types
     ├── arithmetic_heavy.rue  # Expression-heavy code
     └── control_flow.rue      # Complex if/while/match
@@ -20,10 +20,10 @@ benchmarks/
 
 | Benchmark | What it tests | Size |
 |-----------|--------------|------|
-| `many_functions` | Function handling, symbol resolution | 100 functions |
-| `deep_nesting` | Scope handling, block nesting | 10 nesting levels |
-| `large_structs` | Type definitions, field access | 50 struct types |
-| `arithmetic_heavy` | Expression parsing, codegen | ~100 expressions |
+| `many_functions` | Function handling, symbol resolution | 1,000 functions |
+| `deep_nesting` | Scope handling and parser nesting | 120 nested-control functions: 50 block + 50 if + 20 while, each up to 40 levels (`v39`); 30 deep-expression helpers; 12,198 lines |
+| `large_structs` | Type definitions, field access | 700 struct types |
+| `arithmetic_heavy` | Expression parsing, codegen | 250 long-expression functions |
 | `control_flow` | CFG construction | if/while/match mix |
 
 ## Running Benchmarks
@@ -65,6 +65,13 @@ For manual testing or debugging:
 # Get JSON timing output
 ./buck2 run //crates/rue:rue -- --benchmark-json benchmarks/stress/many_functions.rue /tmp/out
 ```
+
+The quick per-pass corpus (`scripts/rue perf`) also includes the exact
+`deep_nesting.rue` file. Each fresh compile of that workload has a fixed
+10-second ceiling even when the general harness timeout is larger. Separately,
+the depth-60 CLI regression in `crates/rue-cli-tests/cases/deep_nesting.toml`
+has its own explicit 10-second timeout; it is the executable complexity gate
+that turns renewed superlinear/exponential nesting behavior into a test failure.
 
 ## Adding Benchmarks
 

--- a/benchmarks/manifest.toml
+++ b/benchmarks/manifest.toml
@@ -12,7 +12,14 @@ description = "1000 functions to stress function handling and symbol resolution"
 [[benchmark]]
 name = "deep_nesting"
 path = "stress/deep_nesting.rue"
-description = "150 functions with deep block/if/while nesting (up to 40 levels)"
+description = "12,198 lines: 120 nested-control functions (50 block, 50 if, 20 while) up to 40 levels, plus 30 deep-expression helpers"
+source_lines = 12198
+nested_control_functions = 120
+block_functions = 50
+if_functions = 50
+while_functions = 20
+deep_expression_functions = 30
+max_nesting_levels = 40
 
 [[benchmark]]
 name = "large_structs"

--- a/crates/rue-cli-tests/BUCK
+++ b/crates/rue-cli-tests/BUCK
@@ -21,3 +21,9 @@ filegroup(
     srcs = glob(["cases/**"]),
     visibility = ["PUBLIC"],
 )
+
+filegroup(
+    name = "deep-nesting-case",
+    srcs = ["cases/deep_nesting.toml"],
+    visibility = ["PUBLIC"],
+)

--- a/crates/rue-cli-tests/cases/deep_nesting.toml
+++ b/crates/rue-cli-tests/cases/deep_nesting.toml
@@ -15,6 +15,7 @@ rather than a silent hang.
 # is `}`-terminated, so with the fix each level is parsed exactly once.
 [[case]]
 name = "deep_nested_blocks_return_value"
+timeout_ms = 10000
 files = [{ path = "main.rue", source = """
 fn main() -> i32 { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { {  42  } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } }
 """ }]

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -24,6 +24,15 @@ it. It is separate from `bench.sh` (which feeds the
 historical website dashboard); this one is a quick, self-contained snapshot
 with no history/network side effects.
 
+The current corpus includes the exact 12,198-line
+`benchmarks/stress/deep_nesting.rue`: 120 nested-control functions (50 block,
+50 if, and 20 while) with locals through `v39` / 40 nesting levels, plus 30
+deep-expression helpers. Each warmup and measured compile of this workload has
+an isolated 10-second ceiling, even when the harness-wide `--timeout` remains
+at its 60-second default. JSON output records the effective timeout on every
+workload result. This ceiling is a baseline safety bound; the depth-60 CLI case
+described below is the focused executable complexity regression.
+
 Every workload invocation explicitly uses Rue program optimization level
 `-O0`, so changes in the compiler's optimization policy do not silently change
 the amount of generated-program optimization being measured. `--release`
@@ -122,10 +131,10 @@ and remain valid as historical compiler-pipeline measurements.
 - Build: the buck2 **DEFAULT** profile as produced by `scripts/rue-bin`
   (unoptimized — see "Build caveat" below). Numbers on an optimized build
   would be smaller, but the *pass profile* (parse-dominated) holds.
-- Corpus: `examples/` (small/medium) + `benchmarks/stress/` (large) + a
-  synthesized 3-file import graph (discovery + multi-file merge paths).
-  `deep_nesting.rue` is
-  excluded — see "Known pathology".
+- Historical corpus: `examples/` (small/medium) + `benchmarks/stress/` (large) +
+  a synthesized 3-file import graph (discovery + multi-file merge paths).
+  This 2026-07-03 table excluded `deep_nesting.rue`; the current harness has
+  restored it under the isolated budget documented above.
 - 7 fresh compiler processes after one host-cache warmup, median.
 
 ### Small / medium programs (ms)
@@ -222,6 +231,16 @@ replaced an already-linearized parser and preserves these guarantees with
 current implementation regressions; it was not the original complexity fix.
 Current benchmark manifests include `deep_nesting`, and this table must not be
 used to characterize the replacement parser.
+
+Two current gates cover different failure modes:
+
+- `scripts/perf-baseline.py` compiles the complete 12,198-line corpus under its
+  workload-local 10-second ceiling, so routine baseline runs cannot hang behind
+  the more generous global timeout.
+- `crates/rue-cli-tests/cases/deep_nesting.toml` compiles a 60-level nested
+  block under an explicit `timeout_ms = 10000`. The historical exponential
+  algorithm exceeded 30 seconds by depth 20, so this case catches recurrence
+  as a timeout rather than merely recording a slower elapsed measurement.
 
 ## Build profile (release vs. DEFAULT)
 

--- a/scripts/perf-baseline.py
+++ b/scripts/perf-baseline.py
@@ -73,6 +73,7 @@ from pathlib import Path
 # own nesting. Schema v2 uses invocation metadata instead of this name list.
 AGGREGATE_PASSES = {"parse", "compile"}
 WALL_CLOCK_PASS = "compile"
+DEEP_NESTING_TIMEOUT_SECONDS = 10.0
 
 # Canonical leaf-pass order for deterministic, pipeline-ordered output. Any
 # leaf the compiler emits that is not listed here is appended afterwards in
@@ -102,7 +103,7 @@ def repo_root() -> Path:
 
 
 def default_corpus(root: Path):
-    """The representative corpus: (label, size-bucket, [files]).
+    """The representative corpus: (label, size-bucket, [files], budget).
 
     Small/medium come from examples/; the large programs are the generated
     stress suite (benchmarks/stress/, also used by bench.sh); the multi-file
@@ -111,16 +112,21 @@ def default_corpus(root: Path):
     ex = root / "examples"
     st = root / "benchmarks" / "stress"
     return [
-        ("hello", "small", [ex / "hello.rue"]),
-        ("fibonacci", "small", [ex / "fibonacci.rue"]),
-        ("quicksort", "medium", [ex / "quicksort.rue"]),
-        ("structs", "medium", [ex / "structs.rue"]),
-        ("many_functions", "large", [st / "many_functions.rue"]),
-        ("large_structs", "large", [st / "large_structs.rue"]),
-        ("arithmetic_heavy", "large", [st / "arithmetic_heavy.rue"]),
-        ("control_flow", "large", [st / "control_flow.rue"]),
-        ("register_pressure", "large", [st / "register_pressure.rue"]),
-        ("deep_nesting", "large", [st / "deep_nesting.rue"]),
+        ("hello", "small", [ex / "hello.rue"], None),
+        ("fibonacci", "small", [ex / "fibonacci.rue"], None),
+        ("quicksort", "medium", [ex / "quicksort.rue"], None),
+        ("structs", "medium", [ex / "structs.rue"], None),
+        ("many_functions", "large", [st / "many_functions.rue"], None),
+        ("large_structs", "large", [st / "large_structs.rue"], None),
+        ("arithmetic_heavy", "large", [st / "arithmetic_heavy.rue"], None),
+        ("control_flow", "large", [st / "control_flow.rue"], None),
+        ("register_pressure", "large", [st / "register_pressure.rue"], None),
+        (
+            "deep_nesting",
+            "large",
+            [st / "deep_nesting.rue"],
+            DEEP_NESTING_TIMEOUT_SECONDS,
+        ),
     ]
 
 
@@ -574,9 +580,14 @@ def run_corpus(rue_bin, corpus, iterations, warmup, workdir, timeout, jobs):
     # the real import graph, so fresh-process time includes module discovery.
     multi_files = [os.path.join(multi_dir, "main.rue")]
 
-    full = list(corpus) + [("multi_file", "multi", multi_files)]
+    full = list(corpus) + [("multi_file", "multi", multi_files, None)]
 
-    for label, bucket, files in full:
+    for label, bucket, files, isolated_timeout in full:
+        workload_timeout = (
+            min(timeout, isolated_timeout)
+            if isolated_timeout is not None
+            else timeout
+        )
         missing = [f for f in files if not Path(f).exists()]
         if missing:
             raise RuntimeError(f"workload {label!r} is missing source file(s): {missing}")
@@ -584,9 +595,9 @@ def run_corpus(rue_bin, corpus, iterations, warmup, workdir, timeout, jobs):
         sys.stderr.flush()
         try:
             for _ in range(warmup):
-                compile_once(rue_bin, files, out_bin, timeout, jobs)
+                compile_once(rue_bin, files, out_bin, workload_timeout, jobs)
             samples = [
-                compile_once(rue_bin, files, out_bin, timeout, jobs)
+                compile_once(rue_bin, files, out_bin, workload_timeout, jobs)
                 for _ in range(iterations)
             ]
             aggregated = aggregate(samples)
@@ -599,6 +610,7 @@ def run_corpus(rue_bin, corpus, iterations, warmup, workdir, timeout, jobs):
                 "bucket": bucket,
                 "target": aggregated["target"],
                 "compiler_version": aggregated["compiler_version"],
+                "compile_timeout_seconds": workload_timeout,
                 # Keep wall_ms as a compatibility alias for generated tables.
                 "wall_ms": aggregated["compile_ms"],
                 "compile_ms": {

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -16,6 +16,12 @@ from unittest import mock
 INPUT_ROOT = Path(
     os.environ.get("RUE_BENCHMARK_TEST_ROOT", Path(__file__).resolve().parent.parent)
 )
+DEEP_NESTING_CASE = Path(
+    os.environ.get(
+        "RUE_DEEP_NESTING_CASE",
+        INPUT_ROOT / "crates/rue-cli-tests/cases/deep_nesting.toml",
+    )
+)
 sys.path.insert(0, str(INPUT_ROOT / "scripts"))
 
 
@@ -457,6 +463,69 @@ class PerfBaselineAggregationTests(unittest.TestCase):
         phase = results[0]["passes"][0]
         self.assertEqual(phase["median_percent"], 30.0)
         self.assertNotIn("percent", phase)
+
+    def test_deep_nesting_corpus_shape_and_explicit_complexity_gate(self):
+        source = (
+            INPUT_ROOT / "benchmarks" / "stress" / "deep_nesting.rue"
+        ).read_text()
+        self.assertEqual(len(source.splitlines()), 12198)
+        self.assertEqual(source.count("fn nested_blocks_"), 50)
+        self.assertEqual(source.count("fn nested_if_"), 50)
+        self.assertEqual(source.count("fn nested_while_"), 20)
+        self.assertEqual(source.count("fn deep_expr_"), 30)
+        self.assertIn("let v39 = 40;", source)
+
+        corpus = perf_baseline.default_corpus(INPUT_ROOT)
+        deep = [entry for entry in corpus if entry[0] == "deep_nesting"]
+        self.assertEqual(len(deep), 1)
+        self.assertEqual(deep[0][2], [INPUT_ROOT / "benchmarks/stress/deep_nesting.rue"])
+        self.assertEqual(
+            deep[0][3], perf_baseline.DEEP_NESTING_TIMEOUT_SECONDS
+        )
+
+        cli_case = DEEP_NESTING_CASE.read_text()
+        self.assertIn("A 60-level nested block", cli_case)
+        self.assertIn("timeout_ms = 10000", cli_case)
+
+    def test_deep_nesting_budget_is_enforced_independently_of_global_timeout(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            ordinary = root / "ordinary.rue"
+            deep = root / "deep_nesting.rue"
+            ordinary.write_text("fn main() -> i32 { 0 }")
+            deep.write_text("fn main() -> i32 { 0 }")
+            seen = []
+
+            def compile_once(_rue, files, _output, timeout, _jobs):
+                seen.append((Path(files[0]).name, timeout))
+                return self.sample(10.0, 12.0)
+
+            corpus = [
+                ("ordinary", "large", [ordinary], None),
+                (
+                    "deep_nesting",
+                    "large",
+                    [deep],
+                    perf_baseline.DEEP_NESTING_TIMEOUT_SECONDS,
+                ),
+            ]
+            with mock.patch.object(perf_baseline.sys, "stderr"):
+                with mock.patch.object(
+                    perf_baseline, "compile_once", side_effect=compile_once
+                ):
+                    results = perf_baseline.run_corpus(
+                        "rue", corpus, 1, 0, temp_dir, 60.0, 1
+                    )
+
+        by_name = {result["name"]: result for result in results}
+        self.assertEqual(by_name["ordinary"]["compile_timeout_seconds"], 60.0)
+        self.assertEqual(
+            by_name["deep_nesting"]["compile_timeout_seconds"],
+            perf_baseline.DEEP_NESTING_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(by_name["multi_file"]["compile_timeout_seconds"], 60.0)
+        self.assertIn(("deep_nesting.rue", 10.0), seen)
+        self.assertIn(("ordinary.rue", 60.0), seen)
 
     def test_compile_once_sanitizes_logging_checks_artifact_and_exact_json(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- restore the exact deep-nesting stress corpus to the per-pass baseline under an isolated 10-second budget
- make the depth-60 parser complexity timeout explicit and test budget enforcement
- reconcile benchmark metadata and documentation with the current 12,198-line corpus shape

## Validation
- `python3 scripts/test-benchmark-tools.py` (79/79)
- `scripts/rue cli deep_nesting` (2/2)
- `scripts/rue quick` (implementation validation)
- exact corpus AST emission: 0.417s under the 10s budget
- real perf baseline recorded ~403ms and the 10s workload limit

Fixes RUE-787