### PR TITLE
RUE-820: share allocation and index lowering policy

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3952,7 +3952,7 @@ impl crate::allocation::ScaleBackend for CfgLower<'_> {
                     dst: Operand::Virtual(dst),
                     src: Operand::Virtual(src),
                 }),
-                ScaleKind::Constant(bytes) if bytes == 8 => self.mir.push(Aarch64Inst::LslImm {
+                ScaleKind::Constant(8) => self.mir.push(Aarch64Inst::LslImm {
                     dst: Operand::Virtual(dst),
                     src: Operand::Virtual(src),
                     imm: 3,

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -12,6 +12,7 @@ use rue_error::CompileResult;
 use rue_target::Target;
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
+use crate::allocation;
 use crate::cfg_lower::CfgLowerContext;
 use crate::types;
 
@@ -111,67 +112,6 @@ impl<'a> CfgLower<'a> {
         self.mir.intern_symbol(symbol)
     }
 
-    /// Per-element stride in bytes for a heap intrinsic (`@alloc`/`@free`/
-    /// `@realloc`) whose pointer type is `ty` (a `ptr mut T`/`ptr const T`):
-    /// `size_of(T)`. All Rue types are 8-byte-slotted, so this is
-    /// `slot_count(T) * 8` — the same stride `@ptr_offset` uses (RUE-1).
-    fn alloc_element_size(&self, ty: Type) -> u64 {
-        let pointee = match ty.kind() {
-            TypeKind::PtrMut(id) => self.ctx.type_pool.ptr_mut_def(id),
-            TypeKind::PtrConst(id) => self.ctx.type_pool.ptr_const_def(id),
-            // Sema guarantees a pointer type here; be defensive on error/never.
-            _ => return 8,
-        };
-        types::type_size_bytes(self.ctx.type_pool, pointee)
-    }
-
-    /// Emit `count_vreg * element_size` (a compile-time constant stride) into a
-    /// fresh vreg, trapping if the hidden byte-size computation overflows.
-    /// Mirrors the scaling used by `@ptr_offset`, but heap intrinsic sizes are
-    /// part of the runtime ABI: silently wrapping here would under-allocate or
-    /// pass the wrong size to free/realloc (RUE-345).
-    fn scale_by_size(&mut self, count_vreg: VReg, element_size: u64) -> VReg {
-        let out = self.mir.alloc_vreg();
-        if element_size == 0 {
-            self.mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(out),
-                imm: 0,
-            });
-        } else if element_size == 1 {
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Virtual(out),
-                src: Operand::Virtual(count_vreg),
-            });
-        } else {
-            let size_vreg = self.mir.alloc_vreg();
-            self.mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(size_vreg),
-                imm: element_size as i64,
-            });
-            self.mir.push(Aarch64Inst::MulRR {
-                dst: Operand::Virtual(out),
-                src1: Operand::Virtual(count_vreg),
-                src2: Operand::Virtual(size_vreg),
-            });
-            let high_vreg = self.mir.alloc_vreg();
-            self.mir.push(Aarch64Inst::UmulhRR {
-                dst: Operand::Virtual(high_vreg),
-                src1: Operand::Virtual(count_vreg),
-                src2: Operand::Virtual(size_vreg),
-            });
-
-            let ok_label = self.mir.alloc_label();
-            self.mir.push(Aarch64Inst::Cbz {
-                src: Operand::Virtual(high_vreg),
-                label: ok_label,
-            });
-            let symbol_id = self.intern_symbol("__rue_overflow");
-            self.mir.push(Aarch64Inst::Bl { symbol_id });
-            self.mir.push(Aarch64Inst::Label { id: ok_label });
-        }
-        out
-    }
-
     /// Recursively collect all scalar vregs from an array value.
     fn collect_array_scalar_vregs(&mut self, value: CfgValue) -> Vec<VReg> {
         let slot_vregs = self.struct_slot_vregs.clone();
@@ -220,43 +160,6 @@ impl<'a> CfgLower<'a> {
                 self.ensure_by_ref_param_ptr(param_slot);
             }
         }
