### PR TITLE
RUE-862: build per-target runtime archives

### DIFF
--- a/crates/rue-runtime-abi/BUCK
+++ b/crates/rue-runtime-abi/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_crate")
 
+export_file(
+    name = "lib.rs",
+    src = "src/lib.rs",
+    visibility = ["//crates/rue-runtime:"],
+)
+
 # This is the dependency-light source of truth for the compiler/runtime ABI.
 # Keep it independent of compiler IR, target, linker, and runtime crates.
 rue_crate(

--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -1,4 +1,10 @@
 load("//crates:defs.bzl", "rue_crate")
+load(
+    ":runtime.bzl",
+    "RUNTIME_AARCH64_RUSTC_FLAGS",
+    "RUNTIME_COMMON_RUSTC_FLAGS",
+    "runtime_staticlib",
+)
 
 # tests = False: the staticlib build below uses no_std-oriented flags
 # (-Cpanic=abort, -Copt-level=z, LTO, static relocation model) that are
@@ -13,19 +19,47 @@ rue_crate(
     ],
     # Force static linkage to ensure the [staticlib] subtarget is available
     preferred_linkage = "static",
-    # Minimize output size and ensure no_std compatibility
-    rustc_flags = [
-        "-Cpanic=abort",
-        "-Copt-level=z",
-        "-Clto=true",
-        # Use static relocation model to avoid GOT-relative relocations
-        # that our simple linker doesn't support
-        "-Crelocation-model=static",
-        # Disable LSE atomics on aarch64 to avoid __aarch64_have_lse_atomics
-        # runtime detection symbol from compiler-rt that we don't have.
-        # We need both -lse (the feature) and -lse2 (newer extension).
-        "-Ctarget-feature=-lse,-lse2,-outline-atomics",
-    ],
+    # Minimize output size and ensure no_std compatibility. AArch64 needs
+    # additional atomics flags that are invalid on x86-64.
+    rustc_flags = RUNTIME_COMMON_RUSTC_FLAGS + select({
+        "prelude//cpu:arm64": RUNTIME_AARCH64_RUSTC_FLAGS,
+        "DEFAULT": [],
+    }),
+)
+
+# These targets deliberately stay in the host configuration. Each invokes the
+# selected hermetic host rustc directly with the pinned std component for its
+# fixed target, avoiding a platform transition for this dependency-free no_std
+# crate while producing the same archive on every supported host.
+runtime_staticlib(
+    name = "rue-runtime-x86_64-unknown-linux-gnu",
+    target_triple = "x86_64-unknown-linux-gnu",
+    target_std = "toolchains//rust:rust-std-x86_64-unknown-linux-gnu",
+    visibility = ["PUBLIC"],
+)
+
+runtime_staticlib(
+    name = "rue-runtime-aarch64-unknown-linux-gnu",
+    target_triple = "aarch64-unknown-linux-gnu",
+    target_std = "toolchains//rust:rust-std-aarch64-unknown-linux-gnu",
+    visibility = ["PUBLIC"],
+)
+
+runtime_staticlib(
+    name = "rue-runtime-aarch64-apple-darwin",
+    target_triple = "aarch64-apple-darwin",
+    target_std = "toolchains//rust:rust-std-aarch64-apple-darwin",
+    visibility = ["PUBLIC"],
+)
+
+sh_test(
+    name = "runtime-archives-test",
+    test = "tests/validate_runtime_archives.py",
+    env = {
+        "RUNTIME_X86_64_LINUX": "$(location :rue-runtime-x86_64-unknown-linux-gnu)",
+        "RUNTIME_AARCH64_LINUX": "$(location :rue-runtime-aarch64-unknown-linux-gnu)",
+        "RUNTIME_AARCH64_MACOS": "$(location :rue-runtime-aarch64-apple-darwin)",
+    },
 )
 
 # Unit tests for the runtime, compiled natively for the host WITHOUT the

