### PR TITLE
RUE-823: share CFG terminator lowering

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
 use rue_air::{FrozenTypeInternPool, TypeKind};
-use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, Terminator, Type};
+use rue_cfg::{BlockId, Cfg, CfgInstData, CfgValue, Place, Type};
 use rue_error::CompileResult;
 use rue_target::Target;
 
@@ -259,61 +259,10 @@ impl<'a> CfgLower<'a> {
         crate::agg_slots::require_aggregate_slots(self, value)
     }
 
-    /// Copy an aggregate value's slot vregs to a block parameter's slot vregs.
-    /// Covers structs, builtin String, and fixed-size arrays — every slot must
-    /// cross the join edge, not just the primary vreg (RUE-167).
-    fn copy_aggregate_to_block_param(
-        &mut self,
-        arg: CfgValue,
-        target_block: BlockId,
-        param_idx: u32,
-    ) {
-        let target_param = self.ctx.cfg.get_block(target_block).params[param_idx as usize].0;
-
-        let src_slots = self.require_aggregate_slots(arg);
-        let dst_slots = self
-            .struct_slot_vregs
-            .get(&target_param)
-            .cloned()
-            .expect("aggregate block param should have slot vregs pre-allocated");
-
-        // Correctness guard (must run in release): a slot-count mismatch would
-        // move the wrong number of aggregate slots and silently miscompile, so
-        // this is a plain `assert!` rather than a `debug_assert!` (RUE-45).
-        assert_eq!(
-            src_slots.len(),
-            dst_slots.len(),
-            "source and destination aggregate slot counts must match"
-        );
-        for (dst_vreg, src_vreg) in dst_slots.iter().zip(src_slots.iter()) {
-            self.mir.push(Aarch64Inst::MovRR {
-                dst: Operand::Virtual(*dst_vreg),
-                src: Operand::Virtual(*src_vreg),
-            });
-        }
-    }
-
     /// Lower CFG to Aarch64Mir.
     pub fn lower(mut self) -> CompileResult<Aarch64Mir> {
-        self.preload_by_ref_param_ptrs();
-
-        // Pre-allocate vregs for block parameters
-        for block in self.ctx.cfg.blocks() {
-            for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
-                let vreg = self.mir.alloc_vreg();
-                self.block_param_vregs
-                    .insert((block.id, param_idx as u32), vreg);
-                self.value_map.insert(*param_val, vreg);
-
-                crate::agg_slots::preallocate_block_param_slots(&mut self, *param_val, *ty, vreg);
-            }
-        }
-
-        // Lower each block
-        for block in self.ctx.cfg.blocks() {
-            self.lower_block(block);
-        }
-
+        let ctx = self.ctx;
+        crate::terminator_plan::lower_cfg(&ctx, &mut self, None, RET_REGS.len() as u32);
         Ok(self.mir)
     }
 
@@ -322,123 +271,19 @@ impl<'a> CfgLower<'a> {
     /// This is like `lower()` but also captures detailed information about
     /// how each CFG instruction maps to MIR instructions.
     pub fn lower_with_debug(mut self) -> CompileResult<(Aarch64Mir, crate::LoweringDebugInfo)> {
-        use crate::cfg_lower::{format_cfg_inst_data_with_interner, format_terminator};
-        use crate::{
-            BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
-        };
-
-        let mut debug_info = LoweringDebugInfo {
+        let mut debug_info = crate::LoweringDebugInfo {
             fn_name: self.fn_name.to_string(),
             target_arch: "aarch64".to_string(),
             blocks: Vec::new(),
         };
 
-        self.preload_by_ref_param_ptrs();
-
-        // Pre-allocate vregs for block parameters (same as lower())
-        for block in self.ctx.cfg.blocks() {
-            for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
-                let vreg = self.mir.alloc_vreg();
-                self.block_param_vregs
-                    .insert((block.id, param_idx as u32), vreg);
-                self.value_map.insert(*param_val, vreg);
-
-                crate::agg_slots::preallocate_block_param_slots(&mut self, *param_val, *ty, vreg);
-            }
-        }
-
-        // Lower each block with debug tracking
-        for block in self.ctx.cfg.blocks() {
-            let mut block_info = BlockLoweringInfo {
-                block_id: block.id,
-                instructions: Vec::new(),
-                terminator: None,
-            };
-
-            // Block parameters are preallocated before the block walk and
-            // therefore never reach `lower_value`'s MIR-emission path. Keep
-            // them in lowering debug output so the trace remains a complete
-            // CFG-to-MIR account, including intentional no-op materialization.
-            for (param_val, _) in &block.params {
-                let param_inst = self.ctx.cfg.get_inst(*param_val);
-                block_info.instructions.push(LoweringDecision {
-                    cfg_value: *param_val,
-                    cfg_inst_desc: format_cfg_inst_data_with_interner(
-                        self.ctx.cfg,
-                        &param_inst.data,
-                        self.interner,
-                    ),
-                    cfg_type: param_inst.ty.name().to_string(),
-                    mir_insts: Vec::new(),
-                    rationale: Some("Block parameter preallocated at the join".to_string()),
-                });
-            }
-
-            // Emit block label (except for entry block)
-            if block.id != self.ctx.cfg.entry {
-                self.mir.push(Aarch64Inst::Label {
-                    id: self.block_label(block.id),
-                });
-            }
-
-            // Lower each instruction with tracking
-            for &value in &block.insts {
-                // Skip if already lowered
-                if self.value_map.contains_key(&value) {
-                    continue;
-                }
-
-                let inst = self.ctx.cfg.get_inst(value);
-                let inst_before = self.mir.inst_count();
-
-                // Lower the instruction
-                self.lower_value(value);
-
-                let inst_after = self.mir.inst_count();
-
-                // Capture the generated instructions
-                let mir_insts: Vec<String> = self.mir.instructions()[inst_before..inst_after]
-                    .iter()
-                    .map(|i| format!("{}", i))
-                    .collect();
-
-                // Generate rationale for interesting cases
-                let rationale = self.get_lowering_rationale(&inst.data, inst.ty);
-
-                block_info.instructions.push(LoweringDecision {
-                    cfg_value: value,
-                    cfg_inst_desc: format_cfg_inst_data_with_interner(
-                        self.ctx.cfg,
-                        &inst.data,
-                        self.interner,
-                    ),
-                    cfg_type: inst.ty.name().to_string(),
-                    mir_insts,
-                    rationale,
-                });
-            }
-
-            // Lower terminator with tracking
-            let term_before = self.mir.inst_count();
-            self.lower_terminator(block);
-            let term_after = self.mir.inst_count();
-
-            let term_mir_insts: Vec<String> = self.mir.instructions()[term_before..term_after]
-                .iter()
-                .map(|i| format!("{}", i))
-                .collect();
-
-            let term_rationale = self.get_terminator_rationale(&block.terminator);
-
-            block_info.terminator = Some(TerminatorLoweringDecision {
-                terminator_desc: format_terminator(self.ctx.cfg, &block.terminator),
-                mir_insts: term_mir_insts,
-                rationale: term_rationale,
-            });
-
-            debug_info.blocks.push(block_info);
-        }
-
+        let ctx = self.ctx;
+        crate::terminator_plan::lower_cfg(
+            &ctx,
+            &mut self,
+            Some(&mut debug_info),
+            RET_REGS.len() as u32,
+        );
         Ok((self.mir, debug_info))
     }
 
@@ -501,43 +346,6 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Generate rationale for terminator lowering decisions.
-    fn get_terminator_rationale(&self, terminator: &Terminator) -> Option<String> {
-        match terminator {
-            Terminator::Branch { .. } => Some("Compare and branch".to_string()),
-            Terminator::Return { value } => {
-                if self.fn_name == "main" {
-                    Some("Main function: return value becomes exit code".to_string())
-                } else if value.is_some() {
-                    Some("Return value in X0 (AAPCS64)".to_string())
-                } else {
-                    None
-                }
-            }
-            Terminator::Switch { cases_len, .. } => {
-                Some(format!("Linear scan through {} cases", cases_len))
-            }
-            _ => None,
-        }
-    }
-
-    /// Lower a single basic block.
-    fn lower_block(&mut self, block: &BasicBlock) {
-        // Emit block label (except for entry block)
-        if block.id != self.ctx.cfg.entry {
-            self.mir.push(Aarch64Inst::Label {
-                id: self.block_label(block.id),
-            });
-        }
-
-        // Lower each instruction
-        for &value in &block.insts {
-            self.lower_value(value);
-        }
-
-        // Lower terminator
-        self.lower_terminator(block);
-    }
-
     /// Lower a CFG value (instruction).
     fn lower_value(&mut self, value: CfgValue) {
         // Skip if already lowered
@@ -3644,243 +3452,149 @@ impl<'a> CfgLower<'a> {
         result_vreg
     }
 
-    /// Lower a block terminator.
-    fn lower_terminator(&mut self, block: &BasicBlock) {
-        match &block.terminator {
-            Terminator::Goto {
-                target,
-                args_start,
-                args_len,
-            } => {
-                // Copy args to target's block params
-                let args = self.ctx.cfg.get_extra(*args_start, *args_len);
-                for (i, &arg) in args.iter().enumerate() {
-                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
-                    if arg_plan.shape.requires_complete_slots() {
-                        // For any multi-slot aggregate arg (struct, String,
-                        // array, payload enum) copy all slot vregs — single
-                        // is_multislot_aggregate predicate (RUE-248).
-                        self.copy_aggregate_to_block_param(arg, *target, i as u32);
-                    } else {
-                        // For scalar args, just copy the single vreg
-                        let arg_vreg = self.get_vreg(arg);
-                        let param_vreg = self.block_param_vregs[&(*target, i as u32)];
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Virtual(param_vreg),
-                            src: Operand::Virtual(arg_vreg),
-                        });
-                    }
-                }
+    fn emit_terminator_plan(&mut self, plan: crate::terminator_plan::TerminatorPlan) {
+        use crate::terminator_plan::{ReturnMode, ReturnValuePlan, TerminatorPlan};
 
-                // Jump to target (unless it's the next block)
-                let next_block_id = BlockId::from_raw(block.id.as_u32() + 1);
-                if *target != next_block_id {
+        match plan {
+            TerminatorPlan::Goto { edge } => {
+                self.emit_edge_moves(&edge);
+                if !edge.fallthrough {
                     self.mir.push(Aarch64Inst::B {
-                        label: self.block_label(*target),
+                        label: self.block_label(edge.target),
                     });
                 }
             }
-
-            Terminator::Branch {
-                cond,
-                then_block,
-                then_args_start,
-                then_args_len,
-                else_block,
-                else_args_start,
-                else_args_len,
+            TerminatorPlan::Branch {
+                condition,
+                then_edge,
+                else_edge,
             } => {
-                let cond_vreg = self.get_vreg(*cond);
-
-                // Generate a unique label for the else path argument setup
-                let else_setup_label = self.mir.alloc_label();
-
-                // If zero, jump to else setup (where we copy else_args)
-                self.mir.push(Aarch64Inst::Cbz {
-                    src: Operand::Virtual(cond_vreg),
-                    label: else_setup_label,
-                });
-
-                // Copy then_args to then_block's params
-                let then_args = self.ctx.cfg.get_extra(*then_args_start, *then_args_len);
-                for (i, &arg) in then_args.iter().enumerate() {
-                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
-                    if arg_plan.shape.requires_complete_slots() {
-                        // For any multi-slot aggregate arg (struct, String,
-                        // array, payload enum) copy all slot vregs — single
-                        // is_multislot_aggregate predicate (RUE-248).
-                        self.copy_aggregate_to_block_param(arg, *then_block, i as u32);
-                    } else {
-                        // For scalar args, just copy the single vreg
-                        let arg_vreg = self.get_vreg(arg);
-                        let param_vreg = self.block_param_vregs[&(*then_block, i as u32)];
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Virtual(param_vreg),
-                            src: Operand::Virtual(arg_vreg),
-                        });
-                    }
-                }
-
-                // Jump to then block
-                self.mir.push(Aarch64Inst::B {
-                    label: self.block_label(*then_block),
-                });
-
-                // Else setup: copy else_args to else_block's params
-                self.mir.push(Aarch64Inst::Label {
-                    id: else_setup_label,
-                });
-                let else_args = self.ctx.cfg.get_extra(*else_args_start, *else_args_len);
-                for (i, &arg) in else_args.iter().enumerate() {
-                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
-                    if arg_plan.shape.requires_complete_slots() {
-                        // For any multi-slot aggregate arg (struct, String,
-                        // array, payload enum) copy all slot vregs — single
-                        // is_multislot_aggregate predicate (RUE-248).
-                        self.copy_aggregate_to_block_param(arg, *else_block, i as u32);
-                    } else {
-                        // For scalar args, just copy the single vreg
-                        let arg_vreg = self.get_vreg(arg);
-                        let param_vreg = self.block_param_vregs[&(*else_block, i as u32)];
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Virtual(param_vreg),
-                            src: Operand::Virtual(arg_vreg),
-                        });
-                    }
-                }
-
-                // Jump to else block (or fall through if next)
-                let next_block_id = BlockId::from_raw(block.id.as_u32() + 1);
-                if *else_block != next_block_id {
-                    self.mir.push(Aarch64Inst::B {
-                        label: self.block_label(*else_block),
+                if then_edge.fallthrough {
+                    let then_setup_label = self.mir.alloc_label();
+                    self.mir.push(Aarch64Inst::Cbnz {
+                        src: Operand::Virtual(condition),
+                        label: then_setup_label,
                     });
+                    self.emit_edge_moves(&else_edge);
+                    if !else_edge.fallthrough {
+                        self.mir.push(Aarch64Inst::B {
+                            label: self.block_label(else_edge.target),
+                        });
+                    }
+                    self.mir.push(Aarch64Inst::Label {
+                        id: then_setup_label,
+                    });
+                    self.emit_edge_moves(&then_edge);
+                } else {
+                    let else_setup_label = self.mir.alloc_label();
+                    self.mir.push(Aarch64Inst::Cbz {
+                        src: Operand::Virtual(condition),
+                        label: else_setup_label,
+                    });
+                    self.emit_edge_moves(&then_edge);
+                    if !then_edge.fallthrough {
+                        self.mir.push(Aarch64Inst::B {
+                            label: self.block_label(then_edge.target),
+                        });
+                    }
+                    self.mir.push(Aarch64Inst::Label {
+                        id: else_setup_label,
+                    });
+                    self.emit_edge_moves(&else_edge);
+                    if !else_edge.fallthrough {
+                        self.mir.push(Aarch64Inst::B {
+                            label: self.block_label(else_edge.target),
+                        });
+                    }
                 }
             }
-
-            Terminator::Switch {
+            TerminatorPlan::Switch {
                 scrutinee,
-                cases_start,
-                cases_len,
+                width,
+                cases,
                 default,
             } => {
-                let scrutinee_vreg = self.get_vreg(*scrutinee);
-                // The case value is materialized as a full 64-bit immediate, so a
-                // 64-bit scrutinee must be compared at 64-bit width; a 32-bit cmp
-                // would match on only the low 32 bits (RUE-27). Sub-64-bit
-                // scrutinees keep the 32-bit compare (correct at their width).
-                let scrutinee_ty = self.ctx.cfg.get_inst(*scrutinee).ty;
-                let scrutinee_is_64 = crate::value_plan::is_64_bit(scrutinee_ty);
-
-                // Generate comparison and jump for each case
-                let cases = self.ctx.cfg.get_switch_cases(*cases_start, *cases_len);
-                for (value, target) in cases {
-                    // Compare scrutinee with case value (supports signed values for negative patterns)
-                    let imm_vreg = self.mir.alloc_vreg();
+                for case in cases {
+                    let case_vreg = self.mir.alloc_vreg();
                     self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Virtual(imm_vreg),
-                        imm: *value,
+                        dst: Operand::Virtual(case_vreg),
+                        imm: case.value,
                     });
-                    if scrutinee_is_64 {
+                    if width.bits == 64 {
                         self.mir.push(Aarch64Inst::Cmp64RR {
-                            src1: Operand::Virtual(scrutinee_vreg),
-                            src2: Operand::Virtual(imm_vreg),
+                            src1: Operand::Virtual(scrutinee),
+                            src2: Operand::Virtual(case_vreg),
                         });
                     } else {
                         self.mir.push(Aarch64Inst::CmpRR {
-                            src1: Operand::Virtual(scrutinee_vreg),
-                            src2: Operand::Virtual(imm_vreg),
+                            src1: Operand::Virtual(scrutinee),
+                            src2: Operand::Virtual(case_vreg),
                         });
                     }
                     self.mir.push(Aarch64Inst::BCond {
                         cond: Cond::Eq,
-                        label: self.block_label(*target),
+                        label: self.block_label(case.target),
                     });
                 }
-
-                // Fall through to default
                 self.mir.push(Aarch64Inst::B {
-                    label: self.block_label(*default),
+                    label: self.block_label(default),
                 });
             }
-
-            Terminator::Return { value } => {
-                // Handle `return;` without expression (unit-returning functions)
-                let Some(value) = value else {
-                    if self.fn_name == "main" {
-                        // Linux enters Rue's `main` directly. Unit has no CFG
-                        // value, so pass the language-defined success status to
-                        // the non-returning runtime exit shim explicitly.
+            TerminatorPlan::Return { mode } => match mode {
+                ReturnMode::Exit { value } => {
+                    if let Some(value) = value {
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Physical(Reg::X0),
+                            src: Operand::Virtual(value),
+                        });
+                    } else {
                         self.mir.push(Aarch64Inst::MovImm {
                             dst: Operand::Physical(Reg::X0),
                             imm: 0,
                         });
-                        let symbol_id = self.intern_symbol("__rue_exit");
-                        self.mir.push(Aarch64Inst::Bl { symbol_id });
-                    } else {
-                        self.mir.push(Aarch64Inst::Ret);
                     }
-                    return;
-                };
-
-                let return_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, *value);
-
-                if self.fn_name == "main" {
-                    let val_vreg = self.get_vreg(*value);
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Physical(Reg::X0),
-                        src: Operand::Virtual(val_vreg),
-                    });
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
-                } else if return_plan.shape.requires_complete_slots() {
-                    // Return a multi-slot aggregate (struct, array, or payload
-                    // enum). Every valid source has exactly `type_slot_count`
-                    // materialized vregs. (RUE-118, RUE-78, RUE-237)
-                    let slot_vregs = self.require_aggregate_slots(*value);
-                    if self.ctx.uses_sret_return(RET_REGS.len() as u32) {
-                        // sret return (String always; aggregates that don't fit
-                        // the return registers): the caller passed a buffer
-                        // pointer as a hidden first argument, which the
-                        // prologue saved at the dedicated frame slot one past
-                        // the param area. Store every slot through it.
-                        crate::agg_slots::store_slots_to_sret(self, &slot_vregs);
-                    } else {
-                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
-                            if i < RET_REGS.len() {
-                                self.mir.push(Aarch64Inst::MovRR {
-                                    dst: Operand::Physical(RET_REGS[i]),
-                                    src: Operand::Virtual(*slot_vreg),
-                                });
+                }
+                ReturnMode::Function { value } => match value {
+                    ReturnValuePlan::ZeroSized => self.mir.push(Aarch64Inst::Ret),
+                    ReturnValuePlan::Scalar { value } => {
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Physical(Reg::X0),
+                            src: Operand::Virtual(value),
+                        });
+                        self.mir.push(Aarch64Inst::Ret);
+                    }
+                    ReturnValuePlan::Aggregate { slots, return_plan } => {
+                        if return_plan.uses_sret() {
+                            crate::agg_slots::store_slots_to_sret(self, &slots);
+                        } else {
+                            for (index, slot) in slots.iter().enumerate() {
+                                if index < RET_REGS.len() {
+                                    self.mir.push(Aarch64Inst::MovRR {
+                                        dst: Operand::Physical(RET_REGS[index]),
+                                        src: Operand::Virtual(*slot),
+                                    });
+                                }
                             }
                         }
+                        self.mir.push(Aarch64Inst::Ret);
                     }
-
-                    self.mir.push(Aarch64Inst::Ret);
-                } else {
-                    let val_vreg = self.get_vreg(*value);
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Physical(Reg::X0),
-                        src: Operand::Virtual(val_vreg),
-                    });
-                    self.mir.push(Aarch64Inst::Ret);
-                }
-            }
-
-            Terminator::Unreachable => {
-                // Defense-in-depth (RUE-208): emit a trap rather than nothing.
-                // The compiler proved this block unreachable, but if a
-                // control-flow bug ever lets execution reach it, `brk` faults
-                // (SIGTRAP) immediately instead of silently falling through into
-                // whatever code the block layout happens to place next.
-                self.mir.push(Aarch64Inst::Brk);
-            }
-
-            Terminator::None => {
-                panic!("block has no terminator");
-            }
+                },
+            },
+            TerminatorPlan::Unreachable => self.mir.push(Aarch64Inst::Brk),
         }
     }
