### PR TITLE
RUE-834: complete typed runtime ABI cleanup

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -246,6 +246,29 @@ sh_test(
 )
 
 sh_test(
+    name = "runtime-abi-inventory-validation",
+    test = "scripts/validate-runtime-abi-inventory.py",
+    args = [
+        "--source", "rue-air=$(location //crates/rue-air:runtime-abi-inventory-sources)",
+        "--source", "rue-builtins=$(location //crates/rue-builtins:runtime-abi-inventory-sources)",
+        "--source", "rue-cfg=$(location //crates/rue-cfg:runtime-abi-inventory-sources)",
+        "--source", "rue-codegen=$(location //crates/rue-codegen:runtime-abi-inventory-sources)",
+        "--source", "rue-compiler=$(location //crates/rue-compiler:runtime-abi-inventory-sources)",
+        "--source", "rue-linker=$(location //crates/rue-linker:runtime-abi-inventory-sources)",
+        "--source", "rue-oracle=$(location //crates/rue-oracle:runtime-abi-inventory-sources)",
+    ],
+)
+
+sh_test(
+    name = "runtime-abi-inventory-tool-tests",
+    test = "scripts/test-runtime-abi-inventory.py",
+    resources = ["scripts/validate-runtime-abi-inventory.py"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
+sh_test(
     name = "benchmark-tool-tests",
     test = "scripts/test-benchmark-tools.py",
     env = {

--- a/crates/rue-air/BUCK
+++ b/crates/rue-air/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_crate")
 
+filegroup(
+    name = "runtime-abi-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-air",
     deps = [

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -353,13 +353,13 @@ impl<'a> BodySema<'a> {
                 if is_next { Type::U64 } else { Type::U32 },
             ));
         }
-        let (fn_name, ret_ty) = match (is_next, lossy) {
-            (true, false) => ("__rue_str_char_next", Type::U64),
-            (true, true) => ("__rue_str_char_next_lossy", Type::U64),
-            (false, false) => ("__rue_str_char_scalar", Type::U32),
-            (false, true) => ("__rue_str_char_scalar_lossy", Type::U32),
+        let (runtime, ret_ty) = match (is_next, lossy) {
+            (true, false) => (crate::RuntimeCallKind::StrCharNext, Type::U64),
+            (true, true) => (crate::RuntimeCallKind::StrCharNextLossy, Type::U64),
+            (false, false) => (crate::RuntimeCallKind::StrCharScalar, Type::U32),
+            (false, true) => (crate::RuntimeCallKind::StrCharScalarLossy, Type::U32),
         };
-        let call_name = self.interner.get_or_intern(fn_name);
+        let call_name = self.interner.get_or_intern(runtime.helper().symbol());
         let (ptr, len, temp_scope) =
             self.project_strbuf_text_fields(air, coll_result.air_ref, coll_result.ty, span, ctx)?;
         let extra = vec![
@@ -373,12 +373,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&extra);
         let call_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
-                runtime: Some(match (is_next, lossy) {
-                    (true, false) => crate::RuntimeCallKind::StrCharNext,
-                    (true, true) => crate::RuntimeCallKind::StrCharNextLossy,
-                    (false, false) => crate::RuntimeCallKind::StrCharScalar,
-                    (false, true) => crate::RuntimeCallKind::StrCharScalarLossy,
-                }),
+                runtime: Some(runtime),
                 name: call_name,
                 args_start,
                 args_len: 3,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5657,10 +5657,11 @@ impl<'a> BodySema<'a> {
             ));
         }
 
-        // Lower to `__rue_str_byte_at(self, index) -> u8`. The 2-word `str`
-        // value is passed by value; codegen decomposes it into ptr/len argument
-        // registers, exactly as it decomposes the 3-word String for byte_at.
-        let call_name = self.interner.get_or_intern("__rue_str_byte_at");
+        // Lower through the typed runtime-call contract. The 2-word `str`
+        // value is passed by value; codegen decomposes it into pointer/length
+        // argument registers.
+        let runtime = crate::RuntimeCallKind::StrByteAt;
+        let call_name = self.interner.get_or_intern(runtime.helper().symbol());
         let extra = [
             base_result.air_ref.as_u32(),
             AirArgMode::Normal.as_u32(),
@@ -5670,7 +5671,7 @@ impl<'a> BodySema<'a> {
         let args_start = air.add_extra(&extra);
         let call_ref = air.add_inst(AirInst {
             data: AirInstData::Call {
-                runtime: Some(crate::RuntimeCallKind::StrByteAt),
+                runtime: Some(runtime),
                 name: call_name,
                 args_start,
                 args_len: 2,

--- a/crates/rue-builtins/BUCK
+++ b/crates/rue-builtins/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_crate")
 
+filegroup(
+    name = "runtime-abi-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-builtins",
     deps = [

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -439,47 +439,34 @@ pub fn is_reserved_enum_name(name: &str) -> bool {
     BUILTIN_ENUMS.iter().any(|e| e.name == name)
 }
 
-/// Runtime symbols exported UNMANGLED outside the `__rue_` prefix, because
-/// their exact names are load-bearing (RUE-354):
-///
-/// - `memcpy`/`memmove`/`memset`/`memcmp`/`bcmp` (`rue-runtime/src/memory.rs`):
-///   rustc/LLVM lowers copies and comparisons to calls with exactly these
-///   compiler-builtin names, so they cannot be moved under `__rue_`.
-/// - `_start` / `_main` (`rue-runtime/src/entry.rs`): the program entry points
-///   the linker resolves on Linux and macOS respectively.
-///
-/// Keep this list in sync with the `#[unsafe(no_mangle)]` items in those two
-/// files — a missed name surfaces as a confusing duplicate-symbol link error
-/// (E1000) instead of the intended E0435 declaration-time diagnostic.
-const RUNTIME_EXPORTED_NAMES: &[&str] = &[
-    "memcpy", "memmove", "memset", "memcmp", "bcmp", "_start", "_main",
-];
-
 /// Check if a name is reserved for a runtime/codegen helper function, and thus
 /// may not be used as a user-defined function name.
 ///
 /// A user function with one of these names would collide with a symbol emitted
-/// by the runtime or codegen. Almost every such symbol lives under the reserved
-/// `__rue_` prefix — allocation, exit, and operator helpers such as
-/// `__rue_alloc`, `__rue_exit`, and `__rue_str_eq` — but the runtime also
-/// exports a handful of unmangled
-/// names whose spellings are fixed by the platform or by rustc/LLVM lowering:
-/// see [`RUNTIME_EXPORTED_NAMES`]. Reserving exactly `__rue_*` plus that short
-/// fixed list (rather than growing the set for every new builtin) means
+/// by the runtime or codegen. The reserved namespace covers runtime helpers,
+/// compiler-generated functions, and target shims. The typed ABI manifest
+/// separately classifies entry points and compiler-built memory routines whose
+/// externally fixed names do not use that namespace. This means
 /// `<BuiltinType>__<method>` spellings like `String__len` are ordinary, legal
 /// user identifiers (RUE-125). Depending on link order a real collision either
 /// fails to link or silently binds calls to the wrong definition, so these
 /// names are rejected at declaration time with a clear diagnostic.
 pub fn is_reserved_function_name(name: &str) -> bool {
-    // Runtime internal helpers, built-in methods, drop glue, operators — every
-    // compiler/runtime symbol not in RUNTIME_EXPORTED_NAMES is emitted under
-    // this prefix.
     if name.starts_with("__rue_") {
         return true;
     }
-    // Entry points and compiler-builtin memory routines the runtime exports
-    // under their fixed platform names (RUE-354).
-    RUNTIME_EXPORTED_NAMES.contains(&name)
+    rue_runtime_abi::ReservedExportId::ALL
+        .iter()
+        .copied()
+        .any(|id| {
+            use rue_runtime_abi::ReservedExportClass;
+
+            let export = id.export();
+            matches!(
+                export.class,
+                ReservedExportClass::CompilerBuiltMemory | ReservedExportClass::ProgramEntry
+            ) && export.symbol == name
+        })
 }
 
 #[cfg(test)]

--- a/crates/rue-cfg/BUCK
+++ b/crates/rue-cfg/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_crate")
 
+filegroup(
+    name = "runtime-abi-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-cfg",
     deps = [

--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_crate")
 
+filegroup(
+    name = "runtime-abi-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-codegen",
     deps = [

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_crate")
 
+filegroup(
+    name = "runtime-abi-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 # The runtime staticlib is mapped into src/ so it can be embedded with include_bytes!
 rue_crate(
     name = "rue-compiler",

--- a/crates/rue-linker/BUCK
+++ b/crates/rue-linker/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_crate")
 
+filegroup(
+    name = "runtime-abi-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-linker",
     deps = [

--- a/crates/rue-oracle/BUCK
+++ b/crates/rue-oracle/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_crate")
 
+filegroup(
+    name = "runtime-abi-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-oracle",
     deps = [

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -63,7 +63,7 @@
 //! - **Deeply-nested `inout` field writes** (non-zero inner offset).
 
 use lasso::ThreadedRodeo;
-use rue_air::{FrozenTypeInternPool, Type, TypeKind, parse_array_type_syntax};
+use rue_air::{FrozenTypeInternPool, RuntimeCallKind, Type, TypeKind, parse_array_type_syntax};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
 use rue_compiler::{
     CompileErrors, CompileOptions, CompilerSession, FunctionWithCfg, PreviewFeatures,
@@ -759,12 +759,14 @@ fn unsupported_intrinsic_kind(name: &str) -> UnsupportedKind {
     }
 }
 
-fn unsupported_runtime_call_kind(name: &str) -> Option<UnsupportedRuntimeCallKind> {
-    match name {
-        "__rue_print" => Some(UnsupportedRuntimeCallKind::Print),
-        "__rue_println" => Some(UnsupportedRuntimeCallKind::Println),
-        "__rue_str_print" => Some(UnsupportedRuntimeCallKind::Print),
-        "__rue_str_println" => Some(UnsupportedRuntimeCallKind::Println),
+fn unsupported_runtime_call_kind(kind: RuntimeCallKind) -> Option<UnsupportedRuntimeCallKind> {
+    match kind {
+        RuntimeCallKind::StrPrintAggregate | RuntimeCallKind::StrPrintProjected => {
+            Some(UnsupportedRuntimeCallKind::Print)
+        }
+        RuntimeCallKind::StrPrintlnAggregate | RuntimeCallKind::StrPrintlnProjected => {
+            Some(UnsupportedRuntimeCallKind::Println)
+        }
         _ => None,
     }
 }
@@ -918,21 +920,20 @@ impl<'a> Interp<'a> {
 
     fn classify_unsupported_runtime_call_static(
         &self,
-        name: &str,
+        kind: RuntimeCallKind,
         arg_types: &[Type],
         arg_modes: &[CfgArgMode],
         result_ty: Type,
     ) -> UnsupportedKind {
-        let Some(runtime_call) = unsupported_runtime_call_kind(name) else {
+        let Some(runtime_call) = unsupported_runtime_call_kind(kind) else {
             return UnsupportedKind::ContractViolation(ContractViolationKind::MissingFunctionBody);
         };
-        let expected_arity = 1;
-        let shared_print = matches!(name, "__rue_str_print" | "__rue_str_println");
-        let arity_matches = if shared_print {
-            matches!(arg_types.len(), 1 | 2) && arg_modes.len() == arg_types.len()
-        } else {
-            arg_types.len() == expected_arity && arg_modes.len() == expected_arity
-        };
+        let projected = matches!(
+            kind,
+            RuntimeCallKind::StrPrintProjected | RuntimeCallKind::StrPrintlnProjected
+        );
+        let expected_arity = if projected { 2 } else { 1 };
+        let arity_matches = arg_types.len() == expected_arity && arg_modes.len() == expected_arity;
         if !arity_matches {
             return UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallArity);
         }
@@ -942,15 +943,14 @@ impl<'a> Interp<'a> {
 
         let signature_matches = match runtime_call {
             UnsupportedRuntimeCallKind::Print | UnsupportedRuntimeCallKind::Println => {
-                ((shared_print
-                    && ((arg_types.len() == 1 && self.is_str_like_type(arg_types[0]))
-                        || (arg_types.len() == 2
-                            && self
-                                .pointer_pointee(arg_types[0])
-                                .is_some_and(|(pointee, _)| pointee == Type::U8)
-                            && arg_types[1] == Type::U64)))
-                    || (!shared_print && self.is_owned_string_type(arg_types[0])))
-                    && result_ty == Type::UNIT
+                let text_matches = if projected {
+                    self.pointer_pointee(arg_types[0])
+                        .is_some_and(|(pointee, _)| pointee == Type::U8)
+                        && arg_types[1] == Type::U64
+                } else {
+                    self.is_str_like_type(arg_types[0])
+                };
+                text_matches && result_ty == Type::UNIT
             }
         };
         if signature_matches {
@@ -962,14 +962,14 @@ impl<'a> Interp<'a> {
 
     fn classify_unsupported_runtime_call(
         &self,
-        name: &str,
+        kind: RuntimeCallKind,
         args: &[Value],
         arg_types: &[Type],
         arg_modes: &[CfgArgMode],
         result_ty: Type,
     ) -> UnsupportedKind {
         let static_kind =
-            self.classify_unsupported_runtime_call_static(name, arg_types, arg_modes, result_ty);
+            self.classify_unsupported_runtime_call_static(kind, arg_types, arg_modes, result_ty);
         let UnsupportedKind::SemanticGap(SemanticGapKind::RuntimeCall(runtime_call)) = static_kind
         else {
             return static_kind;
@@ -981,13 +981,13 @@ impl<'a> Interp<'a> {
         let is_int_value = |index: usize| matches!(args[index], Value::Int(_));
         let values_match = match runtime_call {
             UnsupportedRuntimeCallKind::Print | UnsupportedRuntimeCallKind::Println => {
-                if matches!(name, "__rue_str_print" | "__rue_str_println") {
-                    (args.len() == 1 && matches!(args[0], Value::Str { slots: 2, .. }))
-                        || (args.len() == 2
-                            && matches!(args[0], Value::Str { .. })
-                            && is_int_value(1))
+                if matches!(
+                    kind,
+                    RuntimeCallKind::StrPrintProjected | RuntimeCallKind::StrPrintlnProjected
+                ) {
+                    matches!(args[0], Value::Str { .. }) && is_int_value(1)
                 } else {
-                    matches!(args[0], Value::Str { slots: 3, .. })
+                    matches!(args[0], Value::Str { .. })
                 }
             }
         };
@@ -1872,14 +1872,14 @@ impl<'a> Interp<'a> {
         }
     }
 
-    fn string_builtin_arity(name: &str) -> Option<usize> {
-        match name {
-            "__rue_to_string" | "__rue_to_string_unsigned" => Some(1),
-            "__rue_str_byte_at" => Some(2),
-            "__rue_str_char_scalar"
-            | "__rue_str_char_scalar_lossy"
-            | "__rue_str_char_next"
-            | "__rue_str_char_next_lossy" => Some(3),
+    fn string_builtin_arity(kind: RuntimeCallKind) -> Option<usize> {
+        match kind {
+            RuntimeCallKind::ToString | RuntimeCallKind::ToStringUnsigned => Some(1),
+            RuntimeCallKind::StrByteAt => Some(2),
+            RuntimeCallKind::StrCharScalar
+            | RuntimeCallKind::StrCharScalarLossy
+            | RuntimeCallKind::StrCharNext
+            | RuntimeCallKind::StrCharNextLossy => Some(3),
             _ => None,
         }
     }
@@ -1896,14 +1896,15 @@ impl<'a> Interp<'a> {
     /// an otherwise registrable model gap reached while evaluating an operand.
     fn preflight_string_builtin(
         &self,
-        name: &str,
+        kind: RuntimeCallKind,
         arg_types: &[Type],
         arg_modes: &[CfgArgMode],
         result_ty: Type,
     ) -> Step<bool> {
-        let Some(expected) = Self::string_builtin_arity(name) else {
+        let Some(expected) = Self::string_builtin_arity(kind) else {
             return Ok(false);
         };
+        let name = kind.helper().symbol();
         if arg_types.len() != expected || arg_modes.len() != expected {
             return Err(unsupported(
                 UnsupportedKind::ContractViolation(ContractViolationKind::BuiltinArity),
@@ -1920,14 +1921,16 @@ impl<'a> Interp<'a> {
                 format!("builtin '{name}' argument mode drift"),
             ));
         }
-        let argument_types_match = match name {
-            "__rue_to_string" => arg_types[0] == Type::I64,
-            "__rue_to_string_unsigned" => arg_types[0] == Type::U64,
-            "__rue_str_byte_at" => self.is_str_view_type(arg_types[0]) && arg_types[1].is_integer(),
-            "__rue_str_char_scalar"
-            | "__rue_str_char_scalar_lossy"
-            | "__rue_str_char_next"
-            | "__rue_str_char_next_lossy" => {
+        let argument_types_match = match kind {
+            RuntimeCallKind::ToString => arg_types[0] == Type::I64,
+            RuntimeCallKind::ToStringUnsigned => arg_types[0] == Type::U64,
+            RuntimeCallKind::StrByteAt => {
+                self.is_str_view_type(arg_types[0]) && arg_types[1].is_integer()
+            }
+            RuntimeCallKind::StrCharScalar
+            | RuntimeCallKind::StrCharScalarLossy
+            | RuntimeCallKind::StrCharNext
+            | RuntimeCallKind::StrCharNextLossy => {
                 self.pointer_pointee(arg_types[0])
                     .is_some_and(|(pointee, _)| pointee == Type::U8)
                     && arg_types[1] == Type::U64
@@ -1941,11 +1944,17 @@ impl<'a> Interp<'a> {
                 format!("builtin '{name}' argument type drift"),
             ));
         }
-        let result_type_matches = match name {
-            "__rue_to_string" | "__rue_to_string_unsigned" => self.is_owned_string_type(result_ty),
-            "__rue_str_byte_at" => result_ty == Type::U8,
-            "__rue_str_char_scalar" | "__rue_str_char_scalar_lossy" => result_ty == Type::U32,
-            "__rue_str_char_next" | "__rue_str_char_next_lossy" => result_ty == Type::U64,
+        let result_type_matches = match kind {
+            RuntimeCallKind::ToString | RuntimeCallKind::ToStringUnsigned => {
+                self.is_owned_string_type(result_ty)
+            }
+            RuntimeCallKind::StrByteAt => result_ty == Type::U8,
+            RuntimeCallKind::StrCharScalar | RuntimeCallKind::StrCharScalarLossy => {
+                result_ty == Type::U32
+            }
+            RuntimeCallKind::StrCharNext | RuntimeCallKind::StrCharNextLossy => {
+                result_ty == Type::U64
+            }
             _ => unreachable!("arity and result tables must stay exhaustive"),
         };
         if !result_type_matches {
@@ -1961,30 +1970,33 @@ impl<'a> Interp<'a> {
     /// ordinary source-defined function with a CFG body.
     fn string_builtin(
         &self,
-        name: &str,
+        kind: RuntimeCallKind,
         args: &[Value],
         arg_types: &[Type],
         arg_modes: &[CfgArgMode],
         result_ty: Type,
     ) -> Step<Option<Value>> {
-        if !self.preflight_string_builtin(name, arg_types, arg_modes, result_ty)? {
+        if !self.preflight_string_builtin(kind, arg_types, arg_modes, result_ty)? {
             return Ok(None);
         }
+        let name = kind.helper().symbol();
         if args.len() != arg_types.len() {
             return Err(unsupported(
                 UnsupportedKind::ContractViolation(ContractViolationKind::BuiltinArity),
                 format!("builtin '{name}' runtime argument count drift"),
             ));
         }
-        let shapes_match = match name {
-            "__rue_to_string" | "__rue_to_string_unsigned" => matches!(args[0], Value::Int(_)),
-            "__rue_str_byte_at" => {
+        let shapes_match = match kind {
+            RuntimeCallKind::ToString | RuntimeCallKind::ToStringUnsigned => {
+                matches!(args[0], Value::Int(_))
+            }
+            RuntimeCallKind::StrByteAt => {
                 matches!(args[0], Value::Str { slots: 2, .. }) && matches!(args[1], Value::Int(_))
             }
-            "__rue_str_char_scalar"
-            | "__rue_str_char_scalar_lossy"
-            | "__rue_str_char_next"
-            | "__rue_str_char_next_lossy" => {
+            RuntimeCallKind::StrCharScalar
+            | RuntimeCallKind::StrCharScalarLossy
+            | RuntimeCallKind::StrCharNext
+            | RuntimeCallKind::StrCharNextLossy => {
                 matches!(args[0], Value::Str { .. })
                     && matches!(args[1], Value::Int(_))
                     && matches!(args[2], Value::Int(_))
@@ -2017,10 +2029,12 @@ impl<'a> Interp<'a> {
             }
             Ok(bytes[..len as usize].to_vec())
         };
-        let out = match name {
-            "__rue_to_string" => Value::string((args[0].as_int() as i64).to_string()),
-            "__rue_to_string_unsigned" => Value::string((args[0].as_int() as u64).to_string()),
-            "__rue_str_byte_at" => {
+        let out = match kind {
+            RuntimeCallKind::ToString => Value::string((args[0].as_int() as i64).to_string()),
+            RuntimeCallKind::ToStringUnsigned => {
+                Value::string((args[0].as_int() as u64).to_string())
+            }
+            RuntimeCallKind::StrByteAt => {
                 let bytes = string_bytes(&args[0])?;
                 let index = args[1].as_int();
                 if index < 0 || index as u128 >= bytes.len() as u128 {
@@ -2028,14 +2042,14 @@ impl<'a> Interp<'a> {
                 }
                 Value::Int(bytes[index as usize] as i128)
             }
-            "__rue_str_char_scalar" => {
+            RuntimeCallKind::StrCharScalar => {
                 let bytes = str_bytes(&args[0], &args[1])?;
                 match char_at(&bytes, args[2].as_int()) {
                     Some((scalar, _)) => Value::Int(scalar as i128),
                     None => return Err(Flow::Panic(Panic::runtime(TrapKind::InvalidUtf8))),
                 }
             }
-            "__rue_str_char_next" => {
+            RuntimeCallKind::StrCharNext => {
                 let bytes = str_bytes(&args[0], &args[1])?;
                 let offset = args[2].as_int();
                 match char_at(&bytes, offset) {
@@ -2043,11 +2057,11 @@ impl<'a> Interp<'a> {
                     None => return Err(Flow::Panic(Panic::runtime(TrapKind::InvalidUtf8))),
                 }
             }
-            "__rue_str_char_scalar_lossy" => {
+            RuntimeCallKind::StrCharScalarLossy => {
                 let bytes = str_bytes(&args[0], &args[1])?;
                 Value::Int(char_at_lossy(&bytes, args[2].as_int()).0 as i128)
             }
-            "__rue_str_char_next_lossy" => {
+            RuntimeCallKind::StrCharNextLossy => {
                 let bytes = str_bytes(&args[0], &args[1])?;
                 let offset = args[2].as_int();
                 Value::Int(offset + char_at_lossy(&bytes, offset).1 as i128)
@@ -2411,10 +2425,10 @@ impl<'a> Interp<'a> {
                 Value::Unit
             }
             CfgInstData::Call {
+                runtime,
                 name,
                 args_start,
                 args_len,
-                ..
             } => {
                 let fname = self.interner().resolve(name).to_string();
                 let call_args = cfg.get_call_args(*args_start, *args_len).to_vec();
@@ -2423,16 +2437,29 @@ impl<'a> Interp<'a> {
                     .map(|arg| cfg.get_inst(arg.value).ty)
                     .collect();
                 let arg_modes: Vec<CfgArgMode> = call_args.iter().map(|arg| arg.mode).collect();
-                let is_string_builtin =
-                    self.preflight_string_builtin(&fname, &arg_types, &arg_modes, ty)?;
-                let missing_call_kind = if !is_string_builtin && self.find_cfg(&fname).is_none() {
+                let is_string_builtin = if let Some(runtime) = runtime {
+                    self.preflight_string_builtin(*runtime, &arg_types, &arg_modes, ty)?
+                } else {
+                    false
+                };
+                let missing_call_kind = if !is_string_builtin && runtime.is_some() {
                     let kind = self.classify_unsupported_runtime_call_static(
-                        &fname, &arg_types, &arg_modes, ty,
+                        runtime.expect("checked above"),
+                        &arg_types,
+                        &arg_modes,
+                        ty,
                     );
                     if kind.model_gap().is_none() {
                         return Err(unsupported(kind, format!("call to '{fname}'")));
                     }
                     Some(kind)
+                } else if !is_string_builtin && self.find_cfg(&fname).is_none() {
+                    return Err(unsupported(
+                        UnsupportedKind::ContractViolation(
+                            ContractViolationKind::MissingFunctionBody,
+                        ),
+                        format!("call to '{fname}'"),
+                    ));
                 } else {
                     None
                 };
@@ -2469,12 +2496,22 @@ impl<'a> Interp<'a> {
                 }
                 // Builtin String methods have no CFG body; dispatch them here.
                 if is_string_builtin {
-                    self.string_builtin(&fname, &argvals, &arg_types, &arg_modes, ty)?
-                        .expect("preflight recognized this String builtin")
+                    self.string_builtin(
+                        runtime.expect("typed runtime string builtin"),
+                        &argvals,
+                        &arg_types,
+                        &arg_modes,
+                        ty,
+                    )?
+                    .expect("preflight recognized this String builtin")
                 } else if missing_call_kind.is_some() {
                     return Err(unsupported(
                         self.classify_unsupported_runtime_call(
-                            &fname, &argvals, &arg_types, &arg_modes, ty,
+                            runtime.expect("typed unsupported runtime call"),
+                            &argvals,
+                            &arg_types,
+                            &arg_modes,
+                            ty,
                         ),
                         format!("call to '{fname}'"),
                     ));

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -468,20 +468,24 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
 fn every_known_missing_runtime_call_has_a_closed_kind() {
     use UnsupportedRuntimeCallKind as RuntimeCall;
 
-    for (name, expected) in [
-        ("__rue_print", RuntimeCall::Print),
-        ("__rue_println", RuntimeCall::Println),
-        ("__rue_str_print", RuntimeCall::Print),
-        ("__rue_str_println", RuntimeCall::Println),
+    for (kind, expected) in [
+        (RuntimeCallKind::StrPrintAggregate, RuntimeCall::Print),
+        (RuntimeCallKind::StrPrintProjected, RuntimeCall::Print),
+        (RuntimeCallKind::StrPrintlnAggregate, RuntimeCall::Println),
+        (RuntimeCallKind::StrPrintlnProjected, RuntimeCall::Println),
     ] {
         assert_eq!(
-            unsupported_runtime_call_kind(name),
+            unsupported_runtime_call_kind(kind),
             Some(expected),
-            "{name}"
+            "{kind:?}"
         );
     }
-    for name in ["__rue_str_eq", "user_function", "new_runtime_helper"] {
-        assert_eq!(unsupported_runtime_call_kind(name), None, "{name}");
+    for kind in [
+        RuntimeCallKind::StrByteAt,
+        RuntimeCallKind::DebugI64,
+        RuntimeCallKind::AllocBytes,
+    ] {
+        assert_eq!(unsupported_runtime_call_kind(kind), None, "{kind:?}");
     }
 }
 

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -67,19 +67,20 @@ fn stable_text_runtime_calls_require_exact_metadata() {
         budget: STEP_BUDGET,
         depth: 0,
     };
-    for (name, kind) in [
-        ("__rue_str_print", RuntimeCall::Print),
-        ("__rue_str_println", RuntimeCall::Println),
+    for (runtime, kind) in [
+        (RuntimeCallKind::StrPrintAggregate, RuntimeCall::Print),
+        (RuntimeCallKind::StrPrintlnAggregate, RuntimeCall::Println),
     ] {
+        let name = runtime.helper().symbol();
         let (types, modes, result) = find_call_metadata(&state, name);
         let values = [Value::str_view("x")];
         assert_eq!(
-            interp.classify_unsupported_runtime_call(name, &values, &types, &modes, result),
+            interp.classify_unsupported_runtime_call(runtime, &values, &types, &modes, result),
             UnsupportedKind::SemanticGap(Semantic::RuntimeCall(kind))
         );
         for values in [&[][..], &[Value::str_view("x"), Value::str_view("y")][..]] {
             assert_eq!(
-                interp.classify_unsupported_runtime_call(name, values, &types, &modes, result),
+                interp.classify_unsupported_runtime_call(runtime, values, &types, &modes, result),
                 UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallArity)
             );
         }
@@ -92,17 +93,23 @@ fn stable_text_runtime_calls_require_exact_metadata() {
             (&types[..], &[][..]),
         ] {
             assert_eq!(
-                interp.classify_unsupported_runtime_call(name, &values, types, modes, result),
+                interp.classify_unsupported_runtime_call(runtime, &values, types, modes, result),
                 UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallArity)
             );
         }
         assert_eq!(
-            interp.classify_unsupported_runtime_call(name, &values, &[Type::BOOL], &modes, result,),
+            interp.classify_unsupported_runtime_call(
+                runtime,
+                &values,
+                &[Type::BOOL],
+                &modes,
+                result,
+            ),
             UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature)
         );
         assert_eq!(
             interp.classify_unsupported_runtime_call(
-                name,
+                runtime,
                 &values,
                 &types,
                 &[CfgArgMode::Borrow],
@@ -112,7 +119,7 @@ fn stable_text_runtime_calls_require_exact_metadata() {
         );
         assert_eq!(
             interp.classify_unsupported_runtime_call(
-                name,
+                runtime,
                 &[Value::Int(0)],
                 &types,
                 &modes,
@@ -121,17 +128,17 @@ fn stable_text_runtime_calls_require_exact_metadata() {
             UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature)
         );
         assert_eq!(
-            interp.classify_unsupported_runtime_call(name, &values, &types, &modes, Type::BOOL),
+            interp.classify_unsupported_runtime_call(runtime, &values, &types, &modes, Type::BOOL,),
             UnsupportedKind::ContractViolation(ContractViolationKind::RuntimeCallSignature)
         );
     }
-    for name in [
-        "__rue_str_eq",
-        "__rue_fn_user_function",
-        "__rue_new_runtime_helper",
+    for runtime in [
+        RuntimeCallKind::StrByteAt,
+        RuntimeCallKind::DebugI64,
+        RuntimeCallKind::AllocBytes,
     ] {
         assert_eq!(
-            interp.classify_unsupported_runtime_call(name, &[], &[], &[], Type::UNIT),
+            interp.classify_unsupported_runtime_call(runtime, &[], &[], &[], Type::UNIT),
             UnsupportedKind::ContractViolation(ContractViolationKind::MissingFunctionBody)
         );
     }
@@ -238,7 +245,7 @@ fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
 
     assert_eq!(
         expect_modeled_value(interp.string_builtin(
-            "__rue_str_char_scalar",
+            RuntimeCallKind::StrCharScalar,
             &args,
             &types,
             &modes,
@@ -248,7 +255,7 @@ fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
     );
     assert_eq!(
         expect_modeled_value(interp.string_builtin(
-            "__rue_str_char_next",
+            RuntimeCallKind::StrCharNext,
             &args,
             &types,
             &modes,
@@ -264,7 +271,7 @@ fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
     ];
     assert_eq!(
         expect_modeled_value(interp.string_builtin(
-            "__rue_str_char_scalar_lossy",
+            RuntimeCallKind::StrCharScalarLossy,
             &invalid,
             &types,
             &modes,
@@ -272,13 +279,19 @@ fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
         )),
         Some(Value::Int('\u{fffd}' as i128))
     );
-    match interp.string_builtin("__rue_str_char_scalar", &invalid, &types, &modes, Type::U32) {
+    match interp.string_builtin(
+        RuntimeCallKind::StrCharScalar,
+        &invalid,
+        &types,
+        &modes,
+        Type::U32,
+    ) {
         Err(Flow::Panic(panic)) => assert_eq!(panic.kind, TrapKind::InvalidUtf8),
         _ => panic!("strict invalid UTF-8 must trap"),
     }
 
     let arity = expect_flow_unsupported(interp.string_builtin(
-        "__rue_str_char_scalar",
+        RuntimeCallKind::StrCharScalar,
         &args[..2],
         &types[..2],
         &modes[..2],
@@ -290,7 +303,7 @@ fn shared_str_character_builtins_require_and_model_ptr_len_offset() {
     );
     let wrong_types = [Type::U64, Type::U64, Type::U64];
     let signature = expect_flow_unsupported(interp.string_builtin(
-        "__rue_str_char_scalar",
+        RuntimeCallKind::StrCharScalar,
         &args,
         &wrong_types,
         &modes,

--- a/docs/designs/0055-typed-runtime-abi-manifest.md
+++ b/docs/designs/0055-typed-runtime-abi-manifest.md
@@ -1,12 +1,12 @@
 ---
 id: 0055
 title: Typed compiler-runtime ABI manifest
-status: accepted
+status: implemented
 tags: [architecture, compiler, runtime, abi, codegen]
 feature-flag: null
 created: 2026-07-16
 accepted: 2026-07-16
-implemented:
+implemented: 2026-07-16
 spec-sections: []
 superseded-by:
 relates: ["RUE-355", "RUE-629", "RUE-738", "RUE-783", "RUE-826", "RUE-827", "RUE-828", "RUE-829", "RUE-830", "RUE-831", "RUE-832", "RUE-833", "RUE-834"]
@@ -16,24 +16,24 @@ relates: ["RUE-355", "RUE-629", "RUE-738", "RUE-783", "RUE-826", "RUE-827", "RUE
 
 ## Status
 
-Accepted as the M4 typed-runtime-ABI design by RUE-826 on 2026-07-16.
-This is a design-only increment. It authorizes the dependency-ordered
-implementation slices below and does not itself add or migrate a runtime
-helper.
+Implemented by the M4 typed-runtime-ABI milestone on 2026-07-16. The canonical
+manifest, typed compiler identities, shared call planning, runtime conformance,
+strict embedded-archive validation, and production-source inventory guard are
+all enforced in the current tree.
 
 ## Summary
 
-Rue will define the compiler/runtime boundary once in a dependency-light
-`rue-runtime-abi` crate. An exhaustive `RuntimeHelperId` will identify every
-compiler-callable runtime helper. A typed manifest entry will provide its
+Rue defines the compiler/runtime boundary once in a dependency-light
+`rue-runtime-abi` crate. An exhaustive `RuntimeHelperId` identifies every
+compiler-callable runtime helper. A typed manifest entry provides its
 exported symbol, ordered parameters, explicit out-pointer or scalar return
 shape, safety contract, return behavior, target availability, and calling
 convention.
 
-Compiler phases will carry helper IDs and consume manifest signatures. Raw
-symbol strings will be produced only at display, object, archive, and link
-boundaries. Runtime exports will prove their Rust `extern "C"` types against
-the same manifest, and embedded archives will be checked against its required
+Compiler phases carry helper IDs and consume manifest signatures. Raw
+symbol strings are produced only at display, object, archive, and link
+boundaries. Runtime exports prove their Rust `extern "C"` types against
+the same manifest, and embedded archives are checked against its required
 exports before compiler publication.
 
 Entry points, compiler-built memory routines, runtime-private functions,
@@ -42,8 +42,8 @@ runtime helpers. They remain explicit, separately validated export classes.
 
 ## Context
 
-The current compiler/runtime contract is distributed across independent
-sources:
+Before this decision was implemented, the compiler/runtime contract was
+distributed across independent sources:
 
 - `rue-builtins` publishes raw `runtime_fn: &str`-style constants and prose
   signatures;
@@ -57,10 +57,9 @@ sources:
 - `docs/runtime-abi.md` restates signatures manually and is already stale
   relative to the source.
 
-The archive smoke test proves that an archive parses and is nonempty. It does
-not prove that every helper the compiler may call exists, that a symbol occurs
-once, that it is available for the selected target, or that the Rust function
-type agrees with the compiler's argument and return plan.
+The former archive smoke test proved only that an archive parsed and was
+nonempty. It did not prove complete, unique, target-correct exports or agreement
+between Rust function types and compiler call plans.
 
 This duplication permits three failure classes:
 
@@ -77,58 +76,30 @@ an exhaustive helper ID.
 
 ## Current ABI inventory and disposition
 
-The following table is the accepted callable-helper inventory. RUE-828 must
-create one `RuntimeHelperId` per exported helper symbol listed and preserve the
-current ABI until a separate semantic change is accepted.
+The live inventory is typed data in `crates/rue-runtime-abi`, not a table in
+this ADR:
 
-| Helper group | Current exported symbols | Accepted typed disposition |
-| --- | --- | --- |
-| Process | `__rue_exit` | `Exit`; one `i32` value parameter; never returns |
-| Allocation | `__rue_alloc`, `__rue_free`, `__rue_realloc` | `Alloc`, `Free`, `Realloc`; explicit byte counts, alignment, and mutable-pointer modes |
-| Arithmetic traps | `__rue_div_by_zero`, `__rue_overflow`, `__rue_intcast_overflow`, `__rue_bounds_check` | Four zero-parameter, never-returning helpers |
-| Panic/assert | `__rue_panic`, `__rue_panic_no_msg`, `__rue_assert_failed` | Message pointer/length where present; never returns |
-| Debug | `__rue_dbg_i64`, `__rue_dbg_u64`, `__rue_dbg_bool`, `__rue_dbg_str` | Signed, unsigned, canonical boolean-word, and text-view helpers |
-| Text comparison/indexing | `__rue_str_eq`, `__rue_str_byte_at` | Packed text-view inputs; full-width scalar returns |
-| Strict character iteration | `__rue_str_char_scalar`, `__rue_str_char_next` | Packed text view plus byte offset; full-width `u64` return carrying the scalar or next offset |
-| Lossy character iteration | `__rue_str_char_scalar_lossy`, `__rue_str_char_next_lossy` | Same physical inputs; explicit distinct helper IDs |
-| Formatting | `__rue_to_string`, `__rue_to_string_unsigned` | Explicit `StrBufResult` out pointer followed by `i64` or `u64` |
-| Owned-text I/O | `__rue_print`, `__rue_println` | Borrowed three-slot `StrBuf` representation |
-| Text-view I/O | `__rue_str_print`, `__rue_str_println` | Packed pointer/length view |
-| Input | `__rue_read_line` | Explicit `OptionStrBufResult` out pointer plus concrete `Some`/`None` discriminants |
-| Parsing | `__rue_parse_i32`, `__rue_parse_i64`, `__rue_parse_u32`, `__rue_parse_u64` | Explicit option-result out pointer, text view, and concrete discriminants |
-| Randomness | `__rue_random_u32`, `__rue_random_u64` | Zero parameters with exact scalar return width |
-| UTF-8 trap | `__rue_invalid_utf8` | Callable trap helper used by runtime objects today; zero parameters and never returns |
+- `RuntimeHelperId::ALL` and `RuntimeHelperId::helper()` enumerate callable
+  helpers and expose their canonical signatures and contracts;
+- `ReservedExportId::ALL` and `ReservedExportId::export()` enumerate entry
+  points, compiler-built memory routines, platform shims, and the ABI marker;
+- `AggregateShapeId::ALL` owns explicit result-storage layouts; and
+- `RUNTIME_ABI_VERSION` and `RUNTIME_ABI_VERSION_SYMBOL` own lockstep version
+  metadata.
 
-`__rue_invalid_utf8` is a normal callable helper even though its current caller
-is another runtime object rather than generated program code. Giving it the
-same typed identity lets archive selection, conformance, and any future
-compiler mapping consume one contract.
-
-The following names are deliberately outside `RuntimeHelperId`:
-
-| Export class | Names or pattern | Owner and validation |
-| --- | --- | --- |
-| Program entry | `_start`, `_main` | Target runtime and linker entry policy |
-| Platform startup/signal exports | `__rue_x86_64_linux_start`, `__rue_rt_sigreturn` | Target runtime implementation; target-specific archive export allowlist |
-| Internal runtime callbacks | `__rue_stack_overflow_handler` | Rust function-type conformance only; this is not an unmangled archive ABI symbol |
-| Compiler-built memory | `memcpy`, `memmove`, `memset`, `memcmp`, `bcmp` | Rust compiler lowering contract; typed separately from Rue helpers |
-| Runtime-private functions | UTF-8 decoder helpers and ordinary private Rust functions | Not exported; ordinary Rust checking |
-| Compiler-generated Rue symbols | `__rue_fn_*`, `__rue_drop_*`, `__rue_drop_array_*` | Compiler symbol mangling and drop-glue ownership |
-| Compiler-internal intrinsics | `__rue_iter_len`, `__rue_char_scalar`, `__rue_char_next`, and lossy variants | Typed RIR identity owned by RUE-827, never an exported ABI symbol |
-
-New intentionally externally visible global names must enter one of these
-classes. An unclassified externally visible export is an error rather than an
-implicit helper; ordinary mangled Rust implementation symbols are not part of
-this inventory.
+Runtime-private functions, internal callbacks, compiler-generated Rue symbols,
+and compiler-internal intrinsics are not callable runtime helpers. Each carries
+its own typed or mangled identity in its owning subsystem. An unclassified
+externally visible reserved export is an archive-validation error.
 
 ## Decision
 
 ### A dependency-light Rust manifest crate
 
-RUE-828 will add a leaf crate named `rue-runtime-abi`. It must support `no_std`,
-perform no allocation or initialization, and depend on no compiler IR, semantic
+`rue-runtime-abi` is a leaf `no_std` crate. It performs no allocation or
+initialization and depends on no compiler IR, semantic
 type pool, codegen, linker, or runtime implementation crate. `rue-builtins`,
-`rue-air`, `rue-cfg`, `rue-codegen`, `rue-compiler`, and `rue-runtime` may
+`rue-air`, `rue-cfg`, `rue-codegen`, `rue-compiler`, and `rue-runtime`
 depend on it.
 
 The canonical data is ordinary Rust declarations and `const` tables. A build
@@ -218,14 +189,9 @@ The manifest does not own:
 Existing shared call planning remains the canonical physical assignment path.
 It consumes a manifest signature plus materialized operands. Target adapters
 derive registers, stack locations, and caller-saved clobbers from
-`TargetC`; per-helper register lists are forbidden unless a future helper uses
-a genuinely different convention.
-
-Widths and extension are explicit at the boundary. In particular,
-`__rue_dbg_bool` currently consumes an `i64` word, `__rue_str_eq` returns a
-full-width `u64`, both character-scalar helpers return `u64` even though sema
-exposes a `u32` source value, and `__rue_random_u32` returns `u32`. Consumers
-may not infer these facts from a Rue semantic type or a symbol name.
+`TargetC`; per-helper register lists are forbidden unless a helper uses a
+genuinely different convention. Width and extension are explicit manifest
+facts and are never inferred from a Rue semantic type or symbol name.
 
 ### Safety and checked requirements
 
@@ -239,9 +205,9 @@ Each helper declares a `SafetyContract` sufficient to distinguish:
 - unconditional trap/termination.
 
 This metadata is a compiler/runtime invariant and diagnostic aid, not a new
-source-language effect system. RUE-830 validates compiler-constructed operands
-against the manifest's types and modes. RUE-832 checks whether the Rust export
-is `unsafe extern "C"` whenever raw-pointer validity is a caller obligation.
+source-language effect system. AIR validates compiler-constructed operands
+against the manifest's types and modes. Runtime conformance requires
+`unsafe extern "C"` whenever raw-pointer validity is a caller obligation.
 
 ### Target availability and shims
 
@@ -251,18 +217,17 @@ availability explicitly so a later target-specific helper cannot silently
 appear universal.
 
 Entry points, signal trampolines, startup functions, and compiler-built memory
-routines use separate typed/allowlisted export records. They are checked by
-RUE-832 and RUE-833 but cannot be selected as `RuntimeHelperId`.
+routines use separate typed export records. Runtime conformance and archive
+validation check them, but they cannot be selected as `RuntimeHelperId`.
 
 ### Runtime conformance
 
-RUE-832 will make each Rust export prove its function type against the manifest
-at compile time. The implementation may use manifest-generated function-pointer
-assertions or macros that declare both the manifest row and the typed assertion.
-Source-text parsing is not sufficient because it cannot reliably prove
+Each Rust export proves its function type against the manifest at compile time.
+Manifest-generated wrappers and function-pointer assertions share the same row.
+Source-text parsing is not part of this contract because it cannot prove
 parameter order, result type, cfg applicability, or a single implementation.
 
-For each target, conformance must prove:
+For each target, conformance proves:
 
 1. every applicable helper has exactly one implementation;
 2. the declaration macro or wrapper owns the expected unmangled export
@@ -271,7 +236,7 @@ For each target, conformance must prove:
 4. pointer-bearing exports have the required unsafe contract; and
 5. separately classified shims satisfy their own typed record.
 
-RUE-833 independently inspects every embedded archive. Compile-time type
+The compiler independently inspects every embedded archive. Compile-time type
 assertions/declaration ownership and archive symbol validation are
 complementary: the former proves Rust types and the intended export spelling,
 while the latter proves the artifact actually contains that spelling.
@@ -286,64 +251,63 @@ change increments it.
 Each runtime archive exports one metadata object symbol named
 `__rue_runtime_abi_vN`, where `N` is the decimal manifest version. It is an
 unmangled, retained, one-byte read-only static whose value is zero; the version
-is encoded only in the symbol name, so archive validation need not interpret
-target object data. It is not callable and is not a `RuntimeHelperId`.
+is encoded only in the symbol name. Archive validation checks that the data
+byte is the zero sentinel, not a version payload. It is not callable and is not
+a `RuntimeHelperId`.
 
 Object readers compare normalized linker names: Mach-O's platform-added leading
 underscore is removed in the same way as other parsed symbols before matching.
-RUE-833 requires exactly the expected marker, rejects any other
+Archive validation requires exactly the expected marker, rejects any other
 `__rue_runtime_abi_v*` marker, and rejects multiple definitions before compiler
-publication. During M4, changing the manifest and runtime implementation in the
-same repository is allowed; compatibility across released compiler/runtime
-pairs is not promised.
+publication. Compiler/runtime compatibility across released revisions is not
+promised.
 
 ### Documentation
 
-`docs/runtime-abi.md` becomes a consumer of the canonical classification. Where
-practical, tables are generated or verified from manifest data. Handwritten
-sections may explain target calling conventions and invariants but may not
-restate an unverified peer signature table. RUE-834 removes current stale
-signature declarations.
+`docs/runtime-abi.md` consumes the canonical classification. Handwritten
+sections explain target calling conventions and invariants but do not restate
+an unverified peer signature table.
 
-## Implementation slices and dependencies
+## Implementation record
 
 | Issue | Scope | Dependency |
 | --- | --- | --- |
-| RUE-827 — Replace compiler-internal intrinsic strings with a typed enum | Add exhaustive RIR identity; make desugaring produce it and inference/sema consume it; prevent source-name collision. This is compiler identity cleanup, not a runtime-helper implementation. | RUE-826 |
-| RUE-828 — Add canonical runtime helper IDs and typed signatures | Add `rue-runtime-abi`, the complete helper and ABI-version metadata, validation, display, and representative non-migrating consumers. | RUE-826 |
-| RUE-829 — Migrate builtin runtime mappings | Replace builtin raw helper names and signature restatements with typed mappings. | RUE-828 |
-| RUE-830 — Migrate directly lowered semantic calls | Build AIR calls from manifest records, validate operands, and preserve typed helper identity through AIR-to-CFG lowering. | RUE-828 |
-| RUE-831 — Migrate runtime helper emission | Consume typed CFG helper calls in shared call planning and both target backends; convert to symbols only at MIR relocation/display boundaries. | RUE-828 |
-| RUE-832 — Add runtime-side conformance | Prove Rust export types and exactly one applicable implementation on every target, own export attributes, and emit the target archive's ABI-version marker. | RUE-828 |
-| RUE-833 — Validate embedded runtime exports | Inspect every target archive for required, duplicate, stale, and wrong-target exports and ABI version. | RUE-829, RUE-830, RUE-831, RUE-832 |
-| RUE-834 — Remove remaining raw literals | Restrict string conversion to boundaries, add an inventory guard, update documentation, and run the full ABI/cross-target matrix. | RUE-827, RUE-833 |
+| RUE-827 — Replace compiler-internal intrinsic strings with a typed enum | Added exhaustive RIR identity; desugaring produces it and inference/sema consume it; source-name collision is rejected. | RUE-826 |
+| RUE-828 — Add canonical runtime helper IDs and typed signatures | Added `rue-runtime-abi`, complete helper and ABI-version metadata, validation, and display. | RUE-826 |
+| RUE-829 — Migrate builtin runtime mappings | Replaced builtin raw helper names and signature restatements with typed mappings. | RUE-828 |
+| RUE-830 — Migrate directly lowered semantic calls | AIR calls use manifest records, validate operands, and preserve typed helper identity through AIR-to-CFG lowering. | RUE-828 |
+| RUE-831 — Migrate runtime helper emission | Shared call planning and both target backends consume typed CFG helper calls; symbols appear only at MIR relocation/display boundaries. | RUE-828 |
+| RUE-832 — Add runtime-side conformance | Rust exports prove their types, own export attributes, and emit the target archive's ABI-version marker. | RUE-828 |
+| RUE-833 — Validate embedded runtime exports | Every embedded target archive is checked for required, duplicate, stale, and wrong-target exports and ABI version. | RUE-829, RUE-830, RUE-831, RUE-832 |
+| RUE-834 — Remove remaining raw literals | String conversion is boundary-only; the inventory guard and current architecture documentation are repository gates. | RUE-827, RUE-833 |
 
-RUE-827 and RUE-828 may proceed in parallel after this decision. RUE-829
-through RUE-832 may proceed in parallel after RUE-828. RUE-833 is the
-convergence check, and RUE-834 is the final cleanup.
+The slices were delivered in dependency order: RUE-827 and RUE-828 established
+typed identities; RUE-829 through RUE-832 migrated consumers and runtime
+definitions; RUE-833 added artifact validation; and RUE-834 completed the
+inventory and documentation cleanup.
 
-No slice may redesign Rue's source semantics, native ABI, aggregate layout, or
-target matrix as a convenience. A discovered ABI disagreement is a bug to fix
-or a separately accepted change, not an opportunity to make the manifest match
-one accidental consumer.
+The implemented contract does not redesign Rue's source semantics, native ABI,
+aggregate layout, or target matrix. An ABI disagreement is a bug or a
+separately accepted change, not a reason to make the manifest match one
+accidental consumer.
 
 ## Validation obligations
 
-The M4 implementation must include:
+The repository enforces:
 
 - manifest uniqueness, exhaustive lookup, and aggregate-shape tests;
 - focused builtin, intrinsic, semantic-call, call-plan, and cross-backend tests;
 - compile-time runtime signature checks for all three targets;
 - mutated archive tests for missing, duplicate, stale-version, misspelled, and
   wrong-target exports, parameterized by the expected target;
-- native x86-64 and AArch64 runtime/CLI execution;
+- native runtime/CLI execution on supported CI hosts;
 - cross-target lowering, assembly, and object validation; native archive
   validation in each of the three target CI jobs; and
 - a final production-source inventory that forbids raw helper literals outside
   canonical tables, runtime definitions, display/link boundaries, and tests.
 
-The generated-oracle isolation rule and the full-suite serialization rule in
-`AGENTS.md` apply. Passing host execution alone is not sufficient evidence.
+The generated-oracle isolation rule and full-suite serialization rule in
+`AGENTS.md` apply. Host execution alone is not sufficient evidence.
 M4 does not embed all target runtime archives into one compiler or enable
 foreign-target executable linking. Each compiler build continues to embed and
 validate its target-matching runtime archive; the three native CI jobs
@@ -365,12 +329,10 @@ cross-target executable linking remain owned by RUE-600 and M9.
 
 ### Negative
 
-- The new leaf crate and conformance machinery add deliberate structure around
-  a currently informal boundary.
-- Every helper addition or incompatible change must update the manifest,
+- The leaf crate and conformance machinery add deliberate structure around the
+  compiler/runtime boundary.
+- Every helper addition or incompatible change updates the manifest,
   implementation, validation, and ABI version together.
-- Migrating existing raw-string paths touches several compiler phases and both
-  backends, requiring staged PRs and cross-target CI.
 
 ### Neutral
 
@@ -383,14 +345,13 @@ cross-target executable linking remain owned by RUE-600 and M9.
 ### Keep `docs/runtime-abi.md` as the contract
 
 Prose is useful explanation but cannot enforce Rust function types, archive
-contents, exhaustive compiler mappings, or target availability. The current
-document has already drifted from implementation.
+contents, exhaustive compiler mappings, or target availability.
 
 ### Generate the manifest by parsing runtime Rust source
 
 Source parsing duplicates Rust's type system, is cfg-fragile, and cannot prove
 that compiler call construction consumes the same data. Runtime declarations
-must instead type-check against explicit shared Rust data.
+instead type-check against explicit shared Rust data.
 
 ### Use exported symbols as IDs
 

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -215,5 +215,5 @@ The table is generated from ADR frontmatter. Run
 | [0051](0051-canonical-import-resolution-authority.md) | CanonicalImportGraph as the sole import-resolution authority | Accepted | architecture, compiler, modules, incremental, tooling |
 | [0052](0052-canonical-physical-type-layout.md) | Canonical Physical Type Layout | Proposal | types, semantics, compiler, codegen, abi, memory |
 | [0053](0053-typed-compiler-query-state.md) | Typed CompilerSession query state | Accepted | architecture, compiler, incremental, tooling |
-| [0055](0055-typed-runtime-abi-manifest.md) | Typed compiler-runtime ABI manifest | Accepted | architecture, compiler, runtime, abi, codegen |
+| [0055](0055-typed-runtime-abi-manifest.md) | Typed compiler-runtime ABI manifest | Implemented | architecture, compiler, runtime, abi, codegen |
 <!-- ADR-INDEX:END -->

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -1,535 +1,153 @@
-# Runtime ABI Specification
-
-This document describes the Application Binary Interface (ABI) between the Rue compiler and the `rue-runtime` library. It defines the contract that allows compiler-generated machine code to call runtime functions for operations that cannot be efficiently or safely inlined.
-
-## Overview
-
-The Rue compiler generates machine code that directly calls functions in the `rue-runtime` static library (`.a` file). The runtime provides:
-
-- **Process management**: Program entry/exit
-- **Memory allocation**: Heap allocation for source-defined dynamic types
-- **Runtime checks**: Division by zero, integer overflow detection
-- **Core operations**: `str` views, I/O, formatting, and debugging output
-- **Process and trap support**: entry points, exits, and fail-fast diagnostics
-
-The runtime is compiled as `#![no_std]` with no libc dependency, using direct OS syscalls.
-
-## Calling Conventions
-
-All runtime functions use the standard C calling convention (`extern "C"`) for the target platform.
-
-### x86-64 Linux (System V AMD64 ABI)
-
-| Purpose | Register |
-|---------|----------|
-| 1st argument | `rdi` |
-| 2nd argument | `rsi` |
-| 3rd argument | `rdx` |
-| 4th argument | `rcx` |
-| 5th argument | `r8` |
-| 6th argument | `r9` |
-| 7th+ arguments | Stack (right-to-left) |
-| Return value | `rax` |
-| Return value (128-bit) | `rax:rdx` |
-
-**Register preservation:**
-- **Caller-saved**: `rax`, `rcx`, `rdx`, `rsi`, `rdi`, `r8`, `r9`, `r10`, `r11`
-  - The caller must save these if their values are needed after the call
-- **Callee-saved**: `rbx`, `rbp`, `r12`, `r13`, `r14`, `r15`
-  - The callee (runtime function) must preserve these
-- **Special**: `rsp` (stack pointer) must be preserved, 16-byte aligned before `call`
-
-**Syscall clobbers**: Linux syscalls clobber `rcx` and `r11` in addition to the return register.
-
-### aarch64 macOS and Linux (ARM64 Procedure Call Standard)
-
-| Purpose | Register |
-|---------|----------|
-| 1st argument | `x0` (or `w0` for 32-bit) |
-| 2nd argument | `x1` (or `w1` for 32-bit) |
-| 3rd argument | `x2` (or `w2` for 32-bit) |
-| 4th argument | `x3` (or `w3` for 32-bit) |
-| 5th argument | `x4` |
-| 6th argument | `x5` |
-| 7th argument | `x6` |
-| 8th argument | `x7` |
-| 9th+ arguments | Stack |
-| Return value | `x0` (or `w0` for 32-bit) |
-
-**Register preservation:**
-- **Caller-saved**: `x0-x18`, `x29`, `x30`
-  - The caller must save these if needed after the call
-- **Callee-saved**: `x19-x28`
-  - The callee must preserve these
-- **Special**:
-  - `x29` (frame pointer)
-  - `x30` (link register)
-  - `sp` (stack pointer) must be 16-byte aligned
-
-**Platform differences:**
-- macOS syscalls use different numbers than Linux (e.g., `write` is `0x2000004` on macOS, `64` on Linux aarch64)
-- macOS requires different `mmap` flags for executable memory
-
-## Struct Return Convention (sret)
-
-Runtime functions that return aggregate values use a caller-allocated result
-buffer passed as the first argument. For example, `__rue_to_string` writes the
-three `StrBuf` fields through a `StrBufResult*`; `__rue_read_line` writes
-the four slots of `Option(StrBuf)` through an `OptionStrBufResult*`.
-
-On x86-64 the explicit result pointer is the first C argument (`rdi`). On
-AArch64 it is `x0`, because these runtime functions use an explicit pointer
-parameter rather than the platform's implicit aggregate-return register.
-
-## Memory Layout
-
-### Scalar Types
-
-| Type | Size | Alignment | Notes |
-|------|------|-----------|-------|
-| `i8` | 1 byte | 1 | Signed 8-bit integer |
-| `i16` | 2 bytes | 2 | Signed 16-bit integer |
-| `i32` | 4 bytes | 4 | Signed 32-bit integer |
-| `i64` | 8 bytes | 8 | Signed 64-bit integer |
-| `u8` | 1 byte | 1 | Unsigned 8-bit integer |
-| `u16` | 2 bytes | 2 | Unsigned 16-bit integer |
-| `u32` | 4 bytes | 4 | Unsigned 32-bit integer |
-| `u64` | 8 bytes | 8 | Unsigned 64-bit integer |
-| `bool` | 1 byte | 1 | 0 = false, 1 = true |
-| `()` (unit) | 0 bytes | 1 | Zero-sized type |
-
-### Text Types
-
-Core `str` is a non-owning packed-byte view `{ptr, len}`. Source-defined
-`std.strbuf.StrBuf` adds a capacity word:
-
-```c
-struct StrBufResult {
-    uint8_t* ptr;
-    uint64_t len;
-    uint64_t cap;
-};
-```
-
-A `cap` of zero denotes non-owning static storage. A positive capacity denotes
-an allocation owned by the source-defined `StrBuf` value. Its destructor and
-all growable-buffer algorithms live in `std/strbuf.rue`; they are not runtime
-ABI exports. Runtime producers such as integer formatting and line input use
-this same three-word result layout.
-
-### Arrays
-
-Fixed-size arrays are stored inline (not heap-allocated):
-
-```rust
-// Rue source:
-let arr: [i32; 4] = [1, 2, 3, 4];
-
-// Memory layout:
-// [1, 2, 3, 4]  // 16 consecutive bytes, 4-byte aligned
-```
-
-- **Size**: `element_size * length`
-- **Alignment**: Same as element type
-- **Storage**: Inline (stack or struct field)
-
-### Structs
-
-Structs are laid out with fields in declaration order, with padding for alignment:
-
-```rust
-// Rue source:
-struct Point {
-    x: i32,    // offset 0, size 4
-    y: i64,    // offset 8, size 8 (4 bytes padding before this)
-}
-
-// Memory layout: 16 bytes total, 8-byte aligned
-// [xxxx][----][yyyyyyyy]
-//  x    pad    y
-```
-
-**Rules:**
-- Fields appear in declaration order
-- Each field is aligned to its type's alignment
-- Padding is inserted to satisfy alignment requirements
-- The struct's size is rounded up to its alignment
-
-## Heap Allocation
-
-The runtime provides a simple bump allocator backed by `mmap`.
-
-### Allocation Interface
-
-```c
-// Allocate memory
-uint8_t* __rue_alloc(uint64_t size, uint64_t align);
-
-// Free memory (currently a no-op)
-void __rue_free(uint8_t* ptr, uint64_t size, uint64_t align);
-
-// Reallocate memory
-uint8_t* __rue_realloc(uint8_t* ptr, uint64_t old_size, uint64_t new_size, uint64_t align);
-```
-
-**Arguments:**
-- `size`: Number of bytes to allocate (must be > 0)
-- `align`: Required alignment in bytes (must be a power of 2)
-- `ptr`: Pointer to existing allocation (or null)
-- `old_size`: Size of existing allocation
-- `new_size`: Desired new size
-
-**Return values:**
-- `__rue_alloc`: Pointer to allocated memory (8-byte aligned, zero-initialized), or null on failure
-- `__rue_realloc`: Pointer to reallocated memory, or null on failure
-
-**Failure conditions:**
-- `size == 0` (for alloc)
-- `align == 0` or not a power of 2
-- Out of memory (mmap fails)
-
-**Implementation details:**
-- Memory is allocated in 64 KiB arenas from `mmap`
-- Allocations bump a pointer forward within the arena
-- `free` is a no-op (memory is reclaimed when the program exits)
-- `realloc` may return a new pointer and copy data
-
-## Runtime Function Reference
-
-### Program Entry and Exit
-
-#### `__rue_exit`
-```c
-void __rue_exit(int32_t code);
-```
-
-**Purpose**: Exit the program with the given exit code.
-
-**Arguments:**
-- `code` (in `edi`/`w0`): Exit code (typically the return value of `main`)
-
-**Behavior**: Invokes the `exit` syscall. Never returns.
-
-**Generated by**: Compiler-generated `_start` function after `main` returns.
-
-### Debug Output
-
-#### `__rue_print_i32`
-```c
-void __rue_print_i32(int32_t value);
-```
-
-**Purpose**: Print a signed 32-bit integer to stdout, followed by a newline.
-
-**Arguments:**
-- `value` (in `edi`/`w0`): The i32 value to print
-
-**Clobbers**: `rax`, `rcx`, `rdx`, `rsi`, `r8-r11` (x86-64)
-
-**Generated by**: The `@dbg` builtin for i32 values.
-
-#### `__rue_print_bool`
-```c
-void __rue_print_bool(uint8_t value);
-```
-
-**Purpose**: Print a boolean value (`true` or `false`) to stdout, followed by a newline.
-
-**Arguments:**
-- `value` (in `dil`/`w0`): 0 for false, 1 for true
-
-**Clobbers**: `rax`, `rcx`, `rdx`, `rsi`, `r8-r11` (x86-64)
-
-**Generated by**: The `@dbg` builtin for bool values.
-
-#### `__rue_print_str`
-```c
-void __rue_print_str(const uint8_t* ptr, uint64_t len);
-```
-
-**Purpose**: Print a string (pointer + length) to stdout, followed by a newline.
-
-**Arguments:**
-- `ptr` (in `rdi`/`x0`): Pointer to UTF-8 bytes
-- `len` (in `rsi`/`x1`): Number of bytes
-
-**Clobbers**: `rax`, `rcx`, `rdx`, `rsi`, `rdi`, `r8-r11` (x86-64)
-
-**Generated by**: The `@dbg` builtin for string literals and String values.
-
-### Runtime Errors
-
-#### `__rue_error_div_by_zero`
-```c
-void __rue_error_div_by_zero(void);
-```
-
-**Purpose**: Report a division by zero error and exit with code 101.
-
-**Generated by**: Integer division and remainder operations when the divisor is not a compile-time constant.
-
-**Behavior**: Prints `"runtime error: division by zero"` to stderr and exits.
-
-#### `__rue_error_overflow`
-```c
-void __rue_error_overflow(void);
-```
-
-**Purpose**: Report an integer overflow error and exit with code 101.
-
-**Generated by**: Checked arithmetic operations (add, sub, mul) that overflow.
-
-**Behavior**: Prints `"runtime error: integer overflow"` to stderr and exits.
-
-### Text Operations
-
-#### `__rue_str_eq`
-```c
-uint8_t __rue_str_eq(const uint8_t* ptr1, uint64_t len1, const uint8_t* ptr2, uint64_t len2);
-```
-
-**Purpose**: Compare two packed text views for byte equality.
-
-**Arguments:**
-- `ptr1` (in `rdi`/`x0`): Pointer to first string's bytes
-- `len1` (in `rsi`/`x1`): Length of first string
-- `ptr2` (in `rdx`/`x2`): Pointer to second string's bytes
-- `len2` (in `rcx`/`x3`): Length of second string
-
-**Return value**: 1 if equal, 0 if not equal (in `al`/`w0`)
-
-**Generated by**: Core `str` equality.
-
-**Algorithm:**
-1. Fast path: If lengths differ, return 0
-2. Fast path: If pointers are equal, return 1
-3. Slow path: Compare bytes one by one
-
-#### Core `str` indexing and iteration
-
-```c
-uint64_t __rue_str_byte_at(const uint8_t* ptr, uint64_t len, uint64_t index);
-uint64_t __rue_str_char_scalar(const uint8_t* ptr, uint64_t len, uint64_t offset);
-uint64_t __rue_str_char_next(const uint8_t* ptr, uint64_t len, uint64_t offset);
-uint64_t __rue_str_char_scalar_lossy(const uint8_t* ptr, uint64_t len, uint64_t offset);
-uint64_t __rue_str_char_next_lossy(const uint8_t* ptr, uint64_t len, uint64_t offset);
-```
-
-The byte helper bounds-checks and returns one packed byte. Strict scalar helpers
-trap on invalid UTF-8; lossy helpers substitute U+FFFD and advance by the
-maximal invalid subpart. Full-width returns keep the Rue scalar return register
-zero-extended.
-
-#### Integer formatting
-
-```c
-void __rue_to_string(StrBufResult* out, int64_t value);
-void __rue_to_string_unsigned(StrBufResult* out, uint64_t value);
-```
-
-These helpers allocate and write a canonical three-word `StrBuf` result. All
-other construction, mutation, query, search, concatenation, clone, and drop
-operations are source-defined in `std/strbuf.rue`.
-
-### I/O Operations
-
-#### `__rue_read_line`
-
-```c
-void __rue_read_line(
-    OptionStrBufResult* out,
-    uint64_t some_discriminant,
-    uint64_t none_discriminant
-);
-```
-
-Reads one line from stdin and writes `Option(StrBuf)` as four slots:
-`{discriminant, ptr, len, cap}`. EOF without bytes yields `None`; a partial
-line at EOF yields `Some`. The caller supplies the concrete enum
-discriminants.
-
-### Intrinsics
-
-#### `__rue_intrinsic_likely`
-```c
-uint8_t __rue_intrinsic_likely(uint8_t cond);
-```
-
-**Purpose**: Hint that a condition is likely to be true (branch prediction hint).
-
-**Arguments:**
-- `cond` (in `dil`/`w0`): Boolean condition (0 or 1)
-
-**Return value**: `cond` (unchanged, in `al`/`w0`)
-
-**Generated by**: `@likely(condition)` builtin
-
-**Behavior**: Identity function; the compiler uses this as a marker for branch prediction hints.
-
-#### `__rue_intrinsic_unlikely`
-```c
-uint8_t __rue_intrinsic_unlikely(uint8_t cond);
-```
-
-**Purpose**: Hint that a condition is unlikely to be true (branch prediction hint).
-
-**Arguments:**
-- `cond` (in `dil`/`w0`): Boolean condition (0 or 1)
-
-**Return value**: `cond` (unchanged, in `al`/`w0`)
-
-**Generated by**: `@unlikely(condition)` builtin
-
-**Behavior**: Identity function; the compiler uses this as a marker for branch prediction hints.
-
-#### `__rue_random_u64`
-```c
-uint64_t __rue_random_u64(void);
-```
-
-**Purpose**: Generate a random 64-bit unsigned integer.
-
-**Return value**: Random u64 value (in `rax`/`x0`)
-
-**Generated by**: `@random()` builtin
-
-**Behavior**: Uses platform-specific randomness source (e.g., `/dev/urandom` or `getrandom` syscall).
-
-#### `__rue_parse_i32`
-```c
-int32_t __rue_parse_i32(const uint8_t* ptr, uint64_t len, int32_t* success_out);
-```
-
-**Purpose**: Parse a string as an i32.
-
-**Arguments:**
-- `ptr` (in `rdi`/`x0`): Pointer to string bytes
-- `len` (in `rsi`/`x1`): String length
-- `success_out` (in `rdx`/`x2`): Pointer to output flag (writes 1 on success, 0 on failure)
-
-**Return value**: Parsed i32 value (in `eax`/`w0`), or 0 if parsing failed
-
-**Generated by**: `@parseInt(string)` builtin
-
-**Behavior**: Parses decimal integers with optional leading `+` or `-`. Sets `*success_out = 0` on invalid input or overflow.
-
-## Error Handling and Panics
-
-### Runtime Errors
-
-The runtime reports errors by printing a message to stderr and exiting with code 101:
-
-```
-runtime error: division by zero
-runtime error: integer overflow
-```
-
-### Panic Mechanism
-
-Currently, there is no stack unwinding. When a runtime error occurs:
-
-1. Error message is written to stderr (fd 2)
-2. Program calls `exit(101)` syscall
-3. Process terminates immediately
-
-### Exit Codes
-
-| Code | Meaning |
-|------|---------|
-| 0-100 | User-specified exit code from `main` |
-| 101 | Runtime error (overflow, division by zero, etc.) |
-| 102-255 | Reserved for future use |
-
-## Platform-Specific Details
+# Rue compiler/runtime ABI
+
+Rue emits machine code directly and links it with a target-matching
+`rue-runtime` archive. The compiler and runtime share one typed contract from
+`crates/rue-runtime-abi`; this document explains the architecture and the
+target rules without duplicating that contract's helper table.
+
+## Canonical contract
+
+`rue-runtime-abi` is the source of truth for:
+
+- every compiler-callable runtime helper and its exported symbol;
+- ordered C-boundary parameters, pointer modes, scalar results, and explicit
+  result-storage aggregates;
+- safety requirements, return behavior, target availability, and calling
+  convention;
+- separately classified entry points, compiler-built memory routines,
+  platform shims, and the retained ABI-version marker; and
+- the current lockstep ABI version.
+
+Compiler phases carry `RuntimeHelperId` and typed runtime-call adaptations.
+AIR and CFG do not discover runtime behavior from symbol strings. Shared call
+planning validates the manifest signature before the x86-64 or AArch64 backend
+assigns physical registers and stack locations. A helper symbol is materialized
+only at presentation and MIR relocation boundaries.
+
+The runtime's exported wrappers and compile-time Rust function-type assertions
+are generated from the same manifest rows. The runtime implementation remains
+free to organize private functions normally; only the generated C wrappers own
+the externally visible helper definitions.
+
+The exact current inventory is therefore read through:
+
+- `RuntimeHelperId::ALL` and `RuntimeHelperId::helper()` for callable helpers;
+- `ReservedExportId::ALL` and `ReservedExportId::export()` for other intentional
+  runtime exports; and
+- `RUNTIME_ABI_VERSION` / `RUNTIME_ABI_VERSION_SYMBOL` for version metadata.
+
+Handwritten code and documentation must not maintain a peer signature or
+export table.
+
+## Target C calling conventions
+
+All callable runtime helpers use the target C convention declared by the
+manifest.
 
 ### x86-64 Linux
 
-**Syscall numbers:**
-```c
-#define SYS_READ    0
-#define SYS_WRITE   1
-#define SYS_MMAP    9
-#define SYS_MUNMAP  11
-#define SYS_EXIT    60
-```
+The System V AMD64 convention supplies integer and pointer arguments in `rdi`,
+`rsi`, `rdx`, `rcx`, `r8`, and `r9`, then on the stack. Scalar results use
+`rax`. The stack is 16-byte aligned at a call boundary. `rbx`, `rbp`, and
+`r12`-`r15` are callee-saved; other ordinary argument/result registers are
+caller-saved.
 
-**Syscall convention:**
-- Number in `rax`
-- Args in `rdi`, `rsi`, `rdx`, `r10`, `r8`, `r9` (note: `r10` instead of `rcx`)
-- Return in `rax` (negative on error)
-- Clobbers `rcx`, `r11`
+Linux syscalls are a separate runtime-internal boundary: their number is in
+`rax`, arguments use `rdi`, `rsi`, `rdx`, `r10`, `r8`, and `r9`, and the
+instruction clobbers `rcx` and `r11`.
 
-**Stack alignment**: Must be 16-byte aligned before `call` instruction (enforced by System V ABI).
+### AArch64 Linux and macOS
 
-### aarch64 macOS
+The AArch64 procedure-call standard supplies the first eight integer and
+pointer arguments in `x0`-`x7` (or the corresponding `w` register for a
+32-bit scalar), then on the stack. Scalar results use `x0`/`w0`. The stack is
+16-byte aligned. `x19`-`x28` are callee-saved.
 
-**Syscall numbers:**
-```c
-#define SYS_READ    0x2000003
-#define SYS_WRITE   0x2000004
-#define SYS_MMAP    0x20000C5
-#define SYS_MUNMAP  0x2000049
-#define SYS_EXIT    0x2000001
-```
+Linux and macOS use different syscall conventions and numbers. Those details
+belong to the target-specific runtime modules and do not alter the compiler
+helper ABI.
 
-**Syscall convention:**
-- Number in `x16`
-- Args in `x0-x5`
-- Return in `x0` (negative on error)
-- Invoke with `svc #0x80`
+## Explicit aggregate result storage
 
-**Stack alignment**: Must be 16-byte aligned.
+Helpers that produce aggregate source values receive an explicit writable
+result pointer as their first ordinary C parameter. This is not an implicit
+platform aggregate-return convention.
 
-### aarch64 Linux
+The canonical `repr(C)` storage types live in `rue-runtime-abi`:
 
-**Syscall numbers:**
-```c
-#define SYS_READ    63
-#define SYS_WRITE   64
-#define SYS_MMAP    222
-#define SYS_MUNMAP  215
-#define SYS_EXIT    93
-```
+- `StrBufResult` stores `{ptr, len, cap}`;
+- `OptionStrBufResult` stores `{discriminant, ptr, len, cap}`; and
+- `OptionIntResult` stores `{discriminant, value}`.
 
-**Syscall convention:**
-- Number in `x8`
-- Args in `x0-x5`
-- Return in `x0` (negative on error)
-- Invoke with `svc #0`
+Compile-time size, alignment, and field-offset assertions protect these
+layouts. The manifest identifies the aggregate shape for each out pointer, and
+call planning materializes the concrete source-language discriminants where an
+option result requires them.
 
-**Stack alignment**: Must be 16-byte aligned.
+Core `str` remains a non-owning packed-byte view. `std.strbuf.StrBuf` is the
+source-defined growable string type. Its algorithms and destructor are ordinary
+Rue code, not runtime ABI exports.
 
-## Symbol Name Mangling
+## Safety and termination
 
-All runtime functions use C linkage and are exported with plain `__rue_*`
-names (except fixed platform entry points and compiler memory builtins).
-Growable-buffer methods and destructors are ordinary source-defined Rue
-functions and therefore use normal generated symbol mangling.
+Manifest pointer modes distinguish readable inputs, writable inputs, mutable
+allocation pointers, and aggregate result storage. The runtime wrapper is
+`unsafe extern "C"` whenever the caller must uphold pointer validity or layout
+preconditions; helpers with no caller-side pointer obligation can use a safe
+Rust boundary.
 
-## Linking
+The manifest also distinguishes returning helpers from traps and process
+termination. Rue does not unwind across this boundary. Runtime traps report the
+diagnostic and terminate the process with the runtime-error status.
 
-The runtime is compiled as a static library (`librue_runtime.a`) and linked into every Rue executable:
+## Export classes
 
-1. **Build**: `rue-runtime` is compiled with `-Copt-level=z` and LTO
-2. **Archive**: Object files are packaged into `librue_runtime.a` using `ar`
-3. **Link**: `rue-linker` extracts needed objects from the archive and links them into the final ELF/Mach-O executable
+The reserved `__rue_` namespace contains several deliberately distinct kinds
+of symbol:
 
-**Symbol resolution:**
-- The linker scans the archive for symbols referenced by the generated code
-- Only objects containing referenced symbols are included (dead code elimination)
-- The linker resolves relocations and produces a statically-linked executable
+- callable runtime helpers from `RuntimeHelperId`;
+- target startup and signal shims from `ReservedExportId`;
+- compiler-generated Rue functions and drop glue; and
+- compiler-internal intrinsic presentation names.
 
-## Future Extensions
+The prefix alone is not a runtime-helper identity. Entry points and
+compiler-built memory routines also have fixed non-prefixed exports and are
+classified by `ReservedExportId`.
 
-### Planned Features
+User declarations cannot use the reserved runtime/code-generation namespace or
+the separately classified fixed export names. The declaration check consumes
+the manifest classification rather than duplicating those names.
 
-- **Stack unwinding**: For better error recovery and resource cleanup
-- **Real garbage collection**: Replace bump allocator with a proper GC
-- **Thread support**: Multi-threaded runtime with thread-local allocators
-- **FFI**: Calling C libraries from Rue
+## Archive verification and linking
 
-### Stability Guarantees
+Each compiler build embeds the runtime archive for its own target. Before an
+archive can be used, the compiler parses its object members and validates the
+artifact against the typed manifest:
 
-This ABI is **unstable** and may change between compiler versions. Runtime and compiler must be built from the same version of the Rue codebase.
+- every target-applicable helper and reserved export is defined exactly once;
+- exports unavailable on that target are absent;
+- no unknown reserved export is present;
+- the retained read-only one-byte ABI marker has the exact current versioned
+  symbol and zero value; and
+- object architecture and symbol normalization match the selected target.
 
-When the language reaches v1.0, the runtime ABI will be stabilized and versioned.
+Synthetic mutation tests cover missing, duplicate, misspelled, stale-version,
+wrong-target, and malformed marker cases. Runtime compile-time conformance and
+archive inspection are complementary: one proves Rust types and intended
+exports, while the other proves the bytes that will actually be linked.
+
+The linker extracts required archive members, resolves relocations, and emits
+the final ELF or Mach-O executable. Mach-O's platform-added leading underscore
+is normalized at the object/archive boundary before manifest classification.
+
+## Versioning
+
+Compiler and runtime are lockstep components of one Rue revision. Any
+incompatible helper symbol, signature, mode, aggregate shape, safety contract,
+availability, or reserved-export change increments the manifest ABI version
+and therefore changes the required marker symbol.
+
+This contract is not a cross-release stable ABI. Cross-target executable
+linking and embedding every foreign runtime archive are separate target-support
+work; native CI for x86-64 Linux, AArch64 Linux, and AArch64 macOS collectively
+validates the supported runtime archives.

--- a/scripts/test-runtime-abi-inventory.py
+++ b/scripts/test-runtime-abi-inventory.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Focused tests for the production runtime ABI literal inventory gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-runtime-abi-inventory.py")
+SPEC = importlib.util.spec_from_file_location("runtime_abi_inventory", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+inventory = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(inventory)
+
+
+class InventoryTests(unittest.TestCase):
+    def validate(self, source: str, relative: str = "lib.rs") -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            src = Path(directory) / "materialized"
+            path = src / relative
+            path.parent.mkdir(parents=True)
+            path.write_text(source)
+            return inventory.validate(
+                Path(directory) / "unrelated-root",
+                [("rue-air", src)],
+            )
+
+    def test_production_literal_after_test_module_is_rejected(self) -> None:
+        errors = self.validate(
+            '#[cfg(test)] mod tests { const OK: &str = "__rue_alloc"; }\n'
+            'const DEBT: &str = "__rue_free";\n'
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("'__rue_free'", errors[0])
+
+    def test_line_nested_block_and_doc_comments_are_ignored(self) -> None:
+        self.assertEqual(
+            self.validate(
+                '// "__rue_alloc"\n'
+                '/* outer "__rue_free" /* nested "__rue_exit" */ */\n'
+                '/// example: "__rue_panic"\n'
+                'const OK: &str = "__rue_";\n'
+            ),
+            [],
+        )
+
+    def test_categorical_production_allowances_are_narrow(self) -> None:
+        allowed = "\n".join(
+            f'const OK_{index}: &str = "{value}";'
+            for index, value in enumerate(inventory.ALLOWED_PRODUCTION)
+        )
+        self.assertEqual(self.validate(allowed), [])
+        self.assertTrue(self.validate('const DEBT: &str = "__rue_alloc";'))
+
+    def test_test_paths_and_exact_test_module_spans_are_allowed(self) -> None:
+        self.assertEqual(
+            self.validate('const FIXTURE: &str = "__rue_alloc";', "tests/calls.rs"),
+            [],
+        )
+        self.assertEqual(
+            self.validate(
+                '#[cfg(test)]\nmod checks {\n'
+                '  fn fixture() { let _ = "__rue_alloc"; }\n'
+                '}\n'
+            ),
+            [],
+        )
+
+    def test_buck_materialized_source_mapping_is_stable(self) -> None:
+        errors = self.validate('const DEBT: &str = "__rue_alloc";', "nested/file.rs")
+        self.assertEqual(len(errors), 1)
+        self.assertTrue(errors[0].startswith("crates/rue-air/src/nested/file.rs:1:"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-runtime-abi-inventory.py
+++ b/scripts/validate-runtime-abi-inventory.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Reject raw runtime-helper spellings in compiler consumers.
+
+The typed manifest owns helper symbols. Compiler phases and auxiliary
+consumers carry typed identities; only tests, generated-symbol namespaces, and
+the strict archive/version boundary may mention reserved spellings directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CONSUMER_CRATES = (
+    "rue-builtins",
+    "rue-air",
+    "rue-cfg",
+    "rue-codegen",
+    "rue-compiler",
+    "rue-linker",
+    "rue-oracle",
+)
+LITERAL = re.compile(r'"(__rue_[A-Za-z0-9_$]*)"')
+TEST_MODULE = re.compile(r"#\[cfg\(test\)\]\s*mod\s+[A-Za-z0-9_]+\s*\{", re.MULTILINE)
+RAW_STRING_START = re.compile(r'(?:br|r)(?P<hashes>#{0,255})"')
+
+# These are namespace or generated-symbol boundaries, not runtime-helper
+# identities. Keep this list about categories rather than individual helpers.
+ALLOWED_PRODUCTION = (
+    "__rue_",  # source-name reservation policy
+    "__rue_runtime_abi_v",  # strict archive version-marker namespace
+    "__rue_fn_",  # compiler-generated Rue functions
+    "__rue_drop_",  # compiler-generated destructor glue
+    "__rue_drop_array_",  # compiler-generated array destructor glue
+    "__rue_for_",  # internal desugaring temporaries
+    "__rue_invalid_local_symbol",  # unreachable canonicalization sentinel
+)
+
+
+def mask_rust_non_code(source: str) -> tuple[str, list[tuple[int, int]]]:
+    """Mask comments and literals while preserving byte offsets and newlines."""
+    masked = list(source)
+    comments: list[tuple[int, int]] = []
+
+    def hide(start: int, end: int) -> None:
+        for index in range(start, end):
+            if masked[index] != "\n":
+                masked[index] = " "
+
+    index = 0
+    while index < len(source):
+        if source.startswith("//", index):
+            end = source.find("\n", index + 2)
+            end = len(source) if end < 0 else end
+            comments.append((index, end))
+            hide(index, end)
+            index = end
+            continue
+        if source.startswith("/*", index):
+            start = index
+            depth = 1
+            index += 2
+            while index < len(source) and depth:
+                if source.startswith("/*", index):
+                    depth += 1
+                    index += 2
+                elif source.startswith("*/", index):
+                    depth -= 1
+                    index += 2
+                else:
+                    index += 1
+            comments.append((start, index))
+            hide(start, index)
+            continue
+
+        raw = RAW_STRING_START.match(source, index)
+        if raw:
+            hashes = raw.group("hashes")
+            terminator = '"' + hashes
+            end = source.find(terminator, raw.end())
+            end = len(source) if end < 0 else end + len(terminator)
+            hide(index, end)
+            index = end
+            continue
+
+        quote_start = index + 1 if source.startswith('b"', index) else index
+        if quote_start < len(source) and source[quote_start] == '"':
+            end = quote_start + 1
+            while end < len(source):
+                if source[end] == "\\":
+                    end += 2
+                elif source[end] == '"':
+                    end += 1
+                    break
+                else:
+                    end += 1
+            hide(index, min(end, len(source)))
+            index = end
+            continue
+
+        # Mask a character literal, but do not mistake a Rust lifetime for one.
+        if source[index] == "'":
+            end = index + 1
+            if end < len(source) and source[end] == "\\":
+                end += 2
+            else:
+                end += 1
+            if end < len(source) and source[end] == "'":
+                end += 1
+                hide(index, end)
+                index = end
+                continue
+        index += 1
+    return "".join(masked), comments
+
+
+def test_module_spans(masked_source: str) -> list[tuple[int, int]]:
+    spans = []
+    for match in TEST_MODULE.finditer(masked_source):
+        opening = masked_source.find("{", match.start(), match.end())
+        depth = 1
+        index = opening + 1
+        while index < len(masked_source) and depth:
+            if masked_source[index] == "{":
+                depth += 1
+            elif masked_source[index] == "}":
+                depth -= 1
+            index += 1
+        spans.append((match.start(), index))
+    return spans
+
+
+def contained(offset: int, spans: list[tuple[int, int]]) -> bool:
+    return any(start <= offset < end for start, end in spans)
+
+
+def is_test_path(path: Path) -> bool:
+    return path.name in {"tests.rs", "pipeline_tests.rs", "integration_tests.rs"} or "tests" in path.parts
+
+
+def allowed_production_literal(value: str) -> bool:
+    return value in ALLOWED_PRODUCTION
+
+
+def validate(root: Path, sources: list[tuple[str, Path]] | None = None) -> list[str]:
+    errors: list[str] = []
+    crate_sources = sources or [
+        (crate, root / "crates" / crate / "src") for crate in CONSUMER_CRATES
+    ]
+    for crate, src in crate_sources:
+        if not src.exists():
+            errors.append(f"missing compiler-consumer source directory: {src}")
+            continue
+        for path in sorted(src.rglob("*.rs")):
+            source = path.read_text()
+            masked, comments = mask_rust_non_code(source)
+            tests = test_module_spans(masked)
+            for match in LITERAL.finditer(source):
+                value = match.group(1)
+                if contained(match.start(), comments):
+                    continue
+                if is_test_path(path) or contained(match.start(), tests):
+                    continue
+                if allowed_production_literal(value):
+                    continue
+                line = source.count("\n", 0, match.start()) + 1
+                display = (
+                    path.relative_to(root)
+                    if path.is_relative_to(root)
+                    else Path("crates") / crate / "src" / path.relative_to(src)
+                )
+                errors.append(
+                    f"{display}:{line}: raw reserved symbol literal {value!r}; "
+                    "carry a typed runtime/helper identity or classify a non-runtime namespace"
+                )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        metavar="CRATE=PATH",
+        help="scan one Buck-materialized crate source directory",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    sources = []
+    for item in args.source:
+        crate, separator, path = item.partition("=")
+        if not separator or crate not in CONSUMER_CRATES:
+            parser.error(f"invalid --source {item!r}")
+        sources.append((crate, Path(path).resolve()))
+    errors = validate(root, sources or None)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+    print("runtime ABI inventory valid: no raw helper literals in compiler consumers")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- route remaining AIR, builtins, and oracle runtime references through typed ABI identifiers
- add a repository-wide gate that rejects peer raw runtime-helper symbol tables
- update runtime ABI documentation and mark ADR-0055 implemented

## Validation
- full serialized Rue test suite
- scripts/rue quick
- runtime ABI inventory validation and self-tests
- ADR registry validation
- Rust project validation

Fixes RUE-834