### PR TITLE
RUE-833: validate embedded runtime archive

### DIFF
--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -16,6 +16,7 @@ rue_crate(
         "//crates/rue-linker:rue-linker",
         "//crates/rue-parser:rue-parser",
         "//crates/rue-rir:rue-rir",
+        "//crates/rue-runtime-abi:rue-runtime-abi",
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
         "//third-party:annotate-snippets",

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -114,6 +114,8 @@ impl Drop for TempLinkDir {
 /// other target is therefore refused (see [`runtime_for_target`] and
 /// RUE-36 / ADR-0034) until per-target runtime archives are embedded.
 static RUNTIME_BYTES: &[u8] = include_bytes!("librue_runtime.a");
+static EMBEDDED_RUNTIME_VALIDATION: std::sync::OnceLock<Result<(), String>> =
+    std::sync::OnceLock::new();
 
 /// Return the embedded rue-runtime archive for `target`, or a clear error
 /// if this compiler build doesn't carry a runtime for that target.
@@ -157,17 +159,311 @@ pub(crate) fn runtime_for_target_with_host(
 /// Returns an error message if validation fails.
 #[cfg(test)]
 pub(crate) fn validate_runtime() -> Result<(), String> {
-    parse_runtime_archive(RUNTIME_BYTES).map(|_| ())
+    let target = Target::host().ok_or_else(|| {
+        format!(
+            "cannot validate embedded rue-runtime archive on {}",
+            Target::host_description()
+        )
+    })?;
+    validate_runtime_archive(RUNTIME_BYTES, target).map(|_| ())
 }
 
 pub(crate) fn parse_runtime_archive(runtime_bytes: &[u8]) -> Result<Archive, String> {
-    let archive = Archive::parse(runtime_bytes)
+    let archive = Archive::parse_strict_objects(runtime_bytes)
         .map_err(|e| format!("embedded rue-runtime archive is invalid: {}", e))?;
 
     if archive.is_empty() {
         return Err("embedded rue-runtime archive contains no object files".to_string());
     }
 
+    Ok(archive)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeSymbolKind {
+    Function,
+    Data,
+    Other,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeDefinedSymbol {
+    name: String,
+    kind: RuntimeSymbolKind,
+    size: u64,
+    section_allocated: bool,
+    section_writable: bool,
+    section_executable: bool,
+    bytes_from_symbol: u64,
+    first_byte: Option<u8>,
+}
+
+#[derive(Debug, Default)]
+struct RuntimeArchiveInventory {
+    object_targets: Vec<rue_runtime_abi::RuntimeTarget>,
+    symbols: Vec<RuntimeDefinedSymbol>,
+}
+
+fn runtime_target(target: Target) -> rue_runtime_abi::RuntimeTarget {
+    match target {
+        Target::X86_64Linux => rue_runtime_abi::RuntimeTarget::X86_64Linux,
+        Target::Aarch64Linux => rue_runtime_abi::RuntimeTarget::Aarch64Linux,
+        Target::Aarch64Macos => rue_runtime_abi::RuntimeTarget::Aarch64Macos,
+    }
+}
+
+fn parsed_object_target(
+    object: &ObjectFile,
+    object_index: usize,
+) -> Result<rue_runtime_abi::RuntimeTarget, String> {
+    use rue_linker::{ElfMachine, ObjectFormat};
+    use rue_runtime_abi::RuntimeTarget;
+
+    match (object.format, object.machine) {
+        (ObjectFormat::Elf, ElfMachine::X86_64) => Ok(RuntimeTarget::X86_64Linux),
+        (ObjectFormat::Elf, ElfMachine::Aarch64) => Ok(RuntimeTarget::Aarch64Linux),
+        (ObjectFormat::MachO, ElfMachine::Aarch64) => Ok(RuntimeTarget::Aarch64Macos),
+        (ObjectFormat::MachO, ElfMachine::X86_64) => Err(format!(
+            "embedded rue-runtime archive object {object_index} has unsupported Mach-O/x86-64 target"
+        )),
+    }
+}
+
+fn runtime_archive_inventory(archive: &Archive) -> Result<RuntimeArchiveInventory, String> {
+    use rue_linker::{ObjectFormat, SectionFlags, SymbolBinding, SymbolType};
+
+    let mut inventory = RuntimeArchiveInventory::default();
+    for (object_index, object) in archive.objects.iter().enumerate() {
+        let object_target = parsed_object_target(object, object_index)?;
+        inventory.object_targets.push(object_target);
+
+        for symbol in &object.symbols {
+            if symbol.section_index.is_none()
+                || matches!(symbol.binding, SymbolBinding::Local)
+                || symbol.name.is_empty()
+            {
+                continue;
+            }
+
+            let section_index = symbol.section_index.expect("checked above");
+            let section = object.sections.get(section_index).ok_or_else(|| {
+                format!(
+                    "embedded rue-runtime archive symbol `{}` has invalid section index {}",
+                    symbol.name, section_index
+                )
+            })?;
+            let bytes_from_symbol = u64::try_from(section.data.len())
+                .unwrap_or(u64::MAX)
+                .saturating_sub(symbol.value);
+            let format_size = match object.format {
+                ObjectFormat::Elf => symbol.size,
+                ObjectFormat::MachO => {
+                    let next_symbol = object
+                        .symbols
+                        .iter()
+                        .filter(|candidate| {
+                            candidate.section_index == symbol.section_index
+                                && candidate.value > symbol.value
+                        })
+                        .map(|candidate| candidate.value)
+                        .min()
+                        .unwrap_or(section.size);
+                    next_symbol.saturating_sub(symbol.value)
+                }
+            };
+            inventory.symbols.push(RuntimeDefinedSymbol {
+                name: symbol.name.clone(),
+                kind: match symbol.sym_type {
+                    SymbolType::Func => RuntimeSymbolKind::Function,
+                    SymbolType::Object => RuntimeSymbolKind::Data,
+                    SymbolType::None | SymbolType::Section | SymbolType::File => {
+                        RuntimeSymbolKind::Other
+                    }
+                },
+                // Mach-O's nlist entries do not carry symbol sizes. Derive the
+                // symbol's extent from the next symbol in the same section (or
+                // the section end) so retained ABI data can still be checked
+                // exactly.
+                size: format_size,
+                section_allocated: section.flags.contains(SectionFlags::ALLOC),
+                section_writable: section.flags.contains(SectionFlags::WRITE),
+                section_executable: section.flags.contains(SectionFlags::EXEC),
+                bytes_from_symbol,
+                first_byte: usize::try_from(symbol.value)
+                    .ok()
+                    .and_then(|offset| section.data.get(offset))
+                    .copied(),
+            });
+        }
+    }
+    inventory
+        .symbols
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(inventory)
+}
+
+fn validate_runtime_inventory(
+    inventory: &RuntimeArchiveInventory,
+    target: rue_runtime_abi::RuntimeTarget,
+) -> Result<(), String> {
+    use rue_runtime_abi::{
+        RUNTIME_ABI_VERSION_SYMBOL, ReservedExportId, ReservedExportKind, RuntimeHelperId,
+        classify_export,
+    };
+
+    let mut errors = Vec::new();
+    for (object_index, object_target) in inventory.object_targets.iter().copied().enumerate() {
+        if object_target != target {
+            errors.push(format!(
+                "object {object_index} targets {object_target:?}, expected {target:?}"
+            ));
+        }
+    }
+
+    let definitions = |name: &str| {
+        inventory
+            .symbols
+            .iter()
+            .filter(|symbol| symbol.name == name)
+            .collect::<Vec<_>>()
+    };
+
+    for id in RuntimeHelperId::ALL {
+        let helper = id.helper();
+        let found = definitions(helper.symbol);
+        if helper.availability.contains(target) {
+            match found.len() {
+                0 => errors.push(format!("missing runtime helper `{}`", helper.symbol)),
+                1 => {
+                    if found[0].kind != RuntimeSymbolKind::Function {
+                        errors.push(format!(
+                            "runtime helper `{}` is not callable code",
+                            helper.symbol
+                        ));
+                    }
+                }
+                count => errors.push(format!(
+                    "runtime helper `{}` is defined {count} times",
+                    helper.symbol
+                )),
+            }
+        } else if !found.is_empty() {
+            errors.push(format!(
+                "runtime helper `{}` is not available for {target:?}",
+                helper.symbol
+            ));
+        }
+    }
+
+    for id in ReservedExportId::ALL {
+        let export = id.export();
+        let found = definitions(export.symbol);
+        if export.availability.contains(target) {
+            match found.len() {
+                0 => errors.push(format!(
+                    "missing reserved runtime export `{}`",
+                    export.symbol
+                )),
+                1 => match export.kind {
+                    ReservedExportKind::Function(_) => {
+                        if found[0].kind != RuntimeSymbolKind::Function {
+                            errors.push(format!(
+                                "reserved runtime export `{}` is not callable code",
+                                export.symbol
+                            ));
+                        }
+                    }
+                    ReservedExportKind::ReadOnlyData { size } => {
+                        let marker = found[0];
+                        if marker.kind != RuntimeSymbolKind::Data {
+                            errors.push(format!(
+                                "runtime ABI marker `{}` is not an object symbol",
+                                export.symbol
+                            ));
+                        }
+                        if marker.size != u64::from(size) {
+                            errors.push(format!(
+                                "runtime ABI marker `{}` has size {}, expected {} byte",
+                                export.symbol, marker.size, size
+                            ));
+                        }
+                        if !marker.section_allocated
+                            || marker.section_writable
+                            || marker.section_executable
+                        {
+                            errors.push(format!(
+                                "runtime ABI marker `{}` is not retained read-only data",
+                                export.symbol
+                            ));
+                        }
+                        if marker.bytes_from_symbol < u64::from(size) {
+                            errors.push(format!(
+                                "runtime ABI marker `{}` has no accessible marker byte",
+                                export.symbol
+                            ));
+                        }
+                        if marker.first_byte != Some(0) {
+                            errors.push(format!(
+                                "runtime ABI marker `{}` does not contain the required zero byte",
+                                export.symbol
+                            ));
+                        }
+                    }
+                },
+                count => errors.push(format!(
+                    "reserved runtime export `{}` is defined {count} times",
+                    export.symbol
+                )),
+            }
+        } else if !found.is_empty() {
+            errors.push(format!(
+                "reserved runtime export `{}` is not available for {target:?}",
+                export.symbol
+            ));
+        }
+    }
+
+    for symbol in &inventory.symbols {
+        let abi_owned_name = symbol.name.starts_with("__rue_");
+        if abi_owned_name && classify_export(&symbol.name).is_none() {
+            let message = if symbol.name.starts_with("__rue_runtime_abi_v") {
+                format!(
+                    "stale runtime ABI marker `{}`; expected `{RUNTIME_ABI_VERSION_SYMBOL}`",
+                    symbol.name
+                )
+            } else {
+                format!("unknown runtime ABI export `{}`", symbol.name)
+            };
+            errors.push(message);
+        }
+    }
+
+    errors.sort();
+    errors.dedup();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "embedded rue-runtime archive does not match the typed ABI manifest:\n  - {}",
+            errors.join("\n  - ")
+        ))
+    }
+}
+
+fn validate_runtime_archive(runtime_bytes: &[u8], target: Target) -> Result<Archive, String> {
+    let archive = parse_runtime_archive(runtime_bytes)?;
+    let validate = || {
+        let inventory = runtime_archive_inventory(&archive)?;
+        validate_runtime_inventory(&inventory, runtime_target(target))
+    };
+    let is_embedded_host_runtime = runtime_bytes.len() == RUNTIME_BYTES.len()
+        && std::ptr::eq(runtime_bytes.as_ptr(), RUNTIME_BYTES.as_ptr())
+        && Target::host() == Some(target);
+    if is_embedded_host_runtime {
+        EMBEDDED_RUNTIME_VALIDATION.get_or_init(validate).clone()?;
+    } else {
+        validate()?;
+    }
     Ok(archive)
 }
 
@@ -210,7 +506,7 @@ pub(crate) fn link_internal_with_warnings(
     linker.require_symbol(entry_point);
 
     // Add the runtime library
-    let runtime = parse_runtime_archive(runtime_bytes)
+    let runtime = validate_runtime_archive(runtime_bytes, options.target)
         .map_err(link_error)
         .map_err(CompileErrors::from)?;
     linker
@@ -250,6 +546,9 @@ pub(crate) fn link_system_with_warnings(
     // (RUE-36); a system linker would happily mix architectures (or fail
     // with an opaque message), so catch it here with a clear error.
     let runtime_bytes = runtime_for_target(options.target).map_err(CompileErrors::from)?;
+    validate_runtime_archive(runtime_bytes, options.target)
+        .map_err(link_error)
+        .map_err(CompileErrors::from)?;
 
     // Set up temporary directory with object files and runtime
     let mut temp_dir = TempLinkDir::new().map_err(CompileErrors::from)?;
@@ -331,3 +630,523 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::{info, info_span};
 
 use crate::*;
+
+#[cfg(test)]
+mod runtime_archive_validation_tests {
+    use super::*;
+    use rue_linker::ObjectBuilder;
+    use rue_runtime_abi::{
+        RUNTIME_ABI_VERSION_SYMBOL, ReservedExportId, ReservedExportKind, RuntimeHelperId,
+        RuntimeTarget,
+    };
+
+    fn function(name: &str) -> RuntimeDefinedSymbol {
+        RuntimeDefinedSymbol {
+            name: name.to_owned(),
+            kind: RuntimeSymbolKind::Function,
+            size: 1,
+            section_allocated: true,
+            section_writable: false,
+            section_executable: true,
+            bytes_from_symbol: 1,
+            first_byte: Some(0),
+        }
+    }
+
+    fn marker(name: &str, size: u64) -> RuntimeDefinedSymbol {
+        RuntimeDefinedSymbol {
+            name: name.to_owned(),
+            kind: RuntimeSymbolKind::Data,
+            size,
+            section_allocated: true,
+            section_writable: false,
+            section_executable: false,
+            bytes_from_symbol: 1,
+            first_byte: Some(0),
+        }
+    }
+
+    fn valid_inventory(target: RuntimeTarget, marker_size: u64) -> RuntimeArchiveInventory {
+        let mut symbols = RuntimeHelperId::ALL
+            .iter()
+            .copied()
+            .filter(|id| id.helper().availability.contains(target))
+            .map(|id| function(id.symbol()))
+            .collect::<Vec<_>>();
+        symbols.extend(
+            ReservedExportId::ALL
+                .iter()
+                .copied()
+                .filter(|id| id.export().availability.contains(target))
+                .map(|id| match id.export().kind {
+                    ReservedExportKind::Function(_) => function(id.symbol()),
+                    ReservedExportKind::ReadOnlyData { .. } => marker(id.symbol(), marker_size),
+                }),
+        );
+        RuntimeArchiveInventory {
+            object_targets: vec![target],
+            symbols,
+        }
+    }
+
+    fn error(inventory: &RuntimeArchiveInventory, target: RuntimeTarget) -> String {
+        validate_runtime_inventory(inventory, target).expect_err("inventory must be rejected")
+    }
+
+    fn archive_with_member(name: &str, member: &[u8]) -> Vec<u8> {
+        append_archive_member(b"!<arch>\n", name, member)
+    }
+
+    fn append_archive_member(archive: &[u8], name: &str, member: &[u8]) -> Vec<u8> {
+        assert!(name.len() <= 15);
+        let mut result = archive.to_vec();
+        let header = format!(
+            "{:<16}{:<12}{:<6}{:<6}{:<8}{:<10}`\n",
+            format!("{name}/"),
+            0,
+            0,
+            0,
+            "100644",
+            member.len()
+        );
+        assert_eq!(header.len(), 60);
+        result.extend_from_slice(header.as_bytes());
+        result.extend_from_slice(member);
+        if member.len() % 2 == 1 {
+            result.push(b'\n');
+        }
+        result
+    }
+
+    fn host_object(symbol: &str) -> Vec<u8> {
+        ObjectBuilder::new(Target::host().unwrap(), symbol)
+            .code(vec![0; 4])
+            .build()
+    }
+
+    fn raw_object_symbol(symbol: &str) -> Vec<u8> {
+        let mut raw = Vec::new();
+        if Target::host().is_some_and(|target| target.is_macho()) {
+            raw.push(b'_');
+        }
+        raw.extend_from_slice(symbol.as_bytes());
+        raw.push(0);
+        raw
+    }
+
+    fn replace_export_name(archive: &[u8], old: &str, new: &str) -> Vec<u8> {
+        assert_eq!(old.len(), new.len());
+        let old = raw_object_symbol(old);
+        let new = raw_object_symbol(new);
+        let mut result = archive.to_vec();
+        let mut replacements = 0;
+        for offset in 0..=result.len().saturating_sub(old.len()) {
+            if result[offset..].starts_with(&old) {
+                result[offset..offset + old.len()].copy_from_slice(&new);
+                replacements += 1;
+            }
+        }
+        assert!(replacements > 0, "runtime archive did not contain export");
+        result
+    }
+
+    fn validation_error(bytes: &[u8]) -> String {
+        validate_runtime_archive(bytes, Target::host().unwrap())
+            .expect_err("mutated archive must be rejected")
+    }
+
+    fn foreign_target() -> Target {
+        match Target::host().unwrap() {
+            Target::X86_64Linux => Target::Aarch64Linux,
+            Target::Aarch64Linux | Target::Aarch64Macos => Target::X86_64Linux,
+        }
+    }
+
+    fn non_applicable_export() -> &'static str {
+        match Target::host().unwrap() {
+            Target::X86_64Linux | Target::Aarch64Linux => ReservedExportId::MacosMain.symbol(),
+            Target::Aarch64Macos => ReservedExportId::LinuxStart.symbol(),
+        }
+    }
+
+    #[test]
+    fn accepts_elf_and_macho_marker_metadata() {
+        validate_runtime_inventory(
+            &valid_inventory(RuntimeTarget::X86_64Linux, 1),
+            RuntimeTarget::X86_64Linux,
+        )
+        .unwrap();
+        validate_runtime_inventory(
+            &valid_inventory(RuntimeTarget::Aarch64Macos, 1),
+            RuntimeTarget::Aarch64Macos,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_missing_and_duplicate_helpers() {
+        let mut inventory = valid_inventory(RuntimeTarget::X86_64Linux, 1);
+        inventory
+            .symbols
+            .retain(|symbol| symbol.name != RuntimeHelperId::Alloc.symbol());
+        assert!(
+            error(&inventory, RuntimeTarget::X86_64Linux)
+                .contains("missing runtime helper `__rue_alloc`")
+        );
+
+        inventory
+            .symbols
+            .push(function(RuntimeHelperId::Exit.symbol()));
+        inventory
+            .symbols
+            .push(function(RuntimeHelperId::Exit.symbol()));
+        assert!(
+            error(&inventory, RuntimeTarget::X86_64Linux)
+                .contains("runtime helper `__rue_exit` is defined 3 times")
+        );
+    }
+
+    #[test]
+    fn rejects_missing_stale_and_duplicate_markers() {
+        let mut inventory = valid_inventory(RuntimeTarget::Aarch64Linux, 1);
+        inventory
+            .symbols
+            .retain(|symbol| symbol.name != RUNTIME_ABI_VERSION_SYMBOL);
+        assert!(
+            error(&inventory, RuntimeTarget::Aarch64Linux).contains(&format!(
+                "missing reserved runtime export `{RUNTIME_ABI_VERSION_SYMBOL}`"
+            ))
+        );
+
+        inventory.symbols.push(marker("__rue_runtime_abi_v0", 1));
+        let stale = error(&inventory, RuntimeTarget::Aarch64Linux);
+        assert!(stale.contains(
+            "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v1`"
+        ));
+
+        inventory
+            .symbols
+            .push(marker(RUNTIME_ABI_VERSION_SYMBOL, 1));
+        inventory
+            .symbols
+            .push(marker(RUNTIME_ABI_VERSION_SYMBOL, 1));
+        assert!(
+            error(&inventory, RuntimeTarget::Aarch64Linux).contains(&format!(
+                "reserved runtime export `{RUNTIME_ABI_VERSION_SYMBOL}` is defined 2 times"
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_marker_data_contract() {
+        let mut inventory = valid_inventory(RuntimeTarget::X86_64Linux, 2);
+        let marker = inventory
+            .symbols
+            .iter_mut()
+            .find(|symbol| symbol.name == RUNTIME_ABI_VERSION_SYMBOL)
+            .unwrap();
+        marker.section_writable = true;
+        marker.bytes_from_symbol = 0;
+        marker.first_byte = Some(1);
+        let err = error(&inventory, RuntimeTarget::X86_64Linux);
+        assert!(err.contains("has size 2, expected 1 byte"));
+        assert!(err.contains("is not retained read-only data"));
+        assert!(err.contains("has no accessible marker byte"));
+        assert!(err.contains("does not contain the required zero byte"));
+    }
+
+    #[test]
+    fn rejects_wrong_object_target_and_non_applicable_exports() {
+        let mut inventory = valid_inventory(RuntimeTarget::X86_64Linux, 1);
+        inventory.object_targets[0] = RuntimeTarget::Aarch64Macos;
+        inventory
+            .symbols
+            .push(function(ReservedExportId::MacosMain.symbol()));
+        let err = error(&inventory, RuntimeTarget::X86_64Linux);
+        assert!(err.contains("object 0 targets Aarch64Macos, expected X86_64Linux"));
+        assert!(err.contains("reserved runtime export `_main` is not available for X86_64Linux"));
+    }
+
+    #[test]
+    fn rejects_unknown_abi_owned_export_without_matching_mangled_internals() {
+        let mut inventory = valid_inventory(RuntimeTarget::Aarch64Macos, 1);
+        inventory.symbols.push(function("__rue_removed_helper"));
+        inventory
+            .symbols
+            .push(function("_ZN11rue_runtime26__rue_internal_implementation"));
+        let err = error(&inventory, RuntimeTarget::Aarch64Macos);
+        assert!(err.contains("unknown runtime ABI export `__rue_removed_helper`"));
+        assert!(!err.contains("__rue_internal_implementation"));
+    }
+
+    #[test]
+    fn diagnostics_are_sorted_and_deterministic() {
+        let mut inventory = valid_inventory(RuntimeTarget::X86_64Linux, 1);
+        inventory
+            .symbols
+            .retain(|symbol| symbol.name != RuntimeHelperId::Alloc.symbol());
+        inventory.symbols.push(function("__rue_z_removed_helper"));
+        inventory.symbols.push(function("__rue_a_removed_helper"));
+
+        let first = error(&inventory, RuntimeTarget::X86_64Linux);
+        let second = error(&inventory, RuntimeTarget::X86_64Linux);
+        assert_eq!(first, second);
+        assert!(
+            first.find("__rue_a_removed_helper").unwrap()
+                < first.find("__rue_z_removed_helper").unwrap()
+        );
+    }
+
+    #[test]
+    fn strict_archive_validation_rejects_malformed_native_object_member() {
+        let malformed = archive_with_member("broken.o", b"\x7fELFnot-an-object");
+        let err = validate_runtime_archive(&malformed, Target::host().unwrap()).unwrap_err();
+        assert!(
+            err.contains("failed to parse object member `broken.o/`"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn strict_archive_validation_rejects_unsupported_macho_cpu() {
+        let mut object = ObjectBuilder::new(Target::Aarch64Macos, "wrong_cpu")
+            .code(vec![0; 4])
+            .build();
+        object[4..8].copy_from_slice(&0x0100_0007u32.to_le_bytes());
+        let archive = archive_with_member("x86-macho.o", &object);
+        let err = validate_runtime_archive(&archive, Target::host().unwrap()).unwrap_err();
+        assert!(
+            err.contains("unsupported Mach-O CPU type: 0x1000007"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn strict_archive_validation_skips_true_metadata_and_bitcode_members() {
+        let archive = archive_with_member("metadata", b"rust metadata");
+        let archive = append_archive_member(&archive, "module.bc", b"BC\xc0\xdebitcode");
+        let archive = append_archive_member(&archive, "valid.o", &host_object("fixture"));
+        let parsed = Archive::parse_strict_objects(&archive).unwrap();
+        assert_eq!(parsed.len(), 1);
+    }
+
+    #[test]
+    fn archive_bytes_reject_missing_and_misspelled_helper() {
+        let bytes = replace_export_name(
+            RUNTIME_BYTES,
+            RuntimeHelperId::Alloc.symbol(),
+            "__rue_alloq",
+        );
+        let err = validation_error(&bytes);
+        assert!(
+            err.contains("missing runtime helper `__rue_alloc`"),
+            "{err}"
+        );
+        assert!(
+            err.contains("unknown runtime ABI export `__rue_alloq`"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn archive_bytes_reject_duplicate_helper() {
+        let duplicate = host_object(RuntimeHelperId::Alloc.symbol());
+        let bytes = append_archive_member(RUNTIME_BYTES, "duplicate.o", &duplicate);
+        let err = validation_error(&bytes);
+        assert!(
+            err.contains("runtime helper `__rue_alloc` is defined 2 times"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn archive_bytes_reject_stale_marker() {
+        let bytes = replace_export_name(
+            RUNTIME_BYTES,
+            RUNTIME_ABI_VERSION_SYMBOL,
+            "__rue_runtime_abi_v0",
+        );
+        let err = validation_error(&bytes);
+        assert!(
+            err.contains(
+                "stale runtime ABI marker `__rue_runtime_abi_v0`; expected `__rue_runtime_abi_v1`"
+            ),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn archive_bytes_reject_missing_and_duplicate_current_marker() {
+        let missing = replace_export_name(
+            RUNTIME_BYTES,
+            RUNTIME_ABI_VERSION_SYMBOL,
+            "__rue_runtime_abj_v1",
+        );
+        let err = validation_error(&missing);
+        assert!(
+            err.contains(&format!(
+                "missing reserved runtime export `{RUNTIME_ABI_VERSION_SYMBOL}`"
+            )),
+            "{err}"
+        );
+
+        let duplicate = host_object(RUNTIME_ABI_VERSION_SYMBOL);
+        let bytes = append_archive_member(RUNTIME_BYTES, "marker.o", &duplicate);
+        let err = validation_error(&bytes);
+        assert!(
+            err.contains(&format!(
+                "reserved runtime export `{RUNTIME_ABI_VERSION_SYMBOL}` is defined 2 times"
+            )),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn archive_bytes_reject_wrong_target_object() {
+        let object = ObjectBuilder::new(foreign_target(), "foreign")
+            .code(vec![0; 4])
+            .build();
+        let bytes = append_archive_member(RUNTIME_BYTES, "foreign.o", &object);
+        let err = validation_error(&bytes);
+        assert!(err.contains("expected"), "{err}");
+        assert!(err.contains("object"), "{err}");
+    }
+
+    #[test]
+    fn archive_bytes_reject_non_applicable_reserved_export() {
+        let object = host_object(non_applicable_export());
+        let bytes = append_archive_member(RUNTIME_BYTES, "wrong-os.o", &object);
+        let err = validation_error(&bytes);
+        assert!(
+            err.contains(&format!(
+                "reserved runtime export `{}` is not available",
+                non_applicable_export()
+            )),
+            "{err}"
+        );
+    }
+
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    #[test]
+    fn x86_64_linux_sigreturn_export_is_callable_code() {
+        let archive = parse_runtime_archive(RUNTIME_BYTES).unwrap();
+        let inventory = runtime_archive_inventory(&archive).unwrap();
+        let symbol = inventory
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == ReservedExportId::RtSigreturn.symbol())
+            .unwrap();
+        assert_eq!(symbol.kind, RuntimeSymbolKind::Function);
+        assert!(symbol.section_executable);
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    fn read_u32(bytes: &[u8], offset: usize) -> u32 {
+        u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    fn read_u64(bytes: &[u8], offset: usize) -> u64 {
+        u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap())
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    fn archive_member_ranges(bytes: &[u8]) -> Vec<(usize, usize)> {
+        let mut ranges = Vec::new();
+        let mut offset = 8;
+        while offset + 60 <= bytes.len() {
+            let header = &bytes[offset..offset + 60];
+            let name = std::str::from_utf8(&header[..16]).unwrap().trim();
+            let size: usize = std::str::from_utf8(&header[48..58])
+                .unwrap()
+                .trim()
+                .parse()
+                .unwrap();
+            offset += 60;
+            let name_len = name
+                .strip_prefix("#1/")
+                .map(|length| length.trim().parse().unwrap())
+                .unwrap_or(0);
+            ranges.push((offset + name_len, offset + size));
+            offset += size + (size % 2);
+        }
+        ranges
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    fn macho_marker_offsets(bytes: &[u8]) -> (usize, usize, u64) {
+        const LC_SEGMENT_64: u32 = 0x19;
+        const LC_SYMTAB: u32 = 0x2;
+        let raw_marker = raw_object_symbol(RUNTIME_ABI_VERSION_SYMBOL);
+
+        for (member_start, member_end) in archive_member_ranges(bytes) {
+            let member = &bytes[member_start..member_end];
+            if member.len() < 32 || read_u32(member, 0) != 0xfeed_facf {
+                continue;
+            }
+            let mut sections = Vec::new();
+            let mut symtab = None;
+            let mut command = 32;
+            for _ in 0..read_u32(member, 16) {
+                let kind = read_u32(member, command);
+                let size = read_u32(member, command + 4) as usize;
+                if kind == LC_SEGMENT_64 {
+                    let count = read_u32(member, command + 64) as usize;
+                    let mut section = command + 72;
+                    for _ in 0..count {
+                        sections.push((
+                            read_u64(member, section + 32),
+                            read_u64(member, section + 40),
+                            read_u32(member, section + 48) as usize,
+                        ));
+                        section += 80;
+                    }
+                } else if kind == LC_SYMTAB {
+                    symtab = Some((
+                        read_u32(member, command + 8) as usize,
+                        read_u32(member, command + 12) as usize,
+                        read_u32(member, command + 16) as usize,
+                    ));
+                }
+                command += size;
+            }
+            let Some((symbols, symbol_count, strings)) = symtab else {
+                continue;
+            };
+            for index in 0..symbol_count {
+                let symbol = symbols + index * 16;
+                let name = strings + read_u32(member, symbol) as usize;
+                if !member[name..].starts_with(&raw_marker) {
+                    continue;
+                }
+                let section_index = usize::from(member[symbol + 5]) - 1;
+                let (section_address, _, section_offset) = sections[section_index];
+                let value = read_u64(member, symbol + 8);
+                let data_offset = member_start
+                    + section_offset
+                    + usize::try_from(value - section_address).unwrap();
+                return (data_offset, member_start + symbol + 8, value);
+            }
+        }
+        panic!("embedded Mach-O archive did not contain the ABI marker");
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    #[test]
+    fn real_macho_marker_mutations_reject_nonzero_value_and_nonunit_extent() {
+        let (data_offset, value_offset, value) = macho_marker_offsets(RUNTIME_BYTES);
+
+        let mut nonzero = RUNTIME_BYTES.to_vec();
+        nonzero[data_offset] = 1;
+        let err = validation_error(&nonzero);
+        assert!(
+            err.contains("does not contain the required zero byte"),
+            "{err}"
+        );
+
+        let mut oversized = RUNTIME_BYTES.to_vec();
+        oversized[value_offset..value_offset + 8].copy_from_slice(&(value - 1).to_le_bytes());
+        let err = validation_error(&oversized);
+        assert!(err.contains("has size 2, expected 1 byte"), "{err}");
+    }
+}

--- a/crates/rue-linker/src/archive.rs
+++ b/crates/rue-linker/src/archive.rs
@@ -29,6 +29,8 @@ pub enum ArchiveError {
     InvalidHeader(String),
     /// Failed to parse contained object.
     ObjectParse(ParseError),
+    /// A member with a recognized object-file magic was malformed or unsupported.
+    ObjectMemberParse { member: String, source: ParseError },
     /// Integer overflow in size calculation.
     Overflow,
 }
@@ -40,6 +42,9 @@ impl std::fmt::Display for ArchiveError {
             ArchiveError::TooShort => write!(f, "archive too short"),
             ArchiveError::InvalidHeader(s) => write!(f, "invalid archive header: {}", s),
             ArchiveError::ObjectParse(e) => write!(f, "failed to parse object: {}", e),
+            ArchiveError::ObjectMemberParse { member, source } => {
+                write!(f, "failed to parse object member `{member}`: {source}")
+            }
             ArchiveError::Overflow => write!(f, "integer overflow in archive size calculation"),
         }
     }
@@ -69,6 +74,22 @@ impl Archive {
     /// Special entries like symbol tables (`/`, `//`, `__.SYMDEF`) are skipped.
     #[must_use = "parsing returns a Result that must be checked"]
     pub fn parse(data: &[u8]) -> Result<Self, ArchiveError> {
+        Self::parse_impl(data, false)
+    }
+
+    /// Parse an archive while rejecting malformed members that advertise a
+    /// supported ELF or Mach-O object-file magic.
+    ///
+    /// Rust static libraries also contain symbol indexes, metadata, and may
+    /// contain LLVM bitcode. Those non-object members remain intentionally
+    /// ignored. A member beginning with a recognized native-object magic,
+    /// however, must parse successfully instead of silently disappearing.
+    #[must_use = "parsing returns a Result that must be checked"]
+    pub fn parse_strict_objects(data: &[u8]) -> Result<Self, ArchiveError> {
+        Self::parse_impl(data, true)
+    }
+
+    fn parse_impl(data: &[u8], strict_objects: bool) -> Result<Self, ArchiveError> {
         // Check magic
         if data.len() < AR_MAGIC.len() {
             return Err(ArchiveError::TooShort);
@@ -83,6 +104,9 @@ impl Archive {
         loop {
             let header_end = checked_offset_add(offset, HEADER_SIZE)?;
             if header_end > data.len() {
+                if strict_objects && offset != data.len() {
+                    return Err(ArchiveError::TooShort);
+                }
                 break;
             }
 
@@ -170,6 +194,12 @@ impl Archive {
             // Non-object members (e.g., LLVM bitcode files from LTO builds) are skipped.
             match ObjectFile::parse(member_data) {
                 Ok(obj) => objects.push(obj),
+                Err(source) if strict_objects && looks_like_native_object(member_data) => {
+                    return Err(ArchiveError::ObjectMemberParse {
+                        member: actual_name,
+                        source,
+                    });
+                }
                 Err(_) => {
                     // Member is not a valid object file. This is common for:
                     // - LLVM bitcode files (.bc) in LTO-enabled builds
@@ -200,6 +230,20 @@ impl Archive {
     pub fn len(&self) -> usize {
         self.objects.len()
     }
+}
+
+fn looks_like_native_object(data: &[u8]) -> bool {
+    if data.starts_with(b"\x7fELF") {
+        return true;
+    }
+    let Some(magic) = data
+        .get(..4)
+        .and_then(|bytes| <[u8; 4]>::try_from(bytes).ok())
+        .map(u32::from_le_bytes)
+    else {
+        return false;
+    };
+    matches!(magic, 0xfeed_face | 0xcefa_edfe | 0xfeed_facf | 0xcffa_edfe)
 }
 
 #[cfg(test)]

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -148,6 +148,15 @@ pub struct ObjectFile {
     /// validates this against the link target — without it, an "aarch64"
     /// binary could silently embed x86 code (RUE-131 item 10, RUE-36).
     pub machine: ElfMachine,
+    /// Container format used by this relocatable object.
+    pub format: ObjectFormat,
+}
+
+/// Relocatable object container format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectFormat {
+    Elf,
+    MachO,
 }
 
 /// A section from an object file.
@@ -339,6 +348,8 @@ pub enum ParseError {
     NotRelocatable,
     /// Unsupported machine architecture.
     UnsupportedMachine(u16),
+    /// Unsupported Mach-O CPU architecture.
+    UnsupportedMachOCpu(u32),
     /// Invalid section header.
     InvalidSection(String),
     /// Invalid symbol table.
@@ -367,6 +378,9 @@ impl std::fmt::Display for ParseError {
             ParseError::NotRelocatable => write!(f, "not a relocatable object file"),
             ParseError::UnsupportedMachine(m) => {
                 write!(f, "unsupported ELF machine type: 0x{:x}", m)
+            }
+            ParseError::UnsupportedMachOCpu(cpu) => {
+                write!(f, "unsupported Mach-O CPU type: 0x{:x}", cpu)
             }
             ParseError::InvalidSection(s) => write!(f, "invalid section: {}", s),
             ParseError::InvalidSymbol(s) => write!(f, "invalid symbol: {}", s),
@@ -419,6 +433,10 @@ impl ObjectFile {
         let magic = read_u32(data, 0);
         if magic != MH_MAGIC_64 {
             return Err(ParseError::InvalidMagic);
+        }
+        let cpu = read_u32(data, 4);
+        if cpu != crate::constants::CPU_TYPE_ARM64 {
+            return Err(ParseError::UnsupportedMachOCpu(cpu));
         }
 
         // Parse header
@@ -873,6 +891,7 @@ impl ObjectFile {
             section_map,
             // The Mach-O parser only accepts CPU_TYPE_ARM64 objects.
             machine: ElfMachine::Aarch64,
+            format: ObjectFormat::MachO,
         })
     }
 
@@ -1242,6 +1261,7 @@ impl ObjectFile {
             symbols,
             section_map,
             machine,
+            format: ObjectFormat::Elf,
         })
     }
 

--- a/crates/rue-linker/src/lib.rs
+++ b/crates/rue-linker/src/lib.rs
@@ -19,6 +19,9 @@ pub mod macho;
 mod util;
 
 pub use archive::{Archive, ArchiveError};
-pub use elf::{ObjectFile, Relocation, RelocationType, Section, Symbol};
+pub use elf::{
+    ElfMachine, ObjectFile, ObjectFormat, Relocation, RelocationType, Section, SectionFlags,
+    Symbol, SymbolBinding, SymbolType,
+};
 pub use emit::{CodeRelocation, ObjectBuilder};
 pub use linker::{LinkError, Linker};

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -2045,6 +2045,7 @@ mod tests {
             symbols,
             section_map,
             machine: crate::elf::ElfMachine::X86_64,
+            format: crate::elf::ObjectFormat::Elf,
         }
     }
 
@@ -2141,6 +2142,7 @@ mod tests {
             }],
             section_map: HashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
+            format: crate::elf::ObjectFormat::Elf,
         };
         let _ = Relocation {
             offset: 0,
@@ -2227,6 +2229,7 @@ mod tests {
             ],
             section_map: HashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
+            format: crate::elf::ObjectFormat::Elf,
         };
 
         let mut linker = Linker::new(ELF_TARGET);
@@ -2591,6 +2594,7 @@ mod tests {
             symbols: vec![null_symbol, bad_symbol, main_symbol],
             section_map: HashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
+            format: crate::elf::ObjectFormat::Elf,
         };
 
         let mut linker = Linker::new(ELF_TARGET);
@@ -2664,6 +2668,7 @@ mod tests {
             symbols: vec![null_symbol, main_symbol], // Only 2 symbols, but relocation references index 999
             section_map: HashMap::from([(".text".into(), 0)]),
             machine: crate::elf::ElfMachine::X86_64,
+            format: crate::elf::ObjectFormat::Elf,
         };
 
         let mut linker = Linker::new(ELF_TARGET);
@@ -3572,6 +3577,7 @@ mod tests {
             symbols: vec![main_symbol],
             section_map: [("__text".to_string(), 0)].into_iter().collect(),
             machine: crate::elf::ElfMachine::Aarch64,
+            format: crate::elf::ObjectFormat::MachO,
         };
 
         let mut linker = Linker::new(Target::Aarch64Macos);
@@ -3631,6 +3637,7 @@ mod tests {
             symbols: vec![main_symbol],
             section_map: [("__text".to_string(), 0)].into_iter().collect(),
             machine: crate::elf::ElfMachine::Aarch64,
+            format: crate::elf::ObjectFormat::MachO,
         };
 
         let mut linker = Linker::new(Target::Aarch64Macos);
@@ -3670,6 +3677,7 @@ mod tests {
             symbols: vec![other_symbol],
             section_map: [("__text".to_string(), 0)].into_iter().collect(),
             machine: crate::elf::ElfMachine::Aarch64,
+            format: crate::elf::ObjectFormat::MachO,
         };
 
         let mut linker = Linker::new(Target::Aarch64Macos);
@@ -3705,6 +3713,10 @@ mod tests {
             symbols,
             section_map,
             machine,
+            format: match machine {
+                crate::elf::ElfMachine::X86_64 => crate::elf::ObjectFormat::Elf,
+                crate::elf::ElfMachine::Aarch64 => crate::elf::ObjectFormat::MachO,
+            },
         }
     }
 

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -322,11 +322,24 @@ macro_rules! declare_reserved_assembly {
     (x86_64_linux unsafe $function:ident()) => {
         #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
         core::arch::global_asm!(
+            concat!(
+                ".pushsection .text.",
+                stringify!($function),
+                ",\"ax\",@progbits"
+            ),
             concat!(".globl ", stringify!($function)),
             concat!(".hidden ", stringify!($function)),
+            concat!(".type ", stringify!($function), ",@function"),
             concat!(stringify!($function), ":"),
             "mov rax, 15",
             "syscall",
+            concat!(
+                ".size ",
+                stringify!($function),
+                ", .-",
+                stringify!($function)
+            ),
+            ".popsection",
         );
 
         #[cfg(all(target_arch = "x86_64", target_os = "linux"))]

--- a/rust-project.json
+++ b/rust-project.json
@@ -27,6 +27,10 @@
           "name": "rue_rir"
         },
         {
+          "crate": 16,
+          "name": "rue_runtime_abi"
+        },
+        {
           "crate": 18,
           "name": "rue_span"
         },
@@ -61,7 +65,12 @@
       "display_name": "rue-builtins",
       "root_module": "crates/rue-builtins/src/lib.rs",
       "edition": "2024",
-      "deps": [],
+      "deps": [
+        {
+          "crate": 16,
+          "name": "rue_runtime_abi"
+        }
+      ],
       "is_workspace_member": true,
       "source": {
         "include_dirs": [
@@ -174,6 +183,10 @@
           "name": "rue_error"
         },
         {
+          "crate": 16,
+          "name": "rue_runtime_abi"
+        },
+        {
           "crate": 18,
           "name": "rue_span"
         },
@@ -284,6 +297,10 @@
         {
           "crate": 15,
           "name": "rue_rir"
+        },
+        {
+          "crate": 16,
+          "name": "rue_runtime_abi"
         },
         {
           "crate": 18,
@@ -703,7 +720,12 @@
       "display_name": "rue-runtime",
       "root_module": "crates/rue-runtime/src/lib.rs",
       "edition": "2024",
-      "deps": [],
+      "deps": [
+        {
+          "crate": 16,
+          "name": "rue_runtime_abi"
+        }
+      ],
       "is_workspace_member": true,
       "source": {
         "include_dirs": [


### PR DESCRIPTION
Validate the embedded host runtime archive against the canonical typed ABI manifest before internal or system linking.

Strictly parse recognized native archive members, prove target format and architecture, require each applicable helper and reserved export exactly once, reject stale or unknown ABI exports, and verify the retained zero-valued one-byte ABI marker with ELF- and Mach-O-aware metadata. Add production archive-byte mutation coverage for missing, duplicate, stale, malformed, and wrong-target artifacts.

Fixes RUE-833