-    }
-
-    /// Emit a bounds check for array indexing.
-    ///
-    /// Generates code to check that `index_vreg < length` and calls `__rue_bounds_check`
-    /// if the check fails. Uses unsigned comparison so negative indices also fail.
-    fn emit_bounds_check(&mut self, index_vreg: VReg, length: u64) {
-        // Load the array length into a temporary register
-        let length_vreg = self.mir.alloc_vreg();
-        self.mir.push(Aarch64Inst::MovImm {
-            dst: Operand::Virtual(length_vreg),
-            imm: length as i64,
-        });
-
-        // Compare index (unsigned) against length. The index is a usize
-        // (64-bit) and the length is materialized as a 64-bit immediate, so the
-        // comparison MUST be 64-bit — a 32-bit cmp would ignore the high half of
-        // the index and let an out-of-range index whose low 32 bits happen to be
-        // in range bypass the check, reading out of bounds (RUE-87).
-        self.mir.push(Aarch64Inst::Cmp64RR {
-            src1: Operand::Virtual(index_vreg),
-            src2: Operand::Virtual(length_vreg),
-        });
-
-        // If index < length (unsigned), branch to ok label; otherwise call bounds check
-        let ok_label = self.mir.alloc_label();
-        self.mir.push(Aarch64Inst::BCond {
-            cond: Cond::Lo, // Lower (unsigned <)
-            label: ok_label,
-        });
-
-        // Call the bounds check error handler (never returns)
-        let symbol_id = self.intern_symbol("__rue_bounds_check");
-        self.mir.push(Aarch64Inst::Bl { symbol_id });
-
-        // Continue with valid access
-        self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
     /// Call `symbol` passing `arg_vregs` as flattened by-value slot arguments
@@ -2030,14 +1933,9 @@ impl<'a> CfgLower<'a> {
                     let ptr_vreg = self.get_vreg(ptr_val);
                     let raw_offset_vreg = self.get_vreg(offset_val);
 
-                    // Get the pointer type to determine element size
                     let ptr_type = self.ctx.cfg.get_inst(ptr_val).ty;
-                    let pointee_type = match ptr_type.kind() {
-                        TypeKind::PtrConst(ptr_id) => self.ctx.type_pool.ptr_const_def(ptr_id),
-                        TypeKind::PtrMut(ptr_id) => self.ctx.type_pool.ptr_mut_def(ptr_id),
-                        _ => unreachable!("ptr_offset requires pointer type"),
-                    };
-                    let element_size = types::type_size_bytes(self.ctx.type_pool, pointee_type);
+                    let scale_plan =
+                        allocation::pointer_offset_scale_plan(self.ctx.type_pool, ptr_type);
 
                     // Sign-/zero-extend the index to a full 64-bit value before
                     // the 64-bit scale + add below. A narrow signed index
@@ -2085,34 +1983,8 @@ impl<'a> CfgLower<'a> {
                     // @ptr_offset adds too — they agree, and the add is uniform
                     // for every pointer origin (local array, heap, mmap,
                     // @int_to_ptr). Positive n moves toward higher addresses.
-                    // First, multiply offset by element size.
-                    let scaled_offset_vreg = self.mir.alloc_vreg();
-                    if element_size == 1 {
-                        // No multiplication needed
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Virtual(scaled_offset_vreg),
-                            src: Operand::Virtual(offset_vreg),
-                        });
-                    } else if element_size == 0 {
-                        // Zero-sized type - offset is always 0
-                        self.mir.push(Aarch64Inst::MovImm {
-                            dst: Operand::Virtual(scaled_offset_vreg),
-                            imm: 0,
-                        });
-                    } else {
-                        // Multiply offset by element size
-                        let size_vreg = self.mir.alloc_vreg();
-                        self.mir.push(Aarch64Inst::MovImm {
-                            dst: Operand::Virtual(size_vreg),
-                            imm: element_size as i64,
-                        });
-                        // MUL dst, src1, src2 (dst = src1 * src2)
-                        self.mir.push(Aarch64Inst::MulRR {
-                            dst: Operand::Virtual(scaled_offset_vreg),
-                            src1: Operand::Virtual(offset_vreg),
-                            src2: Operand::Virtual(size_vreg),
-                        });
-                    }
+                    // First, multiply offset by the shared element-width plan.
+                    let scaled_offset_vreg = allocation::lower_scale(self, offset_vreg, scale_plan);
 
                     // Add to pointer (64-bit add for addresses); see the
                     // ascending-layout note above (ADR-0040 / RUE-243).
@@ -2157,8 +2029,11 @@ impl<'a> CfgLower<'a> {
                     let count_vreg = self.get_vreg(args[0]);
 
                     let result_ty = self.ctx.cfg.get_inst(value).ty;
-                    let element_size = self.alloc_element_size(result_ty);
-                    let size_vreg = self.scale_by_size(count_vreg, element_size);
+                    let size_vreg = allocation::lower_scale(
+                        self,
+                        count_vreg,
+                        allocation::allocation_size_scale_plan(self.ctx.type_pool, result_ty),
+                    );
 
                     // size -> X0, align=8 -> X1 (AArch64 C ABI arg registers).
                     self.mir.push(Aarch64Inst::MovRR {
@@ -2187,8 +2062,11 @@ impl<'a> CfgLower<'a> {
                     let count_vreg = self.get_vreg(args[1]);
 
                     let ptr_ty = self.ctx.cfg.get_inst(ptr_val).ty;
-                    let element_size = self.alloc_element_size(ptr_ty);
-                    let size_vreg = self.scale_by_size(count_vreg, element_size);
+                    let size_vreg = allocation::lower_scale(
+                        self,
+                        count_vreg,
+                        allocation::allocation_size_scale_plan(self.ctx.type_pool, ptr_ty),
+                    );
 
                     self.mir.push(Aarch64Inst::MovRR {
                         dst: Operand::Physical(Reg::X0),
@@ -2219,9 +2097,10 @@ impl<'a> CfgLower<'a> {
                     let new_vreg = self.get_vreg(args[2]);
 
                     let result_ty = self.ctx.cfg.get_inst(value).ty;
-                    let element_size = self.alloc_element_size(result_ty);
-                    let old_size_vreg = self.scale_by_size(old_vreg, element_size);
-                    let new_size_vreg = self.scale_by_size(new_vreg, element_size);
+                    let scale_plan =
+                        allocation::allocation_size_scale_plan(self.ctx.type_pool, result_ty);
+                    let old_size_vreg = allocation::lower_scale(self, old_vreg, scale_plan);
+                    let new_size_vreg = allocation::lower_scale(self, new_vreg, scale_plan);
 
                     self.mir.push(Aarch64Inst::MovRR {
                         dst: Operand::Physical(Reg::X0),
@@ -3952,9 +3831,6 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             offset: byte_offset,
         });
     }
-    fn emit_bounds_check(&mut self, index_vreg: VReg, length: u64) {
-        CfgLower::emit_bounds_check(self, index_vreg, length)
-    }
     fn emit_place_addr(&mut self, dst: VReg, place: &Place) {
         crate::place_lower::lower_place_addr(self, dst, place)
     }
@@ -3990,25 +3866,8 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
         });
     }
 
-    fn emit_scale_index_bytes(&mut self, scaled: VReg, elem_slot_count: u32) {
-        if elem_slot_count == 1 {
-            self.mir.push(Aarch64Inst::LslImm {
-                dst: Operand::Virtual(scaled),
-                src: Operand::Virtual(scaled),
-                imm: 3,
-            });
-        } else {
-            let stride = self.mir.alloc_vreg();
-            self.mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Virtual(stride),
-                imm: (elem_slot_count * 8) as i64,
-            });
-            self.mir.push(Aarch64Inst::MulRR {
-                dst: Operand::Virtual(scaled),
-                src1: Operand::Virtual(scaled),
-                src2: Operand::Virtual(stride),
-            });
-        }
+    fn emit_scale_index_bytes(&mut self, scaled: VReg, plan: crate::allocation::ScalePlan) {
+        <Self as crate::allocation::ScaleBackend>::emit_scale(self, scaled, scaled, plan);
     }
 
     fn emit_zero_sized_place(&mut self, dst: VReg) {
@@ -4023,6 +3882,136 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
             dst: Operand::Virtual(dst),
             base: ptr,
         });
+    }
+}
+
+impl crate::allocation::BoundsCheckBackend for CfgLower<'_> {
+    fn alloc_bounds_length(&mut self, length: u64) -> VReg {
+        let vreg = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(vreg),
+            imm: length as i64,
+        });
+        vreg
+    }
+
+    fn emit_bounds_compare(&mut self, index: VReg, length: VReg) {
+        self.mir.push(Aarch64Inst::Cmp64RR {
+            src1: Operand::Virtual(index),
+            src2: Operand::Virtual(length),
+        });
+    }
+
+    fn alloc_bounds_label(&mut self) -> LabelId {
+        self.mir.alloc_label()
+    }
+
+    fn emit_bounds_branch(
+        &mut self,
+        condition: crate::allocation::BoundsCondition,
+        label: LabelId,
+    ) {
+        match condition {
+            crate::allocation::BoundsCondition::UnsignedIndexLessThanLength => {
+                self.mir.push(Aarch64Inst::BCond {
+                    cond: Cond::Lo,
+                    label,
+                });
+            }
+        }
+    }
+
+    fn emit_bounds_trap(&mut self, trap: crate::allocation::BoundsTrap) {
+        match trap {
+            crate::allocation::BoundsTrap::IndexOutOfBounds => {
+                let symbol_id = self.intern_symbol("__rue_bounds_check");
+                self.mir.push(Aarch64Inst::Bl { symbol_id });
+            }
+        }
+    }
+
+    fn emit_bounds_label(&mut self, label: LabelId) {
+        self.mir.push(Aarch64Inst::Label { id: label });
+    }
+}
+
+impl crate::allocation::ScaleBackend for CfgLower<'_> {
+    fn alloc_scale_result(&mut self) -> VReg {
+        self.mir.alloc_vreg()
+    }
+
+    fn emit_scale(&mut self, dst: VReg, src: VReg, plan: crate::allocation::ScalePlan) {
+        use crate::allocation::{OverflowBehavior, ScaleKind, ScalePurpose};
+
+        match (plan.purpose, plan.overflow) {
+            (ScalePurpose::IndexOffset, OverflowBehavior::Wrap) => match plan.kind {
+                ScaleKind::Zero => self.mir.push(Aarch64Inst::MovImm {
+                    dst: Operand::Virtual(dst),
+                    imm: 0,
+                }),
+                ScaleKind::Identity => self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(src),
+                }),
+                ScaleKind::Constant(bytes) if bytes == 8 => self.mir.push(Aarch64Inst::LslImm {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(src),
+                    imm: 3,
+                }),
+                ScaleKind::Constant(bytes) => {
+                    let stride = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Virtual(stride),
+                        imm: bytes as i64,
+                    });
+                    self.mir.push(Aarch64Inst::MulRR {
+                        dst: Operand::Virtual(dst),
+                        src1: Operand::Virtual(src),
+                        src2: Operand::Virtual(stride),
+                    });
+                }
+            },
+            (ScalePurpose::PointerOffset, OverflowBehavior::Wrap)
+            | (ScalePurpose::AllocationSize, OverflowBehavior::Trap) => match plan.kind {
+                ScaleKind::Zero => self.mir.push(Aarch64Inst::MovImm {
+                    dst: Operand::Virtual(dst),
+                    imm: 0,
+                }),
+                ScaleKind::Identity => self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(src),
+                }),
+                ScaleKind::Constant(bytes) => {
+                    let stride = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Virtual(stride),
+                        imm: bytes as i64,
+                    });
+                    self.mir.push(Aarch64Inst::MulRR {
+                        dst: Operand::Virtual(dst),
+                        src1: Operand::Virtual(src),
+                        src2: Operand::Virtual(stride),
+                    });
+                    if plan.purpose == ScalePurpose::AllocationSize {
+                        let high_vreg = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::UmulhRR {
+                            dst: Operand::Virtual(high_vreg),
+                            src1: Operand::Virtual(src),
+                            src2: Operand::Virtual(stride),
+                        });
+                        let ok_label = self.mir.alloc_label();
+                        self.mir.push(Aarch64Inst::Cbz {
+                            src: Operand::Virtual(high_vreg),
+                            label: ok_label,
+                        });
+                        let symbol_id = self.intern_symbol("__rue_overflow");
+                        self.mir.push(Aarch64Inst::Bl { symbol_id });
+                        self.mir.push(Aarch64Inst::Label { id: ok_label });
+                    }
+                }
+            },
+            _ => panic!("invalid shared scaling plan: {plan:?}"),
+        }
     }
 }
 

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2578,11 +2578,10 @@ impl<'a> CfgLower<'a> {
                 // the dummy vreg CFG carries for unit would clobber a
                 // neighboring slot, and a ZST destination's origin shift
                 // underflows. Nothing to do.
-                if self.ctx.type_slot_count(val_type) == 0 {
-                    return;
-                }
                 let vals = if self.ctx.is_multislot_aggregate(val_type) {
                     self.require_aggregate_slots(*val)
+                } else if self.ctx.type_slot_count(val_type) == 0 {
+                    Vec::new()
                 } else {
                     vec![self.get_vreg(*val)]
                 };
@@ -4010,7 +4009,11 @@ impl crate::allocation::ScaleBackend for CfgLower<'_> {
                     }
                 }
             },
