### PR TITLE
RUE-828: add typed runtime ABI manifest

### DIFF
--- a/crates/rue-builtins/BUCK
+++ b/crates/rue-builtins/BUCK
@@ -2,4 +2,7 @@ load("//crates:defs.bzl", "rue_crate")
 
 rue_crate(
     name = "rue-builtins",
+    test_deps = [
+        "//crates/rue-runtime-abi:rue-runtime-abi",
+    ],
 )

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -137,6 +137,7 @@ pub fn is_reserved_function_name(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_runtime_abi::RuntimeHelperId;
 
     #[test]
     fn test_is_reserved_function_name() {
@@ -170,6 +171,28 @@ mod tests {
         assert!(!is_reserved_function_name("memcpy2"));
         assert!(!is_reserved_function_name("my_memcpy"));
         assert!(!is_reserved_function_name("_main_loop"));
+    }
+
+    #[test]
+    fn current_builtin_symbol_constants_have_canonical_helper_identities() {
+        // This is deliberately a non-migrating proof. RUE-829 replaces these
+        // raw constants and their consumers with typed helper IDs.
+        assert_eq!(
+            RuntimeHelperId::from_symbol(TO_STRING_RUNTIME_FN),
+            Some(RuntimeHelperId::ToString)
+        );
+        assert_eq!(
+            RuntimeHelperId::from_symbol(TO_STRING_UNSIGNED_RUNTIME_FN),
+            Some(RuntimeHelperId::ToStringUnsigned)
+        );
+        assert_eq!(
+            RuntimeHelperId::from_symbol(PRINT_RUNTIME_FN),
+            Some(RuntimeHelperId::Print)
+        );
+        assert_eq!(
+            RuntimeHelperId::from_symbol(PRINTLN_RUNTIME_FN),
+            Some(RuntimeHelperId::Println)
+        );
     }
 
     // ========================================================================

--- a/crates/rue-runtime-abi/BUCK
+++ b/crates/rue-runtime-abi/BUCK
@@ -1,0 +1,7 @@
+load("//crates:defs.bzl", "rue_crate")
+
+# This is the dependency-light source of truth for the compiler/runtime ABI.
+# Keep it independent of compiler IR, target, linker, and runtime crates.
+rue_crate(
+    name = "rue-runtime-abi",
+)

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -1,0 +1,1437 @@
+#![no_std]
+
+//! Canonical typed description of the Rue compiler/runtime ABI.
+//!
+//! This crate deliberately has no dependencies. It describes logical C-boundary
+//! facts; target register assignment and compiler semantic types belong to
+//! their respective owners.
+
+use core::fmt;
+
+/// Current lockstep compiler/runtime ABI version.
+pub const RUNTIME_ABI_VERSION: u32 = 1;
+
+/// Retained data symbol exported by each runtime archive for this ABI version.
+pub const RUNTIME_ABI_VERSION_SYMBOL: &str = "__rue_runtime_abi_v1";
+
+/// A physical scalar type at the C boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AbiType {
+    I32,
+    I64,
+    U32,
+    U64,
+    /// The current ABI's canonical boolean representation.
+    BoolWordI64,
+    /// A single opaque byte, used as a pointer pointee.
+    Byte,
+    /// A mutable opaque byte pointer returned in a scalar result or aggregate slot.
+    MutBytePointer,
+    /// The target C ABI's `usize`, used only by compiler-built memory routines.
+    Usize,
+}
+
+/// How a parameter crosses the C boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ParameterMode {
+    Value,
+    ConstPointer,
+    MutPointer,
+    OutPointer(AggregateShapeId),
+}
+
+/// One ordered function parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AbiParameter {
+    pub ty: AbiType,
+    pub mode: ParameterMode,
+}
+
+impl AbiParameter {
+    pub const fn value(ty: AbiType) -> Self {
+        Self {
+            ty,
+            mode: ParameterMode::Value,
+        }
+    }
+
+    pub const fn const_pointer(ty: AbiType) -> Self {
+        Self {
+            ty,
+            mode: ParameterMode::ConstPointer,
+        }
+    }
+
+    pub const fn mut_pointer(ty: AbiType) -> Self {
+        Self {
+            ty,
+            mode: ParameterMode::MutPointer,
+        }
+    }
+
+    pub const fn out_pointer(shape: AggregateShapeId) -> Self {
+        Self {
+            ty: AbiType::Byte,
+            mode: ParameterMode::OutPointer(shape),
+        }
+    }
+}
+
+/// A function's direct C result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AbiResult {
+    Void,
+    Scalar(AbiType),
+}
+
+/// Whether control can continue after a helper call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReturnBehavior {
+    Returns,
+    Never,
+}
+
+/// Calling-convention family. Physical register assignment remains target-owned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CallingConvention {
+    TargetC,
+}
+
+/// Supported runtime targets, represented without depending on `rue-target`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeTarget {
+    X86_64Linux,
+    Aarch64Linux,
+    Aarch64Macos,
+}
+
+/// A composable set of runtime targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TargetSet(u8);
+
+impl TargetSet {
+    pub const X86_64_LINUX: Self = Self(1 << 0);
+    pub const AARCH64_LINUX: Self = Self(1 << 1);
+    pub const AARCH64_MACOS: Self = Self(1 << 2);
+    pub const ALL: Self =
+        Self(Self::X86_64_LINUX.0 | Self::AARCH64_LINUX.0 | Self::AARCH64_MACOS.0);
+
+    pub const fn contains(self, target: RuntimeTarget) -> bool {
+        let bit = match target {
+            RuntimeTarget::X86_64Linux => Self::X86_64_LINUX.0,
+            RuntimeTarget::Aarch64Linux => Self::AARCH64_LINUX.0,
+            RuntimeTarget::Aarch64Macos => Self::AARCH64_MACOS.0,
+        };
+        self.0 & bit != 0
+    }
+
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+
+/// Composable caller obligations and control-flow properties.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SafetyContract(u16);
+
+impl SafetyContract {
+    pub const NONE: Self = Self(0);
+    /// A pointer/length pair must describe readable bytes.
+    pub const READABLE_BYTES: Self = Self(1 << 0);
+    /// An out pointer must address aligned, writable aggregate storage.
+    pub const WRITABLE_RESULT: Self = Self(1 << 1);
+    /// Byte counts and alignment must describe a supported allocation layout.
+    pub const ALLOCATION_LAYOUT: Self = Self(1 << 2);
+    /// A mutable pointer must denote the allocation described by the other arguments.
+    pub const VALID_ALLOCATION: Self = Self(1 << 3);
+    /// Caller-supplied enum discriminants must be concrete and distinct.
+    pub const CONCRETE_DISCRIMINANTS: Self = Self(1 << 4);
+    /// The operation unconditionally traps or terminates the process.
+    pub const TERMINATES: Self = Self(1 << 5);
+
+    pub const fn contains(self, requirement: Self) -> bool {
+        self.0 & requirement.0 == requirement.0
+    }
+
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+
+/// Named aggregate layouts written through explicit out pointers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum AggregateShapeId {
+    StrBufResult,
+    OptionStrBufResult,
+    OptionIntResult,
+}
+
+impl AggregateShapeId {
+    pub const ALL: [Self; 3] = [
+        Self::StrBufResult,
+        Self::OptionStrBufResult,
+        Self::OptionIntResult,
+    ];
+
+    pub const fn shape(self) -> &'static AggregateShape {
+        &AGGREGATE_SHAPES[self as usize]
+    }
+}
+
+/// One aggregate slot in declaration order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AggregateSlot {
+    pub name: &'static str,
+    pub ty: AbiType,
+}
+
+/// A named C-boundary aggregate shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AggregateShape {
+    pub id: AggregateShapeId,
+    pub name: &'static str,
+    pub slots: &'static [AggregateSlot],
+}
+
+const STR_BUF_SLOTS: &[AggregateSlot] = &[
+    AggregateSlot {
+        name: "ptr",
+        ty: AbiType::MutBytePointer,
+    },
+    AggregateSlot {
+        name: "len",
+        ty: AbiType::U64,
+    },
+    AggregateSlot {
+        name: "cap",
+        ty: AbiType::U64,
+    },
+];
+
+const OPTION_STR_BUF_SLOTS: &[AggregateSlot] = &[
+    AggregateSlot {
+        name: "discriminant",
+        ty: AbiType::U64,
+    },
+    AggregateSlot {
+        name: "ptr",
+        ty: AbiType::MutBytePointer,
+    },
+    AggregateSlot {
+        name: "len",
+        ty: AbiType::U64,
+    },
+    AggregateSlot {
+        name: "cap",
+        ty: AbiType::U64,
+    },
+];
+
+const OPTION_INT_SLOTS: &[AggregateSlot] = &[
+    AggregateSlot {
+        name: "discriminant",
+        ty: AbiType::U64,
+    },
+    AggregateSlot {
+        name: "value",
+        ty: AbiType::U64,
+    },
+];
+
+pub const AGGREGATE_SHAPES: [AggregateShape; 3] = [
+    AggregateShape {
+        id: AggregateShapeId::StrBufResult,
+        name: "StrBufResult",
+        slots: STR_BUF_SLOTS,
+    },
+    AggregateShape {
+        id: AggregateShapeId::OptionStrBufResult,
+        name: "OptionStrBufResult",
+        slots: OPTION_STR_BUF_SLOTS,
+    },
+    AggregateShape {
+        id: AggregateShapeId::OptionIntResult,
+        name: "OptionIntResult",
+        slots: OPTION_INT_SLOTS,
+    },
+];
+
+macro_rules! params {
+    () => {
+        &[]
+    };
+    ($($parameter:expr),+ $(,)?) => {
+        &[$($parameter),+]
+    };
+}
+
+const I32_VALUE: AbiParameter = AbiParameter::value(AbiType::I32);
+const I64_VALUE: AbiParameter = AbiParameter::value(AbiType::I64);
+const U64_VALUE: AbiParameter = AbiParameter::value(AbiType::U64);
+const BOOL_WORD_VALUE: AbiParameter = AbiParameter::value(AbiType::BoolWordI64);
+const BYTE_VIEW: AbiParameter = AbiParameter::const_pointer(AbiType::Byte);
+const MUT_BYTE_POINTER: AbiParameter = AbiParameter::mut_pointer(AbiType::Byte);
+const STR_BUF_OUT: AbiParameter = AbiParameter::out_pointer(AggregateShapeId::StrBufResult);
+const OPTION_STR_BUF_OUT: AbiParameter =
+    AbiParameter::out_pointer(AggregateShapeId::OptionStrBufResult);
+const OPTION_INT_OUT: AbiParameter = AbiParameter::out_pointer(AggregateShapeId::OptionIntResult);
+
+const RETURNS: ReturnBehavior = ReturnBehavior::Returns;
+const NEVER: ReturnBehavior = ReturnBehavior::Never;
+const VOID: AbiResult = AbiResult::Void;
+const U32_RESULT: AbiResult = AbiResult::Scalar(AbiType::U32);
+const U64_RESULT: AbiResult = AbiResult::Scalar(AbiType::U64);
+const MUT_POINTER_RESULT: AbiResult = AbiResult::Scalar(AbiType::MutBytePointer);
+const TARGET_C: CallingConvention = CallingConvention::TargetC;
+const ALL_TARGETS: TargetSet = TargetSet::ALL;
+
+const READABLE: SafetyContract = SafetyContract::READABLE_BYTES;
+const WRITABLE: SafetyContract = SafetyContract::WRITABLE_RESULT;
+const TERMINATES: SafetyContract = SafetyContract::TERMINATES;
+const ALLOC_LAYOUT: SafetyContract = SafetyContract::ALLOCATION_LAYOUT;
+const VALID_ALLOC_LAYOUT: SafetyContract =
+    SafetyContract::VALID_ALLOCATION.union(SafetyContract::ALLOCATION_LAYOUT);
+const WRITABLE_DISCRIMINANTS: SafetyContract =
+    SafetyContract::WRITABLE_RESULT.union(SafetyContract::CONCRETE_DISCRIMINANTS);
+const READABLE_WRITABLE_DISCRIMINANTS: SafetyContract =
+    SafetyContract::READABLE_BYTES.union(WRITABLE_DISCRIMINANTS);
+
+macro_rules! runtime_helpers {
+    (
+        $(
+            $variant:ident => {
+                symbol: $symbol:literal,
+                parameters: $parameters:expr,
+                result: $result:expr,
+                safety: $safety:expr,
+                returns: $returns:expr
+            }
+        ),+ $(,)?
+    ) => {
+        /// Exhaustive typed identity for compiler-callable runtime helpers.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[repr(u8)]
+        pub enum RuntimeHelperId {
+            $($variant),+
+        }
+
+        impl RuntimeHelperId {
+            pub const ALL: [Self; runtime_helpers!(@count $($variant),+)] = [
+                $(Self::$variant),+
+            ];
+
+            pub const fn helper(self) -> &'static RuntimeHelper {
+                &RUNTIME_HELPERS[self as usize]
+            }
+
+            pub const fn symbol(self) -> &'static str {
+                self.helper().symbol
+            }
+
+            pub fn from_symbol(symbol: &str) -> Option<Self> {
+                let mut index = 0;
+                while index < Self::ALL.len() {
+                    let id = Self::ALL[index];
+                    if string_eq(id.symbol(), symbol) {
+                        return Some(id);
+                    }
+                    index += 1;
+                }
+                None
+            }
+        }
+
+        impl fmt::Display for RuntimeHelperId {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(self.symbol())
+            }
+        }
+
+        pub const RUNTIME_HELPERS: [RuntimeHelper; runtime_helpers!(@count $($variant),+)] = [
+            $(
+                RuntimeHelper {
+                    id: RuntimeHelperId::$variant,
+                    symbol: $symbol,
+                    parameters: $parameters,
+                    result: $result,
+                    safety: $safety,
+                    return_behavior: $returns,
+                    availability: ALL_TARGETS,
+                    calling_convention: TARGET_C,
+                }
+            ),+
+        ];
+    };
+    (@count $($variant:ident),+) => {
+        <[()]>::len(&[$(runtime_helpers!(@replace $variant ())),+])
+    };
+    (@replace $_variant:ident $value:expr) => {
+        $value
+    };
+}
+
+/// Complete logical signature and contract for one runtime helper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RuntimeHelper {
+    pub id: RuntimeHelperId,
+    pub symbol: &'static str,
+    pub parameters: &'static [AbiParameter],
+    pub result: AbiResult,
+    pub safety: SafetyContract,
+    pub return_behavior: ReturnBehavior,
+    pub availability: TargetSet,
+    pub calling_convention: CallingConvention,
+}
+
+runtime_helpers! {
+    Exit => {
+        symbol: "__rue_exit",
+        parameters: params![I32_VALUE],
+        result: VOID,
+        safety: TERMINATES,
+        returns: NEVER
+    },
+    Alloc => {
+        symbol: "__rue_alloc",
+        parameters: params![U64_VALUE, U64_VALUE],
+        result: MUT_POINTER_RESULT,
+        safety: ALLOC_LAYOUT,
+        returns: RETURNS
+    },
+    Free => {
+        symbol: "__rue_free",
+        parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE],
+        result: VOID,
+        // The current bump allocator's free operation is a no-op and imposes
+        // no pointer or layout precondition.
+        safety: SafetyContract::NONE,
+        returns: RETURNS
+    },
+    Realloc => {
+        symbol: "__rue_realloc",
+        parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE, U64_VALUE],
+        result: MUT_POINTER_RESULT,
+        safety: VALID_ALLOC_LAYOUT,
+        returns: RETURNS
+    },
+    DivByZero => {
+        symbol: "__rue_div_by_zero",
+        parameters: params![],
+        result: VOID,
+        safety: TERMINATES,
+        returns: NEVER
+    },
+    Overflow => {
+        symbol: "__rue_overflow",
+        parameters: params![],
+        result: VOID,
+        safety: TERMINATES,
+        returns: NEVER
+    },
+    IntcastOverflow => {
+        symbol: "__rue_intcast_overflow",
+        parameters: params![],
+        result: VOID,
+        safety: TERMINATES,
+        returns: NEVER
+    },
+    BoundsCheck => {
+        symbol: "__rue_bounds_check",
+        parameters: params![],
+        result: VOID,
+        safety: TERMINATES,
+        returns: NEVER
+    },
+    Panic => {
+        symbol: "__rue_panic",
+        parameters: params![BYTE_VIEW, U64_VALUE],
+        result: VOID,
+        safety: READABLE.union(TERMINATES),
+        returns: NEVER
+    },
+    PanicNoMessage => {
+        symbol: "__rue_panic_no_msg",
+        parameters: params![],
+        result: VOID,
+        safety: TERMINATES,
+        returns: NEVER
+    },
+    AssertFailed => {
+        symbol: "__rue_assert_failed",
+        parameters: params![],
+        result: VOID,
+        safety: TERMINATES,
+        returns: NEVER
+    },
+    DebugI64 => {
+        symbol: "__rue_dbg_i64",
+        parameters: params![I64_VALUE],
+        result: VOID,
+        safety: SafetyContract::NONE,
+        returns: RETURNS
+    },
+    DebugU64 => {
+        symbol: "__rue_dbg_u64",
+        parameters: params![U64_VALUE],
+        result: VOID,
+        safety: SafetyContract::NONE,
+        returns: RETURNS
+    },
+    DebugBool => {
+        symbol: "__rue_dbg_bool",
+        parameters: params![BOOL_WORD_VALUE],
+        result: VOID,
+        safety: SafetyContract::NONE,
+        returns: RETURNS
+    },
+    DebugStr => {
+        symbol: "__rue_dbg_str",
+        parameters: params![BYTE_VIEW, U64_VALUE],
+        result: VOID,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    StrEq => {
+        symbol: "__rue_str_eq",
+        parameters: params![BYTE_VIEW, U64_VALUE, BYTE_VIEW, U64_VALUE],
+        result: U64_RESULT,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    StrByteAt => {
+        symbol: "__rue_str_byte_at",
+        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+        result: U64_RESULT,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    StrCharScalar => {
+        symbol: "__rue_str_char_scalar",
+        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+        result: U64_RESULT,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    StrCharNext => {
+        symbol: "__rue_str_char_next",
+        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+        result: U64_RESULT,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    StrCharScalarLossy => {
+        symbol: "__rue_str_char_scalar_lossy",
+        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+        result: U64_RESULT,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    StrCharNextLossy => {
+        symbol: "__rue_str_char_next_lossy",
+        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+        result: U64_RESULT,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    ToString => {
+        symbol: "__rue_to_string",
+        parameters: params![STR_BUF_OUT, I64_VALUE],
+        result: VOID,
+        safety: WRITABLE,
+        returns: RETURNS
+    },
+    ToStringUnsigned => {
+        symbol: "__rue_to_string_unsigned",
+        parameters: params![STR_BUF_OUT, U64_VALUE],
+        result: VOID,
+        safety: WRITABLE,
+        returns: RETURNS
+    },
+    Print => {
+        symbol: "__rue_print",
+        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+        result: VOID,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    Println => {
+        symbol: "__rue_println",
+        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+        result: VOID,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    StrPrint => {
+        symbol: "__rue_str_print",
+        parameters: params![BYTE_VIEW, U64_VALUE],
+        result: VOID,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    StrPrintln => {
+        symbol: "__rue_str_println",
+        parameters: params![BYTE_VIEW, U64_VALUE],
+        result: VOID,
+        safety: READABLE,
+        returns: RETURNS
+    },
+    ReadLine => {
+        symbol: "__rue_read_line",
+        parameters: params![OPTION_STR_BUF_OUT, U64_VALUE, U64_VALUE],
+        result: VOID,
+        safety: WRITABLE_DISCRIMINANTS,
+        returns: RETURNS
+    },
+    ParseI32 => {
+        symbol: "__rue_parse_i32",
+        parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
+        result: VOID,
+        safety: READABLE_WRITABLE_DISCRIMINANTS,
+        returns: RETURNS
+    },
+    ParseI64 => {
+        symbol: "__rue_parse_i64",
+        parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
+        result: VOID,
+        safety: READABLE_WRITABLE_DISCRIMINANTS,
+        returns: RETURNS
+    },
+    ParseU32 => {
+        symbol: "__rue_parse_u32",
+        parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
+        result: VOID,
+        safety: READABLE_WRITABLE_DISCRIMINANTS,
+        returns: RETURNS
+    },
+    ParseU64 => {
+        symbol: "__rue_parse_u64",
+        parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
+        result: VOID,
+        safety: READABLE_WRITABLE_DISCRIMINANTS,
+        returns: RETURNS
+    },
+    RandomU32 => {
+        symbol: "__rue_random_u32",
+        parameters: params![],
+        result: U32_RESULT,
+        safety: SafetyContract::NONE,
+        returns: RETURNS
+    },
+    RandomU64 => {
+        symbol: "__rue_random_u64",
+        parameters: params![],
+        result: U64_RESULT,
+        safety: SafetyContract::NONE,
+        returns: RETURNS
+    },
+    InvalidUtf8 => {
+        symbol: "__rue_invalid_utf8",
+        parameters: params![],
+        result: VOID,
+        safety: TERMINATES,
+        returns: NEVER
+    }
+}
+
+/// Logical function signature for separately classified non-helper exports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AbiSignature {
+    pub parameters: &'static [AbiParameter],
+    pub result: AbiResult,
+    pub return_behavior: ReturnBehavior,
+    pub calling_convention: CallingConvention,
+}
+
+/// Why a reserved runtime symbol is externally visible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReservedExportClass {
+    CompilerBuiltMemory,
+    ProgramEntry,
+    PlatformShim,
+    AbiVersionMarker,
+}
+
+/// Whether a separately classified export is callable code or retained data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReservedExportKind {
+    Function(AbiSignature),
+    ReadOnlyData { size: u8 },
+}
+
+/// Exhaustive identity for intentionally visible, non-helper runtime exports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum ReservedExportId {
+    Memcpy,
+    Memmove,
+    Memset,
+    Memcmp,
+    Bcmp,
+    LinuxStart,
+    MacosMain,
+    X86_64LinuxStart,
+    RtSigreturn,
+    RuntimeAbiVersion,
+}
+
+impl ReservedExportId {
+    pub const ALL: [Self; 10] = [
+        Self::Memcpy,
+        Self::Memmove,
+        Self::Memset,
+        Self::Memcmp,
+        Self::Bcmp,
+        Self::LinuxStart,
+        Self::MacosMain,
+        Self::X86_64LinuxStart,
+        Self::RtSigreturn,
+        Self::RuntimeAbiVersion,
+    ];
+
+    pub const fn export(self) -> &'static ReservedExport {
+        &RESERVED_EXPORTS[self as usize]
+    }
+
+    pub const fn symbol(self) -> &'static str {
+        self.export().symbol
+    }
+
+    pub fn from_symbol(symbol: &str) -> Option<Self> {
+        let mut index = 0;
+        while index < Self::ALL.len() {
+            let id = Self::ALL[index];
+            if string_eq(id.symbol(), symbol) {
+                return Some(id);
+            }
+            index += 1;
+        }
+        None
+    }
+}
+
+/// A separately classified, intentionally visible runtime export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReservedExport {
+    pub id: ReservedExportId,
+    pub symbol: &'static str,
+    pub class: ReservedExportClass,
+    pub kind: ReservedExportKind,
+    pub availability: TargetSet,
+}
+
+const VOID_FUNCTION: AbiSignature = AbiSignature {
+    parameters: &[],
+    result: VOID,
+    return_behavior: RETURNS,
+    calling_convention: TARGET_C,
+};
+const NEVER_FUNCTION: AbiSignature = AbiSignature {
+    parameters: &[],
+    result: VOID,
+    return_behavior: NEVER,
+    calling_convention: TARGET_C,
+};
+const COPY_FUNCTION: AbiSignature = AbiSignature {
+    parameters: &[
+        AbiParameter::mut_pointer(AbiType::Byte),
+        AbiParameter::const_pointer(AbiType::Byte),
+        AbiParameter::value(AbiType::Usize),
+    ],
+    result: MUT_POINTER_RESULT,
+    return_behavior: RETURNS,
+    calling_convention: TARGET_C,
+};
+const MEMSET_FUNCTION: AbiSignature = AbiSignature {
+    parameters: &[
+        AbiParameter::mut_pointer(AbiType::Byte),
+        AbiParameter::value(AbiType::I32),
+        AbiParameter::value(AbiType::Usize),
+    ],
+    result: MUT_POINTER_RESULT,
+    return_behavior: RETURNS,
+    calling_convention: TARGET_C,
+};
+const COMPARE_FUNCTION: AbiSignature = AbiSignature {
+    parameters: &[
+        AbiParameter::const_pointer(AbiType::Byte),
+        AbiParameter::const_pointer(AbiType::Byte),
+        AbiParameter::value(AbiType::Usize),
+    ],
+    result: AbiResult::Scalar(AbiType::I32),
+    return_behavior: RETURNS,
+    calling_convention: TARGET_C,
+};
+
+pub const RESERVED_EXPORTS: [ReservedExport; 10] = [
+    ReservedExport {
+        id: ReservedExportId::Memcpy,
+        symbol: "memcpy",
+        class: ReservedExportClass::CompilerBuiltMemory,
+        kind: ReservedExportKind::Function(COPY_FUNCTION),
+        availability: ALL_TARGETS,
+    },
+    ReservedExport {
+        id: ReservedExportId::Memmove,
+        symbol: "memmove",
+        class: ReservedExportClass::CompilerBuiltMemory,
+        kind: ReservedExportKind::Function(COPY_FUNCTION),
+        availability: ALL_TARGETS,
+    },
+    ReservedExport {
+        id: ReservedExportId::Memset,
+        symbol: "memset",
+        class: ReservedExportClass::CompilerBuiltMemory,
+        kind: ReservedExportKind::Function(MEMSET_FUNCTION),
+        availability: ALL_TARGETS,
+    },
+    ReservedExport {
+        id: ReservedExportId::Memcmp,
+        symbol: "memcmp",
+        class: ReservedExportClass::CompilerBuiltMemory,
+        kind: ReservedExportKind::Function(COMPARE_FUNCTION),
+        availability: ALL_TARGETS,
+    },
+    ReservedExport {
+        id: ReservedExportId::Bcmp,
+        symbol: "bcmp",
+        class: ReservedExportClass::CompilerBuiltMemory,
+        kind: ReservedExportKind::Function(COMPARE_FUNCTION),
+        availability: ALL_TARGETS,
+    },
+    ReservedExport {
+        id: ReservedExportId::LinuxStart,
+        symbol: "_start",
+        class: ReservedExportClass::ProgramEntry,
+        kind: ReservedExportKind::Function(NEVER_FUNCTION),
+        availability: TargetSet::X86_64_LINUX.union(TargetSet::AARCH64_LINUX),
+    },
+    ReservedExport {
+        id: ReservedExportId::MacosMain,
+        symbol: "_main",
+        class: ReservedExportClass::ProgramEntry,
+        kind: ReservedExportKind::Function(NEVER_FUNCTION),
+        availability: TargetSet::AARCH64_MACOS,
+    },
+    ReservedExport {
+        id: ReservedExportId::X86_64LinuxStart,
+        symbol: "__rue_x86_64_linux_start",
+        class: ReservedExportClass::PlatformShim,
+        kind: ReservedExportKind::Function(NEVER_FUNCTION),
+        availability: TargetSet::X86_64_LINUX,
+    },
+    ReservedExport {
+        id: ReservedExportId::RtSigreturn,
+        symbol: "__rue_rt_sigreturn",
+        class: ReservedExportClass::PlatformShim,
+        kind: ReservedExportKind::Function(VOID_FUNCTION),
+        availability: TargetSet::X86_64_LINUX,
+    },
+    ReservedExport {
+        id: ReservedExportId::RuntimeAbiVersion,
+        symbol: RUNTIME_ABI_VERSION_SYMBOL,
+        class: ReservedExportClass::AbiVersionMarker,
+        kind: ReservedExportKind::ReadOnlyData { size: 1 },
+        availability: ALL_TARGETS,
+    },
+];
+
+/// Classification of a known externally visible runtime name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeExport {
+    Helper(RuntimeHelperId),
+    Reserved(ReservedExportId),
+}
+
+pub fn classify_export(symbol: &str) -> Option<RuntimeExport> {
+    RuntimeHelperId::from_symbol(symbol)
+        .map(RuntimeExport::Helper)
+        .or_else(|| ReservedExportId::from_symbol(symbol).map(RuntimeExport::Reserved))
+}
+
+/// Manifest invariant violated by [`validate_manifest`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ManifestError {
+    HelperIdOrder,
+    DuplicateHelperSymbol,
+    InvalidHelperSymbol,
+    AggregateIdOrder,
+    EmptyAggregate,
+    InvalidAggregateSlot,
+    ReservedExportIdOrder,
+    DuplicateReservedSymbol,
+    HelperReservedSymbolCollision,
+    InvalidVersionMarker,
+}
+
+const fn string_eq(left: &str, right: &str) -> bool {
+    let left = left.as_bytes();
+    let right = right.as_bytes();
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut index = 0;
+    while index < left.len() {
+        if left[index] != right[index] {
+            return false;
+        }
+        index += 1;
+    }
+    true
+}
+
+const fn starts_with(value: &str, prefix: &str) -> bool {
+    let value = value.as_bytes();
+    let prefix = prefix.as_bytes();
+    if value.len() < prefix.len() {
+        return false;
+    }
+    let mut index = 0;
+    while index < prefix.len() {
+        if value[index] != prefix[index] {
+            return false;
+        }
+        index += 1;
+    }
+    true
+}
+
+const fn ends_with_decimal_version(symbol: &str, version: u32) -> bool {
+    // Version 1 is the initial ABI. This explicit check makes an ABI bump update
+    // both metadata values rather than silently retaining a stale symbol.
+    version == 1 && string_eq(symbol, "__rue_runtime_abi_v1")
+}
+
+/// Validate all table ordering, uniqueness, classification, and layout invariants.
+pub const fn validate_manifest() -> Result<(), ManifestError> {
+    let mut index = 0;
+    while index < RUNTIME_HELPERS.len() {
+        let helper = &RUNTIME_HELPERS[index];
+        if helper.id as usize != index || RuntimeHelperId::ALL[index] as usize != index {
+            return Err(ManifestError::HelperIdOrder);
+        }
+        if !starts_with(helper.symbol, "__rue_") || helper.symbol.is_empty() {
+            return Err(ManifestError::InvalidHelperSymbol);
+        }
+        let mut other = index + 1;
+        while other < RUNTIME_HELPERS.len() {
+            if string_eq(helper.symbol, RUNTIME_HELPERS[other].symbol) {
+                return Err(ManifestError::DuplicateHelperSymbol);
+            }
+            other += 1;
+        }
+        index += 1;
+    }
+
+    index = 0;
+    while index < AGGREGATE_SHAPES.len() {
+        let aggregate = &AGGREGATE_SHAPES[index];
+        if aggregate.id as usize != index || AggregateShapeId::ALL[index] as usize != index {
+            return Err(ManifestError::AggregateIdOrder);
+        }
+        if aggregate.slots.is_empty() {
+            return Err(ManifestError::EmptyAggregate);
+        }
+        let mut slot = 0;
+        while slot < aggregate.slots.len() {
+            if aggregate.slots[slot].name.is_empty() {
+                return Err(ManifestError::InvalidAggregateSlot);
+            }
+            slot += 1;
+        }
+        index += 1;
+    }
+
+    index = 0;
+    while index < RESERVED_EXPORTS.len() {
+        let export = &RESERVED_EXPORTS[index];
+        if export.id as usize != index || ReservedExportId::ALL[index] as usize != index {
+            return Err(ManifestError::ReservedExportIdOrder);
+        }
+        let mut helper = 0;
+        while helper < RUNTIME_HELPERS.len() {
+            if string_eq(export.symbol, RUNTIME_HELPERS[helper].symbol) {
+                return Err(ManifestError::HelperReservedSymbolCollision);
+            }
+            helper += 1;
+        }
+        let mut other = index + 1;
+        while other < RESERVED_EXPORTS.len() {
+            if string_eq(export.symbol, RESERVED_EXPORTS[other].symbol) {
+                return Err(ManifestError::DuplicateReservedSymbol);
+            }
+            other += 1;
+        }
+        index += 1;
+    }
+
+    if !ends_with_decimal_version(RUNTIME_ABI_VERSION_SYMBOL, RUNTIME_ABI_VERSION) {
+        return Err(ManifestError::InvalidVersionMarker);
+    }
+    Ok(())
+}
+
+const _: () = assert!(validate_manifest().is_ok());
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use std::format;
+    use std::string::ToString;
+    use std::vec::Vec;
+
+    #[test]
+    fn manifest_is_const_valid_and_exhaustive() {
+        assert_eq!(validate_manifest(), Ok(()));
+        assert_eq!(RuntimeHelperId::ALL.len(), 35);
+        assert_eq!(RuntimeHelperId::ALL.len(), RUNTIME_HELPERS.len());
+        for (index, id) in RuntimeHelperId::ALL.iter().copied().enumerate() {
+            assert_eq!(id as usize, index);
+            assert_eq!(id.helper().id, id);
+            assert_eq!(RuntimeHelperId::from_symbol(id.symbol()), Some(id));
+            assert_eq!(id.to_string(), id.symbol());
+        }
+        assert_eq!(RuntimeHelperId::from_symbol("__rue_not_a_helper"), None);
+    }
+
+    #[test]
+    fn helper_symbols_are_unique() {
+        let symbols: Vec<_> = RUNTIME_HELPERS.iter().map(|helper| helper.symbol).collect();
+        for (index, symbol) in symbols.iter().enumerate() {
+            assert!(!symbols[index + 1..].contains(symbol), "duplicate {symbol}");
+        }
+    }
+
+    #[test]
+    fn helper_inventory_has_the_exact_accepted_symbols_in_stable_order() {
+        let expected = [
+            "__rue_exit",
+            "__rue_alloc",
+            "__rue_free",
+            "__rue_realloc",
+            "__rue_div_by_zero",
+            "__rue_overflow",
+            "__rue_intcast_overflow",
+            "__rue_bounds_check",
+            "__rue_panic",
+            "__rue_panic_no_msg",
+            "__rue_assert_failed",
+            "__rue_dbg_i64",
+            "__rue_dbg_u64",
+            "__rue_dbg_bool",
+            "__rue_dbg_str",
+            "__rue_str_eq",
+            "__rue_str_byte_at",
+            "__rue_str_char_scalar",
+            "__rue_str_char_next",
+            "__rue_str_char_scalar_lossy",
+            "__rue_str_char_next_lossy",
+            "__rue_to_string",
+            "__rue_to_string_unsigned",
+            "__rue_print",
+            "__rue_println",
+            "__rue_str_print",
+            "__rue_str_println",
+            "__rue_read_line",
+            "__rue_parse_i32",
+            "__rue_parse_i64",
+            "__rue_parse_u32",
+            "__rue_parse_u64",
+            "__rue_random_u32",
+            "__rue_random_u64",
+            "__rue_invalid_utf8",
+        ];
+        assert_eq!(
+            RUNTIME_HELPERS.map(|helper| helper.symbol),
+            expected,
+            "changing a helper symbol is an ABI change"
+        );
+    }
+
+    #[test]
+    fn every_helper_has_the_exact_accepted_signature_and_contract() {
+        fn check(
+            visited: &mut [bool; 35],
+            ids: &[RuntimeHelperId],
+            parameters: &[AbiParameter],
+            result: AbiResult,
+            safety: SafetyContract,
+            return_behavior: ReturnBehavior,
+        ) {
+            for id in ids {
+                let helper = id.helper();
+                assert!(!visited[*id as usize], "{id:?} checked twice");
+                visited[*id as usize] = true;
+                assert_eq!(helper.parameters, parameters, "{id:?} parameters");
+                assert_eq!(helper.result, result, "{id:?} result");
+                assert_eq!(helper.safety, safety, "{id:?} safety");
+                assert_eq!(
+                    helper.return_behavior, return_behavior,
+                    "{id:?} return behavior"
+                );
+            }
+        }
+
+        let mut visited = [false; 35];
+        check(
+            &mut visited,
+            &[RuntimeHelperId::Exit],
+            &[I32_VALUE],
+            VOID,
+            TERMINATES,
+            NEVER,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::Alloc],
+            &[U64_VALUE, U64_VALUE],
+            MUT_POINTER_RESULT,
+            ALLOC_LAYOUT,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::Free],
+            &[MUT_BYTE_POINTER, U64_VALUE, U64_VALUE],
+            VOID,
+            SafetyContract::NONE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::Realloc],
+            &[MUT_BYTE_POINTER, U64_VALUE, U64_VALUE, U64_VALUE],
+            MUT_POINTER_RESULT,
+            VALID_ALLOC_LAYOUT,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[
+                RuntimeHelperId::DivByZero,
+                RuntimeHelperId::Overflow,
+                RuntimeHelperId::IntcastOverflow,
+                RuntimeHelperId::BoundsCheck,
+                RuntimeHelperId::PanicNoMessage,
+                RuntimeHelperId::AssertFailed,
+                RuntimeHelperId::InvalidUtf8,
+            ],
+            &[],
+            VOID,
+            TERMINATES,
+            NEVER,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::Panic],
+            &[BYTE_VIEW, U64_VALUE],
+            VOID,
+            READABLE.union(TERMINATES),
+            NEVER,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::DebugI64],
+            &[I64_VALUE],
+            VOID,
+            SafetyContract::NONE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::DebugU64],
+            &[U64_VALUE],
+            VOID,
+            SafetyContract::NONE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::DebugBool],
+            &[BOOL_WORD_VALUE],
+            VOID,
+            SafetyContract::NONE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::DebugStr],
+            &[BYTE_VIEW, U64_VALUE],
+            VOID,
+            READABLE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::StrEq],
+            &[BYTE_VIEW, U64_VALUE, BYTE_VIEW, U64_VALUE],
+            U64_RESULT,
+            READABLE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[
+                RuntimeHelperId::StrByteAt,
+                RuntimeHelperId::StrCharScalar,
+                RuntimeHelperId::StrCharNext,
+                RuntimeHelperId::StrCharScalarLossy,
+                RuntimeHelperId::StrCharNextLossy,
+            ],
+            &[BYTE_VIEW, U64_VALUE, U64_VALUE],
+            U64_RESULT,
+            READABLE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::ToString],
+            &[STR_BUF_OUT, I64_VALUE],
+            VOID,
+            WRITABLE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::ToStringUnsigned],
+            &[STR_BUF_OUT, U64_VALUE],
+            VOID,
+            WRITABLE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::Print, RuntimeHelperId::Println],
+            &[BYTE_VIEW, U64_VALUE, U64_VALUE],
+            VOID,
+            READABLE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::StrPrint, RuntimeHelperId::StrPrintln],
+            &[BYTE_VIEW, U64_VALUE],
+            VOID,
+            READABLE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::ReadLine],
+            &[OPTION_STR_BUF_OUT, U64_VALUE, U64_VALUE],
+            VOID,
+            WRITABLE_DISCRIMINANTS,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[
+                RuntimeHelperId::ParseI32,
+                RuntimeHelperId::ParseI64,
+                RuntimeHelperId::ParseU32,
+                RuntimeHelperId::ParseU64,
+            ],
+            &[OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
+            VOID,
+            READABLE_WRITABLE_DISCRIMINANTS,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::RandomU32],
+            &[],
+            U32_RESULT,
+            SafetyContract::NONE,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::RandomU64],
+            &[],
+            U64_RESULT,
+            SafetyContract::NONE,
+            RETURNS,
+        );
+        assert!(visited.into_iter().all(|was_visited| was_visited));
+    }
+
+    #[test]
+    fn aggregate_shapes_have_exact_slots() {
+        assert_eq!(
+            AggregateShapeId::StrBufResult.shape().slots,
+            [
+                AggregateSlot {
+                    name: "ptr",
+                    ty: AbiType::MutBytePointer
+                },
+                AggregateSlot {
+                    name: "len",
+                    ty: AbiType::U64
+                },
+                AggregateSlot {
+                    name: "cap",
+                    ty: AbiType::U64
+                },
+            ]
+        );
+        assert_eq!(
+            AggregateShapeId::OptionStrBufResult.shape().slots,
+            [
+                AggregateSlot {
+                    name: "discriminant",
+                    ty: AbiType::U64
+                },
+                AggregateSlot {
+                    name: "ptr",
+                    ty: AbiType::MutBytePointer
+                },
+                AggregateSlot {
+                    name: "len",
+                    ty: AbiType::U64
+                },
+                AggregateSlot {
+                    name: "cap",
+                    ty: AbiType::U64
+                },
+            ]
+        );
+        assert_eq!(
+            AggregateShapeId::OptionIntResult.shape().slots,
+            [
+                AggregateSlot {
+                    name: "discriminant",
+                    ty: AbiType::U64
+                },
+                AggregateSlot {
+                    name: "value",
+                    ty: AbiType::U64
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn every_out_pointer_selects_a_declared_shape() {
+        for helper in RUNTIME_HELPERS {
+            for parameter in helper.parameters {
+                if let ParameterMode::OutPointer(id) = parameter.mode {
+                    assert_eq!(id.shape().id, id);
+                    assert!(!id.shape().slots.is_empty());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn signatures_preserve_widths_and_modes_that_must_not_be_inferred() {
+        assert_eq!(
+            RuntimeHelperId::DebugBool.helper().parameters,
+            [AbiParameter::value(AbiType::BoolWordI64)]
+        );
+        assert_eq!(
+            RuntimeHelperId::StrEq.helper().result,
+            AbiResult::Scalar(AbiType::U64)
+        );
+        assert_eq!(
+            RuntimeHelperId::StrCharScalar.helper().result,
+            AbiResult::Scalar(AbiType::U64)
+        );
+        assert_eq!(
+            RuntimeHelperId::StrCharScalarLossy.helper().result,
+            AbiResult::Scalar(AbiType::U64)
+        );
+        assert_eq!(
+            RuntimeHelperId::RandomU32.helper().result,
+            AbiResult::Scalar(AbiType::U32)
+        );
+        assert_eq!(
+            RuntimeHelperId::ToString.helper().parameters[0].mode,
+            ParameterMode::OutPointer(AggregateShapeId::StrBufResult)
+        );
+        assert_eq!(
+            RuntimeHelperId::ParseI64.helper().parameters[0].mode,
+            ParameterMode::OutPointer(AggregateShapeId::OptionIntResult)
+        );
+    }
+
+    #[test]
+    fn safety_requirements_are_composable() {
+        let parse = RuntimeHelperId::ParseI32.helper().safety;
+        assert!(parse.contains(SafetyContract::READABLE_BYTES));
+        assert!(parse.contains(SafetyContract::WRITABLE_RESULT));
+        assert!(parse.contains(SafetyContract::CONCRETE_DISCRIMINANTS));
+        assert!(!parse.contains(SafetyContract::VALID_ALLOCATION));
+
+        let realloc = RuntimeHelperId::Realloc.helper().safety;
+        assert!(realloc.contains(SafetyContract::VALID_ALLOCATION));
+        assert!(realloc.contains(SafetyContract::ALLOCATION_LAYOUT));
+    }
+
+    #[test]
+    fn all_helpers_are_available_on_every_runtime_target_and_use_target_c() {
+        for helper in RUNTIME_HELPERS {
+            for target in [
+                RuntimeTarget::X86_64Linux,
+                RuntimeTarget::Aarch64Linux,
+                RuntimeTarget::Aarch64Macos,
+            ] {
+                assert!(helper.availability.contains(target));
+            }
+            assert_eq!(helper.calling_convention, CallingConvention::TargetC);
+        }
+    }
+
+    #[test]
+    fn reserved_exports_are_separate_and_targeted() {
+        assert_eq!(ReservedExportId::ALL.len(), RESERVED_EXPORTS.len());
+        for (index, id) in ReservedExportId::ALL.iter().copied().enumerate() {
+            assert_eq!(id as usize, index);
+            assert_eq!(id.export().id, id);
+            assert_eq!(ReservedExportId::from_symbol(id.symbol()), Some(id));
+            assert!(RuntimeHelperId::from_symbol(id.symbol()).is_none());
+            assert_eq!(
+                classify_export(id.symbol()),
+                Some(RuntimeExport::Reserved(id))
+            );
+        }
+        assert!(
+            ReservedExportId::LinuxStart
+                .export()
+                .availability
+                .contains(RuntimeTarget::X86_64Linux)
+        );
+        assert!(
+            !ReservedExportId::LinuxStart
+                .export()
+                .availability
+                .contains(RuntimeTarget::Aarch64Macos)
+        );
+        assert!(
+            ReservedExportId::MacosMain
+                .export()
+                .availability
+                .contains(RuntimeTarget::Aarch64Macos)
+        );
+        assert!(
+            !ReservedExportId::RtSigreturn
+                .export()
+                .availability
+                .contains(RuntimeTarget::Aarch64Linux)
+        );
+    }
+
+    #[test]
+    fn abi_version_metadata_is_a_one_byte_data_export() {
+        assert_eq!(RUNTIME_ABI_VERSION, 1);
+        assert_eq!(
+            RUNTIME_ABI_VERSION_SYMBOL,
+            format!("__rue_runtime_abi_v{RUNTIME_ABI_VERSION}")
+        );
+        assert_eq!(
+            ReservedExportId::RuntimeAbiVersion.export().kind,
+            ReservedExportKind::ReadOnlyData { size: 1 }
+        );
+    }
+}

--- a/rust-project.json
+++ b/rust-project.json
@@ -27,19 +27,19 @@
           "name": "rue_rir"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_target"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lasso"
         },
         {
-          "crate": 88,
+          "crate": 89,
           "name": "rayon"
         }
       ],
@@ -90,11 +90,11 @@
           "name": "rue_error"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lasso"
         }
       ],
@@ -118,23 +118,23 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_test_runner"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "tempfile"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "toml"
         }
       ],
@@ -174,19 +174,19 @@
           "name": "rue_error"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_target"
         },
         {
-          "crate": 49,
+          "crate": 50,
           "name": "fixedbitset"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lasso"
         }
       ],
