### PR TITLE
RUE-803: pin actionlint image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,10 @@ jobs:
         # A workflow file GitHub can't parse fails every run in 0s with no
         # useful error, and nothing in ./test.sh can see it — benchmarks.yml
         # was broken this way for five months (gh-991). actionlint also
-        # shellchecks all run: blocks.
-        run: docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color
+        # shellchecks all run: blocks. Keep the reviewed release visible next
+        # to its immutable OCI index digest; docs/process/ci.md documents the
+        # update and verification procedure.
+        run: docker run --rm -v "$PWD:/repo:ro" -w /repo rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color -shellcheck=/usr/local/bin/shellcheck
 
   rust-project:
     runs-on: ubuntu-latest

--- a/BUCK
+++ b/BUCK
@@ -97,6 +97,15 @@ filegroup(
     srcs = glob(["docs/designs/**"]),
 )
 
+# Required pull-request and merge-group CI must not execute a moving container
+# tag. Keep this list explicit so the policy follows branch-protection scope
+# rather than accidentally treating an unrelated maintenance workflow as a
+# required check.
+filegroup(
+    name = "required-ci-workflows",
+    srcs = [".github/workflows/ci.yml"],
+)
+
 benchmark_tool_local_inputs = glob(["benchmarks/**"]) + [
         "scripts/append-benchmark.py",
         "scripts/benchmark_collection.py",
@@ -243,6 +252,21 @@ sh_test(
         "--adr-dir",
         "$(location :adr-designs)/docs/designs",
     ],
+)
+
+sh_test(
+    name = "required-ci-container-pin-validation",
+    test = "scripts/validate-required-ci-container-pins.py",
+    args = ["$(location :required-ci-workflows)/.github/workflows/ci.yml"],
+)
+
+sh_test(
+    name = "required-ci-container-pin-tool-tests",
+    test = "scripts/test-required-ci-container-pins.py",
+    resources = ["scripts/validate-required-ci-container-pins.py"],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
 )
 
 sh_test(

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -28,6 +28,7 @@ Each step has a corresponding document in this directory and a Claude Code comma
 | Implement | [implementation.md](implementation.md) | `/implement` | Write code, tests, and spec updates |
 | Review | [code-review.md](code-review.md) | `/code-review` | Check quality before committing |
 | Commit | [committing.md](committing.md) | `/commit` | Create well-formed commits |
+| - | [ci.md](ci.md) | - | Maintain required CI and its pinned tools |
 | - | [tutorial.md](tutorial.md) | - | Maintain tutorial outline, style, and snippet checks |
 | - | [issue-tracking.md](issue-tracking.md) | Linear MCP tools | Track work with Linear |
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -1,0 +1,48 @@
+# Required CI
+
+The `CI` workflow (`.github/workflows/ci.yml`) supplies the required pull-request
+and merge-group checks. Containers executed by that workflow must use a reviewed,
+human-readable release tag and the immutable OCI index digest for that tag. The
+repository gate `//:required-ci-container-pin-validation` rejects a moving
+`latest` image reference, and the normal `./test.sh` run includes that gate.
+
+## Updating actionlint
+
+1. Find the latest stable release and review its notes and Dockerfile:
+
+   ```bash
+   gh release view --repo rhysd/actionlint
+   gh api 'repos/rhysd/actionlint/contents/Dockerfile?ref=v<VERSION>' \
+     --jq .content | base64 --decode
+   ```
+
+   In particular, confirm that the image still installs ShellCheck. actionlint
+   can use the image's `/usr/local/bin/shellcheck` executable to check every
+   `run:` block while it discovers every workflow under `.github/workflows/`.
+
+2. Resolve the reviewed release tag to its multi-platform OCI index digest:
+
+   ```bash
+   docker buildx imagetools inspect docker.io/rhysd/actionlint:<VERSION>
+   ```
+
+   Update the image in `ci.yml` as
+   `rhysd/actionlint:<VERSION>@sha256:<INDEX-DIGEST>`. Keep both parts: the tag
+   records what humans reviewed, while the digest fixes the bytes CI executes.
+
+3. Verify that the pinned image contains ShellCheck, run actionlint exactly as
+   CI does, then run the repository policy and its focused regression tests:
+
+   ```bash
+   docker run --rm --entrypoint /usr/local/bin/shellcheck \
+     rhysd/actionlint:<VERSION>@sha256:<INDEX-DIGEST> --version
+   docker run --rm -v "$PWD:/repo:ro" -w /repo \
+     rhysd/actionlint:<VERSION>@sha256:<INDEX-DIGEST> \
+     -color -shellcheck=/usr/local/bin/shellcheck
+   ./buck2 test //:required-ci-container-pin-validation \
+     //:required-ci-container-pin-tool-tests
+   ```
+
+Both container invocations must finish successfully. Together they verify that
+the image contains ShellCheck and that actionlint checks the `run:` blocks with
+that binary while linting all discovered workflows.

--- a/scripts/test-required-ci-container-pins.py
+++ b/scripts/test-required-ci-container-pins.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Focused tests for the required-CI container pin policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-required-ci-container-pins.py")
+SPEC = importlib.util.spec_from_file_location("required_ci_container_pins", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+pins = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pins)
+
+
+class RequiredCiContainerPinTests(unittest.TestCase):
+    def validate(self, workflow: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ci.yml"
+            path.write_text(workflow)
+            return pins.validate(path)
+
+    def test_rejects_latest_in_docker_run(self) -> None:
+        errors = self.validate(
+            "jobs:\n  lint:\n    steps:\n"
+            "      - run: docker run --rm example/linter:latest@sha256:"
+            + "a" * 64
+            + " -color\n"
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("example/linter:latest", errors[0])
+
+    def test_rejects_latest_in_job_or_service_image(self) -> None:
+        workflow = (
+            "jobs:\n"
+            "  test:\n"
+            "    container:\n      image: rust:latest\n"
+            "    services:\n      db:\n        image: postgres:latest\n"
+        )
+        errors = self.validate(workflow)
+        self.assertEqual(len(errors), 2)
+
+    def test_accepts_release_with_immutable_digest(self) -> None:
+        self.assertEqual(
+            self.validate(
+                "steps:\n"
+                "  - run: docker run example/linter:1.2.3@sha256:"
+                + "a" * 64
+                + " -color\n"
+            ),
+            [],
+        )
+
+    def test_ignores_latest_in_comments_and_quoted_hashes(self) -> None:
+        self.assertEqual(
+            self.validate(
+                "# Never use example/linter:latest here.\n"
+                "env:\n  MESSAGE: \"the # character is data\"\n"
+                "steps:\n  - run: echo ok # example/linter:latest is forbidden\n"
+            ),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-required-ci-container-pins.py
+++ b/scripts/validate-required-ci-container-pins.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Reject moving container image tags in required CI workflows."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_WORKFLOWS = [ROOT / ".github" / "workflows" / "ci.yml"]
+LATEST_IMAGE = re.compile(
+    r"(?P<image>[A-Za-z0-9][A-Za-z0-9._:/-]*:latest)(?=@|\s|[\"']|$)"
+)
+
+
+def uncommented(line: str) -> str:
+    """Remove a YAML/shell comment while preserving hashes inside quotes."""
+
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\" and quote == '"':
+            escaped = True
+            continue
+        if character in "\"'":
+            if quote is None:
+                quote = character
+            elif quote == character:
+                quote = None
+            continue
+        if character == "#" and quote is None and (index == 0 or line[index - 1].isspace()):
+            return line[:index]
+    return line
+
+
+def validate(path: Path) -> list[str]:
+    errors: list[str] = []
+    for line_number, line in enumerate(path.read_text().splitlines(), 1):
+        for match in LATEST_IMAGE.finditer(uncommented(line)):
+            errors.append(
+                f"{path}:{line_number}: required CI container {match.group('image')!r} "
+                "uses the moving latest tag; use <release>@sha256:<digest>"
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workflows", nargs="*", type=Path)
+    args = parser.parse_args()
+
+    workflows = args.workflows or DEFAULT_WORKFLOWS
+    errors = [error for path in workflows for error in validate(path)]
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"required CI container pins valid: {len(workflows)} workflow(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- pin the actionlint CI image to reviewed release 1.7.12 and its immutable OCI index digest
- keep ShellCheck explicit and mount the repository read-only
- add a required-CI policy gate and focused regression tests rejecting `:latest`
- document the release, digest, and verification update procedure

## Validation

- `./buck2 test //:required-ci-container-pin-validation //:required-ci-container-pin-tool-tests`
- `scripts/rue quick`
- pinned actionlint image linted all 6 workflow files with ShellCheck and reported 0 errors
- verified `rhysd/actionlint:1.7.12` resolves to the committed OCI index digest
- `git diff --check`

Fixes RUE-803
