### PR TITLE
RUE-901: add representative compiler scenarios

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -97,9 +97,7 @@ filegroup(
     srcs = glob(["docs/designs/**"]),
 )
 
-filegroup(
-    name = "benchmark-tool-inputs",
-    srcs = glob(["benchmarks/**"]) + [
+benchmark_tool_local_inputs = glob(["benchmarks/**"]) + [
         "scripts/append-benchmark.py",
         "scripts/benchmark_collection.py",
         "scripts/benchmark_manifest.py",
@@ -109,6 +107,7 @@ filegroup(
         "scripts/benchmark_history.py",
         "scripts/benchmark_metrics.py",
         "scripts/benchmark_recent.py",
+        "scripts/benchmark_scenarios.py",
         "scripts/benchmark_validation.py",
         "scripts/generate-charts.py",
         "scripts/generate-site-status.py",
@@ -119,7 +118,23 @@ filegroup(
         "website/build.sh",
         "website/templates/performance.html",
         "website/templates/index.html",
-    ],
+    ]
+
+filegroup(
+    name = "benchmark-tool-inputs",
+    srcs = dict([(path, path) for path in benchmark_tool_local_inputs] + [
+        ("benchmarks/scenarios/representative/labels.rue", "//benchmarks/scenarios/representative:labels.rue"),
+        ("benchmarks/scenarios/representative/labels_alt.rue", "//benchmarks/scenarios/representative:labels_alt.rue"),
+        ("benchmarks/scenarios/representative/main.rue", "//benchmarks/scenarios/representative:main.rue"),
+        ("benchmarks/scenarios/representative/model.rue", "//benchmarks/scenarios/representative:model.rue"),
+        ("benchmarks/scenarios/representative/report.rue", "//benchmarks/scenarios/representative:report.rue"),
+        ("benchmarks/scenarios/representative/std/_std.rue", "//benchmarks/scenarios/representative:std_root.rue"),
+        ("benchmarks/scenarios/representative/std/math.rue", "//benchmarks/scenarios/representative:std_math.rue"),
+        ("benchmarks/scenarios/representative/worker.rue", "//benchmarks/scenarios/representative:worker.rue"),
+        ("crates/rue/src/main.rs", "//crates/rue:benchmark-definition"),
+        ("crates/rue-compiler-session-bench/src/main.rs", "//crates/rue-compiler-session-bench:benchmark-main-definition"),
+        ("crates/rue-compiler-session-bench/src/representative.rs", "//crates/rue-compiler-session-bench:benchmark-representative-definition"),
+    ]),
 )
 
 sh_test(

--- a/bench.sh
+++ b/bench.sh
@@ -123,6 +123,7 @@ if [[ ! -x "$RUE_BIN" ]]; then
 fi
 
 log_info "Using compiler: $RUE_BIN"
+SESSION_BENCH_BIN="$(./scripts/rue-bin --session-bench --target-platforms //platforms:$BUILD_MODE)"
 
 # Create temp directory for outputs
 TEMP_DIR=$(mktemp -d)
@@ -321,6 +322,11 @@ scaling_json=$(PYTHONPATH="$SCRIPT_DIR/scripts" python3 "$SCRIPT_DIR/scripts/ben
     --manifest "$MANIFEST" --rue-bin "$RUE_BIN" --iterations "$ITERATIONS" \
     --platform "$os" --enforce-budgets)
 
+log_info "Running representative compiler build/query scenarios..."
+scenario_json=$(PYTHONPATH="$SCRIPT_DIR/scripts" python3 "$SCRIPT_DIR/scripts/benchmark_scenarios.py" \
+    --manifest "$MANIFEST" --rue-bin "$RUE_BIN" \
+    --session-bench-bin "$SESSION_BENCH_BIN" --iterations "$ITERATIONS")
+
 # Get metadata
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Get commit hash - try jj first (for local dev), fall back to git (for CI)
@@ -356,6 +362,7 @@ cat > "$RESULTS_FILE" << EOF
   },
   "iterations": $ITERATIONS,
   "scaling": $scaling_json,
+  "scenarios": $scenario_json,
   "benchmarks": [
 EOF
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,9 +1,10 @@
 # Rue Compiler Benchmarks
 
-This directory contains synthetic compiler phase probes. They are diagnostic
+This directory contains synthetic compiler phase probes plus one tracked
+representative compiler fixture. The phase probes are diagnostic
 inputs, not representative Rue applications, and they do not measure the
-runtime performance of compiled programs. Representative scenarios are a
-separate RUE-901 concern and must not be mixed into this aggregate.
+runtime performance of compiled programs. The representative cold/reused
+scenario families are published separately and never enter this aggregate.
 
 ## Structure
 
@@ -71,7 +72,9 @@ The benchmark runner:
 6. Publishes latency, peak memory, robust median/scaled-MAD variation,
    source/pass structural counters, adjacent size-normalized growth bounds,
    and evidence classifications as JSON
-7. Appends to partitioned website history (unless `--no-history`)
+7. Runs the representative root through the real cold batch driver and a fixed
+   edit sequence through canonical `CompilerSession` queries
+8. Appends to partitioned website history (unless `--no-history`)
 
 Scaling tiers have bounded per-compile timeouts plus adjacent-tier latency/unit
 and memory/unit budgets. A violation requires the conservative lower growth
@@ -82,6 +85,17 @@ Both proven violations and indeterminate evidence fail enforcement and are not
 publishable. Passing a loose bound is not a claim of linear complexity.
 Absolute time is shown but is not the complexity budget. The scaling section
 is separate from the static phase-probe aggregate.
+
+`scenarios/representative` is a deterministic multi-module root/import graph
+with control flow, typed functions, strings, and an adjacent minimal standard
+library. Every session variant contains only its root's actual transitive
+closure; the import edit removes one leaf and adds its replacement. Cold
+samples require byte-identical raw compiler output both across iterations and
+against the exact fresh/reused `CompilerSession` base executable. Reused-session
+samples require exact fresh-session artifact/diagnostic/output parity and
+publish direct required/reused module, semantic-body, CFG, and semantic-query
+counters. Unsupported durable conversions fail closed and are reported as
+rebuilds; elapsed time is never used to infer reuse.
 
 ### Running Individual Benchmarks
 

--- a/benchmarks/manifest.toml
+++ b/benchmarks/manifest.toml
@@ -1,9 +1,49 @@
-schema_version = 2
+schema_version = 3
 
 # This is a suite of synthetic compiler diagnostics, not an application suite.
 # Generator definitions participate in the canonical corpus hash automatically.
 [corpus]
-definition_paths = ["../scripts/scaling_workloads.py"]
+definition_paths = [
+  "../scripts/scaling_workloads.py",
+  "../scripts/benchmark_scenarios.py",
+  "../crates/rue/src/main.rs",
+  "../crates/rue-compiler-session-bench/src/main.rs",
+  "../crates/rue-compiler-session-bench/src/representative.rs",
+  "scenarios/representative/main.rue",
+  "scenarios/representative/model.rue",
+  "scenarios/representative/worker.rue",
+  "scenarios/representative/report.rue",
+  "scenarios/representative/labels.rue",
+  "scenarios/representative/labels_alt.rue",
+  "scenarios/representative/std/_std.rue",
+  "scenarios/representative/std/math.rue",
+]
+
+[[scenario_family]]
+name = "cold_batch_root_compiler"
+runner = "cold_batch_root_compiler"
+fixture = "scenarios/representative/main.rue"
+measurement_family = "compiler_build_and_query_performance"
+interpretation = "Fresh real-driver compilations of the representative root module and its transitive import graph."
+not_runtime = "Measures compiler build/query latency and emitted-output parity, not generated-program runtime."
+target = "host-default"
+
+[[scenario_family]]
+name = "reused_compiler_session"
+runner = "reused_compiler_session"
+fixture = "scenarios/representative/main.rue"
+measurement_family = "compiler_build_and_query_performance"
+interpretation = "Fixed edits queried through the canonical CompilerSession graph, with fresh-session parity and authoritative structural work counters."
+not_runtime = "Measures compiler build/query latency and cache behavior, not generated-program runtime."
+target = "host-default"
+scenarios = [
+  { name = "no_change_query", modules = [0, 7], semantic_bodies = [0, 0], cfgs = [0, 0], semantic_queries = [0, 1] },
+  { name = "leaf_edit", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [6, 0], semantic_queries = [1, 0] },
+  { name = "widely_depended_definition_edit", modules = [1, 6], semantic_bodies = [6, 0], cfgs = [6, 0], semantic_queries = [1, 0] },
+  { name = "import_change", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [6, 0], semantic_queries = [1, 0] },
+  { name = "diagnostic_error_edit", modules = [1, 6], semantic_bodies = [5, 0], cfgs = [0, 0], semantic_queries = [1, 0] },
+  { name = "diagnostic_recovery", modules = [2, 5], semantic_bodies = [6, 0], cfgs = [6, 0], semantic_queries = [1, 0] },
+]
 
 [[benchmark]]
 name = "many_functions"

--- a/benchmarks/scenarios/representative/BUCK
+++ b/benchmarks/scenarios/representative/BUCK
@@ -1,0 +1,8 @@
+export_file(name = "labels.rue", visibility = ["PUBLIC"])
+export_file(name = "labels_alt.rue", visibility = ["PUBLIC"])
+export_file(name = "main.rue", visibility = ["PUBLIC"])
+export_file(name = "model.rue", visibility = ["PUBLIC"])
+export_file(name = "report.rue", visibility = ["PUBLIC"])
+export_file(name = "std_root.rue", src = "std/_std.rue", visibility = ["PUBLIC"])
+export_file(name = "std_math.rue", src = "std/math.rue", visibility = ["PUBLIC"])
+export_file(name = "worker.rue", visibility = ["PUBLIC"])

--- a/benchmarks/scenarios/representative/labels.rue
+++ b/benchmarks/scenarios/representative/labels.rue
@@ -1,0 +1,1 @@
+pub fn adjustment() -> i32 { 12 }

--- a/benchmarks/scenarios/representative/labels_alt.rue
+++ b/benchmarks/scenarios/representative/labels_alt.rue
@@ -1,0 +1,1 @@
+pub fn adjustment() -> i32 { 6 + 6 }

--- a/benchmarks/scenarios/representative/main.rue
+++ b/benchmarks/scenarios/representative/main.rue
@@ -1,0 +1,13 @@
+const std = @import("std");
+const model = @import("model.rue");
+const worker = @import("worker.rue");
+const report = @import("report.rue");
+
+fn main() -> i32 {
+    let value = 9;
+    let label = "rue";
+    let base = worker.compute(value);
+    let adjustment = report.adjust(value);
+    let length = std.math.abs(0 - @intCast(label.len()));
+    if base + adjustment + length == 42 { 42 } else { 1 }
+}

--- a/benchmarks/scenarios/representative/model.rue
+++ b/benchmarks/scenarios/representative/model.rue
@@ -1,0 +1,7 @@
+pub struct WeightedValue {
+    value: i32,
+}
+
+pub fn weight(value: i32) -> i32 {
+    value * 3
+}

--- a/benchmarks/scenarios/representative/report.rue
+++ b/benchmarks/scenarios/representative/report.rue
@@ -1,0 +1,6 @@
+const model = @import("model.rue");
+const labels = @import("labels.rue");
+
+pub fn adjust(value: i32) -> i32 {
+    if model.weight(value) > 20 { labels.adjustment() } else { 2 }
+}

--- a/benchmarks/scenarios/representative/std/_std.rue
+++ b/benchmarks/scenarios/representative/std/_std.rue
@@ -1,0 +1,1 @@
+pub const math = @import("math.rue");

--- a/benchmarks/scenarios/representative/std/math.rue
+++ b/benchmarks/scenarios/representative/std/math.rue
@@ -1,0 +1,3 @@
+pub fn abs(value: i32) -> i32 {
+    if value < 0 { 0 - value } else { value }
+}

--- a/benchmarks/scenarios/representative/worker.rue
+++ b/benchmarks/scenarios/representative/worker.rue
@@ -1,0 +1,11 @@
+const model = @import("model.rue");
+
+pub fn compute(value: i32) -> i32 {
+    let mut total = 0;
+    let mut index = 0;
+    while index < 2 {
+        total = total + model.weight(value);
+        index = index + 1;
+    }
+    total / 2
+}

--- a/crates/rue-compiler-session-bench/BUCK
+++ b/crates/rue-compiler-session-bench/BUCK
@@ -1,11 +1,34 @@
 load("//crates:defs.bzl", "rue_binary")
 
+export_file(
+    name = "benchmark-main-definition",
+    src = "src/main.rs",
+    visibility = ["PUBLIC"],
+)
+
+export_file(
+    name = "benchmark-representative-definition",
+    src = "src/representative.rs",
+    visibility = ["PUBLIC"],
+)
+
 rue_binary(
     name = "rue-compiler-session-bench",
+    mapped_srcs = {
+        "//benchmarks/scenarios/representative:labels.rue": "src/fixtures/labels.rue",
+        "//benchmarks/scenarios/representative:labels_alt.rue": "src/fixtures/labels_alt.rue",
+        "//benchmarks/scenarios/representative:main.rue": "src/fixtures/main.rue",
+        "//benchmarks/scenarios/representative:model.rue": "src/fixtures/model.rue",
+        "//benchmarks/scenarios/representative:report.rue": "src/fixtures/report.rue",
+        "//benchmarks/scenarios/representative:std_math.rue": "src/fixtures/std/math.rue",
+        "//benchmarks/scenarios/representative:std_root.rue": "src/fixtures/std/_std.rue",
+        "//benchmarks/scenarios/representative:worker.rue": "src/fixtures/worker.rue",
+    },
     deps = [
         "//crates/rue-air:rue-air",
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-span:rue-span",
         "//third-party:serde_json",
+        "//third-party:sha2",
     ],
 )

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -17,6 +17,9 @@ use rue_compiler::{
 };
 use rue_span::FileId;
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+mod representative;
 
 const DEFAULT_MODULES: usize = 128;
 const DEFAULT_WARMUP: usize = 3;
@@ -27,6 +30,7 @@ struct Config {
     modules: usize,
     warmup: usize,
     iterations: usize,
+    representative: bool,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -597,14 +601,16 @@ where
     let query_delta = QueryCounts::from(work).delta(before);
     // Successful updates replace the current-revision record vectors. Treat
     // that reset as a new zero-based measurement window.
-    let semantic_records =
-        if query_delta.semantic_executions > 0 && work.semantic_records.len() <= semantic_records {
-            0
-        } else {
-            semantic_records
-        };
-    let definition_records = if query_delta.definition_executions > 0
-        && work.definition_records.len() <= definition_records
+    let semantic_records = if work.semantic_records.len() < semantic_records
+        || (query_delta.semantic_executions > 0 && work.semantic_records.len() <= semantic_records)
+    {
+        0
+    } else {
+        semantic_records
+    };
+    let definition_records = if work.definition_records.len() < definition_records
+        || (query_delta.definition_executions > 0
+            && work.definition_records.len() <= definition_records)
     {
         0
     } else {
@@ -838,8 +844,34 @@ fn assert_cold_reused_parity(
     source: &SourceSnapshot,
     options: &CompileOptions,
 ) -> Value {
+    assert_cold_reused_parity_with_discovery(
+        reused_session,
+        reused,
+        source,
+        options,
+        None,
+        |_, _| {},
+        close_completion_discovery,
+    )
+}
+
+fn assert_cold_reused_parity_with_discovery<F, G>(
+    reused_session: &mut CompilerSession,
+    reused: &CanonicalSemanticOutput,
+    source: &SourceSnapshot,
+    options: &CompileOptions,
+    std_dir: Option<&str>,
+    prepare_semantic: F,
+    prepare_executable: G,
+) -> Value
+where
+    F: Fn(&mut CompilerSession, &SourceSnapshot),
+    G: Fn(&mut CompilerSession, &SourceSnapshot),
+{
+    prepare_semantic(reused_session, source);
     let mut cold_session = CompilerSession::new();
     cold_session.update(source).into_result().unwrap();
+    prepare_semantic(&mut cold_session, source);
     let cold = cold_session.semantic(options).unwrap();
     let cold_semantic_work = semantic_work_json(cold_session.work(), 0);
     let cold_count = |path: &[&str]| count(&cold_semantic_work, path);
@@ -855,10 +887,6 @@ fn assert_cold_reused_parity(
     assert_eq!(
         cold_count(&["cfg", "builds_attempted"]),
         cold_count(&["cfg", "builds_succeeded"])
-    );
-    assert_eq!(
-        cold_count(&["declaration_reuse", "durable_cache_population_exports"]),
-        1
     );
     assert_eq!(
         format!("{:?}", reused.functions()),
@@ -961,6 +989,19 @@ fn assert_cold_reused_parity(
         cold.implicit_named_destructor_dependencies_complete()
     );
 
+    let reused_manifest = reused_session
+        .semantic_dependency_inputs(options, std_dir)
+        .unwrap();
+    let cold_manifest = cold_session
+        .semantic_dependency_inputs(options, std_dir)
+        .unwrap();
+    // Dependency queries may publish import-stage diagnostics on only the
+    // cold side when the reused side already retained the manifest. Re-query
+    // the canonical semantic artifact on both sides before comparing the
+    // user-visible semantic diagnostic snapshot.
+    reused_session.semantic(options).unwrap();
+    cold_session.semantic(options).unwrap();
+
     assert_diagnostic_parity(
         reused_session.latest_diagnostics(),
         cold_session.latest_diagnostics(),
@@ -974,12 +1015,6 @@ fn assert_cold_reused_parity(
         cold_session.last_good_semantic_diagnostics(),
     );
 
-    let reused_manifest = reused_session
-        .semantic_dependency_inputs(options, None)
-        .unwrap();
-    let cold_manifest = cold_session
-        .semantic_dependency_inputs(options, None)
-        .unwrap();
     assert_eq!(reused_manifest.input(), cold_manifest.input());
     assert_eq!(reused_manifest.imports(), cold_manifest.imports());
     macro_rules! assert_manifest_field {
@@ -1090,8 +1125,8 @@ fn assert_cold_reused_parity(
         format!("{:?}", cold.implicit_named_destructor_dependencies())
     );
 
-    close_completion_discovery(reused_session, source);
-    close_completion_discovery(&mut cold_session, source);
+    prepare_executable(reused_session, source);
+    prepare_executable(&mut cold_session, source);
     let reused_executable = reused_session.executable(options).unwrap();
     let cold_executable = cold_session.executable(options).unwrap();
     assert_eq!(reused_executable.elf, cold_executable.elf);
@@ -1100,6 +1135,7 @@ fn assert_cold_reused_parity(
         format!("{:?}", cold_executable.warnings)
     );
 
+    let executable_sha256 = format!("{:x}", Sha256::digest(&reused_executable.elf));
     json!({
         "public_semantic_cfg_artifacts": "exact",
         "public_type_universe": "exact_ordered_entries",
@@ -1111,6 +1147,8 @@ fn assert_cold_reused_parity(
         "stable_identities": "exact",
         "dependency_records": "exact",
         "emitted_output": "byte_exact",
+        "emitted_output_sha256": executable_sha256,
+        "emitted_output_size_bytes": reused_executable.elf.len(),
         "work_counters": "reused_and_cold_serialized_with_structural_assertions",
         "cold_semantic_work": cold_semantic_work,
     })
@@ -2075,9 +2113,14 @@ fn parse_config_args(args: impl IntoIterator<Item = String>) -> Result<Config, S
         modules: DEFAULT_MODULES,
         warmup: DEFAULT_WARMUP,
         iterations: DEFAULT_ITERATIONS,
+        representative: false,
     };
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
+        if arg == "--representative" {
+            config.representative = true;
+            continue;
+        }
         let value = args
             .next()
             .ok_or_else(|| format!("missing value for {arg}"))?;
@@ -2097,13 +2140,40 @@ fn parse_config_args(args: impl IntoIterator<Item = String>) -> Result<Config, S
 fn usage(message: &str) -> ! {
     eprintln!("error: {message}");
     eprintln!(
-        "usage: rue-compiler-session-bench [--modules N>=4] [--warmup N] [--iterations N>=1]"
+        "usage: rue-compiler-session-bench [--representative] [--modules N>=4] [--warmup N] [--iterations N>=1]"
     );
     process::exit(2)
 }
 
 fn main() {
     let config = parse_config();
+    if config.representative {
+        for _ in 0..config.warmup {
+            representative::run_iteration();
+        }
+        let iterations = (0..config.iterations)
+            .map(|_| representative::run_iteration())
+            .collect::<Vec<_>>();
+        println!(
+            "{}",
+            json!({
+                "schema_version": 1,
+                "workload": "representative_compiler_session_scenarios",
+                "fixture": "benchmarks/scenarios/representative/main.rue",
+                "measurement_scope": "compiler_build_and_query_performance_not_runtime",
+                "configuration": {
+                    "warmup_iterations": config.warmup,
+                    "measured_iterations": config.iterations,
+                    "canonical_query_graph": "CompilerSession",
+                    "persistent_cache": false,
+                    "timing_inferred_reuse": false,
+                    "fresh_session_parity": true,
+                },
+                "iterations": iterations,
+            })
+        );
+        return;
+    }
     let fixture = Fixture::new(config.modules);
     for _ in 0..config.warmup {
         run_iteration(&fixture);
@@ -2160,7 +2230,17 @@ mod tests {
                 modules: 4,
                 warmup: DEFAULT_WARMUP,
                 iterations: DEFAULT_ITERATIONS,
+                representative: false,
             }
+        );
+    }
+
+    #[test]
+    fn representative_mode_is_explicit() {
+        assert!(
+            parse_config_args(["--representative".to_owned()])
+                .unwrap()
+                .representative
         );
     }
 }

--- a/crates/rue-compiler-session-bench/src/representative.rs
+++ b/crates/rue-compiler-session-bench/src/representative.rs
@@ -1,0 +1,431 @@
+//! Small representative multi-module scenarios for RUE-901.
+//!
+//! The fixture files are also compiled by the real batch driver. This module
+//! embeds those exact bytes and varies them only through the fixed edits below,
+//! so cold and reused measurements cannot drift to different program semantics.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use rue_compiler::{
+    AcceptedImportSource, AcceptedReadManifestEntry, CanonicalSemanticOutput, CompileOptions,
+    CompilerSession, DiscoverySourceAssembler, FileMetadataFingerprint, ImportDiscoveryContext,
+    ImportObservation, ImportObservationLedger, PhysicalFileIdentity, SourceSnapshot,
+};
+use serde_json::{Value, json};
+
+use super::{
+    assert_cold_reused_parity_with_discovery, assert_diagnostic_parity, count, measure, named,
+};
+
+const ROOT: &str = "/bench/main.rue";
+const FILES: &[(&str, &str)] = &[
+    ("/bench/labels.rue", include_str!("fixtures/labels.rue")),
+    (
+        "/bench/labels_alt.rue",
+        include_str!("fixtures/labels_alt.rue"),
+    ),
+    ("/bench/main.rue", include_str!("fixtures/main.rue")),
+    ("/bench/model.rue", include_str!("fixtures/model.rue")),
+    ("/bench/report.rue", include_str!("fixtures/report.rue")),
+    ("/bench/std/_std.rue", include_str!("fixtures/std/_std.rue")),
+    ("/bench/std/math.rue", include_str!("fixtures/std/math.rue")),
+    ("/bench/worker.rue", include_str!("fixtures/worker.rue")),
+];
+
+#[derive(Clone, Copy)]
+enum Variant {
+    Base,
+    LeafEdit,
+    WidelyDependedDefinitionEdit,
+    ImportChange,
+    DiagnosticError,
+}
+
+fn variant_sources(variant: Variant) -> BTreeMap<String, Arc<String>> {
+    FILES
+        .iter()
+        .filter(|(path, _)| match variant {
+            Variant::ImportChange => *path != "/bench/labels.rue",
+            _ => *path != "/bench/labels_alt.rue",
+        })
+        .map(|&(path, source)| {
+            let source = match (variant, path) {
+                (Variant::LeafEdit, "/bench/labels.rue") => source.replace("{ 12 }", "{ 13 }"),
+                (Variant::WidelyDependedDefinitionEdit, "/bench/model.rue") => {
+                    source.replace("value * 3", "value * 4")
+                }
+                (Variant::ImportChange, "/bench/report.rue") => {
+                    source.replace("labels.rue", "labels_alt.rue")
+                }
+                (Variant::DiagnosticError, "/bench/report.rue") => {
+                    source.replace("model.weight(value)", "missing_weight")
+                }
+                _ => source.to_owned(),
+            };
+            (path.to_owned(), Arc::new(source))
+        })
+        .collect()
+}
+
+fn assemble(
+    sources: &BTreeMap<String, Arc<String>>,
+) -> (
+    SourceSnapshot,
+    ImportDiscoveryContext,
+    Arc<[AcceptedReadManifestEntry]>,
+) {
+    let context =
+        ImportDiscoveryContext::new(1, "/bench", Some("/bench/std"), "rue-901-scenario").unwrap();
+    let root = sources.get(ROOT).unwrap().clone();
+    let mut assembler = DiscoverySourceAssembler::new(
+        context.clone(),
+        ROOT,
+        ROOT,
+        PhysicalFileIdentity::new(901, 1),
+        FileMetadataFingerprint::new(root.len() as u64, 0, 1),
+        root,
+    )
+    .unwrap();
+    for (path, source) in sources.iter().filter(|(path, _)| path.as_str() != ROOT) {
+        let identity = identity_for_path(path);
+        assembler
+            .add_explicit(
+                path,
+                path,
+                PhysicalFileIdentity::new(901, identity),
+                FileMetadataFingerprint::new(source.len() as u64, 0, identity),
+                source.clone(),
+            )
+            .unwrap();
+    }
+    (
+        assembler.snapshot().unwrap(),
+        context,
+        assembler.accepted_read_manifest(),
+    )
+}
+
+fn identity_for_path(path: &str) -> u64 {
+    if path == ROOT {
+        return 1;
+    }
+    FILES
+        .iter()
+        .position(|(candidate, _)| *candidate == path)
+        .map(|index| (index + 2) as u64)
+        .unwrap()
+}
+
+fn snapshot(variant: Variant) -> SourceSnapshot {
+    assemble(&variant_sources(variant)).0
+}
+
+fn close_discovery(session: &mut CompilerSession, source: &SourceSnapshot) {
+    if session
+        .committed_import_discovery()
+        .is_some_and(|artifact| artifact.source_revision() == source.source_revision())
+    {
+        return;
+    }
+    let sources = source
+        .files()
+        .map(|file| {
+            let path = if file.path.starts_with('/') {
+                file.path.to_owned()
+            } else {
+                format!("/bench/{}", file.path)
+            };
+            (path, Arc::new(file.source.to_owned()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let (discovered, context, accepted_reads) = assemble(&sources);
+    assert_eq!(discovered.source_revision(), source.source_revision());
+    let mut ledger = ImportObservationLedger::default();
+    loop {
+        let plan = session
+            .stage_import_discovery(
+                &discovered,
+                context.clone(),
+                accepted_reads.clone(),
+                ledger.clone(),
+            )
+            .unwrap();
+        let pending = plan.pending_requests(&ledger);
+        if pending.is_empty() {
+            break;
+        }
+        for request in pending {
+            let requested_path = request.requested_path().to_owned();
+            let observation = if let Some(source) = sources.get(&requested_path) {
+                let identity = identity_for_path(&requested_path);
+                ImportObservation::accepted(
+                    request,
+                    AcceptedImportSource::new(
+                        requested_path.as_str(),
+                        requested_path.as_str(),
+                        PhysicalFileIdentity::new(901, identity),
+                        FileMetadataFingerprint::new(source.len() as u64, 0, identity),
+                        source.clone(),
+                    )
+                    .unwrap(),
+                )
+                .unwrap()
+            } else {
+                ImportObservation::absent(request)
+            };
+            ledger.record(observation).unwrap();
+        }
+    }
+    session.close_import_discovery(ledger).unwrap();
+}
+
+fn measured_project_semantic(
+    session: &mut CompilerSession,
+    source: &SourceSnapshot,
+    options: &CompileOptions,
+) -> (Value, Arc<CanonicalSemanticOutput>) {
+    let mut output = None;
+    let value = measure(session, |session| {
+        let update = session.update(source);
+        let parse = update.work();
+        update.into_result().unwrap();
+        close_discovery(session, source);
+        output = Some(session.semantic(options).unwrap());
+        parse
+    });
+    (value, output.unwrap())
+}
+
+fn work_projection(scenario: &Value) -> Value {
+    json!({
+        "modules": {
+            "required": count(scenario, &["parse", "modules_reparsed"]),
+            "reused": count(scenario, &["parse", "modules_reused"]),
+        },
+        "semantic_bodies": {
+            "required": count(scenario, &["semantic_work", "bodies_attempted"]),
+            "reused": count(scenario, &["semantic_work", "durable_bodies", "reused_bodies"]),
+        },
+        "cfgs": {
+            "required": count(scenario, &["semantic_work", "cfg", "builds_attempted"]),
+            "reused": count(scenario, &["semantic_work", "cfg", "reuses"]),
+        },
+        "semantic_queries": {
+            "required": count(scenario, &["queries", "semantic_executions"]),
+            "reused": count(scenario, &["queries", "semantic_reuses"]),
+        },
+    })
+}
+
+fn successful_edit(name: &str, target: &SourceSnapshot) -> Value {
+    let base = snapshot(Variant::Base);
+    let options = CompileOptions::default();
+    let mut session = CompilerSession::new();
+    measured_project_semantic(&mut session, &base, &options);
+    session
+        .semantic_dependency_inputs(&options, Some("/bench/std"))
+        .unwrap();
+    let (mut value, output) = measured_project_semantic(&mut session, target, &options);
+    let parity = assert_cold_reused_parity_with_discovery(
+        &mut session,
+        &output,
+        target,
+        &options,
+        Some("/bench/std"),
+        close_discovery,
+        |_, _| {},
+    );
+    value["differential_parity"] = parity;
+    value["required_vs_reused_work"] = work_projection(&value);
+    named(name, value)
+}
+
+fn diagnostic_and_recovery() -> (Value, Value) {
+    let base = snapshot(Variant::Base);
+    let failed_source = snapshot(Variant::DiagnosticError);
+    let recovered_source = snapshot(Variant::LeafEdit);
+    let options = CompileOptions::default();
+    let mut session = CompilerSession::new();
+    measured_project_semantic(&mut session, &base, &options);
+    session
+        .semantic_dependency_inputs(&options, Some("/bench/std"))
+        .unwrap();
+    let last_good = session.last_good_semantic_diagnostics().unwrap().clone();
+    let mut failed = measure(&mut session, |session| {
+        let update = session.update(&failed_source);
+        let parse = update.work();
+        update.into_result().unwrap();
+        close_discovery(session, &failed_source);
+        session.semantic(&options).unwrap_err();
+        parse
+    });
+    assert!(Arc::ptr_eq(
+        &last_good,
+        session.last_good_semantic_diagnostics().unwrap()
+    ));
+
+    let mut fresh = CompilerSession::new();
+    fresh.update(&failed_source).into_result().unwrap();
+    close_discovery(&mut fresh, &failed_source);
+    fresh.semantic(&options).unwrap_err();
+    assert_diagnostic_parity(session.latest_diagnostics(), fresh.latest_diagnostics());
+    let diagnostics = session.latest_diagnostics().unwrap();
+    failed["diagnostic_parity"] = json!({
+        "fresh_session": "exact",
+        "error_count": diagnostics.errors().len(),
+        "warning_count": diagnostics.warnings().len(),
+        "last_good_preserved": true,
+    });
+    failed["required_vs_reused_work"] = work_projection(&failed);
+    let failed = named("diagnostic_error_edit", failed);
+
+    let (mut recovered, output) =
+        measured_project_semantic(&mut session, &recovered_source, &options);
+    let parity = assert_cold_reused_parity_with_discovery(
+        &mut session,
+        &output,
+        &recovered_source,
+        &options,
+        Some("/bench/std"),
+        close_discovery,
+        |_, _| {},
+    );
+    recovered["differential_parity"] = parity;
+    recovered["recovered_from_diagnostic_error"] = json!(true);
+    recovered["required_vs_reused_work"] = work_projection(&recovered);
+    let recovered = named("diagnostic_recovery", recovered);
+    (failed, recovered)
+}
+
+pub(super) fn run_iteration() -> Vec<Value> {
+    let base = snapshot(Variant::Base);
+    let mut scenarios = vec![
+        successful_edit("no_change_query", &base),
+        successful_edit("leaf_edit", &snapshot(Variant::LeafEdit)),
+        successful_edit(
+            "widely_depended_definition_edit",
+            &snapshot(Variant::WidelyDependedDefinitionEdit),
+        ),
+        successful_edit("import_change", &snapshot(Variant::ImportChange)),
+    ];
+    let (failed, recovered) = diagnostic_and_recovery();
+    scenarios.push(failed);
+    scenarios.push(recovered);
+    assert_structure(&scenarios);
+    scenarios
+}
+
+fn assert_structure(scenarios: &[Value]) {
+    assert_eq!(scenarios.len(), 6);
+    for scenario in scenarios {
+        let work = &scenario["required_vs_reused_work"];
+        for artifact in ["modules", "semantic_bodies", "cfgs", "semantic_queries"] {
+            assert!(work[artifact]["required"].is_u64());
+            assert!(work[artifact]["reused"].is_u64());
+        }
+    }
+    let get = |name: &str| {
+        scenarios
+            .iter()
+            .find(|value| value["name"] == name)
+            .unwrap()
+    };
+    let expected = [
+        ("no_change_query", [0, 7, 0, 0, 0, 0, 0, 1]),
+        ("leaf_edit", [1, 6, 6, 0, 6, 0, 1, 0]),
+        ("widely_depended_definition_edit", [1, 6, 6, 0, 6, 0, 1, 0]),
+        ("import_change", [2, 5, 6, 0, 6, 0, 1, 0]),
+        ("diagnostic_error_edit", [1, 6, 5, 0, 0, 0, 1, 0]),
+        ("diagnostic_recovery", [2, 5, 6, 0, 6, 0, 1, 0]),
+    ];
+    for (name, counts) in expected {
+        let work = &get(name)["required_vs_reused_work"];
+        let actual = [
+            work["modules"]["required"].as_u64().unwrap(),
+            work["modules"]["reused"].as_u64().unwrap(),
+            work["semantic_bodies"]["required"].as_u64().unwrap(),
+            work["semantic_bodies"]["reused"].as_u64().unwrap(),
+            work["cfgs"]["required"].as_u64().unwrap(),
+            work["cfgs"]["reused"].as_u64().unwrap(),
+            work["semantic_queries"]["required"].as_u64().unwrap(),
+            work["semantic_queries"]["reused"].as_u64().unwrap(),
+        ];
+        assert_eq!(actual, counts, "unexpected structural work for {name}");
+    }
+    for name in [
+        "leaf_edit",
+        "widely_depended_definition_edit",
+        "import_change",
+        "diagnostic_recovery",
+    ] {
+        let scenario = get(name);
+        assert_eq!(
+            count(
+                scenario,
+                &["semantic_work", "durable_bodies", "conversion_failures"]
+            ),
+            1
+        );
+        assert_eq!(
+            count(
+                scenario,
+                &["semantic_work", "durable_bodies", "atomic_discards"]
+            ),
+            1
+        );
+    }
+    assert_eq!(
+        count(
+            get("diagnostic_error_edit"),
+            &["semantic_work", "failed_requests"]
+        ),
+        1
+    );
+    assert_eq!(
+        get("diagnostic_error_edit")["diagnostic_parity"]["fresh_session"],
+        "exact"
+    );
+    assert_eq!(
+        get("diagnostic_recovery")["recovered_from_diagnostic_error"],
+        true
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_variants_are_exact_transitive_closures() {
+        let base = variant_sources(Variant::Base);
+        assert_eq!(base.len(), 7);
+        for &(path, source) in FILES
+            .iter()
+            .filter(|(path, _)| *path != "/bench/labels_alt.rue")
+        {
+            assert_eq!(base[path].as_str(), source);
+        }
+        let import_change = variant_sources(Variant::ImportChange);
+        assert_eq!(import_change.len(), 7);
+        assert!(!import_change.contains_key("/bench/labels.rue"));
+        assert!(import_change.contains_key("/bench/labels_alt.rue"));
+        assert_eq!(identity_for_path("/bench/labels.rue"), 2);
+        assert_eq!(identity_for_path("/bench/labels_alt.rue"), 3);
+        assert_ne!(
+            identity_for_path("/bench/labels.rue"),
+            identity_for_path("/bench/labels_alt.rue")
+        );
+        assert_eq!(identity_for_path("/bench/model.rue"), 5);
+    }
+
+    #[test]
+    fn representative_scenarios_are_bounded_and_structurally_gated() {
+        let scenarios = run_iteration();
+        assert_eq!(scenarios.len(), 6);
+        assert!(
+            scenarios
+                .iter()
+                .all(|scenario| scenario["wall_time_ns"].is_u64())
+        );
+    }
+}

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_binary")
 
+export_file(
+    name = "benchmark-definition",
+    src = "src/main.rs",
+    visibility = ["PUBLIC"],
+)
+
 rue_binary(
     name = "rue",
     deps = [
@@ -9,6 +15,7 @@ rue_binary(
         "//third-party:libc",
         "//third-party:serde",
         "//third-party:serde_json",
+        "//third-party:sha2",
         "//third-party:tracing",
         "//third-party:tracing-subscriber",
     ],

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1051,20 +1051,28 @@ fn print_timing_output(
     benchmark_json: bool,
     target: &Target,
     source_metrics: Option<timing::SourceMetrics>,
+    emitted_output: Option<&[u8]>,
 ) {
     if let Some(timing) = timing_data {
         if benchmark_json {
             // JSON output goes to stdout for easy capture
             // Include metadata and source metrics for historical analysis
-            println!(
-                "{}",
-                timing.to_json_with_metrics(
+            let mut payload: serde_json::Value =
+                serde_json::from_str(&timing.to_json_with_metrics(
                     &target.to_string(),
                     VERSION,
                     source_metrics,
                     get_peak_memory_bytes(),
-                )
-            );
+                ))
+                .unwrap();
+            if let Some(bytes) = emitted_output {
+                use sha2::{Digest, Sha256};
+                payload["emitted_output"] = serde_json::json!({
+                    "sha256": format!("{:x}", Sha256::digest(bytes)),
+                    "size_bytes": bytes.len(),
+                });
+            }
+            println!("{payload}");
         } else if time_passes {
             // Human-readable output goes to stderr
             eprintln!("{}", timing.report());
@@ -1940,6 +1948,7 @@ fn main() {
             options.benchmark_json,
             &options.target,
             None,
+            None,
         );
         return;
     }
@@ -1990,6 +1999,7 @@ fn main() {
             options.time_passes,
             options.benchmark_json,
             &options.target,
+            None,
             None,
         );
         return;
@@ -2113,6 +2123,7 @@ fn main() {
                         tokens: source_stats.tokens,
                     }
                 }),
+                options.benchmark_json.then_some(output.elf.as_slice()),
             );
         }
         Err(errors) => {

--- a/docs/process/benchmark-metrics.md
+++ b/docs/process/benchmark-metrics.md
@@ -28,3 +28,9 @@ Historical `bench.sh` data is identified as `compiler/cold_compilation`; new
 runs record that identity explicitly. Comparison APIs reject a different
 measurement or scenario family, reserving distinct reused-session/query
 scenarios for RUE-901 without conflating them with cold compilation.
+
+Representative compiler scenarios are a separate publication family. Their
+latency is descriptive; correctness and cache claims come from exact emitted
+output/fresh-session parity and direct `CompilerSession` structural counters.
+They measure compiler build/query work, never generated-program runtime, and do
+not feed the static phase-probe performance index or scaling budgets.

--- a/docs/process/session-invalidation-benchmark.md
+++ b/docs/process/session-invalidation-benchmark.md
@@ -13,6 +13,20 @@ Run the deterministic N=128 workload with:
   --modules 128 --warmup 3 --iterations 10 > session-invalidation.json
 ```
 
+Run the schema-1 representative multi-module mode with:
+
+```sh
+./buck2 run //crates/rue-compiler-session-bench:rue-compiler-session-bench -- \
+  --representative --warmup 1 --iterations 5
+```
+
+That mode uses the exact tracked `benchmarks/scenarios/representative` bytes,
+canonical import-discovery closure, and six fixed no-op/edit/error/recovery
+queries over each variant's exact transitive closure. It hard-gates direct
+required/reused work plus exact fresh-session parity, and the base executable's
+digest and size must exactly match the real batch driver's raw compiler output.
+Unsupported durable conversions remain visible as fail-closed rebuilds.
+
 The historical `--modules` spelling is retained for command compatibility. In
 the RUE-720 completion scenarios N is the exact number of reachable analyzed
 bodies: `main` plus N-1 generated functions. One additional unreachable
@@ -119,8 +133,10 @@ The ordinary suite runs an N=4 structural smoke test through
 `//crates/rue-compiler-session-bench:rue-compiler-session-bench-test`. The full
 N=128 timing workload remains opt-in, but it executes the same assertions.
 
-This benchmark is deliberately bounded to synthetic, supported programs.
+This benchmark is deliberately bounded to synthetic, supported programs and
+the one tracked representative fixture.
 [RUE-813](https://linear.app/steve-klabnik/issue/RUE-813) tracks a reusable,
 broader differential oracle. [RUE-901](https://linear.app/steve-klabnik/issue/RUE-901)
-tracks realistic multi-module cold/reused projects and performance baselines.
-Neither gap weakens the exact structural completion evidence recorded here.
+adds the bounded multi-module cold/reused baseline described above. RUE-813
+remains the boundary for a broader reusable differential oracle; the
+representative scenarios do not claim arbitrary-project coverage.

--- a/scripts/benchmark_manifest.py
+++ b/scripts/benchmark_manifest.py
@@ -37,6 +37,9 @@ REQUIRED_SCALING_FIELDS = (
     "memory_per_unit_growth_budget",
     "timeout_seconds",
 )
+REQUIRED_SCENARIO_FAMILY_FIELDS = (
+    "name", "runner", "fixture", "measurement_family", "interpretation", "not_runtime", "target"
+)
 
 
 def _unique(entries: list[dict], label: str) -> None:
@@ -50,8 +53,8 @@ def load_manifest(path: Path) -> dict:
     """Load the single source of benchmark workload semantics."""
     with path.open("rb") as stream:
         manifest = tomllib.load(stream)
-    if manifest.get("schema_version") != 2:
-        raise ValueError("benchmark manifest schema_version must be 2")
+    if manifest.get("schema_version") != 3:
+        raise ValueError("benchmark manifest schema_version must be 3")
     probes = manifest.get("benchmark")
     families = manifest.get("scaling_family")
     if not isinstance(probes, list) or not probes:
@@ -119,6 +122,34 @@ def load_manifest(path: Path) -> dict:
     unknown = sorted(generators - set(GENERATORS))
     if unknown:
         raise ValueError("unknown scaling generator(s): " + ", ".join(unknown))
+    scenario_families = manifest.get("scenario_family")
+    if not isinstance(scenario_families, list) or len(scenario_families) != 2:
+        raise ValueError("manifest must contain exactly two [[scenario_family]] entries")
+    _unique(scenario_families, "scenario family")
+    if [family.get("runner") for family in scenario_families] != [
+        "cold_batch_root_compiler", "reused_compiler_session"
+    ]:
+        raise ValueError("scenario families must declare the canonical cold and reused runners")
+    for index, family in enumerate(scenario_families):
+        for field in REQUIRED_SCENARIO_FAMILY_FIELDS:
+            if not isinstance(family.get(field), str) or not family[field]:
+                raise ValueError(f"scenario family #{index + 1} has no valid {field}")
+        if family["measurement_family"] != "compiler_build_and_query_performance":
+            raise ValueError(f"scenario family '{family['name']}' has invalid measurement family")
+        if family["target"] != "host-default":
+            raise ValueError(f"scenario family '{family['name']}' has invalid target")
+    scenarios = scenario_families[1].get("scenarios")
+    if not isinstance(scenarios, list) or not scenarios:
+        raise ValueError("reused scenario family must contain scenarios")
+    _unique(scenarios, "representative scenario")
+    for scenario in scenarios:
+        for artifact in ("modules", "semantic_bodies", "cfgs", "semantic_queries"):
+            counts = scenario.get(artifact)
+            if (not isinstance(counts, list) or len(counts) != 2 or any(
+                not isinstance(value, int) or isinstance(value, bool) or value < 0
+                for value in counts
+            )):
+                raise ValueError(f"representative scenario '{scenario.get('name')}' has invalid {artifact}")
     corpus = manifest.get("corpus")
     paths = corpus.get("definition_paths") if isinstance(corpus, dict) else None
     if (
@@ -136,6 +167,10 @@ def static_probes(path: Path) -> list[dict]:
 
 def scaling_families(path: Path) -> list[dict]:
     return load_manifest(path)["scaling_family"]
+
+
+def scenario_families(path: Path) -> list[dict]:
+    return load_manifest(path)["scenario_family"]
 
 
 def corpus_paths(path: Path) -> list[tuple[str, Path]]:

--- a/scripts/benchmark_scenarios.py
+++ b/scripts/benchmark_scenarios.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Collect the representative cold-driver and reused-session scenarios."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+from benchmark_collection import parse_iteration_json
+from benchmark_manifest import scenario_families
+
+
+def _mean(samples: list[float]) -> float:
+    return round(sum(samples) / len(samples), 3)
+
+
+def collect_cold(rue: Path, root: Path, iterations: int) -> dict:
+    samples, digest, size = [], None, None
+    environment = os.environ.copy()
+    environment["RUE_STD_PATH"] = str((root.parent / "std").resolve())
+    with tempfile.TemporaryDirectory(prefix="rue-representative-") as directory:
+        for index in range(iterations):
+            output = Path(directory) / f"output-{index}"
+            result = subprocess.run(
+                [str(rue), "--benchmark-json", str(root), "-o", str(output)],
+                check=True, text=True, capture_output=True, env=environment,
+            )
+            timing = parse_iteration_json(result.stdout)
+            samples.append(float(timing["total_ms"]))
+            emitted = timing.get("emitted_output", {})
+            current_digest = emitted.get("sha256")
+            current_size = emitted.get("size_bytes")
+            if not isinstance(current_digest, str) or not isinstance(current_size, int):
+                raise ValueError("cold driver did not report its raw emitted output")
+            if digest is not None and (current_digest, current_size) != (digest, size):
+                raise ValueError("cold scenario emitted output changed between iterations")
+            digest, size = current_digest, current_size
+    return {
+        "name": "cold_batch_root_compiler", "samples_ms": samples,
+        "mean_ms": _mean(samples),
+        "emitted_output": {
+            "parity": "byte_exact",
+            "representation": "raw_compiler_executable_before_platform_postprocessing",
+            "sha256": digest,
+            "size_bytes": size,
+        },
+    }
+
+
+def collect_reused(session_bench: Path, iterations: int) -> tuple[list[dict], dict]:
+    result = subprocess.run(
+        [str(session_bench), "--representative", "--warmup", "1", "--iterations", str(iterations)],
+        check=True, text=True, capture_output=True,
+    )
+    payload = json.loads(result.stdout)
+    if payload.get("schema_version") != 1 or payload.get("workload") != "representative_compiler_session_scenarios":
+        raise ValueError("reused scenario runner returned an unknown schema")
+    rows = payload.get("iterations")
+    if not isinstance(rows, list) or len(rows) != iterations:
+        raise ValueError("reused scenario runner returned the wrong iteration count")
+    names = [entry["name"] for entry in rows[0]]
+    collected = []
+    for position, name in enumerate(names):
+        scenarios = [iteration[position] for iteration in rows]
+        if any(scenario.get("name") != name for scenario in scenarios):
+            raise ValueError("reused scenario sequence changed between iterations")
+        work = scenarios[0].get("required_vs_reused_work")
+        if any(scenario.get("required_vs_reused_work") != work for scenario in scenarios[1:]):
+            raise ValueError(f"structural work changed between iterations for {name}")
+        samples = [scenario["wall_time_ns"] / 1_000_000 for scenario in scenarios]
+        if any(not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0 for value in samples):
+            raise ValueError(f"invalid reused timing sample for {name}")
+        entry = {"name": name, "samples_ms": samples, "mean_ms": _mean(samples), "required_vs_reused_work": work}
+        for evidence in ("differential_parity", "diagnostic_parity", "recovered_from_diagnostic_error"):
+            if evidence in scenarios[0]:
+                entry[evidence] = scenarios[0][evidence]
+        collected.append(entry)
+    no_change_parity = collected[0].get("differential_parity", {})
+    emitted_output = {
+        "sha256": no_change_parity.get("emitted_output_sha256"),
+        "size_bytes": no_change_parity.get("emitted_output_size_bytes"),
+    }
+    return collected, emitted_output
+
+
+def collect(manifest: Path, rue: Path, session_bench: Path, iterations: int) -> dict:
+    families = scenario_families(manifest)
+    root = manifest.parent / families[0]["fixture"]
+    if families[0]["target"] != families[1]["target"]:
+        raise ValueError("cold and reused scenario targets must match")
+    cold = collect_cold(rue, root, iterations)
+    reused, session_output = collect_reused(session_bench, iterations)
+    cold_output = cold["emitted_output"]
+    if (cold_output["sha256"], cold_output["size_bytes"]) != (
+        session_output["sha256"], session_output["size_bytes"]
+    ):
+        raise ValueError(
+            "real batch-driver output differs from fresh/reused CompilerSession output"
+        )
+    return {
+        "schema_version": 1,
+        "measurement_family": "compiler_build_and_query_performance",
+        "representative": True,
+        "generated_program_runtime": False,
+        "cross_family_emitted_output": {
+            "cold_batch_vs_fresh_and_reused_session": "byte_exact",
+            "representation": "raw_compiler_executable_before_platform_postprocessing",
+            "sha256": cold_output["sha256"],
+            "size_bytes": cold_output["size_bytes"],
+        },
+        "iterations": iterations,
+        "families": [
+            {**{key: families[0][key] for key in ("name", "interpretation", "not_runtime")}, "scenarios": [cold]},
+            {**{key: families[1][key] for key in ("name", "interpretation", "not_runtime")}, "scenarios": reused},
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--rue-bin", type=Path, required=True)
+    parser.add_argument("--session-bench-bin", type=Path, required=True)
+    parser.add_argument("--iterations", type=int, required=True)
+    args = parser.parse_args()
+    print(json.dumps(collect(args.manifest, args.rue_bin, args.session_bench_bin, args.iterations)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_validation.py
+++ b/scripts/benchmark_validation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from benchmark_manifest import (
     load_manifest,
+    scenario_families,
     scaling_families,
     validate_readme_inventory,
     validate_static_dimensions,
@@ -168,6 +169,7 @@ def validate_manifest_results(data: object, manifest_path: Path) -> list[str]:
         + validate_readme_inventory(manifest_path)
         + validate_results(data, load_manifest_names(manifest_path))
         + validate_scaling_results(data, manifest_path)
+        + validate_scenario_results(data, manifest_path)
     )
     expected_suite = {
         "kind": "synthetic_phase_probe",
@@ -192,6 +194,112 @@ def validate_manifest_results(data: object, manifest_path: Path) -> list[str]:
         ):
             if bench.get(field) != probe[field]:
                 errors.append(f"benchmark '{bench['name']}' {field} does not match manifest")
+    return errors
+
+
+def validate_scenario_results(data: object, manifest_path: Path) -> list[str]:
+    """Validate representative samples, parity proof, and exact structural work."""
+    scenarios = data.get("scenarios") if isinstance(data, dict) else None
+    if not isinstance(scenarios, dict):
+        return ["benchmark result is missing representative scenarios"]
+    errors = []
+    expected_identity = {
+        "schema_version": 1,
+        "measurement_family": "compiler_build_and_query_performance",
+        "representative": True,
+        "generated_program_runtime": False,
+        "iterations": data.get("iterations"),
+    }
+    for field, expected in expected_identity.items():
+        if scenarios.get(field) != expected:
+            errors.append(f"representative scenarios {field} is malformed")
+    cross_family = scenarios.get("cross_family_emitted_output")
+    if (
+        not isinstance(cross_family, dict)
+        or cross_family.get("cold_batch_vs_fresh_and_reused_session") != "byte_exact"
+        or cross_family.get("representation")
+        != "raw_compiler_executable_before_platform_postprocessing"
+        or not isinstance(cross_family.get("sha256"), str)
+        or len(cross_family["sha256"]) != 64
+        or any(character not in "0123456789abcdef" for character in cross_family["sha256"])
+        or not isinstance(cross_family.get("size_bytes"), int)
+        or cross_family["size_bytes"] <= 0
+    ):
+        errors.append("representative scenarios lack cross-family emitted-output parity")
+    actual_families = scenarios.get("families")
+    declared_families = scenario_families(manifest_path)
+    if not isinstance(actual_families, list) or [family.get("name") for family in actual_families if isinstance(family, dict)] != [family["name"] for family in declared_families]:
+        return errors + ["representative scenario family composition does not match manifest"]
+    iterations = data.get("iterations")
+    for declared, family in zip(declared_families, actual_families):
+        for field in ("interpretation", "not_runtime"):
+            if family.get(field) != declared[field]:
+                errors.append(f"scenario family '{declared['name']}' {field} does not match manifest")
+        rows = family.get("scenarios")
+        expected_names = [declared["name"]] if declared["runner"] == "cold_batch_root_compiler" else [row["name"] for row in declared["scenarios"]]
+        if not isinstance(rows, list) or [row.get("name") for row in rows if isinstance(row, dict)] != expected_names:
+            errors.append(f"scenario family '{declared['name']}' composition does not match manifest")
+            continue
+        for row in rows:
+            samples = row.get("samples_ms")
+            samples_valid = isinstance(samples, list) and len(samples) == iterations and all(_is_finite_non_negative_number(value) and value > 0 for value in samples)
+            if not samples_valid:
+                errors.append(f"representative scenario '{row.get('name')}' has invalid samples")
+            if not _is_finite_non_negative_number(row.get("mean_ms")) or row.get("mean_ms") <= 0:
+                errors.append(f"representative scenario '{row.get('name')}' has invalid mean")
+            elif samples_valid and row["mean_ms"] != round(sum(samples) / len(samples), 3):
+                errors.append(f"representative scenario '{row.get('name')}' mean does not match samples")
+        if declared["runner"] == "cold_batch_root_compiler":
+            emitted = rows[0].get("emitted_output")
+            if not isinstance(emitted, dict) or emitted.get("parity") != "byte_exact" or emitted.get("representation") != "raw_compiler_executable_before_platform_postprocessing" or not isinstance(emitted.get("sha256"), str) or len(emitted["sha256"]) != 64 or any(character not in "0123456789abcdef" for character in emitted.get("sha256", "")) or not isinstance(emitted.get("size_bytes"), int) or emitted["size_bytes"] <= 0:
+                errors.append("cold representative scenario lacks exact emitted-output parity")
+            elif not isinstance(cross_family, dict) or (
+                emitted["sha256"] != cross_family.get("sha256")
+                or emitted["size_bytes"] != cross_family.get("size_bytes")
+            ):
+                errors.append(
+                    "cold representative emitted output does not match cross-family parity"
+                )
+            continue
+        declared_rows = {row["name"]: row for row in declared["scenarios"]}
+        for row in rows:
+            expected = declared_rows[row["name"]]
+            work = row.get("required_vs_reused_work")
+            expected_work = {
+                artifact: {"required": expected[artifact][0], "reused": expected[artifact][1]}
+                for artifact in ("modules", "semantic_bodies", "cfgs", "semantic_queries")
+            }
+            if work != expected_work:
+                errors.append(f"representative scenario '{row['name']}' structural work does not match manifest")
+            if row["name"] == "diagnostic_error_edit":
+                parity = row.get("diagnostic_parity")
+                if not isinstance(parity, dict) or parity.get("fresh_session") != "exact" or parity.get("last_good_preserved") is not True:
+                    errors.append("diagnostic representative scenario lacks exact fresh parity")
+            else:
+                parity = row.get("differential_parity")
+                exact_fields = {
+                    "dependency_records": "exact",
+                    "diagnostics": "exact",
+                    "durable_ordinary_body_manifest_artifacts": "exact",
+                    "durable_specialized_body_payloads": "exact",
+                    "emitted_output": "byte_exact",
+                    "public_semantic_cfg_artifacts": "exact",
+                    "public_type_universe": "exact_ordered_entries",
+                    "stable_identities": "exact",
+                    "warnings": "exact",
+                }
+                if not isinstance(parity, dict) or any(parity.get(field) != value for field, value in exact_fields.items()):
+                    errors.append(f"representative scenario '{row['name']}' lacks differential parity")
+                elif row["name"] == "no_change_query" and (
+                    not isinstance(cross_family, dict) or
+                    parity.get("emitted_output_sha256") != cross_family.get("sha256")
+                    or parity.get("emitted_output_size_bytes")
+                    != cross_family.get("size_bytes")
+                ):
+                    errors.append(f"representative scenario '{row['name']}' emitted output does not match the batch driver")
+        recovery = rows[-1] if rows else {}
+        if recovery.get("recovered_from_diagnostic_error") is not True:
+            errors.append("diagnostic recovery scenario lacks recovery proof")
     return errors
 
 

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -219,6 +219,20 @@ def scaling_diagnostics(runs: list[dict]) -> dict | None:
     return value
 
 
+def scenario_diagnostics(runs: list[dict]) -> dict | None:
+    """Return the latest representative compiler-only scenario publication."""
+    if not runs:
+        return None
+    value = runs[-1].get("scenarios")
+    if (
+        not isinstance(value, dict)
+        or value.get("representative") is not True
+        or value.get("generated_program_runtime") is not False
+    ):
+        return None
+    return value
+
+
 def format_bytes(size_bytes: float) -> str:
     """Format bytes into human-readable form."""
     if size_bytes >= 1024 * 1024:
@@ -1253,6 +1267,7 @@ def generate_platform_charts(history_path: Path, output_dir: Path, platform: Opt
         "summary": summary,
         "latest_benchmarks": latest_benchmarks,
         "latest_scaling": scaling_diagnostics(runs),
+        "latest_scenarios": scenario_diagnostics(runs),
         "coverage": coverage,
         "regimes": regime_summary(runs),
         "metric_semantics": derive_history_metrics(runs),

--- a/scripts/rue-bin
+++ b/scripts/rue-bin
@@ -13,12 +13,21 @@
 # Any extra arguments are passed through to `buck2 build`, e.g. a release build:
 #
 #   RUE_BINARY="$(scripts/rue-bin --target-platforms //platforms:release)"
+#   SESSION_BENCH="$(scripts/rue-bin --session-bench)"
 #
 set -euo pipefail
 
 # Resolve repo root (this script lives in scripts/) so we work from any cwd.
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
+
+target="//crates/rue:rue"
+target_label="crates/rue:rue"
+if [[ "${1:-}" == "--session-bench" ]]; then
+    target="//crates/rue-compiler-session-bench:rue-compiler-session-bench"
+    target_label="crates/rue-compiler-session-bench:rue-compiler-session-bench"
+    shift
+fi
 
 # Build the compiler. Capture Buck's stdout (which carries the --show-output
 # line) and its stderr (build chatter/diagnostics) SEPARATELY, guarding the exit
@@ -30,18 +39,18 @@ cd "$repo_root"
 build_err="$(mktemp)"
 trap 'rm -f "$build_err"' EXIT
 build_status=0
-build_out="$(./buck2 build //crates/rue:rue --show-output "$@" 2>"$build_err")" \
+build_out="$(./buck2 build "$target" --show-output "$@" 2>"$build_err")" \
     || build_status=$?
 
 if [[ $build_status -ne 0 ]]; then
-    echo "rue-bin: 'buck2 build //crates/rue:rue' failed (exit $build_status):" >&2
+    echo "rue-bin: 'buck2 build $target' failed (exit $build_status):" >&2
     cat "$build_err" >&2
     exit "$build_status"
 fi
 
 # stdout stays clean for command substitution; the --show-output line names the
 # binary at a repo-root-relative path.
-rel_path="$(printf '%s\n' "$build_out" | awk '/crates\/rue:rue / {print $2}' | tail -1)"
+rel_path="$(printf '%s\n' "$build_out" | awk -v target="$target_label" 'index($1, target) {print $2}' | tail -1)"
 
 if [[ -z "${rel_path:-}" ]]; then
     echo "rue-bin: build succeeded but --show-output did not name the binary." >&2

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -48,6 +48,7 @@ perf_baseline = load_module("perf_baseline", "scripts/perf-baseline.py")
 parser_profile = load_module("parser_profile", "scripts/parser-profile.py")
 manifest_tools = load_module("benchmark_manifest", "scripts/benchmark_manifest.py")
 scaling = load_module("benchmark_scaling", "scripts/benchmark_scaling.py")
+scenario_tools = load_module("benchmark_scenarios", "scripts/benchmark_scenarios.py")
 
 
 class PerfBaselineAggregationTests(unittest.TestCase):
@@ -747,6 +748,59 @@ class BenchmarkValidationTests(unittest.TestCase):
             "families": families,
             "budget_status": "passed",
         }
+        scenario_families = manifest_tools.scenario_families(manifest_path)
+        reused = []
+        for declared in scenario_families[1]["scenarios"]:
+            work = {
+                artifact: {"required": declared[artifact][0], "reused": declared[artifact][1]}
+                for artifact in ("modules", "semantic_bodies", "cfgs", "semantic_queries")
+            }
+            row = {
+                "name": declared["name"], "samples_ms": [1.0] * 5, "mean_ms": 1.0,
+                "required_vs_reused_work": work,
+            }
+            if declared["name"] == "diagnostic_error_edit":
+                row["diagnostic_parity"] = {"fresh_session": "exact", "last_good_preserved": True}
+            else:
+                row["differential_parity"] = {
+                    "dependency_records": "exact", "diagnostics": "exact",
+                    "durable_ordinary_body_manifest_artifacts": "exact",
+                    "durable_specialized_body_payloads": "exact",
+                    "emitted_output": "byte_exact", "public_semantic_cfg_artifacts": "exact",
+                    "public_type_universe": "exact_ordered_entries", "stable_identities": "exact",
+                    "warnings": "exact",
+                    "emitted_output_sha256": "a" * 64,
+                    "emitted_output_size_bytes": 100,
+                }
+            if declared["name"] == "diagnostic_recovery":
+                row["recovered_from_diagnostic_error"] = True
+            reused.append(row)
+        result["scenarios"] = {
+            "schema_version": 1,
+            "measurement_family": "compiler_build_and_query_performance",
+            "representative": True,
+            "generated_program_runtime": False,
+            "cross_family_emitted_output": {
+                "cold_batch_vs_fresh_and_reused_session": "byte_exact",
+                "representation": "raw_compiler_executable_before_platform_postprocessing",
+                "sha256": "a" * 64,
+                "size_bytes": 100,
+            },
+            "iterations": 5,
+            "families": [
+                {
+                    **{field: scenario_families[0][field] for field in ("name", "interpretation", "not_runtime")},
+                    "scenarios": [{
+                        "name": "cold_batch_root_compiler", "samples_ms": [2.0] * 5, "mean_ms": 2.0,
+                        "emitted_output": {"parity": "byte_exact", "representation": "raw_compiler_executable_before_platform_postprocessing", "sha256": "a" * 64, "size_bytes": 100},
+                    }],
+                },
+                {
+                    **{field: scenario_families[1][field] for field in ("name", "interpretation", "not_runtime")},
+                    "scenarios": reused,
+                },
+            ],
+        }
         return result
 
     def test_exact_manifest_corpus_is_accepted(self):
@@ -762,6 +816,7 @@ class BenchmarkValidationTests(unittest.TestCase):
         self.assertEqual(manifest_tools.validate_readme_inventory(manifest_path), [])
         self.assertEqual(len(manifest["benchmark"]), 7)
         self.assertEqual(len(manifest["scaling_family"]), 5)
+        self.assertEqual(len(manifest["scenario_family"]), 2)
         for probe in manifest["benchmark"]:
             self.assertEqual(probe["kind"], "synthetic_phase_probe")
             self.assertIn("not representative", probe["non_representative"].lower())
@@ -1088,6 +1143,55 @@ class BenchmarkValidationTests(unittest.TestCase):
         self.assertEqual(charts.get_total_time(result), phase_total)
         representative = {"scaling": {**result["scaling"], "representative": True}}
         self.assertIsNone(charts.scaling_diagnostics([representative]))
+        self.assertIs(charts.scenario_diagnostics([result]), result["scenarios"])
+        self.assertIn("Representative compiler build/query scenarios", template)
+        self.assertIn("required_vs_reused_work", template)
+
+    def test_representative_scenario_validation_is_fail_closed(self):
+        manifest_path = INPUT_ROOT / "benchmarks/manifest.toml"
+        result = self.valid_result()
+        self.assertEqual(validator.validate_manifest_results(result, manifest_path), [])
+        result["scenarios"]["families"][1]["scenarios"][1]["required_vs_reused_work"]["modules"]["required"] += 1
+        self.assertTrue(any("structural work" in error for error in validator.validate_manifest_results(result, manifest_path)))
+        missing = self.valid_result()
+        del missing["scenarios"]
+        self.assertIn("benchmark result is missing representative scenarios", validator.validate_manifest_results(missing, manifest_path))
+
+    def test_cross_family_output_parity_is_required(self):
+        manifest_path = INPUT_ROOT / "benchmarks/manifest.toml"
+        result = self.valid_result()
+        result["scenarios"]["cross_family_emitted_output"]["sha256"] = "b" * 64
+        errors = validator.validate_manifest_results(result, manifest_path)
+        self.assertTrue(any("does not match the batch driver" in error for error in errors))
+
+        families = manifest_tools.scenario_families(manifest_path)
+        cold = {
+            "name": "cold_batch_root_compiler",
+            "samples_ms": [1.0],
+            "mean_ms": 1.0,
+            "emitted_output": {"parity": "byte_exact", "representation": "raw_compiler_executable_before_platform_postprocessing", "sha256": "a" * 64, "size_bytes": 100},
+        }
+        with mock.patch.object(scenario_tools, "collect_cold", return_value=cold), mock.patch.object(
+            scenario_tools,
+            "collect_reused",
+            return_value=([], {"sha256": "b" * 64, "size_bytes": 100}),
+        ):
+            with self.assertRaisesRegex(ValueError, "differs from fresh/reused"):
+                scenario_tools.collect(manifest_path, Path("rue"), Path("session"), 1)
+        self.assertEqual(len(families), 2)
+
+    def test_cold_output_must_equal_cross_family_identity(self):
+        manifest_path = INPUT_ROOT / "benchmarks/manifest.toml"
+        for field, value in (("sha256", "b" * 64), ("size_bytes", 101)):
+            with self.subTest(field=field):
+                result = self.valid_result()
+                result["scenarios"]["families"][0]["scenarios"][0][
+                    "emitted_output"
+                ][field] = value
+                errors = validator.validate_manifest_results(result, manifest_path)
+                self.assertTrue(
+                    any("does not match cross-family parity" in error for error in errors)
+                )
 
     def test_missing_unknown_and_duplicate_names_are_rejected(self):
         missing = self.valid_result()
@@ -1351,7 +1455,7 @@ class DurableBenchmarkHistoryTests(unittest.TestCase):
         self.assertNotEqual(first["id"], changed_iterations["id"])
         self.assertNotEqual(first["id"], changed_runner["id"])
 
-    def test_corpus_hash_includes_scaling_generator_definitions(self):
+    def test_corpus_hash_includes_scaling_and_scenario_definitions(self):
         manifest = INPUT_ROOT / "benchmarks/manifest.toml"
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -1366,9 +1470,16 @@ class DurableBenchmarkHistoryTests(unittest.TestCase):
             generator = root / "scripts/scaling_workloads.py"
             generator.write_text(generator.read_text() + "\n# workload definition changed\n")
             after = history_tools.corpus_metadata(copied_manifest)
+            fixture = root / "benchmarks/scenarios/representative/main.rue"
+            fixture.write_text(fixture.read_text() + "\n")
+            after_fixture = history_tools.corpus_metadata(copied_manifest)
         self.assertEqual(before["schema_version"], 2)
         self.assertIn("../scripts/scaling_workloads.py", before["files"])
+        self.assertIn("../scripts/benchmark_scenarios.py", before["files"])
+        self.assertIn("../crates/rue/src/main.rs", before["files"])
+        self.assertIn("../crates/rue-compiler-session-bench/src/main.rs", before["files"])
         self.assertNotEqual(before["sha256"], after["sha256"])
+        self.assertNotEqual(after["sha256"], after_fixture["sha256"])
 
     def test_schema_one_and_two_corpora_remain_loadable_across_regime_boundary(self):
         def published(schema, digest, commit):

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -96,6 +96,24 @@ EOF
   rm -rf "$sb"
 }
 
+test_ruebin_session_bench_uses_canonical_resolver() {
+  local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/scripts" "$sb/fakebin"
+  cp "$SRC_ROOT/scripts/rue-bin" "$sb/scripts/rue-bin"; chmod +x "$sb/scripts/rue-bin"
+  printf '#!/bin/sh\ntrue\n' >"$sb/fakebin/session"; chmod +x "$sb/fakebin/session"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+echo "root//crates/rue-compiler-session-bench:rue-compiler-session-bench fakebin/session"
+EOF
+  chmod +x "$sb/buck2"
+
+  local rc out
+  out="$( "$sb/scripts/rue-bin" --session-bench 2>/dev/null )"; rc=$?
+  check "rue-bin: session benchmark uses canonical absolute resolver" \
+    "$([ "$rc" -eq 0 ] && [ "$out" = "$sb/fakebin/session" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
 # fmt.sh delegates rustfmt's runtime environment to `buck2 run`; a failing
 # invocation must remain loud.
 test_fmt_build_failure_is_loud() {
@@ -534,6 +552,7 @@ test_sanitizer_status_contracts() {
 
 test_ruebin_build_failure_is_loud
 test_ruebin_success_prints_clean_path
+test_ruebin_session_bench_uses_canonical_resolver
 test_fmt_build_failure_is_loud
 test_fmt_uses_one_buck_run_and_preserves_paths
 test_rue_exec_resolves_from_caller_cwd

--- a/website/static/benchmarks/README.md
+++ b/website/static/benchmarks/README.md
@@ -22,14 +22,17 @@ Version 3 uses a compact index whose `shards` array points to per-run files:
 }
 ```
 
-Each new run contains two deliberately separate products: `benchmarks` holds
+Each new run contains three deliberately separate products: `benchmarks` holds
 the non-representative static phase-probe aggregate, while `scaling` holds
 generated multi-size families with latency, peak memory, source/pass structural
 counters, robust variation, conservative adjacent size-normalized growth
 bounds, an extreme-range guard, and proven/indeterminate/within-budget evidence
 status. Failed and indeterminate scaling evidence both block publication.
-Neither product measures generated-program runtime performance; representative
-RUE-901 scenarios use a different scenario family and headline.
+Neither product measures generated-program runtime performance. `scenarios`
+holds representative cold-root and reused-session compiler build/query work,
+with exact cross-family batch/fresh/reused output parity evidence and
+authoritative required/reused counters. It has
+its own section and never changes the synthetic aggregate headline.
 
 ## Updating History
 

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -101,6 +101,12 @@
             </details>
 
             <details>
+                <summary>Representative compiler build/query scenarios</summary>
+                <p class="details-intro">Cold root builds and fixed <code>CompilerSession</code> edits use one tracked multi-module project. They measure compiler work, not generated-program runtime, and remain separate from phase probes and scaling diagnostics.</p>
+                <div id="scenario-diagnostics" class="scaling-diagnostics"></div>
+            </details>
+
+            <details>
                 <summary>Measurement records, coverage, provenance, and raw samples</summary>
                 <p class="details-intro">Technical evidence for reproducing or auditing a point. Fields are labeled; raw samples remain available without exposing serialized objects.</p>
                 <div id="measurement-records"></div>
@@ -125,6 +131,7 @@
         comparison: $('comparison-card'), authored: $('authored-annotations'), derived: $('derived-annotations'),
         multiples: $('workload-multiples'), memory: $('memory-chart'), binary: $('binary-chart'),
         normalized: $('normalized-chart'), metrics: $('metrics-table'), scaling: $('scaling-diagnostics'),
+        scenarios: $('scenario-diagnostics'),
         records: $('measurement-records')
     };
     let rootMetadata = null;
@@ -405,6 +412,44 @@
             els.scaling.appendChild(card);
         });
     }
+    function renderScenarios() {
+        els.scenarios.replaceChildren();
+        const publication = metadata.latest_scenarios;
+        if (!publication?.families?.length) {
+            els.scenarios.appendChild(node('p', 'No representative compiler scenarios are available for this measurement.', 'chart-empty'));
+            return;
+        }
+        publication.families.forEach(family => {
+            const card = node('article', undefined, 'scaling-card');
+            card.appendChild(node('h3', family.name.replaceAll('_', ' ')));
+            card.appendChild(node('p', `${family.interpretation} ${family.not_runtime}`, 'details-intro'));
+            const scroll = node('div', undefined, 'table-scroll');
+            const table = node('table');
+            table.appendChild(node('caption', `${family.name.replaceAll('_', ' ')}: compiler latency and authoritative required/reused work`));
+            const head = node('tr');
+            ['Scenario', 'Mean latency', 'Required / reused', 'Parity evidence'].forEach(label => {
+                const cell = node('th', label); cell.setAttribute('scope', 'col'); head.appendChild(cell);
+            });
+            table.appendChild(head);
+            family.scenarios.forEach(scenario => {
+                const work = scenario.required_vs_reused_work;
+                const workText = work
+                    ? Object.entries(work).map(([name, counts]) => `${name.replaceAll('_', ' ')} ${counts.required}/${counts.reused}`).join('; ')
+                    : 'fresh batch build';
+                const parity = scenario.diagnostic_parity
+                    ? 'exact fresh diagnostics; last-good preserved'
+                    : scenario.differential_parity
+                        ? 'exact fresh-session artifacts and output'
+                        : scenario.emitted_output?.parity === 'byte_exact'
+                            ? 'byte-exact emitted output'
+                            : 'not reported';
+                const row = node('tr');
+                [scenario.name.replaceAll('_', ' '), fmt(scenario.mean_ms, 3), workText, parity].forEach(value => row.appendChild(node('td', value)));
+                table.appendChild(row);
+            });
+            scroll.appendChild(table); card.appendChild(scroll); els.scenarios.appendChild(card);
+        });
+    }
     function labeledField(term, value) { const row = node('div'); row.appendChild(node('dt', term)); row.appendChild(node('dd', value)); return row; }
     function renderRecords() {
         els.records.replaceChildren();
@@ -443,7 +488,7 @@
     }
 
     function renderAll() {
-        renderPrimaryCharts(); populateComparisons(); renderWorkloads(); renderAnnotations(); renderMetrics(); renderScaling(); renderRecords();
+        renderPrimaryCharts(); populateComparisons(); renderWorkloads(); renderAnnotations(); renderMetrics(); renderScaling(); renderScenarios(); renderRecords();
     }
     function configureWorkloads() {
         const previous = els.workload.value; els.workload.replaceChildren();


### PR DESCRIPTION
Summary:
- add a deterministic representative multi-module project and separate cold-driver and reused-CompilerSession scenario families
- hard-gate exact parse, semantic-body, CFG, query, diagnostic, dependency, and executable parity across fixed edit sequences
- publish scenarios separately and version every fixture and measurement definition in the corpus regime

Validation:
- benchmark tool tests (107/107)
- wrapper script tests (38/38)
- CompilerSession benchmark tests (5/5)
- one-iteration cold/fresh/reused executable-parity smoke
- website build and inline JavaScript parse
- scripts/rue quick

Fixes RUE-901