-            _ => panic!("invalid shared scaling plan: {plan:?}"),
+            (ScalePurpose::IndexOffset, OverflowBehavior::Trap)
+            | (ScalePurpose::PointerOffset, OverflowBehavior::Trap)
+            | (ScalePurpose::AllocationSize, OverflowBehavior::Wrap) => {
+                panic!("invalid shared scaling plan: {plan:?}")
+            }
         }
     }
 }

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 use rue_air::{Type, TypeKind};
 use rue_cfg::{CfgInstData, CfgValue, Place, PlaceBase, Projection};
 
+use crate::allocation::{self, BoundsCheckBackend};
 use crate::cfg_lower::CfgLowerContext;
 use crate::vreg::VReg;
 
@@ -32,7 +33,7 @@ use crate::vreg::VReg;
 /// Implementations are thin: `emit_load_slot` is a single frame-relative load
 /// instruction (`mov dst, [rbp+offset]` / `ldr dst, [fp, #offset]`); the rest
 /// expose existing lowerer state.
-pub trait SlotBackend {
+pub trait SlotBackend: BoundsCheckBackend {
     /// The shared lowering context (CFG, type pool, slot counts).
     fn ctx(&self) -> &CfgLowerContext<'_>;
 
@@ -73,9 +74,6 @@ pub trait SlotBackend {
 
     /// Emit a load of the value at `byte_offset` from pointer `ptr` into `dst`.
     fn emit_load_through_ptr(&mut self, dst: VReg, ptr: VReg, byte_offset: i32);
-
-    /// Emit a bounds check trapping when `index_vreg >= length`.
-    fn emit_bounds_check(&mut self, index_vreg: VReg, length: u64);
 
     /// Emit `dst = low-end address of the (possibly projected) place` — the
     /// backend's `lower_place_addr`. The result is the place's lowest-address
@@ -194,7 +192,10 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
                 if let Projection::Index { array_type, index } = proj {
                     let length = b.ctx().array_length(*array_type);
                     let index_vreg = b.get_vreg(*index);
-                    b.emit_bounds_check(index_vreg, length);
+                    allocation::lower_bounds_check(
+                        b,
+                        allocation::BoundsCheckPlan::new(index_vreg, length),
+                    );
                 }
             }
             let addr_vreg = b.alloc_vreg();

--- a/crates/rue-codegen/src/allocation.rs
+++ b/crates/rue-codegen/src/allocation.rs
@@ -64,10 +64,9 @@ pub struct SlotWidth {
 impl SlotWidth {
     #[inline]
     pub const fn from_slots(slots: u32) -> Self {
-        Self {
-            slots,
-            bytes: slots as u64 * SLOT_BYTES,
-        }
+        let bytes = checked_byte_size(slots as u64, SLOT_BYTES)
+            .expect("canonical slot width must fit in a 64-bit byte size");
+        Self { slots, bytes }
     }
 }
 
@@ -128,10 +127,6 @@ pub fn pointer_offset_scale_plan(type_pool: &FrozenTypeInternPool, ptr_ty: Type)
 #[inline]
 pub fn allocation_size_scale_plan(type_pool: &FrozenTypeInternPool, ptr_ty: Type) -> ScalePlan {
     let width = pointer_element_width(type_pool, ptr_ty);
-    debug_assert!(
-        checked_byte_size(1, width.bytes).is_some(),
-        "canonical slot width must fit in a 64-bit byte size"
-    );
     ScalePlan {
         kind: scale_kind(width.bytes),
         purpose: ScalePurpose::AllocationSize,

--- a/crates/rue-codegen/src/allocation.rs
+++ b/crates/rue-codegen/src/allocation.rs
@@ -1,0 +1,250 @@
+//! Shared allocation, index-scaling, and bounds-check policy.
+//!
+//! This module owns the facts that must not be rediscovered by an instruction
+//! selector: every ABI slot is eight bytes, a pointer's element width is the
+//! pointee's aggregate slot width, index scaling is unsigned byte arithmetic,
+//! and array bounds use an unsigned `index < length` condition.  Backends only
+//! lower the resulting plans to their arithmetic, compare, branch, and trap
+//! instructions.
+
+use rue_air::{FrozenTypeInternPool, Type, TypeKind};
+
+use crate::types;
+use crate::vreg::{LabelId, VReg};
+
+/// The byte width of one logical ABI/storage slot.
+pub const SLOT_BYTES: u64 = 8;
+
+/// The semantic purpose of a scaling operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalePurpose {
+    /// Scaling an array projection index before forming an address.
+    IndexOffset,
+    /// Scaling a raw pointer offset before adding it to a pointer.
+    PointerOffset,
+    /// Scaling an allocation count for a runtime heap call.
+    AllocationSize,
+}
+
+/// Whether a scaled product is allowed to wrap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverflowBehavior {
+    /// Trap if the 64-bit byte product overflows.
+    Trap,
+    /// Preserve the raw pointer arithmetic's wrapping behavior.
+    Wrap,
+}
+
+/// The normalized constant multiplier selected by shared policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScaleKind {
+    /// A zero-sized element; the result is always zero.
+    Zero,
+    /// A one-byte element; the source can be copied unchanged.
+    Identity,
+    /// A nontrivial constant byte multiplier.
+    Constant(u64),
+}
+
+/// A complete target-neutral scaling plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScalePlan {
+    pub kind: ScaleKind,
+    pub purpose: ScalePurpose,
+    pub overflow: OverflowBehavior,
+}
+
+/// A type's logical storage width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlotWidth {
+    pub slots: u32,
+    pub bytes: u64,
+}
+
+impl SlotWidth {
+    #[inline]
+    pub const fn from_slots(slots: u32) -> Self {
+        Self {
+            slots,
+            bytes: slots as u64 * SLOT_BYTES,
+        }
+    }
+}
+
+/// Compute the canonical aggregate/storage width for `ty`.
+#[inline]
+pub fn type_width(type_pool: &FrozenTypeInternPool, ty: Type) -> SlotWidth {
+    SlotWidth::from_slots(types::type_slot_count(type_pool, ty))
+}
+
+/// Compute the canonical element width for a pointer type.
+///
+/// Sema guarantees the pointer shape for allocation and pointer intrinsics.
+/// The defensive scalar fallback preserves the old error-path behavior if a
+/// malformed CFG reaches code generation.
+#[inline]
+pub fn pointer_element_width(type_pool: &FrozenTypeInternPool, ptr_ty: Type) -> SlotWidth {
+    let pointee = match ptr_ty.kind() {
+        TypeKind::PtrMut(id) => type_pool.ptr_mut_def(id),
+        TypeKind::PtrConst(id) => type_pool.ptr_const_def(id),
+        _ => return SlotWidth::from_slots(1),
+    };
+    type_width(type_pool, pointee)
+}
+
+/// Select the shared constant scaling operation for a byte width.
+#[inline]
+pub const fn scale_kind(bytes: u64) -> ScaleKind {
+    match bytes {
+        0 => ScaleKind::Zero,
+        1 => ScaleKind::Identity,
+        bytes => ScaleKind::Constant(bytes),
+    }
+}
+
+/// Build the scaling plan used for an array projection.
+#[inline]
+pub fn index_scale_plan(type_pool: &FrozenTypeInternPool, array_type: Type) -> ScalePlan {
+    let (element_type, _) =
+        types::array_type_def_from_type(type_pool, array_type).unwrap_or((array_type, 0));
+    ScalePlan {
+        kind: scale_kind(type_width(type_pool, element_type).bytes),
+        purpose: ScalePurpose::IndexOffset,
+        overflow: OverflowBehavior::Wrap,
+    }
+}
+
+/// Build the scaling plan used by `@ptr_offset`.
+#[inline]
+pub fn pointer_offset_scale_plan(type_pool: &FrozenTypeInternPool, ptr_ty: Type) -> ScalePlan {
+    ScalePlan {
+        kind: scale_kind(pointer_element_width(type_pool, ptr_ty).bytes),
+        purpose: ScalePurpose::PointerOffset,
+        overflow: OverflowBehavior::Wrap,
+    }
+}
+
+/// Build the checked scaling plan used by `@alloc`, `@free`, and `@realloc`.
+#[inline]
+pub fn allocation_size_scale_plan(type_pool: &FrozenTypeInternPool, ptr_ty: Type) -> ScalePlan {
+    let width = pointer_element_width(type_pool, ptr_ty);
+    debug_assert!(
+        checked_byte_size(1, width.bytes).is_some(),
+        "canonical slot width must fit in a 64-bit byte size"
+    );
+    ScalePlan {
+        kind: scale_kind(width.bytes),
+        purpose: ScalePurpose::AllocationSize,
+        overflow: OverflowBehavior::Trap,
+    }
+}
+
+/// Compute the product used by a checked allocation-size calculation.
+#[inline]
+pub const fn checked_byte_size(count: u64, element_bytes: u64) -> Option<u64> {
+    count.checked_mul(element_bytes)
+}
+
+/// The only bounds condition currently produced by the language-level policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoundsCondition {
+    /// The index is valid exactly when it is below the array length as an
+    /// unsigned 64-bit value. This also rejects negative signed indices after
+    /// their canonical extension to the index width.
+    UnsignedIndexLessThanLength,
+}
+
+/// The normalized trap edge for a bounds failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoundsTrap {
+    IndexOutOfBounds,
+}
+
+/// A complete target-neutral bounds-check plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BoundsCheckPlan {
+    pub index: VReg,
+    pub length: u64,
+    pub condition: BoundsCondition,
+    pub trap: BoundsTrap,
+}
+
+impl BoundsCheckPlan {
+    #[inline]
+    pub const fn new(index: VReg, length: u64) -> Self {
+        Self {
+            index,
+            length,
+            condition: BoundsCondition::UnsignedIndexLessThanLength,
+            trap: BoundsTrap::IndexOutOfBounds,
+        }
+    }
+}
+
+/// Target leaves used by the shared bounds-check edge builder.
+pub trait BoundsCheckBackend {
+    fn alloc_bounds_length(&mut self, length: u64) -> VReg;
+    fn emit_bounds_compare(&mut self, index: VReg, length: VReg);
+    fn alloc_bounds_label(&mut self) -> LabelId;
+    fn emit_bounds_branch(&mut self, condition: BoundsCondition, label: LabelId);
+    fn emit_bounds_trap(&mut self, trap: BoundsTrap);
+    fn emit_bounds_label(&mut self, label: LabelId);
+}
+
+/// Lower one normalized bounds check. The condition, failure edge, and edge
+/// order are shared; only the individual target operations are supplied by the
+/// backend.
+pub fn lower_bounds_check<B: BoundsCheckBackend + ?Sized>(b: &mut B, plan: BoundsCheckPlan) {
+    let length = b.alloc_bounds_length(plan.length);
+    b.emit_bounds_compare(plan.index, length);
+    let ok = b.alloc_bounds_label();
+    b.emit_bounds_branch(plan.condition, ok);
+    b.emit_bounds_trap(plan.trap);
+    b.emit_bounds_label(ok);
+}
+
+/// Target leaf for a normalized scaling operation.
+pub trait ScaleBackend {
+    fn alloc_scale_result(&mut self) -> VReg;
+    fn emit_scale(&mut self, dst: VReg, src: VReg, plan: ScalePlan);
+}
+
+/// Lower a target-neutral scaling plan to one backend result vreg.
+#[inline]
+pub fn lower_scale<B: ScaleBackend + ?Sized>(b: &mut B, src: VReg, plan: ScalePlan) -> VReg {
+    let dst = b.alloc_scale_result();
+    b.emit_scale(dst, src, plan);
+    dst
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scale_policy_covers_zero_identity_and_constant_widths() {
+        assert_eq!(scale_kind(0), ScaleKind::Zero);
+        assert_eq!(scale_kind(1), ScaleKind::Identity);
+        assert_eq!(scale_kind(8), ScaleKind::Constant(8));
+        assert_eq!(
+            scale_kind(u32::MAX as u64 * SLOT_BYTES),
+            ScaleKind::Constant(u32::MAX as u64 * 8)
+        );
+    }
+
+    #[test]
+    fn checked_allocation_size_rejects_maximum_length_overflow() {
+        assert_eq!(checked_byte_size(u64::MAX, 0), Some(0));
+        assert_eq!(checked_byte_size(u64::MAX, 1), Some(u64::MAX));
+        assert_eq!(checked_byte_size(u64::MAX, 8), None);
+        assert_eq!(checked_byte_size(u64::MAX / 8, 8), Some(u64::MAX - 7));
+    }
+
+    #[test]
+    fn bounds_policy_is_unsigned_less_than_with_a_trap_edge() {
+        let plan = BoundsCheckPlan::new(VReg::new(3), u64::MAX);
+        assert_eq!(plan.condition, BoundsCondition::UnsignedIndexLessThanLength);
+        assert_eq!(plan.trap, BoundsTrap::IndexOutOfBounds);
+        assert_eq!(plan.index, VReg::new(3));
+    }
+}