--- a/crates/rue-runtime/runtime.bzl
+++ b/crates/rue-runtime/runtime.bzl
@@ -1,0 +1,113 @@
+"""Hermetic per-target build rules for the Rue runtime."""
+
+load("@prelude//rust:rust_toolchain.bzl", "RustToolchainInfo")
+
+# Keep the flags shared with the native rust_library target below. The runtime
+# is linked into freestanding executables, so none of these may depend on the
+# host platform or its C toolchain.
+RUNTIME_COMMON_RUSTC_FLAGS = [
+    "-Cpanic=abort",
+    "-Copt-level=z",
+    "-Clto=true",
+    "-Crelocation-model=static",
+]
+
+# AArch64's LSE atomics use a compiler-rt runtime-detection symbol that Rue
+# does not provide. These flags must not leak into the x86-64 build.
+RUNTIME_AARCH64_RUSTC_FLAGS = [
+    "-Ctarget-feature=-lse,-lse2,-outline-atomics",
+]
+
+def _runtime_staticlib_impl(ctx: AnalysisContext) -> list[Provider]:
+    target = ctx.attrs.target_triple
+    toolchain = ctx.attrs._rust_toolchain[RustToolchainInfo]
+    target_std = ctx.attrs.target_std[DefaultInfo].default_outputs[0]
+
+    # A rust-std component contains an installable `rust-std-$target` tree
+    # below the archive's outer directory. That tree is a complete sysroot for
+    # compiling the no_std ABI and runtime crates for the selected target.
+    target_sysroot = target_std.project("rust-std-{}".format(target))
+    abi_rlib = ctx.actions.declare_output("librue_runtime_abi-{}.rlib".format(target))
+    archive = ctx.actions.declare_output("librue_runtime-{}.a".format(target))
+
+    abi_args = cmd_args(toolchain.compiler)
+    abi_args.add(
+        "--crate-name",
+        "rue_runtime_abi",
+        "--crate-type",
+        "rlib",
+        "--edition",
+        "2024",
+        "--target",
+        target,
+        "--sysroot",
+        target_sysroot,
+        ctx.attrs.abi_crate_root,
+        "-o",
+        abi_rlib.as_output(),
+    )
+
+    ctx.actions.run(
+        abi_args,
+        category = "runtime_abi_rlib",
+        identifier = target,
+    )
+
+    args = cmd_args(toolchain.compiler)
+    args.add(
+        "--crate-name",
+        "rue_runtime",
+        "--crate-type",
+        "staticlib",
+        "--edition",
+        "2024",
+        "--target",
+        target,
+        "--sysroot",
+        target_sysroot,
+    )
+    args.add(ctx.attrs.rustc_flags)
+    args.add(
+        "--extern",
+        cmd_args("rue_runtime_abi=", abi_rlib, delimiter = ""),
+    )
+    args.add(cmd_args(ctx.attrs.crate_root, hidden = ctx.attrs.srcs))
+    args.add("-o", archive.as_output())
+
+    ctx.actions.run(
+        args,
+        category = "runtime_staticlib",
+        identifier = target,
+    )
+
+    return [DefaultInfo(default_output = archive)]
+
+_runtime_staticlib = rule(
+    impl = _runtime_staticlib_impl,
+    attrs = {
+        "abi_crate_root": attrs.source(),
+        "crate_root": attrs.source(),
+        "srcs": attrs.list(attrs.source()),
+        "target_std": attrs.dep(),
+        "target_triple": attrs.string(),
+        "rustc_flags": attrs.list(attrs.arg()),
+        "_rust_toolchain": attrs.toolchain_dep(default = "toolchains//:rust"),
+    },
+)
+
+def runtime_staticlib(name: str, target_triple: str, target_std: str, visibility: list[str] = []):
+    """Build the no_std Rue runtime for a fixed target with the host rustc."""
+    flags = RUNTIME_COMMON_RUSTC_FLAGS
+    if target_triple.startswith("aarch64-"):
+        flags = flags + RUNTIME_AARCH64_RUSTC_FLAGS
+
+    _runtime_staticlib(
+        name = name,
+        abi_crate_root = "//crates/rue-runtime-abi:lib.rs",
+        crate_root = "src/lib.rs",
+        srcs = glob(["src/**/*.rs"]),
+        target_std = target_std,
+        target_triple = target_triple,
+        rustc_flags = flags,
+        visibility = visibility,
+    )

