### PR TITLE
RUE-925: factor a shared may_trap/is_speculatable classifier out of DCE

### DIFF
--- a/crates/rue-cfg/src/opt/classify.rs
+++ b/crates/rue-cfg/src/opt/classify.rs
@@ -1,0 +1,409 @@
+//! Shared trap / speculation classifier for optimizer passes.
+//!
+//! DCE, LICM (RUE-927), and unrolling (RUE-928) all need to reason about whether
+//! a CFG instruction can *trap* — abort the program with a runtime panic that
+//! ADR-0044 counts as defined, observable behavior no optimization level may add
+//! or remove. Historically that knowledge lived only inside DCE's private
+//! `has_side_effects` predicate, which conflated two independent axes. ADR-0054
+//! §2 makes this module the single place that names the trapping set, so the two
+//! axes cannot drift apart across the passes that consult them.
+//!
+//! ## Why a module in `opt` (not `CfgInstData` methods)
+//!
+//! The ADR offers two shapes: an `opt::classify` module or `CfgInstData`-level
+//! `may_trap`/`is_speculatable` methods. This crate already keeps its
+//! optimizer-facing analyses in `opt/` (`dce`, `forward`, `cse`, …) and its
+//! `inst` module deliberately free of pass policy — what "traps" is an optimizer
+//! concern, not an intrinsic property of the instruction enum. The classifier
+//! also needs the `Cfg` (an indexed `PlaceRead` is only trap-carrying when its
+//! projection list contains an `Index`, which lives in `Cfg::projections`), so a
+//! free function taking `(&Cfg, CfgValue)` matches DCE's existing call shape
+//! exactly and lets LICM/unrolling reuse it verbatim.
+//!
+//! ## The two axes (defined independently)
+//!
+//! - [`may_trap`]: the instruction can panic at runtime — overflow-checked
+//!   arithmetic (`Add`/`Sub`/`Mul`/`Neg`), division checks (`Div`/`Mod`), the
+//!   `IntCast` range check (`__rue_intcast_overflow`), and the bounds check of a
+//!   `PlaceRead` whose place contains an `Index` projection. This is the axis
+//!   LICM and unrolling need on its own: hoisting a `may_trap` op into a
+//!   zero-trip preheader would manufacture a trap out of thin air.
+//! - [`has_observable_side_effect`]: the instruction is visible beyond its
+//!   result value — `Call`, `Intrinsic`, `Alloc`, `Store`, `ParamStore`,
+//!   `PlaceWrite`, `Drop`, `StorageLive`/`StorageDead`. This is the axis DCE
+//!   needs to keep an op live even when its result is unused.
+//!
+//! These axes are orthogonal: arithmetic is *pure but trapping* (`may_trap` yet
+//! no observable effect), while `Store` is *effecting but non-trapping*. That
+//! pure-but-trapping case is exactly what motivates the split — DCE must keep it,
+//! LICM must refuse to hoist it, and neither can be expressed with a single
+//! "has effects" bit.
+//!
+//! ## `is_speculatable`
+//!
+//! An op is *speculatable* when it can be evaluated freely on any path — it can
+//! neither trap nor be observed. Stated once, as the single definition every
+//! consumer relies on:
+//!
+//! ```text
+//! is_speculatable(v)  ==  !may_trap(v) && !has_observable_side_effect(v)
+//! ```
+//!
+//! Bitwise ops, shifts (counts are masked per spec, so they never trap),
+//! comparisons, `Not`/`BitNot`, constants, non-indexed `PlaceRead`/`Load`, and
+//! the aggregate constructors are the speculatable set — the ops LICM may hoist.
+
+use crate::{Cfg, CfgInstData, CfgValue, Projection};
+
+/// Returns `true` if evaluating `value` can trap (panic) at runtime.
+///
+/// The trapping set, named once here per ADR-0054 §2:
+/// - overflow-checked arithmetic: `Add`, `Sub`, `Mul`, `Neg`;
+/// - division checks: `Div`, `Mod` (divide-by-zero / `INT_MIN / -1`);
+/// - `IntCast` (range check, panics via `__rue_intcast_overflow`);
+/// - `PlaceRead` through an `Index` projection (array bounds check).
+///
+/// Bitwise ops and shifts do **not** trap (shift counts are masked per spec).
+pub(crate) fn may_trap(cfg: &Cfg, value: CfgValue) -> bool {
+    match &cfg.get_inst(value).data {
+        // Overflow-checked arithmetic and division checks panic at runtime.
+        CfgInstData::Add(..)
+        | CfgInstData::Sub(..)
+        | CfgInstData::Mul(..)
+        | CfgInstData::Div(..)
+        | CfgInstData::Mod(..)
+        | CfgInstData::Neg(..) => true,
+
+        // IntCast range-checks the narrowing conversion and panics when the
+        // value is out of range for the target type.
+        CfgInstData::IntCast { .. } => true,
+
+        // A PlaceRead is pure for field projections, but an array index read
+        // performs a bounds check that panics when out of range. Only a place
+        // containing an Index projection can trap (RUE-57).
+        CfgInstData::PlaceRead { place } => cfg
+            .get_place_projections(place)
+            .iter()
+            .any(|p| matches!(p, Projection::Index { .. })),
+
+        // Everything else evaluates without a runtime trap.
+        _ => false,
+    }
+}
+
+/// Returns `true` if `value` has an effect observable beyond its result value.
+///
+/// These are the ops DCE must keep live even when their result is unused:
+/// `Call`, `Intrinsic`, `Alloc`, `Store`, `ParamStore`, `PlaceWrite`, `Drop`,
+/// and `StorageLive`/`StorageDead`. This axis is independent of [`may_trap`]:
+/// none of these are counted here for their trap potential (a `Call` may of
+/// course trap, but it is kept live for its effect, and it is not part of the
+/// `may_trap` speculation set because it is never a hoist candidate anyway).
+pub(crate) fn has_observable_side_effect(cfg: &Cfg, value: CfgValue) -> bool {
+    match &cfg.get_inst(value).data {
+        // Function and intrinsic calls can have arbitrary effects.
+        CfgInstData::Call { .. } | CfgInstData::Intrinsic { .. } => true,
+
+        // Memory writes.
+        CfgInstData::Alloc { .. }
+        | CfgInstData::Store { .. }
+        | CfgInstData::ParamStore { .. }
+        | CfgInstData::PlaceWrite { .. } => true,
+
+        // Drop runs destructors.
+        CfgInstData::Drop { .. } => true,
+
+        // Storage liveness affects stack allocation.
+        CfgInstData::StorageLive { .. } | CfgInstData::StorageDead { .. } => true,
+
+        _ => false,
+    }
+}
+
+/// Returns `true` if `value` may be evaluated freely on any path.
+///
+/// A speculatable op can neither trap nor be observed, so a pass may move it,
+/// duplicate it, or hoist it without changing observable behavior. This is the
+/// single definition of the relationship between the two axes; see the module
+/// docs:
+///
+/// ```text
+/// is_speculatable(v)  ==  !may_trap(v) && !has_observable_side_effect(v)
+/// ```
+// Exercised by this module's tests today; its release-build consumers are LICM
+// (RUE-927, the hoist predicate) and unrolling (RUE-928), still pending — so it
+// opts out of dead-code denial here rather than being pruned, exactly as the
+// shared `dominators` module does for its pending loop consumers.
+#[allow(dead_code)]
+pub(crate) fn is_speculatable(cfg: &Cfg, value: CfgValue) -> bool {
+    !may_trap(cfg, value) && !has_observable_side_effect(cfg, value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CfgInst, CfgInstData, Place, PlaceBase, Projection, Terminator};
+    use lasso::ThreadedRodeo;
+    use rue_air::Type;
+    use rue_span::Span;
+
+    fn make_cfg() -> Cfg {
+        let mut cfg = Cfg::new(Type::I32, 0, 0, "test".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg
+    }
+
+    fn add(cfg: &mut Cfg, data: CfgInstData, ty: Type) -> CfgValue {
+        let entry = cfg.entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data,
+                ty,
+                span: Span::new(0, 0),
+            },
+        )
+    }
+
+    fn konst(cfg: &mut Cfg, v: u64) -> CfgValue {
+        add(cfg, CfgInstData::Const(v), Type::I32)
+    }
+
+    // --- The trap axis: every trapping op reports may_trap and is NOT
+    //     speculatable, independent of any observable-effect grouping. ---
+
+    #[test]
+    fn arithmetic_may_trap() {
+        let mut cfg = make_cfg();
+        let a = konst(&mut cfg, 1);
+        let b = konst(&mut cfg, 2);
+        let ops = [
+            add(&mut cfg, CfgInstData::Add(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::Sub(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::Mul(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::Div(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::Mod(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::Neg(a), Type::I32),
+        ];
+        for op in ops {
+            assert!(may_trap(&cfg, op), "arithmetic must be may_trap");
+            assert!(
+                !is_speculatable(&cfg, op),
+                "trapping arithmetic must NOT be speculatable"
+            );
+            assert!(
+                !has_observable_side_effect(&cfg, op),
+                "arithmetic is pure — no observable side effect"
+            );
+        }
+    }
+
+    #[test]
+    fn intcast_may_trap() {
+        // IntCast range-checks and panics; it must be in the trapping set even
+        // though it is otherwise pure (the distinction an earlier LICM draft
+        // missed, ADR-0054 §2).
+        let mut cfg = make_cfg();
+        let a = konst(&mut cfg, 300);
+        let cast = add(
+            &mut cfg,
+            CfgInstData::IntCast {
+                value: a,
+                from_ty: Type::I32,
+            },
+            Type::I8,
+        );
+        assert!(may_trap(&cfg, cast), "IntCast must be may_trap");
+        assert!(!is_speculatable(&cfg, cast));
+        assert!(!has_observable_side_effect(&cfg, cast));
+    }
+
+    #[test]
+    fn indexed_place_read_may_trap() {
+        // A PlaceRead through an Index projection performs a bounds check.
+        let mut cfg = make_cfg();
+        let idx = konst(&mut cfg, 0);
+        let place = cfg.make_place(
+            PlaceBase::Local(0),
+            Type::I32,
+            [Projection::Index {
+                array_type: Type::I32,
+                index: idx,
+            }],
+        );
+        let read = add(&mut cfg, CfgInstData::PlaceRead { place }, Type::I32);
+        assert!(may_trap(&cfg, read), "indexed PlaceRead must be may_trap");
+        assert!(!is_speculatable(&cfg, read));
+        assert!(!has_observable_side_effect(&cfg, read));
+    }
+
+    #[test]
+    fn non_indexed_place_read_does_not_trap() {
+        // A field/base PlaceRead has no bounds check: pure and speculatable.
+        let mut cfg = make_cfg();
+        let base = Place::local(0, Type::I32);
+        let read = add(&mut cfg, CfgInstData::PlaceRead { place: base }, Type::I32);
+        assert!(!may_trap(&cfg, read), "non-indexed PlaceRead must not trap");
+        assert!(
+            is_speculatable(&cfg, read),
+            "non-indexed PlaceRead is speculatable"
+        );
+    }
+
+    // --- The side-effect axis: every observable op reports the effect and is
+    //     NOT speculatable, but (except where it also traps) is NOT may_trap. ---
+
+    #[test]
+    fn effecting_ops_are_not_speculatable_and_not_trapping() {
+        let mut cfg = make_cfg();
+        let v = konst(&mut cfg, 7);
+        let interner = ThreadedRodeo::new();
+        let name = interner.get_or_intern("f");
+        let (args_start, args_len) = cfg.push_call_args(std::iter::empty());
+        let (iargs_start, iargs_len) = cfg.push_extra(std::iter::empty());
+
+        let effecting = [
+            add(
+                &mut cfg,
+                CfgInstData::Call {
+                    runtime: None,
+                    name,
+                    args_start,
+                    args_len,
+                },
+                Type::UNIT,
+            ),
+            add(
+                &mut cfg,
+                CfgInstData::Intrinsic {
+                    runtime: None,
+                    name,
+                    args_start: iargs_start,
+                    args_len: iargs_len,
+                },
+                Type::UNIT,
+            ),
+            add(&mut cfg, CfgInstData::Alloc { slot: 0, init: v }, Type::I32),
+            add(
+                &mut cfg,
+                CfgInstData::Store { slot: 0, value: v },
+                Type::UNIT,
+            ),
+            add(
+                &mut cfg,
+                CfgInstData::ParamStore {
+                    param_slot: 0,
+                    value: v,
+                },
+                Type::UNIT,
+            ),
+            add(
+                &mut cfg,
+                CfgInstData::PlaceWrite {
+                    place: Place::local(0, Type::I32),
+                    value: v,
+                },
+                Type::UNIT,
+            ),
+            add(&mut cfg, CfgInstData::Drop { value: v }, Type::UNIT),
+            add(
+                &mut cfg,
+                CfgInstData::StorageLive {
+                    slot: 0,
+                    local_ty: Type::I32,
+                },
+                Type::UNIT,
+            ),
+            add(
+                &mut cfg,
+                CfgInstData::StorageDead {
+                    slot: 0,
+                    local_ty: Type::I32,
+                },
+                Type::UNIT,
+            ),
+        ];
+        for op in effecting {
+            assert!(
+                has_observable_side_effect(&cfg, op),
+                "op must report an observable side effect"
+            );
+            assert!(!may_trap(&cfg, op), "these effecting ops are not may_trap");
+            assert!(
+                !is_speculatable(&cfg, op),
+                "effecting ops must NOT be speculatable"
+            );
+        }
+    }
+
+    // --- The pure-and-speculatable set: bitwise, shifts, comparisons,
+    //     Not/BitNot, and constants. ---
+
+    #[test]
+    fn pure_ops_are_speculatable() {
+        let mut cfg = make_cfg();
+        let a = konst(&mut cfg, 1);
+        let b = konst(&mut cfg, 2);
+        let ops = [
+            konst(&mut cfg, 42),
+            add(&mut cfg, CfgInstData::BoolConst(true), Type::BOOL),
+            add(&mut cfg, CfgInstData::BitAnd(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::BitOr(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::BitXor(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::Shl(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::Shr(a, b), Type::I32),
+            add(&mut cfg, CfgInstData::Eq(a, b), Type::BOOL),
+            add(&mut cfg, CfgInstData::Ne(a, b), Type::BOOL),
+            add(&mut cfg, CfgInstData::Lt(a, b), Type::BOOL),
+            add(&mut cfg, CfgInstData::Gt(a, b), Type::BOOL),
+            add(&mut cfg, CfgInstData::Le(a, b), Type::BOOL),
+            add(&mut cfg, CfgInstData::Ge(a, b), Type::BOOL),
+            add(&mut cfg, CfgInstData::Not(a), Type::BOOL),
+            add(&mut cfg, CfgInstData::BitNot(a), Type::I32),
+        ];
+        for op in ops {
+            assert!(
+                is_speculatable(&cfg, op),
+                "bitwise/shift/comparison/const must be speculatable"
+            );
+            assert!(!may_trap(&cfg, op), "these ops do not trap");
+            assert!(!has_observable_side_effect(&cfg, op));
+        }
+    }
+
+    // --- The distinction that motivates the split: pure-but-trapping. A single
+    //     "has effects" bit cannot express this; the two axes must be
+    //     independent. ---
+
+    #[test]
+    fn pure_but_trapping_is_distinct_from_effecting() {
+        let mut cfg = make_cfg();
+        let a = konst(&mut cfg, 1);
+        let b = konst(&mut cfg, 2);
+        let arith = add(&mut cfg, CfgInstData::Add(a, b), Type::I32);
+        let store = add(
+            &mut cfg,
+            CfgInstData::Store { slot: 0, value: a },
+            Type::UNIT,
+        );
+        let _ = b;
+
+        // Arithmetic: traps but has no observable effect.
+        assert!(may_trap(&cfg, arith));
+        assert!(!has_observable_side_effect(&cfg, arith));
+
+        // Store: has an observable effect but does not trap.
+        assert!(!may_trap(&cfg, store));
+        assert!(has_observable_side_effect(&cfg, store));
+
+        // Neither is speculatable, but for opposite reasons.
+        assert!(!is_speculatable(&cfg, arith));
+        assert!(!is_speculatable(&cfg, store));
+
+        // Give the block a terminator so the CFG is well-formed for any
+        // downstream inspection.
+        let entry = cfg.entry;
+        cfg.set_terminator(entry, Terminator::Return { value: Some(arith) });
+    }
+}

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -12,16 +12,21 @@
 //! 4. Remove dead instructions from basic blocks
 //! 5. Remove unreachable blocks
 //!
-//! ## What counts as a side effect
+//! ## What keeps an instruction live
 //!
-//! - Function calls (may have arbitrary effects)
-//! - Intrinsic calls (e.g., @dbg)
-//! - Store instructions (write to memory)
-//! - Alloc instructions (initialize memory)
-//! - PlaceWrite (write to projected memory)
-//! - Drop instructions (run destructors)
-//! - StorageLive, StorageDead (affect stack allocation)
+//! DCE must not eliminate an instruction that is either *observable* or *can
+//! trap*. Those two axes are named once in the shared classifier
+//! (`super::classify`, ADR-0054 §2), and this pass keeps an op live when either
+//! holds:
+//!
+//! - Observable side effect (`classify::has_observable_side_effect`): function
+//!   calls, intrinsics, `Store`/`ParamStore`/`PlaceWrite`, `Alloc`, `Drop`,
+//!   `StorageLive`/`StorageDead`.
+//! - May trap (`classify::may_trap`): overflow-checked arithmetic and division
+//!   checks, `IntCast` (range check), and an indexed `PlaceRead` (bounds check)
+//!   — the mandatory runtime traps DCE must preserve (RUE-57).
 
+use super::classify;
 use crate::{BlockId, Cfg, CfgInstData, CfgValue, Projection, Terminator};
 
 /// A simple bitset for tracking indices.
@@ -132,57 +137,23 @@ fn compute_live_values(cfg: &Cfg) -> BitSet {
     live
 }
 
-/// Check if an instruction has side effects.
+/// Check whether an instruction must be kept live regardless of use count.
+///
+/// An instruction cannot be eliminated when it is either observable or can
+/// trap. Both axes are named once in the shared classifier (`super::classify`,
+/// ADR-0054 §2), so DCE, LICM, and unrolling agree on the trapping set:
+///
+/// - `classify::has_observable_side_effect` — `Call`, `Intrinsic`, `Alloc`,
+///   `Store`, `ParamStore`, `PlaceWrite`, `Drop`, `StorageLive`/`StorageDead`.
+/// - `classify::may_trap` — overflow-checked arithmetic and division checks,
+///   `IntCast` (range check), and an indexed `PlaceRead` (bounds check). These
+///   are the mandatory runtime traps DCE must preserve even when the result is
+///   unused (RUE-57). Bitwise ops and shifts do not trap (shift counts are
+///   masked per spec), so they remain eligible for elimination.
+///
+/// This is exactly `classify::is_speculatable`'s negation, expressed positively.
 fn has_side_effects(cfg: &Cfg, value: CfgValue) -> bool {
-    match &cfg.get_inst(value).data {
-        // Function calls can have arbitrary effects
-        CfgInstData::Call { .. } => true,
-
-        // Intrinsics (like @dbg) have effects
-        CfgInstData::Intrinsic { .. } => true,
-
-        // Memory writes
-        CfgInstData::Alloc { .. } => true,
-        CfgInstData::Store { .. } => true,
-        CfgInstData::ParamStore { .. } => true,
-
-        // Drop runs destructors
-        CfgInstData::Drop { .. } => true,
-
-        // Storage liveness affects stack allocation
-        CfgInstData::StorageLive { .. } => true,
-        CfgInstData::StorageDead { .. } => true,
-
-        // IntCast can panic (range check), so it has side effects
-        CfgInstData::IntCast { .. } => true,
-
-        // PlaceWrite is a memory write (side effect)
-        CfgInstData::PlaceWrite { .. } => true,
-
-        // A PlaceRead is pure for field projections, but an array index read
-        // performs a bounds check that panics when out of range. A read whose
-        // place contains an Index projection is therefore side-effecting and
-        // must not be eliminated even when its value is unused (RUE-57).
-        CfgInstData::PlaceRead { place } => cfg
-            .get_place_projections(place)
-            .iter()
-            .any(|p| matches!(p, Projection::Index { .. })),
-
-        // Overflow-checked arithmetic (Add/Sub/Mul/Neg) and Div/Mod (division
-        // by zero) panic at runtime. That trap is observable behavior the
-        // optimizer must preserve, so these are side-effecting even when the
-        // result is unused (RUE-57). Bitwise ops and shifts do not trap (shift
-        // counts are masked per spec), so they remain pure.
-        CfgInstData::Add(..)
-        | CfgInstData::Sub(..)
-        | CfgInstData::Mul(..)
-        | CfgInstData::Div(..)
-        | CfgInstData::Mod(..)
-        | CfgInstData::Neg(..) => true,
-
-        // Everything else is pure computation
-        _ => false,
-    }
+    classify::may_trap(cfg, value) || classify::has_observable_side_effect(cfg, value)
 }
 
 /// Visit values used by a terminator.

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -22,6 +22,7 @@
 //! AIR -> CfgBuilder -> CFG -> [optimize] -> CfgLower -> MIR
 //! ```
 
+mod classify;
 mod constfold;
 mod constopt;
 mod cse;

--- a/docs/designs/0049-function-inlining.md
+++ b/docs/designs/0049-function-inlining.md
@@ -593,22 +593,23 @@ Tracking placeholders; this draft implements none of them.
   (by-value materialization at full slot width; by-ref place redirection limited
   to simple local/parameter roots), callee-lifetime storage + copied
   parameter-drop handling (§3), and return→block-param wiring. Unit-tested in
-  `rue-cfg`. (file RUE-NNN)
+  `rue-cfg`. (file RUE-929)
 - [ ] **Phase 2: Free-function driver at `-O2`** — two-phase construction; build
   the call-site graph by CFG scan (§5); conservative leaf/small thresholds;
   single-call-site inlining *without* callee removal; recursion refusal via
   call-site SCC; differential CLI coverage. Inlined callers are **not cached
-  yet** (fail the export gate, §4c). (file RUE-NNN)
+  yet** (fail the export gate, §4c). (file RUE-930)
 - [ ] **Phase 3: `-O3` thresholds** — larger caps, non-leaf callees, shared
-  code-growth budget with unrolling (ADR-0054). (file RUE-NNN)
+  code-growth budget with unrolling (ADR-0054). (file RUE-931)
 - [ ] **Phase 4: Durable cache integration for inlined callers** — multi-body
   `CfgDomainProjection` (§4c), callee-body-fingerprint + policy-version cache key
-  (§4b); turn caching on for inlined callers. (file RUE-NNN)
+  (§4b); turn caching on for inlined callers. (file RUE-932)
 - [ ] **Phase 5: Whole-program dead-function elimination** — separate pass that
   removes now-unreachable functions (including single-call-site callees the
-  inliner consumed) under full reachability analysis (§6). (file RUE-NNN)
+  inliner consumed) under full reachability analysis (§6). (file RUE-933)
 - [ ] **Phase 6: Methods/destructors** — extend as the ADR-0050 method/destructor
-  caller surfaces complete. (file RUE-NNN)
+  caller surfaces complete. (file RUE-NNN — awaits the ADR-0050 method/destructor
+  caller surfaces before it can be scoped and filed.)
 
 ## Consequences
 

--- a/docs/designs/0054-loop-optimizations.md
+++ b/docs/designs/0054-loop-optimizations.md
@@ -416,15 +416,15 @@ Tracking placeholders; this draft implements none of them.
   propagation (`opt/forward.rs`).
 - [ ] **Phase 1: Natural-loop analysis** — natural-loop forest + preheader
   materialization built on the existing `DominatorTree`, with unit tests.
-  (file RUE-NNN)
+  (file RUE-926)
 - [ ] **Phase 2: LICM (trap-free only)** — hoist pure invariant ops; never hoist
-  trapping ops; differential trap-safety cases. `-O3`. (file RUE-NNN)
+  trapping ops; differential trap-safety cases. `-O3`. (file RUE-927)
 - [ ] **Phase 3: Constant-trip full unrolling** — canonical shape only (single
   header, single latch, recognized IV, no unsupported exits); full CFG-subgraph
   cloning; mandatory post-unroll const-fold/simplify/DCE cleanup; under the size
-  budget; shared code-growth budget with ADR-0049 inlining. `-O3`. (file RUE-NNN)
+  budget; shared code-growth budget with ADR-0049 inlining. `-O3`. (file RUE-928)
 - [ ] **Phase 4 (relaxation): guarded trapping-op hoisting** — after loop
-  rotation/guard analysis exists. (file RUE-NNN)
+  rotation/guard analysis exists. (file RUE-934)
 
 ## Consequences
 


### PR DESCRIPTION
First implementation slice of the accepted ADR-0054: LICM (RUE-927) and unrolling (RUE-928) need the trap axis on its own, but the trapping set lived only inside DCE's private `has_side_effects`, which conflates *observable side effect* with *may trap*.

New `opt::classify` module names both sets once — `may_trap` (overflow-checked arithmetic, division checks, the `IntCast` range check, indexed `PlaceRead` bounds checks), `has_observable_side_effect` (`Call`/`Store`/`Drop`/storage markers/…), and `is_speculatable` defined exactly once as neither. The module doc records why a classifier module (not `CfgInstData` methods): trap-ness is pass policy, and the indexed-read case needs the `Cfg`'s projection tables.

DCE's `has_side_effects` becomes `may_trap || has_observable_side_effect` — an identical set union, zero behavior change; its existing unit tests pass unmodified. Seven new classifier tests pin both axes independently, including the pure-but-trapping case that motivates the split.

Also fills the accepted ADRs' implementation-phase placeholders with the filed issue numbers (0054 → RUE-926/927/928/934; 0049 → RUE-929–933, Phase 6 deliberately deferred to ADR-0050 surfaces).

Verified: `rue-cfg` suite green; differential `-O0/-O1/-O2` runs of an index-trap program exit 101 identically; quick and full suites green.

Fixes RUE-925