### PR TITLE
Draft ADRs for review: function inlining (0049) and loop optimizations (0054)

### DIFF
--- a/docs/designs/0049-function-inlining.md
+++ b/docs/designs/0049-function-inlining.md
@@ -1,0 +1,683 @@
+---
+id: 0049
+title: Function Inlining
+status: accepted
+tags: [compiler, codegen, optimization]
+feature-flag: none
+created: 2026-07-15
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+---
+
+<!-- Note: Inlining is a compiler-internal optimization, not a language feature.
+     It never changes what a program means, only how the emitted code is shaped
+     (see ADR-0044's observable-behavior invariant). No preview gate applies. -->
+
+# ADR-0049: Function Inlining
+
+## Status
+
+Proposal
+
+This is a **draft design note for maintainer review**. It analyzes the
+architecture of function inlining and recommends a direction; it makes no
+commitment and nothing here is accepted. ADR-0044 already fixed the *level*
+placement — conservative small/leaf-function inlining at `-O2`, aggressive
+thresholds at `-O3` — so this note answers the *architecture* questions that
+sit under that placement: where inlining runs, what it does mechanically to the
+CFG IR, how it integrates with the **already-landed durable CFG cache**, how it
+handles **parameter ownership and drop**, and how it stays inside the
+observable-behavior invariant. Since the durable CFG cache (`DurableCfgArtifact`)
+and the parameter-mode physical ABI both landed since the first draft, **durable
+caching and parameter ownership are core design constraints here, not deferred
+implementation details**. Tracks RUE-915.
+
+## Summary
+
+Inlining replaces a `Call` to a suitable callee with a copy of the callee's body
+spliced into the caller, renumbered onto the caller's frame and value space, so
+that intra-procedural passes (constant folding/propagation, peephole, CFG
+simplification, value forwarding, CSE, DCE, and the future loop passes) can then
+see across the former call boundary. The central tension
+is that Rue's optimizer is today strictly **per-function**: `build_functions_and_cfgs`
+builds and optimizes each function's CFG independently and in parallel
+(`crates/rue-compiler/src/queries.rs:198`, `into_par_iter().map(...)`), whereas
+inlining is inherently **cross-function** — it needs the callee's body while
+optimizing the caller. This note recommends running inlining as a **dedicated
+inter-procedural stage orchestrated by `rue-compiler`, operating on already-built
+callee CFGs**, sequenced between CFG construction and the existing per-function
+`opt::optimize` pass. That choice keeps `rue-cfg`'s passes purely local and
+reuses the CFG the builder already produces.
+
+Two consequences are load-bearing and are given their own decision sections:
+
+- **Durable cache integration is not optional and cannot be deferred.** Rue
+  already retains, imports, and exports optimized `DurableCfgArtifact`s keyed by
+  optimization level and target (`crates/rue-compiler/src/queries.rs:137`,
+  `217-232`, `330-343`). Inlining changes *what* a cached caller artifact
+  contains (foreign callee domains) and *what invalidates it* (callee body
+  edits). The ADR decides now: cached CFGs are **final optimized, post-inlining**
+  CFGs; caller cache keys must incorporate **callee body fingerprints**; and the
+  caller-only domain projection (`CfgDomainProjection::from_body`) must be
+  extended to carry **foreign callee domains** (§4).
+- **The inliner's call-site graph is a separate structure from the semantic
+  dependency manifest** (§5). Call-site multiplicity, leafness, candidate
+  lookup, and recursion SCCs are answered by **scanning CFG `Call`
+  instructions**; the deduplicated `body_dependencies` manifest
+  (`crates/rue-compiler/src/session.rs:596`, `619`) is used for invalidation and
+  durable reuse. They answer different questions and must not be conflated.
+
+## Context
+
+### The optimizer is per-function today (ground truth)
+
+The optimizer lives entirely in `crates/rue-cfg/src/opt/` and runs as CFG → CFG
+transforms on **one function at a time**. `opt::optimize(cfg, level, type_pool)`
+(`crates/rue-cfg/src/opt/mod.rs:142`) takes a single `&mut Cfg` and has no access
+to any other function. A `Cfg` is one function: it owns that function's
+`blocks`, `values`, `extra`, `call_args`, `num_locals`, `num_params`, `fn_name`,
+`param_modes`, and `address_taken_slots` (`crates/rue-cfg/src/inst.rs:536`).
+
+The production build seam is `build_functions_and_cfgs`
+(`crates/rue-compiler/src/queries.rs:156`). It:
+
+1. synthesizes drop-glue functions (`drop_glue::synthesize_drop_glue`, line 174);
+2. concatenates user functions + glue and **sorts them by machine symbol name**
+   (`all_functions.sort_by(|left, right| left.name.cmp(&right.name))`, line 194) —
+   the machine symbol is the stable semantic identity shared by user, specialized,
+   destructor, and glue functions;
+3. maps each function through an **import-or-build-then-optimize** step in a
+   Rayon parallel map (`into_par_iter().map(...)`, lines 198–360): it tries to
+   reuse a cached `DurableCfgArtifact` (below), else runs `CfgBuilder::build`
+   (line 255) then `opt::optimize` (line 282), then exports the optimized CFG as
+   a fresh artifact (line 330). **No cross-function state is threaded through the
+   map** — each function is built and optimized in isolation.
+
+A `Call` names its callee purely by interned symbol (`CfgInstData::Call { name:
+Spur, .. }`, `crates/rue-cfg/src/inst.rs:351`; lowered at
+`crates/rue-cfg/src/build.rs:875`). That symbol is exactly the key the function
+list is sorted by, so "find the callee body for this call" is a symbol lookup
+over the already-built function set — cheap to express, but it requires a stage
+that can see the *whole set*, which the current per-function parallel map
+deliberately cannot.
+
+### The durable CFG cache has landed (ground truth — supersedes the first draft)
+
+The first draft asserted "there is no CFG cache to invalidate today — every build
+rebuilds every CFG from AIR." **That is no longer true.** A durable, fail-closed
+CFG cache is now in production:
+
+- **Retention.** `CfgFrontendOutput` carries
+  `durable_cfgs: Arc<[DurableCfgArtifact]>` (`crates/rue-compiler/src/queries.rs:129`),
+  retained across semantic requests on the session as `last_successful_cfg_cache`
+  / `successful_cfg_cache` (`crates/rue-compiler/src/session.rs:1676`, `2243`) and
+  threaded back in as `durable_cfg_candidates`
+  (`crates/rue-compiler/src/canonical_semantic.rs:613`, `688`, `857`).
+- **Import (reuse).** `build_functions_and_cfgs` takes
+  `durable_candidates: &[DurableCfgArtifact]` and
+  `stable_inputs: &[StableCfgInput]` (`queries.rs:161-162`). Per function it
+  binary-searches a candidate by machine symbol (`queries.rs:210`) and reuses it
+  only when **every** key component matches:
+  `candidate.schema_version == DURABLE_CFG_SCHEMA_VERSION && candidate.opt_level
+  == opt_level && candidate.target == target` and the stable input agrees
+  (`input.body == candidate.input.body && input.specialization ==
+  candidate.input.specialization && input.type_inputs ==
+  candidate.input.type_inputs`), after which the stored CFG is re-projected into
+  the current domains via `CfgDomainProjection::import_cfg` (`queries.rs:217-232`).
+  Any mismatch falls back to a full build.
+- **Export.** After `opt::optimize` runs (`queries.rs:282`), the **optimized**
+  CFG is exported as a new `DurableCfgArtifact` — gated on the function producing
+  no warnings, no incomplete implicit-destructor edges, and a successful
+  `domains.validate_cfg(&cfg, input.body_span)` round-trip (`queries.rs:330-343`).
+- **Cache key contents.** `DurableCfgArtifact` (`queries.rs:137`) is
+  `{schema_version, input: StableCfgInput, opt_level, target, cfg, domains}`. The
+  key material is `schema_version`, `opt_level`, `target`, and `StableCfgInput`
+  = `{identity, body_span, body: DurableOrdinaryBodyPayload, specialization,
+  type_inputs}` (`crates/rue-compiler/src/durable_cfg.rs:11-17`). **Crucially,
+  `StableCfgInput` fingerprints only the caller's *own* body** — it has no field
+  for the bodies of callees the caller calls.
+
+The consequence for inlining is the opposite of the first draft's: the cache is
+real, the exported CFGs are **already the final optimized CFGs**, and inlining
+must integrate with retention/import/export from day one (§4). A caller that
+inlines callee `f` (a) contains `f`'s domains inside its CFG, which the current
+caller-only projection cannot express, and (b) must be invalidated when `f`'s
+**body** changes, which the current caller-only key cannot detect.
+
+### `CfgDomainProjection::from_body` is caller-only by contract (ground truth)
+
+`CfgDomainProjection::from_body` (`crates/rue-compiler/src/durable_cfg.rs:223`)
+builds the type/string/symbol/span remapping tables that make a cached CFG
+portable across compilation sessions. It derives that mapping **solely from the
+caller's AIR body**: it zips `function.air.iter()` against
+`input.body.instructions` one-for-one (`durable_cfg.rs:235`), and it **rejects
+any instruction whose span falls outside the caller body's span range** —
+`current.span.file_id != input.body_span.file_id || current.span.start <
+input.body_span.start || current.span.end > input.body_span.end` returns
+`CfgDomainFailure::Unsupported` (`durable_cfg.rs:237-242`). The symbol table maps
+only `Call`/`Intrinsic` names that appear in the caller's own AIR
+(`durable_cfg.rs:268-278`); the string table maps only string constants in the
+caller's AIR (`durable_cfg.rs:251-260`).
+
+An inlined callee **introduces foreign domains by definition**: types, string
+constants, callee `Call`/`Intrinsic` symbols, and — fatally for the span check —
+instruction spans that point into the *callee's* source range, not the caller's.
+The existing export boundary therefore cannot treat an inlined CFG as an ordinary
+caller artifact: `from_body` would reject it on the span range check, so today
+inlining would simply make every caller *uncacheable*. §4 designs the fix.
+
+### The semantic dependency manifest (ADR-0050) — what it is and is not
+
+The dependency-derived invalidation machinery is **ADR-0050 (Stable semantic
+dependency manifests)**, with session support in
+`crates/rue-compiler/src/session.rs`:
+
+- `CompilerSession::semantic_dependency_inputs`
+  (`crates/rue-compiler/src/session.rs:5337`) publishes an ordered definition
+  universe whose per-owner body dependencies are
+  `StableBodyDependencyInputRecord`s (`session.rs:596`). Each record's
+  `direct_dependency_inputs: Arc<[StableDefinitionInputFingerprint]>`
+  (`session.rs:601`, `619`) is the owner's dependency set — **sorted and
+  deduplicated** (`direct_dependencies.sort(); direct_dependencies.dedup();`,
+  `session.rs:6018-6019`) — merging call targets, named-method/destructor edges,
+  and declaration-type edges into one flat set of *definition* fingerprints.
+- `CompilerSession::semantic_invalidation_plan` (`session.rs:6373`) memoizes a
+  comparison of two manifests and computes a deterministic **reverse-dependency
+  closure** over those direct edges (`collect_reverse_dependencies`,
+  `session.rs:6561`; `reverse_closure_nodes_visited`, `session.rs:1455`), failing
+  closed (`IncompleteDependencyGraph`) when any endpoint is missing.
+
+The manifest is a **deduplicated definition-dependency graph**, not a call-site
+multigraph. It records *that* a caller depends on a callee's definition; it
+**cannot distinguish one call from ten**, and it folds calls together with type
+and destructor dependencies. This shape is exactly right for invalidation and
+durable reuse — a callee body edit must invalidate every caller that depends on
+it, regardless of call count — and exactly wrong for the inliner's structural
+questions (call multiplicity, leafness, recursion cycles). §5 makes the
+separation an explicit decision.
+
+The body-fingerprint partition ADR-0050 already draws (declaration/signature
+fingerprints vs body fingerprints) is what inlining's cache key needs: a caller
+that inlines callee `f` must be rebuilt when `f`'s **body** fingerprint changes,
+not merely its signature (§4b).
+
+### Runtime traps carry no source location today (ground truth)
+
+The brief asks how spans flow to runtime errors so an inlined callee's trap
+still reports sensibly. The verified answer is that **Rue's runtime traps carry
+no source location at all**. Overflow, divide-by-zero, and bounds traps lower to
+calls to fixed runtime helpers whose symbols are the constants
+`__rue_overflow` / `__rue_bounds_check` (and `__rue_intcast_overflow`) held in
+`RUNTIME_TRAP_SYMBOLS` (`crates/rue-codegen/src/allocation.rs:168-172`), passed
+with no span/line/column argument (`emit_overflow_check` /
+`emit_signed_div_overflow_check` at `crates/rue-codegen/src/x86_64/cfg_lower.rs:244`,
+`emit_bounds_trap` at line 2838, each taking only the trap symbol string). The
+runtime prints a fixed message ("integer overflow", "division by zero", "index
+out of bounds") and exits 101; tests assert only the message string
+(`crates/rue-cli-tests/cases/opt.toml`, `runtime_error_contains`). Spans
+(`CfgInst.span`, `crates/rue-cfg/src/inst.rs:215`) drive **compile-time
+diagnostics**, which run during semantic analysis and CFG construction — *before*
+any inlining would run. This reframes the trap-span obligation (see Decision §7).
+
+## Decision
+
+### 1. Where inlining runs — a dedicated inter-procedural stage in `rue-compiler`
+
+Three options were considered.
+
+**(a) AIR-level inlining, before CFG construction.** Splice callee AIR into
+caller AIR, then build one CFG. *Cost:* AIR is the typed, structured,
+pre-control-flow IR; inlining there means re-implementing parameter binding,
+scope/drop insertion, and move analysis at the AIR level, duplicating what
+`CfgBuilder` already does (drop elaboration, `StorageLive`/`StorageDead`
+pairing, move pre-scan — `crates/rue-cfg/src/build.rs:292, 1124, 2495`). It also
+fights the durable-cache grain: `StableCfgInput` fingerprints an AIR body and
+`from_body` anchors its projection at AIR body boundaries; splicing AIR bodies
+would disturb those anchors and the cache key. Rejected as the most invasive and
+the worst fit for the incremental model.
+
+**(b) CFG-level inlining as a `rue-cfg` pass with access to other CFGs.** Add a
+pass inside `opt::optimize` that reaches other functions' CFGs. *Cost:* this
+breaks the defining property of `rue-cfg`'s optimizer — that a pass sees exactly
+one function — and forces `opt::optimize`'s signature to take the whole function
+set, which then has to be threaded through the Rayon per-function map in
+`queries.rs:198`. It puts cross-function orchestration (callee lookup, recursion
+refusal, threshold policy, cache-key composition) inside `rue-cfg`, which has no
+view of the session, the manifest, or symbol resolution. Rejected:
+it pushes orchestration to the wrong layer.
+
+**(c) A dedicated inter-procedural stage orchestrated by `rue-compiler`,
+operating on built CFGs — RECOMMENDED.** Keep `CfgBuilder::build` producing
+per-function CFGs exactly as today. Restructure the map in
+`build_functions_and_cfgs` (`crates/rue-compiler/src/queries.rs`) so that CFG
+**construction** (import-or-build) runs first for all functions, then a new
+inliner stage runs with the full `{symbol → Cfg}` map, then the existing
+per-function `opt::optimize` + export runs. The inliner itself is a self-contained
+CFG→CFG *splice* primitive that can live in `rue-cfg` (it is pure CFG surgery and
+belongs with the IR it edits), but it is *driven* by `rue-compiler`, which owns
+the callee map, the call-site graph, and the manifest.
+
+Reasoning:
+
+- It preserves the invariant that every `rue-cfg` *optimization* pass is
+  strictly local; the only cross-function code is the orchestration, which lives
+  where the whole-program view already lives (the session).
+- It reuses the CFGs the builder already produces — no second lowering, no
+  AIR-level re-implementation.
+- The one real cost it pays honestly: the per-function step can no longer *also*
+  optimize in the same parallel pass, because inlining needs all callee bodies to
+  exist before any caller is rewritten. Construction and optimization become two
+  phases (build/import-all, then inline+optimize+export) rather than one fused
+  parallel map. Optimization remains embarrassingly parallel *after* the inliner
+  has run (the splice is a batch step; per-caller `optimize` is still
+  independent). At `-O0`/`-O1` the inliner is skipped and the fused single-phase
+  map is retained.
+- Interaction with the cache import path: today import, build, optimize, and
+  export all happen inside the one per-function closure (`queries.rs:206-343`).
+  Two-phasing means **import/build** populates the callee map first; the inliner
+  rewrites callers; then **optimize+export** runs. A caller reused verbatim from
+  the cache (import success) still enters the inliner stage, because its cached
+  form is *already post-inlining* (§4a) — so a reused caller needs no
+  re-splice, and the inliner skips it. Whether that reuse is still valid is a
+  pure cache-key question (§4b).
+
+### 2. What inlining a call means mechanically in this IR
+
+Inlining one `Call` site in caller `C` to callee `E` (`E`'s `Cfg` already built)
+is a splice with the following moving parts. All of them are index-space
+rebasing, because the CFG uses compact index references throughout (AGENTS.md:
+"IR instructions and entities use compact index-based references. Preserve index
+validity across transforms").
+
+- **Value-id offsetting.** `E`'s `values: Vec<CfgInst>` are appended to `C`'s
+  `values`; every `CfgValue` operand inside the copied instructions is shifted by
+  `C.values.len()` before the append. `CfgValue` is a newtype index
+  (`crates/rue-cfg/src/inst.rs`), so this is a uniform add.
+- **Block-id offsetting.** `E`'s `blocks` are appended to `C`'s `blocks`; every
+  `BlockId` in copied terminators (and in `BlockParam` references) is shifted by
+  `C.blocks.len()`. The `extra`, `call_args`, `switch_cases`, and `projections`
+  side-arrays each get their contents appended and every `(start, len)` index in
+  the copied instructions/terminators re-based onto the new lengths.
+- **Slot renumbering.** `E`'s local slots (`0..E.num_locals`) must be rebased
+  onto `C`'s frame: add `C.num_locals`, then `C.num_locals += E.num_locals`.
+  Every `Alloc/Load/Store { slot }`, `StorageLive/StorageDead { slot }`, and
+  `Place` root that names a local slot is shifted. `E`'s `address_taken_slots`
+  are unioned (shifted) into `C`'s — losing this reintroduces the RUE-521 O1+
+  segfault the field exists to prevent (`crates/rue-cfg/src/inst.rs:576` doc). A
+  `Cfg` now *also* tracks address-taken **parameters** separately from locals
+  (`address_taken_params`, `crates/rue-cfg/src/inst.rs:589`, set via
+  `mark_param_address_taken`, `crates/rue-cfg/src/inst.rs:691`, queried by
+  `is_param_address_taken`, `:697`): a by-value parameter whose address escapes
+  through `@raw`/`@raw_mut`/`@field_ptr` is not purity-safe. When a by-value
+  argument is materialized into a fresh caller local (below), any such escape
+  fact on `E`'s parameter must carry onto that new slot's `address_taken_slots`
+  entry, so the splice must consult `is_param_address_taken` while lowering each
+  parameter.
+- **Parameter passing — consult the physical ABI, not the logical mode.** The
+  splice must redirect `E`'s parameter accesses to the caller's arguments, and
+  the correct discriminator is `E`'s **physical** parameter convention, queried
+  by `Cfg::is_param_by_ref` / `is_param_writable`
+  (`crates/rue-cfg/src/inst.rs:763, 773`), **not** the logical
+  `Normal`/`Inout`/`Borrow` source mode. The two can diverge: a slice `borrow
+  s: [T]` is a two-word fat pointer passed **by value** through the multi-slot
+  aggregate ABI, so `is_param_by_ref` is *false* for it even though the source
+  mode is `Borrow` (`crates/rue-air/src/sema/analysis/functions.rs:342-365`,
+  `is_slice_by_value`). Splicing off the logical mode would misclassify these.
+  - *Physically by-value (`is_param_by_ref == false`):* materialize each argument
+    into a fresh caller local (`Alloc` + `StorageLive`), sized at the parameter's
+    **full ABI slot width** — an aggregate/slice occupies
+    `require_layout_slots` slots (`functions.rs:372`), and the materialization
+    must reserve every slot, not one. Rewrite `E`'s `Param { index }` reads to a
+    `Load` of that slot. Ownership/drop of these materialized slots is §3.
+  - *Physically by-reference (`is_param_by_ref == true`):* the call argument is a
+    **place** — non-place by-ref arguments are rejected before codegen (RUE-760,
+    `crates/rue-air/src/sema/analysis.rs:2219`; address formation in
+    `crates/rue-codegen/src/byref_args.rs:21`). The splice redirects `E`'s by-ref
+    parameter accesses (and its `ParamStore { param_slot, value }` write-backs,
+    lowered at `crates/rue-cfg/src/build.rs:832`) to that caller place, using
+    `is_param_writable` to decide read-only vs writable. **Restriction (see §3
+    point 4): the initial inliner accepts only by-ref arguments whose place is a
+    simple local or parameter root, and excludes projected by-ref arguments** —
+    direct substitution of a projected place needs a proof that address-formation
+    timing and trap behavior are preserved, which is deferred.
+- **Return-value wiring via block params.** `E`'s `Return { value }` terminators
+  (`crates/rue-cfg/src/inst.rs:498`) cannot remain returns inside `C`. The call
+  site's block is split: instructions after the call move to a fresh
+  continuation block that takes a single `BlockParam` of the call's result type;
+  each copied `Return { value: Some(v) }` becomes `Goto(continuation, [v])`, and
+  `Return { value: None }` becomes `Goto(continuation, [])`. This reuses the
+  explicit block-parameter mechanism the CFG already uses for phi-like joins
+  (`BlockParam`, `crates/rue-cfg/src/inst.rs:278`), so no new IR concept is
+  needed. `Unreachable`/`-> !` callees (the RUE-347 path,
+  `crates/rue-cfg/src/build.rs:883`) inline with no continuation edge.
+
+### 3. Parameter ownership and drop — a core section
+
+Drop glue is synthesized as *separate functions* (`synthesize_drop_glue`,
+`crates/rue-compiler/src/drop_glue.rs:94`) and invoked from the CFG builder's
+scope-exit elaboration, which emits `Drop` then `StorageDead` per slot in
+reverse order (`crates/rue-cfg/src/build.rs:1124, 2495`). Because drop
+elaboration already ran when `E`'s CFG was built, `E`'s body **already contains**
+its `StorageLive`/`StorageDead`/`Drop` instructions for its own locals. Inlining
+therefore must **not** re-elaborate drops; it copies `E`'s already-elaborated
+drop instructions verbatim (slots rebased). Inlining is strictly *after* drop
+elaboration and strictly *before* MIR lowering, so it never re-runs elaboration
+and never sees un-elaborated drops.
+
+The subtle part is the **materialized by-value parameter**. The callee owns its
+by-value (`Normal`) parameters and drops them at exit unless they are moved out
+(RUE-61); `param_drops` records this obligation (set at
+`crates/rue-air/src/sema/analysis/functions.rs:387`, consulted by the CFG builder
+at `crates/rue-cfg/src/build.rs:329`). When the splice materializes a by-value
+argument into a fresh caller slot, that slot **is** the callee's parameter
+storage for the inlined body's lifetime. The correct rule is therefore **not**
+ordinary caller-scope drop treatment (the first draft's error), but:
+
+1. Emit an explicit **callee-lifetime `StorageLive`** for the materialized slot
+   immediately before the spliced body and an explicit **`StorageDead`** after
+   the continuation join, so the slot's live range is exactly the inlined body's
+   extent — matching the storage lifetime the callee's own frame would have given
+   the parameter.
+2. Reproduce the callee's **copied parameter-drop behavior**: the drop
+   obligation the callee had for that parameter (its `param_drops` entry) is
+   discharged by `E`'s already-elaborated `Drop`/`StorageDead` on the parameter
+   slot — which the splice copies — retargeted to the materialized slot. The
+   splice must **not** additionally synthesize a caller-scope drop for the same
+   slot, or the value is dropped twice; and it must **not** drop the caller's
+   original argument value again, because move semantics already transferred
+   ownership into the materialized slot.
+
+The net rule: **one materialized slot, one live range bounded by the inlined
+body, one drop discharged by the callee's own copied drop instructions.** This
+matrix (moved-out parameter, dropped-at-exit parameter, `Copy` parameter needing
+no drop) is the highest-risk correctness surface and needs a worked elaboration
+example plus differential coverage before Phase 1.
+
+### 4. Durable CFG cache integration — a core section
+
+Inlining touches all three cache operations. The decisions:
+
+**(a) Cached CFGs represent FINAL optimized, post-inlining CFGs.** The export
+point is already *after* `opt::optimize` (`queries.rs:282, 330`), so cached
+artifacts are final optimized CFGs today. With inlining sequenced *before*
+`opt::optimize` (§1c), the exported CFG is naturally **post-inlining and
+post-optimization** — the single fully-transformed artifact. This is the right
+choice: it keeps one artifact per function with no "half-optimized, pre-inline"
+intermediate to store, version, or invalidate separately, and it means an import
+hit reproduces the complete transform for free. The cost is the invalidation
+obligation in (b): a post-inlining artifact depends on its inlined callees'
+bodies, so its key must say so. *Rejected alternative:* caching pre-inlining CFGs
+and re-inlining on every build would make a caller's cache hit useless (the
+expensive cross-function work reruns every time) and would still need the
+callee-body key for the inline decision itself — strictly worse.
+
+**(b) Caller cache keys incorporate callee body fingerprints and inlining
+policy.** `StableCfgInput` (`durable_cfg.rs:11`) today fingerprints only the
+caller's own `body`, `specialization`, and `type_inputs`, and the reuse check
+(`queries.rs:220-224`) compares exactly those. A post-inlining caller artifact is
+invalidated by two more things:
+1. **Every inlined callee's body fingerprint.** The key must gain a set of
+   `{callee identity → StableDefinitionInputFingerprint}` for each callee the
+   caller actually inlined, drawn from the ADR-0050 body-fingerprint partition
+   (`session.rs`, `StableDefinitionInputFingerprint`). Editing an inlined
+   callee's body changes its body fingerprint, which changes the caller's key,
+   which forces a rebuild — exactly the reverse-dependency invalidation
+   `semantic_invalidation_plan` already computes (`session.rs:6373`), now keyed on
+   *body* rather than *signature*.
+2. **The inlining policy revision.** A change to the threshold table or inlining
+   algorithm must invalidate every inlined caller. Bump a coarse
+   `inlining_policy_version` (companion to `DURABLE_CFG_SCHEMA_VERSION`,
+   `queries.rs:132`) into the key; the simplest correct form folds it into the
+   schema version so a policy change invalidates the whole CFG cache. A finer
+   per-caller policy fingerprint is a later refinement.
+
+Only callees actually inlined into *this* caller enter its key — not the caller's
+whole dependency set — so a caller that inlined nothing keeps today's key
+unchanged and its cache behavior is untouched.
+
+**(c) Durable domain projection must carry foreign callee domains.** This is the
+sharpest constraint. `from_body`'s caller-only contract (Context) rejects any
+CFG containing spans, symbols, strings, or types that do not originate in the
+caller's AIR body — which every inlined CFG does. The design:
+
+- During the splice, the inliner already walks each copied callee instruction to
+  rebase indices. At the same time it **accumulates a foreign-domain remapping
+  table**: for each callee type, string constant, `Call`/`Intrinsic` symbol, and
+  span that lands in the caller CFG, record the callee-side stable identity the
+  callee's *own* `CfgDomainProjection` already holds (each callee has one built
+  by `from_body` from its own body). The callee's projection is the authoritative
+  source of stable identities for its domains.
+- Extend `CfgDomainProjection` from a single caller-body projection to a
+  **caller projection unioned with the projections of every inlined callee**,
+  with callee spans anchored relative to the *callee's* `body_span` (the
+  `DurableBodyAnchor` mechanism `from_body` already uses,
+  `durable_cfg.rs:243-249`) plus a callee-identity tag so import can resolve each
+  foreign span against the right body. Concretely, the span check at
+  `durable_cfg.rs:237-242` must change from "reject spans outside the caller
+  body" to "resolve each span against the caller body *or* a recorded inlined
+  callee body," and `import_cfg`'s span/symbol/string/type remappers
+  (`durable_cfg.rs:351-406`, driving `Cfg::try_remap_domains`,
+  `crates/rue-cfg/src/inst.rs:597`) must consult the unioned table.
+- `import_cfg` already remaps whole-CFG domains through `try_remap_domains`
+  (type/struct/enum/symbol/string/span), so the *mechanism* to re-project a
+  multi-body CFG exists; what must change is the *table construction*
+  (`from_body`) and the *span-range contract*. Until that lands, the safe
+  fallback is explicit and cheap: a caller that inlined anything **fails the
+  export gate** (`from_body`/`validate_cfg` returns `Unsupported`) and is simply
+  not cached — correct, just slower, and identical to today's behavior for any
+  function that fails validation. Phase 4 turns caching on for inlined callers.
+
+**Sequencing note:** because import happens per-function (`queries.rs:214-249`), a
+cached post-inlining caller can be imported *without* rebuilding its callees — the
+stored CFG already contains the inlined bodies. The callee-body fingerprints in
+the key (4b) are what make that reuse sound; the multi-body projection (4c) is
+what makes it *expressible*.
+
+### 5. Call-site graph vs semantic dependency manifest — an explicit separation
+
+The inliner needs a **call-site graph** and must build it by **scanning the CFG's
+`Call` instructions**, not by reading the ADR-0050 `body_dependencies` manifest.
+These are different structures answering different questions:
+
+- **Call-site multiplicity** ("is this callee called once or ten times?"): count
+  `CfgInstData::Call` instructions naming a symbol across all caller CFGs. The
+  manifest **cannot** answer this — `direct_dependency_inputs` is deduplicated
+  (`session.rs:6018-6019`), so ten calls to `f` and one call to `f` produce the
+  identical single edge.
+- **Leafness** ("does this callee contain any call?"): scan the callee's
+  `values` for `CfgInstData::Call`. The manifest folds calls together with type
+  and destructor dependencies, so it cannot cleanly report "contains a call."
+- **Candidate lookup** ("what is the callee body for this call?"): the `Call`'s
+  `name: Spur` is the symbol key into the `{symbol → Cfg}` map. This is
+  CFG-native.
+- **Recursion / SCC refusal**: the recursion cycle must be computed over the
+  **actual call-site graph**, not the dependency manifest. Using the whole
+  deduplicated dependency graph for recursion analysis **can produce false
+  cycles**: because it merges calls with type and destructor edges, a
+  non-recursive function that merely *mentions a type* whose destructor
+  transitively references the function's own definition would appear in a cycle
+  and be needlessly refused. The call-site graph contains only real call edges,
+  so its SCCs are exactly the real recursion cycles.
+
+Conversely, the manifest — not the CFG scan — remains authoritative for
+**invalidation and durable reuse**: the reverse-dependency closure
+(`semantic_invalidation_plan`, `session.rs:6373`) and the caller cache key (§4b)
+consume `body_dependencies`. **Scanning the CFG is not a competing invalidation
+path**; it answers the inliner's structural questions, while the manifest answers
+"what must rebuild when a definition changes." Both exist; neither substitutes
+for the other.
+
+### 6. Threshold and candidate policy
+
+Initial, deliberately conservative criteria (concrete numbers are the maintainer
+knob to set; these are the proposed starting points):
+
+- **Callee instruction count** below a small budget. The counter is exact and
+  free: `callee.values.len()`. Proposed initial cap: small (≈ a few dozen
+  instructions) at `-O2`; larger at `-O3` per ADR-0044.
+- **Leaf-ness** from a CFG scan (§5): a callee containing no `CfgInstData::Call`
+  is a leaf and the safest first target. `-O2` = leaf callees under the small
+  cap; `-O3` relaxes to non-leaf and larger caps.
+- **Single-call-site** callees (call multiplicity 1, from the §5 call-site graph)
+  are the highest-value case: inlining them removes a call with no code-size cost
+  at the inlined site. **But the callee is not deleted by the inliner.** Whether a
+  now-uncalled function can be removed is a **whole-program dead-function-
+  elimination decision** made with full reachability knowledge (address-taken
+  functions, exported symbols, call sites in other translation units), not a
+  local inliner side effect. Deleting a function because *this* inliner consumed
+  its only visible call site would be unsound in the presence of any other
+  reference. The inliner inlines; DFE (a separate, later pass over the whole
+  function set) decides removal.
+- **Bounded code growth.** Inlining and `-O3` unrolling (ADR-0054) share one
+  per-function code-growth budget debited by whichever runs, so a function does
+  not both inline heavily and unroll into a size explosion. The budget source is
+  the same `values`-based instruction count.
+- **Counters' provenance.** Instruction counts and call-site multiplicity and
+  leafness all come from CFG scans (§5); no new counting infrastructure and no
+  manifest read are required for the inline *decision*.
+
+**Recursion — must refuse.** Direct recursion is refused by checking callee
+symbol == caller symbol. Mutual recursion is refused by detecting a
+strongly-connected component of size > 1 in the **call-site graph** (§5).
+Refusing on the SCC is strictly sound and avoids unbounded expansion; a later
+relaxation (bounded-depth recursive inlining under a size budget) is out of
+scope.
+
+**Exclusions.** `@intrinsic` calls (`CfgInstData::Intrinsic`,
+`crates/rue-cfg/src/inst.rs:362`) are never inlining candidates — they have no
+Rue-level body. Runtime-helper calls (`__rue_overflow`, `__rue_bounds_check`,
+and friends, emitted only in codegen) never appear as `CfgInstData::Call` in the
+CFG, so they are excluded by construction. Drop-glue functions *are* ordinary
+functions and *could* be inlined, but are excluded initially: they are
+generated, often recursive over aggregate structure, and their call sites are
+already synthesized.
+
+### 7. Safety and semantics
+
+- **The observable-behavior invariant (ADR-0044).** `-O2` already carries
+  content distinct from `-O1` (value forwarding and CSE, RUE-914/913), so the
+  invariant is already exercised beyond `-O0` vs `-O1`; inlining is the first
+  *cross-function* transform to do so. Per ADR-0044, every pass that populates
+  `-O2`/`-O3` must (a) place itself at the assigned level, (b) add multi-case
+  differential CLI coverage for the shapes it rewrites, and (c) keep the full
+  differential set green (`differential_opt = true`, `run_case_differential`,
+  RUE-236, `crates/rue-cli-tests/src/main.rs:802`). Inlining's differential
+  obligations specifically include: callees that trap (overflow / div-by-zero /
+  bounds) — the trap must still fire post-inline exactly as pre-inline; callees
+  with inout/borrow parameters and write-backs; **slice-borrow parameters passed
+  by value**; callees with aggregate by-value parameters (multi-slot); callees
+  that move a by-value parameter and drop it; callees with early `return`; and
+  `-> !` callees. The existing `opt.toml` trap-survival cases are the template.
+- **Trap spans.** As established in Context, runtime traps carry **no** source
+  location today — they are fixed-message aborts. Therefore inlining **cannot
+  regress runtime trap location fidelity, because there is none to regress**: an
+  overflow inside an inlined callee prints the same "integer overflow" and exits
+  101 whether or not it was inlined, which is exactly what the invariant
+  requires. The forward-looking obligation is that the splice must **faithfully
+  copy each callee `CfgInst.span`** onto the moved instruction (which the
+  durable-projection design in §4c already requires, since those spans become
+  foreign-domain entries), so any future location-carrying trap mechanism
+  inherits the callee's real source position. Rue's compile-time diagnostics run
+  *before* inlining, so inlining changes no diagnostic a user sees today. This is
+  a genuine discrepancy with the brief's premise that spans flow to runtime
+  errors; the code says they do not, and the design follows the code.
+
+## Implementation Phases
+
+Tracking placeholders; this draft implements none of them.
+
+- [ ] **Phase 1: Splice primitive** — CFG→CFG inline of one call given caller +
+  callee `Cfg`, with value/block/slot rebasing, physical-ABI parameter lowering
+  (by-value materialization at full slot width; by-ref place redirection limited
+  to simple local/parameter roots), callee-lifetime storage + copied
+  parameter-drop handling (§3), and return→block-param wiring. Unit-tested in
+  `rue-cfg`. (file RUE-NNN)
+- [ ] **Phase 2: Free-function driver at `-O2`** — two-phase construction; build
+  the call-site graph by CFG scan (§5); conservative leaf/small thresholds;
+  single-call-site inlining *without* callee removal; recursion refusal via
+  call-site SCC; differential CLI coverage. Inlined callers are **not cached
+  yet** (fail the export gate, §4c). (file RUE-NNN)
+- [ ] **Phase 3: `-O3` thresholds** — larger caps, non-leaf callees, shared
+  code-growth budget with unrolling (ADR-0054). (file RUE-NNN)
+- [ ] **Phase 4: Durable cache integration for inlined callers** — multi-body
+  `CfgDomainProjection` (§4c), callee-body-fingerprint + policy-version cache key
+  (§4b); turn caching on for inlined callers. (file RUE-NNN)
+- [ ] **Phase 5: Whole-program dead-function elimination** — separate pass that
+  removes now-unreachable functions (including single-call-site callees the
+  inliner consumed) under full reachability analysis (§6). (file RUE-NNN)
+- [ ] **Phase 6: Methods/destructors** — extend as the ADR-0050 method/destructor
+  caller surfaces complete. (file RUE-NNN)
+
+## Consequences
+
+### Positive
+
+- `-O2`/`-O3` gain their first cross-function content, and downstream passes
+  (CSE, copy-prop, loop opts) become far more effective across former call
+  boundaries.
+- The call-site graph (§5) gives the inliner exact multiplicity/leafness/recursion
+  facts the deduplicated manifest cannot, while the manifest keeps one canonical
+  invalidation path.
+- Caching integration is designed up front (§4), so inlined callers become
+  cacheable rather than silently defeating the durable cache.
+
+### Negative
+
+- CFG construction and optimization can no longer be one fused parallel map when
+  inlining is on; they split into build/import-all then inline+optimize+export.
+- The multi-body durable projection (§4c) is real work that must land before
+  inlined callers cache; until Phase 4 they are recomputed every build.
+- The by-ref place-redirection, materialized-parameter drop rules (§3), and the
+  foreign-domain projection are subtle and need a focused correctness matrix.
+- Every inlining PR must grow the differential set (deliberate, per ADR-0044).
+
+### Neutral
+
+- No language-semantics change, no spec sections, no preview gate.
+- `-O0`/`-O1` behavior is unchanged; the inliner is skipped there.
+
+## Open Questions
+
+- **Policy-version granularity** — fold `inlining_policy_version` into
+  `DURABLE_CFG_SCHEMA_VERSION` (coarse, invalidates the whole CFG cache on any
+  policy change) or key it per-caller (finer, more bookkeeping)? Decide when
+  Phase 4 lands; the deciding criterion is whether policy changes are frequent
+  enough that whole-cache invalidation hurts incremental builds.
+- **Materialized-parameter drop elaboration** — the exact instruction sequence
+  for §3's one-slot/one-live-range/one-drop rule needs a worked example and test
+  before Phase 1; deciding criterion is the differential trap/drop-order suite
+  staying green across moved-out, dropped-at-exit, and `Copy` parameters.
+- **Projected by-ref arguments** — excluded initially; the deciding criterion for
+  admitting them is a proof that direct place substitution preserves
+  address-formation timing and trap behavior.
+- **Recursion relaxation** — bounded-depth recursive inlining is possible later;
+  the initial rule refuses all call-site-SCC-participating calls.
+
+## Future Work
+
+- Whole-program dead-function elimination (Phase 5) as its own ADR-worthy pass.
+- Bounded recursive inlining under a size budget.
+- Profile-guided inlining once any profiling exists.
+
+## References
+
+- [ADR-0044: Optimization Levels](0044-optimization-levels.md) — fixes the level
+  placement and the observable-behavior invariant this note operates under.
+- [ADR-0050: Stable semantic dependency manifests](0050-semantic-dependency-manifest.md)
+  — the body-fingerprint partition and reverse-dependency closure inlining's
+  cache key consumes (but whose deduplicated graph is *not* the call-site graph).
+- [ADR-0053: Typed compiler query state](0053-typed-compiler-query-state.md) — the
+  durable CFG cache (`DurableCfgArtifact`) inlining must integrate with.
+- [ADR-0012: Compiler Optimization Passes](0012-optimization-passes.md) — the CFG
+  opt framework.
+- [ADR-0010: Destructors](0010-destructors.md), [ADR-0013: Borrowing Modes](0013-borrowing-modes.md),
+  [ADR-0043: Collection/string type trio](0043-collection-string-type-trio.md)
+  — drop, by-ref, and slice-by-value semantics the splice must preserve.
+- RUE-915 (this design), RUE-236 (differential-opt harness), RUE-57 (trap-survival
+  bug class), RUE-521 (address-taken-slot segfault), RUE-322/RUE-385 (slice/`str`
+  parameter ABI), RUE-760 (non-place by-ref rejection), RUE-347 (`-> !` call
+  divergence).
+</content>
+</invoke>

--- a/docs/designs/0054-loop-optimizations.md
+++ b/docs/designs/0054-loop-optimizations.md
@@ -1,0 +1,489 @@
+---
+id: 0054
+title: Loop Optimizations — LICM and Unrolling
+status: accepted
+tags: [compiler, codegen, optimization]
+feature-flag: none
+created: 2026-07-16
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+---
+
+<!-- Note: Loop optimizations are compiler-internal; they never change what a
+     program means, only how fast/large the emitted code is (ADR-0044's
+     observable-behavior invariant). No preview gate applies. -->
+
+# ADR-0054: Loop Optimizations — LICM and Unrolling
+
+## Status
+
+Proposal
+
+This is a **draft design note for maintainer review**. Nothing here is accepted.
+ADR-0044 places loop-invariant code motion (LICM) and unrolling at `-O3` (the
+speculative, size-spending, speed-chasing tier). This note designs the shared
+loop-analysis infrastructure both need, then the two passes — with the central
+attention on LICM's trap-safety problem, which is the inverse of the RUE-57 bug
+class and the single most dangerous way a loop pass can violate the
+observable-behavior invariant. Tracks RUE-916.
+
+## Summary
+
+Both LICM and unrolling need to recognize natural loops, which needs a dominator
+tree. **The shared dominator tree already landed with RUE-914**
+(`crates/rue-cfg/src/dominators.rs`): a CFG-level `DominatorTree` computed via the
+**Cooper–Harvey–Kennedy iterative algorithm** over `Cfg::compute_predecessors()`,
+today consumed only by copy propagation's `debug_assertions` dominance check and
+awaiting its loop-analysis consumers. What loop optimization still needs to build
+on that base is **natural-loop detection** (back edges + loop bodies) and
+**preheader materialization** — neither exists yet. (The separate, per-backend
+post-lowering back-edge scan in `rue-codegen` used for register allocation stays
+unusable at the CFG level.) This note proposes extending the existing
+`rue-cfg` dominator module with natural-loop detection from back edges,
+recomputed per pass (not cached) initially. On
+that base: **LICM** hoists loop-invariant *pure* ops into the preheader, and its
+governing rule is conservative — **trapping ops are never hoisted in the initial
+version** (only provably-trap-free ops move), because hoisting a possibly-trapping
+op onto a path the source never executed manufactures a trap out of thin air.
+**Unrolling** is limited initially to constant-trip-count full unrolling under a
+size budget. Both carry the ADR-0044 differential-coverage obligation and the
+repository's work-counter discipline.
+
+## Context
+
+### Dominators exist; natural-loop detection does not (ground truth)
+
+The shared dominator tree **landed with RUE-914** and lives at
+`crates/rue-cfg/src/dominators.rs`: a `pub(crate) struct DominatorTree` with
+`DominatorTree::compute(cfg)`, `idom`, and `dominates` queries, built by the
+Cooper–Harvey–Kennedy fixpoint over a reverse-postorder traversal and consuming
+`Cfg::compute_predecessors()` (`crates/rue-cfg/src/inst.rs:1137`). The module's
+own docs mark it "shared analysis infrastructure, not a pass": its only in-tree
+consumer today is copy propagation's `debug_assertions` dominance check
+(`crates/rue-cfg/src/opt/forward.rs:332`), and it explicitly names future LICM
+(RUE-916) and GVN as its pending consumers — so it opts out of dead-code denial
+(`#![allow(dead_code)]`). What is still **absent** is everything loop-specific:
+`crates/rue-cfg/src/dominators.rs` computes dominance but has **no natural-loop
+detection, no loop forest, and no preheader materialization**. That is precisely
+the gap this note fills — it builds on the existing dominator tree rather than
+introducing one.
+
+The rest of `crates/rue-cfg/src/` is `build.rs`, `inst.rs`, `verify.rs`,
+`dominators.rs`, `lib.rs`, and `opt/`; the optimizer directory now holds
+`constfold.rs` (the fold kernel), `constopt.rs` (the sparse worklist driver),
+`simplify.rs`, `peephole.rs`, `cse.rs`, `forward.rs`, `dce.rs`, and `mod.rs`.
+
+The one existing loop analysis lives **downstream in codegen**:
+`analyze_loops_adapter` / `has_back_edge` / `compute_loop_info` in
+`crates/rue-codegen/src/liveness.rs:101, 336, 535` (the `LoopInfo` type itself is
+defined in `crate::regalloc`). It runs on a **flat
+instruction-index space** through a `LivenessAdapter`, is **per-backend**, runs
+**after** CFG→MIR lowering, and exists to pick register-allocation live-range
+strategies and loop depth. It is not reusable for CFG-level LICM/unrolling: it
+sees machine-ish instruction indices, not CFG blocks; it runs too late (after the
+CFG is gone); and it is duplicated per architecture. Building loop analysis at
+the CFG level is the correct, target-independent home and avoids a third copy.
+
+### The passes that exist, and the pass "shape" convention
+
+The `-O1` set has grown well past the original three: `opt::optimize`
+(`crates/rue-cfg/src/opt/mod.rs:142`) runs `constopt::run` (the sparse worklist
+that interleaves constant folding — the `constfold` kernel — with store-to-load
+constant propagation to an internal fixpoint, RUE-794), then `peephole::run`
+(RUE-912), then `simplify::run` (CFG simplification, RUE-910/911), then `dce::run`.
+Two more passes are gated to `-O2`/`-O3` inside that same arm: `forward::run`
+(value forwarding / copy propagation, RUE-914) and `cse::run` (block-local CSE,
+RUE-913), each behind `if matches!(level, OptLevel::O2 | OptLevel::O3)`
+(`crates/rue-cfg/src/opt/mod.rs:184, 193`). So `-O2` already differs from `-O1`;
+`-O3` still aliases `-O2` (there is no distinct `O3` arm yet). Loop passes are
+`-O3` content and will be the first passes gated strictly above `-O2`.
+
+### Work-counter discipline — what the codebase actually does
+
+The brief refers to a "RUE-794 work-counter convention" and to `opt/simplify.rs`
+and `opt/peephole.rs`. **All three now exist** — RUE-794 is the sparse worklist
+driver in `crates/rue-cfg/src/opt/constopt.rs`; `simplify.rs` (RUE-910/911) and
+`peephole.rs` (RUE-912) are landed passes. The convention they establish has two
+layers, and loop passes should follow it:
+
+1. **Per-pass `Stats` with bounded-work counters.** Each mutating pass exposes a
+   `pub struct Stats` of counters and *returns it* from `run`, rather than a bare
+   `bool`. `constopt::run -> Stats` (`fold_attempts`, `folded`, `loads_rewritten`;
+   `crates/rue-cfg/src/opt/constopt.rs:56, 84`), and `simplify::run`,
+   `peephole::run`, `forward::run`, and `cse::run` each likewise return a
+   pass-specific `Stats` (`crates/rue-cfg/src/opt/simplify.rs:66, 81`,
+   `peephole.rs:46, 56`, `forward.rs:87, 110`, `cse.rs:95, 241`). `dce::run`
+   returns `()` (`crates/rue-cfg/src/opt/dce.rs:77`). The fold/propagate
+   **fixpoint now lives inside `constopt`'s sparse worklist** (an instruction is
+   revisited only when one of its operands becomes constant, RUE-794); the old
+   outer `folded || propagated` loop in `opt::optimize` is gone. Passes are run
+   once, in the fixed order `opt::optimize` sets.
+2. **Structured work counters at the orchestration layer.** The session records
+   pass work in `CfgConstructionWork`
+   (`crates/rue-compiler/src/canonical_semantic.rs:282`) — fields like
+   `optimization_attempts`, `optimization_completions`, `optimized_level_attempts`
+   (lines 290–292) — aggregated across the parallel function map in
+   `build_functions_and_cfgs` (`crates/rue-compiler/src/queries.rs:279-283`,
+   `382-384`). This is the "wide events / structured completion" discipline
+   AGENTS.md describes for `tracing`.
+
+Loop passes should therefore **expose their own `Stats` struct** with
+bounded-work counters (loops analyzed, invariants hoisted, loops unrolled,
+budget-rejected) returned from `run`, and contribute into that structured
+`CfgConstructionWork` surface.
+
+## Decision
+
+### 1. Loop analysis infrastructure
+
+**Dominator algorithm: Cooper–Harvey–Kennedy (CHK) iterative — already
+implemented.** The shared analysis already exists at
+`crates/rue-cfg/src/dominators.rs` (RUE-914): `DominatorTree::compute` builds the
+immediate-dominator array by exactly the CHK iterative dataflow method —
+reverse-postorder the blocks, then iterate `idom` to a fixpoint using the
+two-finger "intersect" walk over the RPO numbering, consuming
+`Cfg::compute_predecessors()` (`crates/rue-cfg/src/inst.rs:1137`). Loop analysis
+does **not** need to add a dominator implementation; it extends this module. The
+algorithm choice below is therefore a record of what landed, not an open call.
+
+Justification vs Lengauer–Tarjan (LT), as realized:
+
+- **Scale.** Rue functions are small (the CFG is one function; blocks number in
+  the tens, rarely hundreds). CHK's *observed* running time on real,
+  reducible-heavy CFGs of this size is at or below LT's, with a fraction of the
+  code and no auxiliary DFS-forest/semidominator bookkeeping. Cooper, Harvey, and
+  Kennedy's own "A Simple, Fast Dominance Algorithm" is precisely this argument.
+- **Simplicity and maintainability.** CHK is ~40 lines over an RPO and a
+  predecessor list — both of which the CFG already yields — versus LT's
+  bucket/eval/link machinery. For a first loop-analysis landing, the smaller,
+  auditable implementation wins, especially since it is on the correctness path
+  for a trap-sensitive pass.
+- **LT's asymptotic edge (near-linear vs near-quadratic worst case) does not pay
+  off** until functions are far larger than Rue produces; if that ever changes,
+  swapping the internals behind a stable `Dominators` API is a localized change.
+
+**Natural-loop detection.** From the dominator tree, a back edge is an edge
+`u → h` where `h` dominates `u`; the natural loop of that back edge is `h` plus
+all blocks that can reach `u` without passing through `h`. Loops sharing a header
+are merged. This yields, per loop: header, back edges, body block set, and
+(computed on demand) a **preheader**. Loop nesting is the containment forest over
+body sets.
+
+**Preheader as a dedicated block (not just "the outside predecessor").** LICM
+hoists *into* the preheader, so the preheader must be a real block that dominates
+the header and is guaranteed to execute exactly once per loop entry. The rule for
+obtaining it is not simply "reuse the single non-back-edge predecessor":
+
+- Partition the header's predecessors into **back-edge predecessors** (inside the
+  loop, `h` dominates them) and **outside predecessors** (loop entries).
+- If there is exactly one outside predecessor `p` **and `p`'s terminator targets
+  the header unconditionally as its only successor**, `p` may serve as the
+  preheader directly.
+- **Otherwise insert a dedicated preheader block** `ph`: redirect every outside
+  predecessor edge to `ph`, and give `ph` a single `Goto(h, ...)` terminator.
+  This is required not only when the header has multiple outside predecessors,
+  but **also when the single outside predecessor `p` has other successors** (its
+  terminator is a `Branch`/`Switch` where the header is one arm) — hoisting into
+  such a `p` would execute the hoisted ops on the sibling arm's path too, which
+  is exactly the manufacture-work-on-an-untaken-path hazard §2 guards against.
+  Splitting that edge gives a block that runs only on the header-entry path.
+- **Header block-argument forwarding.** The CFG passes phi-like values as block
+  arguments on edges (`BlockParam`, `crates/rue-cfg/src/inst.rs:278`). When a
+  dedicated `ph` is inserted, the header's block parameters must be preserved:
+  `ph` takes the same parameter list as the header carried for its outside
+  edges, each redirected outside predecessor forwards its header arguments to
+  `ph` instead, and `ph`'s `Goto(h, ...)` forwards them on to the header. Back
+  edges keep passing their own arguments to the header unchanged. The result must
+  satisfy `cfg.verify()` (see Open Questions).
+
+**Where it lives, and reuse.** The dominator module is already a standalone
+`rue-cfg` module (`dominators.rs`), independent of `opt/`, and is **already
+shared**: value forwarding / copy propagation (RUE-914, `opt/forward.rs:332`)
+computes a `DominatorTree` to check under `debug_assertions` that a store's block
+dominates the loads it forwards to. LICM and unrolling become its next consumers.
+Putting dominators in one shared place is the "one canonical computation path"
+principle from AGENTS.md — realized here, not merely proposed; a second dominator
+implementation would be exactly the duplicate-analysis smell that guidance warns
+against, and the landed module already avoids it.
+
+**Invalidation discipline: recompute per pass initially.** Dominators and loops
+are **recomputed by each pass that needs them, not cached across passes.** Loop
+passes mutate the CFG (LICM inserts a preheader and moves instructions;
+unrolling clones blocks), which invalidates dominators; a cache would need
+careful incremental maintenance that is not worth it at Rue's scale and is a
+ready source of stale-analysis miscompiles. Recompute-per-pass is O(blocks) and
+trivially correct. Caching within a *single* pass (compute once, use for all
+loops in that function) is fine and expected; caching *across* passes is
+deferred until profiling shows it matters.
+
+### 2. THE central design problem — LICM trap-safety
+
+Hoisting an operation out of a loop moves it from executing *once per iteration*
+to executing *once in the preheader*, before the loop's entry test. If the loop
+can execute **zero** iterations, a hoisted op runs on a path where the source
+program never executed it. For a **trapping** op that is a catastrophe: it
+**manufactures a trap out of thin air**, changing a program that exits 0 into one
+that exits 101. This is the exact inverse of RUE-57 (where DCE *deleted* a
+mandatory trap); here LICM would *invent* one. It is a direct violation of
+ADR-0044's observable-behavior invariant, which counts Rue's overflow /
+div-by-zero / bounds traps as *defined, observable behavior* that no level may
+add or remove.
+
+Rue's trapping ops are today enumerated inside DCE's private `has_side_effects`
+(`crates/rue-cfg/src/opt/dce.rs:136`): `Add`, `Sub`, `Mul`, `Div`, `Mod`, `Neg`
+(overflow / divide-by-zero checks, lines 176–181); **`IntCast`, which range-checks
+and panics on an out-of-range narrowing conversion via `__rue_intcast_overflow`
+(line 157, "IntCast can panic (range check), so it has side effects")**; and any
+`PlaceRead` whose place contains an `Index` projection (bounds check, lines
+166–169). Bitwise ops and shifts do **not** trap (shift counts are masked per
+spec) and are pure. **`IntCast` must be in LICM's trapping set** — omitting it
+(as an earlier draft did, listing only Add/Sub/Mul/Div/Mod/Neg + index reads)
+would let LICM hoist an invariant narrowing cast into a zero-trip preheader and
+manufacture an intcast panic.
+
+**Factor a shared `may_trap` / `is_speculatable` classifier rather than reusing
+DCE's private predicate.** DCE's `has_side_effects` conflates two distinct
+properties: *observable side effect* (`Store`, `Call`, `Drop`,
+`StorageLive`/`StorageDead`) and *may trap* (the arithmetic set, `IntCast`,
+indexed `PlaceRead`). LICM needs the trap axis specifically — a pure-but-trapping
+op is a hoist hazard, while a side-effecting non-trapping op is a different
+concern — and unrolling's trap-on-iteration reasoning needs the same axis. Making
+DCE's private `has_side_effects` the cross-pass authority couples three passes to
+one function's incidental grouping and risks the two axes drifting apart. The
+proposal: introduce a small shared classifier in `rue-cfg` (e.g.
+`opt::classify` or an `inst`-level `CfgInstData::may_trap(&self, cfg) -> bool`
+and companion `is_speculatable`) that names the trapping set **once**
+— `Add`/`Sub`/`Mul`/`Div`/`Mod`/`Neg`, `IntCast`, indexed `PlaceRead` — and have
+DCE, LICM, and unrolling all consult it. DCE's `has_side_effects` then becomes
+`may_trap(v) || has_pure_side_effect(v)`, preserving its behavior exactly while
+removing the private-authority coupling. This is the "one canonical computation
+path" principle applied to trap classification.
+
+**The rule set:**
+
+1. **Hoist trap-free invariant ops freely.** An op is a LICM candidate if all its
+   operands are loop-invariant (defined outside the loop or themselves hoisted)
+   and the shared classifier reports it `is_speculatable` — i.e. **not**
+   `may_trap` (arithmetic, `IntCast`, indexed `PlaceRead`) and with no observable
+   side effect (`Call`, `Intrinsic`, `Store`, `PlaceWrite`, `Alloc`, `Drop`,
+   `StorageLive`/`StorageDead`). Bitwise/shift/comparison/`Not`/`BitNot` on
+   invariant operands are the sweet spot.
+2. **Trapping invariant ops: do NOT hoist, initially.** Every `may_trap` op —
+   `Add`/`Sub`/`Mul`/`Div`/`Mod`/`Neg`, `IntCast`, and indexed reads — stays in
+   the loop body even when invariant, in the first version. This is
+   unconditionally sound — it can never manufacture a trap — at the cost of
+   leaving some invariant arithmetic un-hoisted.
+3. **The named relaxation path (not in the initial pass): hoist a trapping
+   invariant op only when the loop provably executes it at least once on every
+   path through the preheader.** That proof needs loop-rotation / guard analysis:
+   if the loop is rotated so the body is known to run at least once (a
+   guarded/do-while shape, or a statically non-zero constant trip count), or the
+   entry guard dominates and guarantees ≥1 iteration, then the op already
+   executes on every real path and hoisting adds no new trap. Only under that
+   proof may a trapping op move. This is the standard "hoist is safe if the op is
+   guaranteed to execute" criterion; Rue defers it until loop rotation exists.
+
+**Recommendation: ship rule (2) — never hoist trapping ops — first**, and name
+(3) as the explicit relaxation once loop rotation/guard analysis lands. Rule (2)
+plus rule (1) is a strict subset of a fully general LICM, is trivially inside the
+invariant, and still captures the common trap-free invariants (address
+computations built from bitwise/shift ops, invariant comparisons, invariant
+boolean logic).
+
+### 3. What LICM moves
+
+- **Moves:** pure, side-effect-free ops (per §2 rule 1) whose operands are all
+  loop-invariant, into the loop preheader, in dependency order.
+- **Does NOT move loads.** `Load` / non-indexed `PlaceRead` are memory reads;
+  hoisting one is only sound if no store inside the loop can change the memory it
+  reads. Rue has **no memory-versioning / alias analysis** today, so LICM cannot
+  prove a load invariant. Load hoisting is **copy-propagation / store-forwarding
+  territory (RUE-914)**, not LICM's, and is explicitly out of scope here. (Indexed
+  `PlaceRead` is additionally trapping, excluded by §2 anyway.)
+- **Does NOT move calls.** `Call` and `Intrinsic` may have arbitrary side effects
+  and may trap; they are never hoisted.
+
+Keeping LICM to pure invariant compute — no memory, no calls — makes it sound
+without any alias analysis, which is the right initial scope for a language whose
+memory model for optimization is still being built out (ADR-0050 territory).
+
+### 4. Unrolling
+
+**Initial scope: constant-trip-count full unroll only, on a canonical loop
+shape, under a size budget.** When a loop's trip count is a compile-time constant
+`N` and the unrolled body fits the budget, replace the loop with `N` copies of
+the loop body subgraph and delete the back edge.
+
+**Canonical-shape restriction.** The initial unroller recognizes and rewrites
+**only** loops in an explicit canonical form, and bails (leaves the loop intact)
+on anything else:
+
+- **Single header, single latch** — exactly one back edge into the header, from
+  one latch block. Multiple back edges or irreducible entries are rejected.
+- **Recognized induction variable** — one IV stepping by a compile-time-constant
+  stride from a constant initial value to a constant bound, so the trip count
+  `N` is statically computable. Recognition reads the IV off the CFG *after*
+  `constopt` has folded and propagated the initializer and bound (§ Open
+  Questions covers how much IV analysis is needed).
+- **No unsupported exits** — the only loop exit is the header's trip test. A loop
+  body containing a secondary exit (an early `break`/`return` edge leaving the
+  body, or a trapping op that could abort mid-iteration in a way the copies must
+  order correctly) is out of scope for the first version.
+
+**Full CFG-subgraph cloning, not "straight-line copies."** A loop body is a
+*subgraph* of basic blocks, not a single straight line, so each of the `N`
+iterations is a **clone of the whole body block set** — new `BlockId`s, new
+`CfgValue`s, side-arrays (`extra`, `call_args`, `switch_cases`, `projections`)
+appended and re-based, and internal edges rewired to the clone's blocks (the same
+index-rebasing discipline ADR-0049's splice uses). Iteration `k`'s exit edge
+targets iteration `k+1`'s header-equivalent entry instead of looping back; the
+final iteration falls through to the loop's original exit; the back edge is
+deleted. Describing this as "straight-line copies" is only accurate for a
+single-block body and understates the work for the general canonical case.
+
+This is the safest unroll: no residual/remainder loop, no runtime trip-count
+test, and — once the post-unroll cleanup below runs — it collapses the
+now-constant induction variable.
+
+**Post-unroll cleanup is mandatory (constopt runs *before* unrolling).**
+`constopt` is the *first* pass in `opt::optimize` (`crates/rue-cfg/src/opt/mod.rs:160`),
+running before `peephole`, `simplify`, `forward`, `cse`, and `dce`. A loop pass
+gated at `-O3` runs *after* that whole sequence, so the constants and dead
+control flow unrolling exposes — the per-iteration IV values, the now-dead trip
+test, the collapsed cloned branches — are **not** cleaned up by the constopt that
+already ran. Unrolling must therefore be followed by **another
+const-fold/simplify/DCE sequence** over the affected function: re-run
+`constopt::run` (to fold each clone's now-constant IV and propagate it),
+`simplify::run` (to fold the dead trip-test branches into `Goto`s and thread the
+cloned chain), and `dce::run` (to sweep the dead IV arithmetic and orphaned
+blocks). Without this second sequence, unrolling produces larger, slower code
+than the original loop. The cleanest placement is a small fixpoint or a fixed
+second cleanup pass in the `-O3` arm after the loop passes; the exact shape is an
+implementation detail, but the *requirement* is not optional.
+
+- **Budget knob.** A single integer `unroll_budget` = maximum *total instruction
+  count of the unrolled body* (`N × body_size`). Proposed `-O3` default: a modest
+  cap (a few hundred CFG instructions) — enough to unroll small fixed loops,
+  small enough to bound code growth. `-O0`/`-O1`/`-O2` = 0 (disabled). The count
+  source is the same `cfg.values`-based instruction count LICM and inlining use.
+- **Interaction with inlining's thresholds (ADR-0049).** Both unrolling and
+  aggressive inlining are `-O3` code-growth transforms. They should share **one
+  code-growth budget per function**, debited by whichever runs, so a function
+  that inlines heavily does not *also* unroll into a size explosion (and vice
+  versa). This note proposes a shared per-function growth budget as the
+  coordination point; ADR-0049 Phase 3 is where the two meet. Absent
+  coordination, the two passes can multiply code size.
+- **Out of scope initially:** partial unrolling, runtime-trip-count unrolling with
+  a remainder loop, and unroll-and-jam. Each needs a remainder-loop construction
+  and (for trap-safety) the same guard reasoning as LICM §2.
+
+### 5. Both passes — obligations
+
+- **Differential coverage (ADR-0044).** Each pass lands with multi-case
+  `differential_opt` CLI coverage (`run_case_differential`, RUE-236,
+  `crates/rue-cli-tests/src/main.rs:802`) for the shapes it rewrites, and keeps
+  the full differential set green. For LICM the **mandatory** cases are the
+  trap-safety ones: a zero-iteration loop containing an invariant trapping op
+  (overflow, div-by-zero, invariant index read) must **not** trap after LICM —
+  this is the regression that rule §2 exists to prevent, and it must be pinned
+  the way `opt.toml` pins RUE-57 trap survival. For unrolling: a constant-trip
+  loop with a trap on a specific iteration must trap on that iteration
+  identically unrolled vs not.
+- **Work-counter discipline.** Each pass exposes a `Stats` struct of bounded-work
+  counters returned from `run` (matching `constopt`/`simplify`/`cse`/`forward`/
+  `peephole`; see §"Work-counter discipline") and contributes structured counters
+  (loops analyzed, invariants hoisted, loops unrolled, budget-rejected) into the
+  `CfgConstructionWork` / session work surface
+  (`crates/rue-compiler/src/canonical_semantic.rs:282`,
+  `crates/rue-compiler/src/queries.rs:279-283`), per AGENTS.md tracing guidance.
+- **Placement.** Gated strictly above `-O2` in `opt::optimize` — today a new `O3`
+  case split out of the shared `O1 | O2 | O3` arm (which already carries the
+  `-O2`/`-O3`-gated forward/CSE passes), preserving ADR-0044's monotonic
+  superset rule. The post-optimization structural recheck
+  (`verify_after_optimization_with_type_pool`, `opt/mod.rs:206`) continues to run
+  after, as the
+  structural safety net for the block cloning and preheader insertion these
+  passes perform.
+
+## Implementation Phases
+
+Tracking placeholders; this draft implements none of them.
+
+- [x] **Prerequisite (landed, RUE-914): CHK dominator tree** in
+  `crates/rue-cfg/src/dominators.rs`, with unit tests; already consumed by copy
+  propagation (`opt/forward.rs`).
+- [ ] **Phase 1: Natural-loop analysis** — natural-loop forest + preheader
+  materialization built on the existing `DominatorTree`, with unit tests.
+  (file RUE-NNN)
+- [ ] **Phase 2: LICM (trap-free only)** — hoist pure invariant ops; never hoist
+  trapping ops; differential trap-safety cases. `-O3`. (file RUE-NNN)
+- [ ] **Phase 3: Constant-trip full unrolling** — canonical shape only (single
+  header, single latch, recognized IV, no unsupported exits); full CFG-subgraph
+  cloning; mandatory post-unroll const-fold/simplify/DCE cleanup; under the size
+  budget; shared code-growth budget with ADR-0049 inlining. `-O3`. (file RUE-NNN)
+- [ ] **Phase 4 (relaxation): guarded trapping-op hoisting** — after loop
+  rotation/guard analysis exists. (file RUE-NNN)
+
+## Consequences
+
+### Positive
+
+- First target-independent natural-loop analysis, built on the dominator tree
+  already shared by copy propagation (RUE-914) and reused by LICM and unrolling —
+  one dominator implementation, not three.
+- LICM (even trap-free-only) and constant-trip unrolling give `-O3` its intended
+  speculative speed content per ADR-0044.
+- The conservative trap rule makes the highest-risk loop transform provably safe
+  from day one.
+
+### Negative
+
+- Trap-free-only LICM leaves invariant arithmetic un-hoisted until loop rotation
+  lands (the relaxation path).
+- Unrolling and inlining together can grow code; they must share a budget.
+- Every loop-pass PR must grow the differential set (deliberate, per ADR-0044).
+
+### Neutral
+
+- No language-semantics change, no spec sections, no preview gate.
+- `-O0`/`-O1`/`-O2` behavior unchanged; loop passes are `-O3`-only.
+
+## Open Questions
+
+- **Preheader insertion and `verify()`.** Inserting a preheader and cloning
+  blocks must satisfy `cfg.verify()` (`crates/rue-cfg/src/verify.rs`); the exact
+  block-param/terminator obligations for a synthesized preheader need a worked
+  example before Phase 1.
+- **Induction-variable recognition** for constant trip counts — how much IV
+  analysis is needed, and how much constant folding/propagation (`constopt`) already exposes, before
+  unrolling can read a constant `N` reliably.
+- **Shared code-growth budget shape** with ADR-0049 — one budget debited by both
+  passes, or independent caps with a combined ceiling? Resolve jointly with
+  ADR-0049 Phase 3.
+- **When (if ever) to cache dominators across passes** — deferred until profiling
+  justifies the incremental-maintenance complexity.
+
+## Future Work
+
+- Guarded/loop-rotated hoisting of trapping invariant ops (the §2 relaxation).
+- Load hoisting once store-forwarding / memory versioning (RUE-914) provides
+  alias facts.
+- Partial and runtime-trip-count unrolling with remainder loops; unroll-and-jam.
+- Strength reduction of induction variables; loop fusion; later, vectorization
+  (ADR-0044 Future Work).
+
+## References
+
+- [ADR-0044: Optimization Levels](0044-optimization-levels.md) — places loop opts
+  at `-O3` and defines the observable-behavior invariant.
+- [ADR-0012: Compiler Optimization Passes](0012-optimization-passes.md) — the CFG
+  opt framework and the pass-shape convention.
+- [ADR-0049: Function Inlining](0049-function-inlining.md) — the other `-O3`
+  code-growth transform; shares the code-growth budget.
+- Cooper, Harvey, Kennedy, "A Simple, Fast Dominance Algorithm" — the chosen
+  dominator method.
+- RUE-916 (this design), RUE-236 (differential-opt harness), RUE-57 (the
+  mandatory-trap bug class LICM must not invert), RUE-914 (store-forwarding /
+  copy-prop, which reuses the dominators and owns load hoisting).

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -211,9 +211,11 @@ The table is generated from ADR frontmatter. Run
 | [0046](0046-delete-flat-mode.md) | Delete flat multi-file mode (all cross-file references go through @import) | Accepted | modules, semantics, cli, language-shape, ergonomics |
 | [0047](0047-root-module-build-inputs.md) | Root-module compilation units and build-system inputs | Accepted | modules, compiler, build-system, packages, cli, language-shape |
 | [0048](0048-shared-codegen-middle-layer.md) | Shared codegen middle layer (reduce x86-64/aarch64 backend duplication) | Accepted | codegen, architecture, backends, refactor, maintainability |
+| [0049](0049-function-inlining.md) | Function Inlining | Accepted | compiler, codegen, optimization |
 | [0050](0050-semantic-dependency-manifest.md) | Stable semantic dependency manifests | Accepted | compiler, incremental, tooling |
 | [0051](0051-canonical-import-resolution-authority.md) | CanonicalImportGraph as the sole import-resolution authority | Accepted | architecture, compiler, modules, incremental, tooling |
 | [0052](0052-canonical-physical-type-layout.md) | Canonical Physical Type Layout | Proposal | types, semantics, compiler, codegen, abi, memory |
 | [0053](0053-typed-compiler-query-state.md) | Typed CompilerSession query state | Accepted | architecture, compiler, incremental, tooling |
+| [0054](0054-loop-optimizations.md) | Loop Optimizations — LICM and Unrolling | Accepted | compiler, codegen, optimization |
 | [0055](0055-typed-runtime-abi-manifest.md) | Typed compiler-runtime ABI manifest | Implemented | architecture, compiler, runtime, abi, codegen |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
## NOT for auto-merge — design drafts for maintainer review

These are the design notes RUE-915 and RUE-916 call for, status `proposed`. They analyze and recommend; they decide nothing. Please read at leisure — no urgency.

**ADR-0049 (function inlining, RUE-915):** recommends a dedicated inter-procedural stage in `rue-compiler` between CFG construction and per-function optimization, consuming ADR-0050's `body_dependencies` edges for incremental invalidation rather than inventing a parallel call graph. Covers the mechanics (slot/value/block rebasing, by-ref parameter redirection to caller places, return wiring via block params, drop handling — drops copied verbatim, never re-elaborated), conservative thresholds (leaf + small + single-call-site at -O2), recursion refusal via SCC, and the honest cost: the current fused build+optimize parallel map must split. One open question flagged: drop-ownership of a moved-and-dropped by-value argument needs a concrete elaboration example before implementation.

**ADR-0054 (LICM + unrolling, RUE-916):** builds natural-loop detection and preheaders on the dominator tree that landed with RUE-914. The central design ruling requested: LICM's trap-safety rule — hoisting a possibly-trapping op onto a zero-iteration path manufactures a trap the source never executes (the inverse of RUE-57), so the initial version never hoists trapping ops; the relaxation path (guarded hoisting after loop rotation) is named but deferred. Unrolling: constant-trip-count full unroll only, under a code-growth budget shared with future inlining. (Renumbered from 0051, which canonical-import-resolution claimed.)

Both drafts' code citations were verified against current trunk after tonight's optimizer work landed.

Related: RUE-915, RUE-916 (both Backlog pending these decisions), RUE-909.