### PR TITLE
RUE-712: File IO v0 — std.fs over @syscall, ADR-0057

### DIFF
--- a/crates/rue-cli-tests/cases/fs_file_io.toml
+++ b/crates/rue-cli-tests/cases/fs_file_io.toml
@@ -1,0 +1,424 @@
+# std.fs File IO v0 (RUE-712, ADR-0057) driven end-to-end as a user would: the
+# real std.fs (via RUE_STD_PATH) compiled to a real binary that opens, writes,
+# reads, and closes real files in the harness's per-case temp directory (the
+# program's working directory), asserting byte counts and round-tripped content.
+#
+# std.fs is PURE RUE over @syscall: per-target syscall numbers, open flags,
+# AT_FDCWD, and errno tables are all selected by a @target_arch()/@target_os()
+# match, with no Rust runtime helper. The success-path cases run on every target
+# (openat/read/write/close all return non-error values that are interpreted the
+# same way everywhere). The ERROR-DETECTION cases run on every target too:
+# a failed syscall uniformly returns -errno since RUE-945 normalized Darwin's
+# carry-flag convention in the @syscall lowering, and the
+# current @syscall lowering discards the carry flag, so a failed syscall is
+# indistinguishable from a small-valued success on macOS (ADR-0057, "macOS
+# error-detection gap"; codegen follow-up tracked separately). Linux error paths
+# are correct and validated here on Linux CI.
+
+[section]
+id = "cli.fs_file_io"
+name = "std.fs File IO v0"
+description = "Pure-Rue std.fs over @syscall: create/write/read/append/close round-trips and normalized FileError (RUE-712, ADR-0057)."
+
+# create + write + read-back round-trip. Write 15 bytes, close, reopen, read
+# them back, and assert every byte matches. Exit code is the read count (15).
+[[case]]
+name = "fs_roundtrip"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("roundtrip.dat");
+
+    let msg = "roundtrip-bytes";
+    let mut out = Buf.new();
+    let mut i: u64 = 0;
+    while i < msg.len() { out.push(msg[i]); i = i + 1; }
+
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 91; } };
+    let nw = match f.write(borrow out) { WR.Ok(n) => n, WR.Err(_e) => { return 92; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 93; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 94; } };
+    let mut inb = Buf.with_capacity(64);
+    let nr = match g.read(inout inb) { WR.Ok(n) => n, WR.Err(_e) => { return 95; } };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 96; } };
+
+    if nr != nw { return 97; }
+    let mut j: u64 = 0;
+    while j < nr {
+        if inb.get_or(j, 0) != msg[j] { return 98; }
+        j = j + 1;
+    }
+    @dbg(nr);
+    @intCast(nr)
+}
+""" }]
+stdout = "15\n"
+exit_code = 15
+
+# append semantics: create+write "AB", then File.append (O_APPEND) and write
+# "CD" — the second write must land at end-of-file, not truncate. Read back
+# "ABCD" (4 bytes). Proves append does not truncate and positions at the end.
+[[case]]
+name = "fs_append"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("append.dat");
+
+    let mut ab = Buf.new();
+    ab.push(65); ab.push(66); // "AB"
+    let mut cd = Buf.new();
+    cd.push(67); cd.push(68); // "CD"
+
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 81; } };
+    match f.write(borrow ab) { WR.Ok(_n) => {}, WR.Err(_e) => { return 82; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 83; } };
+
+    let mut g = match F.append(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 84; } };
+    match g.write(borrow cd) { WR.Ok(_n) => {}, WR.Err(_e) => { return 85; } };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 86; } };
+
+    let mut h = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 87; } };
+    let mut inb = Buf.with_capacity(64);
+    let nr = match h.read(inout inb) { WR.Ok(n) => n, WR.Err(_e) => { return 88; } };
+    match h.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 89; } };
+
+    if nr != 4 { return 70; }
+    if inb.get_or(0, 0) != 65 { return 71; }
+    if inb.get_or(1, 0) != 66 { return 72; }
+    if inb.get_or(2, 0) != 67 { return 73; }
+    if inb.get_or(3, 0) != 68 { return 74; }
+    @intCast(nr)
+}
+""" }]
+exit_code = 4
+
+# drop-close releases the fd: an inner block opens the file and reads it, then
+# the File is DROPPED at block exit (no explicit close). Reopening afterward and
+# reading the same content proves the drop closed the descriptor and left the
+# file reusable (a leaked or corrupted fd would break the second read).
+[[case]]
+name = "fs_drop_close_reopen"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("dropclose.dat");
+
+    let mut payload = Buf.new();
+    payload.push(72); payload.push(105); // "Hi"
+
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 61; } };
+    match f.write(borrow payload) { WR.Ok(_n) => {}, WR.Err(_e) => { return 62; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 63; } };
+
+    let mut first: u64 = 0;
+    {
+        let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 64; } };
+        let mut b1 = Buf.with_capacity(16);
+        first = match g.read(inout b1) { WR.Ok(n) => n, WR.Err(_e) => { return 65; } };
+        // g is DROPPED here at block exit: its drop fn closes the fd.
+    }
+
+    let mut h = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 66; } };
+    let mut b2 = Buf.with_capacity(16);
+    let second = match h.read(inout b2) { WR.Ok(n) => n, WR.Err(_e) => { return 67; } };
+    match h.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 68; } };
+
+    if first != 2 { return 51; }
+    if second != 2 { return 52; }
+    if b2.get_or(0, 0) != 72 { return 53; }
+    if b2.get_or(1, 0) != 105 { return 54; }
+    @intCast(second)
+}
+""" }]
+exit_code = 2
+
+# consuming close then double-close safety: close(self) closes the fd and, via
+# the fd == -1 sentinel, makes the value's own scope-exit drop a no-op — the fd
+# is closed exactly once. After the consuming close, the OS is free to reuse the
+# descriptor number; a fresh open + read of the SAME file must return the correct
+# content. A missing sentinel guard would let the consumed File's drop close the
+# reused descriptor, corrupting the second file. Program must also exit cleanly.
+[[case]]
+name = "fs_close_then_reopen_safe"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("dclose.dat");
+
+    let mut payload = Buf.new();
+    payload.push(88); payload.push(89); payload.push(90); // "XYZ"
+
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 41; } };
+    match f.write(borrow payload) { WR.Ok(_n) => {}, WR.Err(_e) => { return 42; } };
+    // consuming close: moves f out; sentinel makes its own drop a no-op.
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 43; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 44; } };
+    let mut inb = Buf.with_capacity(16);
+    let nr = match g.read(inout inb) { WR.Ok(n) => n, WR.Err(_e) => { return 45; } };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 46; } };
+
+    if nr != 3 { return 31; }
+    if inb.get_or(0, 0) != 88 { return 32; }
+    if inb.get_or(1, 0) != 89 { return 33; }
+    if inb.get_or(2, 0) != 90 { return 34; }
+    @intCast(nr)
+}
+""" }]
+exit_code = 3
+
+# read into a FULL buffer (no spare capacity) -> Err(InvalidInput), NOT Ok(0).
+# This is the anti-footgun contract: Ok(0) means EOF only, so a whole-file loop
+# cannot silently truncate. Runs on EVERY target — a full buffer is rejected
+# BEFORE the read syscall, so the macOS carry-flag gap does not apply and this
+# is not Linux-gated (RUE-712 pre-merge dogfooding fix, ADR-0057 §5).
+[[case]]
+name = "fs_read_full_buffer_invalid"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("full.dat");
+
+    let mut seed = Buf.new();
+    seed.push(65); seed.push(66); // "AB"
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 11; } };
+    match f.write(borrow seed) { WR.Ok(_n) => {}, WR.Err(_e) => { return 12; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 13; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 14; } };
+    // A fresh buffer has capacity 0 == len 0: zero spare capacity.
+    let mut full = Buf.new();
+    let code = match g.read(inout full) {
+        WR.Ok(_v) => 1,   // wrong: must not report EOF on a full buffer
+        WR.Err(e) => match e {
+            FE.InvalidInput => 0,
+            _ => 2,
+        },
+    };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => {} };
+    code
+}
+""" }]
+exit_code = 0
+
+# whole-file read loop over a file LARGER than the buffer's initial capacity:
+# reserve a chunk, read, repeat until Ok(0) (EOF). With the InvalidInput contract
+# + ArrayBuf.reserve, the natural loop reads all 20 bytes without truncating at
+# the initial capacity of 8. Exit code is the total byte count (20).
+[[case]]
+name = "fs_read_whole_file_loop"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("wholefile.dat");
+
+    let mut out = Buf.new();
+    let mut k: u64 = 0;
+    while k < 20 { out.push(90); k = k + 1; } // 20 'Z' bytes
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 61; } };
+    match f.write_all(borrow out) { CR.Ok(_u) => {}, CR.Err(_e) => { return 62; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 63; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 64; } };
+    let mut buf = Buf.with_capacity(8); // smaller than the 20-byte file
+    let mut total: u64 = 0;
+    let mut done = false;
+    while !done {
+        buf.reserve(8); // ensure spare room every pass; never a full buffer
+        let n = match g.read(inout buf) { WR.Ok(v) => v, WR.Err(_e) => { return 65; } };
+        if n == 0 { done = true; } else { total = total + n; }
+    }
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 66; } };
+
+    if total != 20 { return 51; }
+    if buf.len() != 20 { return 52; }
+    // every byte round-tripped
+    let mut j: u64 = 0;
+    while j < 20 {
+        if buf.get_or(j, 0) != 90 { return 53; }
+        j = j + 1;
+    }
+    @intCast(total)
+}
+""" }]
+exit_code = 20
+
+# reserve(n) then read fills up to the newly reserved capacity: an empty buffer
+# grows via reserve(16), and a single read pulls all 16 file bytes into that
+# spare capacity in one call. Pins that reserve exposes the spare room read needs.
+[[case]]
+name = "fs_reserve_then_read_fills"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("reservefill.dat");
+
+    let mut out = Buf.new();
+    let mut k: u64 = 0;
+    while k < 16 { out.push(67); k = k + 1; } // 16 'C' bytes
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 41; } };
+    match f.write_all(borrow out) { CR.Ok(_u) => {}, CR.Err(_e) => { return 42; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 43; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 44; } };
+    let mut buf = Buf.new();
+    buf.reserve(16); // grow an empty buffer to hold 16
+    if buf.capacity() < 16 { return 45; }
+    let n = match g.read(inout buf) { WR.Ok(v) => v, WR.Err(_e) => { return 46; } };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 47; } };
+
+    if n != 16 { return 35; }
+    if buf.len() != 16 { return 36; }
+    let mut j: u64 = 0;
+    while j < 16 {
+        if buf.get_or(j, 0) != 67 { return 37; }
+        j = j + 1;
+    }
+    @intCast(n)
+}
+""" }]
+exit_code = 16
+
+# open a missing file -> Err(NotFound). Runs everywhere: a failed openat
+# returns -ENOENT on all targets (RUE-945 normalized Darwin's carry-flag
+# convention). Validates the normalization ENOENT -> FileError.NotFound.
+[[case]]
+name = "fs_open_missing_not_found"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("no_such_dir_rue712/does_not_exist.dat");
+
+    match F.open(borrow path) {
+        R.Ok(_f) => 1,
+        R.Err(e) => match e {
+            FE.NotFound => 0,
+            _ => 2,
+        },
+    }
+}
+""" }]
+exit_code = 0
+
+# write to a read-only-opened file -> Err. Runs everywhere (RUE-945). The
+# file is created first (so it exists), reopened O_RDONLY, then written: the
+# kernel rejects the write on a read-only descriptor with EBADF, which normalizes
+# to FileError.InvalidInput (ADR-0057 FileError table).
+[[case]]
+name = "fs_write_to_readonly"
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("readonly.dat");
+
+    let mut seed = Buf.new();
+    seed.push(122); // "z"
+
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 21; } };
+    match f.write(borrow seed) { WR.Ok(_n) => {}, WR.Err(_e) => { return 22; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 23; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 24; } };
+    let mut payload = Buf.new();
+    payload.push(121); // "y"
+    let outcome = match g.write(borrow payload) {
+        WR.Ok(_n) => 1,
+        WR.Err(e) => match e {
+            FE.InvalidInput => 0,
+            _ => 3,
+        },
+    };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => {} };
+    outcome
+}
+""" }]
+exit_code = 0

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -355,6 +355,66 @@ const ENTRIES: &[Entry] = &[
         semantic(SemanticGapKind::TextProjectionRead),
         &[],
     ),
+    // std.fs File IO v0 (RUE-712, ADR-0057): pure-Rue fs over @syscall. The
+    // oracle model cannot execute the raw-pointer/syscall substrate (StrBuf/
+    // ArrayBuf `@int_to_ptr` prologue, `@alloc_bytes`, `@syscall`), so every
+    // case is accepted debt, exactly like the arraybuf/strbuf CLI cases. The
+    // two error-detection cases run `only_on` Linux (macOS carry-flag gap,
+    // ADR-0057 §3a), so their gap registration is Linux-scoped to match.
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_roundtrip",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_append",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_drop_close_reopen",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_close_then_reopen_safe",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_read_full_buffer_invalid",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_read_whole_file_loop",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_reserve_then_read_fills",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_open_missing_not_found",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_write_to_readonly",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
     Entry::new(
         "cli.heap_intrinsics",
         "alloc_count_size_overflow_traps",

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3822 rejected=152 lex_invalid=35 accepted_source_ast_sha256=b256f910d4ac238500c84a4455a995fe59bfd55910812e709018eeebb3eb7f84
+# pre-RUE-905 Chumsky: accepted=3831 rejected=152 lex_invalid=35 accepted_source_ast_sha256=d14934cbb8bbca7f5538584099122ec9b78638d556dfce02286a3e625ac9b91a
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca

--- a/docs/designs/0057-file-io-v0.md
+++ b/docs/designs/0057-file-io-v0.md
@@ -1,0 +1,328 @@
+---
+id: 0057
+title: "File IO v0: pure-Rue fs over @syscall with normalized FileError"
+status: accepted
+tags: [stdlib, io, syscalls, runtime, error-handling, ownership]
+feature-flag: null
+created: 2026-07-16
+accepted: 2026-07-16
+implemented: 2026-07-16
+spec-sections: []
+superseded-by:
+relates: ["RUE-712", "RUE-713", "RUE-935", "RUE-940", "ADR-0034", "ADR-0038"]
+---
+
+# ADR-0057: File IO v0 — pure-Rue fs over `@syscall`, normalized `FileError`
+
+## Status
+
+Accepted. Ratified by Steve on 2026-07-16, resolving the RUE-712 design gate.
+The rulings below are settled; this ADR records and motivates them. Builds on
+ADR-0034 (per-target runtime, host-only), ADR-0038 (`Result`, must-check via
+linearity), and ADR-0039 (`@drop`). Sets the errno-normalization precedent that
+RUE-713 (network IO) inherits.
+
+**RUE-712 is the implementing issue** and the design gate; `std.fs` v0 lands
+under it. It is one leg of the runtime-facility work: **RUE-935** is the sibling
+argv/env access issue (process inputs, not files), and **RUE-940** is the
+maturity-ladder milestone that consumes both RUE-712 and RUE-935 — neither is a
+File IO implementation phase. **RUE-713** (network IO) is downstream and reuses
+this ADR's errno-normalization and owned-handle patterns.
+
+## Summary
+
+`std.fs` is **pure Rue source** over the `@syscall` intrinsic, not a set of Rust
+runtime helpers. Per-target syscall numbers are selected in Rue by a
+`@target_arch()`/`@target_os()` match, exactly as `std.exit()` already does.
+Paths are byte-string `StrBuf`s, NUL-appended at the syscall boundary. Every
+fallible operation returns `Result(T, FileError)`, where `FileError` is a small
+normalized enum decoded from per-OS errno tables in Rue — a raw errno never
+escapes. A file is an owned `File` struct wrapping the fd, closed by its `drop
+fn` on scope exit, with a consuming `close(self)` for callers that want to check
+the close error. v0 ships `open`/`create`/`append`/`read`/`write`/`write_all`/
+`close`.
+
+## Context
+
+Rue can already terminate a process through a syscall (`std.exit()`), read stdin
+(ADR-0021), and allocate (ADR-0011), but it cannot open, read, or write a file.
+Real programs need this before Rue is dogfoodable, and the surrounding decisions
+— *where* the code lives, how paths and errors are modeled, how the fd's
+lifetime is managed — do not shard into independent issues: the handle type, the
+error type, and the buffer type are one design wearing three hats. RUE-712 was
+opened as the gate to settle them together before any code lands.
+
+Two prior decisions constrain the space. **ADR-0034** established that the Rue
+runtime is embedded per-target and host-only: the compiler embeds exactly one
+architecture's runtime archive, and adding foreign runtime code (new `__rue_*`
+Rust helpers) multiplies the cross-target archive/validation surface that
+ADR-0055 now polices. **ADR-0038** made `Result` the error-carrying type with
+`?` propagation, but its must-check-via-linearity half (a `Result` is not yet a
+`linear` type) is *not* implemented — tracked by RUE-591 — so an ignored
+`Result` is today silently dropped rather than rejected.
+
+## Decision
+
+### 1. Strategy: pure Rue over `@syscall`, per-target dispatch in source
+
+`std.fs` is written in Rue and issues syscalls through `@syscall`. This is the
+direct consequence of ADR-0034: putting IO in the Rust runtime would add
+host-only helpers that every cross-target archive must then carry and validate,
+whereas Rue source compiles for every target for free and keeps the runtime
+freestanding. It follows the `std.exit()` template already in `std/_std.rue`: a
+private helper returns the per-target syscall number via a total
+`@target_arch()` → `@target_os()` match returning integer literals, and the call
+site wraps `@syscall(...)` in a `checked { ... }` block. `std/fs.rue` owns its
+own per-target helpers (`_sys_openat`/`_sys_read`/`_sys_write`/`_sys_close`,
+`_at_fdcwd`, the `_o_*` flag helpers, and the errno tables), each shaped exactly
+like `_exit_syscall_number()`.
+
+The syscall **numbers**, argument shapes, flag values, and errno values are
+per-target data owned by `std.fs`. The tables are the honest home for the traps:
+
+- **openat(2) is used uniformly on every target.** AArch64 Linux has *no*
+  `open` syscall — the generic syscall ABI it uses provides only `openat(2)` —
+  so `std.fs` issues `openat(AT_FDCWD, path, flags, mode)` everywhere rather
+  than special-casing one target. This is both correct on arm64 Linux and
+  uniform elsewhere; the "this target lacks that syscall" fact is stated once,
+  by choosing openat as the single path. The concrete numbers used:
+
+  | op      | x86-64 Linux | aarch64 Linux | macOS (both arches) |
+  | ------- | ------------ | ------------- | ------------------- |
+  | openat  | 257          | 56            | 463                 |
+  | read    | 0            | 63            | 3                   |
+  | write   | 1            | 64            | 4                   |
+  | close   | 3            | 57            | 6                   |
+
+  `AT_FDCWD` is **-100** on Linux and **-2** on macOS (per-OS, not shared).
+
+### 2. Paths: NUL-appended byte strings, no `Path` type
+
+Paths are `StrBuf` (ADR-0035/0043 byte strings — conventionally UTF-8, may hold
+arbitrary bytes, which is exactly right for filesystem paths). `StrBuf` is
+**not** NUL-terminated (`cap`-owned packed bytes, `len` is the byte count), so
+the fs layer copies the bytes into a fresh `len + 1` buffer with a trailing NUL
+at the syscall boundary and never exposes that terminator back to the caller.
+The copy reads the source bytes through the public `StrBuf.byte_at(i) ->
+Option(u8)` accessor (landed for RUE-712's benefit in PR #1714), so `fs` never
+touches `StrBuf`'s private buffer. There is **no `Path`/`PathBuf` abstraction in
+v0** — a byte string is the path. A typed path layer can arrive later without
+changing the syscall boundary.
+
+### 3. Error model: a normalized `FileError`, never a raw errno
+
+Every fallible operation returns `Result(T, FileError)` (the ADR-0038 library
+`Result`; `?` works for it). `FileError` is a payload enum:
+
+```rue
+enum FileError {
+    NotFound,           // ENOENT
+    PermissionDenied,   // EACCES, EPERM
+    AlreadyExists,      // EEXIST
+    Interrupted,        // EINTR — retryable; surfaced, not hidden
+    WouldBlock,         // EAGAIN / EWOULDBLOCK
+    InvalidInput,       // EINVAL, EBADF
+    Other(i64),         // the raw errno, for everything not yet named
+}
+```
+
+The named set is deliberately small and chosen from errno cases that are common
+across both supported kernels and that programs routinely branch on; everything
+else falls through to `Other(i64)` carrying the raw number, so no error is ever
+lost. The normalization is done **in Rue**, from a per-OS errno table, because
+**Linux and macOS assign different integer values to the same logical error**.
+The low numbers agree — `EPERM=1`, `ENOENT=2`, `EINTR=4`, `EBADF=9`, `EACCES=13`,
+`EEXIST=17`, `EINVAL=22` on both — but the two allocations diverge quickly, and
+`std.fs` already crosses one such divergence: **`EAGAIN` is 11 on Linux and 35
+on macOS**, so `WouldBlock` needs a per-OS table row. If `std.fs` returned the
+raw errno as an `i64`, a program that wrote `match e { 2 => ... }` would silently
+mean different things on different targets — a portability trap of exactly the
+kind Rue exists to eliminate. Normalizing to a target-independent enum makes
+error-matching programs mean the same thing everywhere.
+
+This is the **precedent RUE-713 (network IO) inherits**: network errors will be
+normalized from per-OS errno tables into a sibling enum the same way, rather than
+leaking raw errnos.
+
+#### 3a. macOS error-detection gap (discovered during implementation)
+
+Error *detection* here relies on a failed syscall returning a **negative** value
+(`-errno`). Linux does exactly that. **macOS/Darwin does not**: on failure it
+returns the **positive** errno in `x0` and signals failure with the **carry
+flag** — and the current `@syscall` codegen lowering (aarch64 and x86-64)
+**discards the carry flag**, moving only `x0` into the result. Empirically, on
+aarch64-macos a failed `openat` of a missing path returns `2` (positive ENOENT),
+indistinguishable from a successful `openat` that returned fd 2. The Rust
+runtime's own syscall wrappers (`crates/rue-runtime/src/aarch64_macos.rs`)
+already handle this correctly — they `cset err, cs` and negate on carry — but
+that logic lives in hand-written asm, not in the `@syscall` intrinsic.
+
+This could not be fixed inside `std.fs` (the carry flag is not observable from
+Rue); it required a **codegen change to the `@syscall` lowering** (negate-on-
+carry on Darwin, mirroring the runtime wrappers). That fix was filed as RUE-945
+and **landed while this ADR was in flight** (PR #1720): `@syscall` now presents
+the uniform `-errno` convention on every target, the CLI error-detection cases
+run un-gated on all platforms, and this section is retained as the historical
+record of why the intrinsic's contract is what it is.
+
+### 4. Handle: an owned `File` with drop-close and a consuming `close`
+
+```rue
+struct File {
+    fd: i32,
+
+    drop fn(inout self) { ... }                      // closes fd on scope exit
+    fn close(self) -> Result((), FileError) { ... }  // consuming, checkable
+}
+```
+
+`File` owns its fd. Its `drop fn` closes the fd when the value leaves scope, so
+the common case needs no explicit close and cannot leak the descriptor. Callers
+who must observe close failures (a write-back filesystem can report errors only
+at `close`) call the **consuming** `close(self) -> Result((), FileError)`.
+
+**Double-close guard.** `close(self)` takes `File` by value, so the caller's
+binding is moved out and its scope-end drop does not fire on the original. But
+`close`'s own `self` is a live `File` whose drop glue would run at the end of
+`close` — a second close of the same fd (verified: a by-value consumed value
+does run its destructor at the consuming function's scope exit). The guard is a
+**sentinel fd** (`-1`): `close` reads the fd, writes the sentinel back, issues
+the raw close syscall on the saved fd, and returns; when `self`'s drop glue then
+runs, the `drop fn` sees `fd == -1` and no-ops. Because a by-value `self` is
+**immutable** in Rue (there is no `mut self` receiver, and assigning to `self`
+is E0203), the sentinel is written by rebinding `let mut me = self; me.fd = -1;`
+— legal in a normal consuming method (unlike inside a `drop fn`, where moving
+`self` out is E0442). The `drop fn` uses the same `fd >= 0` check, so a sentinel
+value is never closed. This is the mechanism because ADR-0039 deferred
+`@forget`/`@leak`: without a way to consume a value *without* running its
+destructor, the destructor must be made idempotent via the sentinel rather than
+suppressed.
+
+**Known accepted wart.** Because ADR-0038's linearity half is not yet
+implemented (RUE-591), `Result` is not `linear`, so a caller who writes
+`file.close();` and ignores the returned `Result` has that error **silently
+discarded** — the must-check guarantee that would force a `match`/`?`/`@drop`
+does not yet fire. This is accepted for v0 and is exactly the hole ADR-0038 +
+RUE-591 will close; no `std.fs`-specific machinery is added to compensate.
+
+### 5. v0 operation scope and the buffer seam
+
+**In v0:** open via three flag-free constructors — `File.open(path)`
+(`O_RDONLY`), `File.create(path)` (`O_WRONLY|O_CREAT|O_TRUNC`, mode `0o644`),
+and `File.append(path)` (`O_WRONLY|O_CREAT|O_APPEND`, mode `0o644`) — plus
+`read`, `write`, `write_all`, and `close`. Separate constructors avoid a
+flags-enum design in v0. The open-flag *values* are per-OS data (another table
+row), because Linux and macOS disagree: `O_CREAT` is `0o100`=64 on Linux but
+`0x0200`=512 on macOS, `O_TRUNC` is `0o1000`=512 vs `0x0400`=1024, and
+`O_APPEND` is `0o2000`=1024 vs `0x0008`=8 (`O_RDONLY`/`O_WRONLY` agree at 0/1).
+
+**Explicitly deferred:** seek, metadata/`stat`, directory operations,
+`rename`/`unlink`, buffering layers, and any stdin/stdout/file unification.
+
+**Buffers ship on `ArrayBuf(u8)` with raw-pointer marshalling**, because slices
+(`[u8]`) remain preview-gated (ADR-0043's slice rung is not stabilized). `read`
+appends up to the buffer's **spare capacity** (`capacity() - len()`) and
+`write`/`write_all` send the buffer's bytes.
+
+**Read semantics: `Ok(0)` is EOF only; a full buffer is `InvalidInput`.** A
+subtle footgun surfaced in pre-merge dogfooding: if `read` returned `Ok(0)` both
+at real end-of-file *and* when the buffer had zero spare capacity, the natural
+whole-file loop (`loop { n = read(inout buf); if n == 0 { break } }`) would
+silently **truncate** at the buffer's initial capacity — a 20-byte file read
+into a `with_capacity(8)` buffer would report EOF after 8 bytes. v0 closes this:
+`read` on a buffer with no spare capacity (`capacity() == len()`) returns
+`Err(FileError.InvalidInput)`, **never `Ok(0)`**, so `Ok(0)` unambiguously means
+EOF. To make the whole-file loop writable, `ArrayBuf(u8)` exposes a public
+`reserve(inout self, additional: u64)` (the parameterized capacity hint, mirroring
+`StrBuf.reserve`): the loop becomes `loop { buf.reserve(chunk); n =
+read(inout buf)?; if n == 0 { break } }`, growing the buffer each pass so `read`
+always has spare room and only ever returns `Ok(0)` at true EOF. Loud beats
+silent. Because `ArrayBuf`'s backing pointer is module-private and there
+is no cross-module accessor yet, v0 marshals through a **temporary contiguous
+`@alloc_bytes` buffer**, copying bytes in/out via the public `push`/`get_or`
+API, and issues the syscall on that temporary. This is a **known seam, recorded
+with migration intent**: when slices stabilize, the read/write signatures
+migrate to `borrow [u8]` / `inout [u8]` and the temporary-copy disappears — a
+signature change at one boundary, not a redesign. Committing to `ArrayBuf(u8)`
+now unblocks IO without waiting on the slice feature.
+
+`std.fs` source is trusted standard-library input (`ModuleOrigin::
+StandardLibrary`), so its use of the `raw_bytes` packed-byte intrinsics
+(`@alloc_bytes`/`@byte_read`/`@byte_write`/`@ptr_to_int`/`@free_bytes`) is
+authorized without a preview flag, exactly as `std/strbuf.rue` is — programs
+that consume `std.fs` need no `--preview raw_bytes`.
+
+## Implementation status
+
+Implemented under RUE-712 on 2026-07-16:
+
+- `std/fs.rue` (new): the `FileError` enum, per-target syscall/flag/errno tables,
+  path marshalling, and the `File` handle with all v0 operations.
+- `std/_std.rue`: `pub const fs = @import("fs.rue");` re-export.
+- CLI coverage (`crates/rue-cli-tests/cases/fs_file_io.toml`): create+write+
+  read-back round-trip, append semantics, drop-close + reopen, consuming-close +
+  double-close safety (all run on every target); open-missing → `NotFound` and
+  write-to-read-only → `InvalidInput` (gated `only_on` Linux per §3a).
+
+## Consequences
+
+### Positive
+- No new runtime helpers: `std.fs` compiles for every target for free and keeps
+  the runtime host-only per ADR-0034; nothing added to the ADR-0055 archive
+  surface.
+- Error-matching programs are target-independent — the normalized enum means the
+  same thing on every OS, unlike a raw errno.
+- The fd cannot leak (drop-close) yet close errors remain observable (consuming
+  `close`).
+- Reuses existing machinery end to end: the `std.exit()` dispatch template, the
+  ADR-0038 `Result`/`?`, `StrBuf`/`ArrayBuf`, `StrBuf.byte_at`, and `checked`
+  blocks.
+
+### Negative
+- Syscall-number, open-flag, and errno tables are hand-maintained per target; a
+  new target adds rows to all three.
+- **macOS error detection is broken until the `@syscall` lowering negates on the
+  Darwin carry flag** (§3a) — a real hole, scoped out of RUE-712 and filed as a
+  codegen follow-up; macOS error tests are Linux-gated meanwhile.
+- Until RUE-591, an ignored `close()` `Result` is silently dropped.
+- v0 is minimal: no seek/stat/dirs/rename/buffering.
+- The buffer API is on `ArrayBuf(u8)` and pays a temporary-copy per read/write;
+  both the signature and the copy change when slices stabilize.
+
+### Neutral
+- No language-semantics or preview-feature change; this is stdlib + intrinsic use.
+- `Path` typing, buffered IO, and stream unification are left open by design.
+
+## Alternatives Considered
+
+- **Return the raw errno as `i64`.** Rejected: Linux and macOS give the same
+  logical error different integer values (e.g. `EAGAIN` 11 vs 35), so
+  `match e { N => … }` would be silently target-dependent — the portability trap
+  normalization exists to prevent. `Other(i64)` still carries the raw value for
+  the unnamed long tail.
+- **A raw fd (`i32`) handle instead of an owned `File`.** Rejected: a bare fd
+  models nothing — it does not close on scope exit (descriptor leaks) and gives
+  the type system nothing to enforce. The owned `File` with drop-close is the
+  affine-ownership payoff.
+- **Runtime `__rue_*` IO helpers in Rust.** Rejected by ADR-0034: the runtime is
+  host-only and embedded per target, so Rust IO helpers would multiply the
+  cross-target archive and ADR-0055 validation surface. Pure Rue over `@syscall`
+  avoids all of it. (The Darwin carry-flag handling those helpers already do is
+  what §3a wants lifted into the `@syscall` lowering — a small, contained
+  codegen change, not a return to runtime IO.)
+- **Special-casing `open` vs `openat` per target.** Rejected in favor of
+  uniform `openat(AT_FDCWD, …)`: AArch64 Linux has no `open` at all, and openat
+  is available and equivalent everywhere, so one path is simpler and correct.
+- **A `Path`/`PathBuf` type in v0.** Deferred: a byte-string path needs no new
+  type, and the syscall boundary is unaffected by adding typed paths later.
+
+## Future Work
+
+- **Teach the `@syscall` lowering to negate-on-carry on Darwin** so macOS error
+  detection works and the Linux-gated error tests can run on every target (§3a).
+- Seek, `stat`/metadata, directory iteration, `rename`/`unlink`.
+- Buffered IO and stdin/stdout/file unification.
+- Migrate read/write buffers from `ArrayBuf(u8)` to `borrow [u8]`/`inout [u8]`
+  once slices stabilize, dropping the temporary-copy marshalling.
+- Close the must-check hole once ADR-0038's linearity half (RUE-591) lands.
+- RUE-713 network IO, reusing this errno-normalization precedent.

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -219,4 +219,5 @@ The table is generated from ADR frontmatter. Run
 | [0054](0054-loop-optimizations.md) | Loop Optimizations — LICM and Unrolling | Accepted | compiler, codegen, optimization |
 | [0055](0055-typed-runtime-abi-manifest.md) | Typed compiler-runtime ABI manifest | Implemented | architecture, compiler, runtime, abi, codegen |
 | [0056](0056-typed-ir-payload-schemas.md) | Typed IR payload schemas | Accepted | architecture, compiler, ir, performance, validation |
+| [0057](0057-file-io-v0.md) | File IO v0: pure-Rue fs over @syscall with normalized FileError | Accepted | stdlib, io, syscalls, runtime, error-handling, ownership |
 <!-- ADR-INDEX:END -->

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -13,6 +13,7 @@
 // - std.result.Result: Fallible values (Ok/Err), propagated with `?`
 // - std.strbuf.StrBuf: Source-defined growable string buffer header
 // - std.arraybuf.ArrayBuf: Growable heap-backed collections
+// - std.fs.File: File IO v0 (open/create/append/read/write/close over @syscall)
 
 // Re-export library modules.
 pub const math = @import("math.rue");
@@ -24,6 +25,9 @@ pub const option = @import("option.rue");
 pub const result = @import("result.rue");
 pub const strbuf = @import("strbuf.rue");
 pub const arraybuf = @import("arraybuf.rue");
+
+// File IO v0 (RUE-712, ADR-0057): pure-Rue std.fs over @syscall.
+pub const fs = @import("fs.rue");
 
 // Collections (Standard library v1, M2).
 pub const stack = @import("stack.rue");

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -180,38 +180,50 @@ pub fn ArrayBuf(comptime T: type) -> type {
 
         // --- mutation ---
 
-        // Ensure there is room for at least one more element, growing the
-        // buffer (amortized 2x) when full. Internal helper.
-        fn reserve(inout self) {
-            if self.len == self.cap {
-                let new_cap: u64 = if self.cap == 0 {
-                    4
-                } else {
-                    if self.cap > 9223372036854775807 {
-                        @panic("out of memory");
-                    }
-                    self.cap * 2
-                };
-                let element_size: u64 = @intCast(@size_of(T));
-                if element_size > 0 {
-                    if new_cap > 18446744073709551615 / element_size {
-                        @panic("out of memory");
-                    }
-                    checked {
-                        let grown = @realloc(self.buf, self.cap, new_cap);
-                        if @ptr_to_int(grown) == 0 {
-                            @panic("out of memory");
-                        }
-                        self.buf = grown;
-                    };
-                }
-                self.cap = new_cap;
+        // Ensure spare capacity for at least `additional` more elements,
+        // growing the buffer when the current spare (`capacity() - len()`) is
+        // insufficient. Growth is amortized 2x, but always at least enough to
+        // hold `additional` more, so after `reserve(n)` at least `n` more
+        // `push`es (or, for an `ArrayBuf(u8)`, `n` bytes read by
+        // `std.fs.File.read`) proceed without reallocating. `reserve(0)` and an
+        // already-large-enough buffer are no-ops. This mirrors
+        // `StrBuf.reserve(additional)` and is the public capacity hint that
+        // makes a whole-file read loop (`reserve`, `read`, repeat) writable.
+        fn reserve(inout self, additional: u64) {
+            if additional > 18446744073709551615 - self.len {
+                @panic("out of memory");
             }
+            let required = self.len + additional;
+            if required <= self.cap {
+                return;
+            }
+            let mut new_cap: u64 = if self.cap == 0 { 4 } else { self.cap };
+            while new_cap < required {
+                if new_cap > 9223372036854775807 {
+                    new_cap = required;
+                } else {
+                    new_cap = new_cap * 2;
+                }
+            }
+            let element_size: u64 = @intCast(@size_of(T));
+            if element_size > 0 {
+                if new_cap > 18446744073709551615 / element_size {
+                    @panic("out of memory");
+                }
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    if @ptr_to_int(grown) == 0 {
+                        @panic("out of memory");
+                    }
+                    self.buf = grown;
+                };
+            }
+            self.cap = new_cap;
         }
 
         // Append `x` to the end, growing if necessary.
         fn push(inout self, x: T) {
-            self.reserve();
+            self.reserve(1);
             checked {
                 let slot = @ptr_offset(self.buf, self.len);
                 @ptr_write(slot, x);

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -1,0 +1,447 @@
+// std.fs — File IO v0 (RUE-712, ADR-0057).
+//
+// Pure-Rue filesystem access over the `@syscall` intrinsic. There is no Rust
+// runtime helper: per-target syscall numbers, open flags, `AT_FDCWD`, and errno
+// values are all selected in Rue by a total `@target_arch()`/`@target_os()`
+// match, exactly as `std.exit()` selects its exit-syscall number. This keeps
+// IO freestanding — it compiles for every target with no additions to the
+// per-target runtime archive (ADR-0034/0055).
+//
+// v0 surface: `File.open` (read-only), `File.create` (truncate+write),
+// `File.append`, `read`, `write`/`write_all`, and a consuming `close`. Files
+// close themselves via a `drop fn` at scope exit. No seek, stat, directories,
+// rename, or buffering (ADR-0057 defers all of it).
+//
+// PATHS are byte-string `StrBuf`s; the syscall boundary copies the bytes into a
+// NUL-terminated buffer and never exposes that terminator to the caller.
+//
+// ERRORS normalize to `FileError` from per-OS errno tables — a raw errno never
+// escapes. Linux and macOS give the same logical error different integers
+// (e.g. EAGAIN is 11 on Linux, 35 on macOS), so the tables are per-OS.
+//
+// PLATFORM ERROR-DETECTION CAVEAT (ADR-0057, "macOS error-detection gap"):
+// error detection here relies on a failed syscall returning `-errno` (a
+// negative value). Linux does exactly that. macOS/Darwin instead returns a
+// POSITIVE errno and signals failure with the carry flag — and the current
+// `@syscall` codegen lowering discards the carry flag (it just moves x0),
+// so on macOS a failed syscall is indistinguishable from a success that
+// returns a small value (a failed openat returning ENOENT=2 looks exactly
+// like a successful openat returning fd 2). Success paths are correct on
+// macOS; error DETECTION is not, until the `@syscall` lowering is taught to
+// negate-on-carry the way the Rust runtime wrappers already do. Tracked as a
+// codegen follow-up (see ADR-0057). Linux behavior is correct and CI-validated.
+
+const result = @import("result.rue");
+const option = @import("option.rue");
+const strbuf = @import("strbuf.rue");
+const arraybuf = @import("arraybuf.rue");
+
+// A normalized, target-independent file error. Decoded from the per-OS errno
+// tables below so that a program matching on `FileError` means the same thing
+// on every target (ADR-0057 §3). Everything not named here falls through to
+// `Other(i64)` carrying the raw errno, so no error is ever lost.
+pub enum FileError {
+    NotFound,           // ENOENT
+    PermissionDenied,   // EACCES, EPERM
+    AlreadyExists,      // EEXIST
+    Interrupted,        // EINTR
+    WouldBlock,         // EAGAIN / EWOULDBLOCK
+    InvalidInput,       // EINVAL, EBADF
+    Other(i64),         // any other raw errno
+}
+
+// ---------------------------------------------------------------------------
+// Per-target syscall numbers. openat(2) is used UNIFORMLY on every target:
+// AArch64 Linux has no `open` syscall at all (the generic syscall ABI only
+// provides openat), so issuing openat(AT_FDCWD, ...) everywhere is both correct
+// there and uniform elsewhere (ADR-0057 §1).
+// ---------------------------------------------------------------------------
+
+fn _sys_openat() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 257,
+                Os.Macos => 463,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 56,
+                Os.Macos => 463,
+            }
+        },
+    }
+}
+
+fn _sys_close() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 3,
+                Os.Macos => 6,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 57,
+                Os.Macos => 6,
+            }
+        },
+    }
+}
+
+fn _sys_read() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 0,
+                Os.Macos => 3,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 63,
+                Os.Macos => 3,
+            }
+        },
+    }
+}
+
+fn _sys_write() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 1,
+                Os.Macos => 4,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 64,
+                Os.Macos => 4,
+            }
+        },
+    }
+}
+
+// AT_FDCWD as a u64 bit pattern. Linux uses -100, macOS uses -2, so this is
+// per-OS data, not a shared constant.
+fn _at_fdcwd() -> u64 {
+    match @target_os() {
+        Os.Linux => 18446744073709551516, // -100
+        Os.Macos => 18446744073709551614, // -2
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-OS open(2) flag values. O_RDONLY/O_WRONLY/O_RDWR agree across kernels,
+// but O_CREAT/O_TRUNC/O_APPEND diverge (Linux uses the asm-generic octal
+// values, macOS the BSD hex values), so these are per-OS (ADR-0057 §1).
+// ---------------------------------------------------------------------------
+
+fn _o_rdonly() -> u64 { 0 }
+fn _o_wronly() -> u64 { 1 }
+
+fn _o_creat() -> u64 {
+    match @target_os() {
+        Os.Linux => 64,   // 0o100
+        Os.Macos => 512,  // 0x0200
+    }
+}
+
+fn _o_trunc() -> u64 {
+    match @target_os() {
+        Os.Linux => 512,  // 0o1000
+        Os.Macos => 1024, // 0x0400
+    }
+}
+
+fn _o_append() -> u64 {
+    match @target_os() {
+        Os.Linux => 1024, // 0o2000
+        Os.Macos => 8,    // 0x0008
+    }
+}
+
+// Default mode for newly created files: 0o644.
+fn _create_mode() -> u64 { 420 }
+
+// ---------------------------------------------------------------------------
+// Errno normalization. `errno` is the POSITIVE OS error number. The tables are
+// per-OS because the same logical error has different integers on Linux vs
+// macOS (ADR-0057 §3).
+// ---------------------------------------------------------------------------
+
+fn _normalize_errno(errno: i64) -> FileError {
+    match @target_os() {
+        Os.Linux => _normalize_linux(errno),
+        Os.Macos => _normalize_macos(errno),
+    }
+}
+
+fn _normalize_linux(e: i64) -> FileError {
+    // Linux asm-generic errno (same on x86-64 and aarch64):
+    // EPERM=1 ENOENT=2 EINTR=4 EBADF=9 EAGAIN=11 EACCES=13 EEXIST=17 EINVAL=22
+    if e == 2 {
+        FileError.NotFound
+    } else if e == 1 {
+        FileError.PermissionDenied
+    } else if e == 13 {
+        FileError.PermissionDenied
+    } else if e == 17 {
+        FileError.AlreadyExists
+    } else if e == 4 {
+        FileError.Interrupted
+    } else if e == 11 {
+        FileError.WouldBlock
+    } else if e == 22 {
+        FileError.InvalidInput
+    } else if e == 9 {
+        FileError.InvalidInput
+    } else {
+        FileError.Other(e)
+    }
+}
+
+fn _normalize_macos(e: i64) -> FileError {
+    // macOS/Darwin errno:
+    // EPERM=1 ENOENT=2 EINTR=4 EBADF=9 EACCES=13 EEXIST=17 EINVAL=22 EAGAIN=35
+    if e == 2 {
+        FileError.NotFound
+    } else if e == 1 {
+        FileError.PermissionDenied
+    } else if e == 13 {
+        FileError.PermissionDenied
+    } else if e == 17 {
+        FileError.AlreadyExists
+    } else if e == 4 {
+        FileError.Interrupted
+    } else if e == 35 {
+        FileError.WouldBlock
+    } else if e == 22 {
+        FileError.InvalidInput
+    } else if e == 9 {
+        FileError.InvalidInput
+    } else {
+        FileError.Other(e)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path marshalling. `StrBuf` is not NUL-terminated, so copy its bytes into a
+// fresh `len + 1` buffer with a trailing NUL and hand the kernel that pointer.
+// Reads bytes through the public `StrBuf.byte_at` accessor (RUE-712 uses the
+// PR #1714 `byte_at`), so `fs` never touches `StrBuf`'s private buffer.
+// The caller frees the returned buffer with `len + 1`.
+// ---------------------------------------------------------------------------
+
+fn _path_to_cbuf(borrow path: strbuf.StrBuf) -> ptr mut u8 {
+    let n = path.len();
+    let buf: ptr mut u8 = checked { @alloc_bytes(n + 1) };
+    if checked { @ptr_to_int(buf) } == 0 {
+        @panic("out of memory");
+    }
+    let O = option.Option(u8);
+    let mut i: u64 = 0;
+    while i < n {
+        let b = match path.byte_at(i) {
+            O.Some(x) => x,
+            O.None => 0,
+        };
+        checked { @byte_write(buf, i, b); };
+        i = i + 1;
+    }
+    checked { @byte_write(buf, n, 0); };
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// File: an owned descriptor. Closes on scope exit via `drop fn`; `close(self)`
+// consumes the value for callers who need to observe the close error. `fd == -1`
+// is the closed/sentinel state that both the consuming close and the drop path
+// check (ADR-0057 §4).
+// ---------------------------------------------------------------------------
+
+pub struct File {
+    fd: i32,
+
+    // Shared openat path used by the three constructors.
+    fn _open_with(borrow path: strbuf.StrBuf, flags: u64, mode: u64) -> result.Result(File, FileError) {
+        let R = result.Result(File, FileError);
+        let cbuf = _path_to_cbuf(borrow path);
+        let addr: u64 = checked { @ptr_to_int(cbuf) };
+        let free_len = path.len() + 1;
+        let ret: i64 = checked { @syscall(_sys_openat(), _at_fdcwd(), addr, flags, mode) };
+        checked { @free_bytes(cbuf, free_len); };
+        if ret < 0 {
+            R.Err(_normalize_errno(0 - ret))
+        } else {
+            let fd: i32 = @intCast(ret);
+            R.Ok(File { fd: fd })
+        }
+    }
+
+    // Open an existing file read-only (O_RDONLY).
+    fn open(borrow path: strbuf.StrBuf) -> result.Result(File, FileError) {
+        File._open_with(borrow path, _o_rdonly(), 0)
+    }
+
+    // Create-or-truncate for writing (O_WRONLY|O_CREAT|O_TRUNC, mode 0o644).
+    fn create(borrow path: strbuf.StrBuf) -> result.Result(File, FileError) {
+        let flags = _o_wronly() | _o_creat() | _o_trunc();
+        File._open_with(borrow path, flags, _create_mode())
+    }
+
+    // Open-or-create for appending (O_WRONLY|O_CREAT|O_APPEND, mode 0o644).
+    fn append(borrow path: strbuf.StrBuf) -> result.Result(File, FileError) {
+        let flags = _o_wronly() | _o_creat() | _o_append();
+        File._open_with(borrow path, flags, _create_mode())
+    }
+
+    // Read up to the buffer's SPARE capacity (`capacity() - len()`) bytes,
+    // appending them to `buf`, and return the count. `Ok(0)` means END OF FILE
+    // and nothing else. Reading into a buffer that has NO spare capacity
+    // (`capacity() == len()`) is a caller error and returns
+    // `Err(FileError.InvalidInput)` — deliberately NOT `Ok(0)` — so a whole-file
+    // loop (`loop { buf.reserve(chunk); n = f.read(inout buf)?; if n == 0 { break } }`)
+    // cannot silently truncate at the buffer's initial capacity. Grow the buffer
+    // with `ArrayBuf(u8).reserve(n)` (or start with `with_capacity(n)`) before
+    // each read. Marshals through a temporary contiguous buffer (v0 keeps
+    // `ArrayBuf`'s backing pointer private; the copy goes away when read/write
+    // move to `inout [u8]` slices, ADR-0057 §5).
+    fn read(inout self, inout buf: arraybuf.ArrayBuf(u8)) -> result.Result(u64, FileError) {
+        let R = result.Result(u64, FileError);
+        let want = buf.capacity() - buf.len();
+        if want == 0 {
+            // A full buffer is a caller error, distinct from EOF (Ok(0)).
+            return R.Err(FileError.InvalidInput);
+        }
+        let tmp: ptr mut u8 = checked { @alloc_bytes(want) };
+        if checked { @ptr_to_int(tmp) } == 0 {
+            @panic("out of memory");
+        }
+        let addr: u64 = checked { @ptr_to_int(tmp) };
+        let fd_u: u64 = @intCast(self.fd);
+        let ret: i64 = checked { @syscall(_sys_read(), fd_u, addr, want) };
+        if ret < 0 {
+            checked { @free_bytes(tmp, want); };
+            return R.Err(_normalize_errno(0 - ret));
+        }
+        let n: u64 = @intCast(ret);
+        let mut i: u64 = 0;
+        while i < n {
+            let b = checked { @byte_read(tmp, i) };
+            buf.push(b);
+            i = i + 1;
+        }
+        checked { @free_bytes(tmp, want); };
+        R.Ok(n)
+    }
+
+    // Write the bytes of `buf` in a single write(2). May write fewer than
+    // `buf.len()` bytes; the count is returned. `write_all` loops for the
+    // whole-buffer guarantee. Marshals through a temporary contiguous buffer
+    // (see `read`).
+    fn write(inout self, borrow buf: arraybuf.ArrayBuf(u8)) -> result.Result(u64, FileError) {
+        let R = result.Result(u64, FileError);
+        let n = buf.len();
+        if n == 0 {
+            return R.Ok(0);
+        }
+        let tmp: ptr mut u8 = checked { @alloc_bytes(n) };
+        if checked { @ptr_to_int(tmp) } == 0 {
+            @panic("out of memory");
+        }
+        let mut i: u64 = 0;
+        while i < n {
+            checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
+            i = i + 1;
+        }
+        let addr: u64 = checked { @ptr_to_int(tmp) };
+        let fd_u: u64 = @intCast(self.fd);
+        let ret: i64 = checked { @syscall(_sys_write(), fd_u, addr, n) };
+        checked { @free_bytes(tmp, n); };
+        if ret < 0 {
+            R.Err(_normalize_errno(0 - ret))
+        } else {
+            R.Ok(@intCast(ret))
+        }
+    }
+
+    // Write every byte of `buf`, looping over short writes and retrying EINTR.
+    fn write_all(inout self, borrow buf: arraybuf.ArrayBuf(u8)) -> result.Result((), FileError) {
+        let R = result.Result((), FileError);
+        let n = buf.len();
+        if n == 0 {
+            return R.Ok(());
+        }
+        let tmp: ptr mut u8 = checked { @alloc_bytes(n) };
+        if checked { @ptr_to_int(tmp) } == 0 {
+            @panic("out of memory");
+        }
+        let mut i: u64 = 0;
+        while i < n {
+            checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
+            i = i + 1;
+        }
+        let base: u64 = checked { @ptr_to_int(tmp) };
+        let fd_u: u64 = @intCast(self.fd);
+        let mut off: u64 = 0;
+        while off < n {
+            let ret: i64 = checked { @syscall(_sys_write(), fd_u, base + off, n - off) };
+            if ret < 0 {
+                let e = _normalize_errno(0 - ret);
+                let retry = match e {
+                    FileError.Interrupted => true,
+                    _ => false,
+                };
+                if !retry {
+                    checked { @free_bytes(tmp, n); };
+                    return R.Err(e);
+                }
+            } else {
+                let wrote: u64 = @intCast(ret);
+                if wrote == 0 {
+                    // No progress on a non-error write; stop rather than spin.
+                    checked { @free_bytes(tmp, n); };
+                    return R.Err(FileError.Other(0));
+                }
+                off = off + wrote;
+            }
+        }
+        checked { @free_bytes(tmp, n); };
+        R.Ok(())
+    }
+
+    // Consuming close: closes the fd and returns the close error. Moving `self`
+    // out of the caller's binding means the caller's scope-exit drop does not
+    // fire; the sentinel (`fd = -1`) makes THIS value's own scope-exit drop a
+    // no-op, so the fd is closed exactly once (ADR-0057 §4, double-close guard).
+    fn close(self) -> result.Result((), FileError) {
+        let R = result.Result((), FileError);
+        let mut me = self;
+        let fd = me.fd;
+        me.fd = -1;
+        if fd < 0 {
+            return R.Ok(());
+        }
+        let fd_u: u64 = @intCast(fd);
+        let ret: i64 = checked { @syscall(_sys_close(), fd_u) };
+        if ret < 0 {
+            R.Err(_normalize_errno(0 - ret))
+        } else {
+            R.Ok(())
+        }
+    }
+}
+
+// Scope-exit close. Guarded by the `fd == -1` sentinel so a value already
+// consumed by `close(self)` is not closed a second time (ADR-0057 §4). A raw
+// close whose error nobody can observe is the right default for the drop path.
+drop fn File(self) {
+    if self.fd >= 0 {
+        let fd_u: u64 = @intCast(self.fd);
+        checked { @syscall(_sys_close(), fd_u); };
+    }
+}


### PR DESCRIPTION
Implements the File IO v0 ruling from the 2026-07-16 design session (recorded on RUE-712); ADR-0057 is the design record.

**std.fs** — pure Rue over `@syscall` with per-target dispatch (the `std.exit()` template): `FileError` payload enum (`NotFound`/`PermissionDenied`/`AlreadyExists`/`Interrupted`/`WouldBlock`/`InvalidInput`/`Other(errno)`) normalized from per-OS errno tables (Linux/macOS values differ — `EAGAIN` 11 vs 35 is the forcing example); owned `File` with `drop fn` close plus consuming `close()` guarded by an fd sentinel; `open`/`create`/`append` constructors instead of a flags enum; `read`/`write`/`write_all` over `ArrayBuf(u8)`; `openat(AT_FDCWD)` uniformly since AArch64 Linux has no `open` syscall; StrBuf paths NUL-appended at the syscall boundary.

**Pre-merge dogfooding hardened the API before it shipped**: a `cat -n` file-to-file program surfaced that `read` returned `Ok(0)` ambiguously for both EOF and buffer-full — the naive whole-file loop silently truncated at initial capacity. The contract is now `InvalidInput` on a full buffer (`Ok(0)` is EOF, full stop), and `ArrayBuf` gains public `reserve(additional)` so the natural read loop is writable.

**Error detection runs on every target**: the two error-path cases were originally Linux-gated because `@syscall` discarded Darwins carry flag (found by this work, filed as RUE-945, fixed in #1720) — they now pass natively on macOS.

Verified: CLI `fs_file_io` 9/0 natively including both error paths; quick green; full `./test.sh` green (adr-registry-validation fixed by regenerating the ADR index for 0057); corpus re-bless header-only; dogfood program byte-exact on 3-line, empty, and no-trailing-newline inputs.

Fixes RUE-712