### PR TITLE
RUE-912: peephole algebraic simplification with trap-exact scoping

### DIFF
--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -40,15 +40,29 @@ pub(super) fn fold_instruction(cfg: &mut Cfg, value: CfgValue) -> bool {
         }
         CfgInstData::Sub(lhs, rhs) => {
             fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| checked_sub(a, b, ty))
+                // x - x is 0 with no possible overflow, for any x (RUE-912).
+                .or_else(|| (lhs == rhs).then_some(CfgInstData::Const(0)))
         }
         CfgInstData::Mul(lhs, rhs) => {
             fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| checked_mul(a, b, ty))
+                // x * 0 is 0 with no possible overflow, even for non-constant
+                // x; x's own instruction stays behind for DCE's trap-aware
+                // liveness rules (RUE-912).
+                .or_else(|| {
+                    (get_const_int(cfg, *lhs) == Some(0) || get_const_int(cfg, *rhs) == Some(0))
+                        .then_some(CfgInstData::Const(0))
+                })
         }
         CfgInstData::Div(lhs, rhs) => {
             fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| checked_div(a, b, ty))
         }
         CfgInstData::Mod(lhs, rhs) => {
             fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| checked_mod(a, b, ty))
+                // x % 1 is 0 for any x: the divisor is a nonzero constant and
+                // the implied quotient is x itself, so neither trap can fire.
+                // (x % -1 is NOT safe — MIN % -1 traps — and -1's canonical
+                // constant is all-ones, which this test rejects.)
+                .or_else(|| (get_const_int(cfg, *rhs) == Some(1)).then_some(CfgInstData::Const(0)))
         }
 
         // Comparisons (result is always bool)
@@ -80,9 +94,20 @@ pub(super) fn fold_instruction(cfg: &mut Cfg, value: CfgValue) -> bool {
         }
 
         // Bitwise
-        CfgInstData::BitAnd(lhs, rhs) => fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| Some(a & b)),
+        CfgInstData::BitAnd(lhs, rhs) => {
+            fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| Some(a & b))
+                // x & 0 is 0 for any x; bitwise ops never trap (RUE-912).
+                .or_else(|| {
+                    (get_const_int(cfg, *lhs) == Some(0) || get_const_int(cfg, *rhs) == Some(0))
+                        .then_some(CfgInstData::Const(0))
+                })
+        }
         CfgInstData::BitOr(lhs, rhs) => fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| Some(a | b)),
-        CfgInstData::BitXor(lhs, rhs) => fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| Some(a ^ b)),
+        CfgInstData::BitXor(lhs, rhs) => {
+            fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| Some(a ^ b))
+                // x ^ x is 0 for any x; bitwise ops never trap (RUE-912).
+                .or_else(|| (lhs == rhs).then_some(CfgInstData::Const(0)))
+        }
         CfgInstData::Shl(lhs, rhs) => fold_shift(cfg, *lhs, *rhs, ty, true),
         CfgInstData::Shr(lhs, rhs) => fold_shift(cfg, *lhs, *rhs, ty, false),
 

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -23,6 +23,7 @@
 mod constfold;
 mod constopt;
 mod dce;
+mod peephole;
 mod simplify;
 
 use crate::Cfg;
