### PR TITLE
RUE-945: normalize Darwin syscall errors

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1618,6 +1618,24 @@ impl<'a> CfgLower<'a> {
                 } else {
                     Aarch64Inst::Svc { imm: 0 }
                 });
+                if self.target.is_macho() {
+                    // Darwin reports syscall errors by setting carry and returning
+                    // a positive errno in x0. Normalize that to the negative errno
+                    // convention exposed by @syscall. Keep the flag consumer
+                    // immediately after SVC: both instructions are scheduling
+                    // barriers, so no flag-setting instruction can be moved between
+                    // the kernel return and this test.
+                    let success = self.mir.alloc_label();
+                    self.mir.push(Aarch64Inst::BCond {
+                        cond: Cond::Lo,
+                        label: success,
+                    });
+                    self.mir.push(Aarch64Inst::Neg {
+                        dst: Operand::Physical(Reg::X0),
+                        src: Operand::Physical(Reg::X0),
+                    });
+                    self.mir.push(Aarch64Inst::Label { id: success });
+                }
                 if stack_space > 0 {
                     self.mir.push(Aarch64Inst::AddImm {
                         dst: Operand::Physical(Reg::Sp),

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -673,6 +673,8 @@ mod tests {
         .expect("AArch64 Linux assembly generation should succeed");
         assert_same_machine_code(&linux, &linux_asm_code);
         assert!(linux_asm.contains("svc #0x0"));
+        assert!(!linux_asm.contains("b.lo "));
+        assert!(!linux_asm.contains("neg x0, x0"));
 
         let macos = aarch64::generate(
             &cfg,
@@ -692,6 +694,18 @@ mod tests {
         .expect("AArch64 macOS assembly generation should succeed");
         assert_same_machine_code(&macos, &macos_asm_code);
         assert!(macos_asm.contains("svc #0x80"));
+        let svc = macos_asm
+            .find("svc #0x80")
+            .expect("macOS syscall must use Darwin's SVC immediate");
+        let carry_test = macos_asm[svc..]
+            .find("b.lo ")
+            .map(|offset| svc + offset)
+            .expect("macOS syscall must test for carry clear");
+        let negation = macos_asm[carry_test..]
+            .find("neg x0, x0")
+            .map(|offset| carry_test + offset)
+            .expect("macOS syscall must negate carry-set errno");
+        assert!(svc < carry_test && carry_test < negation);
         assert_ne!(linux.code, macos.code);
     }
 }

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -801,6 +801,12 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "runtime.syscall",
+        "syscall_error_is_negative_aarch64_macos",
+        external(ExternalDependencyKind::SystemCall),
+        &["aarch64-macos"],
+    ),
+    Entry::new(
+        "runtime.syscall",
         "syscall_max_args",
         external(ExternalDependencyKind::SystemCall),
         &["x86-64-linux"],

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3809 rejected=152 lex_invalid=35 accepted_source_ast_sha256=d648754916cd35b973fd8c9fb68286500eb89e761ed376c648fd9504beb9a3e0
+# pre-RUE-905 Chumsky: accepted=3810 rejected=152 lex_invalid=35 accepted_source_ast_sha256=968aae5bce82e53e7fc29ba070c50787d537d746a895595fcc8425d481fb68ed
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca

--- a/crates/rue-spec/cases/runtime/syscall.toml
+++ b/crates/rue-spec/cases/runtime/syscall.toml
@@ -49,6 +49,32 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# Darwin reports a positive errno in x0 with carry set. @syscall normalizes
+# that ABI-specific representation to the negative error convention used on
+# every supported target.
+[[case]]
+name = "syscall_error_is_negative_aarch64_macos"
+spec = ["9.2:4"]
+only_on = ["aarch64-macos"]
+source = """
+fn main() -> i32 {
+    // close(-1) is guaranteed to fail with EBADF. Darwin syscall arguments
+    // are u64, so u64::MAX supplies the all-ones file descriptor value.
+    let close_num: u64 = 6;
+    let invalid_fd: u64 = 18446744073709551615;
+    let result: i64 = checked {
+        @syscall(close_num, invalid_fd)
+    };
+    let zero: i64 = 0;
+    if result < zero {
+        42
+    } else {
+        1
+    }
+}
+"""
+exit_code = 42
+
 # Test that @syscall requires at least one argument (the syscall number)
 [[case]]
 name = "syscall_requires_syscall_number"

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -28,7 +28,10 @@ The `@syscall` intrinsic takes at least one argument (the syscall number) and at
 
 {{ rule(id="9.2:4", cat="dynamic-semantics") }}
 
-The `@syscall` intrinsic returns an `i64` value representing the result of the syscall. On Linux x86-64, negative values typically indicate errors. The exact behavior depends on the syscall being invoked and the platform.
+The `@syscall` intrinsic returns an `i64` value representing the result of the
+syscall. On every supported platform, operating-system syscall errors are
+returned as negative error numbers. Successful return values and the meaning of
+each error number depend on the syscall and platform.
 
 {{ rule(id="9.2:5", cat="informative") }}
 


### PR DESCRIPTION
## What changed

- Normalize aarch64-macos `@syscall` failures from Darwin's carry-set, positive-errno ABI to Rue's negative-errno result convention.
- Keep Linux lowering unchanged and add target-specific assembly assertions for the carry check and negation.
- Add a native aarch64-macos execution regression using guaranteed-failing `close(-1)`.
- Specify the cross-platform negative-error convention and refresh the oracle registry and parser corpus fingerprint.

## Why

The Darwin syscall path copied `x0` after `svc #0x80` but discarded the carry flag. A failed syscall therefore returned a small positive errno, making it indistinguishable from a successful small-valued result. The lowering now branches on carry-clear and negates `x0` only when Darwin reports failure.

The RUE-712 `std.fs` cases referenced by the issue are not present on current `trunk`, so there were no platform gates available to remove in this change.

## Validation

- `scripts/rue fmt`
- `scripts/rue unit codegen aarch64_entry_points_preserve_target_specific_syscall_lowering`
- `scripts/rue spec syscall_error_is_negative_aarch64_macos`
- `RUE_BLESS_DIAGNOSTIC_CORPUS=1 scripts/rue unit parser toml_diagnostic_corpus_matches_snapshot`
- `./buck2 test //crates/rue-oracle-diff:oracle-diff-spec-test`
- `scripts/rue quick`

Fixes RUE-945