--- a/crates/rue-codegen/src/byref_args.rs
+++ b/crates/rue-codegen/src/byref_args.rs
@@ -20,9 +20,9 @@
 //! address, from which aggregate slots ascend (`slot k` at `+k*8`), uniform
 //! for frame- and heap-rooted places (ADR-0040 / RUE-311).
 
-use crate::place_lower::PlaceLowerBackend;
+use crate::place_lower::{self, PlaceLowerBackend};
 use crate::vreg::VReg;
-use rue_cfg::{CfgInstData, CfgValue, Place, Projection};
+use rue_cfg::{CfgInstData, CfgValue, Place};
 
 /// Lower a by-ref (inout/borrow) call argument to the vreg holding its
 /// address.
@@ -88,14 +88,7 @@ pub fn lower_byref_arg_addr<B: PlaceLowerBackend + ?Sized>(
             // out-of-bounds index must trap at the call site (the projected
             // PlaceRead the arg expression also lowers to is a dead value —
             // its own bounds check does not protect the address).
-            let projections: Vec<Projection> = b.ctx().cfg.get_place_projections(&place).to_vec();
-            for proj in &projections {
-                if let Projection::Index { array_type, index } = proj {
-                    let length = b.ctx().array_length(*array_type);
-                    let index_vreg = b.get_vreg(*index);
-                    b.emit_bounds_check(index_vreg, length);
-                }
-            }
+            place_lower::lower_place_bounds(b, &place);
             let addr_vreg = b.alloc_vreg();
             b.emit_place_addr(addr_vreg, &place);
             addr_vreg

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -41,6 +41,7 @@ macro_rules! end_inst {
     };
 }
 
