### PR TITLE
RUE-836: migrate type pool APIs to canonical handles

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -14,15 +14,11 @@
 //! - **Structs and enums** are nominal types (same name = same type)
 //! - **Arrays** are structural types (same element type + length = same type)
 //!
-//! The transitional `InternedType` wrapper consumes the same authoritative
-//! primitive assignments as [`Type`]. Its compatibility-only pool-index
-//! encoding is centralized beside the live encoding and is removed by RUE-838.
-//!
 //! [`Type`] is the compact compiler-facing handle. Composite `StructId`,
 //! `EnumId`, `ArrayTypeId`, and pointer IDs are indices into this pool, while
-//! `InternedType` provides the pool's primitive-or-composite encoding for
-//! interning and structural lookup. Definitions and structural identities are
-//! therefore resolved through one pool (ADR-0024).
+//! the pool stores canonical [`Type`] values directly in structural keys and
+//! children. Definitions and structural identities are therefore resolved
+//! through one pool (ADR-0024).
 //!
 //! # Thread Safety
 //!
@@ -30,115 +26,56 @@
 //! - Read lock for lookups (common case)
 //! - Write lock for insertions (rare, during declaration gathering)
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, PoisonError, RwLock};
 
 use lasso::Spur;
 use rue_span::FileId;
 
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
-use crate::type_encoding::{self, Decoded, Primitive};
+use crate::type_encoding;
 use crate::types::{
     ArrayTypeId, EnumDef, EnumId, LangItem, PtrConstTypeId, PtrMutTypeId, StructDef, StructId,
     Type, TypeKind,
 };
 
-/// Interned type index - 32 bits, Copy, cheap comparison.
+/// Private, one-way compatibility encoding retained for RUE-838 cleanup.
 ///
-/// Primitive values are exactly the authoritative [`Type`] encodings.
-/// Composite values use the centralized transitional pool-index encoding.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
-pub struct InternedType(u32);
+/// No pool storage, key, public API, or compiler phase consumes this wrapper.
+/// It can only project a canonical `Type` into the old untyped pool-index
+/// representation; there is deliberately no conversion back to `Type`.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct InternedType(u32);
 
