### PR TITLE
RUE-863: select target runtime archives

### DIFF
--- a/crates/rue-cli-tests/cases/linker.toml
+++ b/crates/rue-cli-tests/cases/linker.toml
@@ -13,22 +13,8 @@ description = "Cross-compile and link-path behavior, including diagnostic cleanl
 # eprintln spew to stderr (it used to print ~270 lines from link_macho and
 # MachOBuilder).
 #
-# Platform behavior differs, so the case is written as a *native macOS success*
-# case and xfailed on the linux hosts:
-#   - macOS: aarch64-macos is the NATIVE target — it compiles & links cleanly,
-#     so this runs as a real regression test (DEBUG guard + successful compile).
-#   - linux (x86-64 / aarch64): aarch64-macos can't cross-link. Since the
-#     RUE-36 stopgap, the compile fails *by design* with the clear
-#     cross-target-runtime error. RUE-85 was the older, *confusing* form of
-#     that failure (a deep Mach-O `E1000: unsupported relocation: Plt32` — the
-#     host x86 runtime's Plt32 relocs fed into the aarch64 Mach-O reloc path);
-#     the RUE-36 guard replaced it with the clear diagnostic now pinned by
-#     `cross_link_to_aarch64_macos_refused` below, so RUE-85 is resolved.
-#     What still fails here is that cross-linking can't yet *produce a runnable
-#     aarch64-macos binary* on a linux host — that needs per-target runtime
-#     archives (RUE-36 / ADR-0034). Hence the xfail is marked known_bug RUE-36
-#     (not RUE-85, which is done): when per-target runtimes land, drop
-#     `known_bug_on` and this becomes a real test on linux too.
+# Per-target runtimes make this a success case on every host. The output is not
+# executed when foreign; RUE-864 adds complete structural matrix validation.
 [[case]]
 name = "aarch64_macos_link_no_debug_spew"
 files = [{ path = "main.rue", source = """
@@ -37,78 +23,40 @@ fn main() -> i32 { 0 }
 args = ["main.rue", "--target", "aarch64-macos", "-o", "prog"]
 compile_only = true
 compile_stderr_not_contains = ["DEBUG"]
-known_bug = "RUE-36"
-known_bug_on = ["x86-64-linux", "aarch64-linux"]
 
 # ---------------------------------------------------------------------------
-# RUE-36 / ADR-0034: cross-target links are refused with a clear error.
-#
-# The compiler embeds exactly one rue-runtime staticlib, built for the HOST.
-# Before the stopgap, `--target <foreign>` happily linked host x86-64 machine
-# code into an "AArch64" ELF (objdump-verified) and reported success. Now the
-# driver refuses at link time with an error that names both targets, cites
-# RUE-36, and points the user at `--emit asm` (which still works for every
-# target on every host).
-#
-# Whether a given `--target` is foreign depends on the host, so each refusal
-# case is scoped with `only_on` to the hosts where the target is a true
-# cross-compile. When per-target runtimes land (ADR-0034), these flip into
-# "cross-compile succeeds and the ELF machine field is correct" cases.
+# RUE-36 / ADR-0034: cross-target executable links select target runtimes.
+# Each case is scoped to hosts where the requested target is foreign.
 # ---------------------------------------------------------------------------
 
 [[case]]
-name = "cross_link_to_aarch64_linux_refused"
-description = "On non-aarch64-linux hosts, --target aarch64-linux must fail clearly instead of emitting an ELF with host machine code (RUE-36)."
+name = "cross_link_to_aarch64_linux_succeeds"
+description = "On non-aarch64-linux hosts, --target aarch64-linux links with the target runtime."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 { 0 }
 """ }]
 args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
-compile_fail = true
-error_contains = [
-    "cannot link an executable for aarch64-linux",
-    "only embeds",
-    "runtime library",
-    "RUE-36",
-    "--emit asm",
-]
+compile_only = true
 only_on = ["x86-64-linux", "aarch64-macos"]
 
 [[case]]