+mod allocation;
 mod codegen_pipeline;
 mod schedule_core;
 mod stack_frame;

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -15,6 +15,7 @@ use rue_air::Type;
 use rue_cfg::{CfgValue, Place, PlaceBase, Projection};
 
 use crate::agg_slots::{self, SlotBackend};
+use crate::allocation::{self, ScalePlan};
 use crate::vreg::VReg;
 
 /// Per-target instruction leaves used by shared place lowering.
@@ -31,9 +32,9 @@ pub trait PlaceLowerBackend: SlotBackend {
     /// Add a nonzero byte displacement to an address in `dst`.
     fn emit_addr_add_imm(&mut self, dst: VReg, byte_offset: i32);
 
-    /// Scale the copied index in `scaled` by `elem_slot_count * 8` bytes.
+    /// Scale the copied index in `scaled` by the normalized byte-width plan.
     /// Implementations may allocate target-specific temporary vregs.
-    fn emit_scale_index_bytes(&mut self, scaled: VReg, elem_slot_count: u32);
+    fn emit_scale_index_bytes(&mut self, scaled: VReg, plan: ScalePlan);
 
     /// Materialize the canonical value for a zero-sized place read.
     ///
@@ -53,7 +54,7 @@ pub trait PlaceLowerBackend: SlotBackend {
 #[derive(Clone, Copy)]
 struct IndexLevel {
     index: CfgValue,
-    elem_slot_count: u32,
+    scale: ScalePlan,
 }
 
 struct ProjectionOffsets {
@@ -150,6 +151,22 @@ pub fn lower_place_write<B: PlaceLowerBackend>(b: &mut B, place: &Place, vals: &
     }
 }
 
+/// Check every index projection in source order. Callers that form an address
+/// directly (by-ref arguments and aggregate materialization) use this helper
+/// so they cannot accidentally bypass the shared trap edge.
+pub fn lower_place_bounds<B: PlaceLowerBackend + ?Sized>(b: &mut B, place: &Place) {
+    let projections = b.ctx().cfg.get_place_projections(place).to_vec();
+    for projection in projections {
+        if let Projection::Index { array_type, index } = projection {
+            let index_vreg = b.get_vreg(index);
+            allocation::lower_bounds_check(
+                b,
+                allocation::BoundsCheckPlan::new(index_vreg, b.ctx().array_length(array_type)),
+            );
+        }
+    }
+}
+
 /// Emit the low-end address of `place` into `dst`.
 ///
 /// Index projections are intentionally unchecked here: `@raw` is unchecked,
@@ -216,11 +233,14 @@ fn analyze_projections<B: PlaceLowerBackend>(
                     // emitted while walking the chain, before any address math.
                     let index_vreg = b.get_vreg(*index);
                     let length = b.ctx().array_length(*array_type);
-                    b.emit_bounds_check(index_vreg, length);
+                    allocation::lower_bounds_check(
+                        b,
+                        allocation::BoundsCheckPlan::new(index_vreg, length),
+                    );
                 }
                 index_levels.push(IndexLevel {
                     index: *index,
-                    elem_slot_count: b.ctx().array_element_slot_count(*array_type),
+                    scale: allocation::index_scale_plan(b.ctx().type_pool, *array_type),
                 });
             }
         }
@@ -297,7 +317,7 @@ fn compute_index_offset<B: PlaceLowerBackend>(b: &mut B, levels: &[IndexLevel]) 
         let index = b.get_vreg(level.index);
         let scaled = b.alloc_vreg();
         b.emit_reg_move(scaled, index);
