### PR TITLE
RUE-919: strip exactly one Mach-O leading underscore so symbol names round-trip

### DIFF
--- a/crates/rue-cli-tests/cases/underscore_symbol_names.toml
+++ b/crates/rue-cli-tests/cases/underscore_symbol_names.toml
@@ -1,0 +1,65 @@
+# Leading underscores are significant in symbol names (RUE-919).
+#
+# The internal linker's Mach-O emission prepends exactly one leading underscore
+# to every symbol, and parsing must strip exactly one to round-trip. A previous
+# off-by-one "preserve double underscore" strip collapsed `_foo` and `__foo`
+# onto the same `__foo` symbol, so a program defining both failed to link with
+# `duplicate symbol: __foo`. Fixing the strip also shortened the runtime entry
+# symbol (`_main` on disk `__main` -> `_main`), so the linker's entry-point
+# lookup was taught to strip in lockstep.
+#
+# The spec token grammar allows any number of leading underscores in an
+# identifier (subject only to the reserved `__rue_*` / `_start` set), so `_foo`,
+# `__foo`, and `___foo` are three distinct functions that must link and run.
+
+[section]
+id = "cli.underscore_symbol_names"
+name = "Leading-underscore symbol names stay distinct"
+description = "Functions differing only in leading-underscore count link as distinct symbols and run correctly."
+
+# The core RUE-919 repro: `_foo` and `__foo` are distinct identifiers. Before the
+# fix this failed with `duplicate symbol: __foo`; now it links and prints both.
+[[case]]
+name = "single_and_double_underscore_distinct"
+files = [{ path = "main.rue", source = """
+fn _foo() -> i32 { 111 }
+fn __foo() -> i32 { 222 }
+fn main() -> i32 {
+    @dbg(_foo());
+    @dbg(__foo());
+    0
+}
+""" }]
+stdout = "111\n222\n"
+
+# Boundary coverage across the underscore count: bare, one, two, and three
+# leading underscores are four distinct functions.
+[[case]]
+name = "underscore_count_boundary_distinct"
+files = [{ path = "main.rue", source = """
+fn foo() -> i32 { 1 }
+fn _foo() -> i32 { 2 }
+fn __foo() -> i32 { 3 }
+fn ___foo() -> i32 { 4 }
+fn main() -> i32 {
+    @dbg(foo());
+    @dbg(_foo());
+    @dbg(__foo());
+    @dbg(___foo());
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n"
+
+# A double-underscore function returning its value as the exit code exercises the
+# entry-point path alongside a user-defined `__`-prefixed symbol: main must still
+# resolve even though the corrected strip shortened the runtime entry symbol.
+[[case]]
+name = "double_underscore_drives_exit_code"
+files = [{ path = "main.rue", source = """
+fn __answer() -> i32 { 42 }
+fn main() -> i32 {
+    __answer()
+}
+""" }]
+exit_code = 42

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -620,18 +620,17 @@ impl ObjectFile {
                     String::new()
                 };
 
-                // Strip leading underscore from Mach-O symbols (but preserve double underscores)
-                // On macOS, all symbols get ONE leading underscore added, so:
-                // - "main" becomes "_main" -> strip to "main"
-                // - "__main" becomes "___main" -> strip ONE to "__main"
-                // - ".rodata.str0" becomes "_.rodata.str0" -> strip to ".rodata.str0"
-                // We need to strip exactly one leading underscore to match what relocations expect
-                if name.starts_with('_') && !name.starts_with("__") {
-                    name = name[1..].to_string();
-                } else if name.starts_with("___") {
-                    // Triple underscore: original had __, so strip one to get back to __
-                    name = name[1..].to_string();
-                }
+                // Undo the single leading underscore that Mach-O emission adds to
+                // every symbol. Emission prepends EXACTLY ONE `_` regardless of the
+                // original name, so the exact inverse strips EXACTLY ONE. This
+                // round-trips for any number of leading underscores (RUE-919):
+                // - "main"          -> emitted "_main"          -> "main"
+                // - "_foo"          -> emitted "__foo"          -> "_foo"
+                // - "__foo"         -> emitted "___foo"         -> "__foo"
+                // - ".rodata.str0"  -> emitted "_.rodata.str0"  -> ".rodata.str0"
+                // The previous "preserve double underscore" logic was off by one and
+                // collapsed "_foo" and "__foo" onto the same "__foo" symbol.
+                name = crate::util::strip_macho_underscore(&name).to_string();
 
                 // Determine binding (external or local)
                 // N_PEXT (0x10) makes a symbol private even if N_EXT is set
@@ -1380,6 +1379,57 @@ mod tests {
         // The function should be defined in a section
         let sym = func_sym.unwrap();
         assert!(sym.section_index.is_some());
+    }
+
+    /// Mach-O emit -> parse must round-trip the function symbol name for any
+    /// number of leading underscores. The emitter prepends exactly one `_` and
+    /// the parser strips exactly one, so distinct identifiers such as `_foo` and
+    /// `__foo` stay distinct rather than collapsing (RUE-919).
+    #[test]
+    fn test_macho_symbol_name_round_trip() {
+        use crate::emit::ObjectBuilder;
+        use rue_target::Target;
+
+        for name in ["foo", "_foo", "__foo", "___foo"] {
+            let obj_bytes = ObjectBuilder::new(Target::Aarch64Macos, name)
+                .code(vec![0xC0, 0x03, 0x5F, 0xD6]) // ret
+                .build();
+            let obj = ObjectFile::parse(&obj_bytes)
+                .unwrap_or_else(|e| panic!("should parse Mach-O for {name:?}: {e:?}"));
+            let found = obj.symbols.iter().find(|s| s.name == name);
+            assert!(
+                found.is_some(),
+                "Mach-O round-trip lost symbol {name:?}; symbols = {:?}",
+                obj.symbols.iter().map(|s| &s.name).collect::<Vec<_>>(),
+            );
+        }
+    }
+
+    /// ELF emit -> parse must NOT add or strip underscores: names pass through
+    /// verbatim on both supported ELF targets. This guards the underscore-count
+    /// boundary on the ELF path so the Mach-O-only strip never leaks into it
+    /// (RUE-919).
+    #[test]
+    fn test_elf_symbol_name_round_trip() {
+        use crate::emit::ObjectBuilder;
+        use rue_target::Target;
+
+        for target in [Target::X86_64Linux, Target::Aarch64Linux] {
+            for name in ["foo", "_foo", "__foo", "___foo"] {
+                let obj_bytes = ObjectBuilder::new(target, name)
+                    .code(vec![0xC3]) // x86 ret (payload is irrelevant to symbol names)
+                    .build();
+                let obj = ObjectFile::parse(&obj_bytes).unwrap_or_else(|e| {
+                    panic!("should parse ELF for {name:?} ({target:?}): {e:?}")
+                });
+                let found = obj.symbols.iter().find(|s| s.name == name);
+                assert!(
+                    found.is_some(),
+                    "ELF round-trip lost symbol {name:?} ({target:?}); symbols = {:?}",
+                    obj.symbols.iter().map(|s| &s.name).collect::<Vec<_>>(),
+                );
+            }
+        }
     }
 
     // ---------------------------------------------------------------------

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -625,7 +625,7 @@ impl ObjectBuilder {
         // On macOS, all external C symbols get a leading underscore prefix.
         // This applies to ALL symbols, regardless of their original name.
         // e.g., "main" -> "_main", "__rue_exit" -> "___rue_exit"
-        let macho_name = format!("_{}", self.name);
+        let macho_name = crate::util::add_macho_underscore(&self.name);
 
         // Build string table
         // Format: starts with null byte (index 0 = empty string), then null-terminated strings
@@ -669,7 +669,7 @@ impl ObjectBuilder {
                 continue;
             }
             // Always add underscore prefix for macOS
-            let macho_sym = format!("_{}", reloc.symbol);
+            let macho_sym = crate::util::add_macho_underscore(&reloc.symbol);
             if !extern_symbols.contains(&macho_sym) {
                 extern_name_offsets.push(strtab.len());
                 strtab.extend_from_slice(macho_sym.as_bytes());
@@ -882,7 +882,7 @@ impl ObjectBuilder {
                     (0_u32, true)
                 } else {
                     // Undefined external symbol
-                    let macho_sym = format!("_{}", reloc.symbol);
+                    let macho_sym = crate::util::add_macho_underscore(&reloc.symbol);
                     let sym_idx = extern_symbols.iter().position(|s| s == &macho_sym).unwrap();
                     // Undefined externals start after function and non-empty string symbols
                     (1 + num_string_syms as u32 + sym_idx as u32, true)

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -1117,10 +1117,22 @@ impl Linker {
         }
 
         // Find entry point (always a global symbol).
-        // On macOS, symbols have underscore prefix, so try both with and without.
+        //
+        // The global symbol table is keyed by source-level names: parsing strips
+        // the single leading underscore that Mach-O adds to every symbol (see
+        // `strip_macho_underscore`). The caller passes the entry point by its
+        // on-disk Mach-O name (e.g. the runtime's `_main` is requested here as
+        // its emitted `__main`), so strip it the same way before looking it up.
+        // We still try the raw and one-more-prefixed forms so an already
+        // source-level entry name, or a differently-prefixed one, resolves too.
+        // Getting the strip right made `_foo`/`__foo` distinct but also shortened
+        // the runtime entry to `_main`, so this lookup must strip in lockstep
+        // (RUE-919).
+        let stripped_entry = crate::util::strip_macho_underscore(entry_point);
         let entry_vaddr = symbol_addresses
             .globals
             .get(entry_point)
+            .or_else(|| symbol_addresses.globals.get(stripped_entry))
             .or_else(|| symbol_addresses.globals.get(&format!("_{}", entry_point)))
             .copied()
             .ok_or_else(|| LinkError::UndefinedSymbol(entry_point.to_string()))?;

--- a/crates/rue-linker/src/util.rs
+++ b/crates/rue-linker/src/util.rs
@@ -7,6 +7,31 @@ pub(crate) fn align_up(value: u64, align: u64) -> u64 {
     (value + align - 1) & !(align - 1)
 }
 
+/// Prepend the single leading underscore that Mach-O uses for every symbol.
+///
+/// Mach-O emission adds EXACTLY ONE `_` to every symbol name, uniformly, with
+/// no special-casing for names that already start with underscores. Keeping
+/// this in one function guarantees the emit side and [`strip_macho_underscore`]
+/// stay exact inverses (RUE-919):
+/// - `"main"`  -> `"_main"`
+/// - `"_foo"`  -> `"__foo"`
+/// - `"__foo"` -> `"___foo"`
+pub(crate) fn add_macho_underscore(name: &str) -> String {
+    format!("_{name}")
+}
+
+/// Inverse of [`add_macho_underscore`]: strip the single leading underscore that
+/// Mach-O emission prepended.
+///
+/// Because emission adds EXACTLY ONE underscore, the exact inverse removes
+/// EXACTLY ONE, which round-trips for any number of leading underscores. This is
+/// what lets `_foo` and `__foo` remain distinct symbols instead of both
+/// collapsing onto `__foo` (RUE-919). A name with no leading underscore is
+/// returned unchanged.
+pub(crate) fn strip_macho_underscore(name: &str) -> &str {
+    name.strip_prefix('_').unwrap_or(name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -21,5 +46,53 @@ mod tests {
         assert_eq!(align_up(7, 8), 8);
         assert_eq!(align_up(8, 8), 8);
         assert_eq!(align_up(9, 8), 16);
+    }
+
+    /// Mach-O add/strip must be exact inverses for any number of leading
+    /// underscores, so distinct source identifiers stay distinct symbols
+    /// (RUE-919). The old strip was off by one and collapsed `_foo`/`__foo`.
+    #[test]
+    fn test_macho_underscore_round_trip() {
+        for name in [
+            "foo",
+            "_foo",
+            "__foo",
+            "___foo",
+            "main",
+            ".rodata.str0",
+            "____many",
+        ] {
+            let emitted = add_macho_underscore(name);
+            assert_eq!(emitted, format!("_{name}"), "emission adds exactly one _");
+            assert_eq!(
+                strip_macho_underscore(&emitted),
+                name,
+                "strip must recover the original name for {name:?}",
+            );
+        }
+    }
+
+    /// The key regression: `_foo` and `__foo` are distinct identifiers and must
+    /// survive the emit/strip round-trip as distinct symbols.
+    #[test]
+    fn test_macho_underscore_keeps_distinct_symbols() {
+        let a = add_macho_underscore("_foo");
+        let b = add_macho_underscore("__foo");
+        assert_ne!(a, b, "distinct names emit to distinct symbols");
+        assert_ne!(
+            strip_macho_underscore(&a),
+            strip_macho_underscore(&b),
+            "distinct names must not collapse on strip",
+        );
+        assert_eq!(strip_macho_underscore(&a), "_foo");
+        assert_eq!(strip_macho_underscore(&b), "__foo");
+    }
+
+    /// A name without a leading underscore is returned unchanged (e.g. a
+    /// synthetic symbol that did not pass through Mach-O emission).
+    #[test]
+    fn test_strip_macho_underscore_no_prefix() {
+        assert_eq!(strip_macho_underscore("foo"), "foo");
+        assert_eq!(strip_macho_underscore(""), "");
     }
 }

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3763 rejected=149 lex_invalid=35 accepted_source_ast_sha256=dfb084587669aac404f631e4b79e75bc5f6d695c661a18d0818035c043c34a10
+# pre-RUE-905 Chumsky: accepted=3766 rejected=149 lex_invalid=35 accepted_source_ast_sha256=db305dfef9d5f90d76ec32d0231c2f8c7d8ec3f3cd27bc262ceb890f5ebb8c55
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca


### PR DESCRIPTION
Mach-O emission prepends exactly one underscore to every symbol, but `parse_macho` stripped conditionally (skipping names already starting with `__`), collapsing distinct identifiers: `_foo` and `__foo` both normalized to `__foo`, so a program defining both failed with a spurious `duplicate symbol: __foo` link error.

This centralizes the convention in `util::add_macho_underscore` / `util::strip_macho_underscore` as exact inverses and rewires emission, parsing, and the `link_macho` entry-point lookup — the lookup must strip in lockstep, since the exact-inverse strip means the runtime entry now parses back to `_main` while the compiler still requests `__main`.

Verification:
- The `_foo`/`__foo` repro links and prints 111/222 (was a hard link failure); plain-`main` control unaffected.
- New round-trip unit tests over `foo`/`_foo`/`__foo`/`___foo` for Mach-O and both ELF targets.
- New CLI integration cases (`underscore_symbol_names.toml`) exercising the real binary.
- Full local suite green.

Fixes RUE-919