### PR TITLE
RUE-835: centralize type encoding and pool states

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -1625,12 +1625,11 @@ impl FrozenTypeInternPool {
             .types
             .iter()
             .enumerate()
-            .filter_map(|(index, data)| {
-                matches!(data, TypeData::Array { .. }).then(|| {
-                    ArrayTypeId::from_pool_index(
-                        checked_pool_index(index).expect("type pool index invariant"),
-                    )
-                })
+            .filter(|(_, data)| matches!(data, TypeData::Array { .. }))
+            .map(|(index, _)| {
+                ArrayTypeId::from_pool_index(
+                    checked_pool_index(index).expect("type pool index invariant"),
+                )
             })
     }
 

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -14,8 +14,9 @@
 //! - **Structs and enums** are nominal types (same name = same type)
 //! - **Arrays** are structural types (same element type + length = same type)
 //!
-//! Primitive types (i8-i64, u8-u64, bool, unit, never, error) are encoded directly
-//! in the `InternedType` index using reserved indices 0-15, requiring no pool lookup.
+//! The transitional `InternedType` wrapper consumes the same authoritative
+//! primitive assignments as [`Type`]. Its compatibility-only pool-index
+//! encoding is centralized beside the live encoding and is removed by RUE-838.
 //!
 //! [`Type`] is the compact compiler-facing handle. Composite `StructId`,
 //! `EnumId`, `ArrayTypeId`, and pointer IDs are indices into this pool, while
@@ -36,6 +37,7 @@ use lasso::Spur;
 use rue_span::FileId;
 
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
+use crate::type_encoding::{self, Decoded, Primitive};
 use crate::types::{
     ArrayTypeId, EnumDef, EnumId, LangItem, PtrConstTypeId, PtrMutTypeId, StructDef, StructId,
     Type, TypeKind,
@@ -43,49 +45,29 @@ use crate::types::{
 
 /// Interned type index - 32 bits, Copy, cheap comparison.
 ///
-/// Reserved indices 0-15 are primitives (no lookup needed).
-/// Index 16+ are composite types stored in the pool.
-///
-/// # Primitive Encoding
-///
-/// The following indices are reserved for primitive types:
-/// - 0: i8
-/// - 1: i16
-/// - 2: i32
-/// - 3: i64
-/// - 4: u8
-/// - 5: u16
-/// - 6: u32
-/// - 7: u64
-/// - 8: bool
-/// - 9: unit
-/// - 10: never
-/// - 11: error
-/// - 12-15: reserved for future primitives
+/// Primitive values are exactly the authoritative [`Type`] encodings.
+/// Composite values use the centralized transitional pool-index encoding.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct InternedType(u32);
 
 impl InternedType {
-    // Reserved indices for primitives
-    pub const I8: InternedType = InternedType(0);
-    pub const I16: InternedType = InternedType(1);
-    pub const I32: InternedType = InternedType(2);
-    pub const I64: InternedType = InternedType(3);
-    pub const U8: InternedType = InternedType(4);
-    pub const U16: InternedType = InternedType(5);
-    pub const U32: InternedType = InternedType(6);
-    pub const U64: InternedType = InternedType(7);
-    pub const BOOL: InternedType = InternedType(8);
-    pub const UNIT: InternedType = InternedType(9);
-    pub const NEVER: InternedType = InternedType(10);
-    pub const ERROR: InternedType = InternedType(11);
-
-    const PRIMITIVE_COUNT: u32 = 16;
+    pub const I8: InternedType = InternedType(Type::I8.raw_encoding());
+    pub const I16: InternedType = InternedType(Type::I16.raw_encoding());
+    pub const I32: InternedType = InternedType(Type::I32.raw_encoding());
+    pub const I64: InternedType = InternedType(Type::I64.raw_encoding());
+    pub const U8: InternedType = InternedType(Type::U8.raw_encoding());
+    pub const U16: InternedType = InternedType(Type::U16.raw_encoding());
+    pub const U32: InternedType = InternedType(Type::U32.raw_encoding());
+    pub const U64: InternedType = InternedType(Type::U64.raw_encoding());
+    pub const BOOL: InternedType = InternedType(Type::BOOL.raw_encoding());
+    pub const UNIT: InternedType = InternedType(Type::UNIT.raw_encoding());
+    pub const ERROR: InternedType = InternedType(Type::ERROR.raw_encoding());
+    pub const NEVER: InternedType = InternedType(Type::NEVER.raw_encoding());
 
     /// Check if this is a primitive type (no pool lookup needed).
     #[inline]
     pub fn is_primitive(self) -> bool {
-        self.0 < Self::PRIMITIVE_COUNT
+        type_encoding::compatibility::is_primitive(self.0)
     }
 
     /// Get the raw index value.
@@ -94,23 +76,28 @@ impl InternedType {
         self.0
     }
 
-    /// Create an InternedType from a raw index.
+    /// Create an `InternedType` from a raw compatibility encoding.
     ///
-    /// # Safety
-    ///
-    /// The caller must ensure the index is valid (either a primitive index 0-15,
-    /// or a composite index that exists in the pool).
+    /// Pool ownership and bounds are validated separately by pool APIs.
     #[inline]
-    pub fn from_raw(index: u32) -> Self {
-        InternedType(index)
+    pub fn try_from_raw(index: u32) -> Option<Self> {
+        if type_encoding::compatibility::is_primitive(index)
+            || type_encoding::compatibility::decode_pool_index(index).is_some()
+        {
+            Some(InternedType(index))
+        } else {
+            None
+        }
     }
 
     /// Create an InternedType for a composite type from its pool index.
     ///
-    /// The pool index is offset by `PRIMITIVE_COUNT` to produce the final index.
+    /// The pool index is mapped through the centralized compatibility encoding.
     #[inline]
     fn from_pool_index(pool_index: u32) -> Self {
-        InternedType(pool_index + Self::PRIMITIVE_COUNT)
+        let encoded = type_encoding::compatibility::encode_pool_index(pool_index)
+            .expect("intern pool index overflow");
+        InternedType(encoded)
     }
 
     /// Get the pool index for a composite type.
@@ -118,35 +105,33 @@ impl InternedType {
     /// Returns `None` for primitive types.
     #[inline]
     pub fn pool_index(self) -> Option<u32> {
-        if self.is_primitive() {
-            None
-        } else {
-            Some(self.0 - Self::PRIMITIVE_COUNT)
-        }
+        type_encoding::compatibility::decode_pool_index(self.0)
     }
 }
 
 impl std::fmt::Debug for InternedType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_primitive() {
-            let name = match self.0 {
-                0 => "i8",
-                1 => "i16",
-                2 => "i32",
-                3 => "i64",
-                4 => "u8",
-                5 => "u16",
-                6 => "u32",
-                7 => "u64",
-                8 => "bool",
-                9 => "()",
-                10 => "!",
-                11 => "<error>",
-                _ => "<reserved>",
+        if let Some(Decoded::Primitive(primitive)) = type_encoding::decode(self.0) {
+            let name = match primitive {
+                Primitive::I8 => "i8",
+                Primitive::I16 => "i16",
+                Primitive::I32 => "i32",
+                Primitive::I64 => "i64",
+                Primitive::U8 => "u8",
+                Primitive::U16 => "u16",
+                Primitive::U32 => "u32",
+                Primitive::U64 => "u64",
+                Primitive::Bool => "bool",
+                Primitive::Unit => "()",
+                Primitive::Error => "<error>",
+                Primitive::Never => "!",
+                Primitive::ComptimeType => "type",
             };
             write!(f, "InternedType({name})")
+        } else if let Some(pool_index) = self.pool_index() {
+            write!(f, "InternedType(pool:{pool_index})")
         } else {
-            write!(f, "InternedType(pool:{})", self.0 - Self::PRIMITIVE_COUNT)
+            write!(f, "InternedType(invalid:{:#x})", self.0)
         }
     }
 }
@@ -161,6 +146,15 @@ impl std::fmt::Debug for InternedType {
 /// - **Array**, **PtrConst**, and **PtrMut** are structural types: identity comes from element/pointee type
 #[derive(Debug, Clone)]
 pub enum TypeData {
+    /// Private anonymous-construction slot. No live [`Type`] is issued for it.
+    ReservedStruct,
+
+    /// Named struct identity whose definition has not completed yet.
+    DeclaredStruct(StructData),
+
+    /// Named enum identity whose definition has not completed yet.
+    DeclaredEnum(EnumData),
+
     /// User-defined struct (nominal type).
     ///
     /// Two structs with the same fields but different names are different types.
@@ -186,6 +180,15 @@ pub enum TypeData {
     ///
     /// `ptr mut T` - pointer to mutable data.
     PtrMut { pointee: InternedType },
+}
+
+impl TypeData {
+    fn is_incomplete(&self) -> bool {
+        matches!(
+            self,
+            Self::ReservedStruct | Self::DeclaredStruct(_) | Self::DeclaredEnum(_)
+        )
+    }
 }
 
 /// Data for a struct type in the intern pool.
@@ -261,7 +264,7 @@ pub struct FrozenTypeInternPool {
 
 #[derive(Debug)]
 struct TypeInternPoolInner {
-    /// All composite type data, indexed by (InternedType.0 - PRIMITIVE_COUNT).
+    /// All composite type data, indexed by the decoded compatibility pool index.
     types: Vec<TypeData>,
 
     /// Structural type deduplication: (element, len) -> InternedType for arrays.
@@ -290,7 +293,17 @@ struct TypeInternPoolInner {
     lang_item_structs: HashMap<LangItem, StructId>,
 }
 
+fn checked_pool_index(index: usize) -> Option<u32> {
+    let index = u32::try_from(index).ok()?;
+    (index <= type_encoding::MAX_PAYLOAD).then_some(index)
+}
+
 impl TypeInternPoolInner {
+    fn next_pool_index(&self) -> u32 {
+        checked_pool_index(self.types.len())
+            .expect("type intern pool exceeds the 24-bit Type payload capacity")
+    }
+
     #[inline]
     fn data(&self, index: u32) -> &TypeData {
         &self.types[index as usize]
@@ -298,7 +311,7 @@ impl TypeInternPoolInner {
 
     fn try_struct_def(&self, id: StructId) -> Option<&StructDef> {
         match self.types.get(id.0 as usize)? {
-            TypeData::Struct(data) => Some(&data.def),
+            TypeData::DeclaredStruct(data) | TypeData::Struct(data) => Some(&data.def),
             _ => None,
         }
     }
@@ -310,7 +323,7 @@ impl TypeInternPoolInner {
 
     fn try_enum_def(&self, id: EnumId) -> Option<&EnumDef> {
         match self.types.get(id.0 as usize)? {
-            TypeData::Enum(data) => Some(&data.def),
+            TypeData::DeclaredEnum(data) | TypeData::Enum(data) => Some(&data.def),
             _ => None,
         }
     }
@@ -322,32 +335,26 @@ impl TypeInternPoolInner {
 
     fn interned_to_type(&self, ty: InternedType) -> Type {
         if ty.is_primitive() {
-            return match ty.0 {
-                0 => Type::I8,
-                1 => Type::I16,
-                2 => Type::I32,
-                3 => Type::I64,
-                4 => Type::U8,
-                5 => Type::U16,
-                6 => Type::U32,
-                7 => Type::U64,
-                8 => Type::BOOL,
-                9 => Type::UNIT,
-                10 => Type::NEVER,
-                11 => Type::ERROR,
-                _ => panic!("Unknown primitive index: {}", ty.0),
-            };
+            return Type::try_from_u32(ty.0)
+                .expect("InternedType primitive must use the canonical Type encoding");
         }
 
         let index = ty.pool_index().expect("non-primitive must have pool index");
         match self.data(index) {
-            TypeData::Struct(_) => Type::new_struct(StructId::from_pool_index(index)),
-            TypeData::Enum(_) => Type::new_enum(EnumId::from_pool_index(index)),
+            TypeData::DeclaredStruct(_) | TypeData::Struct(_) => {
+                Type::new_struct(StructId::from_pool_index(index))
+            }
+            TypeData::DeclaredEnum(_) | TypeData::Enum(_) => {
+                Type::new_enum(EnumId::from_pool_index(index))
+            }
             TypeData::Array { .. } => Type::new_array(ArrayTypeId::from_pool_index(index)),
             TypeData::PtrConst { .. } => {
                 Type::new_ptr_const(PtrConstTypeId::from_pool_index(index))
             }
             TypeData::PtrMut { .. } => Type::new_ptr_mut(PtrMutTypeId::from_pool_index(index)),
+            TypeData::ReservedStruct => {
+                panic!("reserved pool entry {index} cannot be issued as a Type")
+            }
         }
     }
 
@@ -444,7 +451,7 @@ impl TypeInternPoolInner {
 
     fn struct_symbol_name(&self, id: StructId) -> String {
         let data = match self.data(id.0) {
-            TypeData::Struct(data) => data,
+            TypeData::DeclaredStruct(data) | TypeData::Struct(data) => data,
             other => panic!("Expected struct at pool index {}, got {:?}", id.0, other),
         };
         if !data.def.is_builtin && self.nominal_name_collides(data.name) {
@@ -459,7 +466,7 @@ impl TypeInternPoolInner {
 
     fn enum_symbol_name(&self, id: EnumId) -> String {
         let data = match self.data(id.0) {
-            TypeData::Enum(data) => data,
+            TypeData::DeclaredEnum(data) | TypeData::Enum(data) => data,
             other => panic!("Expected enum at pool index {}, got {:?}", id.0, other),
         };
         if self.nominal_name_collides(data.name) {
@@ -524,10 +531,10 @@ impl TypeInternPoolInner {
         };
         for data in &self.types {
             match data {
-                TypeData::Struct(_) => stats.struct_count += 1,
-                TypeData::Enum(_) => stats.enum_count += 1,
+                TypeData::DeclaredStruct(_) | TypeData::Struct(_) => stats.struct_count += 1,
+                TypeData::DeclaredEnum(_) | TypeData::Enum(_) => stats.enum_count += 1,
                 TypeData::Array { .. } => stats.array_count += 1,
-                TypeData::PtrConst { .. } | TypeData::PtrMut { .. } => {}
+                TypeData::ReservedStruct | TypeData::PtrConst { .. } | TypeData::PtrMut { .. } => {}
             }
         }
         stats
@@ -558,12 +565,20 @@ impl TypeInternPool {
     /// remain separate: type definitions retain stable string names rather than
     /// storing a [`Spur`] from a CFG or codegen request.
     pub fn freeze(self) -> FrozenTypeInternPool {
+        let inner = self
+            .inner
+            .into_inner()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some((index, entry)) = inner
+            .types
+            .iter()
+            .enumerate()
+            .find(|(_, entry)| entry.is_incomplete())
+        {
+            panic!("cannot freeze incomplete type-pool entry {index}: {entry:?}");
+        }
         FrozenTypeInternPool {
-            inner: Arc::new(
-                self.inner
-                    .into_inner()
-                    .unwrap_or_else(PoisonError::into_inner),
-            ),
+            inner: Arc::new(inner),
         }
     }
 
@@ -615,7 +630,7 @@ impl TypeInternPool {
         }
 
         // Create new struct type
-        let pool_index = inner.types.len() as u32;
+        let pool_index = inner.next_pool_index();
         let interned = InternedType::from_pool_index(pool_index);
         let struct_id = StructId::from_pool_index(pool_index);
 
@@ -623,6 +638,41 @@ impl TypeInternPool {
         inner.struct_by_file_name.insert(key, interned);
 
         (struct_id, true)
+    }
+
+    /// Register a named struct identity whose definition will be completed
+    /// after declaration type references have been resolved.
+    pub(crate) fn declare_struct(&self, name: Spur, shell: StructDef) -> (StructId, bool) {
+        let key = (shell.file_id, name);
+        {
+            let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+            if let Some(&existing) = inner.struct_by_file_name.get(&key) {
+                return (
+                    StructId::from_pool_index(
+                        existing.pool_index().expect("struct must have pool index"),
+                    ),
+                    false,
+                );
+            }
+        }
+
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        if let Some(&existing) = inner.struct_by_file_name.get(&key) {
+            return (
+                StructId::from_pool_index(
+                    existing.pool_index().expect("struct must have pool index"),
+                ),
+                false,
+            );
+        }
+
+        let pool_index = inner.next_pool_index();
+        let interned = InternedType::from_pool_index(pool_index);
+        inner
+            .types
+            .push(TypeData::DeclaredStruct(StructData { name, def: shell }));
+        inner.struct_by_file_name.insert(key, interned);
+        (StructId::from_pool_index(pool_index), true)
     }
 
     /// Reserve a struct ID without registering the full definition yet.
@@ -645,28 +695,11 @@ impl TypeInternPool {
     /// let def = StructDef { name: name.clone(), ... };
     /// pool.complete_struct_registration(struct_id, name_spur, def);
     /// ```
-    pub fn reserve_struct_id(&self) -> StructId {
+    pub(crate) fn reserve_struct_id(&self) -> StructId {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
 
-        // Reserve a slot by pushing a placeholder
-        // We use a placeholder Struct with empty data that will be overwritten
-        let pool_index = inner.types.len() as u32;
-
-        // Push a placeholder - this reserves the index
-        // The placeholder will be replaced by complete_struct_registration
-        inner.types.push(TypeData::Struct(StructData {
-            name: Spur::default(),
-            def: StructDef {
-                name: String::new(),
-                fields: vec![],
-                is_copy: false,
-                is_linear: false,
-                destructor: None,
-                is_builtin: false,
-                is_pub: false,
-                file_id: rue_span::FileId::DEFAULT,
-            },
-        }));
+        let pool_index = inner.next_pool_index();
+        inner.types.push(TypeData::ReservedStruct);
 
         StructId::from_pool_index(pool_index)
     }
@@ -682,7 +715,12 @@ impl TypeInternPool {
     /// - The struct_id wasn't created by `reserve_struct_id`
     /// - The slot at struct_id doesn't contain a placeholder struct
     /// - A struct with the given name already exists
-    pub fn complete_struct_registration(&self, struct_id: StructId, name: Spur, def: StructDef) {
+    pub(crate) fn complete_struct_registration(
+        &self,
+        struct_id: StructId,
+        name: Spur,
+        def: StructDef,
+    ) {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
         let pool_index = struct_id.0 as usize;
 
@@ -694,7 +732,12 @@ impl TypeInternPool {
             inner.types.len()
         );
 
-        // Check that a struct with this name doesn't already exist
+        assert!(
+            matches!(inner.types.get(pool_index), Some(TypeData::ReservedStruct)),
+            "pool index {} is not a reserved struct entry",
+            pool_index
+        );
+
         assert!(
             !inner.struct_by_file_name.contains_key(&(def.file_id, name)),
             "Struct with this name already exists"
@@ -705,8 +748,39 @@ impl TypeInternPool {
         inner.types[pool_index] = TypeData::Struct(StructData { name, def });
 
         // Register in the defining-file lookup.
-        let interned = InternedType::from_pool_index(pool_index as u32);
+        let interned = InternedType::from_pool_index(struct_id.pool_index());
         inner.struct_by_file_name.insert(key, interned);
+    }
+
+    /// Complete a named struct declaration exactly once.
+    pub(crate) fn complete_declared_struct(&self, struct_id: StructId, def: StructDef) {
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        let pool_index = struct_id.pool_index() as usize;
+        let entry = inner
+            .types
+            .get_mut(pool_index)
+            .unwrap_or_else(|| panic!("Invalid declared struct ID: {pool_index}"));
+        match entry {
+            TypeData::DeclaredStruct(data) => {
+                assert_eq!(
+                    data.def.file_id, def.file_id,
+                    "completed struct changed defining file"
+                );
+                assert_eq!(
+                    data.def.name.as_str(),
+                    def.name.as_str(),
+                    "completed struct changed textual name"
+                );
+                *entry = TypeData::Struct(StructData {
+                    name: data.name,
+                    def,
+                });
+            }
+            other => panic!(
+                "pool index {} is not a declared struct entry: {:?}",
+                pool_index, other
+            ),
+        }
     }
 
     /// Register a new enum (nominal - no deduplication).
@@ -735,13 +809,77 @@ impl TypeInternPool {
         }
 
         // Create new enum type
-        let pool_index = inner.types.len() as u32;
+        let pool_index = inner.next_pool_index();
         let interned = InternedType::from_pool_index(pool_index);
 
         inner.types.push(TypeData::Enum(EnumData { name, def }));
         inner.enum_by_file_name.insert(key, interned);
 
         (EnumId::from_pool_index(pool_index), true)
+    }
+
+    /// Register a named enum identity whose definition will be completed after
+    /// payload type references have been resolved.
+    pub(crate) fn declare_enum(&self, name: Spur, shell: EnumDef) -> (EnumId, bool) {
+        let key = (shell.file_id, name);
+        {
+            let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+            if let Some(&existing) = inner.enum_by_file_name.get(&key) {
+                return (
+                    EnumId::from_pool_index(
+                        existing.pool_index().expect("enum must have pool index"),
+                    ),
+                    false,
+                );
+            }
+        }
+
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        if let Some(&existing) = inner.enum_by_file_name.get(&key) {
+            return (
+                EnumId::from_pool_index(existing.pool_index().expect("enum must have pool index")),
+                false,
+            );
+        }
+
+        let pool_index = inner.next_pool_index();
+        let interned = InternedType::from_pool_index(pool_index);
+        inner
+            .types
+            .push(TypeData::DeclaredEnum(EnumData { name, def: shell }));
+        inner.enum_by_file_name.insert(key, interned);
+        (EnumId::from_pool_index(pool_index), true)
+    }
+
+    /// Complete a named enum declaration exactly once.
+    pub(crate) fn complete_declared_enum(&self, enum_id: EnumId, def: EnumDef) {
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        let pool_index = enum_id.pool_index() as usize;
+        let entry = inner
+            .types
+            .get_mut(pool_index)
+            .unwrap_or_else(|| panic!("Invalid declared enum ID: {pool_index}"));
+        match entry {
+            TypeData::DeclaredEnum(data) => {
+                assert_eq!(
+                    data.def.file_id, def.file_id,
+                    "completed enum changed defining file"
+                );
+                assert_eq!(
+                    data.def.name.as_str(),
+                    def.name.as_str(),
+                    "completed enum changed textual name"
+                );
+                *entry = TypeData::Enum(EnumData {
+                    name: data.name,
+                    def,
+                });
+            }
+            other => panic!(
+                "pool index {} is not a declared enum entry: {:?}",
+                pool_index, other
+            ),
+        }
     }
 
     /// Intern an array type (structural - deduplicates).
@@ -768,7 +906,7 @@ impl TypeInternPool {
         }
 
         // Create new array type
-        let pool_index = inner.types.len() as u32;
+        let pool_index = inner.next_pool_index();
         let interned = InternedType::from_pool_index(pool_index);
 
         inner.types.push(TypeData::Array { element, len });
@@ -799,7 +937,7 @@ impl TypeInternPool {
         }
 
         // Create new pointer type
-        let pool_index = inner.types.len() as u32;
+        let pool_index = inner.next_pool_index();
         let interned = InternedType::from_pool_index(pool_index);
 
         inner.types.push(TypeData::PtrConst { pointee });
@@ -830,7 +968,7 @@ impl TypeInternPool {
         }
 
         // Create new pointer type
-        let pool_index = inner.types.len() as u32;
+        let pool_index = inner.next_pool_index();
         let interned = InternedType::from_pool_index(pool_index);
 
         inner.types.push(TypeData::PtrMut { pointee });
@@ -879,7 +1017,10 @@ impl TypeInternPool {
         if ty.is_primitive() {
             return false;
         }
-        matches!(self.get(ty), Some(TypeData::Struct(_)))
+        matches!(
+            self.get(ty),
+            Some(TypeData::DeclaredStruct(_) | TypeData::Struct(_))
+        )
     }
 
     /// Check if this is an enum type.
@@ -887,7 +1028,10 @@ impl TypeInternPool {
         if ty.is_primitive() {
             return false;
         }
-        matches!(self.get(ty), Some(TypeData::Enum(_)))
+        matches!(
+            self.get(ty),
+            Some(TypeData::DeclaredEnum(_) | TypeData::Enum(_))
+        )
     }
 
     /// Check if this is an array type.
@@ -970,7 +1114,7 @@ impl TypeInternPool {
         assert!(
             matches!(
                 inner.types.get(struct_id.0 as usize),
-                Some(TypeData::Struct(_))
+                Some(TypeData::DeclaredStruct(_) | TypeData::Struct(_))
             ),
             "language items can only be assigned to registered structs"
         );
@@ -1245,7 +1389,11 @@ impl TypeInternPool {
             .iter()
             .enumerate()
             .filter_map(|(idx, data)| match data {
-                TypeData::Struct(_) => Some(StructId::from_pool_index(idx as u32)),
+                TypeData::DeclaredStruct(_) | TypeData::Struct(_) => {
+                    Some(StructId::from_pool_index(
+                        checked_pool_index(idx).expect("type pool index invariant"),
+                    ))
+                }
                 _ => None,
             })
             .collect()
@@ -1262,7 +1410,9 @@ impl TypeInternPool {
             .iter()
             .enumerate()
             .filter_map(|(idx, data)| match data {
-                TypeData::Enum(_) => Some(EnumId::from_pool_index(idx as u32)),
+                TypeData::DeclaredEnum(_) | TypeData::Enum(_) => Some(EnumId::from_pool_index(
+                    checked_pool_index(idx).expect("type pool index invariant"),
+                )),
                 _ => None,
             })
             .collect()
@@ -1279,7 +1429,9 @@ impl TypeInternPool {
             .iter()
             .enumerate()
             .filter_map(|(idx, data)| match data {
-                TypeData::Array { .. } => Some(ArrayTypeId(idx as u32)),
+                TypeData::Array { .. } => Some(ArrayTypeId::from_pool_index(
+                    checked_pool_index(idx).expect("type pool index invariant"),
+                )),
                 _ => None,
             })
             .collect()
@@ -1363,22 +1515,7 @@ impl TypeInternPool {
         if !ty.is_primitive() {
             return None;
         }
-
-        Some(match ty.0 {
-            0 => Type::I8,
-            1 => Type::I16,
-            2 => Type::I32,
-            3 => Type::I64,
-            4 => Type::U8,
-            5 => Type::U16,
-            6 => Type::U32,
-            7 => Type::U64,
-            8 => Type::BOOL,
-            9 => Type::UNIT,
-            10 => Type::NEVER,
-            11 => Type::ERROR,
-            _ => return None,
-        })
+        Type::try_from_u32(ty.0)
     }
 }
 
@@ -1463,7 +1600,11 @@ impl FrozenTypeInternPool {
             .iter()
             .enumerate()
             .filter(|(_, data)| matches!(data, TypeData::Struct(_)))
-            .map(|(index, _)| StructId::from_pool_index(index as u32))
+            .map(|(index, _)| {
+                StructId::from_pool_index(
+                    checked_pool_index(index).expect("type pool index invariant"),
+                )
+            })
     }
 
     pub fn all_enum_ids(&self) -> impl Iterator<Item = EnumId> + '_ {
@@ -1472,7 +1613,11 @@ impl FrozenTypeInternPool {
             .iter()
             .enumerate()
             .filter(|(_, data)| matches!(data, TypeData::Enum(_)))
-            .map(|(index, _)| EnumId::from_pool_index(index as u32))
+            .map(|(index, _)| {
+                EnumId::from_pool_index(
+                    checked_pool_index(index).expect("type pool index invariant"),
+                )
+            })
     }
 
     pub fn all_array_ids(&self) -> impl Iterator<Item = ArrayTypeId> + '_ {
@@ -1481,7 +1626,11 @@ impl FrozenTypeInternPool {
             .iter()
             .enumerate()
             .filter_map(|(index, data)| {
-                matches!(data, TypeData::Array { .. }).then_some(ArrayTypeId(index as u32))
+                matches!(data, TypeData::Array { .. }).then(|| {
+                    ArrayTypeId::from_pool_index(
+                        checked_pool_index(index).expect("type pool index invariant"),
+                    )
+                })
             })
     }
 
@@ -1491,7 +1640,11 @@ impl FrozenTypeInternPool {
             .iter()
             .enumerate()
             .filter(|(_, data)| matches!(data, TypeData::PtrConst { .. }))
-            .map(|(index, _)| PtrConstTypeId::from_pool_index(index as u32))
+            .map(|(index, _)| {
+                PtrConstTypeId::from_pool_index(
+                    checked_pool_index(index).expect("type pool index invariant"),
+                )
+            })
     }
 
     pub fn all_ptr_mut_ids(&self) -> impl Iterator<Item = PtrMutTypeId> + '_ {
@@ -1500,7 +1653,11 @@ impl FrozenTypeInternPool {
             .iter()
             .enumerate()
             .filter(|(_, data)| matches!(data, TypeData::PtrMut { .. }))
-            .map(|(index, _)| PtrMutTypeId::from_pool_index(index as u32))
+            .map(|(index, _)| {
+                PtrMutTypeId::from_pool_index(
+                    checked_pool_index(index).expect("type pool index invariant"),
+                )
+            })
     }
 
     pub fn len(&self) -> usize {
@@ -1603,6 +1760,19 @@ mod tests {
         assert_eq!(InternedType::U8.index(), 4);
         assert_eq!(InternedType::BOOL.index(), 8);
         assert_eq!(InternedType::UNIT.index(), 9);
+        assert_eq!(
+            InternedType::ERROR.index(),
+            Type::ERROR.raw_encoding(),
+            "compatibility wrapper must not swap Error and Never"
+        );
+        assert_eq!(
+            InternedType::NEVER.index(),
+            Type::NEVER.raw_encoding(),
+            "compatibility wrapper must not swap Error and Never"
+        );
+        assert!(InternedType::try_from_raw(13).is_none());
+        assert!(InternedType::try_from_raw(255).is_none());
+        assert!(InternedType::try_from_raw(Type::COMPTIME_TYPE.raw_encoding()).is_none());
     }
 
     #[test]
@@ -1645,6 +1815,157 @@ mod tests {
         let pool = TypeInternPool::new();
         assert!(pool.is_empty());
         assert_eq!(pool.len(), 0);
+    }
+
+    fn struct_def(name: &str, fields: Vec<StructField>) -> StructDef {
+        StructDef {
+            name: name.into(),
+            fields,
+            is_copy: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+            is_pub: false,
+            file_id: FileId::DEFAULT,
+        }
+    }
+
+    fn enum_def(name: &str) -> EnumDef {
+        EnumDef {
+            name: name.into(),
+            variants: vec![],
+            variant_payloads: vec![],
+            is_pub: false,
+            file_id: FileId::DEFAULT,
+        }
+    }
+
+    #[test]
+    fn checked_pool_index_enforces_type_payload_capacity() {
+        let maximum = type_encoding::MAX_PAYLOAD as usize;
+        assert_eq!(
+            checked_pool_index(maximum),
+            Some(type_encoding::MAX_PAYLOAD)
+        );
+        assert_eq!(checked_pool_index(maximum + 1), None);
+    }
+
+    #[test]
+    fn declared_struct_has_identity_before_single_completion() {
+        let interner = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = interner.get_or_intern("Node");
+        let (id, is_new) = pool.declare_struct(name, struct_def("Node", vec![]));
+        assert!(is_new);
+
+        let interned = pool.struct_id_to_interned(id);
+        assert!(matches!(
+            pool.get(interned),
+            Some(TypeData::DeclaredStruct(_))
+        ));
+        assert!(pool.is_struct(interned));
+        assert!(pool.get_struct_def(interned).is_none());
+
+        // The declared identity is legal in a recursive pointer graph before
+        // the nominal definition completes.
+        let next_id = pool.intern_ptr_mut_from_type(Type::new_struct(id));
+        let next = Type::new_ptr_mut(next_id);
+        pool.complete_declared_struct(
+            id,
+            struct_def(
+                "Node",
+                vec![StructField {
+                    name: "next".into(),
+                    ty: next,
+                }],
+            ),
+        );
+
+        assert!(matches!(pool.get(interned), Some(TypeData::Struct(_))));
+        assert_eq!(pool.get_struct_def(interned).unwrap().fields[0].ty, next);
+        let frozen = pool.freeze();
+        assert_eq!(frozen.ptr_mut_def(next_id), Type::new_struct(id));
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a declared struct entry")]
+    fn declared_struct_cannot_complete_twice() {
+        let interner = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = interner.get_or_intern("Once");
+        let (id, _) = pool.declare_struct(name, struct_def("Once", vec![]));
+        pool.complete_declared_struct(id, struct_def("Once", vec![]));
+        pool.complete_declared_struct(id, struct_def("Once", vec![]));
+    }
+
+    #[test]
+    #[should_panic(expected = "completed struct changed textual name")]
+    fn declared_struct_completion_rejects_name_change() {
+        let interner = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = interner.get_or_intern("Before");
+        let (id, _) = pool.declare_struct(name, struct_def("Before", vec![]));
+        pool.complete_declared_struct(id, struct_def("After", vec![]));
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a declared enum entry")]
+    fn declared_enum_cannot_complete_twice() {
+        let interner = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = interner.get_or_intern("Once");
+        let (id, _) = pool.declare_enum(name, enum_def("Once"));
+        pool.complete_declared_enum(id, enum_def("Once"));
+        pool.complete_declared_enum(id, enum_def("Once"));
+    }
+
+    #[test]
+    #[should_panic(expected = "completed enum changed textual name")]
+    fn declared_enum_completion_rejects_name_change() {
+        let interner = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = interner.get_or_intern("Before");
+        let (id, _) = pool.declare_enum(name, enum_def("Before"));
+        pool.complete_declared_enum(id, enum_def("After"));
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a declared struct entry")]
+    fn declared_completion_rejects_wrong_nominal_kind() {
+        let interner = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = interner.get_or_intern("Choice");
+        let (id, _) = pool.declare_enum(name, enum_def("Choice"));
+        pool.complete_declared_struct(
+            StructId::from_pool_index(id.pool_index()),
+            struct_def("Choice", vec![]),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot freeze incomplete type-pool entry")]
+    fn freeze_rejects_declared_entry() {
+        let interner = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = interner.get_or_intern("Later");
+        pool.declare_struct(name, struct_def("Later", vec![]));
+        let _ = pool.freeze();
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot freeze incomplete type-pool entry")]
+    fn freeze_rejects_reserved_entry() {
+        let pool = TypeInternPool::new();
+        pool.reserve_struct_id();
+        let _ = pool.freeze();
+    }
+
+    #[test]
+    fn error_recovery_structural_types_may_freeze() {
+        let pool = TypeInternPool::new();
+        let array_id = pool.intern_array_from_type(Type::ERROR, 1);
+        let frozen = pool.freeze();
+        assert_eq!(frozen.array_def(array_id), (Type::ERROR, 1));
     }
 
     #[test]

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -25,6 +25,7 @@ mod sema;
 mod semantic_body;
 mod semantic_import;
 pub mod specialize;
+mod type_encoding;
 mod types;
 
 pub use canonical_imports::CanonicalImportView;

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -456,6 +456,14 @@ fn finalize_function_body_analysis(
     add_unused_function_warnings(sema, &referenced_for_unused_warnings, &mut all_warnings);
     all_warnings.sort_by_key(|w| w.span().map(|s| s.start));
 
+    // Error results do not expose a SemaOutput, so do not manufacture a
+    // frozen pool merely to discard it. In particular, an unresolved
+    // declaration must remain visibly Declared rather than being laundered
+    // into an empty Complete definition to satisfy freeze.
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
     let output = SemaOutput {
         functions,
         strings: global_strings,
@@ -558,7 +566,7 @@ fn finalize_function_body_analysis(
         type_pool: std::mem::take(&mut sema.type_pool).freeze(),
     };
 
-    errors.into_result_with(output)
+    Ok(output)
 }
 
 /// Emit warnings for unused free functions.

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -501,7 +501,7 @@ impl<'a> DeclarationShells<'a> {
                             })
                         })
                         .collect::<Result<_, DeclarationInstallFailure>>()?;
-                    self.sema.type_pool.update_struct_def(id, def);
+                    self.sema.type_pool.complete_declared_struct(id, def);
                 }
                 (SemanticDeclarationPayload::Enum { variants }, InstData::EnumDecl { .. }) => {
                     let id = *self
@@ -527,7 +527,7 @@ impl<'a> DeclarationShells<'a> {
                                 .collect()
                         })
                         .collect::<Result<_, DeclarationInstallFailure>>()?;
-                    self.sema.type_pool.update_enum_def(id, def);
+                    self.sema.type_pool.complete_declared_enum(id, def);
                 }
                 _ => return Err(DeclarationInstallFailure::KindMismatch),
             }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -413,7 +413,7 @@ impl<'a> Sema<'a> {
                     };
 
                     // Register in type pool and get pool-based EnumId
-                    let (enum_id, _) = self.type_pool.register_enum(*name, enum_def);
+                    let (enum_id, _) = self.type_pool.declare_enum(*name, enum_def);
 
                     // Source declarations are always keyed by their defining file.
                     self.enums_by_file_name.insert(key, enum_id);
@@ -454,7 +454,7 @@ impl<'a> Sema<'a> {
                     };
 
                     // Register in type pool and get pool-based StructId
-                    let (struct_id, _) = self.type_pool.register_struct(*name, struct_def);
+                    let (struct_id, _) = self.type_pool.declare_struct(*name, struct_def);
                     if self
                         .trusted_standard_library_files
                         .contains(&inst.span.file_id)
@@ -759,16 +759,14 @@ impl<'a> Sema<'a> {
                 ..
             } = &inst.data
             {
-                if *payloads_len > 0 {
-                    jobs.push((*name, *payloads_start, *payloads_len, inst.span));
-                }
+                jobs.push((*name, *payloads_start, *payloads_len, inst.span));
             }
         }
 
         for (name, payloads_start, payloads_len, span) in jobs {
             let source_name = self.interner.resolve(&name).to_string();
             self.declaration_type_observer =
-                (!source_name.starts_with("__anon_enum_")).then_some((
+                (payloads_len > 0 && !source_name.starts_with("__anon_enum_")).then_some((
                     span.file_id,
                     source_name,
                     None,
@@ -813,7 +811,7 @@ impl<'a> Sema<'a> {
                 .expect("enum registered in phase 1");
             let mut def = self.type_pool.enum_def(enum_id);
             def.variant_payloads = variant_payloads;
-            self.type_pool.update_enum_def(enum_id, def);
+            self.type_pool.complete_declared_enum(enum_id, def);
         }
         Ok(())
     }
@@ -949,7 +947,8 @@ impl<'a> Sema<'a> {
                 // Update the struct definition in the pool with resolved fields
                 let mut struct_def = self.type_pool.struct_def(struct_id);
                 struct_def.fields = resolved_fields;
-                self.type_pool.update_struct_def(struct_id, struct_def);
+                self.type_pool
+                    .complete_declared_struct(struct_id, struct_def);
             }
         }
         Ok(())

--- a/crates/rue-air/src/type_encoding.rs
+++ b/crates/rue-air/src/type_encoding.rs
@@ -124,10 +124,7 @@ pub(crate) mod compatibility {
     const POOL_INDEX_OFFSET: u32 = 256;
 
     pub(crate) const fn encode_pool_index(pool_index: u32) -> Option<u32> {
-        match pool_index.checked_add(POOL_INDEX_OFFSET) {
-            Some(encoded) => Some(encoded),
-            None => None,
-        }
+        pool_index.checked_add(POOL_INDEX_OFFSET)
     }
 
     pub(crate) const fn decode_pool_index(raw: u32) -> Option<u32> {

--- a/crates/rue-air/src/type_encoding.rs
+++ b/crates/rue-air/src/type_encoding.rs
@@ -1,0 +1,160 @@
+//! Authoritative compact encoding for live [`Type`](crate::Type) handles.
+//!
+//! This module is the only place that assigns primitive values, composite
+//! tags, payload widths, reserved ranges, or the transitional `InternedType`
+//! pool-index offset. Construction and decoding must go through these helpers
+//! so a raw value cannot acquire different meanings in different consumers.
+
+pub(crate) const TAG_MASK: u32 = 0xff;
+pub(crate) const PAYLOAD_SHIFT: u32 = 8;
+pub(crate) const MAX_PAYLOAD: u32 = u32::MAX >> PAYLOAD_SHIFT;
+pub(crate) const RESERVED_AFTER_PRIMITIVES_START: u32 = 13;
+pub(crate) const RESERVED_AFTER_PRIMITIVES_END: u32 = 99;
+pub(crate) const RESERVED_AFTER_COMPOSITES_START: u32 = 106;
+pub(crate) const RESERVED_AFTER_COMPOSITES_END: u32 = TAG_MASK;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum Primitive {
+    I8 = 0,
+    I16 = 1,
+    I32 = 2,
+    I64 = 3,
+    U8 = 4,
+    U16 = 5,
+    U32 = 6,
+    U64 = 7,
+    Bool = 8,
+    Unit = 9,
+    Error = 10,
+    Never = 11,
+    ComptimeType = 12,
+}
+
+impl Primitive {
+    pub(crate) const fn encode(self) -> u32 {
+        self as u32
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum Composite {
+    Struct = 100,
+    Enum = 101,
+    Array = 102,
+    Module = 103,
+    PtrConst = 104,
+    PtrMut = 105,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Decoded {
+    Primitive(Primitive),
+    Composite { kind: Composite, payload: u32 },
+}
+
+pub(crate) const fn encode_composite(kind: Composite, payload: u32) -> Option<u32> {
+    if payload > MAX_PAYLOAD {
+        return None;
+    }
+    Some((payload << PAYLOAD_SHIFT) | kind as u32)
+}
+
+pub(crate) const fn decode(raw: u32) -> Option<Decoded> {
+    // Primitive encodings have no payload. Checking the entire raw value here
+    // prevents values such as 0x100 from silently decoding as `i8`.
+    let primitive = match raw {
+        0 => Some(Primitive::I8),
+        1 => Some(Primitive::I16),
+        2 => Some(Primitive::I32),
+        3 => Some(Primitive::I64),
+        4 => Some(Primitive::U8),
+        5 => Some(Primitive::U16),
+        6 => Some(Primitive::U32),
+        7 => Some(Primitive::U64),
+        8 => Some(Primitive::Bool),
+        9 => Some(Primitive::Unit),
+        10 => Some(Primitive::Error),
+        11 => Some(Primitive::Never),
+        12 => Some(Primitive::ComptimeType),
+        _ => None,
+    };
+    if let Some(primitive) = primitive {
+        return Some(Decoded::Primitive(primitive));
+    }
+
+    let tag = raw & TAG_MASK;
+    if (tag >= RESERVED_AFTER_PRIMITIVES_START && tag <= RESERVED_AFTER_PRIMITIVES_END)
+        || (tag >= RESERVED_AFTER_COMPOSITES_START && tag <= RESERVED_AFTER_COMPOSITES_END)
+    {
+        return None;
+    }
+
+    let kind = match tag {
+        100 => Composite::Struct,
+        101 => Composite::Enum,
+        102 => Composite::Array,
+        103 => Composite::Module,
+        104 => Composite::PtrConst,
+        105 => Composite::PtrMut,
+        _ => return None,
+    };
+    Some(Decoded::Composite {
+        kind,
+        payload: raw >> PAYLOAD_SHIFT,
+    })
+}
+
+pub(crate) const fn has_composite_kind(raw: u32, expected: Composite) -> bool {
+    matches!(
+        decode(raw),
+        Some(Decoded::Composite { kind, .. }) if kind as u8 == expected as u8
+    )
+}
+
+/// Encoding helpers for the compatibility-only `InternedType` wrapper.
+///
+/// Primitive values use the authoritative `Type` primitive encodings exactly.
+/// Pool entries occupy a disjoint range and retain their kind in `TypeData`;
+/// RUE-836/RUE-838 remove this transitional wrapper entirely.
+pub(crate) mod compatibility {
+    use super::{Decoded, decode};
+
+    const POOL_INDEX_OFFSET: u32 = 256;
+
+    pub(crate) const fn encode_pool_index(pool_index: u32) -> Option<u32> {
+        match pool_index.checked_add(POOL_INDEX_OFFSET) {
+            Some(encoded) => Some(encoded),
+            None => None,
+        }
+    }
+
+    pub(crate) const fn decode_pool_index(raw: u32) -> Option<u32> {
+        if raw < POOL_INDEX_OFFSET {
+            None
+        } else {
+            Some(raw - POOL_INDEX_OFFSET)
+        }
+    }
+
+    pub(crate) const fn is_primitive(raw: u32) -> bool {
+        matches!(
+            decode(raw),
+            Some(Decoded::Primitive(
+                super::Primitive::I8
+                    | super::Primitive::I16
+                    | super::Primitive::I32
+                    | super::Primitive::I64
+                    | super::Primitive::U8
+                    | super::Primitive::U16
+                    | super::Primitive::U32
+                    | super::Primitive::U64
+                    | super::Primitive::Bool
+                    | super::Primitive::Unit
+                    | super::Primitive::Error
+                    | super::Primitive::Never
+            ))
+        )
+    }
+}

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -7,6 +7,8 @@
 //! instantiations — well beyond the original i32-only prototype this comment
 //! once described.
 
+use crate::type_encoding::{self, Composite, Decoded, Primitive};
+
 /// A unique identifier for a struct definition.
 ///
 /// The inner value is a pool index into [`TypeInternPool`](crate::TypeInternPool),
@@ -209,10 +211,8 @@ pub enum TypeKind {
 /// # Encoding
 ///
 /// The u32 value uses a tag-based encoding:
-/// - Primitives (0-12): I8=0, I16=1, I32=2, I64=3, U8=4, U16=5, U32=6, U64=7,
-///   Bool=8, Unit=9, Error=10, Never=11, ComptimeType=12
-/// - Composites: low byte is tag (TAG_STRUCT, TAG_ENUM, TAG_ARRAY, TAG_MODULE),
-///   high 24 bits are the ID
+/// Primitive and composite values use the centralized encoding in
+/// `type_encoding`; composite payloads are 24-bit pool or module identifiers.
 ///
 /// # Usage
 ///
@@ -270,16 +270,6 @@ impl std::fmt::Debug for Type {
     }
 }
 
-// Composite type tag constants
-// These are used in the low byte of the u32 encoding to identify composite types.
-// The high 24 bits contain the ID (StructId, EnumId, ArrayTypeId, ModuleId, or pointer type IDs).
-const TAG_STRUCT: u32 = 100;
-const TAG_ENUM: u32 = 101;
-const TAG_ARRAY: u32 = 102;
-const TAG_MODULE: u32 = 103;
-const TAG_PTR_CONST: u32 = 104;
-const TAG_PTR_MUT: u32 = 105;
-
 // Primitive type constants
 impl Type {
     pub(crate) const fn raw_encoding(self) -> u32 {
@@ -287,69 +277,77 @@ impl Type {
     }
 
     /// 8-bit signed integer
-    pub const I8: Type = Type(0);
+    pub const I8: Type = Type(Primitive::I8.encode());
     /// 16-bit signed integer
-    pub const I16: Type = Type(1);
+    pub const I16: Type = Type(Primitive::I16.encode());
     /// 32-bit signed integer
-    pub const I32: Type = Type(2);
+    pub const I32: Type = Type(Primitive::I32.encode());
     /// 64-bit signed integer
-    pub const I64: Type = Type(3);
+    pub const I64: Type = Type(Primitive::I64.encode());
     /// 8-bit unsigned integer
-    pub const U8: Type = Type(4);
+    pub const U8: Type = Type(Primitive::U8.encode());
     /// 16-bit unsigned integer
-    pub const U16: Type = Type(5);
+    pub const U16: Type = Type(Primitive::U16.encode());
     /// 32-bit unsigned integer
-    pub const U32: Type = Type(6);
+    pub const U32: Type = Type(Primitive::U32.encode());
     /// 64-bit unsigned integer
-    pub const U64: Type = Type(7);
+    pub const U64: Type = Type(Primitive::U64.encode());
     /// Boolean
-    pub const BOOL: Type = Type(8);
+    pub const BOOL: Type = Type(Primitive::Bool.encode());
     /// The unit type (for functions that don't return a value)
-    pub const UNIT: Type = Type(9);
+    pub const UNIT: Type = Type(Primitive::Unit.encode());
     /// An error type (used during type checking to continue after errors)
-    pub const ERROR: Type = Type(10);
+    pub const ERROR: Type = Type(Primitive::Error.encode());
     /// The never type - represents computations that don't return
-    pub const NEVER: Type = Type(11);
+    pub const NEVER: Type = Type(Primitive::Never.encode());
     /// The comptime type - the type of types themselves
-    pub const COMPTIME_TYPE: Type = Type(12);
+    pub const COMPTIME_TYPE: Type = Type(Primitive::ComptimeType.encode());
 }
 
 // Composite type constructors
 impl Type {
+    #[inline]
+    const fn new_composite(kind: Composite, payload: u32) -> Type {
+        match type_encoding::encode_composite(kind, payload) {
+            Some(raw) => Type(raw),
+            None => panic!("type encoding payload exceeds 24 bits"),
+        }
+    }
+
     /// Create a struct type from a StructId.
     #[inline]
     pub const fn new_struct(id: StructId) -> Type {
-        Type(TAG_STRUCT | ((id.0 as u32) << 8))
+        Self::new_composite(Composite::Struct, id.0)
     }
 
     /// Create an enum type from an EnumId.
     #[inline]
     pub const fn new_enum(id: EnumId) -> Type {
-        Type(TAG_ENUM | ((id.0 as u32) << 8))
+        Self::new_composite(Composite::Enum, id.0)
     }
 
     /// Create an array type from an ArrayTypeId.
     #[inline]
     pub const fn new_array(id: ArrayTypeId) -> Type {
-        Type(TAG_ARRAY | ((id.0 as u32) << 8))
+        Self::new_composite(Composite::Array, id.0)
     }
 
     /// Create a raw const pointer type from a PtrConstTypeId.
     #[inline]
     pub const fn new_ptr_const(id: PtrConstTypeId) -> Type {
-        Type(TAG_PTR_CONST | ((id.0 as u32) << 8))
+        Self::new_composite(Composite::PtrConst, id.0)
     }
 
     /// Create a raw mut pointer type from a PtrMutTypeId.
     #[inline]
     pub const fn new_ptr_mut(id: PtrMutTypeId) -> Type {
-        Type(TAG_PTR_MUT | ((id.0 as u32) << 8))
+        Self::new_composite(Composite::PtrMut, id.0)
     }
 
     /// Create a module type from a ModuleId.
     #[inline]
     pub const fn new_module(id: ModuleId) -> Type {
-        Type(TAG_MODULE | ((id.0 as u32) << 8))
+        Self::new_composite(Composite::Module, id.0)
     }
 }
 
@@ -548,10 +546,10 @@ impl Type {
             panic!(
                 "invalid Type encoding: raw value {:#010x} (tag={}, id={}). \
                  This indicates data corruption or a bug in Type construction. \
-                 Valid tags are 0-12 (primitives) or 100-105 (composites).",
+                 The tag or payload is malformed or reserved.",
                 self.0,
-                self.0 & 0xFF,
-                self.0 >> 8
+                self.0 & type_encoding::TAG_MASK,
+                self.0 >> type_encoding::PAYLOAD_SHIFT
             )
         })
     }
@@ -575,28 +573,44 @@ impl Type {
     /// ```
     #[inline]
     pub fn try_kind(&self) -> Option<TypeKind> {
-        let tag = self.0 & 0xFF;
-        match tag {
-            0 => Some(TypeKind::I8),
-            1 => Some(TypeKind::I16),
-            2 => Some(TypeKind::I32),
-            3 => Some(TypeKind::I64),
-            4 => Some(TypeKind::U8),
-            5 => Some(TypeKind::U16),
-            6 => Some(TypeKind::U32),
-            7 => Some(TypeKind::U64),
-            8 => Some(TypeKind::Bool),
-            9 => Some(TypeKind::Unit),
-            10 => Some(TypeKind::Error),
-            11 => Some(TypeKind::Never),
-            12 => Some(TypeKind::ComptimeType),
-            TAG_STRUCT => Some(TypeKind::Struct(StructId(self.0 >> 8))),
-            TAG_ENUM => Some(TypeKind::Enum(EnumId(self.0 >> 8))),
-            TAG_ARRAY => Some(TypeKind::Array(ArrayTypeId(self.0 >> 8))),
-            TAG_PTR_CONST => Some(TypeKind::PtrConst(PtrConstTypeId(self.0 >> 8))),
-            TAG_PTR_MUT => Some(TypeKind::PtrMut(PtrMutTypeId(self.0 >> 8))),
-            TAG_MODULE => Some(TypeKind::Module(ModuleId(self.0 >> 8))),
-            _ => None,
+        match type_encoding::decode(self.0)? {
+            Decoded::Primitive(Primitive::I8) => Some(TypeKind::I8),
+            Decoded::Primitive(Primitive::I16) => Some(TypeKind::I16),
+            Decoded::Primitive(Primitive::I32) => Some(TypeKind::I32),
+            Decoded::Primitive(Primitive::I64) => Some(TypeKind::I64),
+            Decoded::Primitive(Primitive::U8) => Some(TypeKind::U8),
+            Decoded::Primitive(Primitive::U16) => Some(TypeKind::U16),
+            Decoded::Primitive(Primitive::U32) => Some(TypeKind::U32),
+            Decoded::Primitive(Primitive::U64) => Some(TypeKind::U64),
+            Decoded::Primitive(Primitive::Bool) => Some(TypeKind::Bool),
+            Decoded::Primitive(Primitive::Unit) => Some(TypeKind::Unit),
+            Decoded::Primitive(Primitive::Error) => Some(TypeKind::Error),
+            Decoded::Primitive(Primitive::Never) => Some(TypeKind::Never),
+            Decoded::Primitive(Primitive::ComptimeType) => Some(TypeKind::ComptimeType),
+            Decoded::Composite {
+                kind: Composite::Struct,
+                payload,
+            } => Some(TypeKind::Struct(StructId(payload))),
+            Decoded::Composite {
+                kind: Composite::Enum,
+                payload,
+            } => Some(TypeKind::Enum(EnumId(payload))),
+            Decoded::Composite {
+                kind: Composite::Array,
+                payload,
+            } => Some(TypeKind::Array(ArrayTypeId(payload))),
+            Decoded::Composite {
+                kind: Composite::Module,
+                payload,
+            } => Some(TypeKind::Module(ModuleId(payload))),
+            Decoded::Composite {
+                kind: Composite::PtrConst,
+                payload,
+            } => Some(TypeKind::PtrConst(PtrConstTypeId(payload))),
+            Decoded::Composite {
+                kind: Composite::PtrMut,
+                payload,
+            } => Some(TypeKind::PtrMut(PtrMutTypeId(payload))),
         }
     }
 
@@ -706,7 +720,19 @@ impl Type {
     /// Optimized: checks tag range directly (0-7 are integer types).
     #[inline]
     pub fn is_integer(&self) -> bool {
-        self.0 <= 7
+        matches!(
+            type_encoding::decode(self.0),
+            Some(Decoded::Primitive(
+                Primitive::I8
+                    | Primitive::I16
+                    | Primitive::I32
+                    | Primitive::I64
+                    | Primitive::U8
+                    | Primitive::U16
+                    | Primitive::U32
+                    | Primitive::U64
+            ))
+        )
     }
 
     /// Check if this is an error type.
@@ -730,14 +756,14 @@ impl Type {
     /// Check if this is a struct type.
     #[inline]
     pub fn is_struct(&self) -> bool {
-        (self.0 & 0xFF) == TAG_STRUCT
+        type_encoding::has_composite_kind(self.0, Composite::Struct)
     }
 
     /// Get the struct ID if this is a struct type.
     #[inline]
     pub fn as_struct(&self) -> Option<StructId> {
         if self.is_struct() {
-            Some(StructId(self.0 >> 8))
+            Some(StructId(self.0 >> type_encoding::PAYLOAD_SHIFT))
         } else {
             None
         }
@@ -746,14 +772,14 @@ impl Type {
     /// Check if this is an array type.
     #[inline]
     pub fn is_array(&self) -> bool {
-        (self.0 & 0xFF) == TAG_ARRAY
+        type_encoding::has_composite_kind(self.0, Composite::Array)
     }
 
     /// Get the array type ID if this is an array type.
     #[inline]
     pub fn as_array(&self) -> Option<ArrayTypeId> {
         if self.is_array() {
-            Some(ArrayTypeId(self.0 >> 8))
+            Some(ArrayTypeId(self.0 >> type_encoding::PAYLOAD_SHIFT))
         } else {
             None
         }
@@ -762,14 +788,14 @@ impl Type {
     /// Check if this is an enum type.
     #[inline]
     pub fn is_enum(&self) -> bool {
-        (self.0 & 0xFF) == TAG_ENUM
+        type_encoding::has_composite_kind(self.0, Composite::Enum)
     }
 
     /// Get the enum ID if this is an enum type.
     #[inline]
     pub fn as_enum(&self) -> Option<EnumId> {
         if self.is_enum() {
-            Some(EnumId(self.0 >> 8))
+            Some(EnumId(self.0 >> type_encoding::PAYLOAD_SHIFT))
         } else {
             None
         }
@@ -778,14 +804,14 @@ impl Type {
     /// Check if this is a module type.
     #[inline]
     pub fn is_module(&self) -> bool {
-        (self.0 & 0xFF) == TAG_MODULE
+        type_encoding::has_composite_kind(self.0, Composite::Module)
     }
 
     /// Get the module ID if this is a module type.
     #[inline]
     pub fn as_module(&self) -> Option<ModuleId> {
         if self.is_module() {
-            Some(ModuleId(self.0 >> 8))
+            Some(ModuleId(self.0 >> type_encoding::PAYLOAD_SHIFT))
         } else {
             None
         }
@@ -794,14 +820,14 @@ impl Type {
     /// Check if this is a raw const pointer type.
     #[inline]
     pub fn is_ptr_const(&self) -> bool {
-        (self.0 & 0xFF) == TAG_PTR_CONST
+        type_encoding::has_composite_kind(self.0, Composite::PtrConst)
     }
 
     /// Get the pointer type ID if this is a ptr const type.
     #[inline]
     pub fn as_ptr_const(&self) -> Option<PtrConstTypeId> {
         if self.is_ptr_const() {
-            Some(PtrConstTypeId(self.0 >> 8))
+            Some(PtrConstTypeId(self.0 >> type_encoding::PAYLOAD_SHIFT))
         } else {
             None
         }
@@ -810,14 +836,14 @@ impl Type {
     /// Check if this is a raw mut pointer type.
     #[inline]
     pub fn is_ptr_mut(&self) -> bool {
-        (self.0 & 0xFF) == TAG_PTR_MUT
+        type_encoding::has_composite_kind(self.0, Composite::PtrMut)
     }
 
     /// Get the pointer type ID if this is a ptr mut type.
     #[inline]
     pub fn as_ptr_mut(&self) -> Option<PtrMutTypeId> {
         if self.is_ptr_mut() {
-            Some(PtrMutTypeId(self.0 >> 8))
+            Some(PtrMutTypeId(self.0 >> type_encoding::PAYLOAD_SHIFT))
         } else {
             None
         }
@@ -826,15 +852,19 @@ impl Type {
     /// Check if this is any raw pointer type (ptr const or ptr mut).
     #[inline]
     pub fn is_ptr(&self) -> bool {
-        let tag = self.0 & 0xFF;
-        tag == TAG_PTR_CONST || tag == TAG_PTR_MUT
+        self.is_ptr_const() || self.is_ptr_mut()
     }
 
     /// Check if this is a signed integer type.
     /// Optimized: checks tag range directly (0-3 are signed integers).
     #[inline]
     pub fn is_signed(&self) -> bool {
-        self.0 <= 3
+        matches!(
+            type_encoding::decode(self.0),
+            Some(Decoded::Primitive(
+                Primitive::I8 | Primitive::I16 | Primitive::I32 | Primitive::I64
+            ))
+        )
     }
 
     /// Check if this is a Copy type (can be implicitly duplicated).
@@ -854,21 +884,13 @@ impl Type {
     /// types since it doesn't have access to StructDefs or array type information.
     /// Use Sema.is_type_copy() for full checking.
     pub fn is_copy(&self) -> bool {
-        let tag = self.0 & 0xFF;
-        match tag {
-            // Primitive Copy types (I8..Unit = 0..9)
-            0..=9 => true,
-            // Error, Never, ComptimeType are Copy for convenience
-            10..=12 => true,
-            // Enum types are Copy (they're small discriminant values)
-            TAG_ENUM => true,
-            // Module types are Copy (they're just compile-time namespace references)
-            TAG_MODULE => true,
-            // Struct types are move types by default
-            TAG_STRUCT => false,
-            // Arrays may be Copy if element type is Copy (need TypeInternPool to check)
-            TAG_ARRAY => false,
-            _ => false,
+        match type_encoding::decode(self.0) {
+            Some(Decoded::Primitive(_)) => true,
+            Some(Decoded::Composite {
+                kind: Composite::Enum | Composite::Module,
+                ..
+            }) => true,
+            Some(Decoded::Composite { .. }) | None => false,
         }
     }
 
@@ -891,7 +913,7 @@ impl Type {
     /// Optimized: checks for I64 (3) or U64 (7).
     #[inline]
     pub fn is_64_bit(&self) -> bool {
-        self.0 == 3 || self.0 == 7
+        matches!(*self, Type::I64 | Type::U64)
     }
 
     /// Check if this type can coerce to the target type.
@@ -909,7 +931,12 @@ impl Type {
     #[inline]
     #[must_use]
     pub fn is_unsigned(&self) -> bool {
-        self.0 >= 4 && self.0 <= 7
+        matches!(
+            type_encoding::decode(self.0),
+            Some(Decoded::Primitive(
+                Primitive::U8 | Primitive::U16 | Primitive::U32 | Primitive::U64
+            ))
+        )
     }
 
     /// Check if a u64 value fits within the range of this integer type.
@@ -921,15 +948,15 @@ impl Type {
     /// For non-integer types, returns `false`.
     #[must_use]
     pub fn literal_fits(&self, value: u64) -> bool {
-        match self.0 {
-            0 => value <= i8::MAX as u64,  // I8
-            1 => value <= i16::MAX as u64, // I16
-            2 => value <= i32::MAX as u64, // I32
-            3 => value <= i64::MAX as u64, // I64
-            4 => value <= u8::MAX as u64,  // U8
-            5 => value <= u16::MAX as u64, // U16
-            6 => value <= u32::MAX as u64, // U32
-            7 => true,                     // U64 - Any u64 value fits
+        match self.try_kind() {
+            Some(TypeKind::I8) => value <= i8::MAX as u64,
+            Some(TypeKind::I16) => value <= i16::MAX as u64,
+            Some(TypeKind::I32) => value <= i32::MAX as u64,
+            Some(TypeKind::I64) => value <= i64::MAX as u64,
+            Some(TypeKind::U8) => value <= u8::MAX as u64,
+            Some(TypeKind::U16) => value <= u16::MAX as u64,
+            Some(TypeKind::U32) => value <= u32::MAX as u64,
+            Some(TypeKind::U64) => true,
             _ => false,
         }
     }
@@ -939,12 +966,12 @@ impl Type {
     /// Returns `None` for non-integer types.
     #[must_use]
     pub fn int_bit_width(&self) -> Option<u32> {
-        if self.is_integer() {
-            // Tags 0..=3 are i8..i64, 4..=7 are u8..u64; the low two bits
-            // select the width in both groups.
-            Some(8 << (self.0 & 3))
-        } else {
-            None
+        match self.try_kind()? {
+            TypeKind::I8 | TypeKind::U8 => Some(8),
+            TypeKind::I16 | TypeKind::U16 => Some(16),
+            TypeKind::I32 | TypeKind::U32 => Some(32),
+            TypeKind::I64 | TypeKind::U64 => Some(64),
+            _ => None,
         }
     }
 
@@ -980,11 +1007,11 @@ impl Type {
     /// Returns `true` if the negated value fits, `false` otherwise.
     #[must_use]
     pub fn negated_literal_fits(&self, value: u64) -> bool {
-        match self.0 {
-            0 => value <= (i8::MIN as i64).unsigned_abs(),  // I8
-            1 => value <= (i16::MIN as i64).unsigned_abs(), // I16
-            2 => value <= (i32::MIN as i64).unsigned_abs(), // I32
-            3 => value <= (i64::MIN).unsigned_abs(),        // I64
+        match self.try_kind() {
+            Some(TypeKind::I8) => value <= (i8::MIN as i64).unsigned_abs(),
+            Some(TypeKind::I16) => value <= (i16::MIN as i64).unsigned_abs(),
+            Some(TypeKind::I32) => value <= (i32::MIN as i64).unsigned_abs(),
+            Some(TypeKind::I64) => value <= (i64::MIN).unsigned_abs(),
             _ => false,
         }
     }
@@ -993,7 +1020,7 @@ impl Type {
     ///
     /// Since Type is now a u32 newtype, this simply returns the inner value.
     #[inline]
-    pub fn as_u32(&self) -> u32 {
+    pub(crate) fn as_u32(&self) -> u32 {
         self.0
     }
 
@@ -1007,7 +1034,7 @@ impl Type {
     /// This method trusts that the input is a valid encoding. For untrusted data,
     /// use [`try_from_u32`](Self::try_from_u32) which validates the encoding.
     #[inline]
-    pub fn from_u32(v: u32) -> Self {
+    pub(crate) fn from_u32(v: u32) -> Self {
         Type(v)
     }
 
@@ -1040,15 +1067,7 @@ impl Type {
     /// Returns `true` if the value represents a valid primitive or composite type.
     #[inline]
     pub fn is_valid_encoding(v: u32) -> bool {
-        let tag = v & 0xFF;
-        match tag {
-            // Primitive types: I8=0 through ComptimeType=12
-            0..=12 => true,
-            // Composite types with valid tags
-            TAG_STRUCT | TAG_ENUM | TAG_ARRAY | TAG_PTR_CONST | TAG_PTR_MUT | TAG_MODULE => true,
-            // Everything else is invalid
-            _ => false,
-        }
+        type_encoding::decode(v).is_some()
     }
 
     /// Check if this Type has a valid encoding.
@@ -1928,7 +1947,9 @@ mod tests {
     #[test]
     fn test_is_valid_encoding_invalid() {
         // Tags between primitives and composites are invalid (13-99)
-        for tag in 13..100u32 {
+        for tag in type_encoding::RESERVED_AFTER_PRIMITIVES_START
+            ..=type_encoding::RESERVED_AFTER_PRIMITIVES_END
+        {
             assert!(
                 !Type::is_valid_encoding(tag),
                 "tag {} should be invalid",
@@ -1937,13 +1958,22 @@ mod tests {
         }
 
         // Tags above composites are invalid (106+)
-        for tag in 106..=255u32 {
+        for tag in type_encoding::RESERVED_AFTER_COMPOSITES_START
+            ..=type_encoding::RESERVED_AFTER_COMPOSITES_END
+        {
             assert!(
                 !Type::is_valid_encoding(tag),
                 "tag {} should be invalid",
                 tag
             );
         }
+
+        // Primitive tags cannot carry a composite payload. This used to
+        // silently decode as I8 because only the low byte was inspected.
+        assert!(!Type::is_valid_encoding(1 << type_encoding::PAYLOAD_SHIFT));
+        assert!(!Type::is_valid_encoding(
+            (17 << type_encoding::PAYLOAD_SHIFT) | Primitive::Never.encode()
+        ));
     }
 
     #[test]
@@ -1965,6 +1995,22 @@ mod tests {
         assert!(Type::try_from_u32(99).is_none());
         assert!(Type::try_from_u32(106).is_none());
         assert!(Type::try_from_u32(255).is_none());
+        assert!(Type::try_from_u32(1 << type_encoding::PAYLOAD_SHIFT).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "type encoding payload exceeds 24 bits")]
+    fn composite_constructor_rejects_payload_overflow() {
+        let _ = Type::new_struct(StructId(type_encoding::MAX_PAYLOAD + 1));
+    }
+
+    #[test]
+    fn composite_constructor_accepts_maximum_payload() {
+        let ty = Type::new_module(ModuleId(type_encoding::MAX_PAYLOAD));
+        assert_eq!(
+            ty.try_kind(),
+            Some(TypeKind::Module(ModuleId(type_encoding::MAX_PAYLOAD)))
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use lasso::{Key, Spur};
@@ -6,6 +6,24 @@ use rue_air::{AirInstData, AnalyzedFunction, Type, TypeKind};
 use rue_span::Span;
 
 use crate::{DurableAirInstData, DurableOrdinaryBodyPayload, DurableType};
+
+fn deduplicate_type_mappings(
+    mappings: Vec<(Type, DurableType)>,
+) -> Result<Vec<(Type, DurableType)>, CfgDomainFailure> {
+    let mut positions: HashMap<Type, usize> = HashMap::with_capacity(mappings.len());
+    let mut unique: Vec<(Type, DurableType)> = Vec::with_capacity(mappings.len());
+    for (current, stable) in mappings {
+        if let Some(&position) = positions.get(&current) {
+            if unique[position].1 != stable {
+                return Err(CfgDomainFailure::Shape);
+            }
+        } else {
+            positions.insert(current, unique.len());
+            unique.push((current, stable));
+        }
+    }
+    Ok(unique)
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StableCfgInput {
@@ -297,11 +315,7 @@ impl CfgDomainProjection {
                 }
             }
         }
-        types.sort_by_key(|(ty, _)| ty.as_u32());
-        types.dedup_by(|left, right| left.0 == right.0 && left.1 == right.1);
-        if types.windows(2).any(|pair| pair[0].0 == pair[1].0) {
-            return Err(CfgDomainFailure::Shape);
-        }
+        let types = deduplicate_type_mappings(types)?;
         stable_strings.sort_by_key(|(index, _)| *index);
         stable_strings.dedup();
         spans.sort_by_key(|(span, _)| (span.file_id.index(), span.start, span.end));
@@ -423,6 +437,28 @@ mod tests {
             )],
             symbols: vec![(symbol, StableCfgSymbol::Intrinsic(Arc::from("stable")))],
         }
+    }
+
+    #[test]
+    fn type_mapping_deduplication_preserves_encounter_order_and_rejects_conflicts() {
+        let mappings = deduplicate_type_mappings(vec![
+            (Type::I64, DurableType::I64),
+            (Type::I32, DurableType::I32),
+            (Type::I64, DurableType::I64),
+        ])
+        .unwrap();
+        assert_eq!(
+            mappings,
+            vec![(Type::I64, DurableType::I64), (Type::I32, DurableType::I32)]
+        );
+
+        assert_eq!(
+            deduplicate_type_mappings(vec![
+                (Type::I32, DurableType::I32),
+                (Type::I32, DurableType::I64),
+            ]),
+            Err(CfgDomainFailure::Shape)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- centralize primitive tags, composite tags, reserved ranges, payload limits, checked construction, and decoding in one type-encoding authority
- align transitional InternedType primitives with Type and remove the Error/Never encoding split
- model reserved, declared, and complete nominal pool entries explicitly, with checked single-completion transitions and incomplete-state freeze rejection
- complete empty enums correctly and avoid constructing discarded frozen output after semantic errors
- bound every pool allocation to the 24-bit Type payload and keep raw Type construction private

## Validation

- scripts/rue fmt
- focused rue-air tests: 428 passed
- focused rue-compiler tests: 557 passed
- scripts/rue quick: 28 targets passed
- scripts/rue test: full suite passed (CLI 1466, oracle 64/64, spec 2071, UI 178, reproducibility)
- adversarial architectural review: clean

Fixes RUE-835