### PR TITLE
RUE-831: centralize runtime call planning

### DIFF
--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -7,6 +7,7 @@ rue_crate(
         "//crates/rue-builtins:rue-builtins",
         "//crates/rue-cfg:rue-cfg",
         "//crates/rue-error:rue-error",
+        "//crates/rue-runtime-abi:rue-runtime-abi",
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
         "//third-party:fixedbitset",

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -140,6 +140,151 @@ impl<'a> CfgLower<'a> {
         self.mir.intern_symbol(symbol)
     }
 
+    fn lower_runtime_call(
+        &mut self,
+        plan: crate::runtime_call_plan::RuntimeCallPlan,
+    ) -> crate::value_plan::MaterializedValue {
+        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallResult};
+        use rue_runtime_abi::CallingConvention;
+
+        assert_eq!(plan.calling_convention(), CallingConvention::TargetC);
+        assert!(
+            plan.args().len() <= ARG_REGS.len(),
+            "runtime manifest exceeds the AArch64 target-C register budget"
+        );
+
+        let out_shape = plan.out_shape();
+        let out_bytes = out_shape
+            .map(|shape| (shape.shape().slots.len() as i32 * 8 + 15) & !15)
+            .unwrap_or(0);
+        if out_bytes > 0 {
+            self.mir.push(Aarch64Inst::SubImm {
+                dst: Operand::Physical(Reg::Sp),
+                src: Operand::Physical(Reg::Sp),
+                imm: out_bytes,
+            });
+        }
+
+        let materialized = plan
+            .args()
+            .iter()
+            .map(|arg| match *arg {
+                RuntimeCallArg::Slot { value, .. } => Some(value),
+                RuntimeCallArg::Scaled { value, scale, .. } => {
+                    Some(crate::allocation::lower_scale(self, value, scale))
+                }
+                RuntimeCallArg::Extended {
+                    value, extension, ..
+                } => {
+                    if extension == crate::value_plan::IntegerExtension::None {
+                        Some(value)
+                    } else {
+                        let extended = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(extended),
+                            src: Operand::Virtual(value),
+                        });
+                        let dst = Operand::Virtual(extended);
+                        let src = Operand::Virtual(extended);
+                        self.mir.push(match extension {
+                            crate::value_plan::IntegerExtension::Sign8 => {
+                                Aarch64Inst::Sxtb { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::Zero8 => {
+                                Aarch64Inst::Uxtb { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::Sign16 => {
+                                Aarch64Inst::Sxth { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::Zero16 => {
+                                Aarch64Inst::Uxth { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::Sign32 => {
+                                Aarch64Inst::Sxtw { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::None => unreachable!(),
+                        });
+                        Some(extended)
+                    }
+                }
+                RuntimeCallArg::Immediate { .. } | RuntimeCallArg::OutPointer { .. } => None,
+            })
+            .collect::<Vec<_>>();
+
+        for (index, (arg, value)) in plan.args().iter().zip(&materialized).enumerate() {
+            let dst = Operand::Physical(ARG_REGS[index]);
+            match *arg {
+                RuntimeCallArg::Slot { .. }
+                | RuntimeCallArg::Scaled { .. }
+                | RuntimeCallArg::Extended { .. } => {
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst,
+                        src: Operand::Virtual(value.expect("materialized runtime argument")),
+                    });
+                }
+                RuntimeCallArg::Immediate { value, .. } => {
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst,
+                        imm: value as i64,
+                    });
+                }
+                RuntimeCallArg::OutPointer { shape } => {
+                    assert_eq!(Some(shape), out_shape);
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst,
+                        src: Operand::Physical(Reg::Sp),
+                    });
+                }
+            }
+        }
+
+        let symbol_id = self.intern_symbol(plan.symbol());
+        self.mir.push(Aarch64Inst::Bl { symbol_id });
+
+        match plan.result() {
+            RuntimeCallResult::OutPointer(shape) => {
+                let slots = (0..shape.shape().slots.len())
+                    .map(|index| {
+                        let slot = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::Ldr {
+                            dst: Operand::Virtual(slot),
+                            base: Reg::Sp,
+                            offset: (index * 8) as i32,
+                        });
+                        slot
+                    })
+                    .collect::<Vec<_>>();
+                self.mir.push(Aarch64Inst::AddImm {
+                    dst: Operand::Physical(Reg::Sp),
+                    src: Operand::Physical(Reg::Sp),
+                    imm: out_bytes,
+                });
+                crate::value_plan::MaterializedValue {
+                    primary: slots[0],
+                    slots,
+                }
+            }
+            RuntimeCallResult::Scalar(_) => {
+                let primary = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Virtual(primary),
+                    src: Operand::Physical(Reg::X0),
+                });
+                crate::value_plan::MaterializedValue {
+                    primary,
+                    slots: Vec::new(),
+                }
+            }
+            RuntimeCallResult::Void => {
+                let primary = self.mir.alloc_vreg();
+                crate::value_plan::MaterializedValue {
+                    primary,
+                    slots: Vec::new(),
+                }
+            }
+        }
+    }
+
     fn emit_store_ptr_base(&mut self, src: VReg, ptr: VReg) {
         self.mir.push(Aarch64Inst::StrIndexed {
             src: Operand::Virtual(src),
@@ -181,7 +326,11 @@ impl<'a> CfgLower<'a> {
 
     /// Emit a target-local cleanup call using the normalized slot vector.
     fn emit_slot_call(&mut self, arg_vregs: &[VReg], symbol: &str) {
-        let plan = crate::call_plan::CallPlan::from_slot_values(symbol, arg_vregs, ARG_REGS.len());
+        let plan = crate::call_plan::CallPlan::from_slot_values(
+            crate::call_plan::CallTarget::rue(symbol),
+            arg_vregs,
+            ARG_REGS.len(),
+        );
         let _ = self.lower_call_plan(plan);
     }
 
@@ -263,7 +412,8 @@ impl<'a> CfgLower<'a> {
         plan: crate::value_plan::ArithmeticPlan,
     ) -> crate::value_plan::MaterializedValue {
         use crate::value_plan::ArithmeticOperation;
-        let trap_symbols = plan.trap_symbols;
+        let overflow_call = plan.overflow_call;
+        let div_by_zero_call = plan.div_by_zero_call;
         let vreg = match plan.operation {
             ArithmeticOperation::Add { lhs, rhs, width } => {
                 let vreg = self.mir.alloc_vreg();
@@ -280,7 +430,7 @@ impl<'a> CfgLower<'a> {
                         src2: Operand::Virtual(rhs),
                     }
                 });
-                self.emit_overflow_check_add(width, vreg, trap_symbols.overflow);
+                self.emit_overflow_check_add(width, vreg, overflow_call.clone());
                 vreg
             }
             ArithmeticOperation::Sub { lhs, rhs, width } => {
@@ -298,7 +448,7 @@ impl<'a> CfgLower<'a> {
                         src2: Operand::Virtual(rhs),
                     }
                 });
-                self.emit_overflow_check_sub(width, vreg, trap_symbols.overflow);
+                self.emit_overflow_check_sub(width, vreg, overflow_call.clone());
                 vreg
             }
             ArithmeticOperation::Mul {
@@ -366,11 +516,10 @@ impl<'a> CfgLower<'a> {
                         cond: Cond::Eq,
                         label: ok,
                     });
-                    let symbol_id = self.intern_symbol(trap_symbols.overflow);
-                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+                    let _ = self.lower_runtime_call(overflow_call.clone());
                     self.mir.push(Aarch64Inst::Label { id: ok });
                 } else {
-                    self.emit_overflow_check_mul(width, vreg, lhs, rhs, trap_symbols.overflow);
+                    self.emit_overflow_check_mul(width, vreg, lhs, rhs, overflow_call.clone());
                 }
                 vreg
             }
@@ -381,11 +530,10 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(rhs),
                     label: ok,
                 });
-                let symbol_id = self.intern_symbol(trap_symbols.div_by_zero);
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
+                let _ = self.lower_runtime_call(div_by_zero_call.clone());
                 self.mir.push(Aarch64Inst::Label { id: ok });
                 if width.signed {
-                    self.emit_signed_div_overflow_check(width, lhs, rhs, trap_symbols.overflow);
+                    self.emit_signed_div_overflow_check(width, lhs, rhs, overflow_call.clone());
                 }
                 self.mir.push(if width.signed {
                     if width.bits == 64 {
@@ -423,11 +571,10 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(rhs),
                     label: ok,
                 });
-                let symbol_id = self.intern_symbol(trap_symbols.div_by_zero);
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
+                let _ = self.lower_runtime_call(div_by_zero_call.clone());
                 self.mir.push(Aarch64Inst::Label { id: ok });
                 if width.signed {
-                    self.emit_signed_div_overflow_check(width, lhs, rhs, trap_symbols.overflow);
+                    self.emit_signed_div_overflow_check(width, lhs, rhs, overflow_call.clone());
                 }
                 let quotient = self.mir.alloc_vreg();
                 self.mir.push(if width.signed {
@@ -487,7 +634,7 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(value),
                     }
                 });
-                self.emit_overflow_check_neg(width, vreg, trap_symbols.overflow);
+                self.emit_overflow_check_neg(width, vreg, overflow_call.clone());
                 vreg
             }
         };
@@ -540,7 +687,7 @@ impl<'a> CfgLower<'a> {
                 src: Operand::Virtual(*arg),
             });
         }