+
+    fn emit_edge_moves(&mut self, edge: &crate::terminator_plan::EdgePlan) {
+        for movement in &edge.moves {
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Virtual(movement.destination),
+                src: Operand::Virtual(movement.source),
+            });
+        }
+    }
+
     /// Get the vreg for a CFG value.
     fn get_vreg(&mut self, value: CfgValue) -> VReg {
         if let Some(&vreg) = self.value_map.get(&value) {
@@ -3894,6 +3608,117 @@ impl<'a> CfgLower<'a> {
             .get(&value)
             .copied()
             .expect("value should have been lowered")
+    }
+}
+
+impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
+    fn materialize_value(
+        &mut self,
+        value: CfgValue,
+        plan: crate::value_plan::ValuePlan,
+    ) -> crate::terminator_plan::MaterializedValue {
+        let primary = self.get_vreg(value);
+        let slots = if plan.shape.requires_complete_slots() {
+            self.require_aggregate_slots(value)
+        } else {
+            Vec::new()
+        };
+        crate::terminator_plan::MaterializedValue { primary, slots }
+    }
+
+    fn materialize_block_param(
+        &mut self,
+        target: BlockId,
+        param_index: u32,
+        value: CfgValue,
+        plan: crate::value_plan::ValuePlan,
+    ) -> crate::terminator_plan::MaterializedValue {
+        let primary = self.block_param_vregs[&(target, param_index)];
+        let slots = if plan.shape.requires_complete_slots() {
+            let slots = self
+                .struct_slot_vregs
+                .get(&value)
+                .cloned()
+                .expect("aggregate block parameter slots should be preallocated");
+            plan.assert_complete_slots(slots.len());
+            slots
+        } else {
+            Vec::new()
+        };
+        crate::terminator_plan::MaterializedValue { primary, slots }
+    }
+
+    fn emit_block_label(&mut self, block: BlockId) {
+        self.mir.push(Aarch64Inst::Label {
+            id: self.block_label(block),
+        });
+    }
+
+    fn emit_terminator(&mut self, plan: crate::terminator_plan::TerminatorPlan) {
+        self.emit_terminator_plan(plan);
+    }
+}
+
+impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
+    fn preload_by_ref_params(&mut self) {
+        self.preload_by_ref_param_ptrs();
+    }
+
+    fn prepare_block_param(&mut self, block: BlockId, index: u32, value: CfgValue, ty: Type) {
+        let vreg = self.mir.alloc_vreg();
+        self.block_param_vregs.insert((block, index), vreg);
+        self.value_map.insert(value, vreg);
+        crate::agg_slots::preallocate_block_param_slots(self, value, ty, vreg);
+    }
+
+    fn value_is_lowered(&self, value: CfgValue) -> bool {
+        self.value_map.contains_key(&value)
+    }
+
+    fn lower_value(&mut self, value: CfgValue) {
+        CfgLower::lower_value(self, value);
+    }
+
+    fn value_description(&self, value: CfgValue) -> String {
+        let inst = self.ctx.cfg.get_inst(value);
+        crate::format_cfg_inst_data_with_interner(self.ctx.cfg, &inst.data, self.interner)
+    }
+
+    fn instruction_count(&self) -> usize {
+        self.mir.inst_count()
+    }
+
+    fn instruction_strings(&self, range: std::ops::Range<usize>) -> Vec<String> {
+        self.mir.instructions()[range]
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    fn value_rationale(&self, data: &CfgInstData, ty: Type) -> Option<String> {
+        self.get_lowering_rationale(data, ty)
+    }
+
+    fn terminator_rationale(
+        &self,
+        plan: &crate::terminator_plan::TerminatorPlan,
+    ) -> Option<String> {
+        use crate::terminator_plan::{ReturnMode, TerminatorPlan};
+        match plan {
+            TerminatorPlan::Branch { .. } => Some("Compare and branch".to_string()),
+            TerminatorPlan::Return {
+                mode: ReturnMode::Exit { .. },
+            } => Some("Main function: return value becomes exit code".to_string()),
+            TerminatorPlan::Return {
+                mode: ReturnMode::Function { value },
+            } if !matches!(value, crate::terminator_plan::ReturnValuePlan::ZeroSized) => {
+                Some("Return value in X0 (AAPCS64)".to_string())
+            }
+            TerminatorPlan::Switch { cases, .. } => {
+                Some(format!("Linear scan through {} cases", cases.len()))
+            }
+            _ => None,
+        }
     }
 }
 

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -49,6 +49,10 @@ pub struct TerminatorLoweringDecision {
     pub mir_insts: Vec<String>,
     /// Rationale for the lowering decision.
     pub rationale: Option<String>,
+    /// Target-independent topology and policy facts observed by both backend
+    /// debug lowerers.  MIR text is intentionally kept separate from this
+    /// trace so cross-target tests do not compare architecture spellings.
+    pub policy_trace: crate::terminator_plan::TerminatorTrace,
 }
 
 /// Debug information for a single basic block's lowering.
@@ -254,87 +258,6 @@ fn format_cfg_inst_data_impl(
     }
 }
 