@@ -218,12 +218,16 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "serde_json"
+        },
+        {
+          "crate": 99,
+          "name": "sha2"
         }
       ],
       "is_workspace_member": true,
@@ -282,39 +286,39 @@
           "name": "rue_rir"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_target"
         },
         {
-          "crate": 30,
+          "crate": 31,
           "name": "annotate_snippets"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lasso"
         },
         {
-          "crate": 88,
+          "crate": 89,
           "name": "rayon"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "serde_json"
         },
         {
-          "crate": 98,
+          "crate": 99,
           "name": "sha2"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tracing"
         }
       ],
@@ -338,11 +342,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 103,
+          "crate": 104,
           "name": "thiserror"
         }
       ],
@@ -382,15 +386,15 @@
           "name": "rue_parser"
         },
         {
-          "crate": 33,
+          "crate": 34,
           "name": "anyhow"
         },
         {
-          "crate": 63,
+          "crate": 64,
           "name": "libc"
         },
         {
-          "crate": 81,
+          "crate": 82,
           "name": "proptest"
         }
       ],
@@ -418,15 +422,15 @@
           "name": "rue_error"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lasso"
         },
         {
-          "crate": 70,
+          "crate": 71,
           "name": "logos"
         }
       ],
@@ -450,11 +454,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_target"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tracing"
         }
       ],
