### PR TITLE
RUE-906: rebenchmark the handwritten parser

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -110,6 +110,7 @@ filegroup(
         "scripts/benchmark_validation.py",
         "scripts/generate-charts.py",
         "scripts/generate-site-status.py",
+        "scripts/parser-profile.py",
         "scripts/perf-baseline.py",
         "scripts/validate-benchmark.py",
         "website/templates/performance.html",

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,8 +23,10 @@ benchmarks/
 | `many_functions` | Function handling, symbol resolution | 1,000 functions |
 | `deep_nesting` | Scope handling and parser nesting | 120 nested-control functions: 50 block + 50 if + 20 while, each up to 40 levels (`v39`); 30 deep-expression helpers; 12,198 lines |
 | `large_structs` | Type definitions, field access | 700 struct types |
-| `arithmetic_heavy` | Expression parsing, codegen | 250 long-expression functions |
-| `control_flow` | CFG construction | if/while/match mix |
+| `arithmetic_heavy` | Expression parsing, codegen | 250 functions with 100-term chains |
+| `control_flow` | CFG construction | 390 functions with if/while/match mixes |
+| `array_heavy` | Array declarations, indexing, mutation | 200 functions |
+| `register_pressure` | Simultaneously live local values | 210 functions |
 
 ## Running Benchmarks
 
@@ -72,6 +74,8 @@ The quick per-pass corpus (`scripts/rue perf`) also includes the exact
 the depth-60 CLI regression in `crates/rue-cli-tests/cases/deep_nesting.toml`
 has its own explicit 10-second timeout; it is the executable complexity gate
 that turns renewed superlinear/exponential nesting behavior into a test failure.
+For parser-only timing and allocation density, including malformed and
+adversarial scaling families, run `scripts/parser-profile.py --release`.
 
 ## Adding Benchmarks
 

--- a/crates/rue-parser-profile/BUCK
+++ b/crates/rue-parser-profile/BUCK
@@ -1,0 +1,12 @@
+load("//crates:defs.bzl", "rue_binary")
+
+rue_binary(
+    name = "rue-parser-profile",
+    deps = [
+        "//crates/rue-lexer:rue-lexer",
+        "//crates/rue-parser:rue-parser",
+        "//crates/rue-span:rue-span",
+        "//third-party:lasso",
+        "//third-party:serde_json",
+    ],
+)

--- a/crates/rue-parser-profile/src/main.rs
+++ b/crates/rue-parser-profile/src/main.rs
@@ -1,0 +1,144 @@
+//! Allocation-counting driver for the isolated Rue parser kernel.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::env;
+use std::fs;
+use std::process;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use lasso::ThreadedRodeo;
+use rue_lexer::Lexer;
+use rue_parser::Parser;
+use rue_span::FileId;
+use serde_json::json;
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !new_pointer.is_null() {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        new_pointer
+    }
+}
+
+fn usage() -> ! {
+    eprintln!("usage: rue-parser-profile FILE [FILE ...]");
+    process::exit(2);
+}
+
+fn main() {
+    let paths: Vec<String> = env::args().skip(1).collect();
+    if paths.is_empty() {
+        usage();
+    }
+
+    let sources: Vec<String> = paths
+        .iter()
+        .map(|path| {
+            fs::read_to_string(path).unwrap_or_else(|error| {
+                eprintln!("cannot read {path}: {error}");
+                process::exit(2);
+            })
+        })
+        .collect();
+    match profile_sources(&sources) {
+        Ok(profile) => println!("{profile}"),
+        Err(index) => {
+            eprintln!("{}: fixture must lex successfully", paths[index]);
+            process::exit(2);
+        }
+    }
+}
+
+fn profile_sources(sources: &[String]) -> Result<serde_json::Value, usize> {
+    let mut interner = ThreadedRodeo::new();
+    let mut parser_ns = 0_u128;
+    let mut allocations = 0_u64;
+    let mut allocated_bytes = 0_u64;
+    let mut source_bytes = 0_usize;
+    let mut tokens = 0_usize;
+    let mut outcome = "success";
+
+    for (source_index, source) in sources.iter().enumerate() {
+        source_bytes += source.len();
+        let lexer = Lexer::with_interner_and_file_id(source.as_str(), interner, FileId::default());
+        let (file_tokens, next_interner) = lexer
+            .tokenize_preserving_interner()
+            .map_err(|(_errors, _interner)| source_index)?;
+        tokens += file_tokens.len();
+
+        ALLOCATIONS.store(0, Ordering::SeqCst);
+        ALLOCATED_BYTES.store(0, Ordering::SeqCst);
+        let started = Instant::now();
+        let parsed = Parser::new(file_tokens, next_interner).parse_preserving_interner();
+        parser_ns += started.elapsed().as_nanos();
+        allocations += ALLOCATIONS.load(Ordering::SeqCst);
+        allocated_bytes += ALLOCATED_BYTES.load(Ordering::SeqCst);
+
+        match parsed {
+            Ok((_ast, next_interner)) => interner = next_interner,
+            Err((_errors, next_interner)) => {
+                interner = next_interner;
+                outcome = "parse_error";
+            }
+        }
+    }
+
+    Ok(json!({
+        "schema_version": 1,
+        "files": sources.len(),
+        "source_bytes": source_bytes,
+        "tokens": tokens,
+        "outcome": outcome,
+        "parser_ns": parser_ns,
+        "allocations": allocations,
+        "allocated_bytes": allocated_bytes,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_smoke_covers_success_error_and_measured_allocation_boundary() {
+        let success = profile_sources(&["fn main() -> i32 { 42 }".to_string()]).unwrap();
+        assert_eq!(success["schema_version"], 1);
+        assert_eq!(success["files"], 1);
+        assert_eq!(success["outcome"], "success");
+        assert!(success["tokens"].as_u64().unwrap() > 0);
+        assert!(success["parser_ns"].as_u64().unwrap() > 0);
+        assert!(success["allocations"].as_u64().unwrap() > 0);
+        assert!(success["allocated_bytes"].as_u64().unwrap() > 0);
+
+        let malformed =
+            profile_sources(&["fn broken() -> i32 { let value: = 0; value }".to_string()]).unwrap();
+        assert_eq!(malformed["outcome"], "parse_error");
+        assert!(malformed["allocations"].as_u64().unwrap() > 0);
+        assert!(malformed["allocated_bytes"].as_u64().unwrap() > 0);
+    }
+}

--- a/docs/process/parser-performance.md
+++ b/docs/process/parser-performance.md
@@ -1,0 +1,87 @@
+# Parser performance and AST allocation decision
+
+RUE-906 rebenchmarked the handwritten parser introduced by RUE-905. The
+canonical full-pipeline measurement remains `scripts/rue perf --release`; the
+parser-only allocation survey is:
+
+```bash
+scripts/parser-profile.py --release
+```
+
+The survey builds a small measurement-only binary and runs every sample in a
+fresh process with an enforced 10-second default timeout. It lexes before
+starting its clock and resetting its counting allocator, then measures exactly
+`Parser::new(...).parse_preserving_interner()`.
+Consequently its allocation calls and requested bytes include parser state,
+AST construction, parser diagnostics, directive validation, and interner work
+initiated by the parser, but exclude source I/O, lexing, session queries,
+lowering, and code generation. Allocation density is a controlled proxy for
+heap scattering/locality pressure; it is not a hardware cache-miss counter.
+The full-pipeline spans establish whether even eliminating that parser cost
+could materially change compilation time.
+
+The corpus covers a tiny valid file, two modules parsed through one shared
+interner, two checked-in stress programs, an 8/32/128/512-function malformed
+recovery series, and a 12/24/48/96/192-level balanced-block series containing
+64 functions at each depth. The checked-in `deep_nesting` workload (150
+functions, nesting up to 40 levels, 12,198 lines) is included in the ordinary
+performance harness. RUE-787 separately owns stronger baseline-shape and
+regression-timeout guarantees for that checked-in corpus.
+
+## 2026-07-14 result
+
+Environment: Apple M5 (10 cores), 24 GiB RAM, macOS 26.5.1, arm64; commit
+`46a8c1e4`; release compiler/driver; seven fresh parser-profile processes after
+one warmup and five fresh full-compiler processes after one warmup; compiler
+jobs fixed at one and Rue programs compiled at `-O0`.
+
+| workload | outcome | tokens | parser ms (median ± MAD) | allocations | bytes/token |
+|---|---:|---:|---:|---:|---:|
+| hello | success | 10 | 0.004 ± 0.000 | 4 | 144.8 |
+| multi-file | success | 39 | 0.006 ± 0.000 | 15 | 125.1 |
+| control-flow stress | success | 47,108 | 0.934 ± 0.020 | 23,660 | 113.7 |
+| deep-nesting stress | success | 41,208 | 0.858 ± 0.004 | 22,383 | 109.6 |
+
+The large valid workloads allocate about 0.50--0.54 times per token. The
+controlled scaling families were:
+
+| family | scale | token growth | time growth | allocation growth | time/token growth |
+|---|---:|---:|---:|---:|---:|
+| malformed recovery | 8 → 512 functions | 63.48x | 22.49x | 50.71x | 0.35x |
+| balanced nesting | 12 → 192 levels | 11.90x | 15.20x | 14.66x | 1.28x |
+
+These endpoints are descriptive, not an asymptotic proof. Across the measured
+range, malformed recovery grows below token count, while the nesting family's
+time and allocations remain within 1.28x and 1.23x of token growth,
+respectively. That is consistent with near-linear work and provides no evidence
+of the former exponential branch search. Every subprocess is independently
+bounded by the configured timeout.
+
+The production full-compiler harness now preserves each inclusive `parser`
+aggregate and computes its percentage per sample before taking the median. In
+the matched release corpus those parser medians total 5.48 ms across 417.04 ms
+of summed compile medians: **1.31%**. The largest measured median share is
+`register_pressure` at 0.85/45.58 ms (1.86%). Aggregate spans overlap their
+children and are therefore reported separately from the leaf-pass ranking.
+This result is comparable within the RUE-906 run, but not as an absolute ratio
+against the old DEFAULT-profile RUE-892 numbers.
+RUE-904's approximately 14.5x candidate comparison and RUE-905's replacement
+smoke tests remain the appropriate matched-regime historical evidence.
+
+## Decision
+
+Do not replace the recursive AST with an indexed/arena AST now. The production
+largest measured inclusive parser share is 1.86%, while an arena
+would spread representation changes across the parser and every AST consumer.
+Even eliminating that span entirely would fall below the decision threshold.
+The current language grammar is amenable to fast
+deterministic recursive descent; malformed recovery and deep nesting do not
+reveal a residual complexity problem.
+
+Reconsider an arena only when a matched release profile shows parser work at
+least 10% of representative compile time (or at least 5 ms of an interactive
+compile), and a prototype demonstrates at least a 20% parser-time reduction or
+a 2% end-to-end reduction. Require cache-miss evidence before attributing a win
+to locality rather than allocation count. This keeps an AST representation
+migration separate from parser implementation work and gives it a measurable
+success threshold.

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -77,6 +77,9 @@ additive breakdown of one median run** and should not be summed to reconstruct
 the compile median. In JSON, a phase's `median_percent` is separately computed
 as the median of its per-sample phase/root ratios; it is not
 `median_ms / compile median`.
+The JSON results preserve non-leaf spans under `inclusive_passes`; compact text
+and Markdown output show the inclusive `parser` span separately from its leaf
+children. These values overlap and must not be added to the leaf-pass table.
 The harness also rejects malformed v2 trees: `compile` must be the sole root
 and must have children, every reported leaf must be nested beneath it, and the
 source workload counters must be non-negative integers with at least one file.
@@ -171,14 +174,27 @@ and remain valid as historical compiler-pipeline measurements.
 
 ## Findings
 
-1. **`parse_file` is the dominant cost — by a wide margin.** It is 62% of total
-   corpus time and rises to **48–79% of a single large compile**. Lexing itself
+### Post-replacement parser result (RUE-906)
+
+The 2026-07-14 matched release profile finds that the production handwritten
+parser's inclusive span is 5.48 ms across 417.04 ms of summed workload medians
+(1.31%). The largest measured median parser share is 1.86%. A separate
+parser-only survey covers valid, multi-file, stress, malformed-recovery, and
+adversarial-nesting
+inputs while counting allocations after lexing and before lowering. Its
+quantitative arena-AST decision and reproduction details are in
+[parser-performance.md](parser-performance.md). Parsing is no longer the
+compiler bottleneck; an arena conversion is not justified by current data.
+
+1. **At the historical baseline, `parse_file` was the dominant cost — by a wide
+   margin.** It was 62% of total
+   corpus time and rose to **48–79% of a single large compile**. Lexing itself
    is cheap (measured ~20 ms for the 12k-line `deep_nesting.rue`); the cost is
    in the former Chumsky parser and AST construction. RUE-276 had already
    removed the nested-block exponential path, and RUE-891 later removed the
    remaining continued-block and slice-type exponential paths. RUE-905 replaced
-   that already-linearized parser; fresh measurements are required before
-   treating parsing as the current dominant cost. Files still parse
+   that already-linearized parser; the RUE-906 measurements above show it is
+   no longer the current dominant cost. Files still parse
    sequentially with a shared interner, so parse parallelism would require
    interner merging and AST symbol remapping.
 
@@ -273,5 +289,7 @@ unoptimized profile.
 
 - RUE-245 — define what each `-O` level does (this baseline informs it).
 - RUE-45 — release-mode CI (the build caveat above is a symptom).
+- [parser-performance.md](parser-performance.md) — current parser-only profile
+  and AST representation decision.
 - `docs/process/logging.md` — the wide-events instrumentation behind
   `--time-passes` / `--benchmark-json`.

--- a/rust-project.json
+++ b/rust-project.json
@@ -19,27 +19,27 @@
           "name": "rue_lexer"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_parser"
         },
         {
-          "crate": 14,
+          "crate": 15,
           "name": "rue_rir"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_span"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_target"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "lasso"
         },
         {
-          "crate": 87,
+          "crate": 88,
           "name": "rayon"
         }
       ],
@@ -90,11 +90,11 @@
           "name": "rue_error"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_span"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "lasso"
         }
       ],