-        let symbol_id = self.intern_symbol(&plan.symbol);
+        let symbol_id = self.intern_symbol(plan.target.symbol());
         self.mir.push(Aarch64Inst::Bl { symbol_id });
         if plan.stack_bytes > 0 {
             self.mir.push(Aarch64Inst::AddImm {
@@ -792,7 +939,8 @@ impl<'a> CfgLower<'a> {
                 lhs,
                 rhs,
                 leaf_types,
-            } => self.lower_comparison(op, lhs, rhs, plan.policy, &leaf_types),
+                runtime_call,
+            } => self.lower_comparison(op, lhs, rhs, plan.policy, &leaf_types, runtime_call),
             ResidualValuePlan::Alloc {
                 slot,
                 init,
@@ -998,7 +1146,7 @@ impl<'a> CfgLower<'a> {
             ResidualValuePlan::IntCast {
                 value,
                 from_width,
-                trap_symbol,
+                trap_call,
             } => {
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovRR {
@@ -1006,7 +1154,7 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(value),
                 });
                 let to_width = width.unwrap();
-                self.emit_int_cast_check(value, from_width, to_width, trap_symbol);
+                self.emit_int_cast_check(value, from_width, to_width, trap_call);
                 if from_width.signed && to_width.bits > from_width.bits {
                     let src = Operand::Virtual(value);
                     let dst = Operand::Virtual(dst);
@@ -1153,6 +1301,7 @@ impl<'a> CfgLower<'a> {
         rhs: crate::value_plan::MaterializedValue,
         policy: crate::value_plan::ValuePlan,
         leaf_types: &[Type],
+        runtime_call: Option<crate::runtime_call_plan::RuntimeCallPlan>,
     ) -> VReg {
         match policy.comparison.expect("comparison plan") {
             crate::value_plan::ComparisonPreparation::Scalar { .. } => {
@@ -1167,28 +1316,9 @@ impl<'a> CfgLower<'a> {
                 dst
             }
             crate::value_plan::ComparisonPreparation::StringContent { .. } => {
-                assert!(
-                    lhs.slots.len() >= 2 && rhs.slots.len() >= 2,
-                    "normalized string comparison needs ptr and len slots"
-                );
-                let dst = self.mir.alloc_vreg();
-                for (reg, slot) in [
-                    (Reg::X0, lhs.slots[0]),
-                    (Reg::X1, lhs.slots[1]),
-                    (Reg::X2, rhs.slots[0]),
-                    (Reg::X3, rhs.slots[1]),
-                ] {
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Physical(reg),
-                        src: Operand::Virtual(slot),
-                    });
-                }
-                let symbol_id = self.intern_symbol("__rue_str_eq");
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::X0),
-                });
+                let dst = self
+                    .lower_runtime_call(runtime_call.expect("string equality runtime call plan"))
+                    .primary;
                 if matches!(op, crate::value_plan::ComparisonOp::Ne) {
                     self.mir.push(Aarch64Inst::EorImm {
                         dst: Operand::Virtual(dst),
@@ -1214,133 +1344,31 @@ impl<'a> CfgLower<'a> {
         &mut self,
         plan: crate::value_plan::TrapPlan,
     ) -> crate::value_plan::MaterializedValue {
-        let panic = |this: &mut Self,
-                     message: Option<crate::value_plan::MaterializedValue>,
-                     symbol: &str| {
-            if let Some(message) = message.filter(|message| message.slots.len() >= 2) {
-                this.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(Reg::X0),
-                    src: Operand::Virtual(message.slots[0]),
-                });
-                this.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(Reg::X1),
-                    src: Operand::Virtual(message.slots[1]),
-                });
-                let symbol_id = this.intern_symbol(symbol);
-                this.mir.push(Aarch64Inst::Bl { symbol_id });
-            } else {
-                let symbol_id = this.intern_symbol(symbol);
-                this.mir.push(Aarch64Inst::Bl { symbol_id });
-            }
-        };
         match plan {
-            crate::value_plan::TrapPlan::Panic { message, symbol } => panic(self, message, &symbol),
-            crate::value_plan::TrapPlan::Assert {
-                condition,
-                message,
-                symbol,
-            } => {
+            crate::value_plan::TrapPlan::Panic { call } => self.lower_runtime_call(call),
+            crate::value_plan::TrapPlan::Assert { condition, call } => {
                 let pass = self.mir.alloc_label();
                 self.mir.push(Aarch64Inst::Cbnz {
                     src: Operand::Virtual(condition),
                     label: pass,
                 });
-                panic(self, message, &symbol);
+                let result = self.lower_runtime_call(call);
                 self.mir.push(Aarch64Inst::Label { id: pass });
+                result
             }
-        }
-        let primary = self.mir.alloc_vreg();
-        self.mir.push(Aarch64Inst::MovImm {
-            dst: Operand::Virtual(primary),
-            imm: 0,
-        });
-        crate::value_plan::MaterializedValue {
-            primary,
-            slots: Vec::new(),
         }
     }
 
     fn lower_option_intrinsic(
         &mut self,
         plan: &crate::value_plan::IntrinsicPlan,
-        intrinsic: crate::value_plan::OptionIntrinsic,
+        _intrinsic: crate::value_plan::OptionIntrinsic,
     ) -> crate::value_plan::MaterializedValue {
-        let crate::value_plan::IntrinsicOperation::Option {
-            some_discriminant: some_disc,
-            none_discriminant: none_disc,
-            ..
-        } = plan.operation
-        else {
-            unreachable!()
-        };
-        let total_slots = plan.result_slots;
-        let sret_bytes = (total_slots as i32 * 8 + 15) & !15;
-        self.mir.push(Aarch64Inst::SubImm {
-            dst: Operand::Physical(Reg::Sp),
-            src: Operand::Physical(Reg::Sp),
-            imm: sret_bytes,
-        });
-        self.mir.push(Aarch64Inst::MovRR {
-            dst: Operand::Physical(Reg::X0),
-            src: Operand::Physical(Reg::Sp),
-        });
-        if intrinsic == crate::value_plan::OptionIntrinsic::ReadLine {
-            self.mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Physical(Reg::X1),
-                imm: some_disc as i64,
-            });
-            self.mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Physical(Reg::X2),
-                imm: none_disc as i64,
-            });
-        } else {
-            assert!(
-                plan.args.first().is_some_and(|arg| arg.slots.len() >= 2),
-                "normalized parse argument needs ptr and len slots"
-            );
-            let arg = &plan.args[0];
-            for (reg, src) in [(Reg::X1, arg.slots[0]), (Reg::X2, arg.slots[1])] {
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(reg),
-                    src: Operand::Virtual(src),
-                });
-            }
-            self.mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Physical(Reg::X3),
-                imm: some_disc as i64,
-            });
-            self.mir.push(Aarch64Inst::MovImm {
-                dst: Operand::Physical(Reg::X4),
-                imm: none_disc as i64,
-            });
-        }
-        let symbol_id = self.intern_symbol(
-            plan.runtime_symbol
-                .as_deref()
-                .expect("option intrinsic runtime symbol"),
-        );
-        self.mir.push(Aarch64Inst::Bl { symbol_id });
-        let slots: Vec<_> = (0..total_slots)
-            .map(|index| {
-                let slot = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::Ldr {
-                    dst: Operand::Virtual(slot),
-                    base: Reg::Sp,
-                    offset: (index * 8) as i32,
-                });
-                slot
-            })
-            .collect();
-        self.mir.push(Aarch64Inst::AddImm {
-            dst: Operand::Physical(Reg::Sp),
-            src: Operand::Physical(Reg::Sp),
-            imm: sret_bytes,
-        });
-        let primary = slots
-            .first()
-            .copied()
-            .unwrap_or_else(|| self.mir.alloc_vreg());
-        crate::value_plan::MaterializedValue { primary, slots }
+        self.lower_runtime_call(
+            plan.runtime_call
+                .clone()
+                .expect("option intrinsic runtime call plan"),
+        )
     }
 
     fn lower_intrinsic_plan(
@@ -1357,18 +1385,11 @@ impl<'a> CfgLower<'a> {
             }
             crate::value_plan::IntrinsicOperation::RandomU32
             | crate::value_plan::IntrinsicOperation::RandomU64 => {
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("random intrinsic runtime symbol"),
-                );
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::X0),
-                });
-                dst
+                self.lower_runtime_call(
+                    plan.runtime_call
+                        .expect("random intrinsic runtime call plan"),
+                )
+                .primary
             }
             crate::value_plan::IntrinsicOperation::PtrToInt
             | crate::value_plan::IntrinsicOperation::IntToPtr => {
@@ -1463,189 +1484,31 @@ impl<'a> CfgLower<'a> {
                 dst
             }
             crate::value_plan::IntrinsicOperation::Alloc { element_size } => {
-                let size = plan
-                    .scale
-                    .map(|scale| allocation::lower_scale(self, plan.args[0].primary, scale))
-                    .unwrap_or(plan.args[0].primary);
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(Reg::X0),
-                    src: Operand::Virtual(size),
-                });
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Physical(Reg::X1),
-                    imm: element_size as i64,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("alloc intrinsic runtime symbol"),
-                );
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::X0),
-                });
-                dst
+                let _ = element_size;
+                self.lower_runtime_call(plan.runtime_call.expect("alloc runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::Free { element_size } => {
-                let size = if element_size == 8 {
-                    allocation::lower_scale(
-                        self,
-                        plan.args[1].primary,
-                        plan.scale.expect("free scale"),
-                    )
-                } else {
-                    plan.args[1].primary
-                };
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(Reg::X0),
-                    src: Operand::Virtual(plan.args[0].primary),
-                });
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(Reg::X1),
-                    src: Operand::Virtual(size),
-                });
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Physical(Reg::X2),
-                    imm: element_size as i64,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("free intrinsic runtime symbol"),
-                );
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Virtual(dst),
-                    imm: 0,
-                });
-                dst
+                let _ = element_size;
+                self.lower_runtime_call(plan.runtime_call.expect("free runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::Realloc { element_size } => {
-                if element_size == 8 {
-                    let old = allocation::lower_scale(
-                        self,
-                        plan.args[1].primary,
-                        plan.scale.expect("realloc scale"),
-                    );
-                    let new = allocation::lower_scale(
-                        self,
-                        plan.args[2].primary,
-                        plan.scale.expect("realloc scale"),
-                    );
-                    for (src, reg) in [
-                        (plan.args[0].primary, Reg::X0),
-                        (old, Reg::X1),
-                        (new, Reg::X2),
-                    ] {
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Physical(reg),
-                            src: Operand::Virtual(src),
-                        });
-                    }
-                    self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Physical(Reg::X3),
-                        imm: 8,
-                    });
-                } else {
-                    for (arg, reg) in plan.args.iter().zip([Reg::X0, Reg::X1, Reg::X2]) {
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Physical(reg),
-                            src: Operand::Virtual(arg.primary),
-                        });
-                    }
-                    self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Physical(Reg::X3),
-                        imm: 1,
-                    });
-                }
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("realloc intrinsic runtime symbol"),
-                );
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::X0),
-                });
-                dst
+                let _ = element_size;
+                self.lower_runtime_call(plan.runtime_call.expect("realloc runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::AllocBytes => {
-                let size = plan.args[0].primary;
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(Reg::X0),
-                    src: Operand::Virtual(size),
-                });
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Physical(Reg::X1),
-                    imm: 1,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("alloc-bytes intrinsic runtime symbol"),
-                );
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::X0),
-                });
-                dst
+                self.lower_runtime_call(plan.runtime_call.expect("alloc-bytes runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::FreeBytes => {
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(Reg::X0),
-                    src: Operand::Virtual(plan.args[0].primary),
-                });
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(Reg::X1),
-                    src: Operand::Virtual(plan.args[1].primary),
-                });
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Physical(Reg::X2),
-                    imm: 1,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("free-bytes intrinsic runtime symbol"),
-                );
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Virtual(dst),
-                    imm: 0,
-                });
-                dst
+                self.lower_runtime_call(plan.runtime_call.expect("free-bytes runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::ReallocBytes => {
-                for (arg, reg) in plan.args.iter().zip([Reg::X0, Reg::X1, Reg::X2]) {
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Physical(reg),
-                        src: Operand::Virtual(arg.primary),
-                    });
-                }
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Physical(Reg::X3),
-                    imm: 1,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("realloc-bytes intrinsic runtime symbol"),
-                );
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::X0),
-                });
-                dst
+                self.lower_runtime_call(plan.runtime_call.expect("realloc-bytes runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::ByteRead => {
                 let addr = self.mir.alloc_vreg();
@@ -1689,127 +1552,8 @@ impl<'a> CfgLower<'a> {
                 dst
             }
             crate::value_plan::IntrinsicOperation::Debug => {
-                let arg = &plan.args[0];
-                if arg.slots.len() >= 2 {
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Physical(Reg::X0),
-                        src: Operand::Virtual(arg.slots[0]),
-                    });
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Physical(Reg::X1),
-                        src: Operand::Virtual(arg.slots[1]),
-                    });
-                    let symbol_id = self.intern_symbol(
-                        plan.runtime_symbol
-                            .as_deref()
-                            .expect("debug intrinsic runtime symbol"),
-                    );
-                    self.mir.push(Aarch64Inst::Bl { symbol_id });
-                } else {
-                    match arg.debug {
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 8,
-                                signed: true,
-                            },
-                        ) => {
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(Aarch64Inst::Sxtb {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Physical(Reg::X0),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 16,
-                                signed: true,
-                            },
-                        ) => {
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(Aarch64Inst::Sxth {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Physical(Reg::X0),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 32,
-                                signed: true,
-                            },
-                        ) => {
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(Aarch64Inst::Sxtw {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Physical(Reg::X0),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 8,
-                                signed: false,
-                            },
-                        ) => {
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(Aarch64Inst::Uxtb {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Physical(Reg::X0),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 16,
-                                signed: false,
-                            },
-                        ) => {
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(Aarch64Inst::Uxth {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Physical(Reg::X0),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Bool
-                        | crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth { bits: 32 | 64, .. },
-                        ) => {
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::String
-                        | crate::value_plan::DebugValuePlan::Other
-                        | crate::value_plan::DebugValuePlan::Integer(_) => {
-                            unreachable!("dbg type")
-                        }
-                    }
-                    let symbol_id = self.intern_symbol(
-                        plan.runtime_symbol
-                            .as_deref()
-                            .expect("debug intrinsic runtime symbol"),
-                    );
-                    self.mir.push(Aarch64Inst::Bl { symbol_id });
-                }
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Virtual(dst),
-                    imm: 0,
-                });
-                dst
+                self.lower_runtime_call(plan.runtime_call.expect("debug runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::Syscall => {
                 let stack_space = ((plan.args.len() * 8 + 15) & !15) as i32;
@@ -1966,7 +1710,7 @@ impl<'a> CfgLower<'a> {
         &mut self,
         width: crate::value_plan::IntegerWidth,
         result_vreg: VReg,
-        trap_symbol: &str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
         let ok_label = self.mir.alloc_label();
 
@@ -1992,8 +1736,7 @@ impl<'a> CfgLower<'a> {
         }
 
         // Overflow occurred - call panic handler
-        let symbol_id = self.intern_symbol(trap_symbol);
-        self.mir.push(Aarch64Inst::Bl { symbol_id });
+        let _ = self.lower_runtime_call(trap_call.clone());
         self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
@@ -2006,7 +1749,7 @@ impl<'a> CfgLower<'a> {
         &mut self,
         width: crate::value_plan::IntegerWidth,
         result_vreg: VReg,
-        trap_symbol: &str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
         let ok_label = self.mir.alloc_label();
 
@@ -2031,8 +1774,7 @@ impl<'a> CfgLower<'a> {
             _ => return,
         }
 
-        let symbol_id = self.intern_symbol(trap_symbol);
-        self.mir.push(Aarch64Inst::Bl { symbol_id });
+        let _ = self.lower_runtime_call(trap_call.clone());
         self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
@@ -2047,7 +1789,7 @@ impl<'a> CfgLower<'a> {
         result_vreg: VReg,
         lhs_vreg: VReg,
         rhs_vreg: VReg,
-        trap_symbol: &str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
         let ok_label = self.mir.alloc_label();
 
@@ -2172,8 +1914,7 @@ impl<'a> CfgLower<'a> {
             _ => return,
         }
 
-        let symbol_id = self.intern_symbol(trap_symbol);
-        self.mir.push(Aarch64Inst::Bl { symbol_id });
+        let _ = self.lower_runtime_call(trap_call.clone());
         self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
@@ -2191,7 +1932,7 @@ impl<'a> CfgLower<'a> {
         width: crate::value_plan::IntegerWidth,
         lhs_vreg: VReg,
         rhs_vreg: VReg,
-        trap_symbol: &str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
         let ok_label = self.mir.alloc_label();
         let is_64 = width.bits == 64;
@@ -2242,8 +1983,7 @@ impl<'a> CfgLower<'a> {
         });
 
         // Overflow - call panic handler
-        let symbol_id = self.intern_symbol(trap_symbol);
-        self.mir.push(Aarch64Inst::Bl { symbol_id });
+        let _ = self.lower_runtime_call(trap_call.clone());
         self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
@@ -2256,7 +1996,7 @@ impl<'a> CfgLower<'a> {
         &mut self,
         width: crate::value_plan::IntegerWidth,
         result_vreg: VReg,
-        trap_symbol: &str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
         let ok_label = self.mir.alloc_label();
 
@@ -2288,8 +2028,7 @@ impl<'a> CfgLower<'a> {
             _ => return,
         }
 
-        let symbol_id = self.intern_symbol(trap_symbol);
-        self.mir.push(Aarch64Inst::Bl { symbol_id });
+        let _ = self.lower_runtime_call(trap_call.clone());
         self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
@@ -2320,7 +2059,7 @@ impl<'a> CfgLower<'a> {
         src_vreg: VReg,
         from_width: crate::value_plan::IntegerWidth,
         to_width: crate::value_plan::IntegerWidth,
-        trap_symbol: &str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
         let from_signed = from_width.signed;
         let to_signed = to_width.signed;
@@ -2370,8 +2109,7 @@ impl<'a> CfgLower<'a> {
                     });
 
                     // Below min - panic
-                    let symbol_id = self.intern_symbol(trap_symbol);
-                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+                    let _ = self.lower_runtime_call(trap_call.clone());
                     self.mir.push(Aarch64Inst::Label { id: ok_label });
 
                     let ok_label2 = self.mir.alloc_label();
@@ -2389,8 +2127,7 @@ impl<'a> CfgLower<'a> {
                     });
 
                     // Above max - panic
-                    let symbol_id = self.intern_symbol(trap_symbol);
-                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+                    let _ = self.lower_runtime_call(trap_call.clone());
                     self.mir.push(Aarch64Inst::Label { id: ok_label2 });
                 }
             } else {
@@ -2437,8 +2174,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Negative - panic
-                let symbol_id = self.intern_symbol(trap_symbol);
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
+                let _ = self.lower_runtime_call(trap_call.clone());
                 self.mir.push(Aarch64Inst::Label { id: ok_label });
 
                 // Also check upper bound if narrowing
@@ -2457,8 +2193,7 @@ impl<'a> CfgLower<'a> {
                     });
 
                     // Above max - panic
-                    let symbol_id = self.intern_symbol(trap_symbol);
-                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+                    let _ = self.lower_runtime_call(trap_call.clone());
                     self.mir.push(Aarch64Inst::Label { id: ok_label2 });
                 }
             }
@@ -2480,8 +2215,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Above max - panic
-                let symbol_id = self.intern_symbol(trap_symbol);
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
+                let _ = self.lower_runtime_call(trap_call.clone());
                 self.mir.push(Aarch64Inst::Label { id: ok_label });
             } else {
                 // Unsigned to unsigned: narrowing check
@@ -2498,8 +2232,7 @@ impl<'a> CfgLower<'a> {
                     });
 
                     // Above max - panic
-                    let symbol_id = self.intern_symbol(trap_symbol);
-                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+                    let _ = self.lower_runtime_call(trap_call.clone());
                     self.mir.push(Aarch64Inst::Label { id: ok_label });
                 }
             }
@@ -2616,20 +2349,8 @@ impl<'a> CfgLower<'a> {
                 });
             }
             TerminatorPlan::Return { mode } => match mode {
-                ReturnMode::Exit { value } => {
-                    if let Some(value) = value {
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Physical(Reg::X0),
-                            src: Operand::Virtual(value),
-                        });
-                    } else {
-                        self.mir.push(Aarch64Inst::MovImm {
-                            dst: Operand::Physical(Reg::X0),
-                            imm: 0,
-                        });
-                    }
-                    let symbol_id = self.intern_symbol("__rue_exit");
-                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+                ReturnMode::Exit { call } => {
+                    let _ = self.lower_runtime_call(call);
                 }
                 ReturnMode::Function { value } => match value {
                     ReturnValuePlan::ZeroSized => self.mir.push(Aarch64Inst::Ret),
@@ -2815,6 +2536,12 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn emit_call(&mut self, plan: crate::call_plan::CallPlan) -> crate::value_plan::ValueResult {
         crate::value_plan::ValueResult::Materialized(self.lower_call_plan(plan))
     }
+    fn emit_runtime_call(
+        &mut self,
+        plan: crate::runtime_call_plan::RuntimeCallPlan,
+    ) -> crate::value_plan::ValueResult {
+        crate::value_plan::ValueResult::Materialized(self.lower_runtime_call(plan))
+    }
     fn emit_intrinsic(
         &mut self,
         plan: crate::value_plan::IntrinsicPlan,
@@ -2974,11 +2701,14 @@ impl crate::allocation::BoundsCheckBackend for CfgLower<'_> {
         }
     }
 
-    fn emit_bounds_trap(&mut self, trap: crate::allocation::BoundsTrap, symbol: &'static str) {
+    fn emit_bounds_trap(
+        &mut self,
+        trap: crate::allocation::BoundsTrap,
+        call: crate::runtime_call_plan::RuntimeCallPlan,
+    ) {
         match trap {
             crate::allocation::BoundsTrap::IndexOutOfBounds => {
-                let symbol_id = self.intern_symbol(symbol);
-                self.mir.push(Aarch64Inst::Bl { symbol_id });
+                let _ = self.lower_runtime_call(call);
             }
         }
     }
@@ -3057,9 +2787,11 @@ impl crate::allocation::ScaleBackend for CfgLower<'_> {
                             src: Operand::Virtual(high_vreg),
                             label: ok_label,
                         });
-                        let symbol_id =
-                            self.intern_symbol(crate::allocation::RUNTIME_TRAP_SYMBOLS.overflow);
-                        self.mir.push(Aarch64Inst::Bl { symbol_id });
+                        let _ = self.lower_runtime_call(
+                            crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                                rue_runtime_abi::RuntimeHelperId::Overflow,
+                            ),
+                        );
                         self.mir.push(Aarch64Inst::Label { id: ok_label });
                     }
                 }
