### PR TITLE
RUE-821: share call ABI slot planning

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -70,6 +70,34 @@ pub struct CfgLower<'a> {
     by_ref_param_ptrs: HashMap<u32, VReg>,
 }
 
+impl crate::call_plan::CallMaterializer for CfgLower<'_> {
+    fn materialize_scalar(&mut self, value: CfgValue) -> VReg {
+        self.get_vreg(value)
+    }
+
+    fn materialize_aggregate(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.require_aggregate_slots(value)
+    }
+
+    fn materialize_by_ref(&mut self, value: CfgValue, mode: rue_cfg::CfgArgMode) -> VReg {
+        crate::byref_args::lower_byref_arg_addr(self, value, mode == rue_cfg::CfgArgMode::Inout)
+    }
+
+    fn materialize_sret_pointer(&mut self, storage_bytes: u32) -> VReg {
+        self.mir.push(Aarch64Inst::SubImm {
+            dst: Operand::Physical(Reg::Sp),
+            src: Operand::Physical(Reg::Sp),
+            imm: storage_bytes as i32,
+        });
+        let pointer = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(pointer),
+            src: Operand::Physical(Reg::Sp),
+        });
+        pointer
+    }
+}
+
 impl<'a> CfgLower<'a> {
     /// Create a new CFG lowering pass.
     pub fn new(
@@ -169,15 +197,11 @@ impl<'a> CfgLower<'a> {
     /// path so every slot beyond the eight register arguments is passed on the
     /// stack (RUE-193).
     fn emit_call_with_slot_args(&mut self, arg_vregs: &[VReg], symbol: &str) {
-        let num_reg_args = arg_vregs.len().min(ARG_REGS.len());
-        let num_stack_args = arg_vregs.len().saturating_sub(ARG_REGS.len());
+        let plan = crate::call_plan::CallPlan::from_slot_values(symbol, arg_vregs, ARG_REGS.len());
+        let num_reg_args = plan.abi_slots.len().min(ARG_REGS.len());
 
         // Allocate stack space for stack arguments (must be 16-byte aligned)
-        let stack_space = if num_stack_args > 0 {
-            (num_stack_args * 8).div_ceil(16) * 16
-        } else {
-            0
-        };
+        let stack_space = plan.stack_bytes as usize;
         if stack_space > 0 {
             self.mir.push(Aarch64Inst::SubImm {
                 dst: Operand::Physical(Reg::Sp),
@@ -187,7 +211,7 @@ impl<'a> CfgLower<'a> {
         }
 
         // Store stack arguments to the allocated space
-        for (i, arg_vreg) in arg_vregs.iter().skip(ARG_REGS.len()).enumerate() {
+        for (i, arg_vreg) in plan.abi_slots.iter().skip(ARG_REGS.len()).enumerate() {
             let offset = (i * 8) as i32;
             self.mir.push(Aarch64Inst::Str {
                 src: Operand::Virtual(*arg_vreg),
@@ -197,14 +221,14 @@ impl<'a> CfgLower<'a> {
         }
 
         // Move register arguments
-        for (i, arg_vreg) in arg_vregs.iter().take(num_reg_args).enumerate() {
+        for (i, arg_vreg) in plan.abi_slots.iter().take(num_reg_args).enumerate() {
             self.mir.push(Aarch64Inst::MovRR {
                 dst: Operand::Physical(ARG_REGS[i]),
                 src: Operand::Virtual(*arg_vreg),
             });
         }
 
-        let symbol_id = self.intern_symbol(symbol);
+        let symbol_id = self.intern_symbol(&plan.symbol);
         self.mir.push(Aarch64Inst::Bl { symbol_id });
 
         // Clean up stack space after the call
@@ -1250,106 +1274,36 @@ impl<'a> CfgLower<'a> {
                 let result_vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, result_vreg);
 
-                // Does this call return via the sret convention? Builtin
-                // String always does (runtime fns take an out-pointer first
-                // param); other aggregates do when their slots exceed the
-                // return registers. See crate::cfg_lower::type_uses_sret_return.
-                let is_sret_call = self.ctx.type_uses_sret(ty, RET_REGS.len() as u32);
-                let ret_slot_count = if self.ctx.is_multislot_aggregate(ty) {
-                    self.ctx.type_slot_count(ty)
-                } else {
-                    1
-                };
-                // Caller-allocated return buffer: one 8-byte slot per
-                // aggregate slot, padded to keep sp 16-byte aligned.
-                let sret_bytes = ((ret_slot_count as i32 * 8) + 15) / 16 * 16;
-
-                // For sret calls, allocate the return buffer on the stack;
-                // we'll pass a pointer to this space as the first argument.
-                if is_sret_call {
-                    self.mir.push(Aarch64Inst::SubImm {
-                        dst: Operand::Physical(Reg::Sp),
-                        src: Operand::Physical(Reg::Sp),
-                        imm: sret_bytes,
-                    });
-                }
-
-                // Flatten struct arguments and handle by-ref arguments (inout and borrow)
-                let mut flattened_vregs: Vec<VReg> = Vec::new();
-
-                // For sret calls, the first argument is the output pointer (current sp)
-                if is_sret_call {
-                    let sret_ptr_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(sret_ptr_vreg),
-                        src: Operand::Physical(Reg::Sp),
-                    });
-                    flattened_vregs.push(sret_ptr_vreg);
-                }
-                // By-value aggregate arguments are passed in REVERSED logical
-                // slot order to Rue-compiled callees (ADR-0040 / RUE-311), which
-                // read them back with the ascending frame convention. Runtime
-                // helpers (`__rue_*`, hand-written with the C ABI) instead expect
-                // a builtin aggregate's slots (e.g. a String's ptr/len/cap) in
-                // natural order, so calls to them are NOT reversed.
-                let callee_is_runtime = self.interner.resolve(name).starts_with("__rue_");
                 let args = self.ctx.cfg.get_call_args(*args_start, *args_len).to_vec();
-                for arg in &args {
-                    let arg_value = arg.value;
-                    let arg_type = self.ctx.cfg.get_inst(arg_value).ty;
-
-                    // For by-ref args (inout or borrow), pass the address of
-                    // the argument place — a variable, field, or array
-                    // element (RUE-143). Single shared implementation — see
-                    // crate::byref_args.
-                    if arg.is_by_ref() {
-                        let addr_vreg = crate::byref_args::lower_byref_arg_addr(
-                            self,
-                            arg_value,
-                            arg.is_inout(),
-                        );
-                        flattened_vregs.push(addr_vreg);
-                        continue;
-                    }
-
-                    // CFG materializes a value for every continuing
-                    // expression, including unit and other zero-sized values,
-                    // but a Normal argument's physical ABI width comes from
-                    // its static type. Do not mistake the dummy CFG value for
-                    // a scalar slot. Keep this after the by-ref branch: a
-                    // borrow/inout ZST still passes one real pointer.
-                    if self.ctx.type_slot_count(arg_type) == 0 {
-                        continue;
-                    }
-
-                    if self.ctx.is_multislot_aggregate(arg_type) {
-                        // Pass all slots of the (possibly multi-slot) aggregate arg —
-                        // struct, builtin String, fixed-size array, or payload enum
-                        // (RUE-221) — regardless of how it was produced. The accessor
-                        // materializes lazily-sourced values (Load/Param/PlaceRead) and
-                        // cache-hits eager ones (StructInit/ArrayInit/Call/BlockParam).
-                        // Reversed for Rue callees, natural for runtime (RUE-311).
-                        let field_vregs = self.require_aggregate_slots(arg_value);
-                        if callee_is_runtime {
-                            flattened_vregs.extend(field_vregs);
-                        } else {
-                            flattened_vregs.extend(field_vregs.into_iter().rev());
-                        }
-                    } else {
-                        flattened_vregs.push(self.get_vreg(arg_value));
-                    }
-                }
+                let symbol = self.interner.resolve(name).to_owned();
+                let inputs = crate::call_plan::CallInputs::from_cfg(
+                    self.ctx.cfg,
+                    self.ctx.type_pool,
+                    ty,
+                    &args,
+                    RET_REGS.len() as u32,
+                );
+                let plan = crate::call_plan::CallPlan::from_inputs(
+                    &symbol,
+                    inputs.return_plan,
+                    &inputs.args,
+                    ARG_REGS.len(),
+                    self,
+                );
+                assert_eq!(
+                    plan.abi_slots.len(),
+                    plan.hidden_sret.map_or(0, |_| 1)
+                        + plan
+                            .user_args
+                            .iter()
+                            .map(|arg| arg.slots.len())
+                            .sum::<usize>()
+                );
 
                 // Move arguments to registers (AAPCS64 uses X0-X7)
-                let num_reg_args = flattened_vregs.len().min(ARG_REGS.len());
-                let num_stack_args = flattened_vregs.len().saturating_sub(ARG_REGS.len());
-
+                let num_reg_args = plan.abi_slots.len().min(ARG_REGS.len());
                 // Allocate stack space for stack arguments (must be 16-byte aligned)
-                let stack_space = if num_stack_args > 0 {
-                    ((num_stack_args * 8 + 15) / 16) * 16
-                } else {
-                    0
-                };
+                let stack_space = plan.stack_bytes as usize;
 
                 if stack_space > 0 {
                     self.mir.push(Aarch64Inst::SubImm {
@@ -1360,7 +1314,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Store stack arguments to allocated space
-                for (i, arg_vreg) in flattened_vregs.iter().skip(ARG_REGS.len()).enumerate() {
+                for (i, arg_vreg) in plan.abi_slots.iter().skip(ARG_REGS.len()).enumerate() {
                     let offset = (i * 8) as i32;
                     self.mir.push(Aarch64Inst::Str {
                         src: Operand::Virtual(*arg_vreg),
@@ -1370,7 +1324,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Move register arguments
-                for (i, arg_vreg) in flattened_vregs.iter().take(num_reg_args).enumerate() {
+                for (i, arg_vreg) in plan.abi_slots.iter().take(num_reg_args).enumerate() {
                     self.mir.push(Aarch64Inst::MovRR {
                         dst: Operand::Physical(ARG_REGS[i]),
                         src: Operand::Virtual(*arg_vreg),
@@ -1378,8 +1332,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Call the function - the linker will add the underscore prefix for macOS
-                let symbol_name = self.interner.resolve(name);
-                let symbol_id = self.intern_symbol(symbol_name);
+                let symbol_id = self.intern_symbol(&plan.symbol);
                 self.mir.push(Aarch64Inst::Bl { symbol_id });
 
                 // Clean up stack space after call
@@ -1394,59 +1347,77 @@ impl<'a> CfgLower<'a> {
                 // Handle struct and string returns (multi-slot types)
                 // sret calls first: the callee wrote the slots to the buffer
                 // at [sp]. (String always; big aggregates per RUE-106.)
-                if is_sret_call {
-                    // Load every slot from the return buffer
-                    let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..ret_slot_count {
-                        let slot_vreg = self.mir.alloc_vreg();
-                        let offset = (slot_idx * 8) as i32;
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(slot_vreg),
-                            base: Reg::Sp,
-                            offset,
-                        });
-                        slot_vregs.push(slot_vreg);
-                    }
-                    // Pop the sret space (including alignment padding)
-                    self.mir.push(Aarch64Inst::AddImm {
-                        dst: Operand::Physical(Reg::Sp),
-                        src: Operand::Physical(Reg::Sp),
-                        imm: sret_bytes,
-                    });
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(result_vreg),
-                        src: Operand::Virtual(slot_vregs[0]),
-                    });
-                } else if self.ctx.is_multislot_aggregate(ty) {
-                    // Aggregates that fit return in registers have a complete
-                    // cached representation populated from RET_REGS, including
-                    // arrays and payload enums. (RUE-78, RUE-237)
-                    let slot_count = ret_slot_count;
-                    let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..slot_count {
-                        let slot_vreg = self.mir.alloc_vreg();
-                        if (slot_idx as usize) < RET_REGS.len() {
-                            self.mir.push(Aarch64Inst::MovRR {
+                match plan.return_plan {
+                    crate::call_plan::ReturnPlan::Sret {
+                        slot_count: ret_slot_count,
+                        storage_bytes: sret_bytes,
+                    } => {
+                        // Load every slot from the return buffer
+                        let mut slot_vregs = Vec::new();
+                        for slot_idx in 0..ret_slot_count {
+                            let slot_vreg = self.mir.alloc_vreg();
+                            let offset = (slot_idx * 8) as i32;
+                            self.mir.push(Aarch64Inst::Ldr {
                                 dst: Operand::Virtual(slot_vreg),
-                                src: Operand::Physical(RET_REGS[slot_idx as usize]),
+                                base: Reg::Sp,
+                                offset,
                             });
+                            slot_vregs.push(slot_vreg);
                         }
-                        slot_vregs.push(slot_vreg);
-                    }
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-                    if let Some(&first_vreg) = slot_vregs.first() {
+                        assert_eq!(slot_vregs.len(), ret_slot_count as usize);
+                        // Pop the sret space (including alignment padding)
+                        self.mir.push(Aarch64Inst::AddImm {
+                            dst: Operand::Physical(Reg::Sp),
+                            src: Operand::Physical(Reg::Sp),
+                            imm: sret_bytes as i32,
+                        });
+                        self.struct_slot_vregs.insert(value, slot_vregs.clone());
                         self.mir.push(Aarch64Inst::MovRR {
                             dst: Operand::Virtual(result_vreg),
-                            src: Operand::Virtual(first_vreg),
+                            src: Operand::Virtual(slot_vregs[0]),
                         });
                     }
-                } else {
-                    // Move result from X0
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(result_vreg),
-                        src: Operand::Physical(Reg::X0),
-                    });
+                    crate::call_plan::ReturnPlan::Registers { slot_count } => {
+                        // Aggregates that fit return in registers have a complete
+                        // cached representation populated from RET_REGS, including
+                        // arrays and payload enums. (RUE-78, RUE-237)
+                        assert!((slot_count as usize) <= RET_REGS.len());
+                        let mut slot_vregs = Vec::new();
+                        for slot_idx in 0..slot_count {
+                            let slot_vreg = self.mir.alloc_vreg();
+                            if (slot_idx as usize) < RET_REGS.len() {
+                                self.mir.push(Aarch64Inst::MovRR {
+                                    dst: Operand::Virtual(slot_vreg),
+                                    src: Operand::Physical(RET_REGS[slot_idx as usize]),
+                                });
+                            }
+                            slot_vregs.push(slot_vreg);
+                        }
+                        assert_eq!(slot_vregs.len(), slot_count as usize);
+                        self.struct_slot_vregs.insert(value, slot_vregs.clone());
+                        if let Some(&first_vreg) = slot_vregs.first() {
+                            self.mir.push(Aarch64Inst::MovRR {
+                                dst: Operand::Virtual(result_vreg),
+                                src: Operand::Virtual(first_vreg),
+                            });
+                        }
+                    }
+                    crate::call_plan::ReturnPlan::Scalar => {
+                        // Move result from X0
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(result_vreg),
+                            src: Operand::Physical(Reg::X0),
+                        });
+                    }
+                    crate::call_plan::ReturnPlan::ZeroSized => {
+                        // Zero-sized values have no ABI return slot. Keep the
+                        // CFG's cached dummy value defined for any later
+                        // storage path that asks for its vreg.
+                        self.mir.push(Aarch64Inst::MovImm {
+                            dst: Operand::Virtual(result_vreg),
+                            imm: 0,
+                        });
+                    }
                 }
             }
 
@@ -1512,7 +1483,7 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(Aarch64Inst::AddImm {
                         dst: Operand::Physical(Reg::Sp),
                         src: Operand::Physical(Reg::Sp),
-                        imm: sret_bytes,
+                        imm: sret_bytes as i32,
                     });
 
                     // Slot 0 (discriminant) is the value's primary vreg, so a

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -1,0 +1,445 @@
+//! Target-independent planning for Rue calls.
+//!
+//! This module decides the logical ABI shape of a call.  It deliberately does
+//! not know about physical registers or target instructions; the two backend
+//! lowerers consume the normalized slot vector and only choose how to marshal
+//! those slots for their ABI.
+
+use rue_air::FrozenTypeInternPool;
+use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, Type};
+
+use crate::cfg_lower::type_uses_sret_return;
+use crate::types;
+use crate::vreg::VReg;
+
+/// The source ABI expected by a call target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CalleeAbi {
+    /// A Rue-compiled function, whose aggregate arguments use reversed ABI
+    /// slot order to preserve the ascending logical frame layout.
+    Rue,
+    /// A runtime helper using the natural C-compatible aggregate slot order.
+    Runtime,
+}
+
+impl CalleeAbi {
+    fn for_symbol(symbol: &str) -> Self {
+        if symbol.starts_with("__rue_") {
+            Self::Runtime
+        } else {
+            Self::Rue
+        }
+    }
+}
+
+/// The logical mode of one user argument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserArgMode {
+    /// A normal argument is passed by value.
+    Value,
+    /// An `inout` argument is represented by one preserved address slot.
+    Inout,
+    /// A `borrow` argument is represented by one preserved address slot.
+    Borrow,
+}
+
+/// One classified user argument.  Its vregs are already materialized by the
+/// shared aggregate/by-ref leaves, but no physical ABI assignment has happened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserArgPlan {
+    pub mode: UserArgMode,
+    pub slots: Vec<VReg>,
+}
+
+/// The hidden caller-provided return storage, when the return uses sret.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HiddenSretPlan {
+    /// The vreg containing the address of the caller-owned storage.
+    pub pointer: VReg,
+    /// The logical ABI position of the hidden pointer.
+    pub abi_slot: usize,
+    /// Number of logical return slots written by the callee.
+    pub slot_count: u32,
+    /// Caller storage size, rounded up to the call-stack alignment.
+    pub storage_bytes: u32,
+}
+
+/// How a call result is reconstructed after the target call instruction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReturnPlan {
+    /// Unit/never/empty aggregates have no materialized slots.
+    ZeroSized,
+    /// A one-slot scalar is returned in the target's primary return register.
+    Scalar,
+    /// A complete aggregate is returned one logical slot per return register.
+    Registers { slot_count: u32 },
+    /// A complete aggregate is written to caller-provided storage.
+    Sret { slot_count: u32, storage_bytes: u32 },
+}
+
+impl ReturnPlan {
+    /// Number of logical return slots represented by this plan.
+    pub const fn slot_count(self) -> u32 {
+        match self {
+            Self::ZeroSized => 0,
+            Self::Scalar => 1,
+            Self::Registers { slot_count } | Self::Sret { slot_count, .. } => slot_count,
+        }
+    }
+
+    pub const fn uses_sret(self) -> bool {
+        matches!(self, Self::Sret { .. })
+    }
+}
+
+/// A normalized call ABI plan consumed by both target adapters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallPlan {
+    pub symbol: String,
+    pub callee_abi: CalleeAbi,
+    pub hidden_sret: Option<HiddenSretPlan>,
+    pub user_args: Vec<UserArgPlan>,
+    /// Complete logical ABI slots, including the hidden sret pointer when
+    /// present.  This is the only slot vector the adapters may marshal.
+    pub abi_slots: Vec<VReg>,
+    pub return_plan: ReturnPlan,
+    pub stack_slot_count: usize,
+    pub stack_bytes: u32,
+}
+
+/// Input metadata for one CFG call argument.  This is copied out of the CFG
+/// before the mutable materialization adapter is borrowed.
+#[derive(Debug, Clone, Copy)]
+pub struct CallArgInput {
+    pub value: rue_cfg::CfgValue,
+    pub mode: CfgArgMode,
+    pub slot_count: u32,
+    pub is_multislot_aggregate: bool,
+}
+
+/// Shared policy inputs copied from a CFG before backend materialization.
+#[derive(Debug, Clone)]
+pub struct CallInputs {
+    pub args: Vec<CallArgInput>,
+    pub return_plan: ReturnPlan,
+}
+
+impl CallInputs {
+    pub fn from_cfg(
+        cfg: &Cfg,
+        type_pool: &FrozenTypeInternPool,
+        return_ty: Type,
+        args: &[CfgCallArg],
+        ret_reg_budget: u32,
+    ) -> Self {
+        let args = args
+            .iter()
+            .map(|arg| {
+                let arg_ty = cfg.get_inst(arg.value).ty;
+                CallArgInput {
+                    value: arg.value,
+                    mode: arg.mode,
+                    slot_count: types::type_slot_count(type_pool, arg_ty),
+                    is_multislot_aggregate: is_multislot_aggregate(type_pool, arg_ty),
+                }
+            })
+            .collect();
+        Self {
+            args,
+            return_plan: return_plan(type_pool, return_ty, ret_reg_budget),
+        }
+    }
+}
+
+impl CallArgInput {
+    fn is_by_ref(self) -> bool {
+        matches!(self.mode, CfgArgMode::Inout | CfgArgMode::Borrow)
+    }
+}
+
+/// Existing backend leaves used to materialize a plan's logical values.
+/// Keeping these as one adapter prevents competing mutable callbacks from
+/// creating a second aggregate or by-ref discovery path.
+pub trait CallMaterializer {
+    fn materialize_scalar(&mut self, value: rue_cfg::CfgValue) -> VReg;
+    fn materialize_aggregate(&mut self, value: rue_cfg::CfgValue) -> Vec<VReg>;
+    fn materialize_by_ref(&mut self, value: rue_cfg::CfgValue, mode: CfgArgMode) -> VReg;
+    fn materialize_sret_pointer(&mut self, storage_bytes: u32) -> VReg;
+}
+
+impl CallPlan {
+    /// Build a complete plan from copied CFG argument metadata.
+    ///
+    /// The callbacks are materialization leaves only: aggregate discovery is
+    /// still required to return exactly the type's canonical slot count, and
+    /// by-reference arguments always return one address vreg, including for a
+    /// zero-sized pointee.
+    pub fn from_inputs<M: CallMaterializer>(
+        symbol: &str,
+        return_plan: ReturnPlan,
+        args: &[CallArgInput],
+        arg_reg_budget: usize,
+        materializer: &mut M,
+    ) -> Self {
+        let callee_abi = CalleeAbi::for_symbol(symbol);
+        let mut hidden_sret = None;
+        let mut abi_slots = Vec::new();
+
+        if let ReturnPlan::Sret {
+            slot_count,
+            storage_bytes,
+        } = return_plan
+        {
+            let pointer = materializer.materialize_sret_pointer(storage_bytes);
+            hidden_sret = Some(HiddenSretPlan {
+                pointer,
+                abi_slot: 0,
+                slot_count,
+                storage_bytes,
+            });
+            abi_slots.push(pointer);
+        }
+
+        let mut user_args = Vec::with_capacity(args.len());
+        for arg in args {
+            let mode = match arg.mode {
+                CfgArgMode::Normal => UserArgMode::Value,
+                CfgArgMode::Inout => UserArgMode::Inout,
+                CfgArgMode::Borrow => UserArgMode::Borrow,
+            };
+
+            let slots = if arg.is_by_ref() {
+                // A reference is an ABI pointer even when the pointee has no
+                // storage slots.  This branch must precede the ZST omission.
+                vec![materializer.materialize_by_ref(arg.value, arg.mode)]
+            } else {
+                let slot_count = arg.slot_count;
+                if slot_count == 0 {
+                    Vec::new()
+                } else if arg.is_multislot_aggregate {
+                    let slots = materializer.materialize_aggregate(arg.value);
+                    assert_eq!(
+                        slots.len(),
+                        slot_count as usize,
+                        "aggregate materialization must produce every logical ABI slot"
+                    );
+                    if callee_abi == CalleeAbi::Runtime {
+                        slots
+                    } else {
+                        slots.into_iter().rev().collect()
+                    }
+                } else {
+                    vec![materializer.materialize_scalar(arg.value)]
+                }
+            };
+
+            abi_slots.extend(slots.iter().copied());
+            user_args.push(UserArgPlan { mode, slots });
+        }
+
+        let stack_slot_count = abi_slots.len().saturating_sub(arg_reg_budget);
+        let stack_bytes = align_up((stack_slot_count * 8) as u32, 16);
+
+        Self {
+            symbol: symbol.to_owned(),
+            callee_abi,
+            hidden_sret,
+            user_args,
+            abi_slots,
+            return_plan,
+            stack_slot_count,
+            stack_bytes,
+        }
+    }
+
+    /// Build the same normalized shape for drop/glue calls whose slots have
+    /// already been materialized by the canonical aggregate leaves.
+    pub fn from_slot_values(symbol: &str, slots: &[VReg], arg_reg_budget: usize) -> Self {
+        let stack_slot_count = slots.len().saturating_sub(arg_reg_budget);
+        Self {
+            symbol: symbol.to_owned(),
+            callee_abi: CalleeAbi::for_symbol(symbol),
+            hidden_sret: None,
+            user_args: vec![UserArgPlan {
+                mode: UserArgMode::Value,
+                slots: slots.to_vec(),
+            }],
+            abi_slots: slots.to_vec(),
+            return_plan: ReturnPlan::ZeroSized,
+            stack_slot_count,
+            stack_bytes: align_up((stack_slot_count * 8) as u32, 16),
+        }
+    }
+}
+
+/// The one shared return policy.  In particular, sret selection remains
+/// delegated to `type_uses_sret_return` rather than being inferred by a caller.
+pub fn return_plan(type_pool: &FrozenTypeInternPool, ty: Type, ret_reg_budget: u32) -> ReturnPlan {
+    let slot_count = types::type_slot_count(type_pool, ty);
+    if slot_count == 0 {
+        ReturnPlan::ZeroSized
+    } else if type_uses_sret_return(type_pool, ty, ret_reg_budget) {
+        ReturnPlan::Sret {
+            slot_count,
+            storage_bytes: align_up(slot_count * 8, 16),
+        }
+    } else if is_multislot_aggregate(type_pool, ty) {
+        ReturnPlan::Registers { slot_count }
+    } else {
+        ReturnPlan::Scalar
+    }
+}
+
+fn is_multislot_aggregate(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
+    matches!(
+        ty.kind(),
+        rue_air::TypeKind::Struct(_) | rue_air::TypeKind::Array(_)
+    ) || (ty.is_enum() && types::type_slot_count(type_pool, ty) > 1)
+}
+
+const fn align_up(value: u32, alignment: u32) -> u32 {
+    (value + alignment - 1) / alignment * alignment
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestMaterializer;
+
+    impl CallMaterializer for TestMaterializer {
+        fn materialize_scalar(&mut self, value: rue_cfg::CfgValue) -> VReg {
+            VReg::new(100 + value.as_u32())
+        }
+
+        fn materialize_aggregate(&mut self, _value: rue_cfg::CfgValue) -> Vec<VReg> {
+            vec![VReg::new(10), VReg::new(11)]
+        }
+
+        fn materialize_by_ref(&mut self, _value: rue_cfg::CfgValue, _mode: CfgArgMode) -> VReg {
+            VReg::new(30)
+        }
+
+        fn materialize_sret_pointer(&mut self, _storage_bytes: u32) -> VReg {
+            VReg::new(40)
+        }
+    }
+
+    #[test]
+    fn slot_call_plan_counts_aligned_stack_slots() {
+        let slots: Vec<_> = (0..9).map(VReg::new).collect();
+        let plan = CallPlan::from_slot_values("drop", &slots, 6);
+
+        assert_eq!(plan.abi_slots, slots);
+        assert_eq!(plan.stack_slot_count, 3);
+        assert_eq!(plan.stack_bytes, 32);
+        assert_eq!(plan.return_plan, ReturnPlan::ZeroSized);
+    }
+
+    #[test]
+    fn zero_sized_normal_arguments_are_omitted_but_by_ref_is_preserved() {
+        let slots = vec![VReg::new(7)];
+        let plan = CallPlan {
+            symbol: "test".into(),
+            callee_abi: CalleeAbi::Rue,
+            hidden_sret: None,
+            user_args: vec![
+                UserArgPlan {
+                    mode: UserArgMode::Value,
+                    slots: vec![],
+                },
+                UserArgPlan {
+                    mode: UserArgMode::Borrow,
+                    slots: slots.clone(),
+                },
+            ],
+            abi_slots: slots.clone(),
+            return_plan: ReturnPlan::ZeroSized,
+            stack_slot_count: 0,
+            stack_bytes: 0,
+        };
+
+        assert!(plan.user_args[0].slots.is_empty());
+        assert_eq!(plan.user_args[1].slots, slots);
+        assert_eq!(plan.abi_slots.len(), 1);
+    }
+
+    #[test]
+    fn return_plan_preserves_sret_storage_alignment() {
+        // This checks the normalized shape independently of a target register
+        // enum; type-pool-backed sret selection is exercised by backend ABI
+        // tests through `return_plan`.
+        assert_eq!(align_up(24, 16), 32);
+        assert_eq!(
+            ReturnPlan::Sret {
+                slot_count: 3,
+                storage_bytes: 32
+            }
+            .slot_count(),
+            3
+        );
+    }
+
+    #[test]
+    fn cfg_plan_orders_aggregate_slots_by_callee_abi_and_keeps_hidden_sret_first() {
+        let args = [
+            CallArgInput {
+                value: rue_cfg::CfgValue::from_raw(1),
+                mode: CfgArgMode::Normal,
+                slot_count: 2,
+                is_multislot_aggregate: true,
+            },
+            CallArgInput {
+                value: rue_cfg::CfgValue::from_raw(2),
+                mode: CfgArgMode::Borrow,
+                slot_count: 0,
+                is_multislot_aggregate: false,
+            },
+            CallArgInput {
+                value: rue_cfg::CfgValue::from_raw(3),
+                mode: CfgArgMode::Normal,
+                slot_count: 0,
+                is_multislot_aggregate: false,
+            },
+        ];
+        let mut materializer = TestMaterializer;
+        let rue = CallPlan::from_inputs(
+            "callee",
+            ReturnPlan::Sret {
+                slot_count: 3,
+                storage_bytes: 32,
+            },
+            &args,
+            3,
+            &mut materializer,
+        );
+
+        assert_eq!(
+            rue.abi_slots,
+            vec![VReg::new(40), VReg::new(11), VReg::new(10), VReg::new(30)]
+        );
+        assert_eq!(rue.hidden_sret.unwrap().abi_slot, 0);
+        assert_eq!(rue.stack_slot_count, 1);
+        assert_eq!(rue.stack_bytes, 16);
+        assert_eq!(rue.user_args[1].mode, UserArgMode::Borrow);
+        assert!(rue.user_args[2].slots.is_empty());
+
+        let mut materializer = TestMaterializer;
+        let runtime = CallPlan::from_inputs(
+            "__rue_runtime",
+            ReturnPlan::Sret {
+                slot_count: 3,
+                storage_bytes: 32,
+            },
+            &args,
+            8,
+            &mut materializer,
+        );
+        assert_eq!(
+            runtime.abi_slots,
+            vec![VReg::new(40), VReg::new(10), VReg::new(11), VReg::new(30)]
+        );
+        assert_eq!(runtime.stack_slot_count, 0);
+        assert_eq!(runtime.stack_bytes, 0);
+    }
+}

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -140,7 +140,7 @@ impl CallInputs {
                     value: arg.value,
                     mode: arg.mode,
                     slot_count: types::type_slot_count(type_pool, arg_ty),
-                    is_multislot_aggregate: is_multislot_aggregate(type_pool, arg_ty),
+                    is_multislot_aggregate: types::is_multislot_aggregate(type_pool, arg_ty),
                 }
             })
             .collect();
@@ -283,18 +283,11 @@ pub fn return_plan(type_pool: &FrozenTypeInternPool, ty: Type, ret_reg_budget: u
             slot_count,
             storage_bytes: align_up(slot_count * 8, 16),
         }
-    } else if is_multislot_aggregate(type_pool, ty) {
+    } else if types::is_multislot_aggregate(type_pool, ty) {
         ReturnPlan::Registers { slot_count }
     } else {
         ReturnPlan::Scalar
     }
-}
-
-fn is_multislot_aggregate(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
-    matches!(
-        ty.kind(),
-        rue_air::TypeKind::Struct(_) | rue_air::TypeKind::Array(_)
-    ) || (ty.is_enum() && types::type_slot_count(type_pool, ty) > 1)
 }
 
 const fn align_up(value: u32, alignment: u32) -> u32 {

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -449,8 +449,7 @@ impl<'a> CfgLowerContext<'a> {
     /// deliberately excluded so it keeps its existing scalar codegen path
     /// (RUE-221).
     pub fn is_multislot_aggregate(&self, ty: Type) -> bool {
-        matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
-            || (ty.is_enum() && self.type_slot_count(ty) > 1)
+        types::is_multislot_aggregate(self.type_pool, ty)
     }
 
     /// Calculate the slot count for a single element of an array type.

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -42,6 +42,7 @@ macro_rules! end_inst {
 }
 
 mod allocation;
+pub mod call_plan;
 mod codegen_pipeline;
 mod schedule_core;
 mod stack_frame;

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -66,6 +66,13 @@ pub fn type_slot_count(type_pool: &FrozenTypeInternPool, ty: Type) -> u32 {
     type_pool.abi_slot_count(ty)
 }
 
+/// Whether `ty` needs a complete aggregate slot representation rather than a
+/// single primary vreg. Discriminant-only enums remain scalar values.
+pub fn is_multislot_aggregate(type_pool: &FrozenTypeInternPool, ty: Type) -> bool {
+    matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
+        || (ty.is_enum() && type_slot_count(type_pool, ty) > 1)
+}
+
 /// Return the `(Some, None)` discriminant values for an `Option`-shaped enum
 /// type, i.e. the variant indices of its `Some` and `None` variants.
 ///

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -77,6 +77,33 @@ pub struct CfgLower<'a> {
     by_ref_param_ptrs: HashMap<u32, VReg>,
 }
 
+impl crate::call_plan::CallMaterializer for CfgLower<'_> {
+    fn materialize_scalar(&mut self, value: CfgValue) -> VReg {
+        self.get_vreg(value)
+    }
+
+    fn materialize_aggregate(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.require_aggregate_slots(value)
+    }
+
+    fn materialize_by_ref(&mut self, value: CfgValue, mode: rue_cfg::CfgArgMode) -> VReg {
+        crate::byref_args::lower_byref_arg_addr(self, value, mode == rue_cfg::CfgArgMode::Inout)
+    }
+
+    fn materialize_sret_pointer(&mut self, storage_bytes: u32) -> VReg {
+        self.mir.push(X86Inst::AddRI {
+            dst: Operand::Physical(Reg::Rsp),
+            imm: -(storage_bytes as i32),
+        });
+        let pointer = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(pointer),
+            src: Operand::Physical(Reg::Rsp),
+        });
+        pointer
+    }
+}
+
 impl<'a> CfgLower<'a> {
     /// Create a new CFG lowering pass.
     pub fn new(
@@ -180,12 +207,13 @@ impl<'a> CfgLower<'a> {
     /// this path so every slot beyond the six register arguments is passed on
     /// the stack (RUE-193).
     fn emit_call_with_slot_args(&mut self, arg_vregs: &[VReg], symbol: &str) {
-        let num_reg_args = arg_vregs.len().min(ARG_REGS.len());
-        let num_stack_args = arg_vregs.len().saturating_sub(ARG_REGS.len());
+        let plan = crate::call_plan::CallPlan::from_slot_values(symbol, arg_vregs, ARG_REGS.len());
+        let num_reg_args = plan.abi_slots.len().min(ARG_REGS.len());
+        let num_stack_args = plan.stack_slot_count;
 
         // RSP must be 16-byte aligned before the call; each push is 8 bytes,
         // so an odd number of stack arguments needs 8 bytes of padding.
-        let needs_alignment = num_stack_args % 2 == 1;
+        let needs_alignment = plan.stack_bytes > (num_stack_args * 8) as u32;
         if needs_alignment {
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
@@ -196,7 +224,7 @@ impl<'a> CfgLower<'a> {
         // Push stack arguments (in reverse, so the lowest-index slot ends up
         // at the lowest address), then stage register arguments via push/pop
         // so regalloc's scratch use of rax can't clobber them.
-        for arg_vreg in arg_vregs.iter().skip(ARG_REGS.len()).rev() {
+        for arg_vreg in plan.abi_slots.iter().skip(ARG_REGS.len()).rev() {
             self.mir.push(X86Inst::MovRR {
                 dst: Operand::Physical(Reg::Rax),
                 src: Operand::Virtual(*arg_vreg),
@@ -205,7 +233,7 @@ impl<'a> CfgLower<'a> {
                 src: Operand::Physical(Reg::Rax),
             });
         }
-        for arg_vreg in arg_vregs.iter().take(num_reg_args).rev() {
+        for arg_vreg in plan.abi_slots.iter().take(num_reg_args).rev() {
             self.mir.push(X86Inst::MovRR {
                 dst: Operand::Physical(Reg::Rax),
                 src: Operand::Virtual(*arg_vreg),
@@ -220,15 +248,12 @@ impl<'a> CfgLower<'a> {
             });
         }
 
-        let symbol_id = self.intern_symbol(symbol);
+        let symbol_id = self.intern_symbol(&plan.symbol);
         self.mir.push(X86Inst::CallRel { symbol_id });
 
         // Clean up stack arguments and alignment padding
         if num_stack_args > 0 || needs_alignment {
-            let mut stack_space = (num_stack_args * 8) as i32;
-            if needs_alignment {
-                stack_space += 8;
-            }
+            let stack_space = plan.stack_bytes as i32;
             self.mir.push(X86Inst::AddRI {
                 dst: Operand::Physical(Reg::Rsp),
                 imm: stack_space,
@@ -1586,116 +1611,38 @@ impl<'a> CfgLower<'a> {
                 let result_vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, result_vreg);
 
-                // By-value aggregate arguments are passed in REVERSED logical
-                // slot order to Rue-compiled callees (ADR-0040 / RUE-311), which
-                // read them back with the ascending frame convention. Runtime
-                // helpers (`__rue_*`, hand-written with the C ABI) instead expect
-                // a builtin aggregate's slots (e.g. a String's ptr/len/cap) in
-                // natural order, so calls to them are NOT reversed.
-                let callee_is_runtime = self.interner.resolve(name).starts_with("__rue_");
-
-                // Does this call return via the sret convention? Builtin
-                // String always does (runtime fns take an out-pointer first
-                // param); other aggregates do when their slots exceed the
-                // return registers. See crate::cfg_lower::type_uses_sret_return.
-                let is_sret_call = self.ctx.type_uses_sret(ty, RET_REGS.len() as u32);
-                let ret_slot_count = if self.ctx.is_multislot_aggregate(ty) {
-                    self.ctx.type_slot_count(ty)
-                } else {
-                    1
-                };
-                // Caller-allocated return buffer: one 8-byte slot per
-                // aggregate slot, padded to keep rsp 16-byte aligned.
-                let sret_bytes = ((ret_slot_count as i32 * 8) + 15) / 16 * 16;
-
-                // For sret calls, allocate the return buffer on the stack;
-                // we'll pass a pointer to this space as the first argument.
-                // Use add with negative offset (no SubRI in MIR)
-                if is_sret_call {
-                    self.mir.push(X86Inst::AddRI {
-                        dst: Operand::Physical(Reg::Rsp),
-                        imm: -sret_bytes,
-                    });
-                }
-
-                // Flatten struct arguments and handle by-ref arguments (inout and borrow)
-                let mut flattened_vregs: Vec<VReg> = Vec::new();
-
-                // For sret calls, the first argument is the output pointer (current rsp)
-                if is_sret_call {
-                    let sret_ptr_vreg = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(sret_ptr_vreg),
-                        src: Operand::Physical(Reg::Rsp),
-                    });
-                    flattened_vregs.push(sret_ptr_vreg);
-                }
                 let args = self.ctx.cfg.get_call_args(*args_start, *args_len).to_vec();
-                for arg in &args {
-                    let arg_value = arg.value;
-                    let arg_type = self.ctx.cfg.get_inst(arg_value).ty;
-
-                    // For by-ref args (inout or borrow), pass the address of
-                    // the argument place — a variable, field, or array
-                    // element (RUE-143). Single shared implementation — see
-                    // crate::byref_args.
-                    if arg.is_by_ref() {
-                        let addr_vreg = crate::byref_args::lower_byref_arg_addr(
-                            self,
-                            arg_value,
-                            arg.is_inout(),
-                        );
-                        flattened_vregs.push(addr_vreg);
-                        continue;
-                    }
-
-                    // CFG materializes a value for every continuing
-                    // expression, including unit and other zero-sized values,
-                    // but a Normal argument's physical ABI width comes from
-                    // its static type. Do not mistake the dummy CFG value for
-                    // a scalar slot. Keep this after the by-ref branch: a
-                    // borrow/inout ZST still passes one real pointer.
-                    if self.ctx.type_slot_count(arg_type) == 0 {
-                        continue;
-                    }
-
-                    if self.ctx.is_multislot_aggregate(arg_type) {
-                        // Pass all slots of the (possibly multi-slot) aggregate arg —
-                        // struct, builtin String, fixed-size array, or payload enum
-                        // (RUE-221) — regardless of how it was produced. The accessor
-                        // materializes lazily-sourced values (Load/Param/PlaceRead) and
-                        // cache-hits eager ones (StructInit/ArrayInit/Call/BlockParam).
-                        // Materialization uses the recursive slot count, so every
-                        // scalar slot of a multidimensional array is passed.
-                        // (RUE-118, RUE-79)
-                        let field_vregs = self.require_aggregate_slots(arg_value);
-                        // Pass a Rue callee's aggregate slots in REVERSED
-                        // logical order (ADR-0040 / RUE-311). The callee
-                        // prologue spills ABI slot j to frame slot base+j, so
-                        // pushing logical slot k at ABI slot (C-1-k) lands it
-                        // at frame slot base + (C-1-k) — exactly the
-                        // ascending frame layout `store_slots`/
-                        // `load_consecutive` use for locals (logical slot 0
-                        // at the low-address end). Runtime callees keep
-                        // natural order.
-                        if callee_is_runtime {
-                            flattened_vregs.extend(field_vregs);
-                        } else {
-                            flattened_vregs.extend(field_vregs.into_iter().rev());
-                        }
-                    } else {
-                        // Note: String is now Type::Struct, handled above
-                        flattened_vregs.push(self.get_vreg(arg_value));
-                    }
-                }
-
-                let num_reg_args = flattened_vregs.len().min(ARG_REGS.len());
-                let num_stack_args = flattened_vregs.len().saturating_sub(ARG_REGS.len());
+                let symbol = self.interner.resolve(name).to_owned();
+                let inputs = crate::call_plan::CallInputs::from_cfg(
+                    self.ctx.cfg,
+                    self.ctx.type_pool,
+                    ty,
+                    &args,
+                    RET_REGS.len() as u32,
+                );
+                let plan = crate::call_plan::CallPlan::from_inputs(
+                    &symbol,
+                    inputs.return_plan,
+                    &inputs.args,
+                    ARG_REGS.len(),
+                    self,
+                );
+                assert_eq!(
+                    plan.abi_slots.len(),
+                    plan.hidden_sret.map_or(0, |_| 1)
+                        + plan
+                            .user_args
+                            .iter()
+                            .map(|arg| arg.slots.len())
+                            .sum::<usize>()
+                );
+                let num_reg_args = plan.abi_slots.len().min(ARG_REGS.len());
+                let num_stack_args = plan.stack_slot_count;
 
                 // Add alignment padding if we have an odd number of stack arguments.
                 // RSP must be 16-byte aligned before the call, and each push is 8 bytes.
                 // If we push an odd number of arguments, we need 8 bytes of padding.
-                let needs_alignment = num_stack_args % 2 == 1;
+                let needs_alignment = plan.stack_bytes > (num_stack_args * 8) as u32;
                 if needs_alignment {
                     // sub rsp, 8 to add alignment padding
                     self.mir.push(X86Inst::AddRI {
@@ -1705,7 +1652,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Push stack arguments
-                for arg_vreg in flattened_vregs.iter().skip(ARG_REGS.len()).rev() {
+                for arg_vreg in plan.abi_slots.iter().skip(ARG_REGS.len()).rev() {
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Physical(Reg::Rax),
                         src: Operand::Virtual(*arg_vreg),
@@ -1716,7 +1663,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Push register arguments temporarily
-                for arg_vreg in flattened_vregs.iter().take(num_reg_args).rev() {
+                for arg_vreg in plan.abi_slots.iter().take(num_reg_args).rev() {
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Physical(Reg::Rax),
                         src: Operand::Virtual(*arg_vreg),
@@ -1733,16 +1680,12 @@ impl<'a> CfgLower<'a> {
                     });
                 }
 
-                let symbol_name = self.interner.resolve(name);
-                let symbol_id = self.intern_symbol(symbol_name);
+                let symbol_id = self.intern_symbol(&plan.symbol);
                 self.mir.push(X86Inst::CallRel { symbol_id });
 
                 // Clean up stack arguments and alignment padding
                 if num_stack_args > 0 || needs_alignment {
-                    let mut stack_space = (num_stack_args * 8) as i32;
-                    if needs_alignment {
-                        stack_space += 8; // Include alignment padding
-                    }
+                    let stack_space = plan.stack_bytes as i32;
                     self.mir.push(X86Inst::AddRI {
                         dst: Operand::Physical(Reg::Rsp),
                         imm: stack_space,
@@ -1752,56 +1695,74 @@ impl<'a> CfgLower<'a> {
                 // Handle struct and string returns (multi-slot types)
                 // sret calls first: the callee wrote the slots to the buffer
                 // at [rsp]. (String always; big aggregates per RUE-106.)
-                if is_sret_call {
-                    // Load every slot from the return buffer
-                    let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..ret_slot_count {
-                        let slot_vreg = self.mir.alloc_vreg();
-                        let offset = (slot_idx * 8) as i32;
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(slot_vreg),
-                            base: Reg::Rsp,
-                            offset,
-                        });
-                        slot_vregs.push(slot_vreg);
-                    }
-                    // Pop the sret space (including alignment padding)
-                    self.mir.push(X86Inst::AddRI {
-                        dst: Operand::Physical(Reg::Rsp),
-                        imm: sret_bytes,
-                    });
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(result_vreg),
-                        src: Operand::Virtual(slot_vregs[0]),
-                    });
-                } else if self.ctx.is_multislot_aggregate(ty) {
-                    // Aggregates that fit return in registers have a complete
-                    // cached representation populated from RET_REGS. (RUE-78)
-                    let slot_count = ret_slot_count;
-                    let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..slot_count {
-                        let slot_vreg = self.mir.alloc_vreg();
-                        if (slot_idx as usize) < RET_REGS.len() {
-                            self.mir.push(X86Inst::MovRR {
+                match plan.return_plan {
+                    crate::call_plan::ReturnPlan::Sret {
+                        slot_count: ret_slot_count,
+                        storage_bytes: sret_bytes,
+                    } => {
+                        // Load every slot from the return buffer
+                        let mut slot_vregs = Vec::new();
+                        for slot_idx in 0..ret_slot_count {
+                            let slot_vreg = self.mir.alloc_vreg();
+                            let offset = (slot_idx * 8) as i32;
+                            self.mir.push(X86Inst::MovRM {
                                 dst: Operand::Virtual(slot_vreg),
-                                src: Operand::Physical(RET_REGS[slot_idx as usize]),
+                                base: Reg::Rsp,
+                                offset,
                             });
+                            slot_vregs.push(slot_vreg);
                         }
-                        slot_vregs.push(slot_vreg);
-                    }
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-                    if let Some(&first_vreg) = slot_vregs.first() {
+                        assert_eq!(slot_vregs.len(), ret_slot_count as usize);
+                        // Pop the sret space (including alignment padding)
+                        self.mir.push(X86Inst::AddRI {
+                            dst: Operand::Physical(Reg::Rsp),
+                            imm: sret_bytes as i32,
+                        });
+                        self.struct_slot_vregs.insert(value, slot_vregs.clone());
                         self.mir.push(X86Inst::MovRR {
                             dst: Operand::Virtual(result_vreg),
-                            src: Operand::Virtual(first_vreg),
+                            src: Operand::Virtual(slot_vregs[0]),
                         });
                     }
-                } else {
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(result_vreg),
-                        src: Operand::Physical(Reg::Rax),
-                    });
+                    crate::call_plan::ReturnPlan::Registers { slot_count } => {
+                        // Aggregates that fit return in registers have a complete
+                        // cached representation populated from RET_REGS. (RUE-78)
+                        assert!((slot_count as usize) <= RET_REGS.len());
+                        let mut slot_vregs = Vec::new();
+                        for slot_idx in 0..slot_count {
+                            let slot_vreg = self.mir.alloc_vreg();
+                            if (slot_idx as usize) < RET_REGS.len() {
+                                self.mir.push(X86Inst::MovRR {
+                                    dst: Operand::Virtual(slot_vreg),
+                                    src: Operand::Physical(RET_REGS[slot_idx as usize]),
+                                });
+                            }
+                            slot_vregs.push(slot_vreg);
+                        }
+                        assert_eq!(slot_vregs.len(), slot_count as usize);
+                        self.struct_slot_vregs.insert(value, slot_vregs.clone());
+                        if let Some(&first_vreg) = slot_vregs.first() {
+                            self.mir.push(X86Inst::MovRR {
+                                dst: Operand::Virtual(result_vreg),
+                                src: Operand::Virtual(first_vreg),
+                            });
+                        }
+                    }
+                    crate::call_plan::ReturnPlan::Scalar => {
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(result_vreg),
+                            src: Operand::Physical(Reg::Rax),
+                        });
+                    }
+                    crate::call_plan::ReturnPlan::ZeroSized => {
+                        // Zero-sized values have no ABI return slot. Keep the
+                        // CFG's cached dummy value defined for any later
+                        // storage path that asks for its vreg.
+                        self.mir.push(X86Inst::MovRI32 {
+                            dst: Operand::Virtual(result_vreg),
+                            imm: 0,
+                        });
+                    }
                 }
             }
 

--- a/crates/rue-spec/cases/golden/ir-dumps.toml
+++ b/crates/rue-spec/cases/golden/ir-dumps.toml
@@ -180,7 +180,7 @@ function main:
     push rax
     pop rdi
     call set
-    mov v3, rax
+    mov v3, 0
     mov v5, [rbp-8]
     mov rdi, v5
     call __rue_exit
@@ -218,7 +218,7 @@ function main:
     add v4, fp, #-8
     mov x0, v4
     bl set
-    mov v3, x0
+    mov v3, #0
     ldr v5, [fp, #-8]
     mov x0, v5
     bl __rue_exit


### PR DESCRIPTION
## Summary

- add a target-independent CallPlan/ReturnPlan for ABI slot classification, sret, argument modes, ordering, stack requirements, and return reconstruction
- route x86-64 and AArch64 ordinary calls plus drop/glue slot calls through the shared plan while retaining target-specific register and instruction emission
- centralize multi-slot aggregate classification and preserve defined zero-width dummy results

## Validation

- scripts/rue quick (27/27; 506 codegen tests)
- scripts/rue cli abi (52/52)
- full scripts/rue test (1,450 CLI, 2,071 spec, 178 UI; generated oracle 64/64)
- release build, formatting, ADR validation, and cross-target reproducibility

Fixes RUE-821