@@ -118,23 +118,23 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_test_runner"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "tempfile"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "toml"
         }
       ],
@@ -174,19 +174,19 @@
           "name": "rue_error"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_span"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_target"
         },
         {
-          "crate": 48,
+          "crate": 49,
           "name": "fixedbitset"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "lasso"
         }
       ],
@@ -210,15 +210,19 @@
       "edition": "2024",
       "deps": [
         {
+          "crate": 0,
+          "name": "rue_air"
+        },
+        {
           "crate": 6,
           "name": "rue_compiler"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_span"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "serde_json"
         }
       ],
@@ -270,47 +274,47 @@
           "name": "rue_linker"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_parser"
         },
         {
-          "crate": 14,
+          "crate": 15,
           "name": "rue_rir"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_span"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_target"
         },
         {
-          "crate": 29,
+          "crate": 30,
           "name": "annotate_snippets"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "lasso"
         },
         {
-          "crate": 87,
+          "crate": 88,
           "name": "rayon"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "serde_json"
         },
         {
-          "crate": 97,
+          "crate": 98,
           "name": "sha2"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "tracing"
         }
       ],
@@ -334,11 +338,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_span"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "thiserror"
         }
       ],
@@ -374,19 +378,19 @@
           "name": "rue_lexer"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_parser"
         },
         {
-          "crate": 32,
+          "crate": 33,
           "name": "anyhow"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "libc"
         },
         {
-          "crate": 80,
+          "crate": 81,
           "name": "proptest"
         }
       ],
