### PR TITLE
RUE-832: enforce runtime ABI conformance

### DIFF
--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -8,11 +8,29 @@
 
 use core::fmt;
 
-/// Current lockstep compiler/runtime ABI version.
-pub const RUNTIME_ABI_VERSION: u32 = 1;
+/// Invoke a callback with the canonical runtime ABI version and marker
+/// identifier.
+///
+/// Both metadata and runtime emission consume this declaration, so an ABI bump
+/// cannot leave behind an independently spelled marker.
+#[macro_export]
+macro_rules! runtime_abi_version {
+    ($callback:ident) => {
+        $callback!(1, __rue_runtime_abi_v1);
+    };
+}
 
-/// Retained data symbol exported by each runtime archive for this ABI version.
-pub const RUNTIME_ABI_VERSION_SYMBOL: &str = "__rue_runtime_abi_v1";
+macro_rules! define_runtime_abi_version {
+    ($version:literal, $marker:ident) => {
+        /// Current lockstep compiler/runtime ABI version.
+        pub const RUNTIME_ABI_VERSION: u32 = $version;
+
+        /// Retained data symbol exported by each runtime archive for this ABI version.
+        pub const RUNTIME_ABI_VERSION_SYMBOL: &str = stringify!($marker);
+    };
+}
+
+runtime_abi_version!(define_runtime_abi_version);
 
 /// A physical scalar type at the C boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -156,6 +174,13 @@ impl SafetyContract {
     pub const fn union(self, other: Self) -> Self {
         Self(self.0 | other.0)
     }
+
+    /// Whether caller-owned pointer validity requires an unsafe Rust boundary.
+    pub const fn requires_unsafe_rust_boundary(self) -> bool {
+        self.contains(Self::READABLE_BYTES)
+            || self.contains(Self::WRITABLE_RESULT)
+            || self.contains(Self::VALID_ALLOCATION)
+    }
 }
 
 /// Named aggregate layouts written through explicit out pointers.
@@ -257,6 +282,48 @@ pub const AGGREGATE_SHAPES: [AggregateShape; 3] = [
     },
 ];
 