@@ -490,19 +494,19 @@
           "name": "rue_oracle"
         },
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_test_runner"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "tempfile"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "toml"
         }
       ],
@@ -538,7 +542,7 @@
           "name": "rue_compiler"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lasso"
         }
       ],
@@ -570,15 +574,15 @@
           "name": "rue_parser"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lasso"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "serde_json"
         }
       ],
@@ -610,19 +614,19 @@
           "name": "rue_lexer"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lasso"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "smallvec"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tracing"
         }
       ],
@@ -654,11 +658,11 @@
           "name": "rue_parser"
         },
         {
-          "crate": 17,
+          "crate": 18,
           "name": "rue_span"
         },
         {
-          "crate": 58,
+          "crate": 59,
           "name": "lasso"
         }
       ],
@@ -666,6 +670,25 @@
       "source": {
         "include_dirs": [
           "crates/rue-rir/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [
+        "test",
+        "debug_assertions"
+      ],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-runtime-abi",
+      "root_module": "crates/rue-runtime-abi/src/lib.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-runtime-abi/src"
         ],
         "exclude_dirs": []
       },
@@ -720,20 +743,16 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_test_runner"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "libtest2_mimic"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "tempfile"
-        },
-        {
-          "crate": 105,
-          "name": "toml"
         }
       ],
       "is_workspace_member": true,
