### PR TITLE
RUE-738: audit target ABI conformance

### DIFF
--- a/cli-test-fixtures/abi_conformance_smoke.rue
+++ b/cli-test-fixtures/abi_conformance_smoke.rue
@@ -1,0 +1,74 @@
+// RUE-738: executable coverage for the two calling conventions that exist
+// today. Native Rue calls exercise register exhaustion, sret, and values live
+// across a Target-C call. Runtime calls exercise narrow integer extension,
+// pointer inputs, scalar results, and explicit out-pointer results.
+
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+
+@copy
+struct Nine {
+    values: [i32; 8],
+    marker: i32,
+}
+
+fn sum_nine(
+    a: i32,
+    b: i32,
+    c: i32,
+    d: i32,
+    e: i32,
+    f: i32,
+    g: i32,
+    h: i32,
+    i: i32,
+) -> i32 {
+    a + b + c + d + e + f + g + h + i
+}
+
+fn bump(value: Nine, delta: i32) -> Nine {
+    let mut result = value;
+    result.marker = result.marker + delta;
+    result
+}
+
+fn live_across_target_c(seed: i32) -> i32 {
+    let a = seed + 1;
+    let b = seed + 2;
+    let c = seed + 3;
+    let d = seed + 4;
+    let e = seed + 5;
+    let f = seed + 6;
+    let g = seed + 7;
+    let h = seed + 8;
+    let i = seed + 9;
+    let j = seed + 10;
+    if "abi" == "abi" { a + b + c + d + e + f + g + h + i + j } else { 0 }
+}
+
+fn main() -> i32 {
+    let signed: i8 = @intCast(0 - 5);
+    let unsigned: u8 = 250;
+    @dbg(signed);
+    @dbg(unsigned);
+
+    let Opt = Option(i32);
+    let parsed: Opt = @parse_i32("42");
+    match parsed {
+        Opt.Some(value) => @dbg(value),
+        Opt.None => return 1,
+    }
+
+    if live_across_target_c(0) != 55 { return 2; }
+    let total = sum_nine(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    let value = Nine { values: [1, 2, 3, 4, 5, 6, 7, 8], marker: total };
+    let changed = bump(value, 1);
+    @dbg(changed.marker);
+
+    let mut buffer: StrBuf = "abc";
+    buffer.push(100);
+    @dbg(buffer);
+    0
+}

--- a/crates/rue-cli-tests/cases/abi_conformance.toml
+++ b/crates/rue-cli-tests/cases/abi_conformance.toml
@@ -1,0 +1,60 @@
+# RUE-738: compile and link the same calling-convention probe for every
+# supported target. Foreign outputs receive structural executable validation;
+# the matching native CI host also executes the independently linked runtime
+# boundary and checks exact results.
+
+[section]
+id = "cli.abi_conformance"
+name = "Calling-convention conformance"
+description = "Native Rue and typed Target-C runtime boundaries compile, link, and execute across the supported target matrix."
+
+[[case]]
+name = "x86_64_linux_abi_conformance"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }" }]
+source_path = "cli-test-fixtures/abi_conformance_smoke.rue"
+args = ["${SOURCE}", "--target", "x86-64-linux", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+executable_target = "x86-64-linux"
+execute_if_native = true
+stdout = """
+-5
+250
+42
+46
+abcd
+"""
+exit_code = 0
+
+[[case]]
+name = "aarch64_linux_abi_conformance"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }" }]
+source_path = "cli-test-fixtures/abi_conformance_smoke.rue"
+args = ["${SOURCE}", "--target", "aarch64-linux", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+executable_target = "aarch64-linux"
+execute_if_native = true
+stdout = """
+-5
+250
+42
+46
+abcd
+"""
+exit_code = 0
+
+[[case]]
+name = "aarch64_macos_abi_conformance"
+files = [{ path = "main.rue", source = "fn main() -> i32 { 0 }" }]
+source_path = "cli-test-fixtures/abi_conformance_smoke.rue"
+args = ["${SOURCE}", "--target", "aarch64-macos", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+executable_target = "aarch64-macos"
+execute_if_native = true
+stdout = """
+-5
+250
+42
+46
+abcd
+"""
+exit_code = 0

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3041,6 +3041,26 @@ mod tests {
             .unwrap_or_else(|| panic!("missing call to {helper:?}"))
     }
 
+    #[test]
+    fn runtime_manifest_fits_register_only_target_c_subset() {
+        for id in rue_runtime_abi::RuntimeHelperId::ALL {
+            let helper = id.helper();
+            assert_eq!(
+                helper.calling_convention,
+                rue_runtime_abi::CallingConvention::TargetC,
+                "{} must use the target C convention",
+                helper.symbol
+            );
+            assert!(
+                helper.parameters.len() <= ARG_REGS.len(),
+                "{} has {} parameters, exceeding the AArch64 register-only runtime-call budget of {}",
+                helper.symbol,
+                helper.parameters.len(),
+                ARG_REGS.len()
+            );
+        }
+    }
+
     fn lower_to_mir(source: &str) -> Aarch64Mir {
         lower_function_to_mir(source, "main")
     }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2914,6 +2914,26 @@ mod tests {
     }
 
     #[test]
+    fn runtime_manifest_fits_register_only_target_c_subset() {
+        for id in rue_runtime_abi::RuntimeHelperId::ALL {
+            let helper = id.helper();
+            assert_eq!(
+                helper.calling_convention,
+                rue_runtime_abi::CallingConvention::TargetC,
+                "{} must use the target C convention",
+                helper.symbol
+            );
+            assert!(
+                helper.parameters.len() <= ARG_REGS.len(),
+                "{} has {} parameters, exceeding the x86-64 register-only runtime-call budget of {}",
+                helper.symbol,
+                helper.parameters.len(),
+                ARG_REGS.len()
+            );
+        }
+    }
+
+    #[test]
     fn test_simple_return() {
         let mir = lower_to_mir("fn main() -> i32 { 42 }");
         assert!(!mir.instructions().is_empty());

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3819 rejected=152 lex_invalid=35 accepted_source_ast_sha256=c951f1d649a4c0541861f24c49f3d628efa5f6ed588e7de838327bbcf86d5e63
+# pre-RUE-905 Chumsky: accepted=3822 rejected=152 lex_invalid=35 accepted_source_ast_sha256=b256f910d4ac238500c84a4455a995fe59bfd55910812e709018eeebb3eb7f84
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -1,0 +1,190 @@
+# FFI ABI conformance audit
+
+Status: verified against the compiler and runtime source for RUE-738.
+
+Rue currently has two distinct calling conventions:
+
+1. A private native convention for calls between Rue functions. It borrows
+   target register and stack rules but deliberately is not a C ABI.
+2. A typed `CallingConvention::TargetC` subset for calls from generated code to
+   the bundled runtime. The compiler and runtime share this contract through
+   `rue-runtime-abi`.
+
+Rue does not yet support general foreign imports or exports. In particular,
+the runtime's zero-argument process entry into Rue `main` is not evidence that
+an arbitrary C caller can invoke an arbitrary Rue function. This audit records
+the boundary that exists today and the gaps an FFI implementation must close.
+
+## Normative references
+
+The target-C comparisons use the upstream specifications:
+
+- [System V AMD64 ABI](https://gitlab.com/x86-psABIs/x86-64-ABI/-/jobs/artifacts/master/raw/x86-64-ABI/abi.pdf?job=build)
+- [Procedure Call Standard for the Arm 64-bit Architecture (AAPCS64)](https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst)
+- [Writing ARM64 code for Apple platforms](https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms)
+- [Addressing architectural differences in your macOS code](https://developer.apple.com/documentation/apple-silicon/addressing-architectural-differences-in-your-macos-code)
+
+This is an implementation audit, not a declaration that native Rue values have
+C layout. C interoperability must use a target-C signature and an explicitly
+supported representation.
+
+## Current convention matrix
+
+| Property | Native Rue: x86-64 Linux | Native Rue: AArch64 Linux/macOS | Current target-C runtime subset |
+| --- | --- | --- | --- |
+| Integer/pointer argument registers | `rdi`, `rsi`, `rdx`, `rcx`, `r8`, `r9` | `x0`-`x7` | Same target registers |
+| Stack arguments | 8-byte slots, first overflow slot nearest return address | 8-byte slots beginning at incoming `sp` | Not implemented; every current helper fits registers |
+| Scalar result | `rax` | `x0` | `rax` or `x0`/`w0` |
+| Multi-slot result | Up to six slots in `rax`, `rdx`, `rcx`, `r8`, `r9`, `r10` | Up to eight slots in `x0`-`x7` | No direct aggregate results |
+| Aggregate result storage | Hidden first ordinary slot (`rdi`) | Hidden first ordinary slot (`x0`) | Explicit first out-pointer parameter where required |
+| Aggregate argument order | Logical slots reversed within each value | Logical slots reversed within each value | Natural order; current parameters are scalars and pointers |
+| Call-site stack alignment | 16 bytes | 16 bytes | 16 bytes |
+| Red zone use | None | None | None |
+
+## Native Rue convention
+
+The canonical native call planner flattens a source value into logical 8-byte
+slots. Scalars occupy one slot, each aggregate leaf occupies one slot, zero-size
+value parameters occupy none, and `borrow`/`inout` parameters occupy one pointer
+slot. This is a compiler representation, not the target C layout algorithm.
+
+For a multi-slot value, the call planner reverses that value's slots before
+assigning argument locations. The callee reconstructs logical field order. This
+means that even an aggregate small enough to remain in registers is not passed
+like the corresponding C struct. C ABIs instead classify and place aggregates
+according to target layout, padding, and register classes.
+
+On x86-64, the first six slots use `rdi`, `rsi`, `rdx`, `rcx`, `r8`, and `r9`.
+Remaining slots are pushed in reverse call order so the first overflow slot is
+at `[rbp+16]` in a conventional callee frame, followed by successive 8-byte
+slots. On AArch64, the first eight slots use `x0`-`x7`; overflow slots begin at
+the incoming `sp` and increase by 8 bytes. Both backends maintain 16-byte stack
+alignment at calls.
+
+Native direct aggregate results use logical order, not the argument reversal.
+x86-64 extends the result register set to six slots (`rax`, `rdx`, `rcx`, `r8`,
+`r9`, `r10`), although System V AMD64 supplies at most two integer eightbytes.
+AArch64 extends direct results through `x0`-`x7`, although AAPCS64 integer-like
+composite results are limited to `x0` and `x1` before indirect return is needed.
+
+`StrBuf` and sufficiently large structs and arrays use native indirect return.
+The caller allocates a 16-byte-aligned buffer and supplies its address as a
+hidden first native slot, shifting user arguments. This differs on both targets:
+
+- System V AMD64 uses `rdi` for the hidden address and requires the callee to
+  return that address in `rax`; native Rue does not promise the `rax` echo.
+- AAPCS64 uses dedicated register `x8` for the indirect-result address; native
+  Rue uses `x0`.
+
+Consequently, neither direct aggregate returns nor native indirect returns may
+be exposed as C entry points without a target-C lowering path.
+
+### Preserved machine state
+
+The x86-64 allocator uses `rbx` and `r12`-`r15` for values live across calls;
+generated prologues save and restore every used callee-saved register along with
+`rbp`. It does not use the 128-byte System V red zone. Rue emits no direction-
+flag-setting, x87, or MMX operations; a conforming clear direction flag remains
+clear on return.
+
+The AArch64 allocator uses `x19`-`x28` for values live across calls and preserves
+them along with frame pointer and link register. It avoids the platform register
+`x18` and veneer scratch registers `x16`/`x17`. Vector registers are currently
+unused. The stack pointer remains 16-byte aligned, and generated code does not
+access memory below `sp`. Condition flags are caller-clobbered.
+
+Apple arm64 permits a 128-byte red zone, but Rue does not use it. Apple's ABI
+also requires callers to extend arguments narrower than 32 bits, gives stacked
+arguments their natural sizes, and places variadic arguments on the stack. The
+current target-C subset has no sub-32-bit parameters, stack parameters, or
+variadic calls, so these amendments are outside its present surface. Native Rue
+continues to use its uniform 8-byte slot model on macOS.
+
+## Typed target-C runtime subset
+
+Every compiler-callable helper is identified by `RuntimeHelperId` and declares
+`CallingConvention::TargetC`, ordered physical parameter types, pointer modes,
+result behavior, and target availability in `rue-runtime-abi`. Shared runtime
+call planning validates the logical signature before either backend assigns
+registers. The runtime exports matching `extern "C"` wrappers generated from the
+same manifest.
+
+The current physical surface is intentionally smaller than either complete C
+ABI:
+
+- direct parameters are `i32`, `i64`, `u32`, `u64`, the 64-bit boolean word,
+  and pointers;
+- direct results are void, those scalar types, or a pointer;
+- no helper accepts or directly returns a by-value aggregate or floating-point
+  value;
+- aggregate source results use an explicit ordinary first out pointer to a
+  canonical `repr(C)` storage shape; and
+- no helper is variadic or requires a stack argument. The largest current
+  signature has five physical parameters.
+
+The x86-64 lowerer maps those parameters to the System V integer registers and
+returns scalars in `rax`. The AArch64 lowerer maps them to `x0`-`x7` and returns
+scalars in `x0`/`w0`. Caller-owned aggregate-result storage is rounded to a
+16-byte call-frame allocation. When source `i8`/`u8` values feed debugging
+helpers, the call adapter sign- or zero-extends them to the manifest's 64-bit
+parameter before the C call.
+
+This subset conforms for all signatures currently present. It must not grow by
+assuming that arbitrary C signatures share the native Rue slot rules. Backend
+unit guards fail if a manifest helper exceeds the current register-only budget;
+adding such a helper requires implementing and testing target-C stack placement.
+
+## Executable evidence
+
+`cli.abi_conformance` compiles and independently links one probe for each
+supported target: x86-64 Linux, AArch64 Linux, and AArch64 macOS. The matching
+native CI host executes it and checks exact output. Foreign targets receive the
+CLI harness's structural executable validation.
+
+The probe covers:
+
+- native argument-register exhaustion and native stack arguments;
+- a nine-slot native aggregate indirect return;
+- values kept live across a target-C runtime call, exercising preserved state;
+- signed `i8` and unsigned `u8` extension into 64-bit debug helpers;
+- scalar target-C results and pointer/length inputs;
+- a five-parameter parse helper with explicit aggregate-result storage; and
+- allocation and mutation through the `StrBuf` runtime boundary.
+
+Backend tests additionally enforce that the typed runtime manifest remains
+target-C and within each backend's implemented register-only subset. This is
+not a complete bidirectional C harness because no general foreign-call syntax or
+export mode exists yet. Those features should extend the matrix with separately
+compiled C caller and callee probes when they introduce their respective
+boundaries.
+
+## Finding
+
+The target-C runtime subset had no conformance defect within its current
+surface. The audit did find one native return-classification defect:
+
+- [RUE-946](https://linear.app/rue/issue/RUE-946/large-payload-enum-returns-exceed-the-register-budget-and-ice-instead)
+  tracks large payload enums. Enum returns are currently excluded from indirect
+  return classification, so a payload wider than six x86-64 slots or eight
+  AArch64 slots indexes beyond the backend's return-register table and panics.
+
+RUE-946 owns the compiler repair and regression cases. Keeping it separate
+prevents an investigative ABI audit from silently becoming a cross-backend
+return-representation change.
+
+## Requirements for future FFI work
+
+Before general FFI can claim conformance, its target-C path must independently
+cover at least:
+
+- C layout and classification for supported by-value aggregates;
+- target-C stack arguments, including Apple's packed stack-area amendment;
+- direct and indirect C aggregate returns, including AAPCS64 `x8`;
+- floating-point/vector arguments and results if exposed;
+- variadic calls, or an explicit diagnostic rejecting them;
+- narrow integer extension at every import and export boundary;
+- pointer provenance, mutability, and lifetime rules; and
+- executable C-to-Rue and Rue-to-C harnesses for every supported target.
+
+Until those paths exist, native Rue functions and native-layout values are not
+an FFI surface.

--- a/docs/runtime-abi.md
+++ b/docs/runtime-abi.md
@@ -39,6 +39,18 @@ The exact current inventory is therefore read through:
 Handwritten code and documentation must not maintain a peer signature or
 export table.
 
+## Runtime ABI versus native Rue ABI
+
+This document describes only the typed target-C boundary from generated Rue
+code to `rue-runtime`. Calls between Rue functions use a separate native Rue
+convention that is intentionally not C-compatible or stable across compiler
+revisions. Rue does not yet expose general foreign imports or exports.
+
+The [FFI ABI conformance audit](notes/ffi-abi-conformance-audit.md) records the
+current native convention, compares both boundaries with System V AMD64,
+AAPCS64, and Apple's arm64 amendments, and defines the executable evidence
+required before the target-C subset is expanded.
+
 ## Target C calling conventions
 
 All callable runtime helpers use the target C convention declared by the


### PR DESCRIPTION
## Summary

- document the two calling conventions Rue actually emits today: the private native Rue convention and the typed target-C runtime subset
- compare register, stack, aggregate, indirect-return, preserved-state, red-zone, and Apple arm64 rules against System V AMD64 and AAPCS64
- add a three-target executable conformance probe plus backend guards for the current register-only runtime-helper surface
- record the large payload-enum return ICE found by the audit as RUE-946

## Impact

Future FFI work now has an evidence-backed baseline and a concrete checklist for extending target-C lowering without accidentally exposing the incompatible native Rue ABI. The current runtime-helper subset remains unchanged.

## Validation

- `scripts/rue unit codegen runtime_manifest_fits_register_only_target_c_subset`
- `scripts/rue cli abi_conformance`
- `scripts/rue quick`
- `scripts/rue test`

Fixes RUE-738