--- a/crates/rue-runtime/tests/validate_runtime_archives.py
+++ b/crates/rue-runtime/tests/validate_runtime_archives.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Validate the object format and architecture of each runtime archive."""
+
+import os
+import struct
+from pathlib import Path
+
+
+AR_MAGIC = b"!<arch>\n"
+ELF_MAGIC = b"\x7fELF"
+
+
+def archive_members(path: Path):
+    data = path.read_bytes()
+    if not data.startswith(AR_MAGIC):
+        raise AssertionError(f"{path}: not an ar archive")
+
+    offset = len(AR_MAGIC)
+    while offset < len(data):
+        header = data[offset : offset + 60]
+        if len(header) != 60 or header[58:60] != b"`\n":
+            raise AssertionError(f"{path}: malformed member header at offset {offset}")
+
+        try:
+            size = int(header[48:58].decode("ascii").strip())
+        except ValueError as error:
+            raise AssertionError(f"{path}: invalid member size at offset {offset}") from error
+
+        name = header[:16].decode("ascii", errors="replace").rstrip()
+        start = offset + 60
+        end = start + size
+        if end > len(data):
+            raise AssertionError(f"{path}: truncated member {name!r}")
+
+        payload = data[start:end]
+        if name.startswith("#1/"):
+            name_size = int(name[3:])
+            name = payload[:name_size].rstrip(b"\0").decode("utf-8", errors="replace")
+            payload = payload[name_size:]
+
+        yield name, payload
+        offset = end + size % 2
+
+
+def elf_machine(payload: bytes):
+    if not payload.startswith(ELF_MAGIC):
+        return None
+    if len(payload) < 20:
+        raise AssertionError("truncated ELF object")
+    if payload[5] == 1:
+        endian = "<"
+    elif payload[5] == 2:
+        endian = ">"
+    else:
+        raise AssertionError(f"invalid ELF endianness {payload[5]}")
+    return struct.unpack_from(endian + "H", payload, 18)[0]
+
+
+def macho_cpu(payload: bytes):
+    byte_order = {
+        b"\xce\xfa\xed\xfe": "<",
+        b"\xcf\xfa\xed\xfe": "<",
+        b"\xfe\xed\xfa\xce": ">",
+        b"\xfe\xed\xfa\xcf": ">",
+    }.get(payload[:4])
+    if byte_order is None:
+        return None
+    if len(payload) < 8:
+        raise AssertionError("truncated Mach-O object")
+    return struct.unpack_from(byte_order + "I", payload, 4)[0]
+
+
+def validate_archive(path: Path, expected_format: str, expected_machine: int):
+    object_count = 0
+    for name, payload in archive_members(path):
+        elf = elf_machine(payload)
+        macho = macho_cpu(payload)
+        if elf is not None:
+            if expected_format != "elf":
+                raise AssertionError(f"{path}: member {name!r} is ELF, expected Mach-O")
+            if elf != expected_machine:
+                raise AssertionError(
+                    f"{path}: member {name!r} has ELF machine {elf}, expected {expected_machine}"
+                )
+            object_count += 1
+        elif macho is not None:
+            if expected_format != "macho":
+                raise AssertionError(f"{path}: member {name!r} is Mach-O, expected ELF")
+            if macho != expected_machine:
+                raise AssertionError(
+                    f"{path}: member {name!r} has Mach-O CPU {macho:#x}, "
+                    f"expected {expected_machine:#x}"
+                )
+            object_count += 1
+
+    if object_count == 0:
+        raise AssertionError(f"{path}: archive contains no recognized object members")
+
+
+def main():
+    validate_archive(Path(os.environ["RUNTIME_X86_64_LINUX"]), "elf", 62)
+    validate_archive(Path(os.environ["RUNTIME_AARCH64_LINUX"]), "elf", 183)
+    validate_archive(Path(os.environ["RUNTIME_AARCH64_MACOS"]), "macho", 0x0100000C)
+
+
+if __name__ == "__main__":
+    main()

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -3,7 +3,7 @@
 # Downloads prebuilt Rust toolchains for reproducible builds.
 # The toolchain includes rustc, cargo, rust-lld, and the standard library.
 
-load(":defs.bzl", "RUST_VERSION", "RUST_RELEASES", "hermetic_rust_toolchain", "rustfmt", "host_rustfmt")
+load(":defs.bzl", "RUST_VERSION", "RUST_RELEASES", "RUST_STD_RELEASES", "hermetic_rust_toolchain", "rustfmt", "host_rustfmt")
 
 # Download Rust for Linux x86_64
 http_archive(
@@ -43,6 +43,36 @@ http_archive(
     strip_prefix = "rust-{}-x86_64-apple-darwin".format(RUST_VERSION),
     type = "tar.xz",
     visibility = [],
+)
+
+# Target standard-library components used by the fixed-target Rue runtime
+# rules. Unlike the full distributions above, these are compiler-host agnostic:
+# whichever hermetic rustc runs consumes the same pinned target sysroot.
+http_archive(
+    name = "rust-std-x86_64-unknown-linux-gnu",
+    urls = [RUST_STD_RELEASES["x86_64-unknown-linux-gnu"].url],
+    sha256 = RUST_STD_RELEASES["x86_64-unknown-linux-gnu"].sha256,
+    strip_prefix = "rust-std-{}-x86_64-unknown-linux-gnu".format(RUST_VERSION),
+    type = "tar.xz",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "rust-std-aarch64-unknown-linux-gnu",
+    urls = [RUST_STD_RELEASES["aarch64-unknown-linux-gnu"].url],
+    sha256 = RUST_STD_RELEASES["aarch64-unknown-linux-gnu"].sha256,
+    strip_prefix = "rust-std-{}-aarch64-unknown-linux-gnu".format(RUST_VERSION),
+    type = "tar.xz",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "rust-std-aarch64-apple-darwin",
+    urls = [RUST_STD_RELEASES["aarch64-apple-darwin"].url],
+    sha256 = RUST_STD_RELEASES["aarch64-apple-darwin"].sha256,
+    strip_prefix = "rust-std-{}-aarch64-apple-darwin".format(RUST_VERSION),
+    type = "tar.xz",
+    visibility = ["PUBLIC"],
 )
 
 # Optimization flags based on build mode (RUE-277).

--- a/toolchains/rust/defs.bzl
+++ b/toolchains/rust/defs.bzl
@@ -33,6 +33,24 @@ RUST_RELEASES = {
     ),
 }
 
+# Standard-library-only components used to cross-compile the no_std Rue
+# runtime. Keep these pins next to the compiler distribution pins so a Rust
+# version update cannot silently mix toolchain releases.
+RUST_STD_RELEASES = {
+    "x86_64-unknown-linux-gnu": struct(
+        url = "https://static.rust-lang.org/dist/rust-std-1.92.0-x86_64-unknown-linux-gnu.tar.xz",
+        sha256 = "5f106805ed86ebf8df287039e53a45cf974391ef4d088c2760776b05b8e48b5d",
+    ),
+    "aarch64-unknown-linux-gnu": struct(
+        url = "https://static.rust-lang.org/dist/rust-std-1.92.0-aarch64-unknown-linux-gnu.tar.xz",
+        sha256 = "ce2ab42c09d633b0a8b4b65a297c700ae0fad47aae890f75894782f95be7e36d",
+    ),
+    "aarch64-apple-darwin": struct(
+        url = "https://static.rust-lang.org/dist/rust-std-1.92.0-aarch64-apple-darwin.tar.xz",
+        sha256 = "ea619984fcb8e24b05dbd568d599b8e10d904435ab458dfba6469e03e0fd69aa",
+    ),
+}
+
 # Paths within the extracted Rust distribution
 # After http_archive extracts and strips the prefix, we have:
 #   rustc/bin/rustc, rustc/bin/rustdoc


### PR DESCRIPTION
Build the dependency-free Rue runtime as three fixed-target static archives using the selected hermetic host `rustc` and pinned Rust 1.92.0 target standard-library components.

This adds one cacheable Buck action per supported Rue target, centralizes the runtime flags shared with the native build, and keeps the AArch64-only atomics feature flags off x86-64. A focused test parses every archive and checks the object format and machine architecture of its members.

This is the build-system foundation for selecting target-matching embedded runtimes in RUE-863. Compiler linking behavior remains unchanged in this increment.

Validation:

- built all three fixed-target archive targets on macOS/AArch64
- focused archive validation and native runtime tests
- Starlark lint
- `scripts/rue quick`
- `scripts/rue test` (full suite)

Fixes RUE-862