-/// Format a CFG terminator as a human-readable string.
-pub fn format_terminator(cfg: &rue_cfg::Cfg, terminator: &rue_cfg::Terminator) -> String {
-    use rue_cfg::Terminator;
-
-    match terminator {
-        Terminator::Goto {
-            target,
-            args_start,
-            args_len,
-        } => {
-            let args = cfg.get_extra(*args_start, *args_len);
-            if args.is_empty() {
-                format!("goto {}", target)
-            } else {
-                let args_str = args
-                    .iter()
-                    .map(|a| format!("{}", a))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("goto {}({})", target, args_str)
-            }
-        }
-        Terminator::Branch {
-            cond,
-            then_block,
-            then_args_start,
-            then_args_len,
-            else_block,
-            else_args_start,
-            else_args_len,
-        } => {
-            let then_args = cfg.get_extra(*then_args_start, *then_args_len);
-            let then_str = if then_args.is_empty() {
-                format!("{}", then_block)
-            } else {
-                let args_str = then_args
-                    .iter()
-                    .map(|a| format!("{}", a))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{}({})", then_block, args_str)
-            };
-            let else_args = cfg.get_extra(*else_args_start, *else_args_len);
-            let else_str = if else_args.is_empty() {
-                format!("{}", else_block)
-            } else {
-                let args_str = else_args
-                    .iter()
-                    .map(|a| format!("{}", a))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{}({})", else_block, args_str)
-            };
-            format!("branch {}, {}, {}", cond, then_str, else_str)
-        }
-        Terminator::Switch {
-            scrutinee,
-            cases_start,
-            cases_len,
-            default,
-        } => {
-            let cases = cfg.get_switch_cases(*cases_start, *cases_len);
-            let cases_str = cases
-                .iter()
-                .map(|(val, target)| format!("{} => {}", val, target))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("switch {} [{}], default: {}", scrutinee, cases_str, default)
-        }
-        Terminator::Return { value } => {
-            if let Some(val) = value {
-                format!("return {}", val)
-            } else {
-                "return".to_string()
-            }
-        }
-        Terminator::Unreachable => "unreachable".to_string(),
-        Terminator::None => "<no terminator>".to_string(),
-    }
-}
-
 // ============================================================================
 // Internal calling convention helpers
 // ============================================================================
