### PR TITLE
RUE-903: add scripts/rue unit for case-level compiler unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ scripts/rue build                    # build the compiler and print its path
 scripts/rue exec prog.rue            # compile and run a quick program
 RUE="$(scripts/rue-bin)"; "$RUE" main.rue -o out
 scripts/rue quick                    # fast unit suite
+scripts/rue unit compiler durable_   # one compiler unit test
 scripts/rue spec 4.2                 # filtered specification tests
 scripts/rue cli abi                  # filtered CLI integration tests
 scripts/rue test [pattern]           # broad/full suite

--- a/scripts/rue
+++ b/scripts/rue
@@ -8,6 +8,10 @@
 #   scripts/rue exec prog.rue      Compile prog.rue to a temp file AND run it
 #   scripts/rue test [pattern]     Full suite (./test.sh), optional filter
 #   scripts/rue quick              Unit tests only (./quick-test.sh)
+#   scripts/rue unit <crate> [args] One crate's Rust unit tests, case-filtered
+#                                  (crate name with or without the rue- prefix,
+#                                  or an explicit <crate>:<target>; forwards
+#                                  <pattern>/--exact/--nocapture to libtest)
 #   scripts/rue spec [pattern]     Spec tests, optional filter
 #   scripts/rue cli [pattern]      CLI integration tests, optional filter
 #   scripts/rue ui [pattern]       UI/diagnostics tests, optional filter
@@ -85,6 +89,61 @@ case "$cmd" in
         ;;
     quick)
         ./quick-test.sh "$@"
+        ;;
+    unit)
+        # Run ONE crate's Rust unit tests with real case-level filtering, the
+        # way spec/cli/ui forward libtest patterns to their harness binaries
+        # (RUE-903). Unlike `test <pattern>`, which still walks the whole unit
+        # graph, this drives a single `//crates/<crate>:<crate>-test` target so
+        # a positional <pattern>, --exact, --nocapture, and -q all behave
+        # natively.
+        if [[ $# -lt 1 ]]; then
+            echo "usage: scripts/rue unit <crate>[:target] [libtest args...]" >&2
+            exit 2
+        fi
+        sel="$1"; shift
+        # Accept an explicit <crate>:<target> so the extra rue-compiler targets
+        # (rue-compiler-public-api-test, rue-compiler-differential-oracle-test)
+        # stay reachable; otherwise the target defaults to <crate>-test.
+        if [[ "$sel" == *:* ]]; then
+            crate="${sel%%:*}"
+            unit_target="${sel#*:}"
+        else
+            crate="$sel"
+            unit_target=""
+        fi
+        # Map the friendly crate name to its package, accepting it with or
+        # without the rue- prefix (`compiler` -> `rue-compiler`).
+        case "$crate" in
+            rue-*) pkg="$crate" ;;
+            *)     pkg="rue-$crate" ;;
+        esac
+        # Validate against the source tree so an unknown crate produces a clear
+        # message instead of a raw buck2 target-not-found dump.
+        if [[ ! -f "crates/$pkg/BUCK" ]]; then
+            echo "scripts/rue unit: unknown crate '$crate' (no crates/$pkg)" >&2
+            exit 2
+        fi
+        [[ -n "$unit_target" ]] || unit_target="$pkg-test"
+        target="//crates/$pkg:$unit_target"
+        # Preflight the same filter with --list: libtest exits 0 when a filter
+        # matches NOTHING, which would otherwise masquerade as a passing run.
+        # A non-empty selection prints one `name: test`/`name: benchmark` line
+        # per case; the trailing "N tests, M benchmarks" summary never matches
+        # that pattern, so its absence means zero cases were selected. --list
+        # runs nothing, so this stays cheap.
+        list_rc=0
+        list_out="$(./buck2 run "$target" -- "$@" --list 2>/dev/null)" || list_rc=$?
+        if [[ $list_rc -eq 0 ]] && ! printf '%s' "$list_out" | grep -qE ': (test|benchmark)$'; then
+            echo "scripts/rue unit: no tests matched the given filter in $target" >&2
+            exit 1
+        fi
+        # Either the selection is non-empty, or the preflight itself failed to
+        # build; run for real so the cases execute (or the build error surfaces
+        # loudly, RUE-550) and propagate the real run's exit code faithfully.
+        rc=0
+        ./buck2 run "$target" -- "$@" || rc=$?
+        exit $rc
         ;;
     spec)
         RUE_BINARY="$(scripts/rue-bin)" \

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -548,6 +548,110 @@ test_sanitizer_status_contracts() {
   rm -rf "$sb"
 }
 