@@ -779,23 +798,23 @@
           "name": "rue_error"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_target"
         },
         {
-          "crate": 63,
+          "crate": 64,
           "name": "libc"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "tempfile"
         },
         {
-          "crate": 105,
+          "crate": 106,
           "name": "toml"
         }
       ],
@@ -819,11 +838,11 @@
       "edition": "2024",
       "deps": [
         {
-          "crate": 20,
+          "crate": 21,
           "name": "rue_test_runner"
         },
         {
-          "crate": 67,
+          "crate": 68,
           "name": "libtest2_mimic"
         }
       ],
@@ -855,27 +874,31 @@
           "name": "rue_rir"
         },
         {
-          "crate": 19,
+          "crate": 20,
           "name": "rue_target"
         },
         {
-          "crate": 63,
+          "crate": 64,
           "name": "libc"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "serde_json"
         },
         {
-          "crate": 109,
+          "crate": 99,
+          "name": "sha2"
+        },
+        {
+          "crate": 110,
           "name": "tracing"
         },
         {
-          "crate": 113,
+          "crate": 114,
           "name": "tracing_subscriber"
         }
       ],
@@ -899,7 +922,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 71,
+          "crate": 72,
           "name": "logos_codegen"
         }
       ],
@@ -923,15 +946,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 80,
+          "crate": 81,
           "name": "proc_macro2"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "quote"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "syn"
         }
       ],