@@ -3206,13 +2938,13 @@ mod tests {
             })
     }
 
-    fn runtime_call_index(mir: &Aarch64Mir, symbol: &str) -> usize {
+    fn runtime_call_index(mir: &Aarch64Mir, helper: rue_runtime_abi::RuntimeHelperId) -> usize {
         mir.instructions()
             .iter()
             .position(|inst| {
-                matches!(inst, Aarch64Inst::Bl { symbol_id } if mir.get_symbol(*symbol_id) == symbol)
+                matches!(inst, Aarch64Inst::Bl { symbol_id } if mir.get_symbol(*symbol_id) == helper.symbol())
             })
-            .unwrap_or_else(|| panic!("missing call to {symbol}"))
+            .unwrap_or_else(|| panic!("missing call to {helper:?}"))
     }
 
     fn lower_to_mir(source: &str) -> Aarch64Mir {
@@ -3300,7 +3032,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_bytes_preview_lowers_to_true_byte_memory_ops() {
+    fn raw_bytes_runtime_helper_identity_and_slots_match_shared_plan() {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::RawBytes);
         let mir = lower_function_to_mir_with_preview(
@@ -3322,16 +3054,16 @@ mod tests {
                 .any(|inst| matches!(inst, Aarch64Inst::LdrbIndexed { .. }))
         );
 
-        let alloc = runtime_call_index(&mir, "__rue_alloc");
+        let alloc = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Alloc);
         assert_eq!(immediate_call_arg(&mir, alloc, Reg::X0), Some(3));
         assert_eq!(immediate_call_arg(&mir, alloc, Reg::X1), Some(1));
 
-        let realloc = runtime_call_index(&mir, "__rue_realloc");
+        let realloc = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Realloc);
         assert_eq!(immediate_call_arg(&mir, realloc, Reg::X1), Some(3));
         assert_eq!(immediate_call_arg(&mir, realloc, Reg::X2), Some(5));
         assert_eq!(immediate_call_arg(&mir, realloc, Reg::X3), Some(1));
 
-        let free = runtime_call_index(&mir, "__rue_free");
+        let free = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Free);
         assert_eq!(immediate_call_arg(&mir, free, Reg::X1), Some(5));
         assert_eq!(immediate_call_arg(&mir, free, Reg::X2), Some(1));
     }

--- a/crates/rue-codegen/src/allocation.rs
+++ b/crates/rue-codegen/src/allocation.rs
@@ -8,6 +8,7 @@
 //! instructions.
 
 use rue_air::{FrozenTypeInternPool, Type, TypeKind};
+use rue_runtime_abi::RuntimeHelperId;
 
 use crate::types;
 use crate::vreg::{LabelId, VReg};
@@ -156,41 +157,43 @@ pub enum BoundsTrap {
 }
 
 /// Runtime entries selected by shared language-level trap policy. Adapters
-/// receive these decided symbols and only intern/marshal the target call.
+/// receive these typed identities and only resolve symbols when building MIR.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RuntimeTrapSymbols {
-    pub bounds: &'static str,
-    pub overflow: &'static str,
-    pub div_by_zero: &'static str,
-    pub intcast_overflow: &'static str,
+pub struct RuntimeTrapHelpers {
+    pub bounds: RuntimeHelperId,
+    pub overflow: RuntimeHelperId,
+    pub div_by_zero: RuntimeHelperId,
+    pub intcast_overflow: RuntimeHelperId,
 }
 
-pub const RUNTIME_TRAP_SYMBOLS: RuntimeTrapSymbols = RuntimeTrapSymbols {
-    bounds: "__rue_bounds_check",
-    overflow: "__rue_overflow",
-    div_by_zero: "__rue_div_by_zero",
-    intcast_overflow: "__rue_intcast_overflow",
+pub const RUNTIME_TRAP_HELPERS: RuntimeTrapHelpers = RuntimeTrapHelpers {
+    bounds: RuntimeHelperId::BoundsCheck,
+    overflow: RuntimeHelperId::Overflow,
+    div_by_zero: RuntimeHelperId::DivByZero,
+    intcast_overflow: RuntimeHelperId::IntcastOverflow,
 };
 
 /// A complete target-neutral bounds-check plan.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BoundsCheckPlan {
     pub index: VReg,
     pub length: u64,
     pub condition: BoundsCondition,
     pub trap: BoundsTrap,
-    pub trap_symbol: &'static str,
+    pub trap_call: crate::runtime_call_plan::RuntimeCallPlan,
 }
 
 impl BoundsCheckPlan {
     #[inline]
-    pub const fn new(index: VReg, length: u64) -> Self {
+    pub fn new(index: VReg, length: u64) -> Self {
         Self {
             index,
             length,
             condition: BoundsCondition::UnsignedIndexLessThanLength,
             trap: BoundsTrap::IndexOutOfBounds,
-            trap_symbol: RUNTIME_TRAP_SYMBOLS.bounds,
+            trap_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                RUNTIME_TRAP_HELPERS.bounds,
+            ),
         }
     }
 }