@@ -414,15 +418,15 @@
           "name": "rue_error"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_span"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "lasso"
         },
         {
-          "crate": 69,
+          "crate": 70,
           "name": "logos"
         }
       ],
@@ -446,11 +450,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_target"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "tracing"
         }
       ],
@@ -486,19 +490,19 @@
           "name": "rue_oracle"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_test_runner"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "tempfile"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "toml"
         }
       ],
@@ -534,7 +538,7 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "lasso"
         }
       ],
@@ -542,6 +546,46 @@
       "source": {
         "include_dirs": [
           "crates/rue-oracle/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-parser-profile",
+      "root_module": "crates/rue-parser-profile/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 9,
+          "name": "rue_lexer"
+        },
+        {
+          "crate": 14,
+          "name": "rue_parser"
+        },
+        {
+          "crate": 17,
+          "name": "rue_span"
+        },
+        {
+          "crate": 58,
+          "name": "lasso"
+        },
+        {
+          "crate": 96,
+          "name": "serde_json"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-parser-profile/src"
         ],
         "exclude_dirs": []
       },
@@ -566,19 +610,19 @@
           "name": "rue_lexer"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_span"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "lasso"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "smallvec"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "tracing"
         }
       ],
@@ -606,15 +650,15 @@
           "name": "rue_lexer"
         },
         {
-          "crate": 13,
+          "crate": 14,
           "name": "rue_parser"
         },
         {
-          "crate": 16,
+          "crate": 17,
           "name": "rue_span"
         },
         {
-          "crate": 57,
+          "crate": 58,
           "name": "lasso"
         }
       ],
@@ -676,19 +720,19 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_test_runner"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "tempfile"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "toml"
         }
       ],
@@ -735,23 +779,23 @@
           "name": "rue_error"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_target"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "libc"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "tempfile"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "toml"
         }
       ],
@@ -775,11 +819,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_test_runner"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "libtest2_mimic"
         }
       ],
@@ -807,31 +851,31 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 14,
+          "crate": 15,
           "name": "rue_rir"
         },
         {
-          "crate": 18,
+          "crate": 19,
           "name": "rue_target"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "libc"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "serde_json"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "tracing"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tracing_subscriber"
         }
       ],
@@ -855,7 +899,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 70,
+          "crate": 71,
           "name": "logos_codegen"
         }
       ],
@@ -879,15 +923,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 79,
+          "crate": 80,
           "name": "proc_macro2"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "quote"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "syn"
         }
       ],
@@ -912,15 +956,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 79,
+          "crate": 80,
           "name": "proc_macro2"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "quote"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "syn"
         }
       ],