-name = "cross_link_to_x86_64_linux_refused"
-description = "On aarch64 hosts, --target x86-64-linux must fail clearly instead of emitting an ELF with host machine code (RUE-36)."
+name = "cross_link_to_x86_64_linux_succeeds"
+description = "On aarch64 hosts, --target x86-64-linux links with the target runtime."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 { 0 }
 """ }]
 args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
-compile_fail = true
-error_contains = [
-    "cannot link an executable for x86-64-linux",
-    "only embeds",
-    "runtime library",
-    "RUE-36",
-    "--emit asm",
-]
+compile_only = true
 only_on = ["aarch64-linux", "aarch64-macos"]
 
 [[case]]
-name = "cross_link_to_aarch64_macos_refused"
-description = "On linux hosts, --target aarch64-macos must fail with the RUE-36 cross-target-runtime error (not a deep Mach-O link failure)."
+name = "cross_link_to_aarch64_macos_succeeds"
+description = "On linux hosts, --target aarch64-macos links with the target runtime without debug spew."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 { 0 }
 """ }]
 args = ["main.rue", "--target", "aarch64-macos", "-o", "prog"]
-compile_fail = true
-error_contains = [
-    "cannot link an executable for aarch64-macos",
-    "only embeds",
-    "runtime library",
-    "RUE-36",
-    "--emit asm",
-]
-# RUE-85 regression: this must be the clean up-front refusal, never the old
-# confusing deep Mach-O link failure (`E1000: unsupported relocation: Plt32`,
-# from the host x86 runtime's Plt32 relocs hitting the aarch64 Mach-O reloc
-# path). Guard the exact stale text so it can't come back.
+compile_only = true
 compile_stderr_not_contains = ["Plt32", "unsupported relocation"]
 only_on = ["x86-64-linux", "aarch64-linux"]
 

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -6,11 +6,14 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
-# The runtime staticlib is mapped into src/ so it can be embedded with include_bytes!
+# Per-target runtime staticlibs are mapped into src/ so the compiler can embed
+# all supported runtimes and select the matching archive at link time.
 rue_crate(
     name = "rue-compiler",
     mapped_srcs = {
-        "//crates/rue-runtime:rue-runtime[staticlib]": "src/librue_runtime.a",
+        "//crates/rue-runtime:rue-runtime-aarch64-apple-darwin": "src/librue_runtime-aarch64-apple-darwin.a",
+        "//crates/rue-runtime:rue-runtime-aarch64-unknown-linux-gnu": "src/librue_runtime-aarch64-unknown-linux-gnu.a",
+        "//crates/rue-runtime:rue-runtime-x86_64-unknown-linux-gnu": "src/librue_runtime-x86_64-unknown-linux-gnu.a",
     },
     deps = [
         "//crates/rue-air:rue-air",

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -734,7 +734,7 @@ drop fn StrBuf(self) { }
         }
 
         let options = CompileOptions::default();
-        let runtime_bytes = crate::linking::runtime_for_target(options.target).unwrap();
+        let runtime_bytes = crate::linking::runtime_for_target(options.target);
         let runtime = crate::linking::parse_runtime_archive(runtime_bytes).unwrap();
         let obsolete_exports: Vec<_> = runtime
             .objects

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -187,9 +187,7 @@ pub(crate) use durable_semantics::{
 };
 pub(crate) use import_graph::validate_canonical_import_graph;
 #[cfg(test)]
-pub(crate) use linking::{
-    parse_runtime_archive, runtime_for_target, runtime_for_target_with_host, validate_runtime,
-};
+pub(crate) use linking::{parse_runtime_archive, validate_runtime};
 pub(crate) use parsed_modules::CanonicalParseUpdate;
 pub(crate) use queries::build_functions_and_cfgs;
 #[cfg(test)]

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -106,66 +106,30 @@ impl Drop for TempLinkDir {
     }
 }
 
