### PR TITLE
Fix str return tail inference

### DIFF
--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -203,17 +203,15 @@ impl<'a> BodySema<'a> {
         // This handles implicit returns like `fn foo() -> i8 { 42 }`.
         // For arrays, we need to convert Type to InferType structurally.
         //
-        // A `str` return type (ADR-0043 Phase 3, RUE-324) accepts an
-        // implicit-return string literal (HM type `String`) by coercion; skip
-        // strict equality there and let sema materialize the static-backed
-        // first-class `str` at the tail expression.
-        if !self.is_str_like(return_type) {
-            cgen.add_constraint(Constraint::equal(
-                body_info.ty,
-                self.type_to_infer_type(return_type),
-                body_info.span,
-            ));
-        }
+        // String literals use marked inference variables whose allowed nominal
+        // targets include `str` and `Str(N)`, so this constraint retains the
+        // implicit literal coercion while rejecting every other mismatched
+        // tail before AIR/CFG construction (RUE-1652).
+        cgen.add_constraint(Constraint::equal(
+            body_info.ty,
+            self.type_to_infer_type(return_type),
+            body_info.span,
+        ));
 
         // Consume the constraint generator to release borrows
         let (

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -532,6 +532,29 @@ mod tests {
     }
 
     #[test]
+    fn non_string_tail_in_str_function_is_rejected_during_sema() {
+        let errors = compile_to_air(
+            r#"
+                fn choose(c: bool) -> str {
+                    if c { "hello" } else { "world" } == choose(true)
+                }
+                fn main() -> i32 {
+                    let s: str = "hello";
+                    if s == choose(true) { 0 } else { 1 }
+                }
+            "#,
+        )
+        .expect_err("a bool tail cannot satisfy a str return type");
+
+        assert!(matches!(
+            &errors.iter().next().unwrap().kind,
+            ErrorKind::TypeMismatch { expected, found }
+                if expected == "bool" && found == "str"
+                    || expected == "str" && found == "bool"
+        ));
+    }
+
+    #[test]
     fn specialization_work_separates_unique_and_duplicate_requests() {
         let output = compile_to_air(
             "fn identity(comptime T: type, value: T) -> T { value }\nfn main() -> i32 { identity(i32, 1) + identity(i32, 2) }",


### PR DESCRIPTION
## Summary

- restore the implicit function-body tail constraint for str return types
- keep literal-to-str coercion through the existing marked string inference variables
- add the fuzz crash reproducer as a semantic-analysis regression test

## Root cause

Semantic inference skipped the body-to-return-type constraint for every str-returning function, although only string literals needed coercion. A boolean tail could therefore reach AIR and CFG as the return value of a str function, where CFG verification panicked.

## Validation

- exact sema regression test
- original crash artifact now reports E0206 instead of panicking
- existing valid implicit string-literal return test
- scripts/rue fmt
- scripts/rue quick (25/25)
- scripts/rue cli str_type (22/22)
- git diff --check

Fixes #1652