@@ -944,15 +988,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 79,
+          "crate": 80,
           "name": "proc_macro2"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "quote"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "syn"
         }
       ],
@@ -976,15 +1020,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 38,
+          "crate": 39,
           "name": "cfg_if"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "once_cell"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "zerocopy"
         }
       ],
@@ -1008,7 +1052,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 72,
+          "crate": 73,
           "name": "memchr"
         }
       ],
@@ -1054,11 +1098,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 31,
+          "crate": 32,
           "name": "anstyle"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "unicode_width"
         }
       ],
@@ -1167,7 +1211,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 35,
+          "crate": 36,
           "name": "bit_vec"
         }
       ],
@@ -1235,7 +1279,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 50,
+          "crate": 51,
           "name": "generic_array"
         }
       ],
@@ -1297,11 +1341,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 41,
+          "crate": 42,
           "name": "crossbeam_epoch"
         },
         {
-          "crate": 42,
+          "crate": 43,
           "name": "crossbeam_utils"
         }
       ],
@@ -1327,7 +1371,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 42,
+          "crate": 43,
           "name": "crossbeam_utils"
         }
       ],
@@ -1374,11 +1418,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 50,
+          "crate": 51,
           "name": "generic_array"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "typenum"
         }
       ],
@@ -1402,27 +1446,27 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 38,
+          "crate": 39,
           "name": "cfg_if"
         },
         {
-          "crate": 42,
+          "crate": 43,
           "name": "crossbeam_utils"
         },
         {
-          "crate": 52,
+          "crate": 53,
           "name": "hashbrown"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "lock_api"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "once_cell"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "parking_lot_core"
         }
       ],
@@ -1447,11 +1491,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 37,
+          "crate": 38,
           "name": "block_buffer"
         },
         {
-          "crate": 43,
+          "crate": 44,
           "name": "crypto_common"
         }
       ],
@@ -1558,7 +1602,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 113,
+          "crate": 114,
           "name": "typenum"
         }
       ],
@@ -1603,11 +1647,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 26,
+          "crate": 27,
           "name": "ahash"
         },
         {
-          "crate": 28,
+          "crate": 29,
           "name": "allocator_api2"
         }
       ],
@@ -1655,11 +1699,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 47,
+          "crate": 48,
           "name": "equivalent"
         },
         {
-          "crate": 53,
+          "crate": 54,
           "name": "hashbrown"
         }
       ],
@@ -1726,11 +1770,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 44,
+          "crate": 45,
           "name": "dashmap"
         },
         {
-          "crate": 52,
+          "crate": 53,
           "name": "hashbrown"
         }
       ],
@@ -1776,11 +1820,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 60,
+          "crate": 61,
           "name": "lexarg_error"
         },
         {
-          "crate": 61,
+          "crate": 62,
           "name": "lexarg_parser"
         }
       ],
@@ -1805,7 +1849,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 61,
+          "crate": 62,
           "name": "lexarg_parser"
         }
       ],
@@ -1871,7 +1915,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 56,
+          "crate": 57,
           "name": "json_write"
         }
       ],
@@ -1897,11 +1941,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 59,
+          "crate": 60,
           "name": "lexarg"
         },
         {
-          "crate": 60,
+          "crate": 61,
           "name": "lexarg_error"
         }
       ],
@@ -1926,27 +1970,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 30,
+          "crate": 31,
           "name": "anstream"
         },
         {
-          "crate": 31,
+          "crate": 32,
           "name": "anstyle"
         },
         {
-          "crate": 60,
+          "crate": 61,
           "name": "lexarg_error"
         },
         {
-          "crate": 61,
+          "crate": 62,
           "name": "lexarg_parser"
         },
         {
-          "crate": 63,
+          "crate": 64,
           "name": "libtest_json"
         },
         {
-          "crate": 64,
+          "crate": 65,
           "name": "libtest_lexarg"
         }
       ],
@@ -1973,11 +2017,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 63,
+          "crate": 64,
           "name": "libtest_json"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "libtest2_harness"
         }
       ],
@@ -2004,7 +2048,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 92,
+          "crate": 93,
           "name": "scopeguard"
         }
       ],
@@ -2050,7 +2094,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 22,
+          "crate": 23,
           "name": "logos_derive"
         }
       ],
@@ -2078,31 +2122,31 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 33,
+          "crate": 34,
           "name": "beef"
         },
         {
-          "crate": 49,
+          "crate": 50,
           "name": "fnv"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lazy_static"
         },
         {
-          "crate": 79,
+          "crate": 80,
           "name": "proc_macro2"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "quote"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "regex_syntax"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "syn"
         }
       ],
@@ -2126,7 +2170,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 89,
+          "crate": 90,
           "name": "regex_automata"
         }
       ],
@@ -2273,7 +2317,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 119,
+          "crate": 120,
           "name": "zerocopy"
         }
       ],
@@ -2299,7 +2343,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 115,
+          "crate": 116,
           "name": "unicode_ident"
         }
       ],
@@ -2325,47 +2369,47 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 34,
+          "crate": 35,
           "name": "bit_set"
         },
         {
-          "crate": 35,
+          "crate": 36,
           "name": "bit_vec"
         },
         {
-          "crate": 36,
+          "crate": 37,
           "name": "bitflags"
         },
         {
-          "crate": 74,
+          "crate": 75,
           "name": "num_traits"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "rand"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "rand_chacha"
         },
         {
-          "crate": 86,
+          "crate": 87,
           "name": "rand_xorshift"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "regex_syntax"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "rusty_fork"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "tempfile"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "unarray"
         }
       ],
@@ -2416,7 +2460,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 79,
+          "crate": 80,
           "name": "proc_macro2"
         }
       ],
@@ -2442,7 +2486,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 85,
+          "crate": 86,
           "name": "rand_core"
         }
       ],
@@ -2469,11 +2513,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 78,
+          "crate": 79,
           "name": "ppv_lite86"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "rand_core"
         }
       ],
@@ -2498,7 +2542,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 51,
+          "crate": 52,
           "name": "getrandom"
         }
       ],
@@ -2524,7 +2568,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 85,
+          "crate": 86,
           "name": "rand_core"
         }
       ],