@@ -201,7 +204,11 @@ pub trait BoundsCheckBackend {
     fn emit_bounds_compare(&mut self, index: VReg, length: VReg);
     fn alloc_bounds_label(&mut self) -> LabelId;
     fn emit_bounds_branch(&mut self, condition: BoundsCondition, label: LabelId);
-    fn emit_bounds_trap(&mut self, trap: BoundsTrap, symbol: &'static str);
+    fn emit_bounds_trap(
+        &mut self,
+        trap: BoundsTrap,
+        call: crate::runtime_call_plan::RuntimeCallPlan,
+    );
     fn emit_bounds_label(&mut self, label: LabelId);
 }
 
@@ -213,7 +220,7 @@ pub fn lower_bounds_check<B: BoundsCheckBackend + ?Sized>(b: &mut B, plan: Bound
     b.emit_bounds_compare(plan.index, length);
     let ok = b.alloc_bounds_label();
     b.emit_bounds_branch(plan.condition, ok);
-    b.emit_bounds_trap(plan.trap, plan.trap_symbol);
+    b.emit_bounds_trap(plan.trap, plan.trap_call);
     b.emit_bounds_label(ok);
 }
 

--- a/crates/rue-codegen/src/call_plan.rs
+++ b/crates/rue-codegen/src/call_plan.rs
@@ -7,6 +7,7 @@
 
 use rue_air::FrozenTypeInternPool;
 use rue_cfg::{Cfg, CfgArgMode, CfgCallArg, Type};
+use rue_runtime_abi::{ReservedExportClass, ReservedExportId};
 
 use crate::cfg_lower::type_uses_sret_return;
 use crate::types;
@@ -18,16 +19,70 @@ pub enum CalleeAbi {
     /// A Rue-compiled function, whose aggregate arguments use reversed ABI
     /// slot order to preserve the ascending logical frame layout.
     Rue,
-    /// A runtime helper using the natural C-compatible aggregate slot order.
+    /// A compiler-built C routine using natural C-compatible slot order.
     Runtime,
 }
 
 impl CalleeAbi {
-    fn for_symbol(symbol: &str) -> Self {
-        if symbol.starts_with("__rue_") {
-            Self::Runtime
-        } else {
-            Self::Rue
+    const fn for_target(target: &CallTarget) -> Self {
+        match target {
+            CallTarget::Rue(_) => Self::Rue,
+            CallTarget::MemoryBuiltin(_) => Self::Runtime,
+        }
+    }
+}
+
+/// Typed logical identity of a call target.
+///
+/// Runtime helpers use the separately validated `RuntimeCallPlan` path. Rue
+/// functions (including generated drop glue) and compiler-built C memory
+/// routines remain separate classes instead of being inferred from a prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CallTarget {
+    Rue(String),
+    MemoryBuiltin(MemoryBuiltinId),
+}
+
+/// Checked identity for one compiler-built C memory routine.
+///
+/// This wrapper prevents other reserved runtime exports (entry points, shims,
+/// or ABI marker data) from being represented as callable memory builtins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryBuiltinId(ReservedExportId);
+
+impl MemoryBuiltinId {
+    pub fn new(id: ReservedExportId) -> Self {
+        assert_eq!(
+            id.export().class,
+            ReservedExportClass::CompilerBuiltMemory,
+            "memory builtin call targets must name compiler-built memory routines"
+        );
+        Self(id)
+    }
+
+    pub const fn export_id(self) -> ReservedExportId {
+        self.0
+    }
+
+    pub const fn symbol(self) -> &'static str {
+        self.0.symbol()
+    }
+}
+
+impl CallTarget {
+    pub fn rue(symbol: impl Into<String>) -> Self {
+        Self::Rue(symbol.into())
+    }
+
+    pub fn memory_builtin(id: ReservedExportId) -> Self {
+        Self::MemoryBuiltin(MemoryBuiltinId::new(id))
+    }
+
+    /// Resolve the external symbol at the MIR symbol-table boundary.
+    pub fn symbol(&self) -> &str {
+        match self {
+            Self::Rue(symbol) => symbol,
+            Self::MemoryBuiltin(id) => id.symbol(),
         }
     }
 }
@@ -113,7 +168,7 @@ impl ReturnPlan {
 /// A normalized call ABI plan consumed by both target adapters.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallPlan {
-    pub symbol: String,
+    pub target: CallTarget,
     pub callee_abi: CalleeAbi,
     pub hidden_sret: Option<HiddenSretPlan>,
     pub user_args: Vec<UserArgPlan>,
@@ -236,14 +291,14 @@ impl CallPlan {
     /// by-reference arguments always return one address vreg, including for a
     /// zero-sized pointee.
     pub fn from_inputs<M: CallMaterializer>(
-        symbol: &str,
+        target: CallTarget,
         return_plan: ReturnPlan,
         args: &[CallArgInput],
         arg_reg_budget: usize,
         materializer: &mut M,
     ) -> Self {
         Self::from_inputs_with_result(
-            symbol,
+            target,
             return_plan,
             args,
             arg_reg_budget,
@@ -253,14 +308,14 @@ impl CallPlan {
     }
 
     pub fn from_inputs_with_result<M: CallMaterializer>(
-        symbol: &str,
+        target: CallTarget,
         return_plan: ReturnPlan,
         args: &[CallArgInput],
         arg_reg_budget: usize,
         materializer: &mut M,
         result: Option<VReg>,
     ) -> Self {
-        let callee_abi = CalleeAbi::for_symbol(symbol);
+        let callee_abi = CalleeAbi::for_target(&target);
         let mut hidden_sret = None;
         let mut abi_slots = Vec::new();
 
@@ -322,7 +377,7 @@ impl CallPlan {
         let stack_bytes = align_up((stack_slot_count * 8) as u32, 16);
 
         Self {
-            symbol: symbol.to_owned(),
+            target,
             callee_abi,
             hidden_sret,
             user_args,
@@ -336,11 +391,11 @@ impl CallPlan {
 
     /// Build the same normalized shape for drop/glue calls whose slots have
     /// already been materialized by the canonical aggregate leaves.
-    pub fn from_slot_values(symbol: &str, slots: &[VReg], arg_reg_budget: usize) -> Self {
+    pub fn from_slot_values(target: CallTarget, slots: &[VReg], arg_reg_budget: usize) -> Self {
         let stack_slot_count = slots.len().saturating_sub(arg_reg_budget);
         Self {
-            symbol: symbol.to_owned(),
-            callee_abi: CalleeAbi::for_symbol(symbol),
+            callee_abi: CalleeAbi::for_target(&target),
+            target,
             hidden_sret: None,
             user_args: vec![UserArgPlan {
                 mode: UserArgMode::Value,
@@ -458,7 +513,7 @@ mod tests {
     #[test]
     fn slot_call_plan_counts_aligned_stack_slots() {
         let slots: Vec<_> = (0..9).map(VReg::new).collect();
-        let plan = CallPlan::from_slot_values("drop", &slots, 6);
+        let plan = CallPlan::from_slot_values(CallTarget::rue("drop"), &slots, 6);
 
         assert_eq!(plan.abi_slots, slots);
         assert_eq!(plan.stack_slot_count, 3);
@@ -470,7 +525,7 @@ mod tests {
     fn zero_sized_normal_arguments_are_omitted_but_by_ref_is_preserved() {
         let slots = vec![VReg::new(7)];
         let plan = CallPlan {
-            symbol: "test".into(),
+            target: CallTarget::rue("test"),
             callee_abi: CalleeAbi::Rue,
             hidden_sret: None,
             user_args: vec![
@@ -534,7 +589,7 @@ mod tests {
         ];
         let mut materializer = TestMaterializer;
         let rue = CallPlan::from_inputs(
-            "callee",
+            CallTarget::rue("callee"),
             ReturnPlan::Sret {
                 slot_count: 3,
                 storage_bytes: 32,
@@ -553,23 +608,36 @@ mod tests {
         assert_eq!(rue.stack_bytes, 16);
         assert_eq!(rue.user_args[1].mode, UserArgMode::Borrow);
         assert!(rue.user_args[2].slots.is_empty());
+    }
+
+    #[test]
+    fn generated_rue_symbols_do_not_trigger_runtime_abi_by_prefix() {
+        let args = [CallArgInput::Value {
+            value: rue_cfg::CfgValue::from_raw(1),
+            slot_count: 2,
+            is_multislot_aggregate: true,
+        }];
 
         let mut materializer = TestMaterializer;
-        let runtime = CallPlan::from_inputs(
-            "__rue_runtime",
-            ReturnPlan::Sret {
-                slot_count: 3,
-                storage_bytes: 32,
-            },
+        let generated_rue = CallPlan::from_inputs(
+            CallTarget::rue("__rue_drop_generated"),
+            ReturnPlan::ZeroSized,
             &args,
             8,
             &mut materializer,
         );
-        assert_eq!(
-            runtime.abi_slots,
-            vec![VReg::new(40), VReg::new(10), VReg::new(11), VReg::new(30)]
-        );
-        assert_eq!(runtime.stack_slot_count, 0);
-        assert_eq!(runtime.stack_bytes, 0);
+        assert_eq!(generated_rue.callee_abi, CalleeAbi::Rue);
+        assert_eq!(generated_rue.abi_slots, vec![VReg::new(11), VReg::new(10)]);
+    }
+
+    #[test]
+    fn memory_builtins_are_distinct_from_helpers_and_rue_symbols() {
+        let target = CallTarget::memory_builtin(ReservedExportId::Memcpy);
+        assert_eq!(target.symbol(), "memcpy");
+        assert_eq!(CalleeAbi::for_target(&target), CalleeAbi::Runtime);
+        assert!(matches!(
+            target,
+            CallTarget::MemoryBuiltin(id) if id.export_id() == ReservedExportId::Memcpy
+        ));
     }
 }

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -44,6 +44,7 @@ macro_rules! end_inst {
 mod allocation;
 pub mod call_plan;
 mod codegen_pipeline;
+pub mod runtime_call_plan;
 mod schedule_core;
 mod stack_frame;
 mod stack_verify;

--- a/crates/rue-codegen/src/runtime_call_plan.rs
+++ b/crates/rue-codegen/src/runtime_call_plan.rs
@@ -1,0 +1,375 @@
+//! Manifest-derived planning for compiler calls into the Rue runtime.
+//!
+//! This is the single logical boundary between language/codegen policy and
+//! target call emission. A plan is keyed by [`RuntimeHelperId`], validated
+//! against that helper's complete manifest signature, and retains logical
+//! argument materialization until a target adapter assigns physical registers.
+
+use rue_runtime_abi::{
+    AbiParameter, AbiResult, AbiType, AggregateShapeId, CallingConvention, ParameterMode,
+    ReturnBehavior, RuntimeHelperId,
+};
+
+use crate::allocation::ScalePlan;
+use crate::call_plan::{CallArgInput, CallMaterializer, ReturnPlan};
+use crate::vreg::VReg;
+
+/// One canonical logical runtime argument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeCallArg {
+    Slot {
+        value: VReg,
+        parameter: AbiParameter,
+    },
+    Immediate {
+        value: u64,
+        parameter: AbiParameter,
+    },
+    Scaled {
+        value: VReg,
+        scale: ScalePlan,
+        parameter: AbiParameter,
+    },
+    Extended {
+        value: VReg,
+        extension: crate::value_plan::IntegerExtension,
+        parameter: AbiParameter,
+    },
+    OutPointer {
+        shape: AggregateShapeId,
+    },
+}
+
+impl RuntimeCallArg {
+    pub const fn value(value: VReg, ty: AbiType) -> Self {
+        Self::Slot {
+            value,
+            parameter: AbiParameter::value(ty),
+        }
+    }
+
+    pub const fn const_pointer(value: VReg, ty: AbiType) -> Self {
+        Self::Slot {
+            value,
+            parameter: AbiParameter::const_pointer(ty),
+        }
+    }
+
+    pub const fn mut_pointer(value: VReg, ty: AbiType) -> Self {
+        Self::Slot {
+            value,
+            parameter: AbiParameter::mut_pointer(ty),
+        }
+    }
+
+    pub const fn immediate(value: u64, ty: AbiType) -> Self {
+        Self::Immediate {
+            value,
+            parameter: AbiParameter::value(ty),
+        }
+    }
+
+    pub const fn scaled(value: VReg, scale: ScalePlan, ty: AbiType) -> Self {
+        Self::Scaled {
+            value,
+            scale,
+            parameter: AbiParameter::value(ty),
+        }
+    }
+
+    pub const fn extended(
+        value: VReg,
+        extension: crate::value_plan::IntegerExtension,
+        ty: AbiType,
+    ) -> Self {
+        Self::Extended {
+            value,
+            extension,
+            parameter: AbiParameter::value(ty),
+        }
+    }
+
+    pub const fn out_pointer(shape: AggregateShapeId) -> Self {
+        Self::OutPointer { shape }
+    }
+
+    pub(crate) const fn from_parameter(value: VReg, parameter: AbiParameter) -> Self {
+        Self::Slot { value, parameter }
+    }
+
+    pub const fn parameter(self) -> AbiParameter {
+        match self {
+            Self::Slot { parameter, .. }
+            | Self::Immediate { parameter, .. }
+            | Self::Scaled { parameter, .. }
+            | Self::Extended { parameter, .. } => parameter,
+            Self::OutPointer { shape } => AbiParameter::out_pointer(shape),
+        }
+    }
+}
+
+/// Manifest-derived result materialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeCallResult {
+    Void,
+    Scalar(AbiType),
+    OutPointer(AggregateShapeId),
+}
+
+/// A complete normalized runtime call consumed identically by both backends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCallPlan {
+    helper: RuntimeHelperId,
+    args: Vec<RuntimeCallArg>,
+    result: RuntimeCallResult,
+    return_behavior: ReturnBehavior,
+    calling_convention: CallingConvention,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeCallPlanError {
+    ParameterCount {
+        expected: usize,
+        actual: usize,
+    },
+    Parameter {
+        index: usize,
+        expected: AbiParameter,
+        actual: AbiParameter,
+    },
+    MultipleOutPointers,
+    OutPointerWithDirectResult,
+    SemanticReturn {
+        expected: RuntimeCallResult,
+        actual: ReturnPlan,
+    },
+    FlattenedSlotCount {
+        expected: usize,
+        actual: usize,
+    },
+}
+
+impl RuntimeCallPlan {
+    pub fn new(
+        helper: RuntimeHelperId,
+        args: impl IntoIterator<Item = RuntimeCallArg>,
+    ) -> Result<Self, RuntimeCallPlanError> {
+        let manifest = helper.helper();
+        let args = args.into_iter().collect::<Vec<_>>();
+        if args.len() != manifest.parameters.len() {
+            return Err(RuntimeCallPlanError::ParameterCount {
+                expected: manifest.parameters.len(),
+                actual: args.len(),
+            });
+        }
+
+        let mut out_shape = None;
+        for (index, (arg, expected)) in args.iter().zip(manifest.parameters).enumerate() {
+            let actual = arg.parameter();
+            if actual != *expected {
+                return Err(RuntimeCallPlanError::Parameter {
+                    index,
+                    expected: *expected,
+                    actual,
+                });
+            }
+            if let ParameterMode::OutPointer(shape) = actual.mode {
+                if out_shape.replace(shape).is_some() {
+                    return Err(RuntimeCallPlanError::MultipleOutPointers);
+                }
+            }
+        }
+
+        let result = match (out_shape, manifest.result) {
+            (Some(_), AbiResult::Scalar(_)) => {
+                return Err(RuntimeCallPlanError::OutPointerWithDirectResult);
+            }
+            (Some(shape), AbiResult::Void) => RuntimeCallResult::OutPointer(shape),
+            (None, AbiResult::Void) => RuntimeCallResult::Void,
+            (None, AbiResult::Scalar(ty)) => RuntimeCallResult::Scalar(ty),
+        };
+
+        Ok(Self {
+            helper,
+            args,
+            result,
+            return_behavior: manifest.return_behavior,
+            calling_convention: manifest.calling_convention,
+        })
+    }
+
+    pub fn expect_manifest(
+        helper: RuntimeHelperId,
+        args: impl IntoIterator<Item = RuntimeCallArg>,
+    ) -> Self {
+        Self::new(helper, args)
+            .unwrap_or_else(|error| panic!("invalid runtime call plan for {helper:?}: {error:?}"))
+    }
+
+    pub fn no_args(helper: RuntimeHelperId) -> Self {
+        Self::expect_manifest(helper, [])
+    }
+
+    /// Transitional exact bridge for CFG calls that still carry only an
+    /// interned symbol. The caller must first resolve that symbol to an exact
+    /// manifest helper identity; no prefix or naming convention is accepted.
+    pub(crate) fn from_cfg_inputs<M: CallMaterializer>(
+        helper: RuntimeHelperId,
+        return_plan: ReturnPlan,
+        args: &[CallArgInput],
+        materializer: &mut M,
+    ) -> Result<Self, RuntimeCallPlanError> {
+        let mut slots = Vec::new();
+        for arg in args {
+            match arg {
+                CallArgInput::ByRef { address, .. } => {
+                    slots.push(materializer.materialize_by_ref(address));
+                }
+                CallArgInput::Value {
+                    value,
+                    slot_count,
+                    is_multislot_aggregate,
+                } => {
+                    if *slot_count == 0 {
+                        continue;
+                    }
+                    if *is_multislot_aggregate {
+                        let materialized = materializer.materialize_aggregate(*value);
+                        assert_eq!(
+                            materialized.len(),
+                            *slot_count as usize,
+                            "aggregate materialization must produce every logical ABI slot"
+                        );
+                        slots.extend(materialized);
+                    } else {
+                        slots.push(materializer.materialize_scalar(*value));
+                    }
+                }
+            }
+        }
+
+        let manifest = helper.helper();
+        let expected_slots = manifest
+            .parameters
+            .iter()
+            .filter(|parameter| !matches!(parameter.mode, ParameterMode::OutPointer(_)))
+            .count();
+        if slots.len() != expected_slots {
+            return Err(RuntimeCallPlanError::FlattenedSlotCount {
+                expected: expected_slots,
+                actual: slots.len(),
+            });
+        }
+
+        let mut slots = slots.into_iter();
+        let call_args = manifest
+            .parameters
+            .iter()
+            .map(|parameter| match parameter.mode {
+                ParameterMode::OutPointer(shape) => RuntimeCallArg::out_pointer(shape),
+                ParameterMode::Value | ParameterMode::ConstPointer | ParameterMode::MutPointer => {
+                    RuntimeCallArg::from_parameter(
+                        slots
+                            .next()
+                            .expect("validated flattened runtime slot count"),
+                        *parameter,
+                    )
+                }
+            });
+        let plan = Self::new(helper, call_args)?;
+        let return_matches = match (plan.result, return_plan) {
+            (RuntimeCallResult::Void, ReturnPlan::ZeroSized)
+            | (RuntimeCallResult::Scalar(_), ReturnPlan::Scalar) => true,
+            (
+                RuntimeCallResult::OutPointer(shape),
+                ReturnPlan::Registers { slot_count } | ReturnPlan::Sret { slot_count, .. },
+            ) => shape.shape().slots.len() == slot_count as usize,
+            _ => false,
+        };
+        if !return_matches {
+            return Err(RuntimeCallPlanError::SemanticReturn {
+                expected: plan.result,
+                actual: return_plan,
+            });
+        }
+        Ok(plan)
+    }
+
+    pub const fn helper(&self) -> RuntimeHelperId {
+        self.helper
+    }
+
+    pub fn args(&self) -> &[RuntimeCallArg] {
+        &self.args
+    }
+
+    pub const fn result(&self) -> RuntimeCallResult {
+        self.result
+    }
+
+    pub const fn return_behavior(&self) -> ReturnBehavior {
+        self.return_behavior
+    }
+
+    pub const fn calling_convention(&self) -> CallingConvention {
+        self.calling_convention
+    }
+
+    pub const fn symbol(&self) -> &'static str {
+        self.helper.symbol()
+    }
+
+    pub fn out_shape(&self) -> Option<AggregateShapeId> {
+        match self.result() {
+            RuntimeCallResult::OutPointer(shape) => Some(shape),
+            RuntimeCallResult::Void | RuntimeCallResult::Scalar(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn panic_rejects_arbitrary_arguments_and_sret() {
+        assert_eq!(
+            RuntimeCallPlan::new(RuntimeHelperId::Panic, []),
+            Err(RuntimeCallPlanError::ParameterCount {
+                expected: 2,
+                actual: 0,
+            })
+        );
+        assert!(matches!(
+            RuntimeCallPlan::new(
+                RuntimeHelperId::Panic,
+                [
+                    RuntimeCallArg::out_pointer(AggregateShapeId::StrBufResult),
+                    RuntimeCallArg::immediate(0, AbiType::U64),
+                ],
+            ),
+            Err(RuntimeCallPlanError::Parameter { index: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn manifest_derives_results_and_control_contracts() {
+        let random = RuntimeCallPlan::no_args(RuntimeHelperId::RandomU64);
+        assert_eq!(random.result, RuntimeCallResult::Scalar(AbiType::U64));
+        assert_eq!(random.return_behavior, ReturnBehavior::Returns);
+        assert_eq!(random.calling_convention, CallingConvention::TargetC);
+
+        let read = RuntimeCallPlan::expect_manifest(
+            RuntimeHelperId::ReadLine,
+            [
+                RuntimeCallArg::out_pointer(AggregateShapeId::OptionStrBufResult),
+                RuntimeCallArg::immediate(1, AbiType::U64),
+                RuntimeCallArg::immediate(0, AbiType::U64),
+            ],
+        );
+        assert_eq!(
+            read.result,
+            RuntimeCallResult::OutPointer(AggregateShapeId::OptionStrBufResult)
+        );
+    }
+}

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -55,12 +55,17 @@ pub enum ReturnValuePlan {
     },
 }
 
-/// Target-neutral return behavior.  `Exit` is the language-level `main`
-/// termination mode; the adapter supplies the platform call sequence.
+/// Target-neutral return behavior. `Exit` is the language-level `main`
+/// termination mode; its manifest-derived call plan is shared, while the
+/// adapter assigns the platform argument registers and call instruction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReturnMode {
-    Exit { value: Option<VReg> },
-    Function { value: ReturnValuePlan },
+    Exit {
+        call: crate::runtime_call_plan::RuntimeCallPlan,
+    },
+    Function {
+        value: ReturnValuePlan,
+    },
 }
 
 /// Exhaustive target-neutral terminator plan.
@@ -434,11 +439,28 @@ pub fn plan_terminator<A: TerminatorAdapter>(
         }
         Terminator::Return { value } => {
             let mode = if fn_name == "main" {
+                let value = value.map(|value| {
+                    let plan = ValuePlan::for_value(ctx, value);
+                    adapter.materialize_value(value, plan).primary
+                });
                 ReturnMode::Exit {
-                    value: value.map(|value| {
-                        let plan = ValuePlan::for_value(ctx, value);
-                        adapter.materialize_value(value, plan).primary
-                    }),
+                    call: crate::runtime_call_plan::RuntimeCallPlan::expect_manifest(
+                        rue_runtime_abi::RuntimeHelperId::Exit,
+                        [value.map_or_else(
+                            || {
+                                crate::runtime_call_plan::RuntimeCallArg::immediate(
+                                    0,
+                                    rue_runtime_abi::AbiType::I32,
+                                )
+                            },
+                            |value| {
+                                crate::runtime_call_plan::RuntimeCallArg::value(
+                                    value,
+                                    rue_runtime_abi::AbiType::I32,
+                                )
+                            },
+                        )],
+                    ),
                 }
             } else {
                 ReturnMode::Function {

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -13,6 +13,7 @@
 use lasso::Spur;
 use rue_air::{EnumId, StructId, TypeKind};
 use rue_cfg::{CfgInstData, CfgValue, Place, PlaceBase, Projection, Type};
+use rue_runtime_abi::RuntimeHelperId;
 
 use crate::call_plan::CallPlan;
 use crate::cfg_lower::CfgLowerContext;
@@ -78,6 +79,7 @@ pub enum ResidualValuePlan {
         lhs: MaterializedValue,
         rhs: MaterializedValue,
         leaf_types: Vec<Type>,
+        runtime_call: Option<crate::runtime_call_plan::RuntimeCallPlan>,
     },
     Bitwise {
         op: BitwiseOp,
@@ -135,7 +137,7 @@ pub enum ResidualValuePlan {
     IntCast {
         value: VReg,
         from_width: IntegerWidth,
-        trap_symbol: &'static str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     },
     Drop {
         actions: Vec<DropAction>,
@@ -176,10 +178,11 @@ pub struct DropAction {
     pub slots: Vec<VReg>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArithmeticPlan {
     pub operation: ArithmeticOperation,
-    pub trap_symbols: crate::allocation::RuntimeTrapSymbols,
+    pub overflow_call: crate::runtime_call_plan::RuntimeCallPlan,
+    pub div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,13 +222,11 @@ pub enum ArithmeticOperation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TrapPlan {
     Panic {
-        message: Option<MaterializedValue>,
-        symbol: String,
+        call: crate::runtime_call_plan::RuntimeCallPlan,
     },
     Assert {
         condition: VReg,
-        message: Option<MaterializedValue>,
-        symbol: String,
+        call: crate::runtime_call_plan::RuntimeCallPlan,
     },
 }
 
@@ -293,9 +294,9 @@ pub enum IntrinsicOperation {
 pub struct IntrinsicPlan {
     pub operation: IntrinsicOperation,
     /// Shared runtime entry selected from the intrinsic semantics. Target
-    /// adapters marshal this symbol through their call leaf and do not map
+    /// adapters marshal this helper through their call leaf and do not map
     /// language intrinsics to runtime names themselves.
-    pub runtime_symbol: Option<String>,
+    pub runtime_call: Option<crate::runtime_call_plan::RuntimeCallPlan>,
     pub args: Vec<IntrinsicArgPlan>,
     pub result_ty: Type,
     pub result_slots: u32,
@@ -366,6 +367,8 @@ pub trait ValueLowerAdapter:
     fn return_register_budget(&self) -> u32;
     fn emit_value(&mut self, plan: ValueEmissionPlan) -> ValueResult;
     fn emit_call(&mut self, plan: CallPlan) -> ValueResult;
+    fn emit_runtime_call(&mut self, plan: crate::runtime_call_plan::RuntimeCallPlan)
+    -> ValueResult;
     fn emit_intrinsic(&mut self, plan: IntrinsicPlan) -> ValueResult;
     fn emit_checked_arithmetic(&mut self, plan: ArithmeticPlan) -> ValueResult;
     fn emit_trap(&mut self, plan: TrapPlan) -> ValueResult;
@@ -690,11 +693,37 @@ fn comparison_plan<A: ValueLowerAdapter>(
     } else {
         Vec::new()
     };
+    let lhs = operand(ctx, adapter, lhs);
+    let rhs = operand(ctx, adapter, rhs);
+    let runtime_call = ctx.is_string_like_for_equality(lhs_ty).then(|| {
+        crate::runtime_call_plan::RuntimeCallPlan::expect_manifest(
+            RuntimeHelperId::StrEq,
+            [
+                crate::runtime_call_plan::RuntimeCallArg::const_pointer(
+                    lhs.slots[0],
+                    rue_runtime_abi::AbiType::Byte,
+                ),
+                crate::runtime_call_plan::RuntimeCallArg::value(
+                    lhs.slots[1],
+                    rue_runtime_abi::AbiType::U64,
+                ),
+                crate::runtime_call_plan::RuntimeCallArg::const_pointer(
+                    rhs.slots[0],
+                    rue_runtime_abi::AbiType::Byte,
+                ),
+                crate::runtime_call_plan::RuntimeCallArg::value(
+                    rhs.slots[1],
+                    rue_runtime_abi::AbiType::U64,
+                ),
+            ],
+        )
+    });
     ResidualValuePlan::Comparison {
         op,
-        lhs: operand(ctx, adapter, lhs),
-        rhs: operand(ctx, adapter, rhs),
+        lhs,
+        rhs,
         leaf_types,
+        runtime_call,
     }
 }
 
@@ -1050,7 +1079,9 @@ fn residual_plan<A: ValueLowerAdapter>(
         ResidualInput::IntCast { value, from_ty } => ResidualValuePlan::IntCast {
             value: operand(ctx, adapter, value).primary,
             from_width: integer_width(from_ty).expect("integer cast source width"),
-            trap_symbol: crate::allocation::RUNTIME_TRAP_SYMBOLS.intcast_overflow,
+            trap_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                RuntimeHelperId::IntcastOverflow,
+            ),
         },
         ResidualInput::Drop { value } => ResidualValuePlan::Drop {
             actions: drop_plan(ctx, adapter, value),
@@ -1145,7 +1176,12 @@ pub fn lower_value<A: ValueLowerAdapter>(
             let rhs = operand(ctx, adapter, rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Add { lhs, rhs, width },
-                trap_symbols: crate::allocation::RUNTIME_TRAP_SYMBOLS,
+                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::Overflow,
+                ),
+                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::DivByZero,
+                ),
             });
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
@@ -1156,7 +1192,12 @@ pub fn lower_value<A: ValueLowerAdapter>(
             let rhs = operand(ctx, adapter, rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Sub { lhs, rhs, width },
-                trap_symbols: crate::allocation::RUNTIME_TRAP_SYMBOLS,
+                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::Overflow,
+                ),
+                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::DivByZero,
+                ),
             });
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
@@ -1181,7 +1222,12 @@ pub fn lower_value<A: ValueLowerAdapter>(
                     width,
                     shift,
                 },
-                trap_symbols: crate::allocation::RUNTIME_TRAP_SYMBOLS,
+                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::Overflow,
+                ),
+                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::DivByZero,
+                ),
             });
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
@@ -1192,7 +1238,12 @@ pub fn lower_value<A: ValueLowerAdapter>(
             let rhs = operand(ctx, adapter, rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Div { lhs, rhs, width },
-                trap_symbols: crate::allocation::RUNTIME_TRAP_SYMBOLS,
+                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::Overflow,
+                ),
+                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::DivByZero,
+                ),
             });
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
@@ -1203,7 +1254,12 @@ pub fn lower_value<A: ValueLowerAdapter>(
             let rhs = operand(ctx, adapter, rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Mod { lhs, rhs, width },
-                trap_symbols: crate::allocation::RUNTIME_TRAP_SYMBOLS,
+                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::Overflow,
+                ),
+                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::DivByZero,
+                ),
             });
             cache_result(adapter, value, result);
             Some(ValueKind::BinaryArithmetic)
@@ -1216,7 +1272,12 @@ pub fn lower_value<A: ValueLowerAdapter>(
                     value: operand_vreg,
                     width,
                 },
-                trap_symbols: crate::allocation::RUNTIME_TRAP_SYMBOLS,
+                overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::Overflow,
+                ),
+                div_by_zero_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                    RuntimeHelperId::DivByZero,
+                ),
             });
             cache_result(adapter, value, result);
             Some(ValueKind::UnaryArithmetic)
@@ -1248,17 +1309,31 @@ pub fn lower_value<A: ValueLowerAdapter>(
                 &by_ref_plans,
                 adapter.return_register_budget(),
             );
-            let result_vreg = adapter.reserve_value_result();
             let symbol = adapter.resolve_symbol(name);
-            let plan = crate::call_plan::CallPlan::from_inputs_with_result(
-                &symbol,
-                inputs.return_plan,
-                &inputs.args,
-                adapter.call_arg_register_budget(),
-                adapter,
-                Some(result_vreg),
-            );
-            let result = adapter.emit_call(plan);
+            let runtime_helper = runtime_helper_for_symbol(&symbol);
+            let result = if let Some(helper) = runtime_helper {
+                let plan = crate::runtime_call_plan::RuntimeCallPlan::from_cfg_inputs(
+                    helper,
+                    inputs.return_plan,
+                    &inputs.args,
+                    adapter,
+                )
+                .unwrap_or_else(|error| {
+                    panic!("invalid CFG runtime call for {helper:?}: {error:?}")
+                });
+                adapter.emit_runtime_call(plan)
+            } else {
+                let result_vreg = adapter.reserve_value_result();
+                let plan = crate::call_plan::CallPlan::from_inputs_with_result(
+                    crate::call_plan::CallTarget::rue(symbol),
+                    inputs.return_plan,
+                    &inputs.args,
+                    adapter.call_arg_register_budget(),
+                    adapter,
+                    Some(result_vreg),
+                );
+                adapter.emit_call(plan)
+            };
             cache_result(adapter, value, result);
             Some(ValueKind::Call)
         }
@@ -1286,14 +1361,24 @@ pub fn lower_value<A: ValueLowerAdapter>(
                 .collect();
             if name_string == "panic" {
                 let result = adapter.emit_trap(TrapPlan::Panic {
-                    message: values.first().map(|arg| MaterializedValue {
-                        primary: arg.primary,
-                        slots: arg.slots.clone(),
-                    }),
-                    symbol: if values.first().is_some_and(|arg| arg.slots.len() >= 2) {
-                        "__rue_panic".to_string()
+                    call: if let Some(arg) = values.first().filter(|arg| arg.slots.len() >= 2) {
+                        crate::runtime_call_plan::RuntimeCallPlan::expect_manifest(
+                            RuntimeHelperId::Panic,
+                            [
+                                crate::runtime_call_plan::RuntimeCallArg::const_pointer(
+                                    arg.slots[0],
+                                    rue_runtime_abi::AbiType::Byte,
+                                ),
+                                crate::runtime_call_plan::RuntimeCallArg::value(
+                                    arg.slots[1],
+                                    rue_runtime_abi::AbiType::U64,
+                                ),
+                            ],
+                        )
                     } else {
-                        "__rue_panic_no_msg".to_string()
+                        crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                            RuntimeHelperId::PanicNoMessage,
+                        )
                     },
                 });
                 cache_result(adapter, value, result);
@@ -1305,8 +1390,7 @@ pub fn lower_value<A: ValueLowerAdapter>(
                 });
                 let result = adapter.emit_trap(TrapPlan::Assert {
                     condition: values[0].primary,
-                    symbol: assert_trap_symbol(message.as_ref()).to_string(),
-                    message,
+                    call: trap_runtime_call(message.as_ref()),
                 });
                 cache_result(adapter, value, result);
                 Some(ValueKind::Intrinsic)
@@ -1415,13 +1499,14 @@ pub fn lower_value<A: ValueLowerAdapter>(
                     }
                     _ => None,
                 };
-                let runtime_symbol = intrinsic_runtime_symbol(&operation, &values);
+                let result_slots = ctx.type_slot_count(inst.ty);
+                let runtime_call = intrinsic_runtime_call(&operation, &values, scale, result_slots);
                 let result = adapter.emit_intrinsic(IntrinsicPlan {
                     operation,
-                    runtime_symbol,
+                    runtime_call,
                     args: values,
                     result_ty: inst.ty,
-                    result_slots: ctx.type_slot_count(inst.ty),
+                    result_slots,
                     scale,
                 });
                 cache_result(adapter, value, result);
@@ -1513,34 +1598,142 @@ pub fn lower_value<A: ValueLowerAdapter>(
     }
 }
 
-fn intrinsic_runtime_symbol(
+/// Transitional bridge until CFG call instructions carry `RuntimeHelperId`.
+/// Matching is against the complete manifest inventory, never a symbol prefix.
+fn runtime_helper_for_symbol(symbol: &str) -> Option<RuntimeHelperId> {
+    RuntimeHelperId::ALL
+        .iter()
+        .copied()
+        .find(|helper| helper.symbol() == symbol)
+}
+
+fn intrinsic_runtime_call(
     operation: &IntrinsicOperation,
     args: &[IntrinsicArgPlan],
-) -> Option<String> {
-    let symbol = match operation {
+    scale: Option<crate::allocation::ScalePlan>,
+    result_slots: u32,
+) -> Option<crate::runtime_call_plan::RuntimeCallPlan> {
+    use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallPlan};
+    use rue_runtime_abi::{AbiType, AggregateShapeId};
+
+    let (helper, call_args) = match operation {
         IntrinsicOperation::Option { intrinsic, .. } => match intrinsic {
-            OptionIntrinsic::ReadLine => "__rue_read_line",
-            OptionIntrinsic::ParseI32 => "__rue_parse_i32",
-            OptionIntrinsic::ParseI64 => "__rue_parse_i64",
-            OptionIntrinsic::ParseU32 => "__rue_parse_u32",
-            OptionIntrinsic::ParseU64 => "__rue_parse_u64",
+            OptionIntrinsic::ReadLine => (
+                RuntimeHelperId::ReadLine,
+                vec![
+                    RuntimeCallArg::out_pointer(AggregateShapeId::OptionStrBufResult),
+                    RuntimeCallArg::immediate(option_discriminants(operation).0, AbiType::U64),
+                    RuntimeCallArg::immediate(option_discriminants(operation).1, AbiType::U64),
+                ],
+            ),
+            intrinsic => {
+                let arg = args.first()?;
+                let helper = match intrinsic {
+                    OptionIntrinsic::ParseI32 => RuntimeHelperId::ParseI32,
+                    OptionIntrinsic::ParseI64 => RuntimeHelperId::ParseI64,
+                    OptionIntrinsic::ParseU32 => RuntimeHelperId::ParseU32,
+                    OptionIntrinsic::ParseU64 => RuntimeHelperId::ParseU64,
+                    OptionIntrinsic::ReadLine => unreachable!(),
+                };
+                (
+                    helper,
+                    vec![
+                        RuntimeCallArg::out_pointer(AggregateShapeId::OptionIntResult),
+                        RuntimeCallArg::const_pointer(arg.slots[0], AbiType::Byte),
+                        RuntimeCallArg::value(arg.slots[1], AbiType::U64),
+                        RuntimeCallArg::immediate(option_discriminants(operation).0, AbiType::U64),
+                        RuntimeCallArg::immediate(option_discriminants(operation).1, AbiType::U64),
+                    ],
+                )
+            }
         },
-        IntrinsicOperation::RandomU32 => "__rue_random_u32",
-        IntrinsicOperation::RandomU64 => "__rue_random_u64",
-        IntrinsicOperation::Alloc { .. } | IntrinsicOperation::AllocBytes => "__rue_alloc",
-        IntrinsicOperation::Free { .. } | IntrinsicOperation::FreeBytes => "__rue_free",
-        IntrinsicOperation::Realloc { .. } | IntrinsicOperation::ReallocBytes => "__rue_realloc",
+        IntrinsicOperation::RandomU32 => (RuntimeHelperId::RandomU32, vec![]),
+        IntrinsicOperation::RandomU64 => (RuntimeHelperId::RandomU64, vec![]),
+        IntrinsicOperation::Alloc { element_size } => (
+            RuntimeHelperId::Alloc,
+            vec![
+                RuntimeCallArg::scaled(args[0].primary, scale?, AbiType::U64),
+                RuntimeCallArg::immediate(*element_size, AbiType::U64),
+            ],
+        ),
+        IntrinsicOperation::AllocBytes => (
+            RuntimeHelperId::Alloc,
+            vec![
+                RuntimeCallArg::value(args[0].primary, AbiType::U64),
+                RuntimeCallArg::immediate(1, AbiType::U64),
+            ],
+        ),
+        IntrinsicOperation::Free { element_size } => (
+            RuntimeHelperId::Free,
+            vec![
+                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
+                RuntimeCallArg::scaled(args[1].primary, scale?, AbiType::U64),
+                RuntimeCallArg::immediate(*element_size, AbiType::U64),
+            ],
+        ),
+        IntrinsicOperation::FreeBytes => (
+            RuntimeHelperId::Free,
+            vec![
+                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
+                RuntimeCallArg::value(args[1].primary, AbiType::U64),
+                RuntimeCallArg::immediate(1, AbiType::U64),
+            ],
+        ),
+        IntrinsicOperation::Realloc { .. } | IntrinsicOperation::ReallocBytes => {
+            let element_size = match operation {
+                IntrinsicOperation::Realloc { element_size } => *element_size,
+                IntrinsicOperation::ReallocBytes => 1,
+                _ => unreachable!(),
+            };
+            let old = if matches!(operation, IntrinsicOperation::Realloc { .. }) {
+                RuntimeCallArg::scaled(args[1].primary, scale?, AbiType::U64)
+            } else {
+                RuntimeCallArg::value(args[1].primary, AbiType::U64)
+            };
+            let new = if matches!(operation, IntrinsicOperation::Realloc { .. }) {
+                RuntimeCallArg::scaled(args[2].primary, scale?, AbiType::U64)
+            } else {
+                RuntimeCallArg::value(args[2].primary, AbiType::U64)
+            };
+            (
+                RuntimeHelperId::Realloc,
+                vec![
+                    RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
+                    old,
+                    new,
+                    RuntimeCallArg::immediate(element_size, AbiType::U64),
+                ],
+            )
+        }
         IntrinsicOperation::Debug => {
             let arg = args.first()?;
             if arg.slots.len() >= 2 {
-                "__rue_dbg_str"
+                (
+                    RuntimeHelperId::DebugStr,
+                    vec![
+                        RuntimeCallArg::const_pointer(arg.slots[0], AbiType::Byte),
+                        RuntimeCallArg::value(arg.slots[1], AbiType::U64),
+                    ],
+                )
             } else {
-                match arg.debug {
-                    DebugValuePlan::Bool => "__rue_dbg_bool",
-                    DebugValuePlan::Integer(IntegerWidth { signed: true, .. }) => "__rue_dbg_i64",
-                    DebugValuePlan::Integer(IntegerWidth { signed: false, .. }) => "__rue_dbg_u64",
+                let (helper, ty) = match arg.debug {
+                    DebugValuePlan::Bool => (RuntimeHelperId::DebugBool, AbiType::BoolWordI64),
+                    DebugValuePlan::Integer(IntegerWidth { signed: true, .. }) => {
+                        (RuntimeHelperId::DebugI64, AbiType::I64)
+                    }
+                    DebugValuePlan::Integer(IntegerWidth { signed: false, .. }) => {
+                        (RuntimeHelperId::DebugU64, AbiType::U64)
+                    }
                     DebugValuePlan::String | DebugValuePlan::Other => return None,
-                }
+                };
+                (
+                    helper,
+                    vec![RuntimeCallArg::extended(
+                        arg.primary,
+                        arg.integer_extension,
+                        ty,
+                    )],
+                )
             }
         }
         IntrinsicOperation::PtrToInt
@@ -1553,14 +1746,48 @@ fn intrinsic_runtime_symbol(
         | IntrinsicOperation::PlaceAddress
         | IntrinsicOperation::Syscall => return None,
     };
-    Some(symbol.to_string())
+    let plan = RuntimeCallPlan::expect_manifest(helper, call_args);
+    if let Some(shape) = plan.out_shape() {
+        assert_eq!(
+            shape.shape().slots.len(),
+            result_slots as usize,
+            "runtime out-pointer shape must match the semantic result slot count"
+        );
+    }
+    Some(plan)
 }
 
-fn assert_trap_symbol(message: Option<&MaterializedValue>) -> &'static str {
+fn option_discriminants(operation: &IntrinsicOperation) -> (u64, u64) {
+    match operation {
+        IntrinsicOperation::Option {
+            some_discriminant,
+            none_discriminant,
+            ..
+        } => (*some_discriminant, *none_discriminant),
+        _ => unreachable!(),
+    }
+}
+
+fn trap_runtime_call(
+    message: Option<&MaterializedValue>,
+) -> crate::runtime_call_plan::RuntimeCallPlan {
     if message.is_some_and(|value| value.slots.len() >= 2) {
-        "__rue_panic"
+        let message = message.unwrap();
+        crate::runtime_call_plan::RuntimeCallPlan::expect_manifest(
+            RuntimeHelperId::Panic,
+            [
+                crate::runtime_call_plan::RuntimeCallArg::const_pointer(
+                    message.slots[0],
+                    rue_runtime_abi::AbiType::Byte,
+                ),
+                crate::runtime_call_plan::RuntimeCallArg::value(
+                    message.slots[1],
+                    rue_runtime_abi::AbiType::U64,
+                ),
+            ],
+        )
     } else {
-        "__rue_assert_failed"
+        crate::runtime_call_plan::RuntimeCallPlan::no_args(RuntimeHelperId::AssertFailed)
     }
 }
 
@@ -1736,13 +1963,15 @@ pub fn assert_slot_policy(plan: ValuePlan, actual: usize) {
 #[cfg(test)]
 mod tests {
     use super::{
-        ComparisonPreparation, IntegerWidth, MaterializationRequirement, MaterializedValue,
+        ComparisonPreparation, DebugValuePlan, IntegerExtension, IntegerWidth, IntrinsicArgPlan,
+        IntrinsicOperation, MaterializationRequirement, MaterializedValue, OptionIntrinsic,
         StoragePolicy, StoreDestination, ValueKind, ValuePlan, ValueShape, assert_slot_policy,
         comparison_integer_width, integer_range, type_bits, type_range,
     };
     use lasso::{Spur, ThreadedRodeo};
     use rue_air::{EnumDef, LangItem, ParamSlotModes, StructDef, StructField, TypeInternPool};
     use rue_cfg::{Cfg, CfgInst, CfgInstData, CfgValue, Place, Terminator, Type};
+    use rue_runtime_abi::RuntimeHelperId;
     use rue_span::{FileId, Span};
     use rue_target::Target;
 
@@ -2789,7 +3018,7 @@ mod tests {
     }
 
     #[test]
-    fn assert_trap_plan_selects_message_runtime_symbol() {
+    fn assert_trap_plan_selects_manifest_runtime_call() {
         let condition = crate::vreg::VReg::new(0);
         let no_message = MaterializedValue {
             primary: condition,
@@ -2800,12 +3029,169 @@ mod tests {
             slots: vec![crate::vreg::VReg::new(1), crate::vreg::VReg::new(2)],
         };
 
-        assert_eq!(super::assert_trap_symbol(None), "__rue_assert_failed");
         assert_eq!(
-            super::assert_trap_symbol(Some(&no_message)),
-            "__rue_assert_failed"
+            super::trap_runtime_call(None).helper(),
+            RuntimeHelperId::AssertFailed
         );
-        assert_eq!(super::assert_trap_symbol(Some(&message)), "__rue_panic");
+        assert_eq!(
+            super::trap_runtime_call(Some(&no_message)).helper(),
+            RuntimeHelperId::AssertFailed
+        );
+        assert_eq!(
+            super::trap_runtime_call(Some(&message)).helper(),
+            RuntimeHelperId::Panic
+        );
+        assert_eq!(super::trap_runtime_call(Some(&message)).args().len(), 2);
+    }
+
+    #[test]
+    fn intrinsic_runtime_policy_uses_manifest_helper_identities() {
+        let scalar_arg = IntrinsicArgPlan {
+            primary: crate::vreg::VReg::new(0),
+            slots: Vec::new(),
+            slot_count: 1,
+            integer_extension: IntegerExtension::None,
+            place: None,
+            debug: DebugValuePlan::Bool,
+        };
+        let string_arg = IntrinsicArgPlan {
+            slots: vec![crate::vreg::VReg::new(0), crate::vreg::VReg::new(1)],
+            debug: DebugValuePlan::String,
+            ..scalar_arg.clone()
+        };
+
+        let option = |intrinsic| IntrinsicOperation::Option {
+            intrinsic,
+            some_discriminant: 1,
+            none_discriminant: 0,
+        };
+        let scale = crate::allocation::ScalePlan {
+            kind: crate::allocation::ScaleKind::Constant(8),
+            purpose: crate::allocation::ScalePurpose::AllocationSize,
+            overflow: crate::allocation::OverflowBehavior::Trap,
+        };
+        let call = |operation, args: &[IntrinsicArgPlan], scale, result_slots| {
+            super::intrinsic_runtime_call(&operation, args, scale, result_slots)
+                .expect("operation should have a runtime call")
+        };
+
+        assert_eq!(
+            call(option(OptionIntrinsic::ReadLine), &[], None, 4).helper(),
+            RuntimeHelperId::ReadLine
+        );
+        for (intrinsic, helper) in [
+            (OptionIntrinsic::ParseI32, RuntimeHelperId::ParseI32),
+            (OptionIntrinsic::ParseI64, RuntimeHelperId::ParseI64),
+            (OptionIntrinsic::ParseU32, RuntimeHelperId::ParseU32),
+            (OptionIntrinsic::ParseU64, RuntimeHelperId::ParseU64),
+        ] {
+            let plan = call(
+                option(intrinsic),
+                std::slice::from_ref(&string_arg),
+                None,
+                2,
+            );
+            assert_eq!(plan.helper(), helper);
+            assert_eq!(plan.args().len(), 5);
+        }
+        assert_eq!(
+            call(IntrinsicOperation::RandomU32, &[], None, 1).helper(),
+            RuntimeHelperId::RandomU32
+        );
+        assert_eq!(
+            call(IntrinsicOperation::RandomU64, &[], None, 1).helper(),
+            RuntimeHelperId::RandomU64
+        );
+        assert_eq!(
+            call(
+                IntrinsicOperation::Alloc { element_size: 8 },
+                std::slice::from_ref(&scalar_arg),
+                Some(scale),
+                1,
+            )
+            .helper(),
+            RuntimeHelperId::Alloc
+        );
+        assert_eq!(
+            call(
+                IntrinsicOperation::Free { element_size: 8 },
+                &[scalar_arg.clone(), scalar_arg.clone()],
+                Some(scale),
+                0,
+            )
+            .helper(),
+            RuntimeHelperId::Free
+        );
+        assert_eq!(
+            call(
+                IntrinsicOperation::Realloc { element_size: 8 },
+                &[scalar_arg.clone(), scalar_arg.clone(), scalar_arg.clone()],
+                Some(scale),
+                1,
+            )
+            .helper(),
+            RuntimeHelperId::Realloc
+        );
+        assert_eq!(
+            call(
+                IntrinsicOperation::Debug,
+                std::slice::from_ref(&scalar_arg),
+                None,
+                0,
+            )
+            .helper(),
+            RuntimeHelperId::DebugBool
+        );
+        assert_eq!(
+            call(
+                IntrinsicOperation::Debug,
+                std::slice::from_ref(&string_arg),
+                None,
+                0,
+            )
+            .helper(),
+            RuntimeHelperId::DebugStr
+        );
+
+        let realloc = call(
+            IntrinsicOperation::Realloc { element_size: 8 },
+            &[scalar_arg.clone(), scalar_arg.clone(), scalar_arg],
+            Some(scale),
+            1,
+        );
+        assert_eq!(
+            realloc
+                .args()
+                .iter()
+                .map(|arg| arg.parameter())
+                .collect::<Vec<_>>(),
+            RuntimeHelperId::Realloc.helper().parameters
+        );
+        assert_eq!(
+            realloc.calling_convention(),
+            RuntimeHelperId::Realloc.helper().calling_convention
+        );
+        assert_eq!(
+            realloc.return_behavior(),
+            RuntimeHelperId::Realloc.helper().return_behavior
+        );
+    }
+
+    #[test]
+    fn cfg_runtime_bridge_accepts_only_exact_manifest_symbols() {
+        assert_eq!(
+            super::runtime_helper_for_symbol("__rue_print"),
+            Some(RuntimeHelperId::Print)
+        );
+        assert_eq!(
+            super::runtime_helper_for_symbol("__rue_println"),
+            Some(RuntimeHelperId::Println)
+        );
+        assert_eq!(
+            super::runtime_helper_for_symbol("__rue_drop_generated"),
+            None
+        );
+        assert_eq!(super::runtime_helper_for_symbol("__rue_print_suffix"), None);
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -145,6 +145,159 @@ impl<'a> CfgLower<'a> {
         self.mir.intern_symbol(symbol)
     }
 
+    fn lower_runtime_call(
+        &mut self,
+        plan: crate::runtime_call_plan::RuntimeCallPlan,
+    ) -> crate::value_plan::MaterializedValue {
+        use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallResult};
+        use rue_runtime_abi::CallingConvention;
+
+        assert_eq!(plan.calling_convention(), CallingConvention::TargetC);
+        assert!(
+            plan.args().len() <= ARG_REGS.len(),
+            "runtime manifest exceeds the x86-64 target-C register budget"
+        );
+
+        let out_shape = plan.out_shape();
+        let out_bytes = out_shape
+            .map(|shape| (shape.shape().slots.len() as i32 * 8 + 15) & !15)
+            .unwrap_or(0);
+        if out_bytes > 0 {
+            self.mir.push(X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rsp),
+                imm: -out_bytes,
+            });
+        }
+
+        let materialized = plan
+            .args()
+            .iter()
+            .map(|arg| match *arg {
+                RuntimeCallArg::Slot { value, .. } => Some(value),
+                RuntimeCallArg::Scaled { value, scale, .. } => {
+                    Some(crate::allocation::lower_scale(self, value, scale))
+                }
+                RuntimeCallArg::Extended {
+                    value, extension, ..
+                } => {
+                    if extension == crate::value_plan::IntegerExtension::None {
+                        Some(value)
+                    } else {
+                        let extended = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(extended),
+                            src: Operand::Virtual(value),
+                        });
+                        let dst = Operand::Virtual(extended);
+                        let src = Operand::Virtual(extended);
+                        self.mir.push(match extension {
+                            crate::value_plan::IntegerExtension::Sign8 => {
+                                X86Inst::Movsx8To64 { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::Zero8 => {
+                                X86Inst::Movzx8To64 { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::Sign16 => {
+                                X86Inst::Movsx16To64 { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::Zero16 => {
+                                X86Inst::Movzx16To64 { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::Sign32 => {
+                                X86Inst::Movsx32To64 { dst, src }
+                            }
+                            crate::value_plan::IntegerExtension::None => unreachable!(),
+                        });
+                        Some(extended)
+                    }
+                }
+                RuntimeCallArg::Immediate { .. } | RuntimeCallArg::OutPointer { .. } => None,
+            })
+            .collect::<Vec<_>>();
+
+        for (index, (arg, value)) in plan.args().iter().zip(&materialized).enumerate() {
+            let dst = Operand::Physical(ARG_REGS[index]);
+            match *arg {
+                RuntimeCallArg::Slot { .. }
+                | RuntimeCallArg::Scaled { .. }
+                | RuntimeCallArg::Extended { .. } => {
+                    self.mir.push(X86Inst::MovRR {
+                        dst,
+                        src: Operand::Virtual(value.expect("materialized runtime argument")),
+                    });
+                }
+                RuntimeCallArg::Immediate { value, parameter } => {
+                    if matches!(
+                        parameter.ty,
+                        rue_runtime_abi::AbiType::I32 | rue_runtime_abi::AbiType::U32
+                    ) {
+                        self.mir.push(X86Inst::MovRI32 {
+                            dst,
+                            imm: value as i32,
+                        });
+                    } else {
+                        self.mir.push(X86Inst::MovRI64 {
+                            dst,
+                            imm: value as i64,
+                        });
+                    }
+                }
+                RuntimeCallArg::OutPointer { shape } => {
+                    assert_eq!(Some(shape), out_shape);
+                    self.mir.push(X86Inst::MovRR {
+                        dst,
+                        src: Operand::Physical(Reg::Rsp),
+                    });
+                }
+            }
+        }
+
+        let symbol_id = self.intern_symbol(plan.symbol());
+        self.mir.push(X86Inst::CallRel { symbol_id });
+
+        match plan.result() {
+            RuntimeCallResult::OutPointer(shape) => {
+                let slots = (0..shape.shape().slots.len())
+                    .map(|index| {
+                        let slot = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::MovRM {
+                            dst: Operand::Virtual(slot),
+                            base: Reg::Rsp,
+                            offset: (index * 8) as i32,
+                        });
+                        slot
+                    })
+                    .collect::<Vec<_>>();
+                self.mir.push(X86Inst::AddRI {
+                    dst: Operand::Physical(Reg::Rsp),
+                    imm: out_bytes,
+                });
+                crate::value_plan::MaterializedValue {
+                    primary: slots[0],
+                    slots,
+                }
+            }
+            RuntimeCallResult::Scalar(_) => {
+                let primary = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(primary),
+                    src: Operand::Physical(Reg::Rax),
+                });
+                crate::value_plan::MaterializedValue {
+                    primary,
+                    slots: Vec::new(),
+                }
+            }
+            RuntimeCallResult::Void => {
+                let primary = self.mir.alloc_vreg();
+                crate::value_plan::MaterializedValue {
+                    primary,
+                    slots: Vec::new(),
+                }
+            }
+        }
+    }
+
     fn emit_store_ptr_base(&mut self, src: VReg, ptr: VReg) {
         self.mir.push(X86Inst::MovMRIndexed {
             base: ptr,
@@ -187,7 +340,11 @@ impl<'a> CfgLower<'a> {
 
     /// Emit a target-local cleanup call using the normalized slot vector.
     fn emit_slot_call(&mut self, arg_vregs: &[VReg], symbol: &str) {
-        let plan = crate::call_plan::CallPlan::from_slot_values(symbol, arg_vregs, ARG_REGS.len());
+        let plan = crate::call_plan::CallPlan::from_slot_values(
+            crate::call_plan::CallTarget::rue(symbol),
+            arg_vregs,
+            ARG_REGS.len(),
+        );
         let _ = self.lower_call_plan(plan);
     }
 
@@ -246,7 +403,7 @@ impl<'a> CfgLower<'a> {
         width: crate::value_plan::IntegerWidth,
         lhs_vreg: VReg,
         rhs_vreg: VReg,
-        trap_symbol: &str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
         let ok_label = self.new_label();
         if width.bits == 64 {
@@ -283,8 +440,7 @@ impl<'a> CfgLower<'a> {
         self.mir.push(X86Inst::Jnz { label: ok_label });
 
         // Overflow - call panic handler
-        let symbol_id = self.intern_symbol(trap_symbol);
-        self.mir.push(X86Inst::CallRel { symbol_id });
+        let _ = self.lower_runtime_call(trap_call.clone());
         self.mir.push(X86Inst::Label { id: ok_label });
     }
 
@@ -415,7 +571,8 @@ impl<'a> CfgLower<'a> {
         plan: crate::value_plan::ArithmeticPlan,
     ) -> crate::value_plan::MaterializedValue {
         use crate::value_plan::ArithmeticOperation;
-        let trap_symbols = plan.trap_symbols;
+        let overflow_call = plan.overflow_call;
+        let div_by_zero_call = plan.div_by_zero_call;
         let vreg = match plan.operation {
             ArithmeticOperation::Add { lhs, rhs, width } => {
                 let vreg = self.mir.alloc_vreg();
@@ -434,7 +591,7 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(rhs),
                     }
                 });
-                self.emit_overflow_check(width, vreg, trap_symbols.overflow);
+                self.emit_overflow_check(width, vreg, overflow_call.clone());
                 vreg
             }
             ArithmeticOperation::Sub { lhs, rhs, width } => {
@@ -454,7 +611,7 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(rhs),
                     }
                 });
-                self.emit_overflow_check(width, vreg, trap_symbols.overflow);
+                self.emit_overflow_check(width, vreg, overflow_call.clone());
                 vreg
             }
             ArithmeticOperation::Mul {
@@ -521,8 +678,7 @@ impl<'a> CfgLower<'a> {
                     });
                     let ok = self.new_label();
                     self.mir.push(X86Inst::Jz { label: ok });
-                    let symbol_id = self.intern_symbol(trap_symbols.overflow);
-                    self.mir.push(X86Inst::CallRel { symbol_id });
+                    let _ = self.lower_runtime_call(overflow_call.clone());
                     self.mir.push(X86Inst::Label { id: ok });
                 } else if !width.signed && width.bits >= 32 {
                     self.mir.push(X86Inst::MovRR {
@@ -542,7 +698,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Physical(Reg::Rax),
                     });
-                    self.emit_overflow_check(width, vreg, trap_symbols.overflow);
+                    self.emit_overflow_check(width, vreg, overflow_call.clone());
                 } else {
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Virtual(vreg),
@@ -559,7 +715,7 @@ impl<'a> CfgLower<'a> {
                             src: Operand::Virtual(rhs),
                         }
                     });
-                    self.emit_overflow_check(width, vreg, trap_symbols.overflow);
+                    self.emit_overflow_check(width, vreg, overflow_call.clone());
                 }
                 vreg
             }
@@ -578,11 +734,10 @@ impl<'a> CfgLower<'a> {
                     }
                 });
                 self.mir.push(X86Inst::Jnz { label: ok });
-                let symbol_id = self.intern_symbol(trap_symbols.div_by_zero);
-                self.mir.push(X86Inst::CallRel { symbol_id });
+                let _ = self.lower_runtime_call(div_by_zero_call.clone());
                 self.mir.push(X86Inst::Label { id: ok });
                 if width.signed {
-                    self.emit_signed_div_overflow_check(width, lhs, rhs, trap_symbols.overflow);
+                    self.emit_signed_div_overflow_check(width, lhs, rhs, overflow_call.clone());
                 }
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Physical(Reg::Rax),
@@ -610,11 +765,10 @@ impl<'a> CfgLower<'a> {
                     }
                 });
                 self.mir.push(X86Inst::Jnz { label: ok });
-                let symbol_id = self.intern_symbol(trap_symbols.div_by_zero);
-                self.mir.push(X86Inst::CallRel { symbol_id });
+                let _ = self.lower_runtime_call(div_by_zero_call.clone());
                 self.mir.push(X86Inst::Label { id: ok });
                 if width.signed {
-                    self.emit_signed_div_overflow_check(width, lhs, rhs, trap_symbols.overflow);
+                    self.emit_signed_div_overflow_check(width, lhs, rhs, overflow_call.clone());
                 }
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Physical(Reg::Rax),
@@ -642,7 +796,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                     }
                 });
-                self.emit_overflow_check(width, vreg, trap_symbols.overflow);
+                self.emit_overflow_check(width, vreg, overflow_call.clone());
                 vreg
             }
         };
@@ -706,7 +860,7 @@ impl<'a> CfgLower<'a> {
                 dst: Operand::Physical(ARG_REGS[index]),
             });
         }
-        let symbol_id = self.intern_symbol(&plan.symbol);
+        let symbol_id = self.intern_symbol(plan.target.symbol());
         self.mir.push(X86Inst::CallRel { symbol_id });
         if num_stack_args > 0 || needs_alignment {
             self.mir.push(X86Inst::AddRI {
@@ -982,7 +1136,8 @@ impl<'a> CfgLower<'a> {
                 lhs,
                 rhs,
                 leaf_types,
-            } => self.lower_comparison(op, lhs, rhs, plan.policy, &leaf_types),
+                runtime_call,
+            } => self.lower_comparison(op, lhs, rhs, plan.policy, &leaf_types, runtime_call),
             ResidualValuePlan::Alloc {
                 slot,
                 init,
@@ -1188,7 +1343,7 @@ impl<'a> CfgLower<'a> {
             ResidualValuePlan::IntCast {
                 value,
                 from_width,
-                trap_symbol,
+                trap_call,
             } => {
                 let dst = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRR {
@@ -1196,7 +1351,7 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(value),
                 });
                 let to_width = width.unwrap();
-                self.emit_int_cast_check(value, from_width, to_width, trap_symbol);
+                self.emit_int_cast_check(value, from_width, to_width, trap_call);
                 if from_width.signed && to_width.bits > from_width.bits {
                     let src = Operand::Virtual(value);
                     let dst = Operand::Virtual(dst);
@@ -1373,6 +1528,7 @@ impl<'a> CfgLower<'a> {
         rhs: crate::value_plan::MaterializedValue,
         policy: crate::value_plan::ValuePlan,
         leaf_types: &[Type],
+        runtime_call: Option<crate::runtime_call_plan::RuntimeCallPlan>,
     ) -> VReg {
         match policy.comparison.expect("comparison plan") {
             crate::value_plan::ComparisonPreparation::Scalar { .. } => {
@@ -1387,28 +1543,9 @@ impl<'a> CfgLower<'a> {
                 dst
             }
             crate::value_plan::ComparisonPreparation::StringContent { .. } => {
-                assert!(
-                    lhs.slots.len() >= 2 && rhs.slots.len() >= 2,
-                    "normalized string comparison needs ptr and len slots"
-                );
-                let dst = self.mir.alloc_vreg();
-                for (reg, slot) in [
-                    (Reg::Rdi, lhs.slots[0]),
-                    (Reg::Rsi, lhs.slots[1]),
-                    (Reg::Rdx, rhs.slots[0]),
-                    (Reg::Rcx, rhs.slots[1]),
-                ] {
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(reg),
-                        src: Operand::Virtual(slot),
-                    });
-                }
-                let symbol_id = self.intern_symbol("__rue_str_eq");
-                self.mir.push(X86Inst::CallRel { symbol_id });
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::Rax),
-                });
+                let dst = self
+                    .lower_runtime_call(runtime_call.expect("string equality runtime call plan"))
+                    .primary;
                 if matches!(op, crate::value_plan::ComparisonOp::Ne) {
                     self.mir.push(X86Inst::XorRI {
                         dst: Operand::Virtual(dst),
@@ -1433,132 +1570,32 @@ impl<'a> CfgLower<'a> {
         &mut self,
         plan: crate::value_plan::TrapPlan,
     ) -> crate::value_plan::MaterializedValue {
-        let panic = |this: &mut Self,
-                     message: Option<crate::value_plan::MaterializedValue>,
-                     symbol: &str| {
-            if let Some(message) = message.filter(|message| message.slots.len() >= 2) {
-                this.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rdi),
-                    src: Operand::Virtual(message.slots[0]),
-                });
-                this.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rsi),
-                    src: Operand::Virtual(message.slots[1]),
-                });
-                let symbol_id = this.intern_symbol(symbol);
-                this.mir.push(X86Inst::CallRel { symbol_id });
-            } else {
-                let symbol_id = this.intern_symbol(symbol);
-                this.mir.push(X86Inst::CallRel { symbol_id });
-            }
-        };
         match plan {
-            crate::value_plan::TrapPlan::Panic { message, symbol } => panic(self, message, &symbol),
-            crate::value_plan::TrapPlan::Assert {
-                condition,
-                message,
-                symbol,
-            } => {
+            crate::value_plan::TrapPlan::Panic { call } => self.lower_runtime_call(call),
+            crate::value_plan::TrapPlan::Assert { condition, call } => {
                 let pass = self.new_label();
                 self.mir.push(X86Inst::CmpRI {
                     src: Operand::Virtual(condition),
                     imm: 0,
                 });
                 self.mir.push(X86Inst::Jnz { label: pass });
-                panic(self, message, &symbol);
+                let result = self.lower_runtime_call(call);
                 self.mir.push(X86Inst::Label { id: pass });
+                result
             }
-        }
-        let primary = self.mir.alloc_vreg();
-        self.mir.push(X86Inst::MovRI32 {
-            dst: Operand::Virtual(primary),
-            imm: 0,
-        });
-        crate::value_plan::MaterializedValue {
-            primary,
-            slots: Vec::new(),
         }
     }
 
     fn lower_option_intrinsic(
         &mut self,
         plan: &crate::value_plan::IntrinsicPlan,
-        intrinsic: crate::value_plan::OptionIntrinsic,
+        _intrinsic: crate::value_plan::OptionIntrinsic,
     ) -> crate::value_plan::MaterializedValue {
-        let crate::value_plan::IntrinsicOperation::Option {
-            some_discriminant: some_disc,
-            none_discriminant: none_disc,
-            ..
-        } = plan.operation
-        else {
-            unreachable!()
-        };
-        let total_slots = plan.result_slots;
-        let sret_bytes = (total_slots as i32 * 8 + 15) & !15;
-        self.mir.push(X86Inst::AddRI {
-            dst: Operand::Physical(Reg::Rsp),
-            imm: -sret_bytes,
-        });
-        self.mir.push(X86Inst::MovRR {
-            dst: Operand::Physical(Reg::Rdi),
-            src: Operand::Physical(Reg::Rsp),
-        });
-        if intrinsic == crate::value_plan::OptionIntrinsic::ReadLine {
-            self.mir.push(X86Inst::MovRI32 {
-                dst: Operand::Physical(Reg::Rsi),
-                imm: some_disc as i32,
-            });
-            self.mir.push(X86Inst::MovRI32 {
-                dst: Operand::Physical(Reg::Rdx),
-                imm: none_disc as i32,
-            });
-        } else {
-            assert!(
-                plan.args.first().is_some_and(|arg| arg.slots.len() >= 2),
-                "normalized parse argument needs ptr and len slots"
-            );
-            let arg = &plan.args[0];
-            for (reg, src) in [(Reg::Rsi, arg.slots[0]), (Reg::Rdx, arg.slots[1])] {
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(reg),
-                    src: Operand::Virtual(src),
-                });
-            }
-            self.mir.push(X86Inst::MovRI32 {
-                dst: Operand::Physical(Reg::Rcx),
-                imm: some_disc as i32,
-            });
-            self.mir.push(X86Inst::MovRI32 {
-                dst: Operand::Physical(Reg::R8),
-                imm: none_disc as i32,
-            });
-        }
-        let symbol_id = self.intern_symbol(
-            plan.runtime_symbol
-                .as_deref()
-                .expect("option intrinsic runtime symbol"),
-        );
-        self.mir.push(X86Inst::CallRel { symbol_id });
-        let slots: Vec<_> = (0..total_slots)
-            .map(|index| {
-                let slot = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRM {
-                    dst: Operand::Virtual(slot),
-                    base: Reg::Rsp,
-                    offset: (index * 8) as i32,
-                });
-                slot
-            })
-            .collect();
-        self.mir.push(X86Inst::AddRI {
-            dst: Operand::Physical(Reg::Rsp),
-            imm: sret_bytes,
-        });
-        let primary = slots
-            .first()
-            .copied()
-            .unwrap_or_else(|| self.mir.alloc_vreg());
-        crate::value_plan::MaterializedValue { primary, slots }
+        self.lower_runtime_call(
+            plan.runtime_call
+                .clone()
+                .expect("option intrinsic runtime call plan"),
+        )
     }
 
     fn lower_intrinsic_plan(
@@ -1575,18 +1612,11 @@ impl<'a> CfgLower<'a> {
             }
             crate::value_plan::IntrinsicOperation::RandomU32
             | crate::value_plan::IntrinsicOperation::RandomU64 => {
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("random intrinsic runtime symbol"),
-                );
-                self.mir.push(X86Inst::CallRel { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::Rax),
-                });
-                dst
+                self.lower_runtime_call(
+                    plan.runtime_call
+                        .expect("random intrinsic runtime call plan"),
+                )
+                .primary
             }
             crate::value_plan::IntrinsicOperation::PtrToInt
             | crate::value_plan::IntrinsicOperation::IntToPtr => {
@@ -1686,192 +1716,31 @@ impl<'a> CfgLower<'a> {
                 dst
             }
             crate::value_plan::IntrinsicOperation::Alloc { element_size } => {
-                let scale = plan.scale;
-                let size = scale
-                    .map(|scale| allocation::lower_scale(self, plan.args[0].primary, scale))
-                    .unwrap_or(plan.args[0].primary);
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rdi),
-                    src: Operand::Virtual(size),
-                });
-                self.mir.push(X86Inst::MovRI64 {
-                    dst: Operand::Physical(Reg::Rsi),
-                    imm: element_size as i64,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("alloc intrinsic runtime symbol"),
-                );
-                self.mir.push(X86Inst::CallRel { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::Rax),
-                });
-                dst
+                let _ = element_size;
+                self.lower_runtime_call(plan.runtime_call.expect("alloc runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::Free { element_size } => {
-                let size = if element_size == 8 {
-                    allocation::lower_scale(
-                        self,
-                        plan.args[1].primary,
-                        plan.scale.expect("free scale"),
-                    )
-                } else {
-                    plan.args[1].primary
-                };
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rdi),
-                    src: Operand::Virtual(plan.args[0].primary),
-                });
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rsi),
-                    src: Operand::Virtual(size),
-                });
-                self.mir.push(X86Inst::MovRI64 {
-                    dst: Operand::Physical(Reg::Rdx),
-                    imm: element_size as i64,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("free intrinsic runtime symbol"),
-                );
-                self.mir.push(X86Inst::CallRel { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRI32 {
-                    dst: Operand::Virtual(dst),
-                    imm: 0,
-                });
-                dst
+                let _ = element_size;
+                self.lower_runtime_call(plan.runtime_call.expect("free runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::Realloc { element_size } => {
-                let mut args = plan.args.iter().map(|arg| arg.primary);
-                if element_size == 8 {
-                    let old = allocation::lower_scale(
-                        self,
-                        plan.args[1].primary,
-                        plan.scale.expect("realloc scale"),
-                    );
-                    let new = allocation::lower_scale(
-                        self,
-                        plan.args[2].primary,
-                        plan.scale.expect("realloc scale"),
-                    );
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(Reg::Rdi),
-                        src: Operand::Virtual(plan.args[0].primary),
-                    });
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(Reg::Rsi),
-                        src: Operand::Virtual(old),
-                    });
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(Reg::Rdx),
-                        src: Operand::Virtual(new),
-                    });
-                    self.mir.push(X86Inst::MovRI64 {
-                        dst: Operand::Physical(Reg::Rcx),
-                        imm: 8,
-                    });
-                } else {
-                    for (arg, reg) in args.by_ref().zip([Reg::Rdi, Reg::Rsi, Reg::Rdx]) {
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Physical(reg),
-                            src: Operand::Virtual(arg),
-                        });
-                    }
-                    self.mir.push(X86Inst::MovRI64 {
-                        dst: Operand::Physical(Reg::Rcx),
-                        imm: 1,
-                    });
-                }
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("realloc intrinsic runtime symbol"),
-                );
-                self.mir.push(X86Inst::CallRel { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::Rax),
-                });
-                dst
+                let _ = element_size;
+                self.lower_runtime_call(plan.runtime_call.expect("realloc runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::AllocBytes => {
-                let size = plan.args[0].primary;
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rdi),
-                    src: Operand::Virtual(size),
-                });
-                self.mir.push(X86Inst::MovRI64 {
-                    dst: Operand::Physical(Reg::Rsi),
-                    imm: 1,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("alloc-bytes intrinsic runtime symbol"),
-                );
-                self.mir.push(X86Inst::CallRel { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::Rax),
-                });
-                dst
+                self.lower_runtime_call(plan.runtime_call.expect("alloc-bytes runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::FreeBytes => {
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rdi),
-                    src: Operand::Virtual(plan.args[0].primary),
-                });
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rsi),
-                    src: Operand::Virtual(plan.args[1].primary),
-                });
-                self.mir.push(X86Inst::MovRI64 {
-                    dst: Operand::Physical(Reg::Rdx),
-                    imm: 1,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("free-bytes intrinsic runtime symbol"),
-                );
-                self.mir.push(X86Inst::CallRel { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRI32 {
-                    dst: Operand::Virtual(dst),
-                    imm: 0,
-                });
-                dst
+                self.lower_runtime_call(plan.runtime_call.expect("free-bytes runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::ReallocBytes => {
-                for (arg, reg) in plan.args.iter().zip([Reg::Rdi, Reg::Rsi, Reg::Rdx]) {
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(reg),
-                        src: Operand::Virtual(arg.primary),
-                    });
-                }
-                self.mir.push(X86Inst::MovRI64 {
-                    dst: Operand::Physical(Reg::Rcx),
-                    imm: 1,
-                });
-                let symbol_id = self.intern_symbol(
-                    plan.runtime_symbol
-                        .as_deref()
-                        .expect("realloc-bytes intrinsic runtime symbol"),
-                );
-                self.mir.push(X86Inst::CallRel { symbol_id });
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(dst),
-                    src: Operand::Physical(Reg::Rax),
-                });
-                dst
+                self.lower_runtime_call(plan.runtime_call.expect("realloc-bytes runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::ByteRead => {
                 let addr = self.mir.alloc_vreg();
@@ -1923,127 +1792,8 @@ impl<'a> CfgLower<'a> {
                 dst
             }
             crate::value_plan::IntrinsicOperation::Debug => {
-                let arg = &plan.args[0];
-                if arg.slots.len() >= 2 {
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(Reg::Rdi),
-                        src: Operand::Virtual(arg.slots[0]),
-                    });
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(Reg::Rsi),
-                        src: Operand::Virtual(arg.slots[1]),
-                    });
-                    let symbol_id = self.intern_symbol(
-                        plan.runtime_symbol
-                            .as_deref()
-                            .expect("debug intrinsic runtime symbol"),
-                    );
-                    self.mir.push(X86Inst::CallRel { symbol_id });
-                } else {
-                    match arg.debug {
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 8,
-                                signed: true,
-                            },
-                        ) => {
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Physical(Reg::Rax),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(X86Inst::Movsx8To64 {
-                                dst: Operand::Physical(Reg::Rdi),
-                                src: Operand::Physical(Reg::Rax),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 16,
-                                signed: true,
-                            },
-                        ) => {
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Physical(Reg::Rax),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(X86Inst::Movsx16To64 {
-                                dst: Operand::Physical(Reg::Rdi),
-                                src: Operand::Physical(Reg::Rax),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 32,
-                                signed: true,
-                            },
-                        ) => {
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Physical(Reg::Rax),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(X86Inst::Movsx32To64 {
-                                dst: Operand::Physical(Reg::Rdi),
-                                src: Operand::Physical(Reg::Rax),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 8,
-                                signed: false,
-                            },
-                        ) => {
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Physical(Reg::Rax),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(X86Inst::Movzx8To64 {
-                                dst: Operand::Physical(Reg::Rdi),
-                                src: Operand::Physical(Reg::Rax),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth {
-                                bits: 16,
-                                signed: false,
-                            },
-                        ) => {
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Physical(Reg::Rax),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                            self.mir.push(X86Inst::Movzx16To64 {
-                                dst: Operand::Physical(Reg::Rdi),
-                                src: Operand::Physical(Reg::Rax),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::Bool
-                        | crate::value_plan::DebugValuePlan::Integer(
-                            crate::value_plan::IntegerWidth { bits: 32 | 64, .. },
-                        ) => {
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Physical(Reg::Rdi),
-                                src: Operand::Virtual(arg.primary),
-                            });
-                        }
-                        crate::value_plan::DebugValuePlan::String
-                        | crate::value_plan::DebugValuePlan::Other
-                        | crate::value_plan::DebugValuePlan::Integer(_) => {
-                            unreachable!("dbg type")
-                        }
-                    }
-                    let symbol_id = self.intern_symbol(
-                        plan.runtime_symbol
-                            .as_deref()
-                            .expect("debug intrinsic runtime symbol"),
-                    );
-                    self.mir.push(X86Inst::CallRel { symbol_id });
-                }
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRI32 {
-                    dst: Operand::Virtual(dst),
-                    imm: 0,
-                });
-                dst
+                self.lower_runtime_call(plan.runtime_call.expect("debug runtime call plan"))
+                    .primary
             }
             crate::value_plan::IntrinsicOperation::Syscall => {
                 let syscall_regs = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::R10, Reg::R8, Reg::R9];
@@ -2089,7 +1839,7 @@ impl<'a> CfgLower<'a> {
         &mut self,
         width: crate::value_plan::IntegerWidth,
         result_vreg: VReg,
-        trap_symbol: &str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
         let ok_label = self.new_label();
 
@@ -2178,8 +1928,7 @@ impl<'a> CfgLower<'a> {
         }
 
         // Overflow occurred - call panic handler
-        let symbol_id = self.intern_symbol(trap_symbol);
-        self.mir.push(X86Inst::CallRel { symbol_id });
+        let _ = self.lower_runtime_call(trap_call.clone());
         self.mir.push(X86Inst::Label { id: ok_label });
     }
 
@@ -2192,7 +1941,7 @@ impl<'a> CfgLower<'a> {
         src_vreg: VReg,
         from_width: crate::value_plan::IntegerWidth,
         to_width: crate::value_plan::IntegerWidth,
-        trap_symbol: &str,
+        trap_call: crate::runtime_call_plan::RuntimeCallPlan,
     ) {
         let from_signed = from_width.signed;
         let to_signed = to_width.signed;
@@ -2246,8 +1995,7 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(X86Inst::Jge { label: ok_label });
 
                     // Below min - panic
-                    let symbol_id = self.intern_symbol(trap_symbol);
-                    self.mir.push(X86Inst::CallRel { symbol_id });
+                    let _ = self.lower_runtime_call(trap_call.clone());
                     self.mir.push(X86Inst::Label { id: ok_label });
 
                     let ok_label2 = self.new_label();
@@ -2271,8 +2019,7 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(X86Inst::Jle { label: ok_label2 });
 
                     // Above max - panic
-                    let symbol_id = self.intern_symbol(trap_symbol);
-                    self.mir.push(X86Inst::CallRel { symbol_id });
+                    let _ = self.lower_runtime_call(trap_call.clone());
                     self.mir.push(X86Inst::Label { id: ok_label2 });
                 }
             } else {
@@ -2292,8 +2039,7 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(X86Inst::Jge { label: ok_label });
 
                 // Negative - panic
-                let symbol_id = self.intern_symbol(trap_symbol);
-                self.mir.push(X86Inst::CallRel { symbol_id });
+                let _ = self.lower_runtime_call(trap_call.clone());
                 self.mir.push(X86Inst::Label { id: ok_label });
 
                 // Also check upper bound if narrowing
@@ -2320,8 +2066,7 @@ impl<'a> CfgLower<'a> {
                     }
 
                     // Above max - panic
-                    let symbol_id = self.intern_symbol(trap_symbol);
-                    self.mir.push(X86Inst::CallRel { symbol_id });
+                    let _ = self.lower_runtime_call(trap_call.clone());
                     self.mir.push(X86Inst::Label { id: ok_label2 });
                 }
             }
