### PR TITLE
RUE-907: restore explanatory performance views

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -116,6 +116,7 @@ benchmark_tool_local_inputs = glob(["benchmarks/**"]) + [
         "scripts/scaling_workloads.py",
         "scripts/validate-benchmark.py",
         "website/build.sh",
+        "website/css/input.css",
         "website/templates/performance.html",
         "website/templates/index.html",
     ]

--- a/scripts/benchmark_evolution.py
+++ b/scripts/benchmark_evolution.py
@@ -127,7 +127,9 @@ def _aggregate(points: list[dict], resolution: str) -> list[dict]:
     return result
 
 
-def _range_view(points: list[dict], start: datetime | None, resolution: str) -> dict:
+def _range_view(
+    points: list[dict], start: datetime | None, end: datetime, resolution: str
+) -> dict:
     start_index = next(
         (
             index for index, point in enumerate(points)
@@ -136,10 +138,28 @@ def _range_view(points: list[dict], start: datetime | None, resolution: str) -> 
         len(points),
     )
     selected = points[start_index:]
+    trend_points = _aggregate(selected, resolution)
+    trend_segments = []
+    for point in trend_points:
+        if not trend_segments or trend_segments[-1]["segment"] != point["segment"]:
+            trend_segments.append({"segment": point["segment"], "points": []})
+        trend_segments[-1]["points"].append(point)
     return {
         "raw_start_index": start_index,
         "rendered_raw_points": _render_subset(selected),
-        "trend_points": _aggregate(selected, resolution),
+        "trend_points": trend_points,
+        # Renderers consume these paths directly so a line can never bridge a
+        # comparison boundary by accident.
+        "trend_segments": trend_segments,
+        # Finite calendar ranges retain their requested domain even when
+        # measurements are sparse. The all-history view derives its domain
+        # from the first and last observed points in the renderer.
+        "calendar_start": (
+            start.isoformat().replace("+00:00", "Z") if start is not None else None
+        ),
+        "calendar_end": (
+            end.isoformat().replace("+00:00", "Z") if start is not None else None
+        ),
         "raw_point_count": len(selected),
         "rendered_raw_point_count": len(_render_subset(selected)),
         "resolution": resolution,
@@ -279,7 +299,7 @@ def evolution_workspace(
                     else None
                 )
                 resolution = "day" if range_id in {"30d", "90d"} else "week"
-                range_views[range_id] = _range_view(points, start, resolution)
+                range_views[range_id] = _range_view(points, start, range_end, resolution)
             all_series.append({
                 "platform": platform,
                 "workload": workload,

--- a/scripts/generate-site-status.py
+++ b/scripts/generate-site-status.py
@@ -26,8 +26,9 @@ import json
 import re
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import quote
 
 from benchmark_history import load_history
 from benchmark_annotations import (
@@ -36,6 +37,7 @@ from benchmark_annotations import (
     load_annotations,
     normalized_annotations,
 )
+from benchmark_evolution import evolution_workspace
 from benchmark_metrics import absolute_latency_ms, derive_history_metrics
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -118,18 +120,21 @@ def _run_suite_ms(run: dict) -> float | None:
     return sum(values) if values else None
 
 
-def _spark_points(values: list[float]) -> tuple[str, str, str]:
+def _spark_points(
+    points: list[dict], window_start: datetime, window_end: datetime
+) -> tuple[str, str, str]:
+    values = [point["index"] for point in points]
     lo, hi = min(values), max(values)
     span = (hi - lo) or 1.0
-    points = []
-    denominator = max(1, len(values) - 1)
-    for index, value in enumerate(values):
-        # Measured commits are evenly spaced: cancelled or idle calendar time
-        # should not create a chart full of empty space.
-        x = SPARK_W * index / denominator
+    coordinates = []
+    window_seconds = max(1.0, (window_end - window_start).total_seconds())
+    for point, value in zip(points, values):
+        instant = _parse_timestamp(point.get("timestamp"))
+        x = SPARK_W * (instant - window_start).total_seconds() / window_seconds
+        x = max(0.0, min(float(SPARK_W), x))
         y = SPARK_Y_MAX - (SPARK_Y_MAX - SPARK_Y_MIN) * (value - lo) / span
-        points.append(f"{x:.0f},{y:.1f}")
-    return " ".join(points), *points[-1].split(",")
+        coordinates.append(f"{x:.0f},{y:.1f}")
+    return " ".join(coordinates), *coordinates[-1].split(",")
 
 
 def _freshness_label(age_seconds: int) -> str:
@@ -151,9 +156,27 @@ def sparkline_data(
     as_of: datetime | None = None,
     resolver=None,
 ) -> dict | None:
-    """Build a compact absolute-time homepage view from canonical semantics."""
+    """Build a compact 30-day view from canonical evolution semantics."""
     if not runs or any(_parse_timestamp(run.get("timestamp")) is None for run in runs):
         return None
+    annotations = annotations or []
+    resolver = resolver or GitCommitResolver(REPO_ROOT)
+    workspace = evolution_workspace({platform: runs}, annotations, resolver)
+    series = next(item for item in workspace["series"] if item["workload"] == "all")
+    view = series["ranges"]["30d"]
+    window_points = series["raw_points"][view["raw_start_index"]:]
+    if not window_points:
+        return None
+    latest_segment = window_points[-1]["segment"]
+    comparable_points = [point for point in window_points if point["segment"] == latest_segment]
+    trend_points = [
+        point for point in view["trend_points"]
+        if point["segment"] == latest_segment and isinstance(point["index"], (int, float))
+    ]
+    range_end = _parse_timestamp(workspace["range_end"])
+    range_start = range_end - timedelta(days=30)
+    endpoint = _spark_points(trend_points, range_start, range_end) if trend_points else None
+
     derived = derive_history_metrics(runs)
     latest_semantic = derived["points"][-1]
     baseline = latest_semantic["rolling_baseline"]
@@ -204,32 +227,54 @@ def sparkline_data(
         "label": _freshness_label(age_seconds),
     }
 
-    # Only the current comparable segment belongs in the homepage trend.
-    segment_start = 0
-    for index, semantic in enumerate(derived["points"]):
-        if semantic["previous"].get("status") != "comparable":
-            segment_start = index
-    trend_runs = runs[segment_start:][-12:]
-    trend_values = [_run_suite_ms(run) for run in trend_runs]
-    trend_values = [value for value in trend_values if value is not None]
-    endpoint = _spark_points(trend_values) if trend_values else None
     suite_ms = _run_suite_ms(latest_run)
+    publication = latest_run.get("publication", {})
+    coverage = publication.get("coverage", {}) if isinstance(publication, dict) else {}
+    coverage_status = {
+        "measured_commit": coverage.get("measured_commit", latest_run.get("commit")),
+        "represented_count": len(coverage.get("represented_commits", [])),
+        "skipped_count": len(coverage.get("skipped_commits", [])),
+        "gap_unknown": coverage.get("gap_unknown", True),
+    }
+
+    events_by_id = {event.get("id"): event for event in annotations}
+    relevant_annotation = None
+    candidates = [
+        (event.get("source") != "authored", -point_index, event.get("id", ""), event)
+        for point_index, point in enumerate(comparable_points)
+        for event_id in point["annotation_ids"]
+        if (event := events_by_id.get(event_id)) is not None
+    ]
+    if candidates:
+        candidates.sort(key=lambda item: item[:3])
+        relevant_annotation = dict(candidates[0][3])
+        annotation_id = quote(str(relevant_annotation.get("id", "")), safe="")
+        relevant_annotation["dashboard_url"] = (
+            f"/performance/?range=30d&platform={quote(platform, safe='')}"
+            f"&annotation={annotation_id}#evolution-workspace"
+        )
+        relevant_annotation["category_label"] = str(
+            relevant_annotation.get("category", "measurement_infrastructure")
+        ).replace("_", " ")
 
     result = {
         "platform": platform,
         "platform_label": "Linux x86-64",
-        "window": "last measured commits",
-        "n_runs": len(trend_values),
-        "n_trend_points": len(trend_values),
+        "window": "30d",
+        "n_runs": len(comparable_points),
+        "n_trend_points": len(trend_points),
         "points": endpoint[0] if endpoint else "",
         "latest_suite_ms": suite_ms,
         "state": state,
         "freshness": freshness,
-        "dashboard_url": "/performance/",
+        "coverage": coverage_status,
+        "dashboard_url": f"/performance/?range=30d&platform={quote(platform, safe='')}#evolution-workspace",
     }
     if endpoint:
         result["last_x"] = endpoint[1]
         result["last_y"] = endpoint[2]
+    if relevant_annotation:
+        result["annotation"] = relevant_annotation
     return result
 
 

--- a/scripts/test-benchmark-tools.py
+++ b/scripts/test-benchmark-tools.py
@@ -1784,7 +1784,7 @@ class BenchmarkMetricSemanticsTests(unittest.TestCase):
         self.assertAlmostEqual(summary["time_delta_pct"], 10.0)
         self.assertEqual(summary["time_delta_str"], "↑ 10.0%")
 
-    def test_status_uses_absolute_suite_time_and_last_measured_commits(self):
+    def test_status_uses_absolute_suite_time_and_thirty_calendar_days(self):
         runs = [
             {
                 **self.sample_run(
@@ -1796,9 +1796,9 @@ class BenchmarkMetricSemanticsTests(unittest.TestCase):
             for index in range(25)
         ]
         status = site_status.sparkline_data(runs)
-        self.assertEqual(status["n_runs"], 12)
+        self.assertEqual(status["n_runs"], 25)
         self.assertEqual(status["latest_suite_ms"], 124)
-        self.assertEqual(status["window"], "last measured commits")
+        self.assertEqual(status["window"], "30d")
         self.assertNotIn("latest_index", status)
 
 
@@ -1852,7 +1852,7 @@ class HomepageBenchmarkStatusTests(unittest.TestCase):
         self.assertEqual(corpus_a["state"], corpus_b["state"])
         self.assertEqual(corpus_a["state"]["kind"], "baseline_reset")
 
-    def test_homepage_omits_annotation_and_coverage_telemetry(self):
+    def test_homepage_exposes_concise_annotation_coverage_and_deep_link(self):
         runs = [self.sample_run(1, 100), self.sample_run(2, 100), self.sample_run(3, 100), self.sample_run(4, 120)]
         event = {
             "id": "capability-cost",
@@ -1870,8 +1870,54 @@ class HomepageBenchmarkStatusTests(unittest.TestCase):
         self.assertEqual(status["state"]["kind"], "regressed")
         self.assertEqual(status["freshness"]["kind"], "stale")
         self.assertEqual(status["freshness"]["label"], "measured 3 days ago")
+        self.assertEqual(status["annotation"]["category"], "capability")
+        self.assertEqual(status["annotation"]["title"], "Intentional capability cost")
+        self.assertEqual(status["coverage"], {
+            "measured_commit": runs[-1]["commit"],
+            "represented_count": 1,
+            "skipped_count": 0,
+            "gap_unknown": False,
+        })
+        self.assertEqual(
+            status["annotation"]["dashboard_url"],
+            "/performance/?range=30d&platform=x86-64-linux&annotation=capability-cost#evolution-workspace",
+        )
+
+    def test_homepage_excludes_events_outside_range_and_current_segment(self):
+        runs = [
+            self.sample_run(1, 100, day=1),
+            self.sample_run(2, 101, day=2),
+            self.sample_run(3, 99, day=3),
+            self.sample_run(4, 100, regime="new", day=4),
+            self.sample_run(5, 100, regime="new", day=5),
+            self.sample_run(6, 100, regime="new", day=6),
+        ]
+        runs[0]["timestamp"] = "2026-05-01T00:00:00Z"
+        def event(identifier, run):
+            return {
+                "id": identifier, "source": "authored",
+                "location": {"kind": "commit", "commit": run["commit"]},
+                "category": "optimization", "title": identifier,
+                "explanation": identifier, "link": "https://github.com/rue-language/rue/pull/1",
+                "scope": {"metrics": ["latency"], "workloads": ["*"], "platforms": ["*"]},
+            }
+        status = self.status(runs, [event("outside-range", runs[0]), event("old-segment", runs[2])])
         self.assertNotIn("annotation", status)
-        self.assertNotIn("coverage", status)
+        self.assertEqual(status["n_runs"], 3)
+
+    def test_homepage_prefers_authored_event_over_newer_derived_event(self):
+        runs = [self.sample_run(index, 100, day=index) for index in range(1, 5)]
+        def event(identifier, run, source):
+            return {
+                "id": identifier, "source": source,
+                "location": {"kind": "commit", "commit": run["commit"]},
+                "category": "optimization" if source == "authored" else "measurement_infrastructure",
+                "title": identifier, "explanation": identifier,
+                "link": "https://github.com/rue-language/rue/pull/1",
+                "scope": {"metrics": ["latency"], "workloads": ["*"], "platforms": ["*"]},
+            }
+        status = self.status(runs, [event("authored", runs[2], "authored"), event("derived", runs[3], "derived")])
+        self.assertEqual(status["annotation"]["id"], "authored")
 
     def test_missing_or_malformed_time_data_is_not_presented(self):
         self.assertIsNone(self.status([]))
@@ -1884,10 +1930,10 @@ class HomepageBenchmarkStatusTests(unittest.TestCase):
         run["benchmarks"][0]["samples_ms"] = [100, 100]
         status = self.status([run])
         self.assertEqual(status["state"]["kind"], "insufficient_data")
-        self.assertEqual(status["n_trend_points"], 1)
+        self.assertEqual(status["n_trend_points"], 0)
         self.assertEqual(status["latest_suite_ms"], 100)
-        self.assertIn("last_x", status)
-        self.assertIn("last_y", status)
+        self.assertNotIn("last_x", status)
+        self.assertNotIn("last_y", status)
 
     def test_legacy_root_compile_timer_wins_over_inflated_mean(self):
         run = self.sample_run(1, 100)
@@ -1898,7 +1944,7 @@ class HomepageBenchmarkStatusTests(unittest.TestCase):
         status = self.status([run])
         self.assertEqual(status["latest_suite_ms"], 123)
 
-    def test_sparkline_uses_measured_commits_in_latest_segment(self):
+    def test_sparkline_uses_thirty_days_and_latest_segment(self):
         runs = [
             self.sample_run(1, 100, day=1),
             self.sample_run(2, 100, day=2),
@@ -1907,10 +1953,10 @@ class HomepageBenchmarkStatusTests(unittest.TestCase):
         ]
         runs[0]["timestamp"] = "2026-05-01T00:00:00Z"
         status = self.status(runs)
-        self.assertEqual(status["window"], "last measured commits")
-        self.assertEqual(status["n_runs"], 4)
+        self.assertEqual(status["window"], "30d")
+        self.assertEqual(status["n_runs"], 3)
 
-    def test_sparkline_x_coordinates_evenly_space_measured_commits(self):
+    def test_sparkline_x_coordinates_use_calendar_distance(self):
         runs = [
             self.sample_run(1, 100, day=1),
             self.sample_run(2, 90, day=2),
@@ -1918,7 +1964,7 @@ class HomepageBenchmarkStatusTests(unittest.TestCase):
         ]
         status = self.status(runs)
         coordinates = [point.split(",") for point in status["points"].split()]
-        self.assertEqual([int(point[0]) for point in coordinates], [0, 150, 300])
+        self.assertEqual([int(point[0]) for point in coordinates], [10, 20, 300])
 
     def test_shallow_checkout_omits_misleading_commit_count(self):
         def fake_git(*args):
@@ -1937,17 +1983,17 @@ class HomepageBenchmarkStatusTests(unittest.TestCase):
 
     def test_homepage_template_reports_honest_states(self):
         template = (INPUT_ROOT / "website" / "templates" / "index.html").read_text()
-        self.assertIn("Absolute suite compilation time", template)
+        self.assertIn("latest_suite_ms", template)
         self.assertIn("status.bench.state.summary", template)
         self.assertIn("status.bench.latest_suite_ms", template)
-        self.assertIn("last {{ status.bench.n_trend_points }} measured commits", template)
+        self.assertIn("comparable daily points", template)
         self.assertIn("history count unavailable", template)
         self.assertIn("benchmark data unavailable", template)
         self.assertIn("{% if status.bench.n_trend_points > 0 %}", template)
-        self.assertNotIn("normalized", template.lower())
-        self.assertNotIn("variation", template.lower())
-        self.assertNotIn("coverage", template.lower())
-        self.assertNotIn("status.bench.annotation", template)
+        self.assertIn("status.bench.coverage", template)
+        self.assertIn("status.bench.annotation.dashboard_url", template)
+        self.assertIn("status.bench.annotation.explanation", template)
+        self.assertNotIn("annotated capability cost", template)
 
 
 class TestBenchmarkAnnotations(unittest.TestCase):
@@ -2152,7 +2198,7 @@ class TestBenchmarkAnnotations(unittest.TestCase):
             [],
         )
 
-    def test_homepage_does_not_surface_the_annotation_stream(self):
+    def test_homepage_surfaces_the_most_relevant_annotation(self):
         run = BenchmarkMetricSemanticsTests.sample_run(
             "a" * 40, {"probe": [10, 10, 10]}
         )
@@ -2164,7 +2210,9 @@ class TestBenchmarkAnnotations(unittest.TestCase):
             [run], stream, resolver=self.Resolver(),
             as_of=datetime(2026, 7, 1, tzinfo=timezone.utc),
         )
-        self.assertNotIn("annotation", status)
+        self.assertEqual(status["annotation"]["source"], "authored")
+        self.assertEqual(status["annotation"]["category"], "optimization")
+        self.assertIn("annotation=", status["annotation"]["dashboard_url"])
 
 
 class TestRecentRegressionWorkspace(unittest.TestCase):
@@ -2274,6 +2322,15 @@ class TestRecentRegressionWorkspace(unittest.TestCase):
         self.assertEqual(model["default_selection"], {"before": "3" * 40, "after": "4" * 40})
         self.assertEqual(model["comparisons"][-1]["before_point"]["subject"], "RUE-903: measured change 3")
         self.assertEqual(model["annotation_groups"][0]["title"], "Queryable compiler")
+        point = model["points"][3]
+        for field in (
+            "commit", "date", "subject", "links", "freshness", "suite_ms", "workloads",
+            "coverage", "comparability", "annotations",
+        ):
+            self.assertIn(field, point)
+        self.assertIn("commit", point["links"])
+        self.assertIn("issues", point["links"])
+        self.assertEqual(point["annotations"][0]["category"], "capability")
         self.assertFalse(any(
             item["before"] == "2" * 40 and item["after"] == "4" * 40
             for item in model["comparisons"]
@@ -2375,12 +2432,16 @@ class TestRecentRegressionWorkspace(unittest.TestCase):
 
     def test_recent_template_keeps_semantics_server_side_and_guards_insufficient_data(self):
         template = (INPUT_ROOT / "website" / "templates" / "performance.html").read_text()
-        self.assertIn("Raw samples are insufficient", template)
-        self.assertIn("point.coverage.skipped_commits.map", template)
-        self.assertIn("appendLink(title, item.title, item.link)", template)
-        self.assertIn("fmt(value.before_ms)", template)
-        self.assertIn("headline.classification === 'insufficient_data'", template)
-        self.assertIn("populateComparisons()", template)
+        for contract in (
+            "Raw samples are insufficient", "point.coverage.skipped_commits.map",
+            "point.links?.commit", "point.date", "point.subject", "point.freshness.latest",
+            "point.comparability.headline", "point.annotations.forEach",
+            "annotationBadge(event.category)", "point.links?.pull_requests", "point.links?.issues",
+            "explanation.workloads.forEach", "explanation.memory_bytes", "explanation.binary_size_bytes",
+            "fmt(value.before_ms)", "headline.classification === 'insufficient_data'",
+            "populateComparisons()",
+        ):
+            self.assertIn(contract, template)
         self.assertNotIn("function calculateDelta", template)
         self.assertNotIn("JSON.stringify", template)
         build = (INPUT_ROOT / "website" / "build.sh").read_text()
@@ -2451,6 +2512,13 @@ class BenchmarkEvolutionTests(unittest.TestCase):
         self.assertEqual(series["ranges"]["all"]["raw_point_count"], 5)
         self.assertEqual(series["ranges"]["30d"]["resolution"], "day")
         self.assertEqual(series["ranges"]["1y"]["resolution"], "week")
+        self.assertEqual(
+            series["ranges"]["30d"]["calendar_start"],
+            (end - evolution.timedelta(days=30)).isoformat().replace("+00:00", "Z"),
+        )
+        self.assertEqual(series["ranges"]["30d"]["calendar_end"], end.isoformat().replace("+00:00", "Z"))
+        self.assertIsNone(series["ranges"]["all"]["calendar_start"])
+        self.assertIsNone(series["ranges"]["all"]["calendar_end"])
         self.assertEqual(model["raw_history_run_count"], len(runs))
         self.assertEqual(model["metric_policy"], "benchmark_metrics.derive_history_metrics")
         self.assertEqual(model["annotation_policy"], "benchmark_annotations.normalized_annotation_stream")
@@ -2470,6 +2538,15 @@ class BenchmarkEvolutionTests(unittest.TestCase):
             {point["segment"] for point in series["ranges"]["all"]["trend_points"]},
             {0, 1, 2, 3},
         )
+        self.assertEqual(model["range_options"], ["30d", "90d", "1y", "all"])
+        self.assertEqual(
+            [segment["segment"] for segment in series["ranges"]["all"]["trend_segments"]],
+            [0, 1, 2, 3],
+        )
+        self.assertTrue(all(
+            {point["segment"] for point in segment["points"]} == {segment["segment"]}
+            for segment in series["ranges"]["all"]["trend_segments"]
+        ))
         self.assertEqual(model["cross_platform_default"], "normalized_index_separate_machine_series")
         self.assertEqual(model["workload_families"][0]["source"], "identity_fallback")
 
@@ -2529,6 +2606,8 @@ class BenchmarkEvolutionTests(unittest.TestCase):
         series = next(item for item in model["series"] if item["workload"] == "all")
         self.assertEqual(series["ranges"]["1y"]["raw_point_count"], 2)
         self.assertEqual(series["ranges"]["1y"]["raw_start_index"], 1)
+        self.assertEqual(series["ranges"]["1y"]["calendar_start"], "2027-02-28T12:00:00Z")
+        self.assertEqual(series["ranges"]["1y"]["calendar_end"], "2028-02-29T12:00:00Z")
 
     def test_trend_uses_exact_canonical_median_and_scaled_mad(self):
         start = datetime(2026, 1, 5, tzinfo=timezone.utc)
@@ -2578,15 +2657,34 @@ class BenchmarkEvolutionTests(unittest.TestCase):
         self.assertIn(runs[350]["commit"], rendered)
         self.assertIn(runs[123]["commit"], rendered)
 
-    def test_evolution_template_only_renders_precomputed_policy(self):
+    def test_evolution_renderer_consumes_complete_precomputed_contract(self):
         template = (INPUT_ROOT / "website" / "templates" / "performance.html").read_text()
-        self.assertIn("workspace.series.filter", template)
-        self.assertIn("item.raw_points.map", template)
-        self.assertIn("Normalized cross-platform evolution", template)
-        self.assertIn("Each machine remains a separate normalized series", template)
-        self.assertIn("drawCommitChart(els.normalized", template)
-        self.assertIn("unit: 'index'", template)
+        for contract in (
+            "workspace.range_options", "workspace.platform_options", "workspace.workload_families",
+            "view.rendered_raw_points", "view.trend_points", "view.trend_segments",
+            "rangeView.calendar_start", "rangeView.calendar_end",
+            "point.variation", "point.boundary", "boundary.skipped_commits",
+            "point.annotation_ids", "annotationBadge(event.category)", "event.link",
+            "range=${encodeURIComponent(activeRange)}", "annotation=${encodeURIComponent(event.id)}",
+        ):
+            self.assertIn(contract, template)
+        self.assertIn("Date.parse(point.timestamp)", template)
+        self.assertIn("evolution-raw-point", template)
+        self.assertIn("evolution-trend", template)
+        self.assertIn("evolution-boundary", template)
+        self.assertIn("Raw evolution measurements with comparison boundaries and coverage", template)
+        self.assertEqual(template.count('id="evolution-workspace"'), 1)
+        self.assertNotIn('id="normalized-chart"', template)
+        self.assertNotIn("renderNormalized", template)
+        self.assertNotIn("comparability: {status: 'comparable'}", template)
+        self.assertIn("view.trend_segments.forEach", template)
         self.assertNotIn("function calculateEvolutionIndex", template)
+        css = (INPUT_ROOT / "website" / "css" / "input.css").read_text()
+        for category in (
+            "capability", "optimization", "benchmark_corpus", "measurement_infrastructure",
+            "known_regression", "repair",
+        ):
+            self.assertIn(f".category-{category}", css)
 
 
 class BenchmarkCollectionTests(unittest.TestCase):

--- a/website/css/input.css
+++ b/website/css/input.css
@@ -802,6 +802,13 @@ pre:not(.z-code) {
 .annotation-note h3, .annotation-note p { margin: 0; }
 .annotation-note h3 { font-family: var(--font-display); font-size: 1.05rem; }
 .annotation-location { color: var(--color-faint); font-family: var(--font-mono); font-size: 0.72rem; }
+.annotation-badge { display: inline-block; margin: 0 0.35rem 0.2rem 0; border: 1px solid currentColor; padding: 0.08rem 0.35rem; font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.05em; text-transform: uppercase; line-height: 1.4; }
+.category-capability { color: #81511d; }
+.category-optimization { color: var(--color-good); }
+.category-benchmark_corpus { color: #6b4788; }
+.category-measurement_infrastructure { color: var(--chart-blue); }
+.category-known_regression { color: var(--chart-regression); }
+.category-repair { color: #306b68; }
 .annotation-empty { margin: 0; border-top: 1px solid var(--color-border); padding: 0.75rem 1.25rem; color: var(--color-muted); font-style: italic; }
 .performance-notes details,
 .secondary-diagnostics > details { border-top: 1px solid var(--color-border); }
@@ -810,6 +817,29 @@ pre:not(.z-code) {
 .performance-notes details[open] > summary,
 .secondary-diagnostics > details[open] > summary { border-bottom: 1px solid var(--color-border); }
 .details-intro { padding: 0.7rem 1.25rem 0; margin: 0; color: var(--color-muted); }
+
+.evolution-disclosure { margin: 0 0 2rem; border: 1px solid var(--color-border-dark); background: var(--color-surface-deep); }
+.evolution-disclosure > summary { cursor: pointer; padding: 0.8rem 1rem; font-family: var(--font-display); font-size: 1.08rem; font-weight: 520; }
+.evolution-disclosure[open] > summary { border-bottom: 1px solid var(--color-border-dark); }
+.evolution-workspace { margin: 0; border: 0; background: var(--color-surface); }
+.evolution-controls { display: grid; grid-template-columns: auto minmax(12rem, 1fr) minmax(14rem, 1fr); gap: 0.8rem 1.2rem; align-items: end; padding: 1rem 1.25rem; border-bottom: 1px solid var(--color-border); }
+.evolution-controls label, .evolution-controls fieldset { display: grid; gap: 0.22rem; margin: 0; padding: 0; border: 0; font-family: var(--font-mono); font-size: 0.69rem; letter-spacing: 0.08em; text-transform: uppercase; }
+.evolution-controls select { width: 100%; border: 1px solid var(--color-border-dark); background: var(--color-surface); color: var(--color-fg); padding: 0.48rem; font-family: var(--font-serif); font-size: 0.92rem; letter-spacing: normal; text-transform: none; }
+.evolution-raw-point { opacity: 0.24; }
+.evolution-variation { opacity: 0.3; stroke-width: 2; }
+.evolution-annotation-marker { fill: none; stroke-width: 2.2; }
+.chart-series-label { font-family: var(--font-mono); font-size: 10px; }
+.evolution-caption { margin: 0.25rem 0.75rem; color: var(--color-faint); font-family: var(--font-mono); font-size: 0.7rem; }
+.evolution-event { display: grid; grid-template-columns: auto 1fr; align-items: baseline; gap: 0 0.35rem; border-top: 1px solid var(--color-border); padding: 0.7rem 1.25rem; }
+.evolution-event h3, .evolution-event p { margin: 0; }
+.evolution-event h3 { font-family: var(--font-display); font-size: 1rem; }
+.evolution-event p, .evolution-event > a { grid-column: 2; font-size: 0.84rem; }
+.evolution-event.selected-annotation { background: color-mix(in srgb, var(--color-gold) 12%, transparent); border-left: 3px solid var(--color-gold); }
+.evolution-raw { border-top: 1px solid var(--color-border); }
+.evolution-raw > summary { cursor: pointer; padding: 0.7rem 1.25rem; font-family: var(--font-display); font-weight: 520; }
+#evolution-details table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+#evolution-details th, #evolution-details td { border-bottom: 1px solid var(--color-border); padding: 0.42rem 0.5rem; text-align: left; vertical-align: top; }
+.comparison-table caption, #evolution-details caption { padding: 0.8rem 0.5rem 0.35rem; text-align: left; color: var(--color-muted); font-family: var(--font-display); font-weight: 520; }
 
 .workload-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0; }
 .workload-card { min-width: 0; border-bottom: 1px solid var(--color-border); padding: 0.7rem; }
@@ -839,6 +869,7 @@ pre:not(.z-code) {
 
 @media (max-width: 720px) {
   .performance-toolbar { grid-template-columns: 1fr; align-items: stretch; }
+  .evolution-controls { grid-template-columns: 1fr; align-items: stretch; }
   .performance-toolbar-note { grid-column: 1; }
   .performance-section-heading { display: block; }
   .chart-key { margin-top: 0.6rem; }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -49,7 +49,7 @@
         </ul>
         {% if status.bench %}
         <div class="sparkline-block performance-snapshot">
-            <div class="spark-label"><b>compiler health</b><span>{{ status.bench.platform_label }}</span></div>
+            <div class="spark-label"><b>compiler health</b><span>{{ status.bench.platform_label }} · 30 days</span></div>
             <p class="performance-verdict performance-{{ status.bench.state.kind }}">{{ status.bench.state.label }}</p>
             {% if status.bench.latest_suite_ms %}
             <p class="performance-reading"><strong>{{ status.bench.latest_suite_ms | round(precision=1) }} ms</strong> for the benchmark suite</p>
@@ -57,8 +57,9 @@
             <p class="performance-reading"><strong>Absolute time unavailable</strong> for the latest measurement</p>
             {% endif %}
             <p class="performance-context">{{ status.bench.state.summary }} · {{ status.bench.freshness.label }}</p>
+            <p class="performance-context">Coverage: {% if status.bench.coverage.gap_unknown %}unknown{% elif status.bench.coverage.skipped_count > 0 %}{{ status.bench.coverage.represented_count }} represented, {{ status.bench.coverage.skipped_count }} skipped{% else %}{{ status.bench.coverage.represented_count }} represented, no known skips{% endif %}</p>
             <svg viewBox="0 0 300 52" preserveAspectRatio="none" role="img"
-                 aria-label="Absolute suite compilation time across the last {{ status.bench.n_trend_points }} measured commits; lower is better">
+                 aria-label="Thirty-day comparable compiler trend across {{ status.bench.n_trend_points }} daily points; higher means faster">
                 <polyline fill="none" stroke="var(--color-border-dark)" stroke-width="1" points="0,46 300,46"/>
                 {% if status.bench.points and status.bench.n_trend_points > 1 %}
                 <polyline fill="none" stroke="var(--color-olive)" stroke-width="1.6"
@@ -68,7 +69,10 @@
                 <circle cx="{{ status.bench.last_x }}" cy="{{ status.bench.last_y }}" r="3" fill="var(--color-gold)"/>
                 {% endif %}
             </svg>
-            <div class="spark-label"><span>last {{ status.bench.n_trend_points }} measured commits</span><span>lower is better</span></div>
+            <div class="spark-label"><span>{{ status.bench.n_trend_points }} comparable daily points</span><span>higher means faster</span></div>
+            {% if status.bench.annotation %}
+            <p class="performance-context"><span class="annotation-badge category-{{ status.bench.annotation.category }}">{{ status.bench.annotation.category_label }}</span> <a href="{{ status.bench.annotation.dashboard_url }}">{{ status.bench.annotation.title }} →</a> · {{ status.bench.annotation.explanation }}</p>
+            {% endif %}
             <a class="performance-details-link" href="{{ status.bench.dashboard_url }}">Investigate compiler performance →</a>
         </div>
         {% else %}

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -65,6 +65,27 @@
             </details>
         </section>
 
+        <details class="evolution-disclosure">
+            <summary>Explore the full performance evolution</summary>
+            <section id="evolution-workspace" class="performance-workspace evolution-workspace" aria-labelledby="evolution-title">
+                <div class="specimen-head"><span class="no">Secondary observation</span><span>normalized, segmented history</span></div>
+                <div class="performance-section-heading">
+                    <div>
+                        <h2 id="evolution-title">Long-term performance evolution</h2>
+                        <p>Calendar-scaled normalized performance. Faint points are measurements; solid daily or weekly trends include observed variation and stop at every gap or regime change.</p>
+                    </div>
+                </div>
+                <div class="evolution-controls">
+                    <fieldset><legend>Calendar range</legend><div id="evolution-range-controls" class="performance-button-group"></div></fieldset>
+                    <label>Machine <select id="evolution-platform-select"></select></label>
+                    <label>Workload or family <select id="evolution-workload-select"></select></label>
+                </div>
+                <div id="evolution-chart" class="diagnostic-chart evolution-chart" aria-live="polite"></div>
+                <div id="evolution-annotations" class="evolution-annotations"></div>
+                <details class="evolution-raw"><summary>Raw measurements, gaps, and coverage</summary><div id="evolution-details" class="table-scroll"></div></details>
+            </section>
+        </details>
+
         <section class="secondary-diagnostics" aria-labelledby="secondary-title">
             <div class="specimen-head"><span class="no">Supporting observations</span><span>open as needed</span></div>
             <h2 id="secondary-title">Other diagnostic views</h2>
@@ -81,12 +102,6 @@
                     <figure><figcaption>Peak memory</figcaption><div id="memory-chart"></div></figure>
                     <figure><figcaption>Combined output binary size</figcaption><div id="binary-chart"></div></figure>
                 </div>
-            </details>
-
-            <details>
-                <summary>Normalized cross-platform evolution</summary>
-                <p class="details-intro">For comparing direction across unlike machines. Each machine remains a separate normalized series; this is not the default latency view.</p>
-                <div id="normalized-chart" class="diagnostic-chart"></div>
             </details>
 
             <details>
@@ -130,9 +145,12 @@
         phases: $('phase-chart'), before: $('before-select'), after: $('after-select'),
         comparison: $('comparison-card'), authored: $('authored-annotations'), derived: $('derived-annotations'),
         multiples: $('workload-multiples'), memory: $('memory-chart'), binary: $('binary-chart'),
-        normalized: $('normalized-chart'), metrics: $('metrics-table'), scaling: $('scaling-diagnostics'),
+        metrics: $('metrics-table'), scaling: $('scaling-diagnostics'),
         scenarios: $('scenario-diagnostics'),
-        records: $('measurement-records')
+        records: $('measurement-records'), evolution: $('evolution-workspace'),
+        evolutionRanges: $('evolution-range-controls'), evolutionPlatform: $('evolution-platform-select'),
+        evolutionWorkload: $('evolution-workload-select'), evolutionChart: $('evolution-chart'),
+        evolutionAnnotations: $('evolution-annotations'), evolutionDetails: $('evolution-details')
     };
     let rootMetadata = null;
     let metadata = null;
@@ -236,6 +254,132 @@
         }
     }
 
+    function annotationBadge(category) {
+        return node('span', String(category || 'measurement_infrastructure').replaceAll('_', ' '), `annotation-badge category-${category || 'measurement_infrastructure'}`);
+    }
+    function configureEvolution(workspace) {
+        const query = new URLSearchParams(location.search);
+        let activeRange = workspace.range_options.includes(query.get('range')) ? query.get('range') : workspace.default_range;
+        const requestedPlatform = query.get('platform');
+        const requestedWorkload = query.get('workload');
+        let activeAnnotation = query.get('annotation');
+        els.evolutionRanges.replaceChildren(); els.evolutionPlatform.replaceChildren(); els.evolutionWorkload.replaceChildren();
+        const allMachines = node('option', 'All machines (separate normalized series)'); allMachines.value = '*'; els.evolutionPlatform.appendChild(allMachines);
+        workspace.platform_options.forEach(platform => { const option = node('option', platform); option.value = platform; els.evolutionPlatform.appendChild(option); });
+        els.evolutionPlatform.value = workspace.platform_options.includes(requestedPlatform) ? requestedPlatform : '*';
+        workspace.workload_options.forEach(workload => {
+            const option = node('option', workload === 'all' ? 'Entire benchmark suite' : `Workload: ${workload.replaceAll('_', ' ')}`);
+            option.value = `workload:${workload}`; els.evolutionWorkload.appendChild(option);
+        });
+        workspace.workload_families.forEach(family => {
+            const option = node('option', `Family: ${family.label}`); option.value = `family:${family.id}`; els.evolutionWorkload.appendChild(option);
+        });
+        if ([...els.evolutionWorkload.options].some(option => option.value === requestedWorkload)) els.evolutionWorkload.value = requestedWorkload;
+
+        const selectedWorkloads = () => {
+            const selection = els.evolutionWorkload.value;
+            if (!selection.startsWith('family:')) return new Set([selection.slice(9)]);
+            const family = workspace.workload_families.find(item => item.id === selection.slice(7));
+            return new Set(family?.workloads || []);
+        };
+        const updateQuery = annotation => {
+            const state = new URLSearchParams(location.search);
+            state.set('range', activeRange); state.set('platform', els.evolutionPlatform.value);
+            state.set('workload', els.evolutionWorkload.value);
+            activeAnnotation = annotation || null;
+            if (activeAnnotation) state.set('annotation', activeAnnotation); else state.delete('annotation');
+            history.replaceState(null, '', `${location.pathname}?${state.toString()}#evolution-workspace`);
+        };
+        const render = () => {
+            const workloads = selectedWorkloads();
+            const platform = els.evolutionPlatform.value;
+            const selected = workspace.series.filter(series => (platform === '*' || series.platform === platform) && workloads.has(series.workload));
+            els.evolutionChart.replaceChildren(); els.evolutionAnnotations.replaceChildren(); els.evolutionDetails.replaceChildren();
+            const allPoints = selected.flatMap(series => series.raw_points.slice(series.ranges[activeRange].raw_start_index));
+            const drawable = allPoints.filter(point => Number.isFinite(point.index));
+            if (!selected.length || !allPoints.length) { els.evolutionChart.appendChild(node('p', 'No measurements exist in this calendar range.', 'chart-empty')); return; }
+            if (!drawable.length) { els.evolutionChart.appendChild(node('p', 'Measurements exist, but no comparable normalized index can be drawn. The raw records remain below.', 'chart-empty')); }
+            const width = 920, height = 360, margin = {left: 64, right: 20, top: 32, bottom: 54};
+            const times = allPoints.map(point => Date.parse(point.timestamp));
+            const observedMinTime = Math.min(...times), observedMaxTime = Math.max(...times);
+            const rangeView = selected[0].ranges[activeRange];
+            const minTime = rangeView.calendar_start ? Date.parse(rangeView.calendar_start) : observedMinTime;
+            const maxTime = rangeView.calendar_end ? Date.parse(rangeView.calendar_end) : observedMaxTime;
+            const indexes = drawable.length ? drawable.map(point => point.index) : [99, 101];
+            const lo0 = Math.min(...indexes), hi0 = Math.max(...indexes), padding = Math.max((hi0 - lo0) * .1, 1);
+            const lo = lo0 - padding, hi = hi0 + padding;
+            const x = timestamp => margin.left + (width - margin.left - margin.right) * (Date.parse(timestamp) - minTime) / Math.max(1, maxTime - minTime);
+            const y = value => margin.top + (height - margin.top - margin.bottom) * (hi - value) / Math.max(1, hi - lo);
+            const svg = svgElement('svg', {viewBox: `0 0 ${width} ${height}`, role: 'img', 'aria-label': `${activeRange} normalized performance by calendar date; raw measurements are faint, trends show variation, and paths stop at gaps`});
+            for (let tick = 0; tick <= 4; tick++) {
+                const value = lo + (hi - lo) * tick / 4, yy = y(value);
+                svg.appendChild(svgElement('line', {x1: margin.left, x2: width - margin.right, y1: yy, y2: yy, class: 'chart-grid'}));
+                const label = svgElement('text', {x: margin.left - 8, y: yy + 4, 'text-anchor': 'end', class: 'chart-axis-label'}); label.textContent = value.toFixed(0); svg.appendChild(label);
+            }
+            [[minTime, margin.left, 'start'], [maxTime, width - margin.right, 'end']].forEach(([time, xx, anchor]) => {
+                const label = svgElement('text', {x: xx, y: height - 18, 'text-anchor': anchor, class: 'chart-axis-label'}); label.textContent = new Date(time).toISOString().slice(0, 10); svg.appendChild(label);
+            });
+            const colors = ['series-0', 'series-1', 'series-2', 'series-3', 'series-4'];
+            selected.forEach((series, seriesIndex) => {
+                const view = series.ranges[activeRange], color = colors[seriesIndex % colors.length];
+                view.rendered_raw_points.filter(point => Number.isFinite(point.index)).forEach(point => {
+                    const raw = svgElement('circle', {cx: x(point.timestamp), cy: y(point.index), r: 2.5, class: `evolution-raw-point ${color}`});
+                    raw.setAttribute('aria-label', `${series.platform}, ${series.workload}, ${point.timestamp}, index ${point.index.toFixed(2)}`); svg.appendChild(raw);
+                    if (point.annotation_ids.length) {
+                        const marker = svgElement('circle', {cx: x(point.timestamp), cy: y(point.index), r: 6, class: `evolution-annotation-marker ${color}`});
+                        marker.setAttribute('aria-label', `Annotated milestone at ${point.timestamp}`); svg.appendChild(marker);
+                    }
+                });
+                view.rendered_raw_points.filter(point => point.boundary).forEach(point => {
+                    svg.appendChild(svgElement('line', {x1: x(point.timestamp), x2: x(point.timestamp), y1: margin.top, y2: height - margin.bottom, class: 'chart-boundary evolution-boundary'}));
+                });
+                view.trend_points.forEach(point => {
+                    svg.appendChild(svgElement('line', {x1: x(point.timestamp), x2: x(point.timestamp), y1: y(point.index - point.variation), y2: y(point.index + point.variation), class: `evolution-variation ${color}`}));
+                });
+                view.trend_segments.forEach(segment => {
+                    const points = segment.points;
+                    if (points.length > 1) svg.appendChild(svgElement('polyline', {points: points.map(point => `${x(point.timestamp)},${y(point.index)}`).join(' '), fill: 'none', class: `chart-line evolution-trend ${color}`}));
+                });
+                const label = svgElement('text', {x: margin.left + 4, y: 16 + seriesIndex * 16, class: `chart-series-label ${color}`}); label.textContent = `${series.platform} / ${series.workload}`; svg.appendChild(label);
+            });
+            if (drawable.length) els.evolutionChart.appendChild(svg);
+            els.evolutionChart.appendChild(node('p', `${activeRange} calendar view · ${selected[0].ranges[activeRange].resolution} median trend ± scaled MAD · ${allPoints.length} raw records selected`, 'evolution-caption'));
+
+            const eventIds = new Set(allPoints.flatMap(point => point.annotation_ids));
+            const events = workspace.annotations.filter(event => eventIds.has(event.id));
+            if (!events.length) els.evolutionAnnotations.appendChild(node('p', 'No milestone annotations apply to this selection.', 'annotation-empty'));
+            events.forEach(event => {
+                const article = node('article', undefined, `evolution-event${event.id === activeAnnotation ? ' selected-annotation' : ''}`);
+                article.id = `annotation-${event.id}`; article.appendChild(annotationBadge(event.category));
+                const title = node('h3'); appendLink(title, event.title, event.link); article.appendChild(title); article.appendChild(node('p', event.explanation));
+                const deep = node('a', `Show this event in the ${activeRange} range`); deep.href = `?range=${encodeURIComponent(activeRange)}&platform=${encodeURIComponent(platform)}&workload=${encodeURIComponent(els.evolutionWorkload.value)}&annotation=${encodeURIComponent(event.id)}#evolution-workspace`; article.appendChild(deep);
+                els.evolutionAnnotations.appendChild(article);
+            });
+
+            const table = node('table'); table.appendChild(node('caption', 'Raw evolution measurements with comparison boundaries and coverage'));
+            const header = node('tr'); ['Machine / workload', 'Date / commit', 'Index / absolute', 'Variation / samples', 'Coverage and comparability', 'Annotations'].forEach(label => { const cell = node('th', label); cell.scope = 'col'; header.appendChild(cell); }); table.appendChild(header);
+            selected.forEach(series => series.raw_points.slice(series.ranges[activeRange].raw_start_index).forEach(point => {
+                const row = node('tr'); row.appendChild(node('td', `${series.platform} / ${series.workload}`));
+                const identity = node('td'); identity.append(`${point.timestamp} · `); appendLink(identity, short(point.commit), point.commit_url); row.appendChild(identity);
+                row.appendChild(node('td', `${Number.isFinite(point.index) ? point.index.toFixed(3) : 'not comparable'} · ${Number.isFinite(point.absolute_ms) ? fmt(point.absolute_ms, 3) : 'absolute unavailable'}`));
+                const samples = Array.isArray(point.raw_samples_ms) ? point.raw_samples_ms : Object.entries(point.raw_samples_ms).map(([name, values]) => `${name}: ${values.join(', ')}`).join('; ');
+                row.appendChild(node('td', `${Number.isFinite(point.variation_pct) ? `${point.variation_pct.toFixed(2)}%` : 'aggregate variation in trend'} · ${samples || 'samples unavailable'}`));
+                const boundary = point.boundary;
+                row.appendChild(node('td', boundary ? `boundary: ${String(boundary.reason).replaceAll('_', ' ')}; regime ${boundary.regime_id}; represented ${boundary.represented_commits.length}; skipped ${boundary.skipped_commits.length}; ${boundary.gap_unknown ? 'coverage gap unknown' : 'coverage gap known'}` : 'continuous comparable segment'));
+                const categories = node('td'); point.annotation_ids.forEach(id => { const event = workspace.annotations.find(item => item.id === id); if (event) categories.appendChild(annotationBadge(event.category)); }); if (!categories.childNodes.length) categories.append('none'); row.appendChild(categories);
+                table.appendChild(row);
+            })); els.evolutionDetails.appendChild(table);
+            if (activeAnnotation || location.hash === '#evolution-workspace') document.querySelector('.evolution-disclosure').open = true;
+        };
+        workspace.range_options.forEach(range => {
+            const button = node('button', range); button.type = 'button'; button.setAttribute('aria-pressed', range === activeRange ? 'true' : 'false');
+            button.onclick = () => { activeRange = range; els.evolutionRanges.querySelectorAll('button').forEach(item => item.setAttribute('aria-pressed', item === button ? 'true' : 'false')); updateQuery(); render(); };
+            els.evolutionRanges.appendChild(button);
+        });
+        els.evolutionPlatform.onchange = () => { updateQuery(); render(); }; els.evolutionWorkload.onchange = () => { updateQuery(); render(); };
+        render();
+    }
+
     function renderPrimaryCharts() {
         const points = visiblePoints();
         drawCommitChart(els.latency, points, [{label: 'Compilation time', values: points.map(selectedValue)}], {points: true, label: 'Absolute compilation time by measured commit'});
@@ -320,11 +464,29 @@
             if (!selectedWorkload && explanation.dominant_workload) cause.append(`Largest workload movement: ${explanation.dominant_workload.name.replaceAll('_', ' ')} (${explanation.dominant_workload.delta_ms >= 0 ? '+' : ''}${explanation.dominant_workload.delta_ms.toFixed(1)} ms).`);
             els.comparison.appendChild(cause);
         }
+        const workloadTable = node('table', undefined, 'comparison-table');
+        workloadTable.appendChild(node('caption', 'Complete per-workload latency comparison'));
+        const workloadHead = node('tr'); ['Workload', 'Before', 'After', 'Delta', 'Relative change', 'Observed variation'].forEach(label => { const cell = node('th', label); cell.scope = 'col'; workloadHead.appendChild(cell); }); workloadTable.appendChild(workloadHead);
+        explanation.workloads.forEach(value => {
+            const row = node('tr');
+            const delta = Number.isFinite(value.delta_ms) ? `${value.delta_ms >= 0 ? '+' : ''}${value.delta_ms.toFixed(1)} ms` : 'unavailable';
+            const relative = Number.isFinite(value.delta_pct) ? `${value.delta_pct >= 0 ? '+' : ''}${value.delta_pct.toFixed(1)}%` : 'unclassified';
+            const variation = Number.isFinite(value.variation_pct) ? `${value.variation_pct.toFixed(1)}%` : 'unavailable';
+            [value.name.replaceAll('_', ' '), fmt(value.reference_median_ms), fmt(value.current_median_ms), delta, relative, variation].forEach(text => row.appendChild(node('td', text))); workloadTable.appendChild(row);
+        });
+        els.comparison.appendChild(workloadTable);
         const table = node('table', undefined, 'comparison-table');
+        table.appendChild(node('caption', 'Complete compiler-phase comparison'));
         const head = node('tr'); ['Compiler phase', 'Before', 'After', 'Contribution'].forEach(label => head.appendChild(node('th', label))); table.appendChild(head);
-        const comparedPasses = selectedWorkload?.passes || explanation.passes;
+        const comparedPasses = explanation.passes;
         comparedPasses.forEach(value => { const row = node('tr'); [value.name.replaceAll('_', ' '), fmt(value.before_ms), fmt(value.after_ms), `${value.delta_ms >= 0 ? '+' : ''}${value.delta_ms.toFixed(1)} ms`].forEach(text => row.appendChild(node('td', text))); table.appendChild(row); });
         if (comparedPasses.length) els.comparison.appendChild(table);
+        [['Peak memory', explanation.memory_bytes], ['Output binary size', explanation.binary_size_bytes]].forEach(([label, values]) => {
+            const product = node('table', undefined, 'comparison-table'); product.appendChild(node('caption', `${label} by workload`));
+            const productHead = node('tr'); ['Workload', 'Before', 'After', 'Delta'].forEach(text => { const cell = node('th', text); cell.scope = 'col'; productHead.appendChild(cell); }); product.appendChild(productHead);
+            values.forEach(value => { const row = node('tr'); [value.name.replaceAll('_', ' '), bytes(value.before), bytes(value.after), `${value.delta >= 0 ? '+' : '−'}${bytes(Math.abs(value.delta))}`].forEach(text => row.appendChild(node('td', text))); product.appendChild(row); });
+            if (values.length) els.comparison.appendChild(product);
+        });
     }
 
     function miniChart(values, label) {
@@ -350,6 +512,7 @@
             if (!items.length) { target.appendChild(node('p', empty, 'annotation-empty')); return; }
             items.forEach(item => {
                 const article = node('article', undefined, 'annotation-note');
+                article.appendChild(annotationBadge(item.category));
                 const title = node('h3'); appendLink(title, item.title, item.link); article.appendChild(title);
                 article.appendChild(node('p', item.explanation));
                 article.appendChild(node('p', item.occurrences.join(' · '), 'annotation-location')); target.appendChild(article);
@@ -455,9 +618,12 @@
         els.records.replaceChildren();
         visiblePoints().slice().reverse().forEach(point => {
             const details = node('details', undefined, 'measurement-record');
-            const summary = node('summary', `${short(point.commit)} · ${point.subject || 'subject unavailable'} · ${fmt(point.suite_ms)}`); details.appendChild(summary);
+            const summary = node('summary'); appendLink(summary, short(point.commit), point.links?.commit); summary.append(` · ${point.subject || 'subject unavailable'} · ${fmt(point.suite_ms)}`); details.appendChild(summary);
             const fields = node('dl', undefined, 'measurement-fields');
+            fields.append(labeledField('Commit date', point.date || 'unavailable'));
+            fields.append(labeledField('Subject', point.subject || 'unavailable'));
             fields.append(labeledField('Measured at', point.measured_at || 'unavailable'));
+            fields.append(labeledField('Freshness', `${point.freshness.latest ? 'latest point' : `${point.freshness.age_from_latest_seconds ?? 'unknown'}s before latest`}; ${point.freshness.stale ? 'stale' : 'current'}`));
             fields.append(labeledField('Measurement regime', point.regime_id || 'unknown'));
             fields.append(labeledField('Measurement family', point.comparability.measurement_family || 'compiler'));
             fields.append(labeledField('Scenario', String(point.comparability.scenario_family || 'cold_compilation').replaceAll('_', ' ')));
@@ -466,6 +632,13 @@
             fields.append(labeledField('Skipped commits', point.coverage.skipped_commits.length ? point.coverage.skipped_commits.map(short).join(', ') : 'none recorded'));
             fields.append(labeledField('Coverage gap', point.coverage.gap_unknown ? 'unknown' : 'known'));
             fields.append(labeledField('Comparison status', point.comparability.status === 'comparable' ? 'comparable with previous measurement' : `new boundary: ${String(point.comparability.reason).replaceAll('_', ' ')}`));
+            const headline = point.comparability.headline;
+            fields.append(labeledField('Absolute suite', fmt(point.suite_ms, 2)));
+            fields.append(labeledField('Relative result', headline && headline.classification !== 'insufficient_data' ? `${headline.classification}; ${headline.delta_pct >= 0 ? '+' : ''}${headline.delta_pct.toFixed(2)}%; variation ${headline.variation_pct.toFixed(2)}%` : 'not classified'));
+            const references = [...(point.links?.pull_requests || []), ...(point.links?.issues || [])];
+            const referenceField = node('div'); referenceField.appendChild(node('dt', 'PRs and issues')); const referenceValue = node('dd');
+            references.forEach((item, index) => { if (index) referenceValue.append(' · '); appendLink(referenceValue, item.id, item.url); }); if (!references.length) referenceValue.append('none discovered'); referenceField.appendChild(referenceValue); fields.append(referenceField);
+            const annotationField = node('div'); annotationField.appendChild(node('dt', 'Annotations')); const annotationValue = node('dd'); point.annotations.forEach(event => { annotationValue.appendChild(annotationBadge(event.category)); const link = node('a', event.title); link.href = event.link; annotationValue.append(' '); annotationValue.appendChild(link); annotationValue.append(' '); }); if (!annotationValue.childNodes.length) annotationValue.append('none'); annotationField.appendChild(annotationValue); fields.append(annotationField);
             details.appendChild(fields);
             const table = node('table', undefined, 'raw-samples-table');
             const head = node('tr'); ['Workload', 'Reported value', 'Estimator', 'Observed variation', 'Raw samples (ms)'].forEach(label => head.appendChild(node('th', label))); table.appendChild(head);
@@ -476,15 +649,12 @@
             details.appendChild(table); els.records.appendChild(details);
         });
     }
-    function renderNormalized(workspace) {
-        const byPlatform = workspace.series.filter(item => item.workload === 'all');
-        const commits = [...new Set(byPlatform.flatMap(item => item.raw_points.map(point => point.commit)))].slice(-50);
-        const points = commits.map(commit => ({commit, comparability: {status: 'comparable'}}));
-        const series = byPlatform.map(item => { const map = new Map(item.raw_points.map(point => [point.commit, point.index])); return {label: item.platform, values: commits.map(commit => map.get(commit) ?? null)}; });
-        drawCommitChart(els.normalized, points, series, {height: 300, unit: 'index', label: 'Normalized performance index by platform and measured commit; higher is better'});
-    }
-    function fetchNormalized() {
-        fetch('/benchmarks/comparison/metadata.json').then(response => response.json()).then(data => renderNormalized(data.evolution_workspace)).catch(() => els.normalized.replaceChildren(node('p', 'Cross-platform data unavailable.', 'chart-empty')));
+    function fetchEvolution() {
+        fetch('/benchmarks/comparison/metadata.json').then(response => response.json()).then(data => {
+            configureEvolution(data.evolution_workspace);
+        }).catch(() => {
+            els.evolutionChart.replaceChildren(node('p', 'Long-term evolution data unavailable.', 'chart-empty'));
+        });
     }
 
     function renderAll() {
@@ -524,7 +694,7 @@
         const available = (data.platforms || []).filter(item => item.has_data);
         available.forEach(item => { const option = node('option', item.name); option.value = item.id; els.platform.appendChild(option); });
         const preferred = available.some(item => item.id === 'x86-64-linux') ? 'x86-64-linux' : (data.default_platform !== 'comparison' ? data.default_platform : available[0]?.id);
-        if (!preferred) throw new Error(); els.platform.value = preferred; loadPlatform(preferred); fetchNormalized();
+        if (!preferred) throw new Error(); els.platform.value = preferred; loadPlatform(preferred); fetchEvolution();
     }).catch(() => {
         els.info.textContent = 'No benchmark data is available yet.';
         els.latency.replaceChildren(node('p', 'Benchmark data unavailable.', 'chart-empty'));


### PR DESCRIPTION
## Summary

- preserve the one-platform absolute diagnostic default while restoring the complete calendar-time evolution workspace
- render canonical comparability segments, gaps, annotations, deep links, and complete point/comparison evidence
- restore truthful 30-day homepage semantics and keep scenario benchmarks separate

## Validation

- `python3 scripts/test-benchmark-tools.py` (110 tests)
- `./buck2 test //:benchmark-tool-tests`
- `website/build.sh`
- `scripts/rue quick`
- adversarial acceptance review: clean

Fixes RUE-907