@@ -956,15 +979,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 80,
+          "crate": 81,
           "name": "proc_macro2"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "quote"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "syn"
         }
       ],
@@ -988,15 +1011,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 80,
+          "crate": 81,
           "name": "proc_macro2"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "quote"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "syn"
         }
       ],
@@ -1020,15 +1043,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 39,
+          "crate": 40,
           "name": "cfg_if"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "once_cell"
         },
         {
-          "crate": 120,
+          "crate": 121,
           "name": "zerocopy"
         }
       ],
@@ -1052,7 +1075,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 73,
+          "crate": 74,
           "name": "memchr"
         }
       ],
@@ -1098,11 +1121,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 32,
+          "crate": 33,
           "name": "anstyle"
         },
         {
-          "crate": 117,
+          "crate": 118,
           "name": "unicode_width"
         }
       ],
@@ -1211,7 +1234,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 36,
+          "crate": 37,
           "name": "bit_vec"
         }
       ],
@@ -1279,7 +1302,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 51,
+          "crate": 52,
           "name": "generic_array"
         }
       ],
@@ -1341,11 +1364,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 42,
+          "crate": 43,
           "name": "crossbeam_epoch"
         },
         {
-          "crate": 43,
+          "crate": 44,
           "name": "crossbeam_utils"
         }
       ],
