### PR TITLE
RUE-900: add deterministic benchmark scaling families

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -102,6 +102,8 @@ filegroup(
     srcs = glob(["benchmarks/**"]) + [
         "scripts/append-benchmark.py",
         "scripts/benchmark_collection.py",
+        "scripts/benchmark_manifest.py",
+        "scripts/benchmark_scaling.py",
         "scripts/benchmark_annotations.py",
         "scripts/benchmark_evolution.py",
         "scripts/benchmark_history.py",
@@ -112,6 +114,7 @@ filegroup(
         "scripts/generate-site-status.py",
         "scripts/parser-profile.py",
         "scripts/perf-baseline.py",
+        "scripts/scaling_workloads.py",
         "scripts/validate-benchmark.py",
         "website/templates/performance.html",
         "website/templates/index.html",

--- a/bench.sh
+++ b/bench.sh
@@ -104,6 +104,8 @@ if [[ ! -f "$MANIFEST" ]]; then
     log_error "Run this script from the rue repository root"
     exit 1
 fi
+PYTHONPATH="$SCRIPT_DIR/scripts" python3 "$SCRIPT_DIR/scripts/benchmark_manifest.py" \
+    --manifest "$MANIFEST" validate
 
 # Detect OS early (needed for platform-specific commands in the loop)
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -133,38 +135,14 @@ log_info "Running benchmarks ($ITERATIONS iterations each)..."
 
 RESULTS_FILE="$TEMP_DIR/results.json"
 
-# Parse benchmarks from manifest
-# Format: [[benchmark]] followed by name = "...", path = "..."
+# Parse the static phase probes through the canonical manifest schema.
 benchmark_names=()
 benchmark_paths=()
-
-current_name=""
-current_path=""
-
-while IFS= read -r line; do
-    # Trim whitespace
-    line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-
-    if [[ "$line" == "[[benchmark]]" ]]; then
-        # Save previous benchmark if we have one
-        if [[ -n "$current_name" && -n "$current_path" ]]; then
-            benchmark_names+=("$current_name")
-            benchmark_paths+=("$current_path")
-        fi
-        current_name=""
-        current_path=""
-    elif [[ "$line" =~ ^name[[:space:]]*=[[:space:]]*\"(.*)\" ]]; then
-        current_name="${BASH_REMATCH[1]}"
-    elif [[ "$line" =~ ^path[[:space:]]*=[[:space:]]*\"(.*)\" ]]; then
-        current_path="${BASH_REMATCH[1]}"
-    fi
-done < "$MANIFEST"
-
-# Don't forget the last one
-if [[ -n "$current_name" && -n "$current_path" ]]; then
-    benchmark_names+=("$current_name")
-    benchmark_paths+=("$current_path")
-fi
+while IFS=$'\t' read -r name path; do
+    benchmark_names+=("$name")
+    benchmark_paths+=("$path")
+done < <(PYTHONPATH="$SCRIPT_DIR/scripts" python3 "$SCRIPT_DIR/scripts/benchmark_manifest.py" \
+    --manifest "$MANIFEST" list-static)
 
 # Run each benchmark
 all_results=()
@@ -336,6 +314,13 @@ fi
 
 log_info "Successfully collected ${#all_results[@]} benchmark(s)"
 
+# Scaling diagnostics are a separate, non-representative metric family. They
+# are published with the same run but never enter the phase-probe aggregate.
+log_info "Running deterministic scaling families..."
+scaling_json=$(PYTHONPATH="$SCRIPT_DIR/scripts" python3 "$SCRIPT_DIR/scripts/benchmark_scaling.py" \
+    --manifest "$MANIFEST" --rue-bin "$RUE_BIN" --iterations "$ITERATIONS" \
+    --platform "$os" --enforce-budgets)
+
 # Get metadata
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Get commit hash - try jj first (for local dev), fall back to git (for CI)
@@ -370,6 +355,7 @@ cat > "$RESULTS_FILE" << EOF
     "arch": "$arch"
   },
   "iterations": $ITERATIONS,
+  "scaling": $scaling_json,
   "benchmarks": [
 EOF
 
@@ -389,6 +375,9 @@ cat >> "$RESULTS_FILE" << EOF
   ]
 }
 EOF
+
+PYTHONPATH="$SCRIPT_DIR/scripts" python3 "$SCRIPT_DIR/scripts/benchmark_manifest.py" \
+    --manifest "$MANIFEST" enrich-results --results "$RESULTS_FILE"
 
 # Output results
 log_info "Benchmark run complete!"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,9 @@
 # Rue Compiler Benchmarks
 
-This directory contains benchmark programs for measuring Rue compiler performance.
+This directory contains synthetic compiler phase probes. They are diagnostic
+inputs, not representative Rue applications, and they do not measure the
+runtime performance of compiled programs. Representative scenarios are a
+separate RUE-901 concern and must not be mixed into this aggregate.
 
 ## Structure
 
@@ -18,15 +21,25 @@ benchmarks/
 
 ## Benchmark Descriptions
 
-| Benchmark | What it tests | Size |
-|-----------|--------------|------|
-| `many_functions` | Function handling, symbol resolution | 1,000 functions |
-| `deep_nesting` | Scope handling and parser nesting | 120 nested-control functions: 50 block + 50 if + 20 while, each up to 40 levels (`v39`); 30 deep-expression helpers; 12,198 lines |
-| `large_structs` | Type definitions, field access | 700 struct types |
-| `arithmetic_heavy` | Expression parsing, codegen | 250 functions with 100-term chains |
-| `control_flow` | CFG construction | 390 functions with if/while/match mixes |
-| `array_heavy` | Array declarations, indexing, mutation | 200 functions |
-| `register_pressure` | Simultaneously live local values | 210 functions |
+The manifest is the canonical classification and dimension source. Its
+verified dimensions are checked against the files before every benchmark run.
+
+<!-- BEGIN GENERATED PROBE INVENTORY -->
+| Probe | Primary subsystem | Workload family | Verified dimensions |
+|---|---|---|---|
+| `many_functions` | frontend/declarations | declaration-volume | 2,120 lines; 1,001 functions |
+| `deep_nesting` | frontend/parser-nesting | nesting-pathology | 12,198 lines; 151 functions |
+| `large_structs` | semantic/types | type-volume | 2,187 lines; 701 functions; 700 structs |
+| `arithmetic_heavy` | frontend-expressions/backend | expression-volume | 5,312 lines; 251 functions |
+| `control_flow` | cfg | control-flow-volume | 10,678 lines; 391 functions |
+| `array_heavy` | semantic/arrays | array-operation-volume | 6,185 lines; 201 functions |
+| `register_pressure` | backend/register-allocation | live-value-volume | 6,109 lines; 211 functions; 10 structs |
+<!-- END GENERATED PROBE INVENTORY -->
+
+The deep-nesting probe contains 120 nested-control functions (50 block + 50
+if + 20 while), each up to 40 levels (`v39`), plus 30 deep-expression helpers.
+Those adversarial details are pinned by focused tests in addition to the
+generic manifest dimension check.
 
 ## Running Benchmarks
 
@@ -50,11 +63,25 @@ The `bench.sh` script handles the complete benchmark workflow:
 
 The benchmark runner:
 1. Builds the compiler in release mode
-2. Parses `manifest.toml` to find benchmarks
+2. Validates and parses the canonical `manifest.toml`
 3. Runs each benchmark multiple times
 4. Calculates mean and standard deviation
-5. Outputs JSON results
-6. Appends to `website/static/benchmarks/history.json` (unless `--no-history`)
+5. Generates five deterministic three-tier scaling families spanning frontend
+   declarations, module imports, types, CFG, and backend pressure
+6. Publishes latency, peak memory, robust median/scaled-MAD variation,
+   source/pass structural counters, adjacent size-normalized growth bounds,
+   and evidence classifications as JSON
+7. Appends to partitioned website history (unless `--no-history`)
+
+Scaling tiers have bounded per-compile timeouts plus adjacent-tier latency/unit
+and memory/unit budgets. A violation requires the conservative lower growth
+bound to exceed its budget; bounds crossing the budget and runs with fewer than
+three samples remain visibly indeterminate. A range guard also keeps extreme
+minority samples from becoming a false `±0` conclusion when MAD is zero.
+Both proven violations and indeterminate evidence fail enforcement and are not
+publishable. Passing a loose bound is not a claim of linear complexity.
+Absolute time is shown but is not the complexity budget. The scaling section
+is separate from the static phase-probe aggregate.
 
 ### Running Individual Benchmarks
 
@@ -86,11 +113,13 @@ adversarial scaling families, run `scripts/parser-profile.py --release`.
 Each benchmark should:
 - Be large enough to produce measurable timing (aim for >1ms compilation)
 - Focus on a specific compiler phase or feature
+- Declare its diagnostic subsystem, family, interpretation,
+  non-representative limitation, and mechanically verified dimensions
 - Return a deterministic exit code for verification
 
 ## Benchmark History
 
-Results are stored in `website/static/benchmarks/history.json` for the performance
-dashboard. The history is limited to 100 most recent runs.
+Results are stored as content-addressed, partitioned history for the performance
+dashboard and retained without a fixed run-count cap.
 
 For more details on the performance tracking workflow, see `docs/perf-branch.md`.

--- a/benchmarks/manifest.toml
+++ b/benchmarks/manifest.toml
@@ -1,47 +1,153 @@
-# Benchmark Manifest
-#
-# This file describes the benchmark suite for the Rue compiler.
-# Each benchmark is a Rue program designed to stress specific compiler phases.
-# Each benchmark should take approximately 1-2 seconds to compile for useful graphs.
+schema_version = 2
+
+# This is a suite of synthetic compiler diagnostics, not an application suite.
+# Generator definitions participate in the canonical corpus hash automatically.
+[corpus]
+definition_paths = ["../scripts/scaling_workloads.py"]
 
 [[benchmark]]
 name = "many_functions"
 path = "stress/many_functions.rue"
-description = "1000 functions to stress function handling and symbol resolution"
+kind = "synthetic_phase_probe"
+subsystem = "frontend/declarations"
+workload_family = "declaration-volume"
+interpretation = "Primarily exposes declaration parsing, indexing, and symbol-resolution cost as function count grows."
+non_representative = "Synthetic compiler phase probe; not representative of application mixes or runtime performance."
+dimensions = { source_lines = 2120, function_declarations = 1001 }
 
 [[benchmark]]
 name = "deep_nesting"
 path = "stress/deep_nesting.rue"
-description = "12,198 lines: 120 nested-control functions (50 block, 50 if, 20 while) up to 40 levels, plus 30 deep-expression helpers"
-source_lines = 12198
-nested_control_functions = 120
-block_functions = 50
-if_functions = 50
-while_functions = 20
-deep_expression_functions = 30
-max_nesting_levels = 40
+kind = "synthetic_phase_probe"
+subsystem = "frontend/parser-nesting"
+workload_family = "nesting-pathology"
+interpretation = "Pins parser/scope behavior on repeated block, if, while, and expression nesting; the separate fixed timeout remains the pathology gate."
+non_representative = "Adversarial nesting corpus; not representative of normal source shape or runtime performance."
+dimensions = { source_lines = 12198, function_declarations = 151 }
 
 [[benchmark]]
 name = "large_structs"
 path = "stress/large_structs.rue"
-description = "700 struct types with 4-8 fields each to stress type handling"
+kind = "synthetic_phase_probe"
+subsystem = "semantic/types"
+workload_family = "type-volume"
+interpretation = "Primarily exposes type declaration, field, and semantic-analysis cost for many flat structs."
+non_representative = "Synthetic flat-type probe; not representative of application type graphs or runtime performance."
+dimensions = { source_lines = 2187, function_declarations = 701, struct_declarations = 700 }
 
 [[benchmark]]
 name = "arithmetic_heavy"
 path = "stress/arithmetic_heavy.rue"
-description = "250 functions with long arithmetic chains (100+ terms) to stress parsing/codegen"
+kind = "synthetic_phase_probe"
+subsystem = "frontend-expressions/backend"
+workload_family = "expression-volume"
+interpretation = "Exposes expression parsing, semantic lowering, and code generation for repeated long arithmetic chains; it does not isolate one pass."
+non_representative = "Synthetic repeated-expression probe; not representative of application mixes or runtime performance."
+dimensions = { source_lines = 5312, function_declarations = 251 }
 
 [[benchmark]]
 name = "control_flow"
 path = "stress/control_flow.rue"
-description = "390 functions with complex if/while/match patterns to stress CFG construction"
+kind = "synthetic_phase_probe"
+subsystem = "cfg"
+workload_family = "control-flow-volume"
+interpretation = "Primarily exposes CFG construction and lowering for repeated if, while, and match shapes."
+non_representative = "Synthetic repeated-control-flow probe; not representative of application branch distributions or runtime performance."
+dimensions = { source_lines = 10678, function_declarations = 391 }
 
 [[benchmark]]
 name = "array_heavy"
 path = "stress/array_heavy.rue"
-description = "200 functions with array declarations, indexing, and modifications"
+kind = "synthetic_phase_probe"
+subsystem = "semantic/arrays"
+workload_family = "array-operation-volume"
+interpretation = "Exposes semantic checking and lowering for repeated array declarations, indexing, and mutation."
+non_representative = "Synthetic repeated-array probe; not representative of application data structures or runtime performance."
+dimensions = { source_lines = 6185, function_declarations = 201 }
 
 [[benchmark]]
 name = "register_pressure"
 path = "stress/register_pressure.rue"
-description = "210 functions with many simultaneous live variables to stress register allocation"
+kind = "synthetic_phase_probe"
+subsystem = "backend/register-allocation"
+workload_family = "live-value-volume"
+interpretation = "Primarily exposes backend lowering and register allocation for repeated functions with many simultaneously live values."
+non_representative = "Synthetic register-pressure probe; not representative of application code or generated-program runtime performance."
+dimensions = { source_lines = 6109, function_declarations = 211, struct_declarations = 10 }
+
+# Scaling families are generated deterministically into temporary directories.
+# Adjacent-tier budgets compare metric growth divided by input-size growth.
+# Median/scaled-MAD bounds plus an extreme-range guard distinguish proven
+# violations from noisy or insufficient evidence. Both failed and
+# indeterminate evidence block publication; a loose bound is not a claim of
+# linear complexity.
+
+[[scaling_family]]
+name = "frontend_declarations"
+generator = "function_declarations"
+subsystem = "frontend/declarations"
+workload_family = "declaration-volume"
+input_axis = "function declarations"
+sizes = [100, 300, 900]
+focus_pass = "parser_grammar_execution"
+interpretation = "Input size grows only the count of same-shape function declarations; inspect lexer/parser/declaration-index counters together."
+non_representative = "Synthetic scaling diagnostic, excluded from representative scenarios and the phase-probe aggregate headline; it does not measure runtime performance."
+latency_per_unit_growth_budget = 2.0
+memory_per_unit_growth_budget = 2.0
+timeout_seconds = 20
+
+[[scaling_family]]
+name = "module_fanout"
+generator = "module_fanout"
+subsystem = "frontend/module-discovery"
+workload_family = "module-volume"
+input_axis = "imported leaf modules"
+sizes = [16, 48, 144]
+focus_pass = "parser_grammar_execution"
+interpretation = "Input size grows direct imports and same-shape leaf modules, exercising discovery, per-module syntax, and merge work."
+non_representative = "Synthetic import-fanout diagnostic, not a representative project dependency graph or runtime scenario."
+latency_per_unit_growth_budget = 2.0
+memory_per_unit_growth_budget = 2.0
+timeout_seconds = 20
+
+[[scaling_family]]
+name = "semantic_types"
+generator = "struct_declarations"
+subsystem = "semantic/types"
+workload_family = "type-volume"
+input_axis = "flat struct declarations"
+sizes = [100, 300, 900]
+focus_pass = "sema"
+interpretation = "Input size grows same-shape flat struct declarations to expose semantic/type-table scaling."
+non_representative = "Synthetic flat-type diagnostic, not a representative application type graph or runtime scenario."
+latency_per_unit_growth_budget = 2.0
+memory_per_unit_growth_budget = 2.0
+timeout_seconds = 20
+
+[[scaling_family]]
+name = "cfg_functions"
+generator = "cfg_functions"
+subsystem = "cfg"
+workload_family = "control-flow-volume"
+input_axis = "fixed-shape branch functions"
+sizes = [100, 300, 900]
+focus_pass = "cfg_construction"
+interpretation = "Input size grows independent functions with one fixed branch shape to expose CFG construction/lowering scaling."
+non_representative = "Synthetic CFG diagnostic, not a representative application control-flow mix or runtime scenario."
+latency_per_unit_growth_budget = 2.0
+memory_per_unit_growth_budget = 2.0
+timeout_seconds = 20
+
+[[scaling_family]]
+name = "backend_pressure"
+generator = "backend_live_values"
+subsystem = "backend/register-allocation"
+workload_family = "live-value-volume"
+input_axis = "fixed-pressure functions"
+sizes = [40, 120, 360]
+focus_pass = "codegen"
+interpretation = "Input size grows independent functions with 24 same-shape live values to expose backend/codegen scaling."
+non_representative = "Synthetic backend diagnostic, not a representative application mix or generated-program runtime scenario."
+latency_per_unit_growth_budget = 2.0
+memory_per_unit_growth_budget = 2.0
+timeout_seconds = 20

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -14,15 +14,22 @@ scripts/perf-baseline.py --format markdown   # prints compact current tables
 scripts/perf-baseline.py --format json       # machine-readable aggregate
 ```
 
-The harness compiles a representative corpus with the real `rue` binary using
+The harness compiles a convenient mix of examples and synthetic phase probes
+with the real `rue` binary using
 `--benchmark-json` (the machine-readable form of `--time-passes`, see
 [logging.md](logging.md)). Every sample is a **fresh compiler process**; the
 optional warmups warm host/filesystem caches, not compiler state. The harness
 reports median absolute deviation alongside both the compiler pipeline span
 and fresh-process wall time, plus peak resident memory where the host exposes
 it. It is separate from `bench.sh` (which feeds the
-historical website dashboard); this one is a quick, self-contained snapshot
+historical website dashboard); this one is a quick, self-contained diagnostic snapshot
 with no history/network side effects.
+
+Neither this snapshot nor the website phase-probe aggregate is a representative
+application benchmark or a compiled-program runtime benchmark. The canonical
+classifications live in `benchmarks/manifest.toml`; deterministic scaling
+families are published separately on the website and are excluded from the
+aggregate headline. Representative scenarios belong to RUE-901.
 
 The current corpus includes the exact 12,198-line
 `benchmarks/stress/deep_nesting.rue`: 120 nested-control functions (50 block,

--- a/scripts/append-benchmark.py
+++ b/scripts/append-benchmark.py
@@ -17,7 +17,7 @@ from benchmark_history import (
     save_history,
     validate_publication,
 )
-from benchmark_validation import DEFAULT_MANIFEST, load_manifest_names, validate_results
+from benchmark_validation import DEFAULT_MANIFEST, validate_manifest_results
 
 
 def latest_measured_commit(runs: list[dict]) -> str | None:
@@ -44,8 +44,7 @@ def main() -> int:
 
     try:
         result = json.loads(args.results.read_text())
-        expected = load_manifest_names(args.manifest)
-        errors = validate_results(result, expected)
+        errors = validate_manifest_results(result, args.manifest)
         for bench in result.get("benchmarks", []) if isinstance(result, dict) else []:
             if isinstance(bench, dict) and "samples_ms" not in bench:
                 errors.append(f"benchmark '{bench.get('name', '?')}' is missing raw samples_ms")

--- a/scripts/benchmark_collection.py
+++ b/scripts/benchmark_collection.py
@@ -60,6 +60,14 @@ def parse_iteration_json(text: str) -> dict:
     names = [row["name"] for row in passes]
     if len(names) != len(set(names)):
         raise ValueError("passes must not contain duplicate names")
+    if "source_metrics" in data:
+        metrics = data["source_metrics"]
+        if not isinstance(metrics, dict):
+            raise ValueError("source_metrics must be an object")
+        for field in ("bytes", "files", "lines", "tokens"):
+            value = metrics.get(field)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ValueError(f"source_metrics {field} must be a non-negative integer")
     return data
 
 
@@ -70,12 +78,19 @@ def aggregate_iterations(payloads: list[str]) -> dict:
 
     pass_data: dict[str, list[float]] = {}
     source_metrics = None
+    source_metrics_present = None
     peak_memory_samples = []
     timing_schema_version = None
     expected_included_passes = None
+    pass_structure = None
 
     for text in payloads:
         data = parse_iteration_json(text)
+        present = "source_metrics" in data
+        if source_metrics_present is None:
+            source_metrics_present = present
+        elif present != source_metrics_present:
+            raise ValueError("source_metrics presence changed between iterations")
         schema_version = data.get("schema_version", 1)
         if timing_schema_version is None:
             timing_schema_version = schema_version
@@ -83,6 +98,7 @@ def aggregate_iterations(payloads: list[str]) -> dict:
             raise ValueError("timing schema_version changed between iterations")
 
         included_passes = set()
+        current_structure = {}
         for row in data["passes"]:
             if schema_version >= 2 and row.get("leaf_invocations") != row.get(
                 "invocations"
@@ -90,21 +106,35 @@ def aggregate_iterations(payloads: list[str]) -> dict:
                 continue
             included_passes.add(row["name"])
             pass_data.setdefault(row["name"], []).append(float(row["duration_ms"]))
+            if schema_version >= 2:
+                current_structure[row["name"]] = {
+                    "invocations": row["invocations"],
+                    "root_invocations": row["root_invocations"],
+                    "leaf_invocations": row["leaf_invocations"],
+                }
         if expected_included_passes is None:
             expected_included_passes = included_passes
         elif included_passes != expected_included_passes:
             raise ValueError("aggregated pass set changed between iterations")
-        if source_metrics is None and "source_metrics" in data:
-            source_metrics = data["source_metrics"]
+        if pass_structure is None:
+            pass_structure = current_structure
+        elif current_structure != pass_structure:
+            raise ValueError("pass invocation structure changed between iterations")
+        if "source_metrics" in data:
+            if source_metrics is None:
+                source_metrics = data["source_metrics"]
+            elif source_metrics != data["source_metrics"]:
+                raise ValueError("source_metrics changed between iterations")
         if "peak_memory_bytes" in data and data["peak_memory_bytes"]:
             peak_memory_samples.append(
                 _non_negative_number(data["peak_memory_bytes"], "peak_memory_bytes")
             )
 
-    passes = {
-        name: {"mean_ms": round(sum(durations) / len(durations), 3)}
-        for name, durations in pass_data.items()
-    }
+    passes = {}
+    for name, durations in pass_data.items():
+        passes[name] = {"mean_ms": round(sum(durations) / len(durations), 3)}
+        if pass_structure and name in pass_structure:
+            passes[name].update(pass_structure[name])
     result = {"passes": passes, "timing_schema_version": timing_schema_version}
     if source_metrics is not None:
         result["source_metrics"] = source_metrics

--- a/scripts/benchmark_history.py
+++ b/scripts/benchmark_history.py
@@ -17,6 +17,8 @@ import tempfile
 from pathlib import Path
 from typing import Callable
 
+from benchmark_manifest import corpus_paths
+
 
 HISTORY_VERSION = 3
 FORMAT = "rue-benchmark-history"
@@ -180,22 +182,16 @@ def save_history(path: Path, runs: list[dict], platform: str) -> None:
 
 
 def corpus_metadata(manifest: Path) -> dict:
-    """Hash the manifest and every declared source file in manifest order."""
-    import tomllib
+    """Hash the manifest, static sources, and generated-workload definitions."""
     raw = manifest.read_bytes()
-    parsed = tomllib.loads(raw.decode())
     digest = hashlib.sha256()
     digest.update(b"manifest\0" + raw)
     files = []
-    for entry in parsed.get("benchmark", []):
-        relative = entry.get("path")
-        if not isinstance(relative, str):
-            raise ValueError("benchmark manifest entry has no path")
-        source = manifest.parent / relative
+    for relative, source in corpus_paths(manifest):
         contents = source.read_bytes()
         digest.update(relative.encode() + b"\0" + contents)
         files.append(relative)
-    return {"schema_version": 1, "sha256": digest.hexdigest(), "files": files}
+    return {"schema_version": 2, "sha256": digest.hexdigest(), "files": files}
 
 
 def regime_metadata(result: dict, platform: str, runner_image: str, corpus: dict) -> dict:
@@ -274,7 +270,7 @@ def validate_publication(run: dict) -> list[str]:
     else:
         errors.append("publication regime must be an object")
     corpus = publication.get("corpus")
-    if not isinstance(corpus, dict) or corpus.get("schema_version") != 1 or not isinstance(corpus.get("sha256"), str) or len(corpus.get("sha256", "")) != 64:
+    if not isinstance(corpus, dict) or corpus.get("schema_version") not in (1, 2) or not isinstance(corpus.get("sha256"), str) or len(corpus.get("sha256", "")) != 64:
         errors.append("publication corpus metadata is malformed")
     compiler = publication.get("compiler")
     if not isinstance(compiler, dict) or compiler.get("commit") != run.get("commit") or not isinstance(compiler.get("identity"), str):

--- a/scripts/benchmark_manifest.py
+++ b/scripts/benchmark_manifest.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Canonical parser and validator for Rue's synthetic benchmark manifest."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import sys
+import tomllib
+
+from scaling_workloads import GENERATORS
+
+
+BENCHMARK_KIND = "synthetic_phase_probe"
+VERIFIED_DIMENSIONS = {"source_lines", "function_declarations", "struct_declarations"}
+REQUIRED_PROBE_FIELDS = (
+    "name",
+    "path",
+    "subsystem",
+    "workload_family",
+    "interpretation",
+    "non_representative",
+)
+REQUIRED_SCALING_FIELDS = (
+    "name",
+    "generator",
+    "subsystem",
+    "workload_family",
+    "input_axis",
+    "sizes",
+    "focus_pass",
+    "interpretation",
+    "non_representative",
+    "latency_per_unit_growth_budget",
+    "memory_per_unit_growth_budget",
+    "timeout_seconds",
+)
+
+
+def _unique(entries: list[dict], label: str) -> None:
+    names = [entry.get("name") for entry in entries]
+    duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+    if duplicates:
+        raise ValueError(f"duplicate {label} name(s): " + ", ".join(duplicates))
+
+
+def load_manifest(path: Path) -> dict:
+    """Load the single source of benchmark workload semantics."""
+    with path.open("rb") as stream:
+        manifest = tomllib.load(stream)
+    if manifest.get("schema_version") != 2:
+        raise ValueError("benchmark manifest schema_version must be 2")
+    probes = manifest.get("benchmark")
+    families = manifest.get("scaling_family")
+    if not isinstance(probes, list) or not probes:
+        raise ValueError("manifest must contain at least one [[benchmark]] entry")
+    if not isinstance(families, list) or len(families) < 3:
+        raise ValueError("manifest must contain at least three [[scaling_family]] entries")
+    for index, probe in enumerate(probes):
+        if not isinstance(probe, dict):
+            raise ValueError(f"manifest benchmark #{index + 1} must be a table")
+        for field in REQUIRED_PROBE_FIELDS:
+            if not isinstance(probe.get(field), str) or not probe[field]:
+                raise ValueError(f"manifest benchmark #{index + 1} has no valid {field}")
+        if probe.get("kind") != BENCHMARK_KIND:
+            raise ValueError(f"manifest benchmark '{probe['name']}' must be {BENCHMARK_KIND}")
+        dimensions = probe.get("dimensions")
+        if not isinstance(dimensions, dict) or not dimensions:
+            raise ValueError(f"manifest benchmark '{probe['name']}' has no dimensions")
+        if any(
+            not isinstance(value, int) or isinstance(value, bool) or value <= 0
+            for value in dimensions.values()
+        ):
+            raise ValueError(
+                f"manifest benchmark '{probe['name']}' dimensions must be positive integers"
+            )
+        unknown_dimensions = sorted(set(dimensions) - VERIFIED_DIMENSIONS)
+        if unknown_dimensions:
+            raise ValueError(
+                f"manifest benchmark '{probe['name']}' has unverifiable dimensions: "
+                + ", ".join(unknown_dimensions)
+            )
+    _unique(probes, "benchmark")
+    generators = set()
+    for index, family in enumerate(families):
+        if not isinstance(family, dict):
+            raise ValueError(f"scaling family #{index + 1} must be a table")
+        for field in REQUIRED_SCALING_FIELDS:
+            value = family.get(field)
+            if field == "sizes":
+                if not isinstance(value, list) or len(value) < 3 or any(
+                    not isinstance(size, int) or isinstance(size, bool) or size <= 0
+                    for size in value
+                ) or value != sorted(set(value)):
+                    raise ValueError(
+                        f"scaling family '{family.get('name', index + 1)}' sizes "
+                        "must be three or more increasing positive integers"
+                    )
+            elif field.endswith("_budget"):
+                if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 1:
+                    raise ValueError(
+                        f"scaling family '{family.get('name', index + 1)}' "
+                        f"{field} must be greater than 1"
+                    )
+            elif field == "timeout_seconds":
+                if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+                    raise ValueError(
+                        f"scaling family '{family.get('name', index + 1)}' "
+                        "timeout_seconds must be positive"
+                    )
+            elif not isinstance(value, str) or not value:
+                raise ValueError(f"scaling family #{index + 1} has no valid {field}")
+        generators.add(family["generator"])
+    _unique(families, "scaling family")
+    if len(generators) != len(families):
+        raise ValueError("scaling families must use distinct generators")
+    unknown = sorted(generators - set(GENERATORS))
+    if unknown:
+        raise ValueError("unknown scaling generator(s): " + ", ".join(unknown))
+    corpus = manifest.get("corpus")
+    paths = corpus.get("definition_paths") if isinstance(corpus, dict) else None
+    if (
+        not isinstance(paths, list)
+        or not paths
+        or any(not isinstance(value, str) or not value for value in paths)
+    ):
+        raise ValueError("manifest corpus.definition_paths must be a non-empty string array")
+    return manifest
+
+
+def static_probes(path: Path) -> list[dict]:
+    return load_manifest(path)["benchmark"]
+
+
+def scaling_families(path: Path) -> list[dict]:
+    return load_manifest(path)["scaling_family"]
+
+
+def corpus_paths(path: Path) -> list[tuple[str, Path]]:
+    manifest = load_manifest(path)
+    result = [(entry["path"], path.parent / entry["path"]) for entry in manifest["benchmark"]]
+    for relative in manifest["corpus"]["definition_paths"]:
+        result.append((relative, path.parent / relative))
+    return result
+
+
+def validate_static_dimensions(path: Path) -> list[str]:
+    errors = []
+    for probe in static_probes(path):
+        source = (path.parent / probe["path"]).read_text()
+        actual = {
+            "source_lines": len(source.splitlines()),
+            "function_declarations": sum(
+                line.startswith("fn ") or line.startswith("pub fn ")
+                for line in source.splitlines()
+            ),
+            "struct_declarations": sum(
+                line.startswith("struct ") or line.startswith("pub struct ")
+                for line in source.splitlines()
+            ),
+        }
+        for name, expected in probe["dimensions"].items():
+            if name in actual and actual[name] != expected:
+                errors.append(f"{probe['name']} {name}: manifest={expected}, source={actual[name]}")
+    return errors
+
+
+def render_probe_inventory(path: Path) -> str:
+    labels = {
+        "source_lines": "lines",
+        "function_declarations": "functions",
+        "struct_declarations": "structs",
+    }
+    rows = [
+        "| Probe | Primary subsystem | Workload family | Verified dimensions |",
+        "|---|---|---|---|",
+    ]
+    for probe in static_probes(path):
+        dimensions = "; ".join(
+            f"{value:,} {labels[name]}" for name, value in probe["dimensions"].items()
+        )
+        rows.append(
+            f"| `{probe['name']}` | {probe['subsystem']} | {probe['workload_family']} | {dimensions} |"
+        )
+    return "\n".join(rows)
+
+
+def validate_readme_inventory(path: Path) -> list[str]:
+    readme = (path.parent / "README.md").read_text()
+    begin = "<!-- BEGIN GENERATED PROBE INVENTORY -->"
+    end = "<!-- END GENERATED PROBE INVENTORY -->"
+    if begin not in readme or end not in readme:
+        return ["benchmark README lacks generated probe inventory markers"]
+    actual = readme.split(begin, 1)[1].split(end, 1)[0].strip()
+    expected = render_probe_inventory(path)
+    return [] if actual == expected else ["benchmark README probe inventory is stale"]
+
+
+def enrich_results(data: dict, path: Path) -> dict:
+    """Attach canonical probe semantics without creating a second schema path."""
+    declared = {probe["name"]: probe for probe in static_probes(path)}
+    for result in data.get("benchmarks", []):
+        probe = declared.get(result.get("name"))
+        if probe is None:
+            continue
+        for field in (
+            "kind",
+            "subsystem",
+            "workload_family",
+            "interpretation",
+            "non_representative",
+            "dimensions",
+        ):
+            result[field] = probe[field]
+    data["probe_suite"] = {
+        "kind": BENCHMARK_KIND,
+        "representative": False,
+        "aggregate_interpretation": "synthetic compiler phase diagnostics only",
+    }
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("command", choices=["list-static", "validate", "enrich-results"])
+    parser.add_argument("--results", type=Path)
+    args = parser.parse_args()
+    try:
+        if args.command == "list-static":
+            for probe in static_probes(args.manifest):
+                print(f"{probe['name']}\t{probe['path']}")
+        elif args.command == "validate":
+            errors = validate_static_dimensions(
+                args.manifest
+            ) + validate_readme_inventory(args.manifest)
+            if errors:
+                raise ValueError("; ".join(errors))
+        else:
+            if args.results is None:
+                raise ValueError("enrich-results requires --results")
+            data = enrich_results(json.loads(args.results.read_text()), args.manifest)
+            args.results.write_text(json.dumps(data, indent=2) + "\n")
+    except (OSError, ValueError, tomllib.TOMLDecodeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark_metrics.py
+++ b/scripts/benchmark_metrics.py
@@ -116,11 +116,24 @@ def robust_summary(values: object) -> dict | None:
     numeric = [float(value) for value in values]
     center = statistics.median(numeric)
     mad = statistics.median(abs(value - center) for value in numeric)
+    scaled_mad = 1.4826 * mad
+    minimum = min(numeric)
+    maximum = max(numeric)
+    sample_range = maximum - minimum
+    # MAD intentionally ignores a minority of outliers. That is useful for a
+    # center estimate, but a zero/tiny MAD must not certify benchmark evidence
+    # when the observed range is extreme. The 50%-of-center floor tolerates
+    # ordinary scheduler noise while six scaled MADs covers dispersed samples.
+    range_guard_threshold = max(abs(center) * 0.5, scaled_mad * 6.0)
+    extreme_range = sample_range > range_guard_threshold
     return {
         "center": center,
-        "scaled_mad": 1.4826 * mad,
-        "minimum": min(numeric),
-        "maximum": max(numeric),
+        "scaled_mad": scaled_mad,
+        "minimum": minimum,
+        "maximum": maximum,
+        "range": sample_range,
+        "relative_range": sample_range / abs(center) if center != 0 else None,
+        "dispersion_classification": "extreme_range" if extreme_range else "robust",
         "sample_count": len(numeric),
     }
 

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Run and derive deterministic compiler scaling-family diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+from benchmark_collection import aggregate_iterations, parse_iteration_json
+from benchmark_manifest import scaling_families
+from benchmark_metrics import robust_summary
+from scaling_workloads import generate
+
+
+def parse_peak_memory(stderr: str, platform: str) -> int | None:
+    for line in stderr.splitlines():
+        if platform == "darwin" and "maximum resident set size" in line:
+            try:
+                return int(line.split()[0])
+            except (IndexError, ValueError):
+                pass
+        if platform != "darwin" and "Maximum resident set size" in line:
+            try:
+                return int(line.rsplit(":", 1)[1].strip()) * 1024
+            except (IndexError, ValueError):
+                pass
+    return None
+
+
+def compile_once(
+    rue_bin: Path, source: Path, output: Path, platform: str, timeout: float
+) -> tuple[str, int | None]:
+    time_args = ["-l"] if platform == "darwin" else ["-v"]
+    process = subprocess.run(
+        [
+            "/usr/bin/time",
+            *time_args,
+            str(rue_bin),
+            "--benchmark-json",
+            str(source),
+            "-o",
+            str(output),
+        ],
+        cwd=source.parent,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+        env={**os.environ, "RUE_LOG": ""},
+    )
+    if process.returncode != 0:
+        raise RuntimeError(f"scaling compile failed for {source}: {process.stderr.strip()}")
+    payload = process.stdout.strip()
+    parse_iteration_json(payload)
+    return payload, parse_peak_memory(process.stderr, platform)
+
+
+MIN_GROWTH_SAMPLES = 3
+
+
+def _metric_summary(samples: list[float | int]) -> dict:
+    summary = robust_summary(samples)
+    if summary is None:
+        raise ValueError("scaling samples must be finite numeric values")
+    return summary
+
+
+def _growth_evidence(
+    previous: dict, current: dict, size_ratio: float, budget: float
+) -> dict:
+    center = (current["center"] / previous["center"]) / size_ratio
+    evidence = {
+        "center": round(center, 4),
+        "lower_bound": None,
+        "upper_bound": None,
+        "budget": budget,
+        "classification": "indeterminate",
+        "reason": "at_least_three_samples_required",
+    }
+    if min(previous["sample_count"], current["sample_count"]) < MIN_GROWTH_SAMPLES:
+        return evidence
+    if "extreme_range" in (
+        previous["dispersion_classification"],
+        current["dispersion_classification"],
+    ):
+        evidence["reason"] = "extreme_sample_range"
+        return evidence
+    previous_low = previous["center"] - previous["scaled_mad"]
+    if previous_low <= 0:
+        evidence["reason"] = "variation_reaches_zero"
+        return evidence
+    lower = (
+        max(0.0, current["center"] - current["scaled_mad"])
+        / (previous["center"] + previous["scaled_mad"])
+        / size_ratio
+    )
+    upper = (
+        (current["center"] + current["scaled_mad"])
+        / previous_low
+        / size_ratio
+    )
+    evidence.update(
+        lower_bound=round(lower, 4),
+        upper_bound=round(upper, 4),
+        reason=None,
+    )
+    if lower > budget:
+        evidence["classification"] = "budget_exceeded"
+    elif upper <= budget:
+        evidence["classification"] = "within_budget"
+    else:
+        evidence["classification"] = "indeterminate"
+        evidence["reason"] = "uncertainty_crosses_budget"
+    return evidence
+
+
+def derive_family(family: dict, tiers: list[dict]) -> dict:
+    """Canonically derive uncertainty-aware growth from raw tier evidence."""
+    derived_tiers = []
+    for tier in tiers:
+        latency = _metric_summary(tier["samples_ms"])
+        memory = _metric_summary(tier["peak_memory_samples_bytes"])
+        derived_tiers.append(
+            {
+                "input_size": tier["input_size"],
+                "samples_ms": tier["samples_ms"],
+                "peak_memory_samples_bytes": tier["peak_memory_samples_bytes"],
+                "latency_summary_ms": latency,
+                "peak_memory_summary_bytes": memory,
+                "median_ms": latency["center"],
+                "peak_memory_bytes": int(memory["center"]),
+                "passes": tier["passes"],
+                "source_metrics": tier["source_metrics"],
+            }
+        )
+    adjacent = []
+    violations = []
+    for previous, current in zip(derived_tiers, derived_tiers[1:]):
+        size_ratio = current["input_size"] / previous["input_size"]
+        latency = _growth_evidence(
+            previous["latency_summary_ms"],
+            current["latency_summary_ms"],
+            size_ratio,
+            family["latency_per_unit_growth_budget"],
+        )
+        memory = _growth_evidence(
+            previous["peak_memory_summary_bytes"],
+            current["peak_memory_summary_bytes"],
+            size_ratio,
+            family["memory_per_unit_growth_budget"],
+        )
+        focus = family["focus_pass"]
+        before_focus = previous.get("passes", {}).get(focus, {}).get("mean_ms", 0)
+        after_focus = current.get("passes", {}).get(focus, {}).get("mean_ms", 0)
+        focus_ratio = after_focus / before_focus if before_focus > 0 else None
+        classifications = {latency["classification"], memory["classification"]}
+        if "budget_exceeded" in classifications:
+            classification = "budget_exceeded"
+        elif "indeterminate" in classifications:
+            classification = "indeterminate"
+        else:
+            classification = "within_normalized_growth_budget"
+        row = {
+            "from_size": previous["input_size"],
+            "to_size": current["input_size"],
+            "size_ratio": round(size_ratio, 4),
+            "latency_per_unit_growth": latency,
+            "memory_per_unit_growth": memory,
+            "focus_pass": focus,
+            "focus_pass_ratio": round(focus_ratio, 4) if focus_ratio is not None else None,
+            "classification": classification,
+        }
+        for metric, evidence in (("latency", latency), ("memory", memory)):
+            if evidence["classification"] == "budget_exceeded":
+                violations.append(
+                    {
+                        "metric": metric,
+                        "from_size": previous["input_size"],
+                        "to_size": current["input_size"],
+                        "lower_bound": evidence["lower_bound"],
+                        "budget": evidence["budget"],
+                    }
+                )
+        adjacent.append(row)
+    row_classes = {row["classification"] for row in adjacent}
+    if violations:
+        classification = "budget_exceeded"
+    elif "indeterminate" in row_classes:
+        classification = "indeterminate"
+    else:
+        classification = "within_normalized_growth_budget"
+    return {
+        "name": family["name"],
+        "kind": "synthetic_scaling_probe",
+        "subsystem": family["subsystem"],
+        "workload_family": family["workload_family"],
+        "input_axis": family["input_axis"],
+        "focus_pass": family["focus_pass"],
+        "interpretation": family["interpretation"],
+        "non_representative": family["non_representative"],
+        "budgets": {
+            "latency_per_unit_growth": family["latency_per_unit_growth_budget"],
+            "memory_per_unit_growth": family["memory_per_unit_growth_budget"],
+            "policy": "adjacent tier metric growth divided by input-size growth",
+            "per_tier_compile_timeout_seconds": family["timeout_seconds"],
+        },
+        "tiers": derived_tiers,
+        "adjacent_growth": adjacent,
+        "classification": classification,
+        "violations": violations,
+    }
+
+
+def run_family(family: dict, rue_bin: Path, iterations: int, platform: str, work: Path) -> dict:
+    tiers = []
+    for size in family["sizes"]:
+        tier_root = work / family["name"] / str(size)
+        source = generate(family["generator"], tier_root, size)
+        payloads = []
+        memory = []
+        for iteration in range(iterations):
+            try:
+                payload, peak = compile_once(
+                    rue_bin,
+                    source,
+                    tier_root / f"out-{iteration}",
+                    platform,
+                    family["timeout_seconds"],
+                )
+            except subprocess.TimeoutExpired as error:
+                raise RuntimeError(
+                    f"scaling compile timed out after {family['timeout_seconds']}s: "
+                    f"{family['name']} size {size}"
+                ) from error
+            payloads.append(payload)
+            if peak is not None and peak > 0:
+                memory.append(peak)
+        aggregate = aggregate_iterations(payloads)
+        samples = [float(parse_iteration_json(payload)["total_ms"]) for payload in payloads]
+        tier = {
+            "input_size": size,
+            "samples_ms": samples,
+            "peak_memory_samples_bytes": memory,
+            "passes": aggregate["passes"],
+            "source_metrics": aggregate["source_metrics"],
+        }
+        tiers.append(tier)
+    return derive_family(family, tiers)
+
+
+def budget_status(families: list[dict]) -> str:
+    if any(family["violations"] for family in families):
+        return "failed"
+    if any(family["classification"] == "indeterminate" for family in families):
+        return "indeterminate"
+    return "passed"
+
+
+def run_scaling(manifest: Path, rue_bin: Path, iterations: int, platform: str) -> dict:
+    with tempfile.TemporaryDirectory(prefix="rue-scaling-") as temp:
+        families = [
+            run_family(family, rue_bin, iterations, platform, Path(temp))
+            for family in scaling_families(manifest)
+        ]
+    return {
+        "schema_version": 1,
+        "measurement_family": "compiler_scaling_diagnostics",
+        "scenario_family": "synthetic_phase_probes",
+        "representative": False,
+        "iterations": iterations,
+        "families": families,
+        "budget_status": budget_status(families),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--rue-bin", type=Path, required=True)
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument(
+        "--platform",
+        choices=["darwin", "linux"],
+        default="darwin" if sys.platform == "darwin" else "linux",
+    )
+    parser.add_argument("--enforce-budgets", action="store_true")
+    args = parser.parse_args()
+    if args.iterations <= 0:
+        parser.error("--iterations must be positive")
+    try:
+        result = run_scaling(args.manifest, args.rue_bin, args.iterations, args.platform)
+    except (OSError, ValueError, RuntimeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    if args.enforce_budgets and result["budget_status"] == "failed":
+        for family in result["families"]:
+            for violation in family["violations"]:
+                print(
+                    f"Budget violation {family['name']}: "
+                    f"{violation['metric']} {violation['from_size']}->{violation['to_size']} "
+                    f"lower bound {violation['lower_bound']} > {violation['budget']}",
+                    file=sys.stderr,
+                )
+        return 2
+    if args.enforce_budgets and result["budget_status"] == "indeterminate":
+        for family in result["families"]:
+            if family["classification"] == "indeterminate":
+                reasons = sorted(
+                    {
+                        evidence["reason"]
+                        for row in family["adjacent_growth"]
+                        for evidence in (
+                            row["latency_per_unit_growth"],
+                            row["memory_per_unit_growth"],
+                        )
+                        if evidence["classification"] == "indeterminate"
+                    }
+                )
+                print(
+                    f"Insufficient scaling evidence {family['name']}: "
+                    + ", ".join(reasons),
+                    file=sys.stderr,
+                )
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark_validation.py
+++ b/scripts/benchmark_validation.py
@@ -3,7 +3,14 @@
 from collections import Counter
 import math
 from pathlib import Path
-import tomllib
+
+from benchmark_manifest import (
+    load_manifest,
+    scaling_families,
+    validate_readme_inventory,
+    validate_static_dimensions,
+)
+from benchmark_scaling import budget_status, derive_family
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -21,27 +28,171 @@ def _is_finite_non_negative_number(value: object) -> bool:
 
 def load_manifest_names(path: Path) -> list[str]:
     """Load and validate the benchmark names declared by the manifest."""
-    with path.open("rb") as f:
-        manifest = tomllib.load(f)
+    return [entry["name"] for entry in load_manifest(path)["benchmark"]]
 
-    entries = manifest.get("benchmark")
-    if not isinstance(entries, list) or not entries:
-        raise ValueError("manifest must contain at least one [[benchmark]] entry")
 
-    names = []
-    for index, entry in enumerate(entries):
-        name = entry.get("name") if isinstance(entry, dict) else None
-        if not isinstance(name, str) or not name:
-            raise ValueError(f"manifest benchmark #{index + 1} has no valid name")
-        names.append(name)
+def validate_scaling_results(data: object, manifest_path: Path) -> list[str]:
+    """Re-derive every scaling claim from finite raw tier evidence."""
+    scaling = data.get("scaling") if isinstance(data, dict) else None
+    if not isinstance(scaling, dict):
+        return ["benchmark result is missing scaling diagnostics"]
+    errors = []
+    expected_identity = {
+        "schema_version": 1,
+        "measurement_family": "compiler_scaling_diagnostics",
+        "scenario_family": "synthetic_phase_probes",
+        "representative": False,
+    }
+    for field, expected_value in expected_identity.items():
+        if scaling.get(field) != expected_value:
+            errors.append(f"scaling diagnostics {field} is malformed")
+    if scaling.get("iterations") != data.get("iterations"):
+        errors.append("scaling diagnostics iterations do not match root iterations")
+    actual = scaling.get("families")
+    if not isinstance(actual, list):
+        return errors + ["scaling diagnostics families must be an array"]
+    if any(not isinstance(family, dict) for family in actual):
+        return errors + ["scaling diagnostics families must contain objects"]
+    declared_families = scaling_families(manifest_path)
+    expected_names = [family["name"] for family in declared_families]
+    if [family.get("name") for family in actual] != expected_names:
+        errors.append("scaling diagnostic family composition does not match manifest")
+        return errors
+    canonical_families = []
+    iterations = data.get("iterations")
+    for declared, family in zip(declared_families, actual):
+        name = declared["name"]
+        tiers = family.get("tiers", [])
+        if not isinstance(tiers, list):
+            errors.append(f"scaling family '{name}' tiers must be an array")
+            continue
+        sizes = [tier.get("input_size") for tier in tiers if isinstance(tier, dict)]
+        if sizes != declared["sizes"]:
+            errors.append(f"scaling family '{name}' tiers do not match manifest sizes")
+        raw_tiers = []
+        for tier in tiers:
+            tier_error_count = len(errors)
+            if not isinstance(tier, dict):
+                errors.append(f"scaling family '{name}' tiers must contain objects")
+                continue
+            latency = tier.get("samples_ms")
+            memory = tier.get("peak_memory_samples_bytes")
+            for label, samples in (("latency", latency), ("peak memory", memory)):
+                if (
+                    not isinstance(samples, list)
+                    or len(samples) != iterations
+                    or any(
+                        not _is_finite_non_negative_number(value) or value <= 0
+                        for value in samples
+                    )
+                ):
+                    errors.append(
+                        f"scaling family '{name}' tier has invalid {label} samples"
+                    )
+            source = tier.get("source_metrics")
+            if not isinstance(source, dict) or any(
+                not isinstance(source.get(field), int)
+                or isinstance(source.get(field), bool)
+                or source[field] < 0
+                for field in ("bytes", "files", "lines", "tokens")
+            ):
+                errors.append(f"scaling family '{name}' tier has invalid source counters")
+            elif source["files"] == 0:
+                errors.append(f"scaling family '{name}' tier has no source files")
+            passes = tier.get("passes")
+            if not isinstance(passes, dict) or not passes:
+                errors.append(f"scaling family '{name}' tier has invalid pass counters")
+            else:
+                for pass_name, counters in passes.items():
+                    if not isinstance(pass_name, str) or not isinstance(counters, dict):
+                        errors.append(f"scaling family '{name}' tier has invalid pass counters")
+                        continue
+                    if not _is_finite_non_negative_number(counters.get("mean_ms")):
+                        errors.append(f"scaling family '{name}' tier has invalid pass timing")
+                    for field in ("invocations", "root_invocations", "leaf_invocations"):
+                        value = counters.get(field)
+                        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                            errors.append(
+                                f"scaling family '{name}' tier has invalid structural counter"
+                            )
+                    invocations = counters.get("invocations")
+                    roots = counters.get("root_invocations")
+                    leaves = counters.get("leaf_invocations")
+                    if (
+                        all(
+                            isinstance(value, int) and not isinstance(value, bool)
+                            for value in (invocations, roots, leaves)
+                        )
+                        and (invocations == 0 or roots > invocations or leaves > invocations)
+                    ):
+                        errors.append(
+                            f"scaling family '{name}' tier has inconsistent structural counters"
+                        )
+                if declared["focus_pass"] not in passes:
+                    errors.append(f"scaling family '{name}' tier lacks focus pass")
+            if len(errors) == tier_error_count:
+                raw_tiers.append(
+                    {
+                        "input_size": tier["input_size"],
+                        "samples_ms": latency,
+                        "peak_memory_samples_bytes": memory,
+                        "passes": passes,
+                        "source_metrics": source,
+                    }
+                )
+        if len(raw_tiers) == len(tiers):
+            try:
+                canonical = derive_family(declared, raw_tiers)
+            except (KeyError, TypeError, ValueError, ZeroDivisionError) as error:
+                errors.append(f"scaling family '{name}' evidence cannot be derived: {error}")
+            else:
+                canonical_families.append(canonical)
+                if family != canonical:
+                    errors.append(
+                        f"scaling family '{name}' derived claims do not match raw evidence"
+                    )
+    if len(canonical_families) == len(declared_families):
+        expected_status = budget_status(canonical_families)
+        if scaling.get("budget_status") != expected_status:
+            errors.append("scaling diagnostics root budget status is not canonical")
+        if expected_status == "failed":
+            errors.append("scaling diagnostics contain a proven complexity budget violation")
+        elif expected_status == "indeterminate":
+            errors.append("scaling diagnostics have insufficient evidence for publication")
+    return errors
 
-    duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
-    if duplicates:
-        raise ValueError(
-            "manifest contains duplicate benchmark name(s): " + ", ".join(duplicates)
-        )
 
-    return names
+def validate_manifest_results(data: object, manifest_path: Path) -> list[str]:
+    errors = (
+        validate_static_dimensions(manifest_path)
+        + validate_readme_inventory(manifest_path)
+        + validate_results(data, load_manifest_names(manifest_path))
+        + validate_scaling_results(data, manifest_path)
+    )
+    expected_suite = {
+        "kind": "synthetic_phase_probe",
+        "representative": False,
+        "aggregate_interpretation": "synthetic compiler phase diagnostics only",
+    }
+    if not isinstance(data, dict) or data.get("probe_suite") != expected_suite:
+        errors.append("benchmark result lacks non-representative phase-probe suite semantics")
+        return errors
+    declared = {probe["name"]: probe for probe in load_manifest(manifest_path)["benchmark"]}
+    for bench in data.get("benchmarks", []):
+        if not isinstance(bench, dict) or bench.get("name") not in declared:
+            continue
+        probe = declared[bench["name"]]
+        for field in (
+            "kind",
+            "subsystem",
+            "workload_family",
+            "interpretation",
+            "non_representative",
+            "dimensions",
+        ):
+            if bench.get(field) != probe[field]:
+                errors.append(f"benchmark '{bench['name']}' {field} does not match manifest")
+    return errors
 
 
 def validate_results(data: object, expected_names: list[str]) -> list[str]:
@@ -131,6 +282,36 @@ def validate_results(data: object, expected_names: list[str]) -> list[str]:
                         f"benchmark '{display_name}' pass '{pass_name}' has no "
                         "finite non-negative mean_ms"
                     )
+                if bench.get("timing_schema_version", 1) >= 2 and isinstance(
+                    pass_data, dict
+                ):
+                    counters = []
+                    for field in (
+                        "invocations",
+                        "root_invocations",
+                        "leaf_invocations",
+                    ):
+                        value = pass_data.get(field)
+                        counters.append(value)
+                        if (
+                            not isinstance(value, int)
+                            or isinstance(value, bool)
+                            or value < 0
+                        ):
+                            errors.append(
+                                f"benchmark '{display_name}' pass '{pass_name}' "
+                                f"has invalid {field}"
+                            )
+                    if all(
+                        isinstance(value, int) and not isinstance(value, bool)
+                        for value in counters
+                    ):
+                        invocations, roots, leaves = counters
+                        if invocations <= 0 or roots > invocations or leaves > invocations:
+                            errors.append(
+                                f"benchmark '{display_name}' pass '{pass_name}' "
+                                "has inconsistent structural counters"
+                            )
 
     duplicates = sorted(
         name for name, count in Counter(result_names).items() if count > 1

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -209,6 +209,16 @@ def get_binary_size(run: dict) -> float:
     return total_bytes / 1024
 
 
+def scaling_diagnostics(runs: list[dict]) -> dict | None:
+    """Return the latest explicitly non-representative scaling publication."""
+    if not runs:
+        return None
+    value = runs[-1].get("scaling")
+    if not isinstance(value, dict) or value.get("representative") is not False:
+        return None
+    return value
+
+
 def format_bytes(size_bytes: float) -> str:
     """Format bytes into human-readable form."""
     if size_bytes >= 1024 * 1024:
@@ -1242,6 +1252,7 @@ def generate_platform_charts(history_path: Path, output_dir: Path, platform: Opt
         "latest_commit": short_commit(runs[-1].get("commit", "")) if runs else None,
         "summary": summary,
         "latest_benchmarks": latest_benchmarks,
+        "latest_scaling": scaling_diagnostics(runs),
         "coverage": coverage,
         "regimes": regime_summary(runs),
         "metric_semantics": derive_history_metrics(runs),

--- a/scripts/scaling_workloads.py
+++ b/scripts/scaling_workloads.py
@@ -1,0 +1,93 @@
+"""Deterministic source generators for compiler scaling diagnostics.
+
+The generated programs are deliberately synthetic. They isolate monotonically
+growing compiler work; they do not model real applications or runtime speed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+GENERATOR_VERSION = 1
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def function_declarations(root: Path, size: int) -> Path:
+    lines = ["// deterministic frontend declaration scaling probe"]
+    lines.extend(f"fn f{i:04}(x: i32) -> i32 {{ x + {i} }}" for i in range(size))
+    lines.append(f"fn main() -> i32 {{ f{size - 1:04}(1) }}")
+    path = root / "main.rue"
+    _write(path, "\n".join(lines) + "\n")
+    return path
+
+
+def module_fanout(root: Path, size: int) -> Path:
+    lines = ["// deterministic module-discovery fanout scaling probe"]
+    for i in range(size):
+        lines.append(f'const m{i:04} = @import("modules/m{i:04}.rue");')
+        _write(root / f"modules/m{i:04}.rue", f"pub fn value() -> i32 {{ {i} }}\n")
+    lines.append(f"fn main() -> i32 {{ m{size - 1:04}.value() }}")
+    path = root / "main.rue"
+    _write(path, "\n".join(lines) + "\n")
+    return path
+
+
+def struct_declarations(root: Path, size: int) -> Path:
+    lines = ["// deterministic semantic/type scaling probe"]
+    lines.extend(
+        f"struct S{i:04} {{ a: i32, b: i32, c: i32, d: i32 }}"
+        for i in range(size)
+    )
+    lines.append(
+        f"fn main() -> i32 {{ let value = S{size - 1:04} "
+        "{ a: 1, b: 2, c: 3, d: 4 }; value.d }"
+    )
+    path = root / "main.rue"
+    _write(path, "\n".join(lines) + "\n")
+    return path
+
+
+def cfg_functions(root: Path, size: int) -> Path:
+    lines = ["// deterministic CFG scaling probe"]
+    lines.extend(
+        f"fn branch{i:04}(x: i32) -> i32 {{ if x < 0 {{ 0 }} "
+        f"else if x == {i} {{ {i} }} else {{ x + 1 }} }}"
+        for i in range(size)
+    )
+    lines.append(f"fn main() -> i32 {{ branch{size - 1:04}(1) }}")
+    path = root / "main.rue"
+    _write(path, "\n".join(lines) + "\n")
+    return path
+
+
+def backend_live_values(root: Path, size: int) -> Path:
+    lines = ["// deterministic backend/register-allocation scaling probe"]
+    body = " ".join(f"let v{i} = x + {i};" for i in range(24))
+    total = " + ".join(f"v{i}" for i in range(24))
+    lines.extend(f"fn pressure{i:04}(x: i32) -> i32 {{ {body} {total} }}" for i in range(size))
+    lines.append(f"fn main() -> i32 {{ pressure{size - 1:04}(1) }}")
+    path = root / "main.rue"
+    _write(path, "\n".join(lines) + "\n")
+    return path
+
+
+GENERATORS = {
+    "function_declarations": function_declarations,
+    "module_fanout": module_fanout,
+    "struct_declarations": struct_declarations,
+    "cfg_functions": cfg_functions,
+    "backend_live_values": backend_live_values,
+}
+
+
+def generate(name: str, root: Path, size: int) -> Path:
+    try:
+        generator = GENERATORS[name]
+    except KeyError as error:
+        raise ValueError(f"unknown scaling generator: {name}") from error
+    return generator(root, size)

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -46,6 +46,8 @@ evolution = load_module("benchmark_evolution", "scripts/benchmark_evolution.py")
 recent = load_module("benchmark_recent", "scripts/benchmark_recent.py")
 perf_baseline = load_module("perf_baseline", "scripts/perf-baseline.py")
 parser_profile = load_module("parser_profile", "scripts/parser-profile.py")
+manifest_tools = load_module("benchmark_manifest", "scripts/benchmark_manifest.py")
+scaling = load_module("benchmark_scaling", "scripts/benchmark_scaling.py")
 
 
 class PerfBaselineAggregationTests(unittest.TestCase):
@@ -685,7 +687,7 @@ class BenchmarkValidationTests(unittest.TestCase):
         )
 
     def valid_result(self):
-        return {
+        result = {
             "version": 1,
             "timestamp": "2026-07-09T00:00:00Z",
             "commit": "probe",
@@ -699,17 +701,393 @@ class BenchmarkValidationTests(unittest.TestCase):
                     "iterations": 5,
                     "samples_ms": [index + 0.5] * 5,
                     "timing_schema_version": 2,
-                    "passes": {"compile": {"mean_ms": index + 0.5}},
+                    "passes": {"compile": {
+                        "mean_ms": index + 0.5,
+                        "invocations": 1,
+                        "root_invocations": 1,
+                        "leaf_invocations": 0,
+                    }},
                 }
                 for index, name in enumerate(self.expected_names)
             ],
         }
+        manifest_path = INPUT_ROOT / "benchmarks" / "manifest.toml"
+        manifest_tools.enrich_results(result, manifest_path)
+        families = []
+        for family in manifest_tools.scaling_families(manifest_path):
+            tiers = [
+                {
+                    "input_size": size,
+                    "samples_ms": [float(size)] * 5,
+                    "peak_memory_samples_bytes": [size * 1024] * 5,
+                    "source_metrics": {
+                        "bytes": size * 8,
+                        "files": 1,
+                        "lines": size,
+                        "tokens": size * 4,
+                    },
+                    "passes": {
+                        family["focus_pass"]: {
+                            "mean_ms": float(size),
+                            "invocations": size,
+                            "root_invocations": 0,
+                            "leaf_invocations": size,
+                        }
+                    },
+                }
+                for size in family["sizes"]
+            ]
+            families.append(scaling.derive_family(family, tiers))
+        result["scaling"] = {
+            "schema_version": 1,
+            "measurement_family": "compiler_scaling_diagnostics",
+            "scenario_family": "synthetic_phase_probes",
+            "representative": False,
+            "iterations": 5,
+            "families": families,
+            "budget_status": "passed",
+        }
+        return result
 
     def test_exact_manifest_corpus_is_accepted(self):
         result = self.valid_result()
         self.assertEqual(validator.validate_results(result, self.expected_names), [])
         result["benchmarks"].reverse()
         self.assertEqual(validator.validate_results(result, self.expected_names), [])
+
+    def test_manifest_classifies_every_probe_and_verified_dimensions_match(self):
+        manifest_path = INPUT_ROOT / "benchmarks" / "manifest.toml"
+        manifest = manifest_tools.load_manifest(manifest_path)
+        self.assertEqual(manifest_tools.validate_static_dimensions(manifest_path), [])
+        self.assertEqual(manifest_tools.validate_readme_inventory(manifest_path), [])
+        self.assertEqual(len(manifest["benchmark"]), 7)
+        self.assertEqual(len(manifest["scaling_family"]), 5)
+        for probe in manifest["benchmark"]:
+            self.assertEqual(probe["kind"], "synthetic_phase_probe")
+            self.assertIn("not representative", probe["non_representative"].lower())
+            self.assertTrue(probe["subsystem"])
+            self.assertTrue(probe["workload_family"])
+        for family in manifest["scaling_family"]:
+            self.assertIn("not", family["non_representative"].lower())
+            self.assertIn("runtime", family["non_representative"].lower())
+        subsystems = {family["subsystem"].split("/", 1)[0] for family in manifest["scaling_family"]}
+        self.assertEqual(subsystems, {"frontend", "semantic", "cfg", "backend"})
+
+    def test_append_authority_rejects_copied_manifest_with_false_dimensions(self):
+        original = INPUT_ROOT / "benchmarks/manifest.toml"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            copied = root / "benchmarks/manifest.toml"
+            copied.parent.mkdir()
+            copied.write_text(
+                original.read_text().replace(
+                    "dimensions = { source_lines = 2120,",
+                    "dimensions = { source_lines = 2121,",
+                    1,
+                )
+            )
+            (copied.parent / "README.md").write_bytes(
+                (original.parent / "README.md").read_bytes()
+            )
+            for relative, source in manifest_tools.corpus_paths(original):
+                target = copied.parent / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(source.read_bytes())
+            errors = validator.validate_manifest_results(self.valid_result(), copied)
+        self.assertTrue(any("manifest=2121, source=2120" in error for error in errors))
+
+    def test_scaling_generators_are_deterministic_and_monotonic(self):
+        workload_module = load_module("scaling_workloads_test", "scripts/scaling_workloads.py")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for name in workload_module.GENERATORS:
+                first = workload_module.generate(name, root / "first", 12)
+                second = workload_module.generate(name, root / "second", 12)
+                first_files = sorted(
+                    (path.relative_to(first.parent), path.read_text())
+                    for path in first.parent.rglob("*.rue")
+                )
+                second_files = sorted(
+                    (path.relative_to(second.parent), path.read_text())
+                    for path in second.parent.rglob("*.rue")
+                )
+                self.assertEqual(first_files, second_files)
+                larger = workload_module.generate(name, root / "larger", 36)
+                self.assertGreater(
+                    sum(path.stat().st_size for path in larger.parent.rglob("*.rue")),
+                    sum(path.stat().st_size for path in first.parent.rglob("*.rue")),
+                )
+
+    def test_scaling_growth_budget_is_size_normalized(self):
+        family = manifest_tools.scaling_families(INPUT_ROOT / "benchmarks/manifest.toml")[0]
+        def tier(size, latency, samples=5):
+            return {
+                "input_size": size,
+                "samples_ms": [latency] * samples,
+                "peak_memory_samples_bytes": [size * 1024] * samples,
+                "source_metrics": {"bytes": size, "files": 1, "lines": size, "tokens": size},
+                "passes": {family["focus_pass"]: {
+                    "mean_ms": latency,
+                    "invocations": 1,
+                    "root_invocations": 0,
+                    "leaf_invocations": 1,
+                }},
+            }
+
+        quiet = scaling.derive_family(
+            family, [tier(100, 10.0), tier(300, 30.0), tier(900, 90.0)]
+        )
+        self.assertEqual(
+            quiet["adjacent_growth"][0]["latency_per_unit_growth"]["center"],
+            1.0,
+        )
+        self.assertEqual(quiet["classification"], "within_normalized_growth_budget")
+        self.assertEqual(scaling.budget_status([quiet]), "passed")
+
+        proven = scaling.derive_family(
+            family, [tier(100, 10.0), tier(300, 90.0), tier(900, 810.0)]
+        )
+        self.assertEqual(proven["classification"], "budget_exceeded")
+        self.assertEqual(scaling.budget_status([proven]), "failed")
+        self.assertGreater(
+            proven["adjacent_growth"][0]["latency_per_unit_growth"]["lower_bound"],
+            family["latency_per_unit_growth_budget"],
+        )
+
+        noisy_tiers = [tier(100, 10.0), tier(300, 60.0), tier(900, 180.0)]
+        noisy_tiers[0]["samples_ms"] = [9.0, 10.0, 11.0]
+        noisy_tiers[1]["samples_ms"] = [50.0, 60.0, 70.0]
+        noisy_tiers[2]["samples_ms"] = [150.0, 180.0, 210.0]
+        noisy = scaling.derive_family(family, noisy_tiers)
+        self.assertEqual(noisy["classification"], "indeterminate")
+        self.assertEqual(scaling.budget_status([noisy]), "indeterminate")
+        self.assertEqual(
+            noisy["adjacent_growth"][0]["latency_per_unit_growth"]["reason"],
+            "uncertainty_crosses_budget",
+        )
+
+        one_sample = scaling.derive_family(
+            family,
+            [tier(100, 10.0, 1), tier(300, 90.0, 1), tier(900, 810.0, 1)],
+        )
+        self.assertEqual(one_sample["classification"], "indeterminate")
+        self.assertEqual(
+            one_sample["adjacent_growth"][0]["latency_per_unit_growth"]["reason"],
+            "at_least_three_samples_required",
+        )
+
+        extreme_tiers = [
+            tier(100, 10.0),
+            tier(300, 30.0),
+            tier(900, 90.0),
+        ]
+        for current, center in zip(extreme_tiers, (10.0, 30.0, 90.0)):
+            current["samples_ms"] = [center, center, center, center * 100, center * 100]
+        extreme = scaling.derive_family(family, extreme_tiers)
+        summary = extreme["tiers"][0]["latency_summary_ms"]
+        self.assertEqual(summary["scaled_mad"], 0.0)
+        self.assertEqual(summary["minimum"], 10.0)
+        self.assertEqual(summary["maximum"], 1000.0)
+        self.assertEqual(summary["range"], 990.0)
+        self.assertEqual(summary["dispersion_classification"], "extreme_range")
+        self.assertEqual(extreme["classification"], "indeterminate")
+        self.assertEqual(scaling.budget_status([extreme]), "indeterminate")
+        self.assertEqual(
+            extreme["adjacent_growth"][0]["latency_per_unit_growth"]["reason"],
+            "extreme_sample_range",
+        )
+        self.assertIn("per_tier_compile_timeout_seconds", quiet["budgets"])
+
+    def test_scaling_cli_enforcement_rejects_failed_and_indeterminate(self):
+        manifest_path = INPUT_ROOT / "benchmarks/manifest.toml"
+        argv = [
+            "benchmark_scaling.py",
+            "--manifest",
+            str(manifest_path),
+            "--rue-bin",
+            "/unused/rue",
+            "--enforce-budgets",
+        ]
+        failed = {
+            "budget_status": "failed",
+            "families": [
+                {
+                    "name": "probe",
+                    "classification": "budget_exceeded",
+                    "violations": [
+                        {
+                            "metric": "latency",
+                            "from_size": 1,
+                            "to_size": 2,
+                            "lower_bound": 3.0,
+                            "budget": 2.0,
+                        }
+                    ],
+                }
+            ],
+        }
+        indeterminate = {
+            "budget_status": "indeterminate",
+            "families": [
+                {
+                    "name": "probe",
+                    "classification": "indeterminate",
+                    "violations": [],
+                    "adjacent_growth": [
+                        {
+                            "latency_per_unit_growth": {
+                                "classification": "indeterminate",
+                                "reason": "extreme_sample_range",
+                            },
+                            "memory_per_unit_growth": {
+                                "classification": "within_budget",
+                                "reason": None,
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        for result, expected, diagnostic in (
+            (failed, 2, "Budget violation"),
+            (indeterminate, 3, "Insufficient scaling evidence"),
+        ):
+            with self.subTest(status=result["budget_status"]):
+                with mock.patch.object(sys, "argv", argv), mock.patch.object(
+                    scaling, "run_scaling", return_value=result
+                ), mock.patch("builtins.print") as printer:
+                    self.assertEqual(scaling.main(), expected)
+                self.assertTrue(
+                    any(diagnostic in str(call) for call in printer.call_args_list)
+                )
+
+    def test_scaling_runner_enforces_bounded_per_tier_compile_timeout(self):
+        family = manifest_tools.scaling_families(INPUT_ROOT / "benchmarks/manifest.toml")[0]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with mock.patch.object(scaling, "generate", return_value=Path(temp_dir) / "main.rue"):
+                with mock.patch.object(
+                    scaling,
+                    "compile_once",
+                    side_effect=subprocess.TimeoutExpired(["rue"], family["timeout_seconds"]),
+                ):
+                    with self.assertRaisesRegex(RuntimeError, "timed out after 20s"):
+                        scaling.run_family(family, Path("rue"), 1, "darwin", Path(temp_dir))
+
+    def test_scaling_validation_requires_structural_counters_and_exact_tiers(self):
+        result = self.valid_result()
+        manifest_path = INPUT_ROOT / "benchmarks/manifest.toml"
+        self.assertEqual(validator.validate_manifest_results(result, manifest_path), [])
+        family = result["scaling"]["families"][0]
+        del family["tiers"][0]["passes"][family["focus_pass"]]["invocations"]
+        self.assertTrue(
+            any(
+                "structural counter" in error
+                for error in validator.validate_manifest_results(
+                    result, manifest_path
+                )
+            )
+        )
+
+    def test_scaling_validation_rederives_all_claims_and_rejects_bad_raw_evidence(self):
+        manifest_path = INPUT_ROOT / "benchmarks/manifest.toml"
+        mutations = [
+            lambda result: result["scaling"].update(measurement_family="other"),
+            lambda result: result["scaling"]["families"][0].update(
+                classification="budget_exceeded"
+            ),
+            lambda result: result["scaling"]["families"][0]["adjacent_growth"][0][
+                "latency_per_unit_growth"
+            ].update(lower_bound=0.0),
+            lambda result: result["scaling"]["families"][0]["tiers"][0][
+                "samples_ms"
+            ].__setitem__(0, float("nan")),
+            lambda result: result["scaling"]["families"][0]["tiers"][0][
+                "peak_memory_samples_bytes"
+            ].__setitem__(0, True),
+            lambda result: result["scaling"]["families"][0]["tiers"][0][
+                "passes"
+            ][result["scaling"]["families"][0]["focus_pass"]].update(
+                invocations=True
+            ),
+            lambda result: result["scaling"]["families"][0]["tiers"][0][
+                "passes"
+            ][result["scaling"]["families"][0]["focus_pass"]].update(
+                invocations=0
+            ),
+            lambda result: result["scaling"]["families"][0].update(tiers=None),
+            lambda result: result["scaling"].update(budget_status="failed"),
+        ]
+        for mutate in mutations:
+            with self.subTest(mutation=mutate):
+                result = self.valid_result()
+                mutate(result)
+                self.assertTrue(validator.validate_manifest_results(result, manifest_path))
+
+        proven = self.valid_result()
+        declared = manifest_tools.scaling_families(manifest_path)[0]
+        existing = proven["scaling"]["families"][0]["tiers"]
+        raw = [
+            {
+                "input_size": tier["input_size"],
+                "samples_ms": [value] * 5,
+                "peak_memory_samples_bytes": tier["peak_memory_samples_bytes"],
+                "passes": tier["passes"],
+                "source_metrics": tier["source_metrics"],
+            }
+            for tier, value in zip(existing, (10.0, 90.0, 810.0))
+        ]
+        proven["scaling"]["families"][0] = scaling.derive_family(declared, raw)
+        proven["scaling"]["budget_status"] = "failed"
+        self.assertTrue(
+            any(
+                "proven complexity budget violation" in error
+                for error in validator.validate_manifest_results(proven, manifest_path)
+            )
+        )
+
+        indeterminate = self.valid_result()
+        declared = manifest_tools.scaling_families(manifest_path)[0]
+        existing = indeterminate["scaling"]["families"][0]["tiers"]
+        raw = []
+        for tier, center in zip(existing, (10.0, 30.0, 90.0)):
+            raw.append(
+                {
+                    "input_size": tier["input_size"],
+                    "samples_ms": [center, center, center, center * 100, center * 100],
+                    "peak_memory_samples_bytes": tier["peak_memory_samples_bytes"],
+                    "passes": tier["passes"],
+                    "source_metrics": tier["source_metrics"],
+                }
+            )
+        indeterminate["scaling"]["families"][0] = scaling.derive_family(
+            declared, raw
+        )
+        indeterminate["scaling"]["budget_status"] = "indeterminate"
+        self.assertTrue(
+            any(
+                "insufficient evidence for publication" in error
+                for error in validator.validate_manifest_results(
+                    indeterminate, manifest_path
+                )
+            )
+        )
+
+    def test_website_publishes_scaling_separately_from_phase_probe_headline(self):
+        template = (INPUT_ROOT / "website/templates/performance.html").read_text()
+        self.assertIn("Synthetic compiler scaling diagnostics", template)
+        self.assertIn("excluded from the aggregate headline", template)
+        self.assertIn("latency_per_unit_growth", template)
+        self.assertIn("<caption", template)
+        self.assertIn('scope="col"', template)
+        self.assertIn("scaled_mad", template)
+        self.assertIn("extreme dispersion", template)
+        result = self.valid_result()
+        self.assertIs(charts.scaling_diagnostics([result]), result["scaling"])
+        phase_total = charts.get_total_time(result)
+        result["scaling"]["families"][0]["tiers"][0]["median_ms"] = 10**12
+        self.assertEqual(charts.get_total_time(result), phase_total)
+        representative = {"scaling": {**result["scaling"], "representative": True}}
+        self.assertIsNone(charts.scaling_diagnostics([representative]))
 
     def test_missing_unknown_and_duplicate_names_are_rejected(self):
         missing = self.valid_result()
@@ -812,14 +1190,14 @@ class BenchmarkValidationTests(unittest.TestCase):
     def test_duplicate_and_malformed_manifest_entries_are_rejected(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             manifest_path = Path(temp_dir) / "manifest.toml"
-            manifest_path.write_text(
-                '[[benchmark]]\nname = "same"\npath = "a.rue"\n'
-                '[[benchmark]]\nname = "same"\npath = "b.rue"\n'
-            )
+            source = (INPUT_ROOT / "benchmarks/manifest.toml").read_text()
+            manifest_path.write_text(source.replace(
+                'name = "deep_nesting"', 'name = "many_functions"', 1
+            ))
             with self.assertRaisesRegex(ValueError, "duplicate benchmark name"):
                 validator.load_manifest_names(manifest_path)
 
-            manifest_path.write_text('[[benchmark]]\npath = "missing-name.rue"\n')
+            manifest_path.write_text(source.replace('name = "many_functions"\n', "", 1))
             with self.assertRaisesRegex(ValueError, "has no valid name"):
                 validator.load_manifest_names(manifest_path)
 
@@ -958,7 +1336,7 @@ class DurableBenchmarkHistoryTests(unittest.TestCase):
                 self.assertTrue(publication["coverage"]["gap_unknown"])
 
     def test_regime_ignores_commit_but_tracks_comparability_dimensions(self):
-        corpus = {"schema_version": 1, "sha256": "a" * 64}
+        corpus = {"schema_version": 2, "sha256": "a" * 64}
         base = {
             "commit": "one",
             "build_mode": "release",
@@ -972,6 +1350,73 @@ class DurableBenchmarkHistoryTests(unittest.TestCase):
         self.assertEqual(first["id"], changed_commit["id"])
         self.assertNotEqual(first["id"], changed_iterations["id"])
         self.assertNotEqual(first["id"], changed_runner["id"])
+
+    def test_corpus_hash_includes_scaling_generator_definitions(self):
+        manifest = INPUT_ROOT / "benchmarks/manifest.toml"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            copied_manifest = root / "benchmarks/manifest.toml"
+            copied_manifest.parent.mkdir()
+            copied_manifest.write_bytes(manifest.read_bytes())
+            for relative, source in manifest_tools.corpus_paths(manifest):
+                target = copied_manifest.parent / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(source.read_bytes())
+            before = history_tools.corpus_metadata(copied_manifest)
+            generator = root / "scripts/scaling_workloads.py"
+            generator.write_text(generator.read_text() + "\n# workload definition changed\n")
+            after = history_tools.corpus_metadata(copied_manifest)
+        self.assertEqual(before["schema_version"], 2)
+        self.assertIn("../scripts/scaling_workloads.py", before["files"])
+        self.assertNotEqual(before["sha256"], after["sha256"])
+
+    def test_schema_one_and_two_corpora_remain_loadable_across_regime_boundary(self):
+        def published(schema, digest, commit):
+            run = {
+                "timestamp": f"2026-07-{schema:02d}T00:00:00Z",
+                "commit": commit,
+                "build_mode": "release",
+                "iterations": 3,
+                "measurement_family": "compiler",
+                "scenario_family": "cold_compilation",
+                "benchmarks": [{
+                    "name": "probe",
+                    "samples_ms": [10.0, 10.0, 10.0],
+                    "mean_ms": 10.0,
+                    "passes": {"compile": {"mean_ms": 10.0}},
+                    "timing_schema_version": 2,
+                }],
+            }
+            corpus = {"schema_version": schema, "sha256": digest, "files": []}
+            regime = history_tools.regime_metadata(run, "x86-64-linux", "runner", corpus)
+            run["publication"] = {
+                "schema_version": 3,
+                "comparable": True,
+                "regime_id": regime["id"],
+                "regime": regime["dimensions"],
+                "corpus": corpus,
+                "timing_schema_versions": [2],
+                "build_mode": "release",
+                "compiler": {"commit": commit, "identity": f"rue@{commit}"},
+                "iteration_policy": {"kind": "fixed", "iterations": 3},
+                "platform": "x86-64-linux",
+                "runner": {"image": "runner", "host": None},
+                "metric_semantics": {"measurement_family": "compiler", "scenario_family": "cold_compilation"},
+                "trigger_reason": "push",
+                "coverage": {"measured_commit": commit, "represented_commits": [commit], "skipped_commits": [], "gap_unknown": False},
+            }
+            self.assertEqual(history_tools.validate_publication(run), [])
+            return run
+
+        old = published(1, "a" * 64, "old")
+        current = published(2, "b" * 64, "current")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "history"
+            history_tools.save_history(path, [old, current], "x86-64-linux")
+            loaded = history_tools.load_history(path)["runs"]
+        self.assertEqual(len(loaded), 2)
+        self.assertTrue(history_tools.comparison_break(loaded[0], loaded[1]))
+        self.assertEqual(metrics.compare_runs(loaded[1], loaded[0])["status"], "non_comparable")
 
     def test_coverage_makes_skipped_commits_and_unknown_gaps_explicit(self):
         completed = subprocess.CompletedProcess([], 0, "middle\ncurrent\n", "")
@@ -2039,7 +2484,12 @@ class BenchmarkCollectionTests(unittest.TestCase):
         result = collection.aggregate_iterations(
             [self.payload(2.0), self.payload(4.0)]
         )
-        self.assertEqual(result["passes"], {"lexer": {"mean_ms": 1.0}})
+        self.assertEqual(result["passes"], {"lexer": {
+            "mean_ms": 1.0,
+            "invocations": 1,
+            "root_invocations": 0,
+            "leaf_invocations": 1,
+        }})
 
     def test_malformed_timing_or_pass_payload_aborts_collection(self):
         bad_payloads = [
@@ -2095,6 +2545,12 @@ class BenchmarkCollectionTests(unittest.TestCase):
         changed = json.loads(self.payload())
         changed["passes"][0]["name"] = "parser"
         with self.assertRaisesRegex(ValueError, "pass set changed"):
+            collection.aggregate_iterations([self.payload(), json.dumps(changed)])
+
+    def test_rejects_structural_counter_drift_between_iterations(self):
+        changed = json.loads(self.payload())
+        changed["passes"][0].update(invocations=2, leaf_invocations=2)
+        with self.assertRaisesRegex(ValueError, "invocation structure changed"):
             collection.aggregate_iterations([self.payload(), json.dumps(changed)])
 
 

--- a/scripts/validate-benchmark.py
+++ b/scripts/validate-benchmark.py
@@ -19,6 +19,7 @@ from benchmark_validation import (
     DEFAULT_MANIFEST,
     load_manifest_names,
     validate_results,
+    validate_manifest_results,
 )
 
 
@@ -36,7 +37,7 @@ def main() -> int:
     try:
         with args.results.open() as f:
             data = json.load(f)
-        expected_names = load_manifest_names(args.manifest)
+        errors = validate_manifest_results(data, args.manifest)
     except (OSError, ValueError) as error:
         print(f"::error::Cannot validate benchmark results: {error}")
         return 1
@@ -54,7 +55,6 @@ def main() -> int:
         if isinstance(mean, (int, float)) and not isinstance(mean, bool):
             print(f"  - {name}: {mean:.2f}ms")
 
-    errors = validate_results(data, expected_names)
     for error in errors:
         print(f"::error::{error}")
 

--- a/website/content/performance.md
+++ b/website/content/performance.md
@@ -3,5 +3,8 @@ title = "Performance"
 template = "performance.html"
 +++
 
-The Rue compiler is designed for fast compilation. This dashboard tracks compilation
-performance over time, helping detect regressions and measure the impact of optimizations.
+This dashboard publishes synthetic compiler phase probes and deterministic
+scaling diagnostics. They help locate compiler regressions; they are not
+representative applications and do not measure compiled-program runtime
+performance. Representative RUE-901 scenarios will remain a separate metric
+family and headline.

--- a/website/static/benchmarks/README.md
+++ b/website/static/benchmarks/README.md
@@ -22,6 +22,15 @@ Version 3 uses a compact index whose `shards` array points to per-run files:
 }
 ```
 
+Each new run contains two deliberately separate products: `benchmarks` holds
+the non-representative static phase-probe aggregate, while `scaling` holds
+generated multi-size families with latency, peak memory, source/pass structural
+counters, robust variation, conservative adjacent size-normalized growth
+bounds, an extreme-range guard, and proven/indeterminate/within-budget evidence
+status. Failed and indeterminate scaling evidence both block publication.
+Neither product measures generated-program runtime performance; representative
+RUE-901 scenarios use a different scenario family and headline.
+
 ## Updating History
 
 History is updated automatically by CI on each commit to trunk. To run manually:

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -146,6 +146,18 @@
             </div>
         </section>
 
+        <section id="scaling-section" class="mb-12">
+            <h2 class="section-title">Synthetic compiler scaling diagnostics</h2>
+            <p class="text-muted mb-4">
+                These generated phase probes are not representative applications and say nothing about
+                compiled-program runtime performance. Adjacent ratios show whether latency and peak-memory
+                growth outpaces input growth; they are excluded from the aggregate headline above.
+            </p>
+            <div id="scaling-container">
+                <p class="text-muted text-center py-8">Loading scaling diagnostics...</p>
+            </div>
+        </section>
+
         <script>
         (function() {
             const platformSelect = document.getElementById('platform-select');
@@ -175,6 +187,8 @@
             const binaryContainer = document.getElementById('binary-chart-container');
             const metricsSection = document.getElementById('metrics-section');
             const metricsContainer = document.getElementById('metrics-table-container');
+            const scalingSection = document.getElementById('scaling-section');
+            const scalingContainer = document.getElementById('scaling-container');
 
             let currentPlatform = 'comparison';
             let platformMetadata = null;
@@ -622,6 +636,50 @@
                 metricsContainer.innerHTML = html;
             }
 
+            function updateScaling(scaling) {
+                if (!scaling || !scaling.families?.length) {
+                    scalingContainer.innerHTML = '<p class="text-muted text-center py-8">No scaling diagnostics available</p>';
+                    return;
+                }
+                scalingContainer.replaceChildren();
+                const growthText = evidence => {
+                    if (!evidence) return '-';
+                    if (evidence.lower_bound === null || evidence.upper_bound === null) {
+                        return `${evidence.center.toFixed(2)} (indeterminate)`;
+                    }
+                    return `${evidence.center.toFixed(2)} [${evidence.lower_bound.toFixed(2)}, ${evidence.upper_bound.toFixed(2)}]`;
+                };
+                const summaryText = (summary, divisor = 1) => {
+                    if (summary.dispersion_classification === 'extreme_range') {
+                        return `${(summary.center / divisor).toFixed(2)}; range ${(summary.minimum / divisor).toFixed(2)}–${(summary.maximum / divisor).toFixed(2)} (extreme dispersion)`;
+                    }
+                    return `${(summary.center / divisor).toFixed(2)} ± ${(summary.scaled_mad / divisor).toFixed(2)}`;
+                };
+                scaling.families.forEach(family => {
+                    const card = node('div', undefined, 'bg-surface border border-themed rounded-lg p-4 mb-4');
+                    card.appendChild(node('h3', family.name.replaceAll('_', ' ')));
+                    card.appendChild(node('p', `${family.interpretation} ${family.non_representative}`, 'text-sm text-muted mb-3'));
+                    let html = `<table class="w-full text-sm"><caption class="text-left text-xs text-muted mb-2">${escapeHtml(family.name.replaceAll('_', ' '))}: input size, observed variation, and conservative adjacent growth bounds</caption><thead><tr>`;
+                    html += `<th scope="col" class="text-left p-2">${escapeHtml(family.input_axis)}</th><th scope="col" class="text-right p-2">Latency dispersion (ms)</th>`;
+                    html += '<th scope="col" class="text-right p-2">Peak memory dispersion (MB)</th><th scope="col" class="text-right p-2">Lines</th><th scope="col" class="text-right p-2">Tokens</th>';
+                    html += `<th scope="col" class="text-right p-2">${escapeHtml(family.focus_pass)} invocations</th><th scope="col" class="text-right p-2">Latency/unit center [bounds]</th><th scope="col" class="text-right p-2">Memory/unit center [bounds]</th><th scope="col" class="text-left p-2">Evidence</th></tr></thead><tbody>`;
+                    family.tiers.forEach((tier, index) => {
+                        const growth = index ? family.adjacent_growth[index - 1] : null;
+                        const focus = tier.passes?.[family.focus_pass] || {};
+                        html += '<tr class="border-t border-themed">';
+                        html += `<td class="p-2">${tier.input_size.toLocaleString()}</td><td class="p-2 text-right">${summaryText(tier.latency_summary_ms)}</td>`;
+                        html += `<td class="p-2 text-right">${summaryText(tier.peak_memory_summary_bytes, 1048576)}</td>`;
+                        html += `<td class="p-2 text-right">${tier.source_metrics?.lines?.toLocaleString() || '-'}</td><td class="p-2 text-right">${tier.source_metrics?.tokens?.toLocaleString() || '-'}</td>`;
+                        html += `<td class="p-2 text-right">${focus.invocations?.toLocaleString() || '-'}</td>`;
+                        html += `<td class="p-2 text-right">${growthText(growth?.latency_per_unit_growth)}</td><td class="p-2 text-right">${growthText(growth?.memory_per_unit_growth)}</td><td class="p-2">${escapeHtml(growth?.classification || 'baseline tier')}</td></tr>`;
+                    });
+                    html += '</tbody></table>';
+                    const table = node('div', undefined, 'overflow-x-auto'); table.innerHTML = html; card.appendChild(table);
+                    card.appendChild(node('p', `Budget status: ${family.classification}; per-tier timeout ${family.budgets.per_tier_compile_timeout_seconds}s.`, 'text-xs text-muted mt-2'));
+                    scalingContainer.appendChild(card);
+                });
+            }
+
             // Load data for a specific platform
             function loadPlatformData(platform) {
                 currentPlatform = platform;
@@ -635,6 +693,7 @@
                     memorySection.style.display = 'none';
                     binarySection.style.display = 'none';
                     metricsSection.style.display = 'none';
+                    scalingSection.style.display = 'none';
 
                     fetch('/benchmarks/comparison/metadata.json')
                         .then(r => r.json())
@@ -659,6 +718,7 @@
                     memorySection.style.display = 'block';
                     binarySection.style.display = 'block';
                     metricsSection.style.display = 'block';
+                    scalingSection.style.display = 'block';
 
                     const basePath = `/benchmarks/platforms/${platform}`;
 
@@ -673,6 +733,7 @@
                         .then(data => {
                             updateStats(data.summary);
                             updateMetricsTable(data.latest_benchmarks);
+                            updateScaling(data.latest_scaling);
                             renderRecentWorkspace(data.recent_workspace);
                             renderEvolutionWorkspace(data.evolution_workspace, false);
 
@@ -691,6 +752,7 @@
                         .catch(() => {
                             updateStats(null);
                             updateMetricsTable(null);
+                            updateScaling(null);
                         });
                 }
             }
@@ -732,6 +794,7 @@
                     memorySection.style.display = 'block';
                     binarySection.style.display = 'block';
                     metricsSection.style.display = 'block';
+                    scalingSection.style.display = 'block';
 
                     loadSvg(timelineContainer, '/benchmarks/timeline.svg');
                     loadSvg(breakdownContainer, '/benchmarks/breakdown.svg');
@@ -744,6 +807,7 @@
                         .then(data => {
                             updateStats(data.summary);
                             updateMetricsTable(data.latest_benchmarks);
+                            updateScaling(data.latest_scaling);
 
                             // Populate benchmark dropdown
                             if (data.benchmarks && data.benchmarks.length > 0) {


### PR DESCRIPTION
Summary:
- classify static synthetic phase probes from one validated manifest
- add five deterministic multi-tier scaling families with robust time, memory, and structural evidence
- publish scaling separately and version corpus definitions

Validation:
- benchmark tool tests (100/100)
- Buck benchmark-tool target
- end-to-end benchmark smoke
- website build and inline JavaScript parse
- scripts/rue quick

Fixes RUE-900