@@ -2350,8 +2095,7 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(X86Inst::Jbe { label: ok_label });
 
                 // Above max - panic
-                let symbol_id = self.intern_symbol(trap_symbol);
-                self.mir.push(X86Inst::CallRel { symbol_id });
+                let _ = self.lower_runtime_call(trap_call.clone());
                 self.mir.push(X86Inst::Label { id: ok_label });
             } else {
                 // Unsigned to unsigned: narrowing check
@@ -2375,8 +2119,7 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(X86Inst::Jbe { label: ok_label });
 
                     // Above max - panic
-                    let symbol_id = self.intern_symbol(trap_symbol);
-                    self.mir.push(X86Inst::CallRel { symbol_id });
+                    let _ = self.lower_runtime_call(trap_call.clone());
                     self.mir.push(X86Inst::Label { id: ok_label });
                 }
             }
@@ -2474,20 +2217,8 @@ impl<'a> CfgLower<'a> {
                 });
             }
             TerminatorPlan::Return { mode } => match mode {
-                ReturnMode::Exit { value } => {
-                    if let Some(value) = value {
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Physical(Reg::Rdi),
-                            src: Operand::Virtual(value),
-                        });
-                    } else {
-                        self.mir.push(X86Inst::MovRI32 {
-                            dst: Operand::Physical(Reg::Rdi),
-                            imm: 0,
-                        });
-                    }
-                    let symbol_id = self.intern_symbol("__rue_exit");
-                    self.mir.push(X86Inst::CallRel { symbol_id });
+                ReturnMode::Exit { call } => {
+                    let _ = self.lower_runtime_call(call);
                 }
                 ReturnMode::Function { value } => match value {
                     ReturnValuePlan::ZeroSized => self.mir.push(X86Inst::Ret),
@@ -2675,6 +2406,12 @@ impl crate::value_plan::ValueLowerAdapter for CfgLower<'_> {
     fn emit_call(&mut self, plan: crate::call_plan::CallPlan) -> crate::value_plan::ValueResult {
         crate::value_plan::ValueResult::Materialized(self.lower_call_plan(plan))
     }
+    fn emit_runtime_call(
+        &mut self,
+        plan: crate::runtime_call_plan::RuntimeCallPlan,
+    ) -> crate::value_plan::ValueResult {
+        crate::value_plan::ValueResult::Materialized(self.lower_runtime_call(plan))
+    }
     fn emit_intrinsic(
         &mut self,
         plan: crate::value_plan::IntrinsicPlan,
@@ -2835,11 +2572,14 @@ impl crate::allocation::BoundsCheckBackend for CfgLower<'_> {
         }
     }
 
