### PR TITLE
RUE-830: type AIR and CFG runtime calls

### DIFF
--- a/crates/rue-air/BUCK
+++ b/crates/rue-air/BUCK
@@ -8,6 +8,7 @@ rue_crate(
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-parser:rue-parser",
         "//crates/rue-rir:rue-rir",
+        "//crates/rue-runtime-abi:rue-runtime-abi",
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
         "//third-party:lasso",

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -841,6 +841,8 @@ pub enum AirInstData {
 
     /// Function call
     Call {
+        /// Typed runtime identity, absent for source-language calls.
+        runtime: Option<crate::RuntimeCallKind>,
         /// Function name (interned symbol)
         name: Spur,
         /// Start index into extra array for arguments
@@ -884,6 +886,8 @@ pub enum AirInstData {
 
     /// Intrinsic call (e.g., @dbg)
     Intrinsic {
+        /// Runtime helper/adaptation selected for runtime-backed intrinsics.
+        runtime: Option<crate::RuntimeCallKind>,
         /// Intrinsic name (without @, interned)
         name: Spur,
         /// Start index into extra array for arguments
@@ -1162,10 +1166,14 @@ impl Air {
                     }
                 }
                 AirInstData::Call {
+                    runtime,
                     name,
                     args_start,
                     args_len,
                 } => {
+                    if let Some(runtime) = runtime {
+                        write!(f, "runtime.{runtime:?} ")?;
+                    }
                     match interner {
                         Some(interner) => write!(f, "call @{}(", interner.resolve(name))?,
                         None => write!(f, "call @{}(", name.into_usize())?,
@@ -1223,10 +1231,14 @@ impl Air {
                     writeln!(f, ")")?;
                 }
                 AirInstData::Intrinsic {
+                    runtime,
                     name,
                     args_start,
                     args_len,
                 } => {
+                    if let Some(runtime) = runtime {
+                        write!(f, "runtime.{runtime:?} ")?;
+                    }
                     match interner {
                         Some(interner) => write!(f, "intrinsic @{}(", interner.resolve(name))?,
                         None => write!(f, "intrinsic @sym:{}(", name.into_usize())?,
@@ -1494,6 +1506,7 @@ mod tests {
 
         for data in [
             AirInstData::Call {
+                runtime: None,
                 name: call,
                 args_start: 0,
                 args_len: 0,
@@ -1508,6 +1521,7 @@ mod tests {
                 args_len: 0,
             },
             AirInstData::Intrinsic {
+                runtime: None,
                 name: intrinsic,
                 args_start: 0,
                 args_len: 0,

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -19,6 +19,7 @@ mod intern_pool;
 mod module_registry;
 mod param_arena;
 mod path_norm;
+mod runtime_call;
 mod scope;
 mod sema;
 mod semantic_body;
@@ -43,6 +44,10 @@ pub use intern_pool::{
 pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};
 pub use path_norm::normalize_module_path;
+pub use runtime_call::{
+    OptionVariant, RuntimeAirArgument, RuntimeAirType, RuntimeCallActivation, RuntimeCallKind,
+    RuntimeOperandOrigin,
+};
 pub use sema::{
     AnalyzedBodyOwnerEvent, AnalyzedFunction, BodyAnalysisFailure, BodyAnalysisWork,
     BodyNamedDependencyEvent, BodyOwnerEndpoint, BodyOwnerKind, BodyOwnerToken, BoundSema,

--- a/crates/rue-air/src/runtime_call.rs
+++ b/crates/rue-air/src/runtime_call.rs
@@ -1,0 +1,806 @@
+//! Compiler-owned descriptions of semantic operands at the runtime ABI.
+
+use rue_runtime_abi::{
+    AbiParameter, AbiResult, AbiType, AggregateShapeId, ParameterMode, ReturnBehavior,
+    RuntimeHelperId,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeOperandOrigin {
+    OutResult(AggregateShapeId),
+    ValueArgument { index: u8, ty: AbiType },
+    SignExtendedArgument(u8),
+    ZeroExtendedArgument(u8),
+    BoolWordArgument(u8),
+    AbiExtendedIntegerArgument(u8),
+    MutablePointerArgument { index: u8, source: RuntimeAirType },
+    TextPointer(u8),
+    TextLength(u8),
+    ProjectedTextPointer(u8),
+    ProjectedTextLength(u8),
+    ResultPointeeAlign,
+    ScaledByResultPointeeSize(u8),
+    PointerPointeeAlign(u8),
+    ScaledByPointerPointeeSize { pointer: u8, count: u8 },
+    OptionDiscriminant(OptionVariant),
+    ByteAlignment,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OptionVariant {
+    Some,
+    None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeCallActivation {
+    Always,
+    WhenArgumentIsFalse(u8),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeAirType {
+    Unit,
+    U8,
+    I64,
+    U64,
+    U32,
+    Bool,
+    SignedInteger,
+    UnsignedInteger,
+    Integer,
+    Text,
+    BytePointer,
+    ConstBytePointer,
+    MutPointer,
+    MutBytePointer,
+    StrBuf,
+    OptionStrBuf,
+    OptionI32,
+    OptionI64,
+    OptionU32,
+    OptionU64,
+    Never,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeAirArgument {
+    pub ty: RuntimeAirType,
+    pub mode: crate::AirArgMode,
+}
+
+impl RuntimeOperandOrigin {
+    fn accepts(self, parameter: AbiParameter) -> bool {
+        match self {
+            Self::OutResult(shape) => parameter.mode == ParameterMode::OutPointer(shape),
+            Self::TextPointer(_) | Self::ProjectedTextPointer(_) => {
+                parameter.ty == AbiType::Byte && parameter.mode == ParameterMode::ConstPointer
+            }
+            Self::TextLength(_)
+            | Self::ProjectedTextLength(_)
+            | Self::ResultPointeeAlign
+            | Self::ScaledByResultPointeeSize(_)
+            | Self::PointerPointeeAlign(_)
+            | Self::ScaledByPointerPointeeSize { .. }
+            | Self::OptionDiscriminant(_)
+            | Self::ByteAlignment => {
+                parameter.ty == AbiType::U64 && parameter.mode == ParameterMode::Value
+            }
+            Self::ValueArgument { ty, .. } => {
+                parameter.ty == ty && parameter.mode == ParameterMode::Value
+            }
+            Self::SignExtendedArgument(_) => {
+                parameter.ty == AbiType::I64 && parameter.mode == ParameterMode::Value
+            }
+            Self::ZeroExtendedArgument(_) | Self::AbiExtendedIntegerArgument(_) => {
+                parameter.ty == AbiType::U64 && parameter.mode == ParameterMode::Value
+            }
+            Self::BoolWordArgument(_) => {
+                parameter.ty == AbiType::BoolWordI64 && parameter.mode == ParameterMode::Value
+            }
+            Self::MutablePointerArgument { .. } => {
+                parameter.ty == AbiType::Byte && parameter.mode == ParameterMode::MutPointer
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeCallKind {
+    StrByteAt,
+    StrCharScalar,
+    StrCharNext,
+    StrCharScalarLossy,
+    StrCharNextLossy,
+    ToString,
+    ToStringUnsigned,
+    StrPrintAggregate,
+    StrPrintProjected,
+    StrPrintlnAggregate,
+    StrPrintlnProjected,
+    DebugI64,
+    DebugU64,
+    DebugBool,
+    DebugStr,
+    Panic,
+    PanicNoMessage,
+    AssertFailed,
+    AssertWithMessage,
+    ReadLine,
+    ParseI32,
+    ParseI64,
+    ParseU32,
+    ParseU64,
+    RandomU32,
+    RandomU64,
+    AllocTyped,
+    FreeTyped,
+    ReallocTyped,
+    AllocBytes,
+    FreeBytes,
+    ReallocBytes,
+}
+
+const STR_BYTE_AT: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::TextPointer(0),
+    RuntimeOperandOrigin::TextLength(0),
+    RuntimeOperandOrigin::AbiExtendedIntegerArgument(1),
+];
+const CHAR_INDEX: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::ProjectedTextPointer(0),
+    RuntimeOperandOrigin::ProjectedTextLength(1),
+    RuntimeOperandOrigin::ValueArgument {
+        index: 2,
+        ty: AbiType::U64,
+    },
+];
+const FORMAT_SIGNED: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::OutResult(AggregateShapeId::StrBufResult),
+    RuntimeOperandOrigin::ValueArgument {
+        index: 0,
+        ty: AbiType::I64,
+    },
+];
+const FORMAT_UNSIGNED: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::OutResult(AggregateShapeId::StrBufResult),
+    RuntimeOperandOrigin::ValueArgument {
+        index: 0,
+        ty: AbiType::U64,
+    },
+];
+const TEXT: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::TextPointer(0),
+    RuntimeOperandOrigin::TextLength(0),
+];
+const PROJECTED_TEXT: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::ProjectedTextPointer(0),
+    RuntimeOperandOrigin::ProjectedTextLength(1),
+];
+const SIGNED_SCALAR: &[RuntimeOperandOrigin] = &[RuntimeOperandOrigin::SignExtendedArgument(0)];
+const UNSIGNED_SCALAR: &[RuntimeOperandOrigin] = &[RuntimeOperandOrigin::ZeroExtendedArgument(0)];
+const BOOL_SCALAR: &[RuntimeOperandOrigin] = &[RuntimeOperandOrigin::BoolWordArgument(0)];
+const NONE: &[RuntimeOperandOrigin] = &[];
+const READ_LINE: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::OutResult(AggregateShapeId::OptionStrBufResult),
+    RuntimeOperandOrigin::OptionDiscriminant(OptionVariant::Some),
+    RuntimeOperandOrigin::OptionDiscriminant(OptionVariant::None),
+];
+const PARSE: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::OutResult(AggregateShapeId::OptionIntResult),
+    RuntimeOperandOrigin::TextPointer(0),
+    RuntimeOperandOrigin::TextLength(0),
+    RuntimeOperandOrigin::OptionDiscriminant(OptionVariant::Some),
+    RuntimeOperandOrigin::OptionDiscriminant(OptionVariant::None),
+];
+const ALLOC_TYPED: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::ScaledByResultPointeeSize(0),
+    RuntimeOperandOrigin::ResultPointeeAlign,
+];
+const FREE_TYPED: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::MutablePointerArgument {
+        index: 0,
+        source: RuntimeAirType::MutPointer,
+    },
+    RuntimeOperandOrigin::ScaledByPointerPointeeSize {
+        pointer: 0,
+        count: 1,
+    },
+    RuntimeOperandOrigin::PointerPointeeAlign(0),
+];
+const REALLOC_TYPED: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::MutablePointerArgument {
+        index: 0,
+        source: RuntimeAirType::MutPointer,
+    },
+    RuntimeOperandOrigin::ScaledByPointerPointeeSize {
+        pointer: 0,
+        count: 1,
+    },
+    RuntimeOperandOrigin::ScaledByPointerPointeeSize {
+        pointer: 0,
+        count: 2,
+    },
+    RuntimeOperandOrigin::PointerPointeeAlign(0),
+];
+const ALLOC_BYTES: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::ValueArgument {
+        index: 0,
+        ty: AbiType::U64,
+    },
+    RuntimeOperandOrigin::ByteAlignment,
+];
+const FREE_BYTES: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::MutablePointerArgument {
+        index: 0,
+        source: RuntimeAirType::MutBytePointer,
+    },
+    RuntimeOperandOrigin::ValueArgument {
+        index: 1,
+        ty: AbiType::U64,
+    },
+    RuntimeOperandOrigin::ByteAlignment,
+];
+const REALLOC_BYTES: &[RuntimeOperandOrigin] = &[
+    RuntimeOperandOrigin::MutablePointerArgument {
+        index: 0,
+        source: RuntimeAirType::MutBytePointer,
+    },
+    RuntimeOperandOrigin::ValueArgument {
+        index: 1,
+        ty: AbiType::U64,
+    },
+    RuntimeOperandOrigin::ValueArgument {
+        index: 2,
+        ty: AbiType::U64,
+    },
+    RuntimeOperandOrigin::ByteAlignment,
+];
+
+impl RuntimeCallKind {
+    pub const ALL: [Self; 32] = [
+        Self::StrByteAt,
+        Self::StrCharScalar,
+        Self::StrCharNext,
+        Self::StrCharScalarLossy,
+        Self::StrCharNextLossy,
+        Self::ToString,
+        Self::ToStringUnsigned,
+        Self::StrPrintAggregate,
+        Self::StrPrintProjected,
+        Self::StrPrintlnAggregate,
+        Self::StrPrintlnProjected,
+        Self::DebugI64,
+        Self::DebugU64,
+        Self::DebugBool,
+        Self::DebugStr,
+        Self::Panic,
+        Self::PanicNoMessage,
+        Self::AssertFailed,
+        Self::AssertWithMessage,
+        Self::ReadLine,
+        Self::ParseI32,
+        Self::ParseI64,
+        Self::ParseU32,
+        Self::ParseU64,
+        Self::RandomU32,
+        Self::RandomU64,
+        Self::AllocTyped,
+        Self::FreeTyped,
+        Self::ReallocTyped,
+        Self::AllocBytes,
+        Self::FreeBytes,
+        Self::ReallocBytes,
+    ];
+
+    pub const fn helper(self) -> RuntimeHelperId {
+        match self {
+            Self::StrByteAt => RuntimeHelperId::StrByteAt,
+            Self::StrCharScalar => RuntimeHelperId::StrCharScalar,
+            Self::StrCharNext => RuntimeHelperId::StrCharNext,
+            Self::StrCharScalarLossy => RuntimeHelperId::StrCharScalarLossy,
+            Self::StrCharNextLossy => RuntimeHelperId::StrCharNextLossy,
+            Self::ToString => RuntimeHelperId::ToString,
+            Self::ToStringUnsigned => RuntimeHelperId::ToStringUnsigned,
+            Self::StrPrintAggregate | Self::StrPrintProjected => RuntimeHelperId::StrPrint,
+            Self::StrPrintlnAggregate | Self::StrPrintlnProjected => RuntimeHelperId::StrPrintln,
+            Self::DebugI64 => RuntimeHelperId::DebugI64,
+            Self::DebugU64 => RuntimeHelperId::DebugU64,
+            Self::DebugBool => RuntimeHelperId::DebugBool,
+            Self::DebugStr => RuntimeHelperId::DebugStr,
+            Self::Panic => RuntimeHelperId::Panic,
+            Self::PanicNoMessage => RuntimeHelperId::PanicNoMessage,
+            Self::AssertFailed => RuntimeHelperId::AssertFailed,
+            Self::AssertWithMessage => RuntimeHelperId::Panic,
+            Self::ReadLine => RuntimeHelperId::ReadLine,
+            Self::ParseI32 => RuntimeHelperId::ParseI32,
+            Self::ParseI64 => RuntimeHelperId::ParseI64,
+            Self::ParseU32 => RuntimeHelperId::ParseU32,
+            Self::ParseU64 => RuntimeHelperId::ParseU64,
+            Self::RandomU32 => RuntimeHelperId::RandomU32,
+            Self::RandomU64 => RuntimeHelperId::RandomU64,
+            Self::AllocTyped | Self::AllocBytes => RuntimeHelperId::Alloc,
+            Self::FreeTyped | Self::FreeBytes => RuntimeHelperId::Free,
+            Self::ReallocTyped | Self::ReallocBytes => RuntimeHelperId::Realloc,
+        }
+    }
+
+    pub const fn operands(self) -> &'static [RuntimeOperandOrigin] {
+        match self {
+            Self::StrByteAt => STR_BYTE_AT,
+            Self::StrCharScalar
+            | Self::StrCharNext
+            | Self::StrCharScalarLossy
+            | Self::StrCharNextLossy => CHAR_INDEX,
+            Self::ToString => FORMAT_SIGNED,
+            Self::ToStringUnsigned => FORMAT_UNSIGNED,
+            Self::StrPrintAggregate | Self::StrPrintlnAggregate | Self::DebugStr | Self::Panic => {
+                TEXT
+            }
+            Self::StrPrintProjected | Self::StrPrintlnProjected => PROJECTED_TEXT,
+            Self::AssertWithMessage => &[
+                RuntimeOperandOrigin::TextPointer(1),
+                RuntimeOperandOrigin::TextLength(1),
+            ],
+            Self::DebugI64 => SIGNED_SCALAR,
+            Self::DebugU64 => UNSIGNED_SCALAR,
+            Self::DebugBool => BOOL_SCALAR,
+            Self::PanicNoMessage | Self::AssertFailed | Self::RandomU32 | Self::RandomU64 => NONE,
+            Self::ReadLine => READ_LINE,
+            Self::ParseI32 | Self::ParseI64 | Self::ParseU32 | Self::ParseU64 => PARSE,
+            Self::AllocTyped => ALLOC_TYPED,
+            Self::FreeTyped => FREE_TYPED,
+            Self::ReallocTyped => REALLOC_TYPED,
+            Self::AllocBytes => ALLOC_BYTES,
+            Self::FreeBytes => FREE_BYTES,
+            Self::ReallocBytes => REALLOC_BYTES,
+        }
+    }
+
+    pub const fn activation(self) -> RuntimeCallActivation {
+        match self {
+            Self::AssertFailed | Self::AssertWithMessage => {
+                RuntimeCallActivation::WhenArgumentIsFalse(0)
+            }
+            _ => RuntimeCallActivation::Always,
+        }
+    }
+
+    pub fn validate(self) -> bool {
+        let parameters = self.helper().helper().parameters;
+        parameters.len() == self.operands().len()
+            && self
+                .operands()
+                .iter()
+                .zip(parameters)
+                .all(|(o, p)| o.accepts(*p))
+    }
+
+    pub fn validate_air_arguments(self, arguments: &[RuntimeAirArgument]) -> bool {
+        Self::validate_air_arguments_for_plan(self.operands(), self.activation(), arguments)
+    }
+
+    pub fn validate_air_call(
+        self,
+        arguments: &[RuntimeAirArgument],
+        result: RuntimeAirType,
+    ) -> bool {
+        self.validate_air_arguments(arguments) && self.validate_air_result(result)
+    }
+
+    pub fn validate_air_result(self, result: RuntimeAirType) -> bool {
+        let helper = self.helper().helper();
+        self.validate_air_result_for_manifest(helper.result, helper.return_behavior, result)
+    }
+
+    fn validate_air_result_for_manifest(
+        self,
+        helper_result: AbiResult,
+        return_behavior: ReturnBehavior,
+        result: RuntimeAirType,
+    ) -> bool {
+        if return_behavior == ReturnBehavior::Never && helper_result != AbiResult::Void {
+            return false;
+        }
+        let expected = match self.activation() {
+            RuntimeCallActivation::WhenArgumentIsFalse(_) => {
+                if return_behavior != ReturnBehavior::Never {
+                    return false;
+                }
+                RuntimeAirType::Unit
+            }
+            RuntimeCallActivation::Always => {
+                if return_behavior == ReturnBehavior::Never {
+                    RuntimeAirType::Never
+                } else if let Some(shape) = self.out_result_shape() {
+                    if helper_result != AbiResult::Void {
+                        return false;
+                    }
+                    match shape {
+                        AggregateShapeId::StrBufResult => RuntimeAirType::StrBuf,
+                        AggregateShapeId::OptionStrBufResult => RuntimeAirType::OptionStrBuf,
+                        AggregateShapeId::OptionIntResult => match self {
+                            Self::ParseI32 => RuntimeAirType::OptionI32,
+                            Self::ParseI64 => RuntimeAirType::OptionI64,
+                            Self::ParseU32 => RuntimeAirType::OptionU32,
+                            Self::ParseU64 => RuntimeAirType::OptionU64,
+                            _ => return false,
+                        },
+                    }
+                } else if self.has_result_pointee_origin() {
+                    if helper_result != AbiResult::Scalar(AbiType::MutBytePointer) {
+                        return false;
+                    }
+                    RuntimeAirType::MutPointer
+                } else if helper_result == AbiResult::Scalar(AbiType::MutBytePointer) {
+                    self.pointer_result_type()
+                } else {
+                    self.logical_scalar_result()
+                        .unwrap_or_else(|| Self::air_type_for_abi_result(helper_result))
+                }
+            }
+        };
+        if result == RuntimeAirType::Never {
+            expected == RuntimeAirType::Never
+        } else {
+            Self::air_type_accepts(expected, result)
+        }
+    }
+
+    fn out_result_shape(self) -> Option<AggregateShapeId> {
+        let mut shape = None;
+        for operand in self.operands() {
+            if let RuntimeOperandOrigin::OutResult(candidate) = operand {
+                if shape.replace(*candidate).is_some() {
+                    return None;
+                }
+            }
+        }
+        shape
+    }
+
+    fn has_result_pointee_origin(self) -> bool {
+        self.operands().iter().any(|operand| {
+            matches!(
+                operand,
+                RuntimeOperandOrigin::ResultPointeeAlign
+                    | RuntimeOperandOrigin::ScaledByResultPointeeSize(_)
+            )
+        })
+    }
+
+    fn pointer_result_type(self) -> RuntimeAirType {
+        self.operands()
+            .iter()
+            .find_map(|operand| match operand {
+                RuntimeOperandOrigin::MutablePointerArgument { source, .. } => Some(*source),
+                _ => None,
+            })
+            .unwrap_or(RuntimeAirType::MutBytePointer)
+    }
+
+    fn logical_scalar_result(self) -> Option<RuntimeAirType> {
+        match self {
+            Self::StrByteAt => Some(RuntimeAirType::U8),
+            Self::StrCharScalar | Self::StrCharScalarLossy => Some(RuntimeAirType::U32),
+            _ => None,
+        }
+    }
+
+    fn validate_air_arguments_for_plan(
+        operands: &[RuntimeOperandOrigin],
+        activation: RuntimeCallActivation,
+        arguments: &[RuntimeAirArgument],
+    ) -> bool {
+        let mut requirements = vec![None; arguments.len()];
+        let mut require = |index: u8, ty: RuntimeAirType| {
+            let Some(slot) = requirements.get_mut(index as usize) else {
+                return false;
+            };
+            match *slot {
+                Some(existing) => existing == ty,
+                None => {
+                    *slot = Some(ty);
+                    true
+                }
+            }
+        };
+        for operand in operands {
+            let valid = match *operand {
+                RuntimeOperandOrigin::OutResult(_)
+                | RuntimeOperandOrigin::ResultPointeeAlign
+                | RuntimeOperandOrigin::OptionDiscriminant(_)
+                | RuntimeOperandOrigin::ByteAlignment => true,
+                RuntimeOperandOrigin::ValueArgument { index, ty } => {
+                    require(index, Self::air_type_for_abi_value(ty))
+                }
+                RuntimeOperandOrigin::SignExtendedArgument(index) => {
+                    require(index, RuntimeAirType::SignedInteger)
+                }
+                RuntimeOperandOrigin::ZeroExtendedArgument(index) => {
+                    require(index, RuntimeAirType::UnsignedInteger)
+                }
+                RuntimeOperandOrigin::BoolWordArgument(index) => {
+                    require(index, RuntimeAirType::Bool)
+                }
+                RuntimeOperandOrigin::AbiExtendedIntegerArgument(index) => {
+                    require(index, RuntimeAirType::Integer)
+                }
+                RuntimeOperandOrigin::MutablePointerArgument { index, source } => {
+                    matches!(
+                        source,
+                        RuntimeAirType::MutPointer | RuntimeAirType::MutBytePointer
+                    ) && require(index, source)
+                }
+                RuntimeOperandOrigin::TextPointer(index)
+                | RuntimeOperandOrigin::TextLength(index) => require(index, RuntimeAirType::Text),
+                RuntimeOperandOrigin::ProjectedTextPointer(index) => {
+                    require(index, RuntimeAirType::BytePointer)
+                }
+                RuntimeOperandOrigin::ProjectedTextLength(index)
+                | RuntimeOperandOrigin::ScaledByResultPointeeSize(index) => {
+                    require(index, RuntimeAirType::U64)
+                }
+                RuntimeOperandOrigin::PointerPointeeAlign(pointer) => {
+                    require(pointer, RuntimeAirType::MutPointer)
+                }
+                RuntimeOperandOrigin::ScaledByPointerPointeeSize { pointer, count } => {
+                    require(pointer, RuntimeAirType::MutPointer)
+                        && require(count, RuntimeAirType::U64)
+                }
+            };
+            if !valid {
+                return false;
+            }
+        }
+        if let RuntimeCallActivation::WhenArgumentIsFalse(index) = activation
+            && !require(index, RuntimeAirType::Bool)
+        {
+            return false;
+        }
+        requirements
+            .iter()
+            .zip(arguments)
+            .all(|(expected, actual)| {
+                expected.is_some_and(|expected| Self::air_type_accepts(expected, actual.ty))
+                    && actual.mode == crate::AirArgMode::Normal
+            })
+    }
+
+    fn air_type_for_abi_value(ty: AbiType) -> RuntimeAirType {
+        match ty {
+            AbiType::I32 => RuntimeAirType::SignedInteger,
+            AbiType::I64 => RuntimeAirType::I64,
+            AbiType::U32 => RuntimeAirType::U32,
+            AbiType::U64 | AbiType::Usize => RuntimeAirType::U64,
+            AbiType::BoolWordI64 => RuntimeAirType::Bool,
+            AbiType::Byte => RuntimeAirType::UnsignedInteger,
+            AbiType::MutBytePointer => RuntimeAirType::MutBytePointer,
+        }
+    }
+
+    fn air_type_for_abi_result(result: AbiResult) -> RuntimeAirType {
+        match result {
+            AbiResult::Void => RuntimeAirType::Unit,
+            AbiResult::Scalar(AbiType::Byte) => RuntimeAirType::U8,
+            AbiResult::Scalar(ty) => Self::air_type_for_abi_value(ty),
+        }
+    }
+
+    fn air_type_accepts(expected: RuntimeAirType, actual: RuntimeAirType) -> bool {
+        use RuntimeAirType as T;
+        if actual == T::Never {
+            return true;
+        }
+        match expected {
+            T::SignedInteger => matches!(actual, T::SignedInteger | T::I64),
+            T::UnsignedInteger => {
+                matches!(actual, T::UnsignedInteger | T::U64 | T::U32)
+            }
+            T::Integer => matches!(
+                actual,
+                T::Integer | T::SignedInteger | T::UnsignedInteger | T::I64 | T::U64 | T::U32
+            ),
+            T::BytePointer => matches!(
+                actual,
+                T::BytePointer | T::ConstBytePointer | T::MutBytePointer
+            ),
+            // A typed allocation specialized with `T = u8` has the same AIR
+            // pointer type as the byte-oriented helpers, while retaining the
+            // typed helper's pointee-scaled operand plan.
+            T::MutPointer => matches!(actual, T::MutPointer | T::MutBytePointer),
+            _ => expected == actual,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_runtime_call_plan_matches_the_manifest() {
+        for kind in RuntimeCallKind::ALL {
+            assert!(kind.validate(), "{kind:?}");
+        }
+        assert_eq!(
+            RuntimeCallKind::AssertWithMessage.activation(),
+            RuntimeCallActivation::WhenArgumentIsFalse(0)
+        );
+        assert_eq!(
+            RuntimeCallKind::Panic.activation(),
+            RuntimeCallActivation::Always
+        );
+    }
+
+    #[test]
+    fn air_argument_validation_rejects_arity_type_and_mode_drift() {
+        let normal = |ty| RuntimeAirArgument {
+            ty,
+            mode: crate::AirArgMode::Normal,
+        };
+        assert!(RuntimeCallKind::ToString.validate_air_arguments(&[normal(RuntimeAirType::I64)]));
+        assert!(!RuntimeCallKind::ToString.validate_air_arguments(&[normal(RuntimeAirType::U64)]));
+        assert!(
+            !RuntimeCallKind::AllocBytes
+                .validate_air_arguments(&[normal(RuntimeAirType::SignedInteger)])
+        );
+        assert!(
+            !RuntimeCallKind::StrCharNext.validate_air_arguments(&[
+                normal(RuntimeAirType::Text),
+                normal(RuntimeAirType::U64),
+            ])
+        );
+        assert!(
+            !RuntimeCallKind::AssertFailed.validate_air_arguments(&[RuntimeAirArgument {
+                ty: RuntimeAirType::Bool,
+                mode: crate::AirArgMode::Borrow,
+            }])
+        );
+    }
+
+    #[test]
+    fn operand_origin_validation_rejects_out_of_range_and_wrong_source_types() {
+        let normal = |ty| RuntimeAirArgument {
+            ty,
+            mode: crate::AirArgMode::Normal,
+        };
+        assert!(!RuntimeCallKind::validate_air_arguments_for_plan(
+            &[RuntimeOperandOrigin::ValueArgument {
+                index: 1,
+                ty: AbiType::U64,
+            }],
+            RuntimeCallActivation::Always,
+            &[normal(RuntimeAirType::U64)],
+        ));
+        assert!(!RuntimeCallKind::validate_air_arguments_for_plan(
+            &[RuntimeOperandOrigin::TextPointer(0)],
+            RuntimeCallActivation::Always,
+            &[normal(RuntimeAirType::U64)],
+        ));
+        assert!(!RuntimeCallKind::validate_air_arguments_for_plan(
+            &[RuntimeOperandOrigin::MutablePointerArgument {
+                index: 0,
+                source: RuntimeAirType::MutBytePointer,
+            }],
+            RuntimeCallActivation::Always,
+            &[normal(RuntimeAirType::MutPointer)],
+        ));
+    }
+
+    #[test]
+    fn scaled_pointer_origins_validate_both_pointer_and_count_indices() {
+        let normal = |ty| RuntimeAirArgument {
+            ty,
+            mode: crate::AirArgMode::Normal,
+        };
+        let scaled = [RuntimeOperandOrigin::ScaledByPointerPointeeSize {
+            pointer: 0,
+            count: 1,
+        }];
+        assert!(RuntimeCallKind::validate_air_arguments_for_plan(
+            &scaled,
+            RuntimeCallActivation::Always,
+            &[
+                normal(RuntimeAirType::MutPointer),
+                normal(RuntimeAirType::U64),
+            ],
+        ));
+        assert!(!RuntimeCallKind::validate_air_arguments_for_plan(
+            &scaled,
+            RuntimeCallActivation::Always,
+            &[
+                normal(RuntimeAirType::U64),
+                normal(RuntimeAirType::MutPointer),
+            ],
+        ));
+        assert!(!RuntimeCallKind::validate_air_arguments_for_plan(
+            &[RuntimeOperandOrigin::ScaledByPointerPointeeSize {
+                pointer: 0,
+                count: 2,
+            }],
+            RuntimeCallActivation::Always,
+            &[
+                normal(RuntimeAirType::MutPointer),
+                normal(RuntimeAirType::U64),
+            ],
+        ));
+    }
+
+    #[test]
+    fn result_validation_rejects_aggregate_pointer_and_control_flow_drift() {
+        assert!(RuntimeCallKind::ToString.validate_air_result(RuntimeAirType::StrBuf));
+        assert!(!RuntimeCallKind::ToString.validate_air_result(RuntimeAirType::Text));
+        assert!(RuntimeCallKind::ReadLine.validate_air_result(RuntimeAirType::OptionStrBuf));
+        assert!(!RuntimeCallKind::ReadLine.validate_air_result(RuntimeAirType::StrBuf));
+        for (kind, expected, wrong_width) in [
+            (
+                RuntimeCallKind::ParseI32,
+                RuntimeAirType::OptionI32,
+                RuntimeAirType::OptionI64,
+            ),
+            (
+                RuntimeCallKind::ParseI64,
+                RuntimeAirType::OptionI64,
+                RuntimeAirType::OptionI32,
+            ),
+            (
+                RuntimeCallKind::ParseU32,
+                RuntimeAirType::OptionU32,
+                RuntimeAirType::OptionU64,
+            ),
+            (
+                RuntimeCallKind::ParseU64,
+                RuntimeAirType::OptionU64,
+                RuntimeAirType::OptionU32,
+            ),
+        ] {
+            assert!(kind.validate_air_result(expected));
+            assert!(!kind.validate_air_result(wrong_width));
+            assert!(!kind.validate_air_result(RuntimeAirType::OptionStrBuf));
+        }
+        assert!(RuntimeCallKind::AllocTyped.validate_air_result(RuntimeAirType::MutPointer));
+        assert!(RuntimeCallKind::AllocTyped.validate_air_result(RuntimeAirType::MutBytePointer));
+        assert!(!RuntimeCallKind::AllocTyped.validate_air_result(RuntimeAirType::U64));
+        assert!(RuntimeCallKind::Panic.validate_air_result(RuntimeAirType::Never));
+        assert!(!RuntimeCallKind::Panic.validate_air_result(RuntimeAirType::Unit));
+        assert!(RuntimeCallKind::AssertFailed.validate_air_result(RuntimeAirType::Unit));
+        assert!(!RuntimeCallKind::AssertFailed.validate_air_result(RuntimeAirType::Never));
+        assert!(RuntimeCallKind::RandomU32.validate_air_result(RuntimeAirType::U32));
+        assert!(!RuntimeCallKind::RandomU32.validate_air_result(RuntimeAirType::U64));
+        assert!(RuntimeCallKind::RandomU64.validate_air_result(RuntimeAirType::U64));
+        assert!(!RuntimeCallKind::RandomU64.validate_air_result(RuntimeAirType::U32));
+        assert!(RuntimeCallKind::StrByteAt.validate_air_result(RuntimeAirType::U8));
+        assert!(!RuntimeCallKind::StrByteAt.validate_air_result(RuntimeAirType::U32));
+        assert!(
+            !RuntimeCallKind::AssertFailed.validate_air_result_for_manifest(
+                AbiResult::Scalar(AbiType::U64),
+                ReturnBehavior::Never,
+                RuntimeAirType::Unit,
+            )
+        );
+    }
+
+    #[test]
+    fn abi_scalar_result_mapping_preserves_exact_widths_and_bool() {
+        assert_eq!(
+            RuntimeCallKind::air_type_for_abi_result(AbiResult::Scalar(AbiType::I64)),
+            RuntimeAirType::I64
+        );
+        assert_eq!(
+            RuntimeCallKind::air_type_for_abi_result(AbiResult::Scalar(AbiType::U32)),
+            RuntimeAirType::U32
+        );
+        assert_eq!(
+            RuntimeCallKind::air_type_for_abi_result(AbiResult::Scalar(AbiType::U64)),
+            RuntimeAirType::U64
+        );
+        assert_eq!(
+            RuntimeCallKind::air_type_for_abi_result(AbiResult::Scalar(AbiType::BoolWordI64)),
+            RuntimeAirType::Bool
+        );
+        assert_eq!(
+            RuntimeCallKind::air_type_for_abi_result(AbiResult::Void),
+            RuntimeAirType::Unit
+        );
+    }
+}

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2540,6 +2540,7 @@ fn emit_module_member_call(
 
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::Call {
+            runtime: None,
             name: function_name,
             args_start: call_args_start,
             args_len: call_args_len,

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -241,6 +241,7 @@ impl<'a> BodySema<'a> {
 
         let call_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
+                runtime: None,
                 name: call_name,
                 args_start,
                 args_len: 2,
@@ -360,6 +361,17 @@ impl<'a> BodySema<'a> {
 
         let call_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
+                runtime: Some(if name == self.known.println {
+                    if source_strbuf {
+                        crate::RuntimeCallKind::StrPrintlnProjected
+                    } else {
+                        crate::RuntimeCallKind::StrPrintlnAggregate
+                    }
+                } else if source_strbuf {
+                    crate::RuntimeCallKind::StrPrintProjected
+                } else {
+                    crate::RuntimeCallKind::StrPrintAggregate
+                }),
                 name: call_name,
                 args_start,
                 args_len: if source_strbuf { 2 } else { 1 },
@@ -535,6 +547,7 @@ impl<'a> BodySema<'a> {
                 ));
                 let equal = air.add_inst(AirInst {
                     data: AirInstData::Call {
+                        runtime: None,
                         name: call_name,
                         args_start,
                         args_len: 2,

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -452,6 +452,7 @@ impl<'a> BodySema<'a> {
 
         let call_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
+                runtime: None,
                 name: call_name_sym,
                 args_start,
                 args_len,
@@ -801,6 +802,7 @@ impl<'a> BodySema<'a> {
 
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
+                runtime: None,
                 name: call_name_sym,
                 args_start,
                 args_len,

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -285,6 +285,7 @@ impl<'a> BodySema<'a> {
             let args_start = air.add_extra(&extra);
             let call_ref = air.add_inst(AirInst {
                 data: AirInstData::Call {
+                    runtime: None,
                     name: call_name,
                     args_start,
                     args_len: 1,
@@ -372,6 +373,12 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&extra);
         let call_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
+                runtime: Some(match (is_next, lossy) {
+                    (true, false) => crate::RuntimeCallKind::StrCharNext,
+                    (true, true) => crate::RuntimeCallKind::StrCharNextLossy,
+                    (false, false) => crate::RuntimeCallKind::StrCharScalar,
+                    (false, true) => crate::RuntimeCallKind::StrCharScalarLossy,
+                }),
                 name: call_name,
                 args_start,
                 args_len: 3,
@@ -490,6 +497,15 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[arg_ref.as_u32()]);
         let intrinsic_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(if arg_type == Type::BOOL {
+                    crate::RuntimeCallKind::DebugBool
+                } else if self.is_strbuf(arg_type) || self.is_str_like(arg_type) {
+                    crate::RuntimeCallKind::DebugStr
+                } else if arg_type.is_signed() {
+                    crate::RuntimeCallKind::DebugI64
+                } else {
+                    crate::RuntimeCallKind::DebugU64
+                }),
                 name: self.known.dbg,
                 args_start,
                 args_len: 1,
@@ -626,6 +642,7 @@ impl<'a> BodySema<'a> {
             // call, `return`, or `break` (spec 3.4:2, 4.13:5b; RUE-512).
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::Intrinsic {
+                    runtime: Some(crate::RuntimeCallKind::PanicNoMessage),
                     name: self.known.panic,
                     args_start: 0,
                     args_len: 0,
@@ -652,6 +669,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[arg_ref.as_u32()]);
         let intrinsic_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::Panic),
                 name: self.known.panic,
                 args_start,
                 args_len: 1,
@@ -735,6 +753,11 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&extra_data);
         let intrinsic_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(if args.len() > 1 {
+                    crate::RuntimeCallKind::AssertWithMessage
+                } else {
+                    crate::RuntimeCallKind::AssertFailed
+                }),
                 name: self.known.assert,
                 args_start,
                 args_len,
@@ -1023,6 +1046,7 @@ impl<'a> BodySema<'a> {
         // into this `Option(StrBuf)` enum (discriminant + StrBuf payload).
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::ReadLine),
                 name,
                 args_start: 0, // No args
                 args_len: 0,
@@ -1120,6 +1144,11 @@ impl<'a> BodySema<'a> {
 
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
+                runtime: Some(if unsigned {
+                    crate::RuntimeCallKind::ToStringUnsigned
+                } else {
+                    crate::RuntimeCallKind::ToString
+                }),
                 name: call_name,
                 args_start,
                 args_len: 1,
@@ -1205,6 +1234,13 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[arg_ref.as_u32()]);
         let intrinsic_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(match intrinsic_name_str {
+                    "parse_i32" => crate::RuntimeCallKind::ParseI32,
+                    "parse_i64" => crate::RuntimeCallKind::ParseI64,
+                    "parse_u32" => crate::RuntimeCallKind::ParseU32,
+                    "parse_u64" => crate::RuntimeCallKind::ParseU64,
+                    _ => unreachable!(),
+                }),
                 name,
                 args_start,
                 args_len: 1,
@@ -1240,6 +1276,7 @@ impl<'a> BodySema<'a> {
         // Create the intrinsic instruction that returns u32
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::RandomU32),
                 name,
                 args_start: 0, // No args
                 args_len: 0,
@@ -1273,6 +1310,7 @@ impl<'a> BodySema<'a> {
         // Create the intrinsic instruction that returns u64
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::RandomU64),
                 name,
                 args_start: 0, // No args
                 args_len: 0,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1109,6 +1109,7 @@ impl<'a> BodySema<'a> {
             let ptr_args = air.add_extra(&[zero_ref.as_u32()]);
             air.add_inst(AirInst {
                 data: AirInstData::Intrinsic {
+                    runtime: None,
                     name: self.known.int_to_ptr,
                     args_start: ptr_args,
                     args_len: 1,
@@ -1134,6 +1135,7 @@ impl<'a> BodySema<'a> {
             let raw_args = air.add_extra(&[elem0_read.as_u32()]);
             air.add_inst(AirInst {
                 data: AirInstData::Intrinsic {
+                    runtime: None,
                     name: self.known.raw,
                     args_start: raw_args,
                     args_len: 1,

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -68,6 +68,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[ptr_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name,
                 args_start,
                 args_len: 1,
@@ -177,6 +178,7 @@ impl<'a> BodySema<'a> {
             air.add_extra(&[ptr_result.air_ref.as_u32(), value_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name,
                 args_start,
                 args_len: 2,
@@ -242,6 +244,7 @@ impl<'a> BodySema<'a> {
             air.add_extra(&[ptr_result.air_ref.as_u32(), offset_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name,
                 args_start,
                 args_len: 2,
@@ -292,6 +295,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[ptr_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name,
                 args_start,
                 args_len: 1,
@@ -372,6 +376,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[addr_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name,
                 args_start,
                 args_len: 1,
@@ -450,6 +455,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[count_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::AllocTyped),
                 name,
                 args_start,
                 args_len: 1,
@@ -513,6 +519,7 @@ impl<'a> BodySema<'a> {
             air.add_extra(&[ptr_result.air_ref.as_u32(), count_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::FreeTyped),
                 name,
                 args_start,
                 args_len: 2,
@@ -582,6 +589,7 @@ impl<'a> BodySema<'a> {
         ]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::ReallocTyped),
                 name,
                 args_start,
                 args_len: 3,
@@ -628,6 +636,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[size.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::AllocBytes),
                 name,
                 args_start,
                 args_len: 1,
@@ -670,6 +679,7 @@ impl<'a> BodySema<'a> {
         ]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::ReallocBytes),
                 name,
                 args_start,
                 args_len: 3,
@@ -706,6 +716,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[ptr.air_ref.as_u32(), size.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::FreeBytes),
                 name,
                 args_start,
                 args_len: 2,
@@ -742,6 +753,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[ptr.air_ref.as_u32(), offset.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name,
                 args_start,
                 args_len: 2,
@@ -784,6 +796,7 @@ impl<'a> BodySema<'a> {
         ]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name,
                 args_start,
                 args_len: 3,
@@ -952,6 +965,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name,
                 args_start,
                 args_len: 1,
@@ -1055,6 +1069,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&arg_refs);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name,
                 args_start,
                 args_len: args.len() as u32,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5597,6 +5597,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&extra);
         let call_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
+                runtime: None,
                 name: call_name,
                 args_start,
                 args_len: 2,
@@ -5669,6 +5670,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&extra);
         let call_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
+                runtime: Some(crate::RuntimeCallKind::StrByteAt),
                 name: call_name,
                 args_start,
                 args_len: 2,
@@ -5781,6 +5783,7 @@ impl<'a> BodySema<'a> {
             let assert_args = air.add_extra(&[lower_bound_ref.as_u32()]);
             Some(air.add_inst(AirInst {
                 data: AirInstData::Intrinsic {
+                    runtime: Some(crate::RuntimeCallKind::AssertFailed),
                     name: self.known.assert,
                     args_start: assert_args,
                     args_len: 1,
@@ -5799,6 +5802,7 @@ impl<'a> BodySema<'a> {
         let upper_assert_args = air.add_extra(&[upper_bound_ref.as_u32()]);
         let upper_assert_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: Some(crate::RuntimeCallKind::AssertFailed),
                 name: self.known.assert,
                 args_start: upper_assert_args,
                 args_len: 1,
@@ -5811,6 +5815,7 @@ impl<'a> BodySema<'a> {
         let off_args = air.add_extra(&[ptr_ref.as_u32(), index_result.air_ref.as_u32()]);
         let off_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name: self.known.ptr_offset,
                 args_start: off_args,
                 args_len: 2,
@@ -5821,6 +5826,7 @@ impl<'a> BodySema<'a> {
         let read_args = air.add_extra(&[off_ref.as_u32()]);
         let elem_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name: self.known.ptr_read,
                 args_start: read_args,
                 args_len: 1,
@@ -6577,6 +6583,7 @@ impl<'a> BodySema<'a> {
 
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::Call {
+                    runtime: None,
                     name,
                     args_start,
                     args_len,

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -352,25 +352,37 @@ impl BodySema<'_> {
                     SemanticBodyInstData::Ret(value.map(|value| r(value, current)).transpose()?)
                 }
                 AirInstData::Call {
+                    runtime,
                     name,
                     args_start,
                     args_len,
-                } => match specialized_calls.and_then(|calls| calls.get(name)) {
-                    Some(identity) => SemanticBodyInstData::CallSpecialized {
-                        identity: identity.clone(),
-                        args: call_args(*args_start, *args_len)?,
-                    },
-                    None => SemanticBodyInstData::Call {
-                        function: self.function_identity(*name)?,
-                        args: call_args(*args_start, *args_len)?,
-                    },
-                },
+                } => {
+                    if let Some(runtime) = runtime {
+                        SemanticBodyInstData::RuntimeCall {
+                            runtime: *runtime,
+                            args: call_args(*args_start, *args_len)?,
+                        }
+                    } else {
+                        match specialized_calls.and_then(|calls| calls.get(name)) {
+                            Some(identity) => SemanticBodyInstData::CallSpecialized {
+                                identity: identity.clone(),
+                                args: call_args(*args_start, *args_len)?,
+                            },
+                            None => SemanticBodyInstData::Call {
+                                function: self.function_identity(*name)?,
+                                args: call_args(*args_start, *args_len)?,
+                            },
+                        }
+                    }
+                }
                 AirInstData::CallGeneric { .. } => return Err(F::UnsupportedGenericCall),
                 AirInstData::Intrinsic {
+                    runtime,
                     name,
                     args_start,
                     args_len,
                 } => SemanticBodyInstData::Intrinsic {
+                    runtime: *runtime,
                     name: Arc::from(self.interner.resolve(name)),
                     args: intrinsic_args(*args_start, *args_len)?,
                 },

--- a/crates/rue-air/src/semantic_body.rs
+++ b/crates/rue-air/src/semantic_body.rs
@@ -303,6 +303,10 @@ pub enum SemanticBodyInstData<K, M> {
         function: K,
         args: Arc<[SemanticBodyCallArg]>,
     },
+    RuntimeCall {
+        runtime: crate::RuntimeCallKind,
+        args: Arc<[SemanticBodyCallArg]>,
+    },
     /// A call to another concrete specialization. Its stable generic origin
     /// and ordered canonical arguments replace the request-local mangled name.
     CallSpecialized {
@@ -311,6 +315,7 @@ pub enum SemanticBodyInstData<K, M> {
     },
     CallGeneric,
     Intrinsic {
+        runtime: Option<crate::RuntimeCallKind>,
         name: Arc<str>,
         args: Arc<[SemanticBodyCallArg]>,
     },
@@ -564,12 +569,21 @@ impl<K, M> SemanticBody<K, M> {
                         function: key(function)?,
                         args: args.clone(),
                     },
+                    D::RuntimeCall { runtime, args } => D::RuntimeCall {
+                        runtime: *runtime,
+                        args: args.clone(),
+                    },
                     D::CallSpecialized { identity, args } => D::CallSpecialized {
                         identity: identity.try_map_keys(key, module)?,
                         args: args.clone(),
                     },
                     D::CallGeneric => D::CallGeneric,
-                    D::Intrinsic { name, args } => D::Intrinsic {
+                    D::Intrinsic {
+                        runtime,
+                        name,
+                        args,
+                    } => D::Intrinsic {
+                        runtime: *runtime,
                         name: name.clone(),
                         args: args.clone(),
                     },

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -407,7 +407,17 @@ where
                     let name = resolve_function(function)?;
                     let (s, l) = call_args(&mut air, args, current)?;
                     AirInstData::Call {
+                        runtime: None,
                         name,
+                        args_start: s,
+                        args_len: l,
+                    }
+                }
+                SemanticBodyInstData::RuntimeCall { runtime, args } => {
+                    let (s, l) = call_args(&mut air, args, current)?;
+                    AirInstData::Call {
+                        runtime: Some(*runtime),
+                        name: intern(runtime.helper().helper().symbol),
                         args_start: s,
                         args_len: l,
                     }
@@ -432,7 +442,11 @@ where
                     }
                 }
                 SemanticBodyInstData::CallGeneric => return Err(F::UnsupportedGenericCall),
-                SemanticBodyInstData::Intrinsic { name, args } => {
+                SemanticBodyInstData::Intrinsic {
+                    runtime,
+                    name,
+                    args,
+                } => {
                     let name = intern(name.as_ref());
                     if args.iter().any(|arg| arg.mode != crate::AirArgMode::Normal) {
                         return Err(F::InvalidParameterModes);
@@ -440,6 +454,7 @@ where
                     let values = args.iter().map(|arg| arg.value).collect::<Vec<_>>();
                     let (s, l) = refs(&mut air, &values, current)?;
                     AirInstData::Intrinsic {
+                        runtime: *runtime,
                         name,
                         args_start: s,
                         args_len: l,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -665,6 +665,7 @@ fn rewrite_call_generic(
                 rewrites.push((
                     i,
                     AirInstData::Call {
+                        runtime: None,
                         name: info.mangled_name,
                         args_start: *args_start,
                         args_len: *args_len,

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -245,6 +245,116 @@ pub struct CfgBuilder<'a> {
 }
 
 impl<'a> CfgBuilder<'a> {
+    fn runtime_air_type(&self, ty: Type) -> Option<rue_air::RuntimeAirType> {
+        use rue_air::RuntimeAirType as R;
+
+        if ty == Type::UNIT {
+            return Some(R::Unit);
+        }
+        if ty == Type::I64 {
+            return Some(R::I64);
+        }
+        if ty == Type::U64 {
+            return Some(R::U64);
+        }
+        if ty == Type::U32 {
+            return Some(R::U32);
+        }
+        if ty == Type::BOOL {
+            return Some(R::Bool);
+        }
+        if ty == Type::NEVER {
+            return Some(R::Never);
+        }
+        if ty.is_signed() {
+            return Some(R::SignedInteger);
+        }
+        if ty.is_unsigned() {
+            return Some(R::UnsignedInteger);
+        }
+        if let TypeKind::Struct(struct_id) = ty.kind() {
+            let name = &self.type_pool.struct_def(struct_id).name;
+            if self.type_pool.is_strbuf(struct_id)
+                || name == "str"
+                || (name.starts_with("Str(") && name.ends_with(')'))
+            {
+                return Some(R::Text);
+            }
+        }
+        if let Some(ptr) = ty.as_ptr_const()
+            && self.type_pool.ptr_const_def(ptr) == Type::U8
+        {
+            return Some(R::ConstBytePointer);
+        }
+        if let Some(ptr) = ty.as_ptr_mut() {
+            return Some(if self.type_pool.ptr_mut_def(ptr) == Type::U8 {
+                R::MutBytePointer
+            } else {
+                R::MutPointer
+            });
+        }
+        None
+    }
+
+    fn runtime_air_result_type(&self, ty: Type) -> Option<rue_air::RuntimeAirType> {
+        use rue_air::RuntimeAirType as R;
+
+        if ty == Type::U8 {
+            return Some(R::U8);
+        }
+        if let TypeKind::Struct(struct_id) = ty.kind()
+            && self.type_pool.is_strbuf(struct_id)
+        {
+            return Some(R::StrBuf);
+        }
+        if let TypeKind::Enum(enum_id) = ty.kind() {
+            let definition = self.type_pool.enum_def(enum_id);
+            let some = definition.find_variant("Some")?;
+            definition.find_variant("None")?;
+            let [payload] = definition.variant_payload(some) else {
+                return None;
+            };
+            if let TypeKind::Struct(struct_id) = payload.kind()
+                && self.type_pool.is_strbuf(struct_id)
+            {
+                return Some(R::OptionStrBuf);
+            }
+            return Some(match *payload {
+                Type::I32 => R::OptionI32,
+                Type::I64 => R::OptionI64,
+                Type::U32 => R::OptionU32,
+                Type::U64 => R::OptionU64,
+                _ => return None,
+            });
+        }
+        self.runtime_air_type(ty)
+    }
+
+    fn assert_valid_runtime_call_args(
+        &self,
+        runtime: rue_air::RuntimeCallKind,
+        args: impl IntoIterator<Item = (AirRef, AirArgMode)>,
+        result: Type,
+    ) {
+        let args = args
+            .into_iter()
+            .map(|(value, mode)| {
+                self.runtime_air_type(self.air.get(value).ty)
+                    .map(|ty| rue_air::RuntimeAirArgument { ty, mode })
+            })
+            .collect::<Option<Vec<_>>>();
+        let Some(args) = args else {
+            panic!("runtime call {runtime:?} has an AIR argument with no runtime type");
+        };
+        let Some(result) = self.runtime_air_result_type(result) else {
+            panic!("runtime call {runtime:?} has an AIR result with no runtime type");
+        };
+        assert!(
+            runtime.validate() && runtime.validate_air_call(&args, result),
+            "runtime call {runtime:?} has invalid AIR arguments {args:?} or result {result:?}"
+        );
+    }
+
     /// Build a CFG from AIR, returning the CFG and any warnings.
     ///
     /// The `type_pool` provides struct/enum/array definitions needed for queries like
@@ -855,10 +965,20 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::Call {
+                runtime,
                 name,
                 args_start,
                 args_len,
             } => {
+                if let Some(runtime) = runtime {
+                    self.assert_valid_runtime_call_args(
+                        *runtime,
+                        self.air
+                            .get_call_args(*args_start, *args_len)
+                            .map(|arg| (arg.value, arg.mode)),
+                        ty,
+                    );
+                }
                 let mut arg_vals = Vec::new();
                 for arg in self.air.get_call_args(*args_start, *args_len) {
                     let Some(value) = self.lower_value(arg.value) else {
@@ -873,6 +993,7 @@ impl<'a> CfgBuilder<'a> {
                 let (args_start, args_len) = self.cfg.push_call_args(arg_vals);
                 let value = self.emit(
                     CfgInstData::Call {
+                        runtime: *runtime,
                         name: *name,
                         args_start,
                         args_len,
@@ -901,10 +1022,20 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::Intrinsic {
+                runtime,
                 name,
                 args_start,
                 args_len,
             } => {
+                if let Some(runtime) = runtime {
+                    self.assert_valid_runtime_call_args(
+                        *runtime,
+                        self.air
+                            .get_air_refs(*args_start, *args_len)
+                            .map(|arg| (arg, AirArgMode::Normal)),
+                        ty,
+                    );
+                }
                 let mut arg_vals = Vec::new();
                 for arg in self.air.get_air_refs(*args_start, *args_len) {
                     let Some(val) = self.lower_value(arg) else {
@@ -945,6 +1076,7 @@ impl<'a> CfgBuilder<'a> {
                 let (args_start, args_len) = self.cfg.push_extra(arg_vals);
                 let intrinsic_value = self.emit(
                     CfgInstData::Intrinsic {
+                        runtime: *runtime,
                         name: *name,
                         args_start,
                         args_len,
@@ -2799,6 +2931,7 @@ impl<'a> CfgBuilder<'a> {
             }));
             self.emit(
                 CfgInstData::Call {
+                    runtime: None,
                     name,
                     args_start,
                     args_len,
@@ -3877,6 +4010,7 @@ mod tests {
             let args = air.add_extra(&[read.as_u32(), AirArgMode::Borrow.as_u32()]);
             let call = air.add_inst(AirInst {
                 data: AirInstData::Call {
+                    runtime: None,
                     name: interner.get_or_intern("consume"),
                     args_start: args,
                     args_len: 1,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -349,6 +349,8 @@ pub enum CfgInstData {
     /// Function call. Arguments are stored in the Cfg's call_args array.
     /// Use `Cfg::get_call_args(args_start, args_len)` to retrieve them.
     Call {
+        /// Typed runtime identity, absent for source-language calls.
+        runtime: Option<rue_air::RuntimeCallKind>,
         /// Function name (interned symbol)
         name: Spur,
         /// Start index into Cfg's call_args array
@@ -360,6 +362,8 @@ pub enum CfgInstData {
     /// Intrinsic call (e.g., @dbg). Arguments are stored in the Cfg's extra array.
     /// Use `Cfg::get_extra(args_start, args_len)` to retrieve them.
     Intrinsic {
+        /// Runtime helper/adaptation selected by semantic analysis.
+        runtime: Option<rue_air::RuntimeCallKind>,
         /// Intrinsic name (interned symbol)
         name: Spur,
         /// Start index into Cfg's extra array
@@ -1383,10 +1387,14 @@ impl Cfg {
                 write!(f, " = {}", value)
             }
             CfgInstData::Call {
+                runtime,
                 name,
                 args_start,
                 args_len,
             } => {
+                if let Some(runtime) = runtime {
+                    write!(f, "runtime.{runtime:?} ")?;
+                }
                 match interner {
                     Some(interner) => write!(f, "call @{}(", interner.resolve(name))?,
                     None => write!(f, "call @{}(", name.into_usize())?,
@@ -1405,10 +1413,14 @@ impl Cfg {
                 write!(f, ")")
             }
             CfgInstData::Intrinsic {
+                runtime,
                 name,
                 args_start,
                 args_len,
             } => {
+                if let Some(runtime) = runtime {
+                    write!(f, "runtime.{runtime:?} ")?;
+                }
                 match interner {
                     Some(interner) => write!(f, "intrinsic @{}(", interner.resolve(name))?,
                     None => write!(f, "intrinsic @{}(", name.into_usize())?,
@@ -1620,6 +1632,7 @@ mod tests {
             entry,
             CfgInst {
                 data: CfgInstData::Call {
+                    runtime: None,
                     name: call,
                     args_start: 0,
                     args_len: 0,
@@ -1632,6 +1645,7 @@ mod tests {
             entry,
             CfgInst {
                 data: CfgInstData::Intrinsic {
+                    runtime: None,
                     name: intrinsic,
                     args_start: 0,
                     args_len: 0,

--- a/crates/rue-cfg/src/opt/constopt.rs
+++ b/crates/rue-cfg/src/opt/constopt.rs
@@ -391,6 +391,7 @@ mod tests {
         let ptr = push(
             &mut cfg,
             CfgInstData::Intrinsic {
+                runtime: None,
                 name: raw_sym,
                 args_start,
                 args_len,
@@ -473,6 +474,7 @@ mod tests {
         push(
             &mut cfg,
             CfgInstData::Call {
+                runtime: None,
                 name: Spur::try_from_usize(0).unwrap(),
                 args_start,
                 args_len,
@@ -535,6 +537,7 @@ mod tests {
         push(
             &mut cfg,
             CfgInstData::Call {
+                runtime: None,
                 name: Spur::try_from_usize(0).unwrap(),
                 args_start,
                 args_len,

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -635,6 +635,7 @@ mod tests {
             entry,
             CfgInst {
                 data: CfgInstData::Call {
+                    runtime: None,
                     name: side_effect_sym,
                     args_start,
                     args_len,

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -465,6 +465,7 @@ mod tests {
         push(
             &mut cfg,
             CfgInstData::Call {
+                runtime: None,
                 name: Spur::try_from_usize(0).unwrap(),
                 args_start,
                 args_len,
@@ -505,6 +506,7 @@ mod tests {
         let ptr = push(
             &mut cfg,
             CfgInstData::Intrinsic {
+                runtime: None,
                 name: Spur::try_from_usize(0).unwrap(),
                 args_start,
                 args_len,

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -2089,6 +2089,7 @@ mod tests {
             entry,
             CfgInst {
                 data: CfgInstData::Call {
+                    runtime: None,
                     name: lasso::Spur::default(),
                     args_start: 1,
                     args_len: 1,

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -179,6 +179,7 @@ fn format_cfg_inst_data_impl(
             format!("param_store %{} = {}", param_slot, value)
         }
         CfgInstData::Call {
+            runtime,
             name,
             args_start,
             args_len,
@@ -191,9 +192,13 @@ fn format_cfg_inst_data_impl(
             let name = interner
                 .map(|interner| interner.resolve(name).to_string())
                 .unwrap_or_else(|| name.into_usize().to_string());
+            let name = runtime
+                .map(|runtime| runtime.helper().helper().symbol.to_string())
+                .unwrap_or(name);
             format!("call @{}({})", name, args.join(", "))
         }
         CfgInstData::Intrinsic {
+            runtime,
             name,
             args_start,
             args_len,
@@ -206,7 +211,10 @@ fn format_cfg_inst_data_impl(
             let name = interner
                 .map(|interner| interner.resolve(name).to_string())
                 .unwrap_or_else(|| name.into_usize().to_string());
-            format!("intrinsic @{}({})", name, args.join(", "))
+            let prefix = runtime
+                .map(|runtime| format!("runtime.{runtime:?} "))
+                .unwrap_or_default();
+            format!("{prefix}intrinsic @{}({})", name, args.join(", "))
         }
         CfgInstData::StructInit {
             struct_id,

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -500,6 +500,7 @@ mod tests {
         let args_start = air.add_extra(&[number.as_u32()]);
         let result = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
+                runtime: None,
                 name: interner.get_or_intern("syscall"),
                 args_start,
                 args_len: 1,

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -1283,6 +1283,7 @@ pub fn lower_value<A: ValueLowerAdapter>(
             Some(ValueKind::UnaryArithmetic)
         }
         CfgInstData::Call {
+            runtime,
             name,
             args_start,
             args_len,
@@ -1309,9 +1310,8 @@ pub fn lower_value<A: ValueLowerAdapter>(
                 &by_ref_plans,
                 adapter.return_register_budget(),
             );
-            let symbol = adapter.resolve_symbol(name);
-            let runtime_helper = runtime_helper_for_symbol(&symbol);
-            let result = if let Some(helper) = runtime_helper {
+            let result = if let Some(runtime) = runtime {
+                let helper = runtime.helper();
                 let plan = crate::runtime_call_plan::RuntimeCallPlan::from_cfg_inputs(
                     helper,
                     inputs.return_plan,
@@ -1323,6 +1323,7 @@ pub fn lower_value<A: ValueLowerAdapter>(
                 });
                 adapter.emit_runtime_call(plan)
             } else {
+                let symbol = adapter.resolve_symbol(name);
                 let result_vreg = adapter.reserve_value_result();
                 let plan = crate::call_plan::CallPlan::from_inputs_with_result(
                     crate::call_plan::CallTarget::rue(symbol),
@@ -1338,10 +1339,12 @@ pub fn lower_value<A: ValueLowerAdapter>(
             Some(ValueKind::Call)
         }
         CfgInstData::Intrinsic {
+            runtime,
             name,
             args_start,
             args_len,
         } => {
+            debug_assert!(runtime.is_none_or(|runtime| runtime.validate()));
             let args = ctx.cfg.get_extra(args_start, args_len);
             let name_string = adapter.resolve_symbol(name);
             let values: Vec<IntrinsicArgPlan> = args
@@ -1596,15 +1599,6 @@ pub fn lower_value<A: ValueLowerAdapter>(
             lower_residual!(ResidualInput::PlaceWrite { place, value })
         }
     }
-}
-
-/// Transitional bridge until CFG call instructions carry `RuntimeHelperId`.
-/// Matching is against the complete manifest inventory, never a symbol prefix.
-fn runtime_helper_for_symbol(symbol: &str) -> Option<RuntimeHelperId> {
-    RuntimeHelperId::ALL
-        .iter()
-        .copied()
-        .find(|helper| helper.symbol() == symbol)
 }
 
 fn intrinsic_runtime_call(
@@ -2172,6 +2166,7 @@ mod tests {
         add(
             &mut cfg,
             CfgInstData::Call {
+                runtime: None,
                 name: call_name,
                 args_start: 0,
                 args_len: 0,
@@ -2182,6 +2177,7 @@ mod tests {
         add(
             &mut cfg,
             CfgInstData::Intrinsic {
+                runtime: None,
                 name: panic_name,
                 args_start: 0,
                 args_len: 0,
@@ -2457,6 +2453,7 @@ mod tests {
             ),
             (
                 CfgInstData::Call {
+                    runtime: None,
                     name: symbol,
                     args_start: 0,
                     args_len: 0,
@@ -2465,6 +2462,7 @@ mod tests {
             ),
             (
                 CfgInstData::Intrinsic {
+                    runtime: None,
                     name: symbol,
                     args_start: 0,
                     args_len: 0,
@@ -3175,23 +3173,6 @@ mod tests {
             realloc.return_behavior(),
             RuntimeHelperId::Realloc.helper().return_behavior
         );
-    }
-
-    #[test]
-    fn cfg_runtime_bridge_accepts_only_exact_manifest_symbols() {
-        assert_eq!(
-            super::runtime_helper_for_symbol("__rue_print"),
-            Some(RuntimeHelperId::Print)
-        );
-        assert_eq!(
-            super::runtime_helper_for_symbol("__rue_println"),
-            Some(RuntimeHelperId::Println)
-        );
-        assert_eq!(
-            super::runtime_helper_for_symbol("__rue_drop_generated"),
-            None
-        );
-        assert_eq!(super::runtime_helper_for_symbol("__rue_print_suffix"), None);
     }
 
     #[test]

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -21,8 +21,8 @@ use crate::{
     StableDefinitionKey, StableDefinitionKind,
 };
 
-pub const DURABLE_ORDINARY_BODY_SCHEMA_VERSION: u32 = 4;
-pub const DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION: u32 = 2;
+pub const DURABLE_ORDINARY_BODY_SCHEMA_VERSION: u32 = 5;
+pub const DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION: u32 = 3;
 
 pub type DurableAirRef = u32;
 pub type DurablePlaceRef = u32;
@@ -148,11 +148,16 @@ pub enum DurableAirInstData {
         function: StableDefinitionKey,
         args: Arc<[DurableCallArg]>,
     },
+    RuntimeCall {
+        runtime: rue_air::RuntimeCallKind,
+        args: Arc<[DurableCallArg]>,
+    },
     CallSpecialized {
         identity: DurableSpecializationIdentity,
         args: Arc<[DurableCallArg]>,
     },
     Intrinsic {
+        runtime: Option<rue_air::RuntimeCallKind>,
         name: Arc<str>,
         args: Arc<[DurableCallArg]>,
     },
@@ -963,6 +968,12 @@ pub fn convert_semantic_body_exports(
                     function: key(function, work)?,
                     args: args.iter().map(arg).collect::<Vec<_>>().into(),
                 },
+                SemanticBodyInstData::RuntimeCall { runtime, args } => {
+                    DurableAirInstData::RuntimeCall {
+                        runtime: *runtime,
+                        args: args.iter().map(arg).collect::<Vec<_>>().into(),
+                    }
+                }
                 SemanticBodyInstData::CallSpecialized { identity, args } => {
                     DurableAirInstData::CallSpecialized {
                         identity: durable_specialization_identity(
@@ -977,7 +988,12 @@ pub fn convert_semantic_body_exports(
                 SemanticBodyInstData::CallGeneric => {
                     return Err(DurableBodyConversionFailure::UnsupportedGenericCall);
                 }
-                SemanticBodyInstData::Intrinsic { name, args } => DurableAirInstData::Intrinsic {
+                SemanticBodyInstData::Intrinsic {
+                    runtime,
+                    name,
+                    args,
+                } => DurableAirInstData::Intrinsic {
+                    runtime: *runtime,
                     name: name.clone(),
                     args: args.iter().map(arg).collect::<Vec<_>>().into(),
                 },
@@ -1418,6 +1434,7 @@ impl DurableOrdinaryBodyPayload {
                 D::Store { value, .. } | D::ParamStore { value, .. } => check(*value),
                 D::Ret(value) => value.map_or(Ok(()), &check),
                 D::Call { args, .. }
+                | D::RuntimeCall { args, .. }
                 | D::CallSpecialized { args, .. }
                 | D::Intrinsic { args, .. } => args.iter().try_for_each(|arg| check(arg.value)),
                 D::Block { statements, value } => {
@@ -1566,11 +1583,20 @@ impl DurableOrdinaryBodyPayload {
                     function: function.clone(),
                     args: args.iter().map(arg).collect::<Vec<_>>().into(),
                 },
+                DurableAirInstData::RuntimeCall { runtime, args } => S::RuntimeCall {
+                    runtime: *runtime,
+                    args: args.iter().map(arg).collect::<Vec<_>>().into(),
+                },
                 DurableAirInstData::CallSpecialized { identity, args } => S::CallSpecialized {
                     identity: identity.import_dto(),
                     args: args.iter().map(arg).collect::<Vec<_>>().into(),
                 },
-                DurableAirInstData::Intrinsic { name, args } => S::Intrinsic {
+                DurableAirInstData::Intrinsic {
+                    runtime,
+                    name,
+                    args,
+                } => S::Intrinsic {
+                    runtime: *runtime,
                     name: name.clone(),
                     args: args.iter().map(arg).collect::<Vec<_>>().into(),
                 },
@@ -1801,6 +1827,25 @@ mod tests {
         assert_eq!(work.projection_attempts, 1);
         assert_eq!(work.projection_completions, 0);
         assert_eq!(work.projection_failures, 1);
+    }
+
+    #[test]
+    fn runtime_calls_round_trip_without_source_definition_edges() {
+        let candidate = payload(vec![instruction(DurableAirInstData::RuntimeCall {
+            runtime: rue_air::RuntimeCallKind::ToString,
+            args: Arc::from([]),
+        })]);
+        assert!(candidate.referenced_definition_keys().is_empty());
+
+        let mut work = DurableBodyWork::default();
+        let projected = candidate.project_semantic_body(&mut work).unwrap();
+        assert!(matches!(
+            projected.instructions[0].data,
+            rue_air::SemanticBodyInstData::RuntimeCall {
+                runtime: rue_air::RuntimeCallKind::ToString,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -69,7 +69,7 @@ pub(crate) fn body_type_dependencies(
             }
             _ => {}
         }
-        if let DurableAirInstData::Intrinsic { name, args } = &instruction.data
+        if let DurableAirInstData::Intrinsic { name, args, .. } = &instruction.data
             && matches!(name.as_ref(), "ptr_read" | "ptr_write" | "ptr_offset")
         {
             for arg in args.iter() {
@@ -435,6 +435,7 @@ mod tests {
             block,
             CfgInst {
                 data: CfgInstData::Call {
+                    runtime: None,
                     name: old,
                     args_start: 0,
                     args_len: 0,

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -941,6 +941,155 @@ mod integration_tests {
         use super::*;
 
         #[test]
+        fn text_runtime_shapes_survive_air_durability_and_cfg_lowering() {
+            use std::collections::{HashMap, HashSet};
+            use std::sync::Arc;
+
+            let root = FileId::new(1);
+            let strbuf = FileId::new(2);
+            let metadata = SourceMetadata::new_with_trusted_standard_library(
+                root,
+                HashMap::from([
+                    (root, "/project/main.rue".to_owned()),
+                    (strbuf, "/project/std/strbuf.rue".to_owned()),
+                ]),
+                HashMap::from([
+                    (root, "main.rue".to_owned()),
+                    (strbuf, "\0rue-std/strbuf.rue".to_owned()),
+                ]),
+                HashSet::from([strbuf]),
+            )
+            .unwrap();
+            let source = r#"
+const strbuf = @import("std/strbuf.rue");
+
+fn probe_chars() -> u32 {
+    let text = "x" + @to_string(1);
+    for c in text.chars() {
+        return c;
+    }
+    0
+}
+
+fn probe_prints() {
+    println("literal");
+    println("value " + @to_string(1));
+}
+
+fn main() -> i32 {
+    probe_prints();
+    probe_chars();
+    0
+}
+"#;
+            let snapshot = SourceSnapshot::new(
+                metadata,
+                vec![
+                    (root, Arc::new(source.to_owned())),
+                    (
+                        strbuf,
+                        Arc::new(
+                            r#"
+pub struct StrBuf {
+    buf: ptr mut u8,
+    len: u64,
+    cap: u64,
+
+    fn concat_borrowed(borrow first: Self, borrow second: Self) -> Self {
+        Self { buf: first.buf, len: first.len + second.len, cap: 0 }
+    }
+
+    fn len(borrow self) -> u64 { self.len }
+}
+
+drop fn StrBuf(self) { }
+"#
+                            .to_owned(),
+                        ),
+                    ),
+                ],
+            )
+            .unwrap();
+            let (_, semantic, _) =
+                test_frontend_snapshot(&snapshot, &CompileOptions::default()).unwrap();
+            let is_target = |runtime| {
+                matches!(
+                    runtime,
+                    rue_air::RuntimeCallKind::StrCharScalar
+                        | rue_air::RuntimeCallKind::StrCharNext
+                        | rue_air::RuntimeCallKind::StrPrintProjected
+                        | rue_air::RuntimeCallKind::StrPrintlnProjected
+                        | rue_air::RuntimeCallKind::StrPrintAggregate
+                        | rue_air::RuntimeCallKind::StrPrintlnAggregate
+                )
+            };
+            let expected = vec![
+                (rue_air::RuntimeCallKind::StrCharScalar, 3),
+                (rue_air::RuntimeCallKind::StrCharNext, 3),
+                (rue_air::RuntimeCallKind::StrPrintlnAggregate, 1),
+                (rue_air::RuntimeCallKind::StrPrintlnProjected, 2),
+            ];
+
+            let mut air_shapes = semantic
+                .functions()
+                .iter()
+                .flat_map(|function| function.analyzed.air.iter())
+                .filter_map(|(_, inst)| match inst.data {
+                    rue_air::AirInstData::Call {
+                        runtime: Some(runtime),
+                        args_len,
+                        ..
+                    } if is_target(runtime) => Some((runtime, args_len)),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            air_shapes.sort_by_key(|(runtime, _)| *runtime as u8);
+            assert_eq!(air_shapes, expected, "AIR must use the manifest shapes");
+
+            let mut durable_shapes = semantic
+                .durable_ordinary_body_payloads()
+                .iter()
+                .flat_map(|payload| payload.instructions.iter())
+                .filter_map(|inst| match &inst.data {
+                    DurableAirInstData::RuntimeCall { runtime, args } if is_target(*runtime) => {
+                        Some((*runtime, args.len() as u32))
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            durable_shapes.sort_by_key(|(runtime, _)| *runtime as u8);
+            assert_eq!(
+                durable_shapes, expected,
+                "durable AIR must retain runtime identities and arities"
+            );
+
+            let mut cfg_shapes = semantic
+                .functions()
+                .iter()
+                .flat_map(|function| {
+                    let cfg = &function.cfg;
+                    cfg.blocks()
+                        .iter()
+                        .flat_map(|block| block.insts.iter())
+                        .filter_map(|value| match cfg.get_inst(*value).data {
+                            rue_cfg::CfgInstData::Call {
+                                runtime: Some(runtime),
+                                args_len,
+                                ..
+                            } if is_target(runtime) => Some((runtime, args_len)),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+            cfg_shapes.sort_by_key(|(runtime, _)| *runtime as u8);
+            assert_eq!(
+                cfg_shapes, expected,
+                "CFG must retain the AIR runtime shapes after durable publication"
+            );
+        }
+
+        #[test]
         fn panic_diverges_through_cfg_and_lowers() {
             // `@panic` is never-typed (RUE-512): the CFG carries a NEVER-typed
             // intrinsic and the block ends in `Unreachable`, not a return, just
@@ -973,6 +1122,24 @@ mod integration_tests {
                     intrinsic_types,
                     vec![Type::NEVER],
                     "{name} must carry the never result into CFG"
+                );
+                let runtime_kinds: Vec<_> = cfg
+                    .blocks()
+                    .iter()
+                    .flat_map(|block| block.insts.iter())
+                    .filter_map(|value| match cfg.get_inst(*value).data {
+                        rue_cfg::CfgInstData::Intrinsic { runtime, .. } => runtime,
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(
+                    runtime_kinds,
+                    vec![if name == "trailing_message" {
+                        rue_air::RuntimeCallKind::Panic
+                    } else {
+                        rue_air::RuntimeCallKind::PanicNoMessage
+                    }],
+                    "CompilerSession CFG artifacts must retain typed panic identity"
                 );
 
                 // A diverging panic has no reachable return; the block that
@@ -1032,6 +1199,24 @@ mod integration_tests {
                     intrinsic_types,
                     vec![Type::UNIT],
                     "{name} must carry the unit result into CFG"
+                );
+                let runtime_kinds: Vec<_> = cfg
+                    .blocks()
+                    .iter()
+                    .flat_map(|block| block.insts.iter())
+                    .filter_map(|value| match cfg.get_inst(*value).data {
+                        rue_cfg::CfgInstData::Intrinsic { runtime, .. } => runtime,
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(
+                    runtime_kinds,
+                    vec![if name == "assertion_with_message" {
+                        rue_air::RuntimeCallKind::AssertWithMessage
+                    } else {
+                        rue_air::RuntimeCallKind::AssertFailed
+                    }],
+                    "CompilerSession CFG artifacts must retain typed assert identity"
                 );
 
                 let return_values: Vec<_> = cfg

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -13026,7 +13026,8 @@ fn main() -> i32 { selected.value() }"#,
                 42,
                 "/p/main.rue",
                 "main.rue",
-                "fn id(comptime T: type, value: T) -> T { value }\nfn main() -> i32 { id(i32, 42) }",
+                "fn sample(comptime T: type) -> u64 { @random_u64() }\n\
+                 fn main() -> i32 { if sample(u64) == 0 { 0 } else { 1 } }",
             )],
             42,
         );
@@ -13034,6 +13035,24 @@ fn main() -> i32 { selected.value() }"#,
         session.update(&source).into_result().unwrap();
         let cold = session.semantic(&CompileOptions::default()).unwrap();
         assert_eq!(cold.durable_specialized_body_payloads().len(), 1);
+        let specialized = &cold.durable_specialized_body_payloads()[0];
+        assert_eq!(
+            specialized.schema_version,
+            crate::DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION
+        );
+        assert!(
+            specialized.body.referenced_definition_keys().is_empty(),
+            "a specialized runtime call must not fabricate a source-definition edge"
+        );
+        assert!(specialized.body.instructions.iter().any(|instruction| {
+            matches!(
+                instruction.data,
+                crate::DurableAirInstData::Intrinsic {
+                    runtime: Some(rue_air::RuntimeCallKind::RandomU64),
+                    ..
+                }
+            )
+        }));
         assert_eq!(
             session
                 .last_successful_body_cache
@@ -13057,6 +13076,30 @@ fn main() -> i32 { selected.value() }"#,
         assert_eq!(work.specialized_body_analyses_skipped, 1);
         assert_eq!(work.specialized_bodies_attempted, 0);
         assert_eq!(work.specialization_rounds, 1);
+        assert!(reused.functions().iter().any(|function| {
+            function.analyzed.air.iter().any(|(_, instruction)| {
+                matches!(
+                    instruction.data,
+                    rue_air::AirInstData::Intrinsic {
+                        runtime: Some(rue_air::RuntimeCallKind::RandomU64),
+                        ..
+                    }
+                )
+            })
+        }));
+        assert!(reused.functions().iter().any(|function| {
+            function.cfg.blocks().iter().any(|block| {
+                block.insts.iter().any(|value| {
+                    matches!(
+                        function.cfg.get_inst(*value).data,
+                        rue_cfg::CfgInstData::Intrinsic {
+                            runtime: Some(rue_air::RuntimeCallKind::RandomU64),
+                            ..
+                        }
+                    )
+                })
+            })
+        }));
 
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&source).into_result().unwrap();

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -2414,6 +2414,7 @@ impl<'a> Interp<'a> {
                 name,
                 args_start,
                 args_len,
+                ..
             } => {
                 let fname = self.interner().resolve(name).to_string();
                 let call_args = cfg.get_call_args(*args_start, *args_len).to_vec();
@@ -2500,6 +2501,7 @@ impl<'a> Interp<'a> {
                 name,
                 args_start,
                 args_len,
+                ..
             } => {
                 let iname = self.interner().resolve(name).to_string();
                 let args = cfg.get_extra(*args_start, *args_len).to_vec();

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -30,6 +30,7 @@ fn find_call_metadata(
                     name,
                     args_start,
                     args_len,
+                    ..
                 } = &inst.data
                 else {
                     continue;
@@ -186,6 +187,7 @@ fn find_intrinsic_in_function<'a>(
             name,
             args_start,
             args_len,
+            ..
         } = &inst.data
         else {
             continue;


### PR DESCRIPTION
Carry typed runtime helper identity and mechanically validated semantic-to-ABI operand/result adaptations through AIR, durable semantic bodies, specialization, CFG construction, optimization, and compiler queries.

Distinguish projected and aggregate text representations, exact scalar and option payload widths, typed and byte allocation scaling, out-result shapes, and conditional/non-returning contracts. Typed CFG calls feed the shared RUE-831 runtime call planner directly without symbol rediscovery or source-definition dependency edges.

Fixes RUE-830