### PR TITLE
RUE-660: freeze backend type metadata

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -30,7 +30,7 @@
 //! - Write lock for insertions (rare, during declaration gathering)
 
 use std::collections::HashMap;
-use std::sync::{PoisonError, RwLock};
+use std::sync::{Arc, PoisonError, RwLock};
 
 use lasso::Spur;
 use rue_span::FileId;
@@ -246,6 +246,19 @@ pub struct TypeInternPool {
     inner: RwLock<TypeInternPoolInner>,
 }
 
+/// Immutable type metadata used after semantic analysis completes.
+///
+/// Semantic analysis is the only phase allowed to extend or update the type
+/// universe. [`TypeInternPool::freeze`] consumes that mutable universe after
+/// specialization and anonymous-type/destructor discovery have reached their
+/// fixed point. CFG construction and code generation receive this type instead:
+/// nominal reads borrow definitions directly, and iteration takes no lock and
+/// allocates no temporary ID vector.
+#[derive(Debug, Clone)]
+pub struct FrozenTypeInternPool {
+    inner: Arc<TypeInternPoolInner>,
+}
+
 #[derive(Debug)]
 struct TypeInternPoolInner {
     /// All composite type data, indexed by (InternedType.0 - PRIMITIVE_COUNT).
@@ -277,6 +290,250 @@ struct TypeInternPoolInner {
     lang_item_structs: HashMap<LangItem, StructId>,
 }
 
+impl TypeInternPoolInner {
+    #[inline]
+    fn data(&self, index: u32) -> &TypeData {
+        &self.types[index as usize]
+    }
+
+    fn try_struct_def(&self, id: StructId) -> Option<&StructDef> {
+        match self.types.get(id.0 as usize)? {
+            TypeData::Struct(data) => Some(&data.def),
+            _ => None,
+        }
+    }
+
+    fn struct_def(&self, id: StructId) -> &StructDef {
+        self.try_struct_def(id)
+            .unwrap_or_else(|| panic!("Expected struct at pool index {}", id.0))
+    }
+
+    fn try_enum_def(&self, id: EnumId) -> Option<&EnumDef> {
+        match self.types.get(id.0 as usize)? {
+            TypeData::Enum(data) => Some(&data.def),
+            _ => None,
+        }
+    }
+
+    fn enum_def(&self, id: EnumId) -> &EnumDef {
+        self.try_enum_def(id)
+            .unwrap_or_else(|| panic!("Expected enum at pool index {}", id.0))
+    }
+
+    fn interned_to_type(&self, ty: InternedType) -> Type {
+        if ty.is_primitive() {
+            return match ty.0 {
+                0 => Type::I8,
+                1 => Type::I16,
+                2 => Type::I32,
+                3 => Type::I64,
+                4 => Type::U8,
+                5 => Type::U16,
+                6 => Type::U32,
+                7 => Type::U64,
+                8 => Type::BOOL,
+                9 => Type::UNIT,
+                10 => Type::NEVER,
+                11 => Type::ERROR,
+                _ => panic!("Unknown primitive index: {}", ty.0),
+            };
+        }
+
+        let index = ty.pool_index().expect("non-primitive must have pool index");
+        match self.data(index) {
+            TypeData::Struct(_) => Type::new_struct(StructId::from_pool_index(index)),
+            TypeData::Enum(_) => Type::new_enum(EnumId::from_pool_index(index)),
+            TypeData::Array { .. } => Type::new_array(ArrayTypeId::from_pool_index(index)),
+            TypeData::PtrConst { .. } => {
+                Type::new_ptr_const(PtrConstTypeId::from_pool_index(index))
+            }
+            TypeData::PtrMut { .. } => Type::new_ptr_mut(PtrMutTypeId::from_pool_index(index)),
+        }
+    }
+
+    fn array_def(&self, id: ArrayTypeId) -> (Type, u64) {
+        match self.data(id.0) {
+            TypeData::Array { element, len } => (self.interned_to_type(*element), *len),
+            other => panic!("Expected array at pool index {}, got {:?}", id.0, other),
+        }
+    }
+
+    fn try_array_def(&self, id: ArrayTypeId) -> Option<(Type, u64)> {
+        match self.types.get(id.0 as usize)? {
+            TypeData::Array { element, len } => Some((self.interned_to_type(*element), *len)),
+            _ => None,
+        }
+    }
+
+    fn ptr_const_def(&self, id: PtrConstTypeId) -> Type {
+        match self.data(id.pool_index()) {
+            TypeData::PtrConst { pointee } => self.interned_to_type(*pointee),
+            other => panic!(
+                "Expected ptr const at pool index {}, got {:?}",
+                id.pool_index(),
+                other
+            ),
+        }
+    }
+
+    fn ptr_mut_def(&self, id: PtrMutTypeId) -> Type {
+        match self.data(id.pool_index()) {
+            TypeData::PtrMut { pointee } => self.interned_to_type(*pointee),
+            other => panic!(
+                "Expected ptr mut at pool index {}, got {:?}",
+                id.pool_index(),
+                other
+            ),
+        }
+    }
+
+    fn abi_slot_count(&self, ty: Type) -> u32 {
+        match ty.kind() {
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Error
+            | TypeKind::PtrConst(_)
+            | TypeKind::PtrMut(_) => 1,
+            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => 0,
+            TypeKind::Struct(id) => self.struct_def(id).fields.iter().fold(0, |total, field| {
+                total.saturating_add(self.abi_slot_count(field.ty))
+            }),
+            TypeKind::Array(id) => {
+                let (element, length) = self.array_def(id);
+                let slots = u64::from(self.abi_slot_count(element));
+                u32::try_from(slots.saturating_mul(length)).unwrap_or(u32::MAX)
+            }
+            TypeKind::Enum(id) => {
+                let def = self.enum_def(id);
+                let payload = (0..def.variant_count())
+                    .map(|index| {
+                        def.variant_payload(index).iter().fold(0u32, |total, &ty| {
+                            total.saturating_add(self.abi_slot_count(ty))
+                        })
+                    })
+                    .max()
+                    .unwrap_or(0);
+                1u32.saturating_add(payload)
+            }
+        }
+    }
+
+    fn file_symbol_component(&self, file_id: FileId) -> String {
+        self.symbol_paths
+            .get(&file_id)
+            .map(|path| mangle_symbol_component(&normalize_module_path(path)))
+            .unwrap_or_else(|| file_id.index().to_string())
+    }
+
+    fn nominal_name_collides(&self, name: Spur) -> bool {
+        self.struct_by_file_name
+            .keys()
+            .chain(self.enum_by_file_name.keys())
+            .filter(|(_, existing_name)| *existing_name == name)
+            .take(2)
+            .count()
+            > 1
+    }
+
+    fn struct_symbol_name(&self, id: StructId) -> String {
+        let data = match self.data(id.0) {
+            TypeData::Struct(data) => data,
+            other => panic!("Expected struct at pool index {}, got {:?}", id.0, other),
+        };
+        if !data.def.is_builtin && self.nominal_name_collides(data.name) {
+            return format!(
+                "{}${}",
+                data.def.name,
+                self.file_symbol_component(data.def.file_id)
+            );
+        }
+        data.def.name.clone()
+    }
+
+    fn enum_symbol_name(&self, id: EnumId) -> String {
+        let data = match self.data(id.0) {
+            TypeData::Enum(data) => data,
+            other => panic!("Expected enum at pool index {}, got {:?}", id.0, other),
+        };
+        if self.nominal_name_collides(data.name) {
+            return format!(
+                "{}${}",
+                data.def.name,
+                self.file_symbol_component(data.def.file_id)
+            );
+        }
+        data.def.name.clone()
+    }
+
+    fn safe_type_name(&self, ty: Type) -> String {
+        match ty.try_kind() {
+            Some(TypeKind::Struct(id)) => self
+                .try_struct_def(id)
+                .map(|def| def.name.clone())
+                .unwrap_or_else(|| format!("<struct#{}>", id.0)),
+            Some(TypeKind::Enum(id)) => self
+                .try_enum_def(id)
+                .map(|def| def.name.clone())
+                .unwrap_or_else(|| format!("<enum#{}>", id.0)),
+            Some(TypeKind::Array(id)) => self
+                .try_array_def(id)
+                .map(|(element, len)| format!("[{}; {}]", self.safe_type_name(element), len))
+                .unwrap_or_else(|| format!("<array#{}>", id.0)),
+            Some(TypeKind::PtrConst(id)) => match self.types.get(id.pool_index() as usize) {
+                Some(TypeData::PtrConst { pointee }) => {
+                    format!(
+                        "ptr const {}",
+                        self.safe_type_name(self.interned_to_type(*pointee))
+                    )
+                }
+                _ => format!("<ptr const#{}>", id.0),
+            },
+            Some(TypeKind::PtrMut(id)) => match self.types.get(id.pool_index() as usize) {
+                Some(TypeData::PtrMut { pointee }) => {
+                    format!(
+                        "ptr mut {}",
+                        self.safe_type_name(self.interned_to_type(*pointee))
+                    )
+                }
+                _ => format!("<ptr mut#{}>", id.0),
+            },
+            Some(_) => ty.name().to_string(),
+            None => format!("<invalid type encoding: {:#x}>", ty.raw_encoding()),
+        }
+    }
+
+    fn is_copy_type(&self, ty: Type) -> bool {
+        ty.as_struct()
+            .map(|id| self.struct_def(id).is_copy)
+            .unwrap_or_else(|| ty.is_copy())
+    }
+
+    fn stats(&self) -> TypeInternPoolStats {
+        let mut stats = TypeInternPoolStats {
+            struct_count: 0,
+            enum_count: 0,
+            array_count: 0,
+            total: self.types.len(),
+        };
+        for data in &self.types {
+            match data {
+                TypeData::Struct(_) => stats.struct_count += 1,
+                TypeData::Enum(_) => stats.enum_count += 1,
+                TypeData::Array { .. } => stats.array_count += 1,
+                TypeData::PtrConst { .. } | TypeData::PtrMut { .. } => {}
+            }
+        }
+        stats
+    }
+}
+
 impl TypeInternPool {
     /// Create a new empty pool.
     pub fn new() -> Self {
@@ -295,33 +552,27 @@ impl TypeInternPool {
         }
     }
 
+    /// Consume the completed semantic type universe for backend-facing reads.
+    ///
+    /// This is the last legal mutation boundary. Request-local symbol interners
+    /// remain separate: type definitions retain stable string names rather than
+    /// storing a [`Spur`] from a CFG or codegen request.
+    pub fn freeze(self) -> FrozenTypeInternPool {
+        FrozenTypeInternPool {
+            inner: Arc::new(
+                self.inner
+                    .into_inner()
+                    .unwrap_or_else(PoisonError::into_inner),
+            ),
+        }
+    }
+
     /// Set relocation-stable source identities for type-derived symbols.
     pub(crate) fn set_symbol_paths(&self, symbol_paths: HashMap<FileId, String>) {
         self.inner
             .write()
             .unwrap_or_else(PoisonError::into_inner)
             .symbol_paths = symbol_paths;
-    }
-
-    fn file_symbol_component(inner: &TypeInternPoolInner, file_id: FileId) -> String {
-        inner
-            .symbol_paths
-            .get(&file_id)
-            .map(|path| mangle_symbol_component(&normalize_module_path(path)))
-            // Preserve the context-free pool's historical fallback. Compiler
-            // entry points install logical identities before analysis.
-            .unwrap_or_else(|| file_id.index().to_string())
-    }
-
-    fn nominal_name_collides(inner: &TypeInternPoolInner, name: Spur) -> bool {
-        inner
-            .struct_by_file_name
-            .keys()
-            .chain(inner.enum_by_file_name.keys())
-            .filter(|(_, existing_name)| *existing_name == name)
-            .take(2)
-            .count()
-            > 1
     }
 
     /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
@@ -331,44 +582,10 @@ impl TypeInternPool {
     /// rejects layouts that exceed the representable slot range before they
     /// can be materialized.
     pub fn abi_slot_count(&self, ty: Type) -> u32 {
-        match ty.kind() {
-            TypeKind::I8
-            | TypeKind::I16
-            | TypeKind::I32
-            | TypeKind::I64
-            | TypeKind::U8
-            | TypeKind::U16
-            | TypeKind::U32
-            | TypeKind::U64
-            | TypeKind::Bool
-            | TypeKind::Error
-            | TypeKind::PtrConst(_)
-            | TypeKind::PtrMut(_) => 1,
-            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => 0,
-            TypeKind::Struct(struct_id) => self
-                .struct_def(struct_id)
-                .fields
-                .iter()
-                .fold(0u32, |total, field| {
-                    total.saturating_add(self.abi_slot_count(field.ty))
-                }),
-            TypeKind::Array(array_id) => {
-                let (element_type, length) = self.array_def(array_id);
-                let element_slots = u64::from(self.abi_slot_count(element_type));
-                u32::try_from(element_slots.saturating_mul(length)).unwrap_or(u32::MAX)
-            }
-            TypeKind::Enum(enum_id) => {
-                let def = self.enum_def(enum_id);
-                let mut max_payload = 0u32;
-                for index in 0..def.variant_count() {
-                    let payload = def.variant_payload(index).iter().fold(0u32, |total, &ty| {
-                        total.saturating_add(self.abi_slot_count(ty))
-                    });
-                    max_payload = max_payload.max(payload);
-                }
-                1u32.saturating_add(max_payload)
-            }
-        }
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .abi_slot_count(ty)
     }
 
     /// Register a new struct (nominal - no deduplication).
@@ -722,23 +939,13 @@ impl TypeInternPool {
     /// Panics if the StructId doesn't correspond to a struct in the pool.
     pub fn struct_def(&self, struct_id: StructId) -> StructDef {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        let pool_index = struct_id.0 as usize;
-        match &inner.types[pool_index] {
-            TypeData::Struct(data) => data.def.clone(),
-            other => panic!(
-                "Expected struct at pool index {}, got {:?}",
-                pool_index, other
-            ),
-        }
+        inner.struct_def(struct_id).clone()
     }
 
     /// Get a struct definition without panicking on an invalid or wrong-kind ID.
     pub fn try_struct_def(&self, struct_id: StructId) -> Option<StructDef> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        match inner.types.get(struct_id.0 as usize)? {
-            TypeData::Struct(data) => Some(data.def.clone()),
-            _ => None,
-        }
+        inner.try_struct_def(struct_id).cloned()
     }
 
     /// Return the stable standard-library identity carried by a nominal type.
@@ -799,23 +1006,13 @@ impl TypeInternPool {
     /// Panics if the EnumId doesn't correspond to an enum in the pool.
     pub fn enum_def(&self, enum_id: EnumId) -> EnumDef {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        let pool_index = enum_id.0 as usize;
-        match &inner.types[pool_index] {
-            TypeData::Enum(data) => data.def.clone(),
-            other => panic!(
-                "Expected enum at pool index {}, got {:?}",
-                pool_index, other
-            ),
-        }
+        inner.enum_def(enum_id).clone()
     }
 
     /// Get an enum definition without panicking on an invalid or wrong-kind ID.
     pub fn try_enum_def(&self, enum_id: EnumId) -> Option<EnumDef> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        match inner.types.get(enum_id.0 as usize)? {
-            TypeData::Enum(data) => Some(data.def.clone()),
-            _ => None,
-        }
+        inner.try_enum_def(enum_id).cloned()
     }
 
     /// The symbol-name component for functions derived from a struct —
@@ -837,22 +1034,7 @@ impl TypeInternPool {
     /// definitions and calls meet at link time.
     pub fn struct_symbol_name(&self, struct_id: StructId) -> String {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        let pool_index = struct_id.0 as usize;
-        let data = match &inner.types[pool_index] {
-            TypeData::Struct(data) => data,
-            other => panic!(
-                "Expected struct at pool index {}, got {:?}",
-                pool_index, other
-            ),
-        };
-        if !data.def.is_builtin && Self::nominal_name_collides(&inner, data.name) {
-            return format!(
-                "{}${}",
-                data.def.name,
-                Self::file_symbol_component(&inner, data.def.file_id)
-            );
-        }
-        data.def.name.clone()
+        inner.struct_symbol_name(struct_id)
     }
 
     /// The symbol-name component for an enum's drop glue (`__rue_drop_E`),
@@ -860,22 +1042,7 @@ impl TypeInternPool {
     /// See [`Self::struct_symbol_name`] (RUE-571) — same rule, same reason.
     pub fn enum_symbol_name(&self, enum_id: EnumId) -> String {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        let pool_index = enum_id.0 as usize;
-        let data = match &inner.types[pool_index] {
-            TypeData::Enum(data) => data,
-            other => panic!(
-                "Expected enum at pool index {}, got {:?}",
-                pool_index, other
-            ),
-        };
-        if Self::nominal_name_collides(&inner, data.name) {
-            return format!(
-                "{}${}",
-                data.def.name,
-                Self::file_symbol_component(&inner, data.def.file_id)
-            );
-        }
-        data.def.name.clone()
+        inner.enum_symbol_name(enum_id)
     }
 
     /// Update a struct definition in the pool.
@@ -949,29 +1116,13 @@ impl TypeInternPool {
     /// Panics if the ArrayTypeId doesn't correspond to an array in the pool.
     pub fn array_def(&self, array_id: ArrayTypeId) -> (Type, u64) {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        let pool_index = array_id.0 as usize;
-        match &inner.types[pool_index] {
-            TypeData::Array { element, len } => {
-                // Convert InternedType back to Type
-                let element_type = Self::interned_to_type_recursive(*element, &inner);
-                (element_type, *len)
-            }
-            other => panic!(
-                "Expected array at pool index {}, got {:?}",
-                pool_index, other
-            ),
-        }
+        inner.array_def(array_id)
     }
 
     /// Get an array definition without panicking on an invalid or wrong-kind ID.
     pub fn try_array_def(&self, array_id: ArrayTypeId) -> Option<(Type, u64)> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        match inner.types.get(array_id.0 as usize)? {
-            TypeData::Array { element, len } => {
-                Some((Self::interned_to_type_recursive(*element, &inner), *len))
-            }
-            _ => None,
-        }
+        inner.try_array_def(array_id)
     }
 
     /// Intern an array type from a Type element.
@@ -1039,61 +1190,13 @@ impl TypeInternPool {
     /// Get ptr const pointee type if this is a ptr const type.
     pub fn ptr_const_def(&self, ptr_id: PtrConstTypeId) -> Type {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        let pool_index = ptr_id.0 as usize;
-        match &inner.types[pool_index] {
-            TypeData::PtrConst { pointee } => Self::interned_to_type_recursive(*pointee, &inner),
-            other => panic!(
-                "Expected ptr const at pool index {}, got {:?}",
-                pool_index, other
-            ),
-        }
+        inner.ptr_const_def(ptr_id)
     }
 
     /// Get ptr mut pointee type if this is a ptr mut type.
     pub fn ptr_mut_def(&self, ptr_id: PtrMutTypeId) -> Type {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        let pool_index = ptr_id.0 as usize;
-        match &inner.types[pool_index] {
-            TypeData::PtrMut { pointee } => Self::interned_to_type_recursive(*pointee, &inner),
-            other => panic!(
-                "Expected ptr mut at pool index {}, got {:?}",
-                pool_index, other
-            ),
-        }
-    }
-
-    /// Convert InternedType to Type recursively (handles composite types).
-    ///
-    /// This is used to convert array element types from InternedType back to Type.
-    fn interned_to_type_recursive(ty: InternedType, inner: &TypeInternPoolInner) -> Type {
-        if ty.is_primitive() {
-            return match ty.0 {
-                0 => Type::I8,
-                1 => Type::I16,
-                2 => Type::I32,
-                3 => Type::I64,
-                4 => Type::U8,
-                5 => Type::U16,
-                6 => Type::U32,
-                7 => Type::U64,
-                8 => Type::BOOL,
-                9 => Type::UNIT,
-                10 => Type::NEVER,
-                11 => Type::ERROR,
-                _ => panic!("Unknown primitive index: {}", ty.0),
-            };
-        }
-
-        let pool_index = ty.pool_index().expect("non-primitive must have pool index");
-        match &inner.types[pool_index as usize] {
-            TypeData::Struct(_) => Type::new_struct(StructId::from_pool_index(pool_index)),
-            TypeData::Enum(_) => Type::new_enum(EnumId::from_pool_index(pool_index)),
-            TypeData::Array { .. } => Type::new_array(ArrayTypeId::from_pool_index(pool_index)),
-            TypeData::PtrConst { .. } => {
-                Type::new_ptr_const(PtrConstTypeId::from_pool_index(pool_index))
-            }
-            TypeData::PtrMut { .. } => Type::new_ptr_mut(PtrMutTypeId::from_pool_index(pool_index)),
-        }
+        inner.ptr_mut_def(ptr_id)
     }
 
     /// Convert Type to InternedType recursively (handles composite types).
@@ -1196,27 +1299,21 @@ impl TypeInternPool {
     /// Get statistics about the pool contents.
     pub fn stats(&self) -> TypeInternPoolStats {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        let mut struct_count = 0;
-        let mut enum_count = 0;
-        let mut array_count = 0;
+        inner.stats()
+    }
 
-        for data in &inner.types {
-            match data {
-                TypeData::Struct(_) => struct_count += 1,
-                TypeData::Enum(_) => enum_count += 1,
-                TypeData::Array { .. } => array_count += 1,
-                TypeData::PtrConst { .. } | TypeData::PtrMut { .. } => {
-                    // Pointer types are not counted separately in stats
-                }
-            }
-        }
+    pub(crate) fn safe_type_name(&self, ty: Type) -> String {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .safe_type_name(ty)
+    }
 
-        TypeInternPoolStats {
-            struct_count,
-            enum_count,
-            array_count,
-            total: inner.types.len(),
-        }
+    pub(crate) fn is_copy_type(&self, ty: Type) -> bool {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .is_copy_type(ty)
     }
 
     // ========================================================================
@@ -1285,6 +1382,154 @@ impl TypeInternPool {
     }
 }
 
+impl FrozenTypeInternPool {
+    pub fn new() -> Self {
+        TypeInternPool::new().freeze()
+    }
+
+    /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
+    pub fn abi_slot_count(&self, ty: Type) -> u32 {
+        self.inner.abi_slot_count(ty)
+    }
+
+    /// Borrow a completed nominal struct definition without locking or cloning.
+    pub fn struct_def(&self, id: StructId) -> &StructDef {
+        self.inner.struct_def(id)
+    }
+
+    pub fn try_struct_def(&self, id: StructId) -> Option<&StructDef> {
+        self.inner.try_struct_def(id)
+    }
+
+    /// Borrow a completed nominal enum definition without locking or cloning.
+    pub fn enum_def(&self, id: EnumId) -> &EnumDef {
+        self.inner.enum_def(id)
+    }
+
+    pub fn try_enum_def(&self, id: EnumId) -> Option<&EnumDef> {
+        self.inner.try_enum_def(id)
+    }
+
+    pub fn array_def(&self, id: ArrayTypeId) -> (Type, u64) {
+        self.inner.array_def(id)
+    }
+
+    pub fn try_array_def(&self, id: ArrayTypeId) -> Option<(Type, u64)> {
+        self.inner.try_array_def(id)
+    }
+
+    pub fn ptr_const_def(&self, id: PtrConstTypeId) -> Type {
+        self.inner.ptr_const_def(id)
+    }
+
+    pub fn ptr_mut_def(&self, id: PtrMutTypeId) -> Type {
+        self.inner.ptr_mut_def(id)
+    }
+
+    /// Look up an already-completed mutable pointer type without modifying the pool.
+    pub fn get_ptr_mut_by_type(&self, pointee_type: Type) -> Option<PtrMutTypeId> {
+        let pointee = TypeInternPool::type_to_interned_recursive(pointee_type);
+        let interned = self.inner.ptr_mut_map.get(&pointee)?;
+        Some(PtrMutTypeId::from_pool_index(interned.pool_index()?))
+    }
+
+    pub fn struct_lang_item(&self, id: StructId) -> Option<LangItem> {
+        self.inner.struct_lang_items.get(&id).copied()
+    }
+
+    pub fn lang_item_type(&self, item: LangItem) -> Option<Type> {
+        self.inner
+            .lang_item_structs
+            .get(&item)
+            .copied()
+            .map(Type::new_struct)
+    }
+
+    pub fn is_strbuf(&self, id: StructId) -> bool {
+        self.struct_lang_item(id) == Some(LangItem::StrBuf)
+    }
+
+    pub fn struct_symbol_name(&self, id: StructId) -> String {
+        self.inner.struct_symbol_name(id)
+    }
+
+    pub fn enum_symbol_name(&self, id: EnumId) -> String {
+        self.inner.enum_symbol_name(id)
+    }
+
+    pub fn all_struct_ids(&self) -> impl Iterator<Item = StructId> + '_ {
+        self.inner
+            .types
+            .iter()
+            .enumerate()
+            .filter(|(_, data)| matches!(data, TypeData::Struct(_)))
+            .map(|(index, _)| StructId::from_pool_index(index as u32))
+    }
+
+    pub fn all_enum_ids(&self) -> impl Iterator<Item = EnumId> + '_ {
+        self.inner
+            .types
+            .iter()
+            .enumerate()
+            .filter(|(_, data)| matches!(data, TypeData::Enum(_)))
+            .map(|(index, _)| EnumId::from_pool_index(index as u32))
+    }
+
+    pub fn all_array_ids(&self) -> impl Iterator<Item = ArrayTypeId> + '_ {
+        self.inner
+            .types
+            .iter()
+            .enumerate()
+            .filter_map(|(index, data)| {
+                matches!(data, TypeData::Array { .. }).then_some(ArrayTypeId(index as u32))
+            })
+    }
+
+    pub fn all_ptr_const_ids(&self) -> impl Iterator<Item = PtrConstTypeId> + '_ {
+        self.inner
+            .types
+            .iter()
+            .enumerate()
+            .filter(|(_, data)| matches!(data, TypeData::PtrConst { .. }))
+            .map(|(index, _)| PtrConstTypeId::from_pool_index(index as u32))
+    }
+
+    pub fn all_ptr_mut_ids(&self) -> impl Iterator<Item = PtrMutTypeId> + '_ {
+        self.inner
+            .types
+            .iter()
+            .enumerate()
+            .filter(|(_, data)| matches!(data, TypeData::PtrMut { .. }))
+            .map(|(index, _)| PtrMutTypeId::from_pool_index(index as u32))
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.types.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.types.is_empty()
+    }
+
+    pub fn stats(&self) -> TypeInternPoolStats {
+        self.inner.stats()
+    }
+
+    pub(crate) fn safe_type_name(&self, ty: Type) -> String {
+        self.inner.safe_type_name(ty)
+    }
+
+    pub(crate) fn is_copy_type(&self, ty: Type) -> bool {
+        self.inner.is_copy_type(ty)
+    }
+}
+
+impl Default for FrozenTypeInternPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Default for TypeInternPool {
     fn default() -> Self {
         Self::new()
@@ -1326,6 +1571,7 @@ pub struct TypeInternPoolStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::StructField;
     use lasso::ThreadedRodeo;
 
     // ========================================================================
@@ -1399,6 +1645,54 @@ mod tests {
         let pool = TypeInternPool::new();
         assert!(pool.is_empty());
         assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn freeze_preserves_complete_nominals_and_borrows_stable_definitions() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = declarations.get_or_intern("Owner");
+        let (owner, _) = pool.register_struct(
+            name,
+            StructDef {
+                name: "Owner".into(),
+                fields: vec![StructField {
+                    name: "value".into(),
+                    ty: Type::I64,
+                }],
+                is_copy: false,
+                is_linear: false,
+                destructor: Some("Owner.__drop".into()),
+                is_builtin: false,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let owner_type = Type::new_struct(owner);
+        let mutable_symbol = pool.struct_symbol_name(owner);
+        let mutable_name = owner_type.safe_name_with_pool(Some(&pool));
+        let mutable_slots = pool.abi_slot_count(owner_type);
+        let mutable_stats = pool.stats();
+
+        let frozen = pool.freeze();
+        let first = frozen.struct_def(owner);
+        let second = frozen.struct_def(owner);
+        assert!(std::ptr::eq(first, second));
+        assert_eq!(frozen.all_struct_ids().collect::<Vec<_>>(), [owner]);
+        assert_eq!(frozen.struct_symbol_name(owner), mutable_symbol);
+        assert_eq!(
+            owner_type.safe_name_with_frozen_pool(Some(&frozen)),
+            mutable_name
+        );
+        assert_eq!(frozen.abi_slot_count(owner_type), mutable_slots);
+        assert_eq!(frozen.stats(), mutable_stats);
+
+        // Destructor provenance crosses the boundary as a stable string. A
+        // backend request chooses its own symbol universe and interns it there.
+        let request_symbols = ThreadedRodeo::default();
+        let destructor = first.destructor.as_deref().unwrap();
+        let request_symbol = request_symbols.get_or_intern(destructor);
+        assert_eq!(request_symbols.resolve(&request_symbol), "Owner.__drop");
     }
 
     #[test]
@@ -2202,6 +2496,7 @@ mod tests {
     #[test]
     fn test_pool_is_send_sync() {
         assert_send_sync::<TypeInternPool>();
+        assert_send_sync::<FrozenTypeInternPool>();
     }
 
     #[test]

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -37,7 +37,8 @@ pub use inst::{
     AirPlace, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
 };
 pub use intern_pool::{
-    EnumData, InternedType, StructData, TypeData, TypeInternPool, TypeInternPoolStats,
+    EnumData, FrozenTypeInternPool, InternedType, StructData, TypeData, TypeInternPool,
+    TypeInternPoolStats,
 };
 pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -552,7 +552,10 @@ fn finalize_function_body_analysis(
         // Body analysis and specialization can intern composite and anonymous
         // types. Transfer the completed pool only after every finalization
         // consumer above has finished reading semantic state.
-        type_pool: std::mem::take(&mut sema.type_pool),
+        // This transfer is deliberately last: specialization and anonymous
+        // destructor discovery above are the final operations allowed to
+        // extend the semantic type universe.
+        type_pool: std::mem::take(&mut sema.type_pool).freeze(),
     };
 
     errors.into_result_with(output)
@@ -2625,7 +2628,7 @@ mod error_invariant_tests {
             functions: vec![func],
             strings: Vec::new(),
             warnings: Vec::new(),
-            type_pool: TypeInternPool::new(),
+            type_pool: TypeInternPool::new().freeze(),
             body_analysis_work: crate::BodyAnalysisWork::default(),
             ordinary_body_exports: Vec::new(),
             specialized_body_exports: Vec::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -5,7 +5,6 @@
 //! - [`SemaOutput`] - Complete output from analyzing a program
 
 use crate::inst::Air;
-use crate::intern_pool::TypeInternPool;
 use crate::{SemanticBodyExport, SemanticSpecializedBodyExport};
 use rue_error::CompileWarning;
 /// Opaque identity issued by the compiler for one supported ordinary body.
@@ -364,8 +363,8 @@ pub struct SemaOutput {
     pub strings: Vec<String>,
     /// Warnings collected during analysis.
     pub warnings: Vec<CompileWarning>,
-    /// Type intern pool (contains all types including arrays).
-    pub type_pool: TypeInternPool,
+    /// Completed immutable type metadata (contains all types including arrays).
+    pub type_pool: crate::FrozenTypeInternPool,
     /// Exact structural work performed while dispatching reachable bodies.
     pub body_analysis_work: BodyAnalysisWork,
     /// Pre-specialization durable candidates for supported ordinary bodies.

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -527,7 +527,7 @@ mod tests {
                 .air
                 .return_type()
                 .safe_name_with_pool(Some(epoch.type_pool())),
-            make_type.safe_name_with_pool(Some(&output.type_pool))
+            make_type.safe_name_with_frozen_pool(Some(&output.type_pool))
         );
     }
 
@@ -602,7 +602,7 @@ mod tests {
                 && function
                     .air
                     .return_type()
-                    .safe_name_with_pool(Some(&output.type_pool))
+                    .safe_name_with_frozen_pool(Some(&output.type_pool))
                     == "[i32; 3]"
         }));
     }
@@ -1362,7 +1362,9 @@ mod tests {
             .find_map(|(_, inst)| matches!(inst.data, AirInstData::StringConst(_)).then_some(inst))
             .expect("main must materialize its literal");
         assert_eq!(
-            literal.ty.safe_name_with_pool(Some(&output.type_pool)),
+            literal
+                .ty
+                .safe_name_with_frozen_pool(Some(&output.type_pool)),
             "str"
         );
         assert_eq!(output.type_pool.abi_slot_count(literal.ty), 2);
@@ -1419,9 +1421,9 @@ mod tests {
             .collect();
         assert_eq!(literal_types.len(), 7);
         assert!(literal_types.iter().all(|&ty| {
-            ty.safe_name_with_pool(Some(&output.type_pool)) == "str"
+            ty.safe_name_with_frozen_pool(Some(&output.type_pool)) == "str"
                 && output.type_pool.abi_slot_count(ty) == 2
-                && ty.is_copy_in_pool(&output.type_pool)
+                && ty.is_copy_in_frozen_pool(&output.type_pool)
         }));
     }
 
@@ -1511,7 +1513,7 @@ mod tests {
             .iter()
             .flat_map(|function| function.air.iter())
             .filter(|(_, inst)| matches!(inst.data, AirInstData::StringConst(_)))
-            .map(|(_, inst)| inst.ty.safe_name_with_pool(Some(&output.type_pool)))
+            .map(|(_, inst)| inst.ty.safe_name_with_frozen_pool(Some(&output.type_pool)))
             .collect();
 
         // Comparison operands and a discarded loop-body value have no buffer
@@ -1657,7 +1659,7 @@ mod tests {
                 .air
                 .get(stored_value)
                 .ty
-                .safe_name_with_pool(Some(&output.type_pool)),
+                .safe_name_with_frozen_pool(Some(&output.type_pool)),
             "Str(8)"
         );
 
@@ -2078,8 +2080,7 @@ mod tests {
             output
                 .type_pool
                 .all_struct_ids()
-                .iter()
-                .map(|id| output.type_pool.struct_def(*id))
+                .map(|id| output.type_pool.struct_def(id))
                 .any(|s| s.name == "Point" && s.is_copy)
         );
     }
@@ -2145,8 +2146,7 @@ mod tests {
             !output
                 .type_pool
                 .all_struct_ids()
-                .iter()
-                .map(|id| output.type_pool.struct_def(*id))
+                .map(|id| output.type_pool.struct_def(id))
                 .any(|s| s.name == "StrBuf")
         );
     }

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -282,6 +282,10 @@ const TAG_PTR_MUT: u32 = 105;
 
 // Primitive type constants
 impl Type {
+    pub(crate) const fn raw_encoding(self) -> u32 {
+        self.0
+    }
+
     /// 8-bit signed integer
     pub const I8: Type = Type(0);
     /// 16-bit signed integer
@@ -637,43 +641,28 @@ impl Type {
     /// This method is safe even if the struct/enum ID is invalid or the pool is None.
     /// It will return a fallback string like `"<struct#123>"` in those cases.
     pub fn safe_name_with_pool(&self, pool: Option<&crate::intern_pool::TypeInternPool>) -> String {
+        pool.map(|pool| pool.safe_type_name(*self))
+            .unwrap_or_else(|| self.safe_name_without_pool())
+    }
+
+    /// Backend-facing counterpart to [`Self::safe_name_with_pool`] for the
+    /// immutable type universe produced by semantic analysis.
+    pub fn safe_name_with_frozen_pool(
+        &self,
+        pool: Option<&crate::intern_pool::FrozenTypeInternPool>,
+    ) -> String {
+        pool.map(|pool| pool.safe_type_name(*self))
+            .unwrap_or_else(|| self.safe_name_without_pool())
+    }
+
+    fn safe_name_without_pool(&self) -> String {
         match self.try_kind() {
-            Some(TypeKind::Struct(struct_id)) => {
-                if let Some(pool) = pool {
-                    let def = pool.struct_def(struct_id);
-                    return def.name.clone();
-                }
-                format!("<struct#{}>", struct_id.0)
-            }
-            Some(TypeKind::Enum(enum_id)) => {
-                if let Some(pool) = pool {
-                    let def = pool.enum_def(enum_id);
-                    return def.name.clone();
-                }
-                format!("<enum#{}>", enum_id.0)
-            }
-            Some(TypeKind::Array(array_id)) => {
-                if let Some(pool) = pool {
-                    let (element, len) = pool.array_def(array_id);
-                    return format!("[{}; {}]", element.safe_name_with_pool(Some(pool)), len);
-                }
-                format!("<array#{}>", array_id.0)
-            }
-            Some(TypeKind::PtrConst(ptr_id)) => {
-                if let Some(pool) = pool {
-                    let pointee = pool.ptr_const_def(ptr_id);
-                    return format!("ptr const {}", pointee.safe_name_with_pool(Some(pool)));
-                }
-                format!("<ptr const#{}>", ptr_id.0)
-            }
-            Some(TypeKind::PtrMut(ptr_id)) => {
-                if let Some(pool) = pool {
-                    let pointee = pool.ptr_mut_def(ptr_id);
-                    return format!("ptr mut {}", pointee.safe_name_with_pool(Some(pool)));
-                }
-                format!("<ptr mut#{}>", ptr_id.0)
-            }
-            Some(_kind) => self.name().to_string(),
+            Some(TypeKind::Struct(id)) => format!("<struct#{}>", id.0),
+            Some(TypeKind::Enum(id)) => format!("<enum#{}>", id.0),
+            Some(TypeKind::Array(id)) => format!("<array#{}>", id.0),
+            Some(TypeKind::PtrConst(id)) => format!("<ptr const#{}>", id.0),
+            Some(TypeKind::PtrMut(id)) => format!("<ptr mut#{}>", id.0),
+            Some(_) => self.name().to_string(),
             None => format!("<invalid type encoding: {:#x}>", self.0),
         }
     }
@@ -888,11 +877,14 @@ impl Type {
     /// This is used during anonymous struct creation to determine if the new struct
     /// should be Copy based on its field types.
     pub fn is_copy_in_pool(&self, type_pool: &crate::intern_pool::TypeInternPool) -> bool {
-        if let Some(struct_id) = self.as_struct() {
-            type_pool.struct_def(struct_id).is_copy
-        } else {
-            self.is_copy()
-        }
+        type_pool.is_copy_type(*self)
+    }
+
+    pub fn is_copy_in_frozen_pool(
+        &self,
+        type_pool: &crate::intern_pool::FrozenTypeInternPool,
+    ) -> bool {
+        type_pool.is_copy_type(*self)
     }
 
     /// Check if this is a 64-bit type (uses 64-bit operations).

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -6,7 +6,7 @@
 use lasso::ThreadedRodeo;
 use rue_air::{
     Air, AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
-    ParamSlotModes, StructId, Type, TypeInternPool, TypeKind,
+    FrozenTypeInternPool, ParamSlotModes, StructId, Type, TypeKind,
 };
 use rue_error::{CompileError, CompileWarning, ErrorKind, WarningKind};
 
@@ -181,7 +181,7 @@ pub struct CfgBuilder<'a> {
     air: &'a Air,
     cfg: Cfg,
     /// Canonical pool for struct, enum, array, and pointer definitions.
-    type_pool: &'a TypeInternPool,
+    type_pool: &'a FrozenTypeInternPool,
     /// Interner for resolving symbols to strings
     interner: &'a ThreadedRodeo,
     /// Current block we're building
@@ -254,7 +254,7 @@ impl<'a> CfgBuilder<'a> {
         num_locals: u32,
         num_params: u32,
         fn_name: &str,
-        type_pool: &'a TypeInternPool,
+        type_pool: &'a FrozenTypeInternPool,
         param_modes: impl Into<ParamSlotModes>,
         interner: &'a ThreadedRodeo,
         allow_unreachable_code: bool,
@@ -2049,15 +2049,15 @@ impl<'a> CfgBuilder<'a> {
                         self.implicit_named_destructors.insert(struct_id);
                     }
                 }
-                for field in def.fields {
+                for field in &def.fields {
                     self.record_implicit_destructors(field.ty);
                 }
             }
             TypeKind::Enum(enum_id) => {
                 let def = self.type_pool.enum_def(enum_id);
-                for payload in def.variant_payloads {
+                for payload in &def.variant_payloads {
                     for field in payload {
-                        self.record_implicit_destructors(field);
+                        self.record_implicit_destructors(*field);
                     }
                 }
             }
@@ -3711,7 +3711,9 @@ mod tests {
 
     #[test]
     fn borrowed_computed_projection_drops_its_owner_once_after_the_consumer() {
-        use rue_air::{Air, AirInst, AirPlaceBase, AirProjection, StructDef, StructField};
+        use rue_air::{
+            Air, AirInst, AirPlaceBase, AirProjection, StructDef, StructField, TypeInternPool,
+        };
         use rue_span::{FileId, Span};
 
         for shape in ["direct", "nested", "index"] {
@@ -3760,6 +3762,7 @@ mod tests {
                 ),
             );
             let owner_ty = Type::new_struct(owner_id);
+            let type_pool = type_pool.freeze();
 
             let mut air = Air::new(Type::UNIT);
             let constant = air.add_inst(AirInst {
@@ -3942,7 +3945,7 @@ mod tests {
 
         let interner = ThreadedRodeo::default();
         let name = interner.get_or_intern("generic_fn");
-        let type_pool = TypeInternPool::new();
+        let type_pool = FrozenTypeInternPool::new();
 
         let mut air = Air::new(Type::I32);
         let call = air.add_inst(AirInst {

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -25,7 +25,7 @@ mod constprop;
 mod dce;
 
 use crate::Cfg;
-use rue_air::TypeInternPool;
+use rue_air::FrozenTypeInternPool;
 
 /// Optimization level, following standard compiler conventions.
 ///
@@ -130,7 +130,7 @@ impl std::fmt::Display for OptLevel {
 /// optimize(&mut cfg, OptLevel::O1, &type_pool);
 /// // cfg is now optimized
 /// ```
-pub fn optimize(cfg: &mut Cfg, level: OptLevel, type_pool: &TypeInternPool) {
+pub fn optimize(cfg: &mut Cfg, level: OptLevel, type_pool: &FrozenTypeInternPool) {
     // Verify construction output before any pass can detach dead values or
     // erase unreachable blocks and thereby hide a malformed definition/use.
     cfg.verify_with_type_pool(type_pool);

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -31,7 +31,7 @@
 //! again after all passes.
 
 use crate::inst::{BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
-use rue_air::{Type, TypeInternPool, TypeKind};
+use rue_air::{FrozenTypeInternPool, Type, TypeKind};
 
 impl Cfg {
     /// Count every operand use of `needle` across instructions and
@@ -107,7 +107,7 @@ impl Cfg {
     /// Verify with the active semantic type pool, enabling exact aggregate
     /// layouts and projection-chain validation. Production callers must use
     /// this entry point.
-    pub fn verify_with_type_pool(&self, type_pool: &TypeInternPool) {
+    pub fn verify_with_type_pool(&self, type_pool: &FrozenTypeInternPool) {
         Verifier::new(self, Some(type_pool), true).verify();
     }
 
@@ -115,7 +115,10 @@ impl Cfg {
     /// in the arena after detaching them from blocks, so attachment completeness
     /// is checked before optimization while every remaining attachment and use
     /// is checked again afterward.
-    pub(crate) fn verify_after_optimization_with_type_pool(&self, type_pool: &TypeInternPool) {
+    pub(crate) fn verify_after_optimization_with_type_pool(
+        &self,
+        type_pool: &FrozenTypeInternPool,
+    ) {
         Verifier::new(self, Some(type_pool), false).verify();
     }
 
@@ -223,7 +226,7 @@ enum Attachment {
 
 struct Verifier<'a> {
     cfg: &'a Cfg,
-    type_pool: Option<&'a TypeInternPool>,
+    type_pool: Option<&'a FrozenTypeInternPool>,
     require_complete_attachments: bool,
     attachments: Vec<Option<Attachment>>,
     reachable: Vec<bool>,
@@ -233,7 +236,7 @@ struct Verifier<'a> {
 impl<'a> Verifier<'a> {
     fn new(
         cfg: &'a Cfg,
-        type_pool: Option<&'a TypeInternPool>,
+        type_pool: Option<&'a FrozenTypeInternPool>,
         require_complete_attachments: bool,
     ) -> Self {
         Self {
@@ -1257,7 +1260,9 @@ mod tests {
     };
     use crate::{OptLevel, opt};
     use lasso::ThreadedRodeo;
-    use rue_air::{ArrayTypeId, StructDef, StructField, StructId, Type, TypeInternPool};
+    use rue_air::{
+        ArrayTypeId, FrozenTypeInternPool, StructDef, StructField, StructId, Type, TypeInternPool,
+    };
     use rue_span::Span;
 
     fn unit_cfg() -> Cfg {
@@ -1821,7 +1826,7 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
-        cfg.verify_with_type_pool(&TypeInternPool::new());
+        cfg.verify_with_type_pool(&FrozenTypeInternPool::new());
     }
 
     #[test]
@@ -1839,7 +1844,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify_with_type_pool(&TypeInternPool::new());
+        cfg.verify_with_type_pool(&FrozenTypeInternPool::new());
     }
 
     #[test]
@@ -1848,6 +1853,7 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let pair = register_struct(&pool, &interner, "Pair", &[Type::I32, Type::I32]);
+        let pool = pool.freeze();
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "wide_local".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -1868,6 +1874,7 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let pair = register_struct(&pool, &interner, "BorrowedPair", &[Type::I32, Type::I32]);
+        let pool = pool.freeze();
         let pair_ty = Type::new_struct(pair);
         let mut cfg = Cfg::new(Type::UNIT, 0, 1, "borrowed_pair".to_string(), vec![true]);
         let entry = cfg.new_block();
@@ -1895,7 +1902,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "references invalid struct id")]
     fn verify_rejects_invalid_struct_projection_id() {
-        let pool = TypeInternPool::new();
+        let pool = FrozenTypeInternPool::new();
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "invalid_struct".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -1922,7 +1929,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "references invalid array id")]
     fn verify_rejects_invalid_array_projection_id() {
-        let pool = TypeInternPool::new();
+        let pool = FrozenTypeInternPool::new();
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "invalid_array".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -1958,6 +1965,7 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let record = register_struct(&pool, &interner, "Record", &[Type::I32]);
+        let pool = pool.freeze();
         let record_ty = Type::new_struct(record);
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "bad_field".to_string(), vec![]);
         let entry = cfg.new_block();
@@ -1990,6 +1998,7 @@ mod tests {
         let inner = register_struct(&pool, &interner, "Inner", &[Type::I32]);
         let wrong = register_struct(&pool, &interner, "Wrong", &[Type::I32]);
         let outer = register_struct(&pool, &interner, "Outer", &[Type::new_struct(inner)]);
+        let pool = pool.freeze();
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "broken_chain".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -2025,6 +2034,7 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let record = register_struct(&pool, &interner, "ResultRecord", &[Type::I32]);
+        let pool = pool.freeze();
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "bad_result".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -2202,7 +2212,7 @@ mod tests {
                     value: Some(result),
                 },
             );
-            opt::optimize(&mut cfg, level, &TypeInternPool::new());
+            opt::optimize(&mut cfg, level, &FrozenTypeInternPool::new());
         }
     }
 
@@ -2231,6 +2241,6 @@ mod tests {
                 value: Some(result),
             },
         );
-        opt::optimize(&mut cfg, OptLevel::O1, &TypeInternPool::new());
+        opt::optimize(&mut cfg, OptLevel::O1, &FrozenTypeInternPool::new());
     }
 }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{TypeInternPool, TypeKind};
+use rue_air::{FrozenTypeInternPool, TypeKind};
 use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, Terminator, Type};
 use rue_error::CompileResult;
 use rue_target::Target;
@@ -73,7 +73,7 @@ impl<'a> CfgLower<'a> {
     /// Create a new CFG lowering pass.
     pub fn new(
         cfg: &'a Cfg,
-        type_pool: &'a TypeInternPool,
+        type_pool: &'a FrozenTypeInternPool,
         interner: &'a ThreadedRodeo,
         target: Target,
     ) -> Self {

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -27,7 +27,7 @@ pub use mir::{Aarch64Inst, Aarch64Mir, Cond, Operand, Reg, VReg};
 pub use regalloc::RegAlloc;
 
 use lasso::ThreadedRodeo;
-use rue_air::TypeInternPool;
+use rue_air::FrozenTypeInternPool;
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
 use rue_target::Target;
@@ -40,7 +40,7 @@ pub use super::{EmittedCode, EmittedRelocation};
 
 fn prepare_backend(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<crate::codegen_pipeline::PreparedMir<Aarch64Mir, Reg>> {
@@ -60,7 +60,7 @@ fn prepare_backend(
 
 fn generate_inner<T, Emit>(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
@@ -108,7 +108,7 @@ where
 /// This is the main entry point for AArch64 code generation.
 pub fn generate(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
@@ -131,7 +131,7 @@ pub fn generate(
 /// showing the actual emitted instructions (including prologue/epilogue).
 pub fn generate_with_asm(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
@@ -155,7 +155,7 @@ pub fn generate_with_asm(
 /// including live ranges, interference, and allocation decisions.
 pub fn generate_regalloc_info(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -20,7 +20,7 @@
 use std::fmt;
 
 use lasso::{Key, ThreadedRodeo};
-use rue_air::{StructId, TypeInternPool, TypeKind};
+use rue_air::{FrozenTypeInternPool, StructId, TypeKind};
 use rue_cfg::{BlockId, Cfg, CfgValue, Type};
 
 use crate::types;
@@ -359,7 +359,11 @@ pub fn format_terminator(cfg: &rue_cfg::Cfg, terminator: &rue_cfg::Terminator) -
 ///   slot through that pointer before returning. (RUE-13/78/91)
 ///
 /// Scalars and unit never use sret.
-pub fn type_uses_sret_return(type_pool: &TypeInternPool, ty: Type, ret_reg_budget: u32) -> bool {
+pub fn type_uses_sret_return(
+    type_pool: &FrozenTypeInternPool,
+    ty: Type,
+    ret_reg_budget: u32,
+) -> bool {
     match ty.kind() {
         TypeKind::Struct(struct_id) => {
             if type_pool.is_strbuf(struct_id) {
@@ -374,7 +378,11 @@ pub fn type_uses_sret_return(type_pool: &TypeInternPool, ty: Type, ret_reg_budge
 
 /// Does this function return its value via the sret convention?
 /// See [`type_uses_sret_return`] for the convention.
-pub fn fn_uses_sret_return(cfg: &Cfg, type_pool: &TypeInternPool, ret_reg_budget: u32) -> bool {
+pub fn fn_uses_sret_return(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    ret_reg_budget: u32,
+) -> bool {
     type_uses_sret_return(type_pool, cfg.return_type(), ret_reg_budget)
 }
 
@@ -396,7 +404,7 @@ pub struct CfgLowerContext<'a> {
     /// The CFG being lowered.
     pub cfg: &'a Cfg,
     /// Type intern pool for struct/enum/array lookups.
-    pub type_pool: &'a TypeInternPool,
+    pub type_pool: &'a FrozenTypeInternPool,
     /// Number of local variable slots.
     pub num_locals: u32,
     /// Number of parameter slots.
@@ -405,7 +413,7 @@ pub struct CfgLowerContext<'a> {
 
 impl<'a> CfgLowerContext<'a> {
     /// Create a new CFG lowering context.
-    pub fn new(cfg: &'a Cfg, type_pool: &'a TypeInternPool) -> Self {
+    pub fn new(cfg: &'a Cfg, type_pool: &'a FrozenTypeInternPool) -> Self {
         Self {
             cfg,
             type_pool,

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -5,7 +5,7 @@
 //! those passes run — and the distinction between spill-placement slots and
 //! emitted-frame locals — is common to every machine-code emission entry point.
 
-use rue_air::TypeInternPool;
+use rue_air::FrozenTypeInternPool;
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
 
@@ -31,7 +31,7 @@ pub(crate) struct PreparedMir<M, R> {
 ///   emitters account for parameters and sret separately.
 pub(crate) fn prepare_mir<M, R, Lower, Allocate, Peephole, Schedule, Verify>(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     return_reg_count: u32,
     lower: Lower,
     allocate: Allocate,
@@ -81,6 +81,7 @@ mod tests {
     fn pass_order_and_frame_slot_formulas_are_single_source() {
         let type_pool = TypeInternPool::new();
         let array_id = type_pool.intern_array_from_type(Type::I32, 7);
+        let type_pool = type_pool.freeze();
         let cfg = Cfg::new(
             Type::new_array(array_id),
             3,

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -399,11 +399,11 @@ pub use x86_64::{Operand, Reg, X86Inst, X86Mir};
 mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
-    use rue_air::{Air, AirInst, AirInstData, Type, TypeInternPool};
+    use rue_air::{Air, AirInst, AirInstData, FrozenTypeInternPool, Type, TypeInternPool};
     use rue_cfg::{Cfg, CfgBuilder};
     use rue_span::Span;
 
-    fn test_cfg() -> (Cfg, TypeInternPool, ThreadedRodeo) {
+    fn test_cfg() -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
         let mut air = Air::new(Type::I32);
 
         let const_ref = air.add_inst(AirInst {
@@ -419,15 +419,16 @@ mod tests {
         });
 
         let interner = ThreadedRodeo::new();
-        let type_pool = TypeInternPool::new();
+        let type_pool = FrozenTypeInternPool::new();
         let cfg_output =
             CfgBuilder::build(&air, 0, 0, "main", &type_pool, vec![], &interner, false);
         (cfg_output.cfg, type_pool, interner)
     }
 
-    fn aggregate_cfg(len: u64) -> (Cfg, TypeInternPool, ThreadedRodeo) {
+    fn aggregate_cfg(len: u64) -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
         let type_pool = TypeInternPool::new();
         let array_id = type_pool.intern_array_from_type(Type::I64, len);
+        let type_pool = type_pool.freeze();
         let array_ty = Type::new_array(array_id);
         let mut air = Air::new(array_ty);
         let span = Span::new(0, 2);
@@ -482,8 +483,8 @@ mod tests {
         (cfg_output.cfg, type_pool, interner)
     }
 
-    fn syscall_cfg() -> (Cfg, TypeInternPool, ThreadedRodeo) {
-        let type_pool = TypeInternPool::new();
+    fn syscall_cfg() -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+        let type_pool = FrozenTypeInternPool::new();
         let interner = ThreadedRodeo::new();
         let mut air = Air::new(Type::I64);
         let span = Span::new(0, 2);

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -5,7 +5,7 @@
 //! calling convention bugs, and understanding how values are laid out on the stack.
 
 use lasso::ThreadedRodeo;
-use rue_air::TypeInternPool;
+use rue_air::FrozenTypeInternPool;
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
 use rue_target::{Arch, Target};
@@ -254,7 +254,7 @@ impl std::fmt::Display for StackFrameInfo {
 pub fn generate_stack_frame_info(
     cfg: &Cfg,
     function_name: &str,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
@@ -272,7 +272,7 @@ pub fn generate_stack_frame_info(
 fn generate_x86_64_stack_frame(
     cfg: &Cfg,
     function_name: &str,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
@@ -420,7 +420,7 @@ fn generate_x86_64_stack_frame(
 fn generate_aarch64_stack_frame(
     cfg: &Cfg,
     function_name: &str,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
@@ -595,11 +595,11 @@ fn generate_aarch64_stack_frame(
 mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
-    use rue_air::{Air, AirInst, AirInstData, Type, TypeInternPool};
+    use rue_air::{Air, AirInst, AirInstData, FrozenTypeInternPool, Type};
     use rue_cfg::CfgBuilder;
     use rue_span::Span;
 
-    fn create_simple_cfg() -> (rue_cfg::Cfg, TypeInternPool, ThreadedRodeo) {
+    fn create_simple_cfg() -> (rue_cfg::Cfg, FrozenTypeInternPool, ThreadedRodeo) {
         let mut air = Air::new(Type::I32);
 
         let const_ref = air.add_inst(AirInst {
@@ -615,7 +615,7 @@ mod tests {
         });
 
         let interner = ThreadedRodeo::new();
-        let type_pool = TypeInternPool::new();
+        let type_pool = FrozenTypeInternPool::new();
         let cfg_output =
             CfgBuilder::build(&air, 0, 0, "test", &type_pool, vec![], &interner, false);
         (cfg_output.cfg, type_pool, interner)

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -4,9 +4,9 @@
 //! field offsets, shared between x86_64 and aarch64 backends.
 //!
 //! Struct, enum, array, and pointer definitions are resolved through the
-//! canonical `TypeInternPool` (ADR-0024).
+//! canonical `FrozenTypeInternPool` (ADR-0024).
 
-use rue_air::{ArrayTypeId, EnumId, StructId, TypeInternPool, TypeKind};
+use rue_air::{ArrayTypeId, EnumId, FrozenTypeInternPool, StructId, TypeKind};
 use rue_cfg::{Cfg, CfgInstData, CfgValue, Type};
 use std::collections::HashMap;
 
@@ -25,7 +25,7 @@ pub fn extract_array_type_id(ty: Type) -> Option<ArrayTypeId> {
 /// Get the array type definition for an array type ID.
 ///
 /// Returns `(element_type, length)`.
-pub fn array_type_def(type_pool: &TypeInternPool, array_type_id: ArrayTypeId) -> (Type, u64) {
+pub fn array_type_def(type_pool: &FrozenTypeInternPool, array_type_id: ArrayTypeId) -> (Type, u64) {
     type_pool.array_def(array_type_id)
 }
 
@@ -33,14 +33,14 @@ pub fn array_type_def(type_pool: &TypeInternPool, array_type_id: ArrayTypeId) ->
 ///
 /// Returns `Some((element_type, length))` if the type is an array type, `None` otherwise.
 #[inline]
-pub fn array_type_def_from_type(type_pool: &TypeInternPool, ty: Type) -> Option<(Type, u64)> {
+pub fn array_type_def_from_type(type_pool: &FrozenTypeInternPool, ty: Type) -> Option<(Type, u64)> {
     extract_array_type_id(ty).map(|id| array_type_def(type_pool, id))
 }
 
 /// Get the length of an array from its Type.
 /// Returns 0 if the type is not an array.
 #[inline]
-pub fn array_length_from_type(type_pool: &TypeInternPool, ty: Type) -> u64 {
+pub fn array_length_from_type(type_pool: &FrozenTypeInternPool, ty: Type) -> u64 {
     array_type_def_from_type(type_pool, ty)
         .map(|(_element_type, length)| length)
         .unwrap_or(0)
@@ -48,7 +48,7 @@ pub fn array_length_from_type(type_pool: &TypeInternPool, ty: Type) -> u64 {
 
 /// Calculate the slot count for a single element of an array from its Type.
 #[inline]
-pub fn array_element_slot_count_from_type(type_pool: &TypeInternPool, ty: Type) -> u32 {
+pub fn array_element_slot_count_from_type(type_pool: &FrozenTypeInternPool, ty: Type) -> u32 {
     if let Some((element_type, _length)) = array_type_def_from_type(type_pool, ty) {
         type_slot_count(type_pool, element_type)
     } else {
@@ -62,7 +62,7 @@ pub fn array_element_slot_count_from_type(type_pool: &TypeInternPool, ty: Type) 
 /// For structs, this is the sum of slot counts for all fields.
 /// For nested types, this recursively calculates.
 /// Zero-sized types (unit, never, empty structs, zero-length arrays) return 0.
-pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
+pub fn type_slot_count(type_pool: &FrozenTypeInternPool, ty: Type) -> u32 {
     type_pool.abi_slot_count(ty)
 }
 
@@ -74,7 +74,7 @@ pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
 /// result (RUE-6, ADR-0038). Sema has already validated the result is
 /// `Option`-shaped, so both variants are present; a missing one is a compiler
 /// bug and panics (a correctness guard, RUE-45).
-pub fn option_variant_discriminants(type_pool: &TypeInternPool, ty: Type) -> (u64, u64) {
+pub fn option_variant_discriminants(type_pool: &FrozenTypeInternPool, ty: Type) -> (u64, u64) {
     let enum_id = ty
         .as_enum()
         .expect("fallible intrinsic result must be an Option enum");
@@ -120,13 +120,13 @@ pub fn slot_needs_wide_compare(ty: Type) -> bool {
 ///   a narrow value is still correct). Padding slots beyond every variant's
 ///   payload are zero and compare as narrow.
 /// - **unit / never**: zero slots (no entries)
-pub fn aggregate_leaf_types(type_pool: &TypeInternPool, ty: Type) -> Vec<Type> {
+pub fn aggregate_leaf_types(type_pool: &FrozenTypeInternPool, ty: Type) -> Vec<Type> {
     let mut out = Vec::new();
     push_leaf_types(type_pool, ty, &mut out);
     out
 }
 
-fn push_leaf_types(type_pool: &TypeInternPool, ty: Type, out: &mut Vec<Type>) {
+fn push_leaf_types(type_pool: &FrozenTypeInternPool, ty: Type, out: &mut Vec<Type>) {
     match ty.kind() {
         TypeKind::Unit | TypeKind::Never => {}
         TypeKind::Struct(struct_id) => {
@@ -176,7 +176,7 @@ fn push_leaf_types(type_pool: &TypeInternPool, ty: Type, out: &mut Vec<Type>) {
 /// accounts for the slot sizes of all preceding payload fields of the same
 /// variant (RUE-221).
 pub fn enum_payload_slot_offset(
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     enum_id: EnumId,
     variant_index: u32,
     field_index: u32,
@@ -194,7 +194,10 @@ pub fn enum_payload_slot_offset(
 }
 
 /// Calculate the slot count for a single element of an array type.
-pub fn array_element_slot_count(type_pool: &TypeInternPool, array_type_id: ArrayTypeId) -> u32 {
+pub fn array_element_slot_count(
+    type_pool: &FrozenTypeInternPool,
+    array_type_id: ArrayTypeId,
+) -> u32 {
     let (element_type, _length) = type_pool.array_def(array_type_id);
     type_slot_count(type_pool, element_type)
 }
@@ -207,7 +210,7 @@ pub fn array_element_slot_count(type_pool: &TypeInternPool, array_type_id: Array
 ///
 /// However, for simplicity and alignment purposes, all types currently use
 /// 8 bytes per slot. This function returns `slot_count * 8`.
-pub fn type_size_bytes(type_pool: &TypeInternPool, ty: Type) -> u64 {
+pub fn type_size_bytes(type_pool: &FrozenTypeInternPool, ty: Type) -> u64 {
     let slots = type_slot_count(type_pool, ty);
     (slots as u64) * 8
 }
@@ -216,7 +219,7 @@ pub fn type_size_bytes(type_pool: &TypeInternPool, ty: Type) -> u64 {
 /// `type_slot_count(Struct(struct_id))`, but reachable directly from a
 /// `StructId` (used to anchor ascending place addressing at a struct root —
 /// ADR-0040 / RUE-311).
-pub fn struct_slot_count(type_pool: &TypeInternPool, struct_id: StructId) -> u32 {
+pub fn struct_slot_count(type_pool: &FrozenTypeInternPool, struct_id: StructId) -> u32 {
     let struct_def = type_pool.struct_def(struct_id);
     let mut total = 0u32;
     for field in &struct_def.fields {
@@ -229,7 +232,7 @@ pub fn struct_slot_count(type_pool: &TypeInternPool, struct_id: StructId) -> u32
 ///
 /// This accounts for the sizes of all preceding fields.
 pub fn struct_field_slot_offset(
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     struct_id: StructId,
     field_index: u32,
 ) -> u32 {
@@ -313,14 +316,14 @@ pub fn collect_array_scalar_vregs(
 ///
 /// The name encodes the element type and length, e.g., `__rue_drop_array_String_3`.
 /// This must match the name generated by `rue_compiler::drop_glue::array_drop_glue_name`.
-pub fn array_drop_glue_name(array_id: ArrayTypeId, type_pool: &TypeInternPool) -> String {
+pub fn array_drop_glue_name(array_id: ArrayTypeId, type_pool: &FrozenTypeInternPool) -> String {
     let (element_type, length) = type_pool.array_def(array_id);
     let element_type_name = type_name(element_type, type_pool);
     format!("__rue_drop_array_{}_{}", element_type_name, length)
 }
 
 /// Get a name for a type (used for generating drop glue function names).
-fn type_name(ty: Type, type_pool: &TypeInternPool) -> String {
+fn type_name(ty: Type, type_pool: &FrozenTypeInternPool) -> String {
     match ty.kind() {
         TypeKind::I8 => "i8".to_string(),
         TypeKind::I16 => "i16".to_string(),

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -28,7 +28,7 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{TypeInternPool, TypeKind};
+use rue_air::{FrozenTypeInternPool, TypeKind};
 use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, Terminator, Type};
 use rue_error::CompileResult;
 
@@ -78,7 +78,11 @@ pub struct CfgLower<'a> {
 
 impl<'a> CfgLower<'a> {
     /// Create a new CFG lowering pass.
-    pub fn new(cfg: &'a Cfg, type_pool: &'a TypeInternPool, interner: &'a ThreadedRodeo) -> Self {
+    pub fn new(
+        cfg: &'a Cfg,
+        type_pool: &'a FrozenTypeInternPool,
+        interner: &'a ThreadedRodeo,
+    ) -> Self {
         let num_params = cfg.num_params();
 
         // Pre-calculate capacity hints to reduce HashMap reallocations

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -29,7 +29,7 @@ pub use regalloc::RegAlloc;
 use crate::regalloc::RegAllocDebugInfo;
 
 use lasso::ThreadedRodeo;
-use rue_air::TypeInternPool;
+use rue_air::FrozenTypeInternPool;
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
 
@@ -38,7 +38,7 @@ pub use super::{EmittedCode, EmittedRelocation, MachineCode};
 
 fn prepare_backend(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
 ) -> CompileResult<crate::codegen_pipeline::PreparedMir<X86Mir, Reg>> {
     crate::codegen_pipeline::prepare_mir(
@@ -57,7 +57,7 @@ fn prepare_backend(
 
 fn generate_inner<T, Emit>(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     emit: Emit,
@@ -105,7 +105,7 @@ where
 /// The pipeline is: CFG → X86Mir → Machine Code
 pub fn generate(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<MachineCode> {
@@ -127,7 +127,7 @@ pub fn generate(
 /// showing the actual emitted instructions (including prologue/epilogue).
 pub fn generate_with_asm(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<(MachineCode, String)> {
@@ -149,7 +149,7 @@ pub fn generate_with_asm(
 /// including live ranges, interference, and allocation decisions.
 pub fn generate_regalloc_info(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
     let num_locals = cfg.num_locals();

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::HashMap, env, process, sync::Arc, time::Instant};
 
-use rue_air::{InternedType, TypeInternPool};
+use rue_air::FrozenTypeInternPool;
 use rue_compiler::{
     AcceptedReadManifestEntry, CanonicalSemanticOutput, CompileOptions, CompilerSession,
     CompilerSessionWork, DiscoverySourceAssembler, DurableBodyWork,
@@ -782,19 +782,30 @@ fn measured_semantic(
     (value, output.unwrap())
 }
 
-fn type_pool_snapshot(pool: &TypeInternPool) -> Vec<String> {
-    // InternedType reserves raw indices 0..16 for primitives. Composite values
-    // are stored densely after that prefix, so this captures the exact ordered
-    // public type universe without relying on HashMap iteration in Debug output.
-    (0..pool.len())
-        .map(|index| {
-            format!(
-                "{:?}",
-                pool.get(InternedType::from_raw(16 + index as u32))
-                    .expect("dense type-pool entry")
-            )
-        })
-        .collect()
+fn type_pool_snapshot(pool: &FrozenTypeInternPool) -> Vec<String> {
+    let mut entries = Vec::with_capacity(pool.len());
+    entries.extend(
+        pool.all_struct_ids()
+            .map(|id| (id.0, format!("struct:{:?}", pool.struct_def(id)))),
+    );
+    entries.extend(
+        pool.all_enum_ids()
+            .map(|id| (id.0, format!("enum:{:?}", pool.enum_def(id)))),
+    );
+    entries.extend(pool.all_array_ids().map(|id| {
+        let (element, len) = pool.array_def(id);
+        (id.0, format!("array:{element:?}:{len}"))
+    }));
+    entries.extend(
+        pool.all_ptr_const_ids()
+            .map(|id| (id.0, format!("ptr_const:{:?}", pool.ptr_const_def(id)))),
+    );
+    entries.extend(
+        pool.all_ptr_mut_ids()
+            .map(|id| (id.0, format!("ptr_mut:{:?}", pool.ptr_mut_def(id)))),
+    );
+    entries.sort_unstable_by_key(|(index, _)| *index);
+    entries.into_iter().map(|(_, entry)| entry).collect()
 }
 
 fn assert_diagnostic_parity(

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -12,7 +12,7 @@
 /// This function is used by the sole one-shot compilation adapter.
 pub(crate) fn compile_backend(
     functions: &[FunctionWithCfg],
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     options: &CompileOptions,
@@ -46,7 +46,7 @@ pub(crate) fn compile_backend(
 /// Generate x86-64 object files for all functions.
 fn generate_x86_64_objects(
     functions: &[FunctionWithCfg],
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     options: &CompileOptions,
@@ -92,7 +92,7 @@ fn generate_x86_64_objects(
 /// Generate AArch64 object files for all functions.
 fn generate_aarch64_objects(
     functions: &[FunctionWithCfg],
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     options: &CompileOptions,
@@ -232,7 +232,7 @@ impl Mir {
 /// This returns the MIR before register allocation, with virtual registers.
 pub fn generate_mir(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<Mir> {
@@ -255,7 +255,7 @@ pub fn generate_mir(
 /// This is closer to the final assembly that will be emitted.
 pub fn generate_allocated_mir(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<Mir> {
@@ -296,7 +296,7 @@ pub fn generate_allocated_mir(
 /// Used by `--emit liveness` to visualize which values are live at each program point.
 pub fn generate_liveness_info(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<rue_codegen::LivenessDebugInfo> {
@@ -321,7 +321,7 @@ pub fn generate_liveness_info(
 /// Used by `--emit lowering` to visualize the instruction selection process.
 pub fn generate_lowering_info(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<rue_codegen::LoweringDebugInfo> {
@@ -350,7 +350,7 @@ pub fn generate_lowering_info(
 /// reflects what's in the binary.
 pub fn generate_emitted_asm(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
@@ -376,7 +376,7 @@ pub fn generate_emitted_asm(
 /// The output is formatted as a human-readable string.
 pub fn generate_regalloc_info(
     cfg: &Cfg,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<String> {

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -43,8 +43,8 @@ use std::cell::Cell;
 use crate::{
     BoundDefinitionSet, BoundDefinitionWork, CanonicalImportGraph, CanonicalMergedProgram,
     CanonicalRirOutput, CodegenInputDescriptor, CompileOptions, CompileWarning,
-    DurableDeclarationSemantic, FunctionWithCfg, MultiErrorResult, SemanticInputDescriptor,
-    TypeInternPool,
+    DurableDeclarationSemantic, FrozenTypeInternPool, FunctionWithCfg, MultiErrorResult,
+    SemanticInputDescriptor,
     bound_definitions::{
         configure_canonical_sema, issue_bound_definitions, issue_shell_definitions,
     },
@@ -389,7 +389,7 @@ fn declaration_resolution_failure(
 pub struct CanonicalSemanticOutput {
     input: CodegenInputDescriptor,
     functions: Vec<FunctionWithCfg>,
-    type_pool: TypeInternPool,
+    type_pool: FrozenTypeInternPool,
     strings: Vec<String>,
     warnings: Vec<CompileWarning>,
     bound_definitions: Option<BoundDefinitionSet>,
@@ -428,7 +428,7 @@ impl CanonicalSemanticOutput {
         self,
     ) -> (
         Vec<FunctionWithCfg>,
-        TypeInternPool,
+        FrozenTypeInternPool,
         Vec<String>,
         Vec<CompileWarning>,
     ) {
@@ -444,7 +444,7 @@ impl CanonicalSemanticOutput {
         &self.functions
     }
     /// Request-local type universe retained by the semantic output.
-    pub fn type_pool(&self) -> &TypeInternPool {
+    pub fn type_pool(&self) -> &FrozenTypeInternPool {
         &self.type_pool
     }
     /// String literals indexed by AIR string-constant index.

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -21,13 +21,13 @@
 //! 2. Drops each element in index order (element 0 first, then 1, etc.)
 
 use rue_air::{
-    Air, AirInst, AirInstData, AirPattern, AirRef, AnalyzedFunction, EnumId, StructDef, Type,
-    TypeInternPool, TypeKind,
+    Air, AirInst, AirInstData, AirPattern, AirRef, AnalyzedFunction, EnumId, FrozenTypeInternPool,
+    StructDef, Type, TypeKind,
 };
 use rue_span::Span;
 
 /// Check if a type needs drop.
-fn type_needs_drop(ty: Type, type_pool: &TypeInternPool) -> bool {
+fn type_needs_drop(ty: Type, type_pool: &FrozenTypeInternPool) -> bool {
     match ty.kind() {
         // Primitive types are trivially droppable
         // ComptimeType is comptime-only, no runtime representation
@@ -91,7 +91,7 @@ fn type_needs_drop(ty: Type, type_pool: &TypeInternPool) -> bool {
 /// Synthesize drop glue functions for all structs and arrays that need them.
 ///
 /// Returns a list of synthesized functions that should be added to the compilation.
-pub fn synthesize_drop_glue(type_pool: &TypeInternPool) -> Vec<AnalyzedFunction> {
+pub fn synthesize_drop_glue(type_pool: &FrozenTypeInternPool) -> Vec<AnalyzedFunction> {
     let mut drop_glue_functions = Vec::new();
 
     // Create drop glue for structs
@@ -111,7 +111,7 @@ pub fn synthesize_drop_glue(type_pool: &TypeInternPool) -> Vec<AnalyzedFunction>
         }
 
         // Create drop glue function for struct
-        let func = create_struct_drop_glue_function(&struct_def, struct_id, type_pool);
+        let func = create_struct_drop_glue_function(struct_def, struct_id, type_pool);
         drop_glue_functions.push(func);
     }
 
@@ -147,7 +147,7 @@ pub fn synthesize_drop_glue(type_pool: &TypeInternPool) -> Vec<AnalyzedFunction>
 fn create_struct_drop_glue_function(
     struct_def: &StructDef,
     struct_id: rue_air::StructId,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
 ) -> AnalyzedFunction {
     // File-qualified when the struct name spans files (RUE-571) — must match
     // the call side in both codegen backends' cfg_lower.
@@ -296,7 +296,7 @@ fn create_struct_drop_glue_function(
 /// each element in index order.
 fn create_array_drop_glue_function(
     array_id: rue_air::ArrayTypeId,
-    type_pool: &TypeInternPool,
+    type_pool: &FrozenTypeInternPool,
 ) -> AnalyzedFunction {
     let fn_name = array_drop_glue_name(array_id, type_pool);
     let span = Span::new(0, 0); // Synthetic span
@@ -434,7 +434,10 @@ fn create_array_drop_glue_function(
 /// each droppable payload field in declaration order. Variants whose payload
 /// needs no drop (and discriminant-only variants) fall through to a no-op
 /// wildcard default arm, so exactly the active variant's payload is dropped.
-fn create_enum_drop_glue_function(enum_id: EnumId, type_pool: &TypeInternPool) -> AnalyzedFunction {
+fn create_enum_drop_glue_function(
+    enum_id: EnumId,
+    type_pool: &FrozenTypeInternPool,
+) -> AnalyzedFunction {
     let enum_def = type_pool.enum_def(enum_id);
     let fn_name = enum_drop_glue_name(enum_id, type_pool);
     let span = Span::new(0, 0); // Synthetic span
@@ -565,7 +568,7 @@ fn create_enum_drop_glue_function(enum_id: EnumId, type_pool: &TypeInternPool) -
 ///
 /// Types share a namespace, so the enum's own name cannot collide with a
 /// struct's `__rue_drop_<name>` glue.
-pub fn enum_drop_glue_name(enum_id: EnumId, type_pool: &TypeInternPool) -> String {
+pub fn enum_drop_glue_name(enum_id: EnumId, type_pool: &FrozenTypeInternPool) -> String {
     // File-qualified when the enum name spans files (RUE-571).
     format!("__rue_drop_{}", type_pool.enum_symbol_name(enum_id))
 }
@@ -573,14 +576,17 @@ pub fn enum_drop_glue_name(enum_id: EnumId, type_pool: &TypeInternPool) -> Strin
 /// Generate the drop glue function name for an array type.
 ///
 /// The name encodes the element type and length, e.g., `__rue_drop_array_String_3`
-pub fn array_drop_glue_name(array_id: rue_air::ArrayTypeId, type_pool: &TypeInternPool) -> String {
+pub fn array_drop_glue_name(
+    array_id: rue_air::ArrayTypeId,
+    type_pool: &FrozenTypeInternPool,
+) -> String {
     let (element_type, length) = type_pool.array_def(array_id);
     let element_type_name = type_name(element_type, type_pool);
     format!("__rue_drop_array_{}_{}", element_type_name, length)
 }
 
 /// Get a name for a type (used for generating drop glue function names).
-fn type_name(ty: Type, type_pool: &TypeInternPool) -> String {
+fn type_name(ty: Type, type_pool: &FrozenTypeInternPool) -> String {
     match ty.kind() {
         TypeKind::I8 => "i8".to_string(),
         TypeKind::I16 => "i16".to_string(),
@@ -623,7 +629,7 @@ fn type_name(ty: Type, type_pool: &TypeInternPool) -> String {
 #[cfg(test)]
 mod tests {
     use lasso::ThreadedRodeo;
-    use rue_air::{EnumDef, ModuleId, StructField};
+    use rue_air::{EnumDef, ModuleId, StructField, TypeInternPool};
 
     use super::*;
 
@@ -820,8 +826,9 @@ mod tests {
             None,
         );
         let outer_ty = Type::new_struct(outer_id);
+        let type_pool = type_pool.freeze();
         let outer =
-            create_struct_drop_glue_function(&type_pool.struct_def(outer_id), outer_id, &type_pool);
+            create_struct_drop_glue_function(type_pool.struct_def(outer_id), outer_id, &type_pool);
         assert_eq!(outer.num_param_slots, type_pool.abi_slot_count(outer_ty));
         assert_eq!(outer.num_param_slots, 28);
         assert_eq!(param_indices(&outer), [20, 21, 23, 25]);

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -89,7 +89,7 @@ pub(crate) fn body_type_dependencies(
 
 pub(crate) fn transitive_body_type_dependencies(
     body: &DurableOrdinaryBodyPayload,
-    pool: &rue_air::TypeInternPool,
+    pool: &rue_air::FrozenTypeInternPool,
     definitions: &crate::BoundDefinitionSet,
 ) -> Result<BTreeSet<crate::StableDefinitionKey>, LayoutDependencyFailure> {
     let mut keys = body_type_dependencies(body);

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -1038,8 +1038,9 @@ mod tests {
             .find(|id| epoch.type_pool().struct_lang_item(*id) == Some(rue_air::LangItem::StrBuf))
             .expect("durable import should restore StrBuf language-item identity");
         assert_eq!(epoch.type_pool().struct_symbol_name(strbuf), "StrBuf");
+        let frozen_types = epoch.type_pool().clone().freeze();
         assert!(rue_codegen::cfg_lower::type_uses_sret_return(
-            epoch.type_pool(),
+            &frozen_types,
             rue_air::Type::new_struct(strbuf),
             8,
         ));

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -614,15 +614,11 @@ mod integration_tests {
                 fn main() -> i32 { 0 }
             "#;
             let result = test_air(src).unwrap();
-            // Verify Point is present
-            let point_name = result.interner.get_or_intern("Point");
-            let point_interned = result
+            let point = result
                 .type_pool
-                .get_struct_by_file_name(rue_span::FileId::DEFAULT, point_name);
-            assert!(
-                point_interned.is_some(),
-                "Point struct should exist in pool"
-            );
+                .all_struct_ids()
+                .find(|&id| result.type_pool.struct_def(id).name == "Point");
+            assert!(point.is_some(), "Point struct should exist in pool");
         }
 
         #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -158,7 +158,7 @@ pub use backend::{
 };
 
 // Small foundational types callers need to configure or inspect the facade.
-pub use rue_air::TypeInternPool;
+pub use rue_air::{FrozenTypeInternPool, TypeInternPool};
 pub use rue_cfg::OptLevel;
 pub use rue_codegen::{
     LoweringDebugInfo, RegAllocDebugInfo, StackFrameInfo, generate_stack_frame_info,

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -114,7 +114,7 @@ mod tests {
             format!("{:?}", fresh.functions())
         );
         assert_eq!(warm.type_pool().stats(), fresh.type_pool().stats());
-        let named_types = |pool: &TypeInternPool| {
+        let named_types = |pool: &FrozenTypeInternPool| {
             (
                 pool.all_struct_ids()
                     .into_iter()

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -107,7 +107,7 @@ pub(crate) struct CompileState {
     /// Analyzed functions with typed IR and control flow graphs.
     pub functions: Vec<FunctionWithCfg>,
     /// Type intern pool containing all struct and enum definitions.
-    pub type_pool: TypeInternPool,
+    pub type_pool: FrozenTypeInternPool,
     /// Warnings collected during compilation.
     pub warnings: Vec<CompileWarning>,
 }
@@ -117,7 +117,7 @@ pub(crate) struct CfgFrontendOutput {
     /// Analyzed functions paired with their optimized CFGs.
     pub(crate) functions: Vec<FunctionWithCfg>,
     /// Type intern pool containing all struct and enum definitions.
-    pub(crate) type_pool: TypeInternPool,
+    pub(crate) type_pool: FrozenTypeInternPool,
     /// String literals indexed by their AIR string_const index.
     pub(crate) strings: Vec<String>,
     /// Warnings collected during semantic analysis and CFG construction.
@@ -320,7 +320,7 @@ pub(crate) fn build_functions_and_cfgs(
                         implicit_edges.push(rue_air::ImplicitNamedDestructorDependencyEvent {
                             source: source.clone(),
                             target_file: target.file_id.index(),
-                            target_owner_name: target.name,
+                            target_owner_name: target.name.clone(),
                         });
                     }
                 }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -562,22 +562,21 @@ mod durable_body_integration_tests {
                 })
                 .collect::<Vec<_>>();
             assert_eq!(imported_strings, ordinary_strings);
+            // The epoch remains mutable for import setup; mirror the real
+            // semantic success boundary before exercising backend consumers.
+            let frozen_types = epoch.type_pool().clone().freeze();
             let mut cfg_output = rue_cfg::CfgBuilder::build(
                 &imported.air,
                 imported.num_locals,
                 imported.num_param_slots,
                 &ordinary.analyzed.name,
-                epoch.type_pool(),
+                &frozen_types,
                 imported.param_modes,
                 epoch.interner(),
                 imported.allow_unreachable_code,
             );
             assert!(cfg_output.errors.is_empty());
-            rue_cfg::opt::optimize(
-                &mut cfg_output.cfg,
-                rue_cfg::OptLevel::O0,
-                epoch.type_pool(),
-            );
+            rue_cfg::opt::optimize(&mut cfg_output.cfg, rue_cfg::OptLevel::O0, &frozen_types);
             assert_eq!(
                 normalize_epoch_symbols(&cfg_output.cfg.to_string()),
                 normalize_epoch_symbols(&ordinary.cfg.to_string())

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -9,25 +9,19 @@ use crate::*;
 /// useful for testing semantic analysis without generating machine code.
 #[derive(Debug)]
 pub struct AirOutput {
-    /// String interner used during compilation.
-    pub interner: ThreadedRodeo,
     /// Type intern pool containing all struct and enum definitions.
-    pub type_pool: TypeInternPool,
+    pub type_pool: FrozenTypeInternPool,
     /// Warnings collected during analysis.
     pub warnings: Vec<CompileWarning>,
 }
 
 pub(crate) fn test_air(source: &str) -> MultiErrorResult<AirOutput> {
     let snapshot = SourceSnapshot::single("<test>", source).map_err(CompileErrors::from)?;
-    let (rir, semantic, _) = test_frontend_snapshot(&snapshot, &CompileOptions::default())?;
-    let rir =
-        std::sync::Arc::try_unwrap(rir).expect("test session uniquely owns its RIR after return");
+    let (_, semantic, _) = test_frontend_snapshot(&snapshot, &CompileOptions::default())?;
     let semantic = std::sync::Arc::try_unwrap(semantic)
         .expect("test session uniquely owns its semantic output after return");
-    let (_, symbols) = rir.into_parts();
     let (_, type_pool, _, warnings) = semantic.into_parts();
     Ok(AirOutput {
-        interner: symbols.into_interner(),
         type_pool,
         warnings,
     })

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -63,7 +63,7 @@
 //! - **Deeply-nested `inout` field writes** (non-zero inner offset).
 
 use lasso::ThreadedRodeo;
-use rue_air::{Type, TypeInternPool, TypeKind, parse_array_type_syntax};
+use rue_air::{FrozenTypeInternPool, Type, TypeKind, parse_array_type_syntax};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
 use rue_compiler::{
     CompileErrors, CompileOptions, CompilerSession, FunctionWithCfg, PreviewFeatures,
@@ -76,7 +76,7 @@ use std::fmt;
 struct CompileState {
     interner: ThreadedRodeo,
     functions: Vec<FunctionWithCfg>,
-    type_pool: TypeInternPool,
+    type_pool: FrozenTypeInternPool,
     strings: Vec<String>,
 }
 

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -210,7 +210,8 @@ fn find_intrinsic_in_function<'a>(
 
 #[test]
 fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
-    let state = query_cfg_state("fn main() -> i32 { 0 }").expect("probe must compile");
+    let state = query_cfg_state("struct Probe { pointer: ptr mut u8 } fn main() -> i32 { 0 }")
+        .expect("probe must compile");
     let interp = Interp {
         state: &state,
         stdout: String::new(),
@@ -220,7 +221,14 @@ fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
         budget: STEP_BUDGET,
         depth: 0,
     };
-    let ptr = Type::new_ptr_mut(state.type_pool.intern_ptr_mut_from_type(Type::U8));
+    // The builtin contract only needs the logical pointer kind. Look up the
+    // pointer registered by Probe rather than mutating the completed universe.
+    let ptr = Type::new_ptr_mut(
+        state
+            .type_pool
+            .get_ptr_mut_by_type(Type::U8)
+            .expect("Probe must register ptr mut u8"),
+    );
     let types = [ptr, Type::U64, Type::U64];
     let modes = [CfgArgMode::Normal; 3];
     let bytes = Value::str_view("hé");

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -21,13 +21,13 @@ use rue_compiler::{
     AcceptedImportSource, Ast, CanonicalRirOutput, CanonicalSemanticOutput, CompileError,
     CompileErrors, CompileOptions, CompileWarning, CompilerSession, DependencyEnvelope,
     DependencyEnvelopeStatus, DiscoverySourceAssembler, ErrorKind, FileId, FileMetadataFingerprint,
-    ImportDiscoveryContext, ImportDiscoveryRevisionArtifact, ImportDiscoveryRevisionStatus,
-    ImportObservation, ImportObservationLedger, ImportObservationStatus, Lexer, LinkerMode,
-    MultiFileFormatter, MultiFileJsonFormatter, OptLevel, PhysicalFileIdentity, PipelineWork,
-    PreviewFeature, PreviewFeatures, SourceInfo, SourceMetadata, SourceSnapshot, Token,
-    TypeInternPool, configure_thread_pool, generate_emitted_asm, generate_liveness_info,
-    generate_lowering_info, generate_mir, generate_regalloc_info, generate_stack_frame_info,
-    parse_source_snapshot_for_ast_presentation,
+    FrozenTypeInternPool, ImportDiscoveryContext, ImportDiscoveryRevisionArtifact,
+    ImportDiscoveryRevisionStatus, ImportObservation, ImportObservationLedger,
+    ImportObservationStatus, Lexer, LinkerMode, MultiFileFormatter, MultiFileJsonFormatter,
+    OptLevel, PhysicalFileIdentity, PipelineWork, PreviewFeature, PreviewFeatures, SourceInfo,
+    SourceMetadata, SourceSnapshot, Token, configure_thread_pool, generate_emitted_asm,
+    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
+    generate_stack_frame_info, parse_source_snapshot_for_ast_presentation,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -155,7 +155,7 @@ impl EmitFrontend {
         self.semantic.functions()
     }
 
-    fn type_pool(&self) -> &TypeInternPool {
+    fn type_pool(&self) -> &FrozenTypeInternPool {
         self.semantic.type_pool()
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,19 @@ can be repeated to request several views.
   verifies invariants, and runs target-independent optimizations such as
   constant folding, propagation, and dead-code elimination.
 
+Semantic analysis owns the mutable `TypeInternPool`. Its reachable-body fixed
+point includes generic specialization plus anonymous type and destructor
+discovery; only after that work completes is the pool consumed into
+`FrozenTypeInternPool`. CFG construction, optimization, and both native
+backends accept only this immutable view. Their nominal lookups borrow complete
+definitions directly and their type iteration requires neither locking nor a
+temporary ID allocation. Destructor names cross this boundary as stable
+strings; each CFG/codegen request interns them into its own symbol universe, so
+request-local `Spur` values never become durable type metadata. Private
+semantic-name indexes remain available for stable collision handling, but the
+frozen public API neither accepts nor exposes their `Spur` values or raw type
+records.
+
 Instructions and types are generally stored densely and referenced by small
 integer IDs. This avoids self-referential lifetimes, makes equality and lookup
 cheap, and keeps IR dumps deterministic. Verifiers and typed index wrappers


### PR DESCRIPTION
## Summary

- consume the completed semantic `TypeInternPool` into an `Arc`-backed `FrozenTypeInternPool` after specialization and anonymous destructor/type discovery
- make CFG, optimization, compiler queries, oracle execution, and both codegen backends accept only immutable type metadata with borrowed nominal reads and lock-free deterministic iteration
- keep raw type records and semantic-interner `Spur` values out of the frozen public API, while sharing every read-only computation through one private canonical implementation
- document and test the mutation/freeze boundary, late-state completeness, request-local destructor symbol interning, and mutable/frozen query parity

## Performance evidence

Three fresh-process samples, zero warmups, default compiler profile, `-O0`, `jobs=1`:

| Workload | CFG before / after | Codegen before / after | Peak RSS before / after |
| --- | ---: | ---: | ---: |
| `large_structs` | 32.280 / 26.737 ms | 87.077 / 84.329 ms | 61,423,616 / 63,438,848 B |
| `many_functions` | 29.022 / 27.663 ms | 75.109 / 72.996 ms | 41,697,280 / 49,741,824 B |
| `arithmetic_heavy` | 46.530 / 44.287 ms | 397.114 / 378.490 ms | 86,507,520 / 86,589,440 B |

The timing samples are observational and improved in this run. Peak RSS rose by 1.92 MiB, 7.67 MiB, and 0.08 MiB respectively; the `many_functions` baseline itself had a 4.17 MiB MAD. The representation adds one `Arc` allocation and retains the same moved inner maps, so this is recorded as noisy follow-up evidence rather than a correctness or architecture blocker.

## Validation

- `scripts/rue fmt`
- focused AIR: 407 passed
- focused compiler: 496 passed
- focused oracle: 88 passed, 1 ignored
- adversarial architectural review: approved with no findings
- `scripts/rue test`: full lightweight, CLI, generated-oracle, reproducibility, spec, and UI suites passed
- post-rebase `scripts/rue quick`: 25 targets passed

Fixes RUE-660