-    fn emit_bounds_trap(&mut self, trap: crate::allocation::BoundsTrap, symbol: &'static str) {
+    fn emit_bounds_trap(
+        &mut self,
+        trap: crate::allocation::BoundsTrap,
+        call: crate::runtime_call_plan::RuntimeCallPlan,
+    ) {
         match trap {
             crate::allocation::BoundsTrap::IndexOutOfBounds => {
-                let symbol_id = self.intern_symbol(symbol);
-                self.mir.push(X86Inst::CallRel { symbol_id });
+                let _ = self.lower_runtime_call(call);
             }
         }
     }
@@ -2958,9 +2698,11 @@ impl crate::allocation::ScaleBackend for CfgLower<'_> {
                     });
                     let ok_label = self.new_label();
                     self.mir.push(X86Inst::Jae { label: ok_label });
-                    let symbol_id =
-                        self.intern_symbol(crate::allocation::RUNTIME_TRAP_SYMBOLS.overflow);
-                    self.mir.push(X86Inst::CallRel { symbol_id });
+                    let _ = self.lower_runtime_call(
+                        crate::runtime_call_plan::RuntimeCallPlan::no_args(
+                            rue_runtime_abi::RuntimeHelperId::Overflow,
+                        ),
+                    );
                     self.mir.push(X86Inst::Label { id: ok_label });
                 }
             },