-        b.emit_scale_index_bytes(scaled, level.elem_slot_count);
+        b.emit_scale_index_bytes(scaled, level.scale);
 
         if let Some(previous) = total {
             b.emit_addr_add(previous, scaled);

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -74,16 +74,22 @@ enum ProjectedAccess {
 /// Lower a scalar [`Place`] read, including projection bounds checks and
 /// address formation.
 pub fn lower_place_read<B: PlaceLowerBackend>(b: &mut B, dst: VReg, place: &Place, ty: Type) {
+    // Even a zero-sized indexed place has a valid language-level access that
+    // must reject an out-of-range index. There is no address to form or load
+    // for the zero-sized value, but the bounds edge still has to be emitted.
+    let projections = b.ctx().cfg.get_place_projections(place).to_vec();
     // This guard must precede root-origin arithmetic: a zero-slot root would
     // underflow at `root_count - 1`, and there are no bytes to load (RUE-577).
     if b.ctx().type_slot_count(ty) == 0 {
+        if !projections.is_empty() {
+            analyze_projections(b, &projections, true);
+        }
         b.emit_zero_sized_place(dst);
         return;
     }
 
     // Clone the compact projection slice so generic emission can mutably
     // borrow the backend without retaining a borrow through its CFG context.
-    let projections = b.ctx().cfg.get_place_projections(place).to_vec();
     if projections.is_empty() {
         match place.base {
             PlaceBase::Local(slot) => b.emit_load_slot(dst, slot),
@@ -113,14 +119,18 @@ pub fn lower_place_read<B: PlaceLowerBackend>(b: &mut B, dst: VReg, place: &Plac
 /// Lower a [`Place`] write. `vals` contains one vreg per logical value slot,
 /// with slot zero first.
 pub fn lower_place_write<B: PlaceLowerBackend>(b: &mut B, place: &Place, vals: &[VReg]) {
+    let projections = b.ctx().cfg.get_place_projections(place).to_vec();
     // A zero-sized value has no storage to update. Current CFG callers filter
-    // these writes before reaching codegen, but keeping the shared boundary
-    // total avoids forming an address for a value with no storage.
+    // these writes before reaching codegen, but the index still needs its
+    // language-level bounds edge. Keeping this boundary total avoids forming
+    // an address for a value with no storage.
     if vals.is_empty() {
+        if !projections.is_empty() {
+            analyze_projections(b, &projections, true);
+        }
         return;
     }
 
-    let projections = b.ctx().cfg.get_place_projections(place).to_vec();
     if projections.is_empty() {
         match place.base {
             PlaceBase::Local(slot) => agg_slots::store_slots(b, vals, slot),
@@ -353,12 +363,17 @@ mod tests {
             fn read_borrow(borrow value: i32) -> i32 { value }
             fn read_inout(inout value: i32) -> i32 { value }
             fn read_unit(value: Empty) -> () { value.unit }
+            fn read_unit_index(borrow arr: [Empty; 2], i: u64) -> () { arr[i].unit }
+            fn write_unit_index(inout arr: [Empty; 2], i: u64) { arr[i] = Empty { unit: () }; }
             fn main() -> i32 {
                 let mut scalar = 7;
                 let _borrow_read = read_borrow(borrow scalar);
                 let _scalar_read = read_inout(inout scalar);
                 let empty = Empty { unit: () };
                 read_unit(empty);
+                let mut empty_values: [Empty; 2] = [Empty { unit: () }, Empty { unit: () }];
+                read_unit_index(borrow empty_values, 0);
+                write_unit_index(inout empty_values, 0);
                 let mut grid = Grid { pad: 9, cells: [[10, 20], [30, 40]] };
                 let i: u64 = 1;
                 let j: u64 = 0;
@@ -526,5 +541,46 @@ mod tests {
             unit_arm.instructions(),
             [Aarch64Inst::MovImm { imm: 0, .. }, Aarch64Inst::Ret]
         ));
+
+        // A zero-sized indexed place has no load/store, but it still has a
+        // language-level bounds check. Both the value and address paths must
+        // retain the shared trap edge even though they materialize no bytes.
+        let unit_index_cfg = build_cfg("read_unit_index");
+        let unit_index_x86 = X86CfgLower::new(&unit_index_cfg, &output.type_pool, &interner)
+            .lower()
+            .expect("x86 indexed ZST fixture should lower");
+        let unit_index_arm = Aarch64CfgLower::new(
+            &unit_index_cfg,
+            &output.type_pool,
+            &interner,
+            Target::Aarch64Linux,
+        )
+        .lower()
+        .expect("AArch64 indexed ZST fixture should lower");
+        assert!(unit_index_x86.instructions().iter().any(|inst| {
+            matches!(inst, X86Inst::CallRel { symbol_id } if unit_index_x86.get_symbol(*symbol_id) == "__rue_bounds_check")
+        }));
+        assert!(unit_index_arm.instructions().iter().any(|inst| {
+            matches!(inst, Aarch64Inst::Bl { symbol_id } if unit_index_arm.get_symbol(*symbol_id) == "__rue_bounds_check")
+        }));
+
+        let unit_write_cfg = build_cfg("write_unit_index");
+        let unit_write_x86 = X86CfgLower::new(&unit_write_cfg, &output.type_pool, &interner)
+            .lower()
+            .expect("x86 indexed ZST write fixture should lower");
+        let unit_write_arm = Aarch64CfgLower::new(
+            &unit_write_cfg,
+            &output.type_pool,
+            &interner,
+            Target::Aarch64Linux,
+        )
+        .lower()
+        .expect("AArch64 indexed ZST write fixture should lower");
+        assert!(unit_write_x86.instructions().iter().any(|inst| {
+            matches!(inst, X86Inst::CallRel { symbol_id } if unit_write_x86.get_symbol(*symbol_id) == "__rue_bounds_check")
+        }));
+        assert!(unit_write_arm.instructions().iter().any(|inst| {
+            matches!(inst, Aarch64Inst::Bl { symbol_id } if unit_write_arm.get_symbol(*symbol_id) == "__rue_bounds_check")
+        }));
     }
 }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2922,11 +2922,10 @@ impl<'a> CfgLower<'a> {
                 // the dummy vreg CFG carries for unit would clobber a
                 // neighboring slot, and a ZST destination's origin shift
                 // underflows. Nothing to do.
-                if self.ctx.type_slot_count(val_type) == 0 {
-                    return;
-                }
                 let vals = if self.ctx.is_multislot_aggregate(val_type) {
                     self.require_aggregate_slots(*val)
+                } else if self.ctx.type_slot_count(val_type) == 0 {
+                    Vec::new()
                 } else {
                     vec![self.get_vreg(*val)]
                 };
@@ -3986,7 +3985,11 @@ impl crate::allocation::ScaleBackend for CfgLower<'_> {
                     self.mir.push(X86Inst::Label { id: ok_label });
                 }
             },
-            _ => panic!("invalid shared scaling plan: {plan:?}"),
+            (ScalePurpose::IndexOffset, OverflowBehavior::Trap)
+            | (ScalePurpose::PointerOffset, OverflowBehavior::Trap)
+            | (ScalePurpose::AllocationSize, OverflowBehavior::Wrap) => {
+                panic!("invalid shared scaling plan: {plan:?}")
+            }
         }
     }
 }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3889,7 +3889,7 @@ impl crate::allocation::ScaleBackend for CfgLower<'_> {
                     dst: Operand::Virtual(dst),
                     src: Operand::Virtual(src),
                 }),
-                ScaleKind::Constant(bytes) if bytes == 8 => {
+                ScaleKind::Constant(8) => {
                     let shift_count = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::MovRI32 {
                         dst: Operand::Virtual(shift_count),

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -33,6 +33,7 @@ use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, Terminator
 use rue_error::CompileResult;
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
+use crate::allocation;
 use crate::cfg_lower::CfgLowerContext;
 use crate::types;
 use crate::vreg::BLOCK_LABEL_BASE;
@@ -117,66 +118,6 @@ impl<'a> CfgLower<'a> {
         self.mir.intern_symbol(symbol)
     }
 
-    /// Per-element stride in bytes for a heap intrinsic (`@alloc`/`@free`/
-    /// `@realloc`) whose pointer type is `ty` (a `ptr mut T`/`ptr const T`):
-    /// `size_of(T)`. All Rue types are 8-byte-slotted, so this is
-    /// `slot_count(T) * 8` — the same stride `@ptr_offset` uses (RUE-1).
-    fn alloc_element_size(&self, ty: Type) -> u64 {
-        let pointee = match ty.kind() {
-            TypeKind::PtrMut(id) => self.ctx.type_pool.ptr_mut_def(id),
-            TypeKind::PtrConst(id) => self.ctx.type_pool.ptr_const_def(id),
-            // Sema guarantees a pointer type here; be defensive on error/never.
-            _ => return 8,
-        };
-        types::type_size_bytes(self.ctx.type_pool, pointee)
-    }
-
-    /// Emit `count_vreg * element_size` (a compile-time constant stride) into a
-    /// fresh vreg, trapping if the hidden byte-size computation overflows.
-    /// Mirrors the scaling used by `@ptr_offset`, but heap intrinsic sizes are
-    /// part of the runtime ABI: silently wrapping here would under-allocate or
-    /// pass the wrong size to free/realloc (RUE-345).
-    fn scale_by_size(&mut self, count_vreg: VReg, element_size: u64) -> VReg {
-        let out = self.mir.alloc_vreg();
-        if element_size == 0 {
-            self.mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(out),
-                imm: 0,
-            });
-        } else if element_size == 1 {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(out),
-                src: Operand::Virtual(count_vreg),
-            });
-        } else {
-            let size_vreg = self.mir.alloc_vreg();
-            self.mir.push(X86Inst::MovRI64 {
-                dst: Operand::Virtual(size_vreg),
-                imm: element_size as i64,
-            });
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Physical(Reg::Rax),
-                src: Operand::Virtual(count_vreg),
-            });
-            self.mir.push(X86Inst::Mul64R {
-                src: Operand::Virtual(size_vreg),
-            });
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(out),
-                src: Operand::Physical(Reg::Rax),
-            });
-
-            // MOV does not modify flags, so MUL's carry flag still records
-            // whether the unsigned product's high half was non-zero.
-            let ok_label = self.new_label();
-            self.mir.push(X86Inst::Jae { label: ok_label });
-            let symbol_id = self.intern_symbol("__rue_overflow");
-            self.mir.push(X86Inst::CallRel { symbol_id });
-            self.mir.push(X86Inst::Label { id: ok_label });
-        }
-        out
-    }
-
     /// Recursively collect all scalar vregs from an array value.
     fn collect_array_scalar_vregs(&mut self, value: CfgValue) -> Vec<VReg> {
         let slot_vregs = self.struct_slot_vregs.clone();
@@ -230,40 +171,6 @@ impl<'a> CfgLower<'a> {
                 self.ensure_by_ref_param_ptr(param_slot);
             }
         }