@@ -1371,7 +1394,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 43,
+          "crate": 44,
           "name": "crossbeam_utils"
         }
       ],
@@ -1418,11 +1441,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 51,
+          "crate": 52,
           "name": "generic_array"
         },
         {
-          "crate": 114,
+          "crate": 115,
           "name": "typenum"
         }
       ],
@@ -1446,27 +1469,27 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 39,
+          "crate": 40,
           "name": "cfg_if"
         },
         {
-          "crate": 43,
+          "crate": 44,
           "name": "crossbeam_utils"
         },
         {
-          "crate": 53,
+          "crate": 54,
           "name": "hashbrown"
         },
         {
-          "crate": 68,
+          "crate": 69,
           "name": "lock_api"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "once_cell"
         },
         {
-          "crate": 77,
+          "crate": 78,
           "name": "parking_lot_core"
         }
       ],
@@ -1491,11 +1514,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 38,
+          "crate": 39,
           "name": "block_buffer"
         },
         {
-          "crate": 44,
+          "crate": 45,
           "name": "crypto_common"
         }
       ],
@@ -1602,7 +1625,7 @@
       "edition": "2015",
       "deps": [
         {
-          "crate": 114,
+          "crate": 115,
           "name": "typenum"
         }
       ],
@@ -1647,11 +1670,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 27,
+          "crate": 28,
           "name": "ahash"
         },
         {
-          "crate": 29,
+          "crate": 30,
           "name": "allocator_api2"
         }
       ],