@@ -3101,13 +2843,13 @@ mod tests {
             })
     }
 
-    fn runtime_call_index(mir: &X86Mir, symbol: &str) -> usize {
+    fn runtime_call_index(mir: &X86Mir, helper: rue_runtime_abi::RuntimeHelperId) -> usize {
         mir.instructions()
             .iter()
             .position(|inst| {
-                matches!(inst, X86Inst::CallRel { symbol_id } if mir.get_symbol(*symbol_id) == symbol)
+                matches!(inst, X86Inst::CallRel { symbol_id } if mir.get_symbol(*symbol_id) == helper.symbol())
             })
-            .unwrap_or_else(|| panic!("missing call to {symbol}"))
+            .unwrap_or_else(|| panic!("missing call to {helper:?}"))
     }
 
     #[test]
@@ -3209,7 +2951,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_bytes_preview_lowers_to_true_byte_memory_ops() {
+    fn raw_bytes_runtime_helper_identity_and_slots_match_shared_plan() {
         let mut preview = PreviewFeatures::new();
         preview.insert(PreviewFeature::RawBytes);
         let mir = lower_to_mir_with_preview(
@@ -3230,16 +2972,16 @@ mod tests {
                 .any(|inst| matches!(inst, X86Inst::Movzx8RMIndexed { .. }))
         );
 
-        let alloc = runtime_call_index(&mir, "__rue_alloc");
+        let alloc = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Alloc);
         assert_eq!(immediate_call_arg(&mir, alloc, Reg::Rdi), Some(3));
         assert_eq!(immediate_call_arg(&mir, alloc, Reg::Rsi), Some(1));
 
-        let realloc = runtime_call_index(&mir, "__rue_realloc");
+        let realloc = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Realloc);
         assert_eq!(immediate_call_arg(&mir, realloc, Reg::Rsi), Some(3));
         assert_eq!(immediate_call_arg(&mir, realloc, Reg::Rdx), Some(5));
         assert_eq!(immediate_call_arg(&mir, realloc, Reg::Rcx), Some(1));
 
-        let free = runtime_call_index(&mir, "__rue_free");
+        let free = runtime_call_index(&mir, rue_runtime_abi::RuntimeHelperId::Free);
         assert_eq!(immediate_call_arg(&mir, free, Reg::Rsi), Some(5));
         assert_eq!(immediate_call_arg(&mir, free, Reg::Rdx), Some(1));
     }

--- a/crates/rue-spec/cases/golden/ir-dumps.toml
+++ b/crates/rue-spec/cases/golden/ir-dumps.toml
@@ -634,11 +634,11 @@ function main:
     cbnz v1, .L0
     bl __rue_div_by_zero
     .L0:
-    mov v3, #-1
-    cmp v1, v3
+    mov v4, #-1
+    cmp v1, v4
     b.ne .L1
-    mov v4, #-2147483648
-    cmp v0, v4
+    mov v5, #-2147483648
+    cmp v0, v5
     b.ne .L1
     bl __rue_overflow
     .L1:
@@ -713,16 +713,16 @@ function main:
     cbnz v1, .L0
     bl __rue_div_by_zero
     .L0:
-    mov v3, #-1
-    cmp v1, v3
+    mov v4, #-1
+    cmp v1, v4
     b.ne .L1
-    mov v4, #-2147483648
-    cmp v0, v4
+    mov v5, #-2147483648
+    cmp v0, v5
     b.ne .L1
     bl __rue_overflow
     .L1:
-    sdiv v5, v0, v1
-    msub v2, v5, v1, v0
+    sdiv v7, v0, v1
+    msub v2, v7, v1, v0
     mov x0, v2
     bl __rue_exit
 """
@@ -948,12 +948,12 @@ function main:
     jb .L0
     call __rue_bounds_check
     .L0:
-    mov v8, v5
-    mov v9, 16
-    imulq v8, v9
-    lea v10, [rbp-8]
-    addq v10, v8
-    mov v6, [v10]
+    mov v9, v5
+    mov v10, 16
+    imulq v9, v10
+    lea v11, [rbp-8]
+    addq v11, v9
+    mov v6, [v11]
     mov rdi, v6
     call __rue_exit
 """
@@ -987,12 +987,12 @@ function main:
     b.lo .L0
     bl __rue_bounds_check
     .L0:
-    mov v8, v5
-    mov v9, #16
-    mul v8, v8, v9
-    add v10, fp, #-8
-    add v10, v10, v8
-    ldr v6, [v10]
+    mov v9, v5
+    mov v10, #16
+    mul v9, v9, v10
+    add v11, fp, #-8
+    add v11, v11, v9
+    ldr v6, [v11]
     mov x0, v6
     bl __rue_exit
 """


### PR DESCRIPTION
Introduce a single manifest-validated runtime call plan shared by x86-64 and AArch64, deriving logical arguments, result and sret shape, calling convention, and return behavior from typed helper identity.

Route allocation, traps, panic, parsing, random, debug, string equality, and process exit through the shared plan. Current CFG symbol bridging is exact against the exhaustive manifest and rejects prefix lookalikes until typed CFG identity lands.

Fixes RUE-831