-    }
-
-    /// Emit a bounds check for array indexing.
-    ///
-    /// Generates code to check that `index_vreg < length` and calls `__rue_bounds_check`
-    /// if the check fails. Uses unsigned comparison so negative indices also fail.
-    fn emit_bounds_check(&mut self, index_vreg: VReg, length: u64) {
-        // Load the array length into a temporary register
-        let length_vreg = self.mir.alloc_vreg();
-        self.mir.push(X86Inst::MovRI64 {
-            dst: Operand::Virtual(length_vreg),
-            imm: length as i64,
-        });
-
-        // Compare index (unsigned) against length. The index is a usize
-        // (64-bit) and the length is materialized as a 64-bit immediate, so the
-        // comparison MUST be 64-bit — a 32-bit cmp would ignore the high half of
-        // the index and let an out-of-range index whose low 32 bits happen to be
-        // in range bypass the check, reading out of bounds (RUE-87).
-        self.mir.push(X86Inst::Cmp64RR {
-            src1: Operand::Virtual(index_vreg),
-            src2: Operand::Virtual(length_vreg),
-        });
-
-        // If index < length (unsigned), jump to ok label; otherwise call bounds check
-        let ok_label = self.new_label();
-        self.mir.push(X86Inst::Jb { label: ok_label });
-
-        // Call the bounds check error handler (never returns)
-        let symbol_id = self.intern_symbol("__rue_bounds_check");
-        self.mir.push(X86Inst::CallRel { symbol_id });
-
-        // Continue with valid access
-        self.mir.push(X86Inst::Label { id: ok_label });
     }
 
     /// Call `symbol` passing `arg_vregs` as flattened by-value slot arguments
@@ -2344,14 +2251,9 @@ impl<'a> CfgLower<'a> {
                     let ptr_vreg = self.get_vreg(ptr_val);
                     let raw_offset_vreg = self.get_vreg(offset_val);
 
-                    // Get the pointer type to determine element size
                     let ptr_type = self.ctx.cfg.get_inst(ptr_val).ty;
-                    let pointee_type = match ptr_type.kind() {
-                        TypeKind::PtrConst(ptr_id) => self.ctx.type_pool.ptr_const_def(ptr_id),
-                        TypeKind::PtrMut(ptr_id) => self.ctx.type_pool.ptr_mut_def(ptr_id),
-                        _ => unreachable!("ptr_offset requires pointer type"),
-                    };
-                    let element_size = types::type_size_bytes(self.ctx.type_pool, pointee_type);
+                    let scale_plan =
+                        allocation::pointer_offset_scale_plan(self.ctx.type_pool, ptr_type);
 
                     // Sign-/zero-extend the index to a full 64-bit value before
                     // the 64-bit scale + add below. A narrow signed index
@@ -2398,36 +2300,8 @@ impl<'a> CfgLower<'a> {
                     // @ptr_offset adds too — they agree, and the add is uniform
                     // for every pointer origin (local array, heap, mmap,
                     // @int_to_ptr). Positive n moves toward higher addresses.
-                    // First, multiply offset by element size.
-                    let scaled_offset_vreg = self.mir.alloc_vreg();
-                    if element_size == 1 {
-                        // No multiplication needed
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(scaled_offset_vreg),
-                            src: Operand::Virtual(offset_vreg),
-                        });
-                    } else if element_size == 0 {
-                        // Zero-sized type - offset is always 0
-                        self.mir.push(X86Inst::MovRI32 {
-                            dst: Operand::Virtual(scaled_offset_vreg),
-                            imm: 0,
-                        });
-                    } else {
-                        // Multiply offset by element size
-                        let size_vreg = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::MovRI64 {
-                            dst: Operand::Virtual(size_vreg),
-                            imm: element_size as i64,
-                        });
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(scaled_offset_vreg),
-                            src: Operand::Virtual(offset_vreg),
-                        });
-                        self.mir.push(X86Inst::ImulRR64 {
-                            dst: Operand::Virtual(scaled_offset_vreg),
-                            src: Operand::Virtual(size_vreg),
-                        });
-                    }
+                    // First, multiply offset by the shared element-width plan.
+                    let scaled_offset_vreg = allocation::lower_scale(self, offset_vreg, scale_plan);
 
                     // Add to pointer (64-bit add for addresses); see the
                     // ascending-layout note above (ADR-0040 / RUE-243).
@@ -2476,10 +2350,12 @@ impl<'a> CfgLower<'a> {
                     let count_vreg = self.get_vreg(args[0]);
 
                     let result_ty = self.ctx.cfg.get_inst(value).ty;
-                    let element_size = self.alloc_element_size(result_ty);
-
                     // size = count * element_size in RDI (first arg register).
-                    let size_vreg = self.scale_by_size(count_vreg, element_size);
+                    let size_vreg = allocation::lower_scale(
+                        self,
+                        count_vreg,
+                        allocation::allocation_size_scale_plan(self.ctx.type_pool, result_ty),
+                    );
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Physical(Reg::Rdi),
                         src: Operand::Virtual(size_vreg),
@@ -2509,8 +2385,11 @@ impl<'a> CfgLower<'a> {
                     let count_vreg = self.get_vreg(count_val);
 
                     let ptr_ty = self.ctx.cfg.get_inst(ptr_val).ty;
-                    let element_size = self.alloc_element_size(ptr_ty);
-                    let size_vreg = self.scale_by_size(count_vreg, element_size);
+                    let size_vreg = allocation::lower_scale(
+                        self,
+                        count_vreg,
+                        allocation::allocation_size_scale_plan(self.ctx.type_pool, ptr_ty),
+                    );
 
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Physical(Reg::Rdi),
@@ -2542,9 +2421,10 @@ impl<'a> CfgLower<'a> {
                     let new_vreg = self.get_vreg(args[2]);
 
                     let result_ty = self.ctx.cfg.get_inst(value).ty;
-                    let element_size = self.alloc_element_size(result_ty);
-                    let old_size_vreg = self.scale_by_size(old_vreg, element_size);
-                    let new_size_vreg = self.scale_by_size(new_vreg, element_size);
+                    let scale_plan =
+                        allocation::allocation_size_scale_plan(self.ctx.type_pool, result_ty);
+                    let old_size_vreg = allocation::lower_scale(self, old_vreg, scale_plan);
+                    let new_size_vreg = allocation::lower_scale(self, new_vreg, scale_plan);
 
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Physical(Reg::Rdi),
@@ -3887,9 +3767,6 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             offset: byte_offset,
         });
     }