@@ -150,6 +151,14 @@ pub fn optimize(cfg: &mut Cfg, level: OptLevel, type_pool: &FrozenTypeInternPool
             // deep chains stay linear instead of forcing quadratic full-CFG
             // rescans (RUE-794).
             constopt::run(cfg);
+
+            // Peephole algebraic simplification (RUE-912): rewire trap-free
+            // identities (x+0, x*1, ...) to their operand and strength-reduce
+            // unsigned division/modulo by powers of two. Runs after constopt
+            // so propagated constants are visible; annihilators that produce
+            // constants (x*0, x-x, ...) live in the constfold kernel inside
+            // the worklist instead, because their results cascade.
+            peephole::run(cfg);
 
             // CFG simplification (RUE-910, RUE-911): fold constant-condition
             // Branch/Switch terminators into Gotos so dead arms drop out of

--- a/crates/rue-cfg/src/opt/peephole.rs
+++ b/crates/rue-cfg/src/opt/peephole.rs
@@ -1,0 +1,415 @@
+//! Peephole algebraic simplification with trap-exact scoping (RUE-912).
+//!
+//! Two kinds of local rewrite run after the sparse constant driver, both
+//! restricted to shapes that are *exactly* trap-equivalent to the original:
+//!
+//! * **Strength reduction**: unsigned `x / 2^k` becomes `x >> k` and
+//!   unsigned `x % 2^k` becomes `x & (2^k - 1)`. Unsigned division by a
+//!   nonzero constant cannot trap and neither can shifts or masks, so the
+//!   rewrite is exact. Signed division is deliberately NOT reduced — an
+//!   arithmetic shift rounds toward negative infinity while Rue division
+//!   rounds toward zero. `x * 2^k` is likewise NOT reduced to a shift:
+//!   multiplication traps on overflow and shifts do not, so the rewrite
+//!   would elide a mandatory trap (the RUE-57 class).
+//!
+//! * **Identity rewiring**: operations that provably return one operand
+//!   unchanged and cannot trap — `x+0`, `0+x`, `x-0`, `x*1`, `1*x`, `x/1`,
+//!   `x|0`, `x^0`, `x<<0`, `x>>0`, `x&x`, `x|x`, `!!x` — have every use
+//!   re-pointed at the operand through one batched
+//!   [`Cfg::rewrite_value_uses`] sweep. The identity instruction itself is
+//!   rewritten to a dead placeholder constant: DCE conservatively keeps any
+//!   arithmetic that might trap, so simply orphaning an `Add` would leave it
+//!   in the emitted code — but these shapes were selected precisely because
+//!   they cannot trap, so replacing them with a side-effect-free placeholder
+//!   is exact and lets DCE drop them.
+//!
+//! Annihilator shapes whose result is a *constant* (`x*0`, `x&0`, `x-x`,
+//! `x^x`, `x%1`) live in the [`super::constfold`] kernel instead: their
+//! results can cascade into further folding, so they belong inside the
+//! sparse worklist where operand-became-constant events re-attempt users.
+//! Identity rewires can never create a constant (a constant operand would
+//! already have folded the whole instruction), so they run once, after the
+//! worklist drains.
+//!
+//! Constant scans here read only pristine, pre-rewrite instruction data:
+//! alias targets are collected first, placeholders are written after, so a
+//! placeholder constant can never be mistaken for a real operand of a later
+//! shape.
+
+use crate::{BlockId, Cfg, CfgInst, CfgInstData, CfgValue};
+use rue_air::TypeKind;
+
+/// Work counters for one run (RUE-794 convention): one scan over the blocks
+/// for strength reduction, one scan over the values for identities, one
+/// batched use-rewrite.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Stats {
+    /// Unsigned `Div`/`Mod` by a power of two rewritten to `Shr`/`BitAnd`.
+    pub divmods_reduced: u64,
+    /// Identity operations whose uses were re-pointed at their operand.
+    pub identities_rewired: u64,
+}
+
+/// Run peephole simplification. Call after the sparse constant driver so
+/// propagated constants are visible, and before DCE so placeholders and
+/// newly dead operands are swept.
+pub fn run(cfg: &mut Cfg) -> Stats {
+    let mut stats = Stats::default();
+    reduce_unsigned_div_mod(cfg, &mut stats);
+    rewire_identities(cfg, &mut stats);
+    stats
+}
+
+/// Is this one of the unsigned integer types? (Deliberately not
+/// `!is_signed`: bool, unit, and aggregate-typed values must not qualify.)
+fn is_unsigned(kind: TypeKind) -> bool {
+    matches!(
+        kind,
+        TypeKind::U8 | TypeKind::U16 | TypeKind::U32 | TypeKind::U64
+    )
+}
+
+fn const_int(cfg: &Cfg, value: CfgValue) -> Option<u64> {
+    match cfg.get_inst(value).data {
+        CfgInstData::Const(v) => Some(v),
+        _ => None,
+    }
+}
+
+/// Rewrite unsigned `Div`/`Mod` by a constant power of two (>= 2; division
+/// by 1 is an identity handled by [`rewire_identities`]) into `Shr`/`BitAnd`.
+///
+/// The shift-amount / mask constant is a new instruction inserted into the
+/// block immediately before the rewritten operation, so evaluation order and
+/// dominance are preserved.
+fn reduce_unsigned_div_mod(cfg: &mut Cfg, stats: &mut Stats) {
+    for block_idx in 0..cfg.block_count() {
+        let block_id = BlockId::from_raw(block_idx as u32);
+        // (position, new constant to insert before it)
+        let mut insertions: Vec<(usize, CfgValue)> = Vec::new();
+
+        for i in 0..cfg.get_block(block_id).insts.len() {
+            let value = cfg.get_block(block_id).insts[i];
+            let inst = cfg.get_inst(value);
+            if !is_unsigned(inst.ty.kind()) {
+                continue;
+            }
+            let (numerator, divisor, is_div) = match inst.data {
+                CfgInstData::Div(a, b) => (a, b, true),
+                CfgInstData::Mod(a, b) => (a, b, false),
+                _ => continue,
+            };
+            let ty = inst.ty;
+            let span = inst.span;
+            let Some(d) = const_int(cfg, divisor) else {
+                continue;
+            };
+            if d < 2 || !d.is_power_of_two() {
+                continue;
+            }
+
+            let new_data = if is_div {
+                CfgInstData::Const(d.trailing_zeros() as u64)
+            } else {
+                CfgInstData::Const(d - 1)
+            };
+            let amount = cfg.add_inst(CfgInst {
+                data: new_data,
+                ty,
+                span,
+            });
+            cfg.get_inst_mut(value).data = if is_div {
+                CfgInstData::Shr(numerator, amount)
+            } else {
+                CfgInstData::BitAnd(numerator, amount)
+            };
+            insertions.push((i, amount));
+            stats.divmods_reduced += 1;
+        }
+
+        // Insert back-to-front so earlier indices stay valid.
+        for (i, amount) in insertions.into_iter().rev() {
+            cfg.get_block_mut(block_id).insts.insert(i, amount);
+        }
+    }
+}
+
+/// If `value` is a can't-trap operation that returns one operand unchanged,
+/// return that operand.
+fn identity_target(cfg: &Cfg, value: CfgValue) -> Option<CfgValue> {
+    let is0 = |v: CfgValue| const_int(cfg, v) == Some(0);
+    let is1 = |v: CfgValue| const_int(cfg, v) == Some(1);
+    match cfg.get_inst(value).data {
+        // x + 0 and x - 0 cannot overflow; x * 1 and x / 1 cannot overflow
+        // or divide by zero.
+        CfgInstData::Add(a, b) => {
+            if is0(b) {
+                Some(a)
+            } else if is0(a) {
+                Some(b)
+            } else {
+                None
+            }
+        }
+        CfgInstData::Sub(a, b) if is0(b) => Some(a),
+        CfgInstData::Mul(a, b) => {
+            if is1(b) {
+                Some(a)
+            } else if is1(a) {
+                Some(b)
+            } else {
+                None
+            }
+        }
+        CfgInstData::Div(a, b) if is1(b) => Some(a),
+        // Bitwise ops and shifts never trap. (x & 0, x ^ x fold to constants
+        // in the constfold kernel instead.)
+        CfgInstData::BitOr(a, b) | CfgInstData::BitXor(a, b) if is0(b) => Some(a),
+        CfgInstData::BitOr(a, b) | CfgInstData::BitXor(a, b) if is0(a) => Some(b),
+        CfgInstData::BitAnd(a, b) | CfgInstData::BitOr(a, b) if a == b => Some(a),
+        CfgInstData::Shl(a, b) | CfgInstData::Shr(a, b) if is0(b) => Some(a),
+        // Boolean double negation.
+        CfgInstData::Not(a) => match cfg.get_inst(a).data {
+            CfgInstData::Not(inner) => Some(inner),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Re-point every use of an identity operation at its operand, then replace
+/// the identity instruction with a dead placeholder constant for DCE.
+fn rewire_identities(cfg: &mut Cfg, stats: &mut Stats) {
+    let value_count = cfg.value_count();
+
+    // Collect aliases against pristine data before mutating anything.
+    let mut alias: Vec<Option<CfgValue>> = vec![None; value_count];
+    let mut any = false;
+    for i in 0..value_count {
+        let value = CfgValue::from_raw(i as u32);
+        if let Some(target) = identity_target(cfg, value) {
+            alias[i] = Some(target);
+            any = true;
+        }
+    }
+    if !any {
+        return;
+    }
+
+    // Dummy the identity instructions out. Their shapes were selected to be
+    // trap-free, so a side-effect-free placeholder is exact; with all uses
+    // re-pointed below, DCE removes it.
+    for (i, target) in alias.iter().enumerate() {
+        if target.is_some() {
+            cfg.get_inst_mut(CfgValue::from_raw(i as u32)).data = CfgInstData::Const(0);
+            stats.identities_rewired += 1;
+        }
+    }
+
+    // Resolve alias-of-alias chains (x+0 feeding y = (x+0)|0), then rewrite
+    // every use in one sweep.
+    let resolve = |mut v: CfgValue| -> CfgValue {
+        while let Some(next) = alias[v.as_u32() as usize] {
+            v = next;
+        }
+        v
+    };
+    cfg.rewrite_value_uses(|v| resolve(v));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Terminator, Type};
+    use rue_span::Span;
+
+    fn make_cfg() -> Cfg {
+        let mut cfg = Cfg::new(Type::I32, 0, 0, "test".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg
+    }
+
+    fn push(cfg: &mut Cfg, data: CfgInstData, ty: Type) -> CfgValue {
+        let entry = cfg.entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data,
+                ty,
+                span: Span::new(0, 0),
+            },
+        )
+    }
+
+    #[test]
+    fn test_add_zero_rewired_to_operand() {
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let zero = push(&mut cfg, CfgInstData::Const(0), Type::I32);
+        let add = push(&mut cfg, CfgInstData::Add(x, zero), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(add) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.identities_rewired, 1);
+        // The return now reads x directly; the add is a dead placeholder.
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == x
+        ));
+        assert!(matches!(cfg.get_inst(add).data, CfgInstData::Const(0)));
+    }
+
+    #[test]
+    fn test_identity_chain_resolves_transitively() {
+        // ((x + 0) | 0) << 0 — every layer is an identity; the final use
+        // must land on x itself.
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let zero = push(&mut cfg, CfgInstData::Const(0), Type::I32);
+        let add = push(&mut cfg, CfgInstData::Add(x, zero), Type::I32);
+        let or = push(&mut cfg, CfgInstData::BitOr(add, zero), Type::I32);
+        let shl = push(&mut cfg, CfgInstData::Shl(or, zero), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(shl) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.identities_rewired, 3);
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == x
+        ));
+    }
+
+    #[test]
+    fn test_double_not_rewired() {
+        let mut cfg = make_cfg();
+        let b = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::BOOL);
+        let not1 = push(&mut cfg, CfgInstData::Not(b), Type::BOOL);
+        let not2 = push(&mut cfg, CfgInstData::Not(not1), Type::BOOL);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(not2) });
+
+        run(&mut cfg);
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == b
+        ));
+        // The inner Not survives untouched (it may have other uses); only
+        // the outer double-negation was rewired.
+        assert!(matches!(cfg.get_inst(not1).data, CfgInstData::Not(_)));
+    }
+
+    #[test]
+    fn test_same_operand_and_or_rewired() {
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::U32);
+        let and = push(&mut cfg, CfgInstData::BitAnd(x, x), Type::U32);
+        let or = push(&mut cfg, CfgInstData::BitOr(and, and), Type::U32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(or) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.identities_rewired, 2);
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == x
+        ));
+    }
+
+    #[test]
+    fn test_non_identity_untouched() {
+        // x + 1 and x - x-with-different-values must not be rewired.
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let one = push(&mut cfg, CfgInstData::Const(1), Type::I32);
+        let add = push(&mut cfg, CfgInstData::Add(x, one), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(add) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.identities_rewired, 0);
+        assert!(matches!(cfg.get_inst(add).data, CfgInstData::Add(..)));
+    }
+
+    #[test]
+    fn test_unsigned_div_by_pow2_becomes_shr() {
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::U32);
+        let eight = push(&mut cfg, CfgInstData::Const(8), Type::U32);
+        let div = push(&mut cfg, CfgInstData::Div(x, eight), Type::U32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(div) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.divmods_reduced, 1);
+        let CfgInstData::Shr(num, amount) = cfg.get_inst(div).data else {
+            panic!("expected Shr, got {:?}", cfg.get_inst(div).data);
+        };
+        assert_eq!(num, x);
+        assert!(matches!(cfg.get_inst(amount).data, CfgInstData::Const(3)));
+        // The shift amount is attached immediately before the rewritten op.
+        let insts = &cfg.get_block(cfg.entry).insts;
+        let div_pos = insts.iter().position(|&v| v == div).unwrap();
+        assert_eq!(insts[div_pos - 1], amount);
+    }
+
+    #[test]
+    fn test_unsigned_mod_by_pow2_becomes_mask() {
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::U64);
+        let sixteen = push(&mut cfg, CfgInstData::Const(16), Type::U64);
+        let modulo = push(&mut cfg, CfgInstData::Mod(x, sixteen), Type::U64);
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Return {
+                value: Some(modulo),
+            },
+        );
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.divmods_reduced, 1);
+        let CfgInstData::BitAnd(num, mask) = cfg.get_inst(modulo).data else {
+            panic!("expected BitAnd, got {:?}", cfg.get_inst(modulo).data);
+        };
+        assert_eq!(num, x);
+        assert!(matches!(cfg.get_inst(mask).data, CfgInstData::Const(15)));
+    }
+
+    #[test]
+    fn test_signed_div_by_pow2_not_reduced() {
+        // Signed division rounds toward zero; an arithmetic shift rounds
+        // toward negative infinity. The rewrite must not happen.
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let two = push(&mut cfg, CfgInstData::Const(2), Type::I32);
+        let div = push(&mut cfg, CfgInstData::Div(x, two), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(div) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.divmods_reduced, 0);
+        assert!(matches!(cfg.get_inst(div).data, CfgInstData::Div(..)));
+    }
+
+    #[test]
+    fn test_non_pow2_divisor_not_reduced() {
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::U32);
+        let six = push(&mut cfg, CfgInstData::Const(6), Type::U32);
+        let div = push(&mut cfg, CfgInstData::Div(x, six), Type::U32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(div) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.divmods_reduced, 0);
+        assert!(matches!(cfg.get_inst(div).data, CfgInstData::Div(..)));
+    }
+
+    #[test]
+    fn test_mul_by_pow2_not_reduced_to_shift() {
+        // Multiplication traps on overflow; a shift does not. The strength
+        // reduction that elides that trap is forbidden (RUE-57 class).
+        let mut cfg = make_cfg();
+        let x = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::U32);
+        let eight = push(&mut cfg, CfgInstData::Const(8), Type::U32);
+        let mul = push(&mut cfg, CfgInstData::Mul(x, eight), Type::U32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(mul) });
+
+        run(&mut cfg);
+        assert!(matches!(cfg.get_inst(mul).data, CfgInstData::Mul(..)));
+    }
+}

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -462,3 +462,61 @@ stdout = """5
 6
 """
 exit_code = 11