@@ -2548,11 +2592,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 46,
+          "crate": 47,
           "name": "either"
         },
         {
-          "crate": 88,
+          "crate": 89,
           "name": "rayon_core"
         }
       ],
@@ -2576,11 +2620,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 40,
+          "crate": 41,
           "name": "crossbeam_deque"
         },
         {
-          "crate": 42,
+          "crate": 43,
           "name": "crossbeam_utils"
         }
       ],
@@ -2604,15 +2648,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 27,
+          "crate": 28,
           "name": "aho_corasick"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "memchr"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "regex_syntax"
         }
       ],
@@ -2689,19 +2733,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 49,
+          "crate": 50,
           "name": "fnv"
         },
         {
-          "crate": 81,
+          "crate": 82,
           "name": "quick_error"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "tempfile"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "wait_timeout"
         }
       ],
@@ -2746,11 +2790,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 23,
+          "crate": 24,
           "name": "serde_derive"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde_core"
         }
       ],
@@ -2799,19 +2843,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 55,
+          "crate": 56,
           "name": "itoa"
         },
         {
-          "crate": 72,
+          "crate": 73,
           "name": "memchr"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde_core"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "zmij"
         }
       ],
@@ -2837,7 +2881,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         }
       ],
@@ -2862,15 +2906,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 38,
+          "crate": 39,
           "name": "cfg_if"
         },
         {
-          "crate": 39,
+          "crate": 40,
           "name": "cpufeatures"
         },
         {
-          "crate": 45,
+          "crate": 46,
           "name": "digest"
         }
       ],
@@ -2894,7 +2938,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lazy_static"
         }
       ],
@@ -2937,15 +2981,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 79,
+          "crate": 80,
           "name": "proc_macro2"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "quote"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "unicode_ident"
         }
       ],
@@ -2999,7 +3043,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 24,
+          "crate": 25,
           "name": "thiserror_impl"
         }
       ],
@@ -3025,7 +3069,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 38,
+          "crate": 39,
           "name": "cfg_if"
         }
       ],
@@ -3049,19 +3093,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "serde_spanned"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "toml_datetime"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "toml_edit"
         }
       ],
@@ -3088,7 +3132,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         }
       ],
@@ -3113,27 +3157,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 54,
+          "crate": 55,
           "name": "indexmap"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "serde_spanned"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "toml_datetime"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "toml_write"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "winnow"
         }
       ],
@@ -3182,15 +3226,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 25,
+          "crate": 26,
           "name": "tracing_attributes"
         },
         {
-          "crate": 77,
+          "crate": 78,
           "name": "pin_project_lite"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tracing_core"
         }
       ],
@@ -3218,7 +3262,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 75,
+          "crate": 76,
           "name": "once_cell"
         }
       ],
@@ -3245,15 +3289,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 68,
+          "crate": 69,
           "name": "log"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "once_cell"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tracing_core"
         }
       ],
@@ -3279,11 +3323,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tracing_core"
         }
       ],
@@ -3307,55 +3351,55 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 71,
+          "crate": 72,
           "name": "matchers"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "nu_ansi_term"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "once_cell"
         },
         {
-          "crate": 89,
+          "crate": 90,
           "name": "regex_automata"
         },
         {
-          "crate": 93,
+          "crate": 94,
           "name": "serde"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "serde_json"
         },
         {
-          "crate": 98,
+          "crate": 99,
           "name": "sharded_slab"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "smallvec"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "thread_local"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "tracing"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tracing_core"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tracing_log"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tracing_serde"
         }
       ],

