### PR TITLE
RUE-920: spec carve-out for program-wide main uniqueness

### DIFF
--- a/.agents/skills/integrate-worker/SKILL.md
+++ b/.agents/skills/integrate-worker/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: integrate-worker
+description: Integrate a worker agent's diff onto fresh trunk — apply, verify repros by hand, cross-check interacting mechanisms, full suite, ship + queue. Use after any worktree worker (fix cycle, hunt follow-up) returns a diff file.
+---
+
+# Integrating a worker diff
+
+Battle-tested protocol from the 2026-06 autonomous runs (~30 PRs integrated).
+Each step exists because skipping it once caused a real failure.
+
+## Steps
+
+1. **Fresh trunk, always.** `jj git fetch && jj new 'trunk()'` then
+   `git reset --quiet` — the colocated git index goes stale after jj
+   working-copy switches and makes `git apply --3way` fail with
+   "does not match index".
+
+2. **Apply with 3-way fallback.** `git apply --3way /tmp/<worker>.diff`.
+   Conflicts mean the worker's base predates trunk changes — resolve by
+   *intent*, not by side: a worker editing code that trunk deleted usually
+   means the worker's edit is subsumed (keep the deletion); append-append
+   conflicts in test TOML files keep both case sets.
+
+3. **Re-verify the repros yourself.** Build (`bash scripts/rue build`) and run
+   every repro the worker claims to fix, on this checkout, by execution. A
+   worker's "full suite green" was true *in its worktree against its base* —
+   not here. Workers have shipped fixes verified against stale drafts of
+   trunk; only integration-time re-verification catches that.
+
+4. **Write the cross-mechanism test.** If this worker and another (landed or
+   in-flight) built *interacting* mechanisms — e.g. one added per-field drop
+   flags while another added drop-on-overwrite — write a test that exercises
+   the combination NOW. The workers' own suites cannot see the seam; twice in
+   one night, individually-green workers were jointly wrong (double-drops).
+
+5. **Full suite + format.** `./test.sh` must exit 0; `bash scripts/rue fmt`.
+
+6. **Ship + queue.** `jj describe` (subject + why + what was verified),
+   `jj git push -c @`, `gh pr create --repo rue-language/rue --base trunk
+   --head steveklabnik:<bookmark>` with one `Fixes RUE-NN` **per line** (a
+   comma list only closes the first), `gh pr merge <n> --auto`. Use
+   `Part of RUE-NN` when items remain — and remember "Part of" strands the
+   issue In Progress (sweep afterwards per AGENTS.md).
+
+7. **Queue bounces** (DIRTY after a sibling merges): `jj rebase -s <change>
+   -d 'trunk()'`, resolve keeping BOTH PRs' semantics, re-run step 3's repros
+   plus the sibling's, full suite, push the bookmark, re-arm `--auto`.
+   Never force-push a branch that is actively queued without re-arming.
+
+## Lane discipline (when dispatching parallel workers)
+
+Parallelize across **disjoint crates**, never across the same hot file. The
+conflict magnets — `rue-air/src/sema/analysis.rs`, the `rue-error` E-code/preview
+registry, and both `codegen/*/cfg_lower.rs` — should be **serialized** (land one,
+then dispatch the next in that lane). Most integration pain this project has hit
+(stale-base 3-way conflicts, the stabilization `--preview` miss) was two workers
+in the same hot file. A worker's cluster should name its crate-set; two clusters
+in the same hot lane go in consecutive cycles, not the same one.
+
+## Keeping the tree tidy
+
+- Prefer `Fixes RUE-NN` over `Part of` whenever the PR actually closes the issue —
+  `Part of` strands it In Progress and you must sweep it later.
+- After a batch of merges, run **`scripts/jj-tidy`** — it deletes orphaned
+  `worktree-wf_*`/`cycle*` branches, merged `push-*` bookmarks, and abandons
+  dangling changes (safe: git protects checked-out branches; only unbookmarked
+  non-`@` heads are abandoned). Without it, `jj log` fills with dozens of dead
+  heads within a session.
+- For disk pressure, run **`scripts/worktree-gc`** (threshold-gated, only removes
+  worktrees git no longer lists as live) — never blanket `rm -rf .Codex/worktrees`,
+  which races running workers.
+
+## Worker-prompt invariants this protocol assumes
+
+Workers were told: reproduce first, refutations are as valuable as fixes,
+file ownership is by region, output is `git diff <base> HEAD` to an OUTFILE
+plus a `.meta` summary. If integrating a diff produced under weaker rules,
+treat every claim as unverified.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/Users/steveklabnik/Code/rue/.codex/hooks/bookmark-guard.sh'"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'if [ -n \"$CLAUDE_ENV_FILE\" ]; then echo \"source ~/.profile\" >> \"$CLAUDE_ENV_FILE\"; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/bookmark-guard.sh
+++ b/.codex/hooks/bookmark-guard.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse guard on Edit/Write: block edits while the working copy (@) sits
+# on a pushed PR branch. Editing @ then pushing mutates a queued PR — this
+# exact mistake put a blog post into PR #981's branch (2026-06-11) and cost
+# twenty minutes of surgery. Deliberate flows are unaffected: bounce
+# resolution uses `jj new <change>` + `jj squash` (where @ carries no
+# bookmark), and `jj new 'trunk()'` is always the fix this hook suggests.
+#
+# Fail-open by design: any error (no jj, worktree checkout, unparseable
+# input) exits 0 so the hook can never wedge unrelated work.
+set -uo pipefail
+
+input=$(cat) || exit 0
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)" || exit 0
+
+file_path=$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    print(json.load(sys.stdin).get("tool_input", {}).get("file_path", ""))
+except Exception:
+    pass
+' 2>/dev/null) || exit 0
+
+# Only guard files inside the main workspace; agent worktrees use git directly.
+case "$file_path" in
+  "$repo_root"/.claude/worktrees/*) exit 0 ;;
+  "$repo_root"/*) ;;
+  *) exit 0 ;;
+esac
+[ -d "$repo_root/.jj" ] || exit 0
+
+bookmarks=$(cd "$repo_root" && jj log --no-graph -r @ -T 'bookmarks' 2>/dev/null) || exit 0
+if printf '%s' "$bookmarks" | grep -q 'push-'; then
+  echo "BLOCKED by bookmark-guard: the working copy (@) is on pushed PR branch '$bookmarks'. Editing it would mutate a queued PR. Run jj new 'trunk()' (new work) or jj new <change> + jj squash (deliberate amend) first." >&2
+  exit 2
+fi
+exit 0

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3763 rejected=149 lex_invalid=35 accepted_source_ast_sha256=dfb084587669aac404f631e4b79e75bc5f6d695c661a18d0818035c043c34a10
+# pre-RUE-905 Chumsky: accepted=3768 rejected=149 lex_invalid=35 accepted_source_ast_sha256=fe821d46034ba25733d3d832bce2d815f6a319eb417c72ae8a2d774fed04d0a1
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -39,6 +39,35 @@ pub fn go2() -> i32 { LIMIT }
 exit_code = 1
 
 [[case]]
+name = "imported_module_second_main_rejected"
+spec = ["10.5:5"]
+description = "`main` is unique program-wide: an imported module defining its own `main` is rejected with E0436 even though that `main` is never called (exception to 10.5:2)"
+source = """
+const helper = @import("helper");
+fn main() -> i32 { helper.answer() }
+"""
+aux_files = { "helper.rue" = """
+pub fn main() -> i32 { 0 }
+pub fn answer() -> i32 { 42 }
+""" }
+compile_fail = true
+error_contains = "E0436"
+
+[[case]]
+name = "non_main_duplicate_names_across_files_still_ok"
+spec = ["10.5:5"]
+description = "The program-wide `main` rule is specific to `main`: every other top-level name, including a duplicated `shared`, remains module-scoped and compiles"
+source = """
+fn main() -> i32 {
+    let a = @import("a");
+    let b = @import("b");
+    a.shared() + b.shared()
+}
+"""
+aux_files = { "a.rue" = "pub fn shared() -> i32 { 1 }", "b.rue" = "pub fn shared() -> i32 { 2 }" }
+exit_code = 3
+
+[[case]]
 name = "same_file_duplicate_function_error"
 spec = ["10.5:1"]
 description = "Two top-level items with one name in ONE file are a duplicate-definition error; the check is per-file"

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -262,6 +262,10 @@ parameters, and **MUST** return either `i32` or `()`. Thus `main` is never a
 generic function and the runtime can invoke it using the executable entry ABI
 without supplying source-level arguments. When it returns `i32`, that value
 becomes the program's exit code. When it returns `()`, the exit code is 0.
+Because an executable import graph has exactly one entry point, `main` is
+unique across the entire program, not merely within its defining file: a
+second `main` in any loaded module is a compile-time error even when it is
+never called (rule 10.5:5).
 
 Programs can also terminate explicitly through the standard library:
 `std.exit(code)` terminates the process immediately with the provided `u64`

--- a/docs/spec/src/10-modules/05-program-composition.md
+++ b/docs/spec/src/10-modules/05-program-composition.md
@@ -31,14 +31,16 @@ It is a compile-time error for one source file to define two top-level
 items with the same name, whether of the same kind (duplicate definition,
 E0436) or of different kinds (a `const` and a `fn` sharing a name, also
 E0436). This check is per-file: it never considers items in other loaded
-files.
+files. The sole exception is the program entry point `main`, whose
+uniqueness is enforced program-wide (rule 10.5:5).
 
 {{ rule(id="10.5:2", cat="normative") }}
 
 Top-level names are scoped to their defining source file (their module).
 Two loaded files **MAY** define top-level items with the same name — of
 the same kind or of different kinds — regardless of visibility and
-regardless of directory. Each file's items are reachable from other files
+regardless of directory, with the single exception of the entry point
+`main` (rule 10.5:5). Each file's items are reachable from other files
 only through a module binding (`m.item`, rule 10.4:1); an unqualified
 reference to a name defined only in another loaded file is a
 name-resolution error (E0201/E0202/E0204, rule 10.3:8), never a silent
@@ -58,6 +60,40 @@ fn main() -> i32 {
     let a = @import("a");
     let b = @import("b");
     a.shared() + b.shared()    // 3: each call resolves in its own module
+}
+```
+
+## Program-Wide Uniqueness of `main`
+
+{{ rule(id="10.5:5", cat="legality-rule") }}
+
+The program entry point `main` is the one top-level name whose uniqueness
+is enforced across the entire program rather than per-file. It is a
+compile-time error (E0436) for two loaded files to each define a top-level
+`main`, even when only one of them is the root file's `main` and the other
+`main` is never called. This is an exception to rule 10.5:2: every other
+top-level name — including `shared` in the 10.5:3 example — remains
+module-scoped and may be duplicated freely across files. The check is
+performed eagerly at declaration gathering, before body reachability is
+known (rule 10.5:4), so a duplicate `main` in a loaded-but-unreferenced
+module is still reported. The restriction exists because an executable
+import graph has exactly one entry point, invoked through the executable
+entry ABI (rules 6.1:7, 6.1:8); ADR-0047 records the rationale and tracks
+the root-module end state that will eventually localize entry-point
+selection.
+
+{{ rule(id="10.5:6", cat="example") }}
+
+```rue
+// helper.rue
+pub fn main() -> i32 { 0 }        // second entry point
+pub fn answer() -> i32 { 42 }
+
+// main.rue
+const helper = @import("helper.rue");
+
+fn main() -> i32 {                // error E0436: `main` is already defined
+    helper.answer()               // helper.main is never called, but is rejected
 }
 ```
 


### PR DESCRIPTION
The compiler deliberately rejects a second `main` in any loaded module (E0436 at declaration-gathering time, program-wide — landed via RUE-582 per ADR-0047), but the normative spec said the opposite: 10.5:1 scoped the duplicate check strictly per-file and 10.5:2 allowed any top-level name to repeat across loaded files.

This aligns the prose with the decided behavior:

- New legality rule **10.5:5** and example **10.5:6**: `main` is the one top-level name whose uniqueness is program-wide, checked eagerly at declaration gathering, with ADR-0047 cited for rationale.
- 10.5:1 and 10.5:2 now point at the exception; every other name stays per-file/module-scoped.
- Cross-reference added from the 6.1 entry-point rules.
- Two new spec cases citing 10.5:5: an imported module defining an unused `main` is rejected with E0436, and duplicate non-`main` names across files still compile.
- Diagnostic corpus snapshot re-blessed on this tree (additive only: accepted 3763 → 3768, rejected rows unchanged).

Verification: E0436 rejection reproduced by hand on this checkout; composition (11/11) and functions (129/129) spec suites; traceability gate green at 100% normative coverage; quick suite 27/27.

Note: this will need a trivial snapshot re-bless if it lands after #1696 (which also grows the corpus); whichever bounces gets rebased and re-blessed.

Fixes RUE-920