+
+# Peephole algebraic simplification (RUE-912): identity rewires (x+0, x*1,
+# x/1, x|0, x^0, shifts by 0, x&x, x|x, !!b), constant-producing annihilators
+# (x*0, x-x, x^x, x%1), and unsigned power-of-two strength reduction. The
+# helper params keep operands dynamic so the rewrites (not constant folding)
+# are what's exercised; -O0 never rewrites and must agree exactly. The signed
+# division uses a NEGATIVE dividend to pin round-toward-zero: an illegal
+# sar-based reduction would produce -4 instead of -3.
+[[case]]
+name = "peephole_identities_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn identities(x: i32) -> i32 {
+    let a: i32 = x + 0;
+    let b: i32 = 0 + a;
+    let c: i32 = b - 0;
+    let d: i32 = c * 1;
+    let e: i32 = 1 * d;
+    let f: i32 = e / 1;
+    let g: i32 = f | 0;
+    let h: i32 = g ^ 0;
+    let i: i32 = h << 0;
+    let j: i32 = i >> 0;
+    j & j | (j | j)
+}
+
+fn annihilators(x: i32) -> i32 {
+    (x - x) + (x ^ x) + (x * 0) + (0 * x) + (x & 0) + (x % 1)
+}
+
+fn unsigned_reduce(x: u32) -> u32 {
+    x / 8 + x % 8 + x / 1
+}
+
+fn signed_round_toward_zero(x: i32) -> i32 {
+    x / 2
+}
+
+fn double_not(x: i32) -> bool {
+    !!(x > 3)
+}
+
+fn main() -> i32 {
+    @dbg(identities(21));
+    @dbg(annihilators(-17));
+    @dbg(unsigned_reduce(100));
+    @dbg(signed_round_toward_zero(-7));
+    if double_not(5) { @dbg(1); } else { @dbg(0); }
+    identities(21) * 2
+}
+""" }]
+stdout = """21
+0
+116
+-3
+1
+"""
+exit_code = 42

--- a/crates/rue-cli-tests/cases/opt.toml
+++ b/crates/rue-cli-tests/cases/opt.toml
@@ -119,3 +119,41 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "-O2", "-o", "prog"]
 exit_code = 42
+
+# RUE-912 peephole must not strength-reduce trapping shapes. x * 8 with a
+# dynamic x that overflows must still trap at every level: reducing it to a
+# shift would silently wrap instead (the RUE-57 class).
+[[case]]
+name = "peephole_keeps_mul_pow2_overflow_trap_at_O2"
+files = [{ path = "main.rue", source = """
+fn scale(x: i32) -> i32 {
+    x * 8
+}
+
+fn main() -> i32 {
+    scale(268435456);
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 101
+runtime_error_contains = ["integer overflow"]
+
+# x % -1 must not be treated like x % 1: MIN % -1 traps (the implied
+# quotient -MIN is unrepresentable), and -1's canonical constant is
+# all-ones, which the fold's == 1 test must reject.
+[[case]]
+name = "peephole_keeps_mod_neg1_overflow_trap_at_O2"
+files = [{ path = "main.rue", source = """
+fn rem(x: i32) -> i32 {
+    x % -1
+}
+
+fn main() -> i32 {
+    rem(-2147483648);
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 101
+runtime_error_contains = ["integer overflow"]

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3754 rejected=149 lex_invalid=35 accepted_source_ast_sha256=2674d0dcdcd1b575cbb955791678ab470f3eff9324dff706bc8c75b1e2580b0c
+# pre-RUE-905 Chumsky: accepted=3757 rejected=149 lex_invalid=35 accepted_source_ast_sha256=b8775dc0d94aefbae4ae0675b3aff1374a403cb9f081fbd4583deef8c3eae6ef
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca


### PR DESCRIPTION
## Change

Local algebraic rewrites at `-O1` (ADR-0044: cheap, local, always-a-win). Every admitted rewrite carries the same proof obligation: the rewritten form traps in exactly the same cases as the original — which for every admitted shape means never, on either side.

**Constant-producing annihilators** (constfold kernel, inside the RUE-794 sparse worklist, because their results cascade): `x*0`, `x&0`, `x−x`, `x^x`, `x%1` → constant, each with the trap argument documented in place. `x%−1` is deliberately NOT folded: `MIN % −1` traps on the unrepresentable implied quotient.

**Identity rewires** (new `opt/peephole.rs`, post-worklist — aliasing can never create a constant, so one scan suffices): `x+0`, `0+x`, `x−0`, `x*1`, `1*x`, `x/1`, `x|0`, `x^0`, shifts by zero, `x&x`, `x|x`, `!!b`. Uses re-pointed in one batched `Cfg::rewrite_value_uses` sweep; the identity instruction becomes a dead placeholder constant — DCE deliberately preserves might-trap arithmetic (RUE-57), and these shapes are provably trap-free, so the placeholder states that explicitly and DCE sweeps it.

**Strength reduction**: unsigned `x / 2^k` → `Shr`, unsigned `x % 2^k` → `BitAnd`, shift-amount/mask constant inserted immediately before the rewritten op. Explicitly forbidden, with negative tests: `x * 2^k → Shl` (elides the overflow trap — the RUE-57 class) and signed `x / 2^k → Sar` (rounds toward −∞, not zero).

Observed at `-O1`: `x+0` / `*1` chains vanish from the emitted CFG entirely; unsigned division by 8 emits as `shr`.

## Testing

- Peephole unit tests: identity rewiring incl. transitive chains and double negation, both strength reductions with insertion-position assertions, and the forbidden signed / non-power-of-two / mul cases.
- Differential CLI: new case exercising every rewrite shape with dynamic operands across `-O0..-O3` — including a negative dividend pinning signed division's round-toward-zero (an illegal sar reduction returns −4 instead of −3).
- Two new `cli.opt` trap cases extending the RUE-57 net: dynamic `x*8` overflow and `MIN % −1` still exit 101 at `-O2`.
- Full local suite passed. Corpus snapshot re-blessed (+1 fixture, accepted 3754 → 3755, rejected rows unchanged).

Fixes RUE-912