### PR TITLE
RUE-827: type compiler-internal intrinsics

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1625,28 +1625,6 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Concrete(Type::new_module(crate::types::ModuleId::UNRESOLVED))
-                } else if intrinsic_name == "__rue_iter_len"
-                    || intrinsic_name == "__rue_char_next"
-                    || intrinsic_name == "__rue_char_next_lossy"
-                {
-                    // Compiler-internal `for`-loop leaves (RUE-220):
-                    // @__rue_iter_len(coll) is the loop bound (byte length /
-                    // array length) and @__rue_char_next{,_lossy}(s, p) is the
-                    // next byte offset — both `usize` (u64).
-                    for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
-                    }
-                    InferType::Concrete(Type::U64)
-                } else if intrinsic_name == "__rue_char_scalar"
-                    || intrinsic_name == "__rue_char_scalar_lossy"
-                {
-                    // @__rue_char_scalar{,_lossy}(s, p): the Unicode scalar at
-                    // byte offset `p`, a u32 (RUE-220; lossy variant RUE-17
-                    // Phase 3).
-                    for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
-                    }
-                    InferType::Concrete(Type::U32)
                 } else {
                     // Generate constraints for arguments (they need to be processed)
                     for arg_ref in args.iter() {
@@ -1654,6 +1632,26 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     // @dbg and other intrinsics return Unit
                     InferType::Concrete(Type::UNIT)
+                }
+            }
+
+            InstData::InternalIntrinsic {
+                intrinsic,
+                args_start,
+                args_len,
+            } => {
+                let args = self.rir.get_inst_refs(*args_start, *args_len);
+                for arg_ref in args {
+                    self.generate(arg_ref, ctx);
+                }
+                match intrinsic {
+                    // The loop bound and next byte offset are usize (u64).
+                    rue_rir::InternalIntrinsic::IterLen
+                    | rue_rir::InternalIntrinsic::CharNext
+                    | rue_rir::InternalIntrinsic::CharNextLossy => InferType::Concrete(Type::U64),
+                    // Character iteration exposes Unicode scalar values.
+                    rue_rir::InternalIntrinsic::CharScalar
+                    | rue_rir::InternalIntrinsic::CharScalarLossy => InferType::Concrete(Type::U32),
                 }
             }
 

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -198,6 +198,7 @@ impl<'a> BodySema<'a> {
 
             // Intrinsic operations
             InstData::Intrinsic { .. }
+            | InstData::InternalIntrinsic { .. }
             | InstData::TypeIntrinsic { .. }
             | InstData::OffsetOf { .. } => self.analyze_intrinsic_ops(air, inst_ref, ctx),
 

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -152,28 +152,65 @@ impl<'a> BodySema<'a> {
         } else if name == known.target_os {
             self.analyze_target_os_intrinsic(air, &args, span)
         } else {
-            // Compiler-internal intrinsics synthesized ONLY by the `for`-loop
-            // desugaring (RUE-220). They never appear in user source (the
-            // parser cannot produce them). Resolving the name string here is
-            // fine: these are rare relative to user-facing intrinsics.
-            match self.interner.resolve(&name) {
-                "__rue_iter_len" => self.analyze_iter_len_intrinsic(air, &args, span, ctx),
-                "__rue_char_scalar" => {
-                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, false, false)
-                }
-                "__rue_char_next" => {
-                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, true, false)
-                }
-                "__rue_char_scalar_lossy" => {
-                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, false, true)
-                }
-                "__rue_char_next_lossy" => {
-                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, true, true)
-                }
-                other => Err(CompileError::new(
-                    ErrorKind::UnknownIntrinsic(other.to_string()),
-                    span,
+            Err(CompileError::new(
+                ErrorKind::UnknownIntrinsic(self.interner.resolve(&name).to_string()),
+                span,
+            ))
+        }
+    }
+
+    pub(crate) fn analyze_internal_intrinsic_impl(
+        &mut self,
+        air: &mut Air,
+        intrinsic: rue_rir::InternalIntrinsic,
+        args_start: u32,
+        args_len: u32,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if args_len != intrinsic.arity() {
+            let argument = if intrinsic.arity() == 1 {
+                "argument"
+            } else {
+                "arguments"
+            };
+            return Err(CompileError::new(
+                ErrorKind::InternalError(format!(
+                    "internal intrinsic `{}` expects {} {}, found {}",
+                    intrinsic.as_str(),
+                    intrinsic.arity(),
+                    argument,
+                    args_len
                 )),
+                span,
+            ));
+        }
+
+        let args: Vec<RirCallArg> = self
+            .rir
+            .get_inst_refs(args_start, args_len)
+            .into_iter()
+            .map(|value| RirCallArg {
+                value,
+                mode: RirArgMode::Normal,
+            })
+            .collect();
+
+        match intrinsic {
+            rue_rir::InternalIntrinsic::IterLen => {
+                self.analyze_iter_len_intrinsic(air, &args, span, ctx)
+            }
+            rue_rir::InternalIntrinsic::CharScalar => {
+                self.analyze_string_char_op_intrinsic(air, &args, span, ctx, false, false)
+            }
+            rue_rir::InternalIntrinsic::CharNext => {
+                self.analyze_string_char_op_intrinsic(air, &args, span, ctx, true, false)
+            }
+            rue_rir::InternalIntrinsic::CharScalarLossy => {
+                self.analyze_string_char_op_intrinsic(air, &args, span, ctx, false, true)
+            }
+            rue_rir::InternalIntrinsic::CharNextLossy => {
+                self.analyze_string_char_op_intrinsic(air, &args, span, ctx, true, true)
             }
         }
     }