-/// The rue-runtime staticlib archive bytes, embedded at compile time.
-/// This is linked into every Rue executable.
-///
-/// NOTE: there is exactly one embedded archive and it is built for the
-/// *host* this compiler binary was built on. Linking an executable for any
-/// other target is therefore refused (see [`runtime_for_target`] and
-/// RUE-36 / ADR-0034) until per-target runtime archives are embedded.
-static RUNTIME_BYTES: &[u8] = include_bytes!("librue_runtime.a");
-static EMBEDDED_RUNTIME_VALIDATION: std::sync::OnceLock<Result<(), String>> =
+/// The three target-specific rue-runtime staticlibs embedded at compile time.
+static RUNTIME_X86_64_LINUX: &[u8] = include_bytes!("librue_runtime-x86_64-unknown-linux-gnu.a");
+static RUNTIME_AARCH64_LINUX: &[u8] = include_bytes!("librue_runtime-aarch64-unknown-linux-gnu.a");
+static RUNTIME_AARCH64_MACOS: &[u8] = include_bytes!("librue_runtime-aarch64-apple-darwin.a");
+static RUNTIME_X86_64_LINUX_VALIDATION: std::sync::OnceLock<Result<(), String>> =
+    std::sync::OnceLock::new();
+static RUNTIME_AARCH64_LINUX_VALIDATION: std::sync::OnceLock<Result<(), String>> =
+    std::sync::OnceLock::new();
+static RUNTIME_AARCH64_MACOS_VALIDATION: std::sync::OnceLock<Result<(), String>> =
     std::sync::OnceLock::new();
 
-/// Return the embedded rue-runtime archive for `target`, or a clear error
-/// if this compiler build doesn't carry a runtime for that target.
-///
-/// The build system embeds only the host-configuration staticlib, so any
-/// cross-target link would silently pull host machine code into the foreign
-/// binary (the original RUE-36 failure mode: an "AArch64" ELF whose entry
-/// point was x86-64 code). Refusing here turns that into an honest,
-/// actionable error while leaving cross-target code generation (`--emit
-/// asm`, `--emit mir`, ...) fully usable. ADR-0034 describes the full fix
-/// (per-target runtime archives selected at link time).
-pub(crate) fn runtime_for_target(target: Target) -> CompileResult<&'static [u8]> {
-    runtime_for_target_with_host(target, Target::host(), Target::host_description())
-}
-
-pub(crate) fn runtime_for_target_with_host(
-    target: Target,
-    host: Option<Target>,
-    host_description: &str,
-) -> CompileResult<&'static [u8]> {
-    match host {
-        Some(host) if target == host => Ok(RUNTIME_BYTES),
-        Some(host) => Err(CompileError::without_span(ErrorKind::LinkError(format!(
-            "cannot link an executable for {target}: this rue compiler was built for {host} \
-             and only embeds the {host} runtime library, so the result would not run on \
-             {target} (RUE-36). Cross-target code generation still works: use \
-             `--emit asm` to inspect {target} assembly.",
-        )))),
-        None => Err(CompileError::without_span(ErrorKind::LinkError(format!(
-            "cannot link an executable for {target}: this rue compiler was built on {} \
-             and does not have a supported host runtime to embed (RUE-36). Cross-target \
-             code generation still works: use `--emit asm` to inspect {target} assembly.",
-            host_description
-        )))),
+/// Return the embedded rue-runtime archive matching `target`.
+pub(crate) fn runtime_for_target(target: Target) -> &'static [u8] {
+    match target {
+        Target::X86_64Linux => RUNTIME_X86_64_LINUX,
+        Target::Aarch64Linux => RUNTIME_AARCH64_LINUX,
+        Target::Aarch64Macos => RUNTIME_AARCH64_MACOS,
     }
 }
 
-/// Validate that the embedded runtime archive is well-formed.
-///
-/// This is called by tests to ensure the runtime is valid at build time.
-/// Returns an error message if validation fails.
+/// Validate the embedded runtime selected for `target`.
 #[cfg(test)]