+/// The three-word growable-string result written by formatting helpers.
+#[repr(C)]
+pub struct StrBufResult {
+    pub ptr: *mut u8,
+    pub len: u64,
+    pub cap: u64,
+}
+
+/// The tagged growable-string option written by `__rue_read_line`.
+#[repr(C)]
+pub struct OptionStrBufResult {
+    pub disc: u64,
+    pub ptr: *mut u8,
+    pub len: u64,
+    pub cap: u64,
+}
+
+/// The tagged integer option written by the parsing helpers.
+#[repr(C)]
+pub struct OptionIntResult {
+    pub disc: u64,
+    pub value: u64,
+}
+
+const _: () = {
+    assert!(core::mem::size_of::<StrBufResult>() == 24);
+    assert!(core::mem::align_of::<StrBufResult>() == 8);
+    assert!(core::mem::offset_of!(StrBufResult, ptr) == 0);
+    assert!(core::mem::offset_of!(StrBufResult, len) == 8);
+    assert!(core::mem::offset_of!(StrBufResult, cap) == 16);
+    assert!(core::mem::size_of::<OptionStrBufResult>() == 32);
+    assert!(core::mem::align_of::<OptionStrBufResult>() == 8);
+    assert!(core::mem::offset_of!(OptionStrBufResult, disc) == 0);
+    assert!(core::mem::offset_of!(OptionStrBufResult, ptr) == 8);
+    assert!(core::mem::offset_of!(OptionStrBufResult, len) == 16);
+    assert!(core::mem::offset_of!(OptionStrBufResult, cap) == 24);
+    assert!(core::mem::size_of::<OptionIntResult>() == 16);
+    assert!(core::mem::align_of::<OptionIntResult>() == 8);
+    assert!(core::mem::offset_of!(OptionIntResult, disc) == 0);
+    assert!(core::mem::offset_of!(OptionIntResult, value) == 8);
+};
+
 macro_rules! params {
     () => {
         &[]
@@ -300,7 +367,9 @@ const READABLE_WRITABLE_DISCRIMINANTS: SafetyContract =
 macro_rules! runtime_helpers {
     (
         $(
-            $variant:ident => {
+            $variant:ident => $safety_kind:ident $function:ident(
+                $($argument:ident : $rust_type:ty),* $(,)?
+            ) $(-> $rust_result:ty)? {
                 symbol: $symbol:literal,
                 parameters: $parameters:expr,
                 result: $result:expr,
@@ -362,12 +431,28 @@ macro_rules! runtime_helpers {
                 }
             ),+
         ];
+
+        const _: () = {
+            $(
+                assert!(string_eq(stringify!($function), $symbol));
+                assert!(
+                    $safety.requires_unsafe_rust_boundary()
+                        == runtime_helpers!(@is_unsafe $safety_kind)
+                );
+            )+
+        };
     };
     (@count $($variant:ident),+) => {
         <[()]>::len(&[$(runtime_helpers!(@replace $variant ())),+])
     };
     (@replace $_variant:ident $value:expr) => {
         $value
+    };
+    (@is_unsafe safe) => {
+        false
+    };
+    (@is_unsafe unsafe) => {
+        true
     };
 }
 
@@ -384,255 +469,326 @@ pub struct RuntimeHelper {
     pub calling_convention: CallingConvention,
 }
 
-runtime_helpers! {
-    Exit => {
-        symbol: "__rue_exit",
-        parameters: params![I32_VALUE],
-        result: VOID,
-        safety: TERMINATES,
-        returns: NEVER
-    },
-    Alloc => {
-        symbol: "__rue_alloc",
-        parameters: params![U64_VALUE, U64_VALUE],
-        result: MUT_POINTER_RESULT,
-        safety: ALLOC_LAYOUT,
-        returns: RETURNS
-    },
-    Free => {
-        symbol: "__rue_free",
-        parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE],
-        result: VOID,
-        // The current bump allocator's free operation is a no-op and imposes
-        // no pointer or layout precondition.
-        safety: SafetyContract::NONE,
-        returns: RETURNS
-    },
-    Realloc => {
-        symbol: "__rue_realloc",
-        parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE, U64_VALUE],
-        result: MUT_POINTER_RESULT,
-        safety: VALID_ALLOC_LAYOUT,
-        returns: RETURNS
-    },
-    DivByZero => {
-        symbol: "__rue_div_by_zero",
-        parameters: params![],
-        result: VOID,
-        safety: TERMINATES,
-        returns: NEVER
-    },
-    Overflow => {
-        symbol: "__rue_overflow",
-        parameters: params![],
-        result: VOID,
-        safety: TERMINATES,
-        returns: NEVER
-    },
-    IntcastOverflow => {
-        symbol: "__rue_intcast_overflow",
-        parameters: params![],
-        result: VOID,
-        safety: TERMINATES,
-        returns: NEVER
-    },
-    BoundsCheck => {
-        symbol: "__rue_bounds_check",
-        parameters: params![],
-        result: VOID,
-        safety: TERMINATES,
-        returns: NEVER
-    },
-    Panic => {
-        symbol: "__rue_panic",
-        parameters: params![BYTE_VIEW, U64_VALUE],
-        result: VOID,
-        safety: READABLE.union(TERMINATES),
-        returns: NEVER
-    },
-    PanicNoMessage => {
-        symbol: "__rue_panic_no_msg",
-        parameters: params![],
-        result: VOID,
-        safety: TERMINATES,
-        returns: NEVER
-    },
-    AssertFailed => {
-        symbol: "__rue_assert_failed",
-        parameters: params![],
-        result: VOID,
-        safety: TERMINATES,
-        returns: NEVER
-    },
-    DebugI64 => {
-        symbol: "__rue_dbg_i64",
-        parameters: params![I64_VALUE],
-        result: VOID,
-        safety: SafetyContract::NONE,
-        returns: RETURNS
-    },
-    DebugU64 => {
-        symbol: "__rue_dbg_u64",
-        parameters: params![U64_VALUE],
-        result: VOID,
-        safety: SafetyContract::NONE,
-        returns: RETURNS
-    },
-    DebugBool => {
-        symbol: "__rue_dbg_bool",
-        parameters: params![BOOL_WORD_VALUE],
-        result: VOID,
-        safety: SafetyContract::NONE,
-        returns: RETURNS
-    },
-    DebugStr => {
-        symbol: "__rue_dbg_str",
-        parameters: params![BYTE_VIEW, U64_VALUE],
-        result: VOID,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    StrEq => {
-        symbol: "__rue_str_eq",
-        parameters: params![BYTE_VIEW, U64_VALUE, BYTE_VIEW, U64_VALUE],
-        result: U64_RESULT,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    StrByteAt => {
-        symbol: "__rue_str_byte_at",
-        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
-        result: U64_RESULT,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    StrCharScalar => {
-        symbol: "__rue_str_char_scalar",
-        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
-        result: U64_RESULT,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    StrCharNext => {
-        symbol: "__rue_str_char_next",
-        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
-        result: U64_RESULT,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    StrCharScalarLossy => {
-        symbol: "__rue_str_char_scalar_lossy",
-        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
-        result: U64_RESULT,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    StrCharNextLossy => {
-        symbol: "__rue_str_char_next_lossy",
-        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
-        result: U64_RESULT,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    ToString => {
-        symbol: "__rue_to_string",
-        parameters: params![STR_BUF_OUT, I64_VALUE],
-        result: VOID,
-        safety: WRITABLE,
-        returns: RETURNS
-    },
-    ToStringUnsigned => {
-        symbol: "__rue_to_string_unsigned",
-        parameters: params![STR_BUF_OUT, U64_VALUE],
-        result: VOID,
-        safety: WRITABLE,
-        returns: RETURNS
-    },
-    Print => {
-        symbol: "__rue_print",
-        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
-        result: VOID,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    Println => {
-        symbol: "__rue_println",
-        parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
-        result: VOID,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    StrPrint => {
-        symbol: "__rue_str_print",
-        parameters: params![BYTE_VIEW, U64_VALUE],
-        result: VOID,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    StrPrintln => {
-        symbol: "__rue_str_println",
-        parameters: params![BYTE_VIEW, U64_VALUE],
-        result: VOID,
-        safety: READABLE,
-        returns: RETURNS
-    },
-    ReadLine => {
-        symbol: "__rue_read_line",
-        parameters: params![OPTION_STR_BUF_OUT, U64_VALUE, U64_VALUE],
-        result: VOID,
-        safety: WRITABLE_DISCRIMINANTS,
-        returns: RETURNS
-    },
-    ParseI32 => {
-        symbol: "__rue_parse_i32",
-        parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
-        result: VOID,
-        safety: READABLE_WRITABLE_DISCRIMINANTS,
-        returns: RETURNS
-    },
-    ParseI64 => {
-        symbol: "__rue_parse_i64",
-        parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
-        result: VOID,
-        safety: READABLE_WRITABLE_DISCRIMINANTS,
-        returns: RETURNS
-    },
-    ParseU32 => {
-        symbol: "__rue_parse_u32",
-        parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
-        result: VOID,
-        safety: READABLE_WRITABLE_DISCRIMINANTS,
-        returns: RETURNS
-    },
-    ParseU64 => {
-        symbol: "__rue_parse_u64",
-        parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
-        result: VOID,
-        safety: READABLE_WRITABLE_DISCRIMINANTS,
-        returns: RETURNS
-    },
-    RandomU32 => {
-        symbol: "__rue_random_u32",
-        parameters: params![],
-        result: U32_RESULT,
-        safety: SafetyContract::NONE,
-        returns: RETURNS
-    },
-    RandomU64 => {
-        symbol: "__rue_random_u64",
-        parameters: params![],
-        result: U64_RESULT,
-        safety: SafetyContract::NONE,
-        returns: RETURNS
-    },
-    InvalidUtf8 => {
-        symbol: "__rue_invalid_utf8",
-        parameters: params![],
-        result: VOID,
-        safety: TERMINATES,
-        returns: NEVER
-    }
+/// Invoke a callback with the canonical Rust declaration and logical contract
+/// for every compiler-callable runtime helper.
+///
+/// The runtime uses the Rust declarations to generate its exported wrappers,
+/// while this crate uses the same rows to build [`RUNTIME_HELPERS`]. Keeping
+/// both consumers on this macro prevents a peer Rust signature table from
+/// drifting away from the manifest.
+#[macro_export]
+macro_rules! for_each_runtime_helper {
+    ($callback:ident) => {
+        $callback! {
+        Exit => safe __rue_exit(status: i32) -> ! {
+            symbol: "__rue_exit",
+            parameters: params![I32_VALUE],
+            result: VOID,
+            safety: TERMINATES,
+            returns: NEVER
+        },
+        Alloc => safe __rue_alloc(size: u64, align: u64) -> *mut u8 {
+            symbol: "__rue_alloc",
+            parameters: params![U64_VALUE, U64_VALUE],
+            result: MUT_POINTER_RESULT,
+            safety: ALLOC_LAYOUT,
+            returns: RETURNS
+        },
+        Free => safe __rue_free(ptr: *mut u8, size: u64, align: u64) {
+            symbol: "__rue_free",
+            parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE],
+            result: VOID,
+            // The current bump allocator's free operation is a no-op and imposes
+            // no pointer or layout precondition.
+            safety: SafetyContract::NONE,
+            returns: RETURNS
+        },
+        Realloc => unsafe __rue_realloc(
+            ptr: *mut u8,
+            old_size: u64,
+            new_size: u64,
+            align: u64,
+        ) -> *mut u8 {
+            symbol: "__rue_realloc",
+            parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE, U64_VALUE],
+            result: MUT_POINTER_RESULT,
+            safety: VALID_ALLOC_LAYOUT,
+            returns: RETURNS
+        },
+        DivByZero => safe __rue_div_by_zero() -> ! {
+            symbol: "__rue_div_by_zero",
+            parameters: params![],
+            result: VOID,
+            safety: TERMINATES,
+            returns: NEVER
+        },
+        Overflow => safe __rue_overflow() -> ! {
+            symbol: "__rue_overflow",
+            parameters: params![],
+            result: VOID,
+            safety: TERMINATES,
+            returns: NEVER
+        },
+        IntcastOverflow => safe __rue_intcast_overflow() -> ! {
+            symbol: "__rue_intcast_overflow",
+            parameters: params![],
+            result: VOID,
+            safety: TERMINATES,
+            returns: NEVER
+        },
+        BoundsCheck => safe __rue_bounds_check() -> ! {
+            symbol: "__rue_bounds_check",
+            parameters: params![],
+            result: VOID,
+            safety: TERMINATES,
+            returns: NEVER
+        },
+        Panic => unsafe __rue_panic(ptr: *const u8, len: u64) -> ! {
+            symbol: "__rue_panic",
+            parameters: params![BYTE_VIEW, U64_VALUE],
+            result: VOID,
+            safety: READABLE.union(TERMINATES),
+            returns: NEVER
+        },
+        PanicNoMessage => safe __rue_panic_no_msg() -> ! {
+            symbol: "__rue_panic_no_msg",
+            parameters: params![],
+            result: VOID,
+            safety: TERMINATES,
+            returns: NEVER
+        },
+        AssertFailed => safe __rue_assert_failed() -> ! {
+            symbol: "__rue_assert_failed",
+            parameters: params![],
+            result: VOID,
+            safety: TERMINATES,
+            returns: NEVER
+        },
+        DebugI64 => safe __rue_dbg_i64(value: i64) {
+            symbol: "__rue_dbg_i64",
+            parameters: params![I64_VALUE],
+            result: VOID,
+            safety: SafetyContract::NONE,
+            returns: RETURNS
+        },
+        DebugU64 => safe __rue_dbg_u64(value: u64) {
+            symbol: "__rue_dbg_u64",
+            parameters: params![U64_VALUE],
+            result: VOID,
+            safety: SafetyContract::NONE,
+            returns: RETURNS
+        },
+        DebugBool => safe __rue_dbg_bool(value: i64) {
+            symbol: "__rue_dbg_bool",
+            parameters: params![BOOL_WORD_VALUE],
+            result: VOID,
+            safety: SafetyContract::NONE,
+            returns: RETURNS
+        },
+        DebugStr => unsafe __rue_dbg_str(ptr: *const u8, len: u64) {
+            symbol: "__rue_dbg_str",
+            parameters: params![BYTE_VIEW, U64_VALUE],
+            result: VOID,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        StrEq => unsafe __rue_str_eq(
+            ptr1: *const u8,
+            len1: u64,
+            ptr2: *const u8,
+            len2: u64,
+        ) -> u64 {
+            symbol: "__rue_str_eq",
+            parameters: params![BYTE_VIEW, U64_VALUE, BYTE_VIEW, U64_VALUE],
+            result: U64_RESULT,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        StrByteAt => unsafe __rue_str_byte_at(ptr: *const u8, len: u64, index: u64) -> u64 {
+            symbol: "__rue_str_byte_at",
+            parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+            result: U64_RESULT,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        StrCharScalar => unsafe __rue_str_char_scalar(
+            ptr: *const u8,
+            len: u64,
+            byte_offset: u64,
+        ) -> u64 {
+            symbol: "__rue_str_char_scalar",
+            parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+            result: U64_RESULT,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        StrCharNext => unsafe __rue_str_char_next(
+            ptr: *const u8,
+            len: u64,
+            byte_offset: u64,
+        ) -> u64 {
+            symbol: "__rue_str_char_next",
+            parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+            result: U64_RESULT,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        StrCharScalarLossy => unsafe __rue_str_char_scalar_lossy(
+            ptr: *const u8,
+            len: u64,
+            byte_offset: u64,
+        ) -> u64 {
+            symbol: "__rue_str_char_scalar_lossy",
+            parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+            result: U64_RESULT,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        StrCharNextLossy => unsafe __rue_str_char_next_lossy(
+            ptr: *const u8,
+            len: u64,
+            byte_offset: u64,
+        ) -> u64 {
+            symbol: "__rue_str_char_next_lossy",
+            parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+            result: U64_RESULT,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        ToString => unsafe __rue_to_string(out: *mut $crate::StrBufResult, n: i64) {
+            symbol: "__rue_to_string",
+            parameters: params![STR_BUF_OUT, I64_VALUE],
+            result: VOID,
+            safety: WRITABLE,
+            returns: RETURNS
+        },
+        ToStringUnsigned => unsafe __rue_to_string_unsigned(
+            out: *mut $crate::StrBufResult,
+            n: u64,
+        ) {
+            symbol: "__rue_to_string_unsigned",
+            parameters: params![STR_BUF_OUT, U64_VALUE],
+            result: VOID,
+            safety: WRITABLE,
+            returns: RETURNS
+        },
+        Print => unsafe __rue_print(ptr: *const u8, len: u64, cap: u64) {
+            symbol: "__rue_print",
+            parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+            result: VOID,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        Println => unsafe __rue_println(ptr: *const u8, len: u64, cap: u64) {
+            symbol: "__rue_println",
+            parameters: params![BYTE_VIEW, U64_VALUE, U64_VALUE],
+            result: VOID,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        StrPrint => unsafe __rue_str_print(ptr: *const u8, len: u64) {
+            symbol: "__rue_str_print",
+            parameters: params![BYTE_VIEW, U64_VALUE],
+            result: VOID,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        StrPrintln => unsafe __rue_str_println(ptr: *const u8, len: u64) {
+            symbol: "__rue_str_println",
+            parameters: params![BYTE_VIEW, U64_VALUE],
+            result: VOID,
+            safety: READABLE,
+            returns: RETURNS
+        },
+        ReadLine => unsafe __rue_read_line(
+            out: *mut $crate::OptionStrBufResult,
+            some_disc: u64,
+            none_disc: u64,
+        ) {
+            symbol: "__rue_read_line",
+            parameters: params![OPTION_STR_BUF_OUT, U64_VALUE, U64_VALUE],
+            result: VOID,
+            safety: WRITABLE_DISCRIMINANTS,
+            returns: RETURNS
+        },
+        ParseI32 => unsafe __rue_parse_i32(
+            out: *mut $crate::OptionIntResult,
+            ptr: *const u8,
+            len: u64,
+            some_disc: u64,
+            none_disc: u64,
+        ) {
+            symbol: "__rue_parse_i32",
+            parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
+            result: VOID,
+            safety: READABLE_WRITABLE_DISCRIMINANTS,
+            returns: RETURNS
+        },
+        ParseI64 => unsafe __rue_parse_i64(
+            out: *mut $crate::OptionIntResult,
+            ptr: *const u8,
+            len: u64,
+            some_disc: u64,
+            none_disc: u64,
+        ) {
+            symbol: "__rue_parse_i64",
+            parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
+            result: VOID,
+            safety: READABLE_WRITABLE_DISCRIMINANTS,
+            returns: RETURNS
+        },
+        ParseU32 => unsafe __rue_parse_u32(
+            out: *mut $crate::OptionIntResult,
+            ptr: *const u8,
+            len: u64,
+            some_disc: u64,
+            none_disc: u64,
+        ) {
+            symbol: "__rue_parse_u32",
+            parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
+            result: VOID,
+            safety: READABLE_WRITABLE_DISCRIMINANTS,
+            returns: RETURNS
+        },
+        ParseU64 => unsafe __rue_parse_u64(
+            out: *mut $crate::OptionIntResult,
+            ptr: *const u8,
+            len: u64,
+            some_disc: u64,
+            none_disc: u64,
+        ) {
+            symbol: "__rue_parse_u64",
+            parameters: params![OPTION_INT_OUT, BYTE_VIEW, U64_VALUE, U64_VALUE, U64_VALUE],
+            result: VOID,
+            safety: READABLE_WRITABLE_DISCRIMINANTS,
+            returns: RETURNS
+        },
+        RandomU32 => safe __rue_random_u32() -> u32 {
+            symbol: "__rue_random_u32",
+            parameters: params![],
+            result: U32_RESULT,
+            safety: SafetyContract::NONE,
+            returns: RETURNS
+        },
+        RandomU64 => safe __rue_random_u64() -> u64 {
+            symbol: "__rue_random_u64",
+            parameters: params![],
+            result: U64_RESULT,
+            safety: SafetyContract::NONE,
+            returns: RETURNS
+        },
+        InvalidUtf8 => safe __rue_invalid_utf8() -> ! {
+            symbol: "__rue_invalid_utf8",
+            parameters: params![],
+            result: VOID,
+            safety: TERMINATES,
+            returns: NEVER
+        }
+            }
+    };
 }
+
+for_each_runtime_helper!(runtime_helpers);
 
 /// Logical function signature for separately classified non-helper exports.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -659,56 +815,122 @@ pub enum ReservedExportKind {
     ReadOnlyData { size: u8 },
 }
 
-/// Exhaustive identity for intentionally visible, non-helper runtime exports.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(u8)]
-pub enum ReservedExportId {
-    Memcpy,
-    Memmove,
-    Memset,
-    Memcmp,
-    Bcmp,
-    LinuxStart,
-    MacosMain,
-    X86_64LinuxStart,
-    RtSigreturn,
-    RuntimeAbiVersion,
-}
-
-impl ReservedExportId {
-    pub const ALL: [Self; 10] = [
-        Self::Memcpy,
-        Self::Memmove,
-        Self::Memset,
-        Self::Memcmp,
-        Self::Bcmp,
-        Self::LinuxStart,
-        Self::MacosMain,
-        Self::X86_64LinuxStart,
-        Self::RtSigreturn,
-        Self::RuntimeAbiVersion,
-    ];
-
-    pub const fn export(self) -> &'static ReservedExport {
-        &RESERVED_EXPORTS[self as usize]
-    }
-
-    pub const fn symbol(self) -> &'static str {
-        self.export().symbol
-    }
-
-    pub fn from_symbol(symbol: &str) -> Option<Self> {
-        let mut index = 0;
-        while index < Self::ALL.len() {
-            let id = Self::ALL[index];
-            if string_eq(id.symbol(), symbol) {
-                return Some(id);
-            }
-            index += 1;
+/// Invoke a callback with every separately classified runtime export.
+///
+/// The callback receives the exact Rust declaration, applicability, and
+/// manifest metadata. Runtime declarations and the typed reserved-export table
+/// are generated from these same rows.
+#[macro_export]
+macro_rules! for_each_reserved_runtime_export {
+    ($callback:ident) => {
+        $callback! {
+            (Memcpy => function all unsafe memcpy(
+                dst: *mut u8,
+                src: *const u8,
+                count: usize,
+            ) -> *mut u8 {
+                class: ReservedExportClass::CompilerBuiltMemory,
+                signature: COPY_FUNCTION
+            }),
+            (Memmove => function all unsafe memmove(
+                dst: *mut u8,
+                src: *const u8,
+                count: usize,
+            ) -> *mut u8 {
+                class: ReservedExportClass::CompilerBuiltMemory,
+                signature: COPY_FUNCTION
+            }),
+            (Memset => function all unsafe memset(
+                dst: *mut u8,
+                value: i32,
+                count: usize,
+            ) -> *mut u8 {
+                class: ReservedExportClass::CompilerBuiltMemory,
+                signature: MEMSET_FUNCTION
+            }),
+            (Memcmp => function all unsafe memcmp(
+                left: *const u8,
+                right: *const u8,
+                count: usize,
+            ) -> i32 {
+                class: ReservedExportClass::CompilerBuiltMemory,
+                signature: COMPARE_FUNCTION
+            }),
+            (Bcmp => function all unsafe bcmp(
+                left: *const u8,
+                right: *const u8,
+                count: usize,
+            ) -> i32 {
+                class: ReservedExportClass::CompilerBuiltMemory,
+                signature: COMPARE_FUNCTION
+            }),
+            (LinuxStart => linux_entry linux unsafe _start() -> ! {
+                class: ReservedExportClass::ProgramEntry,
+                signature: NEVER_FUNCTION
+            }),
+            (MacosMain => function aarch64_macos unsafe _main() -> ! {
+                class: ReservedExportClass::ProgramEntry,
+                signature: NEVER_FUNCTION
+            }),
+            (X86_64LinuxStart => function x86_64_linux safe __rue_x86_64_linux_start() -> ! {
+                class: ReservedExportClass::PlatformShim,
+                signature: NEVER_FUNCTION
+            }),
+            (RtSigreturn => assembly x86_64_linux unsafe __rue_rt_sigreturn() {
+                class: ReservedExportClass::PlatformShim,
+                signature: VOID_FUNCTION
+            }),
+            (RuntimeAbiVersion => marker all {
+                class: ReservedExportClass::AbiVersionMarker,
+                size: 1
+            })
         }
-        None
-    }
+    };
 }
+
+macro_rules! define_reserved_export_ids {
+    (
+        $(
+            ($variant:ident => $kind:ident $($declaration:tt)*)
+        ),+ $(,)?
+    ) => {
+        /// Exhaustive identity for intentionally visible, non-helper runtime exports.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[repr(u8)]
+        pub enum ReservedExportId {
+            $($variant),+
+        }
+
+        impl ReservedExportId {
+            pub const ALL: [Self; <[()]>::len(&[$(define_reserved_export_ids!(@unit $variant)),+])] = [
+                $(Self::$variant),+
+            ];
+
+            pub const fn export(self) -> &'static ReservedExport {
+                &RESERVED_EXPORTS[self as usize]
+            }
+
+            pub const fn symbol(self) -> &'static str {
+                self.export().symbol
+            }
+
+            pub fn from_symbol(symbol: &str) -> Option<Self> {
+                let mut index = 0;
+                while index < Self::ALL.len() {
+                    let id = Self::ALL[index];
+                    if string_eq(id.symbol(), symbol) {
+                        return Some(id);
+                    }
+                    index += 1;
+                }
+                None
+            }
+        }
+    };
+    (@unit $_variant:ident) => { () };
+}
+
+for_each_reserved_runtime_export!(define_reserved_export_ids);
 
 /// A separately classified, intentionally visible runtime export.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -763,78 +985,85 @@ const COMPARE_FUNCTION: AbiSignature = AbiSignature {
     calling_convention: TARGET_C,
 };
 
-pub const RESERVED_EXPORTS: [ReservedExport; 10] = [
-    ReservedExport {
-        id: ReservedExportId::Memcpy,
-        symbol: "memcpy",
-        class: ReservedExportClass::CompilerBuiltMemory,
-        kind: ReservedExportKind::Function(COPY_FUNCTION),
-        availability: ALL_TARGETS,
-    },
-    ReservedExport {
-        id: ReservedExportId::Memmove,
-        symbol: "memmove",
-        class: ReservedExportClass::CompilerBuiltMemory,
-        kind: ReservedExportKind::Function(COPY_FUNCTION),
-        availability: ALL_TARGETS,
-    },
-    ReservedExport {
-        id: ReservedExportId::Memset,
-        symbol: "memset",
-        class: ReservedExportClass::CompilerBuiltMemory,
-        kind: ReservedExportKind::Function(MEMSET_FUNCTION),
-        availability: ALL_TARGETS,
-    },
-    ReservedExport {
-        id: ReservedExportId::Memcmp,
-        symbol: "memcmp",
-        class: ReservedExportClass::CompilerBuiltMemory,
-        kind: ReservedExportKind::Function(COMPARE_FUNCTION),
-        availability: ALL_TARGETS,
-    },
-    ReservedExport {
-        id: ReservedExportId::Bcmp,
-        symbol: "bcmp",
-        class: ReservedExportClass::CompilerBuiltMemory,
-        kind: ReservedExportKind::Function(COMPARE_FUNCTION),
-        availability: ALL_TARGETS,
-    },
-    ReservedExport {
-        id: ReservedExportId::LinuxStart,
-        symbol: "_start",
-        class: ReservedExportClass::ProgramEntry,
-        kind: ReservedExportKind::Function(NEVER_FUNCTION),
-        availability: TargetSet::X86_64_LINUX.union(TargetSet::AARCH64_LINUX),
-    },
-    ReservedExport {
-        id: ReservedExportId::MacosMain,
-        symbol: "_main",
-        class: ReservedExportClass::ProgramEntry,
-        kind: ReservedExportKind::Function(NEVER_FUNCTION),
-        availability: TargetSet::AARCH64_MACOS,
-    },
-    ReservedExport {
-        id: ReservedExportId::X86_64LinuxStart,
-        symbol: "__rue_x86_64_linux_start",
-        class: ReservedExportClass::PlatformShim,
-        kind: ReservedExportKind::Function(NEVER_FUNCTION),
-        availability: TargetSet::X86_64_LINUX,
-    },
-    ReservedExport {
-        id: ReservedExportId::RtSigreturn,
-        symbol: "__rue_rt_sigreturn",
-        class: ReservedExportClass::PlatformShim,
-        kind: ReservedExportKind::Function(VOID_FUNCTION),
-        availability: TargetSet::X86_64_LINUX,
-    },
-    ReservedExport {
-        id: ReservedExportId::RuntimeAbiVersion,
-        symbol: RUNTIME_ABI_VERSION_SYMBOL,
-        class: ReservedExportClass::AbiVersionMarker,
-        kind: ReservedExportKind::ReadOnlyData { size: 1 },
-        availability: ALL_TARGETS,
-    },
-];
+macro_rules! define_reserved_exports {
+    (
+        $(
+            ($variant:ident => $($row:tt)*)
+        ),+ $(,)?
+    ) => {
+        pub const RESERVED_EXPORTS: [ReservedExport; ReservedExportId::ALL.len()] = [
+            $(
+                define_reserved_exports!(@row $variant => $($row)*),
+            )+
+        ];
+    };
+    (
+        @row $variant:ident => function $target:ident $safety:ident $function:ident(
+            $($argument:ident : $rust_type:ty),* $(,)?
+        ) $(-> $rust_result:ty)? {
+            class: $class:path,
+            signature: $signature:ident
+        }
+    ) => {
+        ReservedExport {
+            id: ReservedExportId::$variant,
+            symbol: stringify!($function),
+            class: $class,
+            kind: ReservedExportKind::Function($signature),
+            availability: define_reserved_exports!(@targets $target),
+        }
+    };
+    (
+        @row $variant:ident => linux_entry $target:ident $safety:ident $function:ident()
+            -> $rust_result:ty {
+                class: $class:path,
+                signature: $signature:ident
+            }
+    ) => {
+        ReservedExport {
+            id: ReservedExportId::$variant,
+            symbol: stringify!($function),
+            class: $class,
+            kind: ReservedExportKind::Function($signature),
+            availability: define_reserved_exports!(@targets $target),
+        }
+    };
+    (
+        @row $variant:ident => assembly $target:ident $safety:ident $function:ident()
+            $(-> $rust_result:ty)? {
+                class: $class:path,
+                signature: $signature:ident
+            }
+    ) => {
+        ReservedExport {
+            id: ReservedExportId::$variant,
+            symbol: stringify!($function),
+            class: $class,
+            kind: ReservedExportKind::Function($signature),
+            availability: define_reserved_exports!(@targets $target),
+        }
+    };
+    (
+        @row RuntimeAbiVersion => marker $target:ident {
+            class: $class:path,
+            size: $size:literal
+        }
+    ) => {
+        ReservedExport {
+            id: ReservedExportId::RuntimeAbiVersion,
+            symbol: RUNTIME_ABI_VERSION_SYMBOL,
+            class: $class,
+            kind: ReservedExportKind::ReadOnlyData { size: $size },
+            availability: define_reserved_exports!(@targets $target),
+        }
+    };
+    (@targets all) => { TargetSet::ALL };
+    (@targets linux) => { TargetSet::X86_64_LINUX.union(TargetSet::AARCH64_LINUX) };
+    (@targets aarch64_macos) => { TargetSet::AARCH64_MACOS };
+    (@targets x86_64_linux) => { TargetSet::X86_64_LINUX };
+}
+
+for_each_reserved_runtime_export!(define_reserved_exports);
 
 /// Classification of a known externally visible runtime name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -8,6 +8,9 @@ rue_crate(
     name = "rue-runtime",
     tests = False,
     crate = "rue_runtime",
+    deps = [
+        "//crates/rue-runtime-abi:rue-runtime-abi",
+    ],
     # Force static linkage to ensure the [staticlib] subtarget is available
     preferred_linkage = "static",
     # Minimize output size and ensure no_std compatibility
@@ -34,6 +37,9 @@ rust_test(
     name = "rue-runtime-test",
     srcs = glob(["src/**/*.rs"]),
     crate = "rue_runtime",
+    deps = [
+        "//crates/rue-runtime-abi:rue-runtime-abi",
+    ],
 )
 
 # The x86-64 Linux entry point is raw process-entry code and cannot be exercised

--- a/crates/rue-runtime/src/debug.rs
+++ b/crates/rue-runtime/src/debug.rs
@@ -6,7 +6,7 @@
 
 use crate::platform;
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Debug intrinsic: print a signed 64-bit integer.
     ///
     /// Called by `@dbg(expr)` when the expression is a signed integer type.
@@ -24,7 +24,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Debug intrinsic: print an unsigned 64-bit integer.
     ///
     /// Called by `@dbg(expr)` when the expression is an unsigned integer type.
@@ -42,7 +42,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Debug intrinsic: print a boolean.
     ///
     /// Called by `@dbg(expr)` when the expression is a boolean.
@@ -61,7 +61,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Debug intrinsic: print a string.
     ///
     /// Called by `@dbg(expr)` when the expression is a String type.

--- a/crates/rue-runtime/src/entry.rs
+++ b/crates/rue-runtime/src/entry.rs
@@ -100,31 +100,19 @@ pub(crate) extern "C" fn __rue_stack_overflow_handler(_sig: i32) -> ! {
     platform::exit(101)
 }
 
-/// Raw program entry point for Linux x86-64.
-///
-/// `_start` is reached directly from the kernel, so it must not have a
-/// compiler-generated function prologue. The kernel supplies a 16-byte-aligned
-/// stack; the shim re-establishes that invariant explicitly, then `call` gives
-/// the ordinary Rust helper the SysV-required `rsp % 16 == 8` function-entry
-/// alignment. All further calls are made by normal Rust code.
-#[cfg(all(not(test), target_arch = "x86_64", target_os = "linux"))]
-core::arch::global_asm!(
-    ".pushsection .text._start,\"ax\",@progbits",
-    ".global _start",
-    ".type _start,@function",
-    "_start:",
-    "and rsp, -16",
-    "call __rue_x86_64_linux_start",
-    // The helper is non-returning. Trap if that contract is ever violated.
-    "ud2",
-    ".size _start, .-_start",
-    ".popsection",
-);
+#[cfg(all(
+    not(test),
+    any(
+        all(target_arch = "x86_64", target_os = "linux"),
+        all(target_arch = "aarch64", target_os = "macos"),
+        all(target_arch = "aarch64", target_os = "linux")
+    )
+))]
+const _: extern "C" fn(i32) -> ! = __rue_stack_overflow_handler;
 
 /// Normal SysV function called by the prologue-free x86-64 Linux entry shim.
 #[cfg(all(not(test), target_arch = "x86_64", target_os = "linux"))]
-#[unsafe(no_mangle)]
-extern "C" fn __rue_x86_64_linux_start() -> ! {
+pub(crate) fn __rue_x86_64_linux_start() -> ! {
     unsafe extern "C" {
         fn main() -> i32;
     }
@@ -151,8 +139,7 @@ extern "C" fn __rue_x86_64_linux_start() -> ! {
 /// This must only be entered by the macOS process loader with the initial
 /// stack and register state required by AAPCS64.
 #[cfg(all(not(test), target_arch = "aarch64", target_os = "macos"))]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn _main() -> ! {
+pub(crate) unsafe fn _main() -> ! {
     use core::arch::asm;
 
     // main is defined by the user's code
@@ -196,8 +183,7 @@ pub unsafe extern "C" fn _main() -> ! {
 /// This must only be entered by the Linux process loader with the initial
 /// stack and register state required by AAPCS64.
 #[cfg(all(not(test), target_arch = "aarch64", target_os = "linux"))]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn _start() -> ! {
+pub(crate) unsafe fn _start() -> ! {
     use core::arch::asm;
 
     // main is defined by the user's code
@@ -231,7 +217,7 @@ pub unsafe extern "C" fn _start() -> ! {
     platform::exit(exit_code)
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Exit the process with the given status code.
     ///
     /// This is the main entry point called by Rue-generated code when `main()`

--- a/crates/rue-runtime/src/error.rs
+++ b/crates/rue-runtime/src/error.rs
@@ -36,7 +36,7 @@ pub(crate) fn allocation_failure() -> ! {
     unsafe { __rue_panic(msg.as_ptr(), msg.len() as u64) }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Runtime error: division by zero.
     ///
     /// Called when a division or modulo operation has a zero divisor. This is
@@ -87,7 +87,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Runtime error: integer overflow.
     ///
     /// Called when an arithmetic operation overflows. This is typically triggered
@@ -138,7 +138,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Runtime error: integer cast overflow.
     ///
     /// Called when `@intCast` would produce a value that cannot be represented
@@ -193,7 +193,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Runtime error: index out of bounds.
     ///
     /// Called when an array index operation accesses an element outside the
@@ -254,7 +254,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Runtime error: invalid UTF-8 during decoding.
     ///
     /// Called when `s.chars()` iteration (RUE-220, ADR-0035) decodes a byte
@@ -305,7 +305,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Runtime error: explicit `@panic(msg)` with a message.
     ///
     /// Called by code generated for the `@panic("...")` intrinsic. Writes
@@ -357,7 +357,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Runtime error: explicit `@panic()` with no message.
     ///
     /// Called by code generated for the message-less `@panic()` intrinsic.
@@ -387,7 +387,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Runtime error: failed `@assert(cond)` (no message).
     ///
     /// Called by code generated for `@assert(cond)` when `cond` is false.

--- a/crates/rue-runtime/src/io.rs
+++ b/crates/rue-runtime/src/io.rs
@@ -8,6 +8,7 @@
 use crate::heap;
 use crate::platform;
 use crate::string::STRING_MIN_CAPACITY;
+pub use rue_runtime_abi::OptionStrBufResult;
 
 // =============================================================================
 // String output (RUE-1: print / println)
@@ -25,7 +26,7 @@ use crate::string::STRING_MIN_CAPACITY;
 // function takes ownership, so the caller's String stays valid and is dropped
 // by its owner as usual.
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Write a String's raw bytes to stdout with no trailing newline.
     ///
     /// Called by the `print(s: String)` builtin free function (RUE-1). Writes
@@ -59,7 +60,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Write a shared two-word `str` view to stdout.
     pub unsafe extern "C" fn __rue_str_print(ptr: *const u8, len: u64) {
         if len > 0 {
@@ -69,7 +70,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Write a String's raw bytes to stdout followed by a single newline.
     ///
     /// Called by the `println(s: String)` builtin free function (RUE-1). Writes
@@ -103,7 +104,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Write a shared two-word `str` view followed by a newline.
     pub unsafe extern "C" fn __rue_str_println(ptr: *const u8, len: u64) {
         if len > 0 {
@@ -117,22 +118,6 @@ crate::define_for_all_platforms! {
 /// Initial buffer size for reading lines.
 /// This is a reasonable size for most interactive input.
 const READ_LINE_INITIAL_CAPACITY: u64 = 128;
-
-/// Result of `@read_line`: a tagged-union `Option(StrBuf)` written via sret.
-///
-/// The compiler lays a payload-carrying enum out as slot 0 = discriminant
-/// followed by the payload slots (RUE-221), so the in-memory layout of
-/// `Option(StrBuf)` is `[disc, ptr, len, cap]`. This struct mirrors that
-/// layout exactly so the runtime can write the whole `Option` in one place and
-/// codegen simply loads the four slots back (RUE-6).
-#[repr(C)]
-pub struct OptionStrBufResult {
-    /// Discriminant slot: `some_disc` on success, `none_disc` at EOF.
-    pub disc: u64,
-    pub ptr: *mut u8,
-    pub len: u64,
-    pub cap: u64,
-}
 
 /// Read a line from standard input, returning `Option(StrBuf)`.
 ///
@@ -171,44 +156,8 @@ pub struct OptionStrBufResult {
 ///
 /// `out` must be valid, aligned, writable storage for one
 /// [`OptionStrBufResult`] and must remain exclusively accessible for the call.
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-#[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub unsafe extern "C" fn __rue_read_line(
-    out: *mut OptionStrBufResult,
-    some_disc: u64,
-    none_disc: u64,
-) {
-    read_line_impl(out, some_disc, none_disc);
-}
-
-#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
-/// # Safety
-///
-/// `out` must be valid, aligned, writable storage for one
-/// [`OptionStrBufResult`] and must remain exclusively accessible for the call.
-pub unsafe extern "C" fn __rue_read_line(
-    out: *mut OptionStrBufResult,
-    some_disc: u64,
-    none_disc: u64,
-) {
-    read_line_impl(out, some_disc, none_disc);
-}
-
-#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
-/// # Safety
-///
-/// `out` must be valid, aligned, writable storage for one
-/// [`OptionStrBufResult`] and must remain exclusively accessible for the call.
-pub unsafe extern "C" fn __rue_read_line(
-    out: *mut OptionStrBufResult,
-    some_disc: u64,
-    none_disc: u64,
-) {
+pub unsafe fn __rue_read_line(out: *mut OptionStrBufResult, some_disc: u64, none_disc: u64) {
     read_line_impl(out, some_disc, none_disc);
 }
 

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -108,22 +108,15 @@ compile_error!(
 );
 
 // ============================================================================
-// Platform-agnostic macro for reducing code duplication
+// Platform-agnostic runtime implementations
 // ============================================================================
-//
-// Many runtime functions have identical implementations across platforms,
-// differing only in their `#[cfg]` attributes. This macro generates all
-// three platform-specific versions from a single definition.
 
-/// Define a function for all supported platforms with identical implementation.
-///
-/// This macro generates three `#[cfg]`-gated versions of the same function,
-/// one for each supported platform (x86_64 Linux, aarch64 macOS, aarch64 Linux).
+/// Define the Rust implementation behind a manifest-declared runtime wrapper.
 ///
 /// # Usage
 ///
 /// ```ignore
-/// define_for_all_platforms! {
+/// define_runtime_implementation! {
 ///     /// Documentation for the function
 ///     pub extern "C" fn function_name(arg: Type) -> ReturnType {
 ///         // implementation
@@ -131,44 +124,20 @@ compile_error!(
 /// }
 /// ```
 #[macro_export]
-macro_rules! define_for_all_platforms {
+macro_rules! define_runtime_implementation {
     (
         $(#[$meta:meta])*
         pub unsafe extern "C" fn $name:ident($($arg:ident : $arg_ty:ty),* $(,)?) $(-> $ret:ty)? $body:block
     ) => {
-        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
         $(#[$meta])*
-        #[unsafe(no_mangle)]
-        pub unsafe extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
-
-        #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-        $(#[$meta])*
-        #[unsafe(no_mangle)]
-        pub unsafe extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
-
-        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-        $(#[$meta])*
-        #[unsafe(no_mangle)]
-        pub unsafe extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
+        pub unsafe fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
     };
     (
         $(#[$meta:meta])*
         pub extern "C" fn $name:ident($($arg:ident : $arg_ty:ty),* $(,)?) $(-> $ret:ty)? $body:block
     ) => {
-        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
         $(#[$meta])*
-        #[unsafe(no_mangle)]
-        pub extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
-
-        #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-        $(#[$meta])*
-        #[unsafe(no_mangle)]
-        pub extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
-
-        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-        $(#[$meta])*
-        #[unsafe(no_mangle)]
-        pub extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
+        pub fn $name($($arg : $arg_ty),*) $(-> $ret)? $body
     };
 }
 
@@ -185,6 +154,256 @@ pub mod parse;
 pub mod random;
 pub mod string;
 
+macro_rules! call_runtime_helper_implementation {
+    (__rue_exit($($argument:expr),*)) => { crate::entry::__rue_exit($($argument),*) };
+    (__rue_alloc($($argument:expr),*)) => { crate::string::__rue_alloc($($argument),*) };
+    (__rue_free($($argument:expr),*)) => { crate::string::__rue_free($($argument),*) };
+    (__rue_realloc($($argument:expr),*)) => { crate::string::__rue_realloc($($argument),*) };
+    (__rue_div_by_zero($($argument:expr),*)) => { crate::error::__rue_div_by_zero($($argument),*) };
+    (__rue_overflow($($argument:expr),*)) => { crate::error::__rue_overflow($($argument),*) };
+    (__rue_intcast_overflow($($argument:expr),*)) => { crate::error::__rue_intcast_overflow($($argument),*) };
+    (__rue_bounds_check($($argument:expr),*)) => { crate::error::__rue_bounds_check($($argument),*) };
+    (__rue_panic($($argument:expr),*)) => { crate::error::__rue_panic($($argument),*) };
+    (__rue_panic_no_msg($($argument:expr),*)) => { crate::error::__rue_panic_no_msg($($argument),*) };
+    (__rue_assert_failed($($argument:expr),*)) => { crate::error::__rue_assert_failed($($argument),*) };
+    (__rue_dbg_i64($($argument:expr),*)) => { crate::debug::__rue_dbg_i64($($argument),*) };
+    (__rue_dbg_u64($($argument:expr),*)) => { crate::debug::__rue_dbg_u64($($argument),*) };
+    (__rue_dbg_bool($($argument:expr),*)) => { crate::debug::__rue_dbg_bool($($argument),*) };
+    (__rue_dbg_str($($argument:expr),*)) => { crate::debug::__rue_dbg_str($($argument),*) };
+    (__rue_str_eq($($argument:expr),*)) => { crate::string::__rue_str_eq($($argument),*) };
+    (__rue_str_byte_at($($argument:expr),*)) => { crate::string::__rue_str_byte_at($($argument),*) };
+    (__rue_str_char_scalar($($argument:expr),*)) => { crate::string::__rue_str_char_scalar($($argument),*) };
+    (__rue_str_char_next($($argument:expr),*)) => { crate::string::__rue_str_char_next($($argument),*) };
+    (__rue_str_char_scalar_lossy($($argument:expr),*)) => { crate::string::__rue_str_char_scalar_lossy($($argument),*) };
+    (__rue_str_char_next_lossy($($argument:expr),*)) => { crate::string::__rue_str_char_next_lossy($($argument),*) };
+    (__rue_to_string($($argument:expr),*)) => { crate::string::__rue_to_string($($argument),*) };
+    (__rue_to_string_unsigned($($argument:expr),*)) => { crate::string::__rue_to_string_unsigned($($argument),*) };
+    (__rue_print($($argument:expr),*)) => { crate::io::__rue_print($($argument),*) };
+    (__rue_println($($argument:expr),*)) => { crate::io::__rue_println($($argument),*) };
+    (__rue_str_print($($argument:expr),*)) => { crate::io::__rue_str_print($($argument),*) };
+    (__rue_str_println($($argument:expr),*)) => { crate::io::__rue_str_println($($argument),*) };
+    (__rue_read_line($($argument:expr),*)) => { crate::io::__rue_read_line($($argument),*) };
+    (__rue_parse_i32($($argument:expr),*)) => { crate::parse::__rue_parse_i32($($argument),*) };
+    (__rue_parse_i64($($argument:expr),*)) => { crate::parse::__rue_parse_i64($($argument),*) };
+    (__rue_parse_u32($($argument:expr),*)) => { crate::parse::__rue_parse_u32($($argument),*) };
+    (__rue_parse_u64($($argument:expr),*)) => { crate::parse::__rue_parse_u64($($argument),*) };
+    (__rue_random_u32($($argument:expr),*)) => { crate::random::__rue_random_u32($($argument),*) };
+    (__rue_random_u64($($argument:expr),*)) => { crate::random::__rue_random_u64($($argument),*) };
+    (__rue_invalid_utf8($($argument:expr),*)) => { crate::error::__rue_invalid_utf8($($argument),*) };
+}
+
+macro_rules! declare_runtime_helper {
+    (
+        safe $function:ident($($argument:ident : $rust_type:ty),* $(,)?) $(-> $result:ty)?
+    ) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $function($($argument: $rust_type),*) $(-> $result)? {
+            call_runtime_helper_implementation!($function($($argument),*))
+        }
+    };
+    (
+        unsafe $function:ident($($argument:ident : $rust_type:ty),* $(,)?) $(-> $result:ty)?
+    ) => {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $function($($argument: $rust_type),*) $(-> $result)? {
+            // SAFETY: This wrapper exposes exactly the caller obligations
+            // recorded by the canonical runtime ABI manifest.
+            unsafe { call_runtime_helper_implementation!($function($($argument),*)) }
+        }
+    };
+}
+
+macro_rules! declare_runtime_helpers {
+    (
+        $(
+            $variant:ident => $safety:ident $function:ident(
+                $($argument:ident : $rust_type:ty),* $(,)?
+            ) $(-> $result:ty)? {
+                symbol: $symbol:literal,
+                parameters: $parameters:expr,
+                result: $abi_result:expr,
+                safety: $contract:expr,
+                returns: $returns:expr
+            }
+        ),+ $(,)?
+    ) => {
+        $(
+            declare_runtime_helper! {
+                $safety $function($($argument: $rust_type),*) $(-> $result)?
+            }
+        )+
+    };
+}
+
+rue_runtime_abi::for_each_runtime_helper!(declare_runtime_helpers);
+
+macro_rules! call_reserved_export_implementation {
+    (memcpy($($argument:expr),*)) => { crate::memory::memcpy($($argument),*) };
+    (memmove($($argument:expr),*)) => { crate::memory::memmove($($argument),*) };
+    (memset($($argument:expr),*)) => { crate::memory::memset($($argument),*) };
+    (memcmp($($argument:expr),*)) => { crate::memory::memcmp($($argument),*) };
+    (bcmp($($argument:expr),*)) => { crate::memory::bcmp($($argument),*) };
+    (_main($($argument:expr),*)) => { crate::entry::_main($($argument),*) };
+    (__rue_x86_64_linux_start($($argument:expr),*)) => {
+        crate::entry::__rue_x86_64_linux_start($($argument),*)
+    };
+    (_start($($argument:expr),*)) => { crate::entry::_start($($argument),*) };
+}
+
+macro_rules! declare_reserved_function {
+    (
+        all unsafe $function:ident($($argument:ident : $rust_type:ty),* $(,)?)
+        $(-> $result:ty)?
+    ) => {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $function($($argument: $rust_type),*) $(-> $result)? {
+            // SAFETY: The reserved-export manifest records the complete caller
+            // contract for this compiler-built boundary.
+            unsafe { call_reserved_export_implementation!($function($($argument),*)) }
+        }
+    };
+    (
+        aarch64_macos unsafe $function:ident($($argument:ident : $rust_type:ty),* $(,)?)
+        $(-> $result:ty)?
+    ) => {
+        #[cfg(all(not(test), target_arch = "aarch64", target_os = "macos"))]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $function($($argument: $rust_type),*) $(-> $result)? {
+            // SAFETY: This is entered only through the platform entry ABI.
+            unsafe { call_reserved_export_implementation!($function($($argument),*)) }
+        }
+    };
+    (
+        x86_64_linux safe $function:ident($($argument:ident : $rust_type:ty),* $(,)?)
+        $(-> $result:ty)?
+    ) => {
+        #[cfg(all(not(test), target_arch = "x86_64", target_os = "linux"))]
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $function($($argument: $rust_type),*) $(-> $result)? {
+            call_reserved_export_implementation!($function($($argument),*))
+        }
+    };
+}
+
+macro_rules! declare_linux_entry {
+    (linux unsafe $function:ident() -> $result:ty) => {
+        #[cfg(all(not(test), target_arch = "aarch64", target_os = "linux"))]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $function() -> $result {
+            // SAFETY: This is entered only through the platform entry ABI.
+            unsafe { call_reserved_export_implementation!($function()) }
+        }
+
+        #[cfg(all(not(test), target_arch = "x86_64", target_os = "linux"))]
+        core::arch::global_asm!(
+            concat!(".pushsection .text.", stringify!($function), ",\"ax\",@progbits"),
+            concat!(".global ", stringify!($function)),
+            concat!(".type ", stringify!($function), ",@function"),
+            concat!(stringify!($function), ":"),
+            "and rsp, -16",
+            "call {start}",
+            "ud2",
+            concat!(".size ", stringify!($function), ", .-", stringify!($function)),
+            ".popsection",
+            start = sym __rue_x86_64_linux_start,
+        );
+
+        #[cfg(all(not(test), target_arch = "x86_64", target_os = "linux"))]
+        unsafe extern "C" {
+            fn $function() -> $result;
+        }
+
+        #[cfg(all(not(test), target_arch = "x86_64", target_os = "linux"))]
+        const _: unsafe extern "C" fn() -> $result = $function;
+    };
+}
+
+macro_rules! declare_reserved_assembly {
+    (x86_64_linux unsafe $function:ident()) => {
+        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+        core::arch::global_asm!(
+            concat!(".globl ", stringify!($function)),
+            concat!(".hidden ", stringify!($function)),
+            concat!(stringify!($function), ":"),
+            "mov rax, 15",
+            "syscall",
+        );
+
+        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+        unsafe extern "C" {
+            pub(crate) fn $function();
+        }
+
+        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+        const _: unsafe extern "C" fn() = $function;
+    };
+}
+
+macro_rules! declare_reserved_exports {
+    (
+        $(
+            ($variant:ident => $($row:tt)*)
+        ),+ $(,)?
+    ) => {
+        $(
+            declare_reserved_exports!(@row $variant => $($row)*);
+        )+
+    };
+    (
+        @row $variant:ident => function $target:ident $safety:ident $function:ident(
+            $($argument:ident : $rust_type:ty),* $(,)?
+        ) $(-> $result:ty)? {
+            class: $class:path,
+            signature: $signature:ident
+        }
+    ) => {
+        declare_reserved_function! {
+            $target $safety $function($($argument: $rust_type),*) $(-> $result)?
+        }
+    };
+    (
+        @row $variant:ident => linux_entry $target:ident $safety:ident $function:ident()
+            -> $result:ty {
+                class: $class:path,
+                signature: $signature:ident
+            }
+    ) => {
+        declare_linux_entry! {
+            $target $safety $function() -> $result
+        }
+    };
+    (
+        @row $variant:ident => assembly $target:ident $safety:ident $function:ident()
+            $(-> $result:ty)? {
+                class: $class:path,
+                signature: $signature:ident
+            }
+    ) => {
+        declare_reserved_assembly! {
+            $target $safety $function()
+        }
+    };
+    (
+        @row RuntimeAbiVersion => marker all {
+            class: $class:path,
+            size: 1
+        }
+    ) => {};
+}
+
+rue_runtime_abi::for_each_reserved_runtime_export!(declare_reserved_exports);
+
+macro_rules! declare_runtime_abi_marker {
+    ($version:literal, $marker:ident) => {
+        #[doc(hidden)]
+        #[used]
+        #[unsafe(no_mangle)]
+        pub static $marker: u8 = 0;
+    };
+}
+
+rue_runtime_abi::runtime_abi_version!(declare_runtime_abi_marker);
+
 // Re-export platform functions for tests
 #[cfg(all(test, target_arch = "x86_64", target_os = "linux"))]
 pub use x86_64_linux::{exit, write, write_all, write_stderr};
@@ -196,156 +415,7 @@ pub use aarch64_macos::{exit, write, write_all, write_stderr};
 pub use aarch64_linux::{exit, write, write_all, write_stderr};
 
 #[cfg(test)]
-mod export_safety_tests {
-    extern crate std;
-
-    use self::std::{string::String, vec::Vec};
-    const MODULE_SOURCES: &[(&str, &str)] = &[
-        ("aarch64_linux", include_str!("aarch64_linux.rs")),
-        ("aarch64_macos", include_str!("aarch64_macos.rs")),
-        ("debug", include_str!("debug.rs")),
-        ("entry", include_str!("entry.rs")),
-        ("error", include_str!("error.rs")),
-        ("heap", include_str!("heap.rs")),
-        ("io", include_str!("io.rs")),
-        ("memory", include_str!("memory.rs")),
-        ("parse", include_str!("parse.rs")),
-        ("random", include_str!("random.rs")),
-        ("string", include_str!("string.rs")),
-        ("x86_64_linux", include_str!("x86_64_linux.rs")),
-    ];
-
-    /// Every extern function declaration whose signature contains a raw
-    /// pointer: symbol, whether it is unsafe, and declaration count. Counts are
-    /// one for macro-defined exports and three for hand-written platform copies.
-    /// This is intentionally checked against the
-    /// source declaration rather than by assigning function pointers: Rust
-    /// permits a safe function pointer to coerce to an unsafe one, which would
-    /// let an accidentally-safe export pass a type-only test.
-    const POINTER_EXPORTS: &[(&str, bool, usize)] = &[
-        ("__rue_alloc", false, 1),
-        ("__rue_dbg_str", true, 1),
-        ("__rue_free", false, 1),
-        ("__rue_panic", true, 1),
-        ("__rue_parse_i32", true, 1),
-        ("__rue_parse_i64", true, 1),
-        ("__rue_parse_u32", true, 1),
-        ("__rue_parse_u64", true, 1),
-        ("__rue_print", true, 1),
-        ("__rue_println", true, 1),
-        ("__rue_read_line", true, 3),
-        ("__rue_realloc", true, 1),
-        ("__rue_str_byte_at", true, 1),
-        ("__rue_str_char_next", true, 1),
-        ("__rue_str_char_next_lossy", true, 1),
-        ("__rue_str_char_scalar", true, 1),
-        ("__rue_str_char_scalar_lossy", true, 1),
-        ("__rue_str_eq", true, 1),
-        ("__rue_str_print", true, 1),
-        ("__rue_str_println", true, 1),
-        ("__rue_to_string", true, 1),
-        ("__rue_to_string_unsigned", true, 1),
-        ("bcmp", true, 1),
-        ("memcmp", true, 1),
-        ("memcpy", true, 1),
-        ("memmove", true, 1),
-        ("memset", true, 1),
-    ];
-
-    fn pointer_exports(source: &str) -> Vec<(&str, bool)> {
-        let lines: Vec<_> = source.lines().collect();
-        let mut exports = Vec::new();
-        let mut line_index = 0;
-
-        while line_index < lines.len() {
-            let line = lines[line_index].trim_start();
-            let has_c_abi = line.contains("extern \"C\" fn ");
-            let has_export_attr = lines[line_index.saturating_sub(8)..line_index]
-                .iter()
-                .any(|line| line.contains("no_mangle"));
-            let looks_like_function =
-                line.contains(" fn ") || line.starts_with("fn ") || line.starts_with("unsafe fn ");
-            if line.starts_with("///") || !looks_like_function || (!has_c_abi && !has_export_attr) {
-                line_index += 1;
-                continue;
-            }
-            let declaration_prefix = line
-                .split_once(" fn ")
-                .map(|(prefix, _)| prefix)
-                .unwrap_or(line);
-            let is_unsafe = declaration_prefix
-                .split_whitespace()
-                .any(|word| word == "unsafe");
-
-            let mut signature = String::from(line);
-            while !signature.contains('{') {
-                line_index += 1;
-                signature.push(' ');
-                signature.push_str(lines[line_index].trim());
-            }
-
-            if signature.contains("*const ") || signature.contains("*mut ") {
-                let after_fn = line
-                    .split_once(" fn ")
-                    .map(|(_, rest)| rest)
-                    .or_else(|| line.strip_prefix("fn "))
-                    .or_else(|| line.strip_prefix("unsafe fn "))
-                    .expect("export declaration has fn keyword");
-                let name = after_fn
-                    .split_once('(')
-                    .expect("export declaration has arguments")
-                    .0;
-                exports.push((name, is_unsafe));
-            }
-            line_index += 1;
-        }
-
-        exports
-    }
-
-    #[test]
-    fn raw_pointer_export_safety_is_explicit_and_complete() {
-        let mut actual = Vec::new();
-        for &(_, source) in MODULE_SOURCES {
-            actual.extend(pointer_exports(source));
-        }
-        actual.extend(pointer_exports(include_str!("lib.rs")));
-        actual.sort_unstable();
-
-        let mut counted = Vec::new();
-        for &(name, is_unsafe) in &actual {
-            match counted.last_mut() {
-                Some((last_name, last_unsafe, count))
-                    if *last_name == name && *last_unsafe == is_unsafe =>
-                {
-                    *count += 1;
-                }
-                _ => counted.push((name, is_unsafe, 1)),
-            }
-        }
-
-        assert_eq!(counted, POINTER_EXPORTS);
-    }
-
-    #[test]
-    fn every_declared_runtime_module_is_in_the_export_inventory() {
-        let lib_source = include_str!("lib.rs");
-        let mut declared = Vec::new();
-        for line in lib_source.lines().map(str::trim) {
-            let declaration = line
-                .strip_prefix("pub mod ")
-                .or_else(|| line.strip_prefix("mod "));
-            if let Some(name) = declaration.and_then(|rest| rest.strip_suffix(';')) {
-                declared.push(name);
-            }
-        }
-        declared.sort_unstable();
-
-        let mut inventoried: Vec<_> = MODULE_SOURCES.iter().map(|(name, _)| *name).collect();
-        inventoried.sort_unstable();
-        assert_eq!(inventoried, declared);
-    }
-
+mod boundary_tests {
     #[test]
     fn pointer_taking_safe_exports_have_no_pointer_precondition() {
         // Free is a deliberate bump-allocator no-op, so it never inspects its

--- a/crates/rue-runtime/src/memory.rs
+++ b/crates/rue-runtime/src/memory.rs
@@ -11,8 +11,7 @@
 /// - When `n > 0`, `src` must be non-null and valid for reads of `n` bytes
 /// - Either pointer may be null when `n == 0`
 /// - The memory regions must not overlap
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn memcpy(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+pub unsafe fn memcpy(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
     let mut i = 0;
     while i < n {
         // SAFETY: We are within bounds because:
@@ -34,8 +33,7 @@ pub unsafe extern "C" fn memcpy(dst: *mut u8, src: *const u8, n: usize) -> *mut 
 /// - When `n > 0`, `dst` must be non-null and valid for writes of `n` bytes
 /// - When `n > 0`, `src` must be non-null and valid for reads of `n` bytes
 /// - Either pointer may be null when `n == 0`
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn memmove(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+pub unsafe fn memmove(dst: *mut u8, src: *const u8, n: usize) -> *mut u8 {
     if (dst as usize) < (src as usize) {
         // Copy forwards when dst is before src (or they don't overlap)
         let mut i = 0;
@@ -72,8 +70,7 @@ pub unsafe extern "C" fn memmove(dst: *mut u8, src: *const u8, n: usize) -> *mut
 ///
 /// - When `n > 0`, `dst` must be non-null and valid for writes of `n` bytes
 /// - `dst` may be null when `n == 0`
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn memset(dst: *mut u8, c: i32, n: usize) -> *mut u8 {
+pub unsafe fn memset(dst: *mut u8, c: i32, n: usize) -> *mut u8 {
     let byte = c as u8;
     let mut i = 0;
     while i < n {
@@ -95,8 +92,7 @@ pub unsafe extern "C" fn memset(dst: *mut u8, c: i32, n: usize) -> *mut u8 {
 ///
 /// - When `n > 0`, both pointers must be non-null and valid for reads of `n` bytes
 /// - Either pointer may be null when `n == 0`
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
+pub unsafe fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     let mut i = 0;
     while i < n {
         // SAFETY: We are within bounds because:
@@ -126,8 +122,7 @@ pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
 ///
 /// - When `n > 0`, both pointers must be non-null and valid for reads of `n` bytes
 /// - Either pointer may be null when `n == 0`
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
+pub unsafe fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     let mut i = 0;
     while i < n {
         // SAFETY: We are within bounds because:

--- a/crates/rue-runtime/src/parse.rs
+++ b/crates/rue-runtime/src/parse.rs
@@ -8,19 +8,7 @@
 //! negative value for an unsigned type) yields `None` rather than trapping, so
 //! callers recover instead of aborting.
 
-/// Result of an `@parse_*` intrinsic: a tagged-union `Option(int)` written via
-/// sret. The compiler lays a payload-carrying enum out as slot 0 =
-/// discriminant followed by the payload slots (RUE-221), so the in-memory
-/// layout of `Option(iN)` is `[disc, value]`. This struct mirrors that layout
-/// exactly (RUE-6).
-#[repr(C)]
-pub struct OptionIntResult {
-    /// Discriminant slot: `some_disc` on success, `none_disc` on failure.
-    pub disc: u64,
-    /// Payload slot: the parsed integer's bit pattern (only meaningful when
-    /// `disc == some_disc`). Narrower types occupy the low bits.
-    pub value: u64,
-}
+pub use rue_runtime_abi::OptionIntResult;
 
 /// Parse decimal ASCII into an `i64`, returning `None` on empty input, an
 /// invalid character, or overflow. Shared core for the signed parsers.
@@ -157,7 +145,7 @@ unsafe fn write_parse_result(
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// extern "C" fn __rue_parse_i32(out, ptr, len, some_disc, none_disc)
     ///
     /// # Safety
@@ -179,7 +167,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-define_for_all_platforms! {
+define_runtime_implementation! {
     /// extern "C" fn __rue_parse_i64(out, ptr, len, some_disc, none_disc)
     ///
     /// # Safety
@@ -200,7 +188,7 @@ define_for_all_platforms! {
     }
 }
 
-define_for_all_platforms! {
+define_runtime_implementation! {
     /// extern "C" fn __rue_parse_u32(out, ptr, len, some_disc, none_disc)
     ///
     /// # Safety
@@ -221,7 +209,7 @@ define_for_all_platforms! {
     }
 }
 
-define_for_all_platforms! {
+define_runtime_implementation! {
     /// extern "C" fn __rue_parse_u64(out, ptr, len, some_disc, none_disc)
     ///
     /// # Safety

--- a/crates/rue-runtime/src/random.rs
+++ b/crates/rue-runtime/src/random.rs
@@ -7,7 +7,7 @@
 
 use crate::platform;
 
-define_for_all_platforms! {
+define_runtime_implementation! {
     /// Generate a random u32 value.
     ///
     /// Uses platform-specific entropy source:
@@ -29,7 +29,7 @@ define_for_all_platforms! {
     }
 }
 
-define_for_all_platforms! {
+define_runtime_implementation! {
     /// Generate a random u64 value.
     ///
     /// Uses platform-specific entropy source:

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -6,24 +6,12 @@
 //! results returned through the `StrBuf` three-word representation.
 
 use crate::heap;
+pub use rue_runtime_abi::StrBufResult;
 
 /// Minimum capacity for runtime-produced `StrBuf` values.
 pub const STRING_MIN_CAPACITY: u64 = 16;
 
-/// The three-word `StrBuf` result used by runtime sret functions.
-#[repr(C)]
-pub struct StrBufResult {
-    pub ptr: *mut u8,
-    pub len: u64,
-    pub cap: u64,
-}
-
-const _: () = {
-    assert!(core::mem::size_of::<StrBufResult>() == 24);
-    assert!(core::mem::align_of::<StrBufResult>() == 8);
-};
-
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// `str` equality comparison.
     ///
     /// Called by the `==` operator on `str` values. Compares two strings
@@ -91,7 +79,7 @@ crate::define_for_all_platforms! {
 // Heap Allocation Wrappers
 // =============================================================================
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Allocate memory from the heap.
     ///
     /// This is the main allocation function for Rue programs. Memory is allocated
@@ -121,7 +109,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Free memory previously allocated by `__rue_alloc`.
     ///
     /// # Arguments
@@ -146,7 +134,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Reallocate memory to a new size.
     ///
     /// # Arguments
@@ -197,7 +185,7 @@ crate::define_for_all_platforms! {
 // array indexing. Neither respects UTF-8 char boundaries: any in-range byte
 // index / byte range is valid.
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Read the byte at `index` in a `str`, returning it as `u8` (ADR-0043
     /// ADR-0043, RUE-324).
     ///
@@ -306,7 +294,7 @@ unsafe fn __rue_decode_utf8_at(ptr: *const u8, len: u64, offset: u64) -> (u32, u
     (cp, width as u64)
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Decode one scalar through the shared two-word `str` view ABI.
     pub unsafe extern "C" fn __rue_str_char_scalar(
         ptr: *const u8,
@@ -318,7 +306,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Advance one scalar through the shared two-word `str` view ABI.
     pub unsafe extern "C" fn __rue_str_char_next(
         ptr: *const u8,
@@ -414,7 +402,7 @@ unsafe fn __rue_decode_utf8_lossy_at(ptr: *const u8, len: u64, offset: u64) -> (
     (cp, width as u64)
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Decode one scalar lossily through the shared two-word `str` view ABI.
     pub unsafe extern "C" fn __rue_str_char_scalar_lossy(
         ptr: *const u8,
@@ -426,7 +414,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Advance one scalar lossily through the shared two-word `str` view ABI.
     pub unsafe extern "C" fn __rue_str_char_next_lossy(
         ptr: *const u8,
@@ -444,7 +432,7 @@ crate::define_for_all_platforms! {
 // Integer-to-`StrBuf` formatting (ADR-0035)
 // =============================================================================
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Format an `i64` in base 10 into a freshly heap-allocated `StrBuf`.
     ///
     /// Implements the `@to_string(n)` intrinsic. Handles the full `i64` range,
@@ -517,7 +505,7 @@ crate::define_for_all_platforms! {
     }
 }
 
-crate::define_for_all_platforms! {
+crate::define_runtime_implementation! {
     /// Format a `u64` in base 10 into a freshly heap-allocated `StrBuf`.
     ///
     /// Implements `@to_string(n)` for unsigned integers (RUE-314). The compiler

--- a/crates/rue-runtime/src/x86_64_linux.rs
+++ b/crates/rue-runtime/src/x86_64_linux.rs
@@ -449,33 +449,6 @@ const SA_ONSTACK: u64 = 0x0800_0000;
 /// signal-return trampoline.
 const SA_RESTORER: u64 = 0x0400_0000;
 
-/// Linux x86-64 syscall number for rt_sigreturn.
-const SYS_RT_SIGRETURN: u64 = 15;
-
-// On x86-64 Linux the kernel provides no signal-return trampoline: the raw
-// `rt_sigaction` syscall requires userspace to supply one via `sa_restorer` +
-// `SA_RESTORER`, and *signal delivery itself fails* (a second, SI_KERNEL
-// SIGSEGV that force-kills the process) if it is missing — even when the
-// handler never returns. glibc hides this by always installing its own
-// trampoline; a freestanding runtime must define its own. This one simply
-// issues the `rt_sigreturn` syscall. Our handler exits and never returns, so
-// this is never actually executed, but it must be present and valid for the
-// kernel to accept and deliver the signal.
-core::arch::global_asm!(
-    ".globl __rue_rt_sigreturn",
-    ".hidden __rue_rt_sigreturn",
-    "__rue_rt_sigreturn:",
-    "mov rax, {sysno}",
-    "syscall",
-    sysno = const SYS_RT_SIGRETURN,
-);
-
-unsafe extern "C" {
-    /// Signal-return trampoline defined in `global_asm!` above. Address only —
-    /// never called directly from Rust.
-    fn __rue_rt_sigreturn();
-}
-
 /// Kernel `struct sigaction` layout on x86-64 Linux (the ABI `rt_sigaction`
 /// expects). Field order differs from the userspace/POSIX struct: on x86-64 the
 /// mask comes last. `sa_restorer` must point at a valid signal-return
@@ -581,7 +554,7 @@ pub fn install_stack_overflow_handler(handler: extern "C" fn(i32) -> !) {
     let act = KernelSigaction {
         sa_handler: handler as usize,
         sa_flags: SA_ONSTACK | SA_RESTORER,
-        sa_restorer: __rue_rt_sigreturn as usize,
+        sa_restorer: crate::__rue_rt_sigreturn as usize,
         sa_mask: 0,
     };
     // SAFETY: `act` is a valid KernelSigaction; SIGSEGV is a valid signal.


### PR DESCRIPTION
Generate runtime helper and reserved-export declarations from the canonical typed ABI manifest, making symbol spelling, signatures, safety boundaries, target applicability, and wrapper ownership mechanically consistent.

Move ABI aggregate layouts to the shared manifest crate with compile-time layout assertions, and emit the retained version marker from the same canonical version declaration.

Fixes RUE-832