@@ -188,11 +225,12 @@ impl<'a> BodySema<'a> {
     // and restored so iterating does not consume the source.
     // ========================================================================
 
-    /// `@__rue_iter_len(coll)` → the loop bound (`usize`), dispatching the
+    /// [`rue_rir::InternalIntrinsic::IterLen`] computes the loop bound
+    /// (`usize`), dispatching the
     /// iterable kind by the collection's type: an array's length `N` (a
     /// compile-time constant), or a StrBuf's source-defined byte length. This
     /// is where the whole `for` loop is preview-gated (RUE-220):
-    /// every for-loop emits exactly one `@__rue_iter_len`.
+    /// every for-loop emits exactly one `IterLen`.
     pub(super) fn analyze_iter_len_intrinsic(
         &mut self,
         air: &mut Air,
@@ -276,8 +314,8 @@ impl<'a> BodySema<'a> {
         ))
     }
 
-    /// `@__rue_char_scalar(s, offset)` → the Unicode scalar (`u32`) at byte
-    /// `offset`, and `@__rue_char_next(s, offset)` → the byte offset of the
+    /// `CharScalar` computes the Unicode scalar (`u32`) at byte `offset`, and
+    /// `CharNext` computes the byte offset of the
     /// next character (`usize`). Both back `for c in s.chars()`; the receiver
     /// must be a String. When `lossy` is false these trap at runtime on invalid
     /// UTF-8; when true (`.chars_lossy()`) they substitute U+FFFD instead

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -6894,6 +6894,21 @@ impl<'a> BodySema<'a> {
                 )
             }),
 