-pub(crate) fn validate_runtime() -> Result<(), String> {
-    let target = Target::host().ok_or_else(|| {
-        format!(
-            "cannot validate embedded rue-runtime archive on {}",
-            Target::host_description()
-        )
-    })?;
-    validate_runtime_archive(RUNTIME_BYTES, target).map(|_| ())
+pub(crate) fn validate_runtime(target: Target) -> Result<(), String> {
+    validate_runtime_archive(runtime_for_target(target), target).map(|_| ())
 }
 
 pub(crate) fn parse_runtime_archive(runtime_bytes: &[u8]) -> Result<Archive, String> {
@@ -456,11 +420,14 @@ fn validate_runtime_archive(runtime_bytes: &[u8], target: Target) -> Result<Arch
         let inventory = runtime_archive_inventory(&archive)?;
         validate_runtime_inventory(&inventory, runtime_target(target))
     };
-    let is_embedded_host_runtime = runtime_bytes.len() == RUNTIME_BYTES.len()
-        && std::ptr::eq(runtime_bytes.as_ptr(), RUNTIME_BYTES.as_ptr())
-        && Target::host() == Some(target);
-    if is_embedded_host_runtime {
-        EMBEDDED_RUNTIME_VALIDATION.get_or_init(validate).clone()?;
+    let embedded_runtime = runtime_for_target(target);
+    let embedded_validation = match target {
+        Target::X86_64Linux => &RUNTIME_X86_64_LINUX_VALIDATION,
+        Target::Aarch64Linux => &RUNTIME_AARCH64_LINUX_VALIDATION,
+        Target::Aarch64Macos => &RUNTIME_AARCH64_MACOS_VALIDATION,
+    };
+    if std::ptr::eq(runtime_bytes, embedded_runtime) {
+        embedded_validation.get_or_init(validate).clone()?;
     } else {
         validate()?;
     }
@@ -474,9 +441,7 @@ pub(crate) fn link_internal_with_warnings(
 ) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!("linker", mode = "internal").entered();
 
-    // Refuse cross-target links up front: only the host runtime is embedded
-    // (RUE-36), and linking without a matching runtime is impossible.
-    let runtime_bytes = runtime_for_target(options.target).map_err(CompileErrors::from)?;
+    let runtime_bytes = runtime_for_target(options.target);
 
     let mut linker = Linker::new(options.target);
 
@@ -542,10 +507,9 @@ pub(crate) fn link_system_with_warnings(
 ) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!("linker", mode = "system", command = linker_cmd).entered();
 
-    // Refuse cross-target links up front: only the host runtime is embedded
-    // (RUE-36); a system linker would happily mix architectures (or fail
-    // with an opaque message), so catch it here with a clear error.
-    let runtime_bytes = runtime_for_target(options.target).map_err(CompileErrors::from)?;
+    let runtime_bytes = runtime_for_target(options.target);
+    // The system linker consumes the archive bytes directly, so validate the
+    // embedded target and typed ABI before writing them to disk.
     validate_runtime_archive(runtime_bytes, options.target)
         .map_err(link_error)
         .map_err(CompileErrors::from)?;
@@ -639,6 +603,10 @@ mod runtime_archive_validation_tests {
         RUNTIME_ABI_VERSION_SYMBOL, ReservedExportId, ReservedExportKind, RuntimeHelperId,
         RuntimeTarget,
     };
+
+    fn host_runtime() -> &'static [u8] {
+        runtime_for_target(Target::host().expect("tests require a supported host"))
+    }
 
     fn function(name: &str) -> RuntimeDefinedSymbol {
         RuntimeDefinedSymbol {
@@ -759,6 +727,23 @@ mod runtime_archive_validation_tests {
         match Target::host().unwrap() {
             Target::X86_64Linux => Target::Aarch64Linux,
             Target::Aarch64Linux | Target::Aarch64Macos => Target::X86_64Linux,
+        }
+    }
+
+    #[test]
+    fn embedded_runtime_selection_rejects_every_wrong_archive() {
+        for &target in Target::all() {
+            for &archive_target in Target::all() {
+                if target == archive_target {
+                    continue;
+                }
+                let error = validate_runtime_archive(runtime_for_target(archive_target), target)
+                    .expect_err("runtime validation must reject a foreign archive");
+                assert!(
+                    error.contains("expected"),
+                    "{archive_target} archive accepted for {target}: {error}"
+                );
+            }
         }
     }
 
@@ -933,7 +918,7 @@ mod runtime_archive_validation_tests {
     #[test]
     fn archive_bytes_reject_missing_and_misspelled_helper() {
         let bytes = replace_export_name(
-            RUNTIME_BYTES,
+            host_runtime(),
             RuntimeHelperId::Alloc.symbol(),
             "__rue_alloq",
         );
@@ -951,7 +936,7 @@ mod runtime_archive_validation_tests {
     #[test]
     fn archive_bytes_reject_duplicate_helper() {
         let duplicate = host_object(RuntimeHelperId::Alloc.symbol());
-        let bytes = append_archive_member(RUNTIME_BYTES, "duplicate.o", &duplicate);
+        let bytes = append_archive_member(host_runtime(), "duplicate.o", &duplicate);
         let err = validation_error(&bytes);
         assert!(
             err.contains("runtime helper `__rue_alloc` is defined 2 times"),
@@ -962,7 +947,7 @@ mod runtime_archive_validation_tests {
     #[test]
     fn archive_bytes_reject_stale_marker() {
         let bytes = replace_export_name(
-            RUNTIME_BYTES,
+            host_runtime(),
             RUNTIME_ABI_VERSION_SYMBOL,
             "__rue_runtime_abi_v0",
         );
@@ -978,7 +963,7 @@ mod runtime_archive_validation_tests {
     #[test]
     fn archive_bytes_reject_missing_and_duplicate_current_marker() {
         let missing = replace_export_name(
-            RUNTIME_BYTES,
+            host_runtime(),
             RUNTIME_ABI_VERSION_SYMBOL,
             "__rue_runtime_abj_v1",
         );
@@ -991,7 +976,7 @@ mod runtime_archive_validation_tests {
         );
 
         let duplicate = host_object(RUNTIME_ABI_VERSION_SYMBOL);
-        let bytes = append_archive_member(RUNTIME_BYTES, "marker.o", &duplicate);
+        let bytes = append_archive_member(host_runtime(), "marker.o", &duplicate);
         let err = validation_error(&bytes);
         assert!(
             err.contains(&format!(
@@ -1006,7 +991,7 @@ mod runtime_archive_validation_tests {
         let object = ObjectBuilder::new(foreign_target(), "foreign")
             .code(vec![0; 4])
             .build();
-        let bytes = append_archive_member(RUNTIME_BYTES, "foreign.o", &object);
+        let bytes = append_archive_member(host_runtime(), "foreign.o", &object);
         let err = validation_error(&bytes);
         assert!(err.contains("expected"), "{err}");
         assert!(err.contains("object"), "{err}");
@@ -1015,7 +1000,7 @@ mod runtime_archive_validation_tests {
     #[test]
     fn archive_bytes_reject_non_applicable_reserved_export() {
         let object = host_object(non_applicable_export());
-        let bytes = append_archive_member(RUNTIME_BYTES, "wrong-os.o", &object);
+        let bytes = append_archive_member(host_runtime(), "wrong-os.o", &object);
         let err = validation_error(&bytes);
         assert!(
             err.contains(&format!(
@@ -1029,7 +1014,7 @@ mod runtime_archive_validation_tests {
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     #[test]
     fn x86_64_linux_sigreturn_export_is_callable_code() {
-        let archive = parse_runtime_archive(RUNTIME_BYTES).unwrap();
+        let archive = parse_runtime_archive(host_runtime()).unwrap();
         let inventory = runtime_archive_inventory(&archive).unwrap();
         let symbol = inventory
             .symbols
@@ -1134,9 +1119,9 @@ mod runtime_archive_validation_tests {
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     #[test]
     fn real_macho_marker_mutations_reject_nonzero_value_and_nonunit_extent() {
-        let (data_offset, value_offset, value) = macho_marker_offsets(RUNTIME_BYTES);
+        let (data_offset, value_offset, value) = macho_marker_offsets(host_runtime());
 
-        let mut nonzero = RUNTIME_BYTES.to_vec();
+        let mut nonzero = host_runtime().to_vec();
         nonzero[data_offset] = 1;
         let err = validation_error(&nonzero);
         assert!(
@@ -1144,7 +1129,7 @@ mod runtime_archive_validation_tests {
             "{err}"
         );
 
-        let mut oversized = RUNTIME_BYTES.to_vec();
+        let mut oversized = host_runtime().to_vec();
         oversized[value_offset..value_offset + 8].copy_from_slice(&(value - 1).to_le_bytes());
         let err = validation_error(&oversized);
         assert!(err.contains("has size 2, expected 1 byte"), "{err}");

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -926,21 +926,11 @@ mod tests {
             }
         }
 
-        for options in [
-            CompileOptions {
-                linker: LinkerMode::System("/definitely/missing/rue-linker".to_string()),
-                ..CompileOptions::default()
-            },
-            CompileOptions {
-                target: *Target::all()
-                    .iter()
-                    .find(|&&target| target != Target::host().unwrap())
-                    .expect("at least one non-host target"),
-                ..CompileOptions::default()
-            },
-        ] {
-            compile_snapshot(&snapshots[0], &options).unwrap_err();
-        }
+        let missing_linker = CompileOptions {
+            linker: LinkerMode::System("/definitely/missing/rue-linker".to_string()),
+            ..CompileOptions::default()
+        };
+        compile_snapshot(&snapshots[0], &missing_linker).unwrap_err();
     }
 
     #[test]
@@ -979,8 +969,11 @@ mod tests {
     }
 
     #[test]
-    fn test_embedded_runtime_is_valid() {
-        validate_runtime().expect("embedded runtime should be valid");
+    fn test_embedded_runtimes_are_valid() {
+        for &target in Target::all() {
+            validate_runtime(target)
+                .unwrap_or_else(|error| panic!("embedded {target} runtime is invalid: {error}"));
+        }
     }
 
     #[test]
@@ -989,40 +982,6 @@ mod tests {
             .expect_err("empty archive wrapper must not validate as a usable runtime");
 
         assert_eq!(err, "embedded rue-runtime archive contains no object files");
-    }
-
-    /// The embedded runtime is host-only (RUE-36 / ADR-0034): linking for
-    /// the host target must succeed; any other target must be refused with
-    /// an error that names both targets and points at `--emit asm`.
-    #[test]
-    fn test_runtime_only_available_for_host_target() {
-        let host = Target::host().unwrap();
-        assert!(runtime_for_target(host).is_ok());
-
-        for &target in Target::all() {
-            if target == host {
-                continue;
-            }
-            let err =
-                runtime_for_target(target).expect_err("cross-target link must be refused (RUE-36)");
-            let msg = err.to_string();
-            assert!(msg.contains(&target.to_string()), "names target: {msg}");
-            assert!(msg.contains(&host.to_string()), "names host: {msg}");
-            assert!(msg.contains("RUE-36"), "references RUE-36: {msg}");
-            assert!(msg.contains("--emit asm"), "suggests --emit asm: {msg}");
-        }
-    }
-
-    #[test]
-    fn test_runtime_refused_on_unsupported_host() {
-        let err = runtime_for_target_with_host(Target::X86_64Linux, None, "x86-64-macos")
-            .expect_err("unsupported host must not link by pretending to be another target");
-        let msg = err.to_string();
-
-        assert!(msg.contains("x86-64-linux"), "names target: {msg}");
-        assert!(msg.contains("x86-64-macos"), "names host: {msg}");
-        assert!(msg.contains("RUE-36"), "references RUE-36: {msg}");
-        assert!(msg.contains("--emit asm"), "suggests --emit asm: {msg}");
     }
 
     /// RUE-347: a break-less `loop {}` in value position has type `!` and


### PR DESCRIPTION
## Summary

- embed all three hermetic Rue runtime archives in the compiler
- select and validate the archive for the requested target on both linker paths
- remove host-only executable refusal paths and convert cross-link regressions to successes
- cache typed ABI validation independently for each embedded runtime

## Validation

- focused compiler and linker unit suites
- `scripts/rue cli linker`
- `scripts/rue quick`
- all three target links smoke-tested locally

Fixes RUE-863