@@ -400,6 +323,7 @@ pub fn fn_uses_sret_return(
 /// - Slot offset calculations
 ///
 /// Each backend's `CfgLower` embeds this context and delegates to its methods.
+#[derive(Clone, Copy)]
 pub struct CfgLowerContext<'a> {
     /// The CFG being lowered.
     pub cfg: &'a Cfg,

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -48,6 +48,7 @@ mod schedule_core;
 mod stack_frame;
 mod stack_verify;
 mod storage_lower;
+pub mod terminator_plan;
 pub mod value_plan;
 
 pub mod aarch64;
@@ -383,7 +384,7 @@ pub use x86_64::generate;
 // Re-export shared types
 pub use cfg_lower::{
     BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
-    format_cfg_inst_data, format_cfg_inst_data_with_interner, format_terminator,
+    format_cfg_inst_data, format_cfg_inst_data_with_interner,
 };
 pub use index_map::{Handle, IndexMap};
 pub use regalloc::{

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -532,7 +532,7 @@ pub fn lower_cfg<A: CfgLowerAdapter>(
             }
         }
 
-        let plan = plan_terminator(&ctx, adapter, block, ctx.cfg.fn_name(), ret_reg_budget);
+        let plan = plan_terminator(ctx, adapter, block, ctx.cfg.fn_name(), ret_reg_budget);
         let term_start = adapter.instruction_count();
         adapter.emit_terminator(plan.clone());
         let term_end = adapter.instruction_count();

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -1,0 +1,1451 @@
+//! Target-independent CFG block and terminator lowering policy.
+//!
+//! This module is the single owner of CFG control-flow topology.  It copies
+//! only normalized values and logical slots into [`TerminatorPlan`]; concrete
+//! backends decide how those facts become branch, move, return, and trap MIR.
+
+use std::ops::Range;
+
+use rue_cfg::{BasicBlock, BlockId, CfgValue, Terminator, Type};
+
+use crate::call_plan::{self, ReturnPlan};
+use crate::cfg_lower::CfgLowerContext;
+use crate::value_plan::{self, ValuePlan, ValueShape};
+use crate::vreg::VReg;
+
+/// A materialized CFG value supplied by a concrete adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterializedValue {
+    /// The primary value vreg.  It is used for scalar values and conditions.
+    /// Aggregate plans retain it only as the canonical first-slot bookkeeping
+    /// value; their complete representation is in `slots`.
+    pub primary: VReg,
+    /// Complete logical slots in ascending layout order.  This is empty for a
+    /// zero-sized value and complete for every aggregate.
+    pub slots: Vec<VReg>,
+}
+
+/// One logical slot move performed on a control-flow edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlotMove {
+    /// Position of the CFG edge argument in the target block's parameter
+    /// list. This distinguishes two aggregate arguments carried by one edge.
+    pub argument_index: u32,
+    /// Logical slot within that edge argument, in ascending layout order.
+    pub slot_index: u32,
+    pub source: VReg,
+    pub destination: VReg,
+}
+
+/// Normalized work for one CFG successor edge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EdgePlan {
+    pub target: BlockId,
+    pub moves: Vec<SlotMove>,
+    /// Whether the target is the next logical block in deterministic CFG
+    /// order.  The adapter may omit an unconditional jump only in this case.
+    pub fallthrough: bool,
+}
+
+/// Ordered switch case information.  The source CFG order is preserved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SwitchCasePlan {
+    pub value: i64,
+    pub target: BlockId,
+}
+
+/// Target-neutral return value shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReturnValuePlan {
+    ZeroSized,
+    Scalar {
+        value: VReg,
+    },
+    Aggregate {
+        slots: Vec<VReg>,
+        return_plan: ReturnPlan,
+    },
+}
+
+/// Target-neutral return behavior.  `Exit` is the language-level `main`
+/// termination mode; the adapter supplies the platform call sequence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReturnMode {
+    Exit { value: Option<VReg> },
+    Function { value: ReturnValuePlan },
+}
+
+/// Exhaustive target-neutral terminator plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminatorPlan {
+    Goto {
+        edge: EdgePlan,
+    },
+    Branch {
+        condition: VReg,
+        then_edge: EdgePlan,
+        else_edge: EdgePlan,
+    },
+    Switch {
+        scrutinee: VReg,
+        /// The comparison width selected by the language policy.
+        width: value_plan::IntegerWidth,
+        cases: Vec<SwitchCasePlan>,
+        default: BlockId,
+    },
+    Return {
+        mode: ReturnMode,
+    },
+    Unreachable,
+}
+
+/// Stable cross-backend evidence for the policy decisions in a terminator
+/// plan.  It contains no vregs or target labels, so x86-64 and AArch64 traces
+/// can be compared before instruction encoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminatorTrace {
+    pub kind: TerminatorTraceKind,
+    pub successors: Vec<BlockId>,
+    pub fallthrough: Vec<bool>,
+    pub edge_move_counts: Vec<usize>,
+    /// Ordered logical source/destination slot positions for every edge.
+    pub edge_work: Vec<Vec<(u32, u32)>>,
+    pub switch_width: Option<value_plan::IntegerWidth>,
+    pub switch_cases: Vec<(i64, BlockId)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminatorTraceKind {
+    Goto,
+    Branch,
+    Switch,
+    ReturnExit,
+    ReturnUnit,
+    ReturnScalar,
+    ReturnAggregateRegisters,
+    ReturnAggregateSret,
+    ReturnAggregateZeroSized,
+    Unreachable,
+}
+
+impl TerminatorPlan {
+    /// Extract only policy facts for cross-backend trace comparisons.
+    pub fn trace(&self) -> TerminatorTrace {
+        match self {
+            Self::Goto { edge } => TerminatorTrace {
+                kind: TerminatorTraceKind::Goto,
+                successors: vec![edge.target],
+                fallthrough: vec![edge.fallthrough],
+                edge_move_counts: vec![edge.moves.len()],
+                edge_work: vec![
+                    edge.moves
+                        .iter()
+                        .map(|movement| (movement.argument_index, movement.slot_index))
+                        .collect(),
+                ],
+                switch_width: None,
+                switch_cases: Vec::new(),
+            },
+            Self::Branch {
+                then_edge,
+                else_edge,
+                ..
+            } => TerminatorTrace {
+                kind: TerminatorTraceKind::Branch,
+                successors: vec![then_edge.target, else_edge.target],
+                fallthrough: vec![then_edge.fallthrough, else_edge.fallthrough],
+                edge_move_counts: vec![then_edge.moves.len(), else_edge.moves.len()],
+                edge_work: vec![
+                    then_edge
+                        .moves
+                        .iter()
+                        .map(|movement| (movement.argument_index, movement.slot_index))
+                        .collect(),
+                    else_edge
+                        .moves
+                        .iter()
+                        .map(|movement| (movement.argument_index, movement.slot_index))
+                        .collect(),
+                ],
+                switch_width: None,
+                switch_cases: Vec::new(),
+            },
+            Self::Switch {
+                width,
+                cases,
+                default,
+                ..
+            } => TerminatorTrace {
+                kind: TerminatorTraceKind::Switch,
+                successors: cases
+                    .iter()
+                    .map(|case| case.target)
+                    .chain(std::iter::once(*default))
+                    .collect(),
+                fallthrough: Vec::new(),
+                edge_move_counts: Vec::new(),
+                edge_work: Vec::new(),
+                switch_width: Some(*width),
+                switch_cases: cases.iter().map(|case| (case.value, case.target)).collect(),
+            },
+            Self::Return { mode } => {
+                let kind = match mode {
+                    ReturnMode::Exit { .. } => TerminatorTraceKind::ReturnExit,
+                    ReturnMode::Function { value } => match value {
+                        ReturnValuePlan::ZeroSized => TerminatorTraceKind::ReturnUnit,
+                        ReturnValuePlan::Scalar { .. } => TerminatorTraceKind::ReturnScalar,
+                        ReturnValuePlan::Aggregate { return_plan, .. } => match return_plan {
+                            ReturnPlan::ZeroSized => TerminatorTraceKind::ReturnAggregateZeroSized,
+                            ReturnPlan::Registers { .. } => {
+                                TerminatorTraceKind::ReturnAggregateRegisters
+                            }
+                            ReturnPlan::Sret { .. } => TerminatorTraceKind::ReturnAggregateSret,
+                            ReturnPlan::Scalar => unreachable!("aggregate return cannot be scalar"),
+                        },
+                    },
+                };
+                TerminatorTrace {
+                    kind,
+                    successors: Vec::new(),
+                    fallthrough: Vec::new(),
+                    edge_move_counts: Vec::new(),
+                    edge_work: Vec::new(),
+                    switch_width: None,
+                    switch_cases: Vec::new(),
+                }
+            }
+            Self::Unreachable => TerminatorTrace {
+                kind: TerminatorTraceKind::Unreachable,
+                successors: Vec::new(),
+                fallthrough: Vec::new(),
+                edge_move_counts: Vec::new(),
+                edge_work: Vec::new(),
+                switch_width: None,
+                switch_cases: Vec::new(),
+            },
+        }
+    }
+}
+
+/// The operations needed by the shared policy to obtain vregs and emit one
+/// normalized plan.  No operation accepts a target instruction, register, or
+/// target label.  CFG values are lookup keys used while building the plan and
+/// never appear in the plan itself.
+pub trait TerminatorAdapter {
+    fn materialize_value(&mut self, value: CfgValue, plan: ValuePlan) -> MaterializedValue;
+    fn materialize_block_param(
+        &mut self,
+        target: BlockId,
+        param_index: u32,
+        target_value: CfgValue,
+        plan: ValuePlan,
+    ) -> MaterializedValue;
+    fn emit_block_label(&mut self, block: BlockId);
+    fn emit_terminator(&mut self, plan: TerminatorPlan);
+}
+
+/// The remaining straight-line lowering and debug presentation hooks.  The
+/// block walk itself belongs to this module; value traversal remains an
+/// adapter leaf until the RUE-825 convergence slice.
+pub trait CfgLowerAdapter: TerminatorAdapter {
+    fn preload_by_ref_params(&mut self);
+    fn prepare_block_param(&mut self, block: BlockId, index: u32, value: CfgValue, ty: Type);
+    fn value_is_lowered(&self, value: CfgValue) -> bool;
+    fn lower_value(&mut self, value: CfgValue);
+    fn value_description(&self, value: CfgValue) -> String;
+    fn instruction_count(&self) -> usize;
+    fn instruction_strings(&self, range: Range<usize>) -> Vec<String>;
+    fn value_rationale(&self, data: &rue_cfg::CfgInstData, ty: Type) -> Option<String>;
+    fn terminator_rationale(&self, plan: &TerminatorPlan) -> Option<String>;
+}
+
+fn next_ordered_block(ctx: &CfgLowerContext<'_>, block: BlockId) -> Option<BlockId> {
+    let index = ctx
+        .cfg
+        .blocks()
+        .iter()
+        .position(|candidate| candidate.id == block)?;
+    ctx.cfg.blocks().get(index + 1).map(|block| block.id)
+}
+
+fn moves_for_edge<A: TerminatorAdapter>(
+    ctx: &CfgLowerContext<'_>,
+    adapter: &mut A,
+    source_values: &[CfgValue],
+    target: BlockId,
+    source_block: BlockId,
+) -> EdgePlan {
+    let target_block = ctx.cfg.get_block(target);
+    assert_eq!(
+        source_values.len(),
+        target_block.params.len(),
+        "edge argument count must match target block parameter count"
+    );
+
+    let mut moves = Vec::new();
+    for (index, &value) in source_values.iter().enumerate() {
+        let plan = ValuePlan::for_value(ctx, value);
+        let source = adapter.materialize_value(value, plan);
+        let target_value = target_block.params[index].0;
+        let destination = adapter.materialize_block_param(target, index as u32, target_value, plan);
+
+        match plan.shape {
+            ValueShape::ZeroSized => {
+                assert!(
+                    source.slots.is_empty() && destination.slots.is_empty(),
+                    "zero-sized edge values must not fall back to a scalar slot"
+                );
+            }
+            ValueShape::Scalar => {
+                assert_eq!(
+                    source.slots.len(),
+                    0,
+                    "scalar values have no aggregate slots"
+                );
+                assert_eq!(destination.slots.len(), 0);
+                moves.push(SlotMove {
+                    argument_index: index as u32,
+                    slot_index: 0,
+                    source: source.primary,
+                    destination: destination.primary,
+                });
+            }
+            ValueShape::CompleteAggregate { slot_count } => {
+                assert_eq!(source.slots.len(), slot_count as usize);
+                assert_eq!(destination.slots.len(), slot_count as usize);
+                moves.extend(
+                    source
+                        .slots
+                        .iter()
+                        .copied()
+                        .zip(destination.slots.iter().copied())
+                        .enumerate()
+                        .map(|(slot_index, (source, destination))| SlotMove {
+                            argument_index: index as u32,
+                            slot_index: slot_index as u32,
+                            source,
+                            destination,
+                        }),
+                );
+            }
+        }
+    }
+
+    EdgePlan {
+        target,
+        moves,
+        fallthrough: next_ordered_block(ctx, source_block) == Some(target),
+    }
+}
+
+fn return_value<A: TerminatorAdapter>(
+    ctx: &CfgLowerContext<'_>,
+    adapter: &mut A,
+    value: CfgValue,
+    ret_reg_budget: u32,
+) -> ReturnValuePlan {
+    let value_plan = ValuePlan::for_value(ctx, value);
+    let materialized = adapter.materialize_value(value, value_plan);
+    match value_plan.shape {
+        ValueShape::ZeroSized => ReturnValuePlan::ZeroSized,
+        ValueShape::Scalar => ReturnValuePlan::Scalar {
+            value: materialized.primary,
+        },
+        ValueShape::CompleteAggregate { slot_count } => {
+            assert_eq!(materialized.slots.len(), slot_count as usize);
+            let return_plan =
+                call_plan::return_plan(ctx.type_pool, ctx.cfg.return_type(), ret_reg_budget);
+            assert_eq!(return_plan.slot_count(), slot_count);
+            ReturnValuePlan::Aggregate {
+                slots: materialized.slots,
+                return_plan,
+            }
+        }
+    }
+}
+
+/// Build the one canonical plan for a CFG terminator.
+pub fn plan_terminator<A: TerminatorAdapter>(
+    ctx: &CfgLowerContext<'_>,
+    adapter: &mut A,
+    block: &BasicBlock,
+    fn_name: &str,
+    ret_reg_budget: u32,
+) -> TerminatorPlan {
+    match block.terminator {
+        Terminator::Goto {
+            target,
+            args_start,
+            args_len,
+        } => TerminatorPlan::Goto {
+            edge: moves_for_edge(
+                ctx,
+                adapter,
+                ctx.cfg.get_extra(args_start, args_len),
+                target,
+                block.id,
+            ),
+        },
+        Terminator::Branch {
+            cond,
+            then_block,
+            then_args_start,
+            then_args_len,
+            else_block,
+            else_args_start,
+            else_args_len,
+        } => {
+            let condition_plan = ValuePlan::for_value(ctx, cond);
+            let condition = adapter.materialize_value(cond, condition_plan).primary;
+            let then_edge = moves_for_edge(
+                ctx,
+                adapter,
+                ctx.cfg.get_extra(then_args_start, then_args_len),
+                then_block,
+                block.id,
+            );
+            let mut else_edge = moves_for_edge(
+                ctx,
+                adapter,
+                ctx.cfg.get_extra(else_args_start, else_args_len),
+                else_block,
+                block.id,
+            );
+            // A branch whose two arms name the next physical block still has
+            // only one fallthrough layout. Keep the then arm as the emitted
+            // fallthrough and make the else arm's explicit jump visible in
+            // the normalized policy consumed by both adapters.
+            if then_edge.fallthrough && else_edge.fallthrough {
+                else_edge.fallthrough = false;
+            }
+            TerminatorPlan::Branch {
+                condition,
+                then_edge,
+                else_edge,
+            }
+        }
+        Terminator::Switch {
+            scrutinee,
+            cases_start,
+            cases_len,
+            default,
+        } => {
+            let value_plan = ValuePlan::for_value(ctx, scrutinee);
+            let scrutinee_vreg = adapter.materialize_value(scrutinee, value_plan).primary;
+            let ty = ctx.cfg.get_inst(scrutinee).ty;
+            let width = value_plan::comparison_integer_width(ty);
+            let cases = ctx
+                .cfg
+                .get_switch_cases(cases_start, cases_len)
+                .iter()
+                .copied()
+                .map(|(value, target)| SwitchCasePlan { value, target })
+                .collect();
+            TerminatorPlan::Switch {
+                scrutinee: scrutinee_vreg,
+                width,
+                cases,
+                default,
+            }
+        }
+        Terminator::Return { value } => {
+            let mode = if fn_name == "main" {
+                ReturnMode::Exit {
+                    value: value.map(|value| {
+                        let plan = ValuePlan::for_value(ctx, value);
+                        adapter.materialize_value(value, plan).primary
+                    }),
+                }
+            } else {
+                ReturnMode::Function {
+                    value: value.map_or(ReturnValuePlan::ZeroSized, |value| {
+                        return_value(ctx, adapter, value, ret_reg_budget)
+                    }),
+                }
+            };
+            TerminatorPlan::Return { mode }
+        }
+        Terminator::Unreachable => TerminatorPlan::Unreachable,
+        Terminator::None => panic!("block has no terminator"),
+    }
+}
+
+/// Lower every CFG block through the same block order, label policy, and
+/// terminator planner.  The optional debug sink observes these exact plans;
+/// it does not invoke a presentation-specific lowerer.
+pub fn lower_cfg<A: CfgLowerAdapter>(
+    ctx: &CfgLowerContext<'_>,
+    adapter: &mut A,
+    mut debug_info: Option<&mut crate::LoweringDebugInfo>,
+    ret_reg_budget: u32,
+) {
+    adapter.preload_by_ref_params();
+
+    for block in ctx.cfg.blocks() {
+        for (index, &(value, ty)) in block.params.iter().enumerate() {
+            adapter.prepare_block_param(block.id, index as u32, value, ty);
+        }
+    }
+
+    for block in ctx.cfg.blocks() {
+        let mut block_info = debug_info.as_deref_mut().map(|_| crate::BlockLoweringInfo {
+            block_id: block.id,
+            instructions: Vec::new(),
+            terminator: None,
+        });
+
+        if let Some(info) = block_info.as_mut() {
+            for &(value, _) in &block.params {
+                let inst = ctx.cfg.get_inst(value);
+                info.instructions.push(crate::LoweringDecision {
+                    cfg_value: value,
+                    cfg_inst_desc: adapter.value_description(value),
+                    cfg_type: inst.ty.name().to_string(),
+                    mir_insts: Vec::new(),
+                    rationale: Some("Block parameter preallocated at the join".to_string()),
+                });
+            }
+        }
+
+        if block.id != ctx.cfg.entry {
+            adapter.emit_block_label(block.id);
+        }
+
+        for &value in &block.insts {
+            if let Some(info) = block_info.as_mut() {
+                if adapter.value_is_lowered(value) {
+                    continue;
+                }
+                let inst = ctx.cfg.get_inst(value);
+                let start = adapter.instruction_count();
+                adapter.lower_value(value);
+                let end = adapter.instruction_count();
+                info.instructions.push(crate::LoweringDecision {
+                    cfg_value: value,
+                    cfg_inst_desc: adapter.value_description(value),
+                    cfg_type: inst.ty.name().to_string(),
+                    mir_insts: adapter.instruction_strings(start..end),
+                    rationale: adapter.value_rationale(&inst.data, inst.ty),
+                });
+            } else {
+                adapter.lower_value(value);
+            }
+        }
+
+        let plan = plan_terminator(&ctx, adapter, block, ctx.cfg.fn_name(), ret_reg_budget);
+        let term_start = adapter.instruction_count();
+        adapter.emit_terminator(plan.clone());
+        let term_end = adapter.instruction_count();
+
+        if let Some(info) = block_info.as_mut() {
+            info.terminator = Some(crate::TerminatorLoweringDecision {
+                terminator_desc: format_terminator_plan(&plan),
+                mir_insts: adapter.instruction_strings(term_start..term_end),
+                rationale: adapter.terminator_rationale(&plan),
+                policy_trace: plan.trace(),
+            });
+        }
+
+        if let (Some(debug), Some(info)) = (debug_info.as_deref_mut(), block_info) {
+            debug.blocks.push(info);
+        }
+    }
+}
+
+/// Stable, target-independent debug rendering of a normalized terminator.
+pub fn format_terminator_plan(plan: &TerminatorPlan) -> String {
+    match plan {
+        TerminatorPlan::Goto { edge } => format!("goto {}", edge.target),
+        TerminatorPlan::Branch {
+            then_edge,
+            else_edge,
+            ..
+        } => format!("branch {} else {}", then_edge.target, else_edge.target),
+        TerminatorPlan::Switch { cases, default, .. } => {
+            format!("switch {} cases default {}", cases.len(), default)
+        }
+        TerminatorPlan::Return { mode } => match mode {
+            ReturnMode::Exit { .. } => "return exit".to_string(),
+            ReturnMode::Function { .. } => "return function".to_string(),
+        },
+        TerminatorPlan::Unreachable => "unreachable".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lasso::ThreadedRodeo;
+    use rue_air::{FrozenTypeInternPool, StructDef, StructField, TypeInternPool};
+    use rue_cfg::{Cfg, CfgInst, CfgInstData, Terminator};
+    use rue_span::{FileId, Span};
+    use rue_target::Target;
+
+    use crate::aarch64::{Aarch64Inst, CfgLower as Aarch64CfgLower};
+    use crate::x86_64::{CfgLower as X86CfgLower, X86Inst};
+
+    fn inst(data: rue_cfg::CfgInstData, ty: Type) -> CfgInst {
+        CfgInst {
+            data,
+            ty,
+            span: Span::new(0, 0),
+        }
+    }
+
+    fn lower_both(
+        cfg: &Cfg,
+        pool: &FrozenTypeInternPool,
+        interner: &ThreadedRodeo,
+    ) -> (
+        crate::x86_64::X86Mir,
+        crate::LoweringDebugInfo,
+        crate::aarch64::Aarch64Mir,
+        crate::LoweringDebugInfo,
+    ) {
+        let (x86, x86_debug) = X86CfgLower::new(cfg, pool, interner)
+            .lower_with_debug()
+            .expect("x86 fixture should lower");
+        let (arm, arm_debug) = Aarch64CfgLower::new(cfg, pool, interner, Target::Aarch64Linux)
+            .lower_with_debug()
+            .expect("AArch64 fixture should lower");
+        (x86, x86_debug, arm, arm_debug)
+    }
+
+    fn policy_traces(debug: &crate::LoweringDebugInfo) -> Vec<TerminatorTrace> {
+        debug
+            .blocks
+            .iter()
+            .map(|block| {
+                block
+                    .terminator
+                    .as_ref()
+                    .expect("every fixture block has a terminator")
+                    .policy_trace
+                    .clone()
+            })
+            .collect()
+    }
+
+    fn assert_same_policy_trace(
+        cfg: &Cfg,
+        x86_debug: &crate::LoweringDebugInfo,
+        arm_debug: &crate::LoweringDebugInfo,
+    ) -> Vec<TerminatorTrace> {
+        let x86_trace = policy_traces(x86_debug);
+        let arm_trace = policy_traces(arm_debug);
+        assert_eq!(
+            x86_trace,
+            arm_trace,
+            "policy trace diverged for {}",
+            cfg.fn_name()
+        );
+        x86_trace
+    }
+
+    fn struct_pool(name: &str, fields: Vec<Type>) -> (FrozenTypeInternPool, Type, ThreadedRodeo) {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let struct_fields = fields
+            .into_iter()
+            .enumerate()
+            .map(|(index, ty)| StructField {
+                name: format!("field{index}"),
+                ty,
+            })
+            .collect();
+        let (struct_id, _) = pool.register_struct(
+            interner.get_or_intern(name),
+            StructDef {
+                name: name.to_string(),
+                fields: struct_fields,
+                is_copy: true,
+                is_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        (pool.freeze(), Type::new_struct(struct_id), interner)
+    }
+
+    fn diamond_fixture() -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+        let pool = FrozenTypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let mut cfg = Cfg::new(Type::I32, 0, 0, "diamond".to_string(), vec![]);
+        let entry = cfg.new_block();
+        let then_block = cfg.new_block();
+        let else_block = cfg.new_block();
+        let join = cfg.new_block();
+        cfg.entry = entry;
+        let condition =
+            cfg.add_inst_to_block(entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let value = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(7), Type::I32));
+        let join_value = cfg.add_block_param(join, Type::I32);
+        cfg.set_terminator(
+            entry,
+            Terminator::Branch {
+                cond: condition,
+                then_block,
+                then_args_start: 0,
+                then_args_len: 0,
+                else_block,
+                else_args_start: 0,
+                else_args_len: 0,
+            },
+        );
+        let (then_join_start, then_join_len) = cfg.push_extra([value]);
+        cfg.set_terminator(
+            then_block,
+            Terminator::Goto {
+                target: join,
+                args_start: then_join_start,
+                args_len: then_join_len,
+            },
+        );
+        let (else_join_start, else_join_len) = cfg.push_extra([value]);
+        cfg.set_terminator(
+            else_block,
+            Terminator::Goto {
+                target: join,
+                args_start: else_join_start,
+                args_len: else_join_len,
+            },
+        );
+        cfg.set_terminator(
+            join,
+            Terminator::Return {
+                value: Some(join_value),
+            },
+        );
+        (cfg, pool, interner)
+    }
+
+    fn same_successor_fixture() -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+        let pool = FrozenTypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let mut cfg = Cfg::new(Type::I32, 0, 0, "same_successor".to_string(), vec![]);
+        let entry = cfg.new_block();
+        let target = cfg.new_block();
+        cfg.entry = entry;
+        let condition =
+            cfg.add_inst_to_block(entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let then_value = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(1), Type::I32));
+        let else_value = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(2), Type::I32));
+        let target_value = cfg.add_block_param(target, Type::I32);
+        let (then_args_start, then_args_len) = cfg.push_extra([then_value]);
+        let (else_args_start, else_args_len) = cfg.push_extra([else_value]);
+        cfg.set_terminator(
+            entry,
+            Terminator::Branch {
+                cond: condition,
+                then_block: target,
+                then_args_start,
+                then_args_len,
+                else_block: target,
+                else_args_start,
+                else_args_len,
+            },
+        );
+        cfg.set_terminator(
+            target,
+            Terminator::Return {
+                value: Some(target_value),
+            },
+        );
+        (cfg, pool, interner)
+    }
+
+    fn loop_fixture() -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+        let pool = FrozenTypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let mut cfg = Cfg::new(Type::I32, 0, 0, "loop".to_string(), vec![]);
+        let header = cfg.new_block();
+        let body = cfg.new_block();
+        let exit = cfg.new_block();
+        cfg.entry = header;
+        let condition =
+            cfg.add_inst_to_block(header, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let result = cfg.add_inst_to_block(header, inst(CfgInstData::Const(1), Type::I32));
+        cfg.set_terminator(
+            header,
+            Terminator::Branch {
+                cond: condition,
+                then_block: body,
+                then_args_start: 0,
+                then_args_len: 0,
+                else_block: exit,
+                else_args_start: 0,
+                else_args_len: 0,
+            },
+        );
+        cfg.set_terminator(
+            body,
+            Terminator::Goto {
+                target: header,
+                args_start: 0,
+                args_len: 0,
+            },
+        );
+        cfg.set_terminator(
+            exit,
+            Terminator::Return {
+                value: Some(result),
+            },
+        );
+        (cfg, pool, interner)
+    }
+
+    fn switch_fixture(ty: Type, name: &str) -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+        let pool = FrozenTypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, name.to_string(), vec![]);
+        let entry = cfg.new_block();
+        let first = cfg.new_block();
+        let second = cfg.new_block();
+        let third = cfg.new_block();
+        let default = cfg.new_block();
+        cfg.entry = entry;
+        let scrutinee = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(u64::MAX), ty));
+        let (cases_start, cases_len) =
+            cfg.push_switch_cases([(-1, third), (7, first), (42, second)]);
+        cfg.set_terminator(
+            entry,
+            Terminator::Switch {
+                scrutinee,
+                cases_start,
+                cases_len,
+                default,
+            },
+        );
+        for block in [first, second, third, default] {
+            cfg.set_terminator(block, Terminator::Return { value: None });
+        }
+        (cfg, pool, interner)
+    }
+
+    fn cleanup_edge_fixture() -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+        let (pool, aggregate_ty, interner) = struct_pool("CleanupPair", vec![Type::I32, Type::I32]);
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "cleanup_edge".to_string(), vec![]);
+        let entry = cfg.new_block();
+        let then_block = cfg.new_block();
+        let else_block = cfg.new_block();
+        let cleanup = cfg.new_block();
+        cfg.entry = entry;
+        let condition =
+            cfg.add_inst_to_block(entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let left = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(3), Type::I32));
+        let right = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(4), Type::I32));
+        let (fields_start, fields_len) = cfg.push_extra([left, right]);
+        let aggregate = cfg.add_inst_to_block(
+            entry,
+            inst(
+                CfgInstData::StructInit {
+                    struct_id: match aggregate_ty.kind() {
+                        rue_air::TypeKind::Struct(id) => id,
+                        _ => panic!("fixture aggregate must be a struct"),
+                    },
+                    fields_start,
+                    fields_len,
+                },
+                aggregate_ty,
+            ),
+        );
+        let _cleanup_param = cfg.add_block_param(cleanup, aggregate_ty);
+        cfg.set_terminator(
+            entry,
+            Terminator::Branch {
+                cond: condition,
+                then_block,
+                then_args_start: 0,
+                then_args_len: 0,
+                else_block,
+                else_args_start: 0,
+                else_args_len: 0,
+            },
+        );
+        let (then_cleanup_start, then_cleanup_len) = cfg.push_extra([aggregate]);
+        cfg.set_terminator(
+            then_block,
+            Terminator::Goto {
+                target: cleanup,
+                args_start: then_cleanup_start,
+                args_len: then_cleanup_len,
+            },
+        );
+        let (else_cleanup_start, else_cleanup_len) = cfg.push_extra([aggregate]);
+        cfg.set_terminator(
+            else_block,
+            Terminator::Goto {
+                target: cleanup,
+                args_start: else_cleanup_start,
+                args_len: else_cleanup_len,
+            },
+        );
+        cfg.set_terminator(cleanup, Terminator::Return { value: None });
+        (cfg, pool, interner)
+    }
+
+    fn aggregate_return_fixture(
+        fields: usize,
+        name: &str,
+    ) -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+        let (pool, aggregate_ty, interner) = struct_pool(name, vec![Type::I64; fields]);
+        let mut cfg = Cfg::new(aggregate_ty, 0, 0, name.to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let values = (0..fields)
+            .map(|value| {
+                cfg.add_inst_to_block(entry, inst(CfgInstData::Const(value as u64), Type::I64))
+            })
+            .collect::<Vec<_>>();
+        let (fields_start, fields_len) = cfg.push_extra(values);
+        let aggregate = cfg.add_inst_to_block(
+            entry,
+            inst(
+                CfgInstData::StructInit {
+                    struct_id: match aggregate_ty.kind() {
+                        rue_air::TypeKind::Struct(id) => id,
+                        _ => panic!("fixture aggregate must be a struct"),
+                    },
+                    fields_start,
+                    fields_len,
+                },
+                aggregate_ty,
+            ),
+        );
+        cfg.set_terminator(
+            entry,
+            Terminator::Return {
+                value: Some(aggregate),
+            },
+        );
+        (cfg, pool, interner)
+    }
+
+    fn zero_slot_edge_fixture() -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+        let pool = TypeInternPool::new();
+        let array_id = pool.intern_array_from_type(Type::UNIT, 2);
+        let pool = pool.freeze();
+        let interner = ThreadedRodeo::new();
+        let array_ty = Type::new_array(array_id);
+        let mut cfg = Cfg::new(array_ty, 0, 0, "zero_slot_edge".to_string(), vec![]);
+        let entry = cfg.new_block();
+        let target = cfg.new_block();
+        cfg.entry = entry;
+        let zero = cfg.add_inst_to_block(
+            entry,
+            inst(
+                CfgInstData::ArrayInit {
+                    elements_start: 0,
+                    elements_len: 0,
+                },
+                array_ty,
+            ),
+        );
+        let target_param = cfg.add_block_param(target, array_ty);
+        let (args_start, args_len) = cfg.push_extra([zero]);
+        cfg.set_terminator(
+            entry,
+            Terminator::Goto {
+                target,
+                args_start,
+                args_len,
+            },
+        );
+        cfg.set_terminator(
+            target,
+            Terminator::Return {
+                value: Some(target_param),
+            },
+        );
+        (cfg, pool, interner)
+    }
+
+    #[test]
+    fn real_diamond_and_loop_fixtures_share_topology_edge_work_and_branch_mir() {
+        for (cfg, pool, interner, expected_kinds) in [
+            {
+                let (cfg, pool, interner) = diamond_fixture();
+                (
+                    cfg,
+                    pool,
+                    interner,
+                    vec![
+                        TerminatorTraceKind::Branch,
+                        TerminatorTraceKind::Goto,
+                        TerminatorTraceKind::Goto,
+                        TerminatorTraceKind::ReturnScalar,
+                    ],
+                )
+            },
+            {
+                let (cfg, pool, interner) = loop_fixture();
+                (
+                    cfg,
+                    pool,
+                    interner,
+                    vec![
+                        TerminatorTraceKind::Branch,
+                        TerminatorTraceKind::Goto,
+                        TerminatorTraceKind::ReturnScalar,
+                    ],
+                )
+            },
+        ] {
+            let (x86, x86_debug, arm, arm_debug) = lower_both(&cfg, &pool, &interner);
+            let trace = assert_same_policy_trace(&cfg, &x86_debug, &arm_debug);
+            assert_eq!(
+                trace.iter().map(|trace| trace.kind).collect::<Vec<_>>(),
+                expected_kinds
+            );
+            assert!(trace[0].successors.len() == 2);
+            assert!(trace[0].fallthrough[0]);
+            assert_eq!(trace[0].edge_work, vec![vec![], vec![]]);
+            assert!(
+                x86.instructions()
+                    .iter()
+                    .any(|inst| matches!(inst, X86Inst::Jz { .. } | X86Inst::Jnz { .. }))
+            );
+            assert!(arm.instructions().iter().any(|inst| {
+                matches!(inst, Aarch64Inst::Cbz { .. } | Aarch64Inst::Cbnz { .. })
+            }));
+        }
+    }
+
+    #[test]
+    fn real_same_successor_fixture_selects_one_fallthrough_layout() {
+        let (cfg, pool, interner) = same_successor_fixture();
+        let (x86, x86_debug, arm, arm_debug) = lower_both(&cfg, &pool, &interner);
+        let trace = assert_same_policy_trace(&cfg, &x86_debug, &arm_debug);
+        assert_eq!(trace[0].kind, TerminatorTraceKind::Branch);
+        assert_eq!(trace[0].fallthrough, vec![true, false]);
+        assert_eq!(trace[0].edge_work, vec![vec![(0, 0)], vec![(0, 0)]]);
+        assert!(
+            x86.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::Jnz { .. }))
+        );
+        assert!(
+            arm.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::Cbnz { .. }))
+        );
+    }
+
+    #[test]
+    fn real_switch_fixtures_preserve_signed_64_bit_order_and_target_compare_facts() {
+        for (ty, expected_signed) in [(Type::I64, true), (Type::U64, false)] {
+            let (cfg, pool, interner) = switch_fixture(
+                ty,
+                if expected_signed {
+                    "switch_i64"
+                } else {
+                    "switch_u64"
+                },
+            );
+            let (x86, x86_debug, arm, arm_debug) = lower_both(&cfg, &pool, &interner);
+            let trace = assert_same_policy_trace(&cfg, &x86_debug, &arm_debug);
+            assert_eq!(trace[0].kind, TerminatorTraceKind::Switch);
+            assert_eq!(
+                trace[0].switch_width,
+                Some(value_plan::IntegerWidth {
+                    bits: 64,
+                    signed: expected_signed
+                })
+            );
+            assert_eq!(
+                trace[0].switch_cases,
+                vec![
+                    (-1, BlockId::from_raw(3)),
+                    (7, BlockId::from_raw(1)),
+                    (42, BlockId::from_raw(2)),
+                ]
+            );
+            assert_eq!(
+                trace[0].successors,
+                vec![
+                    BlockId::from_raw(3),
+                    BlockId::from_raw(1),
+                    BlockId::from_raw(2),
+                    BlockId::from_raw(4)
+                ]
+            );
+            assert_eq!(
+                x86.instructions()
+                    .iter()
+                    .filter(|inst| matches!(inst, X86Inst::Cmp64RR { .. }))
+                    .count(),
+                3
+            );
+            assert_eq!(
+                arm.instructions()
+                    .iter()
+                    .filter(|inst| matches!(inst, Aarch64Inst::Cmp64RR { .. }))
+                    .count(),
+                3
+            );
+            assert_eq!(
+                x86.instructions()
+                    .iter()
+                    .filter(|inst| matches!(inst, X86Inst::Jz { .. }))
+                    .count(),
+                3
+            );
+            assert_eq!(
+                arm.instructions()
+                    .iter()
+                    .filter(|inst| matches!(inst, Aarch64Inst::BCond { .. }))
+                    .count(),
+                3
+            );
+        }
+    }
+
+    #[test]
+    fn real_cleanup_fixture_preserves_ordered_aggregate_edge_work() {
+        let (cfg, pool, interner) = cleanup_edge_fixture();
+        let (x86, x86_debug, arm, arm_debug) = lower_both(&cfg, &pool, &interner);
+        let trace = assert_same_policy_trace(&cfg, &x86_debug, &arm_debug);
+        assert_eq!(trace[0].kind, TerminatorTraceKind::Branch);
+        assert_eq!(trace[0].edge_move_counts, vec![0, 0]);
+        assert_eq!(trace[0].edge_work, vec![vec![], vec![]]);
+        assert_eq!(trace[1].edge_move_counts, vec![2]);
+        assert_eq!(trace[2].edge_move_counts, vec![2]);
+        assert_eq!(trace[1].edge_work, vec![vec![(0, 0), (0, 1)]]);
+        assert_eq!(trace[2].edge_work, vec![vec![(0, 0), (0, 1)]]);
+        assert_eq!(
+            x86.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, X86Inst::MovRR { .. }))
+                .count(),
+            arm.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, Aarch64Inst::MovRR { .. }))
+                .count()
+        );
+    }
+
+    #[test]
+    fn real_unreachable_fixture_has_target_traps_and_shared_trap_policy() {
+        let pool = FrozenTypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "trap".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.set_terminator(entry, Terminator::Unreachable);
+        let (x86, x86_debug, arm, arm_debug) = lower_both(&cfg, &pool, &interner);
+        let trace = assert_same_policy_trace(&cfg, &x86_debug, &arm_debug);
+        assert_eq!(
+            trace,
+            vec![TerminatorTrace {
+                kind: TerminatorTraceKind::Unreachable,
+                successors: vec![],
+                fallthrough: vec![],
+                edge_move_counts: vec![],
+                edge_work: vec![],
+                switch_width: None,
+                switch_cases: vec![],
+            }]
+        );
+        assert!(
+            x86.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::Ud2))
+        );
+        assert!(
+            arm.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::Brk))
+        );
+    }
+
+    #[test]
+    fn real_return_fixture_matrix_covers_scalar_unit_main_multiple_and_aggregate_modes() {
+        let scalar_pool = FrozenTypeInternPool::new();
+        let scalar_interner = ThreadedRodeo::new();
+        let mut scalar_cfg = Cfg::new(Type::I32, 0, 0, "scalar".to_string(), vec![]);
+        let scalar_entry = scalar_cfg.new_block();
+        scalar_cfg.entry = scalar_entry;
+        let scalar =
+            scalar_cfg.add_inst_to_block(scalar_entry, inst(CfgInstData::Const(9), Type::I32));
+        scalar_cfg.set_terminator(
+            scalar_entry,
+            Terminator::Return {
+                value: Some(scalar),
+            },
+        );
+
+        let unit_pool = FrozenTypeInternPool::new();
+        let unit_interner = ThreadedRodeo::new();
+        let mut unit_cfg = Cfg::new(Type::UNIT, 0, 0, "unit".to_string(), vec![]);
+        let unit_entry = unit_cfg.new_block();
+        unit_cfg.entry = unit_entry;
+        unit_cfg.set_terminator(unit_entry, Terminator::Return { value: None });
+
+        let main_pool = FrozenTypeInternPool::new();
+        let main_interner = ThreadedRodeo::new();
+        let mut main_cfg = Cfg::new(Type::I32, 0, 0, "main".to_string(), vec![]);
+        let main_entry = main_cfg.new_block();
+        main_cfg.entry = main_entry;
+        let main_value =
+            main_cfg.add_inst_to_block(main_entry, inst(CfgInstData::Const(0), Type::I32));
+        main_cfg.set_terminator(
+            main_entry,
+            Terminator::Return {
+                value: Some(main_value),
+            },
+        );
+
+        for (cfg, pool, interner, expected_kind) in [
+            (
+                &scalar_cfg,
+                &scalar_pool,
+                &scalar_interner,
+                TerminatorTraceKind::ReturnScalar,
+            ),
+            (
+                &unit_cfg,
+                &unit_pool,
+                &unit_interner,
+                TerminatorTraceKind::ReturnUnit,
+            ),
+            (
+                &main_cfg,
+                &main_pool,
+                &main_interner,
+                TerminatorTraceKind::ReturnExit,
+            ),
+        ] {
+            let (x86, x86_debug, arm, arm_debug) = lower_both(cfg, pool, interner);
+            let trace = assert_same_policy_trace(cfg, &x86_debug, &arm_debug);
+            assert_eq!(trace[0].kind, expected_kind);
+            assert!(
+                x86.instructions()
+                    .iter()
+                    .any(|inst| matches!(inst, X86Inst::Ret | X86Inst::CallRel { .. }))
+            );
+            assert!(
+                arm.instructions()
+                    .iter()
+                    .any(|inst| matches!(inst, Aarch64Inst::Ret | Aarch64Inst::Bl { .. }))
+            );
+        }
+
+        let (multi_pool, multi_interner) = (FrozenTypeInternPool::new(), ThreadedRodeo::new());
+        let mut multi_cfg = Cfg::new(Type::I32, 0, 0, "multiple_returns".to_string(), vec![]);
+        let multi_entry = multi_cfg.new_block();
+        let first = multi_cfg.new_block();
+        let second = multi_cfg.new_block();
+        multi_cfg.entry = multi_entry;
+        let condition = multi_cfg
+            .add_inst_to_block(multi_entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let first_value =
+            multi_cfg.add_inst_to_block(first, inst(CfgInstData::Const(1), Type::I32));
+        let second_value =
+            multi_cfg.add_inst_to_block(second, inst(CfgInstData::Const(2), Type::I32));
+        multi_cfg.set_terminator(
+            multi_entry,
+            Terminator::Branch {
+                cond: condition,
+                then_block: first,
+                then_args_start: 0,
+                then_args_len: 0,
+                else_block: second,
+                else_args_start: 0,
+                else_args_len: 0,
+            },
+        );
+        multi_cfg.set_terminator(
+            first,
+            Terminator::Return {
+                value: Some(first_value),
+            },
+        );
+        multi_cfg.set_terminator(
+            second,
+            Terminator::Return {
+                value: Some(second_value),
+            },
+        );
+        let (x86, x86_debug, arm, arm_debug) = lower_both(&multi_cfg, &multi_pool, &multi_interner);
+        let trace = assert_same_policy_trace(&multi_cfg, &x86_debug, &arm_debug);
+        assert_eq!(
+            trace
+                .iter()
+                .filter(|trace| trace.kind == TerminatorTraceKind::ReturnScalar)
+                .count(),
+            2
+        );
+        assert!(
+            x86.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, X86Inst::Ret))
+                .count()
+                >= 2
+        );
+        assert!(
+            arm.instructions()
+                .iter()
+                .filter(|inst| matches!(inst, Aarch64Inst::Ret))
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn real_aggregate_return_and_zero_slot_edge_fixtures_share_abi_shape() {
+        let (register_cfg, register_pool, register_interner) =
+            aggregate_return_fixture(2, "aggregate_registers");
+        let (x86, x86_debug, arm, arm_debug) =
+            lower_both(&register_cfg, &register_pool, &register_interner);
+        let trace = assert_same_policy_trace(&register_cfg, &x86_debug, &arm_debug);
+        assert_eq!(trace[0].kind, TerminatorTraceKind::ReturnAggregateRegisters);
+        assert!(
+            x86.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::Ret))
+        );
+        assert!(
+            arm.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::Ret))
+        );
+
+        let (sret_cfg, sret_pool, sret_interner) = aggregate_return_fixture(9, "aggregate_sret");
+        let (x86, x86_debug, arm, arm_debug) = lower_both(&sret_cfg, &sret_pool, &sret_interner);
+        let trace = assert_same_policy_trace(&sret_cfg, &x86_debug, &arm_debug);
+        assert_eq!(trace[0].kind, TerminatorTraceKind::ReturnAggregateSret);
+        assert!(
+            x86.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::Ret))
+        );
+        assert!(
+            arm.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::Ret))
+        );
+
+        let (zero_cfg, zero_pool, zero_interner) = zero_slot_edge_fixture();
+        let (x86, x86_debug, arm, arm_debug) = lower_both(&zero_cfg, &zero_pool, &zero_interner);
+        let trace = assert_same_policy_trace(&zero_cfg, &x86_debug, &arm_debug);
+        assert_eq!(trace[0].kind, TerminatorTraceKind::Goto);
+        assert_eq!(trace[0].edge_move_counts, vec![0]);
+        assert_eq!(trace[0].edge_work, vec![vec![]]);
+        assert_eq!(trace[1].kind, TerminatorTraceKind::ReturnAggregateZeroSized);
+        assert!(
+            x86.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::Ret))
+        );
+        assert!(
+            arm.instructions()
+                .iter()
+                .any(|inst| matches!(inst, Aarch64Inst::Ret))
+        );
+    }
+
+    #[test]
+    fn edge_fallthrough_is_based_on_logical_block_order() {
+        let pool = FrozenTypeInternPool::new();
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "ordered_blocks".to_string(), vec![]);
+        let first = cfg.new_block();
+        let second = cfg.new_block();
+        let third = cfg.new_block();
+        let ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
+        assert_eq!(next_ordered_block(&ctx, first), Some(second));
+        assert_eq!(next_ordered_block(&ctx, second), Some(third));
+        assert_eq!(next_ordered_block(&ctx, third), None);
+    }
+
+    #[test]
+    fn plan_is_target_free() {
+        let plan = TerminatorPlan::Switch {
+            scrutinee: VReg::new(1),
+            width: value_plan::IntegerWidth {
+                bits: 64,
+                signed: true,
+            },
+            cases: vec![SwitchCasePlan {
+                value: -1,
+                target: BlockId::from_raw(2),
+            }],
+            default: BlockId::from_raw(3),
+        };
+        let text = format!("{plan:?}");
+        assert!(!text.contains("Reg::"));
+        assert!(!text.contains("Inst::"));
+    }
+
+    #[test]
+    fn trace_preserves_ordered_topology_and_switch_width() {
+        let plan = TerminatorPlan::Switch {
+            scrutinee: VReg::new(0),
+            width: value_plan::IntegerWidth {
+                bits: 64,
+                signed: true,
+            },
+            cases: vec![
+                SwitchCasePlan {
+                    value: 7,
+                    target: BlockId::from_raw(4),
+                },
+                SwitchCasePlan {
+                    value: -1,
+                    target: BlockId::from_raw(2),
+                },
+            ],
+            default: BlockId::from_raw(9),
+        };
+        let trace = plan.trace();
+        assert_eq!(trace.kind, TerminatorTraceKind::Switch);
+        assert_eq!(
+            trace.successors,
+            vec![
+                BlockId::from_raw(4),
+                BlockId::from_raw(2),
+                BlockId::from_raw(9)
+            ]
+        );
+        assert_eq!(
+            trace.switch_cases,
+            vec![(7, BlockId::from_raw(4)), (-1, BlockId::from_raw(2))]
+        );
+        assert_eq!(trace.switch_width.unwrap().bits, 64);
+    }
+
+    #[test]
+    fn trace_records_edge_work_and_fallthrough() {
+        let plan = TerminatorPlan::Branch {
+            condition: VReg::new(0),
+            then_edge: EdgePlan {
+                target: BlockId::from_raw(1),
+                moves: vec![SlotMove {
+                    argument_index: 0,
+                    slot_index: 0,
+                    source: VReg::new(1),
+                    destination: VReg::new(2),
+                }],
+                fallthrough: true,
+            },
+            else_edge: EdgePlan {
+                target: BlockId::from_raw(8),
+                moves: vec![],
+                fallthrough: false,
+            },
+        };
+        assert_eq!(
+            plan.trace(),
+            TerminatorTrace {
+                kind: TerminatorTraceKind::Branch,
+                successors: vec![BlockId::from_raw(1), BlockId::from_raw(8)],
+                fallthrough: vec![true, false],
+                edge_move_counts: vec![1, 0],
+                edge_work: vec![vec![(0, 0)], vec![]],
+                switch_width: None,
+                switch_cases: vec![],
+            }
+        );
+    }
+}

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
 use rue_air::{FrozenTypeInternPool, TypeKind};