@@ -1699,11 +1722,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 48,
+          "crate": 49,
           "name": "equivalent"
         },
         {
-          "crate": 54,
+          "crate": 55,
           "name": "hashbrown"
         }
       ],
@@ -1770,11 +1793,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 45,
+          "crate": 46,
           "name": "dashmap"
         },
         {
-          "crate": 53,
+          "crate": 54,
           "name": "hashbrown"
         }
       ],
@@ -1820,11 +1843,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 61,
+          "crate": 62,
           "name": "lexarg_error"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "lexarg_parser"
         }
       ],
@@ -1849,7 +1872,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 62,
+          "crate": 63,
           "name": "lexarg_parser"
         }
       ],
@@ -1915,7 +1938,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 57,
+          "crate": 58,
           "name": "json_write"
         }
       ],
@@ -1941,11 +1964,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 60,
+          "crate": 61,
           "name": "lexarg"
         },
         {
-          "crate": 61,
+          "crate": 62,
           "name": "lexarg_error"
         }
       ],
@@ -1970,27 +1993,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 31,
+          "crate": 32,
           "name": "anstream"
         },
         {
-          "crate": 32,
+          "crate": 33,
           "name": "anstyle"
         },
         {
-          "crate": 61,
+          "crate": 62,
           "name": "lexarg_error"
         },
         {
-          "crate": 62,
+          "crate": 63,
           "name": "lexarg_parser"
         },
         {
-          "crate": 64,
+          "crate": 65,
           "name": "libtest_json"
         },
         {
-          "crate": 65,
+          "crate": 66,
           "name": "libtest_lexarg"
         }
       ],
@@ -2017,11 +2040,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 64,
+          "crate": 65,
           "name": "libtest_json"
         },
         {
-          "crate": 66,
+          "crate": 67,
           "name": "libtest2_harness"
         }
       ],
@@ -2048,7 +2071,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 93,
+          "crate": 94,
           "name": "scopeguard"
         }
       ],
@@ -2094,7 +2117,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 23,
+          "crate": 24,
           "name": "logos_derive"
         }
       ],
@@ -2122,31 +2145,31 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 34,
+          "crate": 35,
           "name": "beef"
         },
         {
-          "crate": 50,
+          "crate": 51,
           "name": "fnv"
         },
         {
-          "crate": 59,
+          "crate": 60,
           "name": "lazy_static"
         },
         {
-          "crate": 80,
+          "crate": 81,
           "name": "proc_macro2"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "quote"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "regex_syntax"
         },
         {
-          "crate": 101,
+          "crate": 102,
           "name": "syn"
         }
       ],
@@ -2170,7 +2193,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 90,
+          "crate": 91,
           "name": "regex_automata"
         }
       ],