+# ===========================================================================
+# RUE-903 — scripts/rue unit runs ONE crate's tests with case-level filtering
+# ===========================================================================
+
+# Build a scripts/rue sandbox for the `unit` subcommand. Installs a copy of the
+# real script, a couple of crate BUCK stubs (so crate-name validation passes),
+# and a fake ./buck2 that logs every invocation's argv. On a --list preflight
+# the fake emits $FAKE_LIST_OUT (a match line by default, so the preflight
+# passes); the real run exits with $FAKE_RUN_EXIT. Echoes the sandbox path.
+make_rue_unit_sandbox() {
+  local sb; sb="$(mktemp -d)"
+  mkdir -p "$sb/scripts" "$sb/crates/rue-parser" "$sb/crates/rue-compiler"
+  cp "$SRC_ROOT/scripts/rue" "$sb/scripts/rue"; chmod +x "$sb/scripts/rue"
+  printf '# stub\n' >"$sb/crates/rue-parser/BUCK"
+  printf '# stub\n' >"$sb/crates/rue-compiler/BUCK"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BUCK_LOG"
+for a in "$@"; do
+  if [ "$a" = "--list" ]; then
+    printf '%s\n' "${FAKE_LIST_OUT-some::case: test}"
+    exit 0
+  fi
+done
+exit "${FAKE_RUN_EXIT:-0}"
+EOF
+  chmod +x "$sb/buck2"
+  printf '%s\n' "$sb"
+}
+
+# The friendly crate name maps to //crates/<pkg>:<pkg>-test both with and
+# without the rue- prefix, and libtest args are forwarded verbatim after `--`.
+test_rue_unit_maps_crate_and_forwards_args() {
+  local sb; sb="$(make_rue_unit_sandbox)"
+  local rc=0
+  ( cd "$sb" && BUCK_LOG="$sb/buck.log" \
+      FAKE_LIST_OUT='parser::tests::diagnostic_corpus: test' \
+      ./scripts/rue unit parser diagnostic_corpus --exact ) >/dev/null 2>&1 || rc=$?
+  check "scripts/rue unit: prefix-less crate reaches the real run" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'run //crates/rue-parser:rue-parser-test -- diagnostic_corpus --exact' "$sb/buck.log" && echo 0 || echo 1)"
+
+  : >"$sb/buck.log"; rc=0
+  ( cd "$sb" && BUCK_LOG="$sb/buck.log" \
+      FAKE_LIST_OUT='parser::tests::diagnostic_corpus: test' \
+      ./scripts/rue unit rue-parser diagnostic_corpus ) >/dev/null 2>&1 || rc=$?
+  check "scripts/rue unit: rue- prefixed crate resolves to the same target" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'run //crates/rue-parser:rue-parser-test -- diagnostic_corpus' "$sb/buck.log" && echo 0 || echo 1)"
+
+  # The explicit <crate>:<target> form reaches an alternate target in the crate.
+  : >"$sb/buck.log"; rc=0
+  ( cd "$sb" && BUCK_LOG="$sb/buck.log" \
+      FAKE_LIST_OUT='some::api_case: test' \
+      ./scripts/rue unit compiler:rue-compiler-public-api-test ) >/dev/null 2>&1 || rc=$?
+  check "scripts/rue unit: explicit crate:target form reaches the alternate target" \
+    "$([ "$rc" -eq 0 ] && grep -Fxq 'run //crates/rue-compiler:rue-compiler-public-api-test --' "$sb/buck.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# A filter that selects nothing (libtest --list shows only its summary line,
+# no `name: test` entries) must fail loudly and NEVER reach the real run.
+test_rue_unit_zero_match_fails_loud() {
+  local sb; sb="$(make_rue_unit_sandbox)"
+  local rc=0 out
+  out="$( cd "$sb" && BUCK_LOG="$sb/buck.log" \
+      FAKE_LIST_OUT='0 tests, 0 benchmarks' \
+      ./scripts/rue unit parser zzznomatch 2>&1 )" || rc=$?
+  check "scripts/rue unit: empty selection exits non-zero" \
+    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "scripts/rue unit: empty selection prints a clear message" \
+    "$(printf '%s\n' "$out" | grep -q 'no tests matched' && echo 0 || echo 1)"
+  # Only the --list preflight should have run; no line lacking --list (the real
+  # run) may appear in the log.
+  check "scripts/rue unit: empty selection never runs the tests for real" \
+    "$([ -z "$(grep -v -- '--list' "$sb/buck.log" 2>/dev/null)" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# A selected test that fails must propagate its non-zero exit code.
+test_rue_unit_failing_test_propagates_exit() {
+  local sb; sb="$(make_rue_unit_sandbox)"
+  local rc=0
+  ( cd "$sb" && BUCK_LOG="$sb/buck.log" \
+      FAKE_LIST_OUT='parser::tests::flaky: test' FAKE_RUN_EXIT=101 \
+      ./scripts/rue unit parser flaky ) >/dev/null 2>&1 || rc=$?
+  check "scripts/rue unit: a failing selected test propagates its exit code" \
+    "$([ "$rc" -eq 101 ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+# An unknown crate name fails with a clear message before any buck2 invocation.
+test_rue_unit_unknown_crate_errors_cleanly() {
+  local sb; sb="$(make_rue_unit_sandbox)"
+  local rc=0 out
+  out="$( cd "$sb" && BUCK_LOG="$sb/buck.log" \
+      ./scripts/rue unit nosuchcrate foo 2>&1 )" || rc=$?
+  check "scripts/rue unit: unknown crate exits non-zero" \
+    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "scripts/rue unit: unknown crate names the missing crate" \
+    "$(printf '%s\n' "$out" | grep -q "unknown crate 'nosuchcrate'" && echo 0 || echo 1)"
+  check "scripts/rue unit: unknown crate never invokes buck2" \
+    "$([ ! -s "$sb/buck.log" ] && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
 # --- run everything ---------------------------------------------------------
 
 test_ruebin_build_failure_is_loud
@@ -559,6 +663,10 @@ test_rue_exec_resolves_from_caller_cwd
 test_rue_run_resolves_relative_output
 test_rue_cli_examples_survive_case_chdir
 test_testsh_cli_examples_survive_case_chdir
+test_rue_unit_maps_crate_and_forwards_args
+test_rue_unit_zero_match_fails_loud
+test_rue_unit_failing_test_propagates_exit
+test_rue_unit_unknown_crate_errors_cleanly
 test_sanitizer_defaults_std_path
 test_sanitizer_recursive_discovery_contract
 test_sanitizer_status_contracts


### PR DESCRIPTION
scripts/rue test <pattern> still walks the whole workspace unit graph, so isolating one compiler assertion meant rerunning everything and filtering very large logs. This adds `scripts/rue unit <crate>[:target] [libtest args...]`, which drives a single `//crates/<crate>:<crate>-test` target the same way spec/cli/ui forward libtest patterns to their harness binaries.

- Crate name accepted with or without the `rue-` prefix; explicit `<crate>:<target>` reaches the extra rue-compiler test targets (public-api, differential-oracle).
- A `--list` preflight catches zero-match filters (libtest exits 0 on an empty selection) and fails loudly with exit 1; a preflight build failure falls through to the real run so genuine build errors surface. The real run exit code propagates.
- Unknown crate names error cleanly (exit 2) instead of dumping a raw buck2 target error.
- Help text and the AGENTS.md quickstart document the subcommand.

Verification: single-case selection verified by execution on rue-parser and rue-compiler (1 matched, rest filtered), both name forms, alternate-target form, no-match and unknown-crate exit codes; new wrapper-script regression tests (4 functions, 12 checks; suite 48/48); quick suite green. Full local suite: 36/37 — the sole failure is `//:benchmark-tool-tests`, pre-existing and environmental on this host (system Python 3.9.6 lacks `tomllib`; fails identically on clean trunk, unrelated to this change).

Fixes RUE-903