### PR TITLE
RUE-838: remove canonical type migration scaffolding

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -269,6 +269,28 @@ sh_test(
 )
 
 sh_test(
+    name = "type-architecture-inventory-validation",
+    test = "scripts/validate-type-architecture.py",
+    args = [
+        "--source", "rue-air=$(location //crates/rue-air:type-architecture-inventory-sources)",
+        "--source", "rue-cfg=$(location //crates/rue-cfg:type-architecture-inventory-sources)",
+        "--source", "rue-codegen=$(location //crates/rue-codegen:type-architecture-inventory-sources)",
+        "--source", "rue-compiler=$(location //crates/rue-compiler:type-architecture-inventory-sources)",
+        "--source", "rue-compiler-session-bench=$(location //crates/rue-compiler-session-bench:type-architecture-inventory-sources)",
+        "--source", "rue-oracle=$(location //crates/rue-oracle:type-architecture-inventory-sources)",
+    ],
+)
+
+sh_test(
+    name = "type-architecture-inventory-tool-tests",
+    test = "scripts/test-type-architecture.py",
+    resources = ["scripts/validate-type-architecture.py"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
+sh_test(
     name = "benchmark-tool-tests",
     test = "scripts/test-benchmark-tools.py",
     env = {

--- a/crates/rue-air/BUCK
+++ b/crates/rue-air/BUCK
@@ -6,6 +6,12 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
+filegroup(
+    name = "type-architecture-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-air",
     deps = [

--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -48,3 +48,92 @@ fn canonical_import_consumers_do_not_grow_resolution_policy() {
         );
     }
 }
+
+#[test]
+fn canonical_type_surface_has_one_checked_handle_and_private_storage_ids() {
+    let types = include_str!("types.rs");
+    let pool = include_str!("intern_pool.rs");
+    let encoding = include_str!("type_encoding.rs");
+    let exports = include_str!("lib.rs");
+    let public_surface = [types, pool, encoding, exports].concat();
+
+    let peer_handle = ["Interned", "Type"].concat();
+    let compatibility_module = ["mod ", "compatibility"].concat();
+    for retired in [
+        peer_handle,
+        ["type_to_", "interned"].concat(),
+        ["interned_to_", "type"].concat(),
+        compatibility_module,
+        ["update_", "struct_def"].concat(),
+        ["update_", "enum_def"].concat(),
+    ] {
+        assert!(
+            !public_surface.contains(&retired),
+            "AIR regained a peer type representation: {retired}"
+        );
+    }
+
+    for line in public_surface.lines().map(str::trim) {
+        for raw_api in [
+            "pub const fn from_pool_index(",
+            "pub fn from_pool_index(",
+            "pub const fn pool_index(",
+            "pub fn pool_index(",
+            "pub const fn raw_encoding(",
+            "pub fn raw_encoding(",
+            "pub const fn from_u32(",
+            "pub fn from_u32(",
+            "pub const fn as_u32(",
+            "pub fn as_u32(",
+        ] {
+            assert!(
+                !line.starts_with(raw_api),
+                "AIR exposed an unchecked raw type API: {line}"
+            );
+        }
+    }
+
+    for line in types.lines().map(str::trim) {
+        for id in [
+            "StructId",
+            "EnumId",
+            "ArrayTypeId",
+            "PtrConstTypeId",
+            "PtrMutTypeId",
+        ] {
+            assert!(
+                !line.starts_with(&format!("pub struct {id}(pub ")),
+                "AIR exposed {id}'s raw storage field"
+            );
+            assert!(
+                !types.contains(&format!("Display for {id}")),
+                "AIR exposed {id}'s raw numeric display"
+            );
+        }
+    }
+
+    assert_eq!(encoding.matches("enum Primitive").count(), 1);
+    assert_eq!(encoding.matches("enum Composite").count(), 1);
+    let consumers = [types, pool, exports].concat();
+    for duplicated_tag in [
+        "Struct = 100",
+        "Enum = 101",
+        "Array = 102",
+        "Module = 103",
+        "PtrConst = 104",
+        "PtrMut = 105",
+    ] {
+        assert!(
+            !consumers.contains(duplicated_tag),
+            "composite tag escaped the authoritative encoding: {duplicated_tag}"
+        );
+    }
+
+    assert!(types.contains("pub fn try_from_u32(v: u32) -> Option<Self>"));
+    assert!(types.contains("pub fn try_kind(&self) -> Option<TypeKind>"));
+    assert!(public_surface.contains("pub struct TypeInternPool"));
+    assert!(pool.contains("pub fn all_types(&self) -> impl ExactSizeIterator<Item = Type> + '_"));
+    assert!(pool.contains("pub(crate) fn mark_struct_linear("));
+    assert!(pool.contains("pub(crate) fn set_struct_destructor("));
+    assert!(pool.contains("pub(crate) fn requalify_struct_destructor("));
+}

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -1156,7 +1156,7 @@ impl Air {
                             AirPattern::EnumVariant {
                                 enum_id,
                                 variant_index,
-                            } => format!("enum#{}::{}", enum_id.0, variant_index),
+                            } => format!("enum#{enum_id:?}::{variant_index}"),
                         };
                         write!(f, "{} => {}", pat_str, body)?;
                     }
@@ -1284,7 +1284,7 @@ impl Air {
                     fields_len,
                     source_order_start,
                 } => {
-                    write!(f, "struct_init #{} {{", struct_id.0)?;
+                    write!(f, "struct_init #{struct_id:?} {{")?;
                     let (fields, source_order) =
                         self.get_struct_init(*fields_start, *fields_len, *source_order_start);
                     for (i, field) in fields.enumerate() {
@@ -1332,7 +1332,7 @@ impl Air {
                     payload_len,
                 } => {
                     if *payload_len == 0 {
-                        writeln!(f, "enum_variant #{}::{}", enum_id.0, variant_index)?;
+                        writeln!(f, "enum_variant #{enum_id:?}::{variant_index}")?;
                     } else {
                         let payload: Vec<String> = self
                             .get_air_refs(*payload_start, *payload_len)
@@ -1340,8 +1340,8 @@ impl Air {
                             .collect();
                         writeln!(
                             f,
-                            "enum_variant #{}::{}({})",
-                            enum_id.0,
+                            "enum_variant #{:?}::{}({})",
+                            enum_id,
                             variant_index,
                             payload.join(", ")
                         )?;
@@ -1355,8 +1355,8 @@ impl Air {
                 } => {
                     writeln!(
                         f,
-                        "enum_payload_get {} #{}::{}.{}",
-                        base, enum_id.0, variant_index, field_index
+                        "enum_payload_get {} #{:?}::{}.{}",
+                        base, enum_id, variant_index, field_index
                     )?;
                 }
                 AirInstData::IntCast { value, from_ty } => {

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -1,7 +1,7 @@
 //! Type intern pool for efficient type representation.
 //!
-//! This module implements a unified type interning system inspired by Zig's `InternPool`.
-//! All types become 32-bit indices into a canonical pool, enabling:
+//! This module implements canonical composite-type storage inspired by Zig's
+//! `InternPool`. Compact [`Type`] handles enable:
 //!
 //! - O(1) type equality (u32 comparison)
 //! - Efficient memory usage
@@ -15,10 +15,10 @@
 //! - **Arrays** are structural types (same element type + length = same type)
 //!
 //! [`Type`] is the compact compiler-facing handle. Composite `StructId`,
-//! `EnumId`, `ArrayTypeId`, and pointer IDs are indices into this pool, while
-//! the pool stores canonical [`Type`] values directly in structural keys and
-//! children. Definitions and structural identities are therefore resolved
-//! through one pool (ADR-0024).
+//! `EnumId`, `ArrayTypeId`, and pointer IDs are opaque typed storage identities.
+//! The pool stores canonical [`Type`] values directly in structural keys and
+//! children, so definitions and structural identities resolve through one pool
+//! (ADR-0024).
 //!
 //! # Thread Safety
 //!
@@ -38,39 +38,6 @@ use crate::types::{
     ArrayTypeId, EnumDef, EnumId, LangItem, PtrConstTypeId, PtrMutTypeId, StructDef, StructId,
     Type, TypeKind,
 };
-
-/// Private, one-way compatibility encoding retained for RUE-838 cleanup.
-///
-/// No pool storage, key, public API, or compiler phase consumes this wrapper.
-/// It can only project a canonical `Type` into the old untyped pool-index
-/// representation; there is deliberately no conversion back to `Type`.
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct InternedType(u32);
-
-#[allow(dead_code)]
-impl InternedType {
-    fn from_type(ty: Type) -> Option<Self> {
-        if type_encoding::compatibility::is_primitive(ty.raw_encoding()) {
-            return Some(Self(ty.raw_encoding()));
-        }
-        let pool_index = match ty.try_kind()? {
-            TypeKind::Struct(id) => id.pool_index(),
-            TypeKind::Enum(id) => id.pool_index(),
-            TypeKind::Array(id) => id.pool_index(),
-            TypeKind::PtrConst(id) => id.pool_index(),
-            TypeKind::PtrMut(id) => id.pool_index(),
-            _ => return None,
-        };
-        Some(Self(type_encoding::compatibility::encode_pool_index(
-            pool_index,
-        )?))
-    }
-
-    fn pool_index(self) -> Option<u32> {
-        type_encoding::compatibility::decode_pool_index(self.0)
-    }
-}
 
 /// Type data stored in the intern pool.
 ///
@@ -377,6 +344,17 @@ impl TypeInternPoolInner {
     fn struct_def(&self, id: StructId) -> &StructDef {
         self.try_struct_def(id)
             .unwrap_or_else(|| panic!("Expected struct at pool index {}", id.0))
+    }
+
+    fn struct_def_mut(&mut self, id: StructId) -> &mut StructDef {
+        let pool_index = id.pool_index() as usize;
+        match self.types.get_mut(pool_index) {
+            Some(TypeData::Struct(data)) => &mut data.def,
+            other => panic!(
+                "Expected complete struct at pool index {}, got {:?}",
+                pool_index, other
+            ),
+        }
     }
 
     fn try_enum_def(&self, id: EnumId) -> Option<&EnumDef> {
@@ -833,7 +811,7 @@ impl TypeInternPool {
 
     /// Register a new struct (nominal - no deduplication).
     ///
-    /// Returns the `StructId` (containing the pool index) and whether it was newly inserted.
+    /// Returns the pool-issued `StructId` and whether it was newly inserted.
     /// If a struct with this name in the same defining file already exists, returns the existing
     /// StructId.
     pub fn register_struct(&self, name: Spur, def: StructDef) -> (StructId, bool) {
@@ -1013,7 +991,7 @@ impl TypeInternPool {
 
     /// Register a new enum (nominal - no deduplication).
     ///
-    /// Returns the `EnumId` (containing the pool index) and whether it was newly inserted.
+    /// Returns the pool-issued `EnumId` and whether it was newly inserted.
     /// If an enum with this name in the same defining file already exists, returns the existing
     /// EnumId.
     pub fn register_enum(&self, name: Spur, def: EnumDef) -> (EnumId, bool) {
@@ -1311,13 +1289,13 @@ impl TypeInternPool {
     // Direct nominal-ID access
     // ========================================================================
     //
-    // These methods allow accessing struct and enum definitions directly via
-    // StructId/EnumId, which now store pool indices instead of vector indices.
+    // These methods access struct and enum definitions through opaque IDs
+    // issued by this pool.
 
     /// Get a struct definition by StructId.
     ///
-    /// The StructId contains a pool index. This method looks up the struct
-    /// in the pool and returns a clone of its definition.
+    /// This method resolves the pool-issued identity and returns a clone of its
+    /// definition.
     ///
     /// # Panics
     ///
@@ -1404,8 +1382,8 @@ impl TypeInternPool {
 
     /// Get an enum definition by EnumId.
     ///
-    /// The EnumId contains a pool index. This method looks up the enum
-    /// in the pool and returns a clone of its definition.
+    /// This method resolves the pool-issued identity and returns a clone of its
+    /// definition.
     ///
     /// # Panics
     ///
@@ -1472,50 +1450,62 @@ impl TypeInternPool {
         inner.enum_symbol_name(enum_id)
     }
 
-    /// Update a struct definition in the pool.
+    /// Monotonically mark a complete struct as linear during semantic
+    /// metadata finalization.
     ///
-    /// This is used during semantic analysis when struct fields are resolved
-    /// after the struct is initially registered.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the StructId doesn't correspond to a struct in the pool.
-    pub fn update_struct_def(&self, struct_id: StructId, new_def: StructDef) {
+    /// This operation is idempotent and cannot change nominal identity,
+    /// fields, or any other completed definition data.
+    pub(crate) fn mark_struct_linear(&self, struct_id: StructId) {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
-        let pool_index = struct_id.0 as usize;
-        match &mut inner.types[pool_index] {
-            TypeData::Struct(data) => data.def = new_def,
-            other => panic!(
-                "Expected struct at pool index {}, got {:?}",
-                pool_index, other
-            ),
-        }
+        inner.struct_def_mut(struct_id).is_linear = true;
     }
 
-    /// Update an enum definition in the pool.
+    /// Assign a complete struct's destructor symbol exactly once.
     ///
-    /// This is used during semantic analysis when enum variants are resolved
-    /// after the enum is initially registered.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the EnumId doesn't correspond to an enum in the pool.
-    pub fn update_enum_def(&self, enum_id: EnumId, new_def: EnumDef) {
+    /// Destructor discovery is a semantic metadata-finalization step. It
+    /// cannot replace fields or any other completed definition data.
+    pub(crate) fn set_struct_destructor(&self, struct_id: StructId, symbol: String) {
+        assert!(
+            symbol.ends_with(".__drop"),
+            "destructor symbol must end with .__drop"
+        );
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
-        let pool_index = enum_id.0 as usize;
-        match &mut inner.types[pool_index] {
-            TypeData::Enum(data) => data.def = new_def,
-            other => panic!(
-                "Expected enum at pool index {}, got {:?}",
-                pool_index, other
-            ),
-        }
+        let def = inner.struct_def_mut(struct_id);
+        assert!(!def.is_copy, "a copy struct cannot acquire a destructor");
+        assert!(
+            def.destructor.is_none(),
+            "struct destructor metadata can only be assigned once"
+        );
+        def.destructor = Some(symbol);
+    }
+
+    /// Requalify an already-assigned destructor symbol after nominal-name
+    /// collisions are known.
+    ///
+    /// Requalification changes only symbol spelling and requires a distinct,
+    /// previously assigned destructor; it cannot create or remove one.
+    pub(crate) fn requalify_struct_destructor(&self, struct_id: StructId, symbol: String) {
+        assert!(
+            symbol.ends_with(".__drop"),
+            "destructor symbol must end with .__drop"
+        );
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        let destructor = inner
+            .struct_def_mut(struct_id)
+            .destructor
+            .as_mut()
+            .expect("destructor requalification requires assigned metadata");
+        assert_ne!(
+            destructor, &symbol,
+            "destructor requalification requires a different symbol"
+        );
+        *destructor = symbol;
     }
 
     /// Get an array type definition by ArrayTypeId.
     ///
-    /// The ArrayTypeId contains a pool index. This method looks up the array
-    /// in the pool and returns its element type and length as a tuple.
+    /// This method resolves the pool-issued identity and returns its element
+    /// type and length as a tuple.
     ///
     /// # Returns
     ///
@@ -1887,6 +1877,30 @@ impl FrozenTypeInternPool {
             })
     }
 
+    /// Iterate over every canonical composite type in pool storage order.
+    ///
+    /// The returned [`Type`] handles preserve global allocation order without
+    /// exposing the raw pool positions used to encode their typed payloads.
+    pub fn all_types(&self) -> impl ExactSizeIterator<Item = Type> + '_ {
+        self.inner.types.iter().enumerate().map(|(index, data)| {
+            let index = checked_pool_index(index).expect("type pool index invariant");
+            match data {
+                TypeData::Struct(_) => Type::new_struct(StructId::from_pool_index(index)),
+                TypeData::Enum(_) => Type::new_enum(EnumId::from_pool_index(index)),
+                TypeData::Array { .. } => Type::new_array(ArrayTypeId::from_pool_index(index)),
+                TypeData::PtrConst { .. } => {
+                    Type::new_ptr_const(PtrConstTypeId::from_pool_index(index))
+                }
+                TypeData::PtrMut { .. } => Type::new_ptr_mut(PtrMutTypeId::from_pool_index(index)),
+                TypeData::ReservedStruct
+                | TypeData::DeclaredStruct(_)
+                | TypeData::DeclaredEnum(_) => {
+                    unreachable!("frozen type pool contains an incomplete entry")
+                }
+            }
+        })
+    }
+
     pub fn len(&self) -> usize {
         self.inner.types.len()
     }
@@ -2230,6 +2244,84 @@ mod tests {
         let destructor = first.destructor.as_deref().unwrap();
         let request_symbol = request_symbols.get_or_intern(destructor);
         assert_eq!(request_symbols.resolve(&request_symbol), "Owner.__drop");
+    }
+
+    #[test]
+    fn struct_metadata_finalization_is_narrow_and_monotonic() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let (owner, _) = pool.register_struct(
+            declarations.get_or_intern("Owner"),
+            struct_def(
+                "Owner",
+                vec![StructField {
+                    name: "value".into(),
+                    ty: Type::I64,
+                }],
+            ),
+        );
+
+        pool.mark_struct_linear(owner);
+        pool.mark_struct_linear(owner);
+        pool.set_struct_destructor(owner, "Owner.__drop".into());
+        pool.requalify_struct_destructor(owner, "Owner$left.__drop".into());
+
+        let def = pool.struct_def(owner);
+        assert!(def.is_linear);
+        assert_eq!(def.destructor.as_deref(), Some("Owner$left.__drop"));
+        assert_eq!(def.name, "Owner");
+        assert_eq!(def.fields.len(), 1);
+        assert_eq!(def.fields[0].ty, Type::I64);
+    }
+
+    #[test]
+    #[should_panic(expected = "struct destructor metadata can only be assigned once")]
+    fn struct_destructor_metadata_cannot_be_assigned_twice() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let (owner, _) = pool.register_struct(
+            declarations.get_or_intern("Owner"),
+            struct_def("Owner", vec![]),
+        );
+        pool.set_struct_destructor(owner, "Owner.__drop".into());
+        pool.set_struct_destructor(owner, "Owner.__drop".into());
+    }
+
+    #[test]
+    #[should_panic(expected = "destructor requalification requires assigned metadata")]
+    fn struct_destructor_cannot_be_created_by_requalification() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let (owner, _) = pool.register_struct(
+            declarations.get_or_intern("Owner"),
+            struct_def("Owner", vec![]),
+        );
+        pool.requalify_struct_destructor(owner, "Owner$left.__drop".into());
+    }
+
+    #[test]
+    fn frozen_all_types_preserves_global_storage_order_without_exposing_positions() {
+        let declarations = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        let (owner, _) = pool.register_struct(
+            declarations.get_or_intern("Owner"),
+            struct_def("Owner", vec![]),
+        );
+        let array = pool.try_intern_array(Type::new_struct(owner), 3).unwrap();
+        let (choice, _) =
+            pool.register_enum(declarations.get_or_intern("Choice"), enum_def("Choice"));
+        let pointer = pool.try_intern_ptr_const(array).unwrap();
+
+        let frozen = pool.freeze();
+        assert_eq!(
+            frozen.all_types().collect::<Vec<_>>(),
+            [
+                Type::new_struct(owner),
+                array,
+                Type::new_enum(choice),
+                pointer
+            ]
+        );
     }
 
     #[test]

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -878,9 +878,7 @@ impl<'a> Sema<'a> {
                     continue;
                 };
                 let cause = (cause.name.clone(), self.format_type_name(cause.ty));
-                let mut def = def;
-                def.is_linear = true;
-                self.type_pool.update_struct_def(struct_id, def);
+                self.type_pool.mark_struct_linear(struct_id);
                 self.infectious_linear.insert(struct_id, cause);
                 changed = true;
             }
@@ -1279,7 +1277,7 @@ impl<'a> Sema<'a> {
                 )
             })?;
 
-        let mut struct_def = self.type_pool.struct_def(struct_id);
+        let struct_def = self.type_pool.struct_def(struct_id);
         if struct_def.destructor.is_some() {
             return Err(CompileError::new(
                 ErrorKind::DuplicateDestructor {
@@ -1314,8 +1312,8 @@ impl<'a> Sema<'a> {
         }
 
         let destructor_name = format!("{}.__drop", type_name_str);
-        struct_def.destructor = Some(destructor_name);
-        self.type_pool.update_struct_def(struct_id, struct_def);
+        self.type_pool
+            .set_struct_destructor(struct_id, destructor_name);
         self.destructor_spans.insert(struct_id, span);
         Ok(())
     }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -288,7 +288,7 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) builtin_os_id: Option<EnumId>,
     /// Pre-interned known symbols for fast comparison.
     pub(crate) known: KnownSymbols,
-    /// Type intern pool for unified type representation (ADR-0024 Phase 1).
+    /// Canonical composite-type storage for this semantic epoch (ADR-0024).
     pub(crate) type_pool: TypeInternPool,
     /// Canonically prepopulated module registry for the current semantic epoch.
     pub(crate) module_registry: crate::module_registry::ModuleRegistry,

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -2531,11 +2531,11 @@ mod tests {
     }
 
     // ========================================================================
-    // Type Intern Pool tests (ADR-0024 Phase 1)
+    // Canonical type pool tests (ADR-0024)
     //
     // These tests verify that the TypeInternPool is correctly populated during
-    // declaration collection and that its contents match the existing type
-    // registries (struct_defs, enum_defs).
+    // declaration collection and that its typed indexes remain internally
+    // consistent.
     // ========================================================================
 
     /// Helper to gather declarations and return the Sema state for testing.

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -359,9 +359,8 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             let qualified = self.destructor_symbol(struct_id);
             let def = self.type_pool.struct_def(struct_id);
             if def.destructor.as_deref() != Some(qualified.as_str()) {
-                let mut def = def.clone();
-                def.destructor = Some(qualified);
-                self.type_pool.update_struct_def(struct_id, def);
+                self.type_pool
+                    .requalify_struct_destructor(struct_id, qualified);
             }
         }
     }

--- a/crates/rue-air/src/type_encoding.rs
+++ b/crates/rue-air/src/type_encoding.rs
@@ -1,9 +1,9 @@
 //! Authoritative compact encoding for live [`Type`](crate::Type) handles.
 //!
 //! This module is the only place that assigns primitive values, composite
-//! tags, payload widths, reserved ranges, or the transitional `InternedType`
-//! pool-index offset. Construction and decoding must go through these helpers
-//! so a raw value cannot acquire different meanings in different consumers.
+//! tags, payload widths, or reserved ranges. Construction and decoding must go
+//! through these helpers so a raw value cannot acquire different meanings in
+//! different consumers.
 
 pub(crate) const TAG_MASK: u32 = 0xff;
 pub(crate) const PAYLOAD_SHIFT: u32 = 8;
@@ -111,47 +111,4 @@ pub(crate) const fn has_composite_kind(raw: u32, expected: Composite) -> bool {
         decode(raw),
         Some(Decoded::Composite { kind, .. }) if kind as u8 == expected as u8
     )
-}
-
-/// Encoding helpers for the compatibility-only `InternedType` wrapper.
-///
-/// Primitive values use the authoritative `Type` primitive encodings exactly.
-/// Pool entries occupy a disjoint range and retain their kind in `TypeData`;
-/// RUE-836/RUE-838 remove this transitional wrapper entirely.
-pub(crate) mod compatibility {
-    use super::{Decoded, decode};
-
-    const POOL_INDEX_OFFSET: u32 = 256;
-
-    pub(crate) const fn encode_pool_index(pool_index: u32) -> Option<u32> {
-        pool_index.checked_add(POOL_INDEX_OFFSET)
-    }
-
-    pub(crate) const fn decode_pool_index(raw: u32) -> Option<u32> {
-        if raw < POOL_INDEX_OFFSET {
-            None
-        } else {
-            Some(raw - POOL_INDEX_OFFSET)
-        }
-    }
-
-    pub(crate) const fn is_primitive(raw: u32) -> bool {
-        matches!(
-            decode(raw),
-            Some(Decoded::Primitive(
-                super::Primitive::I8
-                    | super::Primitive::I16
-                    | super::Primitive::I32
-                    | super::Primitive::I64
-                    | super::Primitive::U8
-                    | super::Primitive::U16
-                    | super::Primitive::U32
-                    | super::Primitive::U64
-                    | super::Primitive::Bool
-                    | super::Primitive::Unit
-                    | super::Primitive::Error
-                    | super::Primitive::Never
-            ))
-        )
-    }
 }

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -1,20 +1,19 @@
 //! Type system for Rue.
 //!
-//! A [`Type`] is a compact `u32` newtype: an index into a `TypeInternPool`
-//! (ADR-0024), so type equality and lookup are cheap and free of
-//! self-referential lifetimes. The system covers the integer and boolean
-//! primitives, user structs and enums, references and raw pointers, and generic
-//! instantiations — well beyond the original i32-only prototype this comment
-//! once described.
+//! A [`Type`] is a compact `u32` newtype. Primitives use direct tags, while
+//! composite types carry a typed payload issued by a [`TypeInternPool`](crate::TypeInternPool)
+//! (ADR-0024). Equality is therefore cheap and free of self-referential
+//! lifetimes. The system covers integer and boolean primitives, user structs
+//! and enums, references and raw pointers, and generic instantiations.
 
 use crate::type_encoding::{self, Composite, Decoded, Primitive};
 
 /// A unique identifier for a struct definition.
 ///
-/// The inner value is a pool index into [`TypeInternPool`](crate::TypeInternPool),
-/// so the identifier and its definition use one canonical index.
+/// Values are issued by [`TypeInternPool`](crate::TypeInternPool); their raw
+/// storage identity is not part of the public API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct StructId(pub u32);
+pub struct StructId(pub(crate) u32);
 
 impl StructId {
     /// Create a StructId from a pool index.
@@ -22,7 +21,7 @@ impl StructId {
     /// The pool index is the raw index into `TypeInternPool`'s composite-type
     /// storage.
     #[inline]
-    pub fn from_pool_index(pool_index: u32) -> Self {
+    pub(crate) fn from_pool_index(pool_index: u32) -> Self {
         StructId(pool_index)
     }
 
@@ -30,17 +29,17 @@ impl StructId {
     ///
     /// This is the index into `TypeInternPool.types`.
     #[inline]
-    pub fn pool_index(self) -> u32 {
+    pub(crate) fn pool_index(self) -> u32 {
         self.0
     }
 }
 
 /// A unique identifier for an enum definition.
 ///
-/// The inner value is a pool index into [`TypeInternPool`](crate::TypeInternPool),
-/// so the identifier and its definition use one canonical index.
+/// Values are issued by [`TypeInternPool`](crate::TypeInternPool); their raw
+/// storage identity is not part of the public API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct EnumId(pub u32);
+pub struct EnumId(pub(crate) u32);
 
 impl EnumId {
     /// Create an EnumId from a pool index.
@@ -48,7 +47,7 @@ impl EnumId {
     /// The pool index is the raw index into `TypeInternPool`'s composite-type
     /// storage.
     #[inline]
-    pub fn from_pool_index(pool_index: u32) -> Self {
+    pub(crate) fn from_pool_index(pool_index: u32) -> Self {
         EnumId(pool_index)
     }
 
@@ -56,15 +55,14 @@ impl EnumId {
     ///
     /// This is the index into `TypeInternPool.types`.
     #[inline]
-    pub fn pool_index(self) -> u32 {
+    pub(crate) fn pool_index(self) -> u32 {
         self.0
     }
 }
 
-/// A unique identifier for an array type.
-/// This is needed because Type is Copy, so we can't use Box<Type> for the element type.
+/// An opaque identifier for an array entry issued by the type pool.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ArrayTypeId(pub u32);
+pub struct ArrayTypeId(pub(crate) u32);
 
 impl ArrayTypeId {
     /// Create an ArrayTypeId from a pool index.
@@ -72,7 +70,7 @@ impl ArrayTypeId {
     /// The pool index is the raw index into `TypeInternPool`'s composite-type
     /// storage.
     #[inline]
-    pub fn from_pool_index(pool_index: u32) -> Self {
+    pub(crate) fn from_pool_index(pool_index: u32) -> Self {
         ArrayTypeId(pool_index)
     }
 
@@ -80,45 +78,43 @@ impl ArrayTypeId {
     ///
     /// Returns the raw index into the TypeInternPool.
     #[inline]
-    pub fn pool_index(self) -> u32 {
+    pub(crate) fn pool_index(self) -> u32 {
         self.0
     }
 }
 
-/// A unique identifier for a `ptr const T` type.
-/// This is needed because Type is Copy, so we can't use Box<Type> for the pointee type.
+/// An opaque identifier for a `ptr const T` entry issued by the type pool.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct PtrConstTypeId(pub u32);
+pub struct PtrConstTypeId(pub(crate) u32);
 
 impl PtrConstTypeId {
     /// Create a PtrConstTypeId from a pool index.
     #[inline]
-    pub fn from_pool_index(pool_index: u32) -> Self {
+    pub(crate) fn from_pool_index(pool_index: u32) -> Self {
         PtrConstTypeId(pool_index)
     }
 
     /// Get the pool index for this pointer type.
     #[inline]
-    pub fn pool_index(self) -> u32 {
+    pub(crate) fn pool_index(self) -> u32 {
         self.0
     }
 }
 
-/// A unique identifier for a `ptr mut T` type.
-/// This is needed because Type is Copy, so we can't use Box<Type> for the pointee type.
+/// An opaque identifier for a `ptr mut T` entry issued by the type pool.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct PtrMutTypeId(pub u32);
+pub struct PtrMutTypeId(pub(crate) u32);
 
 impl PtrMutTypeId {
     /// Create a PtrMutTypeId from a pool index.
     #[inline]
-    pub fn from_pool_index(pool_index: u32) -> Self {
+    pub(crate) fn from_pool_index(pool_index: u32) -> Self {
         PtrMutTypeId(pool_index)
     }
 
     /// Get the pool index for this pointer type.
     #[inline]
-    pub fn pool_index(self) -> u32 {
+    pub(crate) fn pool_index(self) -> u32 {
         self.0
     }
 }
@@ -260,11 +256,11 @@ impl std::fmt::Debug for Type {
             TypeKind::Error => write!(f, "Type::ERROR"),
             TypeKind::Never => write!(f, "Type::NEVER"),
             TypeKind::ComptimeType => write!(f, "Type::COMPTIME_TYPE"),
-            TypeKind::Struct(id) => write!(f, "Type::new_struct(StructId({}))", id.0),
-            TypeKind::Enum(id) => write!(f, "Type::new_enum(EnumId({}))", id.0),
-            TypeKind::Array(id) => write!(f, "Type::new_array(ArrayTypeId({}))", id.0),
-            TypeKind::PtrConst(id) => write!(f, "Type::new_ptr_const(PtrConstTypeId({}))", id.0),
-            TypeKind::PtrMut(id) => write!(f, "Type::new_ptr_mut(PtrMutTypeId({}))", id.0),
+            TypeKind::Struct(id) => write!(f, "Type::new_struct({id:?})"),
+            TypeKind::Enum(id) => write!(f, "Type::new_enum({id:?})"),
+            TypeKind::Array(id) => write!(f, "Type::new_array({id:?})"),
+            TypeKind::PtrConst(id) => write!(f, "Type::new_ptr_const({id:?})"),
+            TypeKind::PtrMut(id) => write!(f, "Type::new_ptr_mut({id:?})"),
             TypeKind::Module(id) => write!(f, "Type::new_module(ModuleId({}))", id.0),
         }
     }
@@ -1018,7 +1014,8 @@ impl Type {
 
     /// Encode this type as a u32 for storage in extra arrays.
     ///
-    /// Since Type is now a u32 newtype, this simply returns the inner value.
+    /// This is crate-private because packed AIR storage is an invariant-proven
+    /// implementation boundary.
     #[inline]
     pub(crate) fn as_u32(&self) -> u32 {
         self.0
@@ -1026,8 +1023,8 @@ impl Type {
 
     /// Decode a type from a u32 value.
     ///
-    /// Since Type is now a u32 newtype, this simply wraps the value.
-    /// Note: This does not validate the encoding - use with values from `as_u32()`.
+    /// This does not validate the encoding and is only for values previously
+    /// produced by `as_u32()` inside AIR.
     ///
     /// # Safety (not unsafe, but correctness)
     ///

--- a/crates/rue-cfg/BUCK
+++ b/crates/rue-cfg/BUCK
@@ -6,6 +6,12 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
+filegroup(
+    name = "type-architecture-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-cfg",
     deps = [

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -450,11 +450,11 @@ impl<'a> CfgBuilder<'a> {
             builder.lower_inst(root);
         }
 
-        let mut implicit_named_destructors = builder
-            .implicit_named_destructors
-            .into_iter()
-            .collect::<Vec<_>>();
-        implicit_named_destructors.sort_by_key(|id| id.0);
+        let implicit_named_destructors = builder
+            .type_pool
+            .all_struct_ids()
+            .filter(|id| builder.implicit_named_destructors.contains(id))
+            .collect();
         CfgOutput {
             cfg: builder.cfg,
             warnings: builder.warnings,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -1449,7 +1449,7 @@ impl Cfg {
                 fields_start,
                 fields_len,
             } => {
-                write!(f, "struct_init #{} {{", struct_id.0)?;
+                write!(f, "struct_init #{struct_id:?} {{")?;
                 let fields = self.get_extra(*fields_start, *fields_len);
                 for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
@@ -1480,12 +1480,12 @@ impl Cfg {
                 payload_len,
             } => {
                 if *payload_len == 0 {
-                    write!(f, "enum_variant #{}::{}", enum_id.0, variant_index)
+                    write!(f, "enum_variant #{enum_id:?}::{variant_index}")
                 } else {
                     // Print the actual payload operands (like StructInit and
                     // ArrayInit do) so the variant's dataflow inputs are
                     // readable in the dump, not just their count.
-                    write!(f, "enum_variant #{}::{}(", enum_id.0, variant_index)?;
+                    write!(f, "enum_variant #{enum_id:?}::{variant_index}(")?;
                     let payload = self.get_extra(*payload_start, *payload_len);
                     for (i, value) in payload.iter().enumerate() {
                         if i > 0 {
@@ -1504,8 +1504,8 @@ impl Cfg {
             } => {
                 write!(
                     f,
-                    "enum_payload_get {} #{}::{}.{}",
-                    base, enum_id.0, variant_index, field_index
+                    "enum_payload_get {} #{:?}::{}.{}",
+                    base, enum_id, variant_index, field_index
                 )
             }
             CfgInstData::IntCast { value, from_ty } => {
@@ -1528,7 +1528,8 @@ impl Cfg {
         write!(f, "{}", self.place_to_string(place))
     }
 
-    /// Render a place with its projections RESOLVED (e.g. `$0.#2.1($arr)[v3]`),
+    /// Render a place with its projections RESOLVED (e.g.
+    /// `$0.#StructId(2).1($arr)[v3]`),
     /// unlike `Place`'s own `Display`, which cannot see this Cfg's projection
     /// arena and can only print the raw index range (`$0[3..5]`). Use this for
     /// any human-facing dump or tracing description of a place.
@@ -1549,7 +1550,7 @@ impl Cfg {
                     struct_id,
                     field_index,
                 } => {
-                    let _ = write!(out, ".#{}.{}", struct_id.0, field_index);
+                    let _ = write!(out, ".#{struct_id:?}.{field_index}");
                 }
                 Projection::Index { array_type, index } => {
                     let _ = write!(out, "({})[{}]", array_type.name(), index);

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -364,7 +364,26 @@ mod tests {
     use super::*;
     use crate::{CfgArgMode, CfgCallArg, CfgInst, Place, Projection, Terminator, Type};
     use lasso::{Key, Spur};
+    use rue_air::{StructDef, StructId, TypeInternPool};
     use rue_span::Span;
+
+    fn test_struct_id() -> StructId {
+        TypeInternPool::new()
+            .register_struct(
+                Spur::try_from_usize(0).unwrap(),
+                StructDef {
+                    name: "Test".to_string(),
+                    fields: vec![],
+                    is_copy: false,
+                    is_linear: false,
+                    destructor: None,
+                    is_builtin: false,
+                    is_pub: false,
+                    file_id: rue_span::FileId::DEFAULT,
+                },
+            )
+            .0
+    }
 
     fn make_cfg(num_locals: u32) -> Cfg {
         let mut cfg = Cfg::new(Type::I32, num_locals, 0, "test".to_string(), vec![]);
@@ -539,7 +558,7 @@ mod tests {
         );
         let field_val = push(&mut cfg, CfgInstData::Const(9), Type::I32);
         let (proj_start, proj_len) = cfg.push_projections([Projection::Field {
-            struct_id: crate::StructId::from_pool_index(0),
+            struct_id: test_struct_id(),
             field_index: 0,
         }]);
         let place = Place {

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -1266,9 +1266,7 @@ mod tests {
     };
     use crate::{OptLevel, opt};
     use lasso::ThreadedRodeo;
-    use rue_air::{
-        ArrayTypeId, FrozenTypeInternPool, StructDef, StructField, StructId, Type, TypeInternPool,
-    };
+    use rue_air::{FrozenTypeInternPool, StructDef, StructField, StructId, Type, TypeInternPool};
     use rue_span::Span;
 
     fn unit_cfg() -> Cfg {
@@ -1321,11 +1319,10 @@ mod tests {
         cfg.verify(); // must not panic
     }
 
-    fn cfg_with_field_place(base_type: Type) -> Cfg {
+    fn cfg_with_field_place(base_type: Type, struct_id: StructId) -> Cfg {
         let mut cfg = Cfg::new(Type::I32, 1, 0, "field_place".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let struct_id = StructId::from_pool_index(9);
         let place = cfg.make_place(
             PlaceBase::Local(0),
             base_type,
@@ -1348,14 +1345,19 @@ mod tests {
 
     #[test]
     fn verify_accepts_matching_place_base_type() {
-        let struct_type = Type::new_struct(StructId::from_pool_index(9));
-        cfg_with_field_place(struct_type).verify();
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let struct_id = register_struct(&pool, &interner, "FieldBase", &[Type::I32]);
+        cfg_with_field_place(Type::new_struct(struct_id), struct_id).verify();
     }
 
     #[test]
     #[should_panic(expected = "first projection requires base type")]
     fn verify_rejects_field_projection_with_wrong_base_type() {
-        cfg_with_field_place(Type::I32).verify();
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let struct_id = register_struct(&pool, &interner, "WrongBase", &[Type::I32]);
+        cfg_with_field_place(Type::I32, struct_id).verify();
     }
 
     #[test]
@@ -1380,7 +1382,9 @@ mod tests {
                 span: Span::new(0, 1),
             },
         );
-        let array_type = Type::new_array(ArrayTypeId::from_pool_index(10));
+        let array_type = TypeInternPool::new()
+            .try_intern_array(Type::I32, 1)
+            .unwrap();
         let place = cfg.make_place(
             PlaceBase::Local(0),
             Type::I32,
@@ -1909,6 +1913,9 @@ mod tests {
     #[should_panic(expected = "references invalid struct id")]
     fn verify_rejects_invalid_struct_projection_id() {
         let pool = FrozenTypeInternPool::new();
+        let source_pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let foreign_struct = register_struct(&source_pool, &interner, "Foreign", &[Type::I32]);
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "invalid_struct".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -1916,7 +1923,7 @@ mod tests {
             PlaceBase::Local(0),
             Type::I32,
             [Projection::Field {
-                struct_id: StructId::from_pool_index(99),
+                struct_id: foreign_struct,
                 field_index: 0,
             }],
         );
@@ -1936,6 +1943,9 @@ mod tests {
     #[should_panic(expected = "references invalid array id")]
     fn verify_rejects_invalid_array_projection_id() {
         let pool = FrozenTypeInternPool::new();
+        let array_type = TypeInternPool::new()
+            .try_intern_array(Type::I32, 1)
+            .unwrap();
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "invalid_array".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
@@ -1947,7 +1957,6 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
-        let array_type = Type::new_array(ArrayTypeId::from_pool_index(99));
         let place = cfg.make_place(
             PlaceBase::Local(0),
             Type::I32,
@@ -2173,7 +2182,9 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
-        let array_type = Type::new_array(ArrayTypeId::from_pool_index(1));
+        let array_type = TypeInternPool::new()
+            .try_intern_array(Type::I32, 1)
+            .unwrap();
         let place = cfg.make_place(
             PlaceBase::Local(0),
             array_type,

--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -6,6 +6,12 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
+filegroup(
+    name = "type-architecture-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-codegen",
     deps = [

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -125,7 +125,7 @@ impl fmt::Display for LoweringDebugInfo {
 }
 
 /// Format a CFG instruction data as a human-readable string. Takes the `Cfg`
-/// so places render with their projections resolved (`$0.#2.1`), not as raw
+/// so places render with their projections resolved (`$0.#StructId(2).1`), not as raw
 /// projection-arena index ranges (`$0[3..5]`).
 pub fn format_cfg_inst_data(cfg: &rue_cfg::Cfg, data: &rue_cfg::CfgInstData) -> String {
     format_cfg_inst_data_impl(cfg, data, None)
@@ -229,7 +229,7 @@ fn format_cfg_inst_data_impl(
                 .iter()
                 .map(|v| format!("{}", v))
                 .collect();
-            format!("struct_init #{} {{{}}}", struct_id.0, fields.join(", "))
+            format!("struct_init #{struct_id:?} {{{}}}", fields.join(", "))
         }
         CfgInstData::ArrayInit { .. } => {
             // Note: Can't show elements without Cfg access
@@ -240,7 +240,7 @@ fn format_cfg_inst_data_impl(
             variant_index,
             ..
         } => {
-            format!("enum_variant #{}.{}", enum_id.0, variant_index)
+            format!("enum_variant #{enum_id:?}.{variant_index}")
         }
         CfgInstData::EnumPayloadGet {
             base,
@@ -249,8 +249,8 @@ fn format_cfg_inst_data_impl(
             field_index,
         } => {
             format!(
-                "enum_payload_get {} #{}.{}.{}",
-                base, enum_id.0, variant_index, field_index
+                "enum_payload_get {} #{:?}.{}.{}",
+                base, enum_id, variant_index, field_index
             )
         }
         CfgInstData::IntCast { value, from_ty } => {

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -346,7 +346,7 @@ fn type_name(ty: Type, type_pool: &FrozenTypeInternPool) -> String {
         TypeKind::Error => "error".to_string(),
         // ComptimeType only exists at compile time, no runtime representation
         TypeKind::ComptimeType => "comptime_type".to_string(),
-        TypeKind::Enum(enum_id) => format!("enum{}", enum_id.0),
+        TypeKind::Enum(enum_id) => type_pool.enum_symbol_name(enum_id),
         // Struct types include builtin types like String
         // File-qualified when the struct name spans files (RUE-571); must
         // match rue_compiler::drop_glue::type_name.

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -2481,6 +2481,31 @@ mod tests {
         let v = dummy_value();
         let place = Place::local(0, Type::I32);
         let symbol = Spur::default();
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let (struct_id, _) = pool.register_struct(
+            interner.get_or_intern("PlannerStruct"),
+            StructDef {
+                name: "PlannerStruct".to_string(),
+                fields: vec![],
+                is_copy: false,
+                is_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let (enum_id, _) = pool.register_enum(
+            interner.get_or_intern("PlannerEnum"),
+            EnumDef {
+                name: "PlannerEnum".to_string(),
+                variants: vec!["Only".to_string()],
+                variant_payloads: vec![],
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
         let cases = vec![
             (CfgInstData::Const(1), ValueKind::Constant),
             (CfgInstData::BoolConst(true), ValueKind::BoolConstant),
@@ -2542,7 +2567,7 @@ mod tests {
             ),
             (
                 CfgInstData::StructInit {
-                    struct_id: rue_air::StructId(0),
+                    struct_id,
                     fields_start: 0,
                     fields_len: 0,
                 },
@@ -2557,7 +2582,7 @@ mod tests {
             ),
             (
                 CfgInstData::EnumVariant {
-                    enum_id: rue_air::EnumId(0),
+                    enum_id,
                     variant_index: 0,
                     payload_start: 0,
                     payload_len: 0,
@@ -2567,7 +2592,7 @@ mod tests {
             (
                 CfgInstData::EnumPayloadGet {
                     base: v,
-                    enum_id: rue_air::EnumId(0),
+                    enum_id,
                     variant_index: 0,
                     field_index: 0,
                 },

--- a/crates/rue-compiler-session-bench/BUCK
+++ b/crates/rue-compiler-session-bench/BUCK
@@ -1,5 +1,11 @@
 load("//crates:defs.bzl", "rue_binary")
 
+filegroup(
+    name = "type-architecture-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 export_file(
     name = "benchmark-main-definition",
     src = "src/main.rs",

--- a/crates/rue-compiler-session-bench/src/main.rs
+++ b/crates/rue-compiler-session-bench/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::HashMap, env, process, sync::Arc, time::Instant};
 
-use rue_air::FrozenTypeInternPool;
+use rue_air::{FrozenTypeInternPool, TypeKind};
 use rue_compiler::{
     AcceptedReadManifestEntry, CanonicalSemanticOutput, CompileOptions, CompilerSession,
     CompilerSessionWork, DiscoverySourceAssembler, DurableBodyWork,
@@ -789,29 +789,19 @@ fn measured_semantic(
 }
 
 fn type_pool_snapshot(pool: &FrozenTypeInternPool) -> Vec<String> {
-    let mut entries = Vec::with_capacity(pool.len());
-    entries.extend(
-        pool.all_struct_ids()
-            .map(|id| (id.0, format!("struct:{:?}", pool.struct_def(id)))),
-    );
-    entries.extend(
-        pool.all_enum_ids()
-            .map(|id| (id.0, format!("enum:{:?}", pool.enum_def(id)))),
-    );
-    entries.extend(pool.all_array_ids().map(|id| {
-        let (element, len) = pool.array_def(id);
-        (id.0, format!("array:{element:?}:{len}"))
-    }));
-    entries.extend(
-        pool.all_ptr_const_ids()
-            .map(|id| (id.0, format!("ptr_const:{:?}", pool.ptr_const_def(id)))),
-    );
-    entries.extend(
-        pool.all_ptr_mut_ids()
-            .map(|id| (id.0, format!("ptr_mut:{:?}", pool.ptr_mut_def(id)))),
-    );
-    entries.sort_unstable_by_key(|(index, _)| *index);
-    entries.into_iter().map(|(_, entry)| entry).collect()
+    pool.all_types()
+        .map(|ty| match ty.kind() {
+            TypeKind::Struct(id) => format!("struct:{:?}", pool.struct_def(id)),
+            TypeKind::Enum(id) => format!("enum:{:?}", pool.enum_def(id)),
+            TypeKind::Array(id) => {
+                let (element, len) = pool.array_def(id);
+                format!("array:{element:?}:{len}")
+            }
+            TypeKind::PtrConst(id) => format!("ptr_const:{:?}", pool.ptr_const_def(id)),
+            TypeKind::PtrMut(id) => format!("ptr_mut:{:?}", pool.ptr_mut_def(id)),
+            _ => unreachable!("type pool stores only composite types"),
+        })
+        .collect()
 }
 
 fn assert_diagnostic_parity(
@@ -2199,6 +2189,21 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rue_air::{Type, TypeInternPool};
+
+    #[test]
+    fn type_pool_snapshot_preserves_global_allocation_order() {
+        let pool = TypeInternPool::new();
+        let pointer = pool.try_intern_ptr_const(Type::I32).unwrap();
+        let array = pool.try_intern_array(Type::I32, 3).unwrap();
+        let frozen = pool.freeze();
+
+        assert_eq!(frozen.all_types().collect::<Vec<_>>(), [pointer, array]);
+        assert_eq!(
+            type_pool_snapshot(&frozen),
+            ["ptr_const:Type::I32", "array:Type::I32:3"]
+        );
+    }
 
     #[test]
     fn small_workload_is_a_structural_smoke_test() {

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -6,6 +6,12 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
+filegroup(
+    name = "type-architecture-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 # Per-target runtime staticlibs are mapped into src/ so the compiler can embed
 # all supported runtimes and select the matching archive at link time.
 rue_crate(

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -602,7 +602,7 @@ fn type_name(ty: Type, type_pool: &FrozenTypeInternPool) -> String {
         TypeKind::Error => "error".to_string(),
         // ComptimeType only exists at compile time
         TypeKind::ComptimeType => "comptime_type".to_string(),
-        TypeKind::Enum(enum_id) => format!("enum{}", enum_id.0),
+        TypeKind::Enum(enum_id) => type_pool.enum_symbol_name(enum_id),
         // Struct types include builtin types like String. File-qualified
         // when the struct name spans files (RUE-571), so arrays of two
         // same-named element types get distinct glue.
@@ -845,5 +845,38 @@ mod tests {
             type_pool.abi_slot_count(drop_enum_ty)
         );
         assert_eq!(param_indices(&enum_glue), [0, 1, 2, 2]);
+    }
+
+    #[test]
+    fn enum_array_drop_glue_names_are_owner_aware_and_match_codegen() {
+        let type_pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let symbol = interner.get_or_intern("Choice");
+        let make_enum = |file_id| EnumDef {
+            name: "Choice".into(),
+            variants: vec!["Only".into()],
+            variant_payloads: vec![vec![]],
+            is_pub: false,
+            file_id,
+        };
+        let (left, _) = type_pool.register_enum(symbol, make_enum(rue_span::FileId::new(1)));
+        let (right, _) = type_pool.register_enum(symbol, make_enum(rue_span::FileId::new(2)));
+        let left_array = type_pool.intern_array_from_type(Type::new_enum(left), 2);
+        let right_array = type_pool.intern_array_from_type(Type::new_enum(right), 2);
+        let type_pool = type_pool.freeze();
+
+        let left_name = array_drop_glue_name(left_array, &type_pool);
+        let right_name = array_drop_glue_name(right_array, &type_pool);
+        assert_eq!(left_name, "__rue_drop_array_Choice$1_2");
+        assert_eq!(right_name, "__rue_drop_array_Choice$2_2");
+        assert_ne!(left_name, right_name);
+        assert_eq!(
+            left_name,
+            rue_codegen::types::array_drop_glue_name(left_array, &type_pool)
+        );
+        assert_eq!(
+            right_name,
+            rue_codegen::types::array_drop_glue_name(right_array, &type_pool)
+        );
     }
 }

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -1024,9 +1024,10 @@ mod tests {
             .unwrap()
             .0;
 
+        let peer_live_handle = ["Interned", "Type"].concat();
         for forbidden in [
             "rue_air::Type",
-            "InternedType",
+            peer_live_handle.as_str(),
             "StructId",
             "EnumId",
             "ArrayTypeId",

--- a/crates/rue-oracle/BUCK
+++ b/crates/rue-oracle/BUCK
@@ -6,6 +6,12 @@ filegroup(
     visibility = ["PUBLIC"],
 )
 
+filegroup(
+    name = "type-architecture-inventory-sources",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+)
+
 rue_crate(
     name = "rue-oracle",
     deps = [

--- a/docs/designs/0024-type-intern-pool.md
+++ b/docs/designs/0024-type-intern-pool.md
@@ -1,12 +1,12 @@
 ---
 id: 0024
 title: Canonical Type Handle and Intern Pool
-status: accepted
+status: implemented
 tags: [architecture, type-system, performance, parallelization]
 feature-flag: null
 created: 2026-01-02
 accepted: 2026-07-16
-implemented:
+implemented: 2026-07-16
 spec-sections: []
 superseded-by:
 relates: ["RUE-766", "RUE-835", "RUE-836", "RUE-837", "RUE-838"]
@@ -16,10 +16,9 @@ relates: ["RUE-766", "RUE-835", "RUE-836", "RUE-837", "RUE-838"]
 
 ## Status
 
-Accepted under RUE-766 on 2026-07-16. The representation convergence is not
-implemented until RUE-835 through RUE-838 land. This is an internal compiler
-architecture decision with no language-semantics, specification, or preview
-feature change.
+Implemented under RUE-766 and RUE-835 through RUE-838 on 2026-07-16. This is an
+internal compiler architecture decision with no language-semantics,
+specification, or preview-feature change.
 
 ## Summary
 
@@ -42,41 +41,19 @@ They deliberately do not reuse the request-local live handle encoding.
 
 ## Context
 
-At acceptance time, the source has most of the intended architecture:
+`Type` in `crates/rue-air/src/types.rs` is the compiler's compact live handle. It
+directly tags primitives and carries typed payloads for composite, module,
+comptime, never, and error categories. `TypeKind` is its checked,
+pattern-matchable view. AIR and every surrounding compiler phase exchange this
+handle.
 
-- `Type` in `crates/rue-air/src/types.rs` is a compact `u32` handle. It directly
-  encodes primitive, composite, module, comptime, never, and error categories.
-- `TypeKind` is the decoded, pattern-matchable view returned by checked decoding
-  APIs.
-- AIR and the surrounding compiler phases overwhelmingly exchange `Type`.
-- `TypeInternPool` owns nominal definitions and canonical structural array and
-  pointer entries. RUE-659 and RUE-660 established
-  `FrozenTypeInternPool` as the backend-facing read-only projection after
-  semantic construction finishes.
-- `DurableType` and the semantic import/export schemas represent stable,
-  request-independent types for reuse and invalidation.
-
-One transitional representation remains: `InternedType` is a second public
-`u32` type universe in `crates/rue-air/src/intern_pool.rs`. It has a different
-primitive table from `Type`, omits comptime and module categories, and maps every
-composite to an offset pool index. Recovering the composite category therefore
-requires consulting pool storage. Public conversions and pool APIs allow both
-representations to persist.
-
-This duplication creates architectural ambiguity:
-
-- a phase API can accidentally choose either handle without expressing a
-  different ownership or lifetime boundary;
-- primitive values can have different raw meanings depending on the wrapper;
-- a bare composite index does not prove whether its entry is a struct, enum,
-  array, or pointer;
-- comptime-only, module, error, and malformed encodings cannot be described
-  uniformly; and
-- tests can validate each representation independently while missing divergence
-  between them.
-
-The compiler needs one live type identity, not a conversion protocol between
-two request-local identities.
+`TypeInternPool` owns nominal definitions and canonical structural array and
+pointer entries. `FrozenTypeInternPool` is the backend-facing read-only
+projection after semantic construction finishes. Opaque category IDs identify
+typed pool entries, while raw positions and their construction and extraction
+remain private to AIR. `DurableType` and the semantic import/export schemas are
+the separate request-independent representation used for reuse and
+invalidation.
 
 ## Decision
 
@@ -162,8 +139,8 @@ intern_ptr_const(pointee: Type) -> Type
 intern_ptr_mut(pointee: Type) -> Type
 ```
 
-The exact Rust spelling may differ, but callers do not convert through
-`InternedType` before or after interning.
+The exact Rust spelling may differ, but structural operations consume and
+return the canonical handle directly.
 
 ### Runtime structural children are validated
 
@@ -217,6 +194,16 @@ The legal transitions are `Reserved -> Complete` for anonymous construction and
 at most once. A completed entry can never be overwritten by another completion.
 Duplicate-name and wrong-kind checks apply to both transitions.
 
+Completion fixes nominal identity and definition shape: fields, variants,
+visibility, copy/builtin status, defining file, and structural children cannot
+be replaced afterward. Before freeze, semantic construction has two narrow
+metadata-finalization operations. Infectious linearity may move `is_linear`
+only from false to true. Destructor discovery may assign a destructor symbol
+once, and collision handling may subsequently requalify only that symbol's
+spelling. These crate-private operations cannot replace a whole definition,
+create a destructor during requalification, remove metadata, or run after the
+pool becomes immutable.
+
 Structural interning and type-graph construction may read the identity and
 category of a declared shell. Definition, layout, durable export, backend, and
 successful-compilation reads require completion. Reserved entries reject all
@@ -231,8 +218,9 @@ of either incomplete state.
 
 ### Mutation and read ownership stay phase-scoped
 
-Semantic construction owns creation, registration, interning, and completion
-of live types. Once the semantic type universe is complete,
+Semantic construction owns creation, registration, interning, completion, and
+the narrow monotonic metadata finalization described above. Once the semantic
+type universe is frozen,
 `FrozenTypeInternPool` remains the shared read authority for CFG and backend
 consumers. Consolidating type handles does not create a peer mutation path in
 later phases.
@@ -280,47 +268,30 @@ Pool/owner contract:
 8. Reserved anonymous entries are never issued as `Type`. Declared nominal
    shells may be issued and referenced recursively, but definition/layout/
    durable/backend reads require completion.
-9. Each reserved or declared entry completes at most once, completed entries
-   cannot be overwritten, and freeze rejects either incomplete state.
+9. Each reserved or declared entry completes at most once, completed definition
+   shape cannot be overwritten, narrow linearity/destructor metadata
+   finalization obeys its monotonic invariants, and freeze rejects either
+   incomplete state.
 10. Recovery-only `Error` graphs may survive error output and freeze but cannot
     enter successful durable output, layout, backend work, or compilation.
 11. Durable type identity contains no live handle encoding or pool index.
-12. Phase APIs do not require bidirectional `Type`/`InternedType` conversion.
+12. Phase APIs exchange `Type` directly and expose no peer live type handle.
 
-## Implementation sequence
+## Implemented architecture
 
-The M5 work proceeds in dependency order:
+The compact encoding has one source of truth for tags, primitives, malformed
+and encoding-reserved patterns, payload limits, construction, and decoding.
+Pool entries retain explicit kind and lifecycle state. Structural interning and
+every compiler consumer operate on `Type`; raw positions are confined to AIR's
+implementation. Whole-definition overwrite APIs do not exist; the only
+post-completion mutations are crate-private monotonic linearity and destructor
+metadata finalization before freeze.
 
-1. **RUE-835 — centralize the canonical encoding and entry states.** Define one
-   source of truth for tags, primitives, malformed and encoding-reserved
-   patterns, checked construction, and decoding. Make pool entries retain
-   explicit kind metadata, and represent reserved anonymous entries, declared
-   nominal shells, and completed definitions distinctly.
-2. **RUE-836 — migrate pool and phase APIs.** Change structural interning,
-   lookup, keys, and consumers to accept and return `Type`. Add the
-   `Reserved -> Complete` and `Declared -> Complete` transitions,
-   operation-specific entry-state checks, the exact structural representability
-   rules, and fallible durable-import validation. Preserve the owner/pool
-   boundary without introducing a branded replacement handle. Use raw pool
-   positions only inside the pool; retain opaque category-specific IDs where
-   the typed public API needs them.
-3. **RUE-837 — prove the representation.** Add round-trip and uniqueness
-   properties, malformed/corrupt encoding tests, the exact child-representability
-   matrix, recursive declared-shell coverage, both single-completion
-   transitions, overwrite rejection, operation-specific incomplete-state
-   failures, recovery-`Error` success-boundary rejection, structural
-   deduplication, durable cross-epoch round trips, and concurrent interning
-   coverage.
-4. **RUE-838 — remove the transitional universe.** Delete `InternedType`,
-   bidirectional conversions, duplicate primitive tables, migration
-   scaffolding, and exports that expose raw pool implementation details. Update
-   this ADR's context, checklist, status, and generated index to describe the
-   completed architecture.
-
-This is a sequential dependency chain, not parallel work. Linear relations must
-record `RUE-836 blockedBy RUE-835` and `RUE-837 blockedBy RUE-836`. The migrated
-API supplies the final surface for RUE-837, and RUE-838 removes compatibility
-code only after those properties pass.
+Bounded property and corruption tests cover encoding round trips, invalid bit
+patterns, pool ownership, lifecycle transitions, structural child legality,
+recovery graphs, durable cross-epoch projection, and concurrent canonical
+interning. Source inventories guard the one-handle API and durable-schema
+boundary.
 
 ## Ownership boundaries
 
@@ -334,8 +305,8 @@ code only after those properties pass.
 | Stable cross-revision type identity | `DurableType` and import/export schemas |
 | Orchestration and artifact lifetime | `CompilerSession` |
 
-No consumer may reproduce a responsibility from another row merely for
-presentation, compatibility, or convenience.
+No consumer may reproduce a responsibility from another row for presentation
+or convenience.
 
 ## Non-goals
 
@@ -368,10 +339,8 @@ This decision does not:
 
 ### Costs and risks
 
-- Migrating keys and APIs touches semantic and pool code broadly even though
-  language behavior is unchanged.
-- A centralized encoding change can have wide impact; property tests and
-  corruption tests must land before compatibility scaffolding is deleted.
+- Changes to the centralized encoding can have wide impact and require the
+  property and corruption suites to remain authoritative.
 - Compact encodings have finite tag and payload space. Constructors must reject
   overflow rather than truncate IDs into a different valid type.
 - Concurrent structural interning must preserve one canonical result under
@@ -382,46 +351,49 @@ This decision does not:
 
 ## Completion criteria
 
-ADR-0024 returns to `implemented` only when:
+ADR-0024 is implemented with these verified properties:
 
-- [ ] RUE-835, RUE-836, RUE-837, and RUE-838 are merged.
-- [ ] Public compiler phase APIs use `Type` for live type values.
-- [ ] `InternedType` and its public conversions and exports no longer exist.
-- [ ] Primitive, tag, malformed/encoding-reserved pattern, construction-limit,
+- [x] RUE-835, RUE-836, RUE-837, and RUE-838 implement the M5 architecture.
+- [x] Public compiler phase APIs use `Type` for live type values.
+- [x] No peer primitive-or-composite live handle, conversion, or export exists.
+- [x] Primitive, tag, malformed/encoding-reserved pattern, construction-limit,
       and decoding logic has one authoritative implementation.
-- [ ] Encoding tests distinguish encoding-valid values from malformed or
+- [x] Encoding tests distinguish encoding-valid values from malformed or
       encoding-reserved values without requiring a pool.
-- [ ] Live phase artifacts retain their authoritative pool, and no API treats
+- [x] Live phase artifacts retain their authoritative pool, and no API treats
       naked `Type` bits as a cross-epoch transfer format.
-- [ ] Pool-aware reads check range, stored category, entry state, and
+- [x] Pool-aware reads check range, stored category, entry state, and
       operation-specific child requirements in the owner-provided pool without
       claiming to detect coincidentally equal foreign bits.
-- [ ] Reserved anonymous entries are private and unissued as `Type`; declared
+- [x] Reserved anonymous entries are private and unissued as `Type`; declared
       nominal shells may be issued and used in recursive structural keys/type
       graphs.
-- [ ] `Reserved -> Complete` and `Declared -> Complete` preserve slot identity,
+- [x] `Reserved -> Complete` and `Declared -> Complete` preserve slot identity,
       happen at most once, reject completed-entry overwrite, and enforce
       duplicate-name and wrong-kind checks.
-- [ ] Definition, layout, durable, backend, and successful-compilation reads
+- [x] Completed definition shape has no replacement API; phase-scoped linearity
+      and destructor metadata finalization is narrow, crate-private, and
+      invariant-checked before freeze.
+- [x] Definition, layout, durable, backend, and successful-compilation reads
       reject declared shells; ordinary reads reject reserved entries; freeze
       rejects either incomplete state.
-- [ ] Structural interning consumes and returns `Type`, enforces the child
+- [x] Structural interning consumes and returns `Type`, enforces the child
       legality matrix, and remains deterministic under concurrency.
-- [ ] Property and corruption tests cover encoding validity, pool/epoch
+- [x] Property and corruption tests cover encoding validity, pool/epoch
       validity under an authoritative owner, all encoding categories, every
       structural child category, recursive declared shells, and malformed,
       wrong-kind, out-of-range, reserved, and declared cases.
-- [ ] Recovery structural types containing `Error` are canonical for diagnostics
+- [x] Recovery structural types containing `Error` are canonical for diagnostics
       and may survive freeze on error paths, but successful durable export,
       layout, backend work, and compilation reject them.
-- [ ] A source and public-API inventory proves durable types contain no live
+- [x] A source and public-API inventory proves durable types contain no live
       bits, pool indices, nominal IDs, or unchecked conversion path.
-- [ ] Durable projection/import tests perform successful cross-epoch round
+- [x] Durable projection/import tests perform successful cross-epoch round
       trips and prove malformed or illegal imports fail closed.
-- [ ] The focused type/pool tests and Rue's required compiler validation suites
+- [x] The focused type/pool tests and Rue's required compiler validation suites
       pass.
-- [ ] RUE-838 updates this ADR's acceptance-time context, checklist, status, and
-      generated README index to record the verified completed architecture.
+- [x] Raw category-ID fields, pool-position constructors, and position
+      extractors are absent from Rue AIR's public surface.
 
 ## References
 

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -186,7 +186,7 @@ The table is generated from ADR frontmatter. Run
 | [0021](0021-stdin-input.md) | Standard Input | Implemented | io, intrinsics, runtime |
 | [0022](0022-integer-parsing.md) | Integer Parsing | Implemented | intrinsics, runtime, strings |
 | [0023](0023-multi-file-compilation.md) | Multi-File Compilation | Superseded | architecture, compiler, scalability |
-| [0024](0024-type-intern-pool.md) | Canonical Type Handle and Intern Pool | Accepted | architecture, type-system, performance, parallelization |
+| [0024](0024-type-intern-pool.md) | Canonical Type Handle and Intern Pool | Implemented | architecture, type-system, performance, parallelization |
 | [0025](0025-comptime.md) | Compile-Time Execution (comptime) | Implemented | compiler, type-system, generics |
 | [0026](0026-module-system.md) | Module System | Stable | architecture, compiler, modules, scalability |
 | [0027](0027-random-intrinsics.md) | Random Number Intrinsics | Implemented | intrinsics, runtime, semantics |

--- a/scripts/test-type-architecture.py
+++ b/scripts/test-type-architecture.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Focused tests for the complete live-type architecture inventory."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-type-architecture.py")
+SPEC = importlib.util.spec_from_file_location("type_architecture_inventory", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+inventory = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(inventory)
+
+
+class InventoryTests(unittest.TestCase):
+    def validate(self, files: dict[str, str], crate: str = "rue-air") -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            source_root = Path(directory) / "materialized"
+            for relative, source in files.items():
+                path = source_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(source)
+            return inventory.validate(
+                Path(directory) / "unrelated-root",
+                [(crate, source_root)],
+            )
+
+    def test_new_nested_consumer_file_is_scanned_without_a_manifest(self) -> None:
+        errors = self.validate({"future/nested.rs": "pub fn pool_index() -> u32 { 0 }"})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("future/nested.rs:1", errors[0])
+
+    def test_authoritative_encoding_is_the_only_tag_assignment_site(self) -> None:
+        self.assertEqual(
+            self.validate({"type_encoding.rs": "enum Composite { Struct = 100 }"}),
+            [],
+        )
+        errors = self.validate(
+            {"semantic_import.rs": "enum Peer { Struct\t=\t0x64_u8 }"}
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("duplicate compact type tag", errors[0])
+
+    def test_peer_handle_and_whole_definition_updater_are_rejected(self) -> None:
+        errors = self.validate(
+            {
+                "sema/new_path.rs": "struct InternedType(u32);",
+                "intern_pool.rs": "pub fn update_struct_def() {}",
+            }
+        )
+        self.assertEqual(len(errors), 3)
+
+    def test_new_public_type_representation_requires_classification(self) -> None:
+        errors = self.validate({"sema/new_path.rs": "pub struct PeerType(u32);"})
+        self.assertEqual(len(errors), 2)
+        self.assertIn("unclassified public type representation", errors[0])
+
+        self.assertEqual(self.validate({"types.rs": "pub struct Type(u32);"}), [])
+
+    def test_renamed_private_compact_handle_requires_classification(self) -> None:
+        errors = self.validate({"sema/new_path.rs": "struct SemanticTy(u32);"})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("unclassified compact u32 newtype", errors[0])
+
+    def test_opaque_ids_reject_public_numeric_traits_and_fields(self) -> None:
+        errors = self.validate(
+            {
+                "types.rs": (
+                    "#[derive(PartialOrd, Ord)] pub struct StructId(pub u32);\n"
+                    "impl std::fmt::Display for StructId {}\n"
+                )
+            }
+        )
+        self.assertEqual(len(errors), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-type-architecture.py
+++ b/scripts/validate-type-architecture.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Guard Rue's canonical live-type representation across every consumer source."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CONSUMER_CRATES = (
+    "rue-air",
+    "rue-cfg",
+    "rue-codegen",
+    "rue-compiler",
+    "rue-compiler-session-bench",
+    "rue-oracle",
+)
+OPAQUE_IDS = (
+    "StructId",
+    "EnumId",
+    "ArrayTypeId",
+    "PtrConstTypeId",
+    "PtrMutTypeId",
+)
+COMPOSITE_TAGS = {
+    "Struct": 100,
+    "Enum": 101,
+    "Array": 102,
+    "Module": 103,
+    "PtrConst": 104,
+    "PtrMut": 105,
+}
+TAG_ASSIGNMENT = re.compile(
+    r"\b(?P<category>" + "|".join(COMPOSITE_TAGS) + r")\s*=\s*"
+    r"(?P<value>0x[0-9a-fA-F_]+|[0-9][0-9_]*)"
+    r"(?:u(?:8|16|32|64|128|size)|i(?:8|16|32|64|128|size))?\b"
+)
+PUBLIC_RAW_API = re.compile(
+    r"^\s*pub\s+(?:const\s+)?fn\s+"
+    r"(?:from_pool_index|pool_index|raw_encoding)\s*\(",
+    re.MULTILINE,
+)
+PUBLIC_UNCHECKED_ENCODING_API = re.compile(
+    r"^\s*pub\s+(?:const\s+)?fn\s+(?:from_u32|as_u32)\s*\(",
+    re.MULTILINE,
+)
+OPAQUE_ID_DERIVE = re.compile(
+    r"#\[derive\((?P<traits>[^)]*)\)\]\s*"
+    r"pub struct (?P<id>" + "|".join(OPAQUE_IDS) + r")\(",
+    re.MULTILINE,
+)
+PUBLIC_TYPE_DECLARATION = re.compile(
+    r"^pub\s+(?:struct|enum)\s+(?P<name>[A-Za-z0-9_]*Type[A-Za-z0-9_]*)\b",
+    re.MULTILINE,
+)
+COMPACT_U32_NEWTYPE = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?struct\s+(?P<name>[A-Za-z0-9_]+)\s*"
+    r"\(\s*(?:pub(?:\([^)]*\))?\s+)?u32\s*\)",
+    re.MULTILINE,
+)
+
+# Every public type-shaped declaration in the scanned production graph must be
+# classified here. A new module is discovered by the Buck glob and a new
+# declaration fails closed until its ownership boundary is explicit.
+PUBLIC_TYPE_DECLARATION_ALLOWLIST = {
+    ("rue-air", "types.rs", "Type"): "canonical live compiler type handle",
+    ("rue-air", "types.rs", "TypeKind"): "checked decoded view of Type",
+    ("rue-air", "types.rs", "StructId"): "opaque typed nominal pool identity",
+    ("rue-air", "types.rs", "EnumId"): "opaque typed nominal pool identity",
+    ("rue-air", "types.rs", "ArrayTypeId"): "opaque typed structural pool identity",
+    ("rue-air", "types.rs", "PtrConstTypeId"): "opaque typed structural pool identity",
+    ("rue-air", "types.rs", "PtrMutTypeId"): "opaque typed structural pool identity",
+    ("rue-air", "types.rs", "ModuleId"): "module identity carried by canonical Type",
+    ("rue-air", "intern_pool.rs", "TypeData"): "canonical pool storage schema",
+    ("rue-air", "intern_pool.rs", "TypeValidationError"): "checked pool boundary error",
+    ("rue-air", "intern_pool.rs", "TypeInternPool"): "mutable semantic type owner",
+    ("rue-air", "intern_pool.rs", "FrozenTypeInternPool"): "read-only downstream type owner",
+    ("rue-air", "intern_pool.rs", "TypeInternPoolStats"): "pool metrics, not a type identity",
+    ("rue-air", "inference/types.rs", "TypeVarId"): "inference-local variable identity",
+    ("rue-air", "inference/types.rs", "InferType"): "inference-only term representation",
+    ("rue-air", "inference/types.rs", "TypeVarAllocator"): "inference-local allocator",
+    ("rue-air", "runtime_call.rs", "RuntimeAirType"): "typed runtime ABI shape classification",
+    ("rue-air", "semantic_import.rs", "SemanticImportType"): "stable semantic import schema",
+    ("rue-air", "semantic_import.rs", "SemanticImportedType"): "validated imported-type result",
+    ("rue-air", "sema/binding_manifest.rs", "SemanticExportType"): "stable semantic export schema",
+    ("rue-air", "sema/output.rs", "DeclarationTypeDependencySourceKind"): "dependency metadata",
+    ("rue-air", "sema/output.rs", "DeclarationTypeDependencyTargetKind"): "dependency metadata",
+    ("rue-air", "sema/output.rs", "DeclarationTypeDependencyKind"): "dependency metadata",
+    ("rue-air", "sema/output.rs", "DeclarationTypeDependencyEvent"): "dependency metadata",
+    ("rue-air", "sema/output.rs", "DeclarationTypeCallHeadDependencyEvent"): "dependency metadata",
+    ("rue-air", "sema/output.rs", "BuiltinTypeCallHead"): "dependency metadata",
+    ("rue-air", "sema/output.rs", "DeclarationBuiltinTypeCallHeadDependencyEvent"): "dependency metadata",
+    ("rue-compiler", "bound_definitions.rs", "StableNamedTypeKey"): "stable definition lookup key",
+    ("rue-compiler", "durable_semantics.rs", "DurableType"): "cross-epoch durable type schema",
+    ("rue-compiler", "source_identity.rs", "ModuleId"): "stable logical source-module identity",
+    ("rue-compiler", "session.rs", "StableDeclarationTypeDependency"): "stable dependency metadata",
+    ("rue-compiler", "session.rs", "StableDeclarationTypeCallHeadDependency"): "stable dependency metadata",
+    ("rue-compiler", "session.rs", "StableBuiltinTypeCallHeadInput"): "stable dependency metadata",
+}
+COMPACT_U32_NEWTYPE_ALLOWLIST = {
+    ("rue-air", "types.rs", "Type"): "canonical live type handle",
+    ("rue-air", "types.rs", "StructId"): "opaque struct pool identity",
+    ("rue-air", "types.rs", "EnumId"): "opaque enum pool identity",
+    ("rue-air", "types.rs", "ArrayTypeId"): "opaque array pool identity",
+    ("rue-air", "types.rs", "PtrConstTypeId"): "opaque const-pointer pool identity",
+    ("rue-air", "types.rs", "PtrMutTypeId"): "opaque mut-pointer pool identity",
+    ("rue-air", "types.rs", "ModuleId"): "request-local module identity",
+    ("rue-air", "inference/types.rs", "TypeVarId"): "inference-local variable identity",
+    ("rue-air", "inst.rs", "AirPlaceRef"): "typed AIR place index",
+    ("rue-air", "inst.rs", "AirRef"): "typed AIR instruction index",
+    ("rue-cfg", "inst.rs", "BlockId"): "typed CFG block index",
+    ("rue-cfg", "inst.rs", "CfgValue"): "typed CFG value index",
+    ("rue-codegen", "vreg.rs", "VReg"): "typed virtual register index",
+    ("rue-codegen", "vreg.rs", "LabelId"): "typed code label index",
+    ("rue-codegen", "index_map.rs", "TestHandle"): "test-only index-map fixture",
+    ("rue-codegen", "regalloc.rs", "TestReg"): "test-only register fixture",
+    ("rue-compiler", "parsed_modules.rs", "ParsedDefinitionOccurrence"): "typed parsed-definition occurrence index",
+}
+
+
+def source_files(root: Path, sources: list[tuple[str, Path]] | None) -> list[tuple[str, Path, Path]]:
+    crate_sources = sources or [
+        (crate, root / "crates" / crate / "src") for crate in CONSUMER_CRATES
+    ]
+    files = []
+    for crate, source_root in crate_sources:
+        for path in sorted(source_root.rglob("*.rs")):
+            files.append((crate, source_root, path))
+    return files
+
+
+def validate(root: Path, sources: list[tuple[str, Path]] | None = None) -> list[str]:
+    errors: list[str] = []
+    crate_sources = sources or [
+        (crate, root / "crates" / crate / "src") for crate in CONSUMER_CRATES
+    ]
+    for crate, source_root in crate_sources:
+        if not source_root.exists():
+            errors.append(f"missing live-type consumer source directory: {source_root}")
+
+    peer_tokens = (
+        "Interned" + "Type",
+        "type_to_" + "interned",
+        "interned_to_" + "type",
+        "mod " + "compatibility",
+    )
+    retired_updaters = ("update_" + "struct_def", "update_" + "enum_def")
+    observed_compact_newtypes: set[tuple[str, str, str]] = set()
+
+    for crate, source_root, path in source_files(root, crate_sources):
+        source = path.read_text()
+        relative = path.relative_to(source_root)
+        if relative.parts and relative.parts[0] == "src":
+            relative = Path(*relative.parts[1:])
+        display = Path("crates") / crate / "src" / relative
+
+        for token in peer_tokens:
+            if token in source:
+                errors.append(f"{display}: peer live-type representation token {token!r}")
+
+        if not (
+            crate == "rue-air"
+            and relative in {Path("type_encoding.rs"), Path("api_inventory.rs")}
+        ):
+            for match in TAG_ASSIGNMENT.finditer(source):
+                value = int(match.group("value").replace("_", ""), 0)
+                category = match.group("category")
+                if value == COMPOSITE_TAGS[category]:
+                    line = source.count("\n", 0, match.start()) + 1
+                    errors.append(
+                        f"{display}:{line}: duplicate compact type tag assignment "
+                        f"{category}={value}"
+                    )
+
+        match = PUBLIC_RAW_API.search(source)
+        if match:
+            line = source.count("\n", 0, match.start()) + 1
+            errors.append(f"{display}:{line}: public raw pool/type encoding API")
+
+        if crate == "rue-air" and relative in {
+            Path("types.rs"),
+            Path("intern_pool.rs"),
+            Path("type_encoding.rs"),
+            Path("lib.rs"),
+        }:
+            match = PUBLIC_UNCHECKED_ENCODING_API.search(source)
+            if match:
+                line = source.count("\n", 0, match.start()) + 1
+                errors.append(f"{display}:{line}: public unchecked type encoding API")
+
+        for updater in retired_updaters:
+            if updater in source:
+                errors.append(f"{display}: whole-definition overwrite API {updater!r}")
+
+        for opaque_id in OPAQUE_IDS:
+            if re.search(rf"pub struct {opaque_id}\(pub\s", source):
+                errors.append(f"{display}: {opaque_id} exposes its raw storage field")
+            if re.search(rf"Display for {opaque_id}\b", source):
+                errors.append(f"{display}: {opaque_id} exposes raw numeric Display")
+
+        for match in OPAQUE_ID_DERIVE.finditer(source):
+            traits = {trait.strip() for trait in match.group("traits").split(",")}
+            if "Ord" in traits or "PartialOrd" in traits:
+                errors.append(
+                    f"{display}: {match.group('id')} exposes raw storage ordering"
+                )
+
+        declarations = [
+            match.group("name") for match in PUBLIC_TYPE_DECLARATION.finditer(source)
+        ]
+        declarations.extend(
+            opaque_id
+            for opaque_id in ("StructId", "EnumId", "ModuleId")
+            if re.search(rf"^pub\s+(?:struct|enum)\s+{opaque_id}\b", source, re.MULTILINE)
+        )
+        for declaration in declarations:
+            key = (crate, relative.as_posix(), declaration)
+            if key not in PUBLIC_TYPE_DECLARATION_ALLOWLIST:
+                errors.append(
+                    f"{display}: unclassified public type representation {declaration!r}"
+                )
+
+        for match in COMPACT_U32_NEWTYPE.finditer(source):
+            key = (crate, relative.as_posix(), match.group("name"))
+            observed_compact_newtypes.add(key)
+            if key not in COMPACT_U32_NEWTYPE_ALLOWLIST:
+                errors.append(
+                    f"{display}: unclassified compact u32 newtype {match.group('name')!r}"
+                )
+
+    if {crate for crate, _ in crate_sources} == set(CONSUMER_CRATES):
+        for key in sorted(set(COMPACT_U32_NEWTYPE_ALLOWLIST) - observed_compact_newtypes):
+            errors.append(
+                "stale compact-u32 classification was not observed: "
+                f"{key[0]}/src/{key[1]}::{key[2]}"
+            )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        metavar="CRATE=PATH",
+        help="scan one Buck-materialized live-type consumer source directory",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    sources = []
+    for item in args.source:
+        crate, separator, path = item.partition("=")
+        if not separator or crate not in CONSUMER_CRATES:
+            parser.error(f"invalid --source {item!r}")
+        sources.append((crate, Path(path).resolve()))
+
+    errors = validate(root, sources or None)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+    print("type architecture inventory valid: one checked live handle across all consumers")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- remove the retired `InternedType` universe, compatibility encoding, and whole-definition overwrite APIs
- make composite category IDs opaque and keep ordering, naming, and raw storage operations pool-owned
- add a glob-backed architecture inventory covering every live-type consumer and mark ADR-0024 implemented

## Validation

- `scripts/rue test`
- `/opt/homebrew/bin/bash ./clippy.sh`
- `scripts/rue fmt`
- `scripts/validate-adrs.py`
- adversarial architectural review: no findings

Fixes RUE-838