+            InstData::InternalIntrinsic {
+                intrinsic,
+                args_start,
+                args_len,
+            } => ctx.with_expected_type(None, |ctx| {
+                self.analyze_internal_intrinsic_impl(
+                    air,
+                    *intrinsic,
+                    *args_start,
+                    *args_len,
+                    inst.span,
+                    ctx,
+                )
+            }),
+
             InstData::TypeIntrinsic { name, type_arg } => {
                 self.analyze_type_intrinsic(air, *name, *type_arg, inst.span, ctx)
             }

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -9,7 +9,7 @@ mod tests {
     use rue_error::{CompileErrors, CompileResult, ErrorKind, MultiErrorResult, PreviewFeatures};
     use rue_lexer::Lexer;
     use rue_parser::Parser;
-    use rue_rir::{AstGen, Rir, RirParamMode};
+    use rue_rir::{AstGen, InstData, InternalIntrinsic, Rir, RirParamMode};
     use rue_span::FileId;
 
     struct TestModule {
@@ -101,6 +101,58 @@ mod tests {
         let air = &functions[0].air;
         assert_eq!(air.return_type(), Type::I32);
         assert_eq!(air.len(), 2); // Const + Ret
+    }
+
+    #[test]
+    fn reserved_looking_source_intrinsics_never_select_internal_operations() {
+        for (name, args) in [
+            ("__rue_iter_len", "0"),
+            ("__rue_char_scalar", "0, 0"),
+            ("__rue_char_next", "0, 0"),
+            ("__rue_char_scalar_lossy", "0, 0"),
+            ("__rue_char_next_lossy", "0, 0"),
+        ] {
+            let source = format!("fn main() {{ @{name}({args}) }}");
+            let errors = compile_to_air(&source).expect_err("source spelling must stay unknown");
+            assert!(
+                errors.iter().any(|error| matches!(
+                    &error.kind,
+                    ErrorKind::UnknownIntrinsic(actual) if actual == name
+                )),
+                "{name}: {errors:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_internal_intrinsic_arity_is_reported_without_panicking() {
+        let source = "fn main() { @dbg(1); }";
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        let (ast, mut interner) = Parser::new(tokens, interner).parse().unwrap();
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let mut rir = astgen.finish();
+        let (intrinsic_ref, args_start) = rir
+            .iter()
+            .find_map(|(inst_ref, inst)| match inst.data {
+                InstData::Intrinsic { args_start, .. } => Some((inst_ref, args_start)),
+                _ => None,
+            })
+            .unwrap();
+        rir.get_mut(intrinsic_ref).data = InstData::InternalIntrinsic {
+            intrinsic: InternalIntrinsic::IterLen,
+            args_start,
+            args_len: 0,
+        };
+
+        let errors = Sema::new(&rir, &mut interner, PreviewFeatures::new())
+            .analyze_all()
+            .expect_err("malformed compiler RIR must be diagnosed");
+        assert!(errors.iter().any(|error| matches!(
+            &error.kind,
+            ErrorKind::InternalError(message)
+                if message.contains("`__rue_iter_len` expects 1 argument, found 0")
+        )));
     }
 
     #[test]

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -30,8 +30,8 @@ use rue_parser::{
 };
 
 use crate::inst::{
-    Inst, InstData, InstRef, RepeatCount, Rir, RirArgMode, RirCallArg, RirDirective, RirParam,
-    RirParamMode, RirPattern,
+    Inst, InstData, InstRef, InternalIntrinsic, RepeatCount, Rir, RirArgMode, RirCallArg,
+    RirDirective, RirParam, RirParamMode, RirPattern,
 };
 
 /// Generates RIR from an AST.
@@ -1229,16 +1229,16 @@ impl<'a> AstGen<'a> {
     ///   } }
     /// ```
     ///
-    /// The type-dependent pieces are three compiler-internal intrinsics that
+    /// The type-dependent pieces are compiler-internal RIR operations that
     /// Sema resolves by the collection's type (dispatching the three iterable
     /// kinds — array, String byte view, String `.chars()` / `.chars_lossy()`
-    /// scalar views): `@__rue_iter_len`, and for the char views
-    /// `@__rue_char_scalar` / `@__rue_char_next` (strict, trap on invalid
-    /// UTF-8) or their `_lossy` counterparts (substitute U+FFFD). Everything
+    /// scalar views): [`InternalIntrinsic::IterLen`], and for the char views
+    /// the scalar/next strict operations (trap on invalid UTF-8) or their lossy
+    /// counterparts (substitute U+FFFD). Everything
     /// else reuses the ordinary
     /// loop/branch/break/index lowering, so move-checking, drop elaboration,
     /// and codegen come for free. The whole thing is preview-gated in Sema at
-    /// the `@__rue_iter_len` intrinsic, which every for-loop emits.
+    /// [`InternalIntrinsic::IterLen`], which every for-loop emits.
     fn gen_for(&mut self, for_expr: &rue_parser::ForExpr) -> InstRef {
         let span = for_expr.span;
         let n = self.for_counter;
@@ -1312,7 +1312,7 @@ impl<'a> AstGen<'a> {
         });
         outer_stmts.push(p_alloc.as_u32());
 
-        // let __len: u64 = @__rue_iter_len(__coll);
+        // let __len: u64 = InternalIntrinsic::IterLen(__coll);
         // These two nodes carry the ITERABLE's span, not the whole statement's:
         // Sema's not-iterable type error (E0206) anchors on the intrinsic, and
         // it should underline the offending iterable expression.
@@ -1322,11 +1322,10 @@ impl<'a> AstGen<'a> {
             data: InstData::VarRef { name: coll_name },
             span: iter_span,
         });
-        let iter_len_sym = self.interner.get_or_intern("__rue_iter_len");
         let (la_start, la_len) = self.rir.add_inst_refs(&[coll_for_len]);
         let len_call = self.rir.add_inst(Inst {
-            data: InstData::Intrinsic {
-                name: iter_len_sym,
+            data: InstData::InternalIntrinsic {
+                intrinsic: InternalIntrinsic::IterLen,
                 args_start: la_start,
                 args_len: la_len,
             },
@@ -1402,15 +1401,15 @@ impl<'a> AstGen<'a> {
             span,
         });
         let get_inst = if is_chars {
-            let sym = self.interner.get_or_intern(if is_lossy {
-                "__rue_char_scalar_lossy"
+            let intrinsic = if is_lossy {
+                InternalIntrinsic::CharScalarLossy
             } else {
-                "__rue_char_scalar"
-            });
+                InternalIntrinsic::CharScalar
+            };
             let (s, l) = self.rir.add_inst_refs(&[coll_for_get, p_for_get]);
             self.rir.add_inst(Inst {
-                data: InstData::Intrinsic {
-                    name: sym,
+                data: InstData::InternalIntrinsic {
+                    intrinsic,
                     args_start: s,
                     args_len: l,
                 },
@@ -1454,15 +1453,15 @@ impl<'a> AstGen<'a> {
                 data: InstData::VarRef { name: coll_name },
                 span,
             });
-            let sym = self.interner.get_or_intern(if is_lossy {
-                "__rue_char_next_lossy"
+            let intrinsic = if is_lossy {
+                InternalIntrinsic::CharNextLossy
             } else {
-                "__rue_char_next"
-            });
+                InternalIntrinsic::CharNext
+            };
             let (s, l) = self.rir.add_inst_refs(&[coll_for_adv, p_for_adv]);
             self.rir.add_inst(Inst {
-                data: InstData::Intrinsic {
-                    name: sym,
+                data: InstData::InternalIntrinsic {
+                    intrinsic,
                     args_start: s,
                     args_len: l,
                 },
@@ -1671,6 +1670,40 @@ mod tests {
                 assert!(matches!(rir.get(*rhs).data, InstData::IntConst(2)));
             }
             _ => panic!("expected Add"),
+        }
+    }
+
+    #[test]
+    fn for_loops_emit_typed_internal_intrinsics() {
+        for (iterable, expected) in [
+            ("[1, 2]", vec![InternalIntrinsic::IterLen]),
+            (
+                "\"ok\".chars()",
+                vec![
+                    InternalIntrinsic::IterLen,
+                    InternalIntrinsic::CharScalar,
+                    InternalIntrinsic::CharNext,
+                ],
+            ),
+            (
+                "\"ok\".chars_lossy()",
+                vec![
+                    InternalIntrinsic::IterLen,
+                    InternalIntrinsic::CharScalarLossy,
+                    InternalIntrinsic::CharNextLossy,
+                ],
+            ),
+        ] {
+            let source = format!("fn main() {{ for _ in {iterable} {{}} }}");
+            let (rir, _) = gen_rir(&source);
+            let actual: Vec<_> = rir
+                .iter()
+                .filter_map(|(_, inst)| match inst.data {
+                    InstData::InternalIntrinsic { intrinsic, .. } => Some(intrinsic),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(actual, expected, "{source}");
         }
     }
 

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -725,6 +725,43 @@ pub enum RepeatCount {
     Named(Spur),
 }
 
+/// A compiler-internal intrinsic synthesized directly into RIR.
+///
+/// These operations are not source intrinsics. Keeping their identity separate
+/// from [`InstData::Intrinsic`] prevents a source spelling that resembles an
+/// implementation detail from selecting compiler-only behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InternalIntrinsic {
+    IterLen,
+    CharScalar,
+    CharNext,
+    CharScalarLossy,
+    CharNextLossy,
+}
+
+impl InternalIntrinsic {
+    /// The diagnostic and RIR-printer spelling for this operation.
+    ///
+    /// This is presentation-only; compiler dispatch must match the enum.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::IterLen => "__rue_iter_len",
+            Self::CharScalar => "__rue_char_scalar",
+            Self::CharNext => "__rue_char_next",
+            Self::CharScalarLossy => "__rue_char_scalar_lossy",
+            Self::CharNextLossy => "__rue_char_next_lossy",
+        }
+    }
+
+    /// Number of RIR operands required by this operation.
+    pub const fn arity(self) -> u32 {
+        match self {
+            Self::IterLen => 1,
+            Self::CharScalar | Self::CharNext | Self::CharScalarLossy | Self::CharNextLossy => 2,
+        }
+    }
+}
+
 /// Instruction data - the actual operation.
 #[derive(Debug, Clone)]
 pub enum InstData {
@@ -910,6 +947,15 @@ pub enum InstData {
         /// Index into extra data where args start
         args_start: u32,
         /// Number of arguments
+        args_len: u32,
+    },
+
+    /// Compiler-internal intrinsic with expression arguments.
+    ///
+    /// Args are stored in the extra array using add_inst_refs/get_inst_refs.
+    InternalIntrinsic {
+        intrinsic: InternalIntrinsic,
+        args_start: u32,
         args_len: u32,
     },
 
@@ -1742,6 +1788,24 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         .map(|a| self.display_ref(*a).to_string())
                         .collect();
                     writeln!(out, "intrinsic @{}({})", name_str, args_str.join(", ")).unwrap();
+                }
+                InstData::InternalIntrinsic {
+                    intrinsic,
+                    args_start,
+                    args_len,
+                } => {
+                    let args = self.rir.get_inst_refs(*args_start, *args_len);
+                    let args_str: Vec<String> = args
+                        .iter()
+                        .map(|a| self.display_ref(*a).to_string())
+                        .collect();
+                    writeln!(
+                        out,
+                        "internal_intrinsic @{}({})",
+                        intrinsic.as_str(),
+                        args_str.join(", ")
+                    )
+                    .unwrap();
                 }
                 InstData::TypeIntrinsic { name, type_arg } => {
                     let name_str = self.interner.resolve(&*name);
@@ -2956,6 +3020,62 @@ mod tests {
         let printer = RirPrinter::new(&rir, &interner);
         let output = printer.to_string();
         assert!(output.contains("intrinsic @dbg(%0)"));
+    }
+
+    #[test]
+    fn test_printer_internal_intrinsic() {
+        let (mut rir, interner) = create_printer_test_rir();
+        let arg = rir.add_inst(Inst {
+            data: InstData::IntConst(42),
+            span: Span::new(0, 2),
+        });
+        let (args_start, args_len) = rir.add_inst_refs(&[arg]);
+        rir.add_inst(Inst {
+            data: InstData::InternalIntrinsic {
+                intrinsic: InternalIntrinsic::IterLen,
+                args_start,
+                args_len,
+            },
+            span: Span::new(0, 10),
+        });
+
+        let output = RirPrinter::new(&rir, &interner).to_string();
+        assert!(output.contains("internal_intrinsic @__rue_iter_len(%0)"));
+    }
+
+    #[test]
+    fn internal_intrinsic_presentation_and_arity_are_exhaustive() {
+        assert_eq!(
+            [
+                (
+                    InternalIntrinsic::IterLen.as_str(),
+                    InternalIntrinsic::IterLen.arity()
+                ),
+                (
+                    InternalIntrinsic::CharScalar.as_str(),
+                    InternalIntrinsic::CharScalar.arity()
+                ),
+                (
+                    InternalIntrinsic::CharNext.as_str(),
+                    InternalIntrinsic::CharNext.arity()
+                ),
+                (
+                    InternalIntrinsic::CharScalarLossy.as_str(),
+                    InternalIntrinsic::CharScalarLossy.arity()
+                ),
+                (
+                    InternalIntrinsic::CharNextLossy.as_str(),
+                    InternalIntrinsic::CharNextLossy.arity()
+                ),
+            ],
+            [
+                ("__rue_iter_len", 1),
+                ("__rue_char_scalar", 2),
+                ("__rue_char_next", 2),
+                ("__rue_char_scalar_lossy", 2),
+                ("__rue_char_next_lossy", 2),
+            ]
+        );
     }
 
     #[test]

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -25,6 +25,6 @@ mod inst;
 
 pub use astgen::AstGen;
 pub use inst::{
-    Inst, InstData, InstRef, RepeatCount, Rir, RirArgMode, RirCallArg, RirDirective, RirParam,
-    RirParamMode, RirPattern, RirPrinter,
+    Inst, InstData, InstRef, InternalIntrinsic, RepeatCount, Rir, RirArgMode, RirCallArg,
+    RirDirective, RirParam, RirParamMode, RirPattern, RirPrinter,
 };


### PR DESCRIPTION
## Summary

- add an exhaustive typed identity for the five compiler-internal for-loop intrinsics
- make RIR desugaring emit internal IDs directly
- make inference and semantic analysis dispatch exhaustively on the enum
- validate malformed internal arity before operand access
- keep user-written intrinsic names separate and reject reserved-looking spellings as unknown

## Why

For-loop lowering previously interned implementation-detail strings that inference and sema independently matched. Since source accepts leading-underscore intrinsic names, raw strings did not provide a real provenance boundary.

## Validation

- `scripts/rue fmt`
- `scripts/rue test rue-rir`
- `scripts/rue spec for` — 57/57
- `scripts/rue cli for_loops` — 6/6
- `scripts/rue quick`
- `git diff --check`
- adversarial review approved with no blocking findings

Fixes RUE-827