+#[allow(dead_code)]
 impl InternedType {
-    pub const I8: InternedType = InternedType(Type::I8.raw_encoding());
-    pub const I16: InternedType = InternedType(Type::I16.raw_encoding());
-    pub const I32: InternedType = InternedType(Type::I32.raw_encoding());
-    pub const I64: InternedType = InternedType(Type::I64.raw_encoding());
-    pub const U8: InternedType = InternedType(Type::U8.raw_encoding());
-    pub const U16: InternedType = InternedType(Type::U16.raw_encoding());
-    pub const U32: InternedType = InternedType(Type::U32.raw_encoding());
-    pub const U64: InternedType = InternedType(Type::U64.raw_encoding());
-    pub const BOOL: InternedType = InternedType(Type::BOOL.raw_encoding());
-    pub const UNIT: InternedType = InternedType(Type::UNIT.raw_encoding());
-    pub const ERROR: InternedType = InternedType(Type::ERROR.raw_encoding());
-    pub const NEVER: InternedType = InternedType(Type::NEVER.raw_encoding());
-
-    /// Check if this is a primitive type (no pool lookup needed).
-    #[inline]
-    pub fn is_primitive(self) -> bool {
-        type_encoding::compatibility::is_primitive(self.0)
-    }
-
-    /// Get the raw index value.
-    #[inline]
-    pub fn index(self) -> u32 {
-        self.0
-    }
-
-    /// Create an `InternedType` from a raw compatibility encoding.
-    ///
-    /// Pool ownership and bounds are validated separately by pool APIs.
-    #[inline]
-    pub fn try_from_raw(index: u32) -> Option<Self> {
-        if type_encoding::compatibility::is_primitive(index)
-            || type_encoding::compatibility::decode_pool_index(index).is_some()
-        {
-            Some(InternedType(index))
-        } else {
-            None
+    fn from_type(ty: Type) -> Option<Self> {
+        if type_encoding::compatibility::is_primitive(ty.raw_encoding()) {
+            return Some(Self(ty.raw_encoding()));
         }
+        let pool_index = match ty.try_kind()? {
+            TypeKind::Struct(id) => id.pool_index(),
+            TypeKind::Enum(id) => id.pool_index(),
+            TypeKind::Array(id) => id.pool_index(),
+            TypeKind::PtrConst(id) => id.pool_index(),
+            TypeKind::PtrMut(id) => id.pool_index(),
+            _ => return None,
+        };
+        Some(Self(type_encoding::compatibility::encode_pool_index(
+            pool_index,
+        )?))
     }
 
-    /// Create an InternedType for a composite type from its pool index.
-    ///
-    /// The pool index is mapped through the centralized compatibility encoding.
-    #[inline]
-    fn from_pool_index(pool_index: u32) -> Self {
-        let encoded = type_encoding::compatibility::encode_pool_index(pool_index)
-            .expect("intern pool index overflow");
-        InternedType(encoded)
-    }
-
-    /// Get the pool index for a composite type.
-    ///
-    /// Returns `None` for primitive types.
-    #[inline]
-    pub fn pool_index(self) -> Option<u32> {
+    fn pool_index(self) -> Option<u32> {
         type_encoding::compatibility::decode_pool_index(self.0)
-    }
-}
-
-impl std::fmt::Debug for InternedType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(Decoded::Primitive(primitive)) = type_encoding::decode(self.0) {
-            let name = match primitive {
-                Primitive::I8 => "i8",
-                Primitive::I16 => "i16",
-                Primitive::I32 => "i32",
-                Primitive::I64 => "i64",
-                Primitive::U8 => "u8",
-                Primitive::U16 => "u16",
-                Primitive::U32 => "u32",
-                Primitive::U64 => "u64",
-                Primitive::Bool => "bool",
-                Primitive::Unit => "()",
-                Primitive::Error => "<error>",
-                Primitive::Never => "!",
-                Primitive::ComptimeType => "type",
-            };
-            write!(f, "InternedType({name})")
-        } else if let Some(pool_index) = self.pool_index() {
-            write!(f, "InternedType(pool:{pool_index})")
-        } else {
-            write!(f, "InternedType(invalid:{:#x})", self.0)
-        }
     }
 }
 
 /// Type data stored in the intern pool.
 ///
-/// This is NOT Copy - it lives in the pool. You work with `InternedType` indices.
+/// This is NOT Copy - it lives in the pool. Structural children are canonical
+/// [`Type`] handles owned by this pool's semantic epoch.
 ///
 /// # Type Categories
 ///
@@ -169,17 +106,30 @@ pub enum TypeData {
     ///
     /// Arrays with the same element type and length are the same type,
     /// regardless of where they were defined.
-    Array { element: InternedType, len: u64 },
+    Array { element: Type, len: u64 },
 
     /// Raw const pointer (structural type).
     ///
     /// `ptr const T` - pointer to immutable data.
-    PtrConst { pointee: InternedType },
+    PtrConst { pointee: Type },
 
     /// Raw mut pointer (structural type).
     ///
     /// `ptr mut T` - pointer to mutable data.
-    PtrMut { pointee: InternedType },
+    PtrMut { pointee: Type },
+}
+
+/// Why a compact [`Type`] cannot be used for a requested pool operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeValidationError {
+    InvalidEncoding,
+    PoolIndexOutOfRange,
+    KindMismatch,
+    ReservedEntry,
+    IncompleteDefinition,
+    ComptimeStructuralChild,
+    ModuleStructuralChild,
+    RecoveryType,
 }
 
 impl TypeData {
@@ -188,6 +138,52 @@ impl TypeData {
             self,
             Self::ReservedStruct | Self::DeclaredStruct(_) | Self::DeclaredEnum(_)
         )
+    }
+
+    fn kind(&self) -> PoolEntryKind {
+        match self {
+            Self::ReservedStruct | Self::DeclaredStruct(_) | Self::Struct(_) => {
+                PoolEntryKind::Struct
+            }
+            Self::DeclaredEnum(_) | Self::Enum(_) => PoolEntryKind::Enum,
+            Self::Array { .. } => PoolEntryKind::Array,
+            Self::PtrConst { .. } => PoolEntryKind::PtrConst,
+            Self::PtrMut { .. } => PoolEntryKind::PtrMut,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PoolEntryKind {
+    Struct,
+    Enum,
+    Array,
+    PtrConst,
+    PtrMut,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ValidationMode {
+    StructuralChild,
+    Complete,
+    CompleteChild,
+}
+
+impl ValidationMode {
+    fn requires_complete(self) -> bool {
+        matches!(self, Self::Complete | Self::CompleteChild)
+    }
+
+    fn is_structural_child(self) -> bool {
+        matches!(self, Self::StructuralChild | Self::CompleteChild)
+    }
+
+    fn child(self) -> Self {
+        if self.requires_complete() {
+            Self::CompleteChild
+        } else {
+            Self::StructuralChild
+        }
     }
 }
 
@@ -213,6 +209,33 @@ pub struct EnumData {
     pub def: EnumDef,
 }
 
+/// Declaration-only struct metadata available before field resolution.
+///
+/// Fields are deliberately absent so declaration consumers cannot mistake a
+/// nominal shell for a complete definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StructDeclarationMetadata {
+    pub name: String,
+    pub is_copy: bool,
+    pub is_linear: bool,
+    pub destructor: Option<String>,
+    pub is_builtin: bool,
+    pub is_pub: bool,
+    pub file_id: FileId,
+}
+
+/// Declaration-only enum metadata available before payload resolution.
+///
+/// Variant names are declaration metadata; payloads are intentionally absent
+/// until the enum reaches the complete state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EnumDeclarationMetadata {
+    pub name: String,
+    pub variants: Vec<String>,
+    pub is_pub: bool,
+    pub file_id: FileId,
+}
+
 /// Thread-safe intern pool for all composite types.
 ///
 /// The pool is designed to be built during declaration gathering (sequential)
@@ -233,7 +256,7 @@ pub struct EnumData {
 /// let (struct_type, is_new) = pool.register_struct(name_spur, struct_def);
 ///
 /// // Intern structural types (arrays)
-/// let array_type = pool.intern_array(element_type, 10);
+/// let array_type = pool.try_intern_array(element_type, 10)?;
 ///
 /// // Look up type data
 /// if let Some(data) = pool.try_get(some_type) {
@@ -262,25 +285,25 @@ pub struct FrozenTypeInternPool {
     inner: Arc<TypeInternPoolInner>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct TypeInternPoolInner {
-    /// All composite type data, indexed by the decoded compatibility pool index.
+    /// All composite type data, indexed by the payload in a canonical `Type`.
     types: Vec<TypeData>,
 
-    /// Structural type deduplication: (element, len) -> InternedType for arrays.
-    array_map: HashMap<(InternedType, u64), InternedType>,
+    /// Structural type deduplication: (element, len) -> canonical array `Type`.
+    array_map: HashMap<(Type, u64), Type>,
 
-    /// Structural type deduplication: pointee -> InternedType for ptr const.
-    ptr_const_map: HashMap<InternedType, InternedType>,
+    /// Structural type deduplication: pointee -> canonical ptr const `Type`.
+    ptr_const_map: HashMap<Type, Type>,
 
-    /// Structural type deduplication: pointee -> InternedType for ptr mut.
-    ptr_mut_map: HashMap<InternedType, InternedType>,
+    /// Structural type deduplication: pointee -> canonical ptr mut `Type`.
+    ptr_mut_map: HashMap<Type, Type>,
 
-    /// Nominal struct lookup: (defining file, source name) -> InternedType.
-    struct_by_file_name: HashMap<(FileId, Spur), InternedType>,
+    /// Nominal struct lookup: (defining file, source name) -> canonical `Type`.
+    struct_by_file_name: HashMap<(FileId, Spur), Type>,
 
-    /// Nominal enum lookup: (defining file, source name) -> InternedType.
-    enum_by_file_name: HashMap<(FileId, Spur), InternedType>,
+    /// Nominal enum lookup: (defining file, source name) -> canonical `Type`.
+    enum_by_file_name: HashMap<(FileId, Spur), Type>,
 
     /// Relocation-stable logical identity for each defining source file.
     symbol_paths: HashMap<FileId, String>,
@@ -311,7 +334,42 @@ impl TypeInternPoolInner {
 
     fn try_struct_def(&self, id: StructId) -> Option<&StructDef> {
         match self.types.get(id.0 as usize)? {
-            TypeData::DeclaredStruct(data) | TypeData::Struct(data) => Some(&data.def),
+            TypeData::Struct(data) => Some(&data.def),
+            _ => None,
+        }
+    }
+
+    /// Declaration resolution may inspect metadata, but never fields, from a
+    /// nominal shell. Definition, layout, durable, and backend reads use the
+    /// complete-only helpers above and below.
+    fn struct_declaration_metadata(&self, id: StructId) -> Option<StructDeclarationMetadata> {
+        match self.types.get(id.0 as usize)? {
+            TypeData::DeclaredStruct(data) => Some(StructDeclarationMetadata {
+                name: data.def.name.clone(),
+                is_copy: data.def.is_copy,
+                is_linear: data.def.is_linear,
+                destructor: data.def.destructor.clone(),
+                is_builtin: data.def.is_builtin,
+                is_pub: data.def.is_pub,
+                file_id: data.def.file_id,
+            }),
+            _ => None,
+        }
+    }
+
+    fn struct_metadata(&self, id: StructId) -> Option<StructDeclarationMetadata> {
+        match self.types.get(id.0 as usize)? {
+            TypeData::DeclaredStruct(data) | TypeData::Struct(data) => {
+                Some(StructDeclarationMetadata {
+                    name: data.def.name.clone(),
+                    is_copy: data.def.is_copy,
+                    is_linear: data.def.is_linear,
+                    destructor: data.def.destructor.clone(),
+                    is_builtin: data.def.is_builtin,
+                    is_pub: data.def.is_pub,
+                    file_id: data.def.file_id,
+                })
+            }
             _ => None,
         }
     }
@@ -323,7 +381,31 @@ impl TypeInternPoolInner {
 
     fn try_enum_def(&self, id: EnumId) -> Option<&EnumDef> {
         match self.types.get(id.0 as usize)? {
-            TypeData::DeclaredEnum(data) | TypeData::Enum(data) => Some(&data.def),
+            TypeData::Enum(data) => Some(&data.def),
+            _ => None,
+        }
+    }
+
+    fn enum_declaration_metadata(&self, id: EnumId) -> Option<EnumDeclarationMetadata> {
+        match self.types.get(id.0 as usize)? {
+            TypeData::DeclaredEnum(data) => Some(EnumDeclarationMetadata {
+                name: data.def.name.clone(),
+                variants: data.def.variants.clone(),
+                is_pub: data.def.is_pub,
+                file_id: data.def.file_id,
+            }),
+            _ => None,
+        }
+    }
+
+    fn enum_metadata(&self, id: EnumId) -> Option<EnumDeclarationMetadata> {
+        match self.types.get(id.0 as usize)? {
+            TypeData::DeclaredEnum(data) | TypeData::Enum(data) => Some(EnumDeclarationMetadata {
+                name: data.def.name.clone(),
+                variants: data.def.variants.clone(),
+                is_pub: data.def.is_pub,
+                file_id: data.def.file_id,
+            }),
             _ => None,
         }
     }
@@ -333,48 +415,23 @@ impl TypeInternPoolInner {
             .unwrap_or_else(|| panic!("Expected enum at pool index {}", id.0))
     }
 
-    fn interned_to_type(&self, ty: InternedType) -> Type {
-        if ty.is_primitive() {
-            return Type::try_from_u32(ty.0)
-                .expect("InternedType primitive must use the canonical Type encoding");
-        }
-
-        let index = ty.pool_index().expect("non-primitive must have pool index");
-        match self.data(index) {
-            TypeData::DeclaredStruct(_) | TypeData::Struct(_) => {
-                Type::new_struct(StructId::from_pool_index(index))
-            }
-            TypeData::DeclaredEnum(_) | TypeData::Enum(_) => {
-                Type::new_enum(EnumId::from_pool_index(index))
-            }
-            TypeData::Array { .. } => Type::new_array(ArrayTypeId::from_pool_index(index)),
-            TypeData::PtrConst { .. } => {
-                Type::new_ptr_const(PtrConstTypeId::from_pool_index(index))
-            }
-            TypeData::PtrMut { .. } => Type::new_ptr_mut(PtrMutTypeId::from_pool_index(index)),
-            TypeData::ReservedStruct => {
-                panic!("reserved pool entry {index} cannot be issued as a Type")
-            }
-        }
-    }
-
     fn array_def(&self, id: ArrayTypeId) -> (Type, u64) {
         match self.data(id.0) {
-            TypeData::Array { element, len } => (self.interned_to_type(*element), *len),
+            TypeData::Array { element, len } => (*element, *len),
             other => panic!("Expected array at pool index {}, got {:?}", id.0, other),
         }
     }
 
     fn try_array_def(&self, id: ArrayTypeId) -> Option<(Type, u64)> {
         match self.types.get(id.0 as usize)? {
-            TypeData::Array { element, len } => Some((self.interned_to_type(*element), *len)),
+            TypeData::Array { element, len } => Some((*element, *len)),
             _ => None,
         }
     }
 
     fn ptr_const_def(&self, id: PtrConstTypeId) -> Type {
         match self.data(id.pool_index()) {
-            TypeData::PtrConst { pointee } => self.interned_to_type(*pointee),
+            TypeData::PtrConst { pointee } => *pointee,
             other => panic!(
                 "Expected ptr const at pool index {}, got {:?}",
                 id.pool_index(),
@@ -385,12 +442,116 @@ impl TypeInternPoolInner {
 
     fn ptr_mut_def(&self, id: PtrMutTypeId) -> Type {
         match self.data(id.pool_index()) {
-            TypeData::PtrMut { pointee } => self.interned_to_type(*pointee),
+            TypeData::PtrMut { pointee } => *pointee,
             other => panic!(
                 "Expected ptr mut at pool index {}, got {:?}",
                 id.pool_index(),
                 other
             ),
+        }
+    }
+
+    fn validate_structural_child(&self, ty: Type) -> Result<(), TypeValidationError> {
+        self.validate_type_inner(ty, ValidationMode::StructuralChild, &mut HashSet::new())
+    }
+
+    fn validate_complete_type(&self, ty: Type) -> Result<(), TypeValidationError> {
+        self.validate_type_inner(ty, ValidationMode::Complete, &mut HashSet::new())
+    }
+
+    fn validate_type_inner(
+        &self,
+        ty: Type,
+        mode: ValidationMode,
+        visited: &mut HashSet<Type>,
+    ) -> Result<(), TypeValidationError> {
+        let kind = ty.try_kind().ok_or(TypeValidationError::InvalidEncoding)?;
+        match kind {
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Unit
+            | TypeKind::Never => return Ok(()),
+            TypeKind::Error => {
+                return if mode.requires_complete() {
+                    Err(TypeValidationError::RecoveryType)
+                } else {
+                    Ok(())
+                };
+            }
+            TypeKind::ComptimeType => {
+                return if mode.is_structural_child() {
+                    Err(TypeValidationError::ComptimeStructuralChild)
+                } else {
+                    Ok(())
+                };
+            }
+            TypeKind::Module(_) => {
+                return if mode.is_structural_child() {
+                    Err(TypeValidationError::ModuleStructuralChild)
+                } else {
+                    Ok(())
+                };
+            }
+            _ => {}
+        }
+
+        if !visited.insert(ty) {
+            return Ok(());
+        }
+
+        let (index, expected) = match kind {
+            TypeKind::Struct(id) => (id.pool_index(), PoolEntryKind::Struct),
+            TypeKind::Enum(id) => (id.pool_index(), PoolEntryKind::Enum),
+            TypeKind::Array(id) => (id.pool_index(), PoolEntryKind::Array),
+            TypeKind::PtrConst(id) => (id.pool_index(), PoolEntryKind::PtrConst),
+            TypeKind::PtrMut(id) => (id.pool_index(), PoolEntryKind::PtrMut),
+            _ => unreachable!("primitive and non-pool kinds returned above"),
+        };
+        let entry = self
+            .types
+            .get(index as usize)
+            .ok_or(TypeValidationError::PoolIndexOutOfRange)?;
+        if entry.kind() != expected {
+            return if matches!(entry, TypeData::ReservedStruct) {
+                Err(TypeValidationError::ReservedEntry)
+            } else {
+                Err(TypeValidationError::KindMismatch)
+            };
+        }
+
+        match entry {
+            TypeData::ReservedStruct => Err(TypeValidationError::ReservedEntry),
+            TypeData::DeclaredStruct(_) | TypeData::DeclaredEnum(_) => {
+                if mode.requires_complete() {
+                    Err(TypeValidationError::IncompleteDefinition)
+                } else {
+                    Ok(())
+                }
+            }
+            TypeData::Struct(data) => data
+                .def
+                .fields
+                .iter()
+                .try_for_each(|field| self.validate_type_inner(field.ty, mode.child(), visited)),
+            TypeData::Enum(data) => data
+                .def
+                .variant_payloads
+                .iter()
+                .flatten()
+                .try_for_each(|&child| self.validate_type_inner(child, mode.child(), visited)),
+            TypeData::Array { element, .. } => {
+                self.validate_type_inner(*element, mode.child(), visited)
+            }
+            TypeData::PtrConst { pointee } | TypeData::PtrMut { pointee } => {
+                self.validate_type_inner(*pointee, mode.child(), visited)
+            }
         }
     }
 
@@ -482,12 +643,12 @@ impl TypeInternPoolInner {
     fn safe_type_name(&self, ty: Type) -> String {
         match ty.try_kind() {
             Some(TypeKind::Struct(id)) => self
-                .try_struct_def(id)
-                .map(|def| def.name.clone())
+                .struct_metadata(id)
+                .map(|metadata| metadata.name)
                 .unwrap_or_else(|| format!("<struct#{}>", id.0)),
             Some(TypeKind::Enum(id)) => self
-                .try_enum_def(id)
-                .map(|def| def.name.clone())
+                .enum_metadata(id)
+                .map(|metadata| metadata.name)
                 .unwrap_or_else(|| format!("<enum#{}>", id.0)),
             Some(TypeKind::Array(id)) => self
                 .try_array_def(id)
@@ -495,19 +656,13 @@ impl TypeInternPoolInner {
                 .unwrap_or_else(|| format!("<array#{}>", id.0)),
             Some(TypeKind::PtrConst(id)) => match self.types.get(id.pool_index() as usize) {
                 Some(TypeData::PtrConst { pointee }) => {
-                    format!(
-                        "ptr const {}",
-                        self.safe_type_name(self.interned_to_type(*pointee))
-                    )
+                    format!("ptr const {}", self.safe_type_name(*pointee))
                 }
                 _ => format!("<ptr const#{}>", id.0),
             },
             Some(TypeKind::PtrMut(id)) => match self.types.get(id.pool_index() as usize) {
                 Some(TypeData::PtrMut { pointee }) => {
-                    format!(
-                        "ptr mut {}",
-                        self.safe_type_name(self.interned_to_type(*pointee))
-                    )
+                    format!("ptr mut {}", self.safe_type_name(*pointee))
                 }
                 _ => format!("<ptr mut#{}>", id.0),
             },
@@ -518,7 +673,11 @@ impl TypeInternPoolInner {
 
     fn is_copy_type(&self, ty: Type) -> bool {
         ty.as_struct()
-            .map(|id| self.struct_def(id).is_copy)
+            .map(|id| {
+                self.struct_metadata(id)
+                    .map(|metadata| metadata.is_copy)
+                    .expect("struct type must have declaration metadata")
+            })
             .unwrap_or_else(|| ty.is_copy())
     }
 
@@ -590,6 +749,35 @@ impl TypeInternPool {
             .symbol_paths = symbol_paths;
     }
 
+    /// Apply a type-pool mutation atomically through an isolated snapshot.
+    ///
+    /// The live write lock remains held while `operation` works on the
+    /// snapshot, so a successful replacement preserves canonical allocation
+    /// order and cannot overwrite concurrent interning. Failure discards the
+    /// entire pool snapshot, including every vector and reverse-map mutation.
+    /// State owned beside the pool (such as a symbol interner) needs its own
+    /// transaction or preflight boundary.
+    ///
+    /// This intentionally simple boundary deep-clones the whole pool while
+    /// holding its global write lock. Callers should account for that per-
+    /// operation cost; it is a correctness mechanism, not a cheap fine-grained
+    /// mutation primitive.
+    pub(crate) fn transaction<T, E>(
+        &self,
+        operation: impl FnOnce(&TypeInternPool) -> Result<T, E>,
+    ) -> Result<T, E> {
+        let mut live = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        let scratch = TypeInternPool {
+            inner: RwLock::new(live.clone()),
+        };
+        let result = operation(&scratch)?;
+        *live = scratch
+            .inner
+            .into_inner()
+            .unwrap_or_else(PoisonError::into_inner);
+        Ok(result)
+    }
+
     /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
     ///
     /// This is the canonical layout query shared by sema, CFG temporary
@@ -597,10 +785,50 @@ impl TypeInternPool {
     /// rejects layouts that exceed the representable slot range before they
     /// can be materialized.
     pub fn abi_slot_count(&self, ty: Type) -> u32 {
+        self.try_abi_slot_count(ty)
+            .expect("layout requires a complete, non-recovery type graph")
+    }
+
+    pub fn try_abi_slot_count(&self, ty: Type) -> Result<u32, TypeValidationError> {
+        let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        inner.validate_complete_type(ty)?;
+        Ok(inner.abi_slot_count(ty))
+    }
+
+    /// Semantic construction may need a phase-scoped provisional width before
+    /// the complete type graph is available. The successful sema boundary
+    /// validates the complete graph before layout or backend consumption.
+    pub(crate) fn provisional_abi_slot_count(&self, ty: Type) -> u32 {
         self.inner
             .read()
             .unwrap_or_else(PoisonError::into_inner)
             .abi_slot_count(ty)
+    }
+
+    /// Validate an encoding-valid type against this pool while allowing the
+    /// recovery and declared-shell states needed during semantic construction.
+    ///
+    /// Validation is relative to this owner pool. Compact handles from another
+    /// epoch can have coincidentally equal bits; epoch-branded artifacts and
+    /// durable import boundaries establish ownership before this check.
+    pub fn validate_structural_child(&self, ty: Type) -> Result<(), TypeValidationError> {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .validate_structural_child(ty)
+    }
+
+    /// Validate that `ty` and its reachable pool graph are complete and contain
+    /// no recovery-only `<error>` node.
+    ///
+    /// Validation is relative to this owner pool. Compact handles from another
+    /// epoch can have coincidentally equal bits; epoch-branded artifacts and
+    /// durable import boundaries establish ownership before this check.
+    pub fn validate_complete_type(&self, ty: Type) -> Result<(), TypeValidationError> {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .validate_complete_type(ty)
     }
 
     /// Register a new struct (nominal - no deduplication).
@@ -614,9 +842,10 @@ impl TypeInternPool {
         {
             let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
             if let Some(&existing) = inner.struct_by_file_name.get(&key) {
-                // Convert InternedType back to StructId via pool_index
-                let pool_index = existing.pool_index().expect("struct must have pool index");
-                return (StructId::from_pool_index(pool_index), false);
+                return (
+                    existing.as_struct().expect("struct lookup kind invariant"),
+                    false,
+                );
             }
         }
 
@@ -625,17 +854,19 @@ impl TypeInternPool {
 
         // Double-check after acquiring write lock
         if let Some(&existing) = inner.struct_by_file_name.get(&key) {
-            let pool_index = existing.pool_index().expect("struct must have pool index");
-            return (StructId::from_pool_index(pool_index), false);
+            return (
+                existing.as_struct().expect("struct lookup kind invariant"),
+                false,
+            );
         }
 
         // Create new struct type
         let pool_index = inner.next_pool_index();
-        let interned = InternedType::from_pool_index(pool_index);
         let struct_id = StructId::from_pool_index(pool_index);
+        let ty = Type::new_struct(struct_id);
 
         inner.types.push(TypeData::Struct(StructData { name, def }));
-        inner.struct_by_file_name.insert(key, interned);
+        inner.struct_by_file_name.insert(key, ty);
 
         (struct_id, true)
     }
@@ -648,9 +879,7 @@ impl TypeInternPool {
             let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
             if let Some(&existing) = inner.struct_by_file_name.get(&key) {
                 return (
-                    StructId::from_pool_index(
-                        existing.pool_index().expect("struct must have pool index"),
-                    ),
+                    existing.as_struct().expect("struct lookup kind invariant"),
                     false,
                 );
             }
@@ -659,19 +888,17 @@ impl TypeInternPool {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
         if let Some(&existing) = inner.struct_by_file_name.get(&key) {
             return (
-                StructId::from_pool_index(
-                    existing.pool_index().expect("struct must have pool index"),
-                ),
+                existing.as_struct().expect("struct lookup kind invariant"),
                 false,
             );
         }
 
         let pool_index = inner.next_pool_index();
-        let interned = InternedType::from_pool_index(pool_index);
+        let ty = Type::new_struct(StructId::from_pool_index(pool_index));
         inner
             .types
             .push(TypeData::DeclaredStruct(StructData { name, def: shell }));
-        inner.struct_by_file_name.insert(key, interned);
+        inner.struct_by_file_name.insert(key, ty);
         (StructId::from_pool_index(pool_index), true)
     }
 
@@ -748,8 +975,9 @@ impl TypeInternPool {
         inner.types[pool_index] = TypeData::Struct(StructData { name, def });
 
         // Register in the defining-file lookup.
-        let interned = InternedType::from_pool_index(struct_id.pool_index());
-        inner.struct_by_file_name.insert(key, interned);
+        inner
+            .struct_by_file_name
+            .insert(key, Type::new_struct(struct_id));
     }
 
     /// Complete a named struct declaration exactly once.
@@ -794,8 +1022,10 @@ impl TypeInternPool {
         {
             let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
             if let Some(&existing) = inner.enum_by_file_name.get(&key) {
-                let pool_index = existing.pool_index().expect("enum must have pool index");
-                return (EnumId::from_pool_index(pool_index), false);
+                return (
+                    existing.as_enum().expect("enum lookup kind invariant"),
+                    false,
+                );
             }
         }
 
@@ -804,18 +1034,21 @@ impl TypeInternPool {
 
         // Double-check after acquiring write lock
         if let Some(&existing) = inner.enum_by_file_name.get(&key) {
-            let pool_index = existing.pool_index().expect("enum must have pool index");
-            return (EnumId::from_pool_index(pool_index), false);
+            return (
+                existing.as_enum().expect("enum lookup kind invariant"),
+                false,
+            );
         }
 
         // Create new enum type
         let pool_index = inner.next_pool_index();
-        let interned = InternedType::from_pool_index(pool_index);
+        let enum_id = EnumId::from_pool_index(pool_index);
+        let ty = Type::new_enum(enum_id);
 
         inner.types.push(TypeData::Enum(EnumData { name, def }));
-        inner.enum_by_file_name.insert(key, interned);
+        inner.enum_by_file_name.insert(key, ty);
 
-        (EnumId::from_pool_index(pool_index), true)
+        (enum_id, true)
     }
 
     /// Register a named enum identity whose definition will be completed after
@@ -826,9 +1059,7 @@ impl TypeInternPool {
             let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
             if let Some(&existing) = inner.enum_by_file_name.get(&key) {
                 return (
-                    EnumId::from_pool_index(
-                        existing.pool_index().expect("enum must have pool index"),
-                    ),
+                    existing.as_enum().expect("enum lookup kind invariant"),
                     false,
                 );
             }
@@ -837,17 +1068,17 @@ impl TypeInternPool {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
         if let Some(&existing) = inner.enum_by_file_name.get(&key) {
             return (
-                EnumId::from_pool_index(existing.pool_index().expect("enum must have pool index")),
+                existing.as_enum().expect("enum lookup kind invariant"),
                 false,
             );
         }
 
         let pool_index = inner.next_pool_index();
-        let interned = InternedType::from_pool_index(pool_index);
+        let ty = Type::new_enum(EnumId::from_pool_index(pool_index));
         inner
             .types
             .push(TypeData::DeclaredEnum(EnumData { name, def: shell }));
-        inner.enum_by_file_name.insert(key, interned);
+        inner.enum_by_file_name.insert(key, ty);
         (EnumId::from_pool_index(pool_index), true)
     }
 
@@ -882,168 +1113,178 @@ impl TypeInternPool {
         }
     }
 
-    /// Intern an array type (structural - deduplicates).
-    ///
-    /// Returns the canonical `InternedType` for arrays with this element type and length.
-    /// If an identical array type already exists, returns the existing type.
-    pub fn intern_array(&self, element: InternedType, len: u64) -> InternedType {
+    /// Intern an array after validating its canonical child in this pool.
+    pub fn try_intern_array(&self, element: Type, len: u64) -> Result<Type, TypeValidationError> {
         let key = (element, len);
 
         // Fast path: check with read lock
         {
             let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+            inner.validate_structural_child(element)?;
             if let Some(&existing) = inner.array_map.get(&key) {
-                return existing;
+                return Ok(existing);
             }
         }
 
         // Slow path: acquire write lock
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        inner.validate_structural_child(element)?;
 
         // Double-check after acquiring write lock
         if let Some(&existing) = inner.array_map.get(&key) {
-            return existing;
+            return Ok(existing);
         }
 
         // Create new array type
         let pool_index = inner.next_pool_index();
-        let interned = InternedType::from_pool_index(pool_index);
+        let ty = Type::new_array(ArrayTypeId::from_pool_index(pool_index));
 
         inner.types.push(TypeData::Array { element, len });
-        inner.array_map.insert(key, interned);
+        inner.array_map.insert(key, ty);
 
-        interned
+        Ok(ty)
     }
 
-    /// Intern a ptr const type (structural - deduplicates).
-    ///
-    /// Returns the canonical `InternedType` for pointers to this pointee type.
-    /// If an identical pointer type already exists, returns the existing type.
-    pub fn intern_ptr_const(&self, pointee: InternedType) -> InternedType {
+    /// Intern a const pointer after validating its canonical child in this pool.
+    pub fn try_intern_ptr_const(&self, pointee: Type) -> Result<Type, TypeValidationError> {
         // Fast path: check with read lock
         {
             let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+            inner.validate_structural_child(pointee)?;
             if let Some(&existing) = inner.ptr_const_map.get(&pointee) {
-                return existing;
+                return Ok(existing);
             }
         }
 
         // Slow path: acquire write lock
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        inner.validate_structural_child(pointee)?;
 
         // Double-check after acquiring write lock
         if let Some(&existing) = inner.ptr_const_map.get(&pointee) {
-            return existing;
+            return Ok(existing);
         }
 
         // Create new pointer type
         let pool_index = inner.next_pool_index();
-        let interned = InternedType::from_pool_index(pool_index);
+        let ty = Type::new_ptr_const(PtrConstTypeId::from_pool_index(pool_index));
 
         inner.types.push(TypeData::PtrConst { pointee });
-        inner.ptr_const_map.insert(pointee, interned);
+        inner.ptr_const_map.insert(pointee, ty);
 
-        interned
+        Ok(ty)
     }
 
-    /// Intern a ptr mut type (structural - deduplicates).
-    ///
-    /// Returns the canonical `InternedType` for mutable pointers to this pointee type.
-    /// If an identical pointer type already exists, returns the existing type.
-    pub fn intern_ptr_mut(&self, pointee: InternedType) -> InternedType {
+    /// Intern a mutable pointer after validating its canonical child in this pool.
+    pub fn try_intern_ptr_mut(&self, pointee: Type) -> Result<Type, TypeValidationError> {
         // Fast path: check with read lock
         {
             let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+            inner.validate_structural_child(pointee)?;
             if let Some(&existing) = inner.ptr_mut_map.get(&pointee) {
-                return existing;
+                return Ok(existing);
             }
         }
 
         // Slow path: acquire write lock
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        inner.validate_structural_child(pointee)?;
 
         // Double-check after acquiring write lock
         if let Some(&existing) = inner.ptr_mut_map.get(&pointee) {
-            return existing;
+            return Ok(existing);
         }
 
         // Create new pointer type
         let pool_index = inner.next_pool_index();
-        let interned = InternedType::from_pool_index(pool_index);
+        let ty = Type::new_ptr_mut(PtrMutTypeId::from_pool_index(pool_index));
 
         inner.types.push(TypeData::PtrMut { pointee });
-        inner.ptr_mut_map.insert(pointee, interned);
+        inner.ptr_mut_map.insert(pointee, ty);
 
-        interned
+        Ok(ty)
     }
 
     /// Look up a struct by defining file and source name.
-    pub fn get_struct_by_file_name(&self, file_id: FileId, name: Spur) -> Option<InternedType> {
+    pub fn get_struct_by_file_name(&self, file_id: FileId, name: Spur) -> Option<Type> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.struct_by_file_name.get(&(file_id, name)).copied()
     }
 
     /// Look up an enum by defining file and source name.
-    pub fn get_enum_by_file_name(&self, file_id: FileId, name: Spur) -> Option<InternedType> {
+    pub fn get_enum_by_file_name(&self, file_id: FileId, name: Spur) -> Option<Type> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.enum_by_file_name.get(&(file_id, name)).copied()
     }
 
     /// Look up an array type by element and length.
-    pub fn get_array(&self, element: InternedType, len: u64) -> Option<InternedType> {
+    pub fn get_array(&self, element: Type, len: u64) -> Option<Type> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.array_map.get(&(element, len)).copied()
     }
 
     /// Get type data for a composite type.
     ///
-    /// Returns `None` for primitive types (use `InternedType::is_primitive()` first).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the index is invalid.
-    pub fn get(&self, ty: InternedType) -> Option<TypeData> {
-        if ty.is_primitive() {
-            return None;
-        }
-
-        let pool_index = ty.pool_index().expect("non-primitive must have pool index");
+    /// Returns `None` for primitives, malformed/out-of-range handles, reserved
+    /// or declared entries, or a handle whose encoded category disagrees with
+    /// its pool entry. Declaration state is exposed only through narrow
+    /// crate-private metadata queries.
+    pub fn get(&self, ty: Type) -> Option<TypeData> {
+        let (pool_index, expected) = match ty.try_kind()? {
+            TypeKind::Struct(id) => (id.pool_index(), PoolEntryKind::Struct),
+            TypeKind::Enum(id) => (id.pool_index(), PoolEntryKind::Enum),
+            TypeKind::Array(id) => (id.pool_index(), PoolEntryKind::Array),
+            TypeKind::PtrConst(id) => (id.pool_index(), PoolEntryKind::PtrConst),
+            TypeKind::PtrMut(id) => (id.pool_index(), PoolEntryKind::PtrMut),
+            _ => return None,
+        };
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        Some(inner.types[pool_index as usize].clone())
+        let entry = inner.types.get(pool_index as usize)?;
+        (entry.kind() == expected
+            && !matches!(
+                entry,
+                TypeData::ReservedStruct | TypeData::DeclaredStruct(_) | TypeData::DeclaredEnum(_)
+            ))
+        .then(|| entry.clone())
     }
 
     /// Check if this is a struct type.
-    pub fn is_struct(&self, ty: InternedType) -> bool {
-        if ty.is_primitive() {
+    pub fn is_struct(&self, ty: Type) -> bool {
+        let Some(id) = ty.as_struct() else {
             return false;
-        }
+        };
         matches!(
-            self.get(ty),
+            self.inner
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .types
+                .get(id.pool_index() as usize),
             Some(TypeData::DeclaredStruct(_) | TypeData::Struct(_))
         )
     }
 
     /// Check if this is an enum type.
-    pub fn is_enum(&self, ty: InternedType) -> bool {
-        if ty.is_primitive() {
+    pub fn is_enum(&self, ty: Type) -> bool {
+        let Some(id) = ty.as_enum() else {
             return false;
-        }
+        };
         matches!(
-            self.get(ty),
+            self.inner
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .types
+                .get(id.pool_index() as usize),
             Some(TypeData::DeclaredEnum(_) | TypeData::Enum(_))
         )
     }
 
     /// Check if this is an array type.
-    pub fn is_array(&self, ty: InternedType) -> bool {
-        if ty.is_primitive() {
-            return false;
-        }
+    pub fn is_array(&self, ty: Type) -> bool {
         matches!(self.get(ty), Some(TypeData::Array { .. }))
     }
 
     /// Get the struct definition if this is a struct type.
-    pub fn get_struct_def(&self, ty: InternedType) -> Option<StructDef> {
+    pub fn get_struct_def(&self, ty: Type) -> Option<StructDef> {
         match self.get(ty)? {
             TypeData::Struct(data) => Some(data.def),
             _ => None,
@@ -1051,7 +1292,7 @@ impl TypeInternPool {
     }
 
     /// Get the enum definition if this is an enum type.
-    pub fn get_enum_def(&self, ty: InternedType) -> Option<EnumDef> {
+    pub fn get_enum_def(&self, ty: Type) -> Option<EnumDef> {
         match self.get(ty)? {
             TypeData::Enum(data) => Some(data.def),
             _ => None,
@@ -1059,7 +1300,7 @@ impl TypeInternPool {
     }
 
     /// Get array info (element type, length) if this is an array type.
-    pub fn get_array_info(&self, ty: InternedType) -> Option<(InternedType, u64)> {
+    pub fn get_array_info(&self, ty: Type) -> Option<(Type, u64)> {
         match self.get(ty)? {
             TypeData::Array { element, len } => Some((element, len)),
             _ => None,
@@ -1081,15 +1322,36 @@ impl TypeInternPool {
     /// # Panics
     ///
     /// Panics if the StructId doesn't correspond to a struct in the pool.
+    #[track_caller]
     pub fn struct_def(&self, struct_id: StructId) -> StructDef {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        inner.struct_def(struct_id).clone()
+        match inner.try_struct_def(struct_id) {
+            Some(def) => def.clone(),
+            None => panic!("Expected complete struct at pool index {}", struct_id.0),
+        }
     }
 
     /// Get a struct definition without panicking on an invalid or wrong-kind ID.
     pub fn try_struct_def(&self, struct_id: StructId) -> Option<StructDef> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.try_struct_def(struct_id).cloned()
+    }
+
+    pub(crate) fn struct_declaration_metadata(
+        &self,
+        struct_id: StructId,
+    ) -> Option<StructDeclarationMetadata> {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .struct_declaration_metadata(struct_id)
+    }
+
+    pub(crate) fn struct_metadata(&self, struct_id: StructId) -> Option<StructDeclarationMetadata> {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .struct_metadata(struct_id)
     }
 
     /// Return the stable standard-library identity carried by a nominal type.
@@ -1148,15 +1410,36 @@ impl TypeInternPool {
     /// # Panics
     ///
     /// Panics if the EnumId doesn't correspond to an enum in the pool.
+    #[track_caller]
     pub fn enum_def(&self, enum_id: EnumId) -> EnumDef {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        inner.enum_def(enum_id).clone()
+        match inner.try_enum_def(enum_id) {
+            Some(def) => def.clone(),
+            None => panic!("Expected complete enum at pool index {}", enum_id.0),
+        }
     }
 
     /// Get an enum definition without panicking on an invalid or wrong-kind ID.
     pub fn try_enum_def(&self, enum_id: EnumId) -> Option<EnumDef> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.try_enum_def(enum_id).cloned()
+    }
+
+    pub(crate) fn enum_declaration_metadata(
+        &self,
+        enum_id: EnumId,
+    ) -> Option<EnumDeclarationMetadata> {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .enum_declaration_metadata(enum_id)
+    }
+
+    pub(crate) fn enum_metadata(&self, enum_id: EnumId) -> Option<EnumDeclarationMetadata> {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .enum_metadata(enum_id)
     }
 
     /// The symbol-name component for functions derived from a struct —
@@ -1229,22 +1512,6 @@ impl TypeInternPool {
         }
     }
 
-    /// Convert a StructId to an InternedType.
-    ///
-    /// Since StructId now contains a pool index, we just add the primitive offset.
-    #[inline]
-    pub fn struct_id_to_interned(&self, struct_id: StructId) -> InternedType {
-        InternedType::from_pool_index(struct_id.0)
-    }
-
-    /// Convert an EnumId to an InternedType.
-    ///
-    /// Since EnumId now contains a pool index, we just add the primitive offset.
-    #[inline]
-    pub fn enum_id_to_interned(&self, enum_id: EnumId) -> InternedType {
-        InternedType::from_pool_index(enum_id.0)
-    }
-
     /// Get an array type definition by ArrayTypeId.
     ///
     /// The ArrayTypeId contains a pool index. This method looks up the array
@@ -1269,22 +1536,24 @@ impl TypeInternPool {
         inner.try_array_def(array_id)
     }
 
-    /// Intern an array type from a Type element.
-    ///
-    /// This is a helper method that converts the Type to InternedType
-    /// and then interns the array.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the element type contains a struct/enum that isn't in the pool.
+    /// Intern an array on an invariant-proven semantic-construction path.
     pub fn intern_array_from_type(&self, element_type: Type, len: u64) -> ArrayTypeId {
-        let element_interned = Self::type_to_interned_recursive(element_type);
-        let array_interned = self.intern_array(element_interned, len);
-        ArrayTypeId::from_pool_index(
-            array_interned
-                .pool_index()
-                .expect("array must have pool index"),
-        )
+        self.try_intern_array(element_type, len)
+            .expect("array child must be representable in this type pool")
+            .as_array()
+            .expect("array interning returns an array Type")
+    }
+
+    /// Fallible category-ID adapter for durable or reconstructed input.
+    pub fn try_intern_array_from_type(
+        &self,
+        element_type: Type,
+        len: u64,
+    ) -> Result<ArrayTypeId, TypeValidationError> {
+        Ok(self
+            .try_intern_array(element_type, len)?
+            .as_array()
+            .expect("array interning returns an array Type"))
     }
 
     /// Look up an array type by Type element and length.
@@ -1292,13 +1561,8 @@ impl TypeInternPool {
     /// Returns None if no such array exists in the pool.
     pub fn get_array_by_type(&self, element_type: Type, len: u64) -> Option<ArrayTypeId> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        let element_interned = Self::type_to_interned_recursive(element_type);
-        let array_interned = inner.array_map.get(&(element_interned, len))?;
-        Some(ArrayTypeId::from_pool_index(
-            array_interned
-                .pool_index()
-                .expect("array must have pool index"),
-        ))
+        inner.validate_structural_child(element_type).ok()?;
+        inner.array_map.get(&(element_type, len))?.as_array()
     }
 
     /// Intern a ptr const type from a Type pointee.
@@ -1307,13 +1571,20 @@ impl TypeInternPool {
     ///
     /// Panics if the pointee type contains a struct/enum that isn't in the pool.
     pub fn intern_ptr_const_from_type(&self, pointee_type: Type) -> PtrConstTypeId {
-        let pointee_interned = Self::type_to_interned_recursive(pointee_type);
-        let ptr_interned = self.intern_ptr_const(pointee_interned);
-        PtrConstTypeId::from_pool_index(
-            ptr_interned
-                .pool_index()
-                .expect("ptr const must have pool index"),
-        )
+        self.try_intern_ptr_const(pointee_type)
+            .expect("pointer child must be representable in this type pool")
+            .as_ptr_const()
+            .expect("const-pointer interning returns a const-pointer Type")
+    }
+
+    pub fn try_intern_ptr_const_from_type(
+        &self,
+        pointee_type: Type,
+    ) -> Result<PtrConstTypeId, TypeValidationError> {
+        Ok(self
+            .try_intern_ptr_const(pointee_type)?
+            .as_ptr_const()
+            .expect("const-pointer interning returns a const-pointer Type"))
     }
 
     /// Intern a ptr mut type from a Type pointee.
@@ -1322,13 +1593,20 @@ impl TypeInternPool {
     ///
     /// Panics if the pointee type contains a struct/enum that isn't in the pool.
     pub fn intern_ptr_mut_from_type(&self, pointee_type: Type) -> PtrMutTypeId {
-        let pointee_interned = Self::type_to_interned_recursive(pointee_type);
-        let ptr_interned = self.intern_ptr_mut(pointee_interned);
-        PtrMutTypeId::from_pool_index(
-            ptr_interned
-                .pool_index()
-                .expect("ptr mut must have pool index"),
-        )
+        self.try_intern_ptr_mut(pointee_type)
+            .expect("pointer child must be representable in this type pool")
+            .as_ptr_mut()
+            .expect("mutable-pointer interning returns a mutable-pointer Type")
+    }
+
+    pub fn try_intern_ptr_mut_from_type(
+        &self,
+        pointee_type: Type,
+    ) -> Result<PtrMutTypeId, TypeValidationError> {
+        Ok(self
+            .try_intern_ptr_mut(pointee_type)?
+            .as_ptr_mut()
+            .expect("mutable-pointer interning returns a mutable-pointer Type"))
     }
 
     /// Get ptr const pointee type if this is a ptr const type.
@@ -1341,41 +1619,6 @@ impl TypeInternPool {
     pub fn ptr_mut_def(&self, ptr_id: PtrMutTypeId) -> Type {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.ptr_mut_def(ptr_id)
-    }
-
-    /// Convert Type to InternedType recursively (handles composite types).
-    ///
-    /// Used when structural interning needs the pool encoding of a [`Type`].
-    fn type_to_interned_recursive(ty: Type) -> InternedType {
-        match ty.kind() {
-            TypeKind::I8 => InternedType::I8,
-            TypeKind::I16 => InternedType::I16,
-            TypeKind::I32 => InternedType::I32,
-            TypeKind::I64 => InternedType::I64,
-            TypeKind::U8 => InternedType::U8,
-            TypeKind::U16 => InternedType::U16,
-            TypeKind::U32 => InternedType::U32,
-            TypeKind::U64 => InternedType::U64,
-            TypeKind::Bool => InternedType::BOOL,
-            TypeKind::Unit => InternedType::UNIT,
-            TypeKind::Never => InternedType::NEVER,
-            TypeKind::Error => InternedType::ERROR,
-            TypeKind::Struct(id) => InternedType::from_pool_index(id.pool_index()),
-            TypeKind::Enum(id) => InternedType::from_pool_index(id.pool_index()),
-            TypeKind::Array(id) => InternedType::from_pool_index(id.pool_index()),
-            TypeKind::PtrConst(id) => InternedType::from_pool_index(id.pool_index()),
-            TypeKind::PtrMut(id) => InternedType::from_pool_index(id.pool_index()),
-            TypeKind::Module(_) => panic!("Cannot intern module types"),
-            TypeKind::ComptimeType => panic!("Cannot intern comptime types"),
-        }
-    }
-
-    /// Convert an ArrayTypeId to an InternedType.
-    ///
-    /// Since ArrayTypeId now contains a pool index, we just add the primitive offset.
-    #[inline]
-    pub fn array_id_to_interned(&self, array_id: ArrayTypeId) -> InternedType {
-        InternedType::from_pool_index(array_id.0)
     }
 
     /// Get all struct IDs registered in the pool.
@@ -1467,56 +1710,6 @@ impl TypeInternPool {
             .unwrap_or_else(PoisonError::into_inner)
             .is_copy_type(ty)
     }
-
-    // ========================================================================
-    // Primitive conversion helpers
-    // ========================================================================
-
-    /// Convert a [`Type`] to an [`InternedType`] when no pool lookup is needed.
-    ///
-    /// # Note
-    ///
-    /// For struct/enum types, the corresponding type must already be registered
-    /// in the pool. For array types, this returns an error since array interning
-    /// requires the pool to already have the element type interned.
-    pub fn type_to_interned(&self, ty: Type) -> Option<InternedType> {
-        match ty.kind() {
-            TypeKind::I8 => Some(InternedType::I8),
-            TypeKind::I16 => Some(InternedType::I16),
-            TypeKind::I32 => Some(InternedType::I32),
-            TypeKind::I64 => Some(InternedType::I64),
-            TypeKind::U8 => Some(InternedType::U8),
-            TypeKind::U16 => Some(InternedType::U16),
-            TypeKind::U32 => Some(InternedType::U32),
-            TypeKind::U64 => Some(InternedType::U64),
-            TypeKind::Bool => Some(InternedType::BOOL),
-            TypeKind::Unit => Some(InternedType::UNIT),
-            TypeKind::Never => Some(InternedType::NEVER),
-            TypeKind::Error => Some(InternedType::ERROR),
-            // Struct, enum, array, pointer, and module require pool lookup by ID - we need the name
-            // to find the interned type. This conversion is not straightforward
-            // without additional context. Return None to indicate we can't convert.
-            TypeKind::Struct(_)
-            | TypeKind::Enum(_)
-            | TypeKind::Array(_)
-            | TypeKind::PtrConst(_)
-            | TypeKind::PtrMut(_)
-            | TypeKind::Module(_) => None,
-            // ComptimeType is a comptime-only type, cannot be interned for runtime
-            TypeKind::ComptimeType => None,
-        }
-    }
-
-    /// Convert a primitive [`InternedType`] back to [`Type`].
-    ///
-    /// Composite encodings return `None` because their concrete ID kind must be
-    /// read from the pool.
-    pub fn interned_to_type(&self, ty: InternedType) -> Option<Type> {
-        if !ty.is_primitive() {
-            return None;
-        }
-        Type::try_from_u32(ty.0)
-    }
 }
 
 impl FrozenTypeInternPool {
@@ -1526,7 +1719,43 @@ impl FrozenTypeInternPool {
 
     /// Return the flattened runtime ABI width of `ty` in eight-byte slots.
     pub fn abi_slot_count(&self, ty: Type) -> u32 {
+        self.validate_complete_type(ty)
+            .expect("backend layout requires a complete, non-recovery type graph");
         self.inner.abi_slot_count(ty)
+    }
+
+    /// Validate a complete type relative to this frozen owner pool.
+    ///
+    /// Coincidentally equal compact bits from a foreign epoch are not
+    /// distinguishable here; artifact branding and durable boundaries establish
+    /// ownership before validation.
+    pub fn validate_complete_type(&self, ty: Type) -> Result<(), TypeValidationError> {
+        self.inner.validate_complete_type(ty)
+    }
+
+    /// Validate every pool entry before crossing the successful sema-to-CFG
+    /// boundary. Freeze remains recovery-tolerant; the operation-specific
+    /// success boundary rejects recovery-only graphs.
+    pub fn validate_for_success(&self) -> Result<(), TypeValidationError> {
+        for (index, entry) in self.inner.types.iter().enumerate() {
+            let index = checked_pool_index(index).expect("type pool index invariant");
+            let ty = match entry {
+                TypeData::Struct(_) => Type::new_struct(StructId::from_pool_index(index)),
+                TypeData::Enum(_) => Type::new_enum(EnumId::from_pool_index(index)),
+                TypeData::Array { .. } => Type::new_array(ArrayTypeId::from_pool_index(index)),
+                TypeData::PtrConst { .. } => {
+                    Type::new_ptr_const(PtrConstTypeId::from_pool_index(index))
+                }
+                TypeData::PtrMut { .. } => Type::new_ptr_mut(PtrMutTypeId::from_pool_index(index)),
+                TypeData::ReservedStruct
+                | TypeData::DeclaredStruct(_)
+                | TypeData::DeclaredEnum(_) => {
+                    return Err(TypeValidationError::IncompleteDefinition);
+                }
+            };
+            self.validate_complete_type(ty)?;
+        }
+        Ok(())
     }
 
     /// Borrow a completed nominal struct definition without locking or cloning.
@@ -1565,9 +1794,8 @@ impl FrozenTypeInternPool {
 
     /// Look up an already-completed mutable pointer type without modifying the pool.
     pub fn get_ptr_mut_by_type(&self, pointee_type: Type) -> Option<PtrMutTypeId> {
-        let pointee = TypeInternPool::type_to_interned_recursive(pointee_type);
-        let interned = self.inner.ptr_mut_map.get(&pointee)?;
-        Some(PtrMutTypeId::from_pool_index(interned.pool_index()?))
+        self.inner.validate_complete_type(pointee_type).ok()?;
+        self.inner.ptr_mut_map.get(&pointee_type)?.as_ptr_mut()
     }
 
     pub fn struct_lang_item(&self, id: StructId) -> Option<LangItem> {
@@ -1731,81 +1959,6 @@ mod tests {
     use lasso::ThreadedRodeo;
 
     // ========================================================================
-    // InternedType tests
-    // ========================================================================
-
-    #[test]
-    fn test_interned_type_primitives() {
-        assert!(InternedType::I8.is_primitive());
-        assert!(InternedType::I16.is_primitive());
-        assert!(InternedType::I32.is_primitive());
-        assert!(InternedType::I64.is_primitive());
-        assert!(InternedType::U8.is_primitive());
-        assert!(InternedType::U16.is_primitive());
-        assert!(InternedType::U32.is_primitive());
-        assert!(InternedType::U64.is_primitive());
-        assert!(InternedType::BOOL.is_primitive());
-        assert!(InternedType::UNIT.is_primitive());
-        assert!(InternedType::NEVER.is_primitive());
-        assert!(InternedType::ERROR.is_primitive());
-    }
-
-    #[test]
-    fn test_interned_type_indices() {
-        assert_eq!(InternedType::I8.index(), 0);
-        assert_eq!(InternedType::I16.index(), 1);
-        assert_eq!(InternedType::I32.index(), 2);
-        assert_eq!(InternedType::I64.index(), 3);
-        assert_eq!(InternedType::U8.index(), 4);
-        assert_eq!(InternedType::BOOL.index(), 8);
-        assert_eq!(InternedType::UNIT.index(), 9);
-        assert_eq!(
-            InternedType::ERROR.index(),
-            Type::ERROR.raw_encoding(),
-            "compatibility wrapper must not swap Error and Never"
-        );
-        assert_eq!(
-            InternedType::NEVER.index(),
-            Type::NEVER.raw_encoding(),
-            "compatibility wrapper must not swap Error and Never"
-        );
-        assert!(InternedType::try_from_raw(13).is_none());
-        assert!(InternedType::try_from_raw(255).is_none());
-        assert!(InternedType::try_from_raw(Type::COMPTIME_TYPE.raw_encoding()).is_none());
-    }
-
-    #[test]
-    fn test_interned_type_pool_index() {
-        // Primitives don't have pool indices
-        assert_eq!(InternedType::I32.pool_index(), None);
-        assert_eq!(InternedType::BOOL.pool_index(), None);
-
-        // Composite types have pool indices
-        let composite = InternedType::from_pool_index(0);
-        assert_eq!(composite.pool_index(), Some(0));
-        assert!(!composite.is_primitive());
-
-        let composite2 = InternedType::from_pool_index(42);
-        assert_eq!(composite2.pool_index(), Some(42));
-    }
-
-    #[test]
-    fn test_interned_type_equality() {
-        assert_eq!(InternedType::I32, InternedType::I32);
-        assert_ne!(InternedType::I32, InternedType::I64);
-        assert_ne!(InternedType::I32, InternedType::from_pool_index(0));
-    }
-
-    #[test]
-    fn test_interned_type_debug() {
-        let i32_str = format!("{:?}", InternedType::I32);
-        assert!(i32_str.contains("i32"));
-
-        let composite_str = format!("{:?}", InternedType::from_pool_index(5));
-        assert!(composite_str.contains("pool:5"));
-    }
-
-    // ========================================================================
     // TypeInternPool tests
     // ========================================================================
 
@@ -1857,13 +2010,16 @@ mod tests {
         let (id, is_new) = pool.declare_struct(name, struct_def("Node", vec![]));
         assert!(is_new);
 
-        let interned = pool.struct_id_to_interned(id);
-        assert!(matches!(
-            pool.get(interned),
-            Some(TypeData::DeclaredStruct(_))
-        ));
+        let interned = Type::new_struct(id);
+        assert!(pool.get(interned).is_none());
         assert!(pool.is_struct(interned));
         assert!(pool.get_struct_def(interned).is_none());
+        assert!(pool.try_struct_def(id).is_none());
+        assert_eq!(pool.struct_declaration_metadata(id).unwrap().name, "Node");
+        assert_eq!(
+            pool.validate_complete_type(interned),
+            Err(TypeValidationError::IncompleteDefinition)
+        );
 
         // The declared identity is legal in a recursive pointer graph before
         // the nominal definition completes.
@@ -1964,7 +2120,68 @@ mod tests {
         let pool = TypeInternPool::new();
         let array_id = pool.intern_array_from_type(Type::ERROR, 1);
         let frozen = pool.freeze();
+        assert_eq!(frozen.len(), 1);
         assert_eq!(frozen.array_def(array_id), (Type::ERROR, 1));
+        assert_eq!(
+            frozen.validate_for_success(),
+            Err(TypeValidationError::RecoveryType)
+        );
+    }
+
+    #[test]
+    fn public_layout_rejects_incomplete_and_recovery_graphs() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = declarations.get_or_intern("Later");
+        let (declared, _) = pool.declare_struct(name, struct_def("Later", vec![]));
+        let declared_ty = Type::new_struct(declared);
+
+        assert_eq!(
+            pool.try_abi_slot_count(declared_ty),
+            Err(TypeValidationError::IncompleteDefinition)
+        );
+
+        let recovery_array = pool.try_intern_array(Type::ERROR, 3).unwrap();
+        assert_eq!(
+            pool.try_abi_slot_count(recovery_array),
+            Err(TypeValidationError::RecoveryType)
+        );
+        assert_eq!(pool.provisional_abi_slot_count(recovery_array), 3);
+    }
+
+    #[test]
+    fn checked_structural_interning_fails_closed_for_illegal_children() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let name = declarations.get_or_intern("Owner");
+        let (owner, _) = pool.register_struct(name, struct_def("Owner", vec![]));
+
+        assert_eq!(
+            pool.try_intern_array(Type::COMPTIME_TYPE, 1),
+            Err(TypeValidationError::ComptimeStructuralChild)
+        );
+        assert_eq!(
+            pool.try_intern_ptr_const(Type::new_module(crate::ModuleId::new(0))),
+            Err(TypeValidationError::ModuleStructuralChild)
+        );
+        assert_eq!(
+            pool.try_intern_ptr_mut(Type::from_u32(13)),
+            Err(TypeValidationError::InvalidEncoding)
+        );
+        assert_eq!(
+            pool.try_intern_array(Type::new_array(ArrayTypeId::from_pool_index(owner.0)), 1),
+            Err(TypeValidationError::KindMismatch)
+        );
+        assert_eq!(
+            pool.try_intern_array(Type::new_struct(StructId::from_pool_index(99)), 1),
+            Err(TypeValidationError::PoolIndexOutOfRange)
+        );
+
+        let reserved = pool.reserve_struct_id();
+        assert_eq!(
+            pool.try_intern_ptr_mut(Type::new_struct(reserved)),
+            Err(TypeValidationError::ReservedEntry)
+        );
     }
 
     #[test]
@@ -2128,22 +2345,22 @@ mod tests {
         let pool = TypeInternPool::new();
 
         // Intern [i32; 5]
-        let arr1 = pool.intern_array(InternedType::I32, 5);
-        assert!(!arr1.is_primitive());
+        let arr1 = pool.try_intern_array(Type::I32, 5).unwrap();
+        assert!(arr1.is_array());
         assert_eq!(pool.len(), 1);
 
         // Interning the same array returns the same type
-        let arr2 = pool.intern_array(InternedType::I32, 5);
+        let arr2 = pool.try_intern_array(Type::I32, 5).unwrap();
         assert_eq!(arr1, arr2);
         assert_eq!(pool.len(), 1);
 
         // Different length is a different type
-        let arr3 = pool.intern_array(InternedType::I32, 10);
+        let arr3 = pool.try_intern_array(Type::I32, 10).unwrap();
         assert_ne!(arr1, arr3);
         assert_eq!(pool.len(), 2);
 
         // Different element type is a different type
-        let arr4 = pool.intern_array(InternedType::I64, 5);
+        let arr4 = pool.try_intern_array(Type::I64, 5).unwrap();
         assert_ne!(arr1, arr4);
         assert_eq!(pool.len(), 3);
     }
@@ -2171,7 +2388,7 @@ mod tests {
         };
 
         let (struct_id, _) = pool.register_struct(name, def);
-        let expected = pool.struct_id_to_interned(struct_id);
+        let expected = Type::new_struct(struct_id);
         assert_eq!(
             pool.get_struct_by_file_name(rue_span::FileId::DEFAULT, name),
             Some(expected)
@@ -2198,7 +2415,7 @@ mod tests {
         };
 
         let (enum_id, _) = pool.register_enum(name, def);
-        let expected = pool.enum_id_to_interned(enum_id);
+        let expected = Type::new_enum(enum_id);
         assert_eq!(
             pool.get_enum_by_file_name(rue_span::FileId::DEFAULT, name),
             Some(expected)
@@ -2209,11 +2426,11 @@ mod tests {
     fn test_pool_get_array() {
         let pool = TypeInternPool::new();
 
-        assert!(pool.get_array(InternedType::I32, 5).is_none());
+        assert!(pool.get_array(Type::I32, 5).is_none());
 
-        let arr = pool.intern_array(InternedType::I32, 5);
-        assert_eq!(pool.get_array(InternedType::I32, 5), Some(arr));
-        assert!(pool.get_array(InternedType::I32, 10).is_none());
+        let arr = pool.try_intern_array(Type::I32, 5).unwrap();
+        assert_eq!(pool.get_array(Type::I32, 5), Some(arr));
+        assert!(pool.get_array(Type::I32, 10).is_none());
     }
 
     #[test]
@@ -2222,7 +2439,7 @@ mod tests {
         let interner = ThreadedRodeo::default();
 
         // Primitive types return None
-        assert!(pool.get(InternedType::I32).is_none());
+        assert!(pool.get(Type::I32).is_none());
 
         // Register a struct
         let struct_name = interner.get_or_intern("Point");
@@ -2237,18 +2454,18 @@ mod tests {
             file_id: rue_span::FileId::DEFAULT,
         };
         let (struct_id, _) = pool.register_struct(struct_name, struct_def);
-        let struct_ty = pool.struct_id_to_interned(struct_id);
+        let struct_ty = Type::new_struct(struct_id);
 
         // Get struct data
         let data = pool.get(struct_ty).expect("should get struct data");
         assert!(matches!(data, TypeData::Struct(_)));
 
         // Intern an array
-        let arr_ty = pool.intern_array(InternedType::I32, 10);
+        let arr_ty = pool.try_intern_array(Type::I32, 10).unwrap();
         let arr_data = pool.get(arr_ty).expect("should get array data");
         match arr_data {
             TypeData::Array { element, len } => {
-                assert_eq!(element, InternedType::I32);
+                assert_eq!(element, Type::I32);
                 assert_eq!(len, 10);
             }
             _ => panic!("expected array data"),
@@ -2272,7 +2489,7 @@ mod tests {
             file_id: rue_span::FileId::DEFAULT,
         };
         let (struct_id, _) = pool.register_struct(struct_name, struct_def);
-        let struct_ty = pool.struct_id_to_interned(struct_id);
+        let struct_ty = Type::new_struct(struct_id);
 
         let enum_name = interner.get_or_intern("Color");
         let enum_def = EnumDef {
@@ -2283,27 +2500,27 @@ mod tests {
             file_id: rue_span::FileId::DEFAULT,
         };
         let (enum_id, _) = pool.register_enum(enum_name, enum_def);
-        let enum_ty = pool.enum_id_to_interned(enum_id);
+        let enum_ty = Type::new_enum(enum_id);
 
-        let array_ty = pool.intern_array(InternedType::I32, 5);
+        let array_ty = pool.try_intern_array(Type::I32, 5).unwrap();
 
         // Check is_struct
         assert!(pool.is_struct(struct_ty));
         assert!(!pool.is_struct(enum_ty));
         assert!(!pool.is_struct(array_ty));
-        assert!(!pool.is_struct(InternedType::I32));
+        assert!(!pool.is_struct(Type::I32));
 
         // Check is_enum
         assert!(!pool.is_enum(struct_ty));
         assert!(pool.is_enum(enum_ty));
         assert!(!pool.is_enum(array_ty));
-        assert!(!pool.is_enum(InternedType::I32));
+        assert!(!pool.is_enum(Type::I32));
 
         // Check is_array
         assert!(!pool.is_array(struct_ty));
         assert!(!pool.is_array(enum_ty));
         assert!(pool.is_array(array_ty));
-        assert!(!pool.is_array(InternedType::I32));
+        assert!(!pool.is_array(Type::I32));
     }
 
     #[test]
@@ -2330,16 +2547,16 @@ mod tests {
         assert_eq!(retrieved.is_copy, def.is_copy);
 
         // The pool encoding resolves to the same definition.
-        let interned = pool.struct_id_to_interned(struct_id);
+        let interned = Type::new_struct(struct_id);
         let retrieved2 = pool
             .get_struct_def(interned)
             .expect("should get struct def");
         assert_eq!(retrieved2.name, def.name);
 
         // Non-struct returns None for get_struct_def
-        let array_ty = pool.intern_array(InternedType::I32, 5);
+        let array_ty = pool.try_intern_array(Type::I32, 5).unwrap();
         assert!(pool.get_struct_def(array_ty).is_none());
-        assert!(pool.get_struct_def(InternedType::I32).is_none());
+        assert!(pool.get_struct_def(Type::I32).is_none());
     }
 
     #[test]
@@ -2363,25 +2580,25 @@ mod tests {
         assert_eq!(retrieved.variants.len(), 2);
 
         // The pool encoding resolves to the same definition.
-        let interned = pool.enum_id_to_interned(enum_id);
+        let interned = Type::new_enum(enum_id);
         let retrieved2 = pool.get_enum_def(interned).expect("should get enum def");
         assert_eq!(retrieved2.name, def.name);
 
         // Non-enum returns None for get_enum_def
-        let array_ty = pool.intern_array(InternedType::I32, 5);
+        let array_ty = pool.try_intern_array(Type::I32, 5).unwrap();
         assert!(pool.get_enum_def(array_ty).is_none());
-        assert!(pool.get_enum_def(InternedType::I32).is_none());
+        assert!(pool.get_enum_def(Type::I32).is_none());
     }
 
     #[test]
     fn test_pool_get_array_info() {
         let pool = TypeInternPool::new();
 
-        let array_ty = pool.intern_array(InternedType::I64, 100);
+        let array_ty = pool.try_intern_array(Type::I64, 100).unwrap();
         let (element, len) = pool
             .get_array_info(array_ty)
             .expect("should get array info");
-        assert_eq!(element, InternedType::I64);
+        assert_eq!(element, Type::I64);
         assert_eq!(len, 100);
 
         // Non-array returns None
@@ -2398,9 +2615,9 @@ mod tests {
             file_id: rue_span::FileId::DEFAULT,
         };
         let (struct_id, _) = pool.register_struct(name, def);
-        let struct_ty = pool.struct_id_to_interned(struct_id);
+        let struct_ty = Type::new_struct(struct_id);
         assert!(pool.get_array_info(struct_ty).is_none());
-        assert!(pool.get_array_info(InternedType::I32).is_none());
+        assert!(pool.get_array_info(Type::I32).is_none());
     }
 
     #[test]
@@ -2449,9 +2666,9 @@ mod tests {
             },
         );
 
-        pool.intern_array(InternedType::I32, 5);
-        pool.intern_array(InternedType::I32, 10);
-        pool.intern_array(InternedType::BOOL, 3);
+        pool.try_intern_array(Type::I32, 5).unwrap();
+        pool.try_intern_array(Type::I32, 10).unwrap();
+        pool.try_intern_array(Type::BOOL, 3).unwrap();
 
         let stats = pool.stats();
         assert_eq!(stats.struct_count, 2);
@@ -2465,10 +2682,10 @@ mod tests {
         let pool = TypeInternPool::new();
 
         // Create [i32; 3]
-        let inner = pool.intern_array(InternedType::I32, 3);
+        let inner = pool.try_intern_array(Type::I32, 3).unwrap();
 
         // Create [[i32; 3]; 4]
-        let outer = pool.intern_array(inner, 4);
+        let outer = pool.try_intern_array(inner, 4).unwrap();
 
         // Verify structure
         let (outer_elem, outer_len) = pool.get_array_info(outer).expect("outer array info");
@@ -2476,78 +2693,8 @@ mod tests {
         assert_eq!(outer_len, 4);
 
         let (inner_elem, inner_len) = pool.get_array_info(inner).expect("inner array info");
-        assert_eq!(inner_elem, InternedType::I32);
+        assert_eq!(inner_elem, Type::I32);
         assert_eq!(inner_len, 3);
-    }
-
-    #[test]
-    fn test_pool_type_to_interned() {
-        let pool = TypeInternPool::new();
-
-        // Primitive types convert correctly
-        assert_eq!(pool.type_to_interned(Type::I8), Some(InternedType::I8));
-        assert_eq!(pool.type_to_interned(Type::I16), Some(InternedType::I16));
-        assert_eq!(pool.type_to_interned(Type::I32), Some(InternedType::I32));
-        assert_eq!(pool.type_to_interned(Type::I64), Some(InternedType::I64));
-        assert_eq!(pool.type_to_interned(Type::U8), Some(InternedType::U8));
-        assert_eq!(pool.type_to_interned(Type::U16), Some(InternedType::U16));
-        assert_eq!(pool.type_to_interned(Type::U32), Some(InternedType::U32));
-        assert_eq!(pool.type_to_interned(Type::U64), Some(InternedType::U64));
-        assert_eq!(pool.type_to_interned(Type::BOOL), Some(InternedType::BOOL));
-        assert_eq!(pool.type_to_interned(Type::UNIT), Some(InternedType::UNIT));
-        assert_eq!(
-            pool.type_to_interned(Type::NEVER),
-            Some(InternedType::NEVER)
-        );
-        assert_eq!(
-            pool.type_to_interned(Type::ERROR),
-            Some(InternedType::ERROR)
-        );
-
-        // Composite types return None (need name lookup)
-        assert!(
-            pool.type_to_interned(Type::new_struct(crate::types::StructId(0)))
-                .is_none()
-        );
-        assert!(
-            pool.type_to_interned(Type::new_enum(crate::types::EnumId(0)))
-                .is_none()
-        );
-        assert!(
-            pool.type_to_interned(Type::new_array(crate::types::ArrayTypeId(0)))
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn test_pool_interned_to_type() {
-        let pool = TypeInternPool::new();
-
-        // Primitive types convert back correctly
-        assert_eq!(pool.interned_to_type(InternedType::I8), Some(Type::I8));
-        assert_eq!(pool.interned_to_type(InternedType::I16), Some(Type::I16));
-        assert_eq!(pool.interned_to_type(InternedType::I32), Some(Type::I32));
-        assert_eq!(pool.interned_to_type(InternedType::I64), Some(Type::I64));
-        assert_eq!(pool.interned_to_type(InternedType::U8), Some(Type::U8));
-        assert_eq!(pool.interned_to_type(InternedType::U16), Some(Type::U16));
-        assert_eq!(pool.interned_to_type(InternedType::U32), Some(Type::U32));
-        assert_eq!(pool.interned_to_type(InternedType::U64), Some(Type::U64));
-        assert_eq!(pool.interned_to_type(InternedType::BOOL), Some(Type::BOOL));
-        assert_eq!(pool.interned_to_type(InternedType::UNIT), Some(Type::UNIT));
-        assert_eq!(
-            pool.interned_to_type(InternedType::NEVER),
-            Some(Type::NEVER)
-        );
-        assert_eq!(
-            pool.interned_to_type(InternedType::ERROR),
-            Some(Type::ERROR)
-        );
-
-        // Composite types return None
-        assert!(
-            pool.interned_to_type(InternedType::from_pool_index(0))
-                .is_none()
-        );
     }
 
     // ========================================================================
@@ -2619,7 +2766,7 @@ mod tests {
         let handles: Vec<_> = (0..10)
             .map(|_| {
                 let pool = Arc::clone(&pool);
-                thread::spawn(move || pool.intern_array(InternedType::I32, 42))
+                thread::spawn(move || pool.try_intern_array(Type::I32, 42).unwrap())
             })
             .collect();
 
@@ -2810,6 +2957,20 @@ mod tests {
         assert_eq!(pool.stats().struct_count, 3);
     }
 
+    #[test]
+    fn public_get_hides_reserved_entries() {
+        let pool = TypeInternPool::new();
+        let reserved = pool.reserve_struct_id();
+        let synthesized = Type::new_struct(reserved);
+
+        assert!(pool.get(synthesized).is_none());
+        assert!(!pool.is_struct(synthesized));
+        assert_eq!(
+            pool.validate_structural_child(synthesized),
+            Err(TypeValidationError::ReservedEntry)
+        );
+    }
+
     // Compile-time assertion that TypeInternPool is Send + Sync
     fn assert_send_sync<T: Send + Sync>() {}
 
@@ -2852,5 +3013,21 @@ mod tests {
             Type::new_ptr_const(pc).safe_name_with_pool(None),
             format!("<ptr const#{}>", pc.0)
         );
+    }
+
+    #[test]
+    fn frozen_pointer_lookup_rejects_direct_and_nested_recovery_types() {
+        let pool = TypeInternPool::new();
+        let direct = pool.intern_ptr_mut_from_type(Type::ERROR);
+        let error_array = Type::new_array(pool.intern_array_from_type(Type::ERROR, 2));
+        let nested = pool.intern_ptr_mut_from_type(error_array);
+        let valid = pool.intern_ptr_mut_from_type(Type::U8);
+        let frozen = pool.freeze();
+
+        assert_eq!(frozen.get_ptr_mut_by_type(Type::ERROR), None);
+        assert_eq!(frozen.get_ptr_mut_by_type(error_array), None);
+        assert_eq!(frozen.get_ptr_mut_by_type(Type::U8), Some(valid));
+        assert_eq!(frozen.ptr_mut_def(direct), Type::ERROR);
+        assert_eq!(frozen.ptr_mut_def(nested), error_array);
     }
 }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -39,8 +39,8 @@ pub use inst::{
     AirPlace, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
 };
 pub use intern_pool::{
-    EnumData, FrozenTypeInternPool, InternedType, StructData, TypeData, TypeInternPool,
-    TypeInternPoolStats,
+    EnumData, FrozenTypeInternPool, StructData, TypeData, TypeInternPool, TypeInternPoolStats,
+    TypeValidationError,
 };
 pub use module_registry::ModuleRegistry;
 pub use param_arena::{ParamArena, ParamRange};

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -131,15 +131,15 @@ pub(crate) fn import_staged_body(
                     _ => return Err(F::NominalKindMismatch),
                 }
             }
-            T::Array { element, len } => Type::new_array(
-                pool.intern_array_from_type(import_type(sema, pool, element)?, *len),
-            ),
-            T::PtrConst(value) => Type::new_ptr_const(
-                pool.intern_ptr_const_from_type(import_type(sema, pool, value)?),
-            ),
-            T::PtrMut(value) => {
-                Type::new_ptr_mut(pool.intern_ptr_mut_from_type(import_type(sema, pool, value)?))
-            }
+            T::Array { element, len } => pool
+                .try_intern_array(import_type(sema, pool, element)?, *len)
+                .map_err(|_| F::InvalidStructuralType)?,
+            T::PtrConst(value) => pool
+                .try_intern_ptr_const(import_type(sema, pool, value)?)
+                .map_err(|_| F::InvalidStructuralType)?,
+            T::PtrMut(value) => pool
+                .try_intern_ptr_mut(import_type(sema, pool, value)?)
+                .map_err(|_| F::InvalidStructuralType)?,
             T::Module(module) => {
                 let id = (0..sema.module_registry.len())
                     .map(|i| ModuleId::new(i as u32))
@@ -378,6 +378,13 @@ fn intern_named_callable_symbols(sema: &BodySema<'_>) {
 /// success (`Ok`) path, so any `<error>` found here is by definition
 /// undiagnosed and indicates a compiler bug.
 fn find_undiagnosed_error_type(output: &SemaOutput) -> Option<CompileError> {
+    if let Err(error) = output.type_pool.validate_for_success() {
+        return Some(CompileError::without_span(ErrorKind::InternalError(
+            format!(
+                "the completed type pool contains an invalid or recovery-only type graph but no diagnostic was emitted: {error:?} (RUE-836)"
+            ),
+        )));
+    }
     for func in &output.functions {
         if func.air.return_type().is_error() {
             return Some(CompileError::without_span(ErrorKind::InternalError(

--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -42,7 +42,12 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         // Check if an equivalent anonymous struct already exists
         // Anonymous structs have names starting with "__anon_struct_"
         for struct_id in self.type_pool.all_struct_ids() {
-            let struct_def = self.type_pool.struct_def(struct_id);
+            let Some(struct_def) = self.type_pool.try_struct_def(struct_id) else {
+                // Named declaration shells participate in recursive identity,
+                // but they are not definitions eligible for anonymous
+                // structural deduplication.
+                continue;
+            };
             if struct_def.name.starts_with("__anon_struct_") {
                 // Check fields match
                 if struct_def.fields.len() != fields.len() {

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -478,8 +478,12 @@ impl<'a> DeclarationShells<'a> {
                         .structs_by_file_name
                         .get(&(pending.shell.declaration_span.file_id, name))
                         .ok_or(DeclarationInstallFailure::MissingNominal)?;
-                    let mut def = self.sema.type_pool.struct_def(id);
-                    if *syntax_linear != *is_linear || def.is_copy != *is_copy {
+                    let metadata = self
+                        .sema
+                        .type_pool
+                        .struct_declaration_metadata(id)
+                        .ok_or(DeclarationInstallFailure::NominalShapeMismatch)?;
+                    if *syntax_linear != *is_linear || metadata.is_copy != *is_copy {
                         return Err(DeclarationInstallFailure::NominalShapeMismatch);
                     }
                     if self
@@ -492,7 +496,7 @@ impl<'a> DeclarationShells<'a> {
                     {
                         return Err(DeclarationInstallFailure::NominalShapeMismatch);
                     }
-                    def.fields = fields
+                    let resolved_fields = fields
                         .iter()
                         .map(|(name, ty)| {
                             Ok(crate::StructField {
@@ -501,6 +505,16 @@ impl<'a> DeclarationShells<'a> {
                             })
                         })
                         .collect::<Result<_, DeclarationInstallFailure>>()?;
+                    let def = crate::StructDef {
+                        name: metadata.name,
+                        fields: resolved_fields,
+                        is_copy: metadata.is_copy,
+                        is_linear: metadata.is_linear,
+                        destructor: metadata.destructor,
+                        is_builtin: metadata.is_builtin,
+                        is_pub: metadata.is_pub,
+                        file_id: metadata.file_id,
+                    };
                     self.sema.type_pool.complete_declared_struct(id, def);
                 }
                 (SemanticDeclarationPayload::Enum { variants }, InstData::EnumDecl { .. }) => {
@@ -509,8 +523,12 @@ impl<'a> DeclarationShells<'a> {
                         .enums_by_file_name
                         .get(&(pending.shell.declaration_span.file_id, name))
                         .ok_or(DeclarationInstallFailure::MissingNominal)?;
-                    let mut def = self.sema.type_pool.enum_def(id);
-                    if def
+                    let metadata = self
+                        .sema
+                        .type_pool
+                        .enum_declaration_metadata(id)
+                        .ok_or(DeclarationInstallFailure::NominalShapeMismatch)?;
+                    if metadata
                         .variants
                         .iter()
                         .map(String::as_str)
@@ -518,7 +536,7 @@ impl<'a> DeclarationShells<'a> {
                     {
                         return Err(DeclarationInstallFailure::NominalShapeMismatch);
                     }
-                    def.variant_payloads = variants
+                    let variant_payloads = variants
                         .iter()
                         .map(|(_, payload)| {
                             payload
@@ -527,6 +545,13 @@ impl<'a> DeclarationShells<'a> {
                                 .collect()
                         })
                         .collect::<Result<_, DeclarationInstallFailure>>()?;
+                    let def = crate::EnumDef {
+                        name: metadata.name,
+                        variants: metadata.variants,
+                        variant_payloads,
+                        is_pub: metadata.is_pub,
+                        file_id: metadata.file_id,
+                    };
                     self.sema.type_pool.complete_declared_enum(id, def);
                 }
                 _ => return Err(DeclarationInstallFailure::KindMismatch),
@@ -710,6 +735,9 @@ impl<'a> DeclarationShells<'a> {
             .check_recursive_value_types()
             .map_err(|_| DeclarationInstallFailure::NominalShapeMismatch)?;
         self.sema.propagate_field_linearity();
+        self.sema
+            .validate_deferred_ownership_gates()
+            .map_err(|_| DeclarationInstallFailure::NominalShapeMismatch)?;
         self.sema.capture_resolved_declaration_type_dependencies();
         self.sema.declaration_type_observer = None;
         self.binding_work.durable_payloads_installed = expected;
@@ -774,22 +802,25 @@ impl Sema<'_> {
                     _ => return Err(DeclarationInstallFailure::KindMismatch),
                 }
             }
-            SemanticExportType::Array { element, len } => {
-                Type::new_array(self.type_pool.intern_array_from_type(
+            SemanticExportType::Array { element, len } => self
+                .type_pool
+                .try_intern_array(
                     self.import_export_type_with_generics(element, generic_parameters)?,
                     *len,
-                ))
-            }
-            SemanticExportType::PtrConst(value) => {
-                Type::new_ptr_const(self.type_pool.intern_ptr_const_from_type(
+                )
+                .map_err(|_| DeclarationInstallFailure::UnsupportedType)?,
+            SemanticExportType::PtrConst(value) => self
+                .type_pool
+                .try_intern_ptr_const(
                     self.import_export_type_with_generics(value, generic_parameters)?,
-                ))
-            }
-            SemanticExportType::PtrMut(value) => {
-                Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(
+                )
+                .map_err(|_| DeclarationInstallFailure::UnsupportedType)?,
+            SemanticExportType::PtrMut(value) => self
+                .type_pool
+                .try_intern_ptr_mut(
                     self.import_export_type_with_generics(value, generic_parameters)?,
-                ))
-            }
+                )
+                .map_err(|_| DeclarationInstallFailure::UnsupportedType)?,
             SemanticExportType::Module(_) => {
                 return Err(DeclarationInstallFailure::UnsupportedType);
             }
@@ -1248,6 +1279,9 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
         ty: Type,
         stack: &mut Vec<Type>,
     ) -> Result<SemanticExportType, SemanticExportFailure> {
+        self.type_pool
+            .validate_complete_type(ty)
+            .map_err(|_| SemanticExportFailure::ErrorType)?;
         if stack.contains(&ty) {
             return Err(SemanticExportFailure::RecursiveStructuralType);
         }

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -73,7 +73,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     pub(crate) fn is_type_linear(&self, ty: Type) -> bool {
         match ty.kind() {
             TypeKind::Struct(struct_id) => {
-                let struct_def = self.type_pool.struct_def(struct_id);
+                let struct_def = self
+                    .type_pool
+                    .try_struct_def(struct_id)
+                    .expect("linearity queries require a complete struct definition");
                 struct_def.is_linear
             }
             // Only struct types can be linear
@@ -87,6 +90,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// Used by infectious linearity (RUE-40): a struct with such a field must
     /// itself be linear, and destructuring a linear struct must not implicitly
     /// drop such a field. Pointers don't own their pointee and don't carry.
+    ///
+    /// Every reachable nominal definition must be complete. During the
+    /// declaration fixpoint the struct flags are the values being converged;
+    /// outside that fixpoint callers require finalized declaration ownership.
     pub(crate) fn type_carries_linear(&self, ty: Type) -> bool {
         match ty.kind() {
             TypeKind::Struct(_) => self.is_type_linear(ty),
@@ -100,7 +107,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             // active variant at runtime, so a conservative static check
             // requires consumption if *any* variant could carry one.
             TypeKind::Enum(enum_id) => {
-                let enum_def = self.type_pool.enum_def(enum_id);
+                let enum_def = self
+                    .type_pool
+                    .try_enum_def(enum_id)
+                    .expect("linearity queries require a complete enum definition");
                 enum_def
                     .variant_payloads
                     .iter()
@@ -121,10 +131,15 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// Used to gate by-copy element reads (`ArrayBuf(T)::get`/`get_or`, RUE-651):
     /// copying a drop-glue element by `@ptr_read` would alias its owned resources
     /// and double-free at scope exit, so those reads are rejected for such `T`.
+    /// Every reachable nominal definition and destructor assignment must be
+    /// finalized before this query is authoritative.
     pub(crate) fn type_has_drop_glue(&self, ty: Type) -> bool {
         match ty.kind() {
             TypeKind::Struct(struct_id) => {
-                let struct_def = self.type_pool.struct_def(struct_id);
+                let struct_def = self
+                    .type_pool
+                    .try_struct_def(struct_id)
+                    .expect("drop-glue queries require a complete struct definition");
                 struct_def.destructor.is_some()
                     || struct_def
                         .fields
@@ -132,7 +147,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                         .any(|f| self.type_has_drop_glue(f.ty))
             }
             TypeKind::Enum(enum_id) => {
-                let enum_def = self.type_pool.enum_def(enum_id);
+                let enum_def = self
+                    .type_pool
+                    .try_enum_def(enum_id)
+                    .expect("drop-glue queries require a complete enum definition");
                 enum_def
                     .variant_payloads
                     .iter()
@@ -144,6 +162,72 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                 self.type_has_drop_glue(element_type)
             }
             _ => false,
+        }
+    }
+
+    /// Whether declaration finalization can still change an ownership query
+    /// for `ty`. Pointers deliberately stop the walk because they do not own
+    /// their pointee; arrays carry their element by value.
+    pub(crate) fn type_ownership_depends_on_nominal(&self, ty: Type) -> bool {
+        match ty.kind() {
+            TypeKind::Struct(_) | TypeKind::Enum(_) => true,
+            TypeKind::Array(array_id) => {
+                let (element_type, _) = self.type_pool.array_def(array_id);
+                self.type_ownership_depends_on_nominal(element_type)
+            }
+            _ => false,
+        }
+    }
+
+    /// Return only declaration-time ownership facts that cannot be invalidated
+    /// by later payload completion or infectious-linearity propagation.
+    pub(crate) fn known_linear_during_binding(&self, ty: Type) -> Option<bool> {
+        match ty.kind() {
+            TypeKind::Struct(id) => self
+                .type_pool
+                .struct_metadata(id)
+                .and_then(|metadata| metadata.is_linear.then_some(true)),
+            TypeKind::Enum(id) => {
+                let def = self.type_pool.try_enum_def(id)?;
+                let mut deferred = false;
+                for payload in def.variant_payloads.iter().flatten() {
+                    match self.known_linear_during_binding(*payload) {
+                        Some(true) => return Some(true),
+                        Some(false) => {}
+                        None => deferred = true,
+                    }
+                }
+                (!deferred).then_some(false)
+            }
+            TypeKind::Array(id) => self.known_linear_during_binding(self.type_pool.array_def(id).0),
+            _ => Some(false),
+        }
+    }
+
+    /// Return only declaration-time drop-glue facts that cannot be invalidated
+    /// by later payload completion or destructor collection.
+    pub(crate) fn known_drop_glue_during_binding(&self, ty: Type) -> Option<bool> {
+        match ty.kind() {
+            TypeKind::Struct(id) => self
+                .type_pool
+                .struct_metadata(id)
+                .and_then(|metadata| metadata.destructor.is_some().then_some(true)),
+            TypeKind::Enum(id) => {
+                let def = self.type_pool.try_enum_def(id)?;
+                let mut deferred = false;
+                for payload in def.variant_payloads.iter().flatten() {
+                    match self.known_drop_glue_during_binding(*payload) {
+                        Some(true) => return Some(true),
+                        Some(false) => {}
+                        None => deferred = true,
+                    }
+                }
+                (!deferred).then_some(false)
+            }
+            TypeKind::Array(id) => {
+                self.known_drop_glue_during_binding(self.type_pool.array_def(id).0)
+            }
+            _ => Some(false),
         }
     }
 }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -55,7 +55,9 @@ use rue_rir::{InstData, InstRef, RepeatCount, RirPattern};
 use rue_span::{FileId, Span};
 
 use super::context::{AnalysisContext, ConstValue, LocalVar, ParamInfo};
-use super::{DeclarationPhase, FunctionInfo, Sema};
+use super::{
+    DeclarationPhase, DeferredOwnershipGate, DeferredOwnershipGateKind, FunctionInfo, Sema,
+};
 use crate::specialize::MAX_SPECIALIZATION_ROUNDS;
 use crate::types::{ArrayLen, StructField, Type, TypeKind};
 
@@ -1185,7 +1187,10 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                 if let Some(ty) = resolved {
                     match ty.kind() {
                         TypeKind::Struct(id) => {
-                            let def = self.type_pool.struct_def(id);
+                            let def = self
+                                .type_pool
+                                .struct_metadata(id)
+                                .expect("struct type must have declaration metadata");
                             self.record_named_const_dependency(
                                 super::NamedConstDependencyTargetEvent::NamedType {
                                     file: def.file_id.index(),
@@ -1195,7 +1200,10 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                             );
                         }
                         TypeKind::Enum(id) => {
-                            let def = self.type_pool.enum_def(id);
+                            let def = self
+                                .type_pool
+                                .enum_metadata(id)
+                                .expect("enum type must have declaration metadata");
                             self.record_named_const_dependency(
                                 super::NamedConstDependencyTargetEvent::NamedType {
                                     file: def.file_id.index(),
@@ -1438,20 +1446,42 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     /// future ADR — deliberately out of scope here), linear elements stay
     /// rejected. A droppable element (primitives, pointers, `Copy` structs,
     /// destructor-bearing structs, nested containers) passes.
-    pub(crate) fn check_require_droppable(&self, ty: Type, span: Span) -> CompileResult<()> {
+    pub(crate) fn check_require_droppable(&mut self, ty: Type, span: Span) -> CompileResult<()> {
+        if self.declaration_binding_active {
+            match self.known_linear_during_binding(ty) {
+                Some(true) => return Err(self.require_droppable_error(ty, span)),
+                Some(false) => return Ok(()),
+                None => {
+                    self.defer_ownership_gate(
+                        DeferredOwnershipGateKind::RequireDroppable,
+                        ty,
+                        span,
+                    );
+                    return Ok(());
+                }
+            }
+        }
+        self.check_require_droppable_finalized(ty, span)
+    }
+
+    fn check_require_droppable_finalized(&self, ty: Type, span: Span) -> CompileResult<()> {
         if self.type_carries_linear(ty) {
-            return Err(CompileError::new(
-                ErrorKind::ContainerElementIsLinear {
-                    ty: self.format_type_name(ty),
-                },
-                span,
-            ));
+            return Err(self.require_droppable_error(ty, span));
         }
         // Droppable-but-non-linear element types are accepted (RUE-646): the
         // container runs each live element's drop glue before freeing its
         // buffer. Linear element types stay rejected because they require a
         // consuming discharge rather than ordinary drop glue.
         Ok(())
+    }
+
+    fn require_droppable_error(&self, ty: Type, span: Span) -> CompileError {
+        CompileError::new(
+            ErrorKind::ContainerElementIsLinear {
+                ty: self.format_type_name(ty),
+            },
+            span,
+        )
     }
 
     /// The `@require_trivially_droppable(T)` gate for by-copy element *reads*
@@ -1469,14 +1499,61 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     ///
     /// A `linear` `T` never reaches here: `@require_droppable` already rejects it
     /// at instantiation, so `ArrayBuf(linear)` cannot be constructed to be read.
-    pub(crate) fn check_trivially_droppable(&self, ty: Type, span: Span) -> CompileResult<()> {
+    pub(crate) fn check_trivially_droppable(&mut self, ty: Type, span: Span) -> CompileResult<()> {
+        if self.declaration_binding_active {
+            match self.known_drop_glue_during_binding(ty) {
+                Some(true) => return Err(self.trivially_droppable_error(ty, span)),
+                Some(false) => return Ok(()),
+                None => {
+                    self.defer_ownership_gate(
+                        DeferredOwnershipGateKind::RequireTriviallyDroppable,
+                        ty,
+                        span,
+                    );
+                    return Ok(());
+                }
+            }
+        }
+        self.check_trivially_droppable_finalized(ty, span)
+    }
+
+    fn check_trivially_droppable_finalized(&self, ty: Type, span: Span) -> CompileResult<()> {
         if self.type_has_drop_glue(ty) {
-            return Err(CompileError::new(
-                ErrorKind::ContainerElementNotTriviallyDroppable {
-                    ty: self.format_type_name(ty),
-                },
-                span,
-            ));
+            return Err(self.trivially_droppable_error(ty, span));
+        }
+        Ok(())
+    }
+
+    fn trivially_droppable_error(&self, ty: Type, span: Span) -> CompileError {
+        CompileError::new(
+            ErrorKind::ContainerElementNotTriviallyDroppable {
+                ty: self.format_type_name(ty),
+            },
+            span,
+        )
+    }
+
+    fn defer_ownership_gate(&mut self, kind: DeferredOwnershipGateKind, ty: Type, span: Span) {
+        debug_assert!(self.declaration_binding_active);
+        debug_assert!(self.type_ownership_depends_on_nominal(ty));
+        let gate = DeferredOwnershipGate { kind, ty, span };
+        if !self.deferred_ownership_gates.contains(&gate) {
+            self.deferred_ownership_gates.push(gate);
+        }
+    }
+
+    /// Discharge ownership gates after declaration binding has completed every
+    /// nominal payload, infectious-linearity fixpoint, and destructor.
+    pub(crate) fn validate_deferred_ownership_gates(&mut self) -> CompileResult<()> {
+        for gate in std::mem::take(&mut self.deferred_ownership_gates) {
+            match gate.kind {
+                DeferredOwnershipGateKind::RequireDroppable => {
+                    self.check_require_droppable_finalized(gate.ty, gate.span)?
+                }
+                DeferredOwnershipGateKind::RequireTriviallyDroppable => {
+                    self.check_trivially_droppable_finalized(gate.ty, gate.span)?
+                }
+            }
         }
         Ok(())
     }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -477,7 +477,11 @@ impl<'a> Sema<'a> {
                         && let Some(module_path) = self.symbol_paths.get(&inst.span.file_id)
                         && let Some(lang_item) = crate::LangItem::from_standard_library_nominal(
                             module_path,
-                            &self.type_pool.struct_def(struct_id).name,
+                            &self
+                                .type_pool
+                                .struct_metadata(struct_id)
+                                .expect("newly declared struct must retain its shell")
+                                .name,
                         )
                     {
                         self.type_pool.set_struct_lang_item(struct_id, lang_item);
@@ -519,6 +523,7 @@ impl<'a> Sema<'a> {
             self.check_recursive_value_types()?;
             self.propagate_field_linearity();
             self.resolve_remaining_declarations()?;
+            self.validate_deferred_ownership_gates()?;
             // Now that value constants are separated from module bindings, reject
             // any value-constant name that collides with a function/struct/enum
             // (order-independent E0436, spec 10.3:1/10.5:1, RUE-239).
@@ -683,7 +688,10 @@ impl<'a> Sema<'a> {
     ) {
         let target = match ty.kind() {
             TypeKind::Struct(id) => {
-                let def = self.type_pool.struct_def(id);
+                let def = self
+                    .type_pool
+                    .struct_metadata(id)
+                    .expect("declaration dependency names a registered struct identity");
                 if def.is_builtin || def.name.starts_with("__anon_struct_") {
                     return;
                 }
@@ -694,7 +702,10 @@ impl<'a> Sema<'a> {
                 ))
             }
             TypeKind::Enum(id) => {
-                let def = self.type_pool.enum_def(id);
+                let def = self
+                    .type_pool
+                    .enum_metadata(id)
+                    .expect("declaration dependency names a registered enum identity");
                 Some((
                     def.file_id,
                     def.name,
@@ -825,8 +836,17 @@ impl<'a> Sema<'a> {
                 .enums_by_file_name
                 .get(&(span.file_id, name))
                 .expect("enum registered in phase 1");
-            let mut def = self.type_pool.enum_def(enum_id);
-            def.variant_payloads = variant_payloads;
+            let metadata = self
+                .type_pool
+                .enum_declaration_metadata(enum_id)
+                .expect("enum registered as a declaration shell in phase 1");
+            let def = EnumDef {
+                name: metadata.name,
+                variants: metadata.variants,
+                variant_payloads,
+                is_pub: metadata.is_pub,
+                file_id: metadata.file_id,
+            };
             self.type_pool.complete_declared_enum(enum_id, def);
         }
         Ok(())
@@ -961,8 +981,20 @@ impl<'a> Sema<'a> {
                 }
 
                 // Update the struct definition in the pool with resolved fields
-                let mut struct_def = self.type_pool.struct_def(struct_id);
-                struct_def.fields = resolved_fields;
+                let metadata = self
+                    .type_pool
+                    .struct_declaration_metadata(struct_id)
+                    .expect("struct registered as a declaration shell in phase 1");
+                let struct_def = StructDef {
+                    name: metadata.name,
+                    fields: resolved_fields,
+                    is_copy: metadata.is_copy,
+                    is_linear: metadata.is_linear,
+                    destructor: metadata.destructor,
+                    is_builtin: metadata.is_builtin,
+                    is_pub: metadata.is_pub,
+                    file_id: metadata.file_id,
+                };
                 self.type_pool
                     .complete_declared_struct(struct_id, struct_def);
             }
@@ -2493,7 +2525,10 @@ impl<'a> Sema<'a> {
         // a claim stale since type-valued constants landed.
         if let Some(mfile) = module_file_id {
             if let Some(struct_id) = self.structs_by_file_name.get(&(mfile, member)).copied() {
-                let def = self.type_pool.struct_def(struct_id);
+                let def = self
+                    .type_pool
+                    .struct_metadata(struct_id)
+                    .expect("named struct must have declaration metadata");
                 let is_pub = def.is_pub;
                 self.check_const_member_visibility(
                     is_pub,
@@ -2514,7 +2549,10 @@ impl<'a> Sema<'a> {
                 ))));
             }
             if let Some(enum_id) = self.enums_by_file_name.get(&(mfile, member)).copied() {
-                let def = self.type_pool.enum_def(enum_id);
+                let def = self
+                    .type_pool
+                    .enum_metadata(enum_id)
+                    .expect("named enum must have declaration metadata");
                 let is_pub = def.is_pub;
                 self.check_const_member_visibility(
                     is_pub,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -196,6 +196,19 @@ impl DeclarationPhase for SourceDeclarations {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeferredOwnershipGateKind {
+    RequireDroppable,
+    RequireTriviallyDroppable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DeferredOwnershipGate {
+    kind: DeferredOwnershipGateKind,
+    ty: Type,
+    span: Span,
+}
+
 /// Semantic analyzer that converts RIR to AIR.
 pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     declarations: D,
@@ -318,6 +331,10 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     /// Maps the struct to the (field name, field type name) that caused it,
     /// for diagnostics explaining why the container is linear.
     pub(crate) infectious_linear: HashMap<StructId, (String, String)>,
+    /// Ownership gates reached while declaration payloads are still mutable.
+    /// Their negative result is not authoritative until nominal payloads,
+    /// infectious linearity, and destructors have all been finalized.
+    pub(crate) deferred_ownership_gates: Vec<DeferredOwnershipGate>,
     /// Current recursion depth of `-> type` comptime-function reduction
     /// (`eval_comptime_type_call`). Unlike value functions — whose comptime
     /// recursion is bounded by the specialization-round limit — a `-> type`
@@ -406,6 +423,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             anon_struct_type_subst,
             destructor_spans,
             infectious_linear,
+            deferred_ownership_gates,
             comptime_type_call_depth,
             fn_signatures_in_flight,
             ctor_type_displays,
@@ -459,6 +477,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             anon_struct_type_subst,
             destructor_spans,
             infectious_linear,
+            deferred_ownership_gates,
             comptime_type_call_depth,
             fn_signatures_in_flight,
             ctor_type_displays,
@@ -778,6 +797,7 @@ impl<'a> Sema<'a> {
             anon_struct_type_subst: HashMap::new(),
             destructor_spans: HashMap::new(),
             infectious_linear: HashMap::new(),
+            deferred_ownership_gates: Vec::new(),
             comptime_type_call_depth: 0,
             fn_signatures_in_flight: HashSet::new(),
             ctor_type_displays: HashMap::new(),

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -582,6 +582,9 @@ impl BodySema<'_> {
         &self,
         ty: Type,
     ) -> Result<SemanticImportType<SemanticBodyDefinitionIdentity, Arc<str>>, F> {
+        self.type_pool
+            .validate_complete_type(ty)
+            .map_err(|_| F::UnsupportedType)?;
         Ok(match ty.kind() {
             TypeKind::I8 => SemanticImportType::I8,
             TypeKind::I16 => SemanticImportType::I16,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -52,8 +52,18 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             TypeKind::Never => "!".to_string(),
             TypeKind::Error => "<error>".to_string(),
             // Nominal strings and generated string views are ordinary structs.
-            TypeKind::Struct(struct_id) => self.type_pool.struct_def(struct_id).name.clone(),
-            TypeKind::Enum(enum_id) => self.type_pool.enum_def(enum_id).name.clone(),
+            TypeKind::Struct(struct_id) => {
+                self.type_pool
+                    .struct_metadata(struct_id)
+                    .expect("struct type must have declaration metadata")
+                    .name
+            }
+            TypeKind::Enum(enum_id) => {
+                self.type_pool
+                    .enum_metadata(enum_id)
+                    .expect("enum type must have declaration metadata")
+                    .name
+            }
             TypeKind::Array(array_id) => {
                 let (element_type, length) = self.type_pool.array_def(array_id);
                 format!("[{}; {}]", self.format_type_name(element_type), length)
@@ -615,7 +625,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             // Spans here are always the reference site (annotation,
             // signature, struct literal), so `span.file_id` is the
             // referencing file.
-            let struct_def = self.type_pool.struct_def(struct_id);
+            let struct_def = self
+                .type_pool
+                .struct_metadata(struct_id)
+                .expect("type lookup names a registered struct identity");
             self.check_unqualified_visibility(
                 "struct",
                 type_name,
@@ -633,7 +646,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             // Privacy (E0460, RUE-185): same rule for enums — an unqualified
             // type reference must not reach a private enum defined in another
             // directory.
-            let enum_def = self.type_pool.enum_def(enum_id);
+            let enum_def = self
+                .type_pool
+                .enum_metadata(enum_id)
+                .expect("type lookup names a registered enum identity");
             self.check_unqualified_visibility(
                 "enum",
                 type_name,
@@ -718,7 +734,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     pub(crate) fn record_resolved_declaration_type(&mut self, ty: Type) {
         match ty.kind() {
             TypeKind::Struct(id) => {
-                let def = self.type_pool.struct_def(id);
+                let def = self
+                    .type_pool
+                    .struct_metadata(id)
+                    .expect("resolved declaration type names a registered struct identity");
                 if !def.is_builtin && !def.name.starts_with("__anon_struct_") {
                     self.record_resolved_declaration_type_target(
                         def.file_id,
@@ -728,7 +747,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                 }
             }
             TypeKind::Enum(id) => {
-                let def = self.type_pool.enum_def(id);
+                let def = self
+                    .type_pool
+                    .enum_metadata(id)
+                    .expect("resolved declaration type names a registered enum identity");
                 self.record_resolved_declaration_type_target(
                     def.file_id,
                     def.name,
@@ -883,7 +905,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                 .get(&(file_id, member_sym))
                 .copied()
         }) {
-            let struct_def = self.type_pool.struct_def(struct_id);
+            let struct_def = self
+                .type_pool
+                .struct_metadata(struct_id)
+                .expect("qualified type lookup names a registered struct identity");
             self.check_unqualified_visibility(
                 "struct",
                 member,
@@ -896,7 +921,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         if let Some(enum_id) = module_file_id
             .and_then(|file_id| self.enums_by_file_name.get(&(file_id, member_sym)).copied())
         {
-            let enum_def = self.type_pool.enum_def(enum_id);
+            let enum_def = self
+                .type_pool
+                .enum_metadata(enum_id)
+                .expect("qualified type lookup names a registered enum identity");
             self.check_unqualified_visibility(
                 "enum",
                 member,
@@ -3175,6 +3203,6 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
     /// every materialization site via [`Self::require_layout_slots`], so the
     /// saturated value is never used for real allocation.
     pub(crate) fn abi_slot_count(&self, ty: Type) -> u32 {
-        self.type_pool.abi_slot_count(ty)
+        self.type_pool.provisional_abi_slot_count(ty)
     }
 }

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -89,6 +89,8 @@ pub enum SemanticImportFailure {
     BuiltinNominalKindMismatch,
     GenericParameterNeedsDeclarationContext,
     GenericParameterOutOfRange,
+    InvalidStructuralType,
+    NominalAlreadyComplete,
     ForeignLocalType,
     ForeignLocalValue,
 }
@@ -148,19 +150,42 @@ where
     K: Clone + Ord,
     M: Clone + Ord + AsRef<str>,
 {
-    /// Atomically reconstruct a structured durable body in this epoch.
-    /// All validation and AIR construction happens in a scratch value; the
-    /// epoch's declaration universe is immutable and cannot be partially
-    /// updated on failure.
+    /// Reconstruct a structured durable body without publishing partial state.
+    ///
+    /// The first pass performs every fallible reconstruction step against the
+    /// type-pool transaction snapshot and an isolated symbol interner. Only a
+    /// body that passes that preflight is rebuilt with the live interner, so a
+    /// returned error changes neither pool nor symbol allocation order.
     pub fn import_body(
         &self,
         body: &SemanticBody<K, M>,
         body_span: Span,
     ) -> Result<SemanticImportedBody, SemanticBodyImportFailure> {
+        self.type_pool.transaction(|type_pool| {
+            let scratch_interner = ThreadedRodeo::new();
+            self.import_body_in_pool(body, body_span, type_pool, &scratch_interner)?;
+
+            // The same immutable body has passed every error path, and the
+            // transaction snapshot now contains every structural type it
+            // needs. This pass can therefore publish symbols without a later
+            // recoverable failure leaving a prefix behind.
+            Ok(self
+                .import_body_in_pool(body, body_span, type_pool, &self.interner)
+                .expect("preflighted semantic body reconstruction must be infallible"))
+        })
+    }
+
+    fn import_body_in_pool(
+        &self,
+        body: &SemanticBody<K, M>,
+        body_span: Span,
+        type_pool: &TypeInternPool,
+        interner: &ThreadedRodeo,
+    ) -> Result<SemanticImportedBody, SemanticBodyImportFailure> {
         Self::import_body_with(
             body,
             body_span,
-            |ty| self.import_type_local(ty),
+            |ty| self.import_type_local_with(ty, type_pool, None),
             |key| match self.nominals.get(key) {
                 Some(LocalNominal::Struct(id)) => Ok(*id),
                 Some(LocalNominal::Enum(_)) => Err(SemanticBodyImportFailure::WrongNominalKind),
@@ -184,7 +209,7 @@ where
                     ))
             },
             |_| Err(SemanticBodyImportFailure::UnsupportedGenericCall),
-            |name| self.interner.get_or_intern(name),
+            |name| interner.get_or_intern(name),
         )
     }
 
@@ -695,7 +720,7 @@ where
             let symbol = interner.get_or_intern(&name);
             let value = match nominal.kind {
                 SemanticImportNominalKind::Struct => {
-                    let (id, _) = type_pool.register_struct(
+                    let (id, _) = type_pool.declare_struct(
                         symbol,
                         StructDef {
                             name,
@@ -714,7 +739,7 @@ where
                     LocalNominal::Struct(id)
                 }
                 SemanticImportNominalKind::Enum => {
-                    let (id, _) = type_pool.register_enum(
+                    let (id, _) = type_pool.declare_enum(
                         symbol,
                         EnumDef {
                             name,
@@ -832,24 +857,26 @@ where
                 Some(LocalNominal::Enum(id)) => Type::new_enum(*id),
                 None => return Err(SemanticImportFailure::MissingNominal),
             },
-            SemanticImportType::Array { element, len } => {
-                Type::new_array(type_pool.intern_array_from_type(
+            SemanticImportType::Array { element, len } => type_pool
+                .try_intern_array(
                     self.import_type_local_with(element, type_pool, generic_parameters)?,
                     *len,
-                ))
-            }
-            SemanticImportType::PtrConst(value) => {
-                Type::new_ptr_const(type_pool.intern_ptr_const_from_type(
-                    self.import_type_local_with(value, type_pool, generic_parameters)?,
-                ))
-            }
-            SemanticImportType::PtrMut(value) => Type::new_ptr_mut(
-                type_pool.intern_ptr_mut_from_type(self.import_type_local_with(
+                )
+                .map_err(|_| SemanticImportFailure::InvalidStructuralType)?,
+            SemanticImportType::PtrConst(value) => type_pool
+                .try_intern_ptr_const(self.import_type_local_with(
                     value,
                     type_pool,
                     generic_parameters,
-                )?),
-            ),
+                )?)
+                .map_err(|_| SemanticImportFailure::InvalidStructuralType)?,
+            SemanticImportType::PtrMut(value) => type_pool
+                .try_intern_ptr_mut(self.import_type_local_with(
+                    value,
+                    type_pool,
+                    generic_parameters,
+                )?)
+                .map_err(|_| SemanticImportFailure::InvalidStructuralType)?,
             SemanticImportType::Module(key) => Type::new_module(
                 *self
                     .modules
@@ -946,6 +973,9 @@ where
         &self,
         value: Type,
     ) -> Result<SemanticImportType<K, M>, SemanticImportFailure> {
+        self.type_pool
+            .validate_complete_type(value)
+            .map_err(|_| SemanticImportFailure::ForeignLocalType)?;
         Ok(match value.kind() {
             crate::TypeKind::I8 => SemanticImportType::I8,
             crate::TypeKind::I16 => SemanticImportType::I16,
@@ -1060,20 +1090,38 @@ where
         else {
             return Err(SemanticImportFailure::NominalKindMismatch);
         };
-        let mut def = self.type_pool.struct_def(id);
-        def.fields = fields
-            .iter()
-            .map(|(name, ty)| {
-                Ok(StructField {
-                    name: name.to_string(),
-                    ty: self.import_type_local(ty)?,
+        self.type_pool.transaction(|type_pool| {
+            let metadata = type_pool.struct_declaration_metadata(id).ok_or_else(|| {
+                if type_pool.try_struct_def(id).is_some() {
+                    SemanticImportFailure::NominalAlreadyComplete
+                } else {
+                    SemanticImportFailure::NominalKindMismatch
+                }
+            })?;
+            let fields = fields
+                .iter()
+                .map(|(name, ty)| {
+                    Ok(StructField {
+                        name: name.to_string(),
+                        ty: self.import_type_local_with(ty, type_pool, None)?,
+                    })
                 })
-            })
-            .collect::<Result<_, _>>()?;
-        def.is_copy = is_copy;
-        def.is_linear = is_linear;
-        self.type_pool.update_struct_def(id, def);
-        Ok(())
+                .collect::<Result<_, _>>()?;
+            type_pool.complete_declared_struct(
+                id,
+                StructDef {
+                    name: metadata.name,
+                    fields,
+                    is_copy,
+                    is_linear,
+                    destructor: metadata.destructor,
+                    is_builtin: metadata.is_builtin,
+                    is_pub: metadata.is_pub,
+                    file_id: metadata.file_id,
+                },
+            );
+            Ok(())
+        })
     }
 
     pub fn complete_enum(
@@ -1089,19 +1137,35 @@ where
         else {
             return Err(SemanticImportFailure::NominalKindMismatch);
         };
-        let mut def = self.type_pool.enum_def(id);
-        def.variants = variants.iter().map(|(name, _)| name.to_string()).collect();
-        def.variant_payloads = variants
-            .iter()
-            .map(|(_, payload)| {
-                payload
-                    .iter()
-                    .map(|ty| self.import_type_local(ty))
-                    .collect()
-            })
-            .collect::<Result<_, _>>()?;
-        self.type_pool.update_enum_def(id, def);
-        Ok(())
+        self.type_pool.transaction(|type_pool| {
+            let metadata = type_pool.enum_declaration_metadata(id).ok_or_else(|| {
+                if type_pool.try_enum_def(id).is_some() {
+                    SemanticImportFailure::NominalAlreadyComplete
+                } else {
+                    SemanticImportFailure::NominalKindMismatch
+                }
+            })?;
+            let variant_payloads = variants
+                .iter()
+                .map(|(_, payload)| {
+                    payload
+                        .iter()
+                        .map(|ty| self.import_type_local_with(ty, type_pool, None))
+                        .collect()
+                })
+                .collect::<Result<_, _>>()?;
+            type_pool.complete_declared_enum(
+                id,
+                EnumDef {
+                    name: metadata.name,
+                    variants: variants.iter().map(|(name, _)| name.to_string()).collect(),
+                    variant_payloads,
+                    is_pub: metadata.is_pub,
+                    file_id: metadata.file_id,
+                },
+            );
+            Ok(())
+        })
     }
 
     pub fn type_pool(&self) -> &TypeInternPool {
@@ -1180,6 +1244,8 @@ mod tests {
             vec!["pkg/main.rue"],
         )
         .unwrap();
+        a.complete_struct(&"node", &[], false, false).unwrap();
+        b.complete_struct(&"node", &[], false, false).unwrap();
         let durable = ImportType::PtrConst(Box::new(ImportType::Nominal("node")));
         let ta = a.import_type(&durable).unwrap();
         let tb = b.import_type(&durable).unwrap();
@@ -1213,6 +1279,19 @@ mod tests {
             vec!["pkg/main.rue"],
         )
         .unwrap();
+        for epoch in [&first, &second] {
+            let left = epoch.nominals["left"];
+            let LocalNominal::Struct(left) = left else {
+                panic!("left must be a struct")
+            };
+            let left_ty = Type::new_struct(left);
+            assert!(epoch.type_pool().get(left_ty).is_none());
+            assert!(epoch.type_pool().try_struct_def(left).is_none());
+            assert_eq!(
+                epoch.type_pool().validate_complete_type(left_ty),
+                Err(crate::TypeValidationError::IncompleteDefinition)
+            );
+        }
         let left_fields = [(
             Arc::from("next"),
             ImportType::PtrConst(Box::new(ImportType::Nominal("right"))),
@@ -1240,6 +1319,102 @@ mod tests {
                 projection(&second, second.import_type(&ty).unwrap().value)
             );
         }
+        let LocalNominal::Struct(left) = first.nominals["left"] else {
+            panic!("left must be a struct")
+        };
+        assert!(first.type_pool().try_struct_def(left).is_some());
+        assert_eq!(
+            first.complete_struct(&"left", &left_fields, false, false),
+            Err(SemanticImportFailure::NominalAlreadyComplete)
+        );
+    }
+
+    #[test]
+    fn enum_shell_completes_once_and_public_reads_are_complete_only() {
+        let epoch = Epoch::new(
+            vec![nominal("choice", "Choice", SemanticImportNominalKind::Enum)],
+            vec![],
+            vec![],
+        )
+        .unwrap();
+        let LocalNominal::Enum(id) = epoch.nominals["choice"] else {
+            panic!("choice must be an enum")
+        };
+        let ty = Type::new_enum(id);
+        assert!(epoch.type_pool().get(ty).is_none());
+        assert!(epoch.type_pool().try_enum_def(id).is_none());
+
+        let variants = [(Arc::from("Value"), Arc::from([ImportType::I32]))];
+        epoch.complete_enum(&"choice", &variants).unwrap();
+        assert_eq!(
+            epoch.type_pool().enum_def(id).variant_payloads,
+            vec![vec![Type::I32]]
+        );
+        assert_eq!(
+            epoch.complete_enum(&"choice", &variants),
+            Err(SemanticImportFailure::NominalAlreadyComplete)
+        );
+    }
+
+    #[test]
+    fn nominal_completion_is_atomic_after_earlier_structural_imports() {
+        let epoch = Epoch::new(
+            vec![
+                nominal("node", "Node", SemanticImportNominalKind::Struct),
+                nominal("choice", "Choice", SemanticImportNominalKind::Enum),
+            ],
+            vec![],
+            vec!["pkg/main.rue"],
+        )
+        .unwrap();
+        let before = epoch.type_pool().stats();
+        let fields = [
+            (
+                Arc::from("good"),
+                ImportType::Array {
+                    element: Box::new(ImportType::U8),
+                    len: 4,
+                },
+            ),
+            (
+                Arc::from("bad"),
+                ImportType::PtrConst(Box::new(ImportType::Module("pkg/main.rue"))),
+            ),
+        ];
+
+        assert_eq!(
+            epoch.complete_struct(&"node", &fields, false, false),
+            Err(SemanticImportFailure::InvalidStructuralType)
+        );
+        assert_eq!(epoch.type_pool().stats(), before);
+        assert_eq!(epoch.type_pool().get_array(Type::U8, 4), None);
+        let LocalNominal::Struct(id) = epoch.nominals["node"] else {
+            panic!("node must be a struct")
+        };
+        assert!(epoch.type_pool().try_struct_def(id).is_none());
+        assert!(epoch.type_pool().struct_declaration_metadata(id).is_some());
+
+        let variants = [(
+            Arc::from("Value"),
+            Arc::from([
+                ImportType::Array {
+                    element: Box::new(ImportType::U16),
+                    len: 5,
+                },
+                ImportType::PtrMut(Box::new(ImportType::Module("pkg/main.rue"))),
+            ]),
+        )];
+        assert_eq!(
+            epoch.complete_enum(&"choice", &variants),
+            Err(SemanticImportFailure::InvalidStructuralType)
+        );
+        assert_eq!(epoch.type_pool().stats(), before);
+        assert_eq!(epoch.type_pool().get_array(Type::U16, 5), None);
+        let LocalNominal::Enum(id) = epoch.nominals["choice"] else {
+            panic!("choice must be an enum")
+        };
+        assert!(epoch.type_pool().try_enum_def(id).is_none());
+        assert!(epoch.type_pool().enum_declaration_metadata(id).is_some());
     }
 
     #[test]
@@ -1260,6 +1435,21 @@ mod tests {
         assert_eq!(
             epoch.import_const_value(&SemanticImportConstValue::Function("missing")),
             Err(SemanticImportFailure::MissingFunction)
+        );
+
+        let epoch = Epoch::new(vec![], vec![], vec!["pkg/main.rue"]).unwrap();
+        assert_eq!(
+            epoch.import_type(&ImportType::Array {
+                element: Box::new(ImportType::ComptimeType),
+                len: 1,
+            }),
+            Err(SemanticImportFailure::InvalidStructuralType)
+        );
+        assert_eq!(
+            epoch.import_type(&ImportType::PtrConst(Box::new(ImportType::Module(
+                "pkg/main.rue",
+            )))),
+            Err(SemanticImportFailure::InvalidStructuralType)
         );
     }
 
@@ -1309,6 +1499,7 @@ mod tests {
             vec!["pkg/main.rue"],
         )
         .unwrap();
+        epoch.complete_struct(&"node", &[], false, false).unwrap();
         let values = [
             ImportType::Array {
                 element: Box::new(ImportType::PtrConst(Box::new(ImportType::Nominal("node")))),
@@ -1533,6 +1724,109 @@ mod tests {
                 .air
                 .len(),
             1
+        );
+    }
+
+    #[test]
+    fn body_import_rolls_back_structural_types_before_later_failures() {
+        use crate::{
+            SemanticBodyAnchor, SemanticBodyImportFailure as F, SemanticBodyInstData as D,
+        };
+        let epoch = Epoch::new(vec![], vec![], vec![]).unwrap();
+        let array = ImportType::Array {
+            element: Box::new(ImportType::U8),
+            len: 9,
+        };
+        let before = epoch.type_pool().stats();
+
+        let mut forward = body(vec![D::Const(0), D::Add(2, 0)]);
+        let mut instructions = forward.instructions.to_vec();
+        instructions[0].ty = array.clone();
+        forward.instructions = instructions.into();
+        let result = epoch.import_body(&forward, Span::with_file(FileId::DEFAULT, 0, 100));
+        assert!(
+            matches!(result, Err(F::InvalidInstructionReference)),
+            "{result:?}"
+        );
+        assert_eq!(epoch.type_pool().stats(), before);
+        assert_eq!(epoch.type_pool().get_array(Type::U8, 9), None);
+
+        let mut warning = body(vec![D::Const(0)]);
+        let mut instructions = warning.instructions.to_vec();
+        instructions[0].ty = array;
+        warning.instructions = instructions.into();
+        warning.warnings = vec![crate::SemanticBodyWarning {
+            code: Arc::from("W"),
+            message: Arc::from("late invalid anchor"),
+            anchor: SemanticBodyAnchor {
+                start: 101,
+                end: 102,
+            },
+        }]
+        .into();
+        assert!(matches!(
+            epoch.import_body(&warning, Span::with_file(FileId::DEFAULT, 0, 100)),
+            Err(F::InvalidAnchor)
+        ));
+        assert_eq!(epoch.type_pool().stats(), before);
+        assert_eq!(epoch.type_pool().get_array(Type::U8, 9), None);
+    }
+
+    #[test]
+    fn failed_body_import_preserves_live_symbol_order_and_packed_air() {
+        use crate::{SemanticBodyImportFailure as F, SemanticBodyInstData as D};
+        let after_failure = Epoch::new(vec![], vec![], vec![]).unwrap();
+        let fresh = Epoch::new(vec![], vec![], vec![]).unwrap();
+        let baseline_symbols = fresh.interner().len();
+        assert_eq!(after_failure.interner().len(), baseline_symbols);
+
+        let invalid = body(vec![
+            D::Intrinsic {
+                runtime: None,
+                name: Arc::from("failed_import_symbol"),
+                args: Arc::new([]),
+            },
+            D::Add(3, 0),
+        ]);
+        assert!(matches!(
+            after_failure.import_body(&invalid, Span::with_file(FileId::DEFAULT, 0, 100)),
+            Err(F::InvalidInstructionReference)
+        ));
+        assert_eq!(
+            after_failure.interner().len(),
+            baseline_symbols,
+            "preflight must not publish an intrinsic symbol before a later failure"
+        );
+
+        let valid = body(vec![D::Intrinsic {
+            runtime: None,
+            name: Arc::from("successful_import_symbol"),
+            args: Arc::new([]),
+        }]);
+        let after_failure_body = after_failure
+            .import_body(&valid, Span::with_file(FileId::DEFAULT, 0, 100))
+            .unwrap();
+        let fresh_body = fresh
+            .import_body(&valid, Span::with_file(FileId::DEFAULT, 0, 100))
+            .unwrap();
+        let crate::AirInstData::Intrinsic {
+            name: after_failure_name,
+            ..
+        } = after_failure_body.air.instructions()[0].data
+        else {
+            panic!("expected reconstructed intrinsic")
+        };
+        let crate::AirInstData::Intrinsic {
+            name: fresh_name, ..
+        } = fresh_body.air.instructions()[0].data
+        else {
+            panic!("expected reconstructed intrinsic")
+        };
+        assert_eq!(after_failure_name, fresh_name);
+        assert_eq!(
+            format!("{:?}", after_failure_body.air),
+            format!("{:?}", fresh_body.air),
+            "a failed import must not perturb any packed AIR word"
         );
     }
 

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -629,7 +629,7 @@ fn type_name(ty: Type, type_pool: &FrozenTypeInternPool) -> String {
 #[cfg(test)]
 mod tests {
     use lasso::ThreadedRodeo;
-    use rue_air::{EnumDef, ModuleId, StructField, TypeInternPool};
+    use rue_air::{EnumDef, StructField, TypeInternPool};
 
     use super::*;
 
@@ -784,9 +784,11 @@ mod tests {
         );
         let drop_enum_ty = Type::new_enum(drop_enum_id);
 
-        // Every TypeKind occurs either directly or through one of the aggregate
-        // shapes below. Keeping the droppable fields last makes their Param
-        // indices a compact assertion over every preceding canonical width.
+        // Every runtime TypeKind occurs either directly or through one of the
+        // aggregate shapes below. Recovery and compile-time-only types are not
+        // valid backend structural children. Keeping the droppable fields last
+        // makes their Param indices a compact assertion over every preceding
+        // canonical width.
         let outer_id = register_struct(
             &type_pool,
             &interner,
@@ -801,11 +803,8 @@ mod tests {
                 Type::U32,
                 Type::U64,
                 Type::BOOL,
-                Type::ERROR,
                 Type::UNIT,
                 Type::NEVER,
-                Type::COMPTIME_TYPE,
-                Type::new_module(ModuleId(0)),
                 const_ptr,
                 mut_ptr,
                 zst_mixed_ty,
@@ -830,8 +829,8 @@ mod tests {
         let outer =
             create_struct_drop_glue_function(type_pool.struct_def(outer_id), outer_id, &type_pool);
         assert_eq!(outer.num_param_slots, type_pool.abi_slot_count(outer_ty));
-        assert_eq!(outer.num_param_slots, 28);
-        assert_eq!(param_indices(&outer), [20, 21, 23, 25]);
+        assert_eq!(outer.num_param_slots, 27);
+        assert_eq!(param_indices(&outer), [19, 20, 22, 24]);
 
         let array = create_array_drop_glue_function(drop_array_id, &type_pool);
         assert_eq!(

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3776 rejected=149 lex_invalid=35 accepted_source_ast_sha256=136c5519132d6691eb463aaf4be3ef99bf92a6e9aefb99b10c583ce8d2bedd2b
+# pre-RUE-905 Chumsky: accepted=3780 rejected=149 lex_invalid=35 accepted_source_ast_sha256=00823426d93fb17579f8502e1a93b8a64d70d73e81ca0886c29bec097d4f4814
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca

--- a/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/droppable_gate.toml
@@ -52,6 +52,37 @@ compile_fail = true
 error_contains = ["E0499", "Token", "required by the type-constructor application here"]
 
 [[case]]
+name = "deferred_named_enum_linear_payload_is_rejected"
+description = "A declaration-time gate defers an incomplete named enum, then rejects it after payload completion and infectious-linearity finalization."
+source = """
+linear struct Token { v: i32 }
+enum Maybe { Some(Token), None }
+fn Gated(comptime T: type) -> type {
+    @require_droppable(T);
+    struct { y: T }
+}
+const G = Gated(Maybe);
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0499", "Maybe"]
+
+[[case]]
+name = "deferred_named_enum_primitive_payload_compiles"
+description = "The same deferred declaration-time query resolves negative after a named enum's primitive payload is complete."
+source = """
+enum Maybe { Some(i32), None }
+fn Gated(comptime T: type) -> type {
+    @require_droppable(T);
+    struct { y: T }
+}
+const G = Gated(Maybe);
+fn main() -> i32 { 0 }
+"""
+compile_fail = false
+exit_code = 0
+
+[[case]]
 name = "e0499_linear_names_and_labels"
 description = "The linear-element rejection (E0499) gets the same application-site label (RUE-610)"
 source = """

--- a/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/trivially_droppable_gate.toml
@@ -89,3 +89,34 @@ fn main() -> i32 {
 """
 compile_fail = false
 exit_code = 7
+
+[[case]]
+name = "deferred_named_struct_late_destructor_is_rejected"
+description = "A declaration-time gate defers a named struct until its later destructor declaration has been installed."
+source = """
+struct D { v: i32 }
+fn Gated(comptime T: type) -> type {
+    @require_trivially_droppable(T);
+    struct { y: T }
+}
+const G = Gated(D);
+drop fn D(self) {}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0711", "D"]
+
+[[case]]
+name = "deferred_named_enum_without_drop_glue_compiles"
+description = "A declaration-time drop-glue query resolves negative after a named enum's primitive payload is complete."
+source = """
+enum Maybe { Some(i32), None }
+fn Gated(comptime T: type) -> type {
+    @require_trivially_droppable(T);
+    struct { y: T }
+}
+const G = Gated(Maybe);
+fn main() -> i32 { 0 }
+"""
+compile_fail = false
+exit_code = 0


### PR DESCRIPTION
## Summary

- migrate structural type-pool and semantic APIs to the canonical Type handle
- separate encoding checks from authoritative pool/state/structural validation
- make durable nominal and body imports fail closed and atomic
- enforce complete-only layout and ownership queries while deferring declaration-time ownership gates
- add lifecycle, corruption, recovery, rollback, and ownership regression coverage

## Validation

- /opt/homebrew/bin/bash ./clippy.sh
- scripts/rue test

Fixes RUE-836