-use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, Terminator, Type};
+use rue_cfg::{BlockId, Cfg, CfgInstData, CfgValue, Place, Type};
 use rue_error::CompileResult;
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
@@ -449,61 +449,10 @@ impl<'a> CfgLower<'a> {
         crate::agg_slots::require_aggregate_slots(self, value)
     }
 
-    /// Copy an aggregate value's slot vregs to a block parameter's slot vregs.
-    /// Covers structs, builtin String, and fixed-size arrays — every slot must
-    /// cross the join edge, not just the primary vreg (RUE-167).
-    fn copy_aggregate_to_block_param(
-        &mut self,
-        arg: CfgValue,
-        target_block: BlockId,
-        param_idx: u32,
-    ) {
-        let target_param = self.ctx.cfg.get_block(target_block).params[param_idx as usize].0;
-
-        let src_slots = self.require_aggregate_slots(arg);
-        let dst_slots = self
-            .struct_slot_vregs
-            .get(&target_param)
-            .cloned()
-            .expect("aggregate block param should have slot vregs pre-allocated");
-
-        // Correctness guard (must run in release): a slot-count mismatch would
-        // move the wrong number of aggregate slots and silently miscompile, so
-        // this is a plain `assert!` rather than a `debug_assert!` (RUE-45).
-        assert_eq!(
-            src_slots.len(),
-            dst_slots.len(),
-            "source and destination aggregate slot counts must match"
-        );
-        for (dst_vreg, src_vreg) in dst_slots.iter().zip(src_slots.iter()) {
-            self.mir.push(X86Inst::MovRR {
-                dst: Operand::Virtual(*dst_vreg),
-                src: Operand::Virtual(*src_vreg),
-            });
-        }
-    }
-
     /// Lower CFG to X86Mir.
     pub fn lower(mut self) -> CompileResult<X86Mir> {
-        self.preload_by_ref_param_ptrs();
-
-        // Pre-allocate vregs for block parameters
-        for block in self.ctx.cfg.blocks() {
-            for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
-                let vreg = self.mir.alloc_vreg();
-                self.block_param_vregs
-                    .insert((block.id, param_idx as u32), vreg);
-                self.value_map.insert(*param_val, vreg);
-
-                crate::agg_slots::preallocate_block_param_slots(&mut self, *param_val, *ty, vreg);
-            }
-        }
-
-        // Lower each block
-        for block in self.ctx.cfg.blocks() {
-            self.lower_block(block);
-        }
-
+        let ctx = self.ctx;
+        crate::terminator_plan::lower_cfg(&ctx, &mut self, None, RET_REGS.len() as u32);
         Ok(self.mir)
     }
 
