### PR TITLE
Fix two optimizer-hunt findings in the RUE-914 passes

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -923,10 +923,20 @@ impl<'a> CfgBuilder<'a> {
                 {
                     match &self.cfg.get_inst(place_val).data {
                         CfgInstData::Load { slot } => self.cfg.mark_address_taken(*slot),
-                        CfgInstData::PlaceRead { place } => {
-                            if let PlaceBase::Local(slot) = place.base {
-                                self.cfg.mark_address_taken(slot);
-                            }
+                        CfgInstData::PlaceRead { place } => match place.base {
+                            PlaceBase::Local(slot) => self.cfg.mark_address_taken(slot),
+                            // A parameter's address escaping means repeated
+                            // Param reads are no longer interchangeable
+                            // (@ptr_write can mutate the storage between
+                            // them) — record it so CSE's param keying skips
+                            // the slot (RUE-914 hunt finding).
+                            PlaceBase::Param(slot) => self.cfg.mark_param_address_taken(slot),
+                        },
+                        // A bare scalar parameter lowers directly to a Param
+                        // value with no backing local; its address escaping
+                        // must be recorded on the PARAM slot.
+                        CfgInstData::Param { index } => {
+                            self.cfg.mark_param_address_taken(*index);
                         }
                         _ => {}
                     }

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -574,6 +574,15 @@ pub struct Cfg {
     /// RUE-521 O1+ segfault. By-ref call arguments are the analogous
     /// per-instruction escape, handled directly in constopt's scan.
     address_taken_slots: std::collections::HashSet<u32>,
+    /// Parameter ABI slots whose ADDRESS escapes through an address-taking
+    /// intrinsic (`@raw` / `@raw_mut` / `@field_ptr` applied to a parameter),
+    /// recorded at construction like `address_taken_slots`. A by-value
+    /// parameter normally cannot change between reads, which is what lets
+    /// CSE key repeated `Param` reads (RUE-914) — but a raw pointer obtained
+    /// from the parameter's storage can mutate it (`@ptr_write`), so reads
+    /// on either side of such a write are NOT interchangeable. Passes that
+    /// treat parameter reads as pure must consult this set.
+    address_taken_params: std::collections::HashSet<u32>,
 }
 
 impl Cfg {
@@ -650,6 +659,7 @@ impl Cfg {
             fn_name,
             param_modes: param_modes.into(),
             address_taken_slots: std::collections::HashSet::new(),
+            address_taken_params: std::collections::HashSet::new(),
         }
     }
 
@@ -666,6 +676,22 @@ impl Cfg {
     #[inline]
     pub fn is_address_taken(&self, slot: u32) -> bool {
         self.address_taken_slots.contains(&slot)
+    }
+
+    /// Record that parameter ABI slot `slot`'s address escapes through an
+    /// address-taking intrinsic. See the `address_taken_params` field docs:
+    /// repeated reads of such a parameter are not interchangeable, because a
+    /// raw pointer into its storage may write between them.
+    #[inline]
+    pub fn mark_param_address_taken(&mut self, slot: u32) {
+        self.address_taken_params.insert(slot);
+    }
+
+    /// Whether parameter ABI slot `slot`'s address escapes through an
+    /// address-taking intrinsic (see [`Cfg::mark_param_address_taken`]).
+    #[inline]
+    pub fn is_param_address_taken(&self, slot: u32) -> bool {
+        self.address_taken_params.contains(&slot)
     }
 
     /// Get the return type.

--- a/crates/rue-cfg/src/opt/cse.rs
+++ b/crates/rue-cfg/src/opt/cse.rs
@@ -204,7 +204,12 @@ fn never_written_params(cfg: &Cfg) -> Vec<bool> {
     let num_params = cfg.num_params() as usize;
     let mut never_written = vec![false; num_params];
     for (slot, flag) in never_written.iter_mut().enumerate() {
-        *flag = !cfg.is_param_writable(slot as u32);
+        // A parameter whose ADDRESS escapes through @raw/@raw_mut/@field_ptr
+        // is mutable through the raw pointer (@ptr_write), so its reads are
+        // NOT interchangeable even though nothing writes it directly — keying
+        // such reads merged a post-write read into the stale pre-write value
+        // (found by the 2026-07-16 optimizer hunt).
+        *flag = !cfg.is_param_writable(slot as u32) && !cfg.is_param_address_taken(slot as u32);
     }
 
     for block in cfg.blocks() {
@@ -622,5 +627,27 @@ mod tests {
             cfg.get_inst(result).data
         );
         assert!(matches!(cfg.get_inst(add2).data, CfgInstData::Const(0)));
+    }
+    #[test]
+    fn test_address_taken_param_not_keyed() {
+        // A parameter whose address escapes via @raw_mut can be mutated
+        // through @ptr_write, so its repeated reads must NOT dedupe
+        // (2026-07-16 optimizer-hunt miscompile: post-write read merged into
+        // the stale pre-write value).
+        let mut cfg = Cfg::new(Type::I32, 0, 1, "test".to_string(), vec![false]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.mark_param_address_taken(0);
+        let p1 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let p2 = push(&mut cfg, CfgInstData::Param { index: 0 }, Type::I32);
+        let sum = push(&mut cfg, CfgInstData::Add(p1, p2), Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
+
+        let stats = run(&mut cfg);
+        assert_eq!(
+            stats.duplicates_replaced, 0,
+            "address-taken param reads must not dedupe"
+        );
+        assert!(matches!(cfg.get_inst(p2).data, CfgInstData::Param { .. }));
     }
 }

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -79,6 +79,8 @@ use std::collections::HashSet;
 
 use crate::{BlockId, Cfg, CfgInstData, CfgValue, PlaceBase};
 
+use super::dce;
+
 /// Work counters for one run (RUE-794 convention): one classification scan, one
 /// forward rewriting scan, and one batched use-rewrite. No fixpoint loop.
 #[derive(Debug, Default, Clone, Copy)]
@@ -108,6 +110,14 @@ enum SlotClass {
 pub fn run(cfg: &mut Cfg) -> Stats {
     let mut stats = Stats::default();
     let num_locals = cfg.num_locals() as usize;
+
+    // Both classification and rewriting are restricted to blocks reachable
+    // AFTER simplify's constant-terminator folding. A load in a statically
+    // dead arm never executes, is never dominated by anything, and must not
+    // be forwarded (it tripped the Rule 1 dominance invariant — 2026-07-16
+    // optimizer hunt); an unreachable store likewise must not count against
+    // (or for) a slot's classification.
+    let reachable = dce::compute_reachable_blocks(cfg);
 
     // ------------------------------------------------------------------
     // Precompute the set of values used as by-ref call arguments. Such a
@@ -162,6 +172,9 @@ pub fn run(cfg: &mut Cfg) -> Stats {
     }
 
     for block in cfg.blocks() {
+        if !reachable.contains(block.id.as_u32()) {
+            continue;
+        }
         for &value in &block.insts {
             match &cfg.get_inst(value).data {
                 CfgInstData::Alloc { slot, init } | CfgInstData::Store { slot, value: init } => {
@@ -214,6 +227,9 @@ pub fn run(cfg: &mut Cfg) -> Stats {
 
     for block_idx in 0..cfg.block_count() {
         let block_id = BlockId::from_raw(block_idx as u32);
+        if !reachable.contains(block_idx as u32) {
+            continue;
+        }
         for slot in last_store.iter_mut() {
             *slot = None;
         }
@@ -679,5 +695,60 @@ mod tests {
         let again = run(&mut cfg);
         assert_eq!(again.loads_forwarded_single_write, 0);
         assert_eq!(again.loads_forwarded_block_local, 0);
+    }
+    #[test]
+    fn test_load_in_unreachable_block_not_forwarded() {
+        // A constant-folded-away arm can still hold a Load of a single-write
+        // slot. That load never executes and is dominated by nothing; it must
+        // not be forwarded, and must not trip the Rule 1 dominance invariant
+        // (2026-07-16 optimizer-hunt ICE at forward.rs debug_assert).
+        let mut cfg = Cfg::new(Type::I32, 1, 0, "test".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let init = push_in(&mut cfg, entry, CfgInstData::Param { index: 0 }, Type::I32);
+        push_in(
+            &mut cfg,
+            entry,
+            CfgInstData::Alloc { slot: 0, init },
+            Type::UNIT,
+        );
+        let dead = cfg.new_block();
+        let live = cfg.new_block();
+        // entry jumps straight to the live block (as after simplify folded a
+        // constant-false branch); the dead block still holds a load.
+        cfg.set_terminator(
+            entry,
+            Terminator::Goto {
+                target: live,
+                args_start: 0,
+                args_len: 0,
+            },
+        );
+        let dead_load = push_in(&mut cfg, dead, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(
+            dead,
+            Terminator::Return {
+                value: Some(dead_load),
+            },
+        );
+        let live_load = push_in(&mut cfg, live, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(
+            live,
+            Terminator::Return {
+                value: Some(live_load),
+            },
+        );
+
+        let stats = run(&mut cfg);
+        // The reachable load forwards; the unreachable one is untouched.
+        assert_eq!(stats.loads_forwarded_single_write, 1);
+        assert!(matches!(
+            cfg.get_inst(dead_load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+        assert!(matches!(
+            cfg.get_block(live).terminator,
+            Terminator::Return { value: Some(v) } if v == init
+        ));
     }
 }

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -630,3 +630,47 @@ fn main() -> i32 {
 """ }]
 stdout = "105\n"
 exit_code = 105
+
+# Optimizer-hunt regressions (2026-07-16): a parameter whose address escapes
+# via @raw_mut and is written through @ptr_write must be re-read after the
+# write — CSE's param keying merged the post-write read into the stale
+# pre-write value at -O2/-O3 (1006 became 12).
+[[case]]
+name = "param_raw_mut_write_reread_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn f(x: i32) -> i32 {
+    let y = x + 1;
+    let p: ptr mut i32 = checked { @raw_mut(x) };
+    checked {
+        @ptr_write(p, 999);
+    };
+    let z = x + 1;
+    y + z
+}
+
+fn main() -> i32 {
+    @dbg(f(5));
+    0
+}
+""" }]
+stdout = """1006
+"""
+exit_code = 0
+
+# Optimizer-hunt regression (2026-07-16): a constant-false arm holding a
+# call-initialized local ICEd the forward pass's dominance invariant at
+# -O2/-O3 (the load in the dead arm was forwarded despite being unreachable).
+[[case]]
+name = "dead_arm_call_local_no_ice_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn ident(x: i32) -> i32 { x }
+
+fn main() -> i32 {
+    let v25: i32 = ident(3);
+    return if false { v25 } else { 7 };
+}
+""" }]
+stdout = ""
+exit_code = 7

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -290,6 +290,12 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     Entry::new(
+        "cli.differential_opt",
+        "param_raw_mut_write_reread_across_opt_levels",
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
+        &[],
+    ),
+    Entry::new(
         "cli.divergence",
         "break_mid_block_no_double_drop",
         intrinsic(UnsupportedIntrinsicKind::AllocateBytes),

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3761 rejected=149 lex_invalid=35 accepted_source_ast_sha256=8a0470a78a7e5a8c02528c423e34ab1bfb0c0ed33fd0540d2d82443df2f9628a
+# pre-RUE-905 Chumsky: accepted=3763 rejected=149 lex_invalid=35 accepted_source_ast_sha256=dfb084587669aac404f631e4b79e75bc5f6d695c661a18d0818035c043c34a10
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca


### PR DESCRIPTION
## Context

The overnight differential hunt confirmed two bugs in the RUE-914 passes minutes after PR #1690 entered the merge queue; the queue picked it up before auto-merge could be disabled, so the fixes land as this immediate follow-up. Both were found by fixed-seed adversarial differential testing and are pinned by three-layer regression coverage (unit, differential CLI, oracle corpus audit).

## Bug 1 — miscompile: CSE param keying ignored address escape

`@raw_mut(x)` on a bare by-value parameter lowers to an intrinsic whose operand is a `Param` value with no backing local, so the address-taken marking in `build.rs` (which only handled `Load`/`Local` place operands) never fired. CSE's `never_written_params` then classified `x` as never written and merged a post-`@ptr_write` read into the stale pre-write value: computing `x+1` before and after `@ptr_write(@raw_mut(x), 999)` returned 12 instead of 1006 at `-O2`/`-O3`.

Fix: `Cfg` records address-taken **parameter** slots (`mark_param_address_taken` / `is_param_address_taken`), `build.rs` marks them for `Param` and `PlaceBase::Param` operands of `@raw`/`@raw_mut`/`@field_ptr`, and CSE excludes such slots from keying.

## Bug 2 — debug ICE: forwarding touched unreachable blocks

The forward pass classified and rewrote loads in blocks left unreachable by simplify's constant-terminator folding. A load in a statically dead arm never executes and is dominated by nothing, so Rule 1's `debug_assert` dominance invariant fired on shapes like `if false { call_result } else { 7 }` at `-O2`/`-O3` in debug builds.

Fix: both scans restrict to reachable blocks (an unreachable store also no longer counts against a slot's single-write classification — strictly more precise).

## Testing

- New unit tests: address-taken param reads never dedupe; unreachable loads never forward (reachable ones still do).
- New differential CLI cases: the `@raw_mut` write-then-reread program (1006 at every level) and the dead-arm ICE shape (exit 7, no ICE); the `@raw_mut` fixture registered in the oracle's model-gap audit.
- Full local suite passed on this exact content before splitting into this clean branch; rue-cfg + quick re-verified after the split. Corpus snapshot re-blessed (+2 fixtures, rejected rows unchanged).

Related: RUE-914 (merged as #1690), RUE-909.