### PR TITLE
RUE-822: share CFG value materialization policy

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -183,10 +183,8 @@ impl<'a> CfgLower<'a> {
     /// flow begins, so the function-wide cache only contains definitions that
     /// dominate every block which may reuse them.
     fn preload_by_ref_param_ptrs(&mut self) {
-        for param_slot in 0..self.ctx.num_params {
-            if self.ctx.cfg.is_param_by_ref(param_slot) {
-                self.ensure_by_ref_param_ptr(param_slot);
-            }
+        for param_slot in crate::value_plan::by_ref_param_slots(&self.ctx) {
+            self.ensure_by_ref_param_ptr(param_slot);
         }
     }
 
@@ -530,8 +528,23 @@ impl<'a> CfgLower<'a> {
             return;
         }
 
+        // Shared policy decides the value shape and language-level
+        // materialization requirements.  This adapter only turns that policy
+        // into AArch64 instructions.
+        let value_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, value);
+
         let inst = self.ctx.cfg.get_inst(value);
         let ty = inst.ty;
+        let plan_is_64 = value_plan
+            .integer_width
+            .is_some_and(|width| width.bits == 64);
+        let plan_is_signed = value_plan.integer_width.is_some_and(|width| width.signed);
+
+        assert_eq!(
+            value_plan.kind,
+            crate::value_plan::kind(&inst.data),
+            "backend value dispatch must consume the shared ValueKind"
+        );
 
         match &inst.data {
             CfgInstData::Const(v) => {
@@ -575,7 +588,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 let mut slot_vregs = vec![ptr_vreg, len_vreg];
-                if self.ctx.type_slot_count(ty) >= 3 {
+                if value_plan.shape.slot_count() >= 3 {
                     let cap_vreg = self.mir.alloc_vreg();
                     self.mir.push(Aarch64Inst::StringConstCap {
                         dst: Operand::Virtual(cap_vreg),
@@ -590,7 +603,10 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::Param { index } => {
                 // Check if this parameter is physically passed by reference.
-                let is_by_ref = self.ctx.cfg.is_param_by_ref(*index);
+                let is_by_ref = matches!(
+                    value_plan.storage,
+                    crate::value_plan::StoragePolicy::ParameterSlot { by_ref: true, .. }
+                );
 
                 // The prologue copies every ABI arg slot — register- and
                 // stack-passed alike — into the contiguous frame param area
@@ -620,8 +636,7 @@ impl<'a> CfgLower<'a> {
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
 
-                    let param_ty = self.ctx.cfg.get_inst(value).ty;
-                    let count = self.ctx.type_slot_count(param_ty).max(1);
+                    let count = value_plan.shape.slot_count().max(1);
                     let slot = self.ctx.num_locals + *index + count - 1;
                     let offset = self.ctx.local_offset(slot);
                     self.mir.push(Aarch64Inst::Ldr {
@@ -645,7 +660,10 @@ impl<'a> CfgLower<'a> {
 
                 // Use ADDS to set overflow and carry flags
                 // Use 64-bit version for 64-bit types to get correct overflow detection
-                if matches!(ty, Type::I64 | Type::U64) {
+                if value_plan
+                    .integer_width
+                    .is_some_and(|width| width.bits == 64)
+                {
                     self.mir.push(Aarch64Inst::AddsRR64 {
                         dst: Operand::Virtual(vreg),
                         src1: Operand::Virtual(lhs_vreg),
@@ -660,7 +678,12 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Overflow check - use appropriate flag based on signedness
-                self.emit_overflow_check_add(ty, vreg);
+                self.emit_overflow_check_add(
+                    value_plan
+                        .integer_width
+                        .expect("add plan must include integer width"),
+                    vreg,
+                );
             }
 
             CfgInstData::Sub(lhs, rhs) => {
@@ -671,7 +694,10 @@ impl<'a> CfgLower<'a> {
                 let rhs_vreg = self.get_vreg(*rhs);
 
                 // Use 64-bit version for 64-bit types to get correct overflow detection
-                if matches!(ty, Type::I64 | Type::U64) {
+                if value_plan
+                    .integer_width
+                    .is_some_and(|width| width.bits == 64)
+                {
                     self.mir.push(Aarch64Inst::SubsRR64 {
                         dst: Operand::Virtual(vreg),
                         src1: Operand::Virtual(lhs_vreg),
@@ -686,7 +712,12 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Overflow check - use appropriate flag based on signedness
-                self.emit_overflow_check_sub(ty, vreg);
+                self.emit_overflow_check_sub(
+                    value_plan
+                        .integer_width
+                        .expect("sub plan must include integer width"),
+                    vreg,
+                );
             }
 
             CfgInstData::Mul(lhs, rhs) => {
@@ -703,7 +734,9 @@ impl<'a> CfgLower<'a> {
                 //
                 // Future optimization: x * 2 could use `add x, x` instead of `lsl x, #1`
                 // (same latency but potentially better for some microarchitectures).
-                let is_word_or_larger = matches!(ty, Type::I32 | Type::I64 | Type::U32 | Type::U64);
+                let is_word_or_larger = value_plan
+                    .integer_width
+                    .is_some_and(|width| width.bits >= 32);
                 let shift_amount = if is_word_or_larger {
                     self.try_power_of_two_shift(*rhs)
                         .or_else(|| self.try_power_of_two_shift(*lhs))
@@ -720,7 +753,7 @@ impl<'a> CfgLower<'a> {
                     };
 
                     // Emit shift left
-                    if ty.is_64_bit() {
+                    if plan_is_64 {
                         self.mir.push(Aarch64Inst::LslImm {
                             dst: Operand::Virtual(vreg),
                             src: Operand::Virtual(src_vreg),
@@ -739,8 +772,8 @@ impl<'a> CfgLower<'a> {
                     let check_vreg = self.mir.alloc_vreg();
 
                     // Use arithmetic shift (ASR) for signed, logical shift (LSR) for unsigned
-                    if ty.is_signed() {
-                        if ty.is_64_bit() {
+                    if plan_is_signed {
+                        if plan_is_64 {
                             self.mir.push(Aarch64Inst::Asr64Imm {
                                 dst: Operand::Virtual(check_vreg),
                                 src: Operand::Virtual(vreg),
@@ -753,7 +786,7 @@ impl<'a> CfgLower<'a> {
                                 imm: shift,
                             });
                         }
-                    } else if ty.is_64_bit() {
+                    } else if plan_is_64 {
                         self.mir.push(Aarch64Inst::Lsr64Imm {
                             dst: Operand::Virtual(check_vreg),
                             src: Operand::Virtual(vreg),
@@ -769,7 +802,7 @@ impl<'a> CfgLower<'a> {
 
                     // Compare with original value
                     let ok_label = self.mir.alloc_label();
-                    if ty.is_64_bit() {
+                    if plan_is_64 {
                         self.mir.push(Aarch64Inst::Cmp64RR {
                             src1: Operand::Virtual(check_vreg),
                             src2: Operand::Virtual(src_vreg),
@@ -796,7 +829,14 @@ impl<'a> CfgLower<'a> {
                     let rhs_vreg = self.get_vreg(*rhs);
 
                     // Overflow check for multiplication
-                    self.emit_overflow_check_mul(ty, vreg, lhs_vreg, rhs_vreg);
+                    self.emit_overflow_check_mul(
+                        value_plan
+                            .integer_width
+                            .expect("multiply plan must include integer width"),
+                        vreg,
+                        lhs_vreg,
+                        rhs_vreg,
+                    );
                 }
             }
 
@@ -819,15 +859,21 @@ impl<'a> CfgLower<'a> {
 
                 // Signed MIN / -1 overflows; SDIV silently wraps per the ARM
                 // architecture, so trap it explicitly (RUE-30).
-                if ty.is_signed() {
-                    self.emit_signed_div_overflow_check(ty, lhs_vreg, rhs_vreg);
+                if plan_is_signed {
+                    self.emit_signed_div_overflow_check(
+                        value_plan
+                            .integer_width
+                            .expect("division plan must include integer width"),
+                        lhs_vreg,
+                        rhs_vreg,
+                    );
                 }
 
                 // Use SDIV for signed types, UDIV for unsigned types, selecting
                 // 64-bit (X-register) forms for 64-bit operands — the 32-bit
                 // (W-register) forms only divide the low 32 bits (RUE-26).
-                let is_64 = ty.is_64_bit();
-                if ty.is_signed() {
+                let is_64 = plan_is_64;
+                if plan_is_signed {
                     self.mir.push(if is_64 {
                         Aarch64Inst::Sdiv64RR {
                             dst: Operand::Virtual(vreg),
@@ -878,15 +924,21 @@ impl<'a> CfgLower<'a> {
                 // Signed MIN % -1 overflows like MIN / -1 (the implied
                 // quotient -MIN is unrepresentable); SDIV silently wraps per
                 // the ARM architecture, so trap it explicitly (RUE-30).
-                if ty.is_signed() {
-                    self.emit_signed_div_overflow_check(ty, lhs_vreg, rhs_vreg);
+                if plan_is_signed {
+                    self.emit_signed_div_overflow_check(
+                        value_plan
+                            .integer_width
+                            .expect("division plan must include integer width"),
+                        lhs_vreg,
+                        rhs_vreg,
+                    );
                 }
 
                 // Compute quotient first using SDIV or UDIV based on signedness,
                 // selecting 64-bit forms for 64-bit operands (RUE-26).
-                let is_64 = ty.is_64_bit();
+                let is_64 = plan_is_64;
                 let quot_vreg = self.mir.alloc_vreg();
-                if ty.is_signed() {
+                if plan_is_signed {
                     self.mir.push(if is_64 {
                         Aarch64Inst::Sdiv64RR {
                             dst: Operand::Virtual(quot_vreg),
@@ -944,7 +996,7 @@ impl<'a> CfgLower<'a> {
                 // Use 32-bit variant for 32-bit and sub-word types, 64-bit for I64/U64
                 let dst = Operand::Virtual(vreg);
                 let src = Operand::Virtual(operand_vreg);
-                if matches!(ty, Type::I64 | Type::U64) {
+                if plan_is_64 {
                     self.mir.push(Aarch64Inst::Negs { dst, src });
                 } else {
                     self.mir.push(Aarch64Inst::Negs32 { dst, src });
@@ -953,7 +1005,12 @@ impl<'a> CfgLower<'a> {
                 // Overflow check - use appropriate flag based on signedness
                 // For signed: V flag indicates overflow (when negating MIN_VALUE)
                 // For unsigned: C flag indicates non-zero operand (0 - x wraps for x != 0)
-                self.emit_overflow_check_neg(ty, vreg);
+                self.emit_overflow_check_neg(
+                    value_plan
+                        .integer_width
+                        .expect("negation plan must include integer width"),
+                    vreg,
+                );
             }
 
             CfgInstData::Not(operand) => {
@@ -973,12 +1030,18 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Eq(lhs, rhs) => {
                 let lhs_ty = self.ctx.cfg.get_inst(*lhs).ty;
 
-                if self.ctx.is_string_like_for_equality(lhs_ty) {
+                if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::StringContent { .. })
+                ) {
                     // String-like equality compares byte content, not the
                     // pointer/len/cap fields structurally.
                     let vreg = self.emit_string_eq_call(*lhs, *rhs);
                     self.value_map.insert(value, vreg);
-                } else if lhs_ty == Type::UNIT {
+                } else if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Unit)
+                ) {
                     // Unit equality: () == () is always true
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
@@ -986,7 +1049,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 1,
                     });
-                } else if self.ctx.is_multislot_aggregate(lhs_ty) {
+                } else if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Aggregate { .. })
+                ) {
                     // Structural equality: compare every slot (struct fields,
                     // array elements, or an enum's tag + payload). (RUE-285)
                     self.emit_aggregate_equality(value, *lhs, *rhs, lhs_ty, false);
@@ -998,7 +1064,10 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Ne(lhs, rhs) => {
                 let lhs_ty = self.ctx.cfg.get_inst(*lhs).ty;
 
-                if self.ctx.is_string_like_for_equality(lhs_ty) {
+                if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::StringContent { .. })
+                ) {
                     // String-like inequality is the inverse of byte-content
                     // equality.
                     let vreg = self.emit_string_eq_call(*lhs, *rhs);
@@ -1009,7 +1078,10 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(vreg),
                         imm: 1,
                     });
-                } else if lhs_ty == Type::UNIT {
+                } else if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Unit)
+                ) {
                     // Unit inequality: () != () is always false
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
@@ -1017,7 +1089,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 0,
                     });
-                } else if self.ctx.is_multislot_aggregate(lhs_ty) {
+                } else if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Aggregate { .. })
+                ) {
                     // Structural inequality: compare every slot, invert result.
                     // (RUE-285)
                     self.emit_aggregate_equality(value, *lhs, *rhs, lhs_ty, true);
@@ -1027,7 +1102,12 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Lt(lhs, rhs) => {
-                let cond = if self.is_unsigned_comparison(*lhs) {
+                let cond = if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Scalar {
+                        width: crate::value_plan::IntegerWidth { signed: false, .. }
+                    })
+                ) {
                     Cond::Lo // unsigned lower
                 } else {
                     Cond::Lt // signed less than
@@ -1036,7 +1116,12 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Gt(lhs, rhs) => {
-                let cond = if self.is_unsigned_comparison(*lhs) {
+                let cond = if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Scalar {
+                        width: crate::value_plan::IntegerWidth { signed: false, .. }
+                    })
+                ) {
                     Cond::Hi // unsigned higher
                 } else {
                     Cond::Gt // signed greater than
@@ -1045,7 +1130,12 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Le(lhs, rhs) => {
-                let cond = if self.is_unsigned_comparison(*lhs) {
+                let cond = if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Scalar {
+                        width: crate::value_plan::IntegerWidth { signed: false, .. }
+                    })
+                ) {
                     Cond::Ls // unsigned lower or same
                 } else {
                     Cond::Le // signed less than or equal
@@ -1054,7 +1144,12 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Ge(lhs, rhs) => {
-                let cond = if self.is_unsigned_comparison(*lhs) {
+                let cond = if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Scalar {
+                        width: crate::value_plan::IntegerWidth { signed: false, .. }
+                    })
+                ) {
                     Cond::Hs // unsigned higher or same
                 } else {
                     Cond::Ge // signed greater than or equal
@@ -1072,7 +1167,7 @@ impl<'a> CfgLower<'a> {
                 // is zero-extended above the operand width; the 64-bit mvn
                 // would set the upper 32 bits (wrong for u32, whose consumers
                 // assume zero-extended registers) (RUE-59).
-                self.mir.push(if ty.is_64_bit() {
+                self.mir.push(if plan_is_64 {
                     Aarch64Inst::MvnRR {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Virtual(operand_vreg),
@@ -1143,7 +1238,7 @@ impl<'a> CfgLower<'a> {
                 let rhs_inst = &self.ctx.cfg.get_inst(*rhs).data;
                 if let CfgInstData::Const(shift_amount) = rhs_inst {
                     let imm = (*shift_amount & count_mask) as u8;
-                    if ty.is_64_bit() {
+                    if plan_is_64 {
                         self.mir.push(Aarch64Inst::LslImm {
                             dst: Operand::Virtual(vreg),
                             src: Operand::Virtual(lhs_vreg),
@@ -1159,7 +1254,7 @@ impl<'a> CfgLower<'a> {
                 } else {
                     // Variable shift amount - mask it (mod bit width).
                     let count_vreg = self.emit_masked_shift_count(*rhs, ty);
-                    if ty.is_64_bit() {
+                    if plan_is_64 {
                         self.mir.push(Aarch64Inst::LslRR {
                             dst: Operand::Virtual(vreg),
                             src1: Operand::Virtual(lhs_vreg),
@@ -1191,19 +1286,19 @@ impl<'a> CfgLower<'a> {
                 if let CfgInstData::Const(shift_amount) = rhs_inst {
                     let imm = (*shift_amount & count_mask) as u8;
                     // Use arithmetic shift (ASR) for signed types, logical shift (LSR) for unsigned
-                    if ty.is_64_bit() && ty.is_signed() {
+                    if plan_is_64 && plan_is_signed {
                         self.mir.push(Aarch64Inst::Asr64Imm {
                             dst: Operand::Virtual(vreg),
                             src: Operand::Virtual(lhs_vreg),
                             imm,
                         });
-                    } else if ty.is_64_bit() {
+                    } else if plan_is_64 {
                         self.mir.push(Aarch64Inst::Lsr64Imm {
                             dst: Operand::Virtual(vreg),
                             src: Operand::Virtual(lhs_vreg),
                             imm,
                         });
-                    } else if ty.is_signed() {
+                    } else if plan_is_signed {
                         self.mir.push(Aarch64Inst::Asr32Imm {
                             dst: Operand::Virtual(vreg),
                             src: Operand::Virtual(lhs_vreg),
@@ -1219,19 +1314,19 @@ impl<'a> CfgLower<'a> {
                 } else {
                     // Variable shift amount - mask it (mod bit width).
                     let count_vreg = self.emit_masked_shift_count(*rhs, ty);
-                    if ty.is_64_bit() && ty.is_signed() {
+                    if plan_is_64 && plan_is_signed {
                         self.mir.push(Aarch64Inst::AsrRR {
                             dst: Operand::Virtual(vreg),
                             src1: Operand::Virtual(lhs_vreg),
                             src2: Operand::Virtual(count_vreg),
                         });
-                    } else if ty.is_64_bit() {
+                    } else if plan_is_64 {
                         self.mir.push(Aarch64Inst::LsrRR {
                             dst: Operand::Virtual(vreg),
                             src1: Operand::Virtual(lhs_vreg),
                             src2: Operand::Virtual(count_vreg),
                         });
-                    } else if ty.is_signed() {
+                    } else if plan_is_signed {
                         self.mir.push(Aarch64Inst::Asr32RR {
                             dst: Operand::Virtual(vreg),
                             src1: Operand::Virtual(lhs_vreg),
@@ -1922,7 +2017,10 @@ impl<'a> CfgLower<'a> {
                     });
                     let ext_dst = Operand::Virtual(offset_vreg);
                     let ext_src = Operand::Virtual(offset_vreg);
-                    match (Self::type_bits(offset_ty), offset_ty.is_signed()) {
+                    match (
+                        Self::type_bits(offset_ty),
+                        crate::value_plan::type_is_signed(offset_ty),
+                    ) {
                         (8, true) => self.mir.push(Aarch64Inst::Sxtb {
                             dst: ext_dst,
                             src: ext_src,
@@ -2301,8 +2399,7 @@ impl<'a> CfgLower<'a> {
                 payload_len,
                 ..
             } => {
-                let vty = self.ctx.cfg.get_inst(value).ty;
-                if *payload_len == 0 && self.ctx.type_slot_count(vty) <= 1 {
+                if matches!(value_plan.shape, crate::value_plan::ValueShape::Scalar) {
                     // Discriminant-only (C-like) enum: single-slot scalar.
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
@@ -2327,8 +2424,7 @@ impl<'a> CfgLower<'a> {
                 let (enum_id, variant_index, field_index) =
                     (*enum_id, *variant_index, *field_index);
                 let base = *base;
-                let vty = self.ctx.cfg.get_inst(value).ty;
-                let field_slots = self.ctx.type_slot_count(vty) as usize;
+                let field_slots = value_plan.shape.slot_count() as usize;
                 let offset = types::enum_payload_slot_offset(
                     self.ctx.type_pool,
                     enum_id,
@@ -2365,26 +2461,30 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IntCast {
                 value: src_value,
-                from_ty,
+                from_ty: _,
             } => {
                 // Integer cast with runtime range check
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
                 let src_vreg = self.get_vreg(*src_value);
-                let to_ty = self.ctx.cfg.get_inst(value).ty;
-
                 // Emit range check and panic if out of bounds
-                self.emit_int_cast_check(src_vreg, *from_ty, to_ty);
+                let from_width = value_plan
+                    .source_integer_width
+                    .expect("integer cast plan must include source width");
+                let to_width = value_plan
+                    .integer_width
+                    .expect("integer cast plan must include destination width");
+                self.emit_int_cast_check(src_vreg, from_width, to_width);
 
                 // Move the value to the result vreg. A signed source widened to a
                 // larger type must be SIGN-extended into the high bits — a plain
                 // 64-bit copy would carry the source's zero-extended high bits,
                 // turning e.g. i32 -5 into 4294967291 (RUE-88). Emit an explicit
                 // sxtb/sxth/sxtw for that case.
-                let from_bits = Self::type_bits(*from_ty);
-                let to_bits = Self::type_bits(to_ty);
-                if from_ty.is_signed() && to_bits > from_bits {
+                let from_bits = from_width.bits;
+                let to_bits = to_width.bits;
+                if from_width.signed && to_bits > from_bits {
                     let dst = Operand::Virtual(vreg);
                     let src = Operand::Virtual(src_vreg);
                     match from_bits {
@@ -2418,7 +2518,9 @@ impl<'a> CfgLower<'a> {
                     // Multi-slot structs use the complete aggregate
                     // representation. Zero- and one-slot structs use their
                     // scalar/ZST flattening.
-                    let field_vregs = if self.ctx.is_multislot_aggregate(dropped_ty) {
+                    let dropped_plan =
+                        crate::value_plan::ValuePlan::for_value(&self.ctx, *dropped_value);
+                    let field_vregs = if dropped_plan.shape.requires_complete_slots() {
                         self.require_aggregate_slots(*dropped_value)
                     } else {
                         self.collect_struct_scalar_vregs(*dropped_value)
@@ -2476,7 +2578,9 @@ impl<'a> CfgLower<'a> {
                     // slot counts past the argument registers go on the stack
                     // via emit_call_with_slot_args — e.g. [String; 3] is 9
                     // slots, RUE-193)
-                    let mut element_vregs = if self.ctx.is_multislot_aggregate(dropped_ty) {
+                    let dropped_plan =
+                        crate::value_plan::ValuePlan::for_value(&self.ctx, *dropped_value);
+                    let mut element_vregs = if dropped_plan.shape.requires_complete_slots() {
                         self.require_aggregate_slots(*dropped_value)
                     } else {
                         self.collect_array_scalar_vregs(*dropped_value)
@@ -2544,14 +2648,14 @@ impl<'a> CfgLower<'a> {
                 // A multi-slot aggregate value (struct, String, array, or
                 // payload enum) has one vreg per logical slot; PlaceWrite must
                 // store that complete representation. (RUE-118, RUE-23)
-                let val_type = self.ctx.cfg.get_inst(*val).ty;
+                let val_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, *val);
                 // A zero-sized value has no bytes to store (RUE-577): writing
                 // the dummy vreg CFG carries for unit would clobber a
                 // neighboring slot, and a ZST destination's origin shift
                 // underflows. Nothing to do.
-                let vals = if self.ctx.is_multislot_aggregate(val_type) {
+                let vals = if val_plan.shape.requires_complete_slots() {
                     self.require_aggregate_slots(*val)
-                } else if self.ctx.type_slot_count(val_type) == 0 {
+                } else if val_plan.shape.slot_count() == 0 {
                     Vec::new()
                 } else {
                     vec![self.get_vreg(*val)]
@@ -2559,13 +2663,16 @@ impl<'a> CfgLower<'a> {
                 crate::place_lower::lower_place_write(self, place, &vals);
             }
         }
-    }
 
-    /// Check if a comparison should use unsigned comparison instructions.
-    ///
-    /// Sema guarantees both operands have the same signedness, so we only need to check one.
-    fn is_unsigned_comparison(&self, lhs: CfgValue) -> bool {
-        self.ctx.cfg.get_inst(lhs).ty.is_unsigned()
+        if matches!(
+            value_plan.requirement,
+            crate::value_plan::MaterializationRequirement::CompleteSlots
+        ) {
+            let slots = crate::agg_slots::require_aggregate_slots(self, value);
+            crate::value_plan::assert_slot_policy(value_plan, slots.len());
+        } else if let Some(slots) = self.struct_slot_vregs.get(&value) {
+            crate::value_plan::assert_slot_policy(value_plan, slots.len());
+        }
     }
 
     /// Try to extract a power-of-two shift amount from a constant value.
@@ -2608,9 +2715,14 @@ impl<'a> CfgLower<'a> {
     /// - I16: sign-extend and compare with original
     ///
     /// Branches to `ok_label` if the value is in range (no overflow).
-    fn emit_subword_range_check(&mut self, ty: Type, result_vreg: VReg, ok_label: LabelId) {
-        match ty.kind() {
-            TypeKind::U8 => {
+    fn emit_subword_range_check(
+        &mut self,
+        width: crate::value_plan::IntegerWidth,
+        result_vreg: VReg,
+        ok_label: LabelId,
+    ) {
+        match (width.bits, width.signed) {
+            (8, false) => {
                 // Result must be <= 255
                 self.mir.push(Aarch64Inst::CmpImm {
                     src: Operand::Virtual(result_vreg),
@@ -2622,7 +2734,7 @@ impl<'a> CfgLower<'a> {
                     label: ok_label,
                 });
             }
-            TypeKind::U16 => {
+            (16, false) => {
                 // Result must be <= 65535
                 let max_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovImm {
@@ -2638,7 +2750,7 @@ impl<'a> CfgLower<'a> {
                     label: ok_label,
                 });
             }
-            TypeKind::I8 => {
+            (8, true) => {
                 // Sign-extend to 64-bit and compare with original
                 let sext_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::Sxtb {
@@ -2659,7 +2771,7 @@ impl<'a> CfgLower<'a> {
                     label: ok_label,
                 });
             }
-            TypeKind::I16 => {
+            (16, true) => {
                 // Sign-extend to 64-bit and compare with original
                 let sext_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::Sxth {
@@ -2686,25 +2798,29 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    fn emit_overflow_check_add(&mut self, ty: Type, result_vreg: VReg) {
+    fn emit_overflow_check_add(
+        &mut self,
+        width: crate::value_plan::IntegerWidth,
+        result_vreg: VReg,
+    ) {
         let ok_label = self.mir.alloc_label();
 
-        match ty.kind() {
+        match (width.bits, width.signed) {
             // 32-bit and 64-bit unsigned: C=1 means overflow (carry out)
             // Branch to ok if C=0 (no overflow)
-            TypeKind::U32 | TypeKind::U64 => {
+            (32 | 64, false) => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Lo, // Lo = C=0 (no carry)
                     label: ok_label,
                 });
             }
             // 32-bit and 64-bit signed: V flag indicates overflow
-            TypeKind::I32 | TypeKind::I64 => {
+            (32 | 64, true) => {
                 self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
             // Sub-word types: check if result fits in type's range
-            TypeKind::U8 | TypeKind::U16 | TypeKind::I8 | TypeKind::I16 => {
-                self.emit_subword_range_check(ty, result_vreg, ok_label);
+            (8 | 16, _) => {
+                self.emit_subword_range_check(width, result_vreg, ok_label);
             }
             // Other types don't have arithmetic
             _ => return,
@@ -2721,25 +2837,29 @@ impl<'a> CfgLower<'a> {
     /// For ARM64 SUBS:
     /// - Signed: V flag indicates overflow
     /// - Unsigned: C=0 means borrow (underflow), C=1 means no borrow
-    fn emit_overflow_check_sub(&mut self, ty: Type, result_vreg: VReg) {
+    fn emit_overflow_check_sub(
+        &mut self,
+        width: crate::value_plan::IntegerWidth,
+        result_vreg: VReg,
+    ) {
         let ok_label = self.mir.alloc_label();
 
-        match ty.kind() {
+        match (width.bits, width.signed) {
             // 32-bit and 64-bit unsigned: C=0 means borrow (underflow)
             // Branch to ok if C=1 (no underflow)
-            TypeKind::U32 | TypeKind::U64 => {
+            (32 | 64, false) => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Hs, // Hs = C=1 (no borrow)
                     label: ok_label,
                 });
             }
             // 32-bit and 64-bit signed: V flag indicates overflow
-            TypeKind::I32 | TypeKind::I64 => {
+            (32 | 64, true) => {
                 self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
             // Sub-word types: check if result fits in type's range
-            TypeKind::U8 | TypeKind::U16 | TypeKind::I8 | TypeKind::I16 => {
-                self.emit_subword_range_check(ty, result_vreg, ok_label);
+            (8 | 16, _) => {
+                self.emit_subword_range_check(width, result_vreg, ok_label);
             }
             // Other types don't have arithmetic
             _ => return,
@@ -2757,16 +2877,16 @@ impl<'a> CfgLower<'a> {
     /// - Unsigned: Use UMULL (64-bit result), check if high bits are non-zero
     fn emit_overflow_check_mul(
         &mut self,
-        ty: Type,
+        width: crate::value_plan::IntegerWidth,
         result_vreg: VReg,
         lhs_vreg: VReg,
         rhs_vreg: VReg,
     ) {
         let ok_label = self.mir.alloc_label();
 
-        match ty.kind() {
+        match (width.bits, width.signed) {
             // 32-bit signed: SMULL gives 64-bit result
-            TypeKind::I32 => {
+            (32, true) => {
                 let smull_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::SmullRR {
                     dst: Operand::Virtual(smull_vreg),
@@ -2795,7 +2915,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // 32-bit unsigned: UMULL gives 64-bit result
-            TypeKind::U32 => {
+            (32, false) => {
                 let umull_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::UmullRR {
                     dst: Operand::Virtual(umull_vreg),
@@ -2820,7 +2940,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // 64-bit signed: Use SMULH for high bits
-            TypeKind::I64 => {
+            (64, true) => {
                 // Do the multiply first
                 self.mir.push(Aarch64Inst::MulRR {
                     dst: Operand::Virtual(result_vreg),
@@ -2852,7 +2972,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // 64-bit unsigned: Use UMULH for high bits
-            TypeKind::U64 => {
+            (64, false) => {
                 // Do the multiply first
                 self.mir.push(Aarch64Inst::MulRR {
                     dst: Operand::Virtual(result_vreg),
@@ -2873,14 +2993,14 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // Sub-word types: do the multiply, then check range
-            TypeKind::I8 | TypeKind::I16 | TypeKind::U8 | TypeKind::U16 => {
+            (8 | 16, _) => {
                 // For sub-word, just do the multiply and check range
                 self.mir.push(Aarch64Inst::MulRR {
                     dst: Operand::Virtual(result_vreg),
                     src1: Operand::Virtual(lhs_vreg),
                     src2: Operand::Virtual(rhs_vreg),
                 });
-                self.emit_subword_range_check(ty, result_vreg, ok_label);
+                self.emit_subword_range_check(width, result_vreg, ok_label);
             }
             _ => return,
         }
@@ -2899,9 +3019,14 @@ impl<'a> CfgLower<'a> {
     /// For 32-bit-and-narrower types the compares run at W-register width:
     /// sub-word values are kept sign-extended in the low 32 bits of their
     /// registers, so comparing against the type's MIN there is exact.
-    fn emit_signed_div_overflow_check(&mut self, ty: Type, lhs_vreg: VReg, rhs_vreg: VReg) {
+    fn emit_signed_div_overflow_check(
+        &mut self,
+        width: crate::value_plan::IntegerWidth,
+        lhs_vreg: VReg,
+        rhs_vreg: VReg,
+    ) {
         let ok_label = self.mir.alloc_label();
-        let is_64 = ty.is_64_bit();
+        let is_64 = width.bits == 64;
 
         // divisor == -1? (-1 doesn't fit CMP's imm12; materialize it)
         let neg1_vreg = self.mir.alloc_vreg();
@@ -2926,7 +3051,7 @@ impl<'a> CfgLower<'a> {
         });
 
         // dividend == MIN?
-        let (min_val, _) = Self::type_range(ty);
+        let (min_val, _) = crate::value_plan::integer_range(width);
         let min_vreg = self.mir.alloc_vreg();
         self.mir.push(Aarch64Inst::MovImm {
             dst: Operand::Virtual(min_vreg),
@@ -2959,24 +3084,28 @@ impl<'a> CfgLower<'a> {
     /// For NEGS (0 - x):
     /// - Signed: V flag indicates overflow (when negating MIN_VALUE)
     /// - Unsigned: Any non-zero value causes overflow (since 0 - x wraps)
-    fn emit_overflow_check_neg(&mut self, ty: Type, result_vreg: VReg) {
+    fn emit_overflow_check_neg(
+        &mut self,
+        width: crate::value_plan::IntegerWidth,
+        result_vreg: VReg,
+    ) {
         let ok_label = self.mir.alloc_label();
 
-        match ty.kind() {
+        match (width.bits, width.signed) {
             // Unsigned: NEGS sets C=0 for non-zero operands (which is overflow)
             // Branch to ok if C=1 (meaning operand was 0, no overflow)
-            TypeKind::U32 | TypeKind::U64 => {
+            (32 | 64, false) => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Hs, // Hs = C=1
                     label: ok_label,
                 });
             }
             // Signed: V flag indicates overflow
-            TypeKind::I32 | TypeKind::I64 => {
+            (32 | 64, true) => {
                 self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
             // Sub-word unsigned types: only 0 is valid (negating to 0)
-            TypeKind::U8 | TypeKind::U16 => {
+            (8 | 16, false) => {
                 // Result must be 0 for no overflow
                 self.mir.push(Aarch64Inst::Cbz {
                     src: Operand::Virtual(result_vreg),
@@ -2984,8 +3113,8 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // Sub-word signed types: check if result fits in type's range
-            TypeKind::I8 | TypeKind::I16 => {
-                self.emit_subword_range_check(ty, result_vreg, ok_label);
+            (8 | 16, true) => {
+                self.emit_subword_range_check(width, result_vreg, ok_label);
             }
             _ => return,
         }
@@ -3041,12 +3170,16 @@ impl<'a> CfgLower<'a> {
     ///
     /// Checks if the source value can be represented in the target type.
     /// Panics via `__rue_intcast_overflow` if the value is out of range.
-    fn emit_int_cast_check(&mut self, src_vreg: VReg, from_ty: Type, to_ty: Type) {
-        // Get type properties
-        let from_signed = from_ty.is_signed();
-        let to_signed = to_ty.is_signed();
-        let from_bits = Self::type_bits(from_ty);
-        let to_bits = Self::type_bits(to_ty);
+    fn emit_int_cast_check(
+        &mut self,
+        src_vreg: VReg,
+        from_width: crate::value_plan::IntegerWidth,
+        to_width: crate::value_plan::IntegerWidth,
+    ) {
+        let from_signed = from_width.signed;
+        let to_signed = to_width.signed;
+        let from_bits = from_width.bits;
+        let to_bits = to_width.bits;
 
         // If casting to a larger or equal-sized type with compatible signedness,
         // and source is unsigned or both are signed, no check needed
@@ -3067,7 +3200,7 @@ impl<'a> CfgLower<'a> {
         let ok_label = self.mir.alloc_label();
 
         // Calculate the min and max values for the target type
-        let (min_val, max_val) = Self::type_range(to_ty);
+        let (min_val, max_val) = crate::value_plan::integer_range(to_width);
 
         if from_signed {
             // Source is signed - need to check both min and max
@@ -3123,26 +3256,25 @@ impl<'a> CfgLower<'a> {
                 // make -1 appear as a large positive number in 64-bit compare.
                 let compare_vreg = if from_bits < 64 {
                     let sext_vreg = self.mir.alloc_vreg();
-                    match from_ty.kind() {
-                        TypeKind::I8 => {
+                    match from_bits {
+                        8 => {
                             self.mir.push(Aarch64Inst::Sxtb {
                                 dst: Operand::Virtual(sext_vreg),
                                 src: Operand::Virtual(src_vreg),
                             });
                         }
-                        TypeKind::I16 => {
+                        16 => {
                             self.mir.push(Aarch64Inst::Sxth {
                                 dst: Operand::Virtual(sext_vreg),
                                 src: Operand::Virtual(src_vreg),
                             });
                         }
-                        TypeKind::I32 => {
+                        _ => {
                             self.mir.push(Aarch64Inst::Sxtw {
                                 dst: Operand::Virtual(sext_vreg),
                                 src: Operand::Virtual(src_vreg),
                             });
                         }
-                        _ => unreachable!("non-integer type in intcast"),
                     }
                     sext_vreg
                 } else {
@@ -3230,13 +3362,7 @@ impl<'a> CfgLower<'a> {
 
     /// Get the bit width of an integer type.
     fn type_bits(ty: Type) -> u32 {
-        match ty.kind() {
-            TypeKind::I8 | TypeKind::U8 => 8,
-            TypeKind::I16 | TypeKind::U16 => 16,
-            TypeKind::I32 | TypeKind::U32 => 32,
-            TypeKind::I64 | TypeKind::U64 => 64,
-            _ => panic!("type_bits called on non-integer type: {:?}", ty),
-        }
+        crate::value_plan::type_bits(ty)
     }
 
     /// Get the min and max values for an integer type.
@@ -3281,25 +3407,15 @@ impl<'a> CfgLower<'a> {
         let dst = Operand::Virtual(vreg);
         let src = Operand::Virtual(vreg);
         match Self::type_bits(ty) {
-            8 if ty.is_signed() => self.mir.push(Aarch64Inst::Sxtb { dst, src }),
+            8 if crate::value_plan::type_is_signed(ty) => {
+                self.mir.push(Aarch64Inst::Sxtb { dst, src })
+            }
             8 => self.mir.push(Aarch64Inst::Uxtb { dst, src }),
-            16 if ty.is_signed() => self.mir.push(Aarch64Inst::Sxth { dst, src }),
+            16 if crate::value_plan::type_is_signed(ty) => {
+                self.mir.push(Aarch64Inst::Sxth { dst, src })
+            }
             16 => self.mir.push(Aarch64Inst::Uxth { dst, src }),
             _ => {}
-        }
-    }
-
-    fn type_range(ty: Type) -> (i64, i64) {
-        match ty.kind() {
-            TypeKind::I8 => (i8::MIN as i64, i8::MAX as i64),
-            TypeKind::I16 => (i16::MIN as i64, i16::MAX as i64),
-            TypeKind::I32 => (i32::MIN as i64, i32::MAX as i64),
-            TypeKind::I64 => (i64::MIN, i64::MAX),
-            TypeKind::U8 => (0, u8::MAX as i64),
-            TypeKind::U16 => (0, u16::MAX as i64),
-            TypeKind::U32 => (0, u32::MAX as i64),
-            TypeKind::U64 => (0, i64::MAX), // Can't represent u64::MAX in i64, but we use unsigned compare
-            _ => panic!("type_range called on non-integer type: {:?}", ty),
         }
     }
 
@@ -3308,10 +3424,15 @@ impl<'a> CfgLower<'a> {
         let vreg = self.mir.alloc_vreg();
         self.value_map.insert(value, vreg);
 
-        let lhs_ty = self.ctx.cfg.get_inst(lhs).ty;
+        let comparison = crate::value_plan::ValuePlan::for_value(&self.ctx, value)
+            .comparison
+            .expect("comparison value must have a shared comparison preparation");
 
         // Special handling for string comparisons
-        if self.ctx.is_string_like_for_equality(lhs_ty) {
+        if matches!(
+            comparison,
+            crate::value_plan::ComparisonPreparation::StringContent { .. }
+        ) {
             // String-like comparison requires calling __rue_str_eq. Both
             // `str`/`Str(N)` and `StrBuf` have ptr/len in the first two slots.
 
@@ -3371,8 +3492,14 @@ impl<'a> CfgLower<'a> {
             let lhs_vreg = self.get_vreg(lhs);
             let rhs_vreg = self.get_vreg(rhs);
 
-            // Use 64-bit compare for i64/u64 types
-            if matches!(lhs_ty, Type::I64 | Type::U64) {
+            // The shared comparison plan selects the compare width; this
+            // helper only chooses the AArch64 encoding for that width.
+            if matches!(
+                comparison,
+                crate::value_plan::ComparisonPreparation::Scalar {
+                    width: crate::value_plan::IntegerWidth { bits: 64, .. }
+                }
+            ) {
                 self.mir.push(Aarch64Inst::Cmp64RR {
                     src1: Operand::Virtual(lhs_vreg),
                     src2: Operand::Virtual(rhs_vreg),
@@ -3607,7 +3734,8 @@ impl<'a> CfgLower<'a> {
                 // 64-bit scrutinee must be compared at 64-bit width; a 32-bit cmp
                 // would match on only the low 32 bits (RUE-27). Sub-64-bit
                 // scrutinees keep the 32-bit compare (correct at their width).
-                let scrutinee_is_64 = self.ctx.cfg.get_inst(*scrutinee).ty.is_64_bit();
+                let scrutinee_ty = self.ctx.cfg.get_inst(*scrutinee).ty;
+                let scrutinee_is_64 = crate::value_plan::is_64_bit(scrutinee_ty);
 
                 // Generate comparison and jump for each case
                 let cases = self.ctx.cfg.get_switch_cases(*cases_start, *cases_len);

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -355,6 +355,25 @@ impl<'a> CfgLower<'a> {
                 terminator: None,
             };
 
+            // Block parameters are preallocated before the block walk and
+            // therefore never reach `lower_value`'s MIR-emission path. Keep
+            // them in lowering debug output so the trace remains a complete
+            // CFG-to-MIR account, including intentional no-op materialization.
+            for (param_val, _) in &block.params {
+                let param_inst = self.ctx.cfg.get_inst(*param_val);
+                block_info.instructions.push(LoweringDecision {
+                    cfg_value: *param_val,
+                    cfg_inst_desc: format_cfg_inst_data_with_interner(
+                        self.ctx.cfg,
+                        &param_inst.data,
+                        self.interner,
+                    ),
+                    cfg_type: param_inst.ty.name().to_string(),
+                    mir_insts: Vec::new(),
+                    rationale: Some("Block parameter preallocated at the join".to_string()),
+                });
+            }
+
             // Emit block label (except for entry block)
             if block.id != self.ctx.cfg.entry {
                 self.mir.push(Aarch64Inst::Label {
@@ -386,19 +405,17 @@ impl<'a> CfgLower<'a> {
                 // Generate rationale for interesting cases
                 let rationale = self.get_lowering_rationale(&inst.data, inst.ty);
 
-                if !mir_insts.is_empty() {
-                    block_info.instructions.push(LoweringDecision {
-                        cfg_value: value,
-                        cfg_inst_desc: format_cfg_inst_data_with_interner(
-                            self.ctx.cfg,
-                            &inst.data,
-                            self.interner,
-                        ),
-                        cfg_type: inst.ty.name().to_string(),
-                        mir_insts,
-                        rationale,
-                    });
-                }
+                block_info.instructions.push(LoweringDecision {
+                    cfg_value: value,
+                    cfg_inst_desc: format_cfg_inst_data_with_interner(
+                        self.ctx.cfg,
+                        &inst.data,
+                        self.interner,
+                    ),
+                    cfg_type: inst.ty.name().to_string(),
+                    mir_insts,
+                    rationale,
+                });
             }
 
             // Lower terminator with tracking
@@ -614,7 +631,19 @@ impl<'a> CfgLower<'a> {
                 // aggregate, and write paths all use uniform frame-slot loads,
                 // including ABI slots beyond the eight argument registers.
                 // (RUE-13/79/91)
-                if is_by_ref {
+                if is_by_ref && value_plan.shape.requires_complete_slots() {
+                    // Aggregate parameters must materialize their complete
+                    // logical representation through the shared slot policy.
+                    // In particular, a zero-slot struct/array has no frame
+                    // load at all; `max(1)` here would read a neighboring
+                    // slot and turn a ZST into a scalar value.
+                    let slots = self.require_aggregate_slots(value);
+                    let primary = slots
+                        .first()
+                        .copied()
+                        .unwrap_or_else(|| self.mir.alloc_vreg());
+                    self.value_map.insert(value, primary);
+                } else if is_by_ref {
                     // For by-ref params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.
                     let ptr_vreg = self.ensure_by_ref_param_ptr(*index);
@@ -627,6 +656,13 @@ impl<'a> CfgLower<'a> {
                     });
 
                     self.value_map.insert(value, val_vreg);
+                } else if value_plan.shape.requires_complete_slots() {
+                    let slots = self.require_aggregate_slots(value);
+                    let primary = slots
+                        .first()
+                        .copied()
+                        .unwrap_or_else(|| self.mir.alloc_vreg());
+                    self.value_map.insert(value, primary);
                 } else {
                     // Normal parameter: the primary vreg is the value's LOGICAL
                     // slot 0 (e.g. an enum's discriminant). Ascending layout
@@ -636,8 +672,7 @@ impl<'a> CfgLower<'a> {
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
 
-                    let count = value_plan.shape.slot_count().max(1);
-                    let slot = self.ctx.num_locals + *index + count - 1;
+                    let slot = self.ctx.num_locals + *index;
                     let offset = self.ctx.local_offset(slot);
                     self.mir.push(Aarch64Inst::Ldr {
                         dst: Operand::Virtual(vreg),
@@ -3620,8 +3655,8 @@ impl<'a> CfgLower<'a> {
                 // Copy args to target's block params
                 let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                 for (i, &arg) in args.iter().enumerate() {
-                    let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if self.ctx.is_multislot_aggregate(arg_type) {
+                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
+                    if arg_plan.shape.requires_complete_slots() {
                         // For any multi-slot aggregate arg (struct, String,
                         // array, payload enum) copy all slot vregs — single
                         // is_multislot_aggregate predicate (RUE-248).
@@ -3669,8 +3704,8 @@ impl<'a> CfgLower<'a> {
                 // Copy then_args to then_block's params
                 let then_args = self.ctx.cfg.get_extra(*then_args_start, *then_args_len);
                 for (i, &arg) in then_args.iter().enumerate() {
-                    let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if self.ctx.is_multislot_aggregate(arg_type) {
+                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
+                    if arg_plan.shape.requires_complete_slots() {
                         // For any multi-slot aggregate arg (struct, String,
                         // array, payload enum) copy all slot vregs — single
                         // is_multislot_aggregate predicate (RUE-248).
@@ -3697,8 +3732,8 @@ impl<'a> CfgLower<'a> {
                 });
                 let else_args = self.ctx.cfg.get_extra(*else_args_start, *else_args_len);
                 for (i, &arg) in else_args.iter().enumerate() {
-                    let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if self.ctx.is_multislot_aggregate(arg_type) {
+                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
+                    if arg_plan.shape.requires_complete_slots() {
                         // For any multi-slot aggregate arg (struct, String,
                         // array, payload enum) copy all slot vregs — single
                         // is_multislot_aggregate predicate (RUE-248).
@@ -3788,7 +3823,7 @@ impl<'a> CfgLower<'a> {
                     return;
                 };
 
-                let return_type = self.ctx.cfg.return_type();
+                let return_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, *value);
 
                 if self.fn_name == "main" {
                     let val_vreg = self.get_vreg(*value);
@@ -3798,7 +3833,7 @@ impl<'a> CfgLower<'a> {
                     });
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
-                } else if self.ctx.is_multislot_aggregate(return_type) {
+                } else if return_plan.shape.requires_complete_slots() {
                     // Return a multi-slot aggregate (struct, array, or payload
                     // enum). Every valid source has exactly `type_slot_count`
                     // materialized vregs. (RUE-118, RUE-78, RUE-237)

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -224,11 +224,14 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
 /// invariant in release builds.
 pub fn require_aggregate_slots<B: SlotBackend>(b: &mut B, value: CfgValue) -> Vec<VReg> {
     let ty = b.ctx().cfg.get_inst(value).ty;
+    let plan = crate::value_plan::ValuePlan::for_value(b.ctx(), value);
     assert!(
-        b.ctx().is_multislot_aggregate(ty),
-        "aggregate slot materialization requires a multi-slot aggregate value: {value}"
+        plan.shape.requires_complete_slots(),
+        "aggregate slot materialization requires a multi-slot aggregate value: {value} (type={ty:?}, shape={:?}, kind={:?})",
+        plan.shape,
+        plan.kind
     );
-    let expected = b.ctx().type_slot_count(ty) as usize;
+    let expected = plan.shape.slot_count() as usize;
     let slots = get_or_compute_field_vregs(b, value).unwrap_or_else(|| match expected {
         // A zero-slot aggregate's empty representation is complete. Producers
         // intentionally have no slot-cache entry because there are no vregs to

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -48,6 +48,7 @@ mod schedule_core;
 mod stack_frame;
 mod stack_verify;
 mod storage_lower;
+pub mod value_plan;
 
 pub mod aarch64;
 pub mod agg_slots;

--- a/crates/rue-codegen/src/storage_lower.rs
+++ b/crates/rue-codegen/src/storage_lower.rs
@@ -23,8 +23,8 @@ pub(crate) trait StorageLowerBackend: PlaceLowerBackend {
 
 /// Lower a local allocation and its initializer.
 pub(crate) fn lower_alloc<B: StorageLowerBackend>(b: &mut B, slot: u32, init: CfgValue) {
-    let init_type = b.ctx().cfg.get_inst(init).ty;
-    if b.ctx().is_strbuf(init_type) {
+    let init_plan = crate::value_plan::ValuePlan::for_value(b.ctx(), init);
+    if init_plan.is_strbuf {
         // StrBuf is always the ptr/len/cap three-slot fat pointer. Keep this
         // before generic aggregates so a layout drift fails loudly.
         let field_vregs = agg_slots::require_aggregate_slots(b, init);
@@ -34,11 +34,11 @@ pub(crate) fn lower_alloc<B: StorageLowerBackend>(b: &mut B, slot: u32, init: Cf
             "string should have 3 fields (ptr, len, cap)"
         );
         agg_slots::store_slots(b, &field_vregs, slot);
-    } else if b.ctx().is_multislot_aggregate(init_type) {
+    } else if init_plan.shape.requires_complete_slots() {
         // Every multi-slot aggregate initializer has one vreg per logical slot.
         let scalar_vregs = agg_slots::require_aggregate_slots(b, init);
         agg_slots::store_slots(b, &scalar_vregs, slot);
-    } else if init_type.is_array() {
+    } else if b.ctx().cfg.get_inst(init).ty.is_array() {
         // Zero- and one-slot arrays use their scalar/ZST representation.
         let scalar_vregs = b.collect_array_scalars(init);
         agg_slots::store_slots(b, &scalar_vregs, slot);
@@ -50,15 +50,15 @@ pub(crate) fn lower_alloc<B: StorageLowerBackend>(b: &mut B, slot: u32, init: Cf
 
 /// Lower a local load, including flattened aggregate cache bookkeeping.
 pub(crate) fn lower_load<B: StorageLowerBackend>(b: &mut B, value: CfgValue, slot: u32) {
-    let load_type = b.ctx().cfg.get_inst(value).ty;
+    let load_plan = crate::value_plan::ValuePlan::for_value(b.ctx(), value);
 
-    if b.ctx().is_strbuf(load_type) {
+    if load_plan.is_strbuf {
         let slot_vregs = agg_slots::load_slots_at_low(b, slot + 2, 3);
         let ptr_vreg = slot_vregs[0];
         b.slot_cache().insert(value, slot_vregs);
         b.map_value(value, ptr_vreg);
-    } else if load_type.is_array() || b.ctx().is_multislot_aggregate(load_type) {
-        let slot_count = b.ctx().type_slot_count(load_type);
+    } else if load_plan.shape.requires_complete_slots() {
+        let slot_count = load_plan.shape.slot_count();
         let slot_vregs = if slot_count > 0 {
             agg_slots::load_slots_at_low(b, slot + slot_count - 1, slot_count)
         } else {
@@ -81,10 +81,10 @@ pub(crate) fn lower_load<B: StorageLowerBackend>(b: &mut B, value: CfgValue, slo
 
 /// Lower a store to either a local frame slot or a by-ref parameter's pointee.
 pub(crate) fn lower_store<B: StorageLowerBackend>(b: &mut B, slot: u32, value: CfgValue) {
-    let value_type = b.ctx().cfg.get_inst(value).ty;
-    let aggregate_vregs = b
-        .ctx()
-        .is_multislot_aggregate(value_type)
+    let value_plan = crate::value_plan::ValuePlan::for_value(b.ctx(), value);
+    let aggregate_vregs = value_plan
+        .shape
+        .requires_complete_slots()
         .then(|| agg_slots::require_aggregate_slots(b, value));
 
     if let Some(slot_vregs) = aggregate_vregs {
@@ -115,10 +115,10 @@ pub(crate) fn lower_param_store<B: StorageLowerBackend>(
         panic!("ParamStore used on non-writable param slot {}", param_slot);
     }
 
-    let value_type = b.ctx().cfg.get_inst(value).ty;
-    let aggregate_vregs = b
-        .ctx()
-        .is_multislot_aggregate(value_type)
+    let value_plan = crate::value_plan::ValuePlan::for_value(b.ctx(), value);
+    let aggregate_vregs = value_plan
+        .shape
+        .requires_complete_slots()
         .then(|| agg_slots::require_aggregate_slots(b, value));
 
     let ptr = b.ensure_by_ref_param_ptr(param_slot);

--- a/crates/rue-codegen/src/storage_lower.rs
+++ b/crates/rue-codegen/src/storage_lower.rs
@@ -38,10 +38,6 @@ pub(crate) fn lower_alloc<B: StorageLowerBackend>(b: &mut B, slot: u32, init: Cf
         // Every multi-slot aggregate initializer has one vreg per logical slot.
         let scalar_vregs = agg_slots::require_aggregate_slots(b, init);
         agg_slots::store_slots(b, &scalar_vregs, slot);
-    } else if b.ctx().cfg.get_inst(init).ty.is_array() {
-        // Zero- and one-slot arrays use their scalar/ZST representation.
-        let scalar_vregs = b.collect_array_scalars(init);
-        agg_slots::store_slots(b, &scalar_vregs, slot);
     } else {
         let init_vreg = b.get_vreg(init);
         b.emit_store_slot(init_vreg, slot);

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -316,13 +316,14 @@ pub fn integer_width(ty: Type) -> Option<IntegerWidth> {
     })
 }
 
-/// Select the width used by a scalar comparison. Booleans are represented in
-/// the ordinary 32-bit scalar register form; every other valid scalar
-/// comparison operand must be an integer. Do not silently assign an integer
-/// width to malformed or unsupported types: doing so would let the backends
-/// choose a target-specific interpretation of the same invalid CFG.
+/// Select the width used by a scalar comparison. Booleans and discriminant-only
+/// enums are represented in the ordinary 32-bit unsigned scalar register form;
+/// every other valid scalar comparison operand must be an integer. Do not
+/// silently assign an integer width to malformed or unsupported types: doing so
+/// would let the backends choose a target-specific interpretation of the same
+/// invalid CFG.
 pub fn comparison_integer_width(ty: Type) -> IntegerWidth {
-    if ty == Type::BOOL {
+    if ty == Type::BOOL || ty.is_enum() {
         IntegerWidth {
             bits: 32,
             signed: false,
@@ -778,6 +779,72 @@ mod tests {
                 bits: 32,
                 signed: false
             }
+        );
+    }
+
+    #[test]
+    fn enum_scalar_comparison_uses_unsigned_discriminant_width() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let enum_name = interner.get_or_intern("ComparisonEnum");
+        let (enum_id, _) = pool.register_enum(
+            enum_name,
+            EnumDef {
+                name: "ComparisonEnum".to_string(),
+                variants: vec!["First".to_string(), "Second".to_string()],
+                variant_payloads: vec![vec![], vec![]],
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let pool = pool.freeze();
+        let enum_ty = Type::new_enum(enum_id);
+        let values = vec![
+            inst(CfgInstData::Const(0), enum_ty),
+            inst(CfgInstData::Const(1), enum_ty),
+            inst(
+                CfgInstData::Eq(CfgValue::from_raw(0), CfgValue::from_raw(1)),
+                Type::BOOL,
+            ),
+        ];
+        let cfg = synthetic_cfg(values, 0, 0, vec![], CfgValue::from_raw(2));
+        let ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
+        assert_eq!(
+            ValuePlan::for_value(&ctx, CfgValue::from_raw(2)).comparison,
+            Some(ComparisonPreparation::Scalar {
+                width: IntegerWidth {
+                    bits: 32,
+                    signed: false,
+                },
+            })
+        );
+
+        let x86 = X86CfgLower::new(&cfg, &pool, &interner)
+            .lower()
+            .expect("x86 enum comparison should lower");
+        assert!(
+            x86.instructions()
+                .iter()
+                .any(|instruction| matches!(instruction, X86Inst::CmpRR { .. }))
+        );
+        assert!(
+            !x86.instructions()
+                .iter()
+                .any(|instruction| matches!(instruction, X86Inst::Cmp64RR { .. }))
+        );
+
+        let arm = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
+            .lower()
+            .expect("AArch64 enum comparison should lower");
+        assert!(
+            arm.instructions()
+                .iter()
+                .any(|instruction| matches!(instruction, Aarch64Inst::CmpRR { .. }))
+        );
+        assert!(
+            !arm.instructions()
+                .iter()
+                .any(|instruction| matches!(instruction, Aarch64Inst::Cmp64RR { .. }))
         );
     }
 

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -19,7 +19,9 @@ use crate::cfg_lower::CfgLowerContext;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValueShape {
     /// No storage slots exist.  A primary vreg may still be used as a
-    /// never-read placeholder for CFG bookkeeping.
+    /// never-read placeholder for CFG bookkeeping.  A zero-slot struct or
+    /// array is represented by `CompleteAggregate { slot_count: 0 }` instead;
+    /// this shape is reserved for non-aggregate zero-sized values.
     ZeroSized,
     /// Exactly one logical slot; the primary vreg is the complete value.
     Scalar,
@@ -198,10 +200,7 @@ impl ValuePlan {
                     Some(ComparisonPreparation::Unit)
                 } else {
                     Some(ComparisonPreparation::Scalar {
-                        width: integer_width(lhs_ty).unwrap_or(IntegerWidth {
-                            bits: 32,
-                            signed: false,
-                        }),
+                        width: comparison_integer_width(lhs_ty),
                     })
                 }
             }
@@ -317,6 +316,24 @@ pub fn integer_width(ty: Type) -> Option<IntegerWidth> {
     })
 }
 
+/// Select the width used by a scalar comparison. Booleans are represented in
+/// the ordinary 32-bit scalar register form; every other valid scalar
+/// comparison operand must be an integer. Do not silently assign an integer
+/// width to malformed or unsupported types: doing so would let the backends
+/// choose a target-specific interpretation of the same invalid CFG.
+pub fn comparison_integer_width(ty: Type) -> IntegerWidth {
+    if ty == Type::BOOL {
+        IntegerWidth {
+            bits: 32,
+            signed: false,
+        }
+    } else {
+        integer_width(ty).unwrap_or_else(|| {
+            panic!("scalar comparison requires an integer or bool type, got {ty:?}")
+        })
+    }
+}
+
 /// Shared signedness query for target encodings that need a flag or extension
 /// form after the integer policy has been selected.
 pub fn type_is_signed(ty: Type) -> bool {
@@ -383,10 +400,11 @@ pub fn assert_slot_policy(plan: ValuePlan, actual: usize) {
 mod tests {
     use super::{
         ComparisonPreparation, IntegerWidth, MaterializationRequirement, StoragePolicy, ValueKind,
-        ValuePlan, ValueShape, assert_slot_policy, integer_range, kind, type_bits, type_range,
+        ValuePlan, ValueShape, assert_slot_policy, comparison_integer_width, integer_range, kind,
+        type_bits, type_range,
     };
     use lasso::{Spur, ThreadedRodeo};
-    use rue_air::{LangItem, StructDef, StructField, TypeInternPool};
+    use rue_air::{EnumDef, LangItem, ParamSlotModes, StructDef, StructField, TypeInternPool};
     use rue_cfg::{Cfg, CfgInst, CfgInstData, CfgValue, Place, Terminator, Type};
     use rue_span::{FileId, Span};
     use rue_target::Target;
@@ -436,6 +454,303 @@ mod tests {
         CfgValue::from_raw(0)
     }
 
+    fn all_value_kinds() -> &'static [ValueKind] {
+        use ValueKind::*;
+        &[
+            Constant,
+            BoolConstant,
+            StringConstant,
+            Parameter,
+            BlockParameter,
+            BinaryArithmetic,
+            Comparison,
+            UnaryArithmetic,
+            Bitwise,
+            Shift,
+            Allocation,
+            Load,
+            Store,
+            ParameterStore,
+            Call,
+            Intrinsic,
+            StructInit,
+            ArrayInit,
+            EnumVariant,
+            EnumPayloadGet,
+            IntegerCast,
+            Drop,
+            StorageLive,
+            StorageDead,
+            PlaceRead,
+            PlaceWrite,
+        ]
+    }
+
+    /// Construct one valid CFG containing every current CfgInstData variant.
+    /// The exhaustive `kind` match and `all_value_kinds` inventory make adding
+    /// a language-level variant a compile-time/test-time coverage obligation;
+    /// the two adapters then lower this same fixture and expose each value in
+    /// their debug traces.
+    fn every_cfg_value_fixture() -> (
+        Cfg,
+        rue_air::FrozenTypeInternPool,
+        ThreadedRodeo,
+        Vec<CfgValue>,
+    ) {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let (str_id, _) = pool.register_struct(
+            interner.get_or_intern("str"),
+            StructDef {
+                name: "str".to_string(),
+                fields: vec![
+                    StructField {
+                        name: "ptr".to_string(),
+                        ty: Type::U64,
+                    },
+                    StructField {
+                        name: "len".to_string(),
+                        ty: Type::U64,
+                    },
+                ],
+                is_copy: true,
+                is_linear: false,
+                destructor: None,
+                is_builtin: true,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let (struct_id, _) = pool.register_struct(
+            interner.get_or_intern("CoverageStruct"),
+            StructDef {
+                name: "CoverageStruct".to_string(),
+                fields: vec![
+                    StructField {
+                        name: "left".to_string(),
+                        ty: Type::I32,
+                    },
+                    StructField {
+                        name: "right".to_string(),
+                        ty: Type::I32,
+                    },
+                ],
+                is_copy: false,
+                is_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let (enum_id, _) = pool.register_enum(
+            interner.get_or_intern("CoverageEnum"),
+            EnumDef {
+                name: "CoverageEnum".to_string(),
+                variants: vec!["None".to_string(), "Some".to_string()],
+                variant_payloads: vec![vec![], vec![Type::I32]],
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let array_id = pool.intern_array_from_type(Type::I32, 2);
+        let str_ty = Type::new_struct(str_id);
+        let struct_ty = Type::new_struct(struct_id);
+        let enum_ty = Type::new_enum(enum_id);
+        let array_ty = Type::new_array(array_id);
+
+        let mut cfg = Cfg::new(
+            Type::I32,
+            2,
+            1,
+            "every_cfg_value_variant".to_string(),
+            ParamSlotModes::new(vec![true], vec![true]),
+        );
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let mut values = Vec::new();
+        let block_parameter = cfg.add_inst(inst(CfgInstData::BlockParam { index: 0 }, Type::I32));
+        cfg.get_block_mut(entry)
+            .params
+            .push((block_parameter, Type::I32));
+        values.push(block_parameter);
+        let mut add = |cfg: &mut Cfg, data: CfgInstData, ty: Type| {
+            let value = cfg.add_inst(inst(data, ty));
+            cfg.get_block_mut(entry).insts.push(value);
+            values.push(value);
+            value
+        };
+
+        let constant = add(&mut cfg, CfgInstData::Const(7), Type::I32);
+        let bool_constant = add(&mut cfg, CfgInstData::BoolConst(true), Type::BOOL);
+        let _string_constant = add(&mut cfg, CfgInstData::StringConst(0), str_ty);
+        let _parameter = add(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+
+        for data in [
+            CfgInstData::Add(constant, constant),
+            CfgInstData::Sub(constant, constant),
+            CfgInstData::Mul(constant, constant),
+            CfgInstData::Div(constant, constant),
+            CfgInstData::Mod(constant, constant),
+            CfgInstData::Eq(constant, constant),
+            CfgInstData::Ne(constant, constant),
+            CfgInstData::Lt(constant, constant),
+            CfgInstData::Gt(constant, constant),
+            CfgInstData::Le(constant, constant),
+            CfgInstData::Ge(constant, constant),
+            CfgInstData::BitAnd(constant, constant),
+            CfgInstData::BitOr(constant, constant),
+            CfgInstData::BitXor(constant, constant),
+            CfgInstData::Shl(constant, constant),
+            CfgInstData::Shr(constant, constant),
+            CfgInstData::Neg(constant),
+            CfgInstData::BitNot(constant),
+        ] {
+            add(&mut cfg, data, Type::I32);
+        }
+        add(&mut cfg, CfgInstData::Not(bool_constant), Type::BOOL);
+        add(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: constant,
+            },
+            Type::UNIT,
+        );
+        let load = add(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        add(
+            &mut cfg,
+            CfgInstData::Store {
+                slot: 0,
+                value: constant,
+            },
+            Type::UNIT,
+        );
+        add(
+            &mut cfg,
+            CfgInstData::ParamStore {
+                param_slot: 0,
+                value: constant,
+            },
+            Type::UNIT,
+        );
+        let call_name = interner.get_or_intern("coverage_call");
+        add(
+            &mut cfg,
+            CfgInstData::Call {
+                name: call_name,
+                args_start: 0,
+                args_len: 0,
+            },
+            Type::I32,
+        );
+        let panic_name = interner.get_or_intern("panic");
+        add(
+            &mut cfg,
+            CfgInstData::Intrinsic {
+                name: panic_name,
+                args_start: 0,
+                args_len: 0,
+            },
+            Type::UNIT,
+        );
+        let (fields_start, fields_len) = cfg.push_extra([constant, load]);
+        let struct_value = add(
+            &mut cfg,
+            CfgInstData::StructInit {
+                struct_id,
+                fields_start,
+                fields_len,
+            },
+            struct_ty,
+        );
+        let (elements_start, elements_len) = cfg.push_extra([constant, load]);
+        add(
+            &mut cfg,
+            CfgInstData::ArrayInit {
+                elements_start,
+                elements_len,
+            },
+            array_ty,
+        );
+        let (payload_start, payload_len) = cfg.push_extra([constant]);
+        let enum_value = add(
+            &mut cfg,
+            CfgInstData::EnumVariant {
+                enum_id,
+                variant_index: 1,
+                payload_start,
+                payload_len,
+            },
+            enum_ty,
+        );
+        add(
+            &mut cfg,
+            CfgInstData::EnumPayloadGet {
+                base: enum_value,
+                enum_id,
+                variant_index: 1,
+                field_index: 0,
+            },
+            Type::I32,
+        );
+        add(
+            &mut cfg,
+            CfgInstData::IntCast {
+                value: constant,
+                from_ty: Type::I32,
+            },
+            Type::U64,
+        );
+        add(
+            &mut cfg,
+            CfgInstData::Drop {
+                value: struct_value,
+            },
+            Type::UNIT,
+        );
+        add(
+            &mut cfg,
+            CfgInstData::StorageLive {
+                slot: 1,
+                local_ty: Type::I32,
+            },
+            Type::UNIT,
+        );
+        add(
+            &mut cfg,
+            CfgInstData::StorageDead {
+                slot: 1,
+                local_ty: Type::I32,
+            },
+            Type::UNIT,
+        );
+        add(
+            &mut cfg,
+            CfgInstData::PlaceRead {
+                place: Place::local(0, Type::I32),
+            },
+            Type::I32,
+        );
+        add(
+            &mut cfg,
+            CfgInstData::PlaceWrite {
+                place: Place::local(0, Type::I32),
+                value: constant,
+            },
+            Type::UNIT,
+        );
+        cfg.set_terminator(
+            entry,
+            Terminator::Return {
+                value: Some(constant),
+            },
+        );
+
+        assert_eq!(values.len(), 40, "fixture must contain every CFG variant");
+        (cfg, pool.freeze(), interner, values)
+    }
+
     #[test]
     fn aggregate_shape_has_no_single_slot_fallback() {
         let shape = ValueShape::CompleteAggregate { slot_count: 3 };
@@ -457,6 +772,19 @@ mod tests {
             }),
             (0, 65535)
         );
+        assert_eq!(
+            comparison_integer_width(Type::BOOL),
+            IntegerWidth {
+                bits: 32,
+                signed: false
+            }
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "scalar comparison requires an integer or bool type")]
+    fn invalid_scalar_comparison_type_is_not_defaulted_to_32_bits() {
+        comparison_integer_width(Type::UNIT);
     }
 
     #[test]
@@ -898,6 +1226,132 @@ mod tests {
                 .instructions()
                 .iter()
                 .any(|inst| matches!(inst, Aarch64Inst::LdrIndexed { .. }))
+        );
+    }
+
+    #[test]
+    fn both_target_debug_traces_cover_every_cfg_value_variant() {
+        let (cfg, pool, interner, values) = every_cfg_value_fixture();
+        let (x86, x86_debug) = X86CfgLower::new(&cfg, &pool, &interner)
+            .lower_with_debug()
+            .expect("x86 coverage fixture should lower");
+        let (arm, arm_debug) = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
+            .lower_with_debug()
+            .expect("AArch64 coverage fixture should lower");
+
+        let signature = |debug: &crate::LoweringDebugInfo| {
+            let mut entries = debug
+                .blocks
+                .iter()
+                .flat_map(|block| block.instructions.iter())
+                .map(|decision| {
+                    (
+                        decision.cfg_value.as_u32(),
+                        decision.cfg_inst_desc.clone(),
+                        decision.cfg_type.clone(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            entries.sort_by_key(|entry| entry.0);
+            entries
+        };
+        assert_eq!(signature(&x86_debug), signature(&arm_debug));
+
+        let mut expected_ids = values
+            .iter()
+            .map(|value| value.as_u32())
+            .collect::<Vec<_>>();
+        expected_ids.sort_unstable();
+        let actual_ids = signature(&x86_debug)
+            .iter()
+            .map(|entry| entry.0)
+            .collect::<Vec<_>>();
+        assert_eq!(actual_ids, expected_ids);
+
+        for value in &values {
+            let expected_kind = kind(&cfg.get_inst(*value).data);
+            assert!(
+                all_value_kinds().contains(&expected_kind),
+                "variant {expected_kind:?} must be in the exhaustive policy inventory"
+            );
+            let x86_decision = x86_debug
+                .blocks
+                .iter()
+                .flat_map(|block| block.instructions.iter())
+                .find(|decision| decision.cfg_value == *value)
+                .expect("x86 debug trace must contain every CFG value");
+            let arm_decision = arm_debug
+                .blocks
+                .iter()
+                .flat_map(|block| block.instructions.iter())
+                .find(|decision| decision.cfg_value == *value)
+                .expect("AArch64 debug trace must contain every CFG value");
+
+            // Only the three intentional no-op policies lack target MIR: a
+            // preallocated block parameter and storage lifetime markers.
+            if !matches!(
+                expected_kind,
+                ValueKind::BlockParameter | ValueKind::StorageLive | ValueKind::StorageDead
+            ) {
+                assert!(
+                    !x86_decision.mir_insts.is_empty(),
+                    "x86 variant {expected_kind:?} must produce MIR"
+                );
+                assert!(
+                    !arm_decision.mir_insts.is_empty(),
+                    "AArch64 variant {expected_kind:?} must produce MIR"
+                );
+            }
+        }
+
+        // These are the aggregate cases whose complete slot policy must be
+        // visible in the same fixture rather than inferred from planner-only
+        // assertions.
+        for value in &values {
+            let ty = cfg.get_inst(*value).ty;
+            if ty.is_struct() || ty.is_array() || ty.is_enum() {
+                let plan = ValuePlan::for_value(
+                    &crate::cfg_lower::CfgLowerContext::new(&cfg, &pool),
+                    *value,
+                );
+                assert!(plan.shape.requires_complete_slots());
+                assert!(plan.shape.slot_count() > 0 || ty.is_struct() || ty.is_array());
+            }
+        }
+
+        assert!(!x86.instructions().is_empty());
+        assert!(!arm.instructions().is_empty());
+    }
+
+    #[test]
+    fn zero_slot_aggregate_parameter_emits_no_frame_load_on_either_target() {
+        let pool = TypeInternPool::new();
+        let array_id = pool.intern_array_from_type(Type::UNIT, 2);
+        let pool = pool.freeze();
+        let array_ty = Type::new_array(array_id);
+        let mut cfg = Cfg::new(array_ty, 0, 1, "zero_slot_param".to_string(), vec![false]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let param = cfg.add_inst(inst(CfgInstData::Param { index: 0 }, array_ty));
+        cfg.get_block_mut(entry).insts.push(param);
+        cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
+        let interner = ThreadedRodeo::new();
+
+        let x86 = X86CfgLower::new(&cfg, &pool, &interner)
+            .lower()
+            .expect("x86 zero-slot parameter should lower");
+        let arm = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
+            .lower()
+            .expect("AArch64 zero-slot parameter should lower");
+        assert!(
+            !x86.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::MovRM { .. }))
+        );
+        assert!(
+            !arm.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::Ldr { .. }))
         );
     }
 }

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1,0 +1,903 @@
+//! Target-independent CFG value materialization policy.
+//!
+//! `ValuePlan` is the policy record shared by both concrete MIR lowerers.  It
+//! deliberately contains no CFG value references and no target state: the
+//! lowerers use the CFG value only as the lookup key, then consume the same
+//! decided shape, width, and requirements while selecting instructions.
+//!
+//! This module is intentionally a decision tree rather than a generic MIR
+//! abstraction.  Adding a `CfgInstData` variant that participates in value
+//! materialization requires updating the exhaustive match below, so an
+//! architecture cannot quietly invent a different scalar/aggregate policy.
+
+use rue_air::TypeKind;
+use rue_cfg::{CfgInstData, CfgValue, Type};
+
+use crate::cfg_lower::CfgLowerContext;
+
+/// The representation required by a value consumer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueShape {
+    /// No storage slots exist.  A primary vreg may still be used as a
+    /// never-read placeholder for CFG bookkeeping.
+    ZeroSized,
+    /// Exactly one logical slot; the primary vreg is the complete value.
+    Scalar,
+    /// Every logical slot must be present.  The first slot is the primary
+    /// vreg, and the vector is always in ascending logical order.
+    CompleteAggregate { slot_count: u32 },
+}
+
+impl ValueShape {
+    pub const fn slot_count(self) -> u32 {
+        match self {
+            Self::ZeroSized => 0,
+            Self::Scalar => 1,
+            Self::CompleteAggregate { slot_count } => slot_count,
+        }
+    }
+
+    pub const fn requires_complete_slots(self) -> bool {
+        matches!(self, Self::CompleteAggregate { .. })
+    }
+}
+
+/// Integer width and signedness selected once for arithmetic/comparison and
+/// coercion preparation.  Non-integer values use `None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IntegerWidth {
+    pub bits: u32,
+    pub signed: bool,
+}
+
+/// The language operation whose target adapter must emit instructions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueKind {
+    Constant,
+    BoolConstant,
+    StringConstant,
+    Parameter,
+    BlockParameter,
+    BinaryArithmetic,
+    Comparison,
+    UnaryArithmetic,
+    Bitwise,
+    Shift,
+    Allocation,
+    Load,
+    Store,
+    ParameterStore,
+    Call,
+    Intrinsic,
+    StructInit,
+    ArrayInit,
+    EnumVariant,
+    EnumPayloadGet,
+    IntegerCast,
+    Drop,
+    StorageLive,
+    StorageDead,
+    PlaceRead,
+    PlaceWrite,
+}
+
+/// Extra language policy required by a materialization site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaterializationRequirement {
+    /// The primary vreg is sufficient.
+    Primary,
+    /// The complete logical slot vector must be materialized and consumed.
+    CompleteSlots,
+    /// The operation is a side effect and its value is only a bookkeeping
+    /// placeholder (for example a store or storage marker).
+    SideEffect,
+}
+
+/// How a comparison must be prepared before target-specific condition codes
+/// are selected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComparisonPreparation {
+    Unit,
+    Scalar { width: IntegerWidth },
+    Aggregate { slot_count: u32 },
+    StringContent { slot_count: u32 },
+}
+
+/// How a value is rooted in storage.  This is shared because by-ref loading,
+/// frame loading, and place loading must agree on whether a pointer is a
+/// value or an address of the value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoragePolicy {
+    None,
+    LocalSlot { slot: u32 },
+    ParameterSlot { slot: u32, by_ref: bool },
+    Place,
+}
+
+/// A complete target-neutral value materialization decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ValuePlan {
+    pub kind: ValueKind,
+    pub shape: ValueShape,
+    pub requirement: MaterializationRequirement,
+    pub integer_width: Option<IntegerWidth>,
+    /// The source width selected for an integer cast, when this value is a
+    /// cast. Keeping both sides here prevents an adapter from re-deriving
+    /// cast width or signedness from the source type.
+    pub source_integer_width: Option<IntegerWidth>,
+    pub comparison: Option<ComparisonPreparation>,
+    pub storage: StoragePolicy,
+    /// StrBuf has a fixed three-slot ownership representation even though it
+    /// is otherwise handled through the ordinary aggregate slot machinery.
+    pub is_strbuf: bool,
+}
+
+impl ValuePlan {
+    /// Decide the policy for one CFG instruction.  `value` is only used to
+    /// inspect operand types; it is not retained in the returned plan.
+    pub fn for_value(ctx: &CfgLowerContext<'_>, value: CfgValue) -> Self {
+        let inst = ctx.cfg.get_inst(value);
+        let ty = inst.ty;
+        let shape = shape(ctx, ty);
+        let value_width = integer_width(ty);
+        let mut plan = Self {
+            kind: kind(&inst.data),
+            shape,
+            requirement: if shape.requires_complete_slots() {
+                MaterializationRequirement::CompleteSlots
+            } else {
+                MaterializationRequirement::Primary
+            },
+            integer_width: value_width,
+            source_integer_width: match &inst.data {
+                CfgInstData::IntCast { from_ty, .. } => integer_width(*from_ty),
+                _ => None,
+            },
+            comparison: None,
+            storage: StoragePolicy::None,
+            is_strbuf: ctx.is_strbuf(ty),
+        };
+
+        plan.storage = match &inst.data {
+            CfgInstData::Alloc { slot, .. }
+            | CfgInstData::Load { slot }
+            | CfgInstData::StorageLive { slot, .. }
+            | CfgInstData::StorageDead { slot, .. } => StoragePolicy::LocalSlot { slot: *slot },
+            CfgInstData::Param { index } => {
+                let by_ref = ctx.cfg.is_param_by_ref(*index);
+                StoragePolicy::ParameterSlot {
+                    slot: *index,
+                    by_ref,
+                }
+            }
+            CfgInstData::ParamStore { param_slot, .. } => StoragePolicy::ParameterSlot {
+                slot: *param_slot,
+                by_ref: true,
+            },
+            CfgInstData::PlaceRead { .. } | CfgInstData::PlaceWrite { .. } => StoragePolicy::Place,
+            _ => StoragePolicy::None,
+        };
+
+        plan.comparison = match &inst.data {
+            CfgInstData::Eq(lhs, _)
+            | CfgInstData::Ne(lhs, _)
+            | CfgInstData::Lt(lhs, _)
+            | CfgInstData::Gt(lhs, _)
+            | CfgInstData::Le(lhs, _)
+            | CfgInstData::Ge(lhs, _) => {
+                let lhs_ty = ctx.cfg.get_inst(*lhs).ty;
+                if ctx.is_string_like_for_equality(lhs_ty) {
+                    Some(ComparisonPreparation::StringContent {
+                        slot_count: ctx.type_slot_count(lhs_ty),
+                    })
+                } else if ctx.is_multislot_aggregate(lhs_ty) {
+                    Some(ComparisonPreparation::Aggregate {
+                        slot_count: ctx.type_slot_count(lhs_ty),
+                    })
+                } else if lhs_ty == Type::UNIT {
+                    Some(ComparisonPreparation::Unit)
+                } else {
+                    Some(ComparisonPreparation::Scalar {
+                        width: integer_width(lhs_ty).unwrap_or(IntegerWidth {
+                            bits: 32,
+                            signed: false,
+                        }),
+                    })
+                }
+            }
+            _ => None,
+        };
+
+        if matches!(
+            inst.data,
+            CfgInstData::Store { .. }
+                | CfgInstData::ParamStore { .. }
+                | CfgInstData::PlaceWrite { .. }
+                | CfgInstData::StorageLive { .. }
+                | CfgInstData::StorageDead { .. }
+                | CfgInstData::Drop { .. }
+        ) {
+            plan.requirement = MaterializationRequirement::SideEffect;
+        }
+
+        plan
+    }
+
+    /// Enforce the no-single-slot fallback invariant at the shared boundary.
+    pub fn assert_complete_slots(self, actual: usize) {
+        if let ValueShape::CompleteAggregate { slot_count } = self.shape {
+            assert_eq!(
+                actual, slot_count as usize,
+                "complete aggregate plan requires {slot_count} slots, got {actual}"
+            );
+        }
+    }
+
+    /// Return the already-decided width for a scalar comparison.  Aggregate,
+    /// string, and unit comparisons are handled by their own shared modes.
+    pub fn comparison_width(self) -> IntegerWidth {
+        match self.comparison {
+            Some(ComparisonPreparation::Scalar { width }) => width,
+            other => panic!("scalar comparison width requested for {other:?}"),
+        }
+    }
+}
+
+/// Classify every current language-level CFG value variant.  Keeping this
+/// match separate from target MIR code makes the classification auditable and
+/// prevents either backend from silently adding a scalar fallback.
+pub const fn kind(data: &CfgInstData) -> ValueKind {
+    match data {
+        CfgInstData::Const(_) => ValueKind::Constant,
+        CfgInstData::BoolConst(_) => ValueKind::BoolConstant,
+        CfgInstData::StringConst(_) => ValueKind::StringConstant,
+        CfgInstData::Param { .. } => ValueKind::Parameter,
+        CfgInstData::BlockParam { .. } => ValueKind::BlockParameter,
+        CfgInstData::Add(..)
+        | CfgInstData::Sub(..)
+        | CfgInstData::Mul(..)
+        | CfgInstData::Div(..)
+        | CfgInstData::Mod(..) => ValueKind::BinaryArithmetic,
+        CfgInstData::Eq(..)
+        | CfgInstData::Ne(..)
+        | CfgInstData::Lt(..)
+        | CfgInstData::Gt(..)
+        | CfgInstData::Le(..)
+        | CfgInstData::Ge(..) => ValueKind::Comparison,
+        CfgInstData::Neg(..) | CfgInstData::Not(..) => ValueKind::UnaryArithmetic,
+        CfgInstData::BitNot(..) => ValueKind::Bitwise,
+        CfgInstData::BitAnd(..) | CfgInstData::BitOr(..) | CfgInstData::BitXor(..) => {
+            ValueKind::Bitwise
+        }
+        CfgInstData::Shl(..) | CfgInstData::Shr(..) => ValueKind::Shift,
+        CfgInstData::Alloc { .. } => ValueKind::Allocation,
+        CfgInstData::Load { .. } => ValueKind::Load,
+        CfgInstData::Store { .. } => ValueKind::Store,
+        CfgInstData::ParamStore { .. } => ValueKind::ParameterStore,
+        CfgInstData::Call { .. } => ValueKind::Call,
+        CfgInstData::Intrinsic { .. } => ValueKind::Intrinsic,
+        CfgInstData::StructInit { .. } => ValueKind::StructInit,
+        CfgInstData::ArrayInit { .. } => ValueKind::ArrayInit,
+        CfgInstData::EnumVariant { .. } => ValueKind::EnumVariant,
+        CfgInstData::EnumPayloadGet { .. } => ValueKind::EnumPayloadGet,
+        CfgInstData::IntCast { .. } => ValueKind::IntegerCast,
+        CfgInstData::Drop { .. } => ValueKind::Drop,
+        CfgInstData::StorageLive { .. } => ValueKind::StorageLive,
+        CfgInstData::StorageDead { .. } => ValueKind::StorageDead,
+        CfgInstData::PlaceRead { .. } => ValueKind::PlaceRead,
+        CfgInstData::PlaceWrite { .. } => ValueKind::PlaceWrite,
+    }
+}
+
+fn shape(ctx: &CfgLowerContext<'_>, ty: Type) -> ValueShape {
+    let slots = ctx.type_slot_count(ty);
+    if ctx.is_multislot_aggregate(ty) {
+        // A zero-slot struct/array is still an aggregate.  Its complete
+        // representation is the empty vector, not a scalar placeholder.
+        ValueShape::CompleteAggregate { slot_count: slots }
+    } else if slots == 0 {
+        ValueShape::ZeroSized
+    } else {
+        ValueShape::Scalar
+    }
+}
+
+/// Select the language integer width and signedness used by all adapters.
+pub fn integer_width(ty: Type) -> Option<IntegerWidth> {
+    let bits = match ty.kind() {
+        TypeKind::I8 | TypeKind::U8 => 8,
+        TypeKind::I16 | TypeKind::U16 => 16,
+        TypeKind::I32 | TypeKind::U32 => 32,
+        TypeKind::I64 | TypeKind::U64 => 64,
+        _ => return None,
+    };
+    Some(IntegerWidth {
+        bits,
+        signed: ty.is_signed(),
+    })
+}
+
+/// Shared signedness query for target encodings that need a flag or extension
+/// form after the integer policy has been selected.
+pub fn type_is_signed(ty: Type) -> bool {
+    integer_width(ty).is_some_and(|width| width.signed)
+}
+
+/// Shared integer-width helper used by both target adapters.
+pub fn type_bits(ty: Type) -> u32 {
+    integer_width(ty)
+        .map(|width| width.bits)
+        .unwrap_or_else(|| panic!("type_bits called on non-integer type: {:?}", ty))
+}
+
+/// Return whether an integer type uses the machine's 64-bit value width.
+///
+/// This preserves the old `Type::is_64_bit` behavior for non-integer types:
+/// those types are not 64-bit integers, so callers that are only selecting an
+/// integer instruction width must receive `false` rather than forcing an
+/// integer-only plan.
+pub fn is_64_bit(ty: Type) -> bool {
+    integer_width(ty).is_some_and(|width| width.bits == 64)
+}
+
+/// Shared integer range helper used by checked casts and division guards.
+pub fn type_range(ty: Type) -> (i64, i64) {
+    integer_width(ty)
+        .map(integer_range)
+        .unwrap_or_else(|| panic!("type_range called on non-integer type: {:?}", ty))
+}
+
+/// Return the representable range selected by a shared integer-width plan.
+pub fn integer_range(width: IntegerWidth) -> (i64, i64) {
+    match (width.bits, width.signed) {
+        (8, true) => (i8::MIN as i64, i8::MAX as i64),
+        (16, true) => (i16::MIN as i64, i16::MAX as i64),
+        (32, true) => (i32::MIN as i64, i32::MAX as i64),
+        (64, true) => (i64::MIN, i64::MAX),
+        (8, false) => (0, u8::MAX as i64),
+        (16, false) => (0, u16::MAX as i64),
+        (32, false) => (0, u32::MAX as i64),
+        (64, false) => (0, i64::MAX),
+        _ => panic!("invalid integer width: {width:?}"),
+    }
+}
+
+/// Return the by-reference parameter slots that must be preloaded before the
+/// block walk.  Both backends use this exact policy and cache rule.
+pub fn by_ref_param_slots(ctx: &CfgLowerContext<'_>) -> Vec<u32> {
+    (0..ctx.num_params)
+        .filter(|&slot| ctx.cfg.is_param_by_ref(slot))
+        .collect()
+}
+
+/// Validate the shared slot policy for a value and its materialized cache.
+pub fn assert_slot_policy(plan: ValuePlan, actual: usize) {
+    if plan.shape.requires_complete_slots() {
+        plan.assert_complete_slots(actual);
+    } else if actual > 1 {
+        panic!("scalar value plan unexpectedly has {actual} materialized slots");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ComparisonPreparation, IntegerWidth, MaterializationRequirement, StoragePolicy, ValueKind,
+        ValuePlan, ValueShape, assert_slot_policy, integer_range, kind, type_bits, type_range,
+    };
+    use lasso::{Spur, ThreadedRodeo};
+    use rue_air::{LangItem, StructDef, StructField, TypeInternPool};
+    use rue_cfg::{Cfg, CfgInst, CfgInstData, CfgValue, Place, Terminator, Type};
+    use rue_span::{FileId, Span};
+    use rue_target::Target;
+
+    use crate::aarch64::{Aarch64Inst, CfgLower as Aarch64CfgLower};
+    use crate::x86_64::{CfgLower as X86CfgLower, X86Inst};
+
+    fn synthetic_cfg(
+        values: impl IntoIterator<Item = CfgInst>,
+        num_locals: u32,
+        num_params: u32,
+        param_modes: Vec<bool>,
+        return_value: CfgValue,
+    ) -> Cfg {
+        let mut cfg = Cfg::new(
+            Type::I32,
+            num_locals,
+            num_params,
+            "value_plan_test".to_string(),
+            param_modes,
+        );
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        for (index, inst) in values.into_iter().enumerate() {
+            let value = cfg.add_inst(inst);
+            assert_eq!(value.as_u32(), index as u32);
+            cfg.get_block_mut(entry).insts.push(value);
+        }
+        cfg.set_terminator(
+            entry,
+            Terminator::Return {
+                value: Some(return_value),
+            },
+        );
+        cfg
+    }
+
+    fn inst(data: CfgInstData, ty: Type) -> CfgInst {
+        CfgInst {
+            data,
+            ty,
+            span: Span::new(0, 0),
+        }
+    }
+
+    fn dummy_value() -> CfgValue {
+        CfgValue::from_raw(0)
+    }
+
+    #[test]
+    fn aggregate_shape_has_no_single_slot_fallback() {
+        let shape = ValueShape::CompleteAggregate { slot_count: 3 };
+        assert!(shape.requires_complete_slots());
+        assert_eq!(shape.slot_count(), 3);
+        assert!(ValueShape::CompleteAggregate { slot_count: 0 }.requires_complete_slots());
+    }
+
+    #[test]
+    fn shared_integer_policy_carries_width_and_signedness() {
+        assert_eq!(type_bits(Type::I8), 8);
+        assert_eq!(type_bits(Type::U64), 64);
+        assert_eq!(type_range(Type::I16), (i16::MIN as i64, i16::MAX as i64));
+        assert_eq!(type_range(Type::U32), (0, u32::MAX as i64));
+        assert_eq!(
+            integer_range(IntegerWidth {
+                bits: 16,
+                signed: false
+            }),
+            (0, 65535)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "scalar value plan unexpectedly has 2 materialized slots")]
+    fn scalar_plan_cannot_accept_multiple_slots() {
+        assert_slot_policy(
+            ValuePlan {
+                kind: ValueKind::Load,
+                shape: ValueShape::Scalar,
+                requirement: MaterializationRequirement::Primary,
+                integer_width: Some(IntegerWidth {
+                    bits: 32,
+                    signed: true,
+                }),
+                source_integer_width: None,
+                comparison: None,
+                storage: super::StoragePolicy::None,
+                is_strbuf: false,
+            },
+            2,
+        );
+    }
+
+    #[test]
+    fn planner_is_exhaustive_for_every_cfg_value_variant() {
+        let v = dummy_value();
+        let place = Place::local(0, Type::I32);
+        let symbol = Spur::default();
+        let cases = vec![
+            (CfgInstData::Const(1), ValueKind::Constant),
+            (CfgInstData::BoolConst(true), ValueKind::BoolConstant),
+            (CfgInstData::StringConst(0), ValueKind::StringConstant),
+            (CfgInstData::Param { index: 0 }, ValueKind::Parameter),
+            (
+                CfgInstData::BlockParam { index: 0 },
+                ValueKind::BlockParameter,
+            ),
+            (CfgInstData::Add(v, v), ValueKind::BinaryArithmetic),
+            (CfgInstData::Sub(v, v), ValueKind::BinaryArithmetic),
+            (CfgInstData::Mul(v, v), ValueKind::BinaryArithmetic),
+            (CfgInstData::Div(v, v), ValueKind::BinaryArithmetic),
+            (CfgInstData::Mod(v, v), ValueKind::BinaryArithmetic),
+            (CfgInstData::Eq(v, v), ValueKind::Comparison),
+            (CfgInstData::Ne(v, v), ValueKind::Comparison),
+            (CfgInstData::Lt(v, v), ValueKind::Comparison),
+            (CfgInstData::Gt(v, v), ValueKind::Comparison),
+            (CfgInstData::Le(v, v), ValueKind::Comparison),
+            (CfgInstData::Ge(v, v), ValueKind::Comparison),
+            (CfgInstData::BitAnd(v, v), ValueKind::Bitwise),
+            (CfgInstData::BitOr(v, v), ValueKind::Bitwise),
+            (CfgInstData::BitXor(v, v), ValueKind::Bitwise),
+            (CfgInstData::Shl(v, v), ValueKind::Shift),
+            (CfgInstData::Shr(v, v), ValueKind::Shift),
+            (CfgInstData::Neg(v), ValueKind::UnaryArithmetic),
+            (CfgInstData::Not(v), ValueKind::UnaryArithmetic),
+            (CfgInstData::BitNot(v), ValueKind::Bitwise),
+            (
+                CfgInstData::Alloc { slot: 0, init: v },
+                ValueKind::Allocation,
+            ),
+            (CfgInstData::Load { slot: 0 }, ValueKind::Load),
+            (CfgInstData::Store { slot: 0, value: v }, ValueKind::Store),
+            (
+                CfgInstData::ParamStore {
+                    param_slot: 0,
+                    value: v,
+                },
+                ValueKind::ParameterStore,
+            ),
+            (
+                CfgInstData::Call {
+                    name: symbol,
+                    args_start: 0,
+                    args_len: 0,
+                },
+                ValueKind::Call,
+            ),
+            (
+                CfgInstData::Intrinsic {
+                    name: symbol,
+                    args_start: 0,
+                    args_len: 0,
+                },
+                ValueKind::Intrinsic,
+            ),
+            (
+                CfgInstData::StructInit {
+                    struct_id: rue_air::StructId(0),
+                    fields_start: 0,
+                    fields_len: 0,
+                },
+                ValueKind::StructInit,
+            ),
+            (
+                CfgInstData::ArrayInit {
+                    elements_start: 0,
+                    elements_len: 0,
+                },
+                ValueKind::ArrayInit,
+            ),
+            (
+                CfgInstData::EnumVariant {
+                    enum_id: rue_air::EnumId(0),
+                    variant_index: 0,
+                    payload_start: 0,
+                    payload_len: 0,
+                },
+                ValueKind::EnumVariant,
+            ),
+            (
+                CfgInstData::EnumPayloadGet {
+                    base: v,
+                    enum_id: rue_air::EnumId(0),
+                    variant_index: 0,
+                    field_index: 0,
+                },
+                ValueKind::EnumPayloadGet,
+            ),
+            (
+                CfgInstData::IntCast {
+                    value: v,
+                    from_ty: Type::I32,
+                },
+                ValueKind::IntegerCast,
+            ),
+            (CfgInstData::Drop { value: v }, ValueKind::Drop),
+            (
+                CfgInstData::StorageLive {
+                    slot: 0,
+                    local_ty: Type::I32,
+                },
+                ValueKind::StorageLive,
+            ),
+            (
+                CfgInstData::StorageDead {
+                    slot: 0,
+                    local_ty: Type::I32,
+                },
+                ValueKind::StorageDead,
+            ),
+            (CfgInstData::PlaceRead { place }, ValueKind::PlaceRead),
+            (
+                CfgInstData::PlaceWrite { place, value: v },
+                ValueKind::PlaceWrite,
+            ),
+        ];
+
+        let values = cases
+            .iter()
+            .map(|(data, _)| inst(data.clone(), Type::I32))
+            .collect::<Vec<_>>();
+        let cfg = synthetic_cfg(values, 1, 1, vec![true], dummy_value());
+        let pool = rue_air::FrozenTypeInternPool::new();
+        let ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
+
+        for (index, (_, expected)) in cases.iter().enumerate() {
+            let value = CfgValue::from_raw(index as u32);
+            let plan = ValuePlan::for_value(&ctx, value);
+            assert_eq!(plan.kind, *expected, "variant at CFG value {value}");
+            assert_eq!(plan.kind, kind(&cfg.get_inst(value).data));
+        }
+        assert_eq!(cases.len(), 40, "test must cover every CfgInstData variant");
+    }
+
+    #[test]
+    fn planner_decides_storage_comparison_and_cast_policy_from_real_cfg_values() {
+        let v = dummy_value();
+        let values = vec![
+            inst(CfgInstData::Const(7), Type::I64),
+            inst(CfgInstData::Const(9), Type::I64),
+            inst(
+                CfgInstData::Lt(CfgValue::from_raw(0), CfgValue::from_raw(1)),
+                Type::BOOL,
+            ),
+            inst(CfgInstData::Alloc { slot: 2, init: v }, Type::I64),
+            inst(CfgInstData::Load { slot: 2 }, Type::I64),
+            inst(CfgInstData::Store { slot: 2, value: v }, Type::UNIT),
+            inst(
+                CfgInstData::IntCast {
+                    value: v,
+                    from_ty: Type::I8,
+                },
+                Type::U64,
+            ),
+        ];
+        let cfg = synthetic_cfg(values, 3, 1, vec![true], CfgValue::from_raw(4));
+        let pool = rue_air::FrozenTypeInternPool::new();
+        let ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
+
+        assert_eq!(
+            ValuePlan::for_value(&ctx, CfgValue::from_raw(0)).integer_width,
+            Some(IntegerWidth {
+                bits: 64,
+                signed: true
+            })
+        );
+        assert_eq!(
+            ValuePlan::for_value(&ctx, CfgValue::from_raw(2)).comparison,
+            Some(ComparisonPreparation::Scalar {
+                width: IntegerWidth {
+                    bits: 64,
+                    signed: true
+                }
+            })
+        );
+        assert_eq!(
+            ValuePlan::for_value(&ctx, CfgValue::from_raw(3)).storage,
+            StoragePolicy::LocalSlot { slot: 2 }
+        );
+        assert_eq!(
+            ValuePlan::for_value(&ctx, CfgValue::from_raw(4)).storage,
+            StoragePolicy::LocalSlot { slot: 2 }
+        );
+        assert_eq!(
+            ValuePlan::for_value(&ctx, CfgValue::from_raw(5)).requirement,
+            MaterializationRequirement::SideEffect
+        );
+        assert_eq!(
+            ValuePlan::for_value(&ctx, CfgValue::from_raw(6)).integer_width,
+            Some(IntegerWidth {
+                bits: 64,
+                signed: false
+            })
+        );
+        assert_eq!(
+            ValuePlan::for_value(&ctx, CfgValue::from_raw(6)).source_integer_width,
+            Some(IntegerWidth {
+                bits: 8,
+                signed: true
+            })
+        );
+
+        let byref_cfg = synthetic_cfg(
+            vec![inst(CfgInstData::Param { index: 0 }, Type::I32)],
+            0,
+            1,
+            vec![true],
+            dummy_value(),
+        );
+        let byref_pool = rue_air::FrozenTypeInternPool::new();
+        let byref_ctx = crate::cfg_lower::CfgLowerContext::new(&byref_cfg, &byref_pool);
+        assert_eq!(
+            ValuePlan::for_value(&byref_ctx, dummy_value()).storage,
+            StoragePolicy::ParameterSlot {
+                slot: 0,
+                by_ref: true
+            }
+        );
+
+        let unsigned_cfg = synthetic_cfg(
+            vec![
+                inst(CfgInstData::Const(1), Type::U32),
+                inst(CfgInstData::Const(2), Type::U32),
+                inst(
+                    CfgInstData::Lt(CfgValue::from_raw(0), CfgValue::from_raw(1)),
+                    Type::BOOL,
+                ),
+            ],
+            0,
+            0,
+            vec![],
+            CfgValue::from_raw(2),
+        );
+        let unsigned_pool = rue_air::FrozenTypeInternPool::new();
+        let unsigned_ctx = crate::cfg_lower::CfgLowerContext::new(&unsigned_cfg, &unsigned_pool);
+        assert_eq!(
+            ValuePlan::for_value(&unsigned_ctx, CfgValue::from_raw(2)).comparison,
+            Some(ComparisonPreparation::Scalar {
+                width: IntegerWidth {
+                    bits: 32,
+                    signed: false
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn planner_preserves_zero_sized_aggregate_and_strbuf_layouts() {
+        let empty_pool = TypeInternPool::new();
+        let empty_array_id = empty_pool.intern_array_from_type(Type::UNIT, 2);
+        let empty_pool = empty_pool.freeze();
+        let empty_array_ty = Type::new_array(empty_array_id);
+        let empty_cfg = synthetic_cfg(
+            vec![inst(
+                CfgInstData::ArrayInit {
+                    elements_start: 0,
+                    elements_len: 0,
+                },
+                empty_array_ty,
+            )],
+            0,
+            0,
+            vec![],
+            dummy_value(),
+        );
+        let empty_ctx = crate::cfg_lower::CfgLowerContext::new(&empty_cfg, &empty_pool);
+        let empty_plan = ValuePlan::for_value(&empty_ctx, dummy_value());
+        assert_eq!(
+            empty_plan.shape,
+            ValueShape::CompleteAggregate { slot_count: 0 }
+        );
+        assert_eq!(
+            empty_plan.requirement,
+            MaterializationRequirement::CompleteSlots
+        );
+        assert_slot_policy(empty_plan, 0);
+
+        let strbuf_pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let name = interner.get_or_intern("StrBuf");
+        let (struct_id, _) = strbuf_pool.register_struct(
+            name,
+            StructDef {
+                name: "StrBuf".to_string(),
+                fields: vec![
+                    StructField {
+                        name: "ptr".to_string(),
+                        ty: Type::U64,
+                    },
+                    StructField {
+                        name: "len".to_string(),
+                        ty: Type::U64,
+                    },
+                    StructField {
+                        name: "cap".to_string(),
+                        ty: Type::U64,
+                    },
+                ],
+                is_copy: false,
+                is_linear: false,
+                destructor: None,
+                is_builtin: true,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        strbuf_pool.set_struct_lang_item(struct_id, LangItem::StrBuf);
+        let strbuf_pool = strbuf_pool.freeze();
+        let strbuf_ty = Type::new_struct(struct_id);
+        let strbuf_cfg = synthetic_cfg(
+            vec![inst(
+                CfgInstData::StructInit {
+                    struct_id,
+                    fields_start: 0,
+                    fields_len: 0,
+                },
+                strbuf_ty,
+            )],
+            0,
+            0,
+            vec![],
+            dummy_value(),
+        );
+        let strbuf_ctx = crate::cfg_lower::CfgLowerContext::new(&strbuf_cfg, &strbuf_pool);
+        let strbuf_plan = ValuePlan::for_value(&strbuf_ctx, dummy_value());
+        assert!(strbuf_plan.is_strbuf);
+        assert_eq!(strbuf_plan.shape.slot_count(), 3);
+        assert!(strbuf_plan.shape.requires_complete_slots());
+    }
+
+    #[test]
+    fn both_target_adapters_consume_shared_width_and_byref_policy() {
+        let values = vec![
+            inst(CfgInstData::Const(7), Type::I64),
+            inst(CfgInstData::Const(9), Type::I64),
+            inst(
+                CfgInstData::Lt(CfgValue::from_raw(0), CfgValue::from_raw(1)),
+                Type::BOOL,
+            ),
+            inst(
+                CfgInstData::IntCast {
+                    value: CfgValue::from_raw(0),
+                    from_ty: Type::I64,
+                },
+                Type::U64,
+            ),
+            inst(CfgInstData::Const(1), Type::I32),
+        ];
+        let cfg = synthetic_cfg(values, 0, 0, vec![], CfgValue::from_raw(4));
+        let pool = rue_air::FrozenTypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let (x86, x86_debug) = X86CfgLower::new(&cfg, &pool, &interner)
+            .lower_with_debug()
+            .expect("x86 fixture should lower");
+        let (arm, arm_debug) = Aarch64CfgLower::new(&cfg, &pool, &interner, Target::Aarch64Linux)
+            .lower_with_debug()
+            .expect("AArch64 fixture should lower");
+
+        let x86_debug_cases = x86_debug
+            .blocks
+            .iter()
+            .flat_map(|block| block.instructions.iter())
+            .map(|decision| (&decision.cfg_inst_desc, &decision.cfg_type))
+            .collect::<Vec<_>>();
+        let arm_debug_cases = arm_debug
+            .blocks
+            .iter()
+            .flat_map(|block| block.instructions.iter())
+            .map(|decision| (&decision.cfg_inst_desc, &decision.cfg_type))
+            .collect::<Vec<_>>();
+        assert_eq!(x86_debug_cases, arm_debug_cases);
+
+        assert_eq!(
+            x86.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, X86Inst::Cmp64RR { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            arm.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, Aarch64Inst::Cmp64RR { .. }))
+                .count(),
+            1
+        );
+
+        let byref_cfg = synthetic_cfg(
+            vec![inst(CfgInstData::Param { index: 0 }, Type::I32)],
+            0,
+            1,
+            vec![true],
+            dummy_value(),
+        );
+        let x86_byref = X86CfgLower::new(&byref_cfg, &pool, &interner)
+            .lower()
+            .expect("x86 by-ref fixture should lower");
+        let arm_byref = Aarch64CfgLower::new(&byref_cfg, &pool, &interner, Target::Aarch64Linux)
+            .lower()
+            .expect("AArch64 by-ref fixture should lower");
+        assert!(
+            x86_byref
+                .instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::MovRMIndexed { .. }))
+        );
+        assert!(
+            arm_byref
+                .instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::LdrIndexed { .. }))
+        );
+    }
+}

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -545,6 +545,25 @@ impl<'a> CfgLower<'a> {
                 terminator: None,
             };
 
+            // Block parameters are preallocated before the block walk and
+            // therefore never reach `lower_value`'s MIR-emission path. Keep
+            // them in lowering debug output so the trace remains a complete
+            // CFG-to-MIR account, including intentional no-op materialization.
+            for (param_val, _) in &block.params {
+                let param_inst = self.ctx.cfg.get_inst(*param_val);
+                block_info.instructions.push(LoweringDecision {
+                    cfg_value: *param_val,
+                    cfg_inst_desc: format_cfg_inst_data_with_interner(
+                        self.ctx.cfg,
+                        &param_inst.data,
+                        self.interner,
+                    ),
+                    cfg_type: param_inst.ty.name().to_string(),
+                    mir_insts: Vec::new(),
+                    rationale: Some("Block parameter preallocated at the join".to_string()),
+                });
+            }
+
             // Emit block label (except for entry block)
             if block.id != self.ctx.cfg.entry {
                 self.mir.push(X86Inst::Label {
@@ -576,19 +595,17 @@ impl<'a> CfgLower<'a> {
                 // Generate rationale for interesting cases
                 let rationale = self.get_lowering_rationale(&inst.data, inst.ty);
 
-                if !mir_insts.is_empty() {
-                    block_info.instructions.push(LoweringDecision {
-                        cfg_value: value,
-                        cfg_inst_desc: format_cfg_inst_data_with_interner(
-                            self.ctx.cfg,
-                            &inst.data,
-                            self.interner,
-                        ),
-                        cfg_type: inst.ty.name().to_string(),
-                        mir_insts,
-                        rationale,
-                    });
-                }
+                block_info.instructions.push(LoweringDecision {
+                    cfg_value: value,
+                    cfg_inst_desc: format_cfg_inst_data_with_interner(
+                        self.ctx.cfg,
+                        &inst.data,
+                        self.interner,
+                    ),
+                    cfg_type: inst.ty.name().to_string(),
+                    mir_insts,
+                    rationale,
+                });
             }
 
             // Lower terminator with tracking
@@ -852,7 +869,19 @@ impl<'a> CfgLower<'a> {
                 // aggregate, and write paths all use uniform frame-slot loads,
                 // including ABI slots beyond the six argument registers.
                 // (RUE-13/79/91)
-                if is_by_ref {
+                if is_by_ref && value_plan.shape.requires_complete_slots() {
+                    // Aggregate parameters must materialize their complete
+                    // logical representation through the shared slot policy.
+                    // In particular, a zero-slot struct/array has no frame
+                    // load at all; `max(1)` here would read a neighboring
+                    // slot and turn a ZST into a scalar value.
+                    let slots = self.require_aggregate_slots(value);
+                    let primary = slots
+                        .first()
+                        .copied()
+                        .unwrap_or_else(|| self.mir.alloc_vreg());
+                    self.value_map.insert(value, primary);
+                } else if is_by_ref {
                     // For by-ref params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.
                     let ptr_vreg = self.ensure_by_ref_param_ptr(*index);
@@ -866,6 +895,13 @@ impl<'a> CfgLower<'a> {
                     });
 
                     self.value_map.insert(value, val_vreg);
+                } else if value_plan.shape.requires_complete_slots() {
+                    let slots = self.require_aggregate_slots(value);
+                    let primary = slots
+                        .first()
+                        .copied()
+                        .unwrap_or_else(|| self.mir.alloc_vreg());
+                    self.value_map.insert(value, primary);
                 } else {
                     // Normal parameter: the primary vreg is the value's LOGICAL
                     // slot 0 (e.g. an enum's discriminant). Ascending layout
@@ -875,8 +911,7 @@ impl<'a> CfgLower<'a> {
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
 
-                    let count = value_plan.shape.slot_count().max(1);
-                    let slot = self.ctx.num_locals + *index + count - 1;
+                    let slot = self.ctx.num_locals + *index;
                     let offset = self.ctx.local_offset(slot);
                     self.mir.push(X86Inst::MovRM {
                         dst: Operand::Virtual(vreg),
@@ -3523,8 +3558,8 @@ impl<'a> CfgLower<'a> {
                 // Copy args to target's block params
                 let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                 for (i, &arg) in args.iter().enumerate() {
-                    let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if self.ctx.is_multislot_aggregate(arg_type) {
+                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
+                    if arg_plan.shape.requires_complete_slots() {
                         // For aggregate args (structs, String, arrays), copy all slot vregs
                         self.copy_aggregate_to_block_param(arg, *target, i as u32);
                     } else {
@@ -3575,8 +3610,8 @@ impl<'a> CfgLower<'a> {
                 // Copy then_args to then_block's params
                 let then_args = self.ctx.cfg.get_extra(*then_args_start, *then_args_len);
                 for (i, &arg) in then_args.iter().enumerate() {
-                    let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if self.ctx.is_multislot_aggregate(arg_type) {
+                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
+                    if arg_plan.shape.requires_complete_slots() {
                         // For aggregate args (structs, String, arrays), copy all slot vregs
                         self.copy_aggregate_to_block_param(arg, *then_block, i as u32);
                     } else {
@@ -3601,8 +3636,8 @@ impl<'a> CfgLower<'a> {
                 });
                 let else_args = self.ctx.cfg.get_extra(*else_args_start, *else_args_len);
                 for (i, &arg) in else_args.iter().enumerate() {
-                    let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if self.ctx.is_multislot_aggregate(arg_type) {
+                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
+                    if arg_plan.shape.requires_complete_slots() {
                         // For aggregate args (structs, String, arrays), copy all slot vregs
                         self.copy_aggregate_to_block_param(arg, *else_block, i as u32);
                     } else {
@@ -3689,7 +3724,7 @@ impl<'a> CfgLower<'a> {
                     return;
                 };
 
-                let return_type = self.ctx.cfg.return_type();
+                let return_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, *value);
 
                 if self.fn_name == "main" {
                     let val_vreg = self.get_vreg(*value);
@@ -3703,7 +3738,7 @@ impl<'a> CfgLower<'a> {
                     // it 0 mod 16 at callee entry, violating SysV ABI).
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(X86Inst::CallRel { symbol_id });
-                } else if self.ctx.is_multislot_aggregate(return_type) {
+                } else if return_plan.shape.requires_complete_slots() {
                     // Return a multi-slot aggregate (struct, array, or payload
                     // enum). Every valid source has exactly `type_slot_count`
                     // materialized vregs. (RUE-118, RUE-78, RUE-237)

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -193,10 +193,8 @@ impl<'a> CfgLower<'a> {
     /// flow begins, so the function-wide cache only contains definitions that
     /// dominate every block which may reuse them.
     fn preload_by_ref_param_ptrs(&mut self) {
-        for param_slot in 0..self.ctx.num_params {
-            if self.ctx.cfg.is_param_by_ref(param_slot) {
-                self.ensure_by_ref_param_ptr(param_slot);
-            }
+        for param_slot in crate::value_plan::by_ref_param_slots(&self.ctx) {
+            self.ensure_by_ref_param_ptr(param_slot);
         }
     }
 
@@ -311,9 +309,14 @@ impl<'a> CfgLower<'a> {
     /// For 32-bit-and-narrower types the compares run at 32-bit width:
     /// sub-word values are kept sign-extended in the low 32 bits of their
     /// registers, so comparing against the type's MIN there is exact.
-    fn emit_signed_div_overflow_check(&mut self, ty: Type, lhs_vreg: VReg, rhs_vreg: VReg) {
+    fn emit_signed_div_overflow_check(
+        &mut self,
+        width: crate::value_plan::IntegerWidth,
+        lhs_vreg: VReg,
+        rhs_vreg: VReg,
+    ) {
         let ok_label = self.new_label();
-        if ty.is_64_bit() {
+        if width.bits == 64 {
             // divisor == -1?
             self.mir.push(X86Inst::Cmp64RI {
                 src: Operand::Virtual(rhs_vreg),
@@ -331,7 +334,7 @@ impl<'a> CfgLower<'a> {
                 src2: Operand::Virtual(min_vreg),
             });
         } else {
-            let (min_val, _) = Self::type_range(ty);
+            let (min_val, _) = crate::value_plan::integer_range(width);
             // divisor == -1?
             self.mir.push(X86Inst::CmpRI {
                 src: Operand::Virtual(rhs_vreg),
@@ -397,9 +400,13 @@ impl<'a> CfgLower<'a> {
         let dst = Operand::Virtual(vreg);
         let src = Operand::Virtual(vreg);
         match Self::type_bits(ty) {
-            8 if ty.is_signed() => self.mir.push(X86Inst::Movsx8To64 { dst, src }),
+            8 if crate::value_plan::type_is_signed(ty) => {
+                self.mir.push(X86Inst::Movsx8To64 { dst, src })
+            }
             8 => self.mir.push(X86Inst::Movzx8To64 { dst, src }),
-            16 if ty.is_signed() => self.mir.push(X86Inst::Movsx16To64 { dst, src }),
+            16 if crate::value_plan::type_is_signed(ty) => {
+                self.mir.push(X86Inst::Movsx16To64 { dst, src })
+            }
             16 => self.mir.push(X86Inst::Movzx16To64 { dst, src }),
             _ => {}
         }
@@ -612,7 +619,7 @@ impl<'a> CfgLower<'a> {
     fn get_lowering_rationale(&self, data: &CfgInstData, ty: Type) -> Option<String> {
         match data {
             CfgInstData::Add(_, _) | CfgInstData::Sub(_, _) | CfgInstData::Mul(_, _) => {
-                if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
+                if crate::value_plan::is_64_bit(ty) {
                     Some("64-bit operation with 64-bit overflow check".to_string())
                 } else if matches!(
                     ty.kind(),
@@ -747,8 +754,25 @@ impl<'a> CfgLower<'a> {
             return;
         }
 
+        // Decide scalar-vs-complete-slot shape, storage root, comparison
+        // preparation, and integer width in the shared policy layer before any
+        // target instruction is selected.  The backend match below is an
+        // instruction-selection adapter; it must not make a competing shape
+        // decision.
+        let value_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, value);
+
         let inst = self.ctx.cfg.get_inst(value);
         let ty = inst.ty;
+        let plan_is_64 = value_plan
+            .integer_width
+            .is_some_and(|width| width.bits == 64);
+        let plan_is_signed = value_plan.integer_width.is_some_and(|width| width.signed);
+
+        assert_eq!(
+            value_plan.kind,
+            crate::value_plan::kind(&inst.data),
+            "backend value dispatch must consume the shared ValueKind"
+        );
 
         match &inst.data {
             CfgInstData::Const(v) => {
@@ -802,7 +826,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 let mut slot_vregs = vec![ptr_vreg, len_vreg];
-                if self.ctx.type_slot_count(ty) >= 3 {
+                if value_plan.shape.slot_count() >= 3 {
                     let cap_vreg = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::StringConstCap {
                         dst: Operand::Virtual(cap_vreg),
@@ -817,7 +841,10 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::Param { index } => {
                 // Check if this parameter is physically passed by reference.
-                let is_by_ref = self.ctx.cfg.is_param_by_ref(*index);
+                let is_by_ref = matches!(
+                    value_plan.storage,
+                    crate::value_plan::StoragePolicy::ParameterSlot { by_ref: true, .. }
+                );
 
                 // The prologue copies every ABI arg slot — register- and
                 // stack-passed alike — into the contiguous frame param area
@@ -848,8 +875,7 @@ impl<'a> CfgLower<'a> {
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
 
-                    let param_ty = self.ctx.cfg.get_inst(value).ty;
-                    let count = self.ctx.type_slot_count(param_ty).max(1);
+                    let count = value_plan.shape.slot_count().max(1);
                     let slot = self.ctx.num_locals + *index + count - 1;
                     let offset = self.ctx.local_offset(slot);
                     self.mir.push(X86Inst::MovRM {
@@ -877,7 +903,10 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Use 64-bit add for 64-bit types to get correct overflow detection
-                if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
+                if value_plan
+                    .integer_width
+                    .is_some_and(|width| width.bits == 64)
+                {
                     self.mir.push(X86Inst::AddRR64 {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Virtual(rhs_vreg),
@@ -890,7 +919,12 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Overflow check - use appropriate flag based on signedness
-                self.emit_overflow_check(ty, vreg);
+                self.emit_overflow_check(
+                    value_plan
+                        .integer_width
+                        .expect("arithmetic plan must include integer width"),
+                    vreg,
+                );
             }
 
             CfgInstData::Sub(lhs, rhs) => {
@@ -906,7 +940,10 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Use 64-bit sub for 64-bit types to get correct overflow detection
-                if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
+                if value_plan
+                    .integer_width
+                    .is_some_and(|width| width.bits == 64)
+                {
                     self.mir.push(X86Inst::SubRR64 {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Virtual(rhs_vreg),
@@ -919,7 +956,12 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Overflow check - use appropriate flag based on signedness
-                self.emit_overflow_check(ty, vreg);
+                self.emit_overflow_check(
+                    value_plan
+                        .integer_width
+                        .expect("arithmetic plan must include integer width"),
+                    vreg,
+                );
             }
 
             CfgInstData::Mul(lhs, rhs) => {
@@ -936,10 +978,9 @@ impl<'a> CfgLower<'a> {
                 //
                 // Future optimization: x * 2 could use `add x, x` instead of `shl x, 1`
                 // (same latency but potentially better for some microarchitectures).
-                let is_word_or_larger = matches!(
-                    ty.kind(),
-                    TypeKind::I32 | TypeKind::I64 | TypeKind::U32 | TypeKind::U64
-                );
+                let is_word_or_larger = value_plan
+                    .integer_width
+                    .is_some_and(|width| width.bits >= 32);
                 let shift_amount = if is_word_or_larger {
                     self.try_power_of_two_shift(*rhs)
                         .or_else(|| self.try_power_of_two_shift(*lhs))
@@ -962,7 +1003,7 @@ impl<'a> CfgLower<'a> {
                     });
 
                     // Emit shift left
-                    if ty.is_64_bit() {
+                    if plan_is_64 {
                         self.mir.push(X86Inst::ShlRI {
                             dst: Operand::Virtual(vreg),
                             imm: shift,
@@ -983,8 +1024,8 @@ impl<'a> CfgLower<'a> {
                     });
 
                     // Use arithmetic shift (SAR) for signed, logical shift (SHR) for unsigned
-                    if ty.is_signed() {
-                        if ty.is_64_bit() {
+                    if plan_is_signed {
+                        if plan_is_64 {
                             self.mir.push(X86Inst::SarRI {
                                 dst: Operand::Virtual(check_vreg),
                                 imm: shift,
@@ -995,7 +1036,7 @@ impl<'a> CfgLower<'a> {
                                 imm: shift,
                             });
                         }
-                    } else if ty.is_64_bit() {
+                    } else if plan_is_64 {
                         self.mir.push(X86Inst::ShrRI {
                             dst: Operand::Virtual(check_vreg),
                             imm: shift,
@@ -1008,7 +1049,7 @@ impl<'a> CfgLower<'a> {
                     }
 
                     // Compare with original value
-                    if ty.is_64_bit() {
+                    if plan_is_64 {
                         self.mir.push(X86Inst::Cmp64RR {
                             src1: Operand::Virtual(check_vreg),
                             src2: Operand::Virtual(src_vreg),
@@ -1028,7 +1069,7 @@ impl<'a> CfgLower<'a> {
                     let symbol_id = self.intern_symbol("__rue_overflow");
                     self.mir.push(X86Inst::CallRel { symbol_id });
                     self.mir.push(X86Inst::Label { id: ok_label });
-                } else if matches!(ty.kind(), TypeKind::U32 | TypeKind::U64) {
+                } else if !plan_is_signed && is_word_or_larger {
                     // Unsigned 32/64-bit: two-operand IMUL's OF/CF report
                     // *signed* overflow, which both misses real unsigned
                     // overflows and falsely fires on valid products with the
@@ -1042,7 +1083,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Physical(Reg::Rax),
                         src: Operand::Virtual(lhs_vreg),
                     });
-                    self.mir.push(if ty.is_64_bit() {
+                    self.mir.push(if plan_is_64 {
                         X86Inst::Mul64R {
                             src: Operand::Virtual(rhs_vreg),
                         }
@@ -1058,7 +1099,12 @@ impl<'a> CfgLower<'a> {
 
                     // MOV does not modify flags, so MUL's CF still drives the
                     // JAE check here.
-                    self.emit_overflow_check(ty, vreg);
+                    self.emit_overflow_check(
+                        value_plan
+                            .integer_width
+                            .expect("arithmetic plan must include integer width"),
+                        vreg,
+                    );
                 } else {
                     // Fall back to IMUL for non-power-of-2 constants
                     let rhs_vreg = self.get_vreg(*rhs);
@@ -1069,7 +1115,7 @@ impl<'a> CfgLower<'a> {
                     });
 
                     // Use 64-bit mul for 64-bit types to get correct overflow detection
-                    if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
+                    if plan_is_64 {
                         self.mir.push(X86Inst::ImulRR64 {
                             dst: Operand::Virtual(vreg),
                             src: Operand::Virtual(rhs_vreg),
@@ -1088,7 +1134,12 @@ impl<'a> CfgLower<'a> {
                     // exact product mod 2^32, and emit_overflow_check
                     // range-checks that value against the type's bounds.
                     // (u32/u64 take the one-operand MUL branch above.)
-                    self.emit_overflow_check(ty, vreg);
+                    self.emit_overflow_check(
+                        value_plan
+                            .integer_width
+                            .expect("arithmetic plan must include integer width"),
+                        vreg,
+                    );
                 }
             }
 
@@ -1103,7 +1154,10 @@ impl<'a> CfgLower<'a> {
                 // 64-bit — a 32-bit test would only look at the low half and
                 // falsely trap (or fail to trap) when the high bits differ
                 // (RUE-26).
-                let is_64 = ty.is_64_bit();
+                let width = value_plan
+                    .integer_width
+                    .expect("division plan must include integer width");
+                let is_64 = width.bits == 64;
                 let ok_label = self.new_label();
                 if is_64 {
                     self.mir.push(X86Inst::Test64RR {
@@ -1122,8 +1176,14 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(X86Inst::Label { id: ok_label });
 
                 // Signed MIN / -1 overflows; trap it explicitly (RUE-30).
-                if ty.is_signed() {
-                    self.emit_signed_div_overflow_check(ty, lhs_vreg, rhs_vreg);
+                if width.signed {
+                    self.emit_signed_div_overflow_check(
+                        value_plan
+                            .integer_width
+                            .expect("division plan must include integer width"),
+                        lhs_vreg,
+                        rhs_vreg,
+                    );
                 }
 
                 self.mir.push(X86Inst::MovRR {
@@ -1134,7 +1194,7 @@ impl<'a> CfgLower<'a> {
                 // Use signed division (CDQ/CQO + IDIV) for signed types,
                 // unsigned division (XOR EDX,EDX + DIV) for unsigned types,
                 // selecting 64-bit forms for 64-bit operands (RUE-26).
-                self.emit_div_core(is_64, ty.is_signed(), rhs_vreg);
+                self.emit_div_core(is_64, width.signed, rhs_vreg);
 
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Virtual(vreg),
@@ -1149,7 +1209,10 @@ impl<'a> CfgLower<'a> {
                 let lhs_vreg = self.get_vreg(*lhs);
                 let rhs_vreg = self.get_vreg(*rhs);
 
-                let is_64 = ty.is_64_bit();
+                let width = value_plan
+                    .integer_width
+                    .expect("modulo plan must include integer width");
+                let is_64 = width.bits == 64;
                 let ok_label = self.new_label();
                 if is_64 {
                     self.mir.push(X86Inst::Test64RR {
@@ -1169,8 +1232,14 @@ impl<'a> CfgLower<'a> {
 
                 // Signed MIN % -1 overflows like MIN / -1 (the implied
                 // quotient -MIN is unrepresentable); trap it (RUE-30).
-                if ty.is_signed() {
-                    self.emit_signed_div_overflow_check(ty, lhs_vreg, rhs_vreg);
+                if width.signed {
+                    self.emit_signed_div_overflow_check(
+                        value_plan
+                            .integer_width
+                            .expect("modulo plan must include integer width"),
+                        lhs_vreg,
+                        rhs_vreg,
+                    );
                 }
 
                 self.mir.push(X86Inst::MovRR {
@@ -1181,7 +1250,7 @@ impl<'a> CfgLower<'a> {
                 // Use signed division (CDQ/CQO + IDIV) for signed types,
                 // unsigned division (XOR EDX,EDX + DIV) for unsigned types,
                 // selecting 64-bit forms for 64-bit operands (RUE-26).
-                self.emit_div_core(is_64, ty.is_signed(), rhs_vreg);
+                self.emit_div_core(is_64, width.signed, rhs_vreg);
 
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Virtual(vreg),
@@ -1201,7 +1270,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Use 64-bit neg for 64-bit types to get correct overflow detection
-                if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
+                if plan_is_64 {
                     self.mir.push(X86Inst::Neg64 {
                         dst: Operand::Virtual(vreg),
                     });
@@ -1216,7 +1285,12 @@ impl<'a> CfgLower<'a> {
                 // For unsigned types: NEG sets CF for all non-zero values,
                 // but we only care about -0 = 0 (no overflow). Since negation
                 // of any non-zero unsigned value would wrap (0 - x), we check CF.
-                self.emit_overflow_check(ty, vreg);
+                self.emit_overflow_check(
+                    value_plan
+                        .integer_width
+                        .expect("arithmetic plan must include integer width"),
+                    vreg,
+                );
             }
 
             CfgInstData::Not(operand) => {
@@ -1247,7 +1321,7 @@ impl<'a> CfgLower<'a> {
                 });
                 // 64-bit operands need a REX.W `not`; the 32-bit form would
                 // zero the high 32 bits of the result (RUE-59).
-                self.mir.push(if ty.is_64_bit() {
+                self.mir.push(if plan_is_64 {
                     X86Inst::Not64R {
                         dst: Operand::Virtual(vreg),
                     }
@@ -1275,7 +1349,7 @@ impl<'a> CfgLower<'a> {
                 });
                 // 64-bit operands need a REX.W `and`; a 32-bit `and` would zero
                 // the high 32 bits of the result (RUE-58).
-                self.mir.push(if ty.is_64_bit() {
+                self.mir.push(if plan_is_64 {
                     X86Inst::And64RR {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Virtual(rhs_vreg),
@@ -1299,7 +1373,7 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Virtual(lhs_vreg),
                 });
-                self.mir.push(if ty.is_64_bit() {
+                self.mir.push(if plan_is_64 {
                     X86Inst::Or64RR {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Virtual(rhs_vreg),
@@ -1323,7 +1397,7 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Virtual(lhs_vreg),
                 });
-                self.mir.push(if ty.is_64_bit() {
+                self.mir.push(if plan_is_64 {
                     X86Inst::Xor64RR {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Virtual(rhs_vreg),
@@ -1357,7 +1431,7 @@ impl<'a> CfgLower<'a> {
                 let rhs_inst = &self.ctx.cfg.get_inst(*rhs).data;
                 if let CfgInstData::Const(shift_amount) = rhs_inst {
                     let imm = (*shift_amount & count_mask) as u8;
-                    if ty.is_64_bit() {
+                    if plan_is_64 {
                         self.mir.push(X86Inst::ShlRI {
                             dst: Operand::Virtual(vreg),
                             imm,
@@ -1375,7 +1449,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Physical(Reg::Rcx),
                         src: Operand::Virtual(count_vreg),
                     });
-                    if ty.is_64_bit() {
+                    if plan_is_64 {
                         self.mir.push(X86Inst::ShlRCl {
                             dst: Operand::Virtual(vreg),
                         });
@@ -1411,17 +1485,17 @@ impl<'a> CfgLower<'a> {
                     let imm = (*shift_amount & count_mask) as u8;
                     // Use arithmetic shift (SAR) for signed types, logical shift (SHR) for unsigned
                     // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                    if ty.is_64_bit() && ty.is_signed() {
+                    if plan_is_64 && plan_is_signed {
                         self.mir.push(X86Inst::SarRI {
                             dst: Operand::Virtual(vreg),
                             imm,
                         });
-                    } else if ty.is_64_bit() {
+                    } else if plan_is_64 {
                         self.mir.push(X86Inst::ShrRI {
                             dst: Operand::Virtual(vreg),
                             imm,
                         });
-                    } else if ty.is_signed() {
+                    } else if plan_is_signed {
                         self.mir.push(X86Inst::Sar32RI {
                             dst: Operand::Virtual(vreg),
                             imm,
@@ -1442,15 +1516,15 @@ impl<'a> CfgLower<'a> {
 
                     // Use arithmetic shift (SAR) for signed types, logical shift (SHR) for unsigned
                     // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                    if ty.is_64_bit() && ty.is_signed() {
+                    if plan_is_64 && plan_is_signed {
                         self.mir.push(X86Inst::SarRCl {
                             dst: Operand::Virtual(vreg),
                         });
-                    } else if ty.is_64_bit() {
+                    } else if plan_is_64 {
                         self.mir.push(X86Inst::ShrRCl {
                             dst: Operand::Virtual(vreg),
                         });
-                    } else if ty.is_signed() {
+                    } else if plan_is_signed {
                         self.mir.push(X86Inst::Sar32RCl {
                             dst: Operand::Virtual(vreg),
                         });
@@ -1465,12 +1539,18 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Eq(lhs, rhs) => {
                 let lhs_ty = self.ctx.cfg.get_inst(*lhs).ty;
 
-                if self.ctx.is_string_like_for_equality(lhs_ty) {
+                if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::StringContent { .. })
+                ) {
                     // String-like equality compares byte content, not the
                     // pointer/len/cap fields structurally.
                     let vreg = self.emit_builtin_eq_call(*lhs, *rhs, "__rue_str_eq");
                     self.value_map.insert(value, vreg);
-                } else if lhs_ty == Type::UNIT {
+                } else if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Unit)
+                ) {
                     // Unit equality: () == () is always true
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
@@ -1478,7 +1558,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 1,
                     });
-                } else if self.ctx.is_multislot_aggregate(lhs_ty) {
+                } else if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Aggregate { .. })
+                ) {
                     // Structural equality: compare every slot (struct fields,
                     // array elements, or an enum's tag + payload). (RUE-285)
                     self.emit_aggregate_equality(value, *lhs, *rhs, lhs_ty, false);
@@ -1494,7 +1577,10 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Ne(lhs, rhs) => {
                 let lhs_ty = self.ctx.cfg.get_inst(*lhs).ty;
 
-                if self.ctx.is_string_like_for_equality(lhs_ty) {
+                if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::StringContent { .. })
+                ) {
                     // String-like inequality is the inverse of byte-content
                     // equality.
                     let vreg = self.emit_builtin_eq_call(*lhs, *rhs, "__rue_str_eq");
@@ -1503,7 +1589,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 1,
                     });
-                } else if lhs_ty == Type::UNIT {
+                } else if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Unit)
+                ) {
                     // Unit inequality: () != () is always false
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
@@ -1511,7 +1600,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 0,
                     });
-                } else if self.ctx.is_multislot_aggregate(lhs_ty) {
+                } else if matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Aggregate { .. })
+                ) {
                     // Structural inequality: compare every slot, invert result.
                     // (RUE-285)
                     self.emit_aggregate_equality(value, *lhs, *rhs, lhs_ty, true);
@@ -1525,7 +1617,12 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Lt(lhs, rhs) => {
-                let is_unsigned = self.is_unsigned_comparison(*lhs);
+                let is_unsigned = matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Scalar {
+                        width: crate::value_plan::IntegerWidth { signed: false, .. }
+                    })
+                );
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
                     if is_unsigned {
                         mir.push(X86Inst::Setb {
@@ -1540,7 +1637,12 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Gt(lhs, rhs) => {
-                let is_unsigned = self.is_unsigned_comparison(*lhs);
+                let is_unsigned = matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Scalar {
+                        width: crate::value_plan::IntegerWidth { signed: false, .. }
+                    })
+                );
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
                     if is_unsigned {
                         mir.push(X86Inst::Seta {
@@ -1555,7 +1657,12 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Le(lhs, rhs) => {
-                let is_unsigned = self.is_unsigned_comparison(*lhs);
+                let is_unsigned = matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Scalar {
+                        width: crate::value_plan::IntegerWidth { signed: false, .. }
+                    })
+                );
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
                     if is_unsigned {
                         mir.push(X86Inst::Setbe {
@@ -1570,7 +1677,12 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Ge(lhs, rhs) => {
-                let is_unsigned = self.is_unsigned_comparison(*lhs);
+                let is_unsigned = matches!(
+                    value_plan.comparison,
+                    Some(crate::value_plan::ComparisonPreparation::Scalar {
+                        width: crate::value_plan::IntegerWidth { signed: false, .. }
+                    })
+                );
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
                     if is_unsigned {
                         mir.push(X86Inst::Setae {
@@ -2229,7 +2341,10 @@ impl<'a> CfgLower<'a> {
                     });
                     let ext_dst = Operand::Virtual(offset_vreg);
                     let ext_src = Operand::Virtual(offset_vreg);
-                    match (Self::type_bits(offset_ty), offset_ty.is_signed()) {
+                    match (
+                        Self::type_bits(offset_ty),
+                        crate::value_plan::type_is_signed(offset_ty),
+                    ) {
                         (8, true) => self.mir.push(X86Inst::Movsx8To64 {
                             dst: ext_dst,
                             src: ext_src,
@@ -2624,8 +2739,7 @@ impl<'a> CfgLower<'a> {
                 payload_len,
                 ..
             } => {
-                let vty = self.ctx.cfg.get_inst(value).ty;
-                if *payload_len == 0 && self.ctx.type_slot_count(vty) <= 1 {
+                if matches!(value_plan.shape, crate::value_plan::ValueShape::Scalar) {
                     // Discriminant-only (C-like) enum: a single-slot scalar
                     // holding the variant index.
                     let vreg = self.mir.alloc_vreg();
@@ -2651,8 +2765,7 @@ impl<'a> CfgLower<'a> {
                 let (enum_id, variant_index, field_index) =
                     (*enum_id, *variant_index, *field_index);
                 let base = *base;
-                let vty = self.ctx.cfg.get_inst(value).ty;
-                let field_slots = self.ctx.type_slot_count(vty) as usize;
+                let field_slots = value_plan.shape.slot_count() as usize;
                 let offset = types::enum_payload_slot_offset(
                     self.ctx.type_pool,
                     enum_id,
@@ -2690,26 +2803,30 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IntCast {
                 value: src_value,
-                from_ty,
+                from_ty: _,
             } => {
                 // Integer cast with runtime range check
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
                 let src_vreg = self.get_vreg(*src_value);
-                let to_ty = self.ctx.cfg.get_inst(value).ty;
-
                 // Emit range check and panic if out of bounds
-                self.emit_int_cast_check(src_vreg, *from_ty, to_ty);
+                let from_width = value_plan
+                    .source_integer_width
+                    .expect("integer cast plan must include source width");
+                let to_width = value_plan
+                    .integer_width
+                    .expect("integer cast plan must include destination width");
+                self.emit_int_cast_check(src_vreg, from_width, to_width);
 
                 // Move the value to the result vreg. A signed source widened to a
                 // larger type must be SIGN-extended into the high bits — a plain
                 // 64-bit copy would carry the source's zero-extended high bits,
                 // turning e.g. i32 -5 into 4294967291 (RUE-88). The value is held
                 // zero-extended in the register, so emit an explicit movsx.
-                let from_bits = Self::type_bits(*from_ty);
-                let to_bits = Self::type_bits(to_ty);
-                if from_ty.is_signed() && to_bits > from_bits {
+                let from_bits = from_width.bits;
+                let to_bits = to_width.bits;
+                if from_width.signed && to_bits > from_bits {
                     let dst = Operand::Virtual(vreg);
                     let src = Operand::Virtual(src_vreg);
                     match from_bits {
@@ -2745,7 +2862,9 @@ impl<'a> CfgLower<'a> {
                     // Multi-slot structs use the complete aggregate
                     // representation. Zero- and one-slot structs use their
                     // scalar/ZST flattening.
-                    let field_vregs = if self.ctx.is_multislot_aggregate(dropped_ty) {
+                    let dropped_plan =
+                        crate::value_plan::ValuePlan::for_value(&self.ctx, *dropped_value);
+                    let field_vregs = if dropped_plan.shape.requires_complete_slots() {
                         self.require_aggregate_slots(*dropped_value)
                     } else {
                         self.collect_struct_scalar_vregs(*dropped_value)
@@ -2810,7 +2929,9 @@ impl<'a> CfgLower<'a> {
                     // slot counts past the argument registers go on the stack
                     // via emit_call_with_slot_args — e.g. [String; 3] is 9
                     // slots, RUE-193)
-                    let mut element_vregs = if self.ctx.is_multislot_aggregate(dropped_ty) {
+                    let dropped_plan =
+                        crate::value_plan::ValuePlan::for_value(&self.ctx, *dropped_value);
+                    let mut element_vregs = if dropped_plan.shape.requires_complete_slots() {
                         self.require_aggregate_slots(*dropped_value)
                     } else {
                         self.collect_array_scalar_vregs(*dropped_value)
@@ -2878,14 +2999,14 @@ impl<'a> CfgLower<'a> {
                 // A multi-slot aggregate value (struct, String, array, or
                 // payload enum) has one vreg per logical slot; PlaceWrite must
                 // store that complete representation. (RUE-118, RUE-23)
-                let val_type = self.ctx.cfg.get_inst(*val).ty;
+                let val_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, *val);
                 // A zero-sized value has no bytes to store (RUE-577): writing
                 // the dummy vreg CFG carries for unit would clobber a
                 // neighboring slot, and a ZST destination's origin shift
                 // underflows. Nothing to do.
-                let vals = if self.ctx.is_multislot_aggregate(val_type) {
+                let vals = if val_plan.shape.requires_complete_slots() {
                     self.require_aggregate_slots(*val)
-                } else if self.ctx.type_slot_count(val_type) == 0 {
+                } else if val_plan.shape.slot_count() == 0 {
                     Vec::new()
                 } else {
                     vec![self.get_vreg(*val)]
@@ -2893,13 +3014,16 @@ impl<'a> CfgLower<'a> {
                 crate::place_lower::lower_place_write(self, place, &vals);
             }
         }
-    }
 
-    /// Check if a comparison should use unsigned comparison instructions.
-    ///
-    /// Sema guarantees both operands have the same signedness, so we only need to check one.
-    fn is_unsigned_comparison(&self, lhs: CfgValue) -> bool {
-        self.ctx.cfg.get_inst(lhs).ty.is_unsigned()
+        if matches!(
+            value_plan.requirement,
+            crate::value_plan::MaterializationRequirement::CompleteSlots
+        ) {
+            let slots = crate::agg_slots::require_aggregate_slots(self, value);
+            crate::value_plan::assert_slot_policy(value_plan, slots.len());
+        } else if let Some(slots) = self.struct_slot_vregs.get(&value) {
+            crate::value_plan::assert_slot_policy(value_plan, slots.len());
+        }
     }
 
     /// Try to extract a power-of-two shift amount from a constant value.
@@ -2938,20 +3062,20 @@ impl<'a> CfgLower<'a> {
     ///
     /// For sub-word types (8/16-bit), the arithmetic is done in 32/64-bit registers,
     /// so we need to check if the result fits in the original type's range.
-    fn emit_overflow_check(&mut self, ty: Type, result_vreg: VReg) {
+    fn emit_overflow_check(&mut self, width: crate::value_plan::IntegerWidth, result_vreg: VReg) {
         let ok_label = self.new_label();
 
-        match ty.kind() {
+        match (width.bits, width.signed) {
             // 32-bit and 64-bit unsigned: check carry flag
-            TypeKind::U32 | TypeKind::U64 => {
+            (32 | 64, false) => {
                 self.mir.push(X86Inst::Jae { label: ok_label });
             }
             // 32-bit and 64-bit signed: check overflow flag
-            TypeKind::I32 | TypeKind::I64 => {
+            (32 | 64, true) => {
                 self.mir.push(X86Inst::Jno { label: ok_label });
             }
             // Sub-word unsigned types: check if result fits in range [0, max]
-            TypeKind::U8 => {
+            (8, false) => {
                 // Result must be <= 255
                 self.mir.push(X86Inst::CmpRI {
                     src: Operand::Virtual(result_vreg),
@@ -2960,7 +3084,7 @@ impl<'a> CfgLower<'a> {
                 // Jump if below or equal (unsigned)
                 self.mir.push(X86Inst::Jbe { label: ok_label });
             }
-            TypeKind::U16 => {
+            (16, false) => {
                 // Result must be <= 65535
                 let max_vreg = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRI32 {
@@ -2975,7 +3099,7 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(X86Inst::Jbe { label: ok_label });
             }
             // Sub-word signed types: check if result fits in range [min, max]
-            TypeKind::I8 => {
+            (8, true) => {
                 // For i8: result must be in [-128, 127]
                 // Sign-extend to 64-bit and compare with original
                 // If they differ, overflow occurred
@@ -2997,7 +3121,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(X86Inst::Jz { label: ok_label });
             }
-            TypeKind::I16 => {
+            (16, true) => {
                 // For i16: result must be in [-32768, 32767]
                 // Sign-extend to 64-bit and compare with original
                 let sext_vreg = self.mir.alloc_vreg();
@@ -3060,12 +3184,16 @@ impl<'a> CfgLower<'a> {
     ///
     /// Checks if the source value can be represented in the target type.
     /// Panics via `__rue_intcast_overflow` if the value is out of range.
-    fn emit_int_cast_check(&mut self, src_vreg: VReg, from_ty: Type, to_ty: Type) {
-        // Get type properties
-        let from_signed = from_ty.is_signed();
-        let to_signed = to_ty.is_signed();
-        let from_bits = Self::type_bits(from_ty);
-        let to_bits = Self::type_bits(to_ty);
+    fn emit_int_cast_check(
+        &mut self,
+        src_vreg: VReg,
+        from_width: crate::value_plan::IntegerWidth,
+        to_width: crate::value_plan::IntegerWidth,
+    ) {
+        let from_signed = from_width.signed;
+        let to_signed = to_width.signed;
+        let from_bits = from_width.bits;
+        let to_bits = to_width.bits;
 
         // If casting to a larger or equal-sized type with compatible signedness,
         // and source is unsigned or both are signed, no check needed
@@ -3086,7 +3214,7 @@ impl<'a> CfgLower<'a> {
         let ok_label = self.new_label();
 
         // Calculate the min and max values for the target type
-        let (min_val, max_val) = Self::type_range(to_ty);
+        let (min_val, max_val) = crate::value_plan::integer_range(to_width);
 
         if from_signed {
             // Source is signed - need to check both min and max
@@ -3253,28 +3381,7 @@ impl<'a> CfgLower<'a> {
 
     /// Get the bit width of an integer type.
     fn type_bits(ty: Type) -> u32 {
-        match ty.kind() {
-            TypeKind::I8 | TypeKind::U8 => 8,
-            TypeKind::I16 | TypeKind::U16 => 16,
-            TypeKind::I32 | TypeKind::U32 => 32,
-            TypeKind::I64 | TypeKind::U64 => 64,
-            _ => panic!("type_bits called on non-integer type: {:?}", ty),
-        }
-    }
-
-    /// Get the min and max values for an integer type.
-    fn type_range(ty: Type) -> (i64, i64) {
-        match ty.kind() {
-            TypeKind::I8 => (i8::MIN as i64, i8::MAX as i64),
-            TypeKind::I16 => (i16::MIN as i64, i16::MAX as i64),
-            TypeKind::I32 => (i32::MIN as i64, i32::MAX as i64),
-            TypeKind::I64 => (i64::MIN, i64::MAX),
-            TypeKind::U8 => (0, u8::MAX as i64),
-            TypeKind::U16 => (0, u16::MAX as i64),
-            TypeKind::U32 => (0, u32::MAX as i64),
-            TypeKind::U64 => (0, i64::MAX), // Can't represent u64::MAX in i64, but we use unsigned compare
-            _ => panic!("type_range called on non-integer type: {:?}", ty),
-        }
+        crate::value_plan::type_bits(ty)
     }
 
     /// Emit a comparison instruction.
@@ -3288,9 +3395,12 @@ impl<'a> CfgLower<'a> {
         let lhs_vreg = self.get_vreg(lhs);
         let rhs_vreg = self.get_vreg(rhs);
 
-        // Use 64-bit compare for i64/u64 types
-        let lhs_ty = self.ctx.cfg.get_inst(lhs).ty;
-        if matches!(lhs_ty.kind(), TypeKind::I64 | TypeKind::U64) {
+        // The shared comparison plan selects the compare width; this helper
+        // only chooses the x86 encoding for that decided width.
+        let compare_bits = crate::value_plan::ValuePlan::for_value(&self.ctx, value)
+            .comparison_width()
+            .bits;
+        if compare_bits == 64 {
             self.mir.push(X86Inst::Cmp64RR {
                 src1: Operand::Virtual(lhs_vreg),
                 src2: Operand::Virtual(rhs_vreg),
@@ -3526,7 +3636,8 @@ impl<'a> CfgLower<'a> {
                 // 64-bit scrutinee must be compared at 64-bit width; a 32-bit cmp
                 // would match on only the low 32 bits (RUE-27). Sub-64-bit
                 // scrutinees keep the 32-bit compare (correct at their width).
-                let scrutinee_is_64 = self.ctx.cfg.get_inst(*scrutinee).ty.is_64_bit();
+                let scrutinee_ty = self.ctx.cfg.get_inst(*scrutinee).ty;
+                let scrutinee_is_64 = crate::value_plan::is_64_bit(scrutinee_ty);
 
                 // Generate comparison and jump for each case
                 let cases = self.ctx.cfg.get_switch_cases(*cases_start, *cases_len);


### PR DESCRIPTION
## Summary

- add one target-neutral, exhaustive CFG value materialization plan shared by x86-64 and AArch64
- centralize aggregate shape/slot, storage, comparison, integer width/signedness, cast, by-reference parameter, block-argument, and return policy
- enforce complete aggregate representations, including zero-slot aggregates, and add cross-backend debug/MIR coverage for all current CFG instruction variants

## Validation

- scripts/rue quick (27 targets)
- focused rue-codegen tests (516 passed)
- scripts/rue cli abi (52 passed)
- scripts/rue spec (2,071 passed, 18 ignored)
- release build
- unfiltered scripts/rue test (CLI 1,450 passed/3 ignored; oracle 64/64; reproducibility; spec 2,071/18 ignored; UI 178/178)
- git diff --check

Native AArch64 execution remains CI authority.

Fixes RUE-822