@@ -512,123 +461,19 @@ impl<'a> CfgLower<'a> {
     /// This is like `lower()` but also captures detailed information about
     /// how each CFG instruction maps to MIR instructions.
     pub fn lower_with_debug(mut self) -> CompileResult<(X86Mir, crate::LoweringDebugInfo)> {
-        use crate::cfg_lower::{format_cfg_inst_data_with_interner, format_terminator};
-        use crate::{
-            BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
-        };
-
-        let mut debug_info = LoweringDebugInfo {
+        let mut debug_info = crate::LoweringDebugInfo {
             fn_name: self.fn_name.to_string(),
             target_arch: "x86_64".to_string(),
             blocks: Vec::new(),
         };
 
-        self.preload_by_ref_param_ptrs();
-
-        // Pre-allocate vregs for block parameters (same as lower())
-        for block in self.ctx.cfg.blocks() {
-            for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
-                let vreg = self.mir.alloc_vreg();
-                self.block_param_vregs
-                    .insert((block.id, param_idx as u32), vreg);
-                self.value_map.insert(*param_val, vreg);
-
-                crate::agg_slots::preallocate_block_param_slots(&mut self, *param_val, *ty, vreg);
-            }
-        }
-
-        // Lower each block with debug tracking
-        for block in self.ctx.cfg.blocks() {
-            let mut block_info = BlockLoweringInfo {
-                block_id: block.id,
-                instructions: Vec::new(),
-                terminator: None,
-            };
-
-            // Block parameters are preallocated before the block walk and
-            // therefore never reach `lower_value`'s MIR-emission path. Keep
-            // them in lowering debug output so the trace remains a complete
-            // CFG-to-MIR account, including intentional no-op materialization.
-            for (param_val, _) in &block.params {
-                let param_inst = self.ctx.cfg.get_inst(*param_val);
-                block_info.instructions.push(LoweringDecision {
-                    cfg_value: *param_val,
-                    cfg_inst_desc: format_cfg_inst_data_with_interner(
-                        self.ctx.cfg,
-                        &param_inst.data,
-                        self.interner,
-                    ),
-                    cfg_type: param_inst.ty.name().to_string(),
-                    mir_insts: Vec::new(),
-                    rationale: Some("Block parameter preallocated at the join".to_string()),
-                });
-            }
-
-            // Emit block label (except for entry block)
-            if block.id != self.ctx.cfg.entry {
-                self.mir.push(X86Inst::Label {
-                    id: self.block_label(block.id),
-                });
-            }
-
-            // Lower each instruction with tracking
-            for &value in &block.insts {
-                // Skip if already lowered
-                if self.value_map.contains_key(&value) {
-                    continue;
-                }
-
-                let inst = self.ctx.cfg.get_inst(value);
-                let inst_before = self.mir.inst_count();
-
-                // Lower the instruction
-                self.lower_value(value);
-
-                let inst_after = self.mir.inst_count();
-
-                // Capture the generated instructions
-                let mir_insts: Vec<String> = self.mir.instructions()[inst_before..inst_after]
-                    .iter()
-                    .map(|i| format!("{}", i))
-                    .collect();
-
-                // Generate rationale for interesting cases
-                let rationale = self.get_lowering_rationale(&inst.data, inst.ty);
-
-                block_info.instructions.push(LoweringDecision {
-                    cfg_value: value,
-                    cfg_inst_desc: format_cfg_inst_data_with_interner(
-                        self.ctx.cfg,
-                        &inst.data,
-                        self.interner,
-                    ),
-                    cfg_type: inst.ty.name().to_string(),
-                    mir_insts,
-                    rationale,
-                });
-            }
-
-            // Lower terminator with tracking
-            let term_before = self.mir.inst_count();
-            self.lower_terminator(block);
-            let term_after = self.mir.inst_count();
-
-            let term_mir_insts: Vec<String> = self.mir.instructions()[term_before..term_after]
-                .iter()
-                .map(|i| format!("{}", i))
-                .collect();
-
-            let term_rationale = self.get_terminator_rationale(&block.terminator);
-
-            block_info.terminator = Some(TerminatorLoweringDecision {
-                terminator_desc: format_terminator(self.ctx.cfg, &block.terminator),
-                mir_insts: term_mir_insts,
-                rationale: term_rationale,
-            });
-
-            debug_info.blocks.push(block_info);
-        }
-
+        let ctx = self.ctx;
+        crate::terminator_plan::lower_cfg(
+            &ctx,
+            &mut self,
+            Some(&mut debug_info),
+            RET_REGS.len() as u32,
+        );
         Ok((self.mir, debug_info))
     }
 
@@ -727,43 +572,6 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Generate rationale for terminator lowering decisions.
-    fn get_terminator_rationale(&self, terminator: &Terminator) -> Option<String> {
-        match terminator {
-            Terminator::Branch { .. } => Some("Compare with zero, conditional jump".to_string()),
-            Terminator::Return { value } => {
-                if self.fn_name == "main" {
-                    Some("Main function: return value becomes exit code".to_string())
-                } else if value.is_some() {
-                    Some("Return value in RAX (SysV ABI)".to_string())
-                } else {
-                    None
-                }
-            }
-            Terminator::Switch { cases_len, .. } => {
-                Some(format!("Linear scan through {} cases", cases_len))
-            }
-            _ => None,
-        }
-    }
-
-    /// Lower a single basic block.
-    fn lower_block(&mut self, block: &BasicBlock) {
-        // Emit block label (except for entry block)
-        if block.id != self.ctx.cfg.entry {
-            self.mir.push(X86Inst::Label {
-                id: self.block_label(block.id),
-            });
-        }
-
-        // Lower each instruction
-        for &value in &block.insts {
-            self.lower_value(value);
-        }
-
-        // Lower terminator
-        self.lower_terminator(block);
-    }
-
     /// Lower a CFG value (instruction).
     fn lower_value(&mut self, value: CfgValue) {
         // Skip if already lowered
@@ -3547,246 +3355,147 @@ impl<'a> CfgLower<'a> {
         result_vreg
     }
 
-    /// Lower a block terminator.
-    fn lower_terminator(&mut self, block: &BasicBlock) {
-        match &block.terminator {
-            Terminator::Goto {
-                target,
-                args_start,
-                args_len,
-            } => {
-                // Copy args to target's block params
-                let args = self.ctx.cfg.get_extra(*args_start, *args_len);
-                for (i, &arg) in args.iter().enumerate() {
-                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
-                    if arg_plan.shape.requires_complete_slots() {
-                        // For aggregate args (structs, String, arrays), copy all slot vregs
-                        self.copy_aggregate_to_block_param(arg, *target, i as u32);
-                    } else {
-                        // For scalar args, just copy the single vreg
-                        let arg_vreg = self.get_vreg(arg);
-                        let param_vreg = self.block_param_vregs[&(*target, i as u32)];
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(param_vreg),
-                            src: Operand::Virtual(arg_vreg),
-                        });
-                    }
-                }
+    fn emit_terminator_plan(&mut self, plan: crate::terminator_plan::TerminatorPlan) {
+        use crate::terminator_plan::{ReturnMode, ReturnValuePlan, TerminatorPlan};
 
-                // Jump to target (unless it's the next block)
-                let next_block_id = BlockId::from_raw(block.id.as_u32() + 1);
-                if *target != next_block_id {
+        match plan {
+            TerminatorPlan::Goto { edge } => {
+                self.emit_edge_moves(&edge);
+                if !edge.fallthrough {
                     self.mir.push(X86Inst::Jmp {
-                        label: self.block_label(*target),
+                        label: self.block_label(edge.target),
                     });
                 }
             }
-
-            Terminator::Branch {
-                cond,
-                then_block,
-                then_args_start,
-                then_args_len,
-                else_block,
-                else_args_start,
-                else_args_len,
+            TerminatorPlan::Branch {
+                condition,
+                then_edge,
+                else_edge,
             } => {
-                let cond_vreg = self.get_vreg(*cond);
-
-                // Generate a unique label for the else path argument setup
-                let else_setup_label = self.new_label();
-
-                // Test condition
                 self.mir.push(X86Inst::CmpRI {
-                    src: Operand::Virtual(cond_vreg),
+                    src: Operand::Virtual(condition),
                     imm: 0,
                 });
-
-                // If false (zero), jump to else setup (where we copy else_args)
-                self.mir.push(X86Inst::Jz {
-                    label: else_setup_label.clone(),
-                });
-
-                // Copy then_args to then_block's params
-                let then_args = self.ctx.cfg.get_extra(*then_args_start, *then_args_len);
-                for (i, &arg) in then_args.iter().enumerate() {
-                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
-                    if arg_plan.shape.requires_complete_slots() {
-                        // For aggregate args (structs, String, arrays), copy all slot vregs
-                        self.copy_aggregate_to_block_param(arg, *then_block, i as u32);
-                    } else {
-                        // For scalar args, just copy the single vreg
-                        let arg_vreg = self.get_vreg(arg);
-                        let param_vreg = self.block_param_vregs[&(*then_block, i as u32)];
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(param_vreg),
-                            src: Operand::Virtual(arg_vreg),
-                        });
-                    }
-                }
-
-                // Jump to then block
-                self.mir.push(X86Inst::Jmp {
-                    label: self.block_label(*then_block),
-                });
-
-                // Else setup: copy else_args to else_block's params
-                self.mir.push(X86Inst::Label {
-                    id: else_setup_label,
-                });
-                let else_args = self.ctx.cfg.get_extra(*else_args_start, *else_args_len);
-                for (i, &arg) in else_args.iter().enumerate() {
-                    let arg_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, arg);
-                    if arg_plan.shape.requires_complete_slots() {
-                        // For aggregate args (structs, String, arrays), copy all slot vregs
-                        self.copy_aggregate_to_block_param(arg, *else_block, i as u32);
-                    } else {
-                        // For scalar args, just copy the single vreg
-                        let arg_vreg = self.get_vreg(arg);
-                        let param_vreg = self.block_param_vregs[&(*else_block, i as u32)];
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(param_vreg),
-                            src: Operand::Virtual(arg_vreg),
-                        });
-                    }
-                }
-
-                // Jump to else block (or fall through if next)
-                let next_block_id = BlockId::from_raw(block.id.as_u32() + 1);
-                if *else_block != next_block_id {
-                    self.mir.push(X86Inst::Jmp {
-                        label: self.block_label(*else_block),
+                if then_edge.fallthrough {
+                    let then_setup_label = self.new_label();
+                    self.mir.push(X86Inst::Jnz {
+                        label: then_setup_label,
                     });
+                    self.emit_edge_moves(&else_edge);
+                    if !else_edge.fallthrough {
+                        self.mir.push(X86Inst::Jmp {
+                            label: self.block_label(else_edge.target),
+                        });
+                    }
+                    self.mir.push(X86Inst::Label {
+                        id: then_setup_label,
+                    });
+                    self.emit_edge_moves(&then_edge);
+                } else {
+                    let else_setup_label = self.new_label();
+                    self.mir.push(X86Inst::Jz {
+                        label: else_setup_label,
+                    });
+                    self.emit_edge_moves(&then_edge);
+                    if !then_edge.fallthrough {
+                        self.mir.push(X86Inst::Jmp {
+                            label: self.block_label(then_edge.target),
+                        });
+                    }
+                    self.mir.push(X86Inst::Label {
+                        id: else_setup_label,
+                    });
+                    self.emit_edge_moves(&else_edge);
+                    if !else_edge.fallthrough {
+                        self.mir.push(X86Inst::Jmp {
+                            label: self.block_label(else_edge.target),
+                        });
+                    }
                 }
             }
-
-            Terminator::Switch {
+            TerminatorPlan::Switch {
                 scrutinee,
-                cases_start,
-                cases_len,
+                width,
+                cases,
                 default,
             } => {
-                let scrutinee_vreg = self.get_vreg(*scrutinee);
-                // The case value is materialized as a full 64-bit immediate, so a
-                // 64-bit scrutinee must be compared at 64-bit width; a 32-bit cmp
-                // would match on only the low 32 bits (RUE-27). Sub-64-bit
-                // scrutinees keep the 32-bit compare (correct at their width).
-                let scrutinee_ty = self.ctx.cfg.get_inst(*scrutinee).ty;
-                let scrutinee_is_64 = crate::value_plan::is_64_bit(scrutinee_ty);
-
-                // Generate comparison and jump for each case
-                let cases = self.ctx.cfg.get_switch_cases(*cases_start, *cases_len);
-                for (value, target) in cases {
-                    // Load case value into a register (supports signed values for negative patterns)
+                for case in cases {
                     let case_vreg = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::MovRI64 {
                         dst: Operand::Virtual(case_vreg),
-                        imm: *value,
+                        imm: case.value,
                     });
-                    if scrutinee_is_64 {
+                    if width.bits == 64 {
                         self.mir.push(X86Inst::Cmp64RR {
-                            src1: Operand::Virtual(scrutinee_vreg),
+                            src1: Operand::Virtual(scrutinee),
                             src2: Operand::Virtual(case_vreg),
                         });
                     } else {
                         self.mir.push(X86Inst::CmpRR {
-                            src1: Operand::Virtual(scrutinee_vreg),
+                            src1: Operand::Virtual(scrutinee),
                             src2: Operand::Virtual(case_vreg),
                         });
                     }
                     self.mir.push(X86Inst::Jz {
-                        label: self.block_label(*target),
+                        label: self.block_label(case.target),
                     });
                 }
-
-                // Fall through to default
                 self.mir.push(X86Inst::Jmp {
-                    label: self.block_label(*default),
+                    label: self.block_label(default),
                 });
             }
-
-            Terminator::Return { value } => {
-                // Handle `return;` without expression (unit-returning functions)
-                let Some(value) = value else {
-                    if self.fn_name == "main" {
-                        // Linux enters Rue's `main` directly. Unit has no CFG
-                        // value, so pass the language-defined success status to
-                        // the non-returning runtime exit shim explicitly.
+            TerminatorPlan::Return { mode } => match mode {
+                ReturnMode::Exit { value } => {
+                    if let Some(value) = value {
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Physical(Reg::Rdi),
+                            src: Operand::Virtual(value),
+                        });
+                    } else {
                         self.mir.push(X86Inst::MovRI32 {
                             dst: Operand::Physical(Reg::Rdi),
                             imm: 0,
                         });
-                        let symbol_id = self.intern_symbol("__rue_exit");
-                        self.mir.push(X86Inst::CallRel { symbol_id });
-                    } else {
-                        self.mir.push(X86Inst::Ret);
                     }
-                    return;
-                };
-
-                let return_plan = crate::value_plan::ValuePlan::for_value(&self.ctx, *value);
-
-                if self.fn_name == "main" {
-                    let val_vreg = self.get_vreg(*value);
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(Reg::Rdi),
-                        src: Operand::Virtual(val_vreg),
-                    });
-                    // Don't emit epilogue before __rue_exit - it never returns, and
-                    // restoring the frame would break stack alignment for the call
-                    // (after pop rbp, rsp is 8 mod 16; call pushes 8 more, making
-                    // it 0 mod 16 at callee entry, violating SysV ABI).
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(X86Inst::CallRel { symbol_id });
-                } else if return_plan.shape.requires_complete_slots() {
-                    // Return a multi-slot aggregate (struct, array, or payload
-                    // enum). Every valid source has exactly `type_slot_count`
-                    // materialized vregs. (RUE-118, RUE-78, RUE-237)
-                    let slot_vregs = self.require_aggregate_slots(*value);
-                    if self.ctx.uses_sret_return(RET_REGS.len() as u32) {
-                        // sret return (String always; aggregates that don't fit
-                        // the return registers): the caller passed a buffer
-                        // pointer as a hidden first argument, which the
-                        // prologue saved at the dedicated frame slot one past
-                        // the param area. Store every slot through it.
-                        crate::agg_slots::store_slots_to_sret(self, &slot_vregs);
-                    } else {
-                        // Move slot values to return registers in REVERSE order: regalloc
-                        // uses Rax as scratch when loading spilled values, so moving to Rax
-                        // (RET_REGS[0]) last avoids clobbering it with later slots' loads.
-                        for (i, slot_vreg) in slot_vregs.iter().enumerate().rev() {
-                            if i < RET_REGS.len() {
-                                self.mir.push(X86Inst::MovRR {
-                                    dst: Operand::Physical(RET_REGS[i]),
-                                    src: Operand::Virtual(*slot_vreg),
-                                });
+                }
+                ReturnMode::Function { value } => match value {
+                    ReturnValuePlan::ZeroSized => self.mir.push(X86Inst::Ret),
+                    ReturnValuePlan::Scalar { value } => {
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Physical(Reg::Rax),
+                            src: Operand::Virtual(value),
+                        });
+                        self.mir.push(X86Inst::Ret);
+                    }
+                    ReturnValuePlan::Aggregate { slots, return_plan } => {
+                        if return_plan.uses_sret() {
+                            crate::agg_slots::store_slots_to_sret(self, &slots);
+                        } else {
+                            for (index, slot) in slots.iter().enumerate().rev() {
+                                if index < RET_REGS.len() {
+                                    self.mir.push(X86Inst::MovRR {
+                                        dst: Operand::Physical(RET_REGS[index]),
+                                        src: Operand::Virtual(*slot),
+                                    });
+                                }
                             }
                         }
+                        self.mir.push(X86Inst::Ret);
                     }
+                },
+            },
+            TerminatorPlan::Unreachable => self.mir.push(X86Inst::Ud2),
+        }
+    }
 
-                    self.mir.push(X86Inst::Ret);
-                } else {
-                    let val_vreg = self.get_vreg(*value);
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(Reg::Rax),
-                        src: Operand::Virtual(val_vreg),
-                    });
-                    self.mir.push(X86Inst::Ret);
-                }
-            }
-
-            Terminator::Unreachable => {
-                // Defense-in-depth (RUE-208): emit a trap rather than nothing.
-                // The compiler proved this block unreachable, but if a
-                // control-flow bug ever lets execution reach it, `ud2` faults
-                // (SIGILL) immediately instead of silently falling through into
-                // whatever code the block layout happens to place next.
-                self.mir.push(X86Inst::Ud2);
-            }
-
-            Terminator::None => {
-                panic!("block has no terminator");
-            }
+    fn emit_edge_moves(&mut self, edge: &crate::terminator_plan::EdgePlan) {
+        for movement in &edge.moves {
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(movement.destination),
+                src: Operand::Virtual(movement.source),
+            });
         }
     }
 