-    fn emit_bounds_check(&mut self, index_vreg: VReg, length: u64) {
-        CfgLower::emit_bounds_check(self, index_vreg, length)
-    }
     fn emit_place_addr(&mut self, dst: VReg, place: &Place) {
         crate::place_lower::lower_place_addr(self, dst, place)
     }
@@ -3928,28 +3805,8 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
         });
     }
 
-    fn emit_scale_index_bytes(&mut self, scaled: VReg, elem_slot_count: u32) {
-        if elem_slot_count == 1 {
-            let shift_count = self.mir.alloc_vreg();
-            self.mir.push(X86Inst::MovRI32 {
-                dst: Operand::Virtual(shift_count),
-                imm: 3,
-            });
-            self.mir.push(X86Inst::Shl {
-                dst: Operand::Virtual(scaled),
-                count: Operand::Virtual(shift_count),
-            });
-        } else {
-            let stride = self.mir.alloc_vreg();
-            self.mir.push(X86Inst::MovRI64 {
-                dst: Operand::Virtual(stride),
-                imm: (elem_slot_count * 8) as i64,
-            });
-            self.mir.push(X86Inst::ImulRR64 {
-                dst: Operand::Virtual(scaled),
-                src: Operand::Virtual(stride),
-            });
-        }
+    fn emit_scale_index_bytes(&mut self, scaled: VReg, plan: crate::allocation::ScalePlan) {
+        <Self as crate::allocation::ScaleBackend>::emit_scale(self, scaled, scaled, plan);
     }
 
     fn emit_zero_sized_place(&mut self, dst: VReg) {
@@ -3965,6 +3822,172 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
             base: ptr,
             offset: 0,
         });
+    }
+}
+
+impl crate::allocation::BoundsCheckBackend for CfgLower<'_> {
+    fn alloc_bounds_length(&mut self, length: u64) -> VReg {
+        let vreg = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(vreg),
+            imm: length as i64,
+        });
+        vreg
+    }
+
+    fn emit_bounds_compare(&mut self, index: VReg, length: VReg) {
+        self.mir.push(X86Inst::Cmp64RR {
+            src1: Operand::Virtual(index),
+            src2: Operand::Virtual(length),
+        });
+    }
+
+    fn alloc_bounds_label(&mut self) -> LabelId {
+        self.new_label()
+    }
+
+    fn emit_bounds_branch(
+        &mut self,
+        condition: crate::allocation::BoundsCondition,
+        label: LabelId,
+    ) {
+        match condition {
+            crate::allocation::BoundsCondition::UnsignedIndexLessThanLength => {
+                self.mir.push(X86Inst::Jb { label });
+            }
+        }
+    }
+
+    fn emit_bounds_trap(&mut self, trap: crate::allocation::BoundsTrap) {
+        match trap {
+            crate::allocation::BoundsTrap::IndexOutOfBounds => {
+                let symbol_id = self.intern_symbol("__rue_bounds_check");
+                self.mir.push(X86Inst::CallRel { symbol_id });
+            }
+        }
+    }
+
+    fn emit_bounds_label(&mut self, label: LabelId) {
+        self.mir.push(X86Inst::Label { id: label });
+    }
+}
+
+impl crate::allocation::ScaleBackend for CfgLower<'_> {
+    fn alloc_scale_result(&mut self) -> VReg {
+        self.mir.alloc_vreg()
+    }
+
+    fn emit_scale(&mut self, dst: VReg, src: VReg, plan: crate::allocation::ScalePlan) {
+        use crate::allocation::{OverflowBehavior, ScaleKind, ScalePurpose};
+
+        match (plan.purpose, plan.overflow) {
+            (ScalePurpose::IndexOffset, OverflowBehavior::Wrap) => match plan.kind {
+                ScaleKind::Zero => self.mir.push(X86Inst::MovRI32 {
+                    dst: Operand::Virtual(dst),
+                    imm: 0,
+                }),
+                ScaleKind::Identity => self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(src),
+                }),
+                ScaleKind::Constant(bytes) if bytes == 8 => {
+                    let shift_count = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRI32 {
+                        dst: Operand::Virtual(shift_count),
+                        imm: 3,
+                    });
+                    if dst != src {
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(src),
+                        });
+                    }
+                    self.mir.push(X86Inst::Shl {
+                        dst: Operand::Virtual(dst),
+                        count: Operand::Virtual(shift_count),
+                    });
+                }
+                ScaleKind::Constant(bytes) => {
+                    let stride = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Virtual(stride),
+                        imm: bytes as i64,
+                    });
+                    if dst != src {
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(src),
+                        });
+                    }
+                    self.mir.push(X86Inst::ImulRR64 {
+                        dst: Operand::Virtual(dst),
+                        src: Operand::Virtual(stride),
+                    });
+                }
+            },
+            (ScalePurpose::PointerOffset, OverflowBehavior::Wrap) => match plan.kind {
+                ScaleKind::Zero => self.mir.push(X86Inst::MovRI32 {
+                    dst: Operand::Virtual(dst),
+                    imm: 0,
+                }),
+                ScaleKind::Identity => self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(src),
+                }),
+                ScaleKind::Constant(bytes) => {
+                    let stride = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Virtual(stride),
+                        imm: bytes as i64,
+                    });
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rax),
+                        src: Operand::Virtual(src),
+                    });
+                    self.mir.push(X86Inst::Mul64R {
+                        src: Operand::Virtual(stride),
+                    });
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(dst),
+                        src: Operand::Physical(Reg::Rax),
+                    });
+                }
+            },
+            (ScalePurpose::AllocationSize, OverflowBehavior::Trap) => match plan.kind {
+                ScaleKind::Zero => self.mir.push(X86Inst::MovRI32 {
+                    dst: Operand::Virtual(dst),
+                    imm: 0,
+                }),
+                ScaleKind::Identity => self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(src),
+                }),
+                ScaleKind::Constant(bytes) => {
+                    let stride = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Virtual(stride),
+                        imm: bytes as i64,
+                    });
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rax),
+                        src: Operand::Virtual(src),
+                    });
+                    self.mir.push(X86Inst::Mul64R {
+                        src: Operand::Virtual(stride),
+                    });
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(dst),
+                        src: Operand::Physical(Reg::Rax),
+                    });
+                    let ok_label = self.new_label();
+                    self.mir.push(X86Inst::Jae { label: ok_label });
+                    let symbol_id = self.intern_symbol("__rue_overflow");
+                    self.mir.push(X86Inst::CallRel { symbol_id });
+                    self.mir.push(X86Inst::Label { id: ok_label });
+                }
+            },
+            _ => panic!("invalid shared scaling plan: {plan:?}"),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- centralize allocation sizing, index scaling, overflow, and bounds policy in the shared codegen middle layer
- keep target-specific arithmetic and branch emission behind exhaustive backend adapters
- preserve bounds checks for zero-sized indexed reads and writes across both backends

## Validation
- scripts/rue quick
- focused codegen, CLI, specification, and golden tests
- scripts/rue test

Fixes RUE-820