### PR TITLE
RUE-819: accept shared backend policy design

### DIFF
--- a/docs/designs/0048-shared-codegen-middle-layer.md
+++ b/docs/designs/0048-shared-codegen-middle-layer.md
@@ -1,162 +1,326 @@
 ---
 id: 0048
 title: "Shared codegen middle layer (reduce x86-64/aarch64 backend duplication)"
-status: proposal
+status: accepted
 tags: [codegen, architecture, backends, refactor, maintainability]
 created: 2026-07-11
-accepted:
+accepted: 2026-07-15
 implemented:
 spec-sections: []
 supersedes:
-relates: ["RUE-250", "RUE-3", "RUE-31", "RUE-237", "RUE-248", "RUE-205", "RUE-45"]
+relates: ["RUE-250", "RUE-819", "RUE-820", "RUE-821", "RUE-822", "RUE-823", "RUE-824", "RUE-825", "RUE-3", "RUE-31", "RUE-237", "RUE-248", "RUE-205", "RUE-45"]
 ---
 
 # ADR-0048: Shared Codegen Middle Layer
 
 ## Status
 
-Proposed — Fable, 2026-07-11, as the design pass RUE-250 asked for ("a real look
-at the current structure before committing"). This ADR **maps** the duplication
-and recommends where a shared middle layer pays off; it does **not** implement the
-refactor. Executing any increment below is a separate, human-approved decision
-(the refactor touches working codegen — see [Risks](#risks)).
+Accepted as the M3 shared-backend policy design by RUE-819, 2026-07-15. This
+ADR is a design-only increment. It authorizes the dependency-ordered
+implementation slices below; it does not implement any of them.
 
 ## Summary
 
-RUE-250 proposed factoring the target-independent parts of codegen into a shared
-middle layer so each backend implements only the genuinely target-specific bits
-(register set, instruction encoding, calling convention). A structural audit of
-`crates/rue-codegen/src/{x86_64,aarch64}/` against the shared top-level modules
-shows that **most of that middle layer already exists** and both backends already
-plug into it through adapter traits. The crate is not two monolithic parallel
-backends; it is a shared spine with per-target leaves.
+Rue already has a shared codegen spine. `agg_slots`, place lowering, storage
+lowering, aggregate equality, by-reference argument addressing, liveness,
+scheduling, register-allocation algorithms, stack-frame accounting, and pass
+sequencing are single-copy code or shared algorithms with target adapters. The
+remaining problem is that the two `CfgLower` implementations still mix three
+responsibilities in the same methods:
 
-The remaining duplication is concentrated in two places: (1) the two
-`cfg_lower.rs` files, whose *routing skeleton* is near-identical but whose leaf
-instruction emission is inlined rather than pushed through a trait, and (2) the
-`mir.rs` instruction/operand **container** (as opposed to the instruction *set*,
-which is legitimately per-target). The single largest, lowest-risk wins are
-extracting the `cfg_lower.rs` terminator/value routing skeleton and making the MIR
-container generic.
+1. language and CFG policy (value routing, aggregate completeness, block
+   parameters, sret decisions, and terminator semantics);
+2. target ABI policy (register and stack locations, call/return marshalling,
+   platform runtime entry points); and
+3. instruction selection (MIR variants, flags, immediates, scratch registers,
+   and target encodings).
 
-## Current state — what is already shared
+M3 makes the first responsibility single-copy and makes the boundary between
+the first two and the third explicit. The shared layer produces normalized
+lowering plans. An x86-64 or AArch64 adapter consumes those plans and selects
+instructions. There is no target-independent instruction set, register enum,
+or third generic backend.
 
-A target-independent layer at `rue-codegen/src/` (≈8,450 LOC) is consumed by both
-backends via traits. Each backend's `CfgLower` already implements five shared
-traits (`SlotBackend`, `PlaceLowerBackend`, `StorageLowerBackend`,
-`AggregateEqBackend`, `ByrefAddrBackend`).
+## Current source audit
 
-| Shared module | LOC | Role | Seam |
-|---|---|---|---|
-| `regalloc.rs` | 2659 | Linear-scan, cost model, coalescing, spill-slot alloc, remat | generic `linear_scan*<Reg>`, `coalesce<Reg>` |
-| `liveness.rs` | 984 | Backward dataflow, live ranges, loop info, pressure | `LivenessAdapter` |
-| `stack_frame.rs` | 678 | Stack-frame / ABI analysis | operates on CFG |
-| `cfg_lower.rs` | 610 | `CfgLowerContext` (type/slot/ABI/sret helpers), formatting | shared struct + free fns |
-| `agg_slots.rs` | 569 | Aggregate slot routing (struct/array/enum/String, sret store) | `SlotBackend` |
-| `place_lower.rs` | 511 | Place/lvalue addressing | `PlaceLowerBackend` |
-| `schedule_core.rs` | 374 | Dependency DAG, list scheduling, BB splitting | `SchedulerAdapter` |
-| `types.rs` | 423 | Type slot math | primitive |
-| `storage_lower.rs` / `aggregate_eq.rs` / `byref_args.rs` | 147/121/129 | load/store, structural eq, byref args | traits |
-| `codegen_pipeline.rs` | 136 | `prepare_mir` orchestration | generic `<Mir, Reg>` + closures |
-| `index_map.rs` / `vreg.rs` | 220/87 | dense maps, `VReg`/`LabelId` | primitives |
+The current source, rather than the historical RUE-250 design pass, is the
+authority for this decision. The shared top-level codegen modules currently
+contain 7,571 lines including tests. The backend files currently measure as
+follows; `code` stops immediately before each file's `#[cfg(test)]` module.
 
-So the algorithms RUE-250 named as candidates — CFG-lowering *helpers*, liveness,
-scheduling, aggregate-slot routing — are **already single-copy**. The dataflow is
-generic over a trait; only the per-instruction fact tables live in the backends.
+| Backend file | x86-64 total/code | AArch64 total/code | Current classification |
+| --- | ---: | ---: | --- |
+| `cfg_lower.rs` | 4,221 / 4,033 | 4,309 / 4,089 | mixed CFG policy, ABI policy, and instruction selection; primary M3 target |
+| `mir.rs` | 973 / 916 | 1,435 / 1,338 | target instruction and register definitions plus duplicated container plumbing |
+| `regalloc.rs` | 1,712 / 1,247 | 1,690 / 1,223 | shared algorithm calls plus target rewrite and spill emission |
+| `liveness.rs` | 724 / 449 | 664 / 391 | shared analysis adapter plus target uses/defs/clobbers facts |
+| `schedule.rs` | 1,028 / 629 | 817 / 511 | shared scheduler adapter plus target latency/dependency facts |
+| `peephole.rs` | 1,001 / 301 | 978 / 267 | target flag model and instruction patterns |
+| `emit.rs` | 4,858 / 2,758 | 3,761 / 2,240 | target encoding, relocations, prologue, epilogue, and ABI entry |
 
-## Residual duplication (per-file)
+The current shared seams are concrete, not proposed abstractions:
 
-LOC is total; "code" excludes the trailing `#[cfg(test)]` module.
+- `crate::liveness::analyze_adapter`, `analyze_debug_adapter`, and
+  `analyze_loops_adapter` own the dataflow algorithms; the backend files only
+  provide instruction facts ([`liveness.rs`](../../crates/rue-codegen/src/liveness.rs:35)).
+- `schedule_core::schedule_instructions` owns dependency construction and list
+  scheduling; each backend supplies latency, memory, register, and flag facts
+  ([`schedule_core.rs`](../../crates/rue-codegen/src/schedule_core.rs:12)).
+- `agg_slots`, `place_lower`, `storage_lower`, `aggregate_eq`, and `byref_args`
+  already own aggregate, place, storage, equality, and by-reference policy
+  ([`agg_slots.rs`](../../crates/rue-codegen/src/agg_slots.rs:35),
+  [`place_lower.rs`](../../crates/rue-codegen/src/place_lower.rs:21)).
+- `codegen_pipeline::prepare_mir` already owns pass order and the distinction
+  between existing frame slots and emitted locals
+  ([`codegen_pipeline.rs`](../../crates/rue-codegen/src/codegen_pipeline.rs:19)).
+- `rue-compiler::backend` dispatches to the two target lowerers; it is not a
+  second lowering implementation ([`backend.rs`](../../crates/rue-compiler/src/backend.rs:233)).
 
-| File | x86 (code) | aarch64 (code) | Structural similarity | Est. still-shareable | What blocks it |
-|---|---|---|---|---|---|
-| `cfg_lower.rs` | 4295 (4237) | 4310 (4218) | routing skeleton near-identical; leaf emission + overflow strategy diverge | **~55–60%** | inlined leaf `Inst` construction; genuinely different overflow/flag logic |
-| `emit.rs` | 4788 (2708) | 3703 (2202) | fundamentally different (ModRM/REX vs fixed 32-bit words) | ~0–5% | machine encoding is the definition of target-specific |
-| `regalloc.rs` | 1646 (1181) | 1624 (1157) | driver near-identical (already thin over shared); `rewrite_inst` per-target | ~20% | `ALLOCATABLE_REGS`, spill/reload emit target instructions |
-| `mir.rs` | 933 (876) | 1295 (1198) | `Mir` container + `Operand` identical shape; `Inst`/`Reg` specific | ~20–25% | instruction set (91 vs 73 variants), `Reg` file, encodings |
-| `schedule.rs` | 1013 (614) | 801 (495) | adapter glue byte-identical; fact tables category-parallel | ~30% | latency numbers + variant names per-target |
-| `liveness.rs` | 724 (449) | 664 (391) | adapter glue identical; uses/defs category-parallel, per-variant | ~30% | uses/defs bound to each `Inst` enum |
-| `peephole.rs` | 1001 (~300) | 978 (~300) | standalone `optimize`; target pattern matches | ~10–15% | patterns are per-ISA |
+The stale ADR-0048 claims that shared codegen is approximately 8,450 lines,
+that the lowerers are roughly 4,295/4,310 lines, and that the work is two
+optional extractions. Those figures are no longer true. More importantly,
+"extract the skeleton" is not a sufficient ownership boundary: the current
+`lower_value` and `lower_terminator` bodies still decide language and ABI
+semantics while constructing target instructions.
 
-### The `cfg_lower.rs` skeleton is copied by hand
+## Function-level ownership inventory
 
-`lower_terminator` is essentially line-for-line identical between backends
-(`x86_64/cfg_lower.rs:3759` vs `aarch64/cfg_lower.rs:3754`): same arm order
-(`Goto`/`Branch`/`Switch`/`Return`/`Unreachable`/`None`), same aggregate-vs-scalar
-block-param routing, same fall-through elision, same Switch lowering, same sret
-return path via shared `agg_slots::store_slots_to_sret`. **The RUE-ticket comments
-(RUE-237, RUE-92, RUE-118) are copied verbatim in both files.** The only leaf
-differences are instruction names (`X86Inst::Jmp/CmpRI+Jz` vs
-`Aarch64Inst::B/Cbz`) and one real semantic delta (x86 iterates return slots
-`.rev()` for Rax-scratch avoidance; aarch64 forward). `lower_value`
-(`x86_64/cfg_lower.rs:827` vs `aarch64/cfg_lower.rs:617`) shares the same preamble
-and arm order for `Const`/`BoolConst`/`StringConst`/`Param`/block-param/aggregate
-arms.
+This is the complete inventory of duplicated non-test lowering functions and
+their current owner. A name appearing in both backend files does not imply
+that its implementation should be shared; the classification below records
+the reason.
 
-That hand-kept lockstep — not the raw line count — is the real cost RUE-250 should
-quantify: it is the mechanism behind the divergence-by-omission bug class (e.g.
-RUE-31's aarch64-only comparison-width bug, RUE-237's aarch64-only enum ICE where
-the x86 fix did not share the gate). Every codegen fix in the shared skeleton is
-applied twice today and can be forgotten once.
+### CFG lowering
 
-### Where the two `cfg_lower.rs` files genuinely diverge
+| Current function(s) | Current locations | M3 owner | Classification and action |
+| --- | --- | --- | --- |
+| `new`, `lower`, `lower_with_debug` | x86-64 `cfg_lower.rs:81,548,575`; AArch64 `cfg_lower.rs:74,372,399` | target entrypoint + shared core | Keep target construction and return types in the two entrypoints, but make both call the same core walk. Debug output must observe the same plans as normal lowering. |
+| `lower_block`, `lower_value`, `lower_terminator`, `get_vreg` | x86-64 `cfg_lower.rs:794,812,3566,3808`; AArch64 `cfg_lower.rs:582,600,3637,3873` | shared CFG core | Move the block walk, value cache lookup, dependency recursion, terminator case analysis, and fall-through/label policy into one generic driver. The driver passes normalized plans to an adapter. |
+| `copy_aggregate_to_block_param` | x86-64 `:516`; AArch64 `:340` | shared CFG core + `agg_slots` | Move block-parameter slot routing into the core. Require complete logical slot vectors and retain the existing ascending-layout invariant. |
+| `get_or_compute_field_vregs`, `require_aggregate_slots` | x86-64 `:503,509`; AArch64 `:327,333` | `agg_slots` | These are duplicated wrappers around the existing shared aggregate policy. Delete the wrappers or make them direct calls; do not create a second aggregate path in the new core. |
+| `collect_array_scalar_vregs`, `collect_struct_scalar_vregs` | x86-64 `:181,189`; AArch64 `:176,184` | `types`/shared CFG core | Keep only the shared recursive collection algorithm and a core-owned cache view. |
+| `alloc_element_size`, `is_unsigned_comparison`, `try_power_of_two_shift`, `type_bits`, `type_range`, `shift_count_mask` | both `cfg_lower.rs` files | shared pure policy | Deduplicate the type/range/stride calculations. The adapter receives the resulting width, signedness, and immediate policy rather than re-reading CFG types. |
+| `ensure_by_ref_param_ptr`, `preload_by_ref_param_ptrs` | x86-64 `:202,227`; AArch64 `:192,217` | shared by-ref policy + adapter load | The cache, parameter classification, and “load once” rule are shared. Loading the pointer and any required move remain adapter leaves. Bounds checks must precede address formation. |
+| `scale_by_size` | x86-64 `:139`; AArch64 `:133` | shared size plan + target adapter | Share overflow intent and element-size calculation. Keep the multiply/high-half/flag sequence per target. |
+| `emit_bounds_check`, `emit_masked_shift_count`, `emit_subword_narrow`, `emit_comparison`, `emit_signed_div_overflow_check` | both `cfg_lower.rs` files | target adapter consuming a normalized plan | The language rule and operands are shared; comparison conditions, flags, narrowing instructions, and overflow sequences are target facts. |
+| `emit_call_with_slot_args` | x86-64 `:275`; AArch64 `:268` | shared `CallPlan` + target ABI adapter | Flattening, by-ref arguments, sret selection, and logical slot order are shared. Register assignment, stack argument offsets, alignment, and the runtime call instruction remain target-specific. |
+| `get_lowering_rationale`, `get_terminator_rationale` | x86-64 `:680,774`; AArch64 `:504,562` | presentation adapter | These are debug presentation, not compiler policy. They may consume shared plan metadata, but must not become a second lowering implementation. Target ABI names in the explanation remain target-specific. |
+| `intern_symbol`, `new_label`, `block_label`, `ctx`, `slot_cache`, `alloc_vreg`, `map_value`, `emit_aggregate_equality`, and the `SlotBackend`/`PlaceLowerBackend`/`StorageLowerBackend`/`AggregateEqBackend` methods | both backend files | target adapter plumbing | These are state access and instruction leaves. Retain the existing adapter traits; do not move target MIR construction into a shared module. |
 
-The ~40% that is *not* shareable is real target-specific logic, chiefly overflow
-and flags: x86 uses the hardware overflow flag with a single `emit_overflow_check`
-+ `Jo` (`x86_64/cfg_lower.rs:3290`), while aarch64 synthesizes overflow and has
-four routines `emit_overflow_check_{add,sub,mul,neg}`
-(`aarch64/cfg_lower.rs:2957/2992/3026/3230`; the `mul` case is ~140 lines using
-`smulh`). Comparisons are cmp+`setcc` (closure-based, `x86_64:3634`) vs cmp+`cset`
-(`Cond`-based, `aarch64:3575`). This belongs in the backends.
+The non-paired functions are evidence for the boundary, not missing work:
 
-## Recommendation
+- x86-64 keeps `emit_div_core`, `emit_overflow_check`, and
+  `emit_builtin_eq_call` for its implicit RAX/RDX and FLAGS behavior.
+- AArch64 keeps `emit_overflow_check_add`, `emit_overflow_check_sub`,
+  `emit_overflow_check_mul`, `emit_overflow_check_neg`, `emit_string_eq_call`,
+  `emit_subword_range_check`, and `push_cmp_rr` for its NZCV and high-half
+  arithmetic behavior.
+- Platform-specific AArch64 runtime entry selection remains in the AArch64
+  adapter (`cfg_lower.rs` carries the Linux/macOS distinction).
 
-Rank the increments by payoff/risk; do them independently, each behind the
-existing oracle-diff (RUE-205) + release-mode CI (RUE-45) safety net, one PR each,
-with the differential oracle green before and after.
+### Other duplicated backend modules
 
-1. **Extract the `cfg_lower.rs` terminator + value routing skeleton (highest
-   payoff).** Turn `lower_terminator` (~240 lines/backend, ~95% identical) into a
-   shared generic driver that calls an enriched instruction-builder trait
-   (`emit_jump`, `emit_cond_branch_zero`, `emit_cmp_imm`, `emit_trap`,
-   `emit_call`) — the backends already expose most of these as trait methods. Do
-   the scalar/const/param/string/block-param/aggregate arms of `lower_value` the
-   same way. Realistic ~55–60% of two ~4,200-line files, and it directly closes
-   the divergence-by-omission gap for terminators.
-2. **Make the MIR container generic (`Mir<Inst>`) with a shared `Operand<Reg>`.**
-   The container methods (`new`/`push`/`alloc_vreg`/`alloc_label`/`instructions*`/
-   `into_instructions`) are the same names with the same bodies
-   (`x86_64/mir.rs:739` ≡ `aarch64/mir.rs:1043`); `Operand` is already identical.
-   Mechanical, ~150 lines/backend, low risk.
-3. **(Optional, modest) Declarative fact tables for liveness/schedule.** A
-   per-variant "operand roles / instruction-class" descriptor could let a shared
-   helper derive uses/defs/latency, but it is bounded by each `Inst` enum;
-   probably not worth more than ~30% and lower priority than 1–2.
+| Module/function family | Current source evidence | Owner after M3 |
+| --- | --- | --- |
+| `liveness::{analyze, analyze_debug, analyze_loops}` | x86-64 `liveness.rs:63-73`; AArch64 `liveness.rs:63-73` | Thin target wrappers over shared analysis. `get_label`, `get_successors`, `uses`, `defs`, and `clobbers` remain per instruction set. |
+| `schedule::{schedule}` and `SchedulerAdapter` forwarding methods | x86-64 `schedule.rs:34-68,653`; AArch64 `schedule.rs:34-68,535` | Thin wrappers over `schedule_core`. `get_latency`, memory classification, register reads/writes, and FLAGS/NZCV facts remain per target. |
+| `RegAlloc::{new, allocate, allocate_with_spills, allocate_with_debug, assign_registers, assign_registers_with_debug, rewrite_instructions, rewrite_inst, load_operand, get_allocation}` plus shared-shape helpers `emit_binop`, `emit_unop`, `emit_unop_imm` (x86-64) and `emit_binop`, `emit_ternop`, `emit_binop_imm` (AArch64) | x86-64 `regalloc.rs:65-221,996`; AArch64 `regalloc.rs:68-209,1051` | Shared linear scan, coalescing, spill-slot allocation, and cost model stay in `regalloc.rs`. The target driver may remain thin; `ALLOCATABLE_REGS`, operand rewriting, scratch registers, and spill/reload MIR remain local. |
+| `X86Mir`/`Aarch64Mir` container methods (`new`, `push`, `alloc_vreg`, `alloc_label`, `instructions`, `instructions_mut`, `into_instructions`, counts) | x86-64 `mir.rs:761-903`; AArch64 `mir.rs:1162-1325` | A generic `Mir<Inst>` container may be extracted only after CFG plans are stable. `Inst`, `Reg`, `Cond`, operand encodings, and target display remain local. |
+| `peephole::optimize` and helpers | x86-64 `peephole.rs:44-301`; AArch64 `peephole.rs:44-267` | Keep completely per target. The two passes do not have the same flag semantics: x86 FLAGS and AArch64 NZCV are materially different. |
+| `emit::{emit, emit_all}` and all encoder helpers | x86-64 `emit.rs:346-355`; AArch64 `emit.rs:457-466` | Keep completely per target. ModRM/REX, fixed-width AArch64 words, relocations, prologues, epilogues, and native ABI entry are not middle-layer policy. |
 
-**Explicitly keep per-target:** `emit.rs` (encoding), `regalloc.rs::rewrite_inst`
-+ `ALLOCATABLE_REGS` (register file + spill emission), `peephole.rs` patterns, the
-`Inst`/`Reg`/`Cond` enum definitions, and the overflow/flag portions of
-`cfg_lower.rs`. These are the true register-set / encoding / calling-convention
-core, and forcing them into a shared abstraction would add indirection without
-removing real duplication.
+## Accepted policy and adapter boundary
 
-## Risks
+### Shared policy
 
-- The refactor touches working codegen; a botched extraction is a silent
-  miscompile. Mitigation: the differential oracle (RUE-205) and release-mode CI
-  (RUE-45) now exist precisely to catch this — neither did when RUE-250 was filed,
-  which is why it is safer to attempt now. Gate each increment on oracle-green.
-- Over-abstracting the leaf emission (pushing genuinely target-specific overflow
-  logic behind a trait) trades duplication for indirection and can *hide* the
-  x86-vs-aarch64 semantic differences that reviewers need to see. Increment 1 is
-  scoped to the routing skeleton, not the flag model, for this reason.
-- aarch64 is not runnable on an x86 dev box (ADR-0034 / RUE-36); correctness of
-  the aarch64 side rides on CI's native arm64 + macOS jobs. Land increments where
-  CI can execute both backends.
+The shared layer owns one `CfgLowerCore` instantiated once for each concrete
+adapter. It may depend on `CfgLowerContext`, CFG types, `agg_slots`,
+`place_lower`, `storage_lower`, `aggregate_eq`, `byref_args`, and the shared
+index/vreg types. It owns:
 
-## Decision needed
+- the single CFG block walk and value memoization path;
+- `CfgInstData` classification and dependency ordering;
+- scalar versus complete aggregate slot representation;
+- block-parameter routing and ascending logical slot order;
+- place bounds-check ordering and by-reference parameter classification;
+- the language-level overflow, narrowing, division, comparison, and shift
+  *requirements*;
+- logical call and return plans, including flattened arguments, by-ref
+  pointers, sret selection, stack-slot counts, and alignment requirements;
+- the one-shot pass and debug-plan sequencing; and
+- shared invariants and diagnostics when a CFG or slot vector is malformed.
 
-Whether to execute increments 1–2 (and file them as tracked implementation
-issues), or to accept the current architecture as "good enough" and instead invest
-only in the cheaper divergence-guard (a shared golden test that fails when the two
-`lower_terminator`s drift). This ADR does not decide that — it hands Steve the map.
+The shared layer must emit no `X86Inst`, `Aarch64Inst`, physical register, or
+target encoding. It must not know that a result is in RAX, X0, or any other
+register.
+
+### Adapter interface
+
+The new interface is an event boundary, not a universal backend API. The
+implementation may use Rust traits and generic monomorphization, but the
+interface must remain no larger than these six policy-facing operations in
+addition to the existing state/leaf traits:
+
+```text
+emit_value(ValuePlan) -> ValueResult
+emit_call(CallPlan) -> CallResult
+emit_terminator(TerminatorPlan)
+emit_intrinsic(IntrinsicPlan)
+emit_checked_arithmetic(ArithmeticPlan)
+emit_trap(TrapKind)
+```
+
+`ValuePlan`, `CallPlan`, `TerminatorPlan`, `IntrinsicPlan`, and
+`ArithmeticPlan` are target-neutral records/enums containing vregs, logical
+slot vectors, type width/signedness, symbol identities, logical labels, and
+the already-decided language/ABI requirements. They contain no `Reg`, `Cond`,
+target instruction, or raw CFG reference. Existing `SlotBackend`,
+`PlaceLowerBackend`, `StorageLowerBackend`, `AggregateEqBackend`, and
+`byref_args::lower_byref_arg_addr` and the existing storage/place traits remain
+the narrow leaf interfaces for memory and aggregate operations; they are not
+expanded to accept CFG policy.
+
+The adapter may allocate vregs/labels and append target MIR, consult its
+register file and instruction set, choose immediates, model flags, and emit
+target ABI instructions. It may not inspect `Cfg`, recompute type slot counts,
+choose sret versus register return, reorder aggregate slots, classify an
+argument as by-reference, or implement a second terminator/value dispatcher.
+Those operations are only valid in the core. A backend adapter that needs a
+new semantic fact must extend the shared plan, not read the CFG again.
+
+This boundary is deliberately not a `Backend` trait with a generic `Inst`.
+There are two concrete adapters—x86-64 and AArch64—and their MIR enums remain
+the instruction-selection endpoint. A future third architecture can implement
+the same plans without requiring a third generic backend in the core.
+
+### Invariants at the boundary
+
+Every migration slice must preserve these invariants:
+
+1. A CFG value has one primary vreg mapping; aggregate values additionally
+   have exactly `type_slot_count` logical slot vregs, including the `StrBuf`
+   three-slot representation.
+2. Logical slot zero and ascending memory layout follow ADR-0040 everywhere;
+   target adapters cannot reverse a slot vector to compensate for a policy
+   mistake. Any target-required emission order is an adapter-local operation
+   after the plan is formed.
+3. Every index projection is bounds-checked before address formation, including
+   by-reference and aggregate paths.
+4. `type_uses_sret_return` remains the single sret decision. Callers and
+   callees consume the same `CallPlan`/`ReturnPlan` shape.
+5. Logical call arguments and returns are fully classified before the adapter
+   assigns registers or stack offsets. Hidden sret pointers and by-reference
+   arguments are included in the plan, not rediscovered by instruction
+   selection.
+6. Block labels and inline labels remain disjoint and deterministic.
+7. A plan is lowered once. `--emit lowering`, normal compilation, and debug
+   views observe the same plan and do not invoke a presentation-specific
+   lowerer.
+
+## Dependency-ordered M3 migration
+
+The issue titles are not recorded in this repository, so the mapping below
+uses the dependency order and acceptance scope supplied by RUE-819. Before
+each implementation PR, its issue description must be reconciled with the
+slice name here; the dependency order is normative.
+
+| Order | Issue | Migration slice and endpoint | Required review/test gate |
+| ---: | --- | --- | --- |
+| 1 | RUE-820 | Introduce the target-neutral plan types, adapter contract, and invariant tests. Wire no new semantic behavior yet. Establish a before/after lowering-dump corpus for both backends. | Unit-test plan validation and slot/label invariants. Existing codegen unit tests and the full lowering corpus must remain unchanged. Review rejects any plan carrying raw CFG, `Reg`, `Cond`, or target MIR. |
+| 2 | RUE-821 | Move `lower_block`, `lower_value` routing, `lower_terminator`, `get_vreg`, and block-param/aggregate routing into `CfgLowerCore`. Backend files become plan consumers plus instruction selection. | Native x86-64 and native AArch64 compile/run coverage; cross-target lowering and assembly dumps; differential oracle; release-mode compiler. Review verifies one core dispatcher and no duplicate CFG terminator match. |
+| 3 | RUE-822 | Move call/return, sret, by-ref, aggregate flattening, bounds-check ordering, and intrinsic-size policy into shared `CallPlan`/`ReturnPlan`/`IntrinsicPlan` construction. Keep register/stack marshalling and overflow sequences in adapters. | ABI CLI cases, aggregate and `StrBuf` cases, by-ref/inout cases, sret spill cases, runtime entry cases, native execution on x86-64 and AArch64, plus cross-target assembly/encoding assertions. Review checks `type_uses_sret_return` and slot order have one call path. |
+| 4 | RUE-823 | Extract the duplicated MIR container plumbing behind `Mir<Inst>` if the plan migration leaves it mechanically identical. Keep `Inst`, `Reg`, `Cond`, display, encodings, and target operands separate. | MIR construction/display unit tests, exact lowering and regalloc dumps, both encoder suites, and cross-target assembly/encoding tests. Review rejects a generic instruction enum or target facts hidden in the container. |
+| 5 | RUE-824 | Remove residual duplicated post-lowering policy: use the existing shared liveness/scheduling/regalloc algorithms and `prepare_mir` pipeline through thin target fact adapters. Do not merge target fact tables or peephole passes. | Liveness, regalloc, scheduling, spill, and stack-frame tests; oracle-diff; release-mode suite; native x86-64 and AArch64 execution; cross-target assembly/encoding. Review re-runs the full inventory and classifies every remaining backend function. |
+| 6 | RUE-825 | Endpoint audit and cleanup: delete superseded wrappers, refresh architecture/code-review documentation, and record measured ownership. This is the completion ticket, not a place to add new abstractions. | Full `scripts/rue test`, documentation/index validation, formatting, both native target CI matrices, and cross-target assembly/encoding CI. The endpoint criteria below must be demonstrated in the PR description. |
+
+No slice may change language semantics, the established Rue ABI, or the target
+matrix as a refactor convenience. If a plan cannot express a behavior without
+target facts, that behavior belongs to the adapter and the inventory must say
+why.
+
+## Explicit non-goals and target facts
+
+The following remain per backend by design:
+
+- `Reg`, `Cond`, `Inst`, operand encodings, and MIR display details;
+- System V AMD64 versus AAPCS64 argument and return register sets, stack
+  offsets, frame-pointer conventions, callee-saved registers, and syscall
+  entry sequences;
+- x86 FLAGS versus AArch64 NZCV, including overflow, carry, compare, shift,
+  division, and narrowing sequences;
+- x86 implicit RAX/RDX division operands and scratch-register constraints;
+- AArch64 high-half multiplication and immediate encoding constraints;
+- target-specific instruction selection, spill/reload instructions, liveness
+  uses/defs/clobbers, schedule latency and flag facts;
+- target peephole transformations and their flag-safety proofs;
+- machine encoders, relocations, assembly formatting, prologues, epilogues,
+  and native object/linker details; and
+- target-specific runtime entry differences, including AArch64 Linux versus
+  macOS behavior.
+
+M3 does not attempt to make the backend files equal in line count, share
+encoding code, introduce LLVM or another code generator, redesign the Rue
+ABI, unify peephole optimizers, or create a third generic backend. It also does
+not turn debug presentation into a second semantic pipeline.
+
+## Test and review obligations
+
+Every slice must preserve the existing golden stages (`lowering`, `liveness`,
+`regalloc`, `mir`, and `asm`) wherever target output is intentionally
+unchanged. Where a plan changes textual formatting, the PR must explain the
+format-only delta and retain machine-code and execution coverage.
+
+The complete target obligation is:
+
+- native x86-64 execution on the supported x86-64 CI platforms;
+- native AArch64 execution on Linux AArch64 and macOS AArch64 CI;
+- cross-target x86-64 and AArch64 lowering, assembly, and encoder tests from
+  hosts that cannot natively execute the other target; and
+- differential oracle and release-mode coverage for language/ABI behavior,
+  with the isolated generated-oracle rerun rule in `AGENTS.md` applying to
+  timeout-only local failures.
+
+Reviewers must inspect both backend adapters for every slice and verify that
+the shared core owns the semantic decision named in the diff. A passing output
+corpus is not sufficient if a backend still reconstructs the decision from
+the CFG.
+
+## Objective completion criterion
+
+RUE-825 is complete only when all of the following are measurable from the
+current source and its tests:
+
+1. The function inventory above has an owner for every non-test backend
+   function; the remaining target-local functions are justified by a listed
+   register, instruction, flag, immediate, encoding, or native-ABI fact.
+2. There is exactly one implementation of CFG value/terminator routing,
+   aggregate slot completeness, block-parameter routing, by-reference
+   classification, and sret selection. Neither backend contains a second
+   `lower_value`/`lower_terminator` policy dispatcher.
+3. The shared adapter boundary has at most the six policy-facing operations
+   specified above, exposes no generic target instruction or register type,
+   and accepts normalized plans rather than raw CFG references.
+4. The backend CFG lowerers consist of adapter state/leaf plumbing and target
+   instruction selection; their remaining duplicated methods are the thin
+   liveness/scheduling/regalloc/container wrappers explicitly classified here.
+5. Native x86-64, native AArch64, cross-target assembly/encoding, oracle, and
+   release-mode gates are green for the final source, and the documentation
+   and generated ADR index validate.
+
+The measurable endpoint is therefore ownership and semantic centralization,
+not a percentage of lines deleted. Line count is retained only as audit
+evidence and must not be used to force target-specific code through the
+adapter.
+
+## Risks and uncertainties
+
+The principal risk is silent miscompilation when a policy decision moves from
+one backend into a plan. The required native, cross-target, oracle, golden,
+and release-mode gates are mandatory because a compile-only check cannot prove
+the ABI and flag obligations.
+
+The repository does not contain the titles or comments for RUE-820 through
+RUE-825. This ADR therefore names the dependency-ordered slices from the
+RUE-819 acceptance brief rather than guessing external issue prose. The
+coordinating maintainer should reconcile those labels before implementation;
+the ownership boundary and completion criteria remain the design decision.

--- a/docs/designs/0048-shared-codegen-middle-layer.md
+++ b/docs/designs/0048-shared-codegen-middle-layer.md
@@ -16,7 +16,7 @@ relates: ["RUE-250", "RUE-819", "RUE-820", "RUE-821", "RUE-822", "RUE-823", "RUE
 ## Status
 
 Accepted as the M3 shared-backend policy design by RUE-819, 2026-07-15. This
-ADR is a design-only increment. It authorizes the dependency-ordered
+ADR is a design-only increment. It authorizes the dependency-defined
 implementation slices below; it does not implement any of them.
 
 ## Summary
@@ -35,18 +35,19 @@ responsibilities in the same methods:
 3. instruction selection (MIR variants, flags, immediates, scratch registers,
    and target encodings).
 
-M3 makes the first responsibility single-copy and makes the boundary between
-the first two and the third explicit. The shared layer produces normalized
-lowering plans. An x86-64 or AArch64 adapter consumes those plans and selects
-instructions. There is no target-independent instruction set, register enum,
-or third generic backend.
+M3 makes the language/CFG responsibility single-copy and makes logical ABI
+planning explicit; physical ABI facts remain in the adapters. The shared layer
+produces normalized lowering plans. An x86-64 or AArch64 adapter consumes those
+plans and selects instructions. There is no target-independent instruction set,
+register enum, or third generic backend.
 
 ## Current source audit
 
 The current source, rather than the historical RUE-250 design pass, is the
 authority for this decision. The shared top-level codegen modules currently
-contain 7,571 lines including tests. The backend files currently measure as
-follows; `code` stops immediately before each file's `#[cfg(test)]` module.
+contain 8,404 lines including tests (`crates/rue-codegen/src/*.rs`). The backend
+files currently measure as follows; `code` stops immediately before each file's
+`#[cfg(test)]` module.
 
 | Backend file | x86-64 total/code | AArch64 total/code | Current classification |
 | --- | ---: | ---: | --- |
@@ -125,7 +126,7 @@ The non-paired functions are evidence for the boundary, not missing work:
 | `liveness::{analyze, analyze_debug, analyze_loops}` | x86-64 `liveness.rs:63-73`; AArch64 `liveness.rs:63-73` | Thin target wrappers over shared analysis. `get_label`, `get_successors`, `uses`, `defs`, and `clobbers` remain per instruction set. |
 | `schedule::{schedule}` and `SchedulerAdapter` forwarding methods | x86-64 `schedule.rs:34-68,653`; AArch64 `schedule.rs:34-68,535` | Thin wrappers over `schedule_core`. `get_latency`, memory classification, register reads/writes, and FLAGS/NZCV facts remain per target. |
 | `RegAlloc::{new, allocate, allocate_with_spills, allocate_with_debug, assign_registers, assign_registers_with_debug, rewrite_instructions, rewrite_inst, load_operand, get_allocation}` plus shared-shape helpers `emit_binop`, `emit_unop`, `emit_unop_imm` (x86-64) and `emit_binop`, `emit_ternop`, `emit_binop_imm` (AArch64) | x86-64 `regalloc.rs:65-221,996`; AArch64 `regalloc.rs:68-209,1051` | Shared linear scan, coalescing, spill-slot allocation, and cost model stay in `regalloc.rs`. The target driver may remain thin; `ALLOCATABLE_REGS`, operand rewriting, scratch registers, and spill/reload MIR remain local. |
-| `X86Mir`/`Aarch64Mir` container methods (`new`, `push`, `alloc_vreg`, `alloc_label`, `instructions`, `instructions_mut`, `into_instructions`, counts) | x86-64 `mir.rs:761-903`; AArch64 `mir.rs:1162-1325` | A generic `Mir<Inst>` container may be extracted only after CFG plans are stable. `Inst`, `Reg`, `Cond`, operand encodings, and target display remain local. |
+| `X86Mir`/`Aarch64Mir` container methods (`new`, `push`, `alloc_vreg`, `alloc_label`, `instructions`, `instructions_mut`, `into_instructions`, counts) | x86-64 `mir.rs:761-903`; AArch64 `mir.rs:1162-1325` | Defer outside M3. The current container duplication is recorded for audit only; `Inst`, `Reg`, `Cond`, operand encodings, and target display remain local. |
 | `peephole::optimize` and helpers | x86-64 `peephole.rs:44-301`; AArch64 `peephole.rs:44-267` | Keep completely per target. The two passes do not have the same flag semantics: x86 FLAGS and AArch64 NZCV are materially different. |
 | `emit::{emit, emit_all}` and all encoder helpers | x86-64 `emit.rs:346-355`; AArch64 `emit.rs:457-466` | Keep completely per target. ModRM/REX, fixed-width AArch64 words, relocations, prologues, epilogues, and native ABI entry are not middle-layer policy. |
 
@@ -142,11 +143,15 @@ index/vreg types. It owns:
 - `CfgInstData` classification and dependency ordering;
 - scalar versus complete aggregate slot representation;
 - block-parameter routing and ascending logical slot order;
-- place bounds-check ordering and by-reference parameter classification;
+- edge-local value/cleanup work and deterministic successor order;
+- place bounds-check ordering, address-versus-value decisions, and by-reference
+  parameter classification;
 - the language-level overflow, narrowing, division, comparison, and shift
   *requirements*;
 - logical call and return plans, including flattened arguments, by-ref
   pointers, sret selection, stack-slot counts, and alignment requirements;
+- allocation assignment, spill-slot selection, rewrite bookkeeping, and
+  before/after spill insertion order;
 - the one-shot pass and debug-plan sequencing; and
 - shared invariants and diagnostics when a CFG or slot vector is malformed.
 
@@ -180,18 +185,34 @@ target instruction, or raw CFG reference. Existing `SlotBackend`,
 the narrow leaf interfaces for memory and aggregate operations; they are not
 expanded to accept CFG policy.
 
-The adapter may allocate vregs/labels and append target MIR, consult its
-register file and instruction set, choose immediates, model flags, and emit
-target ABI instructions. It may not inspect `Cfg`, recompute type slot counts,
-choose sret versus register return, reorder aggregate slots, classify an
-argument as by-reference, or implement a second terminator/value dispatcher.
-Those operations are only valid in the core. A backend adapter that needs a
-new semantic fact must extend the shared plan, not read the CFG again.
+The six operations are separate domain events, not one catch-all event enum:
+`emit_value` covers the exhaustive `CfgValue`/aggregate materialization tree;
+`emit_call` covers a fully classified logical call; `emit_terminator` covers
+block topology, branches, returns, fallthrough, and edge work;
+`emit_intrinsic` covers normalized runtime/intrinsic operations;
+`emit_checked_arithmetic` covers arithmetic with its already-decided width,
+signedness, and checked-overflow requirement; and `emit_trap` covers the
+normalized trap selected by shared policy. Each plan is exhaustively matched
+within its own operation, so adding a language-level case changes the shared
+dispatcher and both adapters without creating a target-neutral instruction
+enum.
 
-This boundary is deliberately not a `Backend` trait with a generic `Inst`.
-There are two concrete adapters—x86-64 and AArch64—and their MIR enums remain
-the instruction-selection endpoint. A future third architecture can implement
-the same plans without requiring a third generic backend in the core.
+The adapter may allocate target virtual registers and target label handles,
+append target MIR, consult its register file and instruction set, choose
+immediates, model flags, and emit target ABI instructions. The core owns the
+logical labels, topology, vreg/slot identity, and event order; adapter-local
+handles cannot create new CFG edges or reorder logical slots. An adapter may
+not inspect `Cfg`, recompute type slot counts, choose sret versus register
+return, reorder aggregate slots, classify an argument as by-reference, or
+implement a second terminator/value dispatcher. Those operations are only
+valid in the core. A backend adapter that needs a new semantic fact must extend
+the shared plan, not read the CFG again.
+
+This boundary is deliberately not a `Backend` trait with a generic `Inst`, nor
+a single target-neutral instruction/event enum. There are two concrete
+adapters—x86-64 and AArch64—and their MIR enums remain the instruction-selection
+endpoint. A future third architecture can implement the same plans without
+requiring a third generic backend in the core.
 
 ### Invariants at the boundary
 
@@ -217,21 +238,23 @@ Every migration slice must preserve these invariants:
    views observe the same plan and do not invoke a presentation-specific
    lowerer.
 
-## Dependency-ordered M3 migration
+## M3 migration slices and dependencies
 
-The issue titles are not recorded in this repository, so the mapping below
-uses the dependency order and acceptance scope supplied by RUE-819. Before
-each implementation PR, its issue description must be reconciled with the
-slice name here; the dependency order is normative.
+RUE-820, RUE-821, RUE-822, RUE-823, and RUE-824 are parallel implementation
+slices. Each depends on RUE-819 and may proceed independently; none is a
+precondition for another. RUE-825 depends on all five and is the final
+convergence slice. The issue titles and scopes below are the canonical Linear
+scopes, mirrored here so an implementation cannot silently drift into a
+different slice.
 
-| Order | Issue | Migration slice and endpoint | Required review/test gate |
-| ---: | --- | --- | --- |
-| 1 | RUE-820 | Introduce the target-neutral plan types, adapter contract, and invariant tests. Wire no new semantic behavior yet. Establish a before/after lowering-dump corpus for both backends. | Unit-test plan validation and slot/label invariants. Existing codegen unit tests and the full lowering corpus must remain unchanged. Review rejects any plan carrying raw CFG, `Reg`, `Cond`, or target MIR. |
-| 2 | RUE-821 | Move `lower_block`, `lower_value` routing, `lower_terminator`, `get_vreg`, and block-param/aggregate routing into `CfgLowerCore`. Backend files become plan consumers plus instruction selection. | Native x86-64 and native AArch64 compile/run coverage; cross-target lowering and assembly dumps; differential oracle; release-mode compiler. Review verifies one core dispatcher and no duplicate CFG terminator match. |
-| 3 | RUE-822 | Move call/return, sret, by-ref, aggregate flattening, bounds-check ordering, and intrinsic-size policy into shared `CallPlan`/`ReturnPlan`/`IntrinsicPlan` construction. Keep register/stack marshalling and overflow sequences in adapters. | ABI CLI cases, aggregate and `StrBuf` cases, by-ref/inout cases, sret spill cases, runtime entry cases, native execution on x86-64 and AArch64, plus cross-target assembly/encoding assertions. Review checks `type_uses_sret_return` and slot order have one call path. |
-| 4 | RUE-823 | Extract the duplicated MIR container plumbing behind `Mir<Inst>` if the plan migration leaves it mechanically identical. Keep `Inst`, `Reg`, `Cond`, display, encodings, and target operands separate. | MIR construction/display unit tests, exact lowering and regalloc dumps, both encoder suites, and cross-target assembly/encoding tests. Review rejects a generic instruction enum or target facts hidden in the container. |
-| 5 | RUE-824 | Remove residual duplicated post-lowering policy: use the existing shared liveness/scheduling/regalloc algorithms and `prepare_mir` pipeline through thin target fact adapters. Do not merge target fact tables or peephole passes. | Liveness, regalloc, scheduling, spill, and stack-frame tests; oracle-diff; release-mode suite; native x86-64 and AArch64 execution; cross-target assembly/encoding. Review re-runs the full inventory and classifies every remaining backend function. |
-| 6 | RUE-825 | Endpoint audit and cleanup: delete superseded wrappers, refresh architecture/code-review documentation, and record measured ownership. This is the completion ticket, not a place to add new abstractions. | Full `scripts/rue test`, documentation/index validation, formatting, both native target CI matrices, and cross-target assembly/encoding CI. The endpoint criteria below must be demonstrated in the PR description. |
+| Issue | Linear scope and endpoint | Required review/test gate |
+| --- | --- | --- |
+| RUE-820 — Share allocation sizing, index scaling, and bounds-check lowering | One shared algorithm decides allocation element/aggregate slot sizing, constant/dynamic index scaling, checked arithmetic, bounds conditions/trap edges, zero-width/overflow handling, and address-versus-value decisions. Backend hooks emit arithmetic, compare, and branch instructions only. | Array, string, pointer, zero-sized, maximum-length, and overflow tests on both backends; exhaustive hook removal must fail to compile; slot/index invariants, cross-target lowering/assembly, and differential oracle coverage. |
+| RUE-821 — Share call ABI slot planning and argument materialization | One target-independent `CallPlan`/`ReturnPlan` covers hidden sret storage, argument modes and logical slots, zero-width/multi-slot values, address/value materialization, ordering, and return reconstruction. Physical registers, moves, stack offsets, and target ABI instructions remain local. Both backends consume the same plan and assert that every slot is handled. | Ordinary, method, intrinsic, runtime, by-ref, inout, aggregate, zero-sized, and stack-spill ABI cases on both backends; native execution plus cross-target assembly/encoding assertions. |
+| RUE-822 — Share scalar and aggregate CFG value materialization | One exhaustive decision tree covers `CfgValue`, constants/coercions, loads/stores, flattened aggregate collection/reconstruction, by-reference preloads, comparison preparation, and width/signedness. Adapters retain target MIR and flags behavior and cannot choose slot counts or aggregate widths. | Cross-backend MIR/debug traces for every CFG value variant, aggregate and `StrBuf` cases, no-single-slot fallback assertions, native x86-64 and AArch64 execution, and cross-target lowering tests. |
+| RUE-823 — Share CFG control-flow and terminator lowering | One shared path owns block/label mapping, conditional/unconditional branches, switch planning, return/trap/fallthrough, edge-local value/cleanup work, and deterministic order. Branch instructions, flags, and fixups remain local. | Diamond, loop, switch, trap, cleanup, and multi-return topology/trace comparisons on both backends, with identical successor topology before encoding; native execution and cross-target assembly/encoding tests. |
+| RUE-824 — Consolidate register-allocation rewrite and spill orchestration | One implementation owns assignment, spill-slot allocation, rewrite bookkeeping, and before/after spill insertion sequencing. Hooks provide operand constraints, physical/scratch registers, implicit uses/defs, and concrete load/store instructions. | High-pressure, fixed-register, call-clobber, loop, and spill-heavy tests on both backends; liveness/regalloc/scheduling/stack-frame tests, deterministic debug output with intentional golden updates where needed, oracle-diff, release-mode, and native execution. |
+| RUE-825 — Final convergence after RUE-820–824 | Move the remaining shared traversal/dispatch shell into the accepted layer, make each hook a documented target fact, remove superseded wrappers, and refresh the contribution checklist. Do not add MIR-container or other new abstractions here. | Full `scripts/rue test`, ADR/index validation, formatting, complete native x86-64 and AArch64 matrices, cross-target assembly/encoding CI, and the endpoint criteria below. |
 
 No slice may change language semantics, the established Rue ABI, or the target
 matrix as a refactor convenience. If a plan cannot express a behavior without
@@ -259,9 +282,10 @@ The following remain per backend by design:
   macOS behavior.
 
 M3 does not attempt to make the backend files equal in line count, share
-encoding code, introduce LLVM or another code generator, redesign the Rue
-ABI, unify peephole optimizers, or create a third generic backend. It also does
-not turn debug presentation into a second semantic pipeline.
+encoding code, genericize the MIR containers, introduce LLVM or another code
+generator, redesign the Rue ABI, unify peephole optimizers, or create a third
+generic backend. It also does not turn debug presentation into a second
+semantic pipeline.
 
 ## Test and review obligations
 
@@ -301,8 +325,9 @@ current source and its tests:
    specified above, exposes no generic target instruction or register type,
    and accepts normalized plans rather than raw CFG references.
 4. The backend CFG lowerers consist of adapter state/leaf plumbing and target
-   instruction selection; their remaining duplicated methods are the thin
-   liveness/scheduling/regalloc/container wrappers explicitly classified here.
+   instruction selection; their remaining duplicated methods are justified by
+   the target facts explicitly classified here. MIR-container genericization is
+   not an RUE-825 completion requirement.
 5. Native x86-64, native AArch64, cross-target assembly/encoding, oracle, and
    release-mode gates are green for the final source, and the documentation
    and generated ADR index validate.
@@ -319,8 +344,7 @@ one backend into a plan. The required native, cross-target, oracle, golden,
 and release-mode gates are mandatory because a compile-only check cannot prove
 the ABI and flag obligations.
 
-The repository does not contain the titles or comments for RUE-820 through
-RUE-825. This ADR therefore names the dependency-ordered slices from the
-RUE-819 acceptance brief rather than guessing external issue prose. The
-coordinating maintainer should reconcile those labels before implementation;
-the ownership boundary and completion criteria remain the design decision.
+Linear is the canonical source for the RUE-820 through RUE-825 titles,
+descriptions, and dependency edges. This ADR mirrors those scopes and records
+the shared ownership boundary; implementation PRs must keep their changes
+within the corresponding Linear slice.

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -210,7 +210,7 @@ The table is generated from ADR frontmatter. Run
 | [0045](0045-lazy-semantic-analysis.md) | Lazy semantic analysis (compile-on-reference) | Accepted | compiler, semantics, comptime, modules, stdlib, language-shape |
 | [0046](0046-delete-flat-mode.md) | Delete flat multi-file mode (all cross-file references go through @import) | Accepted | modules, semantics, cli, language-shape, ergonomics |
 | [0047](0047-root-module-build-inputs.md) | Root-module compilation units and build-system inputs | Accepted | modules, compiler, build-system, packages, cli, language-shape |
-| [0048](0048-shared-codegen-middle-layer.md) | Shared codegen middle layer (reduce x86-64/aarch64 backend duplication) | Proposal | codegen, architecture, backends, refactor, maintainability |
+| [0048](0048-shared-codegen-middle-layer.md) | Shared codegen middle layer (reduce x86-64/aarch64 backend duplication) | Accepted | codegen, architecture, backends, refactor, maintainability |
 | [0050](0050-semantic-dependency-manifest.md) | Stable semantic dependency manifests | Accepted | compiler, incremental, tooling |
 | [0051](0051-canonical-import-resolution-authority.md) | CanonicalImportGraph as the sole import-resolution authority | Accepted | architecture, compiler, modules, incremental, tooling |
 | [0052](0052-canonical-physical-type-layout.md) | Canonical Physical Type Layout | Proposal | types, semantics, compiler, codegen, abi, memory |


### PR DESCRIPTION
## Summary

- accept ADR-0048 as the shared-backend policy for M3
- inventory current shared and target-specific codegen ownership
- define the target-neutral plan boundary and backend adapter invariants
- align the independent RUE-820 through RUE-824 slices and final RUE-825 convergence with Linear
- record native, cross-target, oracle, and release-mode validation obligations

This is a design-only increment. It does not implement any of the dependent backend refactors.

## Validation

- ADR registry validation: 53 records valid
- `//:adr-registry-validation`
- `git diff --check`
- separate adversarial architecture review

Fixes RUE-819