@@ -2317,7 +2340,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 120,
+          "crate": 121,
           "name": "zerocopy"
         }
       ],
@@ -2343,7 +2366,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 116,
+          "crate": 117,
           "name": "unicode_ident"
         }
       ],
@@ -2369,47 +2392,47 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 35,
+          "crate": 36,
           "name": "bit_set"
         },
         {
-          "crate": 36,
+          "crate": 37,
           "name": "bit_vec"
         },
         {
-          "crate": 37,
+          "crate": 38,
           "name": "bitflags"
         },
         {
-          "crate": 75,
+          "crate": 76,
           "name": "num_traits"
         },
         {
-          "crate": 84,
+          "crate": 85,
           "name": "rand"
         },
         {
-          "crate": 85,
+          "crate": 86,
           "name": "rand_chacha"
         },
         {
-          "crate": 87,
+          "crate": 88,
           "name": "rand_xorshift"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "regex_syntax"
         },
         {
-          "crate": 92,
+          "crate": 93,
           "name": "rusty_fork"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "tempfile"
         },
         {
-          "crate": 115,
+          "crate": 116,
           "name": "unarray"
         }
       ],
@@ -2460,7 +2483,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 80,
+          "crate": 81,
           "name": "proc_macro2"
         }
       ],
@@ -2486,7 +2509,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 86,
+          "crate": 87,
           "name": "rand_core"
         }
       ],
@@ -2513,11 +2536,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 79,
+          "crate": 80,
           "name": "ppv_lite86"
         },
         {
-          "crate": 86,
+          "crate": 87,
           "name": "rand_core"
         }
       ],
@@ -2542,7 +2565,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 52,
+          "crate": 53,
           "name": "getrandom"
         }
       ],
@@ -2568,7 +2591,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 86,
+          "crate": 87,
           "name": "rand_core"
         }
       ],
@@ -2592,11 +2615,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 47,
+          "crate": 48,
           "name": "either"
         },
         {
-          "crate": 89,
+          "crate": 90,
           "name": "rayon_core"
         }
       ],
@@ -2620,11 +2643,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 41,
+          "crate": 42,
           "name": "crossbeam_deque"
         },
         {
-          "crate": 43,
+          "crate": 44,
           "name": "crossbeam_utils"
         }
       ],
@@ -2648,15 +2671,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 28,
+          "crate": 29,
           "name": "aho_corasick"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "memchr"
         },
         {
-          "crate": 91,
+          "crate": 92,
           "name": "regex_syntax"
         }
       ],
@@ -2733,19 +2756,19 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 50,
+          "crate": 51,
           "name": "fnv"
         },
         {
-          "crate": 82,
+          "crate": 83,
           "name": "quick_error"
         },
         {
-          "crate": 102,
+          "crate": 103,
           "name": "tempfile"
         },
         {
-          "crate": 118,
+          "crate": 119,
           "name": "wait_timeout"
         }
       ],
@@ -2790,11 +2813,11 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 24,
+          "crate": 25,
           "name": "serde_derive"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "serde_core"
         }
       ],
@@ -2843,19 +2866,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 56,
+          "crate": 57,
           "name": "itoa"
         },
         {
-          "crate": 73,
+          "crate": 74,
           "name": "memchr"
         },
         {
-          "crate": 95,
+          "crate": 96,
           "name": "serde_core"
         },
         {
-          "crate": 121,
+          "crate": 122,
           "name": "zmij"
         }
       ],
@@ -2881,7 +2904,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         }
       ],
@@ -2906,15 +2929,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 39,
+          "crate": 40,
           "name": "cfg_if"
         },
         {
-          "crate": 40,
+          "crate": 41,
           "name": "cpufeatures"
         },
         {
-          "crate": 46,
+          "crate": 47,
           "name": "digest"
         }
       ],
@@ -2938,7 +2961,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 59,
+          "crate": 60,
           "name": "lazy_static"
         }
       ],
@@ -2981,15 +3004,15 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 80,
+          "crate": 81,
           "name": "proc_macro2"
         },
         {
-          "crate": 83,
+          "crate": 84,
           "name": "quote"
         },
         {
-          "crate": 116,
+          "crate": 117,
           "name": "unicode_ident"
         }
       ],
@@ -3043,7 +3066,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 25,
+          "crate": 26,
           "name": "thiserror_impl"
         }
       ],
@@ -3069,7 +3092,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 39,
+          "crate": 40,
           "name": "cfg_if"
         }
       ],
@@ -3093,19 +3116,19 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         },
         {
-          "crate": 97,
+          "crate": 98,
           "name": "serde_spanned"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "toml_datetime"
         },
         {
-          "crate": 107,
+          "crate": 108,
           "name": "toml_edit"
         }
       ],
@@ -3132,7 +3155,7 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         }
       ],
@@ -3157,27 +3180,27 @@
       "edition": "2021",
       "deps": [
         {
-          "crate": 55,
+          "crate": 56,
           "name": "indexmap"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         },
         {
-          "crate": 97,
+          "crate": 98,
           "name": "serde_spanned"
         },
         {
-          "crate": 106,
+          "crate": 107,
           "name": "toml_datetime"
         },
         {
-          "crate": 108,
+          "crate": 109,
           "name": "toml_write"
         },
         {
-          "crate": 119,
+          "crate": 120,
           "name": "winnow"
         }
       ],
@@ -3226,15 +3249,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 26,
+          "crate": 27,
           "name": "tracing_attributes"
         },
         {
-          "crate": 78,
+          "crate": 79,
           "name": "pin_project_lite"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tracing_core"
         }
       ],
@@ -3262,7 +3285,7 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 76,
+          "crate": 77,
           "name": "once_cell"
         }
       ],
@@ -3289,15 +3312,15 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 69,
+          "crate": 70,
           "name": "log"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "once_cell"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tracing_core"
         }
       ],
@@ -3323,11 +3346,11 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tracing_core"
         }
       ],
@@ -3351,55 +3374,55 @@
       "edition": "2018",
       "deps": [
         {
-          "crate": 72,
+          "crate": 73,
           "name": "matchers"
         },
         {
-          "crate": 74,
+          "crate": 75,
           "name": "nu_ansi_term"
         },
         {
-          "crate": 76,
+          "crate": 77,
           "name": "once_cell"
         },
         {
-          "crate": 90,
+          "crate": 91,
           "name": "regex_automata"
         },
         {
-          "crate": 94,
+          "crate": 95,
           "name": "serde"
         },
         {
-          "crate": 96,
+          "crate": 97,
           "name": "serde_json"
         },
         {
-          "crate": 99,
+          "crate": 100,
           "name": "sharded_slab"
         },
         {
-          "crate": 100,
+          "crate": 101,
           "name": "smallvec"
         },
         {
-          "crate": 104,
+          "crate": 105,
           "name": "thread_local"
         },
         {
-          "crate": 109,
+          "crate": 110,
           "name": "tracing"
         },
         {
-          "crate": 110,
+          "crate": 111,
           "name": "tracing_core"
         },
         {
-          "crate": 111,
+          "crate": 112,
           "name": "tracing_log"
         },
         {
-          "crate": 112,
+          "crate": 113,
           "name": "tracing_serde"
         }
       ],


### PR DESCRIPTION
## Summary

- add the zero-dependency, no-std `rue-runtime-abi` leaf crate
- define all 35 runtime helper IDs and exact typed ABI signatures
- define aggregate out-pointer shapes, safety contracts, target availability, calling convention, and return behavior
- classify non-helper entry points, memory routines, platform shims, and ABI-version metadata separately
- validate manifest ordering, uniqueness, collisions, shapes, and version coherence at compile time
- add a representative test-only builtin consumer without beginning downstream migrations

## Why

ADR-0055 requires one machine-checkable compiler/runtime contract before builtins, sema, codegen, and runtime exports migrate. This slice establishes that dependency-light source of truth while preserving every current ABI.

## Validation

- `scripts/rue fmt`
- focused manifest and builtins tests — 18/18
- `scripts/rue quick` — 28 targets
- `git diff --check`
- adversarial review approved all signatures and ownership boundaries

Fixes RUE-828
