### PR TITLE
RUE-914: value forwarding, dominator infrastructure, and CSE param keying

### DIFF
--- a/crates/rue-cfg/src/dominators.rs
+++ b/crates/rue-cfg/src/dominators.rs
@@ -1,0 +1,394 @@
+//! Iterative dominator-tree construction (RUE-914).
+//!
+//! Computes the immediate-dominator tree of a [`Cfg`] with the
+//! Cooper–Harvey–Kennedy "A Simple, Fast Dominance Algorithm" fixpoint over a
+//! reverse-postorder traversal. The graph and its predecessor lists come from
+//! [`Cfg::compute_predecessors`], so the tree always reflects the current
+//! terminators (no cached edges to fall out of sync after a pass rewrites
+//! control flow).
+//!
+//! This is shared analysis infrastructure, not a pass: nothing in the pipeline
+//! runs it directly today. Its first consumers are the copy-propagation pass
+//! (RUE-914), which uses [`DominatorTree::dominates`] under `debug_assertions`
+//! to turn sema's definite-initialization argument into a checked invariant,
+//! and future loop-invariant code motion (RUE-916) and a wider GVN.
+//!
+//! ## Definitions
+//!
+//! Block `a` *dominates* block `b` when every path from the entry to `b` passes
+//! through `a`; `a` is the *immediate dominator* (`idom`) of `b` when it is the
+//! closest strict dominator on every such path. The entry block has no
+//! immediate dominator, and an unreachable block has none either (no path
+//! reaches it). Dominance is reflexive: a block dominates itself.
+//!
+//! ## Algorithm
+//!
+//! 1. Number the reachable blocks in postorder via a DFS from the entry. The
+//!    entry finishes last, so it holds the largest postorder number — the
+//!    property the intersection step relies on.
+//! 2. Seed `idom[entry] = entry` (a self-loop sentinel) and leave every other
+//!    reachable block undefined.
+//! 3. Sweep the blocks in reverse postorder (entry first, excluding it from the
+//!    update) until no `idom` changes. Each block's new immediate dominator is
+//!    the running intersection of its already-processed predecessors. By RPO
+//!    order at least one predecessor is always processed before a block is
+//!    visited, so the fixpoint is reached in a handful of sweeps for reducible
+//!    graphs.
+//!
+//! `intersect(a, b)` walks the two fingers up the partial tree, each time
+//! advancing whichever finger has the smaller postorder number (i.e. is deeper,
+//! farther from the entry), until they meet at the common dominator.
+//!
+//! The only in-tree consumer today is copy propagation's `debug_assertions`-only
+//! dominance check, and the `idom` query is exercised solely by this module's
+//! tests; the wider consumers (RUE-916 LICM, GVN) are still pending. This
+//! shared infrastructure is therefore unused in a release, non-test build, so
+//! the module opts out of the toolchain's dead-code denial rather than pruning
+//! API the tracking issue explicitly requested.
+#![allow(dead_code)]
+
+use crate::{BlockId, Cfg, Terminator};
+
+/// The immediate-dominator tree of a [`Cfg`].
+///
+/// Query it with [`DominatorTree::idom`] and [`DominatorTree::dominates`].
+pub(crate) struct DominatorTree {
+    /// Immediate dominator of each block by raw block index.
+    ///
+    /// - The entry maps to itself (the CHK self-loop sentinel); [`Self::idom`]
+    ///   reports `None` for it since the entry has no immediate dominator.
+    /// - A reachable non-entry block maps to its immediate dominator.
+    /// - An unreachable block maps to `None`.
+    idom: Vec<Option<BlockId>>,
+    /// Postorder number of each block by raw index; `None` when unreachable.
+    /// The entry holds the maximum among reachable blocks.
+    post_num: Vec<Option<u32>>,
+}
+
+impl DominatorTree {
+    /// Build the dominator tree of `cfg`.
+    pub(crate) fn compute(cfg: &Cfg) -> Self {
+        let n = cfg.block_count();
+        let entry = cfg.entry;
+
+        // Precompute successor lists once so the DFS and the fixpoint do not
+        // re-decode terminators repeatedly.
+        let succs: Vec<Vec<BlockId>> = (0..n)
+            .map(|i| successors_of(cfg, BlockId::from_raw(i as u32)))
+            .collect();
+
+        // ------------------------------------------------------------------
+        // Postorder DFS from the entry. `post_order` lists reachable blocks in
+        // the order their DFS finishes; the entry is last.
+        // ------------------------------------------------------------------
+        let mut post_order: Vec<BlockId> = Vec::new();
+        let mut post_num: Vec<Option<u32>> = vec![None; n];
+        let mut visited = vec![false; n];
+
+        if (entry.as_u32() as usize) < n {
+            visited[entry.as_u32() as usize] = true;
+            // Stack of (block, next successor index to explore).
+            let mut stack: Vec<(BlockId, usize)> = vec![(entry, 0)];
+            while let Some(&(block, idx)) = stack.last() {
+                let block_succs = &succs[block.as_u32() as usize];
+                if idx < block_succs.len() {
+                    stack.last_mut().unwrap().1 += 1;
+                    let s = block_succs[idx];
+                    let si = s.as_u32() as usize;
+                    if !visited[si] {
+                        visited[si] = true;
+                        stack.push((s, 0));
+                    }
+                } else {
+                    stack.pop();
+                    post_num[block.as_u32() as usize] = Some(post_order.len() as u32);
+                    post_order.push(block);
+                }
+            }
+        }
+
+        // Reverse postorder: entry first.
+        let rpo: Vec<BlockId> = post_order.iter().rev().copied().collect();
+
+        // ------------------------------------------------------------------
+        // CHK fixpoint. idom[entry] = entry seeds the self-loop; all other
+        // reachable blocks start undefined and converge.
+        // ------------------------------------------------------------------
+        let mut idom: Vec<Option<BlockId>> = vec![None; n];
+        if (entry.as_u32() as usize) < n {
+            idom[entry.as_u32() as usize] = Some(entry);
+        }
+        let preds = cfg.compute_predecessors();
+
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for &b in &rpo {
+                if b == entry {
+                    continue;
+                }
+                let mut new_idom: Option<BlockId> = None;
+                for &p in &preds[b.as_u32() as usize] {
+                    // Skip predecessors the DFS never reached and predecessors
+                    // whose idom is not yet computed in this sweep.
+                    if post_num[p.as_u32() as usize].is_none() {
+                        continue;
+                    }
+                    if idom[p.as_u32() as usize].is_none() {
+                        continue;
+                    }
+                    new_idom = Some(match new_idom {
+                        None => p,
+                        Some(cur) => intersect(p, cur, &idom, &post_num),
+                    });
+                }
+                if let Some(ni) = new_idom {
+                    if idom[b.as_u32() as usize] != Some(ni) {
+                        idom[b.as_u32() as usize] = Some(ni);
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        DominatorTree { idom, post_num }
+    }
+
+    /// The immediate dominator of `block`, or `None` when `block` is the entry
+    /// or is unreachable.
+    pub(crate) fn idom(&self, block: BlockId) -> Option<BlockId> {
+        let i = block.as_u32() as usize;
+        match self.idom.get(i).copied().flatten() {
+            // The entry's self-loop sentinel is reported as "no immediate
+            // dominator".
+            Some(d) if d == block => None,
+            other => other,
+        }
+    }
+
+    /// Whether `a` dominates `b` (every path from the entry to `b` passes
+    /// through `a`). Reflexive: a block dominates itself. An unreachable `b` is
+    /// dominated only by itself.
+    pub(crate) fn dominates(&self, a: BlockId, b: BlockId) -> bool {
+        let bi = b.as_u32() as usize;
+        if bi >= self.idom.len() {
+            return a == b;
+        }
+        // Unreachable blocks have no idom entry; only self-dominance holds.
+        if self.post_num[bi].is_none() {
+            return a == b;
+        }
+        // Walk up b's idom chain to the entry. The entry's self-loop terminates
+        // the walk.
+        let mut cur = b;
+        loop {
+            if cur == a {
+                return true;
+            }
+            match self.idom[cur.as_u32() as usize] {
+                Some(d) if d != cur => cur = d,
+                // Reached the entry sentinel (d == cur) without finding `a`.
+                _ => return false,
+            }
+        }
+    }
+}
+
+/// Intersect two nodes of the partial dominator tree, per Cooper–Harvey–Kennedy:
+/// advance whichever finger is deeper (smaller postorder number) until the two
+/// fingers meet. Every node visited here is reachable, so the `idom`/`post_num`
+/// lookups are always populated.
+fn intersect(
+    mut a: BlockId,
+    mut b: BlockId,
+    idom: &[Option<BlockId>],
+    post_num: &[Option<u32>],
+) -> BlockId {
+    while a != b {
+        let mut pa = post_num[a.as_u32() as usize].expect("reachable finger");
+        let mut pb = post_num[b.as_u32() as usize].expect("reachable finger");
+        while pa < pb {
+            a = idom[a.as_u32() as usize].expect("processed finger has an idom");
+            pa = post_num[a.as_u32() as usize].expect("reachable finger");
+        }
+        while pb < pa {
+            b = idom[b.as_u32() as usize].expect("processed finger has an idom");
+            pb = post_num[b.as_u32() as usize].expect("reachable finger");
+        }
+    }
+    a
+}
+
+/// Successor blocks of `block` in control-flow order.
+fn successors_of(cfg: &Cfg, block: BlockId) -> Vec<BlockId> {
+    match &cfg.get_block(block).terminator {
+        Terminator::Goto { target, .. } => vec![*target],
+        Terminator::Branch {
+            then_block,
+            else_block,
+            ..
+        } => vec![*then_block, *else_block],
+        Terminator::Switch {
+            cases_start,
+            cases_len,
+            default,
+            ..
+        } => {
+            let mut out: Vec<BlockId> = cfg
+                .get_switch_cases(*cases_start, *cases_len)
+                .iter()
+                .map(|(_, target)| *target)
+                .collect();
+            out.push(*default);
+            out
+        }
+        Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CfgInst, CfgInstData, Terminator, Type};
+    use rue_span::Span;
+
+    fn make_cfg() -> Cfg {
+        Cfg::new(Type::I32, 0, 0, "test".to_string(), vec![])
+    }
+
+    fn goto(target: BlockId) -> Terminator {
+        Terminator::Goto {
+            target,
+            args_start: 0,
+            args_len: 0,
+        }
+    }
+
+    fn bool_const(cfg: &mut Cfg, block: BlockId) -> crate::CfgValue {
+        cfg.add_inst_to_block(
+            block,
+            CfgInst {
+                data: CfgInstData::BoolConst(true),
+                ty: Type::BOOL,
+                span: Span::new(0, 0),
+            },
+        )
+    }
+
+    fn branch(cond: crate::CfgValue, then_block: BlockId, else_block: BlockId) -> Terminator {
+        Terminator::Branch {
+            cond,
+            then_block,
+            then_args_start: 0,
+            then_args_len: 0,
+            else_block,
+            else_args_start: 0,
+            else_args_len: 0,
+        }
+    }
+
+    #[test]
+    fn test_entry_has_no_idom_and_dominates_all() {
+        // entry -> a -> b (straight line).
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let a = cfg.new_block();
+        let b = cfg.new_block();
+        cfg.set_terminator(entry, goto(a));
+        cfg.set_terminator(a, goto(b));
+        cfg.set_terminator(b, Terminator::Return { value: None });
+
+        let dom = DominatorTree::compute(&cfg);
+        assert_eq!(dom.idom(entry), None);
+        assert_eq!(dom.idom(a), Some(entry));
+        assert_eq!(dom.idom(b), Some(a));
+
+        for block in [entry, a, b] {
+            assert!(dom.dominates(entry, block), "entry must dominate {block}");
+            assert!(dom.dominates(block, block), "dominance is reflexive");
+        }
+        assert!(dom.dominates(a, b));
+        assert!(!dom.dominates(b, a));
+    }
+
+    #[test]
+    fn test_diamond() {
+        // entry -> {t, e} -> merge. entry is the only dominator of merge; the
+        // arms dominate only themselves.
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let t = cfg.new_block();
+        let e = cfg.new_block();
+        let merge = cfg.new_block();
+
+        let cond = bool_const(&mut cfg, entry);
+        cfg.set_terminator(entry, branch(cond, t, e));
+        cfg.set_terminator(t, goto(merge));
+        cfg.set_terminator(e, goto(merge));
+        cfg.set_terminator(merge, Terminator::Return { value: None });
+
+        let dom = DominatorTree::compute(&cfg);
+        assert_eq!(dom.idom(t), Some(entry));
+        assert_eq!(dom.idom(e), Some(entry));
+        // merge is reachable from both arms, so its immediate dominator is the
+        // entry, not either arm.
+        assert_eq!(dom.idom(merge), Some(entry));
+
+        assert!(dom.dominates(entry, merge));
+        assert!(!dom.dominates(t, merge));
+        assert!(!dom.dominates(e, merge));
+        assert!(!dom.dominates(t, e));
+    }
+
+    #[test]
+    fn test_loop_with_back_edge() {
+        // entry -> header -> body -> header (back edge); header -> exit.
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let header = cfg.new_block();
+        let body = cfg.new_block();
+        let exit = cfg.new_block();
+
+        cfg.set_terminator(entry, goto(header));
+        let cond = bool_const(&mut cfg, header);
+        cfg.set_terminator(header, branch(cond, body, exit));
+        cfg.set_terminator(body, goto(header));
+        cfg.set_terminator(exit, Terminator::Return { value: None });
+
+        let dom = DominatorTree::compute(&cfg);
+        assert_eq!(dom.idom(header), Some(entry));
+        assert_eq!(dom.idom(body), Some(header));
+        assert_eq!(dom.idom(exit), Some(header));
+
+        // The header dominates everything in and after the loop.
+        assert!(dom.dominates(header, body));
+        assert!(dom.dominates(header, exit));
+        // The body is inside the loop; it does not dominate the exit (the
+        // header can branch straight to exit without entering the body).
+        assert!(!dom.dominates(body, exit));
+    }
+
+    #[test]
+    fn test_unreachable_block_has_no_idom() {
+        // entry -> a; `island` has no path from entry.
+        let mut cfg = make_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let a = cfg.new_block();
+        let island = cfg.new_block();
+        cfg.set_terminator(entry, goto(a));
+        cfg.set_terminator(a, Terminator::Return { value: None });
+        cfg.set_terminator(island, Terminator::Return { value: None });
+
+        let dom = DominatorTree::compute(&cfg);
+        assert_eq!(dom.idom(island), None);
+        // Nothing reachable dominates the unreachable block, and it dominates
+        // nothing but itself.
+        assert!(!dom.dominates(entry, island));
+        assert!(dom.dominates(island, island));
+        assert!(!dom.dominates(island, a));
+    }
+}

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -17,6 +17,7 @@
 //! ```
 
 mod build;
+mod dominators;
 mod inst;
 pub mod opt;
 mod verify;

--- a/crates/rue-cfg/src/opt/cse.rs
+++ b/crates/rue-cfg/src/opt/cse.rs
@@ -19,15 +19,39 @@
 //!
 //! Only pure-by-value instructions whose result is a deterministic function of
 //! their SSA operands: `Const`, `BoolConst`, `StringConst`, the binary
-//! arithmetic/comparison/bitwise/shift ops, and the unary `Neg`/`Not`/`BitNot`.
-//! These read only SSA values, never memory, so there are no memory barriers to
-//! track. Deliberately NOT keyed:
+//! arithmetic/comparison/bitwise/shift ops, the unary `Neg`/`Not`/`BitNot`, and
+//! reads of a never-written parameter (see below). These read only SSA values,
+//! never memory, so there are no memory barriers to track. Deliberately NOT
+//! keyed:
 //!
 //! * `Load`/`PlaceRead` — read memory, which needs versioning to dedupe safely
 //!   (a store between two loads can change the result). Out of scope here.
 //! * `Call`/`Intrinsic` — side effects; two calls are not interchangeable.
 //! * everything else (allocs, stores, struct/array/enum construction, casts,
 //!   drops, storage markers) — either side-effecting or not a pure value.
+//!
+//! ### Never-written parameter reads (RUE-914)
+//!
+//! Each `Param { index }` re-materializes the parameter's ABI-slot value, so two
+//! reads of the same parameter produce separate SSA ids. That defeats CSE of
+//! expressions over parameters: in `let s = a + b; let t = a + b;` the two `a`
+//! reads and the two `b` reads carry different ids, so the two adds never key
+//! equal. Keying `Param { index }` collapses repeated reads of the same
+//! parameter to their first occurrence, which in turn lets the adds dedupe.
+//!
+//! This is sound ONLY for a parameter that is never written, so its every read
+//! yields the identical value. A `Param { index }`'s `index` is the parameter's
+//! ABI slot (the same numbering as [`Cfg::is_param_writable`] and a
+//! `ParamStore`'s `param_slot`; both flow from sema's `abi_slot`). A slot is
+//! treated as never-written when it is (a) not logically writable by-ref
+//! (`is_param_writable(slot) == false`, i.e. `borrow` or by-value, never
+//! `inout`) and (b) receives no `ParamStore` anywhere among the block-attached
+//! instructions. By-value (`Normal`) parameters are immutable in the callee
+//! (assignment is rejected, E0203) and `borrow` parameters cannot be written, so
+//! only `inout` slots — excluded by (a) — and any slot a `ParamStore` targets —
+//! excluded by (b) — are left out. (As defense in depth, a projected
+//! `PlaceWrite` whose base is a parameter slot also excludes it, though such a
+//! write only ever targets an already-excluded `inout` slot.)
 //!
 //! Constants MUST be keyed: two separately materialized `Const(1)` instructions
 //! would otherwise give `x + 1` and `x + 1` different operand ids, defeating the
@@ -83,6 +107,10 @@ enum VnKey {
     Const(u64, Type),
     BoolConst(bool, Type),
     StringConst(u32, Type),
+    /// A read of a never-written parameter, keyed by its ABI slot and type
+    /// (RUE-914). Only inserted for slots proven never-written; every such read
+    /// yields the identical value.
+    Param(u32, Type),
     /// `(opcode tag, operand, type)`.
     Unary(u8, CfgValue, Type),
     /// `(opcode tag, lhs, rhs, type)`. For commutative ops the operands are
@@ -113,13 +141,29 @@ fn commutative(tag: u8, a: CfgValue, b: CfgValue, ty: Type) -> VnKey {
 /// Compute the value-number key for `value`, resolving operands through the
 /// substitution map. Returns `None` for instructions this pass does not number
 /// (memory reads, calls, and everything with side effects or non-value results).
-fn key_of(cfg: &Cfg, value: CfgValue, r: impl Fn(CfgValue) -> CfgValue) -> Option<VnKey> {
+fn key_of(
+    cfg: &Cfg,
+    value: CfgValue,
+    never_written_param: &[bool],
+    r: impl Fn(CfgValue) -> CfgValue,
+) -> Option<VnKey> {
     let inst = cfg.get_inst(value);
     let ty = inst.ty;
     Some(match inst.data {
         CfgInstData::Const(v) => VnKey::Const(v, ty),
         CfgInstData::BoolConst(b) => VnKey::BoolConst(b, ty),
         CfgInstData::StringConst(s) => VnKey::StringConst(s, ty),
+
+        // A read of a never-written parameter is a pure value: key it only when
+        // the slot is proven never-written (RUE-914).
+        CfgInstData::Param { index }
+            if never_written_param
+                .get(index as usize)
+                .copied()
+                .unwrap_or(false) =>
+        {
+            VnKey::Param(index, ty)
+        }
 
         // Commutative binary ops: operands sorted.
         CfgInstData::Add(a, b) => commutative(0, r(a), r(b), ty),
@@ -150,6 +194,42 @@ fn key_of(cfg: &Cfg, value: CfgValue, r: impl Fn(CfgValue) -> CfgValue) -> Optio
     })
 }
 
+/// Compute, per parameter ABI slot, whether the parameter is never written and
+/// so its reads are all the identical pure value (RUE-914). A slot is
+/// never-written when it is not logically writable by-ref (`inout`) and receives
+/// no `ParamStore` (nor, defensively, a projected `PlaceWrite`) among the
+/// block-attached instructions. Indexed by ABI slot; `Param { index }`'s `index`
+/// is exactly that slot.
+fn never_written_params(cfg: &Cfg) -> Vec<bool> {
+    let num_params = cfg.num_params() as usize;
+    let mut never_written = vec![false; num_params];
+    for (slot, flag) in never_written.iter_mut().enumerate() {
+        *flag = !cfg.is_param_writable(slot as u32);
+    }
+
+    for block in cfg.blocks() {
+        for &value in &block.insts {
+            match &cfg.get_inst(value).data {
+                CfgInstData::ParamStore { param_slot, .. } => {
+                    if let Some(flag) = never_written.get_mut(*param_slot as usize) {
+                        *flag = false;
+                    }
+                }
+                CfgInstData::PlaceWrite { place, .. } => {
+                    if let crate::PlaceBase::Param(slot) = place.base {
+                        if let Some(flag) = never_written.get_mut(slot as usize) {
+                            *flag = false;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    never_written
+}
+
 /// Run block-local CSE. Call at `-O2`/`-O3` after simplification (more
 /// duplicates are exposed once blocks are merged) and before DCE (which sweeps
 /// the dead placeholders).
@@ -160,6 +240,8 @@ pub fn run(cfg: &mut Cfg) -> Stats {
     // stays correct), while the value-number table is per-block.
     let mut subst: Vec<Option<CfgValue>> = vec![None; cfg.value_count()];
 
+    let never_written_param = never_written_params(cfg);
+
     for block_idx in 0..cfg.block_count() {
         let block_id = BlockId::from_raw(block_idx as u32);
         let mut table: HashMap<VnKey, CfgValue> = HashMap::new();
@@ -168,7 +250,7 @@ pub fn run(cfg: &mut Cfg) -> Stats {
             let value = cfg.get_block(block_id).insts[i];
             stats.insts_scanned += 1;
 
-            let Some(key) = key_of(cfg, value, |v| resolve(&subst, v)) else {
+            let Some(key) = key_of(cfg, value, &never_written_param, |v| resolve(&subst, v)) else {
                 continue;
             };
 
@@ -400,5 +482,145 @@ mod tests {
         // Idempotent: nothing left to eliminate.
         let again = run(&mut cfg);
         assert_eq!(again.duplicates_replaced, 0);
+    }
+
+    #[test]
+    fn test_never_written_param_reads_dedupe() {
+        // Two separate reads of the same never-written parameter carry different
+        // SSA ids; keying `Param { index }` collapses the second to the first.
+        let mut cfg = Cfg::new(Type::I32, 0, 2, "f".to_string(), vec![false, false]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let a1 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let a2 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let sum = push(&mut cfg, CfgInstData::Add(a1, a2), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.duplicates_replaced, 1);
+        // The add now reads the first parameter value twice.
+        assert!(matches!(cfg.get_inst(sum).data, CfgInstData::Add(x, y) if x == a1 && y == a1));
+        assert!(matches!(cfg.get_inst(a2).data, CfgInstData::Const(0)));
+    }
+
+    #[test]
+    fn test_writable_inout_param_reads_not_deduped() {
+        // An `inout` (writable) parameter may change between reads, so its reads
+        // must NOT be numbered together.
+        let mut cfg = Cfg::new(
+            Type::I32,
+            0,
+            1,
+            "f".to_string(),
+            rue_air::ParamSlotModes::new(vec![true], vec![true]),
+        );
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let a1 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let a2 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let sum = push(&mut cfg, CfgInstData::Add(a1, a2), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.duplicates_replaced, 0);
+        assert!(matches!(
+            cfg.get_inst(a1).data,
+            CfgInstData::Param { index: 0 }
+        ));
+        assert!(matches!(
+            cfg.get_inst(a2).data,
+            CfgInstData::Param { index: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_paramstore_written_param_reads_not_deduped() {
+        // A by-value parameter targeted by a `ParamStore` (however that arises)
+        // is written, so its reads must not be numbered together either.
+        let mut cfg = Cfg::new(Type::I32, 0, 1, "f".to_string(), vec![false]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let a1 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let c = push(&mut cfg, CfgInstData::Const(5), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::ParamStore {
+                param_slot: 0,
+                value: c,
+            },
+            Type::UNIT,
+        );
+        let a2 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let sum = push(&mut cfg, CfgInstData::Add(a1, a2), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.duplicates_replaced, 0);
+    }
+
+    #[test]
+    fn test_forward_then_cse_dedupes_param_expression() {
+        // The RUE-914 acceptance shape:
+        //   fn f(a: i32, b: i32) -> i32 { let s = a + b; let t = a + b; s + t }
+        // CfgBuilder materializes each parameter use as a fresh `Param`, spills
+        // `s`/`t` to slots, and reads them back. Running the release pipeline
+        // stages in order — constopt, forward, cse — must leave the two adds
+        // computed once: forwarding turns the `Load`s of `s`/`t` into the two
+        // add values, param keying collapses the duplicated `a`/`b` reads, and
+        // CSE then sees the second add as a duplicate of the first.
+        let mut cfg = Cfg::new(Type::I32, 2, 2, "f".to_string(), vec![false, false]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+
+        // let s = a + b;  (slot 0)
+        let a1 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let b1 = push(&mut cfg, CfgInstData::Param { index: 1 }, Type::I32);
+        let add1 = push(&mut cfg, CfgInstData::Add(a1, b1), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 0,
+                init: add1,
+            },
+            Type::UNIT,
+        );
+        // let t = a + b;  (slot 1) — fresh param reads per source use.
+        let a2 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let b2 = push(&mut cfg, CfgInstData::Param { index: 1 }, Type::I32);
+        let add2 = push(&mut cfg, CfgInstData::Add(a2, b2), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc {
+                slot: 1,
+                init: add2,
+            },
+            Type::UNIT,
+        );
+        // s + t
+        let load_s = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        let load_t = push(&mut cfg, CfgInstData::Load { slot: 1 }, Type::I32);
+        let result = push(&mut cfg, CfgInstData::Add(load_s, load_t), Type::I32);
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Return {
+                value: Some(result),
+            },
+        );
+
+        super::super::constopt::run(&mut cfg);
+        let fwd = super::super::forward::run(&mut cfg);
+        // Both `Load`s forwarded to their slot's single write (the adds).
+        assert_eq!(fwd.loads_forwarded_single_write, 2);
+
+        let cse = run(&mut cfg);
+        // a2, b2, and the second add are all duplicates.
+        assert_eq!(cse.duplicates_replaced, 3);
+        // The result now adds the single surviving add to itself.
+        assert!(
+            matches!(cfg.get_inst(result).data, CfgInstData::Add(x, y) if x == add1 && y == add1),
+            "result should be add1 + add1, got {:?}",
+            cfg.get_inst(result).data
+        );
+        assert!(matches!(cfg.get_inst(add2).data, CfgInstData::Const(0)));
     }
 }

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -1,0 +1,683 @@
+//! Value forwarding: store-to-load / copy propagation (RUE-914).
+//!
+//! Replaces `Load { slot }` results with an SSA value that already holds the
+//! slot's contents, so later passes see the value directly instead of a memory
+//! read. Runs at `-O2`/`-O3` only, after [`super::simplify`] and before
+//! [`super::cse`] — forwarding turns memory reads into ordinary values, which is
+//! exactly what feeds common-subexpression elimination (two `a + b`
+//! expressions built from forwarded loads become keyable adds).
+//!
+//! Both rules are *trap-exact*: a `Load` never traps, and the value it is
+//! replaced with was already computed earlier on every path that reaches the
+//! load, so no computation is added, removed, or reordered — only a redundant
+//! memory read is bypassed.
+//!
+//! ## Rule 1 — global single-write forwarding
+//!
+//! Generalizes constant store-to-load propagation ([`super::constopt`]) from
+//! constants to arbitrary SSA values. A local slot *qualifies* when it has
+//! exactly ONE whole-slot write among block-attached instructions — its `Alloc`
+//! or a single `Store` — and is never written through any other channel:
+//!
+//! - no projected `PlaceWrite` whose base is that local,
+//! - never passed by-ref (`inout`/`borrow` call argument rooted at a `Load` or
+//!   `PlaceRead` of the slot — the callee may write through the pointer),
+//! - not address-taken (`@raw`/`@raw_mut`/`@field_ptr`, RUE-521 — a raw pointer
+//!   may write the slot behind the optimizer's back).
+//!
+//! For a qualifying slot every `Load` of it is replaced by the single write's
+//! stored value. No dominator tree is needed to justify this: with exactly one
+//! write site, sema's definite-initialization guarantee means every load
+//! executes after the write on every path, so the write's block dominates every
+//! load and the stored value — computed *before* the store — is available at
+//! each load. This is the same dominance argument [`super::constopt`] makes for
+//! constants, now stated for general values. (`debug_assertions` builds verify
+//! it explicitly against [`crate::dominators`].)
+//!
+//! Note a subtlety the value form makes vacuous: the stored value could itself
+//! be a `Load` of another slot that some later write modifies between the store
+//! and a forwarded load. That would be a hazard if we *re-executed* the load,
+//! but we forward the already-computed SSA id (the value as it was at store
+//! time), never a recomputation, so there is nothing to invalidate.
+//!
+//! ## Rule 2 — block-local forwarding for multi-write slots
+//!
+//! A mutated slot (two or more writes) does not qualify for Rule 1, but within
+//! a single block its most recent whole-slot store is still available. A
+//! forward walk tracks `last_store[slot] = value` from each `Alloc`/`Store`; a
+//! `Load { slot }` with a live entry forwards to that value. Entries are killed
+//! when the stored value may no longer be current:
+//!
+//! - a later `Store`/`Alloc` to the slot replaces the entry;
+//! - a `PlaceWrite` whose base is that local (a partial write) kills it;
+//! - any `Call` with a by-ref argument rooted at that local kills it (the
+//!   callee may write through the pointer). A by-ref argument rooted at a shape
+//!   this pass cannot identify as a specific local or parameter clears the whole
+//!   table conservatively.
+//!
+//! The table resets at each block boundary. Address-taken slots are excluded
+//! from it entirely: a raw pointer may alias them and store between a tracked
+//! write and a load (RUE-521 covers reads after an aliased write, not only
+//! place preservation).
+//!
+//! A `Load` that is itself a by-ref call argument is never forwarded under
+//! either rule: the by-ref lowering requires that argument to remain a place.
+//!
+//! ## Applying substitutions and cleanup
+//!
+//! Both rules record `subst[load] = value`; all substitutions apply in one
+//! [`Cfg::rewrite_value_uses`] sweep, resolving chains (a forwarded value may
+//! itself be a forwarded load) exactly as [`super::cse`] and
+//! [`super::peephole`] do. A forwarded `Load` then has no remaining uses.
+//! Unlike CSE — which must overwrite a duplicated *trapping* op with a dead
+//! placeholder because DCE deliberately preserves possibly-trapping arithmetic
+//! (RUE-57) — loads never trap and are not on DCE's side-effect list, so DCE
+//! sweeps the orphaned loads on its own. They are left as plain `Load`
+//! instructions, not dummied out.
+
+use std::collections::HashSet;
+
+use crate::{BlockId, Cfg, CfgInstData, CfgValue, PlaceBase};
+
+/// Work counters for one run (RUE-794 convention): one classification scan, one
+/// forward rewriting scan, and one batched use-rewrite. No fixpoint loop.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Stats {
+    /// Block-attached instructions visited by the forward rewriting walk.
+    pub insts_scanned: u64,
+    /// Loads forwarded by Rule 1 (global single-write slots).
+    pub loads_forwarded_single_write: u64,
+    /// Loads forwarded by Rule 2 (block-local last store of a multi-write slot).
+    pub loads_forwarded_block_local: u64,
+}
+
+/// Classification of a local slot's whole-slot writes, for Rule 1.
+#[derive(Clone, Copy)]
+enum SlotClass {
+    /// No write seen yet.
+    None,
+    /// Exactly one whole-slot write storing this value, in this block.
+    One(CfgValue, BlockId),
+    /// Multiple writes, a partial/aliased write, an address escape, or a by-ref
+    /// pass. Never forwarded by Rule 1 (Rule 2 may still forward block-locally).
+    Disqualified,
+}
+
+/// Run value forwarding. Call at `-O2`/`-O3` after simplification and before
+/// CSE.
+pub fn run(cfg: &mut Cfg) -> Stats {
+    let mut stats = Stats::default();
+    let num_locals = cfg.num_locals() as usize;
+
+    // ------------------------------------------------------------------
+    // Precompute the set of values used as by-ref call arguments. Such a
+    // value must stay a place (its address is taken by the callee), so it is
+    // never forwarded regardless of rule.
+    // ------------------------------------------------------------------
+    let mut byref_arg_values: HashSet<CfgValue> = HashSet::new();
+    for block in cfg.blocks() {
+        for &value in &block.insts {
+            if let CfgInstData::Call {
+                args_start,
+                args_len,
+                ..
+            } = &cfg.get_inst(value).data
+            {
+                for arg in cfg.get_call_args(*args_start, *args_len) {
+                    if arg.is_by_ref() {
+                        byref_arg_values.insert(arg.value);
+                    }
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Rule 1 classification. Exactly the discipline in `constopt`, but the
+    // stored value need not be constant. Only block-attached instructions
+    // matter; orphaned values never execute. Nothing here depends on later
+    // rewriting, so one scan suffices.
+    // ------------------------------------------------------------------
+    let mut slot_class = vec![SlotClass::None; num_locals];
+
+    // Address-taken slots can be written behind the optimizer's back through a
+    // raw pointer, so they never qualify for Rule 1 (and are excluded from the
+    // Rule 2 table below too).
+    for (slot, class) in slot_class.iter_mut().enumerate() {
+        if cfg.is_address_taken(slot as u32) {
+            *class = SlotClass::Disqualified;
+        }
+    }
+
+    // Out-of-range slots (a trailing zero-sized local occupies 0 slots and is
+    // assigned index == num_locals) move no bytes: skip them (RUE-194).
+    fn record_write(slot_class: &mut [SlotClass], slot: u32, write: Option<(CfgValue, BlockId)>) {
+        let Some(class) = slot_class.get_mut(slot as usize) else {
+            return;
+        };
+        *class = match (&*class, write) {
+            (SlotClass::None, Some((v, block))) => SlotClass::One(v, block),
+            _ => SlotClass::Disqualified,
+        };
+    }
+
+    for block in cfg.blocks() {
+        for &value in &block.insts {
+            match &cfg.get_inst(value).data {
+                CfgInstData::Alloc { slot, init } | CfgInstData::Store { slot, value: init } => {
+                    record_write(&mut slot_class, *slot, Some((*init, block.id)));
+                }
+                CfgInstData::PlaceWrite { place, .. } => {
+                    if let PlaceBase::Local(slot) = place.base {
+                        record_write(&mut slot_class, slot, None);
+                    }
+                }
+                CfgInstData::Call {
+                    args_start,
+                    args_len,
+                    ..
+                } => {
+                    for arg in cfg.get_call_args(*args_start, *args_len) {
+                        if !arg.is_by_ref() {
+                            continue;
+                        }
+                        match &cfg.get_inst(arg.value).data {
+                            CfgInstData::Load { slot } => {
+                                record_write(&mut slot_class, *slot, None);
+                            }
+                            CfgInstData::PlaceRead { place } => {
+                                if let PlaceBase::Local(slot) = place.base {
+                                    record_write(&mut slot_class, slot, None);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Forward rewriting walk. One pass over every block-attached instruction
+    // produces both rules' substitutions and maintains Rule 2's per-block
+    // `last_store` table.
+    // ------------------------------------------------------------------
+    let mut subst: Vec<Option<CfgValue>> = vec![None; cfg.value_count()];
+    // (single-write block, forwarded load block) pairs for the debug dominance
+    // check.
+    #[cfg(debug_assertions)]
+    let mut rule1_dominance_checks: Vec<(BlockId, BlockId)> = Vec::new();
+    // Rule 2 last whole-slot store per local, reset per block.
+    let mut last_store: Vec<Option<CfgValue>> = vec![None; num_locals];
+
+    for block_idx in 0..cfg.block_count() {
+        let block_id = BlockId::from_raw(block_idx as u32);
+        for slot in last_store.iter_mut() {
+            *slot = None;
+        }
+
+        for i in 0..cfg.get_block(block_id).insts.len() {
+            let value = cfg.get_block(block_id).insts[i];
+            stats.insts_scanned += 1;
+
+            match cfg.get_inst(value).data.clone() {
+                CfgInstData::Alloc { slot, init } | CfgInstData::Store { slot, value: init } => {
+                    // Address-taken slots stay out of the block-local table.
+                    if !cfg.is_address_taken(slot) && (slot as usize) < num_locals {
+                        last_store[slot as usize] = Some(init);
+                    }
+                }
+                CfgInstData::Load { slot } => {
+                    // A by-ref argument load must remain a place.
+                    if byref_arg_values.contains(&value) {
+                        continue;
+                    }
+                    if let Some(SlotClass::One(write_value, write_block)) =
+                        slot_class.get(slot as usize).copied()
+                    {
+                        // Rule 1: global single-write forwarding.
+                        subst[value.as_u32() as usize] = Some(write_value);
+                        stats.loads_forwarded_single_write += 1;
+                        #[cfg(debug_assertions)]
+                        rule1_dominance_checks.push((write_block, block_id));
+                        let _ = write_block;
+                    } else if !cfg.is_address_taken(slot) {
+                        // Rule 2: block-local forwarding for multi-write slots.
+                        if let Some(&Some(stored)) = last_store.get(slot as usize) {
+                            subst[value.as_u32() as usize] = Some(stored);
+                            stats.loads_forwarded_block_local += 1;
+                        }
+                    }
+                }
+                CfgInstData::PlaceWrite { place, .. } => {
+                    // A partial write invalidates the whole-slot value.
+                    if let PlaceBase::Local(slot) = place.base {
+                        if (slot as usize) < num_locals {
+                            last_store[slot as usize] = None;
+                        }
+                    }
+                }
+                CfgInstData::Call {
+                    args_start,
+                    args_len,
+                    ..
+                } => {
+                    let mut clear_all = false;
+                    for arg in cfg.get_call_args(args_start, args_len).to_vec() {
+                        if !arg.is_by_ref() {
+                            continue;
+                        }
+                        match &cfg.get_inst(arg.value).data {
+                            CfgInstData::Load { slot } => {
+                                if (*slot as usize) < num_locals {
+                                    last_store[*slot as usize] = None;
+                                }
+                            }
+                            CfgInstData::PlaceRead { place } => match place.base {
+                                // A local base: the callee may write that local.
+                                PlaceBase::Local(slot) => {
+                                    if (slot as usize) < num_locals {
+                                        last_store[slot as usize] = None;
+                                    }
+                                }
+                                // A parameter base writes through a parameter,
+                                // not a local slot: nothing to kill.
+                                PlaceBase::Param(_) => {}
+                            },
+                            // An unidentifiable by-ref root: be safe and clear
+                            // the whole table at this call.
+                            _ => clear_all = true,
+                        }
+                    }
+                    if clear_all {
+                        for slot in last_store.iter_mut() {
+                            *slot = None;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let forwarded = stats.loads_forwarded_single_write + stats.loads_forwarded_block_local;
+    if forwarded == 0 {
+        return stats;
+    }
+
+    // Turn the definite-initialization argument for Rule 1 into a checked
+    // invariant: the single write's block must dominate every load it feeds.
+    // Only computed when debug assertions are on and Rule 1 actually fired.
+    #[cfg(debug_assertions)]
+    {
+        if !rule1_dominance_checks.is_empty() {
+            let dom = crate::dominators::DominatorTree::compute(cfg);
+            for (write_block, load_block) in &rule1_dominance_checks {
+                debug_assert!(
+                    dom.dominates(*write_block, *load_block),
+                    "Rule 1 forwarded a load in {load_block} whose single write \
+                     block {write_block} does not dominate it",
+                );
+            }
+        }
+    }
+
+    // Resolve chains once, then re-point every use in a single sweep.
+    let resolved: Vec<CfgValue> = (0..cfg.value_count())
+        .map(|i| resolve(&subst, CfgValue::from_raw(i as u32)))
+        .collect();
+    cfg.rewrite_value_uses(|v| resolved[v.as_u32() as usize]);
+
+    stats
+}
+
+/// Walk `subst` chains to the surviving value. A forwarded value can itself be
+/// a forwarded load (`let a = 5; let b = a;`), so resolution is iterative;
+/// chains are acyclic because a stored value is always defined before its store.
+fn resolve(subst: &[Option<CfgValue>], mut v: CfgValue) -> CfgValue {
+    while let Some(next) = subst[v.as_u32() as usize] {
+        v = next;
+    }
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CfgArgMode, CfgCallArg, CfgInst, Place, Projection, Terminator, Type};
+    use lasso::{Key, Spur};
+    use rue_span::Span;
+
+    fn make_cfg(num_locals: u32) -> Cfg {
+        let mut cfg = Cfg::new(Type::I32, num_locals, 0, "test".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg
+    }
+
+    fn push(cfg: &mut Cfg, data: CfgInstData, ty: Type) -> CfgValue {
+        let entry = cfg.entry;
+        push_in(cfg, entry, data, ty)
+    }
+
+    fn push_in(cfg: &mut Cfg, block: BlockId, data: CfgInstData, ty: Type) -> CfgValue {
+        cfg.add_inst_to_block(
+            block,
+            CfgInst {
+                data,
+                ty,
+                span: Span::new(0, 0),
+            },
+        )
+    }
+
+    #[test]
+    fn test_single_write_nonconst_forwarded() {
+        // let s = a + b; s  — the slot has one write (its Alloc) initializing
+        // from a non-constant Add. Every Load of s forwards to that Add value.
+        let mut cfg = make_cfg(1);
+        let a = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let b = push(&mut cfg, CfgInstData::Param { index: 1 }, Type::I32);
+        let sum = push(&mut cfg, CfgInstData::Add(a, b), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: sum },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_forwarded_single_write, 1);
+        assert_eq!(stats.loads_forwarded_block_local, 0);
+        // The return now reads the Add directly.
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == sum
+        ));
+    }
+
+    #[test]
+    fn test_block_local_multiwrite_forwarded_with_kill_on_store() {
+        // let mut x = 1; read1 = x; x = 2; read2 = x;
+        // Two writes => not a Rule 1 slot; block-local forwarding sends read1
+        // to the first value and read2 to the second (the store kills+replaces).
+        let mut cfg = make_cfg(1);
+        let c1 = push(&mut cfg, CfgInstData::Const(1), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c1 },
+            Type::UNIT,
+        );
+        let read1 = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        let c2 = push(&mut cfg, CfgInstData::Const(2), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Store { slot: 0, value: c2 },
+            Type::UNIT,
+        );
+        let read2 = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        let sum = push(&mut cfg, CfgInstData::Add(read1, read2), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_forwarded_single_write, 0);
+        assert_eq!(stats.loads_forwarded_block_local, 2);
+        // read1 -> c1, read2 -> c2.
+        assert!(matches!(cfg.get_inst(sum).data, CfgInstData::Add(x, y) if x == c1 && y == c2));
+    }
+
+    #[test]
+    fn test_byref_call_kills_block_local_entry() {
+        // let mut x = 1; f(inout x); read = x;
+        // The store before the call is killed by the by-ref argument, so the
+        // load after the call is NOT forwarded (the callee may have written x).
+        let mut cfg = make_cfg(1);
+        let c1 = push(&mut cfg, CfgInstData::Const(1), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c1 },
+            Type::UNIT,
+        );
+        let arg_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        let (args_start, args_len) = cfg.push_call_args([CfgCallArg {
+            value: arg_load,
+            mode: CfgArgMode::Inout,
+        }]);
+        push(
+            &mut cfg,
+            CfgInstData::Call {
+                name: Spur::try_from_usize(0).unwrap(),
+                args_start,
+                args_len,
+            },
+            Type::UNIT,
+        );
+        let read = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(read) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_forwarded_single_write, 0);
+        assert_eq!(stats.loads_forwarded_block_local, 0);
+        // Neither load was rewritten: the arg load stays a place, and the load
+        // after the call still reads memory.
+        assert!(matches!(
+            cfg.get_inst(arg_load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == read
+        ));
+    }
+
+    #[test]
+    fn test_address_taken_slot_never_forwarded() {
+        // A single-write slot whose address is taken must keep its loads as
+        // places (RUE-521): neither rule may forward.
+        let mut cfg = make_cfg(1);
+        let c = push(&mut cfg, CfgInstData::Const(42), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        let (args_start, args_len) = cfg.push_extra(vec![load]);
+        let ptr = push(
+            &mut cfg,
+            CfgInstData::Intrinsic {
+                name: Spur::try_from_usize(0).unwrap(),
+                args_start,
+                args_len,
+            },
+            Type::I32,
+        );
+        cfg.mark_address_taken(0);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(ptr) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_forwarded_single_write, 0);
+        assert_eq!(stats.loads_forwarded_block_local, 0);
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_placewrite_kills_block_local_entry() {
+        // let mut x = 1; x.field = ...; read = x;
+        // A projected write invalidates the tracked whole-slot value, and it is
+        // a second write so Rule 1 is out too. The load is not forwarded.
+        let mut cfg = make_cfg(1);
+        let c1 = push(&mut cfg, CfgInstData::Const(1), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c1 },
+            Type::UNIT,
+        );
+        let field_val = push(&mut cfg, CfgInstData::Const(9), Type::I32);
+        let (proj_start, proj_len) = cfg.push_projections([Projection::Field {
+            struct_id: crate::StructId::from_pool_index(0),
+            field_index: 0,
+        }]);
+        let place = Place {
+            base: PlaceBase::Local(0),
+            base_type: Type::I32,
+            proj_start,
+            proj_len,
+        };
+        push(
+            &mut cfg,
+            CfgInstData::PlaceWrite {
+                place,
+                value: field_val,
+            },
+            Type::UNIT,
+        );
+        let read = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(read) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_forwarded_single_write, 0);
+        assert_eq!(stats.loads_forwarded_block_local, 0);
+        assert!(matches!(
+            cfg.get_block(cfg.entry).terminator,
+            Terminator::Return { value: Some(v) } if v == read
+        ));
+    }
+
+    #[test]
+    fn test_zero_sized_out_of_range_slot_ignored() {
+        // A trailing zero-sized local is assigned slot index == num_locals,
+        // out of range for the slot tables. Its Alloc/Load must be skipped, not
+        // panic (RUE-194), and nothing is forwarded.
+        let mut cfg = make_cfg(0);
+        let c = push(&mut cfg, CfgInstData::Const(0), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::UNIT);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: None });
+        let _ = load;
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_forwarded_single_write, 0);
+        assert_eq!(stats.loads_forwarded_block_local, 0);
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_cross_block_multiwrite_not_forwarded() {
+        // A multi-write slot's store in block A does not forward into a load in
+        // block B: Rule 2 is block-local, and the slot is disqualified for Rule
+        // 1. (Store in entry; load in a successor block.)
+        let mut cfg = make_cfg(1);
+        let c1 = push(&mut cfg, CfgInstData::Const(1), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c1 },
+            Type::UNIT,
+        );
+        let c2 = push(&mut cfg, CfgInstData::Const(2), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Store { slot: 0, value: c2 },
+            Type::UNIT,
+        );
+        let block2 = cfg.new_block();
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Goto {
+                target: block2,
+                args_start: 0,
+                args_len: 0,
+            },
+        );
+        let load = push_in(&mut cfg, block2, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(block2, Terminator::Return { value: Some(load) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_forwarded_single_write, 0);
+        assert_eq!(stats.loads_forwarded_block_local, 0);
+        assert!(matches!(
+            cfg.get_block(block2).terminator,
+            Terminator::Return { value: Some(v) } if v == load
+        ));
+    }
+
+    #[test]
+    fn test_single_write_forwards_across_blocks() {
+        // A single-write slot forwards even into a different block: the write's
+        // block dominates the load's block, so Rule 1 applies. (This also
+        // exercises the debug dominance assertion.)
+        let mut cfg = make_cfg(1);
+        let c = push(&mut cfg, CfgInstData::Const(7), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c },
+            Type::UNIT,
+        );
+        let block2 = cfg.new_block();
+        cfg.set_terminator(
+            cfg.entry,
+            Terminator::Goto {
+                target: block2,
+                args_start: 0,
+                args_len: 0,
+            },
+        );
+        let load = push_in(&mut cfg, block2, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(block2, Terminator::Return { value: Some(load) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.loads_forwarded_single_write, 1);
+        assert!(matches!(
+            cfg.get_block(block2).terminator,
+            Terminator::Return { value: Some(v) } if v == c
+        ));
+    }
+
+    #[test]
+    fn test_work_counters_one_scan() {
+        // insts_scanned counts every block-attached instruction; a single run
+        // suffices (a second finds nothing new).
+        let mut cfg = make_cfg(1);
+        let a = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let b = push(&mut cfg, CfgInstData::Param { index: 1 }, Type::I32);
+        let sum = push(&mut cfg, CfgInstData::Add(a, b), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: sum },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
+
+        let total_insts: usize = (0..cfg.block_count())
+            .map(|i| cfg.get_block(BlockId::from_raw(i as u32)).insts.len())
+            .sum();
+
+        let stats = run(&mut cfg);
+        assert_eq!(stats.insts_scanned, total_insts as u64);
+        assert_eq!(stats.loads_forwarded_single_write, 1);
+
+        // Forwarding leaves the orphaned load in place for DCE (unlike CSE,
+        // which dummies its duplicates). A second run WITHOUT DCE therefore
+        // re-forwards the still-present load — the pass is idempotent in effect
+        // (the load already has no uses) but not in its work counter. Once DCE
+        // sweeps the load, a re-run finds nothing.
+        super::super::dce::run(&mut cfg);
+        let again = run(&mut cfg);
+        assert_eq!(again.loads_forwarded_single_write, 0);
+        assert_eq!(again.loads_forwarded_block_local, 0);
+    }
+}

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -10,7 +10,8 @@
 //! - `-O0`: No optimization (default)
 //! - `-O1`: Basic optimizations (constant folding, peephole, CFG
 //!   simplification, dead code elimination)
-//! - `-O2`: `-O1` plus block-local common-subexpression elimination (RUE-913)
+//! - `-O2`: `-O1` plus value forwarding / copy propagation (RUE-914) and
+//!   block-local common-subexpression elimination (RUE-913)
 //! - `-O3`: Aggressive optimizations (same as -O2 for now)
 //!
 //! ## Pipeline
@@ -25,6 +26,7 @@ mod constfold;
 mod constopt;
 mod cse;
 mod dce;
+mod forward;
 mod peephole;
 mod simplify;
 
@@ -52,7 +54,9 @@ pub enum OptLevel {
 
     /// Standard optimizations (`-O2`).
     ///
-    /// Superset of `-O1`: runs everything `-O1` does, then block-local
+    /// Superset of `-O1`: runs everything `-O1` does, then value forwarding /
+    /// copy propagation (RUE-914), which replaces redundant `Load`s with the
+    /// SSA value already holding the slot's contents, followed by block-local
     /// common-subexpression elimination (RUE-913), which replaces duplicate
     /// pure computations within a block with their first occurrence.
     O2,
@@ -170,11 +174,22 @@ pub fn optimize(cfg: &mut Cfg, level: OptLevel, type_pool: &FrozenTypeInternPool
             // before DCE prunes the leftovers.
             simplify::run(cfg);
 
+            // Value forwarding / copy propagation (RUE-914), at -O2/-O3 only.
+            // Runs after simplify and before CSE: it turns redundant `Load`s
+            // into the SSA value already holding the slot's contents (a global
+            // single-write rule plus a block-local last-store rule), which is
+            // exactly what lets CSE key expressions built over those loads.
+            // Both rules are trap-exact — a load never traps and the forwarded
+            // value is already computed — so the orphaned loads fall to DCE.
+            if matches!(level, OptLevel::O2 | OptLevel::O3) {
+                forward::run(cfg);
+            }
+
             // Block-local common-subexpression elimination (RUE-913), at
             // -O2/-O3 only (ADR-0044 places CSE at the release-default level).
-            // Runs after simplify — merged straight-line blocks expose more
-            // intra-block duplicates — and before DCE, which sweeps the dead
-            // placeholders each replaced duplicate leaves behind.
+            // Runs after forwarding — expressions over forwarded loads are now
+            // keyable — and before DCE, which sweeps the dead placeholders each
+            // replaced duplicate (and each forwarded load) leaves behind.
             if matches!(level, OptLevel::O2 | OptLevel::O3) {
                 cse::run(cfg);
             }

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -573,3 +573,60 @@ fn main() -> i32 {
 stdout = ""
 exit_code = 101
 runtime_error_contains = ["division by zero"]
+
+# Value forwarding + CSE over parameter expressions (RUE-914). `a` and `b` are
+# never-written by-value parameters, so their repeated reads are the same pure
+# value: forwarding turns the `let s`/`let t`/`let u` loads into the single
+# `a + b`, CSE's parameter keying (RUE-914) collapses the duplicated reads, and
+# the three `a + b` computations become one. `acc` is a multi-write local, so it
+# exercises block-local forwarding with kill-on-store between its mutations. The
+# result must be identical at every level — forwarding and CSE are semantics-
+# preserving, not just at -O2 where they fire.
+[[case]]
+name = "forward_and_cse_param_expressions_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn compute(a: i32, b: i32) -> i32 {
+    let s = a + b;
+    let t = a + b;
+    let mut acc = s + t;
+    acc = acc + a;
+    acc = acc * b;
+    let u = a + b;
+    acc + u
+}
+
+fn main() -> i32 {
+    let x = compute(3, 4);
+    @dbg(x);
+    x
+}
+""" }]
+stdout = "75\n"
+exit_code = 75
+
+# A store followed by an `inout` call followed by a load must RELOAD, not
+# forward the pre-call value (RUE-914). The callee writes through the by-ref
+# pointer, so forwarding kills the slot's tracked store at the call; `let r = v`
+# then reads the mutated value. If forwarding wrongly propagated the pre-call
+# `5`, -O2 would print/return `5` while -O0 returns `105` — the differential net
+# names that divergence. The `inout` argument's own load also stays a place at
+# every level (the by-ref lowering requires it).
+[[case]]
+name = "inout_call_between_store_and_load_reloads_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn bump(inout x: i32) {
+    x = x + 100;
+}
+
+fn main() -> i32 {
+    let mut v: i32 = 5;
+    bump(inout v);
+    let r = v;
+    @dbg(r);
+    r
+}
+""" }]
+stdout = "105\n"
+exit_code = 105

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3759 rejected=149 lex_invalid=35 accepted_source_ast_sha256=6285a16bc19faa3ba2830fdbda7c4f0b7f20861b1148d309d8e7c0b02e6570b8
+# pre-RUE-905 Chumsky: accepted=3761 rejected=149 lex_invalid=35 accepted_source_ast_sha256=8a0470a78a7e5a8c02528c423e34ab1bfb0c0ed33fd0540d2d82443df2f9628a
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca

--- a/docs/designs/0044-optimization-levels.md
+++ b/docs/designs/0044-optimization-levels.md
@@ -192,8 +192,8 @@ shapes each new pass targets (see Sequencing).
 |-------|----------|----------------|-----------------------|
 | `-O0` | No optimization. Codegen tracks source; fastest compile; best debugging. **Default.** | none (only always-on `verify()`) | stays empty |
 | `-O1` | Cheap, always-safe, compile-time-neutral-or-positive local cleanups. | sparse constfold/constprop (RUE-794) → peephole (RUE-912) → simplify-cfg (RUE-910/911) → DCE | complete for now |
-| `-O2` | **Release default.** All balanced optimizations that reliably help without a size blow-up. Superset of `-O1`. | `-O1` + block-local CSE (RUE-913) | + conservative inlining (small/leaf fns); copy propagation; wider GVN; better regalloc |
-| `-O3` | `-O2` plus speculative, size-spending, speed-chasing transforms. Superset of `-O2`. | = `-O1` today | + aggressive inlining; loop opts (LICM, unrolling); later, vectorization |
+| `-O2` | **Release default.** All balanced optimizations that reliably help without a size blow-up. Superset of `-O1`. | `-O1` + copy propagation / store-to-load forwarding (RUE-914) → block-local CSE (RUE-913) | + conservative inlining (small/leaf fns); wider GVN; better regalloc |
+| `-O3` | `-O2` plus speculative, size-spending, speed-chasing transforms. Superset of `-O2`. | = `-O2` today | + aggressive inlining (RUE-915, pending); loop opts (LICM, unrolling); later, vectorization |
 
 Rules that make the table a *contract* rather than a wishlist:
 
@@ -264,8 +264,10 @@ as Linear issues under RUE-245. **This ADR implements none of them.**
   added at `-O1` with differential coverage. (RUE-910, RUE-911, RUE-912; merged
   2026-07-16)
 - [ ] **Phase 3: `-O2` content** — CSE/GVN, copy prop, conservative inlining;
-  `-O2` stops aliasing `-O1`. Partial: block-local CSE landed (RUE-913), so
-  `-O2` no longer aliases `-O1`; copy propagation (RUE-914) and conservative
+  `-O2` stops aliasing `-O1`. Partial: block-local CSE (RUE-913) and copy
+  propagation / store-to-load forwarding (RUE-914, which also keys never-written
+  parameter reads in CSE and lands the shared dominator-tree infrastructure for
+  later LICM/GVN) have landed, so `-O2` no longer aliases `-O1`; conservative
   inlining (RUE-915) still pending. (file RUE-NNN)
 - [ ] **Phase 4: `-O3` content** — aggressive inlining + loop opts; `-O3` stops
   aliasing `-O2`. (file RUE-NNN)


### PR DESCRIPTION
## Change

Three related pieces that make `-O2`'s propagation real:

**1. Value forwarding** (`opt/forward.rs`, `-O2`/`-O3`, after simplify, before CSE). Two trap-exact rules replacing `Load` results with an already-computed SSA value (loads never trap; the value is *used*, not recomputed):
- *Global single-write forwarding*: constopt's store-to-load discipline generalized from constants to arbitrary SSA values. Slot qualifies with exactly one whole-slot write, no partial writes, no by-ref exposure, no address escape (RUE-521). No dominator tree needed — sema's definite-initialization guarantee means the single write dominates every load (the argument constopt already documents), now a debug-assertions-checked invariant.
- *Block-local forwarding* for multi-write slots: last-store tracking with kills on intervening stores, partial `PlaceWrite`s, and by-ref call arguments; unidentifiable by-ref roots conservatively clear the whole table; address-taken slots excluded entirely.

Forwarded loads become unused and DCE sweeps them (loads aren't in DCE's trap-preservation set — the asymmetry with CSE's dummied trapping duplicates is documented).

**2. Dominator tree** (`src/dominators.rs`): Cooper–Harvey–Kennedy iterative dominators as shared crate infrastructure for LICM (RUE-916) and wider GVN; consumed today by forwarding's debug-mode dominance assertion.

**3. CSE parameter keying** (`opt/cse.rs`): `Param` joins the value-number table for parameter slots that are never written (`is_param_writable` false + no `ParamStore`; index verified to be the shared ABI slot). Parameter reads re-materialize fresh values per read, which had made CSE inert over parameter expressions.

**Compounding result** (verified in emitted CFG): `fn f(a,b) { let s = a + b; let t = a + b; s + t }` computes the add ONCE at `-O2` — forwarding erases the loads, param keying unifies operands, CSE merges the adds — and `-O1` is unchanged.

## Testing

- 17 new unit tests: all forwarding kill/escape rules (by-ref, PlaceWrite, address-taken, zero-sized slots, cross-block negative), 4 dominator-tree cases, CSE param keying incl. the acceptance-shape pipeline test.
- Differential CLI: param-expression forwarding+CSE with mutation kills; an `inout` call between store and load proving the reload happens. Identical behavior at `-O0..-O3` (18/18 differential cases).
- Full local suite passed. Corpus snapshot re-blessed (+2 fixtures, rejected rows unchanged). ADR-0044 level table updated.

Fixes RUE-914