@@ -3803,6 +3512,119 @@ impl<'a> CfgLower<'a> {
             .get(&value)
             .copied()
             .expect("value should have been lowered")
+    }
+}
+
+impl crate::terminator_plan::TerminatorAdapter for CfgLower<'_> {
+    fn materialize_value(
+        &mut self,
+        value: CfgValue,
+        plan: crate::value_plan::ValuePlan,
+    ) -> crate::terminator_plan::MaterializedValue {
+        let primary = self.get_vreg(value);
+        let slots = if plan.shape.requires_complete_slots() {
+            self.require_aggregate_slots(value)
+        } else {
+            Vec::new()
+        };
+        crate::terminator_plan::MaterializedValue { primary, slots }
+    }
+
+    fn materialize_block_param(
+        &mut self,
+        target: BlockId,
+        param_index: u32,
+        value: CfgValue,
+        plan: crate::value_plan::ValuePlan,
+    ) -> crate::terminator_plan::MaterializedValue {
+        let primary = self.block_param_vregs[&(target, param_index)];
+        let slots = if plan.shape.requires_complete_slots() {
+            let slots = self
+                .struct_slot_vregs
+                .get(&value)
+                .cloned()
+                .expect("aggregate block parameter slots should be preallocated");
+            plan.assert_complete_slots(slots.len());
+            slots
+        } else {
+            Vec::new()
+        };
+        crate::terminator_plan::MaterializedValue { primary, slots }
+    }
+
+    fn emit_block_label(&mut self, block: BlockId) {
+        self.mir.push(X86Inst::Label {
+            id: self.block_label(block),
+        });
+    }
+
+    fn emit_terminator(&mut self, plan: crate::terminator_plan::TerminatorPlan) {
+        self.emit_terminator_plan(plan);
+    }
+}
+
+impl crate::terminator_plan::CfgLowerAdapter for CfgLower<'_> {
+    fn preload_by_ref_params(&mut self) {
+        self.preload_by_ref_param_ptrs();
+    }
+
+    fn prepare_block_param(&mut self, block: BlockId, index: u32, value: CfgValue, ty: Type) {
+        let vreg = self.mir.alloc_vreg();
+        self.block_param_vregs.insert((block, index), vreg);
+        self.value_map.insert(value, vreg);
+        crate::agg_slots::preallocate_block_param_slots(self, value, ty, vreg);
+    }
+
+    fn value_is_lowered(&self, value: CfgValue) -> bool {
+        self.value_map.contains_key(&value)
+    }
+
+    fn lower_value(&mut self, value: CfgValue) {
+        CfgLower::lower_value(self, value);
+    }
+
+    fn value_description(&self, value: CfgValue) -> String {
+        let inst = self.ctx.cfg.get_inst(value);
+        crate::format_cfg_inst_data_with_interner(self.ctx.cfg, &inst.data, self.interner)
+    }
+
+    fn instruction_count(&self) -> usize {
+        self.mir.inst_count()
+    }
+
+    fn instruction_strings(&self, range: std::ops::Range<usize>) -> Vec<String> {
+        self.mir.instructions()[range]
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    fn value_rationale(&self, data: &CfgInstData, ty: Type) -> Option<String> {
+        self.get_lowering_rationale(data, ty)
+    }
+
+    fn terminator_rationale(
+        &self,
+        plan: &crate::terminator_plan::TerminatorPlan,
+    ) -> Option<String> {
+        use crate::terminator_plan::{ReturnMode, TerminatorPlan};
+        match plan {
+            TerminatorPlan::Branch { .. } => {
+                Some("Compare with zero, conditional jump".to_string())
+            }
+            TerminatorPlan::Return {
+                mode: ReturnMode::Exit { .. },
+            } => Some("Main function: return value becomes exit code".to_string()),
+            TerminatorPlan::Return {
+                mode: ReturnMode::Function { value },
+            } if !matches!(value, crate::terminator_plan::ReturnValuePlan::ZeroSized) => {
+                Some("Return value in RAX (SysV ABI)".to_string())
+            }
+            TerminatorPlan::Switch { cases, .. } => {
+                Some(format!("Linear scan through {} cases", cases.len()))
+            }
+            _ => None,
+        }
     }
 }
 

--- a/crates/rue-spec/cases/golden/ir-dumps.toml
+++ b/crates/rue-spec/cases/golden/ir-dumps.toml
@@ -894,7 +894,7 @@ bb0:
     -> mov v0, 42
     Decision: 32-bit immediate (zero-extends to 64-bit)
 
-  Terminator: return v0
+  Terminator: return exit
     -> mov rdi, v0
     -> call sym0
     Decision: Main function: return value becomes exit code


### PR DESCRIPTION
## Summary

- add one target-independent CFG block walk and exhaustive terminator planner
- normalize successor topology, fallthrough, switch policy, return/trap modes, and ordered edge slot moves before target instruction selection
- keep x86-64 and AArch64 branch, register, label, and trap instructions in their adapters
- add real cross-backend topology/MIR coverage for diamonds, loops, switches, traps, cleanup edges, return shapes, aggregate and zero-slot values

## Validation

- `scripts/rue quick`
- `scripts/rue cli abi`
- focused codegen, spec, and UI filters
- release build
- unfiltered serialized `scripts/rue test`

Fixes RUE-823