### PR TITLE
RUE-790: make RIR payload reads zero-allocation

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1881,7 +1881,7 @@ impl<'a> ConstraintGenerator<'a> {
                 // errors when arms disagree). This is a strict subset of the
                 // scrutinees sema prunes, so the selected arm always has an
                 // inferred type when sema later prunes to it.
-                if let Some(selected) = self.comptime_selected_arm(*scrutinee, &arms) {
+                if let Some(selected) = self.comptime_selected_arm(*scrutinee, arms.iter()) {
                     self.enter_scope(ctx);
                     let body_info = self.generate(selected, ctx);
                     self.exit_scope(ctx);
@@ -1893,7 +1893,7 @@ impl<'a> ConstraintGenerator<'a> {
                 let mut arm_types: Vec<ExprInfo> = Vec::new();
                 for (pattern, body) in arms.iter() {
                     // Patterns constrain the scrutinee type
-                    let pattern_ty = self.pattern_type(pattern);
+                    let pattern_ty = self.pattern_type(&pattern);
                     self.add_constraint(Constraint::equal(
                         scrutinee_info.ty.clone(),
                         pattern_ty,
@@ -1906,14 +1906,14 @@ impl<'a> ConstraintGenerator<'a> {
                     // (RUE-221). Without this, `Circle(r) => r` leaves `r`
                     // unbound and its type poisons the match result.
                     self.enter_scope(ctx);
-                    if let rue_rir::RirPattern::Path {
+                    if let rue_rir::RirPatternView::Path {
                         module,
                         type_name,
                         variant,
                         bindings,
                         span: pat_span,
                         ..
-                    } = pattern
+                    } = &pattern
                     {
                         if !bindings.is_empty() {
                             // NOTE: an inline type-constructor pattern head
@@ -1939,7 +1939,7 @@ impl<'a> ConstraintGenerator<'a> {
                                 for (i, bname) in bindings.iter().enumerate() {
                                     // A `_` payload (RUE-601) binds nothing —
                                     // skip registering a local for it.
-                                    if self.interner.resolve(bname) == "_" {
+                                    if self.interner.resolve(&bname) == "_" {
                                         continue;
                                     }
                                     if let Some(&pty) = payload.get(i) {
@@ -1958,7 +1958,7 @@ impl<'a> ConstraintGenerator<'a> {
                     }
 
                     // Generate body and collect its type
-                    let body_info = self.generate(*body, ctx);
+                    let body_info = self.generate(body, ctx);
                     self.exit_scope(ctx);
                     arm_types.push(body_info);
                 }
@@ -2047,9 +2047,9 @@ impl<'a> ConstraintGenerator<'a> {
                     // field's width instead of silently wrapping
                     // (`S { a: 300 }` with a: u8 used to truncate to 44).
                     // (RUE-72)
-                    for (field_name, value_ref) in fields.iter() {
-                        let value_info = self.generate(*value_ref, ctx);
-                        if let Some(field_ty) = self.field_type_of(struct_ty, *field_name) {
+                    for (field_name, value_ref) in fields.values() {
+                        let value_info = self.generate(value_ref, ctx);
+                        if let Some(field_ty) = self.field_type_of(struct_ty, field_name) {
                             let expected = self.type_to_infer(field_ty);
                             // A `str` field (ADR-0043 Phase 3, RUE-324) accepts a
                             // string literal (HM type `String`) by coercion; skip
@@ -2070,8 +2070,8 @@ impl<'a> ConstraintGenerator<'a> {
                     // skipping them left compound initializers (`-1`, `1+2`)
                     // with unresolved variables, which sema then reported as
                     // an internal compiler error (RUE-170).
-                    for (_, value_ref) in fields.iter() {
-                        self.generate(*value_ref, ctx);
+                    for (_, value_ref) in fields.values() {
+                        self.generate(value_ref, ctx);
                     }
                     InferType::Concrete(Type::ERROR)
                 }
@@ -2239,7 +2239,7 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                 } else {
                     // Get element type from first element, constrain rest to match
-                    let first_info = self.generate(elements[0], ctx);
+                    let first_info = self.generate(elements.get(0).unwrap(), ctx);
                     for elem_ref in elements.iter().skip(1) {
                         let elem_info = self.generate(*elem_ref, ctx);
                         self.add_constraint(Constraint::equal(
@@ -3134,16 +3134,16 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     /// Get the inferred type for a pattern.
-    fn pattern_type(&mut self, pattern: &rue_rir::RirPattern) -> InferType {
+    fn pattern_type(&mut self, pattern: &rue_rir::RirPatternView<'_>) -> InferType {
         match pattern {
-            rue_rir::RirPattern::Wildcard(_) => {
+            rue_rir::RirPatternView::Wildcard(_) => {
                 // Wildcard matches anything - use a fresh type variable
                 let var = self.fresh_var();
                 InferType::Var(var)
             }
-            rue_rir::RirPattern::Int { .. } => InferType::IntLiteral,
-            rue_rir::RirPattern::Bool(_, _) => InferType::Concrete(Type::BOOL),
-            rue_rir::RirPattern::Path {
+            rue_rir::RirPatternView::Int { .. } => InferType::IntLiteral,
+            rue_rir::RirPatternView::Bool(_, _) => InferType::Concrete(Type::BOOL),
+            rue_rir::RirPatternView::Path {
                 module, type_name, ..
             } => {
                 let enum_ty = module
@@ -3391,12 +3391,12 @@ impl<'a> ConstraintGenerator<'a> {
     /// handled here are a strict subset of those sema prunes with the same
     /// value and patterns, so whenever this prunes, sema also prunes to the
     /// *same* arm — the only arm whose body inference generated a type for.
-    fn comptime_selected_arm(
+    fn comptime_selected_arm<'r>(
         &self,
         scrutinee: InstRef,
-        arms: &[(rue_rir::RirPattern, InstRef)],
+        arms: impl Iterator<Item = (rue_rir::RirPatternView<'r>, InstRef)>,
     ) -> Option<InstRef> {
-        use rue_rir::RirPattern;
+        use rue_rir::RirPatternView as RirPattern;
 
         // Only prune inside a specialization that has comptime value params in
         // scope (mirrors sema's `!ctx.comptime_value_vars.is_empty()` gate in
@@ -3413,7 +3413,7 @@ impl<'a> ConstraintGenerator<'a> {
         let mut bool_true_covered = false;
         let mut bool_false_covered = false;
         for (pattern, body) in arms {
-            let matched = match pattern {
+            let matched = match &pattern {
                 RirPattern::Wildcard(_) => {
                     has_wildcard = true;
                     true
@@ -3449,7 +3449,7 @@ impl<'a> ConstraintGenerator<'a> {
                 _ => return None,
             };
             if matched && selected.is_none() {
-                selected = Some(*body);
+                selected = Some(body);
             }
         }
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -17,7 +17,7 @@ use rue_error::{
     CompileError, CompileErrors, CompileResult, CompileWarning, ErrorKind,
     IntrinsicTypeMismatchError, MultiErrorResult, OptionExt, PreviewFeature, WarningKind,
 };
-use rue_rir::{InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective, RirParamMode};
+use rue_rir::{InstData, InstRef, Rir, RirArgMode, RirCallArg, RirParamMode};
 use rue_span::{FileId, Span};
 use rue_target::{Arch, Os};
 
@@ -1231,7 +1231,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 &infer_ctx,
                 &fn_name_str,
                 return_type,
-                &params,
+                params.values(),
                 body,
                 span,
                 fn_info.allow_unused_variable,
@@ -1672,7 +1672,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 &infer_ctx,
                 &full_name,
                 *return_type,
-                &params,
+                params.values(),
                 *body,
                 method_inst.span,
                 method_info.struct_type,
@@ -2412,16 +2412,21 @@ pub(crate) fn root_variable_of(rir: &Rir, inst_ref: InstRef) -> Option<Spur> {
 ///
 /// The law of exclusivity: either one mutable (inout) access OR any number of
 /// immutable (borrow) accesses, never both simultaneously.
-fn check_exclusive_access_in(
+fn check_exclusive_access_in<A>(
     rir: &Rir,
     interner: &ThreadedRodeo,
-    args: &[RirCallArg],
+    args: A,
     call_span: Span,
-) -> CompileResult<()> {
+) -> CompileResult<()>
+where
+    A: IntoIterator,
+    A::Item: std::ops::Deref<Target = RirCallArg>,
+{
     let mut inout_vars: HashSet<Spur> = HashSet::new();
     let mut borrow_vars: HashSet<Spur> = HashSet::new();
 
     for arg in args {
+        let arg = &*arg;
         let maybe_var_symbol = root_variable_of(rir, arg.value);
 
         // Check that inout/borrow arguments are lvalues
@@ -2492,7 +2497,7 @@ fn check_module_member_call(
     member_file_id: FileId,
     fn_name_str: &str,
     param_types: &[Type],
-    args: &[RirCallArg],
+    argument_count: usize,
     accessible: bool,
     via_reexport: bool,
     span: Span,
@@ -2523,11 +2528,11 @@ fn check_module_member_call(
     }
 
     // Check argument count
-    if args.len() != param_types.len() {
+    if argument_count != param_types.len() {
         return Err(CompileError::new(
             ErrorKind::WrongArgumentCount {
                 expected: param_types.len(),
-                found: args.len(),
+                found: argument_count,
             },
             span,
         ));

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -294,7 +294,7 @@ impl<'a> BodySema<'a> {
             .with_help(format!("`{fn_name}` takes exactly one text argument")));
         }
         self.validate_explicit_call_modes(&args, std::iter::once(RirParamMode::Normal))?;
-        let arg_value = args[0].value;
+        let arg_value = args.get(0).unwrap().value;
 
         // Borrow the argument (like a `+` operand): analyze in projection mode
         // and cancel any move marker so a variable operand is not consumed and

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -379,7 +379,7 @@ impl<'a> BodySema<'a> {
                         RirArgMode::Borrow
                     },
                 });
-                excl_args.extend(args.iter().cloned());
+                excl_args.extend(args.iter().map(|arg| *arg));
                 self.check_exclusive_access(&excl_args, span)?;
 
                 // By-ref receivers are borrows, not moves. The receiver was
@@ -425,7 +425,7 @@ impl<'a> BodySema<'a> {
         }
         let args_result = self.analyze_call_args_coerced(
             air,
-            &args,
+            args.values(),
             &method_param_types,
             &method_param_modes,
             ctx,
@@ -556,7 +556,7 @@ impl<'a> BodySema<'a> {
             fn_info.file_id,
             &fn_name_str,
             &param_types,
-            &args,
+            args.len(),
             accessible,
             via_reexport,
             span,
@@ -596,7 +596,7 @@ impl<'a> BodySema<'a> {
         // calls do (RUE-559) — std functions taking `borrow s: str` are called
         // this way.
         let air_args =
-            self.analyze_call_args_coerced(air, &args, &param_types, &param_modes, ctx)?;
+            self.analyze_call_args_coerced(air, args.values(), &param_types, &param_modes, ctx)?;
 
         // Inference cannot recover the defining file for a function-local
         // `let m = @import(...)`: the intrinsic deliberately carries an
@@ -777,7 +777,7 @@ impl<'a> BodySema<'a> {
         // source modes remain Borrow (RUE-634).
         let air_args = self.analyze_call_args_coerced(
             air,
-            &args,
+            args.values(),
             &method_param_types,
             &method_param_modes,
             ctx,

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -6,12 +6,12 @@
 use super::*;
 
 impl<'a> BodySema<'a> {
-    pub(super) fn analyze_single_function(
+    pub(super) fn analyze_single_function<P>(
         &mut self,
         infer_ctx: &InferenceContext,
         fn_name: &str,
         return_type: Spur,
-        params: &[rue_rir::RirParam],
+        params: P,
         body: InstRef,
         span: Span,
         allow_unused_variable: bool,
@@ -22,12 +22,14 @@ impl<'a> BodySema<'a> {
         Vec<String>,
         HashSet<Spur>,
         HashSet<(StructId, Spur)>,
-    )> {
+    )>
+    where
+        P: ExactSizeIterator<Item = rue_rir::RirParam> + Clone,
+    {
         let ret_type = self.resolve_type(return_type, span)?;
 
         // Resolve parameter types and modes
         let param_info: Vec<(Spur, Type, RirParamMode, bool)> = params
-            .iter()
             .map(|p| {
                 let ty = self.resolve_type(p.ty, span)?;
                 // spec 4.14:5 — a parameter of type `type` must be marked
@@ -79,12 +81,12 @@ impl<'a> BodySema<'a> {
     /// The `infer_ctx` provides pre-computed type information for constraint generation.
     ///
     /// Returns the analyzed function, any warnings, and local strings collected during analysis.
-    pub(super) fn analyze_method_function(
+    pub(super) fn analyze_method_function<P>(
         &mut self,
         infer_ctx: &InferenceContext,
         full_name: &str,
         return_type: Spur,
-        params: &[rue_rir::RirParam],
+        params: P,
         body: InstRef,
         span: Span,
         struct_type: Type,
@@ -96,7 +98,10 @@ impl<'a> BodySema<'a> {
         Vec<String>,
         HashSet<Spur>,
         HashSet<(StructId, Spur)>,
-    )> {
+    )>
+    where
+        P: ExactSizeIterator<Item = rue_rir::RirParam> + Clone,
+    {
         // `Self` in a method signature (return or parameter position) resolves
         // to the enclosing struct's type, just like the receiver (RUE-123).
         let ret_type = self.resolve_type_with_self(return_type, struct_type, span)?;
@@ -112,7 +117,7 @@ impl<'a> BodySema<'a> {
         }
 
         // Add regular parameters with their modes
-        for p in params.iter() {
+        for p in params {
             let ty = self.resolve_type_with_self(p.ty, struct_type, span)?;
             // spec 4.14:5 — a parameter of type `type` must be marked
             // `comptime` (RUE-217); reject the runtime-`type` case cleanly

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -34,9 +34,9 @@ impl FirstClassStrSite {
 
 impl<'a> BodySema<'a> {
     /// Check if directives contain @allow for a specific warning name.
-    pub(crate) fn has_allow_directive(
+    pub(crate) fn has_allow_directive<'r>(
         &self,
-        directives: &[RirDirective],
+        directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
         warning_name: &str,
     ) -> bool {
         let allow_sym = self.interner.get("allow");
@@ -638,11 +638,11 @@ impl<'a> BodySema<'a> {
 
     /// Check exclusivity rules for inout and borrow parameters in a call
     /// (adapter over the shared [`check_exclusive_access_in`], RUE-141).
-    pub(crate) fn check_exclusive_access(
-        &self,
-        args: &[RirCallArg],
-        call_span: Span,
-    ) -> CompileResult<()> {
+    pub(crate) fn check_exclusive_access<A>(&self, args: A, call_span: Span) -> CompileResult<()>
+    where
+        A: IntoIterator,
+        A::Item: std::ops::Deref<Target = RirCallArg>,
+    {
         check_exclusive_access_in(self.rir, self.interner, args, call_span)
     }
 
@@ -839,18 +839,21 @@ impl<'a> BodySema<'a> {
     /// through the existing by-value aggregate ABI (the parameter is by-value —
     /// see [`crate::sema::Sema`] parameter setup). All other arguments retain
     /// the ordinary by-value/by-reference analysis in this same chokepoint.
-    pub(crate) fn analyze_call_args_coerced(
+    pub(crate) fn analyze_call_args_coerced<A>(
         &mut self,
         air: &mut Air,
-        args: &[RirCallArg],
+        args: A,
         param_types: &[Type],
         param_modes: &[RirParamMode],
         ctx: &mut AnalysisContext,
-    ) -> CompileResult<Vec<AirCallArg>> {
+    ) -> CompileResult<Vec<AirCallArg>>
+    where
+        A: ExactSizeIterator<Item = rue_rir::RirCallArg> + Clone,
+    {
         // Loan-frame discipline (RUE-523): a by-value move of a root this call
         // passes `inout`/`borrow` conflicts in either argument order.
         let frame: Vec<(Spur, CallLoanKind)> = args
-            .iter()
+            .clone()
             .filter_map(|arg| {
                 let kind = if arg.is_inout() {
                     CallLoanKind::Inout
@@ -875,16 +878,19 @@ impl<'a> BodySema<'a> {
 
     /// The argument loop behind [`Sema::analyze_call_args_coerced`], factored
     /// out so the loan frame is popped on every exit path.
-    fn analyze_call_args_coerced_inner(
+    fn analyze_call_args_coerced_inner<A>(
         &mut self,
         air: &mut Air,
-        args: &[RirCallArg],
+        args: A,
         param_types: &[Type],
         param_modes: &[RirParamMode],
         ctx: &mut AnalysisContext,
-    ) -> CompileResult<Vec<AirCallArg>> {
+    ) -> CompileResult<Vec<AirCallArg>>
+    where
+        A: ExactSizeIterator<Item = rue_rir::RirCallArg>,
+    {
         let mut air_args = Vec::with_capacity(args.len());
-        for (i, arg) in args.iter().enumerate() {
+        for (i, arg) in args.enumerate() {
             // A `str` parameter (ADR-0043 Phase 3, RUE-324) is a first-class
             // 2-word value, not a `borrow`-materialized fat pointer. A string
             // literal argument materializes as a `str` under the expected type;
@@ -915,7 +921,7 @@ impl<'a> BodySema<'a> {
                 // rejected non-lvalue `borrow` arguments (E0427) before
                 // argument analysis began.
                 if arg.is_borrow() && self.is_str_struct(str_ty) {
-                    let value = self.coerce_borrow_str_place_to_view(air, arg, str_ty, ctx)?;
+                    let value = self.coerce_borrow_str_place_to_view(air, &arg, str_ty, ctx)?;
                     air_args.push(AirCallArg {
                         value,
                         // The 2-word view is passed BY VALUE (multi-slot
@@ -974,7 +980,7 @@ impl<'a> BodySema<'a> {
                 .is_some_and(|pt| self.slice_element_type(*pt).is_some());
             if is_slice_param && !is_inout_str_param && !is_exact_str_fixed_ref {
                 let slice_ty = param_types[i];
-                let value = self.coerce_borrow_array_to_slice(air, arg, slice_ty, ctx)?;
+                let value = self.coerce_borrow_array_to_slice(air, &arg, slice_ty, ctx)?;
                 air_args.push(AirCallArg {
                     value,
                     // The fat pointer is passed BY VALUE (multi-slot aggregate).
@@ -984,7 +990,7 @@ impl<'a> BodySema<'a> {
             }
 
             let byref_root = if arg.is_inout() || arg.is_borrow() {
-                let root = require_byref_place_arg(self.rir, arg)?;
+                let root = require_byref_place_arg(self.rir, &arg)?;
                 if arg.is_inout()
                     && !ctx.locals.contains_key(&root)
                     && ctx

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -27,7 +27,7 @@ use rue_error::{
     CompileError, CompileResult, CompileWarning, ErrorKind, MissingFieldsError, OptionExt,
     PreviewFeature, WarningKind,
 };
-use rue_rir::{InstData, InstRef, RirParamMode, RirPattern};
+use rue_rir::{InstData, InstRef, RirParamMode, RirPatternView as RirPattern};
 
 use crate::sema::context::ConstValue;
 use rue_span::Span;
@@ -1286,9 +1286,9 @@ impl<'a> BodySema<'a> {
     ///
     /// The warning shapes and messages mirror the normal per-arm loop exactly,
     /// so a pruned match and an ordinary match report identical diagnostics.
-    fn warn_unreachable_pruned_arms(
+    fn warn_unreachable_pruned_arms<'r>(
         &self,
-        arms: &[(RirPattern, InstRef)],
+        arms: impl Iterator<Item = (rue_rir::RirPatternView<'r>, InstRef)>,
         scrutinee_type: Type,
         ctx: &mut AnalysisContext,
     ) {
@@ -1301,7 +1301,7 @@ impl<'a> BodySema<'a> {
 
             // Any arm after a wildcard is unreachable.
             if let Some(first_wildcard_span) = wildcard_span {
-                let pat_str = match pattern {
+                let pat_str = match &pattern {
                     RirPattern::Wildcard(_) => "_".to_string(),
                     RirPattern::Int {
                         value, negative, ..
@@ -1331,7 +1331,7 @@ impl<'a> BodySema<'a> {
                 continue;
             }
 
-            match pattern {
+            match &pattern {
                 RirPattern::Wildcard(_) => {
                     // A `_` after both booleans are already covered is
                     // unreachable. An integer scrutinee is never fully covered
@@ -1442,8 +1442,8 @@ impl<'a> BodySema<'a> {
                 let mut has_wildcard = false;
                 let mut bool_true_covered = false;
                 let mut bool_false_covered = false;
-                for (pattern, body) in &arms {
-                    let matched = match (pattern, &value) {
+                for (pattern, body) in arms.iter() {
+                    let matched = match (&pattern, &value) {
                         (RirPattern::Wildcard(_), _) => {
                             has_wildcard = true;
                             true
@@ -1477,7 +1477,7 @@ impl<'a> BodySema<'a> {
                         }
                     };
                     if matched && selected.is_none() {
-                        selected = Some(*body);
+                        selected = Some(body);
                     }
                 }
                 // Exhaustiveness is a property of the pattern set, not of
@@ -1507,12 +1507,12 @@ impl<'a> BodySema<'a> {
                     let scrutinee_type =
                         Self::get_resolved_type(ctx, scrutinee, span, "match scrutinee")?;
                     if scrutinee_type.is_integer() {
-                        for (pattern, _) in &arms {
+                        for (pattern, _) in arms.iter() {
                             if let RirPattern::Int {
                                 value: magnitude,
                                 negative,
                                 ..
-                            } = pattern
+                            } = &pattern
                             {
                                 self.check_pattern_int(
                                     *magnitude,
@@ -1531,7 +1531,7 @@ impl<'a> BodySema<'a> {
                     // skipped by the early return, so run them here. Only
                     // pattern shapes are inspected — no arm body is analyzed,
                     // honoring 4.14:19.
-                    self.warn_unreachable_pruned_arms(&arms, scrutinee_type, ctx);
+                    self.warn_unreachable_pruned_arms(arms.iter(), scrutinee_type, ctx);
                     if let Some(body) = selected {
                         ctx.push_scope();
                         let result = self.analyze_inst(air, body, ctx)?;
@@ -1551,7 +1551,7 @@ impl<'a> BodySema<'a> {
         // are ignored — pattern legality is checked on the normal path below.
         let arms_for_expected = self.rir.get_match_arms(arms_start, arms_len);
         let expected_scrutinee = arms_for_expected.iter().find_map(|(pattern, _)| {
-            if let RirPattern::Path { type_name, .. } = pattern {
+            if let RirPattern::Path { type_name, .. } = &pattern {
                 self.resolve_type_with_ctx(*type_name, span, ctx)
                     .ok()
                     .filter(|ty| ty.is_enum())
@@ -1631,7 +1631,7 @@ impl<'a> BodySema<'a> {
 
             // If we've seen a wildcard, everything after is unreachable
             if let Some(first_wildcard_span) = wildcard_span {
-                let pat_str = match pattern {
+                let pat_str = match &pattern {
                     RirPattern::Wildcard(_) => "_".to_string(),
                     RirPattern::Int {
                         value, negative, ..
@@ -1666,7 +1666,7 @@ impl<'a> BodySema<'a> {
             }
 
             // Validate pattern against scrutinee type and check for duplicates
-            match pattern {
+            match &pattern {
                 RirPattern::Wildcard(_) => {
                     // A `_` arm after the preceding arms already cover every
                     // value (both bools, or every enum variant) is unreachable
@@ -1864,7 +1864,7 @@ impl<'a> BodySema<'a> {
             // The enclosing match dispatched on the discriminant, so in this
             // arm the payload is read (move mode) via `EnumPayloadGet`.
             let mut binding_stmts =
-                self.materialize_match_bindings(air, pattern, scrutinee_result.air_ref, ctx)?;
+                self.materialize_match_bindings(air, &pattern, scrutinee_result.air_ref, ctx)?;
 
             // RUE-238: a non-binding arm (a wildcard `_`, or a variant matched
             // without binding its payload) still *consumes* the scrutinee — the
@@ -1890,7 +1890,7 @@ impl<'a> BodySema<'a> {
             }
 
             // Analyze arm body
-            let body_result = self.analyze_inst(air, *body, ctx)?;
+            let body_result = self.analyze_inst(air, body, ctx)?;
             let body_type = body_result.ty;
 
             ctx.pop_scope();
@@ -1909,7 +1909,7 @@ impl<'a> BodySema<'a> {
                         return Err(self.type_mismatch_error(
                             prev,
                             body_type,
-                            self.rir.get(*body).span,
+                            self.rir.get(body).span,
                         ));
                     } else {
                         prev
@@ -1918,7 +1918,7 @@ impl<'a> BodySema<'a> {
             });
 
             // Convert pattern to AIR pattern
-            let air_pattern = match pattern {
+            let air_pattern = match &pattern {
                 RirPattern::Wildcard(_) => AirPattern::Wildcard,
                 RirPattern::Int {
                     value, negative, ..
@@ -2428,13 +2428,13 @@ impl<'a> BodySema<'a> {
         // rather than losing a field (RUE-269). The `_` discard (RUE-601) is
         // exempt: it binds nothing, so any number may repeat (`Rect(_, _)`).
         for (i, name) in bindings.iter().enumerate() {
-            if self.interner.resolve(name) == "_" {
+            if self.interner.resolve(&name) == "_" {
                 continue;
             }
-            if bindings[..i].contains(name) {
+            if bindings.values().take(i).any(|existing| existing == *name) {
                 return Err(CompileError::new(
                     ErrorKind::DuplicatePatternBinding {
-                        name: self.interner.resolve(name).to_string(),
+                        name: self.interner.resolve(&name).to_string(),
                     },
                     pattern_span,
                 ));
@@ -2449,7 +2449,7 @@ impl<'a> BodySema<'a> {
             // discriminant-only match on a payload-carrying variant. The
             // enumerate index `i` still tracks the real field position for the
             // other bindings.
-            if self.interner.resolve(binding_name) == "_" {
+            if self.interner.resolve(&binding_name) == "_" {
                 continue;
             }
             let field_ty = payload[i];
@@ -2879,7 +2879,7 @@ impl<'a> BodySema<'a> {
 
         // Check if @allow(unused_variable) directive is present
         let directives = self.rir.get_directives(directives_start, directives_len);
-        let allow_unused = self.has_allow_directive(&directives, "unused_variable");
+        let allow_unused = self.has_allow_directive(directives.iter(), "unused_variable");
 
         // Allocate slots
         let slot = ctx.next_slot;
@@ -3724,8 +3724,8 @@ impl<'a> BodySema<'a> {
 
         // Check for unknown or duplicate fields
         let mut seen_fields = std::collections::HashSet::new();
-        for (init_field_name, _) in field_inits.iter() {
-            let init_name = self.interner.resolve(&*init_field_name);
+        for (init_field_name, _) in field_inits.values() {
+            let init_name = self.interner.resolve(&init_field_name);
 
             if !field_index_map.contains_key(init_name) {
                 return Err(CompileError::new(
@@ -3769,15 +3769,15 @@ impl<'a> BodySema<'a> {
         let mut analyzed_fields: Vec<Option<AirRef>> = vec![None; struct_def.fields.len()];
         let mut source_order: Vec<usize> = Vec::with_capacity(field_inits.len());
 
-        for (init_field_name, field_value) in field_inits.iter() {
-            let init_name = self.interner.resolve(&*init_field_name);
+        for (init_field_name, field_value) in field_inits.values() {
+            let init_name = self.interner.resolve(&init_field_name);
             let field_idx = field_index_map[init_name];
             let expected_field_type = struct_def.fields[field_idx].ty;
 
             // Check if this is an integer literal that needs type coercion
             // This handles the case where HM inference couldn't resolve the type
             // (e.g., when the struct comes from a comptime type variable)
-            let field_inst = self.rir.get(*field_value);
+            let field_inst = self.rir.get(field_value);
             let field_result = if let InstData::IntConst(value) = &field_inst.data {
                 // Integer literal - use the expected field type directly, but
                 // range-check it first because this shortcut bypasses
@@ -3804,12 +3804,12 @@ impl<'a> BodySema<'a> {
                 // materializes as a static-backed 2-word `str` (first-class,
                 // storable in a struct) rather than a 3-word `String`.
                 let prev_expected = ctx.expected_type.replace(expected_field_type);
-                let r = self.analyze_inst(air, *field_value, ctx);
+                let r = self.analyze_inst(air, field_value, ctx);
                 ctx.expected_type = prev_expected;
                 r?
             } else {
                 // Not an integer literal - analyze normally
-                self.analyze_inst(air, *field_value, ctx)?
+                self.analyze_inst(air, field_value, ctx)?
             };
 
             // Two-types model (ADR-0043, RUE-386): storing into a first-class
@@ -3820,7 +3820,7 @@ impl<'a> BodySema<'a> {
             // `str`); only the same-typed view needs this dedicated check.
             if self.is_str_struct(expected_field_type) {
                 self.reject_non_first_class_str(
-                    *field_value,
+                    field_value,
                     field_result.ty,
                     FirstClassStrSite::Field,
                     span,
@@ -5003,7 +5003,7 @@ impl<'a> BodySema<'a> {
         // the comptime-only `type`, would reach the intern pool and panic
         // (RUE-253).
         for elem_ref in &elem_refs {
-            if let Some(elem_ty) = ctx.resolved_types.get(elem_ref).copied() {
+            if let Some(elem_ty) = ctx.resolved_types.get(&elem_ref).copied() {
                 self.reject_non_runtime_array_element(elem_ty, span)?;
             }
         }
@@ -6272,7 +6272,7 @@ impl<'a> BodySema<'a> {
                 if !*is_comptime {
                     continue;
                 }
-                let value = self.evaluate_const_in_fn(args[i].value, ctx)?;
+                let value = self.evaluate_const_in_fn(args.get(i).unwrap().value, ctx)?;
                 if param_comptime_type[i] {
                     match value {
                         Some(ConstValue::Type(ty)) => {
@@ -6287,7 +6287,7 @@ impl<'a> BodySema<'a> {
                                     reason: "comptime type parameter must be a type literal"
                                         .to_string(),
                                 },
-                                self.rir.get(args[i].value).span,
+                                self.rir.get(args.get(i).unwrap().value).span,
                             ));
                         }
                         None => {
@@ -6295,7 +6295,7 @@ impl<'a> BodySema<'a> {
                                 ErrorKind::ComptimeArgNotConst {
                                     param_name: self.interner.resolve(&param_names[i]).to_string(),
                                 },
-                                self.rir.get(args[i].value).span,
+                                self.rir.get(args.get(i).unwrap().value).span,
                             ));
                         }
                     }
@@ -6306,7 +6306,7 @@ impl<'a> BodySema<'a> {
                         ErrorKind::ComptimeArgNotConst {
                             param_name: self.interner.resolve(&param_names[i]).to_string(),
                         },
-                        self.rir.get(args[i].value).span,
+                        self.rir.get(args.get(i).unwrap().value).span,
                     ));
                 }
             }
@@ -6365,7 +6365,7 @@ impl<'a> BodySema<'a> {
         // Analyze all arguments. Slice parameters (ADR-0043, RUE-322) coerce a
         // `borrow arr` argument into a by-value fat pointer here.
         let air_args =
-            self.analyze_call_args_coerced(air, &args, &param_types, &param_modes, ctx)?;
+            self.analyze_call_args_coerced(air, args.values(), &param_types, &param_modes, ctx)?;
 
         // Handle generic function calls differently
         if is_generic {
@@ -6419,7 +6419,7 @@ impl<'a> BodySema<'a> {
                         // a compile-time constant (RUE-166). The argument is
                         // still also passed at runtime (value parameters are
                         // not erased from the signature).
-                        match self.try_evaluate_const_in_fn(args[i].value, ctx) {
+                        match self.try_evaluate_const_in_fn(args.get(i).unwrap().value, ctx) {
                             Some(const_val) => {
                                 value_args.push(const_val);
                                 value_subst.insert(param_names[i], const_val);
@@ -6430,7 +6430,7 @@ impl<'a> BodySema<'a> {
                                     ErrorKind::ComptimeArgNotConst {
                                         param_name: param_name.clone(),
                                     },
-                                    self.rir.get(args[i].value).span,
+                                    self.rir.get(args.get(i).unwrap().value).span,
                                 )
                                 .with_help(format!(
                                     "parameter '{}' is declared as 'comptime' and requires \
@@ -6478,7 +6478,7 @@ impl<'a> BodySema<'a> {
                             expected: expected.safe_name_with_pool(Some(&self.type_pool)),
                             found: found.safe_name_with_pool(Some(&self.type_pool)),
                         },
-                        self.rir.get(args[i].value).span,
+                        self.rir.get(args.get(i).unwrap().value).span,
                     ));
                 }
             }
@@ -6506,7 +6506,9 @@ impl<'a> BodySema<'a> {
                     if *is_comptime && !param_comptime_type[i] {
                         // This is a comptime VALUE parameter - extract its const value
                         // (evaluated in the calling function's context)
-                        if let Some(const_val) = self.try_evaluate_const_in_fn(args[i].value, ctx) {
+                        if let Some(const_val) =
+                            self.try_evaluate_const_in_fn(args.get(i).unwrap().value, ctx)
+                        {
                             value_subst.insert(param_names[i], const_val);
                         }
                     }

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -490,8 +490,8 @@ impl<'a> DeclarationShells<'a> {
                         .sema
                         .rir
                         .get_field_decls(*fields_start, *fields_len)
-                        .iter()
-                        .map(|(name, _)| self.sema.interner.resolve(name))
+                        .values()
+                        .map(|(name, _)| self.sema.interner.resolve(&name))
                         .ne(fields.iter().map(|field| field.0.as_ref()))
                     {
                         return Err(DeclarationInstallFailure::NominalShapeMismatch);
@@ -678,13 +678,13 @@ impl<'a> DeclarationShells<'a> {
                             .get_directives(*directives_start, *directives_len);
                         let allow_unused_function = self
                             .sema
-                            .has_allow_directive(&directives, "unused_function");
+                            .has_allow_directive(directives.iter(), "unused_function");
                         let allow_unused_variable = self
                             .sema
-                            .has_allow_directive(&directives, "unused_variable");
+                            .has_allow_directive(directives.iter(), "unused_variable");
                         let allow_unreachable_code = self
                             .sema
-                            .has_allow_directive(&directives, "unreachable_code");
+                            .has_allow_directive(directives.iter(), "unreachable_code");
                         self.sema
                             .functions_by_file_name
                             .insert((pending.shell.declaration_span.file_id, *name), internal);

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -51,7 +51,7 @@ use std::sync::LazyLock;
 
 use lasso::{Key, Spur};
 use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
-use rue_rir::{InstData, InstRef, RepeatCount, RirPattern};
+use rue_rir::{InstData, InstRef, RepeatCount};
 use rue_span::{FileId, Span};
 
 use super::context::{AnalysisContext, ConstValue, LocalVar, ParamInfo};
@@ -228,14 +228,14 @@ impl<'a> ComptimeEnv<'a> {
 /// - `None` — the match can't be decided at compile time here (an enum-variant
 ///   `Path` pattern, or a scrutinee whose kind the pattern can't compare
 ///   against), so the caller treats the whole `match` as non-evaluable.
-fn const_pattern_matches(pattern: &RirPattern, scrut: ConstValue) -> Option<bool> {
+fn const_pattern_matches(pattern: &rue_rir::RirPatternView<'_>, scrut: ConstValue) -> Option<bool> {
     match pattern {
-        RirPattern::Wildcard(_) => Some(true),
-        RirPattern::Bool(b, _) => match scrut {
+        rue_rir::RirPatternView::Wildcard(_) => Some(true),
+        rue_rir::RirPatternView::Bool(b, _) => match scrut {
             ConstValue::Bool(sb) => Some(sb == *b),
             _ => None,
         },
-        RirPattern::Int {
+        rue_rir::RirPatternView::Int {
             value, negative, ..
         } => match scrut {
             ConstValue::Integer(n) => {
@@ -247,7 +247,7 @@ fn const_pattern_matches(pattern: &RirPattern, scrut: ConstValue) -> Option<bool
         },
         // Enum-variant patterns aren't representable as a `ConstValue` (there
         // is no comptime enum-value form), so they can't be decided here.
-        RirPattern::Path { .. } => None,
+        rue_rir::RirPatternView::Path { .. } => None,
     }
 }
 
@@ -855,7 +855,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                     return Ok(None);
                 };
                 let arms = self.rir.get_match_arms(arms_start, arms_len);
-                for (pattern, body) in arms {
+                for (pattern, body) in arms.iter() {
                     match const_pattern_matches(&pattern, scrut) {
                         Some(true) => return self.eval_const_expr(body, env),
                         Some(false) => continue,
@@ -947,7 +947,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                     };
 
                     let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
-                    let first_method_ref = method_refs[0];
+                    let first_method_ref = method_refs.get(0).unwrap();
                     let first_method_inst = self.rir.get(first_method_ref);
                     if let InstData::FnDecl {
                         name: method_name, ..
@@ -1631,7 +1631,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         let param_modes = self.param_arena.modes(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
         let param_comptime_type = self.comptime_type_param_flags(&fn_info);
-        let args = self.rir.get_call_args(args_start, args_len).to_vec();
+        let args = self.rir.get_call_args(args_start, args_len);
         if args.len() != param_names.len() {
             return Ok(None);
         }
@@ -2099,7 +2099,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                     .rir
                     .get_match_arms(*arms_start, *arms_len)
                     .iter()
-                    .map(|(_, body)| *body)
+                    .map(|(_, body)| body)
                     .collect();
                 for body in bodies {
                     self.walk_comptime_type_locals(

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, HashSet};
 
 use lasso::{Key, Spur};
 use rue_error::{CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, ice};
-use rue_rir::{InstData, InstRef, RirDirective, RirParamMode};
+use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::{FileId, Span};
 
 use super::{
@@ -311,7 +311,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         }
     }
     /// Check if a directive list contains the @copy directive
-    pub(crate) fn has_copy_directive(&self, directives: &[RirDirective]) -> bool {
+    pub(crate) fn has_copy_directive<'r>(
+        &self,
+        directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
+    ) -> bool {
         let copy_sym = self.interner.get("copy");
         for directive in directives {
             if Some(directive.name) == copy_sym {
@@ -361,14 +364,14 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
 }
 
 impl<'a> Sema<'a> {
-    pub(crate) fn has_allow_directive(
+    pub(crate) fn has_allow_directive<'r>(
         &self,
-        directives: &[RirDirective],
+        mut directives: impl Iterator<Item = rue_rir::RirDirectiveView<'r>>,
         warning_name: &str,
     ) -> bool {
         let allow_sym = self.interner.get("allow");
         let warning_sym = self.interner.get(warning_name);
-        directives.iter().any(|directive| {
+        directives.any(|directive| {
             Some(directive.name) == allow_sym
                 && directive.args.iter().any(|arg| Some(*arg) == warning_sym)
         })
@@ -447,7 +450,7 @@ impl<'a> Sema<'a> {
                     let key = (inst.span.file_id, *name);
 
                     let directives = self.rir.get_directives(*directives_start, *directives_len);
-                    let is_copy = self.has_copy_directive(&directives);
+                    let is_copy = self.has_copy_directive(directives.iter());
 
                     // Linear types cannot be @copy
                     if *is_linear && is_copy {
@@ -924,9 +927,9 @@ impl<'a> Sema<'a> {
 
                 // Check for duplicate field names
                 let mut seen_fields: HashSet<Spur> = HashSet::new();
-                for (field_name, _) in &fields {
-                    if !seen_fields.insert(*field_name) {
-                        let field_name_str = self.interner.resolve(&*field_name).to_string();
+                for (field_name, _) in fields.values() {
+                    if !seen_fields.insert(field_name) {
+                        let field_name_str = self.interner.resolve(&field_name).to_string();
                         return Err(CompileError::new(
                             ErrorKind::DuplicateField {
                                 struct_name,
@@ -947,16 +950,16 @@ impl<'a> Sema<'a> {
                         super::DeclarationTypeDependencyKind::Field,
                     ));
                 let mut resolved_fields = Vec::new();
-                for (field_name, field_type) in &fields {
+                for (field_name, field_type) in fields.values() {
                     // A slice type `[T]` is second-class (ADR-0037, ADR-0043,
                     // RUE-322): storing it in a struct field would let the
                     // fat-pointer view escape its borrow's scope (E0488).
                     self.reject_slice_escape(
-                        *field_type,
+                        field_type,
                         inst.span,
                         ErrorKind::SliceInAggregateField,
                     )?;
-                    let field_ty = self.resolve_type(*field_type, inst.span)?;
+                    let field_ty = self.resolve_type(field_type, inst.span)?;
                     // spec 4.14:6 — type values cannot exist at runtime. A
                     // struct field of type `type` is a runtime storage slot for
                     // a type value, which is forbidden; reject it at the
@@ -973,7 +976,7 @@ impl<'a> Sema<'a> {
                         ));
                     }
                     resolved_fields.push(StructField {
-                        name: self.interner.resolve(&*field_name).to_string(),
+                        name: self.interner.resolve(&field_name).to_string(),
                         ty: field_ty,
                     });
                 }
@@ -1216,7 +1219,7 @@ impl<'a> Sema<'a> {
         span: Span,
     ) -> CompileResult<()> {
         let directives = self.rir.get_directives(directives_start, directives_len);
-        if !self.has_copy_directive(&directives) {
+        if !self.has_copy_directive(directives.iter()) {
             return Ok(());
         }
 
@@ -1406,9 +1409,10 @@ impl<'a> Sema<'a> {
 
         let params = self.rir.get_params(params_start, params_len);
         let directives = self.rir.get_directives(directives_start, directives_len);
-        let allow_unused_function = self.has_allow_directive(&directives, "unused_function");
-        let allow_unused_variable = self.has_allow_directive(&directives, "unused_variable");
-        let allow_unreachable_code = self.has_allow_directive(&directives, "unreachable_code");
+        let allow_unused_function = self.has_allow_directive(directives.iter(), "unused_function");
+        let allow_unused_variable = self.has_allow_directive(directives.iter(), "unused_variable");
+        let allow_unreachable_code =
+            self.has_allow_directive(directives.iter(), "unreachable_code");
 
         let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
         let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
@@ -1865,7 +1869,7 @@ impl<'a> Sema<'a> {
                         "compiler import preflight rejects malformed @import calls"
                     );
                     let arg_refs = self.rir.get_inst_refs(*args_start, *args_len);
-                    let arg_inst = self.rir.get(arg_refs[0]);
+                    let arg_inst = self.rir.get(arg_refs.get(0).unwrap());
                     let import_path = match &arg_inst.data {
                         InstData::StringConst(path_spur) => {
                             self.interner.resolve(path_spur).to_string()
@@ -2659,7 +2663,7 @@ impl<'a> Sema<'a> {
         let param_modes = self.param_arena.modes(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
         let param_comptime_type = self.comptime_type_param_flags(&fn_info);
-        let args = self.rir.get_call_args(args_start, args_len).to_vec();
+        let args = self.rir.get_call_args(args_start, args_len);
         if args.len() != param_names.len() {
             return Err(CompileError::new(
                 ErrorKind::ConstExprNotSupported {

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -584,13 +584,20 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         self.body_analysis_work.named_const_dependency_events += 1;
     }
 
-    pub(crate) fn validate_explicit_call_modes(
+    pub(crate) fn validate_explicit_call_modes<A>(
         &self,
-        args: &[rue_rir::RirCallArg],
+        args: A,
         expected_modes: impl ExactSizeIterator<Item = rue_rir::RirParamMode>,
-    ) -> rue_error::CompileResult<()> {
+    ) -> rue_error::CompileResult<()>
+    where
+        A: IntoIterator,
+        A::IntoIter: ExactSizeIterator,
+        A::Item: std::ops::Deref<Target = rue_rir::RirCallArg>,
+    {
+        let args = args.into_iter();
         assert_eq!(args.len(), expected_modes.len());
-        for (arg, expected_mode) in args.iter().zip(expected_modes) {
+        for (arg, expected_mode) in args.zip(expected_modes) {
+            let arg = &*arg;
             use rue_rir::{RirArgMode, RirParamMode};
             match (expected_mode, arg.mode) {
                 (RirParamMode::Inout, RirArgMode::Inout)

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -906,7 +906,7 @@ mod tests {
                     return None;
                 };
                 (interner.resolve(&name) == "import").then(|| {
-                    let argument = rir.get_inst_refs(args_start, 1)[0];
+                    let argument = rir.get_inst_refs(args_start, 1).get(0).unwrap();
                     let rue_rir::InstData::StringConst(specifier) = rir.get(argument).data else {
                         unreachable!()
                     };

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -1644,7 +1644,7 @@ mod tests {
             } => {
                 assert_eq!(interner.resolve(&*name), "main");
                 let params = rir.get_params(*params_start, *params_len);
-                assert!(params.is_empty());
+                assert_eq!(params.len(), 0);
                 assert_eq!(interner.resolve(&*return_type), "i32");
                 assert!(!has_self); // Regular functions don't have self
                 // Body should be the int constant
@@ -1970,7 +1970,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(interner.resolve(&*name), "Point");
-                let methods = rir.get_inst_refs(*methods_start, *methods_len);
+                let methods = rir.get_inst_refs(*methods_start, *methods_len).to_vec();
                 assert_eq!(methods.len(), 1);
 
                 // Check the method is a FnDecl with has_self=true
@@ -2066,7 +2066,7 @@ mod tests {
             } => {
                 assert_eq!(interner.resolve(&*method), "get_x");
                 let args = rir.get_call_args(*args_start, *args_len);
-                assert!(args.is_empty()); // No explicit args (self is implicit)
+                assert_eq!(args.len(), 0); // No explicit args (self is implicit)
             }
             _ => panic!("expected MethodCall"),
         }
@@ -2110,7 +2110,7 @@ mod tests {
                 }
                 assert_eq!(interner.resolve(&*method), "origin");
                 let args = rir.get_call_args(*args_start, *args_len);
-                assert!(args.is_empty());
+                assert_eq!(args.len(), 0);
             }
             _ => panic!("expected MethodCall"),
         }
@@ -2142,7 +2142,11 @@ mod tests {
                 arms_len,
                 ..
             } => {
-                let arms = rir.get_match_arms(*arms_start, *arms_len);
+                let arms: Vec<_> = rir
+                    .get_match_arms(*arms_start, *arms_len)
+                    .iter()
+                    .map(|(pattern, body)| (pattern.to_owned(), body))
+                    .collect();
                 assert_eq!(arms.len(), 1);
                 assert!(matches!(arms[0].0, RirPattern::Wildcard(_)));
             }
@@ -2176,7 +2180,11 @@ mod tests {
                 arms_len,
                 ..
             } => {
-                let arms = rir.get_match_arms(*arms_start, *arms_len);
+                let arms: Vec<_> = rir
+                    .get_match_arms(*arms_start, *arms_len)
+                    .iter()
+                    .map(|(pattern, body)| (pattern.to_owned(), body))
+                    .collect();
                 assert_eq!(arms.len(), 3);
                 assert!(matches!(
                     arms[0].0,
@@ -2226,7 +2234,11 @@ mod tests {
                 arms_len,
                 ..
             } => {
-                let arms = rir.get_match_arms(*arms_start, *arms_len);
+                let arms: Vec<_> = rir
+                    .get_match_arms(*arms_start, *arms_len)
+                    .iter()
+                    .map(|(pattern, body)| (pattern.to_owned(), body))
+                    .collect();
                 assert_eq!(arms.len(), 3);
                 assert!(matches!(
                     arms[0].0,
@@ -2275,7 +2287,11 @@ mod tests {
                 arms_len,
                 ..
             } => {
-                let arms = rir.get_match_arms(*arms_start, *arms_len);
+                let arms: Vec<_> = rir
+                    .get_match_arms(*arms_start, *arms_len)
+                    .iter()
+                    .map(|(pattern, body)| (pattern.to_owned(), body))
+                    .collect();
                 assert_eq!(arms.len(), 2);
                 assert!(matches!(arms[0].0, RirPattern::Bool(true, _)));
                 assert!(matches!(arms[1].0, RirPattern::Bool(false, _)));
@@ -2311,7 +2327,11 @@ mod tests {
                 arms_len,
                 ..
             } => {
-                let arms = rir.get_match_arms(*arms_start, *arms_len);
+                let arms: Vec<_> = rir
+                    .get_match_arms(*arms_start, *arms_len)
+                    .iter()
+                    .map(|(pattern, body)| (pattern.to_owned(), body))
+                    .collect();
                 assert_eq!(arms.len(), 3);
 
                 // Check first arm is Color.Red
@@ -2319,8 +2339,8 @@ mod tests {
                     RirPattern::Path {
                         type_name, variant, ..
                     } => {
-                        assert_eq!(interner.resolve(&*type_name), "Color");
-                        assert_eq!(interner.resolve(&*variant), "Red");
+                        assert_eq!(interner.resolve(type_name), "Color");
+                        assert_eq!(interner.resolve(variant), "Red");
                     }
                     _ => panic!("expected Path pattern"),
                 }
@@ -2330,8 +2350,8 @@ mod tests {
                     RirPattern::Path {
                         type_name, variant, ..
                     } => {
-                        assert_eq!(interner.resolve(&*type_name), "Color");
-                        assert_eq!(interner.resolve(&*variant), "Green");
+                        assert_eq!(interner.resolve(type_name), "Color");
+                        assert_eq!(interner.resolve(variant), "Green");
                     }
                     _ => panic!("expected Path pattern"),
                 }
@@ -2341,8 +2361,8 @@ mod tests {
                     RirPattern::Path {
                         type_name, variant, ..
                     } => {
-                        assert_eq!(interner.resolve(&*type_name), "Color");
-                        assert_eq!(interner.resolve(&*variant), "Blue");
+                        assert_eq!(interner.resolve(type_name), "Color");
+                        assert_eq!(interner.resolve(variant), "Blue");
                     }
                     _ => panic!("expected Path pattern"),
                 }
@@ -2451,7 +2471,7 @@ mod tests {
                 methods_len,
                 ..
             } => {
-                let methods = rir.get_inst_refs(*methods_start, *methods_len);
+                let methods = rir.get_inst_refs(*methods_start, *methods_len).to_vec();
                 let method_inst = rir.get(methods[0]);
                 match &method_inst.data {
                     InstData::FnDecl {
@@ -2464,7 +2484,7 @@ mod tests {
                         assert_eq!(interner.resolve(&*name), "add");
                         assert!(*has_self);
                         // params should contain 'amount', not 'self'
-                        let params = rir.get_params(*params_start, *params_len);
+                        let params = rir.get_params(*params_start, *params_len).to_vec();
                         assert_eq!(params.len(), 1);
                         assert_eq!(interner.resolve(&params[0].name), "amount");
                     }
@@ -2541,7 +2561,7 @@ mod tests {
                 methods_len,
             } => {
                 // Should have 2 fields (x and y)
-                let fields = rir.get_field_decls(*fields_start, *fields_len);
+                let fields = rir.get_field_decls(*fields_start, *fields_len).to_vec();
                 assert_eq!(fields.len(), 2);
                 assert_eq!(interner.resolve(&fields[0].0), "x");
                 assert_eq!(interner.resolve(&fields[1].0), "y");

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -74,7 +74,7 @@ impl RirParamMode {
 }
 
 /// A parameter in a function declaration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct RirParam {
     /// Parameter name
     pub name: Spur,
@@ -126,7 +126,7 @@ impl RirArgMode {
 }
 
 /// An argument in a function call.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct RirCallArg {
     /// The argument expression
     pub value: InstRef,
@@ -196,6 +196,237 @@ impl RirPattern {
             RirPattern::Int { span, .. } => *span,
             RirPattern::Bool(_, span) => *span,
             RirPattern::Path { span, .. } => *span,
+        }
+    }
+}
+
+/// A lazily decoded, borrowing view of a match pattern stored in RIR.
+///
+/// Unlike [`RirPattern`], a path pattern's bindings remain in the compact RIR
+/// word store and are decoded only as they are traversed.
+#[derive(Debug, Clone)]
+pub enum RirPatternView<'a> {
+    Wildcard(Span),
+    Int {
+        value: u64,
+        negative: bool,
+        span: Span,
+    },
+    Bool(bool, Span),
+    Path {
+        module: Option<InstRef>,
+        ctor_head: Option<InstRef>,
+        type_name: Spur,
+        variant: Spur,
+        bindings: RirSymbols<'a>,
+        span: Span,
+    },
+}
+
+impl RirPatternView<'_> {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Wildcard(span) | Self::Bool(_, span) => *span,
+            Self::Int { span, .. } | Self::Path { span, .. } => *span,
+        }
+    }
+
+    /// Materialize an owned pattern when it must outlive the RIR borrow.
+    pub fn to_owned(&self) -> RirPattern {
+        match self {
+            Self::Wildcard(span) => RirPattern::Wildcard(*span),
+            Self::Int {
+                value,
+                negative,
+                span,
+            } => RirPattern::Int {
+                value: *value,
+                negative: *negative,
+                span: *span,
+            },
+            Self::Bool(value, span) => RirPattern::Bool(*value, *span),
+            Self::Path {
+                module,
+                ctor_head,
+                type_name,
+                variant,
+                bindings,
+                span,
+            } => RirPattern::Path {
+                module: *module,
+                ctor_head: *ctor_head,
+                type_name: *type_name,
+                variant: *variant,
+                bindings: bindings.to_vec(),
+                span: *span,
+            },
+        }
+    }
+}
+
+/// A reusable, zero-allocation view of fixed-width records in the RIR word store.
+pub struct RirSlice<'a, T> {
+    words: &'a [u32],
+    width: usize,
+    decode: fn(&[u32]) -> T,
+}
+
+impl<T> std::fmt::Debug for RirSlice<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RirSlice")
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
+impl<T> Clone for RirSlice<'_, T> {
+    fn clone(&self) -> Self {
+        Self {
+            words: self.words,
+            width: self.width,
+            decode: self.decode,
+        }
+    }
+}
+
+impl<'a, T: 'a> RirSlice<'a, T> {
+    fn new(words: &'a [u32], width: usize, decode: fn(&[u32]) -> T) -> Self {
+        assert!(width != 0 && words.len().is_multiple_of(width));
+        for record in words.chunks_exact(width) {
+            decode(record);
+        }
+        Self {
+            words,
+            width,
+            decode,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.words.len() / self.width
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.words.is_empty()
+    }
+
+    pub fn iter(&self) -> DecodedIter<impl ExactSizeIterator<Item = T> + Clone + 'a> {
+        DecodedIter(self.values())
+    }
+
+    pub fn values(&self) -> impl ExactSizeIterator<Item = T> + Clone + 'a {
+        RirSliceIter {
+            words: self.words.chunks_exact(self.width),
+            decode: self.decode,
+        }
+    }
+
+    pub fn get(&self, index: usize) -> Option<T> {
+        self.values().nth(index)
+    }
+
+    pub fn to_vec(&self) -> Vec<T> {
+        self.values().collect()
+    }
+}
+
+impl<'a, T> IntoIterator for RirSlice<'a, T> {
+    type Item = T;
+    type IntoIter = RirSliceIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RirSliceIter {
+            words: self.words.chunks_exact(self.width),
+            decode: self.decode,
+        }
+    }
+}
+
+impl<'a, T> IntoIterator for &RirSlice<'a, T> {
+    type Item = Decoded<T>;
+    type IntoIter = DecodedIter<RirSliceIter<'a, T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        DecodedIter(RirSliceIter {
+            words: self.words.chunks_exact(self.width),
+            decode: self.decode,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Decoded<T>(T);
+
+impl<T> std::ops::Deref for Decoded<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DecodedIter<I>(I);
+
+impl<I: Iterator> Iterator for DecodedIter<I> {
+    type Item = Decoded<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Decoded)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<I: ExactSizeIterator> ExactSizeIterator for DecodedIter<I> {}
+
+pub struct RirSliceIter<'a, T> {
+    words: std::slice::ChunksExact<'a, u32>,
+    decode: fn(&[u32]) -> T,
+}
+
+impl<T> Clone for RirSliceIter<'_, T> {
+    fn clone(&self) -> Self {
+        Self {
+            words: self.words.clone(),
+            decode: self.decode,
+        }
+    }
+}
+
+impl<T> Iterator for RirSliceIter<'_, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.words.next().map(self.decode)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.words.size_hint()
+    }
+}
+
+impl<T> ExactSizeIterator for RirSliceIter<'_, T> {}
+
+pub type RirSymbols<'a> = RirSlice<'a, Spur>;
+
+/// A borrowing directive view. Arguments are decoded lazily from RIR.
+#[derive(Debug, Clone)]
+pub struct RirDirectiveView<'a> {
+    pub name: Spur,
+    pub args: RirSymbols<'a>,
+    pub span: Span,
+}
+
+impl RirDirectiveView<'_> {
+    /// Materialize an owned directive when it must outlive the RIR borrow.
+    pub fn to_owned(&self) -> RirDirective {
+        RirDirective {
+            name: self.name,
+            args: self.args.to_vec(),
+            span: self.span,
         }
     }
 }
@@ -362,11 +593,10 @@ impl Rir {
     }
 
     /// Retrieve InstRefs from the extra array.
-    pub fn get_inst_refs(&self, start: u32, len: u32) -> Vec<InstRef> {
-        self.get_extra(start, len)
-            .iter()
-            .map(|&v| InstRef::from_raw(v))
-            .collect()
+    pub fn get_inst_refs(&self, start: u32, len: u32) -> RirSlice<'_, InstRef> {
+        RirSlice::new(self.get_extra(start, len), 1, |record| {
+            InstRef::from_raw(record[0])
+        })
     }
 
     /// Store a slice of Spurs and return (start, len).
@@ -377,11 +607,10 @@ impl Rir {
     }
 
     /// Retrieve Spurs from the extra array.
-    pub fn get_symbols(&self, start: u32, len: u32) -> Vec<Spur> {
-        self.get_extra(start, len)
-            .iter()
-            .map(|&v| Spur::try_from_usize(v as usize).unwrap())
-            .collect()
+    pub fn get_symbols(&self, start: u32, len: u32) -> RirSymbols<'_> {
+        RirSlice::new(self.get_extra(start, len), 1, |record| {
+            Spur::try_from_usize(record[0] as usize).unwrap()
+        })
     }
 
     /// Store RirCallArgs and return (start, len).
@@ -397,15 +626,13 @@ impl Rir {
     }
 
     /// Retrieve RirCallArgs from the extra array.
-    pub fn get_call_args(&self, start: u32, len: u32) -> Vec<RirCallArg> {
-        let data = self.get_extra(start, len * CALL_ARG_SIZE);
-        let mut args = Vec::with_capacity(len as usize);
-        for chunk in data.chunks(CALL_ARG_SIZE as usize) {
-            let value = InstRef::from_raw(chunk[0]);
-            let mode = RirArgMode::from_u32(chunk[1]);
-            args.push(RirCallArg { value, mode });
-        }
-        args
+    pub fn get_call_args(&self, start: u32, len: u32) -> RirSlice<'_, RirCallArg> {
+        let words = len.checked_mul(CALL_ARG_SIZE).unwrap();
+        let data = self.get_extra(start, words);
+        RirSlice::new(data, CALL_ARG_SIZE as usize, |chunk| RirCallArg {
+            value: InstRef::from_raw(chunk[0]),
+            mode: RirArgMode::from_u32(chunk[1]),
+        })
     }
 
     /// Store RirParams and return (start, len).
@@ -427,24 +654,16 @@ impl Rir {
     }
 
     /// Retrieve RirParams from the extra array.
-    pub fn get_params(&self, start: u32, len: u32) -> Vec<RirParam> {
-        let data = self.get_extra(start, len * PARAM_SIZE);
-        let mut params = Vec::with_capacity(len as usize);
-        for chunk in data.chunks(PARAM_SIZE as usize) {
-            let name = Spur::try_from_usize(chunk[0] as usize).unwrap();
-            let ty = Spur::try_from_usize(chunk[1] as usize).unwrap();
-            let mode = RirParamMode::from_u32(chunk[2]);
-            let is_comptime = chunk[3] != 0;
-            let span = Span::with_file(FileId::new(chunk[4]), chunk[5], chunk[6]);
-            params.push(RirParam {
-                name,
-                ty,
-                mode,
-                is_comptime,
-                span,
-            });
-        }
-        params
+    pub fn get_params(&self, start: u32, len: u32) -> RirSlice<'_, RirParam> {
+        let words = len.checked_mul(PARAM_SIZE).unwrap();
+        let data = self.get_extra(start, words);
+        RirSlice::new(data, PARAM_SIZE as usize, |chunk| RirParam {
+            name: Spur::try_from_usize(chunk[0] as usize).unwrap(),
+            ty: Spur::try_from_usize(chunk[1] as usize).unwrap(),
+            mode: RirParamMode::from_u32(chunk[2]),
+            is_comptime: chunk[3] != 0,
+            span: Span::with_file(FileId::new(chunk[4]), chunk[5], chunk[6]),
+        })
     }
 
     /// Store match arms (pattern + body pairs) and return (start, arm_count).
@@ -526,87 +745,14 @@ impl Rir {
     }
 
     /// Retrieve match arms from the extra array.
-    pub fn get_match_arms(&self, start: u32, arm_count: u32) -> Vec<(RirPattern, InstRef)> {
-        let mut arms = Vec::with_capacity(arm_count as usize);
-        let mut pos = start as usize;
-
-        for _ in 0..arm_count {
-            let kind = self.extra[pos];
-            match kind {
-                k if k == PatternKind::Wildcard as u32 => {
-                    let span = Self::decode_pattern_span(&self.extra, pos);
-                    let body = InstRef::from_raw(self.extra[pos + 4]);
-                    arms.push((RirPattern::Wildcard(span), body));
-                    pos += PATTERN_WILDCARD_SIZE as usize;
-                }
-                k if k == PatternKind::Int as u32 => {
-                    let span = Self::decode_pattern_span(&self.extra, pos);
-                    let value_lo = self.extra[pos + 4] as u64;
-                    let value_hi = self.extra[pos + 5] as u64;
-                    let value = value_lo | (value_hi << 32);
-                    let negative = self.extra[pos + 6] != 0;
-                    let body = InstRef::from_raw(self.extra[pos + 7]);
-                    arms.push((
-                        RirPattern::Int {
-                            value,
-                            negative,
-                            span,
-                        },
-                        body,
-                    ));
-                    pos += PATTERN_INT_SIZE as usize;
-                }
-                k if k == PatternKind::Bool as u32 => {
-                    let span = Self::decode_pattern_span(&self.extra, pos);
-                    let value = self.extra[pos + 4] != 0;
-                    let body = InstRef::from_raw(self.extra[pos + 5]);
-                    arms.push((RirPattern::Bool(value, span), body));
-                    pos += PATTERN_BOOL_SIZE as usize;
-                }
-                k if k == PatternKind::Path as u32 => {
-                    let span = Self::decode_pattern_span(&self.extra, pos);
-                    // Decode module: u32::MAX means None
-                    let module_raw = self.extra[pos + 4];
-                    let module = if module_raw == u32::MAX {
-                        None
-                    } else {
-                        Some(InstRef::from_raw(module_raw))
-                    };
-                    // Decode ctor_head (inline type-constructor pattern head,
-                    // RUE-596): u32::MAX means None.
-                    let ctor_head_raw = self.extra[pos + 5];
-                    let ctor_head = if ctor_head_raw == u32::MAX {
-                        None
-                    } else {
-                        Some(InstRef::from_raw(ctor_head_raw))
-                    };
-                    let type_name = Spur::try_from_usize(self.extra[pos + 6] as usize).unwrap();
-                    let variant = Spur::try_from_usize(self.extra[pos + 7] as usize).unwrap();
-                    // Variable-length payload bindings (RUE-221).
-                    let n_bindings = self.extra[pos + 8] as usize;
-                    let mut bindings = Vec::with_capacity(n_bindings);
-                    for i in 0..n_bindings {
-                        bindings
-                            .push(Spur::try_from_usize(self.extra[pos + 9 + i] as usize).unwrap());
-                    }
-                    let body = InstRef::from_raw(self.extra[pos + 9 + n_bindings]);
-                    arms.push((
-                        RirPattern::Path {
-                            module,
-                            ctor_head,
-                            type_name,
-                            variant,
-                            bindings,
-                            span,
-                        },
-                        body,
-                    ));
-                    pos += 10 + n_bindings;
-                }
-                _ => panic!("Unknown pattern kind: {}", kind),
-            }
-        }
-        arms
+    pub fn get_match_arms(&self, start: u32, arm_count: u32) -> RirMatchArms<'_> {
+        let view = RirMatchArms {
+            extra: &self.extra,
+            start: start as usize,
+            len: arm_count as usize,
+        };
+        view.iter().for_each(drop);
+        view
     }
 
     /// Store field initializers (name, value) and return (start, len).
@@ -622,15 +768,15 @@ impl Rir {
     }
 
     /// Retrieve field initializers from the extra array.
-    pub fn get_field_inits(&self, start: u32, len: u32) -> Vec<(Spur, InstRef)> {
-        let data = self.get_extra(start, len * FIELD_INIT_SIZE);
-        let mut fields = Vec::with_capacity(len as usize);
-        for chunk in data.chunks(FIELD_INIT_SIZE as usize) {
-            let name = Spur::try_from_usize(chunk[0] as usize).unwrap();
-            let value = InstRef::from_raw(chunk[1]);
-            fields.push((name, value));
-        }
-        fields
+    pub fn get_field_inits(&self, start: u32, len: u32) -> RirSlice<'_, (Spur, InstRef)> {
+        let words = len.checked_mul(FIELD_INIT_SIZE).unwrap();
+        let data = self.get_extra(start, words);
+        RirSlice::new(data, FIELD_INIT_SIZE as usize, |chunk| {
+            (
+                Spur::try_from_usize(chunk[0] as usize).unwrap(),
+                InstRef::from_raw(chunk[1]),
+            )
+        })
     }
 
     /// Store field declarations (name, type) and return (start, len).
@@ -646,15 +792,15 @@ impl Rir {
     }
 
     /// Retrieve field declarations from the extra array.
-    pub fn get_field_decls(&self, start: u32, len: u32) -> Vec<(Spur, Spur)> {
-        let data = self.get_extra(start, len * FIELD_DECL_SIZE);
-        let mut fields = Vec::with_capacity(len as usize);
-        for chunk in data.chunks(FIELD_DECL_SIZE as usize) {
-            let name = Spur::try_from_usize(chunk[0] as usize).unwrap();
-            let ty = Spur::try_from_usize(chunk[1] as usize).unwrap();
-            fields.push((name, ty));
-        }
-        fields
+    pub fn get_field_decls(&self, start: u32, len: u32) -> RirSlice<'_, (Spur, Spur)> {
+        let words = len.checked_mul(FIELD_DECL_SIZE).unwrap();
+        let data = self.get_extra(start, words);
+        RirSlice::new(data, FIELD_DECL_SIZE as usize, |chunk| {
+            (
+                Spur::try_from_usize(chunk[0] as usize).unwrap(),
+                Spur::try_from_usize(chunk[1] as usize).unwrap(),
+            )
+        })
     }
 
     /// Store directives and return (start, directive_count).
@@ -680,29 +826,222 @@ impl Rir {
     }
 
     /// Retrieve directives from the extra array.
-    pub fn get_directives(&self, start: u32, directive_count: u32) -> Vec<RirDirective> {
-        let mut directives = Vec::with_capacity(directive_count as usize);
-        let mut pos = start as usize;
-
-        for _ in 0..directive_count {
-            let name = Spur::try_from_usize(self.extra[pos] as usize).unwrap();
-            let span_start = self.extra[pos + 1];
-            let span_len = self.extra[pos + 2];
-            let file_id = rue_span::FileId::new(self.extra[pos + 3]);
-            let span = Span::with_file(file_id, span_start, span_start + span_len);
-            let args_len = self.extra[pos + 4] as usize;
-            pos += 5;
-
-            let args: Vec<Spur> = (0..args_len)
-                .map(|i| Spur::try_from_usize(self.extra[pos + i] as usize).unwrap())
-                .collect();
-            pos += args_len;
-
-            directives.push(RirDirective { name, args, span });
-        }
-        directives
+    pub fn get_directives(&self, start: u32, directive_count: u32) -> RirDirectives<'_> {
+        let view = RirDirectives {
+            extra: &self.extra,
+            start: start as usize,
+            len: directive_count as usize,
+        };
+        view.iter().for_each(drop);
+        view
     }
 }
+
+/// Reusable zero-allocation view over variable-width RIR match arms.
+#[derive(Debug, Clone)]
+pub struct RirMatchArms<'a> {
+    extra: &'a [u32],
+    start: usize,
+    len: usize,
+}
+
+impl<'a> RirMatchArms<'a> {
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn iter(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (RirPatternView<'a>, InstRef)> + Clone + 'a {
+        RirMatchArmsIter {
+            extra: self.extra,
+            pos: self.start,
+            remaining: self.len,
+        }
+    }
+
+    pub fn get(&self, index: usize) -> Option<(RirPatternView<'a>, InstRef)> {
+        self.iter().nth(index)
+    }
+
+    pub fn to_vec(&self) -> Vec<(RirPatternView<'a>, InstRef)> {
+        self.iter().collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RirMatchArmsIter<'a> {
+    extra: &'a [u32],
+    pos: usize,
+    remaining: usize,
+}
+
+impl<'a> Iterator for RirMatchArmsIter<'a> {
+    type Item = (RirPatternView<'a>, InstRef);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let pos = self.pos;
+        let kind = self.extra[pos];
+        let result = match kind {
+            k if k == PatternKind::Wildcard as u32 => {
+                let span = Rir::decode_pattern_span(self.extra, pos);
+                let body = InstRef::from_raw(self.extra[pos + 4]);
+                self.pos += PATTERN_WILDCARD_SIZE as usize;
+                (RirPatternView::Wildcard(span), body)
+            }
+            k if k == PatternKind::Int as u32 => {
+                let span = Rir::decode_pattern_span(self.extra, pos);
+                let value_lo = self.extra[pos + 4] as u64;
+                let value_hi = self.extra[pos + 5] as u64;
+                let value = value_lo | (value_hi << 32);
+                let negative = self.extra[pos + 6] != 0;
+                let body = InstRef::from_raw(self.extra[pos + 7]);
+                self.pos += PATTERN_INT_SIZE as usize;
+                (
+                    RirPatternView::Int {
+                        value,
+                        negative,
+                        span,
+                    },
+                    body,
+                )
+            }
+            k if k == PatternKind::Bool as u32 => {
+                let span = Rir::decode_pattern_span(self.extra, pos);
+                let value = self.extra[pos + 4] != 0;
+                let body = InstRef::from_raw(self.extra[pos + 5]);
+                self.pos += PATTERN_BOOL_SIZE as usize;
+                (RirPatternView::Bool(value, span), body)
+            }
+            k if k == PatternKind::Path as u32 => {
+                let span = Rir::decode_pattern_span(self.extra, pos);
+                // Decode module: u32::MAX means None
+                let module_raw = self.extra[pos + 4];
+                let module = if module_raw == u32::MAX {
+                    None
+                } else {
+                    Some(InstRef::from_raw(module_raw))
+                };
+                // Decode ctor_head (inline type-constructor pattern head,
+                // RUE-596): u32::MAX means None.
+                let ctor_head_raw = self.extra[pos + 5];
+                let ctor_head = if ctor_head_raw == u32::MAX {
+                    None
+                } else {
+                    Some(InstRef::from_raw(ctor_head_raw))
+                };
+                let type_name = Spur::try_from_usize(self.extra[pos + 6] as usize).unwrap();
+                let variant = Spur::try_from_usize(self.extra[pos + 7] as usize).unwrap();
+                // Variable-length payload bindings (RUE-221).
+                let n_bindings = self.extra[pos + 8] as usize;
+                let bindings =
+                    RirSlice::new(&self.extra[pos + 9..pos + 9 + n_bindings], 1, |record| {
+                        Spur::try_from_usize(record[0] as usize).unwrap()
+                    });
+                let body = InstRef::from_raw(self.extra[pos + 9 + n_bindings]);
+                self.pos += 10 + n_bindings;
+                (
+                    RirPatternView::Path {
+                        module,
+                        ctor_head,
+                        type_name,
+                        variant,
+                        bindings,
+                        span,
+                    },
+                    body,
+                )
+            }
+            _ => panic!("Unknown pattern kind: {}", kind),
+        };
+        self.remaining -= 1;
+        Some(result)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for RirMatchArmsIter<'_> {}
+
+/// Reusable zero-allocation view over variable-width RIR directives.
+#[derive(Debug, Clone)]
+pub struct RirDirectives<'a> {
+    extra: &'a [u32],
+    start: usize,
+    len: usize,
+}
+
+impl<'a> RirDirectives<'a> {
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = RirDirectiveView<'a>> + Clone + 'a {
+        RirDirectivesIter {
+            extra: self.extra,
+            pos: self.start,
+            remaining: self.len,
+        }
+    }
+
+    pub fn get(&self, index: usize) -> Option<RirDirectiveView<'a>> {
+        self.iter().nth(index)
+    }
+
+    pub fn to_vec(&self) -> Vec<RirDirectiveView<'a>> {
+        self.iter().collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RirDirectivesIter<'a> {
+    extra: &'a [u32],
+    pos: usize,
+    remaining: usize,
+}
+
+impl<'a> Iterator for RirDirectivesIter<'a> {
+    type Item = RirDirectiveView<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let name = Spur::try_from_usize(self.extra[self.pos] as usize).unwrap();
+        let span_start = self.extra[self.pos + 1];
+        let span_len = self.extra[self.pos + 2];
+        let file_id = FileId::new(self.extra[self.pos + 3]);
+        let span = Span::with_file(file_id, span_start, span_start + span_len);
+        let args_len = self.extra[self.pos + 4] as usize;
+        let args_start = self.pos + 5;
+        let args_end = args_start + args_len;
+        let args = RirSlice::new(&self.extra[args_start..args_end], 1, |record| {
+            Spur::try_from_usize(record[0] as usize).unwrap()
+        });
+        self.pos = args_end;
+        self.remaining -= 1;
+        Some(RirDirectiveView { name, args, span })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for RirDirectivesIter<'_> {}
 
 /// A single RIR instruction.
 #[derive(Debug, Clone)]
@@ -1371,9 +1710,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
     }
 
     /// Format a list of call arguments.
-    fn format_call_args(&self, args: &[RirCallArg]) -> String {
-        args.iter()
-            .map(|arg| self.format_call_arg(arg))
+    fn format_call_args(&self, args: impl IntoIterator<Item = RirCallArg>) -> String {
+        args.into_iter()
+            .map(|arg| self.format_call_arg(&arg))
             .collect::<Vec<_>>()
             .join(", ")
     }
@@ -1382,7 +1721,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
     /// (empty string when there are none).
     fn format_directives(&self, start: u32, len: u32) -> String {
         let directives = self.rir.get_directives(start, len);
-        if directives.is_empty() {
+        if directives.len() == 0 {
             return String::new();
         }
         let dir_names: Vec<String> = directives
@@ -1393,10 +1732,10 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
     }
 
     /// Format a pattern for printing.
-    fn format_pattern(&self, pat: &RirPattern) -> String {
+    fn format_pattern(&self, pat: &RirPatternView<'_>) -> String {
         match pat {
-            RirPattern::Wildcard(_) => "_".to_string(),
-            RirPattern::Int {
+            RirPatternView::Wildcard(_) => "_".to_string(),
+            RirPatternView::Int {
                 value, negative, ..
             } => {
                 if *negative {
@@ -1405,8 +1744,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     value.to_string()
                 }
             }
-            RirPattern::Bool(b, _) => b.to_string(),
-            RirPattern::Path {
+            RirPatternView::Bool(b, _) => b.to_string(),
+            RirPatternView::Path {
                 module,
                 type_name,
                 variant,
@@ -1428,7 +1767,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     base
                 } else {
                     let names: Vec<&str> =
-                        bindings.iter().map(|b| self.interner.resolve(b)).collect();
+                        bindings.iter().map(|b| self.interner.resolve(&b)).collect();
                     format!("{}({})", base, names.join(", "))
                 }
             }
@@ -1654,8 +1993,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         .map(|(pat, body)| {
                             format!(
                                 "{} => {}",
-                                self.format_pattern(pat),
-                                self.display_ref(*body)
+                                self.format_pattern(&pat),
+                                self.display_ref(body)
                             )
                         })
                         .collect();
@@ -1702,7 +2041,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     };
                     let params = self.rir.get_params(*params_start, *params_len);
                     let params_str: Vec<String> = params
-                        .iter()
+                        .values()
                         .map(|p| {
                             let comptime_prefix = if p.is_comptime { "comptime " } else { "" };
                             let mode_prefix = match p.mode {
@@ -1774,7 +2113,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 } => {
                     let name_str = self.interner.resolve(&*name);
                     let args = self.rir.get_call_args(*args_start, *args_len);
-                    writeln!(out, "call {}({})", name_str, self.format_call_args(&args)).unwrap();
+                    writeln!(out, "call {}({})", name_str, self.format_call_args(args)).unwrap();
                 }
                 InstData::Intrinsic {
                     name,
@@ -1784,8 +2123,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let name_str = self.interner.resolve(&*name);
                     let args = self.rir.get_inst_refs(*args_start, *args_len);
                     let args_str: Vec<String> = args
-                        .iter()
-                        .map(|a| self.display_ref(*a).to_string())
+                        .values()
+                        .map(|a| self.display_ref(a).to_string())
                         .collect();
                     writeln!(out, "intrinsic @{}({})", name_str, args_str.join(", ")).unwrap();
                 }
@@ -1796,8 +2135,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 } => {
                     let args = self.rir.get_inst_refs(*args_start, *args_len);
                     let args_str: Vec<String> = args
-                        .iter()
-                        .map(|a| self.display_ref(*a).to_string())
+                        .values()
+                        .map(|a| self.display_ref(a).to_string())
                         .collect();
                     writeln!(
                         out,
@@ -1881,24 +2220,24 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let name_str = self.interner.resolve(&*name);
                     let fields = self.rir.get_field_decls(*fields_start, *fields_len);
                     let fields_str: Vec<String> = fields
-                        .iter()
+                        .values()
                         .map(|(fname, ftype)| {
                             format!(
                                 "{}: {}",
-                                self.interner.resolve(&*fname),
-                                self.interner.resolve(&*ftype)
+                                self.interner.resolve(&fname),
+                                self.interner.resolve(&ftype)
                             )
                         })
                         .collect();
                     let linear_str = if *is_linear { "linear " } else { "" };
                     let directives_str = self.format_directives(*directives_start, *directives_len);
                     let methods = self.rir.get_inst_refs(*methods_start, *methods_len);
-                    let methods_str = if methods.is_empty() {
+                    let methods_str = if methods.len() == 0 {
                         String::new()
                     } else {
                         let method_refs: Vec<String> = methods
-                            .iter()
-                            .map(|m| self.display_ref(*m).to_string())
+                            .values()
+                            .map(|m| self.display_ref(m).to_string())
                             .collect();
                         format!(" methods: [{}]", method_refs.join(", "))
                     };
@@ -1931,12 +2270,12 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let type_str = self.interner.resolve(&*type_name);
                     let fields = self.rir.get_field_inits(*fields_start, *fields_len);
                     let fields_str: Vec<String> = fields
-                        .iter()
+                        .values()
                         .map(|(fname, value)| {
                             format!(
                                 "{}: {}",
-                                self.interner.resolve(&*fname),
-                                self.display_ref(*value)
+                                self.interner.resolve(&fname),
+                                self.display_ref(value)
                             )
                         })
                         .collect();
@@ -1994,7 +2333,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         .iter()
                         .enumerate()
                         .map(|(i, v)| {
-                            let base = self.interner.resolve(&*v).to_string();
+                            let base = self.interner.resolve(&v).to_string();
                             match payload_arities.get(i) {
                                 Some(k) if *k > 0 => format!("{}/{}", base, k),
                                 _ => base,
@@ -2035,8 +2374,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 } => {
                     let elements = self.rir.get_inst_refs(*elems_start, *elems_len);
                     let elems_str: Vec<String> = elements
-                        .iter()
-                        .map(|e| self.display_ref(*e).to_string())
+                        .values()
+                        .map(|e| self.display_ref(e).to_string())
                         .collect();
                     writeln!(out, "array_init [{}]", elems_str.join(", ")).unwrap();
                 }
@@ -2088,7 +2427,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         "method_call {}.{}({})",
                         self.display_ref(*receiver),
                         self.interner.resolve(&*method),
-                        self.format_call_args(&args)
+                        self.format_call_args(args)
                     )
                     .unwrap();
                 }
@@ -2130,22 +2469,22 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 } => {
                     write!(out, "struct {{ ").unwrap();
                     let fields = self.rir.get_field_decls(*fields_start, *fields_len);
-                    for (i, (name, ty)) in fields.iter().enumerate() {
+                    for (i, (name, ty)) in fields.values().enumerate() {
                         if i > 0 {
                             write!(out, ", ").unwrap();
                         }
-                        let name_str = self.interner.resolve(name);
-                        let ty_str = self.interner.resolve(ty);
+                        let name_str = self.interner.resolve(&name);
+                        let ty_str = self.interner.resolve(&ty);
                         write!(out, "{}: {}", name_str, ty_str).unwrap();
                     }
                     // Print methods if any
                     if *methods_len > 0 {
                         let methods = self.rir.get_inst_refs(*methods_start, *methods_len);
                         let methods_str: Vec<String> = methods
-                            .iter()
-                            .map(|m| self.display_ref(*m).to_string())
+                            .values()
+                            .map(|m| self.display_ref(m).to_string())
                             .collect();
-                        if !fields.is_empty() {
+                        if fields.len() != 0 {
                             write!(out, ", ").unwrap();
                         }
                         write!(out, "methods: [{}]", methods_str.join(", ")).unwrap();
@@ -2174,7 +2513,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         .iter()
                         .enumerate()
                         .map(|(i, v)| {
-                            let base = self.interner.resolve(&*v).to_string();
+                            let base = self.interner.resolve(&v).to_string();
                             match payload_arities.get(i) {
                                 Some(k) if *k > 0 => format!("{}/{}", base, k),
                                 _ => base,
@@ -2199,6 +2538,60 @@ impl fmt::Display for RirPrinter<'_, '_> {
 mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::cell::Cell;
+
+    struct CountingAllocator;
+
+    thread_local! {
+        static COUNT_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
+        static ALLOCATION_COUNT: Cell<usize> = const { Cell::new(0) };
+    }
+
+    unsafe impl GlobalAlloc for CountingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            COUNT_ALLOCATIONS.with(|enabled| {
+                if enabled.get() {
+                    ALLOCATION_COUNT.with(|count| count.set(count.get() + 1));
+                }
+            });
+            unsafe { System.alloc(layout) }
+        }
+
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            COUNT_ALLOCATIONS.with(|enabled| {
+                if enabled.get() {
+                    ALLOCATION_COUNT.with(|count| count.set(count.get() + 1));
+                }
+            });
+            unsafe { System.alloc_zeroed(layout) }
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) }
+        }
+
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            COUNT_ALLOCATIONS.with(|enabled| {
+                if enabled.get() {
+                    ALLOCATION_COUNT.with(|count| count.set(count.get() + 1));
+                }
+            });
+            unsafe { System.realloc(ptr, layout, new_size) }
+        }
+    }
+
+    #[global_allocator]
+    static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+    fn allocations_during(f: impl FnOnce()) -> usize {
+        COUNT_ALLOCATIONS.with(|enabled| enabled.set(false));
+        ALLOCATION_COUNT.with(|count| count.set(0));
+        COUNT_ALLOCATIONS.with(|enabled| enabled.set(true));
+        f();
+        COUNT_ALLOCATIONS.with(|enabled| enabled.set(false));
+        ALLOCATION_COUNT.with(Cell::get)
+    }
 
     #[test]
     fn test_inst_ref_size() {
@@ -2363,7 +2756,7 @@ mod tests {
             },
         ]);
 
-        let args = rir.get_call_args(args_start, args_len);
+        let args = rir.get_call_args(args_start, args_len).to_vec();
         assert_eq!(args.len(), 3);
         assert_eq!(args[0].value, InstRef::from_raw(1));
         assert_eq!(args[0].mode, RirArgMode::Normal);
@@ -2410,7 +2803,7 @@ mod tests {
 
         assert_eq!(decoded.len(), modes.len());
         assert_eq!(
-            decoded.iter().map(|param| param.mode).collect::<Vec<_>>(),
+            decoded.values().map(|param| param.mode).collect::<Vec<_>>(),
             modes
         );
         assert_eq!(modes.map(RirParamMode::as_u32), [0, 1, 2]);
@@ -2432,6 +2825,251 @@ mod tests {
         let params_start = rir.add_extra(&[0, 0, 99, 0, 0, 0, 0]);
 
         let _ = rir.get_params(params_start, 1);
+    }
+
+    #[test]
+    fn borrowing_payload_views_are_exact_for_empty_fixed_and_variable_records() {
+        fn exact_len(iter: impl ExactSizeIterator) -> usize {
+            iter.len()
+        }
+
+        let mut rir = Rir::new();
+        assert_eq!(exact_len(rir.get_inst_refs(0, 0).values()), 0);
+        assert_eq!(exact_len(rir.get_symbols(0, 0).iter()), 0);
+        assert_eq!(exact_len(rir.get_call_args(0, 0).values()), 0);
+        assert_eq!(exact_len(rir.get_params(0, 0).values()), 0);
+        assert_eq!(exact_len(rir.get_match_arms(0, 0).iter()), 0);
+        assert_eq!(exact_len(rir.get_field_inits(0, 0).values()), 0);
+        assert_eq!(exact_len(rir.get_field_decls(0, 0).values()), 0);
+        assert_eq!(exact_len(rir.get_directives(0, 0).iter()), 0);
+
+        let interner = ThreadedRodeo::new();
+        let type_name = interner.get_or_intern("Shape");
+        let variant = interner.get_or_intern("Rect");
+        let left = interner.get_or_intern("left");
+        let right = interner.get_or_intern("right");
+        let body = rir.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: Span::new(20, 21),
+        });
+        let (arms_start, arms_len) = rir.add_match_arms(&[(
+            RirPattern::Path {
+                module: None,
+                ctor_head: None,
+                type_name,
+                variant,
+                bindings: vec![left, right],
+                span: Span::new(3, 18),
+            },
+            body,
+        )]);
+        let arms = rir.get_match_arms(arms_start, arms_len);
+        assert_eq!(arms.len(), 1);
+        let (pattern, decoded_body) = arms.iter().next().unwrap();
+        assert_eq!(arms.len(), 1);
+        assert_eq!(decoded_body, body);
+        let RirPatternView::Path { bindings, span, .. } = pattern else {
+            panic!("expected path-pattern view")
+        };
+        assert_eq!(span, Span::new(3, 18));
+        assert_eq!(exact_len(bindings.iter()), 2);
+        assert_eq!(bindings.to_vec(), vec![left, right]);
+
+        let directive_name = interner.get_or_intern("allow");
+        let warning = interner.get_or_intern("unused_variable");
+        let (directives_start, directives_len) = rir.add_directives(&[RirDirective {
+            name: directive_name,
+            args: vec![warning],
+            span: Span::new(30, 42),
+        }]);
+        let directives = rir.get_directives(directives_start, directives_len);
+        assert_eq!(directives.len(), 1);
+        let directive = directives.iter().next().unwrap();
+        assert_eq!(directive.span, Span::new(30, 42));
+        assert_eq!(exact_len(directive.args.iter()), 1);
+        assert_eq!(directive.args.to_vec(), vec![warning]);
+    }
+
+    #[test]
+    fn every_borrowing_payload_family_traverses_without_allocating() {
+        let interner = ThreadedRodeo::new();
+        let first = interner.get_or_intern("first");
+        let second = interner.get_or_intern("second");
+        let ty = interner.get_or_intern("i32");
+        let directive_name = interner.get_or_intern("allow");
+        let span = Span::new(1, 2);
+        let refs = [InstRef::from_raw(1), InstRef::from_raw(2)];
+        let mut rir = Rir::new();
+        let inst_refs = rir.add_inst_refs(&refs);
+        let symbols = rir.add_symbols(&[first, second]);
+        let call_args = rir.add_call_args(&[
+            RirCallArg {
+                value: refs[0],
+                mode: RirArgMode::Normal,
+            },
+            RirCallArg {
+                value: refs[1],
+                mode: RirArgMode::Inout,
+            },
+        ]);
+        let params = rir.add_params(&[
+            RirParam {
+                name: first,
+                ty,
+                mode: RirParamMode::Normal,
+                is_comptime: false,
+                span,
+            },
+            RirParam {
+                name: second,
+                ty,
+                mode: RirParamMode::Inout,
+                is_comptime: false,
+                span,
+            },
+        ]);
+        let match_arms = rir.add_match_arms(&[(
+            RirPattern::Path {
+                module: None,
+                ctor_head: None,
+                type_name: ty,
+                variant: first,
+                bindings: vec![second],
+                span,
+            },
+            refs[0],
+        )]);
+        let field_inits = rir.add_field_inits(&[(first, refs[0]), (second, refs[1])]);
+        let field_decls = rir.add_field_decls(&[(first, ty), (second, ty)]);
+        let directives = rir.add_directives(&[RirDirective {
+            name: directive_name,
+            args: vec![first, second],
+            span,
+        }]);
+
+        let checks = [
+            (
+                "inst refs",
+                allocations_during(|| {
+                    std::hint::black_box(
+                        rir.get_inst_refs(inst_refs.0, inst_refs.1).values().count(),
+                    );
+                }),
+            ),
+            (
+                "symbols",
+                allocations_during(|| {
+                    std::hint::black_box(rir.get_symbols(symbols.0, symbols.1).values().count());
+                }),
+            ),
+            (
+                "call args",
+                allocations_during(|| {
+                    std::hint::black_box(
+                        rir.get_call_args(call_args.0, call_args.1).values().count(),
+                    );
+                }),
+            ),
+            (
+                "params",
+                allocations_during(|| {
+                    std::hint::black_box(rir.get_params(params.0, params.1).values().count());
+                }),
+            ),
+            (
+                "match arms",
+                allocations_during(|| {
+                    std::hint::black_box(
+                        rir.get_match_arms(match_arms.0, match_arms.1)
+                            .iter()
+                            .count(),
+                    );
+                }),
+            ),
+            (
+                "field inits",
+                allocations_during(|| {
+                    std::hint::black_box(
+                        rir.get_field_inits(field_inits.0, field_inits.1)
+                            .values()
+                            .count(),
+                    );
+                }),
+            ),
+            (
+                "field decls",
+                allocations_during(|| {
+                    std::hint::black_box(
+                        rir.get_field_decls(field_decls.0, field_decls.1)
+                            .values()
+                            .count(),
+                    );
+                }),
+            ),
+            (
+                "directives",
+                allocations_during(|| {
+                    std::hint::black_box(
+                        rir.get_directives(directives.0, directives.1)
+                            .iter()
+                            .count(),
+                    );
+                }),
+            ),
+        ];
+        for (family, allocations) in checks {
+            assert_eq!(allocations, 0, "{family} traversal allocated");
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn fixed_payload_view_rejects_an_out_of_bounds_range() {
+        let rir = Rir::new();
+        let _ = rir.get_call_args(0, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn variable_payload_view_rejects_a_truncated_path_record() {
+        let mut rir = Rir::new();
+        let start = rir.add_extra(&[
+            PatternKind::Path as u32,
+            0,
+            1,
+            0,
+            u32::MAX,
+            u32::MAX,
+            0,
+            0,
+            2,
+            0,
+        ]);
+        let _ = rir.get_match_arms(start, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid RirArgMode value: 99")]
+    fn fixed_payload_view_eagerly_rejects_a_malformed_later_record() {
+        let mut rir = Rir::new();
+        let start = rir.add_extra(&[0, RirArgMode::Normal.as_u32(), 1, 99]);
+        let _ = rir.get_call_args(start, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unknown pattern kind: 99")]
+    fn match_arm_view_eagerly_rejects_a_malformed_later_record() {
+        let mut rir = Rir::new();
+        let start = rir.add_extra(&[PatternKind::Wildcard as u32, 0, 0, 0, 0, 99]);
+        let _ = rir.get_match_arms(start, 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn directive_view_eagerly_rejects_a_truncated_later_record() {
+        let mut rir = Rir::new();
+        let start = rir.add_extra(&[0, 0, 0, 0, 0, 0]);
+        let _ = rir.get_directives(start, 2);
     }
 
     // RirPrinter tests
@@ -3328,7 +3966,11 @@ mod tests {
             },
         ];
         let (start, len) = rir.add_directives(&original);
-        let decoded = rir.get_directives(start, len);
+        let decoded: Vec<_> = rir
+            .get_directives(start, len)
+            .iter()
+            .map(|directive| directive.to_owned())
+            .collect();
         assert_eq!(decoded, original);
     }
 

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -26,5 +26,5 @@ mod inst;
 pub use astgen::AstGen;
 pub use inst::{
     Inst, InstData, InstRef, InternalIntrinsic, RepeatCount, Rir, RirArgMode, RirCallArg,
-    RirDirective, RirParam, RirParamMode, RirPattern, RirPrinter,
+    RirDirective, RirDirectiveView, RirParam, RirParamMode, RirPattern, RirPatternView, RirPrinter,
 };

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -1,5 +1,17 @@
 load("//crates:defs.bzl", "rue_binary")
 
+_DEPS = [
+    "//crates/rue-compiler:rue-compiler",
+    "//crates/rue-rir:rue-rir",
+    "//crates/rue-target:rue-target",
+    "//third-party:libc",
+    "//third-party:serde",
+    "//third-party:serde_json",
+    "//third-party:sha2",
+    "//third-party:tracing",
+    "//third-party:tracing-subscriber",
+]
+
 export_file(
     name = "benchmark-definition",
     src = "src/main.rs",
@@ -8,15 +20,22 @@ export_file(
 
 rue_binary(
     name = "rue",
-    deps = [
-        "//crates/rue-compiler:rue-compiler",
-        "//crates/rue-rir:rue-rir",
-        "//crates/rue-target:rue-target",
-        "//third-party:libc",
-        "//third-party:serde",
-        "//third-party:serde_json",
-        "//third-party:sha2",
-        "//third-party:tracing",
-        "//third-party:tracing-subscriber",
+    deps = _DEPS,
+    rustc_flags = [
+        "--check-cfg=cfg(rue_benchmark_allocations)",
+        "--check-cfg=cfg(test)",
     ],
+)
+
+# Allocation accounting changes the global allocator and is intentionally
+# isolated from the production compiler target.
+rue_binary(
+    name = "rue-benchmark",
+    deps = _DEPS,
+    rustc_flags = [
+        "--cfg=rue_benchmark_allocations",
+        "--check-cfg=cfg(rue_benchmark_allocations)",
+        "--check-cfg=cfg(test)",
+    ],
+    tests = False,
 )

--- a/crates/rue/src/allocation.rs
+++ b/crates/rue/src/allocation.rs
@@ -1,0 +1,78 @@
+//! Benchmark-only whole-compiler allocation accounting.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+pub(crate) struct CountingAllocator;
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+#[global_allocator]
+pub(crate) static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() && ENABLED.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc_zeroed(layout) };
+        if !pointer.is_null() && ENABLED.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !new_pointer.is_null() && ENABLED.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        new_pointer
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AllocationMetrics {
+    pub(crate) allocations: u64,
+    pub(crate) allocated_bytes: u64,
+}
+
+pub(crate) fn begin() {
+    ENABLED.store(false, Ordering::SeqCst);
+    ALLOCATIONS.store(0, Ordering::SeqCst);
+    ALLOCATED_BYTES.store(0, Ordering::SeqCst);
+    ENABLED.store(true, Ordering::SeqCst);
+}
+
+pub(crate) fn pause() {
+    ENABLED.store(false, Ordering::SeqCst);
+}
+
+pub(crate) fn resume() {
+    ENABLED.store(true, Ordering::SeqCst);
+}
+
+pub(crate) fn finish() {
+    pause();
+}
+
+pub(crate) fn snapshot() -> AllocationMetrics {
+    AllocationMetrics {
+        allocations: ALLOCATIONS.load(Ordering::SeqCst),
+        allocated_bytes: ALLOCATED_BYTES.load(Ordering::SeqCst),
+    }
+}

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -13,6 +13,8 @@ use tracing::{Level, info_span};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::{EnvFilter, Layer as _, fmt};
 
+#[cfg(rue_benchmark_allocations)]
+mod allocation;
 mod timing;
 
 #[cfg(test)]
@@ -1124,6 +1126,15 @@ fn print_timing_output(
                     "size_bytes": bytes.len(),
                 });
             }
+            #[cfg(rue_benchmark_allocations)]
+            {
+                let metrics = allocation::snapshot();
+                payload["compiler_allocations"] = serde_json::json!({
+                    "count": metrics.allocations,
+                    "requested_bytes": metrics.allocated_bytes,
+                    "boundary": "canonical compile root including discovery and backend",
+                });
+            }
             println!("{payload}");
         } else if time_passes {
             // Human-readable output goes to stderr
@@ -1862,6 +1873,10 @@ fn main() {
     // the discovery parse as a second timing root.
     let compile_span = tracing::info_span!("compile", target = %options.target);
     let captured_std_root = env::var_os("RUE_STD_PATH").map(PathBuf::from);
+    #[cfg(rue_benchmark_allocations)]
+    if options.benchmark_json {
+        allocation::begin();
+    }
     let mut import_discovery = {
         let _compile = compile_span.enter();
         match discover_and_load_imports(
@@ -1874,6 +1889,10 @@ fn main() {
             Err(()) => std::process::exit(1),
         }
     };
+    #[cfg(rue_benchmark_allocations)]
+    if options.benchmark_json {
+        allocation::pause();
+    }
     let source_snapshot = import_discovery.source_snapshot.clone();
 
     // Create multi-file diagnostic formatters from the snapshot's borrowed
@@ -1981,6 +2000,10 @@ fn main() {
         opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
     };
+    #[cfg(rue_benchmark_allocations)]
+    if options.benchmark_json {
+        allocation::resume();
+    }
     let compile_result = {
         let _compile = compile_span.enter();
         import_discovery
@@ -1988,6 +2011,10 @@ fn main() {
             .executable_in_compile_scope(&compile_options)
     };
     drop(compile_span);
+    #[cfg(rue_benchmark_allocations)]
+    if options.benchmark_json {
+        allocation::finish();
+    }
     match compile_result {
         Ok(output) => {
             // Print warnings using the diagnostic formatter

--- a/docs/process/rue-790-performance.md
+++ b/docs/process/rue-790-performance.md
@@ -1,0 +1,318 @@
+# RUE-790 borrowing RIR payload performance record
+
+Measured 2026-07-16 for the RUE-790 pre-schema migration required by
+[ADR-0056](../designs/0056-typed-ir-payload-schemas.md). This is a paired
+baseline/candidate record; it does not update the historical performance
+dashboard.
+
+## Exact revisions and environment
+
+- Baseline source revision: `50deb00da2e3aa65ae54d037619451c4882d1864`.
+- Candidate source: that revision plus the frozen RUE-790 compiler patch whose
+  SHA-256 is
+  `0febfd0bb50a981949243ed4b7973f7663a6de2e6cecb5a6657136cef361790f`.
+  The fingerprint is over the binary `git diff` for `crates/rue-air`,
+  `crates/rue-rir`, `crates/rue/BUCK`, `crates/rue/src/main.rs`, and the new
+  `crates/rue/src/allocation.rs`; the evidence document is deliberately not
+  part of the compiler-source fingerprint.
+- Uninstrumented production candidate binary SHA-256:
+  `cac7d769fbb8c6aec8276dc3b7aed8a2f21f85451deaf82a157498dd858f9262`.
+- Pristine upstream baseline production binary SHA-256:
+  `4b84283fe49feeb012414318f374b029c2ed98c2faf9cd2476e1cdd2ceff1bb1`.
+- Dedicated candidate `rue-benchmark` binary SHA-256:
+  `997702303bb5e89c506bcee504e53489c32f9c0474d9ff91a403179390bfd055`.
+- Dedicated baseline `rue-benchmark` binary SHA-256:
+  `b29ba8979983adcf3f8ae46472b1bfac98c1de249802a5e63c105b243b272f85`.
+- The baseline dedicated target received only the same benchmark-accounting
+  patch used by the candidate. Its binary patch SHA-256 is
+  `1a913e214e7b39a772fe24a58b81c80cd21d45649ead7e6bf7cabc7d35f86e4d`.
+- Host: Apple arm64, macOS 26.5.2 (build 25F84), otherwise idle.
+- Target/profile/linker: `aarch64-macos`, Buck2 default profile, internal
+  linker.
+- Toolchain: Rust 1.92.0 (`ded5c06cf`, 2025-12-08); Buck2
+  `2026-06-30-c88d791e34884e58617b92d5b98c7f71faee823c`.
+
+The compiler patch and all measured binaries were frozen before the series
+below. No compiler source changed between fingerprint/build and measurement.
+
+For publication, the reviewed commit was rebased onto upstream `17f09b56`.
+The RUE-790 patch against that parent has SHA-256
+`4d227466a20718a5cfe60e3182f0d61c6e0b745331f4fdb6f6e31e544828df8c` using
+the same `git diff --binary` path set above. The only conflict was in
+`crates/rue/src/main.rs`: upstream RUE-767 had deleted the legacy positional
+input check adjacent to the benchmark allocation boundary. Resolution kept
+upstream's deletion and the measured RUE-790 `allocation::pause()` boundary;
+no measured RIR, AIR, allocation-accounting, or benchmark-target logic changed.
+The publication patch also elides one iterator-implementation lifetime and
+removes six needless borrows in tests to satisfy the Linux clippy gate; neither
+change affects generated production code.
+The paired `50deb00d` series remains the isolated before/after evidence for
+RUE-790, while post-rebase correctness is covered by the publication checks.
+
+## Workloads and protocol
+
+| Workload | Source or generator | SHA-256 |
+| --- | --- | --- |
+| Many small functions/calls | `benchmarks/stress/many_functions.rue` | `6de992cedb83f6c5f73788574a994d4f74a8a1fa8c45697afffa325f2876e38f` |
+| Match-heavy path bindings | generated `/tmp/rue790-match-path-bindings.rue` | `6f3d14e2af1740d240c863032262a60ad554a9396ebef910114e5da1498aa785` |
+| Generic/comptime | `examples/generics.rue` | `6962376ddebf6f280ece700601549978203817f2160355d5b7fd66f511bb5225` |
+
+The match workload has 400 functions. Every function matches the qualified
+paths `Payload.Empty`, `Payload.One`, `Payload.Pair`, and `Payload.Quad` with
+zero, one, two, and four bindings respectively. Its generator is:
+
+```python
+print("enum Payload { Empty, One(i32), Pair(i32, i32), Quad(i32, i32, i32, i32) }")
+for index in range(400):
+    print(f"fn _match_bind_{index:03}(value: Payload) -> i32 {{")
+    print("    match value {")
+    print("        Payload.Empty => 0,")
+    print("        Payload.One(a) => a,")
+    print("        Payload.Pair(a, b) => a + b,")
+    print("        Payload.Quad(a, b, c, d) => a + b + c + d,")
+    print("    }")
+    print("}")
+print("fn main() -> i32 { _match_bind_399(Payload.Quad(1, 2, 3, 4)) - 10 }")
+```
+
+Each revision received one discarded warmup for each workload. Seven measured
+pairs followed. The chronological order alternated:
+
+| Pair | Order |
+| ---: | --- |
+| 1 | baseline, candidate |
+| 2 | candidate, baseline |
+| 3 | baseline, candidate |
+| 4 | candidate, baseline |
+| 5 | baseline, candidate |
+| 6 | candidate, baseline |
+| 7 | baseline, candidate |
+
+Values in every raw row below are pair 1 through pair 7; the table above gives
+their chronological execution order. The command shape was:
+
+```text
+/usr/bin/time -l -o <accounting> <exact-rue-binary> \
+  --benchmark-json <source> -o <unique-output> > <sample-json>
+```
+
+Wall time and peak RSS come from `/usr/bin/time -l`. Compiler and phase times
+come from `--benchmark-json`. Medians and median absolute deviations (MAD) use
+the seven raw values.
+
+### Allocation boundary
+
+Only `//crates/rue:rue-benchmark` installs the counting allocator. The ordinary
+`//crates/rue:rue` target does not compile the allocation module, does not set a
+global allocator, and contains no allocation-counter atomic load. For
+`--benchmark-json`, the dedicated target resets immediately before the
+canonical `compile` root begins and enables atomic counters only
+while one of that root's intervals is active. The boundary includes import
+discovery, parsing, RIR, semantic analysis, CFG construction, code generation,
+and linking; CLI setup, output-file writing, diagnostics printing, and JSON
+formatting are outside it. Successful `alloc`, `alloc_zeroed`, and `realloc`
+calls count as allocation calls, and requested bytes include each successful
+allocation size or reallocation's new size. Counting is disabled for ordinary
+compiler invocations. Identical instrumentation is compiled into the two
+dedicated benchmark binaries.
+
+## Dedicated benchmark-target results
+
+| Workload | Revision | wall s, median ± MAD | peak RSS bytes, median ± MAD | compiler ms, median ± MAD | allocations, median ± MAD | requested bytes, median ± MAD |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Many functions | baseline | 0.33 ± 0.00 | 50,511,872 ± 163,840 | 315.606 ± 0.796 | 725,309 ± 3 | 108,132,487 ± 2,008 |
+| Many functions | candidate | 0.33 ± 0.00 | 50,200,576 ± 212,992 | 318.689 ± 4.329 | 714,304 ± 4 | 107,921,647 ± 3,688 |
+| Match/path bindings | baseline | 0.09 ± 0.00 | 25,149,440 ± 16,384 | 79.780 ± 0.153 | 101,860 ± 2 | 18,781,606 ± 376 |
+| Match/path bindings | candidate | 0.09 ± 0.00 | 25,247,744 ± 49,152 | 79.861 ± 0.093 | 99,034 ± 4 | 18,749,565 ± 1,232 |
+| Generic/comptime | baseline | 0.02 ± 0.00 | 21,561,344 ± 32,768 | 10.485 ± 0.146 | 46,877 ± 1 | 6,734,894 ± 208 |
+| Generic/comptime | candidate | 0.02 ± 0.00 | 21,594,112 ± 49,152 | 10.396 ± 0.121 | 46,749 ± 2 | 6,727,810 ± 416 |
+
+Allocation non-increase is stronger than a median-only result: the maximum
+candidate allocation count is below the minimum baseline count in every
+workload.
+
+| Workload | baseline minimum | candidate maximum | proof |
+| --- | ---: | ---: | --- |
+| Many functions | 725,303 | 714,311 | candidate maximum is 10,992 lower |
+| Match/path bindings | 101,857 | 99,044 | candidate maximum is 2,813 lower |
+| Generic/comptime | 46,876 | 46,753 | candidate maximum is 123 lower |
+
+## Uninstrumented production wall time and RSS
+
+The production comparison used the pristine upstream `50deb00d` `rue` binary
+and the final candidate's ordinary `//crates/rue:rue` binary. Neither binary
+contains the counting allocator. It used the same warmup, seven alternating
+pairs, workloads, command shape, and pair order documented above.
+
+| Workload | Revision | wall s, median ± MAD | peak RSS bytes, median ± MAD |
+| --- | --- | ---: | ---: |
+| Many functions | baseline | 0.31 ± 0.00 | 52,723,712 ± 245,760 |
+| Many functions | candidate | 0.31 ± 0.00 | 53,182,464 ± 294,912 |
+| Match/path bindings | baseline | 0.09 ± 0.00 | 26,263,552 ± 131,072 |
+| Match/path bindings | candidate | 0.09 ± 0.00 | 26,476,544 ± 81,920 |
+| Generic/comptime | baseline | 0.02 ± 0.00 | 21,954,560 ± 32,768 |
+| Generic/comptime | candidate | 0.02 ± 0.00 | 21,938,176 ± 32,768 |
+
+Raw samples, pair 1 through pair 7:
+
+| Workload/revision | wall seconds | peak RSS bytes |
+| --- | --- | --- |
+| many/baseline | 0.31, 0.31, 0.30, 0.31, 0.31, 0.32, 0.31 | 52723712, 52330496, 52740096, 52969472, 52576256, 53067776, 52445184 |
+| many/candidate | 0.31, 0.31, 0.31, 0.30, 0.32, 0.31, 0.31 | 52150272, 53198848, 51806208, 53477376, 51855360, 53215232, 53182464 |
+| match/baseline | 0.09, 0.09, 0.09, 0.09, 0.09, 0.09, 0.09 | 26132480, 26099712, 26263552, 26378240, 26394624, 25804800, 26296320 |
+| match/candidate | 0.09, 0.09, 0.09, 0.09, 0.09, 0.09, 0.09 | 26476544, 26509312, 26312704, 26558464, 26361856, 26542080, 26312704 |
+| generic/baseline | 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02 | 21938176, 21938176, 22036480, 21889024, 21954560, 22003712, 21987328 |
+| generic/candidate | 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02 | 21790720, 21954560, 21872640, 21889024, 21938176, 21954560, 21970944 |
+
+Wall medians are unchanged. Many-functions RSS increases by 0.87%, and
+match/path-binding RSS increases by 0.81%; both are below their 2% gates.
+Generic/comptime RSS decreases by 0.07%. The uninstrumented production series
+passes the ADR-0056 wall/RSS gate without relying on symmetric allocator
+overhead.
+
+The target separation was also checked directly:
+
+```text
+normal rue --benchmark-json: compiler_allocations key absent
+nm <normal-rue> | rg CountingAllocator: no matches
+dedicated rue-benchmark --benchmark-json: compiler_allocations key present
+nm <rue-benchmark> | rg CountingAllocator: allocator symbols present
+```
+
+Thus an ordinary compiler invocation uses Rust's unwrapped platform allocator
+and incurs no allocation-counter load or instrumentation branch.
+
+## Raw compiler samples
+
+### Many functions
+
+| Revision | wall s | peak RSS bytes | compiler ms | allocations | requested bytes |
+| --- | --- | --- | --- | --- | --- |
+| baseline | 0.33, 0.33, 0.33, 0.33, 0.33, 0.33, 0.33 | 50511872, 49889280, 50659328, 50675712, 49790976, 50495488, 50790400 | 315.385, 314.810, 315.601, 316.548, 315.606, 318.355, 317.980 | 725312, 725312, 725321, 725308, 725303, 725309, 725308 | 108132911, 108134511, 108140983, 108131279, 108125639, 108132487, 108130479 |
+| candidate | 0.33, 0.34, 0.33, 0.33, 0.33, 0.36, 0.33 | 50544640, 50200576, 50626560, 50905088, 49987584, 50036736, 50036736 | 314.994, 323.887, 318.689, 318.876, 314.360, 346.584, 314.219 | 714303, 714308, 714297, 714304, 714302, 714309, 714311 | 107920839, 107925335, 107916391, 107921647, 107920431, 107927287, 107928103 |
+
+### Match/path bindings
+
+| Revision | wall s | peak RSS bytes | compiler ms | allocations | requested bytes |
+| --- | --- | --- | --- | --- | --- |
+| baseline | 0.09, 0.09, 0.09, 0.09, 0.09, 0.09, 0.09 | 25165824, 25100288, 25116672, 25149440, 25149440, 25116672, 25165824 | 79.627, 80.042, 79.925, 80.262, 79.780, 79.538, 79.666 | 101865, 101860, 101864, 101858, 101860, 101861, 101857 | 18784062, 18782422, 18781654, 18781606, 18781022, 18781230, 18781398 |
+| candidate | 0.09, 0.09, 0.09, 0.09, 0.09, 0.09, 0.09 | 25247744, 24772608, 25296896, 25296896, 25247744, 25280512, 24805376 | 79.941, 79.861, 80.029, 80.007, 79.591, 79.847, 79.768 | 99028, 99040, 99044, 99034, 99030, 99034, 99038 | 18745917, 18749613, 18752045, 18747365, 18748333, 18749565, 18750197 |
+
+### Generic/comptime
+
+| Revision | wall s | peak RSS bytes | compiler ms | allocations | requested bytes |
+| --- | --- | --- | --- | --- | --- |
+| baseline | 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02 | 21512192, 21594112, 21561344, 21528576, 21643264, 21561344, 21495808 | 10.631, 10.305, 10.485, 10.370, 10.668, 11.037, 10.415 | 46878, 46878, 46879, 46877, 46877, 46876, 46877 | 6735102, 6735102, 6735310, 6734894, 6734894, 6734686, 6734894 |
+| candidate | 0.02, 0.02, 0.02, 0.02, 0.06, 0.02, 0.02 | 21610496, 21168128, 21594112, 21544960, 21594112, 21184512, 21643264 | 10.390, 10.594, 10.396, 10.692, 10.359, 10.274, 10.914 | 46747, 46749, 46747, 46749, 46750, 46753, 46752 | 6727394, 6727810, 6727394, 6727810, 6728018, 6728642, 6728434 |
+
+## Phase timings
+
+Phase medians ± MAD, in milliseconds:
+
+| workload/revision | semantic astgen | RIR declaration index | sema | CFG | codegen |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| many/baseline | 7.715 ± 0.156 | 1.435 ± 0.016 | 93.163 ± 0.160 | 29.891 ± 0.278 | 69.947 ± 0.645 |
+| many/candidate | 7.571 ± 0.063 | 1.444 ± 0.009 | 93.146 ± 0.863 | 29.764 ± 0.086 | 70.059 ± 0.548 |
+| match/baseline | 6.752 ± 0.014 | 0.582 ± 0.005 | 13.969 ± 0.113 | 0.267 ± 0.016 | 0.453 ± 0.005 |
+| match/candidate | 6.874 ± 0.042 | 0.606 ± 0.016 | 14.149 ± 0.056 | 0.273 ± 0.013 | 0.458 ± 0.005 |
+| generic/baseline | 0.235 ± 0.004 | 0.085 ± 0.001 | 0.956 ± 0.008 | 0.317 ± 0.015 | 0.764 ± 0.030 |
+| generic/candidate | 0.234 ± 0.003 | 0.086 ± 0.002 | 0.976 ± 0.015 | 0.324 ± 0.019 | 0.754 ± 0.005 |
+
+Raw phase samples follow; each row is pair 1 through pair 7.
+
+### Many-functions phases
+
+| Revision/phase | raw ms |
+| --- | --- |
+| baseline/semantic astgen | 7.720, 7.715, 7.671, 7.870, 8.221, 7.533, 7.434 |
+| baseline/RIR declaration index | 1.413, 1.427, 1.416, 1.460, 1.450, 1.440, 1.435 |
+| baseline/sema | 91.910, 92.392, 93.323, 93.229, 94.007, 93.014, 93.163 |
+| baseline/CFG | 29.635, 30.377, 29.748, 28.341, 29.891, 30.168, 30.302 |
+| baseline/codegen | 70.592, 69.947, 68.677, 70.326, 68.007, 69.911, 71.076 |
+| candidate/semantic astgen | 7.785, 8.031, 7.468, 7.536, 7.571, 7.513, 7.634 |
+| candidate/RIR declaration index | 1.444, 1.456, 1.453, 1.452, 1.443, 1.418, 1.427 |
+| candidate/sema | 93.061, 94.232, 94.009, 95.043, 92.958, 93.146, 92.128 |
+| candidate/CFG | 29.791, 29.622, 29.712, 29.883, 29.764, 29.850, 29.589 |
+| candidate/codegen | 70.059, 70.296, 71.162, 69.512, 69.510, 99.262, 69.155 |
+
+### Match/path-binding phases
+
+| Revision/phase | raw ms |
+| --- | --- |
+| baseline/semantic astgen | 6.811, 6.758, 6.738, 6.752, 6.739, 6.685, 6.947 |
+| baseline/RIR declaration index | 0.577, 0.612, 0.574, 0.584, 0.594, 0.580, 0.582 |
+| baseline/sema | 14.083, 13.969, 13.962, 14.551, 13.856, 13.955, 14.090 |
+| baseline/CFG | 0.280, 0.250, 0.341, 0.251, 0.336, 0.267, 0.251 |
+| baseline/codegen | 0.470, 0.449, 0.448, 0.511, 0.453, 0.452, 0.476 |
+| candidate/semantic astgen | 6.741, 6.885, 6.990, 6.878, 6.874, 6.786, 6.831 |
+| candidate/RIR declaration index | 0.602, 0.606, 0.588, 0.600, 0.622, 0.633, 0.629 |
+| candidate/sema | 13.930, 14.149, 14.001, 14.232, 14.171, 14.093, 14.197 |
+| candidate/CFG | 0.356, 0.343, 0.256, 0.273, 0.269, 0.278, 0.260 |
+| candidate/codegen | 0.470, 0.450, 0.465, 0.453, 0.458, 0.456, 0.458 |
+
+### Generic/comptime phases
+
+| Revision/phase | raw ms |
+| --- | --- |
+| baseline/semantic astgen | 0.231, 0.231, 0.208, 0.235, 0.236, 0.249, 0.237 |
+| baseline/RIR declaration index | 0.085, 0.086, 0.077, 0.085, 0.083, 0.094, 0.084 |
+| baseline/sema | 0.956, 0.948, 0.943, 0.961, 0.963, 1.054, 0.932 |
+| baseline/CFG | 0.306, 0.293, 0.333, 0.317, 0.338, 0.326, 0.266 |
+| baseline/codegen | 0.757, 0.712, 0.794, 0.764, 0.834, 0.796, 0.744 |
+| candidate/semantic astgen | 0.244, 0.234, 0.232, 0.235, 0.232, 0.231, 0.243 |
+| candidate/RIR declaration index | 0.080, 0.086, 0.084, 0.086, 0.088, 0.087, 0.090 |
+| candidate/sema | 0.991, 0.949, 0.976, 0.978, 0.976, 0.950, 1.014 |
+| candidate/CFG | 0.331, 0.311, 0.324, 0.355, 0.305, 0.297, 0.379 |
+| candidate/codegen | 0.751, 0.749, 0.754, 0.804, 0.844, 0.753, 0.856 |
+
+## Cold versus reused CompilerSession
+
+The repository's `rue-compiler-session-bench` ran with 64 modules, one warmup,
+and seven measured iterations for each revision:
+
+```text
+./buck2 run //crates/rue-compiler-session-bench:rue-compiler-session-bench \
+  -- --modules 64 --warmup 1 --iterations 7
+```
+
+`cold` constructs and queries a new session. `exact_noop` repeats the same
+snapshot in that session. The benchmark structurally asserts that the reused
+case performs zero lexer/parser, RIR, and semantic executions and records RIR
+and semantic reuse instead. Times are milliseconds.
+
+| Revision/scenario | raw samples | median ± MAD |
+| --- | --- | ---: |
+| baseline/cold | 11.580, 11.541, 11.856, 11.479, 11.563, 11.544, 11.676 | 11.563 ± 0.022 |
+| candidate/cold | 11.620, 11.487, 11.736, 11.266, 11.540, 11.266, 11.373 | 11.487 ± 0.133 |
+| baseline/exact noop reuse | 1.575, 1.596, 1.626, 1.594, 1.580, 1.533, 1.560 | 1.580 ± 0.015 |
+| candidate/exact noop reuse | 1.596, 1.566, 1.564, 1.521, 1.582, 1.550, 1.583 | 1.566 ± 0.016 |
+
+Both cold and reused-session medians decrease. The reused path remains a true
+query reuse rather than a hidden recomputation.
+
+## Focused traversal allocation gate
+
+The RIR unit test wraps construction and complete consumption of each of the
+eight migrated payload getters with a thread-local counting allocator. Every
+family reports exactly zero allocations. Construction is included; the test
+does not stop after creating an iterator. This complements the whole-compiler
+counts above.
+
+## Verdict
+
+ADR-0056's noisy-metric allowance is the larger of 2% of the baseline median
+or three times the larger MAD. Dedicated-target wall medians are unchanged.
+The largest dedicated-target RSS increase is match/path bindings: 98,304
+bytes, or 0.39%, below the 2% gate of 502,989 bytes. The largest compiler-span
+increase is many-functions at 3.082 ms (0.98%), below both its 2% gate and its
+noise allowance; match/path bindings increases by 0.082 ms (0.10%), and
+generic/comptime decreases. The separate uninstrumented production series has
+unchanged wall medians; its RSS changes are +0.87%, +0.81%, and -0.07%, all
+within the gate.
+
+Whole-compiler allocation counts decrease for all workloads, with disjoint raw
+baseline/candidate ranges. Focused payload traversals remain exactly zero
+allocation. Cold and reused-session medians both decrease. The production
+binary has no counting allocator or atomic allocation path. RUE-790 therefore
+passes the requested wall-time, RSS, allocation, phase-timing, variable
+path-binding, session-reuse, and zero-production-instrumentation gates.


### PR DESCRIPTION
## Summary

- replace all eight eager RIR variable-payload getters with reusable borrowing views and exact-size iterators
- preserve eager malformed-range validation while making complete traversal allocate zero times
- convert inference and semantic consumers to borrowing scans, with explicit ownership only at genuine boundaries
- add a dedicated benchmark-only allocator target and paired baseline/candidate performance evidence

## Validation

- `scripts/rue unit rir` (99 passed)
- `scripts/rue unit air` (440 passed)
- `scripts/rue quick` (29 targets passed)
- `scripts/rue build`
- production and benchmark-target binary instrumentation checks
- paired uninstrumented wall/RSS and instrumented allocation/phase benchmarks in `docs/process/rue-790-performance.md`

Fixes RUE-790