--- a/scripts/parser-profile.py
+++ b/scripts/parser-profile.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Reproducible parser-only timing and allocation survey (RUE-906)."""
+
+import argparse
+import json
+import math
+import statistics
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+TARGET = "//crates/rue-parser-profile:rue-parser-profile"
+
+
+def resolve_driver(release: bool) -> str:
+    command = [str(ROOT / "buck2"), "build", TARGET, "--show-full-output"]
+    if release:
+        command += ["--target-platforms", "//platforms:release"]
+    result = subprocess.run(command, cwd=ROOT, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        raise RuntimeError("failed to build parser profile driver")
+    for line in result.stdout.splitlines():
+        if line.startswith((TARGET, "root" + TARGET)) and " " in line:
+            return line.split(" ", 1)[1]
+    raise RuntimeError("Buck2 did not report the parser profile driver path")
+
+
+def write_fixtures(workdir: Path):
+    multi = workdir / "multi"
+    multi.mkdir()
+    (multi / "main.rue").write_text('const a = @import("a.rue");\nfn main() -> i32 { a.square(4) }\n')
+    (multi / "a.rue").write_text("pub fn square(x: i32) -> i32 { x * x }\n")
+    fixtures = [
+        ("hello", "small", None, [ROOT / "examples/hello.rue"]),
+        ("multi_file", "multi", None, [multi / "main.rue", multi / "a.rue"]),
+        ("control_flow", "stress", None, [ROOT / "benchmarks/stress/control_flow.rue"]),
+        ("deep_nesting", "stress", None, [ROOT / "benchmarks/stress/deep_nesting.rue"]),
+    ]
+    for functions in (8, 32, 128, 512):
+        malformed = workdir / f"malformed_{functions}.rue"
+        malformed.write_text(
+            "".join(
+                f"fn broken_{index}() -> i32 {{ let x: = 0; x }}\n"
+                for index in range(functions)
+            )
+        )
+        fixtures.append(
+            (f"malformed_{functions}", "malformed", functions, [malformed])
+        )
+    # Repeat each depth enough times that the smallest member is measurable;
+    # depth remains the only changing structural variable in this family.
+    for depth in (12, 24, 48, 96, 192):
+        adversarial = workdir / f"adversarial_nesting_{depth}.rue"
+        body = "{ " * depth + "42" + " }" * depth
+        adversarial.write_text(
+            "".join(f"fn nested_{index}() -> i32 {{ {body} }}\n" for index in range(64))
+        )
+        fixtures.append(
+            (f"adversarial_nesting_{depth}", "adversarial", depth, [adversarial])
+        )
+    return fixtures
+
+
+def run(driver: str, files, iterations: int, warmup: int, timeout: float):
+    command = [driver, *map(str, files)]
+    samples = []
+    for sample in range(warmup + iterations):
+        try:
+            result = subprocess.run(
+                command,
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError(f"parser profile exceeded {timeout:g}s timeout") from error
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or "parser profile driver failed")
+        parsed = json.loads(result.stdout)
+        if sample >= warmup:
+            samples.append(parsed)
+    first = samples[0]
+    stable = ("files", "source_bytes", "tokens", "outcome")
+    if any(any(sample[key] != first[key] for key in stable) for sample in samples[1:]):
+        raise RuntimeError("non-timing parser profile metrics changed across fresh processes")
+    times = [sample["parser_ns"] / 1_000_000 for sample in samples]
+    median = statistics.median(times)
+    mad = statistics.median(abs(value - median) for value in times)
+    allocation_samples = [sample["allocations"] for sample in samples]
+    byte_samples = [sample["allocated_bytes"] for sample in samples]
+    allocation_median = statistics.median(allocation_samples)
+    allocated_byte_median = statistics.median(byte_samples)
+    return {
+        **{key: first[key] for key in stable},
+        "parser_ms": {"median": median, "mad": mad},
+        "allocations": {
+            "median": allocation_median,
+            "mad": statistics.median(abs(value - allocation_median) for value in allocation_samples),
+        },
+        "allocated_bytes": {
+            "median": allocated_byte_median,
+            "mad": statistics.median(abs(value - allocated_byte_median) for value in byte_samples),
+        },
+        "allocations_per_ktoken": allocation_median / first["tokens"] * 1000,
+        "allocated_bytes_per_token": allocated_byte_median / first["tokens"],
+    }
+
+
+def scaling_summary(results, kind: str):
+    family = [result for result in results if result["class"] == kind]
+    first, last = family[0], family[-1]
+    token_growth = last["tokens"] / first["tokens"]
+    time_growth = last["parser_ms"]["median"] / first["parser_ms"]["median"]
+    allocation_growth = last["allocations"]["median"] / first["allocations"]["median"]
+    return {
+        "members": len(family),
+        "first_scale": first["scale"],
+        "last_scale": last["scale"],
+        "token_growth": token_growth,
+        "time_growth": time_growth,
+        "allocation_growth": allocation_growth,
+        "time_growth_per_token_growth": time_growth / token_growth,
+        "allocation_growth_per_token_growth": allocation_growth / token_growth,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iterations", type=int, default=7)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--release", action="store_true")
+    parser.add_argument(
+        "--timeout", type=float, default=10.0, help="seconds allowed per fresh process"
+    )
+    args = parser.parse_args()
+    if (
+        args.iterations < 1
+        or args.warmup < 0
+        or not math.isfinite(args.timeout)
+        or args.timeout <= 0
+    ):
+        parser.error("iterations and timeout must be positive and warmup non-negative")
+    try:
+        driver = resolve_driver(args.release)
+        with tempfile.TemporaryDirectory(prefix="rue-parser-profile-") as directory:
+            results = [
+                {
+                    "name": name,
+                    "class": kind,
+                    "scale": scale,
+                    **run(driver, files, args.iterations, args.warmup, args.timeout),
+                }
+                for name, kind, scale, files in write_fixtures(Path(directory))
+            ]
+    except (RuntimeError, OSError, json.JSONDecodeError) as error:
+        sys.exit(f"parser-profile: {error}")
+    print(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "profile": "release" if args.release else "default",
+                "iterations": args.iterations,
+                "warmup": args.warmup,
+                "timeout_seconds": args.timeout,
+                "scaling": {
+                    kind: scaling_summary(results, kind)
+                    for kind in ("malformed", "adversarial")
+                },
+                "results": results,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/perf-baseline.py
+++ b/scripts/perf-baseline.py
@@ -30,8 +30,9 @@ the raw JSON contains both leaf passes and their aggregate parents:
 
 Schema v2 marks root and leaf invocations explicitly. `total_ms` is the
 inclusive duration of root compiler spans; nested pass rows are also inclusive
-and therefore overlap their parents. This harness reports only leaves in its
-phase table. Leaf/root ratio, unattributed time, overlap, and driver overhead
+and therefore overlap their parents. This harness ranks only leaves in its hot
+phase table, and reports the inclusive parser aggregate separately. Leaf/root
+ratio, unattributed time, overlap, and driver overhead
 are calculated within each sample before their medians are taken, so unrelated
 samples are never combined into a fictional timing breakdown. It also measures
 the fresh process around `subprocess.run`: that includes startup, source
@@ -303,6 +304,7 @@ def aggregate(samples):
     if not samples:
         return {
             "rows": [],
+            "inclusive_rows": [],
             "compile_ms": 0.0,
             "compile_mad_ms": 0.0,
             "process_ms": 0.0,
@@ -323,6 +325,7 @@ def aggregate(samples):
         }
 
     per_pass = {}
+    per_inclusive_pass = {}
     order_seen = []
     compile_samples = []
     process_samples = []
@@ -336,6 +339,7 @@ def aggregate(samples):
     source_metrics_seen = False
     compiler_identity = None
     expected_leaf_names = None
+    expected_inclusive_names = None
     expected_schema_version = None
 
     for sample_index, sample in enumerate(samples):
@@ -431,6 +435,14 @@ def aggregate(samples):
             if is_leaf_pass(pass_data, schema_version)
         ]
         leaf_name_set = set(leaf_names)
+        inclusive_names = [
+            pass_data["name"]
+            for pass_data in passes
+            if schema_version == 2
+            and pass_data["name"] != WALL_CLOCK_PASS
+            and pass_data["leaf_invocations"] != pass_data["invocations"]
+        ]
+        inclusive_name_set = set(inclusive_names)
         if expected_leaf_names is None:
             expected_leaf_names = leaf_name_set
             order_seen.extend(leaf_names)
@@ -445,6 +457,18 @@ def aggregate(samples):
 
         for name in per_pass:
             per_pass[name].append(pass_ms[name])
+        if expected_inclusive_names is None:
+            expected_inclusive_names = inclusive_name_set
+            per_inclusive_pass = {name: [] for name in inclusive_names}
+        elif inclusive_name_set != expected_inclusive_names:
+            missing = sorted(expected_inclusive_names - inclusive_name_set)
+            extra = sorted(inclusive_name_set - expected_inclusive_names)
+            raise ValueError(
+                f"sample {sample_index + 1} inclusive pass set drifted; "
+                f"missing={missing}, extra={extra}"
+            )
+        for name in per_inclusive_pass:
+            per_inclusive_pass[name].append(pass_ms[name])
 
         leaf_work_ms = sum(pass_ms[name] for name in leaf_names)
         if compile_ms == 0 and leaf_work_ms > 0:
@@ -540,8 +564,21 @@ def aggregate(samples):
             for pass_ms, root_ms in zip(per_pass[name], compile_samples)
         )
         rows.append((name, med, pct))
+    inclusive_rows = []
+    for name, durations in per_inclusive_pass.items():
+        inclusive_rows.append(
+            (
+                name,
+                statistics.median(durations),
+                statistics.median(
+                    pass_ms / root_ms * 100.0 if root_ms > 0 else 0.0
+                    for pass_ms, root_ms in zip(durations, compile_samples)
+                ),
+            )
+        )
     return {
         "rows": rows,
+        "inclusive_rows": inclusive_rows,
         "compile_ms": compile_ms,
         "compile_mad_ms": compile_mad_ms,
         "process_ms": process_ms,
@@ -649,6 +686,10 @@ def run_corpus(rue_bin, corpus, iterations, warmup, workdir, timeout, jobs):
                     {"name": n, "median_ms": ms, "median_percent": pct}
                     for n, ms, pct in aggregated["rows"]
                 ],
+                "inclusive_passes": [
+                    {"name": n, "median_ms": ms, "median_percent": pct}
+                    for n, ms, pct in aggregated["inclusive_rows"]
+                ],
                 "source_metrics": aggregated["source_metrics"],
             }
         )
@@ -674,13 +715,23 @@ def print_text(results, iterations):
     for r in results:
         print(f"\n{r['name']}  ({r['bucket']}, n={iterations} fresh processes, median)")
         sm = r["source_metrics"] or {}
+        namew = max(
+            [len(p["name"]) for p in r["passes"]] + [len("parser (inclusive)"), 8]
+        )
         if sm:
             print(
                 f"  source: {sm.get('files', '?')} files, "
                 f"{sm.get('lines', '?')} lines, "
                 f"{sm.get('bytes', '?')} bytes, {sm.get('tokens', '?')} tokens"
             )
-        namew = max((len(p["name"]) for p in r["passes"]), default=8)
+        parser = next(
+            (p for p in r["inclusive_passes"] if p["name"] == "parser"), None
+        )
+        if parser is not None:
+            print(
+                f"  {'parser (inclusive)':<{namew}}  {parser['median_ms']:>8.2f} ms  "
+                f"({parser['median_percent']:>4.1f}% median phase/root; overlaps children)"
+            )
         for p in r["passes"]:
             print(
                 f"  {p['name']:<{namew}}  {p['median_ms']:>8.2f} ms  "
@@ -742,15 +793,35 @@ def _md_table(results, bucket_filter=None):
         for pass_data in result["passes"]:
             if pass_data["name"] not in names:
                 names.append(pass_data["name"])
-    header = "| program | " + " | ".join(names) + " | **compile** | **process** |"
-    sep = "|" + "|".join(["---"] * (len(names) + 3)) + "|"
+    has_inclusive_parser = any(
+        any(p["name"] == "parser" for p in r.get("inclusive_passes", []))
+        for r in rows
+    )
+    parser_header = " | parser (inclusive)" if has_inclusive_parser else ""
+    header = (
+        "| program | "
+        + " | ".join(names)
+        + parser_header
+        + " | **compile** | **process** |"
+    )
+    sep = "|" + "|".join(
+        ["---"] * (len(names) + 3 + int(has_inclusive_parser))
+    ) + "|"
     lines = [header, sep]
     for r in rows:
         pm = {p["name"]: p["median_ms"] for p in r["passes"]}
+        inclusive = {
+            p["name"]: p["median_ms"] for p in r.get("inclusive_passes", [])
+        }
         cells = [f"{pm.get(n, 0.0):.2f}" for n in names]
         lines.append(
             f"| {r['name']} | "
             + " | ".join(cells)
+            + (
+                f" | {inclusive['parser']:.2f}"
+                if has_inclusive_parser and "parser" in inclusive
+                else (" | N/A" if has_inclusive_parser else "")
+            )
             + f" | **{r['compile_ms']['median']:.2f}**"
             + f" | **{r['process_ms']['median']:.2f}** |"
         )

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -45,6 +45,7 @@ metrics = load_module("benchmark_metrics", "scripts/benchmark_metrics.py")
 evolution = load_module("benchmark_evolution", "scripts/benchmark_evolution.py")
 recent = load_module("benchmark_recent", "scripts/benchmark_recent.py")
 perf_baseline = load_module("perf_baseline", "scripts/perf-baseline.py")
+parser_profile = load_module("parser_profile", "scripts/parser-profile.py")
 
 
 class PerfBaselineAggregationTests(unittest.TestCase):
@@ -125,6 +126,7 @@ class PerfBaselineAggregationTests(unittest.TestCase):
         )
         self.assertEqual(result["unattributed_ms"], 2.0)
         self.assertEqual(result["unattributed_mad_ms"], 1.0)
+        self.assertEqual(result["inclusive_rows"], [("parse", 5.5, 50.0)])
         self.assertEqual(result["overlapping_leaf_work_ms"], 0.0)
         self.assertEqual(result["overlapping_leaf_work_mad_ms"], 0.0)
         self.assertEqual(result["peak_memory_bytes"], 1024.0)
@@ -133,6 +135,35 @@ class PerfBaselineAggregationTests(unittest.TestCase):
             [name for name, _ms, _percent in result["rows"]],
             ["lexer", "parser", "codegen"],
         )
+
+    def test_inclusive_ratio_handles_zero_root_and_is_paired_before_median(self):
+        zero = self.sample(
+            0.0,
+            0.0,
+            leaf_durations={"lexer": 0.0, "parser": 0.0, "codegen": 0.0},
+        )
+        next(pass_data for pass_data in zero["passes"] if pass_data["name"] == "parse")[
+            "duration_ms"
+        ] = 0.0
+        self.assertEqual(
+            perf_baseline.aggregate([zero])["inclusive_rows"],
+            [("parse", 0.0, 0.0)],
+        )
+
+        samples = [
+            self.sample(10.0, 11.0),
+            self.sample(100.0, 101.0),
+            self.sample(1000.0, 1001.0),
+        ]
+        for sample, duration in zip(samples, (1.0, 40.0, 100.0)):
+            next(
+                pass_data
+                for pass_data in sample["passes"]
+                if pass_data["name"] == "parse"
+            )["duration_ms"] = duration
+        inclusive = perf_baseline.aggregate(samples)["inclusive_rows"][0]
+        self.assertEqual(inclusive[1], 40.0)
+        self.assertEqual(inclusive[2], 10.0)
 
     def test_current_leaf_order_includes_semantic_lowering_and_frontend_indexes(self):
         result = perf_baseline.aggregate(
@@ -439,6 +470,15 @@ class PerfBaselineAggregationTests(unittest.TestCase):
                     "median_percent": 15.0,
                 },
             ],
+            "inclusive_passes": [
+                {"name": "parser", "median_ms": 6.0, "median_percent": 30.0}
+            ],
+            "source_metrics": {"files": 1, "lines": 1, "bytes": 10, "tokens": 5},
+            "driver_overhead_ms": {"median": 5.0, "mad": 0.0},
+            "leaf_to_root_ratio_percent": {"median": 40.0, "mad": 0.0},
+            "unattributed_ms": {"median": 12.0, "mad": 0.0},
+            "overlapping_leaf_work_ms": {"median": 0.0, "mad": 0.0},
+            "peak_memory_bytes": None,
         }
         self.assertEqual(
             perf_baseline.hot_passes([result]),
@@ -448,6 +488,14 @@ class PerfBaselineAggregationTests(unittest.TestCase):
         self.assertIn("future_phase", markdown)
         self.assertIn("**20.00**", markdown)
         self.assertIn("**25.00**", markdown)
+        with mock.patch("builtins.print") as output:
+            perf_baseline.print_text([result], 3)
+        self.assertTrue(
+            any("parser (inclusive)" in str(call) for call in output.call_args_list)
+        )
+        v1 = dict(result)
+        v1.pop("inclusive_passes")
+        self.assertNotIn("parser (inclusive)", perf_baseline._md_table([v1]))
 
     def test_corpus_json_names_paired_phase_ratio_as_a_median(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -463,6 +511,9 @@ class PerfBaselineAggregationTests(unittest.TestCase):
         phase = results[0]["passes"][0]
         self.assertEqual(phase["median_percent"], 30.0)
         self.assertNotIn("percent", phase)
+        inclusive = results[0]["inclusive_passes"][0]
+        self.assertEqual(inclusive["name"], "parse")
+        self.assertAlmostEqual(inclusive["median_percent"], 55.0)
 
     def test_deep_nesting_corpus_shape_and_explicit_complexity_gate(self):
         source = (
@@ -575,6 +626,55 @@ class PerfBaselineAggregationTests(unittest.TestCase):
                     perf_baseline.compile_once(
                         "rue", ["main.rue"], str(output), 1.0, 1
                     )
+
+
+class ParserProfileTests(unittest.TestCase):
+    def test_fixture_matrix_covers_required_parser_regimes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixtures = parser_profile.write_fixtures(Path(directory))
+            self.assertEqual(
+                [scale for _name, kind, scale, _files in fixtures if kind == "malformed"],
+                [8, 32, 128, 512],
+            )
+            self.assertEqual(
+                [scale for _name, kind, scale, _files in fixtures if kind == "adversarial"],
+                [12, 24, 48, 96, 192],
+            )
+            malformed = fixtures[4][3][0].read_text()
+            adversarial = fixtures[-1][3][0].read_text()
+            self.assertEqual(malformed.count("fn broken_"), 8)
+            self.assertEqual(adversarial.count("{ "), 64 * 193)
+
+    def test_scaling_summary_normalizes_endpoint_growth_by_tokens(self):
+        results = [
+            {
+                "class": "adversarial",
+                "scale": 12,
+                "tokens": 100,
+                "parser_ms": {"median": 1.0},
+                "allocations": {"median": 50},
+            },
+            {
+                "class": "adversarial",
+                "scale": 192,
+                "tokens": 1000,
+                "parser_ms": {"median": 8.0},
+                "allocations": {"median": 500},
+            },
+        ]
+        summary = parser_profile.scaling_summary(results, "adversarial")
+        self.assertEqual(summary["token_growth"], 10)
+        self.assertEqual(summary["time_growth_per_token_growth"], 0.8)
+        self.assertEqual(summary["allocation_growth_per_token_growth"], 1.0)
+
+    def test_profile_run_enforces_subprocess_timeout(self):
+        with mock.patch.object(
+            parser_profile.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["driver"], 0.25),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "exceeded 0.25s timeout"):
+                parser_profile.run("driver", ["fixture.rue"], 1, 0, 0.25)
 
 
 class BenchmarkValidationTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a reproducible parser-only timing and allocation survey across small, multi-file, stress, malformed-recovery, and adversarial-nesting workloads
- preserve inclusive parser spans in the canonical performance baseline so parser/compile ratios are paired per sample
- document current results and the quantitative decision not to migrate the AST to an arena yet
- retain RUE-787’s deep-nesting shape and timeout guarantees

## Results

- inclusive parser medians total 5.48 ms across 417.04 ms of compile medians (1.31%)
- largest measured median parser share is 1.86%
- malformed and nesting scaling families remain near token growth over the measured ranges

## Validation

- `scripts/rue quick`
- `python3 scripts/test-benchmark-tools.py` (92 tests)
- `./buck2 test //crates/rue-parser-profile:rue-parser-profile-test`
- `python3 scripts/validate-rust-project.py`
- `scripts/rue fmt`

Fixes RUE-906