### PR TITLE
RUE-840: type CFG payload side tables

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -12,8 +12,12 @@ use rue_error::{CompileError, CompileWarning, ErrorKind, WarningKind};
 
 use crate::CfgOutput;
 use crate::inst::{
-    BlockId, Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData, CfgValue, Place, PlaceBase,
-    Projection, Terminator,
+    BlockId, Cfg, CfgArgMode, CfgCallArg, CfgEditError, CfgInst, CfgInstData, CfgValue, Place,
+    PlaceBase, Projection, Terminator,
+};
+use crate::payload::{
+    CfgArrayElements, CfgCallArgs, CfgElseArgs, CfgEnumPayload, CfgGotoArgs, CfgIntrinsicArgs,
+    CfgProjections, CfgStructFields, CfgSwitchCases, CfgThenArgs,
 };
 
 /// Result of lowering an expression.
@@ -245,6 +249,24 @@ pub struct CfgBuilder<'a> {
 }
 
 impl<'a> CfgBuilder<'a> {
+    fn payload_or<T>(
+        &mut self,
+        result: Result<T, CfgEditError>,
+        fallback: T,
+        span: rue_span::Span,
+    ) -> T {
+        match result {
+            Ok(value) => value,
+            Err(error) => {
+                self.errors.push(CompileError::new(
+                    ErrorKind::InternalError(format!("CFG payload construction failed: {error:?}")),
+                    span,
+                ));
+                fallback
+            }
+        }
+    }
+
     fn runtime_air_type(&self, ty: Type) -> Option<rue_air::RuntimeAirType> {
         use rue_air::RuntimeAirType as R;
 
@@ -455,8 +477,18 @@ impl<'a> CfgBuilder<'a> {
             .all_struct_ids()
             .filter(|id| builder.implicit_named_destructors.contains(id))
             .collect();
+        let cfg = match builder.cfg.finish(builder.type_pool) {
+            Ok(cfg) => Some(cfg),
+            Err(error) => {
+                builder.errors.push(CompileError::new(
+                    ErrorKind::InternalError(error.to_string()),
+                    rue_span::Span::default(),
+                ));
+                None
+            }
+        };
         CfgOutput {
-            cfg: builder.cfg,
+            cfg,
             warnings: builder.warnings,
             errors: builder.errors,
             implicit_named_destructors,
@@ -1035,13 +1067,13 @@ impl<'a> CfgBuilder<'a> {
                     });
                 }
                 // Store args in extra array
-                let (args_start, args_len) = self.cfg.push_call_args(arg_vals);
+                let args_result = self.cfg.push_call_args(arg_vals);
+                let args = self.payload_or(args_result, CfgCallArgs::EMPTY, span);
                 let value = self.emit(
                     CfgInstData::Call {
                         runtime: *runtime,
                         name: *name,
-                        args_start,
-                        args_len,
+                        args,
                     },
                     ty,
                     span,
@@ -1118,13 +1150,13 @@ impl<'a> CfgBuilder<'a> {
                     }
                 }
                 // Store args in extra array
-                let (args_start, args_len) = self.cfg.push_extra(arg_vals);
+                let args_result = self.cfg.push_intrinsic_args(arg_vals);
+                let args = self.payload_or(args_result, CfgIntrinsicArgs::EMPTY, span);
                 let intrinsic_value = self.emit(
                     CfgInstData::Intrinsic {
                         runtime: *runtime,
                         name: *name,
-                        args_start,
-                        args_len,
+                        args,
                     },
                     ty,
                     span,
@@ -1190,12 +1222,12 @@ impl<'a> CfgBuilder<'a> {
                     .collect();
 
                 // Store fields in extra array
-                let (fields_start, fields_len) = self.cfg.push_extra(field_vals);
+                let fields_result = self.cfg.push_struct_fields(field_vals);
+                let fields = self.payload_or(fields_result, CfgStructFields::EMPTY, span);
                 let value = self.emit(
                     CfgInstData::StructInit {
                         struct_id: *struct_id,
-                        fields_start,
-                        fields_len,
+                        fields,
                     },
                     ty,
                     span,
@@ -1380,18 +1412,18 @@ impl<'a> CfgBuilder<'a> {
                 let else_type = else_value.map(|e| self.air.get(e).ty);
 
                 // Branch to then/else
-                let (then_args_start, then_args_len) = self.cfg.push_extra(std::iter::empty());
-                let (else_args_start, else_args_len) = self.cfg.push_extra(std::iter::empty());
+                let then_result = self.cfg.push_then_args(std::iter::empty());
+                let then_args = self.payload_or(then_result, CfgThenArgs::EMPTY, span);
+                let else_result = self.cfg.push_else_args(std::iter::empty());
+                let else_args = self.payload_or(else_result, CfgElseArgs::EMPTY, span);
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Branch {
                         cond: cond_val,
                         then_block,
-                        then_args_start,
-                        then_args_len,
+                        then_args,
                         else_block,
-                        else_args_start,
-                        else_args_len,
+                        else_args,
                     },
                 );
 
@@ -1525,18 +1557,18 @@ impl<'a> CfgBuilder<'a> {
                 });
 
                 // Branch: if true go to body, if false exit
-                let (then_args_start, then_args_len) = self.cfg.push_extra(std::iter::empty());
-                let (else_args_start, else_args_len) = self.cfg.push_extra(std::iter::empty());
+                let then_result = self.cfg.push_then_args(std::iter::empty());
+                let then_args = self.payload_or(then_result, CfgThenArgs::EMPTY, span);
+                let else_result = self.cfg.push_else_args(std::iter::empty());
+                let else_args = self.payload_or(else_result, CfgElseArgs::EMPTY, span);
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Branch {
                         cond: cond_val,
                         then_block: body_block,
-                        then_args_start,
-                        then_args_len,
+                        then_args,
                         else_block: exit_block,
-                        else_args_start,
-                        else_args_len,
+                        else_args,
                     },
                 );
 
@@ -1708,13 +1740,13 @@ impl<'a> CfgBuilder<'a> {
                 });
 
                 // Set the switch terminator on current block
-                let (cases_start, cases_len) = self.cfg.push_switch_cases(switch_cases);
+                let cases_result = self.cfg.push_switch_cases(switch_cases);
+                let cases = self.payload_or(cases_result, CfgSwitchCases::EMPTY, span);
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Switch {
                         scrutinee: scrutinee_val,
-                        cases_start,
-                        cases_len,
+                        cases,
                         default,
                     },
                 );
@@ -1863,15 +1895,9 @@ impl<'a> CfgBuilder<'a> {
                     element_vals.push(val);
                 }
                 // Store elements in extra array
-                let (elements_start, elements_len) = self.cfg.push_extra(element_vals);
-                let value = self.emit(
-                    CfgInstData::ArrayInit {
-                        elements_start,
-                        elements_len,
-                    },
-                    ty,
-                    span,
-                );
+                let elements_result = self.cfg.push_array_elements(element_vals);
+                let elements = self.payload_or(elements_result, CfgArrayElements::EMPTY, span);
+                let value = self.emit(CfgInstData::ArrayInit { elements }, ty, span);
                 self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),
@@ -1957,7 +1983,7 @@ impl<'a> CfgBuilder<'a> {
                     };
                     self.emit_projected_overwrite_drop(
                         base_key,
-                        cfg_place,
+                        cfg_place.duplicate_with_owner(),
                         val_ty,
                         field_moved,
                         field_flag,
@@ -2032,13 +2058,13 @@ impl<'a> CfgBuilder<'a> {
                     };
                     payload_vals.push(v);
                 }
-                let (cfg_payload_start, cfg_payload_len) = self.cfg.push_extra(payload_vals);
+                let payload_result = self.cfg.push_enum_payload(payload_vals);
+                let payload = self.payload_or(payload_result, CfgEnumPayload::EMPTY, span);
                 let value = self.emit(
                     CfgInstData::EnumVariant {
                         enum_id: *enum_id,
                         variant_index: *variant_index,
-                        payload_start: cfg_payload_start,
-                        payload_len: cfg_payload_len,
+                        payload,
                     },
                     ty,
                     span,
@@ -2279,47 +2305,24 @@ impl<'a> CfgBuilder<'a> {
         let result_param = self.cfg.add_block_param(join_block, Type::BOOL);
         let short_circuit_value = self.emit(CfgInstData::BoolConst(!is_and), Type::BOOL, span);
 
-        let (short_args_start, short_args_len) =
-            self.cfg.push_extra(std::iter::once(short_circuit_value));
-        let (rhs_args_start, rhs_args_len) = self.cfg.push_extra(std::iter::empty::<CfgValue>());
-
-        let (
-            then_block,
-            then_args_start,
-            then_args_len,
-            else_block,
-            else_args_start,
-            else_args_len,
-        ) = if is_and {
-            (
-                rhs_block,
-                rhs_args_start,
-                rhs_args_len,
-                join_block,
-                short_args_start,
-                short_args_len,
-            )
+        let (then_block, then_values, else_block, else_values) = if is_and {
+            (rhs_block, vec![], join_block, vec![short_circuit_value])
         } else {
-            (
-                join_block,
-                short_args_start,
-                short_args_len,
-                rhs_block,
-                rhs_args_start,
-                rhs_args_len,
-            )
+            (join_block, vec![short_circuit_value], rhs_block, vec![])
         };
+        let then_result = self.cfg.push_then_args(then_values);
+        let then_args = self.payload_or(then_result, CfgThenArgs::EMPTY, span);
+        let else_result = self.cfg.push_else_args(else_values);
+        let else_args = self.payload_or(else_result, CfgElseArgs::EMPTY, span);
 
         self.cfg.set_terminator(
             self.current_block,
             Terminator::Branch {
                 cond: lhs_val,
                 then_block,
-                then_args_start,
-                then_args_len,
+                then_args,
                 else_block,
-                else_args_start,
-                else_args_len,
+                else_args,
             },
         );
 
@@ -2329,13 +2332,13 @@ impl<'a> CfgBuilder<'a> {
         let moved_before_rhs = self.moved.clone();
         self.current_block = rhs_block;
         if let Some(rhs_val) = self.lower_value(rhs) {
-            let (args_start, args_len) = self.cfg.push_extra(std::iter::once(rhs_val));
+            let args_result = self.cfg.push_goto_args(std::iter::once(rhs_val));
+            let args = self.payload_or(args_result, CfgGotoArgs::EMPTY, span);
             self.cfg.set_terminator(
                 self.current_block,
                 Terminator::Goto {
                     target: join_block,
-                    args_start,
-                    args_len,
+                    args,
                 },
             );
         }
@@ -2351,15 +2354,10 @@ impl<'a> CfgBuilder<'a> {
 
     /// Terminate `exit_block` with a `Goto` to `target` and no block args.
     fn goto_no_args(&mut self, exit_block: BlockId, target: BlockId) {
-        let (args_start, args_len) = self.cfg.push_extra(std::iter::empty::<CfgValue>());
-        self.cfg.set_terminator(
-            exit_block,
-            Terminator::Goto {
-                target,
-                args_start,
-                args_len,
-            },
-        );
+        let args_result = self.cfg.push_goto_args(std::iter::empty::<CfgValue>());
+        let args = self.payload_or(args_result, CfgGotoArgs::EMPTY, rue_span::Span::default());
+        self.cfg
+            .set_terminator(exit_block, Terminator::Goto { target, args });
     }
 
     /// Terminate `exit_block` with a `Goto` into `join_block`, passing the
@@ -2379,13 +2377,13 @@ impl<'a> CfgBuilder<'a> {
             (Some(val), Some(_)) => vec![val],
             _ => vec![],
         };
-        let (args_start, args_len) = self.cfg.push_extra(args);
+        let args_result = self.cfg.push_goto_args(args);
+        let args = self.payload_or(args_result, CfgGotoArgs::EMPTY, rue_span::Span::default());
         self.cfg.set_terminator(
             exit_block,
             Terminator::Goto {
                 target: join_block,
-                args_start,
-                args_len,
+                args,
             },
         );
     }
@@ -2736,18 +2734,18 @@ impl<'a> CfgBuilder<'a> {
 
         let drop_block = self.cfg.new_block();
         let cont_block = self.cfg.new_block();
-        let (then_args_start, then_args_len) = self.cfg.push_extra(std::iter::empty());
-        let (else_args_start, else_args_len) = self.cfg.push_extra(std::iter::empty());
+        let then_result = self.cfg.push_then_args(std::iter::empty());
+        let then_args = self.payload_or(then_result, CfgThenArgs::EMPTY, span);
+        let else_result = self.cfg.push_else_args(std::iter::empty());
+        let else_args = self.payload_or(else_result, CfgElseArgs::EMPTY, span);
         self.cfg.set_terminator(
             self.current_block,
             Terminator::Branch {
                 cond,
                 then_block: drop_block,
-                then_args_start,
-                then_args_len,
+                then_args,
                 else_block: cont_block,
-                else_args_start,
-                else_args_len,
+                else_args,
             },
         );
         self.current_block = drop_block;
@@ -2966,20 +2964,29 @@ impl<'a> CfgBuilder<'a> {
                     MovedSlot::Param(index) => self.emit(CfgInstData::Param { index }, ty, span),
                 }
             } else {
-                let place = self.cfg.make_place(base, root_type, projs.iter().copied());
+                let place_result = self.cfg.make_place(base, root_type, projs.iter().copied());
+                let place = self.payload_or(
+                    place_result,
+                    Place {
+                        base,
+                        base_type: root_type,
+                        projections: CfgProjections::EMPTY,
+                    },
+                    span,
+                );
                 self.emit(CfgInstData::PlaceRead { place }, ty, span)
             };
             let name = self.interner.get_or_intern(destructor_name);
-            let (args_start, args_len) = self.cfg.push_call_args(std::iter::once(CfgCallArg {
+            let args_result = self.cfg.push_call_args(std::iter::once(CfgCallArg {
                 value: whole_val,
                 mode: CfgArgMode::Normal,
             }));
+            let args = self.payload_or(args_result, CfgCallArgs::EMPTY, span);
             self.emit(
                 CfgInstData::Call {
                     runtime: None,
                     name,
-                    args_start,
-                    args_len,
+                    args,
                 },
                 Type::UNIT,
                 span,
@@ -3054,7 +3061,16 @@ impl<'a> CfgBuilder<'a> {
                 false
             };
             if !recursed {
-                let place = self.cfg.make_place(base, root_type, projs.iter().copied());
+                let place_result = self.cfg.make_place(base, root_type, projs.iter().copied());
+                let place = self.payload_or(
+                    place_result,
+                    Place {
+                        base,
+                        base_type: root_type,
+                        projections: CfgProjections::EMPTY,
+                    },
+                    span,
+                );
                 let field_val = self.emit(CfgInstData::PlaceRead { place }, field.ty, span);
                 self.emit(CfgInstData::Drop { value: field_val }, Type::UNIT, span);
             }
@@ -3149,7 +3165,16 @@ impl<'a> CfgBuilder<'a> {
                 false
             };
             if !recursed {
-                let place = self.cfg.make_place(base, root_type, projs.iter().copied());
+                let place_result = self.cfg.make_place(base, root_type, projs.iter().copied());
+                let place = self.payload_or(
+                    place_result,
+                    Place {
+                        base,
+                        base_type: root_type,
+                        projections: CfgProjections::EMPTY,
+                    },
+                    span,
+                );
                 let elem_val = self.emit(CfgInstData::PlaceRead { place }, elem_ty, span);
                 self.emit(CfgInstData::Drop { value: elem_val }, Type::UNIT, span);
             }
@@ -3228,11 +3253,19 @@ impl<'a> CfgBuilder<'a> {
         }
 
         // Create the CFG place
-        let place = self
+        match self
             .cfg
-            .make_place(base, air_place.base_type, cfg_projections);
-
-        Some(place)
+            .make_place(base, air_place.base_type, cfg_projections)
+        {
+            Ok(place) => Some(place),
+            Err(error) => {
+                self.errors.push(CompileError::new(
+                    ErrorKind::InternalError(format!("CFG place construction failed: {error:?}")),
+                    rue_span::Span::default(),
+                ));
+                None
+            }
+        }
     }
 }
 
@@ -3301,6 +3334,8 @@ mod tests {
             func.allow_unreachable_code,
         )
         .cfg
+        .unwrap()
+        .into_editor()
     }
 
     /// Count the Drop instructions in a CFG.
@@ -3330,7 +3365,7 @@ mod tests {
                     else {
                         return None;
                     };
-                    Some((*place, struct_id))
+                    Some((place.duplicate_with_owner(), struct_id))
                 }
                 _ => None,
             })
@@ -3367,9 +3402,9 @@ mod tests {
             .blocks()
             .iter()
             .flat_map(|block| block.insts.iter().copied())
-            .find_map(|value| match cfg.get_inst(value).data {
+            .find_map(|value| match &cfg.get_inst(value).data {
                 CfgInstData::PlaceRead { place } if matches!(place.base, PlaceBase::Local(0)) => {
-                    Some(place)
+                    Some(place.duplicate_with_owner())
                 }
                 _ => None,
             })
@@ -4079,8 +4114,9 @@ mod tests {
                 span,
             });
 
-            let cfg =
-                CfgBuilder::build(&air, 1, 0, "probe", &type_pool, vec![], &interner, false).cfg;
+            let cfg = CfgBuilder::build(&air, 1, 0, "probe", &type_pool, vec![], &interner, false)
+                .cfg
+                .unwrap();
             let instructions = cfg
                 .blocks()
                 .iter()

--- a/crates/rue-cfg/src/dominators.rs
+++ b/crates/rue-cfg/src/dominators.rs
@@ -228,14 +228,9 @@ fn successors_of(cfg: &Cfg, block: BlockId) -> Vec<BlockId> {
             else_block,
             ..
         } => vec![*then_block, *else_block],
-        Terminator::Switch {
-            cases_start,
-            cases_len,
-            default,
-            ..
-        } => {
+        Terminator::Switch { cases, default, .. } => {
             let mut out: Vec<BlockId> = cfg
-                .get_switch_cases(*cases_start, *cases_len)
+                .switch_cases(cases)
                 .iter()
                 .map(|(_, target)| *target)
                 .collect();
@@ -259,8 +254,7 @@ mod tests {
     fn goto(target: BlockId) -> Terminator {
         Terminator::Goto {
             target,
-            args_start: 0,
-            args_len: 0,
+            args: crate::payload::CfgGotoArgs::EMPTY,
         }
     }
 
@@ -279,11 +273,9 @@ mod tests {
         Terminator::Branch {
             cond,
             then_block,
-            then_args_start: 0,
-            then_args_len: 0,
+            then_args: crate::payload::CfgThenArgs::EMPTY,
             else_block,
-            else_args_start: 0,
-            else_args_len: 0,
+            else_args: crate::payload::CfgElseArgs::EMPTY,
         }
     }
 

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -28,6 +28,11 @@ use lasso::{Key, Spur, ThreadedRodeo};
 use rue_air::{EnumId, ParamSlotModes, StructId, Type};
 use rue_span::Span;
 
+use crate::payload::{
+    self, CfgArrayElements, CfgCallArgs, CfgElseArgs, CfgEnumPayload, CfgGotoArgs,
+    CfgIntrinsicArgs, CfgProjections, CfgStructFields, CfgSwitchCases, CfgThenArgs,
+};
+
 // ============================================================================
 // Place Expressions
 // ============================================================================
@@ -44,7 +49,7 @@ use rue_span::Span;
 /// - `arr[i]` → `Place { base: Local(0), base_type: Array, ... }` with `Index` projection
 /// - `point.x` → `Place { base: Local(0), base_type: Point, ... }` with `Field` projection
 /// - `arr[i].x` → the same `Array` base type with `Index` then `Field`
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Place {
     /// The base of the place - either a local slot or parameter slot
     pub base: PlaceBase,
@@ -56,20 +61,25 @@ pub struct Place {
     /// projection instead of trusting its self-described container.
     pub base_type: Type,
     /// Start index into Cfg's projections array
-    pub proj_start: u32,
-    /// Number of projections
-    pub proj_len: u32,
+    pub(crate) projections: CfgProjections,
 }
 
 impl Place {
+    pub(crate) fn duplicate_with_owner(&self) -> Self {
+        Self {
+            base: self.base,
+            base_type: self.base_type,
+            projections: self.projections.duplicate(),
+        }
+    }
+
     /// Create a place for a local variable with no projections.
     #[inline]
     pub const fn local(slot: u32, base_type: Type) -> Self {
         Self {
             base: PlaceBase::Local(slot),
             base_type,
-            proj_start: 0,
-            proj_len: 0,
+            projections: CfgProjections::EMPTY,
         }
     }
 
@@ -79,15 +89,28 @@ impl Place {
         Self {
             base: PlaceBase::Param(slot),
             base_type,
-            proj_start: 0,
-            proj_len: 0,
+            projections: CfgProjections::EMPTY,
         }
+    }
+
+    /// Return this place with a different base, preserving its opaque
+    /// projection payload.
+    #[inline]
+    pub const fn with_base(self, base: PlaceBase) -> Self {
+        Self { base, ..self }
+    }
+
+    /// Return this place with a different root type, preserving its opaque
+    /// projection payload.
+    #[inline]
+    pub const fn with_base_type(self, base_type: Type) -> Self {
+        Self { base_type, ..self }
     }
 
     /// Returns the local slot if this is a simple local place with no projections.
     #[inline]
     pub const fn as_local(&self) -> Option<u32> {
-        if self.proj_len == 0 {
+        if self.projections.is_empty() {
             match self.base {
                 PlaceBase::Local(slot) => Some(slot),
                 PlaceBase::Param(_) => None,
@@ -100,7 +123,7 @@ impl Place {
     /// Returns the param slot if this is a simple param place with no projections.
     #[inline]
     pub const fn as_param(&self) -> Option<u32> {
-        if self.proj_len == 0 {
+        if self.projections.is_empty() {
             match self.base {
                 PlaceBase::Param(slot) => Some(slot),
                 PlaceBase::Local(_) => None,
@@ -111,19 +134,126 @@ impl Place {
     }
 }
 
+impl CfgInstData {
+    pub(crate) fn duplicate_with_owner(&self) -> Self {
+        match self {
+            Self::Const(v) => Self::Const(*v),
+            Self::BoolConst(v) => Self::BoolConst(*v),
+            Self::StringConst(v) => Self::StringConst(*v),
+            Self::Param { index } => Self::Param { index: *index },
+            Self::BlockParam { index } => Self::BlockParam { index: *index },
+            Self::Add(a, b) => Self::Add(*a, *b),
+            Self::Sub(a, b) => Self::Sub(*a, *b),
+            Self::Mul(a, b) => Self::Mul(*a, *b),
+            Self::WrappingAdd(a, b) => Self::WrappingAdd(*a, *b),
+            Self::WrappingSub(a, b) => Self::WrappingSub(*a, *b),
+            Self::WrappingMul(a, b) => Self::WrappingMul(*a, *b),
+            Self::Div(a, b) => Self::Div(*a, *b),
+            Self::Mod(a, b) => Self::Mod(*a, *b),
+            Self::Eq(a, b) => Self::Eq(*a, *b),
+            Self::Ne(a, b) => Self::Ne(*a, *b),
+            Self::Lt(a, b) => Self::Lt(*a, *b),
+            Self::Gt(a, b) => Self::Gt(*a, *b),
+            Self::Le(a, b) => Self::Le(*a, *b),
+            Self::Ge(a, b) => Self::Ge(*a, *b),
+            Self::BitAnd(a, b) => Self::BitAnd(*a, *b),
+            Self::BitOr(a, b) => Self::BitOr(*a, *b),
+            Self::BitXor(a, b) => Self::BitXor(*a, *b),
+            Self::Shl(a, b) => Self::Shl(*a, *b),
+            Self::Shr(a, b) => Self::Shr(*a, *b),
+            Self::Neg(v) => Self::Neg(*v),
+            Self::Not(v) => Self::Not(*v),
+            Self::BitNot(v) => Self::BitNot(*v),
+            Self::Alloc { slot, init } => Self::Alloc {
+                slot: *slot,
+                init: *init,
+            },
+            Self::Load { slot } => Self::Load { slot: *slot },
+            Self::Store { slot, value } => Self::Store {
+                slot: *slot,
+                value: *value,
+            },
+            Self::ParamStore { param_slot, value } => Self::ParamStore {
+                param_slot: *param_slot,
+                value: *value,
+            },
+            Self::PlaceRead { place } => Self::PlaceRead {
+                place: place.duplicate_with_owner(),
+            },
+            Self::PlaceWrite { place, value } => Self::PlaceWrite {
+                place: place.duplicate_with_owner(),
+                value: *value,
+            },
+            Self::Call {
+                runtime,
+                name,
+                args,
+            } => Self::Call {
+                runtime: *runtime,
+                name: *name,
+                args: args.duplicate(),
+            },
+            Self::Intrinsic {
+                runtime,
+                name,
+                args,
+            } => Self::Intrinsic {
+                runtime: *runtime,
+                name: *name,
+                args: args.duplicate(),
+            },
+            Self::StructInit { struct_id, fields } => Self::StructInit {
+                struct_id: *struct_id,
+                fields: fields.duplicate(),
+            },
+            Self::ArrayInit { elements } => Self::ArrayInit {
+                elements: elements.duplicate(),
+            },
+            Self::EnumVariant {
+                enum_id,
+                variant_index,
+                payload,
+            } => Self::EnumVariant {
+                enum_id: *enum_id,
+                variant_index: *variant_index,
+                payload: payload.duplicate(),
+            },
+            Self::EnumPayloadGet {
+                base,
+                enum_id,
+                variant_index,
+                field_index,
+            } => Self::EnumPayloadGet {
+                base: *base,
+                enum_id: *enum_id,
+                variant_index: *variant_index,
+                field_index: *field_index,
+            },
+            Self::IntCast { value, from_ty } => Self::IntCast {
+                value: *value,
+                from_ty: *from_ty,
+            },
+            Self::Drop { value } => Self::Drop { value: *value },
+            Self::StorageLive { slot, local_ty } => Self::StorageLive {
+                slot: *slot,
+                local_ty: *local_ty,
+            },
+            Self::StorageDead { slot, local_ty } => Self::StorageDead {
+                slot: *slot,
+                local_ty: *local_ty,
+            },
+        }
+    }
+}
+
 impl fmt::Display for Place {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.base {
             PlaceBase::Local(slot) => write!(f, "${}", slot)?,
             PlaceBase::Param(slot) => write!(f, "%{}", slot)?,
         }
-        if self.proj_len > 0 {
-            write!(
-                f,
-                "[{}..{}]",
-                self.proj_start,
-                self.proj_start + self.proj_len
-            )?;
+        if !self.projections.is_empty() {
+            write!(f, "[{} projections]", self.projections.extent())?;
         }
         Ok(())
     }
@@ -140,8 +270,8 @@ pub enum PlaceBase {
 
 /// A projection applied to a place to reach a nested location.
 ///
-/// Projections are stored in `Cfg::projections` and referenced by
-/// `Place::proj_start` and `Place::proj_len`.
+/// Projections are stored in CFG's typed projection store and referenced by
+/// the owning place's opaque projection range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Projection {
     /// Field access: `.field_name`
@@ -208,7 +338,7 @@ impl fmt::Display for CfgValue {
 }
 
 /// A single CFG instruction with its metadata.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CfgInst {
     pub data: CfgInstData,
     pub ty: Type,
@@ -257,7 +387,8 @@ impl CfgCallArg {
 ///
 /// Unlike AIR, there are NO control flow instructions here.
 /// Control flow is handled entirely by terminators.
-#[derive(Debug, Clone)]
+#[allow(private_interfaces)]
+#[derive(Debug)]
 pub enum CfgInstData {
     /// Integer constant (typed)
     Const(u64),
@@ -350,64 +481,50 @@ pub enum CfgInstData {
     },
 
     // Function calls
-    /// Function call. Arguments are stored in the Cfg's call_args array.
-    /// Use `Cfg::get_call_args(args_start, args_len)` to retrieve them.
+    /// Function call. Arguments are stored in CFG's typed call-argument store.
     Call {
         /// Typed runtime identity, absent for source-language calls.
         runtime: Option<rue_air::RuntimeCallKind>,
         /// Function name (interned symbol)
         name: Spur,
         /// Start index into Cfg's call_args array
-        args_start: u32,
-        /// Number of arguments
-        args_len: u32,
+        args: CfgCallArgs,
     },
 
-    /// Intrinsic call (e.g., @dbg). Arguments are stored in the Cfg's extra array.
-    /// Use `Cfg::get_extra(args_start, args_len)` to retrieve them.
+    /// Intrinsic call (e.g., @dbg). Arguments use the intrinsic-value family.
     Intrinsic {
         /// Runtime helper/adaptation selected by semantic analysis.
         runtime: Option<rue_air::RuntimeCallKind>,
         /// Intrinsic name (interned symbol)
         name: Spur,
         /// Start index into Cfg's extra array
-        args_start: u32,
-        /// Number of arguments
-        args_len: u32,
+        args: CfgIntrinsicArgs,
     },
 
     // Struct operations
-    /// Struct initialization. Field values are stored in the Cfg's extra array.
-    /// Use `Cfg::get_extra(fields_start, fields_len)` to retrieve them.
+    /// Struct initialization. Field values use the struct-field family.
     StructInit {
         struct_id: StructId,
         /// Start index into Cfg's extra array
-        fields_start: u32,
-        /// Number of fields
-        fields_len: u32,
+        fields: CfgStructFields,
     },
     // Array operations
-    /// Array initialization. Element values are stored in the Cfg's extra array.
-    /// Use `Cfg::get_extra(elements_start, elements_len)` to retrieve them.
+    /// Array initialization. Element values use the array-element family.
     /// The array type is stored in `CfgInst.ty`.
     ArrayInit {
         /// Start index into Cfg's extra array
-        elements_start: u32,
-        /// Number of elements
-        elements_len: u32,
+        elements: CfgArrayElements,
     },
     // Enum operations
     /// Create an enum variant value: the discriminant plus (for tuple
     /// variants, RUE-221) the payload operands, stored in the Cfg's extra
-    /// array. Use `Cfg::get_extra(payload_start, payload_len)` to retrieve the
-    /// payload values (empty for a discriminant-only variant).
+    /// array. Payload operands use the enum-payload family (empty for a
+    /// discriminant-only variant).
     EnumVariant {
         enum_id: EnumId,
         variant_index: u32,
         /// Start index into the Cfg's extra array for payload values.
-        payload_start: u32,
-        /// Number of payload values.
-        payload_len: u32,
+        payload: CfgEnumPayload,
     },
     /// Read payload field `field_index` of a tuple variant from an enum value
     /// (RUE-221). The result is the payload field, read from the tagged-union
@@ -461,16 +578,15 @@ pub enum CfgInstData {
 /// Block arguments are stored in the CFG's `extra` array for efficiency.
 /// Use `Cfg::get_goto_args()`, `Cfg::get_branch_then_args()`, and
 /// `Cfg::get_branch_else_args()` to retrieve the arguments.
-#[derive(Debug, Clone, Copy)]
+#[allow(private_interfaces)]
+#[derive(Debug)]
 pub enum Terminator {
     /// Unconditional jump to another block.
     /// Arguments are stored in Cfg's extra array.
     Goto {
         target: BlockId,
         /// Start index into Cfg's extra array
-        args_start: u32,
-        /// Number of arguments
-        args_len: u32,
+        args: CfgGotoArgs,
     },
 
     /// Conditional branch.
@@ -479,14 +595,10 @@ pub enum Terminator {
         cond: CfgValue,
         then_block: BlockId,
         /// Start index into Cfg's extra array for then branch args
-        then_args_start: u32,
-        /// Number of arguments for then branch
-        then_args_len: u32,
+        then_args: CfgThenArgs,
         else_block: BlockId,
         /// Start index into Cfg's extra array for else branch args
-        else_args_start: u32,
-        /// Number of arguments for else branch
-        else_args_len: u32,
+        else_args: CfgElseArgs,
     },
 
     /// Multi-way branch (switch/match).
@@ -495,9 +607,7 @@ pub enum Terminator {
         /// The value to switch on
         scrutinee: CfgValue,
         /// Start index into Cfg's switch_cases array
-        cases_start: u32,
-        /// Number of cases
-        cases_len: u32,
+        cases: CfgSwitchCases,
         /// Default block (for wildcard pattern)
         default: BlockId,
     },
@@ -514,8 +624,44 @@ pub enum Terminator {
     None,
 }
 
+impl Terminator {
+    fn duplicate_with_owner(&self) -> Self {
+        match self {
+            Self::Goto { target, args } => Self::Goto {
+                target: *target,
+                args: args.duplicate(),
+            },
+            Self::Branch {
+                cond,
+                then_block,
+                then_args,
+                else_block,
+                else_args,
+            } => Self::Branch {
+                cond: *cond,
+                then_block: *then_block,
+                then_args: then_args.duplicate(),
+                else_block: *else_block,
+                else_args: else_args.duplicate(),
+            },
+            Self::Switch {
+                scrutinee,
+                cases,
+                default,
+            } => Self::Switch {
+                scrutinee: *scrutinee,
+                cases: cases.duplicate(),
+                default: *default,
+            },
+            Self::Return { value } => Self::Return { value: *value },
+            Self::Unreachable => Self::Unreachable,
+            Self::None => Self::None,
+        }
+    }
+}
+
 /// A basic block in the CFG.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BasicBlock {
     /// Block identifier
     pub id: BlockId,
@@ -540,7 +686,7 @@ impl BasicBlock {
 }
 
 /// The complete CFG for a function.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Cfg {
     /// All basic blocks
     blocks: Vec<BasicBlock>,
@@ -552,16 +698,16 @@ pub struct Cfg {
     values: Vec<CfgInst>,
     /// Extra storage for variable-length CfgValue data (struct fields, array elements, intrinsic args,
     /// and terminator block arguments). Instructions and terminators store (start, len) indices into this array.
-    extra: Vec<CfgValue>,
+    extra: payload::Values,
     /// Extra storage for call arguments (CfgCallArg).
     /// Call instructions store (start, len) indices into this array.
-    call_args: Vec<CfgCallArg>,
+    call_args: payload::CallArgs,
     /// Extra storage for switch cases (value, target block pairs).
     /// Switch terminators store (start, len) indices into this array.
-    switch_cases: Vec<(i64, BlockId)>,
+    switch_cases: payload::SwitchCases,
     /// Extra storage for place projections.
     /// Place instructions store (start, len) indices into this array.
-    projections: Vec<Projection>,
+    projections: payload::Projections,
     /// Number of local variable slots
     num_locals: u32,
     /// Number of parameter slots
@@ -593,6 +739,149 @@ pub struct Cfg {
     address_taken_params: std::collections::HashSet<u32>,
 }
 
+/// Mutable CFG construction and transformation state.
+///
+/// Only an editor can mutate owner-bound payload stores. Consumers receive a
+/// [`ValidatedCfg`] after verification has consumed the editor.
+pub type CfgEditor = Cfg;
+
+/// Recoverable failure from an owner-level CFG edit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CfgEditError {
+    /// A block, value, target, or instruction kind was invalid before mutation.
+    InvalidBuilderInput {
+        operation: &'static str,
+        detail: &'static str,
+    },
+    /// A payload cannot be represented by the compact `u32` range format.
+    ResourceLimitExceeded { family: &'static str },
+    /// Reserving storage failed without changing the CFG.
+    CapacityFailure { family: &'static str },
+}
+
+/// Failure from a validated owner-level edit transaction.
+#[derive(Debug)]
+pub enum CfgEditTransactionError {
+    /// The requested edit was rejected before publication.
+    Edit(CfgEditError),
+    /// The edited owner did not pass complete structural and type validation.
+    Verification(crate::CfgVerificationError),
+}
+
+/// Failure while remapping an entire CFG owner into new request-local domains.
+#[derive(Debug)]
+pub enum CfgRemapError<E> {
+    /// A caller-supplied domain mapping rejected a value.
+    Domain(E),
+    /// Rebuilding an owner-bound payload failed without publishing a CFG.
+    Edit(CfgEditError),
+}
+
+impl fmt::Display for CfgEditTransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Edit(error) => write!(f, "CFG edit was rejected: {error:?}"),
+            Self::Verification(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for CfgEditTransactionError {}
+
+impl From<payload::PayloadBuildError> for CfgEditError {
+    fn from(error: payload::PayloadBuildError) -> Self {
+        match error {
+            payload::PayloadBuildError::ResourceLimitExceeded { family } => {
+                Self::ResourceLimitExceeded { family }
+            }
+            payload::PayloadBuildError::CapacityFailure { family } => {
+                Self::CapacityFailure { family }
+            }
+        }
+    }
+}
+
+/// An immutable CFG whose complete owner and payload stores passed structural
+/// verification together.
+#[derive(Debug)]
+pub struct ValidatedCfg(pub(crate) Cfg);
+
+impl std::ops::Deref for ValidatedCfg {
+    type Target = Cfg;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Clone for ValidatedCfg {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl ValidatedCfg {
+    pub(crate) fn into_editor(self) -> CfgEditor {
+        self.0
+    }
+
+    /// Apply a mutation transaction to a private editor and publish it only if
+    /// structural verification still succeeds.
+    pub fn try_edit<R>(
+        &mut self,
+        type_pool: &rue_air::FrozenTypeInternPool,
+        edit: impl FnOnce(&mut CfgEditor) -> Result<R, CfgEditError>,
+    ) -> Result<R, CfgEditTransactionError> {
+        let mut editor = self.0.clone();
+        let result = edit(&mut editor).map_err(CfgEditTransactionError::Edit)?;
+        editor
+            .verify_with_type_pool(type_pool)
+            .map_err(CfgEditTransactionError::Verification)?;
+        self.0 = editor;
+        Ok(result)
+    }
+}
+
+impl Clone for Cfg {
+    /// Clone the complete owner so every opaque payload range remains paired
+    /// with the physical store whose positions it addresses.
+    fn clone(&self) -> Self {
+        Self {
+            blocks: self
+                .blocks
+                .iter()
+                .map(|block| BasicBlock {
+                    id: block.id,
+                    params: block.params.clone(),
+                    insts: block.insts.clone(),
+                    terminator: block.terminator.duplicate_with_owner(),
+                })
+                .collect(),
+            entry: self.entry,
+            return_type: self.return_type,
+            values: self
+                .values
+                .iter()
+                .map(|inst| CfgInst {
+                    data: inst.data.duplicate_with_owner(),
+                    ty: inst.ty,
+                    span: inst.span,
+                })
+                .collect(),
+            extra: self.extra.clone(),
+            call_args: self.call_args.clone(),
+            switch_cases: self.switch_cases.clone(),
+            projections: self.projections.clone(),
+            num_locals: self.num_locals,
+            num_params: self.num_params,
+            fn_name: self.fn_name.clone(),
+            param_modes: self.param_modes.clone(),
+            address_taken_slots: self.address_taken_slots.clone(),
+            address_taken_params: self.address_taken_params.clone(),
+        }
+    }
+}
+
 impl Cfg {
     /// Clone and atomically remap every request-local payload domain embedded
     /// in this CFG. Block and value numbers are structural within the graph;
@@ -606,41 +895,250 @@ impl Cfg {
         mut symbol: impl FnMut(Spur) -> Result<Spur, E>,
         mut string: impl FnMut(u32) -> Result<u32, E>,
         mut span: impl FnMut(Span) -> Result<Span, E>,
-    ) -> Result<Self, E> {
-        let mut cfg = self.clone();
-        cfg.return_type = ty(cfg.return_type)?;
-        for block in &mut cfg.blocks {
-            for (_, value_ty) in &mut block.params {
-                *value_ty = ty(*value_ty)?;
-            }
+    ) -> Result<Self, CfgRemapError<E>> {
+        use CfgInstData::*;
+        let mut cfg = Self::new(
+            ty(self.return_type).map_err(CfgRemapError::Domain)?,
+            self.num_locals,
+            self.num_params,
+            self.fn_name.clone(),
+            self.param_modes.clone(),
+        );
+        cfg.entry = self.entry;
+        cfg.address_taken_slots = self.address_taken_slots.clone();
+        cfg.address_taken_params = self.address_taken_params.clone();
+
+        macro_rules! binary {
+            ($variant:ident, $a:expr, $b:expr) => {
+                $variant(*$a, *$b)
+            };
         }
-        for projection in &mut cfg.projections {
-            match projection {
-                Projection::Field { struct_id, .. } => *struct_id = strukt(*struct_id)?,
-                Projection::Index { array_type, .. } => *array_type = ty(*array_type)?,
-            }
+        macro_rules! domain {
+            ($value:expr) => {
+                $value.map_err(CfgRemapError::Domain)?
+            };
         }
-        for inst in &mut cfg.values {
-            inst.ty = ty(inst.ty)?;
-            inst.span = span(inst.span)?;
-            match &mut inst.data {
-                CfgInstData::StringConst(index) => *index = string(*index)?,
-                CfgInstData::Call { name, .. } | CfgInstData::Intrinsic { name, .. } => {
-                    *name = symbol(*name)?
-                }
-                CfgInstData::StructInit { struct_id, .. } => *struct_id = strukt(*struct_id)?,
-                CfgInstData::EnumVariant { enum_id, .. }
-                | CfgInstData::EnumPayloadGet { enum_id, .. } => *enum_id = enm(*enum_id)?,
-                CfgInstData::IntCast { from_ty, .. } => *from_ty = ty(*from_ty)?,
-                CfgInstData::StorageLive { local_ty, .. }
-                | CfgInstData::StorageDead { local_ty, .. } => *local_ty = ty(*local_ty)?,
-                _ => {}
-            }
-            if let CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } =
-                &mut inst.data
-            {
-                place.base_type = ty(place.base_type)?;
-            }
+        for source in &self.values {
+            let data = match &source.data {
+                Const(value) => Const(*value),
+                BoolConst(value) => BoolConst(*value),
+                StringConst(index) => StringConst(domain!(string(*index))),
+                Param { index } => Param { index: *index },
+                BlockParam { index } => BlockParam { index: *index },
+                Add(a, b) => binary!(Add, a, b),
+                Sub(a, b) => binary!(Sub, a, b),
+                Mul(a, b) => binary!(Mul, a, b),
+                WrappingAdd(a, b) => binary!(WrappingAdd, a, b),
+                WrappingSub(a, b) => binary!(WrappingSub, a, b),
+                WrappingMul(a, b) => binary!(WrappingMul, a, b),
+                Div(a, b) => binary!(Div, a, b),
+                Mod(a, b) => binary!(Mod, a, b),
+                Eq(a, b) => binary!(Eq, a, b),
+                Ne(a, b) => binary!(Ne, a, b),
+                Lt(a, b) => binary!(Lt, a, b),
+                Gt(a, b) => binary!(Gt, a, b),
+                Le(a, b) => binary!(Le, a, b),
+                Ge(a, b) => binary!(Ge, a, b),
+                BitAnd(a, b) => binary!(BitAnd, a, b),
+                BitOr(a, b) => binary!(BitOr, a, b),
+                BitXor(a, b) => binary!(BitXor, a, b),
+                Shl(a, b) => binary!(Shl, a, b),
+                Shr(a, b) => binary!(Shr, a, b),
+                Neg(value) => Neg(*value),
+                Not(value) => Not(*value),
+                BitNot(value) => BitNot(*value),
+                Alloc { slot, init } => Alloc {
+                    slot: *slot,
+                    init: *init,
+                },
+                Load { slot } => Load { slot: *slot },
+                Store { slot, value } => Store {
+                    slot: *slot,
+                    value: *value,
+                },
+                ParamStore { param_slot, value } => ParamStore {
+                    param_slot: *param_slot,
+                    value: *value,
+                },
+                PlaceRead { place } => PlaceRead {
+                    place: cfg
+                        .make_place(
+                            place.base,
+                            domain!(ty(place.base_type)),
+                            self.get_place_projections(place)
+                                .iter()
+                                .map(|projection| match projection {
+                                    Projection::Field {
+                                        struct_id,
+                                        field_index,
+                                    } => Ok(Projection::Field {
+                                        struct_id: domain!(strukt(*struct_id)),
+                                        field_index: *field_index,
+                                    }),
+                                    Projection::Index { array_type, index } => {
+                                        Ok(Projection::Index {
+                                            array_type: domain!(ty(*array_type)),
+                                            index: *index,
+                                        })
+                                    }
+                                })
+                                .collect::<Result<Vec<_>, CfgRemapError<E>>>()?,
+                        )
+                        .map_err(CfgRemapError::Edit)?,
+                },
+                PlaceWrite { place, value } => PlaceWrite {
+                    place: cfg
+                        .make_place(
+                            place.base,
+                            domain!(ty(place.base_type)),
+                            self.get_place_projections(place)
+                                .iter()
+                                .map(|projection| match projection {
+                                    Projection::Field {
+                                        struct_id,
+                                        field_index,
+                                    } => Ok(Projection::Field {
+                                        struct_id: domain!(strukt(*struct_id)),
+                                        field_index: *field_index,
+                                    }),
+                                    Projection::Index { array_type, index } => {
+                                        Ok(Projection::Index {
+                                            array_type: domain!(ty(*array_type)),
+                                            index: *index,
+                                        })
+                                    }
+                                })
+                                .collect::<Result<Vec<_>, CfgRemapError<E>>>()?,
+                        )
+                        .map_err(CfgRemapError::Edit)?,
+                    value: *value,
+                },
+                Call {
+                    runtime,
+                    name,
+                    args,
+                } => Call {
+                    runtime: *runtime,
+                    name: domain!(symbol(*name)),
+                    args: cfg
+                        .push_call_args(self.call_args(args).iter().copied())
+                        .map_err(CfgRemapError::Edit)?,
+                },
+                Intrinsic {
+                    runtime,
+                    name,
+                    args,
+                } => Intrinsic {
+                    runtime: *runtime,
+                    name: domain!(symbol(*name)),
+                    args: cfg
+                        .push_intrinsic_args(self.intrinsic_args(args).iter().copied())
+                        .map_err(CfgRemapError::Edit)?,
+                },
+                StructInit { struct_id, fields } => StructInit {
+                    struct_id: domain!(strukt(*struct_id)),
+                    fields: cfg
+                        .push_struct_fields(self.struct_fields(fields).iter().copied())
+                        .map_err(CfgRemapError::Edit)?,
+                },
+                ArrayInit { elements } => ArrayInit {
+                    elements: cfg
+                        .push_array_elements(self.array_elements(elements).iter().copied())
+                        .map_err(CfgRemapError::Edit)?,
+                },
+                EnumVariant {
+                    enum_id,
+                    variant_index,
+                    payload,
+                } => EnumVariant {
+                    enum_id: domain!(enm(*enum_id)),
+                    variant_index: *variant_index,
+                    payload: cfg
+                        .push_enum_payload(self.enum_payload(payload).iter().copied())
+                        .map_err(CfgRemapError::Edit)?,
+                },
+                EnumPayloadGet {
+                    base,
+                    enum_id,
+                    variant_index,
+                    field_index,
+                } => EnumPayloadGet {
+                    base: *base,
+                    enum_id: domain!(enm(*enum_id)),
+                    variant_index: *variant_index,
+                    field_index: *field_index,
+                },
+                IntCast { value, from_ty } => IntCast {
+                    value: *value,
+                    from_ty: domain!(ty(*from_ty)),
+                },
+                Drop { value } => Drop { value: *value },
+                StorageLive { slot, local_ty } => StorageLive {
+                    slot: *slot,
+                    local_ty: domain!(ty(*local_ty)),
+                },
+                StorageDead { slot, local_ty } => StorageDead {
+                    slot: *slot,
+                    local_ty: domain!(ty(*local_ty)),
+                },
+            };
+            cfg.add_inst(CfgInst {
+                data,
+                ty: domain!(ty(source.ty)),
+                span: domain!(span(source.span)),
+            });
+        }
+
+        for source in &self.blocks {
+            let terminator = match &source.terminator {
+                Terminator::Goto { target, args } => Terminator::Goto {
+                    target: *target,
+                    args: cfg
+                        .push_goto_args(self.goto_args(args).iter().copied())
+                        .map_err(CfgRemapError::Edit)?,
+                },
+                Terminator::Branch {
+                    cond,
+                    then_block,
+                    then_args,
+                    else_block,
+                    else_args,
+                } => Terminator::Branch {
+                    cond: *cond,
+                    then_block: *then_block,
+                    then_args: cfg
+                        .push_then_args(self.then_args(then_args).iter().copied())
+                        .map_err(CfgRemapError::Edit)?,
+                    else_block: *else_block,
+                    else_args: cfg
+                        .push_else_args(self.else_args(else_args).iter().copied())
+                        .map_err(CfgRemapError::Edit)?,
+                },
+                Terminator::Switch {
+                    scrutinee,
+                    cases,
+                    default,
+                } => Terminator::Switch {
+                    scrutinee: *scrutinee,
+                    cases: cfg
+                        .push_switch_cases(self.switch_cases(cases).iter().copied())
+                        .map_err(CfgRemapError::Edit)?,
+                    default: *default,
+                },
+                Terminator::Return { value } => Terminator::Return { value: *value },
+                Terminator::Unreachable => Terminator::Unreachable,
+                Terminator::None => Terminator::None,
+            };
+            cfg.blocks.push(BasicBlock {
+                id: source.id,
+                params: source
+                    .params
+                    .iter()
+                    .map(|(value, value_ty)| Ok((*value, domain!(ty(*value_ty)))))
+                    .collect::<Result<Vec<_>, CfgRemapError<E>>>()?,
+                insts: source.insts.clone(),
+                terminator,
+            });
         }
         Ok(cfg)
     }
@@ -658,10 +1156,10 @@ impl Cfg {
             entry: BlockId(0),
             return_type,
             values: Vec::new(),
-            extra: Vec::new(),
-            call_args: Vec::new(),
-            switch_cases: Vec::new(),
-            projections: Vec::new(),
+            extra: payload::Values::new(),
+            call_args: payload::CallArgs::new(),
+            switch_cases: payload::SwitchCases::new(),
+            projections: payload::Projections::new(),
             num_locals,
             num_params,
             fn_name,
@@ -803,12 +1301,12 @@ impl Cfg {
 
     /// Get a block mutably by ID.
     #[inline]
-    pub fn get_block_mut(&mut self, id: BlockId) -> &mut BasicBlock {
+    pub(crate) fn get_block_mut(&mut self, id: BlockId) -> &mut BasicBlock {
         &mut self.blocks[id.0 as usize]
     }
 
     /// Add an instruction and return its value reference.
-    pub fn add_inst(&mut self, inst: CfgInst) -> CfgValue {
+    pub(crate) fn add_inst(&mut self, inst: CfgInst) -> CfgValue {
         let value = CfgValue::from_raw(self.values.len() as u32);
         self.values.push(inst);
         value
@@ -822,7 +1320,7 @@ impl Cfg {
 
     /// Get a mutable instruction by value reference.
     #[inline]
-    pub fn get_inst_mut(&mut self, value: CfgValue) -> &mut CfgInst {
+    pub(crate) fn get_inst_mut(&mut self, value: CfgValue) -> &mut CfgInst {
         &mut self.values[value.0 as usize]
     }
 
@@ -832,116 +1330,475 @@ impl Cfg {
         self.values.len()
     }
 
-    #[inline]
-    pub(crate) fn extra_len(&self) -> usize {
-        self.extra.len()
+    pub(crate) fn push_intrinsic_args(
+        &mut self,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<CfgIntrinsicArgs, CfgEditError> {
+        payload::push_intrinsic_args(&mut self.extra, values).map_err(Into::into)
+    }
+    pub(crate) fn intrinsic_args(&self, range: &CfgIntrinsicArgs) -> &[CfgValue] {
+        payload::intrinsic_args(&self.extra, range)
+    }
+    pub(crate) fn checked_intrinsic_args(
+        &self,
+        range: &CfgIntrinsicArgs,
+    ) -> Result<&[CfgValue], payload::PayloadError> {
+        payload::checked_intrinsic_args(&self.extra, range)
+    }
+    pub(crate) fn push_struct_fields(
+        &mut self,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<CfgStructFields, CfgEditError> {
+        payload::push_struct_fields(&mut self.extra, values).map_err(Into::into)
+    }
+    pub(crate) fn struct_fields(&self, range: &CfgStructFields) -> &[CfgValue] {
+        payload::struct_fields(&self.extra, range)
+    }
+    pub(crate) fn checked_struct_fields(
+        &self,
+        range: &CfgStructFields,
+    ) -> Result<&[CfgValue], payload::PayloadError> {
+        payload::checked_struct_fields(&self.extra, range)
+    }
+    pub(crate) fn push_array_elements(
+        &mut self,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<CfgArrayElements, CfgEditError> {
+        payload::push_array_elements(&mut self.extra, values).map_err(Into::into)
+    }
+    pub(crate) fn array_elements(&self, range: &CfgArrayElements) -> &[CfgValue] {
+        payload::array_elements(&self.extra, range)
+    }
+    pub(crate) fn checked_array_elements(
+        &self,
+        range: &CfgArrayElements,
+    ) -> Result<&[CfgValue], payload::PayloadError> {
+        payload::checked_array_elements(&self.extra, range)
+    }
+    pub(crate) fn push_enum_payload(
+        &mut self,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<CfgEnumPayload, CfgEditError> {
+        payload::push_enum_payload(&mut self.extra, values).map_err(Into::into)
+    }
+    pub(crate) fn enum_payload(&self, range: &CfgEnumPayload) -> &[CfgValue] {
+        payload::enum_payload(&self.extra, range)
+    }
+    pub(crate) fn checked_enum_payload(
+        &self,
+        range: &CfgEnumPayload,
+    ) -> Result<&[CfgValue], payload::PayloadError> {
+        payload::checked_enum_payload(&self.extra, range)
+    }
+    pub(crate) fn push_goto_args(
+        &mut self,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<CfgGotoArgs, CfgEditError> {
+        payload::push_goto_args(&mut self.extra, values).map_err(Into::into)
+    }
+    pub(crate) fn goto_args(&self, range: &CfgGotoArgs) -> &[CfgValue] {
+        payload::goto_args(&self.extra, range)
+    }
+    pub(crate) fn checked_goto_args(
+        &self,
+        range: &CfgGotoArgs,
+    ) -> Result<&[CfgValue], payload::PayloadError> {
+        payload::checked_goto_args(&self.extra, range)
+    }
+    pub(crate) fn then_args(&self, range: &CfgThenArgs) -> &[CfgValue] {
+        payload::then_args(&self.extra, range)
+    }
+    pub(crate) fn checked_then_args(
+        &self,
+        range: &CfgThenArgs,
+    ) -> Result<&[CfgValue], payload::PayloadError> {
+        payload::checked_then_args(&self.extra, range)
+    }
+    pub(crate) fn else_args(&self, range: &CfgElseArgs) -> &[CfgValue] {
+        payload::else_args(&self.extra, range)
+    }
+    pub(crate) fn checked_else_args(
+        &self,
+        range: &CfgElseArgs,
+    ) -> Result<&[CfgValue], payload::PayloadError> {
+        payload::checked_else_args(&self.extra, range)
+    }
+    pub(crate) fn push_then_args(
+        &mut self,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<CfgThenArgs, CfgEditError> {
+        payload::push_then_args(&mut self.extra, values).map_err(Into::into)
+    }
+    pub(crate) fn push_else_args(
+        &mut self,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<CfgElseArgs, CfgEditError> {
+        payload::push_else_args(&mut self.extra, values).map_err(Into::into)
+    }
+    pub(crate) fn push_call_args(
+        &mut self,
+        args: impl IntoIterator<Item = CfgCallArg>,
+    ) -> Result<CfgCallArgs, CfgEditError> {
+        payload::push_call_args(&mut self.call_args, args).map_err(Into::into)
+    }
+    pub(crate) fn call_args(&self, range: &CfgCallArgs) -> &[CfgCallArg] {
+        payload::call_args(&self.call_args, range)
+    }
+    pub(crate) fn checked_call_args(
+        &self,
+        range: &CfgCallArgs,
+    ) -> Result<&[CfgCallArg], payload::PayloadError> {
+        payload::checked_call_args(&self.call_args, range)
     }
 
-    #[inline]
-    pub(crate) fn call_args_len(&self) -> usize {
-        self.call_args.len()
+    /// Borrow call arguments from an instruction without exposing its opaque
+    /// owner-bound payload range.
+    pub fn get_call_args<'a>(&'a self, data: &CfgInstData) -> &'a [CfgCallArg] {
+        match data {
+            CfgInstData::Call { args, .. } => self.call_args(args),
+            _ => panic!("get_call_args called on non-Call instruction"),
+        }
     }
 
-    #[inline]
-    pub(crate) fn switch_cases_len(&self) -> usize {
-        self.switch_cases.len()
+    pub fn get_intrinsic_args<'a>(&'a self, data: &CfgInstData) -> &'a [CfgValue] {
+        match data {
+            CfgInstData::Intrinsic { args, .. } => self.intrinsic_args(args),
+            _ => panic!("get_intrinsic_args called on non-Intrinsic instruction"),
+        }
     }
 
-    #[inline]
-    pub(crate) fn projections_len(&self) -> usize {
-        self.projections.len()
+    pub fn get_struct_fields<'a>(&'a self, data: &CfgInstData) -> &'a [CfgValue] {
+        match data {
+            CfgInstData::StructInit { fields, .. } => self.struct_fields(fields),
+            _ => panic!("get_struct_fields called on non-StructInit instruction"),
+        }
     }
 
-    /// Add values to the extra array and return (start, len).
+    pub fn get_array_elements<'a>(&'a self, data: &CfgInstData) -> &'a [CfgValue] {
+        match data {
+            CfgInstData::ArrayInit { elements } => self.array_elements(elements),
+            _ => panic!("get_array_elements called on non-ArrayInit instruction"),
+        }
+    }
+
+    pub fn get_enum_payload<'a>(&'a self, data: &CfgInstData) -> &'a [CfgValue] {
+        match data {
+            CfgInstData::EnumVariant { payload, .. } => self.enum_payload(payload),
+            _ => panic!("get_enum_payload called on non-EnumVariant instruction"),
+        }
+    }
+    pub fn replace_call_args(
+        &mut self,
+        value: CfgValue,
+        values: impl IntoIterator<Item = CfgCallArg>,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "call arguments";
+        if !matches!(
+            self.values.get(value.0 as usize).map(|inst| &inst.data),
+            Some(CfgInstData::Call { .. })
+        ) {
+            return Err(Self::invalid_edit(OP, "target is not a Call instruction"));
+        }
+        let staged = Self::stage_edit(OP, values)?;
+        self.validate_value_refs(OP, staged.iter(), |arg| arg.value)?;
+        let args = payload::push_call_args(&mut self.call_args, staged)?;
+        let CfgInstData::Call { args: stored, .. } = &mut self.values[value.0 as usize].data else {
+            return Err(Self::invalid_edit(OP, "target changed during replacement"));
+        };
+        *stored = args;
+        Ok(())
+    }
+    pub fn replace_intrinsic_args(
+        &mut self,
+        value: CfgValue,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "intrinsic arguments";
+        if !matches!(
+            self.values.get(value.0 as usize).map(|inst| &inst.data),
+            Some(CfgInstData::Intrinsic { .. })
+        ) {
+            return Err(Self::invalid_edit(
+                OP,
+                "target is not an Intrinsic instruction",
+            ));
+        }
+        let staged = Self::stage_edit(OP, values)?;
+        self.validate_value_refs(OP, staged.iter(), |value| *value)?;
+        let args = payload::push_intrinsic_args(&mut self.extra, staged)?;
+        let CfgInstData::Intrinsic { args: stored, .. } = &mut self.values[value.0 as usize].data
+        else {
+            return Err(Self::invalid_edit(OP, "target changed during replacement"));
+        };
+        *stored = args;
+        Ok(())
+    }
+
+    /// Replace the static result type of an instruction.
     ///
-    /// Used for StructInit fields, ArrayInit elements, and Intrinsic args.
-    pub fn push_extra(&mut self, values: impl IntoIterator<Item = CfgValue>) -> (u32, u32) {
-        let start = self.extra.len() as u32;
-        self.extra.extend(values);
-        let len = self.extra.len() as u32 - start;
-        (start, len)
+    /// This is primarily useful to construct verifier and oracle probes while
+    /// keeping the instruction arena encapsulated.
+    pub fn replace_inst_type(&mut self, value: CfgValue, ty: Type) -> Result<(), CfgEditError> {
+        let Some(inst) = self.values.get_mut(value.0 as usize) else {
+            return Err(Self::invalid_edit(
+                "instruction type",
+                "target instruction is undefined",
+            ));
+        };
+        inst.ty = ty;
+        Ok(())
     }
 
-    /// Get a slice from the extra array.
-    #[inline]
-    pub fn get_extra(&self, start: u32, len: u32) -> &[CfgValue] {
-        &self.extra[start as usize..(start + len) as usize]
+    /// Replace an integer cast without exposing mutable instruction storage.
+    pub fn replace_int_cast(
+        &mut self,
+        value: CfgValue,
+        operand: CfgValue,
+        from_ty: Type,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "integer cast";
+        if operand.0 as usize >= self.values.len() {
+            return Err(Self::invalid_edit(OP, "operand is undefined"));
+        }
+        let Some(data) = self
+            .values
+            .get_mut(value.0 as usize)
+            .map(|inst| &mut inst.data)
+        else {
+            return Err(Self::invalid_edit(OP, "target instruction is undefined"));
+        };
+        if !matches!(data, CfgInstData::IntCast { .. }) {
+            return Err(Self::invalid_edit(
+                OP,
+                "target is not an IntCast instruction",
+            ));
+        }
+        *data = CfgInstData::IntCast {
+            value: operand,
+            from_ty,
+        };
+        Ok(())
     }
 
-    /// Add call arguments to the call_args array and return (start, len).
-    ///
-    /// Used for Call instruction arguments.
-    pub fn push_call_args(&mut self, args: impl IntoIterator<Item = CfgCallArg>) -> (u32, u32) {
-        let start = self.call_args.len() as u32;
-        self.call_args.extend(args);
-        let len = self.call_args.len() as u32 - start;
-        (start, len)
+    /// Replace a struct initializer's fields in this CFG's payload store.
+    pub fn replace_struct_fields(
+        &mut self,
+        value: CfgValue,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "struct fields";
+        if !matches!(
+            self.values.get(value.0 as usize).map(|inst| &inst.data),
+            Some(CfgInstData::StructInit { .. })
+        ) {
+            return Err(Self::invalid_edit(
+                OP,
+                "target is not a StructInit instruction",
+            ));
+        }
+        let staged = Self::stage_edit(OP, values)?;
+        self.validate_value_refs(OP, staged.iter(), |value| *value)?;
+        let fields = payload::push_struct_fields(&mut self.extra, staged)?;
+        let CfgInstData::StructInit { fields: stored, .. } =
+            &mut self.values[value.0 as usize].data
+        else {
+            return Err(Self::invalid_edit(OP, "target changed during replacement"));
+        };
+        *stored = fields;
+        Ok(())
     }
 
-    /// Get a slice from the call_args array.
-    #[inline]
-    pub fn get_call_args(&self, start: u32, len: u32) -> &[CfgCallArg] {
-        &self.call_args[start as usize..(start + len) as usize]
+    /// Replace an array initializer's elements atomically.
+    pub fn replace_array_elements(
+        &mut self,
+        value: CfgValue,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "array elements";
+        if !matches!(
+            self.values.get(value.0 as usize).map(|inst| &inst.data),
+            Some(CfgInstData::ArrayInit { .. })
+        ) {
+            return Err(Self::invalid_edit(
+                OP,
+                "target is not an ArrayInit instruction",
+            ));
+        }
+        let staged = Self::stage_edit(OP, values)?;
+        self.validate_value_refs(OP, staged.iter(), |value| *value)?;
+        let elements = payload::push_array_elements(&mut self.extra, staged)?;
+        let CfgInstData::ArrayInit { elements: stored } = &mut self.values[value.0 as usize].data
+        else {
+            return Err(Self::invalid_edit(OP, "target changed during replacement"));
+        };
+        *stored = elements;
+        Ok(())
     }
 
-    /// Add switch cases to the switch_cases array and return (start, len).
-    ///
-    /// Used for Switch terminator cases.
-    pub fn push_switch_cases(
+    /// Replace an enum constructor's payload atomically after validating its
+    /// nominal target and variant against the canonical type context.
+    pub fn replace_enum_payload(
+        &mut self,
+        type_pool: &rue_air::FrozenTypeInternPool,
+        value: CfgValue,
+        values: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "enum payload";
+        let Some(CfgInstData::EnumVariant {
+            enum_id,
+            variant_index,
+            ..
+        }) = self.values.get(value.0 as usize).map(|inst| &inst.data)
+        else {
+            return Err(Self::invalid_edit(
+                OP,
+                "target is not an EnumVariant instruction",
+            ));
+        };
+        let Some(def) = type_pool.try_enum_def(*enum_id) else {
+            return Err(Self::invalid_edit(OP, "enum target is undefined"));
+        };
+        if *variant_index as usize >= def.variant_count() {
+            return Err(Self::invalid_edit(OP, "enum variant is out of bounds"));
+        }
+        let staged = Self::stage_edit(OP, values)?;
+        self.validate_value_refs(OP, staged.iter(), |value| *value)?;
+        let payload = payload::push_enum_payload(&mut self.extra, staged)?;
+        let CfgInstData::EnumVariant {
+            payload: stored, ..
+        } = &mut self.values[value.0 as usize].data
+        else {
+            return Err(Self::invalid_edit(OP, "target changed during replacement"));
+        };
+        *stored = payload;
+        Ok(())
+    }
+
+    /// Replace a place read, storing its projections in this CFG owner.
+    pub fn replace_place_read(
+        &mut self,
+        value: CfgValue,
+        base: PlaceBase,
+        base_type: Type,
+        projections: impl IntoIterator<Item = Projection>,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "projections";
+        if !matches!(
+            self.values.get(value.0 as usize).map(|inst| &inst.data),
+            Some(CfgInstData::PlaceRead { .. })
+        ) {
+            return Err(Self::invalid_edit(
+                OP,
+                "target is not a PlaceRead instruction",
+            ));
+        }
+        let staged = Self::stage_edit(OP, projections)?;
+        self.validate_place_input(OP, base, &staged)?;
+        let projections = payload::push_projections(&mut self.projections, staged)?;
+        self.values[value.0 as usize].data = CfgInstData::PlaceRead {
+            place: Place {
+                base,
+                base_type,
+                projections,
+            },
+        };
+        Ok(())
+    }
+
+    /// Replace a place write, storing its projections in this CFG owner.
+    pub fn replace_place_write(
+        &mut self,
+        instruction: CfgValue,
+        base: PlaceBase,
+        base_type: Type,
+        projections: impl IntoIterator<Item = Projection>,
+        value: CfgValue,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "projections";
+        if !matches!(
+            self.values
+                .get(instruction.0 as usize)
+                .map(|inst| &inst.data),
+            Some(CfgInstData::PlaceWrite { .. })
+        ) {
+            return Err(Self::invalid_edit(
+                OP,
+                "target is not a PlaceWrite instruction",
+            ));
+        }
+        if value.0 as usize >= self.values.len() {
+            return Err(Self::invalid_edit(OP, "written value is undefined"));
+        }
+        let staged = Self::stage_edit(OP, projections)?;
+        self.validate_place_input(OP, base, &staged)?;
+        let projections = payload::push_projections(&mut self.projections, staged)?;
+        self.values[instruction.0 as usize].data = CfgInstData::PlaceWrite {
+            place: Place {
+                base,
+                base_type,
+                projections,
+            },
+            value,
+        };
+        Ok(())
+    }
+    pub(crate) fn push_switch_cases(
         &mut self,
         cases: impl IntoIterator<Item = (i64, BlockId)>,
-    ) -> (u32, u32) {
-        let start = self.switch_cases.len() as u32;
-        self.switch_cases.extend(cases);
-        let len = self.switch_cases.len() as u32 - start;
-        (start, len)
+    ) -> Result<CfgSwitchCases, CfgEditError> {
+        payload::push_switch_cases(&mut self.switch_cases, cases).map_err(Into::into)
+    }
+    pub(crate) fn switch_cases(&self, range: &CfgSwitchCases) -> &[(i64, BlockId)] {
+        payload::switch_cases(&self.switch_cases, range)
+    }
+    pub(crate) fn checked_switch_cases(
+        &self,
+        range: &CfgSwitchCases,
+    ) -> Result<&[(i64, BlockId)], payload::PayloadError> {
+        payload::checked_switch_cases(&self.switch_cases, range)
     }
 
-    /// Get a slice from the switch_cases array.
-    #[inline]
-    pub fn get_switch_cases(&self, start: u32, len: u32) -> &[(i64, BlockId)] {
-        &self.switch_cases[start as usize..(start + len) as usize]
+    pub fn get_switch_cases<'a>(&'a self, term: &Terminator) -> &'a [(i64, BlockId)] {
+        match term {
+            Terminator::Switch { cases, .. } => self.switch_cases(cases),
+            _ => panic!("get_switch_cases called on non-Switch terminator"),
+        }
     }
-
-    /// Add projections to the projections array and return (start, len).
-    ///
-    /// Used for `PlaceRead` and `PlaceWrite` instructions.
-    pub fn push_projections(&mut self, projs: impl IntoIterator<Item = Projection>) -> (u32, u32) {
-        let start = self.projections.len() as u32;
-        self.projections.extend(projs);
-        let len = self.projections.len() as u32 - start;
-        (start, len)
-    }
-
-    /// Get a slice from the projections array.
-    #[inline]
-    pub fn get_projections(&self, start: u32, len: u32) -> &[Projection] {
-        &self.projections[start as usize..(start + len) as usize]
+    pub(crate) fn push_projections(
+        &mut self,
+        projs: impl IntoIterator<Item = Projection>,
+    ) -> Result<CfgProjections, CfgEditError> {
+        payload::push_projections(&mut self.projections, projs).map_err(Into::into)
     }
 
     /// Get projections for a place.
     #[inline]
     pub fn get_place_projections(&self, place: &Place) -> &[Projection] {
-        self.get_projections(place.proj_start, place.proj_len)
+        payload::projections(&self.projections, &place.projections)
+    }
+    pub(crate) fn checked_place_projections(
+        &self,
+        place: &Place,
+    ) -> Result<&[Projection], payload::PayloadError> {
+        payload::checked_projections(&self.projections, &place.projections)
     }
 
     /// Create a place with the given base and projections.
     ///
     /// This adds the projections to the projections array and returns a Place
     /// that references them.
-    pub fn make_place(
+    pub(crate) fn make_place(
         &mut self,
         base: PlaceBase,
         base_type: Type,
         projs: impl IntoIterator<Item = Projection>,
-    ) -> Place {
-        let (proj_start, proj_len) = self.push_projections(projs);
-        Place {
+    ) -> Result<Place, CfgEditError> {
+        let projections = self.push_projections(projs)?;
+        Ok(Place {
             base,
             base_type,
-            proj_start,
-            proj_len,
-        }
+            projections,
+        })
     }
 
     /// Get the block arguments from a Goto terminator.
@@ -952,11 +1809,7 @@ impl Cfg {
     #[inline]
     pub fn get_goto_args(&self, term: &Terminator) -> &[CfgValue] {
         match term {
-            Terminator::Goto {
-                args_start,
-                args_len,
-                ..
-            } => self.get_extra(*args_start, *args_len),
+            Terminator::Goto { args, .. } => payload::goto_args(&self.extra, args),
             _ => panic!("get_goto_args called on non-Goto terminator"),
         }
     }
@@ -969,11 +1822,7 @@ impl Cfg {
     #[inline]
     pub fn get_branch_then_args(&self, term: &Terminator) -> &[CfgValue] {
         match term {
-            Terminator::Branch {
-                then_args_start,
-                then_args_len,
-                ..
-            } => self.get_extra(*then_args_start, *then_args_len),
+            Terminator::Branch { then_args, .. } => payload::then_args(&self.extra, then_args),
             _ => panic!("get_branch_then_args called on non-Branch terminator"),
         }
     }
@@ -986,20 +1835,319 @@ impl Cfg {
     #[inline]
     pub fn get_branch_else_args(&self, term: &Terminator) -> &[CfgValue] {
         match term {
-            Terminator::Branch {
-                else_args_start,
-                else_args_len,
-                ..
-            } => self.get_extra(*else_args_start, *else_args_len),
+            Terminator::Branch { else_args, .. } => payload::else_args(&self.extra, else_args),
             _ => panic!("get_branch_else_args called on non-Branch terminator"),
         }
     }
 
     /// Add an instruction to a block.
-    pub fn add_inst_to_block(&mut self, block: BlockId, inst: CfgInst) -> CfgValue {
+    pub(crate) fn add_inst_to_block(&mut self, block: BlockId, inst: CfgInst) -> CfgValue {
         let value = self.add_inst(inst);
         self.blocks[block.0 as usize].insts.push(value);
         value
+    }
+
+    fn invalid_edit(operation: &'static str, detail: &'static str) -> CfgEditError {
+        CfgEditError::InvalidBuilderInput { operation, detail }
+    }
+
+    fn stage_edit<E>(
+        operation: &'static str,
+        values: impl IntoIterator<Item = E>,
+    ) -> Result<Vec<E>, CfgEditError> {
+        let values = values.into_iter();
+        let (lower, _) = values.size_hint();
+        if lower > u32::MAX as usize {
+            return Err(CfgEditError::ResourceLimitExceeded { family: operation });
+        }
+        let mut staged = Vec::new();
+        staged
+            .try_reserve(lower)
+            .map_err(|_| CfgEditError::CapacityFailure { family: operation })?;
+        for value in values {
+            if staged.len() == u32::MAX as usize {
+                return Err(CfgEditError::ResourceLimitExceeded { family: operation });
+            }
+            staged
+                .try_reserve(1)
+                .map_err(|_| CfgEditError::CapacityFailure { family: operation })?;
+            staged.push(value);
+        }
+        Ok(staged)
+    }
+
+    fn preflight_append(
+        &mut self,
+        operation: &'static str,
+        block: BlockId,
+    ) -> Result<(), CfgEditError> {
+        let block = self
+            .blocks
+            .get_mut(block.0 as usize)
+            .ok_or_else(|| Self::invalid_edit(operation, "block is out of bounds"))?;
+        self.values
+            .try_reserve(1)
+            .map_err(|_| CfgEditError::CapacityFailure { family: "values" })?;
+        block
+            .insts
+            .try_reserve(1)
+            .map_err(|_| CfgEditError::CapacityFailure {
+                family: "block instructions",
+            })
+    }
+
+    fn validate_value_refs<E>(
+        &self,
+        operation: &'static str,
+        values: impl IntoIterator<Item = E>,
+        value: impl Fn(E) -> CfgValue,
+    ) -> Result<(), CfgEditError> {
+        if values
+            .into_iter()
+            .any(|item| value(item).0 as usize >= self.values.len())
+        {
+            return Err(Self::invalid_edit(operation, "payload value is undefined"));
+        }
+        Ok(())
+    }
+
+    fn validate_place_input(
+        &self,
+        operation: &'static str,
+        base: PlaceBase,
+        projections: &[Projection],
+    ) -> Result<(), CfgEditError> {
+        let base_valid = match base {
+            PlaceBase::Local(slot) => slot < self.num_locals,
+            PlaceBase::Param(slot) => slot < self.num_params,
+        };
+        if !base_valid {
+            return Err(Self::invalid_edit(operation, "place base is out of bounds"));
+        }
+        if projections.iter().any(|projection| {
+            matches!(projection, Projection::Index { index, .. } if index.0 as usize >= self.values.len())
+        }) {
+            return Err(Self::invalid_edit(
+                operation,
+                "projection index value is undefined",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Append an instruction whose data has no owner-bound payload.
+    ///
+    /// Payload-bearing instructions cannot be constructed outside this crate;
+    /// use the corresponding `append_*` method so the payload and its opaque
+    /// range are created by the same CFG owner.
+    pub fn append_inst(&mut self, block: BlockId, inst: CfgInst) -> CfgValue {
+        self.add_inst_to_block(block, inst)
+    }
+
+    /// Append a call and store its arguments in this CFG's call-argument store.
+    pub fn append_call(
+        &mut self,
+        block: BlockId,
+        runtime: Option<rue_air::RuntimeCallKind>,
+        name: Spur,
+        args: impl IntoIterator<Item = CfgCallArg>,
+        ty: Type,
+        span: Span,
+    ) -> Result<CfgValue, CfgEditError> {
+        const OP: &str = "call arguments";
+        let staged = Self::stage_edit(OP, args)?;
+        self.validate_value_refs(OP, staged.iter(), |arg| arg.value)?;
+        self.preflight_append(OP, block)?;
+        let args = payload::push_call_args(&mut self.call_args, staged)?;
+        Ok(self.add_inst_to_block(
+            block,
+            CfgInst {
+                data: CfgInstData::Call {
+                    runtime,
+                    name,
+                    args,
+                },
+                ty,
+                span,
+            },
+        ))
+    }
+
+    /// Append an intrinsic and store its operands in this CFG's value store.
+    pub fn append_intrinsic(
+        &mut self,
+        block: BlockId,
+        runtime: Option<rue_air::RuntimeCallKind>,
+        name: Spur,
+        args: impl IntoIterator<Item = CfgValue>,
+        ty: Type,
+        span: Span,
+    ) -> Result<CfgValue, CfgEditError> {
+        const OP: &str = "intrinsic arguments";
+        let staged = Self::stage_edit(OP, args)?;
+        self.validate_value_refs(OP, staged.iter(), |value| *value)?;
+        self.preflight_append(OP, block)?;
+        let args = payload::push_intrinsic_args(&mut self.extra, staged)?;
+        Ok(self.add_inst_to_block(
+            block,
+            CfgInst {
+                data: CfgInstData::Intrinsic {
+                    runtime,
+                    name,
+                    args,
+                },
+                ty,
+                span,
+            },
+        ))
+    }
+
+    /// Append a struct initializer owned by this CFG.
+    pub fn append_struct_init(
+        &mut self,
+        block: BlockId,
+        struct_id: StructId,
+        fields: impl IntoIterator<Item = CfgValue>,
+        ty: Type,
+        span: Span,
+    ) -> Result<CfgValue, CfgEditError> {
+        const OP: &str = "struct fields";
+        let staged = Self::stage_edit(OP, fields)?;
+        self.validate_value_refs(OP, staged.iter(), |value| *value)?;
+        self.preflight_append(OP, block)?;
+        let fields = payload::push_struct_fields(&mut self.extra, staged)?;
+        Ok(self.add_inst_to_block(
+            block,
+            CfgInst {
+                data: CfgInstData::StructInit { struct_id, fields },
+                ty,
+                span,
+            },
+        ))
+    }
+
+    /// Append an array initializer owned by this CFG.
+    pub fn append_array_init(
+        &mut self,
+        block: BlockId,
+        elements: impl IntoIterator<Item = CfgValue>,
+        ty: Type,
+        span: Span,
+    ) -> Result<CfgValue, CfgEditError> {
+        const OP: &str = "array elements";
+        let staged = Self::stage_edit(OP, elements)?;
+        self.validate_value_refs(OP, staged.iter(), |value| *value)?;
+        self.preflight_append(OP, block)?;
+        let elements = payload::push_array_elements(&mut self.extra, staged)?;
+        Ok(self.add_inst_to_block(
+            block,
+            CfgInst {
+                data: CfgInstData::ArrayInit { elements },
+                ty,
+                span,
+            },
+        ))
+    }
+
+    /// Append an enum variant owned by this CFG.
+    pub fn append_enum_variant(
+        &mut self,
+        type_pool: &rue_air::FrozenTypeInternPool,
+        block: BlockId,
+        enum_id: EnumId,
+        variant_index: u32,
+        payload: impl IntoIterator<Item = CfgValue>,
+        ty: Type,
+        span: Span,
+    ) -> Result<CfgValue, CfgEditError> {
+        const OP: &str = "enum payload";
+        let Some(def) = type_pool.try_enum_def(enum_id) else {
+            return Err(Self::invalid_edit(OP, "enum target is undefined"));
+        };
+        if variant_index as usize >= def.variant_count() {
+            return Err(Self::invalid_edit(OP, "enum variant is out of bounds"));
+        }
+        let staged = Self::stage_edit(OP, payload)?;
+        self.validate_value_refs(OP, staged.iter(), |value| *value)?;
+        self.preflight_append(OP, block)?;
+        let payload = payload::push_enum_payload(&mut self.extra, staged)?;
+        Ok(self.add_inst_to_block(
+            block,
+            CfgInst {
+                data: CfgInstData::EnumVariant {
+                    enum_id,
+                    variant_index,
+                    payload,
+                },
+                ty,
+                span,
+            },
+        ))
+    }
+
+    /// Append a place read whose projections are owned by this CFG.
+    pub fn append_place_read(
+        &mut self,
+        block: BlockId,
+        base: PlaceBase,
+        base_type: Type,
+        projections: impl IntoIterator<Item = Projection>,
+        ty: Type,
+        span: Span,
+    ) -> Result<CfgValue, CfgEditError> {
+        const OP: &str = "projections";
+        let staged = Self::stage_edit(OP, projections)?;
+        self.validate_place_input(OP, base, &staged)?;
+        self.preflight_append(OP, block)?;
+        let projections = payload::push_projections(&mut self.projections, staged)?;
+        let place = Place {
+            base,
+            base_type,
+            projections,
+        };
+        Ok(self.add_inst_to_block(
+            block,
+            CfgInst {
+                data: CfgInstData::PlaceRead { place },
+                ty,
+                span,
+            },
+        ))
+    }
+
+    /// Append a place write whose projections are owned by this CFG.
+    #[allow(clippy::too_many_arguments)]
+    pub fn append_place_write(
+        &mut self,
+        block: BlockId,
+        base: PlaceBase,
+        base_type: Type,
+        projections: impl IntoIterator<Item = Projection>,
+        value: CfgValue,
+        ty: Type,
+        span: Span,
+    ) -> Result<CfgValue, CfgEditError> {
+        const OP: &str = "projections";
+        if value.0 as usize >= self.values.len() {
+            return Err(Self::invalid_edit(OP, "written value is undefined"));
+        }
+        let staged = Self::stage_edit(OP, projections)?;
+        self.validate_place_input(OP, base, &staged)?;
+        self.preflight_append(OP, block)?;
+        let projections = payload::push_projections(&mut self.projections, staged)?;
+        let place = Place {
+            base,
+            base_type,
+            projections,
+        };
+        Ok(self.add_inst_to_block(
+            block,
+            CfgInst {
+                data: CfgInstData::PlaceWrite { place, value },
+                ty,
+                span,
+            },
+        ))
     }
 
     /// Add a block parameter and return its value.
@@ -1022,7 +2170,7 @@ impl Cfg {
     /// how divergence bugs hide — e.g. a diverging let-initializer's `Return`
     /// being clobbered by the code after the `let` (RUE-128) — so that is a
     /// loud assertion that runs in release too (correctness guard, RUE-45).
-    pub fn set_terminator(&mut self, block: BlockId, term: Terminator) {
+    pub(crate) fn set_terminator(&mut self, block: BlockId, term: Terminator) {
         assert!(
             matches!(
                 self.blocks[block.0 as usize].terminator,
@@ -1034,6 +2182,164 @@ impl Cfg {
             term
         );
         self.blocks[block.0 as usize].terminator = term;
+    }
+
+    /// Terminate a block with an unconditional edge owned by this CFG.
+    pub fn set_goto(
+        &mut self,
+        block: BlockId,
+        target: BlockId,
+        args: impl IntoIterator<Item = CfgValue>,
+    ) {
+        self.try_set_goto(block, target, args)
+            .expect("valid CFG goto edit");
+    }
+
+    pub fn try_set_goto(
+        &mut self,
+        block: BlockId,
+        target: BlockId,
+        args: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "goto arguments";
+        if block.0 as usize >= self.blocks.len() || target.0 as usize >= self.blocks.len() {
+            return Err(Self::invalid_edit(OP, "block target is out of bounds"));
+        }
+        if !matches!(
+            self.blocks[block.0 as usize].terminator,
+            Terminator::None | Terminator::Unreachable
+        ) {
+            return Err(Self::invalid_edit(OP, "block already has a terminator"));
+        }
+        let staged = Self::stage_edit(OP, args)?;
+        self.validate_value_refs(OP, staged.iter(), |value| *value)?;
+        let args = payload::push_goto_args(&mut self.extra, staged)?;
+        self.set_terminator(block, Terminator::Goto { target, args });
+        Ok(())
+    }
+
+    /// Terminate a block with a conditional edge owned by this CFG.
+    pub fn set_branch(
+        &mut self,
+        block: BlockId,
+        cond: CfgValue,
+        then_block: BlockId,
+        then_args: impl IntoIterator<Item = CfgValue>,
+        else_block: BlockId,
+        else_args: impl IntoIterator<Item = CfgValue>,
+    ) {
+        self.try_set_branch(block, cond, then_block, then_args, else_block, else_args)
+            .expect("valid CFG branch edit");
+    }
+
+    pub fn try_set_branch(
+        &mut self,
+        block: BlockId,
+        cond: CfgValue,
+        then_block: BlockId,
+        then_args: impl IntoIterator<Item = CfgValue>,
+        else_block: BlockId,
+        else_args: impl IntoIterator<Item = CfgValue>,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "branch arguments";
+        if block.0 as usize >= self.blocks.len()
+            || then_block.0 as usize >= self.blocks.len()
+            || else_block.0 as usize >= self.blocks.len()
+        {
+            return Err(Self::invalid_edit(OP, "block target is out of bounds"));
+        }
+        if cond.0 as usize >= self.values.len() {
+            return Err(Self::invalid_edit(OP, "condition value is undefined"));
+        }
+        if !matches!(
+            self.blocks[block.0 as usize].terminator,
+            Terminator::None | Terminator::Unreachable
+        ) {
+            return Err(Self::invalid_edit(OP, "block already has a terminator"));
+        }
+        let then_staged = Self::stage_edit(OP, then_args)?;
+        let else_staged = Self::stage_edit(OP, else_args)?;
+        self.validate_value_refs(OP, then_staged.iter(), |value| *value)?;
+        self.validate_value_refs(OP, else_staged.iter(), |value| *value)?;
+        let additional = then_staged
+            .len()
+            .checked_add(else_staged.len())
+            .ok_or(CfgEditError::ResourceLimitExceeded { family: OP })?;
+        payload::reserve_values(&mut self.extra, additional)?;
+        let then_args = payload::push_then_args(&mut self.extra, then_staged)?;
+        let else_args = payload::push_else_args(&mut self.extra, else_staged)?;
+        self.set_terminator(
+            block,
+            Terminator::Branch {
+                cond,
+                then_block,
+                then_args,
+                else_block,
+                else_args,
+            },
+        );
+        Ok(())
+    }
+
+    /// Terminate a block with a switch owned by this CFG.
+    pub fn set_switch(
+        &mut self,
+        block: BlockId,
+        scrutinee: CfgValue,
+        cases: impl IntoIterator<Item = (i64, BlockId)>,
+        default: BlockId,
+    ) {
+        self.try_set_switch(block, scrutinee, cases, default)
+            .expect("valid CFG switch edit");
+    }
+
+    pub fn try_set_switch(
+        &mut self,
+        block: BlockId,
+        scrutinee: CfgValue,
+        cases: impl IntoIterator<Item = (i64, BlockId)>,
+        default: BlockId,
+    ) -> Result<(), CfgEditError> {
+        const OP: &str = "switch cases";
+        if block.0 as usize >= self.blocks.len() || default.0 as usize >= self.blocks.len() {
+            return Err(Self::invalid_edit(OP, "block target is out of bounds"));
+        }
+        if scrutinee.0 as usize >= self.values.len() {
+            return Err(Self::invalid_edit(OP, "scrutinee value is undefined"));
+        }
+        if !matches!(
+            self.blocks[block.0 as usize].terminator,
+            Terminator::None | Terminator::Unreachable
+        ) {
+            return Err(Self::invalid_edit(OP, "block already has a terminator"));
+        }
+        let staged = Self::stage_edit(OP, cases)?;
+        if staged
+            .iter()
+            .any(|(_, target)| target.0 as usize >= self.blocks.len())
+        {
+            return Err(Self::invalid_edit(OP, "case target is out of bounds"));
+        }
+        let cases = payload::push_switch_cases(&mut self.switch_cases, staged)?;
+        self.set_terminator(
+            block,
+            Terminator::Switch {
+                scrutinee,
+                cases,
+                default,
+            },
+        );
+        Ok(())
+    }
+
+    /// Terminate a block by returning a value, or unit when `None`.
+    pub fn set_return(&mut self, block: BlockId, value: Option<CfgValue>) {
+        self.set_terminator(block, Terminator::Return { value });
+    }
+
+    /// Mark a block as unreachable.
+    pub fn set_unreachable(&mut self, block: BlockId) {
+        self.set_terminator(block, Terminator::Unreachable);
     }
 
     /// Get all blocks.
@@ -1066,8 +2372,24 @@ impl Cfg {
     /// This is the canonical use-rewrite for optimization passes that
     /// substitute one value for another (e.g. block-merge parameter
     /// substitution, RUE-911). One call visits every use site exactly once.
-    pub fn rewrite_value_uses(&mut self, map: impl Fn(CfgValue) -> CfgValue) {
+    pub(crate) fn rewrite_value_uses(
+        &mut self,
+        map: impl Fn(CfgValue) -> CfgValue,
+    ) -> Result<(), CfgEditError> {
+        let mut rewritten = self.clone();
+        rewritten.rewrite_value_uses_in_place(map)?;
+        *self = rewritten;
+        Ok(())
+    }
+
+    fn rewrite_value_uses_in_place(
+        &mut self,
+        map: impl Fn(CfgValue) -> CfgValue,
+    ) -> Result<(), CfgEditError> {
         use CfgInstData::*;
+        let old_extra = std::mem::replace(&mut self.extra, payload::Values::new());
+        let old_call_args = std::mem::replace(&mut self.call_args, payload::CallArgs::new());
+        let old_projections = std::mem::replace(&mut self.projections, payload::Projections::new());
         for inst in &mut self.values {
             match &mut inst.data {
                 Add(a, b)
@@ -1096,48 +2418,147 @@ impl Cfg {
                 Alloc { init: v, .. }
                 | Store { value: v, .. }
                 | ParamStore { value: v, .. }
-                | PlaceWrite { value: v, .. }
                 | EnumPayloadGet { base: v, .. }
                 | IntCast { value: v, .. }
                 | Drop { value: v } => *v = map(*v),
+                PlaceRead { place } => {
+                    place.projections = payload::push_projections(
+                        &mut self.projections,
+                        payload::projections(&old_projections, &place.projections)
+                            .iter()
+                            .map(|projection| match projection {
+                                Projection::Field {
+                                    struct_id,
+                                    field_index,
+                                } => Projection::Field {
+                                    struct_id: *struct_id,
+                                    field_index: *field_index,
+                                },
+                                Projection::Index { array_type, index } => Projection::Index {
+                                    array_type: *array_type,
+                                    index: map(*index),
+                                },
+                            }),
+                    )?;
+                }
+                PlaceWrite { place, value } => {
+                    *value = map(*value);
+                    place.projections = payload::push_projections(
+                        &mut self.projections,
+                        payload::projections(&old_projections, &place.projections)
+                            .iter()
+                            .map(|projection| match projection {
+                                Projection::Field {
+                                    struct_id,
+                                    field_index,
+                                } => Projection::Field {
+                                    struct_id: *struct_id,
+                                    field_index: *field_index,
+                                },
+                                Projection::Index { array_type, index } => Projection::Index {
+                                    array_type: *array_type,
+                                    index: map(*index),
+                                },
+                            }),
+                    )?;
+                }
+                Call { args, .. } => {
+                    *args = payload::push_call_args(
+                        &mut self.call_args,
+                        payload::call_args(&old_call_args, args)
+                            .iter()
+                            .map(|arg| CfgCallArg {
+                                value: map(arg.value),
+                                mode: arg.mode,
+                            }),
+                    )?;
+                }
+                Intrinsic { args, .. } => {
+                    *args = payload::push_intrinsic_args(
+                        &mut self.extra,
+                        payload::intrinsic_args(&old_extra, args)
+                            .iter()
+                            .copied()
+                            .map(&map),
+                    )?;
+                }
+                StructInit { fields, .. } => {
+                    *fields = payload::push_struct_fields(
+                        &mut self.extra,
+                        payload::struct_fields(&old_extra, fields)
+                            .iter()
+                            .copied()
+                            .map(&map),
+                    )?;
+                }
+                ArrayInit { elements } => {
+                    *elements = payload::push_array_elements(
+                        &mut self.extra,
+                        payload::array_elements(&old_extra, elements)
+                            .iter()
+                            .copied()
+                            .map(&map),
+                    )?;
+                }
+                EnumVariant { payload: range, .. } => {
+                    *range = payload::push_enum_payload(
+                        &mut self.extra,
+                        payload::enum_payload(&old_extra, range)
+                            .iter()
+                            .copied()
+                            .map(&map),
+                    )?;
+                }
                 Const(_)
                 | BoolConst(_)
                 | StringConst(_)
                 | Param { .. }
                 | BlockParam { .. }
                 | Load { .. }
-                | PlaceRead { .. }
-                | Call { .. }
-                | Intrinsic { .. }
-                | StructInit { .. }
-                | ArrayInit { .. }
-                | EnumVariant { .. }
                 | StorageLive { .. }
                 | StorageDead { .. } => {}
             }
         }
-        for value in &mut self.extra {
-            *value = map(*value);
-        }
-        for arg in &mut self.call_args {
-            arg.value = map(arg.value);
-        }
-        for proj in &mut self.projections {
-            if let Projection::Index { index, .. } = proj {
-                *index = map(*index);
-            }
-        }
         for block in &mut self.blocks {
             match &mut block.terminator {
-                Terminator::Branch { cond, .. } => *cond = map(*cond),
+                Terminator::Goto { args, .. } => {
+                    *args = payload::push_goto_args(
+                        &mut self.extra,
+                        payload::goto_args(&old_extra, args)
+                            .iter()
+                            .copied()
+                            .map(&map),
+                    )?;
+                }
+                Terminator::Branch {
+                    cond,
+                    then_args,
+                    else_args,
+                    ..
+                } => {
+                    *cond = map(*cond);
+                    *then_args = payload::push_then_args(
+                        &mut self.extra,
+                        payload::then_args(&old_extra, then_args)
+                            .iter()
+                            .copied()
+                            .map(&map),
+                    )?;
+                    *else_args = payload::push_else_args(
+                        &mut self.extra,
+                        payload::else_args(&old_extra, else_args)
+                            .iter()
+                            .copied()
+                            .map(&map),
+                    )?;
+                }
                 Terminator::Switch { scrutinee, .. } => *scrutinee = map(*scrutinee),
                 Terminator::Return { value: Some(value) } => *value = map(*value),
-                Terminator::Goto { .. }
-                | Terminator::Return { value: None }
-                | Terminator::Unreachable
-                | Terminator::None => {}
+                Terminator::Return { value: None } | Terminator::Unreachable | Terminator::None => {
+                }
             }
         }
+        Ok(())
     }
 
     /// Compute predecessor lists for all blocks, indexed by block id.
@@ -1161,13 +2582,8 @@ impl Cfg {
                     preds[then_block.0 as usize].push(block.id);
                     preds[else_block.0 as usize].push(block.id);
                 }
-                Terminator::Switch {
-                    cases_start,
-                    cases_len,
-                    default,
-                    ..
-                } => {
-                    for (_, target) in self.get_switch_cases(*cases_start, *cases_len) {
+                Terminator::Switch { cases, default, .. } => {
+                    for (_, target) in self.switch_cases(cases) {
                         preds[target.0 as usize].push(block.id);
                     }
                     preds[default.0 as usize].push(block.id);
@@ -1245,16 +2661,12 @@ impl Cfg {
             // Print terminator
             write!(f, "    ")?;
             match &block.terminator {
-                Terminator::Goto {
-                    target,
-                    args_start,
-                    args_len,
-                } => {
+                Terminator::Goto { target, args: _ } => {
                     write!(f, "goto {}", target)?;
-                    let args = self.get_extra(*args_start, *args_len);
-                    if !args.is_empty() {
+                    let values = self.get_goto_args(&block.terminator);
+                    if !values.is_empty() {
                         write!(f, "(")?;
-                        for (i, arg) in args.iter().enumerate() {
+                        for (i, arg) in values.iter().enumerate() {
                             if i > 0 {
                                 write!(f, ", ")?;
                             }
@@ -1266,14 +2678,12 @@ impl Cfg {
                 Terminator::Branch {
                     cond,
                     then_block,
-                    then_args_start,
-                    then_args_len,
+                    then_args: _,
                     else_block,
-                    else_args_start,
-                    else_args_len,
+                    else_args: _,
                 } => {
                     write!(f, "branch {}, {}", cond, then_block)?;
-                    let then_args = self.get_extra(*then_args_start, *then_args_len);
+                    let then_args = self.get_branch_then_args(&block.terminator);
                     if !then_args.is_empty() {
                         write!(f, "(")?;
                         for (i, arg) in then_args.iter().enumerate() {
@@ -1285,7 +2695,7 @@ impl Cfg {
                         write!(f, ")")?;
                     }
                     write!(f, ", {}", else_block)?;
-                    let else_args = self.get_extra(*else_args_start, *else_args_len);
+                    let else_args = self.get_branch_else_args(&block.terminator);
                     if !else_args.is_empty() {
                         write!(f, "(")?;
                         for (i, arg) in else_args.iter().enumerate() {
@@ -1299,13 +2709,12 @@ impl Cfg {
                 }
                 Terminator::Switch {
                     scrutinee,
-                    cases_start,
-                    cases_len,
+                    cases,
                     default,
                 } => {
                     write!(f, "switch {} [", scrutinee)?;
-                    let cases = self.get_switch_cases(*cases_start, *cases_len);
-                    for (i, (val, target)) in cases.iter().enumerate() {
+                    let cases_view = self.switch_cases(cases);
+                    for (i, (val, target)) in cases_view.iter().enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;
                         }
@@ -1399,8 +2808,7 @@ impl Cfg {
             CfgInstData::Call {
                 runtime,
                 name,
-                args_start,
-                args_len,
+                args,
             } => {
                 if let Some(runtime) = runtime {
                     write!(f, "runtime.{runtime:?} ")?;
@@ -1409,8 +2817,7 @@ impl Cfg {
                     Some(interner) => write!(f, "call @{}(", interner.resolve(name))?,
                     None => write!(f, "call @{}(", name.into_usize())?,
                 }
-                let args = self.get_call_args(*args_start, *args_len);
-                for (i, arg) in args.iter().enumerate() {
+                for (i, arg) in self.call_args(args).iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
@@ -1425,8 +2832,7 @@ impl Cfg {
             CfgInstData::Intrinsic {
                 runtime,
                 name,
-                args_start,
-                args_len,
+                args,
             } => {
                 if let Some(runtime) = runtime {
                     write!(f, "runtime.{runtime:?} ")?;
@@ -1435,8 +2841,7 @@ impl Cfg {
                     Some(interner) => write!(f, "intrinsic @{}(", interner.resolve(name))?,
                     None => write!(f, "intrinsic @{}(", name.into_usize())?,
                 }
-                let args = self.get_extra(*args_start, *args_len);
-                for (i, arg) in args.iter().enumerate() {
+                for (i, arg) in self.intrinsic_args(args).iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
@@ -1444,14 +2849,9 @@ impl Cfg {
                 }
                 write!(f, ")")
             }
-            CfgInstData::StructInit {
-                struct_id,
-                fields_start,
-                fields_len,
-            } => {
+            CfgInstData::StructInit { struct_id, fields } => {
                 write!(f, "struct_init #{struct_id:?} {{")?;
-                let fields = self.get_extra(*fields_start, *fields_len);
-                for (i, field) in fields.iter().enumerate() {
+                for (i, field) in self.struct_fields(fields).iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
@@ -1459,13 +2859,9 @@ impl Cfg {
                 }
                 write!(f, "}}")
             }
-            CfgInstData::ArrayInit {
-                elements_start,
-                elements_len,
-            } => {
+            CfgInstData::ArrayInit { elements } => {
                 write!(f, "array_init [")?;
-                let elements = self.get_extra(*elements_start, *elements_len);
-                for (i, elem) in elements.iter().enumerate() {
+                for (i, elem) in self.array_elements(elements).iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
@@ -1476,18 +2872,16 @@ impl Cfg {
             CfgInstData::EnumVariant {
                 enum_id,
                 variant_index,
-                payload_start,
-                payload_len,
+                payload,
             } => {
-                if *payload_len == 0 {
+                if payload.is_empty() {
                     write!(f, "enum_variant #{enum_id:?}::{variant_index}")
                 } else {
                     // Print the actual payload operands (like StructInit and
                     // ArrayInit do) so the variant's dataflow inputs are
                     // readable in the dump, not just their count.
                     write!(f, "enum_variant #{enum_id:?}::{variant_index}(")?;
-                    let payload = self.get_extra(*payload_start, *payload_len);
-                    for (i, value) in payload.iter().enumerate() {
+                    for (i, value) in self.enum_payload(payload).iter().enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;
                         }
@@ -1645,8 +3039,7 @@ mod tests {
                 data: CfgInstData::Call {
                     runtime: None,
                     name: call,
-                    args_start: 0,
-                    args_len: 0,
+                    args: crate::payload::CfgCallArgs::EMPTY,
                 },
                 ty: Type::UNIT,
                 span: Span::new(0, 0),
@@ -1658,8 +3051,7 @@ mod tests {
                 data: CfgInstData::Intrinsic {
                     runtime: None,
                     name: intrinsic,
-                    args_start: 0,
-                    args_len: 0,
+                    args: crate::payload::CfgIntrinsicArgs::EMPTY,
                 },
                 ty: Type::UNIT,
                 span: Span::new(0, 0),
@@ -1675,5 +3067,318 @@ mod tests {
         let raw = cfg.to_string();
         assert!(raw.contains(&format!("call @{}()", call.into_usize())));
         assert!(raw.contains(&format!("intrinsic @{}()", intrinsic.into_usize())));
+    }
+
+    #[test]
+    fn fallible_owner_edits_reject_invalid_input_atomically() {
+        struct ImpossiblePayload;
+        impl Iterator for ImpossiblePayload {
+            type Item = CfgCallArg;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                None
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                (u32::MAX as usize + 1, None)
+            }
+        }
+
+        let mut cfg = Cfg::new(Type::UNIT, 0, 0, "atomic".into(), vec![]);
+        let entry = cfg.new_block();
+        let target = cfg.new_block();
+        cfg.entry = entry;
+        let before = cfg.to_string();
+        let before_values = cfg.value_count();
+
+        let call_error = cfg
+            .append_call(
+                entry,
+                None,
+                Spur::default(),
+                [CfgCallArg {
+                    value: CfgValue::from_raw(99),
+                    mode: CfgArgMode::Normal,
+                }],
+                Type::UNIT,
+                Span::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            call_error,
+            CfgEditError::InvalidBuilderInput { .. }
+        ));
+        assert_eq!(cfg.value_count(), before_values);
+        assert_eq!(cfg.to_string(), before);
+
+        let resource_error = cfg.push_call_args(ImpossiblePayload).unwrap_err();
+        assert!(matches!(
+            resource_error,
+            CfgEditError::ResourceLimitExceeded { .. }
+        ));
+        assert_eq!(cfg.to_string(), before);
+
+        let branch_error = cfg
+            .try_set_branch(entry, CfgValue::from_raw(99), target, [], target, [])
+            .unwrap_err();
+        assert!(matches!(
+            branch_error,
+            CfgEditError::InvalidBuilderInput { .. }
+        ));
+        assert_eq!(cfg.to_string(), before);
+    }
+
+    #[test]
+    fn whole_owner_clone_remap_rewrite_and_print_preserve_typed_payloads() {
+        use rue_air::{EnumDef, FrozenTypeInternPool, StructDef, StructField, TypeInternPool};
+        use rue_span::FileId;
+
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let (struct_id, _) = pool.register_struct(
+            interner.get_or_intern("Pair"),
+            StructDef {
+                name: "Pair".into(),
+                fields: vec![
+                    StructField {
+                        name: "a".into(),
+                        ty: Type::I32,
+                    },
+                    StructField {
+                        name: "b".into(),
+                        ty: Type::I32,
+                    },
+                ],
+                is_copy: true,
+                is_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let (enum_id, _) = pool.register_enum(
+            interner.get_or_intern("Maybe"),
+            EnumDef {
+                name: "Maybe".into(),
+                variants: vec!["None".into(), "Some".into()],
+                variant_payloads: vec![vec![], vec![Type::I32]],
+                is_pub: false,
+                file_id: FileId::DEFAULT,
+            },
+        );
+        let array_id = pool.intern_array_from_type(Type::I32, 2);
+        let pool: FrozenTypeInternPool = pool.freeze();
+        let array_ty = Type::new_array(array_id);
+        let mut cfg = Cfg::new(Type::I32, 2, 0, "payloads".into(), vec![]);
+        let entry = cfg.new_block();
+        let then_block = cfg.new_block();
+        let else_block = cfg.new_block();
+        let exit = cfg.new_block();
+        cfg.entry = entry;
+        let old = cfg.append_inst(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(1),
+                ty: Type::I32,
+                span: Span::new(3, 4),
+            },
+        );
+        let replacement = cfg.append_inst(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(2),
+                ty: Type::I32,
+                span: Span::new(5, 6),
+            },
+        );
+        let call = cfg
+            .append_call(
+                entry,
+                None,
+                interner.get_or_intern("callee"),
+                [CfgCallArg {
+                    value: old,
+                    mode: CfgArgMode::Borrow,
+                }],
+                Type::I32,
+                Span::new(7, 8),
+            )
+            .unwrap();
+        let intrinsic = cfg
+            .append_intrinsic(
+                entry,
+                None,
+                interner.get_or_intern("intrinsic"),
+                [old],
+                Type::I32,
+                Span::new(9, 10),
+            )
+            .unwrap();
+        let strukt = cfg
+            .append_struct_init(
+                entry,
+                struct_id,
+                [old, replacement],
+                Type::new_struct(struct_id),
+                Span::new(11, 12),
+            )
+            .unwrap();
+        let array = cfg
+            .append_array_init(entry, [old, replacement], array_ty, Span::new(13, 14))
+            .unwrap();
+        let enm = cfg
+            .append_enum_variant(
+                &pool,
+                entry,
+                enum_id,
+                1,
+                [old],
+                Type::new_enum(enum_id),
+                Span::new(15, 16),
+            )
+            .unwrap();
+        let place = cfg
+            .append_place_read(
+                entry,
+                PlaceBase::Local(0),
+                array_ty,
+                [Projection::Index {
+                    array_type: array_ty,
+                    index: old,
+                }],
+                Type::I32,
+                Span::new(17, 18),
+            )
+            .unwrap();
+        cfg.set_branch(entry, old, then_block, [old], else_block, [replacement]);
+        cfg.set_goto(then_block, exit, [old]);
+        cfg.set_switch(else_block, old, [(1, exit)], exit);
+        cfg.set_return(exit, Some(replacement));
+
+        let printed = cfg.display_with_interner(&interner).to_string();
+        for needle in [
+            "call @callee",
+            "intrinsic @intrinsic",
+            "struct_init",
+            "array_init",
+            "enum_variant",
+            "place_read",
+            "branch",
+            "goto",
+            "switch",
+        ] {
+            assert!(printed.contains(needle), "missing {needle} in {printed}");
+        }
+
+        let cloned = cfg.clone();
+        assert_eq!(cloned.to_string(), cfg.to_string());
+        assert_eq!(
+            cloned.get_call_args(&cloned.get_inst(call).data)[0].mode,
+            CfgArgMode::Borrow
+        );
+        assert_eq!(
+            cloned.get_struct_fields(&cloned.get_inst(strukt).data),
+            [old, replacement]
+        );
+
+        let remapped = cfg
+            .try_remap_domains::<()>(Ok, Ok, Ok, Ok, Ok, |span| {
+                Ok(Span::new(span.start + 100, span.end + 100))
+            })
+            .unwrap();
+        assert_eq!(remapped.to_string(), cfg.to_string());
+        assert_eq!(remapped.get_inst(call).span, Span::new(107, 108));
+        assert_eq!(
+            remapped.get_array_elements(&remapped.get_inst(array).data),
+            [old, replacement]
+        );
+        assert_eq!(
+            remapped.get_enum_payload(&remapped.get_inst(enm).data),
+            [old]
+        );
+
+        let mut rewritten = remapped;
+        rewritten
+            .rewrite_value_uses(|value| if value == old { replacement } else { value })
+            .unwrap();
+        assert_eq!(
+            rewritten.get_call_args(&rewritten.get_inst(call).data)[0].value,
+            replacement
+        );
+        assert_eq!(
+            rewritten.get_call_args(&rewritten.get_inst(call).data)[0].mode,
+            CfgArgMode::Borrow
+        );
+        assert_eq!(
+            rewritten.get_intrinsic_args(&rewritten.get_inst(intrinsic).data),
+            [replacement]
+        );
+        assert_eq!(
+            rewritten.get_struct_fields(&rewritten.get_inst(strukt).data),
+            [replacement, replacement]
+        );
+        assert_eq!(
+            rewritten.get_array_elements(&rewritten.get_inst(array).data),
+            [replacement, replacement]
+        );
+        assert_eq!(
+            rewritten.get_enum_payload(&rewritten.get_inst(enm).data),
+            [replacement]
+        );
+        let CfgInstData::PlaceRead {
+            place: rewritten_place,
+        } = &rewritten.get_inst(place).data
+        else {
+            unreachable!()
+        };
+        assert!(matches!(
+            rewritten.get_place_projections(rewritten_place),
+            [Projection::Index { index, .. }] if *index == replacement
+        ));
+        assert!(rewritten.to_string().contains("branch v1"));
+
+        let before_rejections = rewritten.to_string();
+        for error in [
+            rewritten
+                .replace_struct_fields(old, [replacement])
+                .unwrap_err(),
+            rewritten
+                .replace_array_elements(old, [replacement])
+                .unwrap_err(),
+            rewritten
+                .replace_enum_payload(&pool, old, [replacement])
+                .unwrap_err(),
+            rewritten
+                .replace_place_read(old, PlaceBase::Local(0), array_ty, [])
+                .unwrap_err(),
+            rewritten
+                .replace_place_write(old, PlaceBase::Local(0), array_ty, [], replacement)
+                .unwrap_err(),
+        ] {
+            assert!(matches!(error, CfgEditError::InvalidBuilderInput { .. }));
+            assert_eq!(rewritten.to_string(), before_rejections);
+        }
+
+        rewritten
+            .replace_struct_fields(strukt, [replacement, replacement])
+            .unwrap();
+        rewritten
+            .replace_array_elements(array, [replacement, replacement])
+            .unwrap();
+        rewritten
+            .replace_enum_payload(&pool, enm, [replacement])
+            .unwrap();
+        rewritten
+            .replace_place_read(
+                place,
+                PlaceBase::Local(0),
+                array_ty,
+                [Projection::Index {
+                    array_type: array_ty,
+                    index: replacement,
+                }],
+            )
+            .unwrap();
     }
 }

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -20,16 +20,20 @@ mod build;
 mod dominators;
 mod inst;
 pub mod opt;
+mod payload;
 mod verify;
 
 use rue_error::{CompileError, CompileWarning};
 
 pub use build::CfgBuilder;
 pub use inst::{
-    BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgDisplay, CfgInst, CfgInstData, CfgValue,
-    Place, PlaceBase, Projection, Terminator,
+    BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgDisplay, CfgEditError,
+    CfgEditTransactionError, CfgEditor, CfgInst, CfgInstData, CfgRemapError, CfgValue, Place,
+    PlaceBase, Projection, Terminator, ValidatedCfg,
 };
 pub use opt::OptLevel;
+pub use payload::PayloadError;
+pub use verify::{CfgVerificationError, CfgVerificationLocation};
 
 // Re-export types from rue-air that we use
 pub use rue_air::{StructDef, StructId, Type, TypeKind};
@@ -40,7 +44,7 @@ pub use rue_air::{StructDef, StructId, Type, TypeKind};
 /// construction (e.g., unreachable code).
 pub struct CfgOutput {
     /// The constructed control flow graph.
-    pub cfg: Cfg,
+    pub cfg: Option<ValidatedCfg>,
     /// Warnings detected during CFG construction.
     pub warnings: Vec<CompileWarning>,
     /// Internal-compiler-error diagnostics detected during CFG construction
@@ -54,4 +58,44 @@ pub struct CfgOutput {
     /// Whether an implicit destructor target was anonymous and therefore has
     /// no stable definition endpoint.
     pub anonymous_destructor_dependency_incomplete: bool,
+}
+
+#[cfg(test)]
+pub(crate) mod allocation_test_support {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::cell::Cell;
+
+    thread_local! {
+        static ACTIVE: Cell<bool> = const { Cell::new(false) };
+        static COUNT: Cell<usize> = const { Cell::new(0) };
+    }
+
+    struct CountingAllocator;
+
+    unsafe impl GlobalAlloc for CountingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            ACTIVE.with(|active| {
+                if active.get() {
+                    COUNT.with(|count| count.set(count.get() + 1));
+                }
+            });
+            unsafe { System.alloc(layout) }
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) }
+        }
+    }
+
+    #[global_allocator]
+    static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+    pub(crate) fn allocations_during<R>(f: impl FnOnce() -> R) -> (R, usize) {
+        COUNT.with(|count| count.set(0));
+        ACTIVE.with(|active| active.set(true));
+        let result = f();
+        ACTIVE.with(|active| active.set(false));
+        let count = COUNT.with(Cell::get);
+        (result, count)
+    }
 }

--- a/crates/rue-cfg/src/opt/classify.rs
+++ b/crates/rue-cfg/src/opt/classify.rs
@@ -224,14 +224,16 @@ mod tests {
         // A PlaceRead through an Index projection performs a bounds check.
         let mut cfg = make_cfg();
         let idx = konst(&mut cfg, 0);
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            Type::I32,
-            [Projection::Index {
-                array_type: Type::I32,
-                index: idx,
-            }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                Type::I32,
+                [Projection::Index {
+                    array_type: Type::I32,
+                    index: idx,
+                }],
+            )
+            .unwrap();
         let read = add(&mut cfg, CfgInstData::PlaceRead { place }, Type::I32);
         assert!(may_trap(&cfg, read), "indexed PlaceRead must be may_trap");
         assert!(!is_speculatable(&cfg, read));
@@ -260,8 +262,8 @@ mod tests {
         let v = konst(&mut cfg, 7);
         let interner = ThreadedRodeo::new();
         let name = interner.get_or_intern("f");
-        let (args_start, args_len) = cfg.push_call_args(std::iter::empty());
-        let (iargs_start, iargs_len) = cfg.push_extra(std::iter::empty());
+        let args = cfg.push_call_args(std::iter::empty()).unwrap();
+        let iargs = cfg.push_intrinsic_args(std::iter::empty()).unwrap();
 
         let effecting = [
             add(
@@ -269,8 +271,7 @@ mod tests {
                 CfgInstData::Call {
                     runtime: None,
                     name,
-                    args_start,
-                    args_len,
+                    args,
                 },
                 Type::UNIT,
             ),
@@ -279,8 +280,7 @@ mod tests {
                 CfgInstData::Intrinsic {
                     runtime: None,
                     name,
-                    args_start: iargs_start,
-                    args_len: iargs_len,
+                    args: iargs,
                 },
                 Type::UNIT,
             ),

--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -304,9 +304,13 @@ fn get_enum_variant(cfg: &Cfg, value: CfgValue) -> Option<(EnumId, u32, u32)> {
         CfgInstData::EnumVariant {
             enum_id,
             variant_index,
-            payload_len,
+            payload,
             ..
-        } => Some((*enum_id, *variant_index, *payload_len)),
+        } => Some((
+            *enum_id,
+            *variant_index,
+            cfg.enum_payload(payload).len() as u32,
+        )),
         _ => None,
     }
 }

--- a/crates/rue-cfg/src/opt/constopt.rs
+++ b/crates/rue-cfg/src/opt/constopt.rs
@@ -136,12 +136,8 @@ pub fn run(cfg: &mut Cfg) -> Stats {
                 // place: the callee may write through it (inout), and the
                 // by-ref lowering needs the arg to remain a Load/PlaceRead.
                 // Disqualify any local the argument is rooted at.
-                CfgInstData::Call {
-                    args_start,
-                    args_len,
-                    ..
-                } => {
-                    for arg in cfg.get_call_args(*args_start, *args_len) {
+                CfgInstData::Call { args, .. } => {
+                    for arg in cfg.call_args(args) {
                         if !arg.is_by_ref() {
                             continue;
                         }
@@ -262,7 +258,7 @@ pub fn run(cfg: &mut Cfg) -> Stats {
             let payload = const_payload(cfg, value)
                 .expect("became_const events carry Const/BoolConst values");
             for &load in &loads_of_slot[slot as usize] {
-                cfg.get_inst_mut(load).data = payload.clone();
+                cfg.get_inst_mut(load).data = payload.duplicate_with_owner();
                 stats.loads_rewritten += 1;
                 became_const.push_back(load);
             }
@@ -389,15 +385,14 @@ mod tests {
             Type::UNIT,
         );
         let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
-        let (args_start, args_len) = cfg.push_extra(vec![load]);
+        let args = cfg.push_intrinsic_args(vec![load]).unwrap();
         let raw_sym = Spur::try_from_usize(0).unwrap();
         let ptr = push(
             &mut cfg,
             CfgInstData::Intrinsic {
                 runtime: None,
                 name: raw_sym,
-                args_start,
-                args_len,
+                args,
             },
             Type::I32,
         );
@@ -470,17 +465,18 @@ mod tests {
             Type::UNIT,
         );
         let arg_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
-        let (args_start, args_len) = cfg.push_call_args([CfgCallArg {
-            value: arg_load,
-            mode: CfgArgMode::Inout,
-        }]);
+        let args = cfg
+            .push_call_args([CfgCallArg {
+                value: arg_load,
+                mode: CfgArgMode::Inout,
+            }])
+            .unwrap();
         push(
             &mut cfg,
             CfgInstData::Call {
                 runtime: None,
                 name: Spur::try_from_usize(0).unwrap(),
-                args_start,
-                args_len,
+                args,
             },
             Type::UNIT,
         );
@@ -533,17 +529,18 @@ mod tests {
             Type::UNIT,
         );
         let arg_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
-        let (args_start, args_len) = cfg.push_call_args([CfgCallArg {
-            value: arg_load,
-            mode: CfgArgMode::Normal,
-        }]);
+        let args = cfg
+            .push_call_args([CfgCallArg {
+                value: arg_load,
+                mode: CfgArgMode::Normal,
+            }])
+            .unwrap();
         push(
             &mut cfg,
             CfgInstData::Call {
                 runtime: None,
                 name: Spur::try_from_usize(0).unwrap(),
-                args_start,
-                args_len,
+                args,
             },
             Type::UNIT,
         );

--- a/crates/rue-cfg/src/opt/cse.rs
+++ b/crates/rue-cfg/src/opt/cse.rs
@@ -238,7 +238,7 @@ fn never_written_params(cfg: &Cfg) -> Vec<bool> {
 /// Run block-local CSE. Call at `-O2`/`-O3` after simplification (more
 /// duplicates are exposed once blocks are merged) and before DCE (which sweeps
 /// the dead placeholders).
-pub fn run(cfg: &mut Cfg) -> Stats {
+pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
     let mut stats = Stats::default();
     // `subst[dup] = first` for every replaced duplicate. Persists across blocks
     // (each entry points earlier within its own block, so global resolution
@@ -280,10 +280,10 @@ pub fn run(cfg: &mut Cfg) -> Stats {
         let resolved: Vec<CfgValue> = (0..cfg.value_count())
             .map(|i| resolve(&subst, CfgValue::from_raw(i as u32)))
             .collect();
-        cfg.rewrite_value_uses(|v| resolved[v.as_u32() as usize]);
+        cfg.rewrite_value_uses(|v| resolved[v.as_u32() as usize])?;
     }
 
-    stats
+    Ok(stats)
 }
 
 #[cfg(test)]
@@ -326,7 +326,7 @@ mod tests {
         let add2 = push(&mut cfg, CfgInstData::Add(x, y), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(add2) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 1);
         // The return now reads the first add directly.
         assert!(matches!(
@@ -349,7 +349,7 @@ mod tests {
         let div2 = push(&mut cfg, CfgInstData::Div(a, b), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(div2) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 1);
         assert!(matches!(cfg.get_inst(div1).data, CfgInstData::Div(x, y) if x == a && y == b));
         assert!(matches!(cfg.get_inst(div2).data, CfgInstData::Const(0)));
@@ -369,7 +369,7 @@ mod tests {
         let add2 = push(&mut cfg, CfgInstData::Add(b, a), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(add2) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 1);
         assert!(matches!(
             cfg.get_block(cfg.entry).terminator,
@@ -387,7 +387,7 @@ mod tests {
         let sub2 = push(&mut cfg, CfgInstData::Sub(b, a), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sub2) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 0);
         assert!(matches!(cfg.get_inst(sub1).data, CfgInstData::Sub(..)));
         assert!(matches!(cfg.get_inst(sub2).data, CfgInstData::Sub(..)));
@@ -406,7 +406,7 @@ mod tests {
         let add2 = push(&mut cfg, CfgInstData::Add(x, one_b), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(add2) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 2);
         // Surviving const and add are the first occurrences.
         assert!(matches!(cfg.get_inst(one_a).data, CfgInstData::Const(1)));
@@ -428,7 +428,7 @@ mod tests {
         let add = push(&mut cfg, CfgInstData::Add(load1, load2), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(add) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 0);
         assert!(matches!(
             cfg.get_inst(load1).data,
@@ -452,14 +452,13 @@ mod tests {
             cfg.entry,
             Terminator::Goto {
                 target: block2,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         let add2 = push_in(&mut cfg, block2, CfgInstData::Add(a, b), Type::I32);
         cfg.set_terminator(block2, Terminator::Return { value: Some(add2) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 0);
         assert!(matches!(cfg.get_inst(add1).data, CfgInstData::Add(..)));
         assert!(matches!(cfg.get_inst(add2).data, CfgInstData::Add(..)));
@@ -480,12 +479,12 @@ mod tests {
             .map(|i| cfg.get_block(BlockId::from_raw(i as u32)).insts.len())
             .sum();
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.insts_scanned, total_insts as u64);
         assert_eq!(stats.duplicates_replaced, 1);
 
         // Idempotent: nothing left to eliminate.
-        let again = run(&mut cfg);
+        let again = run(&mut cfg).unwrap();
         assert_eq!(again.duplicates_replaced, 0);
     }
 
@@ -501,7 +500,7 @@ mod tests {
         let sum = push(&mut cfg, CfgInstData::Add(a1, a2), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 1);
         // The add now reads the first parameter value twice.
         assert!(matches!(cfg.get_inst(sum).data, CfgInstData::Add(x, y) if x == a1 && y == a1));
@@ -526,7 +525,7 @@ mod tests {
         let sum = push(&mut cfg, CfgInstData::Add(a1, a2), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 0);
         assert!(matches!(
             cfg.get_inst(a1).data,
@@ -559,7 +558,7 @@ mod tests {
         let sum = push(&mut cfg, CfgInstData::Add(a1, a2), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.duplicates_replaced, 0);
     }
 
@@ -613,11 +612,11 @@ mod tests {
         );
 
         super::super::constopt::run(&mut cfg);
-        let fwd = super::super::forward::run(&mut cfg);
+        let fwd = super::super::forward::run(&mut cfg).unwrap();
         // Both `Load`s forwarded to their slot's single write (the adds).
         assert_eq!(fwd.loads_forwarded_single_write, 2);
 
-        let cse = run(&mut cfg);
+        let cse = run(&mut cfg).unwrap();
         // a2, b2, and the second add are all duplicates.
         assert_eq!(cse.duplicates_replaced, 3);
         // The result now adds the single surviving add to itself.
@@ -643,7 +642,7 @@ mod tests {
         let sum = push(&mut cfg, CfgInstData::Add(p1, p2), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(
             stats.duplicates_replaced, 0,
             "address-taken param reads must not dedupe"

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -163,28 +163,22 @@ fn has_side_effects(cfg: &Cfg, value: CfgValue) -> bool {
 #[inline]
 fn visit_terminator_uses(cfg: &Cfg, term: &Terminator, mut f: impl FnMut(CfgValue)) {
     match term {
-        Terminator::Goto {
-            args_start,
-            args_len,
-            ..
-        } => {
-            for &arg in cfg.get_extra(*args_start, *args_len) {
+        Terminator::Goto { args: _, .. } => {
+            for &arg in cfg.get_goto_args(term) {
                 f(arg);
             }
         }
         Terminator::Branch {
             cond,
-            then_args_start,
-            then_args_len,
-            else_args_start,
-            else_args_len,
+            then_args: _,
+            else_args: _,
             ..
         } => {
             f(*cond);
-            for &arg in cfg.get_extra(*then_args_start, *then_args_len) {
+            for &arg in cfg.get_branch_then_args(term) {
                 f(arg);
             }
-            for &arg in cfg.get_extra(*else_args_start, *else_args_len) {
+            for &arg in cfg.get_branch_else_args(term) {
                 f(arg);
             }
         }
@@ -246,52 +240,32 @@ fn visit_instruction_uses(cfg: &Cfg, value: CfgValue, mut f: impl FnMut(CfgValue
         CfgInstData::ParamStore { value, .. } => f(*value),
 
         // Function calls
-        CfgInstData::Call {
-            args_start,
-            args_len,
-            ..
-        } => {
-            for arg in cfg.get_call_args(*args_start, *args_len) {
+        CfgInstData::Call { args, .. } => {
+            for arg in cfg.call_args(args) {
                 f(arg.value);
             }
         }
-        CfgInstData::Intrinsic {
-            args_start,
-            args_len,
-            ..
-        } => {
-            for &v in cfg.get_extra(*args_start, *args_len) {
+        CfgInstData::Intrinsic { args, .. } => {
+            for &v in cfg.intrinsic_args(args) {
                 f(v);
             }
         }
 
         // Struct operations
-        CfgInstData::StructInit {
-            fields_start,
-            fields_len,
-            ..
-        } => {
-            for &v in cfg.get_extra(*fields_start, *fields_len) {
+        CfgInstData::StructInit { fields, .. } => {
+            for &v in cfg.struct_fields(fields) {
                 f(v);
             }
         }
         // Array operations
-        CfgInstData::ArrayInit {
-            elements_start,
-            elements_len,
-            ..
-        } => {
-            for &v in cfg.get_extra(*elements_start, *elements_len) {
+        CfgInstData::ArrayInit { elements, .. } => {
+            for &v in cfg.array_elements(elements) {
                 f(v);
             }
         }
         // Enum operations: a tuple variant reads its payload operands.
-        CfgInstData::EnumVariant {
-            payload_start,
-            payload_len,
-            ..
-        } => {
-            for &v in cfg.get_extra(*payload_start, *payload_len) {
+        CfgInstData::EnumVariant { payload, .. } => {
+            for &v in cfg.enum_payload(payload) {
                 f(v);
             }
         }
@@ -388,13 +362,8 @@ pub(super) fn compute_reachable_blocks(cfg: &Cfg) -> BitSet {
                 worklist.push(*then_block);
                 worklist.push(*else_block);
             }
-            Terminator::Switch {
-                cases_start,
-                cases_len,
-                default,
-                ..
-            } => {
-                for (_, target) in cfg.get_switch_cases(*cases_start, *cases_len) {
+            Terminator::Switch { cases, default, .. } => {
+                for (_, target) in cfg.switch_cases(cases) {
                     worklist.push(*target);
                 }
                 worklist.push(*default);
@@ -604,15 +573,14 @@ mod tests {
         // Create a call (side effect) that's not used by return
         let interner = ThreadedRodeo::new();
         let side_effect_sym = interner.get_or_intern("side_effect");
-        let (args_start, args_len) = cfg.push_call_args(std::iter::empty());
+        let args = cfg.push_call_args(std::iter::empty()).unwrap();
         let call = cfg.add_inst_to_block(
             entry,
             CfgInst {
                 data: CfgInstData::Call {
                     runtime: None,
                     name: side_effect_sym,
-                    args_start,
-                    args_len,
+                    args,
                 },
                 ty: Type::UNIT,
                 span: Span::new(0, 0),

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -107,7 +107,7 @@ enum SlotClass {
 
 /// Run value forwarding. Call at `-O2`/`-O3` after simplification and before
 /// CSE.
-pub fn run(cfg: &mut Cfg) -> Stats {
+pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
     let mut stats = Stats::default();
     let num_locals = cfg.num_locals() as usize;
 
@@ -127,13 +127,8 @@ pub fn run(cfg: &mut Cfg) -> Stats {
     let mut byref_arg_values: HashSet<CfgValue> = HashSet::new();
     for block in cfg.blocks() {
         for &value in &block.insts {
-            if let CfgInstData::Call {
-                args_start,
-                args_len,
-                ..
-            } = &cfg.get_inst(value).data
-            {
-                for arg in cfg.get_call_args(*args_start, *args_len) {
+            if let CfgInstData::Call { args, .. } = &cfg.get_inst(value).data {
+                for arg in cfg.call_args(args) {
                     if arg.is_by_ref() {
                         byref_arg_values.insert(arg.value);
                     }
@@ -185,12 +180,8 @@ pub fn run(cfg: &mut Cfg) -> Stats {
                         record_write(&mut slot_class, slot, None);
                     }
                 }
-                CfgInstData::Call {
-                    args_start,
-                    args_len,
-                    ..
-                } => {
-                    for arg in cfg.get_call_args(*args_start, *args_len) {
+                CfgInstData::Call { args, .. } => {
+                    for arg in cfg.call_args(args) {
                         if !arg.is_by_ref() {
                             continue;
                         }
@@ -238,7 +229,7 @@ pub fn run(cfg: &mut Cfg) -> Stats {
             let value = cfg.get_block(block_id).insts[i];
             stats.insts_scanned += 1;
 
-            match cfg.get_inst(value).data.clone() {
+            match cfg.get_inst(value).data.duplicate_with_owner() {
                 CfgInstData::Alloc { slot, init } | CfgInstData::Store { slot, value: init } => {
                     // Address-taken slots stay out of the block-local table.
                     if !cfg.is_address_taken(slot) && (slot as usize) < num_locals {
@@ -275,13 +266,9 @@ pub fn run(cfg: &mut Cfg) -> Stats {
                         }
                     }
                 }
-                CfgInstData::Call {
-                    args_start,
-                    args_len,
-                    ..
-                } => {
+                CfgInstData::Call { args, .. } => {
                     let mut clear_all = false;
-                    for arg in cfg.get_call_args(args_start, args_len).to_vec() {
+                    for arg in cfg.call_args(&args).to_vec() {
                         if !arg.is_by_ref() {
                             continue;
                         }
@@ -320,7 +307,7 @@ pub fn run(cfg: &mut Cfg) -> Stats {
 
     let forwarded = stats.loads_forwarded_single_write + stats.loads_forwarded_block_local;
     if forwarded == 0 {
-        return stats;
+        return Ok(stats);
     }
 
     // Turn the definite-initialization argument for Rule 1 into a checked
@@ -344,9 +331,9 @@ pub fn run(cfg: &mut Cfg) -> Stats {
     let resolved: Vec<CfgValue> = (0..cfg.value_count())
         .map(|i| resolve(&subst, CfgValue::from_raw(i as u32)))
         .collect();
-    cfg.rewrite_value_uses(|v| resolved[v.as_u32() as usize]);
+    cfg.rewrite_value_uses(|v| resolved[v.as_u32() as usize])?;
 
-    stats
+    Ok(stats)
 }
 
 /// Walk `subst` chains to the surviving value. A forwarded value can itself be
@@ -424,7 +411,7 @@ mod tests {
         let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loads_forwarded_single_write, 1);
         assert_eq!(stats.loads_forwarded_block_local, 0);
         // The return now reads the Add directly.
@@ -457,7 +444,7 @@ mod tests {
         let sum = push(&mut cfg, CfgInstData::Add(read1, read2), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(sum) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loads_forwarded_single_write, 0);
         assert_eq!(stats.loads_forwarded_block_local, 2);
         // read1 -> c1, read2 -> c2.
@@ -477,24 +464,25 @@ mod tests {
             Type::UNIT,
         );
         let arg_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
-        let (args_start, args_len) = cfg.push_call_args([CfgCallArg {
-            value: arg_load,
-            mode: CfgArgMode::Inout,
-        }]);
+        let args = cfg
+            .push_call_args([CfgCallArg {
+                value: arg_load,
+                mode: CfgArgMode::Inout,
+            }])
+            .unwrap();
         push(
             &mut cfg,
             CfgInstData::Call {
                 runtime: None,
                 name: Spur::try_from_usize(0).unwrap(),
-                args_start,
-                args_len,
+                args,
             },
             Type::UNIT,
         );
         let read = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(read) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loads_forwarded_single_write, 0);
         assert_eq!(stats.loads_forwarded_block_local, 0);
         // Neither load was rewritten: the arg load stays a place, and the load
@@ -521,21 +509,20 @@ mod tests {
             Type::UNIT,
         );
         let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
-        let (args_start, args_len) = cfg.push_extra(vec![load]);
+        let args = cfg.push_intrinsic_args(vec![load]).unwrap();
         let ptr = push(
             &mut cfg,
             CfgInstData::Intrinsic {
                 runtime: None,
                 name: Spur::try_from_usize(0).unwrap(),
-                args_start,
-                args_len,
+                args,
             },
             Type::I32,
         );
         cfg.mark_address_taken(0);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(ptr) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loads_forwarded_single_write, 0);
         assert_eq!(stats.loads_forwarded_block_local, 0);
         assert!(matches!(
@@ -557,15 +544,16 @@ mod tests {
             Type::UNIT,
         );
         let field_val = push(&mut cfg, CfgInstData::Const(9), Type::I32);
-        let (proj_start, proj_len) = cfg.push_projections([Projection::Field {
-            struct_id: test_struct_id(),
-            field_index: 0,
-        }]);
+        let projections = cfg
+            .push_projections([Projection::Field {
+                struct_id: test_struct_id(),
+                field_index: 0,
+            }])
+            .unwrap();
         let place = Place {
             base: PlaceBase::Local(0),
             base_type: Type::I32,
-            proj_start,
-            proj_len,
+            projections,
         };
         push(
             &mut cfg,
@@ -578,7 +566,7 @@ mod tests {
         let read = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(read) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loads_forwarded_single_write, 0);
         assert_eq!(stats.loads_forwarded_block_local, 0);
         assert!(matches!(
@@ -603,7 +591,7 @@ mod tests {
         cfg.set_terminator(cfg.entry, Terminator::Return { value: None });
         let _ = load;
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loads_forwarded_single_write, 0);
         assert_eq!(stats.loads_forwarded_block_local, 0);
         assert!(matches!(
@@ -635,14 +623,13 @@ mod tests {
             cfg.entry,
             Terminator::Goto {
                 target: block2,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         let load = push_in(&mut cfg, block2, CfgInstData::Load { slot: 0 }, Type::I32);
         cfg.set_terminator(block2, Terminator::Return { value: Some(load) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loads_forwarded_single_write, 0);
         assert_eq!(stats.loads_forwarded_block_local, 0);
         assert!(matches!(
@@ -668,14 +655,13 @@ mod tests {
             cfg.entry,
             Terminator::Goto {
                 target: block2,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         let load = push_in(&mut cfg, block2, CfgInstData::Load { slot: 0 }, Type::I32);
         cfg.set_terminator(block2, Terminator::Return { value: Some(load) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.loads_forwarded_single_write, 1);
         assert!(matches!(
             cfg.get_block(block2).terminator,
@@ -703,7 +689,7 @@ mod tests {
             .map(|i| cfg.get_block(BlockId::from_raw(i as u32)).insts.len())
             .sum();
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.insts_scanned, total_insts as u64);
         assert_eq!(stats.loads_forwarded_single_write, 1);
 
@@ -713,7 +699,7 @@ mod tests {
         // (the load already has no uses) but not in its work counter. Once DCE
         // sweeps the load, a re-run finds nothing.
         super::super::dce::run(&mut cfg);
-        let again = run(&mut cfg);
+        let again = run(&mut cfg).unwrap();
         assert_eq!(again.loads_forwarded_single_write, 0);
         assert_eq!(again.loads_forwarded_block_local, 0);
     }
@@ -741,8 +727,7 @@ mod tests {
             entry,
             Terminator::Goto {
                 target: live,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         let dead_load = push_in(&mut cfg, dead, CfgInstData::Load { slot: 0 }, Type::I32);
@@ -760,7 +745,7 @@ mod tests {
             },
         );
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         // The reachable load forwards; the unreachable one is untouched.
         assert_eq!(stats.loads_forwarded_single_write, 1);
         assert!(matches!(

--- a/crates/rue-cfg/src/opt/loops.rs
+++ b/crates/rue-cfg/src/opt/loops.rs
@@ -40,8 +40,11 @@
 #![allow(dead_code)]
 
 use crate::dominators::DominatorTree;
-use crate::{BlockId, Cfg, Terminator};
+use crate::{BlockId, Cfg, CfgEditError, Terminator};
+use rue_air::FrozenTypeInternPool;
 use std::collections::HashSet;
+
+use super::CfgOptimizationError;
 
 /// Index of a [`NaturalLoop`] within its [`LoopForest`].
 pub(crate) type LoopId = usize;
@@ -337,7 +340,74 @@ pub(crate) fn loops_with_stats(cfg: &Cfg, dom: &DominatorTree) -> (LoopForest, S
 /// The result leaves the CFG verifier-clean: `ph`'s block parameters mirror the
 /// header's, each redirected outside edge keeps its arity, and `ph`'s own
 /// parameters (defined in `ph`) are what it forwards on.
-pub(crate) fn ensure_preheader(cfg: &mut Cfg, lp: &NaturalLoop) -> BlockId {
+pub(crate) fn ensure_preheader(
+    cfg: &mut Cfg,
+    lp: &NaturalLoop,
+    type_pool: &FrozenTypeInternPool,
+) -> Result<BlockId, CfgOptimizationError> {
+    ensure_preheader_transaction(cfg, lp, type_pool, PayloadFailureInjection::default())
+}
+
+#[derive(Default)]
+struct PayloadFailureInjection {
+    #[cfg(test)]
+    fail_at: Option<usize>,
+    #[cfg(test)]
+    next: usize,
+}
+
+impl PayloadFailureInjection {
+    fn before(&mut self, family: &'static str) -> Result<(), CfgEditError> {
+        #[cfg(test)]
+        {
+            let stage = self.next;
+            self.next += 1;
+            if self.fail_at == Some(stage) {
+                return Err(CfgEditError::CapacityFailure { family });
+            }
+        }
+        #[cfg(not(test))]
+        let _ = family;
+        Ok(())
+    }
+
+    fn before_validation(&mut self, cfg: &mut Cfg, ph: BlockId) {
+        #[cfg(test)]
+        {
+            let stage = self.next;
+            self.next += 1;
+            if self.fail_at == Some(stage) {
+                // Deterministic corruption of the private candidate.
+                // Verification must reject it before owner publication.
+                cfg.get_block_mut(ph).terminator = Terminator::None;
+            }
+        }
+        #[cfg(not(test))]
+        let _ = (cfg, ph);
+    }
+}
+
+fn ensure_preheader_transaction(
+    cfg: &mut Cfg,
+    lp: &NaturalLoop,
+    type_pool: &FrozenTypeInternPool,
+    mut injection: PayloadFailureInjection,
+) -> Result<BlockId, CfgOptimizationError> {
+    let mut editor = cfg.clone();
+    let ph = ensure_preheader_in(&mut editor, lp, &mut injection)?;
+    injection.before_validation(&mut editor, ph);
+    editor
+        .verify_with_type_pool(type_pool)
+        .map_err(CfgOptimizationError::Verification)?;
+    *cfg = editor;
+    Ok(ph)
+}
+
+fn ensure_preheader_in(
+    cfg: &mut Cfg,
+    lp: &NaturalLoop,
+    injection: &mut PayloadFailureInjection,
+) -> Result<BlockId, CfgEditError> {
     let header = lp.header;
 
     // Partition the header's predecessors: a pred inside the body is a latch
@@ -356,7 +426,7 @@ pub(crate) fn ensure_preheader(cfg: &mut Cfg, lp: &NaturalLoop) -> BlockId {
         let p = outside[0];
         if matches!(cfg.get_block(p).terminator, Terminator::Goto { target, .. } if target == header)
         {
-            return p;
+            return Ok(p);
         }
     }
 
@@ -374,17 +444,17 @@ pub(crate) fn ensure_preheader(cfg: &mut Cfg, lp: &NaturalLoop) -> BlockId {
         .iter()
         .map(|&ty| cfg.add_block_param(ph, ty))
         .collect();
-    let (args_start, args_len) = cfg.push_extra(ph_params);
+    injection.before("goto args")?;
+    let args = cfg.push_goto_args(ph_params)?;
     cfg.get_block_mut(ph).terminator = Terminator::Goto {
         target: header,
-        args_start,
-        args_len,
+        args,
     };
 
     // Redirect every outside edge from the header to `ph`, preserving each
     // edge's arguments (they now feed `ph`'s mirror parameters).
     for p in outside {
-        redirect_edges(cfg, p, header, ph);
+        redirect_edges(cfg, p, header, ph, injection)?;
     }
 
     // If the header was the entry, the preheader becomes the new entry so it
@@ -393,37 +463,36 @@ pub(crate) fn ensure_preheader(cfg: &mut Cfg, lp: &NaturalLoop) -> BlockId {
         cfg.entry = ph;
     }
 
-    ph
+    Ok(ph)
 }
 
 /// Retarget every edge `from -> old_target` in `from`'s terminator to `new`,
 /// keeping each edge's block arguments. Latch/back edges are never passed here.
-fn redirect_edges(cfg: &mut Cfg, from: BlockId, old_target: BlockId, new: BlockId) {
-    let term = cfg.get_block(from).terminator;
+fn redirect_edges(
+    cfg: &mut Cfg,
+    from: BlockId,
+    old_target: BlockId,
+    new: BlockId,
+    injection: &mut PayloadFailureInjection,
+) -> Result<(), CfgEditError> {
+    let term = std::mem::replace(
+        &mut cfg.get_block_mut(from).terminator,
+        Terminator::Unreachable,
+    );
     let new_term = match term {
-        Terminator::Goto {
-            target,
-            args_start,
-            args_len,
-        } => {
+        Terminator::Goto { target, args } => {
             if target == old_target {
-                Terminator::Goto {
-                    target: new,
-                    args_start,
-                    args_len,
-                }
+                Terminator::Goto { target: new, args }
             } else {
-                return;
+                Terminator::Goto { target, args }
             }
         }
         Terminator::Branch {
             cond,
             then_block,
-            then_args_start,
-            then_args_len,
+            then_args,
             else_block,
-            else_args_start,
-            else_args_len,
+            else_args,
         } => {
             let new_then = if then_block == old_target {
                 new
@@ -438,17 +507,14 @@ fn redirect_edges(cfg: &mut Cfg, from: BlockId, old_target: BlockId, new: BlockI
             Terminator::Branch {
                 cond,
                 then_block: new_then,
-                then_args_start,
-                then_args_len,
+                then_args,
                 else_block: new_else,
-                else_args_start,
-                else_args_len,
+                else_args,
             }
         }
         Terminator::Switch {
             scrutinee,
-            cases_start,
-            cases_len,
+            cases,
             default,
         } => {
             // Switch edges carry no block arguments, so retargeting only
@@ -456,21 +522,32 @@ fn redirect_edges(cfg: &mut Cfg, from: BlockId, old_target: BlockId, new: BlockI
             // fresh; the old range is left as unreferenced arena slack (the
             // husk discipline simplify uses).
             let new_cases: Vec<(i64, BlockId)> = cfg
-                .get_switch_cases(cases_start, cases_len)
+                .switch_cases(&cases)
                 .iter()
                 .map(|&(v, t)| (v, if t == old_target { new } else { t }))
                 .collect();
-            let (new_start, new_len) = cfg.push_switch_cases(new_cases);
+            injection.before("switch cases")?;
+            let new_cases = match cfg.push_switch_cases(new_cases) {
+                Ok(new_cases) => new_cases,
+                Err(error) => {
+                    cfg.get_block_mut(from).terminator = Terminator::Switch {
+                        scrutinee,
+                        cases,
+                        default,
+                    };
+                    return Err(error);
+                }
+            };
             Terminator::Switch {
                 scrutinee,
-                cases_start: new_start,
-                cases_len: new_len,
+                cases: new_cases,
                 default: if default == old_target { new } else { default },
             }
         }
-        Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => return,
+        term @ (Terminator::Return { .. } | Terminator::Unreachable | Terminator::None) => term,
     };
     cfg.get_block_mut(from).terminator = new_term;
+    Ok(())
 }
 
 /// Successor blocks of `block` in control-flow order.
@@ -482,14 +559,9 @@ fn successors_of(cfg: &Cfg, block: BlockId) -> Vec<BlockId> {
             else_block,
             ..
         } => vec![*then_block, *else_block],
-        Terminator::Switch {
-            cases_start,
-            cases_len,
-            default,
-            ..
-        } => {
+        Terminator::Switch { cases, default, .. } => {
             let mut out: Vec<BlockId> = cfg
-                .get_switch_cases(*cases_start, *cases_len)
+                .switch_cases(cases)
                 .iter()
                 .map(|(_, target)| *target)
                 .collect();
@@ -512,11 +584,14 @@ mod tests {
         Cfg::new(Type::UNIT, 0, 0, "test".to_string(), vec![])
     }
 
+    fn test_type_pool() -> FrozenTypeInternPool {
+        rue_air::TypeInternPool::new().freeze()
+    }
+
     fn goto(target: BlockId) -> Terminator {
         Terminator::Goto {
             target,
-            args_start: 0,
-            args_len: 0,
+            args: crate::payload::CfgGotoArgs::EMPTY,
         }
     }
 
@@ -535,11 +610,22 @@ mod tests {
         Terminator::Branch {
             cond,
             then_block,
-            then_args_start: 0,
-            then_args_len: 0,
+            then_args: crate::payload::CfgThenArgs::EMPTY,
             else_block,
-            else_args_start: 0,
-            else_args_len: 0,
+            else_args: crate::payload::CfgElseArgs::EMPTY,
+        }
+    }
+
+    fn switch(
+        cfg: &mut Cfg,
+        scrutinee: CfgValue,
+        cases: impl IntoIterator<Item = (i64, BlockId)>,
+        default: BlockId,
+    ) -> Terminator {
+        Terminator::Switch {
+            scrutinee,
+            cases: cfg.push_switch_cases(cases).unwrap(),
+            default,
         }
     }
 
@@ -821,11 +907,11 @@ mod tests {
         let dom = DominatorTree::compute(&cfg);
         let forest = loops(&cfg, &dom);
         let lp = loop_of(&forest, header);
-        let ph = ensure_preheader(&mut cfg, lp);
+        let ph = ensure_preheader(&mut cfg, lp, &test_type_pool()).unwrap();
 
         assert_eq!(ph, entry, "the entry Goto is reused as the preheader");
         assert_eq!(cfg.block_count(), before, "no block inserted for reuse");
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -854,7 +940,7 @@ mod tests {
         let dom = DominatorTree::compute(&cfg);
         let forest = loops(&cfg, &dom);
         let lp = loop_of(&forest, header);
-        let ph = ensure_preheader(&mut cfg, lp);
+        let ph = ensure_preheader(&mut cfg, lp, &test_type_pool()).unwrap();
 
         assert_eq!(cfg.block_count(), before + 1, "a preheader is inserted");
         assert_ne!(ph, entry);
@@ -881,7 +967,7 @@ mod tests {
             cfg.get_block(body).terminator,
             Terminator::Goto { target, .. } if target == header
         ));
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -912,7 +998,7 @@ mod tests {
         let dom = DominatorTree::compute(&cfg);
         let forest = loops(&cfg, &dom);
         let lp = loop_of(&forest, header);
-        let ph = ensure_preheader(&mut cfg, lp);
+        let ph = ensure_preheader(&mut cfg, lp, &test_type_pool()).unwrap();
 
         assert_eq!(cfg.block_count(), before + 1);
         assert!(matches!(
@@ -934,7 +1020,97 @@ mod tests {
         let mut expected = vec![ph, body];
         expected.sort_by_key(|b| b.as_u32());
         assert_eq!(header_preds, expected);
-        cfg.verify();
+        cfg.verify().unwrap();
+    }
+
+    #[test]
+    fn preheader_failure_at_every_payload_stage_leaves_owner_unchanged() {
+        // Three fallible payload stages are exercised: the preheader's Goto
+        // arguments and one rewritten switch-case payload for each outside
+        // predecessor. The fourth stage forces publication-time verification
+        // to reject the finished private candidate. The transaction must
+        // discard its complete private owner at every boundary, including
+        // blocks, parameters, values, terminators, and payload side tables
+        // already changed by earlier stages.
+        let mut original = make_cfg();
+        let entry = original.new_block();
+        original.entry = entry;
+        let p1 = original.new_block();
+        let p2 = original.new_block();
+        let side1 = original.new_block();
+        let side2 = original.new_block();
+        let header = original.new_block();
+        let body = original.new_block();
+        let exit = original.new_block();
+
+        let entry_cond = bool_const(&mut original, entry);
+        original.set_terminator(entry, branch(entry_cond, p1, p2));
+        let p1_cond = bool_const(&mut original, p1);
+        let p1_term = switch(&mut original, p1_cond, [(1, header)], side1);
+        original.set_terminator(p1, p1_term);
+        let p2_cond = bool_const(&mut original, p2);
+        let p2_term = switch(&mut original, p2_cond, [(1, header)], side2);
+        original.set_terminator(p2, p2_term);
+        original.set_terminator(side1, Terminator::Return { value: None });
+        original.set_terminator(side2, Terminator::Return { value: None });
+        let header_cond = bool_const(&mut original, header);
+        original.set_terminator(header, branch(header_cond, body, exit));
+        original.set_terminator(body, goto(header));
+        original.set_terminator(exit, Terminator::Return { value: None });
+        original.verify().unwrap();
+
+        let forest = analyze(&original);
+        let lp = loop_of(&forest, header);
+        let before_debug = format!("{original:?}");
+        let before_display = original.to_string();
+        let before_shape = (
+            original.block_count(),
+            original.value_count(),
+            successors_of(&original, p1),
+            successors_of(&original, p2),
+        );
+
+        for fail_at in 0..4 {
+            let mut cfg = original.clone();
+            let error = ensure_preheader_transaction(
+                &mut cfg,
+                lp,
+                &test_type_pool(),
+                PayloadFailureInjection {
+                    fail_at: Some(fail_at),
+                    next: 0,
+                },
+            )
+            .unwrap_err();
+            if fail_at < 3 {
+                assert!(matches!(
+                    error,
+                    CfgOptimizationError::Edit(CfgEditError::CapacityFailure { .. })
+                ));
+            } else {
+                assert!(matches!(error, CfgOptimizationError::Verification(_)));
+            }
+            assert_eq!(
+                format!("{cfg:?}"),
+                before_debug,
+                "debug owner at stage {fail_at}"
+            );
+            assert_eq!(
+                cfg.to_string(),
+                before_display,
+                "display at stage {fail_at}"
+            );
+            assert_eq!(
+                (
+                    cfg.block_count(),
+                    cfg.value_count(),
+                    successors_of(&cfg, p1),
+                    successors_of(&cfg, p2),
+                ),
+                before_shape,
+                "structural equality at stage {fail_at}"
+            );
+        }
     }
 
     #[test]
@@ -961,16 +1137,16 @@ mod tests {
 
         let dom = DominatorTree::compute(&cfg);
         let forest = loops(&cfg, &dom);
-        let ph1 = ensure_preheader(&mut cfg, loop_of(&forest, header));
+        let ph1 = ensure_preheader(&mut cfg, loop_of(&forest, header), &test_type_pool()).unwrap();
         assert_eq!(cfg.block_count(), base + 1, "first call inserts one block");
 
         // Recompute from scratch (per-pass discipline) and call again.
         let dom = DominatorTree::compute(&cfg);
         let forest = loops(&cfg, &dom);
-        let ph2 = ensure_preheader(&mut cfg, loop_of(&forest, header));
+        let ph2 = ensure_preheader(&mut cfg, loop_of(&forest, header), &test_type_pool()).unwrap();
         assert_eq!(ph2, ph1, "the existing preheader is reused");
         assert_eq!(cfg.block_count(), base + 1, "second call inserts nothing");
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1003,13 +1179,12 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
-        let (s1, l1) = cfg.push_extra(vec![v10]);
+        let args = cfg.push_goto_args(vec![v10]).unwrap();
         cfg.set_terminator(
             p1,
             Terminator::Goto {
                 target: header,
-                args_start: s1,
-                args_len: l1,
+                args,
             },
         );
         let v20 = cfg.add_inst_to_block(
@@ -1020,13 +1195,12 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
-        let (s2, l2) = cfg.push_extra(vec![v20]);
+        let args = cfg.push_goto_args(vec![v20]).unwrap();
         cfg.set_terminator(
             p2,
             Terminator::Goto {
                 target: header,
-                args_start: s2,
-                args_len: l2,
+                args,
             },
         );
 
@@ -1051,23 +1225,22 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
-        let (sb, lb) = cfg.push_extra(vec![next]);
+        let args = cfg.push_goto_args(vec![next]).unwrap();
         cfg.set_terminator(
             body,
             Terminator::Goto {
                 target: header,
-                args_start: sb,
-                args_len: lb,
+                args,
             },
         );
         cfg.set_terminator(exit, Terminator::Return { value: None });
 
-        cfg.verify();
+        cfg.verify().unwrap();
 
         let dom = DominatorTree::compute(&cfg);
         let forest = loops(&cfg, &dom);
         let lp = loop_of(&forest, header);
-        let ph = ensure_preheader(&mut cfg, lp);
+        let ph = ensure_preheader(&mut cfg, lp, &test_type_pool()).unwrap();
 
         // ph mirrors the header's single parameter.
         assert_eq!(cfg.get_block(ph).params.len(), 1);
@@ -1099,7 +1272,7 @@ mod tests {
 
         // The whole rewrite is verifier-clean: arity and types agree on every
         // edge, and ph dominates the header.
-        cfg.verify();
+        cfg.verify().unwrap();
         let dom = DominatorTree::compute(&cfg);
         assert!(dom.dominates(ph, header));
     }
@@ -1123,14 +1296,14 @@ mod tests {
         let dom = DominatorTree::compute(&cfg);
         let forest = loops(&cfg, &dom);
         let lp = loop_of(&forest, entry);
-        let ph = ensure_preheader(&mut cfg, lp);
+        let ph = ensure_preheader(&mut cfg, lp, &test_type_pool()).unwrap();
 
         assert_eq!(cfg.entry, ph, "the preheader is the new entry");
         assert!(matches!(
             cfg.get_block(ph).terminator,
             Terminator::Goto { target, .. } if target == entry
         ));
-        cfg.verify();
+        cfg.verify().unwrap();
         let dom = DominatorTree::compute(&cfg);
         assert!(dom.dominates(ph, entry));
     }

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -32,7 +32,7 @@ mod loops;
 mod peephole;
 mod simplify;
 
-use crate::Cfg;
+use crate::{CfgEditError, CfgVerificationError, ValidatedCfg};
 use rue_air::FrozenTypeInternPool;
 
 /// Optimization level, following standard compiler conventions.
@@ -104,6 +104,38 @@ impl std::fmt::Display for ParseOptLevelError {
 
 impl std::error::Error for ParseOptLevelError {}
 
+/// Recoverable failure while optimizing a validated CFG.
+#[derive(Debug)]
+pub enum CfgOptimizationError {
+    /// An optimizer payload edit could not be represented or allocated.
+    Edit(CfgEditError),
+    /// The optimized graph failed the publication-time verification boundary.
+    Verification(CfgVerificationError),
+}
+
+impl std::fmt::Display for CfgOptimizationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Edit(error) => write!(f, "CFG optimizer edit was rejected: {error:?}"),
+            Self::Verification(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for CfgOptimizationError {}
+
+impl From<CfgEditError> for CfgOptimizationError {
+    fn from(error: CfgEditError) -> Self {
+        Self::Edit(error)
+    }
+}
+
+impl From<CfgVerificationError> for CfgOptimizationError {
+    fn from(error: CfgVerificationError) -> Self {
+        Self::Verification(error)
+    }
+}
+
 impl std::str::FromStr for OptLevel {
     type Err = ParseOptLevelError;
 
@@ -141,76 +173,106 @@ impl std::fmt::Display for OptLevel {
 /// optimize(&mut cfg, OptLevel::O1, &type_pool);
 /// // cfg is now optimized
 /// ```
-pub fn optimize(cfg: &mut Cfg, level: OptLevel, type_pool: &FrozenTypeInternPool) {
-    // Verify construction output before any pass can detach dead values or
-    // erase unreachable blocks and thereby hide a malformed definition/use.
-    cfg.verify_with_type_pool(type_pool);
+pub fn optimize(
+    cfg: ValidatedCfg,
+    level: OptLevel,
+    type_pool: &FrozenTypeInternPool,
+) -> Result<ValidatedCfg, CfgOptimizationError> {
+    let mut cfg = cfg.into_editor();
 
-    match level {
-        OptLevel::O0 => {
-            // No optimization
-        }
-        OptLevel::O1 | OptLevel::O2 | OptLevel::O3 => {
-            // Constant folding interleaved with store-to-load constant
-            // propagation: folding a let's initializer can expose a constant
-            // store, and propagating it into Loads can expose new foldable
-            // operations (chains of single-assignment lets, RUE-154). The
-            // sparse worklist driver reaches that fixpoint by revisiting an
-            // instruction only when one of its inputs becomes constant, so
-            // deep chains stay linear instead of forcing quadratic full-CFG
-            // rescans (RUE-794).
-            constopt::run(cfg);
-
-            // Peephole algebraic simplification (RUE-912): rewire trap-free
-            // identities (x+0, x*1, ...) to their operand and strength-reduce
-            // unsigned division/modulo by powers of two. Runs after constopt
-            // so propagated constants are visible; annihilators that produce
-            // constants (x*0, x-x, ...) live in the constfold kernel inside
-            // the worklist instead, because their results cascade.
-            peephole::run(cfg);
-
-            // CFG simplification (RUE-910, RUE-911): fold constant-condition
-            // Branch/Switch terminators into Gotos so dead arms drop out of
-            // reachability, then thread empty forwarding blocks and merge
-            // single-predecessor Goto chains into straight-line blocks
-            // before DCE prunes the leftovers.
-            simplify::run(cfg);
-
-            // Value forwarding / copy propagation (RUE-914), at -O2/-O3 only.
-            // Runs after simplify and before CSE: it turns redundant `Load`s
-            // into the SSA value already holding the slot's contents (a global
-            // single-write rule plus a block-local last-store rule), which is
-            // exactly what lets CSE key expressions built over those loads.
-            // Both rules are trap-exact — a load never traps and the forwarded
-            // value is already computed — so the orphaned loads fall to DCE.
-            if matches!(level, OptLevel::O2 | OptLevel::O3) {
-                forward::run(cfg);
+    let pass_result = (|| {
+        match level {
+            OptLevel::O0 => {
+                // No optimization
             }
+            OptLevel::O1 | OptLevel::O2 | OptLevel::O3 => {
+                // Constant folding interleaved with store-to-load constant
+                // propagation: folding a let's initializer can expose a constant
+                // store, and propagating it into Loads can expose new foldable
+                // operations (chains of single-assignment lets, RUE-154). The
+                // sparse worklist driver reaches that fixpoint by revisiting an
+                // instruction only when one of its inputs becomes constant, so
+                // deep chains stay linear instead of forcing quadratic full-CFG
+                // rescans (RUE-794).
+                constopt::run(&mut cfg);
 
-            // Block-local common-subexpression elimination (RUE-913), at
-            // -O2/-O3 only (ADR-0044 places CSE at the release-default level).
-            // Runs after forwarding — expressions over forwarded loads are now
-            // keyable — and before DCE, which sweeps the dead placeholders each
-            // replaced duplicate (and each forwarded load) leaves behind.
-            if matches!(level, OptLevel::O2 | OptLevel::O3) {
-                cse::run(cfg);
+                // Peephole algebraic simplification (RUE-912): rewire trap-free
+                // identities (x+0, x*1, ...) to their operand and strength-reduce
+                // unsigned division/modulo by powers of two. Runs after constopt
+                // so propagated constants are visible; annihilators that produce
+                // constants (x*0, x-x, ...) live in the constfold kernel inside
+                // the worklist instead, because their results cascade.
+                peephole::run(&mut cfg)?;
+
+                // CFG simplification (RUE-910, RUE-911): fold constant-condition
+                // Branch/Switch terminators into Gotos so dead arms drop out of
+                // reachability, then thread empty forwarding blocks and merge
+                // single-predecessor Goto chains into straight-line blocks
+                // before DCE prunes the leftovers.
+                simplify::run(&mut cfg)?;
+
+                // Value forwarding / copy propagation (RUE-914), at -O2/-O3 only.
+                // Runs after simplify and before CSE: it turns redundant `Load`s
+                // into the SSA value already holding the slot's contents (a global
+                // single-write rule plus a block-local last-store rule), which is
+                // exactly what lets CSE key expressions built over those loads.
+                // Both rules are trap-exact — a load never traps and the forwarded
+                // value is already computed — so the orphaned loads fall to DCE.
+                if matches!(level, OptLevel::O2 | OptLevel::O3) {
+                    forward::run(&mut cfg)?;
+                }
+
+                // Block-local common-subexpression elimination (RUE-913), at
+                // -O2/-O3 only (ADR-0044 places CSE at the release-default level).
+                // Runs after forwarding — expressions over forwarded loads are now
+                // keyable — and before DCE, which sweeps the dead placeholders each
+                // replaced duplicate (and each forwarded load) leaves behind.
+                if matches!(level, OptLevel::O2 | OptLevel::O3) {
+                    cse::run(&mut cfg)?;
+                }
+
+                // Dead code elimination: remove unused values and unreachable blocks
+                dce::run(&mut cfg);
             }
-
-            // Dead code elimination: remove unused values and unreachable blocks
-            dce::run(cfg);
         }
-    }
+        Ok(())
+    })();
 
+    publish_optimization(cfg, pass_result, type_pool)
+}
+
+fn publish_optimization(
+    cfg: crate::CfgEditor,
+    pass_result: Result<(), CfgEditError>,
+    type_pool: &FrozenTypeInternPool,
+) -> Result<ValidatedCfg, CfgOptimizationError> {
+    pass_result?;
     // Recheck the graph handed to codegen. DCE deliberately leaves detached
     // dead values in the arena, so attachment completeness was established by
     // the strict pre-pass check above; all live attachments and uses are still
     // checked here. See `crate::verify`.
-    cfg.verify_after_optimization_with_type_pool(type_pool);
+    cfg.finish_after_optimization(type_pool).map_err(Into::into)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn optimizer_edit_failures_preserve_the_failure_kind() {
+        let cfg = crate::Cfg::new(crate::Type::UNIT, 0, 0, "test".to_string(), vec![]);
+        let type_pool = rue_air::TypeInternPool::new().freeze();
+        let error = CfgEditError::CapacityFailure {
+            family: "optimizer failure injection",
+        };
+        let propagated = publish_optimization(cfg, Err(error), &type_pool).unwrap_err();
+        assert!(matches!(
+            propagated,
+            CfgOptimizationError::Edit(CfgEditError::CapacityFailure {
+                family: "optimizer failure injection"
+            })
+        ));
+    }
 
     #[test]
     fn test_opt_level_from_str() {

--- a/crates/rue-cfg/src/opt/peephole.rs
+++ b/crates/rue-cfg/src/opt/peephole.rs
@@ -53,11 +53,11 @@ pub struct Stats {
 /// Run peephole simplification. Call after the sparse constant driver so
 /// propagated constants are visible, and before DCE so placeholders and
 /// newly dead operands are swept.
-pub fn run(cfg: &mut Cfg) -> Stats {
+pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
     let mut stats = Stats::default();
     reduce_unsigned_div_mod(cfg, &mut stats);
-    rewire_identities(cfg, &mut stats);
-    stats
+    rewire_identities(cfg, &mut stats)?;
+    Ok(stats)
 }
 
 /// Is this one of the unsigned integer types? (Deliberately not
@@ -179,7 +179,7 @@ fn identity_target(cfg: &Cfg, value: CfgValue) -> Option<CfgValue> {
 
 /// Re-point every use of an identity operation at its operand, then replace
 /// the identity instruction with a dead placeholder constant for DCE.
-fn rewire_identities(cfg: &mut Cfg, stats: &mut Stats) {
+fn rewire_identities(cfg: &mut Cfg, stats: &mut Stats) -> Result<(), crate::CfgEditError> {
     let value_count = cfg.value_count();
 
     // Collect aliases against pristine data before mutating anything.
@@ -193,7 +193,7 @@ fn rewire_identities(cfg: &mut Cfg, stats: &mut Stats) {
         }
     }
     if !any {
-        return;
+        return Ok(());
     }
 
     // Dummy the identity instructions out. Their shapes were selected to be
@@ -214,7 +214,7 @@ fn rewire_identities(cfg: &mut Cfg, stats: &mut Stats) {
         }
         v
     };
-    cfg.rewrite_value_uses(|v| resolve(v));
+    cfg.rewrite_value_uses(resolve)
 }
 
 #[cfg(test)]
@@ -250,7 +250,7 @@ mod tests {
         let add = push(&mut cfg, CfgInstData::Add(x, zero), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(add) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.identities_rewired, 1);
         // The return now reads x directly; the add is a dead placeholder.
         assert!(matches!(
@@ -272,7 +272,7 @@ mod tests {
         let shl = push(&mut cfg, CfgInstData::Shl(or, zero), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(shl) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.identities_rewired, 3);
         assert!(matches!(
             cfg.get_block(cfg.entry).terminator,
@@ -288,7 +288,7 @@ mod tests {
         let not2 = push(&mut cfg, CfgInstData::Not(not1), Type::BOOL);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(not2) });
 
-        run(&mut cfg);
+        run(&mut cfg).unwrap();
         assert!(matches!(
             cfg.get_block(cfg.entry).terminator,
             Terminator::Return { value: Some(v) } if v == b
@@ -306,7 +306,7 @@ mod tests {
         let or = push(&mut cfg, CfgInstData::BitOr(and, and), Type::U32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(or) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.identities_rewired, 2);
         assert!(matches!(
             cfg.get_block(cfg.entry).terminator,
@@ -323,7 +323,7 @@ mod tests {
         let add = push(&mut cfg, CfgInstData::Add(x, one), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(add) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.identities_rewired, 0);
         assert!(matches!(cfg.get_inst(add).data, CfgInstData::Add(..)));
     }
@@ -336,7 +336,7 @@ mod tests {
         let div = push(&mut cfg, CfgInstData::Div(x, eight), Type::U32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(div) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.divmods_reduced, 1);
         let CfgInstData::Shr(num, amount) = cfg.get_inst(div).data else {
             panic!("expected Shr, got {:?}", cfg.get_inst(div).data);
@@ -362,7 +362,7 @@ mod tests {
             },
         );
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.divmods_reduced, 1);
         let CfgInstData::BitAnd(num, mask) = cfg.get_inst(modulo).data else {
             panic!("expected BitAnd, got {:?}", cfg.get_inst(modulo).data);
@@ -381,7 +381,7 @@ mod tests {
         let div = push(&mut cfg, CfgInstData::Div(x, two), Type::I32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(div) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.divmods_reduced, 0);
         assert!(matches!(cfg.get_inst(div).data, CfgInstData::Div(..)));
     }
@@ -394,7 +394,7 @@ mod tests {
         let div = push(&mut cfg, CfgInstData::Div(x, six), Type::U32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(div) });
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.divmods_reduced, 0);
         assert!(matches!(cfg.get_inst(div).data, CfgInstData::Div(..)));
     }
@@ -409,7 +409,7 @@ mod tests {
         let mul = push(&mut cfg, CfgInstData::Mul(x, eight), Type::U32);
         cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(mul) });
 
-        run(&mut cfg);
+        run(&mut cfg).unwrap();
         assert!(matches!(cfg.get_inst(mul).data, CfgInstData::Mul(..)));
     }
 }

--- a/crates/rue-cfg/src/opt/simplify.rs
+++ b/crates/rue-cfg/src/opt/simplify.rs
@@ -78,12 +78,12 @@ pub struct Stats {
 
 /// Run all simplification phases: fold constant-condition terminators, then
 /// thread empty forwarders, then merge single-predecessor `Goto` chains.
-pub fn run(cfg: &mut Cfg) -> Stats {
+pub fn run(cfg: &mut Cfg) -> Result<Stats, crate::CfgEditError> {
     let mut stats = Stats::default();
-    fold_terminators(cfg, &mut stats);
-    thread_forwarders(cfg, &mut stats);
-    merge_chains(cfg, &mut stats);
-    stats
+    fold_terminators(cfg, &mut stats)?;
+    thread_forwarders(cfg, &mut stats)?;
+    merge_chains(cfg, &mut stats)?;
+    Ok(stats)
 }
 
 /// Rewrite constant-condition `Branch`/`Switch` terminators into `Goto`s.
@@ -91,43 +91,37 @@ pub fn run(cfg: &mut Cfg) -> Stats {
 /// Terminators are rewritten in place (not via `Cfg::set_terminator`, whose
 /// already-set assertion guards *construction*; replacing a real terminator
 /// is exactly this pass's job). Instructions are never touched.
-fn fold_terminators(cfg: &mut Cfg, stats: &mut Stats) {
+fn fold_terminators(cfg: &mut Cfg, stats: &mut Stats) -> Result<(), crate::CfgEditError> {
     for block_idx in 0..cfg.block_count() {
         let block_id = BlockId::from_raw(block_idx as u32);
         stats.blocks_scanned += 1;
 
-        match cfg.get_block(block_id).terminator {
+        match &cfg.get_block(block_id).terminator {
             Terminator::Branch {
                 cond,
                 then_block,
-                then_args_start,
-                then_args_len,
+                then_args,
                 else_block,
-                else_args_start,
-                else_args_len,
+                else_args,
             } => {
-                let CfgInstData::BoolConst(taken) = cfg.get_inst(cond).data else {
+                let CfgInstData::BoolConst(taken) = cfg.get_inst(*cond).data else {
                     continue;
                 };
-                let (target, args_start, args_len) = if taken {
-                    (then_block, then_args_start, then_args_len)
+                let (target, values) = if taken {
+                    (*then_block, cfg.then_args(then_args).to_vec())
                 } else {
-                    (else_block, else_args_start, else_args_len)
+                    (*else_block, cfg.else_args(else_args).to_vec())
                 };
-                cfg.get_block_mut(block_id).terminator = Terminator::Goto {
-                    target,
-                    args_start,
-                    args_len,
-                };
+                let args = cfg.push_goto_args(values)?;
+                cfg.get_block_mut(block_id).terminator = Terminator::Goto { target, args };
                 stats.branches_folded += 1;
             }
             Terminator::Switch {
                 scrutinee,
-                cases_start,
-                cases_len,
+                cases,
                 default,
             } => {
-                let inst = cfg.get_inst(scrutinee);
+                let inst = cfg.get_inst(*scrutinee);
                 let scrut_val = match inst.data {
                     CfgInstData::Const(v) => v,
                     // Bool match arms lower to cases 0/1 (see CfgBuilder's
@@ -147,17 +141,16 @@ fn fold_terminators(cfg: &mut Cfg, stats: &mut Stats) {
                     }
                 };
                 let target = cfg
-                    .get_switch_cases(cases_start, cases_len)
+                    .switch_cases(cases)
                     .iter()
                     .find(|(case, _)| matches(*case))
                     .map(|(_, target)| *target)
-                    .unwrap_or(default);
+                    .unwrap_or(*default);
                 // Switch edges carry no block arguments, so the Goto is
                 // argument-free.
                 cfg.get_block_mut(block_id).terminator = Terminator::Goto {
                     target,
-                    args_start: 0,
-                    args_len: 0,
+                    args: crate::payload::CfgGotoArgs::EMPTY,
                 };
                 stats.switches_folded += 1;
             }
@@ -167,18 +160,19 @@ fn fold_terminators(cfg: &mut Cfg, stats: &mut Stats) {
             | Terminator::None => {}
         }
     }
+    Ok(())
 }
 
-/// A `Goto` edge payload: target plus block-argument range.
-#[derive(Clone, Copy, PartialEq, Eq)]
+/// A decoded `Goto` edge payload. Keeping values here prevents a range from
+/// being detached from its owning CFG while the forwarding graph is solved.
+#[derive(Clone, PartialEq, Eq)]
 struct Edge {
     target: BlockId,
-    args_start: u32,
-    args_len: u32,
+    args: Vec<CfgValue>,
 }
 
 /// Retarget edges that point at empty, parameterless forwarding blocks.
-fn thread_forwarders(cfg: &mut Cfg, stats: &mut Stats) {
+fn thread_forwarders(cfg: &mut Cfg, stats: &mut Stats) -> Result<(), crate::CfgEditError> {
     let reachable = dce::compute_reachable_blocks(cfg);
 
     // A forwarder holds no instructions and no parameters, so jumping to it
@@ -194,15 +188,10 @@ fn thread_forwarders(cfg: &mut Cfg, stats: &mut Stats) {
             if !block.insts.is_empty() || !block.params.is_empty() {
                 return None;
             }
-            match block.terminator {
-                Terminator::Goto {
-                    target,
-                    args_start,
-                    args_len,
-                } => Some(Edge {
-                    target,
-                    args_start,
-                    args_len,
+            match &block.terminator {
+                Terminator::Goto { target, args } => Some(Edge {
+                    target: *target,
+                    args: cfg.goto_args(args).to_vec(),
                 }),
                 _ => None,
             }
@@ -214,22 +203,25 @@ fn thread_forwarders(cfg: &mut Cfg, stats: &mut Stats) {
     // resolved at most once, so the whole phase is linear in blocks.
     let mut resolved: Vec<Option<Edge>> = vec![None; cfg.block_count()];
     let resolve = |resolved: &mut Vec<Option<Edge>>, start: BlockId| -> Option<Edge> {
-        forward_edge[start.as_u32() as usize]?;
-        if let Some(edge) = resolved[start.as_u32() as usize] {
-            return Some(edge);
+        forward_edge[start.as_u32() as usize].as_ref()?;
+        if let Some(edge) = &resolved[start.as_u32() as usize] {
+            return Some(edge.clone());
         }
         // Walk the chain, tracking visited forwarders to stop on cycles.
         let mut chain = vec![start];
-        let mut edge = forward_edge[start.as_u32() as usize].unwrap();
-        while let Some(next) = forward_edge[edge.target.as_u32() as usize] {
+        let mut edge = forward_edge[start.as_u32() as usize]
+            .as_ref()
+            .unwrap()
+            .clone();
+        while let Some(next) = &forward_edge[edge.target.as_u32() as usize] {
             if chain.contains(&edge.target) {
                 break; // forwarder cycle: an empty infinite loop, keep as-is
             }
             chain.push(edge.target);
-            edge = next;
+            edge = next.clone();
         }
         for block in chain {
-            resolved[block.as_u32() as usize] = Some(edge);
+            resolved[block.as_u32() as usize] = Some(edge.clone());
         }
         Some(edge)
     };
@@ -241,18 +233,18 @@ fn thread_forwarders(cfg: &mut Cfg, stats: &mut Stats) {
         }
         // Only Goto and Branch edges are threaded; Switch edges cannot carry
         // the forwarder's block arguments (see module docs).
-        match cfg.get_block(block_id).terminator {
+        match &cfg.get_block(block_id).terminator {
             Terminator::Goto { target, .. } => {
-                if target == block_id {
+                if *target == block_id {
                     continue;
                 }
-                if let Some(edge) = resolve(&mut resolved, target) {
+                if let Some(edge) = resolve(&mut resolved, *target) {
                     // An edge into a parameterless block carries no args, so
                     // the forwarder chain's final args replace them whole.
+                    let args = cfg.push_goto_args(edge.args)?;
                     cfg.get_block_mut(block_id).terminator = Terminator::Goto {
                         target: edge.target,
-                        args_start: edge.args_start,
-                        args_len: edge.args_len,
+                        args,
                     };
                     stats.edges_threaded += 1;
                 }
@@ -260,59 +252,48 @@ fn thread_forwarders(cfg: &mut Cfg, stats: &mut Stats) {
             Terminator::Branch {
                 cond,
                 then_block,
-                then_args_start,
-                then_args_len,
+                then_args,
                 else_block,
-                else_args_start,
-                else_args_len,
+                else_args,
             } => {
-                let thread_side = |resolved: &mut Vec<Option<Edge>>,
-                                   side: BlockId,
-                                   start: u32,
-                                   len: u32,
-                                   stats: &mut Stats| {
-                    match resolve(resolved, side) {
-                        Some(edge) => {
-                            stats.edges_threaded += 1;
-                            (edge.target, edge.args_start, edge.args_len)
+                let cond = *cond;
+                let thread_side =
+                    |resolved: &mut Vec<Option<Edge>>, side: BlockId, stats: &mut Stats| {
+                        match resolve(resolved, side) {
+                            Some(edge) => {
+                                stats.edges_threaded += 1;
+                                (edge.target, Some(edge.args))
+                            }
+                            None => (side, None),
                         }
-                        None => (side, start, len),
-                    }
-                };
-                let (new_then, new_then_start, new_then_len) = thread_side(
-                    &mut resolved,
-                    then_block,
-                    then_args_start,
-                    then_args_len,
-                    stats,
-                );
-                let (new_else, new_else_start, new_else_len) = thread_side(
-                    &mut resolved,
-                    else_block,
-                    else_args_start,
-                    else_args_len,
-                    stats,
-                );
-                if (new_then, new_else) != (then_block, else_block) {
+                    };
+                let (new_then, forwarded_then) = thread_side(&mut resolved, *then_block, stats);
+                let (new_else, forwarded_else) = thread_side(&mut resolved, *else_block, stats);
+                if (new_then, new_else) != (*then_block, *else_block) {
+                    let then_values =
+                        forwarded_then.unwrap_or_else(|| cfg.then_args(then_args).to_vec());
+                    let else_values =
+                        forwarded_else.unwrap_or_else(|| cfg.else_args(else_args).to_vec());
+                    let then_args = cfg.push_then_args(then_values)?;
+                    let else_args = cfg.push_else_args(else_values)?;
                     cfg.get_block_mut(block_id).terminator = Terminator::Branch {
                         cond,
                         then_block: new_then,
-                        then_args_start: new_then_start,
-                        then_args_len: new_then_len,
+                        then_args,
                         else_block: new_else,
-                        else_args_start: new_else_start,
-                        else_args_len: new_else_len,
+                        else_args,
                     };
                 }
             }
             _ => {}
         }
     }
+    Ok(())
 }
 
 /// Absorb blocks whose only incoming edge is a `Goto` into their
 /// predecessor, substituting block parameters with the edge's arguments.
-fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) {
+fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) -> Result<(), crate::CfgEditError> {
     let reachable = dce::compute_reachable_blocks(cfg);
 
     // Count incoming EDGES (not predecessor blocks: a Branch with both sides
@@ -324,7 +305,7 @@ fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) {
             continue;
         }
         let block_id = BlockId::from_raw(block_idx as u32);
-        match cfg.get_block(block_id).terminator {
+        match &cfg.get_block(block_id).terminator {
             Terminator::Goto { target, .. } => incoming[target.as_u32() as usize] += 1,
             Terminator::Branch {
                 then_block,
@@ -334,13 +315,8 @@ fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) {
                 incoming[then_block.as_u32() as usize] += 1;
                 incoming[else_block.as_u32() as usize] += 1;
             }
-            Terminator::Switch {
-                cases_start,
-                cases_len,
-                default,
-                ..
-            } => {
-                for (_, target) in cfg.get_switch_cases(cases_start, cases_len) {
+            Terminator::Switch { cases, default, .. } => {
+                for (_, target) in cfg.switch_cases(cases) {
                     incoming[target.as_u32() as usize] += 1;
                 }
                 incoming[default.as_u32() as usize] += 1;
@@ -363,14 +339,10 @@ fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) {
         // Absorb the whole downstream chain into `head`. Each absorbed block
         // is marked consumed, so total splice work is linear.
         loop {
-            let Terminator::Goto {
-                target,
-                args_start,
-                args_len,
-            } = cfg.get_block(head).terminator
-            else {
+            let Terminator::Goto { target, args } = &cfg.get_block(head).terminator else {
                 break;
             };
+            let target = *target;
             let target_idx = target.as_u32() as usize;
             if target == head
                 || target == cfg.entry
@@ -381,7 +353,7 @@ fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) {
             }
 
             // Record param -> arg substitutions for the edge being erased.
-            let args: Vec<CfgValue> = cfg.get_extra(args_start, args_len).to_vec();
+            let args: Vec<CfgValue> = cfg.goto_args(args).to_vec();
             let params = std::mem::take(&mut cfg.get_block_mut(target).params);
             debug_assert_eq!(params.len(), args.len(), "verified edge arity");
             for ((param, _ty), arg) in params.into_iter().zip(args) {
@@ -390,8 +362,10 @@ fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) {
 
             // Splice the target into the head and husk the target.
             let target_insts = std::mem::take(&mut cfg.get_block_mut(target).insts);
-            let target_term = cfg.get_block(target).terminator;
-            cfg.get_block_mut(target).terminator = Terminator::Unreachable;
+            let target_term = std::mem::replace(
+                &mut cfg.get_block_mut(target).terminator,
+                Terminator::Unreachable,
+            );
             let head_block = cfg.get_block_mut(head);
             head_block.insts.extend(target_insts);
             head_block.terminator = target_term;
@@ -402,7 +376,7 @@ fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) {
     }
 
     if stats.blocks_merged == 0 {
-        return;
+        return Ok(());
     }
 
     // Resolve substitution chains (a merged block's argument can itself be a
@@ -417,7 +391,7 @@ fn merge_chains(cfg: &mut Cfg, stats: &mut Stats) {
     let resolved: Vec<CfgValue> = (0..cfg.value_count())
         .map(|i| resolve(&subst, CfgValue::from_raw(i as u32)))
         .collect();
-    cfg.rewrite_value_uses(|v| resolved[v.as_u32() as usize]);
+    cfg.rewrite_value_uses(|v| resolved[v.as_u32() as usize])
 }
 
 #[cfg(test)]
@@ -468,7 +442,7 @@ mod tests {
 
     fn fold_only(cfg: &mut Cfg) -> Stats {
         let mut stats = Stats::default();
-        fold_terminators(cfg, &mut stats);
+        fold_terminators(cfg, &mut stats).unwrap();
         stats
     }
 
@@ -486,18 +460,16 @@ mod tests {
         let _else_param = cfg.add_block_param(else_block, Type::I32);
         let then_arg = push(&mut cfg, CfgInstData::Const(10), Type::I32);
         let else_arg = push(&mut cfg, CfgInstData::Const(20), Type::I32);
-        let (then_args_start, then_args_len) = cfg.push_extra(vec![then_arg]);
-        let (else_args_start, else_args_len) = cfg.push_extra(vec![else_arg]);
+        let then_args = cfg.push_then_args(vec![then_arg]).unwrap();
+        let else_args = cfg.push_else_args(vec![else_arg]).unwrap();
         cfg.set_terminator(
             cfg.entry,
             Terminator::Branch {
                 cond,
                 then_block,
-                then_args_start,
-                then_args_len,
+                then_args,
                 else_block,
-                else_args_start,
-                else_args_len,
+                else_args,
             },
         );
         cfg.set_terminator(
@@ -531,11 +503,9 @@ mod tests {
             Terminator::Branch {
                 cond,
                 then_block,
-                then_args_start: 0,
-                then_args_len: 0,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
                 else_block,
-                else_args_start: 0,
-                else_args_len: 0,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
             },
         );
         ret_const(&mut cfg, then_block, 1);
@@ -560,11 +530,9 @@ mod tests {
             Terminator::Branch {
                 cond: x,
                 then_block,
-                then_args_start: 0,
-                then_args_len: 0,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
                 else_block,
-                else_args_start: 0,
-                else_args_len: 0,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
             },
         );
         ret_const(&mut cfg, then_block, 1);
@@ -583,19 +551,20 @@ mod tests {
         let scrutinee = push(&mut cfg, CfgInstData::Const(scrut_val), scrut_ty);
         let case_blocks: Vec<BlockId> = cases.iter().map(|_| cfg.new_block()).collect();
         let default = cfg.new_block();
-        let (cases_start, cases_len) = cfg.push_switch_cases(
-            cases
-                .iter()
-                .zip(&case_blocks)
-                .map(|(v, b)| (*v, *b))
-                .collect::<Vec<_>>(),
-        );
+        let case_payload = cfg
+            .push_switch_cases(
+                cases
+                    .iter()
+                    .zip(&case_blocks)
+                    .map(|(v, b)| (*v, *b))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
         cfg.set_terminator(
             cfg.entry,
             Terminator::Switch {
                 scrutinee,
-                cases_start,
-                cases_len,
+                cases: case_payload,
                 default,
             },
         );
@@ -659,15 +628,15 @@ mod tests {
         let scrutinee = push(&mut cfg, CfgInstData::BoolConst(true), Type::BOOL);
         let false_block = cfg.new_block();
         let true_block = cfg.new_block();
-        let (cases_start, cases_len) =
-            cfg.push_switch_cases(vec![(0, false_block), (1, true_block)]);
+        let cases = cfg
+            .push_switch_cases(vec![(0, false_block), (1, true_block)])
+            .unwrap();
         let default = false_block;
         cfg.set_terminator(
             cfg.entry,
             Terminator::Switch {
                 scrutinee,
-                cases_start,
-                cases_len,
+                cases,
                 default,
             },
         );
@@ -696,11 +665,9 @@ mod tests {
                 Terminator::Branch {
                     cond,
                     then_block,
-                    then_args_start: 0,
-                    then_args_len: 0,
+                    then_args: crate::payload::CfgThenArgs::EMPTY,
                     else_block,
-                    else_args_start: 0,
-                    else_args_len: 0,
+                    else_args: crate::payload::CfgElseArgs::EMPTY,
                 },
             );
             ret_const(&mut cfg, else_block, 0);
@@ -732,27 +699,18 @@ mod tests {
             cfg.entry,
             Terminator::Goto {
                 target: f1,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         cfg.set_terminator(
             f1,
             Terminator::Goto {
                 target: f2,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
-        let (args_start, args_len) = cfg.push_extra(vec![arg]);
-        cfg.set_terminator(
-            f2,
-            Terminator::Goto {
-                target: tail,
-                args_start,
-                args_len,
-            },
-        );
+        let args = cfg.push_goto_args(vec![arg]).unwrap();
+        cfg.set_terminator(f2, Terminator::Goto { target: tail, args });
         cfg.set_terminator(
             tail,
             Terminator::Return {
@@ -760,7 +718,7 @@ mod tests {
             },
         );
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert!(stats.edges_threaded >= 1);
         // After threading, entry pointed at tail with f2's arg; merging then
         // absorbed tail into entry, substituting the param with the arg.
@@ -781,28 +739,25 @@ mod tests {
             cfg.entry,
             Terminator::Goto {
                 target: a,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         cfg.set_terminator(
             a,
             Terminator::Goto {
                 target: b,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         cfg.set_terminator(
             b,
             Terminator::Goto {
                 target: a,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
 
-        run(&mut cfg);
+        run(&mut cfg).unwrap();
         // Control still enters the a<->b cycle; whichever block entry now
         // targets, it must be part of the cycle, and the cycle must persist.
         let Terminator::Goto { target, .. } = cfg.get_block(cfg.entry).terminator else {
@@ -834,13 +789,12 @@ mod tests {
         let mut source = cfg.entry;
         let mut carried = start;
         for &(block, out) in &blocks {
-            let (args_start, args_len) = cfg.push_extra(vec![carried]);
+            let args = cfg.push_goto_args(vec![carried]).unwrap();
             cfg.set_terminator(
                 source,
                 Terminator::Goto {
                     target: block,
-                    args_start,
-                    args_len,
+                    args,
                 },
             );
             source = block;
@@ -853,7 +807,7 @@ mod tests {
             },
         );
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.blocks_merged, 3);
         // Everything lives in entry now: 1 const + 3 adds, ending in Return.
         let entry = cfg.get_block(cfg.entry);
@@ -885,11 +839,9 @@ mod tests {
             Terminator::Branch {
                 cond,
                 then_block,
-                then_args_start: 0,
-                then_args_len: 0,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
                 else_block,
-                else_args_start: 0,
-                else_args_len: 0,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
             },
         );
         let t = push_in(&mut cfg, then_block, CfgInstData::Const(1), Type::I32);
@@ -898,8 +850,7 @@ mod tests {
             then_block,
             Terminator::Goto {
                 target: join,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         let e = push_in(&mut cfg, else_block, CfgInstData::Const(2), Type::I32);
@@ -908,13 +859,12 @@ mod tests {
             else_block,
             Terminator::Goto {
                 target: join,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         ret_const(&mut cfg, join, 3);
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.blocks_merged, 0);
         assert!(matches!(
             cfg.get_block(join).terminator,
@@ -936,8 +886,7 @@ mod tests {
             cfg.entry,
             Terminator::Goto {
                 target: header,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         cfg.set_terminator(
@@ -945,11 +894,9 @@ mod tests {
             Terminator::Branch {
                 cond,
                 then_block: body,
-                then_args_start: 0,
-                then_args_len: 0,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
                 else_block: exit,
-                else_args_start: 0,
-                else_args_len: 0,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
             },
         );
         let work = push_in(&mut cfg, body, CfgInstData::Const(1), Type::I32);
@@ -958,13 +905,12 @@ mod tests {
             body,
             Terminator::Goto {
                 target: header,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
         ret_const(&mut cfg, exit, 0);
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         // body merges into nothing (header has 2 incoming edges); body itself
         // has 1 incoming edge and CAN be absorbed into header's then-side?
         // No: absorption requires the predecessor to end in a Goto, and
@@ -994,8 +940,7 @@ mod tests {
                 source,
                 Terminator::Goto {
                     target: block,
-                    args_start: 0,
-                    args_len: 0,
+                    args: crate::payload::CfgGotoArgs::EMPTY,
                 },
             );
             blocks.push(block);
@@ -1003,7 +948,7 @@ mod tests {
         }
         ret_const(&mut cfg, source, 0);
 
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         assert_eq!(stats.blocks_merged, 100);
         assert_eq!(cfg.get_block(cfg.entry).insts.len(), 101);
     }
@@ -1034,31 +979,27 @@ mod tests {
             Terminator::Branch {
                 cond,
                 then_block,
-                then_args_start: 0,
-                then_args_len: 0,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
                 else_block,
-                else_args_start: 0,
-                else_args_len: 0,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
             },
         );
         let t = push_in(&mut cfg, then_block, CfgInstData::Const(1), Type::I32);
-        let (t_start, t_len) = cfg.push_extra(vec![t]);
+        let t_args = cfg.push_goto_args(vec![t]).unwrap();
         cfg.set_terminator(
             then_block,
             Terminator::Goto {
                 target: join,
-                args_start: t_start,
-                args_len: t_len,
+                args: t_args,
             },
         );
         let e = push_in(&mut cfg, else_block, CfgInstData::Const(2), Type::I32);
-        let (e_start, e_len) = cfg.push_extra(vec![e]);
+        let e_args = cfg.push_goto_args(vec![e]).unwrap();
         cfg.set_terminator(
             else_block,
             Terminator::Goto {
                 target: join,
-                args_start: e_start,
-                args_len: e_len,
+                args: e_args,
             },
         );
         cfg.set_terminator(
@@ -1069,7 +1010,7 @@ mod tests {
         );
 
         super::super::constopt::run(&mut cfg);
-        let stats = run(&mut cfg);
+        let stats = run(&mut cfg).unwrap();
         super::super::dce::run(&mut cfg);
 
         assert_eq!(stats.branches_folded, 1);

--- a/crates/rue-cfg/src/payload.rs
+++ b/crates/rue-cfg/src/payload.rs
@@ -1,0 +1,520 @@
+//! Typed schemas for CFG variable-length payloads.
+//!
+//! CFG deliberately keeps values, call arguments, switch cases, and place
+//! projections in separate element stores.  This module is the only owner of
+//! their positional arithmetic; the rest of the crate deals in family-specific
+//! ranges and borrowing views.
+
+use std::{fmt, marker::PhantomData};
+
+use crate::{BlockId, CfgCallArg, CfgValue, Projection};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PayloadBuildError {
+    ResourceLimitExceeded { family: &'static str },
+    CapacityFailure { family: &'static str },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PayloadError {
+    family: &'static str,
+    start: u32,
+    extent: u32,
+    store_len: usize,
+}
+
+impl PayloadError {
+    pub fn family(&self) -> &'static str {
+        self.family
+    }
+}
+
+impl fmt::Display for PayloadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CFG {} payload range {}+{} is outside store of length {}",
+            self.family, self.start, self.extent, self.store_len
+        )
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Range<F> {
+    start: u32,
+    extent: u32,
+    family: PhantomData<fn() -> F>,
+}
+
+trait Family {
+    type Store;
+}
+
+macro_rules! family {
+    ($name:ident, $marker:ident, $store:ty, $label:literal) => {
+        #[derive(Debug, PartialEq, Eq)]
+        enum $marker {}
+        #[repr(transparent)]
+        #[derive(Debug, PartialEq, Eq)]
+        pub(crate) struct $name(Range<$marker>);
+        impl Family for $marker {
+            type Store = $store;
+        }
+        #[allow(dead_code)]
+        impl $name {
+            pub(crate) const EMPTY: Self = Self(Range {
+                start: 0,
+                extent: 0,
+                family: PhantomData,
+            });
+            pub(crate) const FAMILY: &'static str = $label;
+            pub(crate) const fn is_empty(&self) -> bool {
+                self.0.extent == 0
+            }
+            pub(crate) const fn extent(&self) -> u32 {
+                self.0.extent
+            }
+            pub(crate) const fn duplicate(&self) -> Self {
+                Self(Range {
+                    start: self.0.start,
+                    extent: self.0.extent,
+                    family: PhantomData,
+                })
+            }
+            #[cfg(test)]
+            pub(crate) const fn malformed(start: u32, extent: u32) -> Self {
+                Self(Range {
+                    start,
+                    extent,
+                    family: PhantomData,
+                })
+            }
+        }
+        const _: () = assert!(std::mem::size_of::<$name>() == 2 * std::mem::size_of::<u32>());
+        const _: () = assert!(std::mem::align_of::<$name>() == std::mem::align_of::<u32>());
+    };
+}
+
+family!(
+    CfgIntrinsicArgs,
+    IntrinsicArgsFamily,
+    ValueStore,
+    "intrinsic arguments"
+);
+family!(
+    CfgStructFields,
+    StructFieldsFamily,
+    ValueStore,
+    "struct fields"
+);
+family!(
+    CfgArrayElements,
+    ArrayElementsFamily,
+    ValueStore,
+    "array elements"
+);
+family!(
+    CfgEnumPayload,
+    EnumPayloadFamily,
+    ValueStore,
+    "enum payload"
+);
+family!(CfgGotoArgs, GotoArgsFamily, ValueStore, "goto arguments");
+family!(CfgThenArgs, ThenArgsFamily, ValueStore, "then arguments");
+family!(CfgElseArgs, ElseArgsFamily, ValueStore, "else arguments");
+family!(CfgCallArgs, CallArgsFamily, CallArgStore, "call arguments");
+family!(
+    CfgSwitchCases,
+    SwitchCasesFamily,
+    SwitchCaseStore,
+    "switch cases"
+);
+family!(
+    CfgProjections,
+    ProjectionsFamily,
+    ProjectionStore,
+    "projections"
+);
+
+#[derive(Debug, Clone)]
+pub(crate) struct Store<S, E> {
+    elements: Vec<E>,
+    marker: PhantomData<fn() -> S>,
+}
+
+impl<S, E> Store<S, E> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            elements: Vec::new(),
+            marker: PhantomData,
+        }
+    }
+    fn reserve(
+        &mut self,
+        family: &'static str,
+        additional: usize,
+    ) -> Result<(), PayloadBuildError> {
+        let end = self
+            .elements
+            .len()
+            .checked_add(additional)
+            .ok_or(PayloadBuildError::ResourceLimitExceeded { family })?;
+        if end > u32::MAX as usize {
+            return Err(PayloadBuildError::ResourceLimitExceeded { family });
+        }
+        self.elements
+            .try_reserve(additional)
+            .map_err(|_| PayloadBuildError::CapacityFailure { family })
+    }
+    fn append<F>(
+        &mut self,
+        family: &'static str,
+        values: impl IntoIterator<Item = E>,
+    ) -> Result<Range<F>, PayloadBuildError>
+    where
+        F: Family<Store = S>,
+    {
+        let values = values.into_iter();
+        let mut staged = Vec::new();
+        let (lower_bound, _) = values.size_hint();
+        if u32::try_from(lower_bound).is_err() {
+            return Err(PayloadBuildError::ResourceLimitExceeded { family });
+        }
+        staged
+            .try_reserve(lower_bound)
+            .map_err(|_| PayloadBuildError::CapacityFailure { family })?;
+        for value in values {
+            if staged.len() == u32::MAX as usize {
+                return Err(PayloadBuildError::ResourceLimitExceeded { family });
+            }
+            staged
+                .try_reserve(1)
+                .map_err(|_| PayloadBuildError::CapacityFailure { family })?;
+            staged.push(value);
+        }
+        if staged.is_empty() {
+            return Ok(Range {
+                start: 0,
+                extent: 0,
+                family: PhantomData,
+            });
+        }
+        let start = u32::try_from(self.elements.len())
+            .map_err(|_| PayloadBuildError::ResourceLimitExceeded { family })?;
+        let extent = u32::try_from(staged.len())
+            .map_err(|_| PayloadBuildError::ResourceLimitExceeded { family })?;
+        start
+            .checked_add(extent)
+            .ok_or(PayloadBuildError::ResourceLimitExceeded { family })?;
+        self.elements
+            .try_reserve(staged.len())
+            .map_err(|_| PayloadBuildError::CapacityFailure { family })?;
+        self.elements.extend(staged);
+        Ok(Range {
+            start,
+            extent,
+            family: PhantomData,
+        })
+    }
+
+    fn view<F>(&self, range: &Range<F>, family: &'static str) -> Result<&[E], PayloadError>
+    where
+        F: Family<Store = S>,
+    {
+        if range.extent == 0 {
+            return if range.start == 0 {
+                Ok(&[])
+            } else {
+                Err(PayloadError {
+                    family,
+                    start: range.start,
+                    extent: 0,
+                    store_len: self.elements.len(),
+                })
+            };
+        }
+        let start = usize::try_from(range.start).map_err(|_| PayloadError {
+            family,
+            start: range.start,
+            extent: range.extent,
+            store_len: self.elements.len(),
+        })?;
+        let extent = usize::try_from(range.extent).map_err(|_| PayloadError {
+            family,
+            start: range.start,
+            extent: range.extent,
+            store_len: self.elements.len(),
+        })?;
+        let end = start.checked_add(extent).ok_or(PayloadError {
+            family,
+            start: range.start,
+            extent: range.extent,
+            store_len: self.elements.len(),
+        })?;
+        self.elements.get(start..end).ok_or(PayloadError {
+            family,
+            start: range.start,
+            extent: range.extent,
+            store_len: self.elements.len(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ValueStore {}
+#[derive(Debug, Clone)]
+pub(crate) enum CallArgStore {}
+#[derive(Debug, Clone)]
+pub(crate) enum SwitchCaseStore {}
+#[derive(Debug, Clone)]
+pub(crate) enum ProjectionStore {}
+
+pub(crate) type Values = Store<ValueStore, CfgValue>;
+pub(crate) type CallArgs = Store<CallArgStore, CfgCallArg>;
+pub(crate) type SwitchCases = Store<SwitchCaseStore, (i64, BlockId)>;
+pub(crate) type Projections = Store<ProjectionStore, Projection>;
+
+pub(crate) fn reserve_values(
+    store: &mut Values,
+    additional: usize,
+) -> Result<(), PayloadBuildError> {
+    store.reserve("value", additional)
+}
+
+macro_rules! accessors {
+    ($push:ident, $view:ident, $checked:ident, $range:ident, $store:ty, $elem:ty) => {
+        pub(crate) fn $push(
+            store: &mut $store,
+            values: impl IntoIterator<Item = $elem>,
+        ) -> Result<$range, PayloadBuildError> {
+            store.append($range::FAMILY, values).map($range)
+        }
+        pub(crate) fn $checked<'a>(
+            store: &'a $store,
+            range: &$range,
+        ) -> Result<&'a [$elem], PayloadError> {
+            store.view(&range.0, $range::FAMILY)
+        }
+        pub(crate) fn $view<'a>(store: &'a $store, range: &$range) -> &'a [$elem] {
+            $checked(store, range).expect("validated CFG payload")
+        }
+    };
+}
+
+accessors!(
+    push_intrinsic_args,
+    intrinsic_args,
+    checked_intrinsic_args,
+    CfgIntrinsicArgs,
+    Values,
+    CfgValue
+);
+accessors!(
+    push_struct_fields,
+    struct_fields,
+    checked_struct_fields,
+    CfgStructFields,
+    Values,
+    CfgValue
+);
+accessors!(
+    push_array_elements,
+    array_elements,
+    checked_array_elements,
+    CfgArrayElements,
+    Values,
+    CfgValue
+);
+accessors!(
+    push_enum_payload,
+    enum_payload,
+    checked_enum_payload,
+    CfgEnumPayload,
+    Values,
+    CfgValue
+);
+accessors!(
+    push_goto_args,
+    goto_args,
+    checked_goto_args,
+    CfgGotoArgs,
+    Values,
+    CfgValue
+);
+accessors!(
+    push_then_args,
+    then_args,
+    checked_then_args,
+    CfgThenArgs,
+    Values,
+    CfgValue
+);
+accessors!(
+    push_else_args,
+    else_args,
+    checked_else_args,
+    CfgElseArgs,
+    Values,
+    CfgValue
+);
+accessors!(
+    push_call_args,
+    call_args,
+    checked_call_args,
+    CfgCallArgs,
+    CallArgs,
+    CfgCallArg
+);
+accessors!(
+    push_switch_cases,
+    switch_cases,
+    checked_switch_cases,
+    CfgSwitchCases,
+    SwitchCases,
+    (i64, BlockId)
+);
+accessors!(
+    push_projections,
+    projections,
+    checked_projections,
+    CfgProjections,
+    Projections,
+    Projection
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_ranges_are_canonical_and_append_nothing() {
+        let mut store = Values::new();
+        let first = push_struct_fields(&mut store, []).unwrap();
+        push_intrinsic_args(&mut store, [CfgValue::from_raw(7)]).unwrap();
+        let second = push_struct_fields(&mut store, []).unwrap();
+        assert_eq!(first.0.start, 0);
+        assert_eq!(first.0.extent, 0);
+        assert_eq!(second.0.start, 0);
+        assert_eq!(second.0.extent, 0);
+        assert_eq!(store.elements.len(), 1);
+    }
+
+    #[test]
+    fn family_views_share_a_compact_value_store_without_aliasing_ranges() {
+        let mut store = Values::new();
+        let fields =
+            push_struct_fields(&mut store, [CfgValue::from_raw(1), CfgValue::from_raw(2)]).unwrap();
+        let intrinsic = push_intrinsic_args(&mut store, [CfgValue::from_raw(3)]).unwrap();
+        assert_eq!(struct_fields(&store, &fields).len(), 2);
+        assert_eq!(intrinsic_args(&store, &intrinsic)[0].as_u32(), 3);
+        assert_eq!(store.elements.len(), 3);
+    }
+
+    #[test]
+    fn checked_view_rejects_overflow_and_noncanonical_empty_metadata() {
+        let store = Values::new();
+        let overflow = CfgArrayElements::malformed(u32::MAX, 2);
+        let error = checked_array_elements(&store, &overflow).unwrap_err();
+        assert_eq!(error.family, "array elements");
+        assert_eq!(error.start, u32::MAX);
+        let noncanonical = CfgArrayElements::malformed(1, 0);
+        assert!(checked_array_elements(&store, &noncanonical).is_err());
+    }
+
+    #[test]
+    fn typed_ranges_preserve_the_two_word_layout() {
+        assert_eq!(std::mem::size_of::<CfgCallArgs>(), 8);
+        assert_eq!(std::mem::align_of::<CfgCallArgs>(), 4);
+        assert_eq!(std::mem::size_of::<CfgSwitchCases>(), 8);
+        assert_eq!(std::mem::size_of::<CfgProjections>(), 8);
+    }
+
+    #[test]
+    fn every_payload_family_read_traverses_with_exactly_zero_allocations() {
+        let mut values = Values::new();
+        let intrinsic = push_intrinsic_args(&mut values, [CfgValue::from_raw(1)]).unwrap();
+        let fields = push_struct_fields(&mut values, [CfgValue::from_raw(2)]).unwrap();
+        let elements = push_array_elements(&mut values, [CfgValue::from_raw(3)]).unwrap();
+        let enum_range = push_enum_payload(&mut values, [CfgValue::from_raw(4)]).unwrap();
+        let goto = push_goto_args(&mut values, [CfgValue::from_raw(5)]).unwrap();
+        let then_range = push_then_args(&mut values, [CfgValue::from_raw(6)]).unwrap();
+        let else_range = push_else_args(&mut values, [CfgValue::from_raw(7)]).unwrap();
+        let mut call_store = CallArgs::new();
+        let calls = push_call_args(
+            &mut call_store,
+            [CfgCallArg {
+                value: CfgValue::from_raw(8),
+                mode: crate::CfgArgMode::Normal,
+            }],
+        )
+        .unwrap();
+        let mut cases = SwitchCases::new();
+        let switch = push_switch_cases(&mut cases, [(1, BlockId::from_raw(0))]).unwrap();
+        let mut projections = Projections::new();
+        let place = push_projections(
+            &mut projections,
+            [Projection::Index {
+                array_type: crate::Type::I32,
+                index: CfgValue::from_raw(9),
+            }],
+        )
+        .unwrap();
+
+        let (sum, allocations) = crate::allocation_test_support::allocations_during(|| {
+            intrinsic_args(&values, &intrinsic).len()
+                + struct_fields(&values, &fields).len()
+                + array_elements(&values, &elements).len()
+                + enum_payload(&values, &enum_range).len()
+                + goto_args(&values, &goto).len()
+                + then_args(&values, &then_range).len()
+                + else_args(&values, &else_range).len()
+                + call_args(&call_store, &calls).len()
+                + switch_cases(&cases, &switch).len()
+                + super::projections(&projections, &place).len()
+        });
+        assert_eq!(sum, 10);
+        assert_eq!(allocations, 0, "payload traversal allocated");
+    }
+
+    #[test]
+    fn owner_bound_range_and_raw_mutation_apis_stay_private() {
+        let facade = include_str!("lib.rs");
+        for family in [
+            "CfgIntrinsicArgs",
+            "CfgStructFields",
+            "CfgArrayElements",
+            "CfgEnumPayload",
+            "CfgGotoArgs",
+            "CfgThenArgs",
+            "CfgElseArgs",
+            "CfgCallArgs",
+            "CfgSwitchCases",
+            "CfgProjections",
+        ] {
+            assert!(
+                !facade.contains(family),
+                "owner-bound payload family {family} must not be exported"
+            );
+        }
+
+        let inst = include_str!("inst.rs");
+        for raw_api in [
+            "pub(crate) fn add_inst(",
+            "pub(crate) fn get_inst_mut(",
+            "pub(crate) fn get_block_mut(",
+            "pub(crate) fn add_inst_to_block(",
+            "pub(crate) fn set_terminator(",
+            "pub(crate) fn make_place(",
+        ] {
+            assert!(
+                inst.contains(raw_api),
+                "raw CFG mutation API lost its crate-private boundary: {raw_api}"
+            );
+        }
+        assert!(inst.contains("impl Clone for Cfg"));
+        assert!(!inst.contains("impl Clone for Place"));
+        assert!(!inst.contains("impl Clone for CfgInstData"));
+        assert!(!inst.contains("impl Clone for Terminator"));
+    }
+}

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -30,10 +30,67 @@
 //! DCE can detach dead arena values, then verifies the remaining live graph
 //! again after all passes.
 
-use crate::inst::{BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
+use crate::PayloadError;
+use crate::inst::{
+    BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, ValidatedCfg,
+};
 use rue_air::{FrozenTypeInternPool, Type, TypeKind};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CfgVerificationLocation {
+    Artifact,
+    Instruction { block: BlockId, value: CfgValue },
+    Terminator { block: BlockId },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CfgVerificationError {
+    function: String,
+    location: CfgVerificationLocation,
+    message: String,
+    payload: Option<PayloadError>,
+}
+
+impl CfgVerificationError {
+    pub fn location(&self) -> CfgVerificationLocation {
+        self.location
+    }
+
+    pub fn payload(&self) -> Option<&PayloadError> {
+        self.payload.as_ref()
+    }
+}
+
+impl std::fmt::Display for CfgVerificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CFG verification failed in `{}`: {}",
+            self.function, self.message
+        )
+    }
+}
+
+impl std::error::Error for CfgVerificationError {}
+
 impl Cfg {
+    /// Consume an editor and publish it only after whole-owner verification.
+    pub fn finish(
+        self,
+        type_pool: &FrozenTypeInternPool,
+    ) -> Result<ValidatedCfg, CfgVerificationError> {
+        self.verify_with_type_pool(type_pool)?;
+        Ok(ValidatedCfg(self))
+    }
+
+    pub(crate) fn finish_after_optimization(
+        self,
+        type_pool: &FrozenTypeInternPool,
+    ) -> Result<ValidatedCfg, CfgVerificationError> {
+        self.verify_after_optimization_with_type_pool(type_pool)?;
+        Ok(ValidatedCfg(self))
+    }
+
     /// Count every operand use of `needle` across instructions and
     /// terminators.
     ///
@@ -51,33 +108,27 @@ impl Cfg {
                     .count();
             }
             match &block.terminator {
-                Terminator::Goto {
-                    args_start,
-                    args_len,
-                    ..
-                } => {
+                Terminator::Goto { args: _, .. } => {
                     count += self
-                        .get_extra(*args_start, *args_len)
+                        .get_goto_args(&block.terminator)
                         .iter()
                         .filter(|value| **value == needle)
                         .count();
                 }
                 Terminator::Branch {
                     cond,
-                    then_args_start,
-                    then_args_len,
-                    else_args_start,
-                    else_args_len,
+                    then_args: _,
+                    else_args: _,
                     ..
                 } => {
                     count += usize::from(*cond == needle);
                     count += self
-                        .get_extra(*then_args_start, *then_args_len)
+                        .get_branch_then_args(&block.terminator)
                         .iter()
                         .filter(|value| **value == needle)
                         .count();
                     count += self
-                        .get_extra(*else_args_start, *else_args_len)
+                        .get_branch_else_args(&block.terminator)
                         .iter()
                         .filter(|value| **value == needle)
                         .count();
@@ -100,15 +151,18 @@ impl Cfg {
     /// See the module docs for the invariants and the rationale for the hard
     /// panic. This is a compiler-bug guard: a well-formed pipeline never trips
     /// it; the check is paid to pin future lowering regressions to their source.
-    pub fn verify(&self) {
-        Verifier::new(self, None, true).verify();
+    pub fn verify(&self) -> Result<(), CfgVerificationError> {
+        Verifier::new(self, None, true).verify()
     }
 
     /// Verify with the active semantic type pool, enabling exact aggregate
     /// layouts and projection-chain validation. Production callers must use
     /// this entry point.
-    pub fn verify_with_type_pool(&self, type_pool: &FrozenTypeInternPool) {
-        Verifier::new(self, Some(type_pool), true).verify();
+    pub fn verify_with_type_pool(
+        &self,
+        type_pool: &FrozenTypeInternPool,
+    ) -> Result<(), CfgVerificationError> {
+        Verifier::new(self, Some(type_pool), true).verify()
     }
 
     /// Verify the optimized live graph. DCE intentionally retains dead values
@@ -118,8 +172,8 @@ impl Cfg {
     pub(crate) fn verify_after_optimization_with_type_pool(
         &self,
         type_pool: &FrozenTypeInternPool,
-    ) {
-        Verifier::new(self, Some(type_pool), false).verify();
+    ) -> Result<(), CfgVerificationError> {
+        Verifier::new(self, Some(type_pool), false).verify()
     }
 
     /// Collect every `CfgValue` operand referenced by an instruction into
@@ -174,35 +228,22 @@ impl Cfg {
                 out.push(*value);
             }
 
-            CfgInstData::Call {
-                args_start,
-                args_len,
-                ..
-            } => {
-                for arg in self.get_call_args(*args_start, *args_len) {
+            CfgInstData::Call { args, .. } => {
+                for arg in self.call_args(args) {
                     out.push(arg.value);
                 }
             }
-            CfgInstData::Intrinsic {
-                args_start,
-                args_len,
-                ..
-            } => out.extend_from_slice(self.get_extra(*args_start, *args_len)),
+            CfgInstData::Intrinsic { args, .. } => out.extend_from_slice(self.intrinsic_args(args)),
 
-            CfgInstData::StructInit {
-                fields_start,
-                fields_len,
-                ..
-            } => out.extend_from_slice(self.get_extra(*fields_start, *fields_len)),
-            CfgInstData::ArrayInit {
-                elements_start,
-                elements_len,
-            } => out.extend_from_slice(self.get_extra(*elements_start, *elements_len)),
-            CfgInstData::EnumVariant {
-                payload_start,
-                payload_len,
-                ..
-            } => out.extend_from_slice(self.get_extra(*payload_start, *payload_len)),
+            CfgInstData::StructInit { fields, .. } => {
+                out.extend_from_slice(self.struct_fields(fields))
+            }
+            CfgInstData::ArrayInit { elements } => {
+                out.extend_from_slice(self.array_elements(elements))
+            }
+            CfgInstData::EnumVariant { payload, .. } => {
+                out.extend_from_slice(self.enum_payload(payload))
+            }
             CfgInstData::EnumPayloadGet { base, .. } => out.push(*base),
 
             CfgInstData::IntCast { value, .. } => out.push(*value),
@@ -252,77 +293,94 @@ impl<'a> Verifier<'a> {
         }
     }
 
-    fn fail(&self, message: impl std::fmt::Display) -> ! {
-        panic!(
-            "internal compiler error: CFG verification failed in function `{}`: {}. This is a compiler bug (RUE-797).",
-            self.cfg.fn_name(),
-            message
-        )
+    fn error(&self, message: impl std::fmt::Display) -> CfgVerificationError {
+        CfgVerificationError {
+            function: self.cfg.fn_name().to_string(),
+            location: CfgVerificationLocation::Artifact,
+            message: message.to_string(),
+            payload: None,
+        }
     }
 
-    fn verify(mut self) {
-        self.verify_block_table_and_attachments();
-        self.verify_targets_and_slices();
+    fn payload_error(
+        &self,
+        location: CfgVerificationLocation,
+        error: PayloadError,
+    ) -> CfgVerificationError {
+        CfgVerificationError {
+            function: self.cfg.fn_name().to_string(),
+            location,
+            message: error.to_string(),
+            payload: Some(error),
+        }
+    }
+
+    fn verify(mut self) -> Result<(), CfgVerificationError> {
+        self.verify_block_table_and_attachments()?;
+        self.verify_targets_and_slices()?;
         self.compute_reachability();
         self.compute_dominators();
 
         for block in self.cfg.blocks() {
             let block_index = block.id.as_u32() as usize;
             if self.reachable[block_index] && matches!(block.terminator, Terminator::None) {
-                self.fail(format_args!(
+                return Err(self.error(format_args!(
                     "reachable block {} has no terminator",
                     block.id
-                ));
+                )));
             }
 
             for (position, &value) in block.insts.iter().enumerate() {
-                self.verify_inst(block.id, position, value);
+                self.verify_inst(block.id, position, value)?;
             }
             if !matches!(block.terminator, Terminator::None) {
-                self.verify_terminator_use(block.id, &block.terminator);
+                self.verify_terminator_use(block.id, &block.terminator)?;
             }
         }
+        Ok(())
     }
 
-    fn verify_block_table_and_attachments(&mut self) {
+    fn verify_block_table_and_attachments(&mut self) -> Result<(), CfgVerificationError> {
         let block_count = self.cfg.block_count();
         if self.cfg.entry.as_u32() as usize >= block_count {
-            self.fail(format_args!(
+            return Err(self.error(format_args!(
                 "entry block {} is out of bounds (only {} blocks exist)",
                 self.cfg.entry, block_count
-            ));
+            )));
         }
 
         for (expected, block) in self.cfg.blocks().iter().enumerate() {
             if block.id.as_u32() as usize != expected {
-                self.fail(format_args!(
+                return Err(self.error(format_args!(
                     "block table slot {} contains mismatched id {}",
                     expected, block.id
-                ));
+                )));
             }
             for (index, &(value, stored_ty)) in block.params.iter().enumerate() {
                 self.attach(
                     value,
                     Attachment::Param { block: block.id },
                     "block parameter",
-                );
-                let inst = self.inst(value, block.id, "block parameter");
+                )?;
+                let inst = self.inst(value, block.id, "block parameter")?;
                 match inst.data {
                     CfgInstData::BlockParam { index: actual } if actual == index as u32 => {}
-                    CfgInstData::BlockParam { index: actual } => self.fail(format_args!(
+                    CfgInstData::BlockParam { index: actual } => return Err(self.error(format_args!(
                         "block parameter {} in block {} is stored at index {} but declares index {}",
                         value, block.id, index, actual
-                    )),
-                    ref other => self.fail(format_args!(
+                    ))),
+                    ref other => {
+                        return Err(self.error(format_args!(
                         "block parameter {} in block {} has non-BlockParam data {:?}",
                         value, block.id, other
-                    )),
+                    )))
+                    }
                 }
                 if inst.ty != stored_ty {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "block parameter {} in block {} stores type {:?} but its value has type {:?}",
                         value, block.id, stored_ty, inst.ty
-                    ));
+                    )));
                 }
             }
             for (position, &value) in block.insts.iter().enumerate() {
@@ -333,15 +391,15 @@ impl<'a> Verifier<'a> {
                         position,
                     },
                     "instruction",
-                );
+                )?;
                 if matches!(
-                    self.inst(value, block.id, "instruction").data,
+                    self.inst(value, block.id, "instruction")?.data,
                     CfgInstData::BlockParam { .. }
                 ) {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "ordinary instruction {} in block {} has BlockParam data",
                         value, block.id
-                    ));
+                    )));
                 }
             }
         }
@@ -349,34 +407,41 @@ impl<'a> Verifier<'a> {
         if self.require_complete_attachments {
             for (index, attachment) in self.attachments.iter().enumerate() {
                 if attachment.is_none() {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "value v{} is unattached (every value must be exactly one block parameter or ordinary instruction)",
                         index
-                    ));
+                    )));
                 }
             }
         }
+        Ok(())
     }
 
-    fn attach(&mut self, value: CfgValue, attachment: Attachment, role: &str) {
+    fn attach(
+        &mut self,
+        value: CfgValue,
+        attachment: Attachment,
+        role: &str,
+    ) -> Result<(), CfgVerificationError> {
         let index = value.as_u32() as usize;
         if index >= self.attachments.len() {
-            self.fail(format_args!(
+            return Err(self.error(format_args!(
                 "{} {} references an undefined value (only {} values exist)",
                 role,
                 value,
                 self.attachments.len()
-            ));
+            )));
         }
         if let Some(previous) = self.attachments[index] {
-            self.fail(format_args!(
+            return Err(self.error(format_args!(
                 "value {} has duplicate attachments ({}, then {})",
                 value,
                 Self::attachment_name(previous),
                 Self::attachment_name(attachment)
-            ));
+            )));
         }
         self.attachments[index] = Some(attachment);
+        Ok(())
     }
 
     fn attachment_name(attachment: Attachment) -> String {
@@ -388,194 +453,122 @@ impl<'a> Verifier<'a> {
         }
     }
 
-    fn inst(&self, value: CfgValue, block: BlockId, role: &str) -> &crate::inst::CfgInst {
+    fn inst(
+        &self,
+        value: CfgValue,
+        block: BlockId,
+        role: &str,
+    ) -> Result<&crate::inst::CfgInst, CfgVerificationError> {
         if value.as_u32() as usize >= self.cfg.value_count() {
-            self.fail(format_args!(
+            return Err(self.error(format_args!(
                 "{} {} in block {} is undefined (only {} values exist)",
                 role,
                 value,
                 block,
                 self.cfg.value_count()
-            ));
+            )));
         }
-        self.cfg.get_inst(value)
+        Ok(self.cfg.get_inst(value))
     }
 
-    fn verify_targets_and_slices(&self) {
+    fn verify_targets_and_slices(&self) -> Result<(), CfgVerificationError> {
         for block in self.cfg.blocks() {
             for &value in &block.insts {
-                let data = &self.inst(value, block.id, "instruction").data;
+                let data = &self.inst(value, block.id, "instruction")?.data;
+                let location = CfgVerificationLocation::Instruction {
+                    block: block.id,
+                    value,
+                };
                 match data {
-                    CfgInstData::Call {
-                        args_start,
-                        args_len,
-                        ..
-                    } => self.check_range(
-                        *args_start,
-                        *args_len,
-                        self.cfg.call_args_len(),
-                        block.id,
-                        value,
-                        "call-argument",
-                    ),
-                    CfgInstData::Intrinsic {
-                        args_start,
-                        args_len,
-                        ..
-                    } => self.check_extra(*args_start, *args_len, block.id, value, "intrinsic"),
-                    CfgInstData::StructInit {
-                        fields_start,
-                        fields_len,
-                        ..
-                    } => self.check_extra(
-                        *fields_start,
-                        *fields_len,
-                        block.id,
-                        value,
-                        "struct fields",
-                    ),
-                    CfgInstData::ArrayInit {
-                        elements_start,
-                        elements_len,
-                    } => self.check_extra(
-                        *elements_start,
-                        *elements_len,
-                        block.id,
-                        value,
-                        "array elements",
-                    ),
-                    CfgInstData::EnumVariant {
-                        payload_start,
-                        payload_len,
-                        ..
-                    } => self.check_extra(
-                        *payload_start,
-                        *payload_len,
-                        block.id,
-                        value,
-                        "enum payload",
-                    ),
+                    CfgInstData::Call { args, .. } => {
+                        self.cfg
+                            .checked_call_args(args)
+                            .map_err(|error| self.payload_error(location, error))?;
+                    }
+                    CfgInstData::Intrinsic { args, .. } => {
+                        self.cfg
+                            .checked_intrinsic_args(args)
+                            .map_err(|error| self.payload_error(location, error))?;
+                    }
+                    CfgInstData::StructInit { fields, .. } => {
+                        self.cfg
+                            .checked_struct_fields(fields)
+                            .map_err(|error| self.payload_error(location, error))?;
+                    }
+                    CfgInstData::ArrayInit { elements } => {
+                        self.cfg
+                            .checked_array_elements(elements)
+                            .map_err(|error| self.payload_error(location, error))?;
+                    }
+                    CfgInstData::EnumVariant { payload, .. } => {
+                        self.cfg
+                            .checked_enum_payload(payload)
+                            .map_err(|error| self.payload_error(location, error))?;
+                    }
                     CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } => {
-                        self.check_range(
-                            place.proj_start,
-                            place.proj_len,
-                            self.cfg.projections_len(),
-                            block.id,
-                            value,
-                            "projection",
-                        )
+                        self.cfg
+                            .checked_place_projections(place)
+                            .map_err(|error| self.payload_error(location, error))?;
                     }
                     _ => {}
                 }
             }
+            let location = CfgVerificationLocation::Terminator { block: block.id };
             match &block.terminator {
-                Terminator::Goto {
-                    target,
-                    args_start,
-                    args_len,
-                } => {
-                    self.check_target(block.id, *target, "goto");
-                    self.check_term_extra(*args_start, *args_len, block.id, "goto arguments");
+                Terminator::Goto { target, args } => {
+                    self.check_target(block.id, *target, "goto")?;
+                    self.cfg
+                        .checked_goto_args(args)
+                        .map_err(|error| self.payload_error(location, error))?;
                 }
                 Terminator::Branch {
                     then_block,
-                    then_args_start,
-                    then_args_len,
+                    then_args,
                     else_block,
-                    else_args_start,
-                    else_args_len,
+                    else_args,
                     ..
                 } => {
-                    self.check_target(block.id, *then_block, "branch then");
-                    self.check_target(block.id, *else_block, "branch else");
-                    self.check_term_extra(
-                        *then_args_start,
-                        *then_args_len,
-                        block.id,
-                        "branch then arguments",
-                    );
-                    self.check_term_extra(
-                        *else_args_start,
-                        *else_args_len,
-                        block.id,
-                        "branch else arguments",
-                    );
+                    self.check_target(block.id, *then_block, "branch then")?;
+                    self.check_target(block.id, *else_block, "branch else")?;
+                    self.cfg
+                        .checked_then_args(then_args)
+                        .map_err(|error| self.payload_error(location, error))?;
+                    self.cfg
+                        .checked_else_args(else_args)
+                        .map_err(|error| self.payload_error(location, error))?;
                 }
-                Terminator::Switch {
-                    cases_start,
-                    cases_len,
-                    default,
-                    ..
-                } => {
-                    self.check_range(
-                        *cases_start,
-                        *cases_len,
-                        self.cfg.switch_cases_len(),
-                        block.id,
-                        CfgValue::from_raw(0),
-                        "switch-case",
-                    );
-                    for &(_, target) in self.cfg.get_switch_cases(*cases_start, *cases_len) {
-                        self.check_target(block.id, target, "switch case");
+                Terminator::Switch { cases, default, .. } => {
+                    let cases = self
+                        .cfg
+                        .checked_switch_cases(cases)
+                        .map_err(|error| self.payload_error(location, error))?;
+                    for &(_, target) in cases {
+                        self.check_target(block.id, target, "switch case")?;
                     }
-                    self.check_target(block.id, *default, "switch default");
+                    self.check_target(block.id, *default, "switch default")?;
                 }
                 Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
             }
         }
+        Ok(())
     }
 
-    fn check_target(&self, from: BlockId, target: BlockId, role: &str) {
+    fn check_target(
+        &self,
+        from: BlockId,
+        target: BlockId,
+        role: &str,
+    ) -> Result<(), CfgVerificationError> {
         if target.as_u32() as usize >= self.cfg.block_count() {
-            self.fail(format_args!(
+            return Err(self.error(format_args!(
                 "{} target {} from block {} is out of bounds (only {} blocks exist)",
                 role,
                 target,
                 from,
                 self.cfg.block_count()
-            ));
+            )));
         }
-    }
-
-    fn check_extra(&self, start: u32, len: u32, block: BlockId, value: CfgValue, role: &str) {
-        self.check_range(start, len, self.cfg.extra_len(), block, value, role);
-    }
-
-    fn check_term_extra(&self, start: u32, len: u32, block: BlockId, role: &str) {
-        let end = start.checked_add(len).map(|v| v as usize);
-        if end.is_none_or(|end| start as usize > end || end > self.cfg.extra_len()) {
-            self.fail(format_args!(
-                "{} in terminator of block {} uses out-of-bounds slice {}..{} (storage length {})",
-                role,
-                block,
-                start,
-                end.map_or_else(|| "overflow".to_string(), |v| v.to_string()),
-                self.cfg.extra_len()
-            ));
-        }
-    }
-
-    fn check_range(
-        &self,
-        start: u32,
-        len: u32,
-        storage_len: usize,
-        block: BlockId,
-        value: CfgValue,
-        role: &str,
-    ) {
-        let end = start.checked_add(len).map(|v| v as usize);
-        if end.is_none_or(|end| start as usize > end || end > storage_len) {
-            self.fail(format_args!(
-                "{} slice for instruction {} in block {} is out of bounds: {}..{} (storage length {})",
-                role,
-                value,
-                block,
-                start,
-                end.map_or_else(|| "overflow".to_string(), |v| v.to_string()),
-                storage_len
-            ));
-        }
+        Ok(())
     }
 
     fn compute_reachability(&mut self) {
@@ -601,13 +594,8 @@ impl<'a> Verifier<'a> {
                 f(*then_block);
                 f(*else_block);
             }
-            Terminator::Switch {
-                cases_start,
-                cases_len,
-                default,
-                ..
-            } => {
-                for &(_, target) in self.cfg.get_switch_cases(*cases_start, *cases_len) {
+            Terminator::Switch { cases, default, .. } => {
+                for &(_, target) in self.cfg.switch_cases(cases) {
                     f(target);
                 }
                 f(*default);
@@ -669,64 +657,80 @@ impl<'a> Verifier<'a> {
         }
     }
 
-    fn verify_inst(&self, block: BlockId, position: usize, value: CfgValue) {
-        let inst = self.inst(value, block, "instruction");
+    fn verify_inst(
+        &self,
+        block: BlockId,
+        position: usize,
+        value: CfgValue,
+    ) -> Result<(), CfgVerificationError> {
+        let inst = self.inst(value, block, "instruction")?;
         match &inst.data {
             CfgInstData::Param { index } => {
-                self.check_param_slot(*index, inst.ty, block, value, "Param")
+                self.check_param_slot(*index, inst.ty, block, value, "Param")?
             }
             CfgInstData::Alloc { slot, init } => self.check_local_slot(
                 *slot,
-                self.inst(*init, block, "allocation initializer").ty,
+                self.inst(*init, block, "allocation initializer")?.ty,
                 block,
                 value,
                 "Alloc",
-            ),
+            )?,
             CfgInstData::Load { slot } => {
-                self.check_local_slot(*slot, inst.ty, block, value, "Load")
+                self.check_local_slot(*slot, inst.ty, block, value, "Load")?
             }
             CfgInstData::Store {
                 slot,
                 value: stored,
             } => self.check_local_slot(
                 *slot,
-                self.inst(*stored, block, "stored value").ty,
+                self.inst(*stored, block, "stored value")?.ty,
                 block,
                 value,
                 "Store",
-            ),
+            )?,
             CfgInstData::StorageLive { slot, local_ty } => {
-                self.check_local_slot(*slot, *local_ty, block, value, "StorageLive")
+                self.check_local_slot(*slot, *local_ty, block, value, "StorageLive")?
             }
             CfgInstData::StorageDead { slot, local_ty } => {
-                self.check_local_slot(*slot, *local_ty, block, value, "StorageDead")
+                self.check_local_slot(*slot, *local_ty, block, value, "StorageDead")?
             }
             CfgInstData::ParamStore {
                 param_slot,
                 value: stored,
             } => self.check_param_slot(
                 *param_slot,
-                self.inst(*stored, block, "stored parameter value").ty,
+                self.inst(*stored, block, "stored parameter value")?.ty,
                 block,
                 value,
                 "ParamStore",
-            ),
+            )?,
             CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } => {
-                self.verify_place(block, value, place)
+                self.verify_place(block, value, place)?
             }
             CfgInstData::BlockParam { .. } => unreachable!(),
             _ => {}
         }
+        let mut operand_result = Ok(());
         self.for_each_inst_operand(block, value, &inst.data, |operand, role| {
-            self.verify_use(block, Some(position), operand, role)
+            if operand_result.is_ok() {
+                operand_result = self.verify_use(block, Some(position), operand, role);
+            }
         });
+        operand_result
     }
 
-    fn check_local_slot(&self, slot: u32, ty: Type, block: BlockId, value: CfgValue, role: &str) {
-        let width = self.abi_slot_count(ty, block, value, role);
+    fn check_local_slot(
+        &self,
+        slot: u32,
+        ty: Type,
+        block: BlockId,
+        value: CfgValue,
+        role: &str,
+    ) -> Result<(), CfgVerificationError> {
+        let width = self.abi_slot_count(ty, block, value, role)?;
         let end = slot.checked_add(width);
         if end.is_none_or(|end| end > self.cfg.num_locals()) {
-            self.fail(format_args!(
+            return Err(self.error(format_args!(
                 "{} instruction {} in block {} uses local slot range {}..{} for type {:?}, but only {} local slots exist",
                 role,
                 value,
@@ -735,22 +739,30 @@ impl<'a> Verifier<'a> {
                 end.map_or_else(|| "overflow".to_string(), |end| end.to_string()),
                 ty,
                 self.cfg.num_locals()
-            ));
+            )));
         }
+        Ok(())
     }
 
-    fn check_param_slot(&self, slot: u32, ty: Type, block: BlockId, value: CfgValue, role: &str) {
+    fn check_param_slot(
+        &self,
+        slot: u32,
+        ty: Type,
+        block: BlockId,
+        value: CfgValue,
+        role: &str,
+    ) -> Result<(), CfgVerificationError> {
         // Borrowed and inout parameters carry one physical pointer slot even
         // when their logical type is a multi-slot aggregate. Places retain the
         // logical type so projection validation can follow the pointee shape.
         let width = if self.cfg.is_param_by_ref(slot) {
             1
         } else {
-            self.abi_slot_count(ty, block, value, role)
+            self.abi_slot_count(ty, block, value, role)?
         };
         let end = slot.checked_add(width);
         if end.is_none_or(|end| end > self.cfg.num_params()) {
-            self.fail(format_args!(
+            return Err(self.error(format_args!(
                 "{} instruction {} in block {} uses parameter slot range {}..{} for type {:?}, but only {} parameter slots exist",
                 role,
                 value,
@@ -759,12 +771,19 @@ impl<'a> Verifier<'a> {
                 end.map_or_else(|| "overflow".to_string(), |end| end.to_string()),
                 ty,
                 self.cfg.num_params()
-            ));
+            )));
         }
+        Ok(())
     }
 
-    fn abi_slot_count(&self, ty: Type, block: BlockId, value: CfgValue, role: &str) -> u32 {
-        match ty.kind() {
+    fn abi_slot_count(
+        &self,
+        ty: Type,
+        block: BlockId,
+        value: CfgValue,
+        role: &str,
+    ) -> Result<u32, CfgVerificationError> {
+        let width = match ty.kind() {
             TypeKind::I8
             | TypeKind::I16
             | TypeKind::I32
@@ -780,52 +799,57 @@ impl<'a> Verifier<'a> {
             TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType | TypeKind::Module(_) => 0,
             TypeKind::Struct(struct_id) => {
                 let Some(pool) = self.type_pool else {
-                    return 0;
+                    return Ok(0);
                 };
                 let Some(def) = pool.try_struct_def(struct_id) else {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "{} instruction {} in block {} references invalid struct type {:?}",
                         role, value, block, struct_id
-                    ));
+                    )));
                 };
-                def.fields.iter().fold(0u32, |total, field| {
-                    total.saturating_add(self.abi_slot_count(field.ty, block, value, role))
-                })
+                let mut width = 0u32;
+                for field in &def.fields {
+                    width =
+                        width.saturating_add(self.abi_slot_count(field.ty, block, value, role)?);
+                }
+                width
             }
             TypeKind::Array(array_id) => {
                 let Some(pool) = self.type_pool else {
-                    return 0;
+                    return Ok(0);
                 };
                 let Some((element, len)) = pool.try_array_def(array_id) else {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "{} instruction {} in block {} references invalid array type {:?}",
                         role, value, block, array_id
-                    ));
+                    )));
                 };
-                let element_width = u64::from(self.abi_slot_count(element, block, value, role));
+                let element_width = u64::from(self.abi_slot_count(element, block, value, role)?);
                 u32::try_from(element_width.saturating_mul(len)).unwrap_or(u32::MAX)
             }
             TypeKind::Enum(enum_id) => {
                 let Some(pool) = self.type_pool else {
-                    return 0;
+                    return Ok(0);
                 };
                 let Some(def) = pool.try_enum_def(enum_id) else {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "{} instruction {} in block {} references invalid enum type {:?}",
                         role, value, block, enum_id
-                    ));
+                    )));
                 };
-                let payload_width = (0..def.variant_count())
-                    .map(|index| {
-                        def.variant_payload(index).iter().fold(0u32, |total, &ty| {
-                            total.saturating_add(self.abi_slot_count(ty, block, value, role))
-                        })
-                    })
-                    .max()
-                    .unwrap_or(0);
+                let mut payload_width = 0;
+                for index in 0..def.variant_count() {
+                    let mut variant_width = 0u32;
+                    for &payload_ty in def.variant_payload(index) {
+                        variant_width = variant_width
+                            .saturating_add(self.abi_slot_count(payload_ty, block, value, role)?);
+                    }
+                    payload_width = payload_width.max(variant_width);
+                }
                 1u32.saturating_add(payload_width)
             }
-        }
+        };
+        Ok(width)
     }
 
     fn is_fixed_str_to_view_coercion(&self, source: Type, result: Type) -> bool {
@@ -858,13 +882,18 @@ impl<'a> Verifier<'a> {
                 .all(|(source, result)| source.ty == result.ty)
     }
 
-    fn verify_place(&self, block: BlockId, value: CfgValue, place: &Place) {
+    fn verify_place(
+        &self,
+        block: BlockId,
+        value: CfgValue,
+        place: &Place,
+    ) -> Result<(), CfgVerificationError> {
         match place.base {
             PlaceBase::Local(slot) => {
-                self.check_local_slot(slot, place.base_type, block, value, "place")
+                self.check_local_slot(slot, place.base_type, block, value, "place")?
             }
             PlaceBase::Param(slot) => {
-                self.check_param_slot(slot, place.base_type, block, value, "place")
+                self.check_param_slot(slot, place.base_type, block, value, "place")?
             }
         }
         let projections = self.cfg.get_place_projections(place);
@@ -877,20 +906,20 @@ impl<'a> Verifier<'a> {
                         field_index,
                     } => {
                         let Some(def) = pool.try_struct_def(*struct_id) else {
-                            self.fail(format_args!(
+                            return Err(self.error(format_args!(
                                 "projection {} in place instruction {} in block {} references invalid struct id {:?}",
                                 projection_index, value, block, struct_id
-                            ));
+                            )));
                         };
                         let expected = Type::new_struct(*struct_id);
                         if current_ty != expected {
-                            self.fail(format_args!(
+                            return Err(self.error(format_args!(
                                 "projection {} in place instruction {} in block {} expects container type {:?}, but previous link produced {:?}",
                                 projection_index, value, block, expected, current_ty
-                            ));
+                            )));
                         }
                         let Some(field) = def.fields.get(*field_index as usize) else {
-                            self.fail(format_args!(
+                            return Err(self.error(format_args!(
                                 "projection {} in place instruction {} in block {} references field {} of struct {:?}, which has {} fields",
                                 projection_index,
                                 value,
@@ -898,28 +927,28 @@ impl<'a> Verifier<'a> {
                                 field_index,
                                 struct_id,
                                 def.fields.len()
-                            ));
+                            )));
                         };
                         field.ty
                     }
                     Projection::Index { array_type, .. } => {
                         let TypeKind::Array(array_id) = array_type.kind() else {
-                            self.fail(format_args!(
+                            return Err(self.error(format_args!(
                                 "projection {} in place instruction {} in block {} has non-array container type {:?}",
                                 projection_index, value, block, array_type
-                            ));
+                            )));
                         };
                         let Some((element_ty, _)) = pool.try_array_def(array_id) else {
-                            self.fail(format_args!(
+                            return Err(self.error(format_args!(
                                 "projection {} in place instruction {} in block {} references invalid array id {:?}",
                                 projection_index, value, block, array_id
-                            ));
+                            )));
                         };
                         if current_ty != *array_type {
-                            self.fail(format_args!(
+                            return Err(self.error(format_args!(
                                 "projection {} in place instruction {} in block {} expects container type {:?}, but previous link produced {:?}",
                                 projection_index, value, block, array_type, current_ty
-                            ));
+                            )));
                         }
                         element_ty
                     }
@@ -932,24 +961,24 @@ impl<'a> Verifier<'a> {
                     if inst.ty != current_ty
                         && !self.is_fixed_str_to_view_coercion(current_ty, inst.ty) =>
                 {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "place-read instruction {} in block {} has result type {:?}, but its projection chain produces {:?}",
                         value, block, inst.ty, current_ty
-                    ));
+                    )));
                 }
                 CfgInstData::PlaceWrite { value: stored, .. } => {
-                    let stored_ty = self.inst(*stored, block, "place-write value").ty;
+                    let stored_ty = self.inst(*stored, block, "place-write value")?.ty;
                     if stored_ty != current_ty {
-                        self.fail(format_args!(
+                        return Err(self.error(format_args!(
                             "place-write instruction {} in block {} stores type {:?}, but its projection chain produces {:?}",
                             value, block, stored_ty, current_ty
-                        ));
+                        )));
                     }
                     if inst.ty != Type::UNIT {
-                        self.fail(format_args!(
+                        return Err(self.error(format_args!(
                             "place-write instruction {} in block {} has result type {:?}, expected unit",
                             value, block, inst.ty
-                        ));
+                        )));
                     }
                 }
                 _ => {}
@@ -961,30 +990,30 @@ impl<'a> Verifier<'a> {
                 Projection::Field { struct_id, .. } => Type::new_struct(*struct_id),
                 Projection::Index { array_type, .. } => {
                     if !matches!(array_type.kind(), TypeKind::Array(_)) {
-                        self.fail(format_args!(
+                        return Err(self.error(format_args!(
                             "place in instruction {} in block {} has Index projection with non-array container type {:?}",
                             value, block, array_type
-                        ));
+                        )));
                     }
                     *array_type
                 }
             };
             if place.base_type != required {
-                self.fail(format_args!(
+                return Err(self.error(format_args!(
                     "place in instruction {} in block {} has logical base type {:?}, but its first projection requires base type {:?}",
                     value, block, place.base_type, required
-                ));
+                )));
             }
         }
         for projection in projections {
             if let Projection::Index { array_type, index } = projection {
                 if !matches!(array_type.kind(), TypeKind::Array(_)) {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "place in instruction {} in block {} has Index projection with non-array container type {:?}",
                         value, block, array_type
-                    ));
+                    )));
                 }
-                let index_ty = self.inst(*index, block, "projection index").ty;
+                let index_ty = self.inst(*index, block, "projection index")?.ty;
                 if !matches!(
                     index_ty.kind(),
                     TypeKind::I8
@@ -996,114 +1025,122 @@ impl<'a> Verifier<'a> {
                         | TypeKind::U32
                         | TypeKind::U64
                 ) {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "projection index {} used by instruction {} in block {} has non-integer type {:?}",
                         index, value, block, index_ty
-                    ));
+                    )));
                 }
             }
         }
+        Ok(())
     }
 
-    fn verify_terminator_use(&self, block: BlockId, term: &Terminator) {
+    fn verify_terminator_use(
+        &self,
+        block: BlockId,
+        term: &Terminator,
+    ) -> Result<(), CfgVerificationError> {
         match term {
             Terminator::Goto {
                 target,
-                args_start,
-                args_len,
+                args: _,
             } => {
-                let args = self.cfg.get_extra(*args_start, *args_len);
+                let args = self.cfg.get_goto_args(term);
                 for &arg in args {
-                    self.verify_use(block, None, arg, "goto argument");
+                    self.verify_use(block, None, arg, "goto argument")?;
                 }
-                self.verify_edge(block, *target, args);
+                self.verify_edge(block, *target, args)?;
             }
             Terminator::Branch {
                 cond,
                 then_block,
-                then_args_start,
-                then_args_len,
+                then_args: _,
                 else_block,
-                else_args_start,
-                else_args_len,
+                else_args: _,
             } => {
-                self.verify_use(block, None, *cond, "branch condition");
-                if self.inst(*cond, block, "branch condition").ty != Type::BOOL {
-                    self.fail(format_args!(
+                self.verify_use(block, None, *cond, "branch condition")?;
+                if self.inst(*cond, block, "branch condition")?.ty != Type::BOOL {
+                    return Err(self.error(format_args!(
                         "branch condition {} in block {} has type {:?}, expected bool",
                         cond,
                         block,
                         self.cfg.get_inst(*cond).ty
-                    ));
+                    )));
                 }
-                let then_args = self.cfg.get_extra(*then_args_start, *then_args_len);
+                let then_args = self.cfg.get_branch_then_args(term);
                 for &arg in then_args {
-                    self.verify_use(block, None, arg, "branch-then argument");
+                    self.verify_use(block, None, arg, "branch-then argument")?;
                 }
-                self.verify_edge(block, *then_block, then_args);
-                let else_args = self.cfg.get_extra(*else_args_start, *else_args_len);
+                self.verify_edge(block, *then_block, then_args)?;
+                let else_args = self.cfg.get_branch_else_args(term);
                 for &arg in else_args {
-                    self.verify_use(block, None, arg, "branch-else argument");
+                    self.verify_use(block, None, arg, "branch-else argument")?;
                 }
-                self.verify_edge(block, *else_block, else_args);
+                self.verify_edge(block, *else_block, else_args)?;
             }
             Terminator::Switch {
                 scrutinee,
-                cases_start,
-                cases_len,
+                cases,
                 default,
             } => {
-                self.verify_use(block, None, *scrutinee, "switch scrutinee");
-                for &(_, target) in self.cfg.get_switch_cases(*cases_start, *cases_len) {
-                    self.verify_edge(block, target, &[]);
+                self.verify_use(block, None, *scrutinee, "switch scrutinee")?;
+                for &(_, target) in self.cfg.switch_cases(cases) {
+                    self.verify_edge(block, target, &[])?;
                 }
-                self.verify_edge(block, *default, &[]);
+                self.verify_edge(block, *default, &[])?;
             }
             Terminator::Return { value } => match (self.cfg.return_type(), value) {
                 (Type::UNIT, None) => {}
-                (Type::UNIT, Some(value)) => self.fail(format_args!(
+                (Type::UNIT, Some(value)) => return Err(self.error(format_args!(
                     "return in block {} supplies unit value {}; unit-returning functions must use Return {{ value: None }}",
                     block, value
-                )),
-                (return_ty, None) => self.fail(format_args!(
+                ))),
+                (return_ty, None) => return Err(self.error(format_args!(
                     "return in block {} has no value but function return type is {:?}",
                     block, return_ty
-                )),
+                ))),
                 (return_ty, Some(value)) => {
-                    self.verify_use(block, None, *value, "return value");
+                    self.verify_use(block, None, *value, "return value")?;
                     let value_ty = self.cfg.get_inst(*value).ty;
                     if value_ty != return_ty {
-                        self.fail(format_args!(
+                        return Err(self.error(format_args!(
                             "return value {} in block {} has type {:?}, expected {:?}",
                             value, block, value_ty, return_ty
-                        ));
+                        )));
                     }
                 }
             },
             Terminator::Unreachable | Terminator::None => {}
         }
+        Ok(())
     }
 
-    fn verify_edge(&self, from: BlockId, to: BlockId, args: &[CfgValue]) {
+    fn verify_edge(
+        &self,
+        from: BlockId,
+        to: BlockId,
+        args: &[CfgValue],
+    ) -> Result<(), CfgVerificationError> {
         let params = &self.cfg.get_block(to).params;
         if params.len() != args.len() {
-            self.fail(format_args!(
+            return Err(self.error(format_args!(
                 "edge {} -> {} passes {} block arguments but target expects {}",
                 from,
                 to,
                 args.len(),
                 params.len()
-            ));
+            )));
         }
         for (index, (&arg, &(_, param_ty))) in args.iter().zip(params).enumerate() {
             let arg_ty = self.cfg.get_inst(arg).ty;
             if arg_ty != param_ty {
-                self.fail(format_args!(
+                return Err(self.error(format_args!(
                     "edge {} -> {} argument {} ({}) has type {:?}, target parameter has type {:?} (ill-typed edge)",
                     from, to, index, arg, arg_ty, param_ty
-                ));
+                )));
             }
         }
+        Ok(())
     }
 
     fn verify_use(
@@ -1112,22 +1149,22 @@ impl<'a> Verifier<'a> {
         use_position: Option<usize>,
         value: CfgValue,
         role: &str,
-    ) {
-        let _ = self.inst(value, use_block, role);
+    ) -> Result<(), CfgVerificationError> {
+        let _ = self.inst(value, use_block, role)?;
         let Some(attachment) = self.attachments[value.as_u32() as usize] else {
-            self.fail(format_args!(
+            return Err(self.error(format_args!(
                 "{} {} in block {} refers to an unattached value",
                 role, value, use_block
-            ));
+            )));
         };
         match attachment {
             Attachment::Param { block } if block == use_block => {}
             Attachment::Inst { block, position } if block == use_block => {
                 if use_position.is_some_and(|use_position| position >= use_position) {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "{} {} in block {} is used before its definition at instruction position {}",
                         role, value, use_block, position
-                    ));
+                    )));
                 }
             }
             Attachment::Param { block: def_block }
@@ -1138,13 +1175,14 @@ impl<'a> Verifier<'a> {
                 if self.reachable[use_index]
                     && !self.dominators[use_index][def_block.as_u32() as usize]
                 {
-                    self.fail(format_args!(
+                    return Err(self.error(format_args!(
                         "{} {} in reachable block {} is defined in block {}, which does not dominate the use",
                         role, value, use_block, def_block
-                    ));
+                    )));
                 }
             }
         }
+        Ok(())
     }
 
     fn for_each_inst_operand(
@@ -1207,47 +1245,28 @@ impl<'a> Verifier<'a> {
                 }
                 f(*value, "place-write value");
             }
-            CfgInstData::Call {
-                args_start,
-                args_len,
-                ..
-            } => {
-                for arg in self.cfg.get_call_args(*args_start, *args_len) {
+            CfgInstData::Call { args, .. } => {
+                for arg in self.cfg.call_args(args) {
                     f(arg.value, "call argument");
                 }
             }
-            CfgInstData::Intrinsic {
-                args_start,
-                args_len,
-                ..
-            } => {
-                for &operand in self.cfg.get_extra(*args_start, *args_len) {
+            CfgInstData::Intrinsic { args, .. } => {
+                for &operand in self.cfg.intrinsic_args(args) {
                     f(operand, "intrinsic argument");
                 }
             }
-            CfgInstData::StructInit {
-                fields_start,
-                fields_len,
-                ..
-            } => {
-                for &operand in self.cfg.get_extra(*fields_start, *fields_len) {
+            CfgInstData::StructInit { fields, .. } => {
+                for &operand in self.cfg.struct_fields(fields) {
                     f(operand, "struct field");
                 }
             }
-            CfgInstData::ArrayInit {
-                elements_start,
-                elements_len,
-            } => {
-                for &operand in self.cfg.get_extra(*elements_start, *elements_len) {
+            CfgInstData::ArrayInit { elements } => {
+                for &operand in self.cfg.array_elements(elements) {
                     f(operand, "array element");
                 }
             }
-            CfgInstData::EnumVariant {
-                payload_start,
-                payload_len,
-                ..
-            } => {
-                for &operand in self.cfg.get_extra(*payload_start, *payload_len) {
+            CfgInstData::EnumVariant { payload, .. } => {
+                for &operand in self.cfg.enum_payload(payload) {
                     f(operand, "enum payload");
                 }
             }
@@ -1262,9 +1281,9 @@ impl<'a> Verifier<'a> {
 #[cfg(test)]
 mod tests {
     use crate::inst::{
-        BlockId, Cfg, CfgInst, CfgInstData, Place, PlaceBase, Projection, Terminator,
+        BlockId, Cfg, CfgInst, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator,
     };
-    use crate::{OptLevel, opt};
+    use crate::{CfgVerificationLocation, OptLevel, opt};
     use lasso::ThreadedRodeo;
     use rue_air::{FrozenTypeInternPool, StructDef, StructField, StructId, Type, TypeInternPool};
     use rue_span::Span;
@@ -1316,21 +1335,23 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Return { value: Some(v) });
-        cfg.verify(); // must not panic
+        cfg.verify().unwrap(); // must not panic
     }
 
     fn cfg_with_field_place(base_type: Type, struct_id: StructId) -> Cfg {
         let mut cfg = Cfg::new(Type::I32, 1, 0, "field_place".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            base_type,
-            [Projection::Field {
-                struct_id,
-                field_index: 0,
-            }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                base_type,
+                [Projection::Field {
+                    struct_id,
+                    field_index: 0,
+                }],
+            )
+            .unwrap();
         let read = cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -1348,7 +1369,9 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let struct_id = register_struct(&pool, &interner, "FieldBase", &[Type::I32]);
-        cfg_with_field_place(Type::new_struct(struct_id), struct_id).verify();
+        cfg_with_field_place(Type::new_struct(struct_id), struct_id)
+            .verify()
+            .unwrap();
     }
 
     #[test]
@@ -1357,7 +1380,7 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let struct_id = register_struct(&pool, &interner, "WrongBase", &[Type::I32]);
-        cfg_with_field_place(Type::I32, struct_id).verify();
+        cfg_with_field_place(Type::I32, struct_id).verify().unwrap();
     }
 
     #[test]
@@ -1385,11 +1408,13 @@ mod tests {
         let array_type = TypeInternPool::new()
             .try_intern_array(Type::I32, 1)
             .unwrap();
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            Type::I32,
-            [Projection::Index { array_type, index }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                Type::I32,
+                [Projection::Index { array_type, index }],
+            )
+            .unwrap();
         cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -1400,7 +1425,7 @@ mod tests {
         );
         cfg.set_terminator(entry, Terminator::Return { value: None });
 
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1417,14 +1442,16 @@ mod tests {
                 span: Span::new(0, 1),
             },
         );
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            Type::I32,
-            [Projection::Index {
-                array_type: Type::I32,
-                index,
-            }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                Type::I32,
+                [Projection::Index {
+                    array_type: Type::I32,
+                    index,
+                }],
+            )
+            .unwrap();
         let read = cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -1435,7 +1462,7 @@ mod tests {
         );
         cfg.set_terminator(entry, Terminator::Return { value: Some(read) });
 
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1453,7 +1480,7 @@ mod tests {
             },
         );
         // Deliberately leave the reachable entry block with Terminator::None.
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1472,7 +1499,7 @@ mod tests {
         cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
         // An orphan block, never wired in, with no terminator: must be skipped.
         let _orphan = cfg.new_block();
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1490,11 +1517,10 @@ mod tests {
             entry,
             Terminator::Goto {
                 target,
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     /// Build `entry --goto(one arg of `arg_ty`)--> target(param: i32)`.
@@ -1513,28 +1539,21 @@ mod tests {
                 span: Span::new(0, 1),
             },
         );
-        let (args_start, args_len) = cfg.push_extra(vec![arg]);
-        cfg.set_terminator(
-            entry,
-            Terminator::Goto {
-                target,
-                args_start,
-                args_len,
-            },
-        );
+        let args = cfg.push_goto_args(vec![arg]).unwrap();
+        cfg.set_terminator(entry, Terminator::Goto { target, args });
         cfg
     }
 
     #[test]
     fn verify_accepts_well_typed_edge() {
-        cfg_with_typed_edge(Type::I32).verify(); // must not panic
+        cfg_with_typed_edge(Type::I32).verify().unwrap(); // must not panic
     }
 
     #[test]
     #[should_panic(expected = "ill-typed edge")]
     fn verify_catches_edge_type_mismatch() {
         // The RUE-347 shape: a unit value passed into an i32 block parameter.
-        cfg_with_typed_edge(Type::UNIT).verify();
+        cfg_with_typed_edge(Type::UNIT).verify().unwrap();
     }
 
     #[test]
@@ -1572,16 +1591,15 @@ mod tests {
                 span: Span::new(0, 1),
             },
         );
-        let (args_start, args_len) = cfg.push_extra(vec![arg]);
+        let args = cfg.push_goto_args(vec![arg]).unwrap();
         cfg.set_terminator(
             orphan_from,
             Terminator::Goto {
                 target: orphan_to,
-                args_start,
-                args_len,
+                args,
             },
         );
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1596,7 +1614,7 @@ mod tests {
             span: Span::new(0, 0),
         });
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1615,7 +1633,7 @@ mod tests {
         );
         cfg.get_block_mut(entry).insts.push(value);
         cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1627,7 +1645,7 @@ mod tests {
         let param = cfg.add_block_param(entry, Type::I32);
         cfg.get_inst_mut(param).data = CfgInstData::BlockParam { index: 1 };
         cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1639,7 +1657,7 @@ mod tests {
         let param = cfg.add_block_param(entry, Type::I32);
         cfg.get_inst_mut(param).data = CfgInstData::Const(0);
         cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1651,7 +1669,7 @@ mod tests {
         let param = cfg.add_block_param(entry, Type::I32);
         cfg.get_block_mut(entry).params[0].1 = Type::U64;
         cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1683,7 +1701,7 @@ mod tests {
                 value: Some(earlier),
             },
         );
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1707,11 +1725,9 @@ mod tests {
             Terminator::Branch {
                 cond,
                 then_block: left,
-                then_args_start: 0,
-                then_args_len: 0,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
                 else_block: right,
-                else_args_start: 0,
-                else_args_len: 0,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
             },
         );
         let value = cfg.add_inst_to_block(
@@ -1724,7 +1740,7 @@ mod tests {
         );
         cfg.set_terminator(left, Terminator::Return { value: Some(value) });
         cfg.set_terminator(right, Terminator::Return { value: Some(value) });
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1747,15 +1763,13 @@ mod tests {
             Terminator::Branch {
                 cond,
                 then_block: target,
-                then_args_start: 0,
-                then_args_len: 0,
+                then_args: crate::payload::CfgThenArgs::EMPTY,
                 else_block: target,
-                else_args_start: 0,
-                else_args_len: 0,
+                else_args: crate::payload::CfgElseArgs::EMPTY,
             },
         );
         cfg.set_terminator(target, Terminator::Unreachable);
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1765,7 +1779,7 @@ mod tests {
         let entry = cfg.new_block();
         cfg.entry = entry;
         cfg.set_terminator(entry, Terminator::Return { value: None });
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1783,7 +1797,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Return { value: Some(value) });
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1792,7 +1806,7 @@ mod tests {
         let mut cfg = unit_cfg();
         cfg.new_block();
         cfg.entry = BlockId::from_raw(7);
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1805,11 +1819,10 @@ mod tests {
             entry,
             Terminator::Goto {
                 target: BlockId::from_raw(9),
-                args_start: 0,
-                args_len: 0,
+                args: crate::payload::CfgGotoArgs::EMPTY,
             },
         );
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -1836,7 +1849,8 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
-        cfg.verify_with_type_pool(&FrozenTypeInternPool::new());
+        cfg.verify_with_type_pool(&FrozenTypeInternPool::new())
+            .unwrap();
     }
 
     #[test]
@@ -1854,7 +1868,8 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify_with_type_pool(&FrozenTypeInternPool::new());
+        cfg.verify_with_type_pool(&FrozenTypeInternPool::new())
+            .unwrap();
     }
 
     #[test]
@@ -1876,7 +1891,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify_with_type_pool(&pool);
+        cfg.verify_with_type_pool(&pool).unwrap();
     }
 
     #[test]
@@ -1889,14 +1904,16 @@ mod tests {
         let mut cfg = Cfg::new(Type::UNIT, 0, 1, "borrowed_pair".to_string(), vec![true]);
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let place = cfg.make_place(
-            PlaceBase::Param(0),
-            pair_ty,
-            [Projection::Field {
-                struct_id: pair,
-                field_index: 1,
-            }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Param(0),
+                pair_ty,
+                [Projection::Field {
+                    struct_id: pair,
+                    field_index: 1,
+                }],
+            )
+            .unwrap();
         cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -1906,7 +1923,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Return { value: None });
-        cfg.verify_with_type_pool(&pool);
+        cfg.verify_with_type_pool(&pool).unwrap();
     }
 
     #[test]
@@ -1919,14 +1936,16 @@ mod tests {
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "invalid_struct".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            Type::I32,
-            [Projection::Field {
-                struct_id: foreign_struct,
-                field_index: 0,
-            }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                Type::I32,
+                [Projection::Field {
+                    struct_id: foreign_struct,
+                    field_index: 0,
+                }],
+            )
+            .unwrap();
         cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -1936,7 +1955,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify_with_type_pool(&pool);
+        cfg.verify_with_type_pool(&pool).unwrap();
     }
 
     #[test]
@@ -1957,11 +1976,13 @@ mod tests {
                 span: Span::new(0, 0),
             },
         );
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            Type::I32,
-            [Projection::Index { array_type, index }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                Type::I32,
+                [Projection::Index { array_type, index }],
+            )
+            .unwrap();
         cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -1971,7 +1992,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify_with_type_pool(&pool);
+        cfg.verify_with_type_pool(&pool).unwrap();
     }
 
     #[test]
@@ -1985,14 +2006,16 @@ mod tests {
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "bad_field".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            record_ty,
-            [Projection::Field {
-                struct_id: record,
-                field_index: 1,
-            }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                record_ty,
+                [Projection::Field {
+                    struct_id: record,
+                    field_index: 1,
+                }],
+            )
+            .unwrap();
         cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -2002,7 +2025,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify_with_type_pool(&pool);
+        cfg.verify_with_type_pool(&pool).unwrap();
     }
 
     #[test]
@@ -2017,20 +2040,22 @@ mod tests {
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "broken_chain".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            Type::new_struct(outer),
-            [
-                Projection::Field {
-                    struct_id: outer,
-                    field_index: 0,
-                },
-                Projection::Field {
-                    struct_id: wrong,
-                    field_index: 0,
-                },
-            ],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                Type::new_struct(outer),
+                [
+                    Projection::Field {
+                        struct_id: outer,
+                        field_index: 0,
+                    },
+                    Projection::Field {
+                        struct_id: wrong,
+                        field_index: 0,
+                    },
+                ],
+            )
+            .unwrap();
         cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -2040,7 +2065,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify_with_type_pool(&pool);
+        cfg.verify_with_type_pool(&pool).unwrap();
     }
 
     #[test]
@@ -2053,14 +2078,16 @@ mod tests {
         let mut cfg = Cfg::new(Type::UNIT, 1, 0, "bad_result".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            Type::new_struct(record),
-            [Projection::Field {
-                struct_id: record,
-                field_index: 0,
-            }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                Type::new_struct(record),
+                [Projection::Field {
+                    struct_id: record,
+                    field_index: 0,
+                }],
+            )
+            .unwrap();
         cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -2070,11 +2097,10 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify_with_type_pool(&pool);
+        cfg.verify_with_type_pool(&pool).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "array elements slice")]
     fn verify_rejects_invalid_extra_slice_before_slicing() {
         let mut cfg = unit_cfg();
         let entry = cfg.new_block();
@@ -2083,19 +2109,25 @@ mod tests {
             entry,
             CfgInst {
                 data: CfgInstData::ArrayInit {
-                    elements_start: u32::MAX,
-                    elements_len: 2,
+                    elements: crate::payload::CfgArrayElements::malformed(u32::MAX, 2),
                 },
                 ty: Type::I32,
                 span: Span::new(0, 0),
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify();
+        let error = cfg.verify().unwrap_err();
+        assert_eq!(error.payload().unwrap().family(), "array elements");
+        assert_eq!(
+            error.location(),
+            CfgVerificationLocation::Instruction {
+                block: entry,
+                value: CfgValue::from_raw(0),
+            }
+        );
     }
 
     #[test]
-    #[should_panic(expected = "call-argument slice")]
     fn verify_rejects_invalid_call_argument_slice_before_slicing() {
         let mut cfg = unit_cfg();
         let entry = cfg.new_block();
@@ -2106,19 +2138,25 @@ mod tests {
                 data: CfgInstData::Call {
                     runtime: None,
                     name: lasso::Spur::default(),
-                    args_start: 1,
-                    args_len: 1,
+                    args: crate::payload::CfgCallArgs::malformed(1, 1),
                 },
                 ty: Type::I32,
                 span: Span::new(0, 0),
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify();
+        let error = cfg.verify().unwrap_err();
+        assert_eq!(error.payload().unwrap().family(), "call arguments");
+        assert_eq!(
+            error.location(),
+            CfgVerificationLocation::Instruction {
+                block: entry,
+                value: CfgValue::from_raw(0),
+            }
+        );
     }
 
     #[test]
-    #[should_panic(expected = "switch-case slice")]
     fn verify_rejects_invalid_switch_case_slice_before_slicing() {
         let mut cfg = unit_cfg();
         let entry = cfg.new_block();
@@ -2135,16 +2173,19 @@ mod tests {
             entry,
             Terminator::Switch {
                 scrutinee: value,
-                cases_start: 1,
-                cases_len: 1,
+                cases: crate::payload::CfgSwitchCases::malformed(1, 1),
                 default: entry,
             },
         );
-        cfg.verify();
+        let error = cfg.verify().unwrap_err();
+        assert_eq!(error.payload().unwrap().family(), "switch cases");
+        assert_eq!(
+            error.location(),
+            CfgVerificationLocation::Terminator { block: entry }
+        );
     }
 
     #[test]
-    #[should_panic(expected = "projection slice")]
     fn verify_rejects_invalid_projection_slice_before_slicing() {
         let mut cfg = Cfg::new(Type::I32, 1, 0, "projection_slice".to_string(), vec![]);
         let entry = cfg.new_block();
@@ -2156,8 +2197,7 @@ mod tests {
                     place: Place {
                         base: PlaceBase::Local(0),
                         base_type: Type::I32,
-                        proj_start: 1,
-                        proj_len: 1,
+                        projections: crate::payload::CfgProjections::malformed(1, 1),
                     },
                 },
                 ty: Type::I32,
@@ -2165,7 +2205,15 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify();
+        let error = cfg.verify().unwrap_err();
+        assert_eq!(error.payload().unwrap().family(), "projections");
+        assert_eq!(
+            error.location(),
+            CfgVerificationLocation::Instruction {
+                block: entry,
+                value: CfgValue::from_raw(0),
+            }
+        );
     }
 
     #[test]
@@ -2185,11 +2233,13 @@ mod tests {
         let array_type = TypeInternPool::new()
             .try_intern_array(Type::I32, 1)
             .unwrap();
-        let place = cfg.make_place(
-            PlaceBase::Local(0),
-            array_type,
-            [Projection::Index { array_type, index }],
-        );
+        let place = cfg
+            .make_place(
+                PlaceBase::Local(0),
+                array_type,
+                [Projection::Index { array_type, index }],
+            )
+            .unwrap();
         cfg.add_inst_to_block(
             entry,
             CfgInst {
@@ -2199,7 +2249,7 @@ mod tests {
             },
         );
         cfg.set_terminator(entry, Terminator::Unreachable);
-        cfg.verify();
+        cfg.verify().unwrap();
     }
 
     #[test]
@@ -2230,12 +2280,13 @@ mod tests {
                     value: Some(result),
                 },
             );
-            opt::optimize(&mut cfg, level, &FrozenTypeInternPool::new());
+            let pool = FrozenTypeInternPool::new();
+            let cfg = cfg.finish(&pool).unwrap();
+            opt::optimize(cfg, level, &pool).unwrap();
         }
     }
 
     #[test]
-    #[should_panic(expected = "is unattached")]
     fn o1_cannot_hide_unattached_value_with_dce() {
         let mut cfg = unit_cfg();
         let entry = cfg.new_block();
@@ -2259,6 +2310,7 @@ mod tests {
                 value: Some(result),
             },
         );
-        opt::optimize(&mut cfg, OptLevel::O1, &FrozenTypeInternPool::new());
+        let error = cfg.finish(&FrozenTypeInternPool::new()).unwrap_err();
+        assert!(error.to_string().contains("is unattached"));
     }
 }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2992,7 +2992,7 @@ mod tests {
 
         // Use host target for tests
         CfgLower::new(
-            &cfg_output.cfg,
+            cfg_output.cfg.as_ref().unwrap(),
             type_pool,
             &interner,
             Target::host().expect("test lowering requires a supported Rue host target"),

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -181,14 +181,9 @@ fn format_cfg_inst_data_impl(
         CfgInstData::ParamStore { param_slot, value } => {
             format!("param_store %{} = {}", param_slot, value)
         }
-        CfgInstData::Call {
-            runtime,
-            name,
-            args_start,
-            args_len,
-        } => {
+        CfgInstData::Call { runtime, name, .. } => {
             let args: Vec<String> = cfg
-                .get_call_args(*args_start, *args_len)
+                .get_call_args(data)
                 .iter()
                 .map(|a| format!("{}", a.value))
                 .collect();
@@ -200,14 +195,9 @@ fn format_cfg_inst_data_impl(
                 .unwrap_or(name);
             format!("call @{}({})", name, args.join(", "))
         }
-        CfgInstData::Intrinsic {
-            runtime,
-            name,
-            args_start,
-            args_len,
-        } => {
+        CfgInstData::Intrinsic { runtime, name, .. } => {
             let args: Vec<String> = cfg
-                .get_extra(*args_start, *args_len)
+                .get_intrinsic_args(data)
                 .iter()
                 .map(|v| format!("{}", v))
                 .collect();
@@ -219,13 +209,9 @@ fn format_cfg_inst_data_impl(
                 .unwrap_or_default();
             format!("{prefix}intrinsic @{}({})", name, args.join(", "))
         }
-        CfgInstData::StructInit {
-            struct_id,
-            fields_start,
-            fields_len,
-        } => {
+        CfgInstData::StructInit { struct_id, .. } => {
             let fields: Vec<String> = cfg
-                .get_extra(*fields_start, *fields_len)
+                .get_struct_fields(data)
                 .iter()
                 .map(|v| format!("{}", v))
                 .collect();

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -404,10 +404,10 @@ mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
     use rue_air::{Air, AirInst, AirInstData, FrozenTypeInternPool, Type, TypeInternPool};
-    use rue_cfg::{Cfg, CfgBuilder};
+    use rue_cfg::{CfgBuilder, ValidatedCfg};
     use rue_span::Span;
 
-    fn test_cfg() -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+    fn test_cfg() -> (ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
         let mut air = Air::new(Type::I32);
 
         let const_ref = air.add_inst(AirInst {
@@ -426,10 +426,10 @@ mod tests {
         let type_pool = FrozenTypeInternPool::new();
         let cfg_output =
             CfgBuilder::build(&air, 0, 0, "main", &type_pool, vec![], &interner, false);
-        (cfg_output.cfg, type_pool, interner)
+        (cfg_output.cfg.unwrap(), type_pool, interner)
     }
 
-    fn aggregate_cfg(len: u64) -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+    fn aggregate_cfg(len: u64) -> (ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
         let type_pool = TypeInternPool::new();
         let array_id = type_pool.intern_array_from_type(Type::I64, len);
         let type_pool = type_pool.freeze();
@@ -484,10 +484,10 @@ mod tests {
             &interner,
             false,
         );
-        (cfg_output.cfg, type_pool, interner)
+        (cfg_output.cfg.unwrap(), type_pool, interner)
     }
 
-    fn syscall_cfg() -> (Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+    fn syscall_cfg() -> (ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
         let type_pool = FrozenTypeInternPool::new();
         let interner = ThreadedRodeo::new();
         let mut air = Air::new(Type::I64);
@@ -524,7 +524,7 @@ mod tests {
             &interner,
             false,
         );
-        (cfg_output.cfg, type_pool, interner)
+        (cfg_output.cfg.unwrap(), type_pool, interner)
     }
 
     fn assert_same_machine_code(normal: &MachineCode, with_asm: &MachineCode) {

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -323,7 +323,7 @@ enum ProjectedAccess {
 mod tests {
     use lasso::ThreadedRodeo;
     use rue_air::{Sema, StructDef, StructField, Type, TypeInternPool};
-    use rue_cfg::{Cfg, CfgBuilder, CfgInst, CfgInstData, PlaceBase, Projection, Terminator};
+    use rue_cfg::{Cfg, CfgBuilder, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
     use rue_parser::Parser;
@@ -392,6 +392,7 @@ mod tests {
                 function.allow_unreachable_code,
             )
             .cfg
+            .unwrap()
         };
         let cfg = build_cfg("main");
 
@@ -500,29 +501,28 @@ mod tests {
         let mut indexed_cfg = Cfg::new(pair_ty, 1, 1, "indexed_pair_read".to_string(), vec![false]);
         let indexed_entry = indexed_cfg.new_block();
         indexed_cfg.entry = indexed_entry;
-        let index = indexed_cfg.add_inst(CfgInst {
-            data: CfgInstData::Param { index: 0 },
-            ty: Type::U64,
-            span: Span::new(0, 0),
-        });
-        let place = indexed_cfg.make_place(
-            PlaceBase::Local(0),
-            array_ty,
-            [Projection::Index {
-                array_type: array_ty,
-                index,
-            }],
+        let index = indexed_cfg.append_inst(
+            indexed_entry,
+            CfgInst {
+                data: CfgInstData::Param { index: 0 },
+                ty: Type::U64,
+                span: Span::new(0, 0),
+            },
         );
-        let read = indexed_cfg.add_inst(CfgInst {
-            data: CfgInstData::PlaceRead { place },
-            ty: pair_ty,
-            span: Span::new(0, 0),
-        });
-        indexed_cfg
-            .get_block_mut(indexed_entry)
-            .insts
-            .extend([index, read]);
-        indexed_cfg.set_terminator(indexed_entry, Terminator::Return { value: Some(read) });
+        let read = indexed_cfg
+            .append_place_read(
+                indexed_entry,
+                PlaceBase::Local(0),
+                array_ty,
+                [Projection::Index {
+                    array_type: array_ty,
+                    index,
+                }],
+                pair_ty,
+                Span::new(0, 0),
+            )
+            .unwrap();
+        indexed_cfg.set_return(indexed_entry, Some(read));
         let pair_x86 = X86CfgLower::new(&indexed_cfg, &synthetic_types, &interner)
             .lower()
             .expect("x86 indexed aggregate read should lower");

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -599,7 +599,7 @@ mod tests {
     use rue_cfg::CfgBuilder;
     use rue_span::Span;
 
-    fn create_simple_cfg() -> (rue_cfg::Cfg, FrozenTypeInternPool, ThreadedRodeo) {
+    fn create_simple_cfg() -> (rue_cfg::ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
         let mut air = Air::new(Type::I32);
 
         let const_ref = air.add_inst(AirInst {
@@ -618,7 +618,7 @@ mod tests {
         let type_pool = FrozenTypeInternPool::new();
         let cfg_output =
             CfgBuilder::build(&air, 0, 0, "test", &type_pool, vec![], &interner, false);
-        (cfg_output.cfg, type_pool, interner)
+        (cfg_output.cfg.unwrap(), type_pool, interner)
     }
 
     #[test]

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -361,43 +361,36 @@ pub fn plan_terminator<A: TerminatorAdapter>(
     fn_name: &str,
     ret_reg_budget: u32,
 ) -> TerminatorPlan {
-    match block.terminator {
-        Terminator::Goto {
-            target,
-            args_start,
-            args_len,
-        } => TerminatorPlan::Goto {
+    match &block.terminator {
+        Terminator::Goto { target, .. } => TerminatorPlan::Goto {
             edge: moves_for_edge(
                 ctx,
                 adapter,
-                ctx.cfg.get_extra(args_start, args_len),
-                target,
+                ctx.cfg.get_goto_args(&block.terminator),
+                *target,
                 block.id,
             ),
         },
         Terminator::Branch {
             cond,
             then_block,
-            then_args_start,
-            then_args_len,
             else_block,
-            else_args_start,
-            else_args_len,
+            ..
         } => {
-            let condition_plan = ValuePlan::for_value(ctx, cond);
-            let condition = adapter.materialize_value(cond, condition_plan).primary;
+            let condition_plan = ValuePlan::for_value(ctx, *cond);
+            let condition = adapter.materialize_value(*cond, condition_plan).primary;
             let then_edge = moves_for_edge(
                 ctx,
                 adapter,
-                ctx.cfg.get_extra(then_args_start, then_args_len),
-                then_block,
+                ctx.cfg.get_branch_then_args(&block.terminator),
+                *then_block,
                 block.id,
             );
             let mut else_edge = moves_for_edge(
                 ctx,
                 adapter,
-                ctx.cfg.get_extra(else_args_start, else_args_len),
-                else_block,
+                ctx.cfg.get_branch_else_args(&block.terminator),
+                *else_block,
                 block.id,
             );
             // A branch whose two arms name the next physical block still has
@@ -414,18 +407,15 @@ pub fn plan_terminator<A: TerminatorAdapter>(
             }
         }
         Terminator::Switch {
-            scrutinee,
-            cases_start,
-            cases_len,
-            default,
+            scrutinee, default, ..
         } => {
-            let value_plan = ValuePlan::for_value(ctx, scrutinee);
-            let scrutinee_vreg = adapter.materialize_value(scrutinee, value_plan).primary;
-            let ty = ctx.cfg.get_inst(scrutinee).ty;
+            let value_plan = ValuePlan::for_value(ctx, *scrutinee);
+            let scrutinee_vreg = adapter.materialize_value(*scrutinee, value_plan).primary;
+            let ty = ctx.cfg.get_inst(*scrutinee).ty;
             let width = value_plan::comparison_integer_width(ty);
             let cases = ctx
                 .cfg
-                .get_switch_cases(cases_start, cases_len)
+                .get_switch_cases(&block.terminator)
                 .iter()
                 .copied()
                 .map(|(value, target)| SwitchCasePlan { value, target })
@@ -434,12 +424,12 @@ pub fn plan_terminator<A: TerminatorAdapter>(
                 scrutinee: scrutinee_vreg,
                 width,
                 cases,
-                default,
+                default: *default,
             }
         }
         Terminator::Return { value } => {
             let mode = if fn_name == "main" {
-                let value = value.map(|value| {
+                let value = (*value).map(|value| {
                     let plan = ValuePlan::for_value(ctx, value);
                     adapter.materialize_value(value, plan).primary
                 });
@@ -464,7 +454,7 @@ pub fn plan_terminator<A: TerminatorAdapter>(
                 }
             } else {
                 ReturnMode::Function {
-                    value: value.map_or(ReturnValuePlan::ZeroSized, |value| {
+                    value: (*value).map_or(ReturnValuePlan::ZeroSized, |value| {
                         return_value(ctx, adapter, value, ret_reg_budget)
                     }),
                 }
@@ -584,7 +574,7 @@ mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
     use rue_air::{FrozenTypeInternPool, StructDef, StructField, TypeInternPool};
-    use rue_cfg::{Cfg, CfgInst, CfgInstData, Terminator};
+    use rue_cfg::{Cfg, CfgInst, CfgInstData};
     use rue_span::{FileId, Span};
     use rue_target::Target;
 
@@ -685,46 +675,13 @@ mod tests {
         let else_block = cfg.new_block();
         let join = cfg.new_block();
         cfg.entry = entry;
-        let condition =
-            cfg.add_inst_to_block(entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
-        let value = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(7), Type::I32));
+        let condition = cfg.append_inst(entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let value = cfg.append_inst(entry, inst(CfgInstData::Const(7), Type::I32));
         let join_value = cfg.add_block_param(join, Type::I32);
-        cfg.set_terminator(
-            entry,
-            Terminator::Branch {
-                cond: condition,
-                then_block,
-                then_args_start: 0,
-                then_args_len: 0,
-                else_block,
-                else_args_start: 0,
-                else_args_len: 0,
-            },
-        );
-        let (then_join_start, then_join_len) = cfg.push_extra([value]);
-        cfg.set_terminator(
-            then_block,
-            Terminator::Goto {
-                target: join,
-                args_start: then_join_start,
-                args_len: then_join_len,
-            },
-        );
-        let (else_join_start, else_join_len) = cfg.push_extra([value]);
-        cfg.set_terminator(
-            else_block,
-            Terminator::Goto {
-                target: join,
-                args_start: else_join_start,
-                args_len: else_join_len,
-            },
-        );
-        cfg.set_terminator(
-            join,
-            Terminator::Return {
-                value: Some(join_value),
-            },
-        );
+        cfg.set_branch(entry, condition, then_block, [], else_block, []);
+        cfg.set_goto(then_block, join, [value]);
+        cfg.set_goto(else_block, join, [value]);
+        cfg.set_return(join, Some(join_value));
         (cfg, pool, interner)
     }
 
@@ -735,31 +692,12 @@ mod tests {
         let entry = cfg.new_block();
         let target = cfg.new_block();
         cfg.entry = entry;
-        let condition =
-            cfg.add_inst_to_block(entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
-        let then_value = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(1), Type::I32));
-        let else_value = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(2), Type::I32));
+        let condition = cfg.append_inst(entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let then_value = cfg.append_inst(entry, inst(CfgInstData::Const(1), Type::I32));
+        let else_value = cfg.append_inst(entry, inst(CfgInstData::Const(2), Type::I32));
         let target_value = cfg.add_block_param(target, Type::I32);
-        let (then_args_start, then_args_len) = cfg.push_extra([then_value]);
-        let (else_args_start, else_args_len) = cfg.push_extra([else_value]);
-        cfg.set_terminator(
-            entry,
-            Terminator::Branch {
-                cond: condition,
-                then_block: target,
-                then_args_start,
-                then_args_len,
-                else_block: target,
-                else_args_start,
-                else_args_len,
-            },
-        );
-        cfg.set_terminator(
-            target,
-            Terminator::Return {
-                value: Some(target_value),
-            },
-        );
+        cfg.set_branch(entry, condition, target, [then_value], target, [else_value]);
+        cfg.set_return(target, Some(target_value));
         (cfg, pool, interner)
     }
 
@@ -771,35 +709,11 @@ mod tests {
         let body = cfg.new_block();
         let exit = cfg.new_block();
         cfg.entry = header;
-        let condition =
-            cfg.add_inst_to_block(header, inst(CfgInstData::BoolConst(true), Type::BOOL));
-        let result = cfg.add_inst_to_block(header, inst(CfgInstData::Const(1), Type::I32));
-        cfg.set_terminator(
-            header,
-            Terminator::Branch {
-                cond: condition,
-                then_block: body,
-                then_args_start: 0,
-                then_args_len: 0,
-                else_block: exit,
-                else_args_start: 0,
-                else_args_len: 0,
-            },
-        );
-        cfg.set_terminator(
-            body,
-            Terminator::Goto {
-                target: header,
-                args_start: 0,
-                args_len: 0,
-            },
-        );
-        cfg.set_terminator(
-            exit,
-            Terminator::Return {
-                value: Some(result),
-            },
-        );
+        let condition = cfg.append_inst(header, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let result = cfg.append_inst(header, inst(CfgInstData::Const(1), Type::I32));
+        cfg.set_branch(header, condition, body, [], exit, []);
+        cfg.set_goto(body, header, []);
+        cfg.set_return(exit, Some(result));
         (cfg, pool, interner)
     }
 
@@ -813,20 +727,15 @@ mod tests {
         let third = cfg.new_block();
         let default = cfg.new_block();
         cfg.entry = entry;
-        let scrutinee = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(u64::MAX), ty));
-        let (cases_start, cases_len) =
-            cfg.push_switch_cases([(-1, third), (7, first), (42, second)]);
-        cfg.set_terminator(
+        let scrutinee = cfg.append_inst(entry, inst(CfgInstData::Const(u64::MAX), ty));
+        cfg.set_switch(
             entry,
-            Terminator::Switch {
-                scrutinee,
-                cases_start,
-                cases_len,
-                default,
-            },
+            scrutinee,
+            [(-1, third), (7, first), (42, second)],
+            default,
         );
         for block in [first, second, third, default] {
-            cfg.set_terminator(block, Terminator::Return { value: None });
+            cfg.set_return(block, None);
         }
         (cfg, pool, interner)
     }
@@ -839,57 +748,26 @@ mod tests {
         let else_block = cfg.new_block();
         let cleanup = cfg.new_block();
         cfg.entry = entry;
-        let condition =
-            cfg.add_inst_to_block(entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
-        let left = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(3), Type::I32));
-        let right = cfg.add_inst_to_block(entry, inst(CfgInstData::Const(4), Type::I32));
-        let (fields_start, fields_len) = cfg.push_extra([left, right]);
-        let aggregate = cfg.add_inst_to_block(
-            entry,
-            inst(
-                CfgInstData::StructInit {
-                    struct_id: match aggregate_ty.kind() {
-                        rue_air::TypeKind::Struct(id) => id,
-                        _ => panic!("fixture aggregate must be a struct"),
-                    },
-                    fields_start,
-                    fields_len,
+        let condition = cfg.append_inst(entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let left = cfg.append_inst(entry, inst(CfgInstData::Const(3), Type::I32));
+        let right = cfg.append_inst(entry, inst(CfgInstData::Const(4), Type::I32));
+        let aggregate = cfg
+            .append_struct_init(
+                entry,
+                match aggregate_ty.kind() {
+                    rue_air::TypeKind::Struct(id) => id,
+                    _ => panic!("fixture aggregate must be a struct"),
                 },
+                [left, right],
                 aggregate_ty,
-            ),
-        );
+                Span::new(0, 0),
+            )
+            .unwrap();
         let _cleanup_param = cfg.add_block_param(cleanup, aggregate_ty);
-        cfg.set_terminator(
-            entry,
-            Terminator::Branch {
-                cond: condition,
-                then_block,
-                then_args_start: 0,
-                then_args_len: 0,
-                else_block,
-                else_args_start: 0,
-                else_args_len: 0,
-            },
-        );
-        let (then_cleanup_start, then_cleanup_len) = cfg.push_extra([aggregate]);
-        cfg.set_terminator(
-            then_block,
-            Terminator::Goto {
-                target: cleanup,
-                args_start: then_cleanup_start,
-                args_len: then_cleanup_len,
-            },
-        );
-        let (else_cleanup_start, else_cleanup_len) = cfg.push_extra([aggregate]);
-        cfg.set_terminator(
-            else_block,
-            Terminator::Goto {
-                target: cleanup,
-                args_start: else_cleanup_start,
-                args_len: else_cleanup_len,
-            },
-        );
-        cfg.set_terminator(cleanup, Terminator::Return { value: None });
+        cfg.set_branch(entry, condition, then_block, [], else_block, []);
+        cfg.set_goto(then_block, cleanup, [aggregate]);
+        cfg.set_goto(else_block, cleanup, [aggregate]);
+        cfg.set_return(cleanup, None);
         (cfg, pool, interner)
     }
 
@@ -902,31 +780,21 @@ mod tests {
         let entry = cfg.new_block();
         cfg.entry = entry;
         let values = (0..fields)
-            .map(|value| {
-                cfg.add_inst_to_block(entry, inst(CfgInstData::Const(value as u64), Type::I64))
-            })
+            .map(|value| cfg.append_inst(entry, inst(CfgInstData::Const(value as u64), Type::I64)))
             .collect::<Vec<_>>();
-        let (fields_start, fields_len) = cfg.push_extra(values);
-        let aggregate = cfg.add_inst_to_block(
-            entry,
-            inst(
-                CfgInstData::StructInit {
-                    struct_id: match aggregate_ty.kind() {
-                        rue_air::TypeKind::Struct(id) => id,
-                        _ => panic!("fixture aggregate must be a struct"),
-                    },
-                    fields_start,
-                    fields_len,
+        let aggregate = cfg
+            .append_struct_init(
+                entry,
+                match aggregate_ty.kind() {
+                    rue_air::TypeKind::Struct(id) => id,
+                    _ => panic!("fixture aggregate must be a struct"),
                 },
+                values,
                 aggregate_ty,
-            ),
-        );
-        cfg.set_terminator(
-            entry,
-            Terminator::Return {
-                value: Some(aggregate),
-            },
-        );
+                Span::new(0, 0),
+            )
+            .unwrap();
+        cfg.set_return(entry, Some(aggregate));
         (cfg, pool, interner)
     }
 
@@ -940,32 +808,12 @@ mod tests {
         let entry = cfg.new_block();
         let target = cfg.new_block();
         cfg.entry = entry;
-        let zero = cfg.add_inst_to_block(
-            entry,
-            inst(
-                CfgInstData::ArrayInit {
-                    elements_start: 0,
-                    elements_len: 0,
-                },
-                array_ty,
-            ),
-        );
+        let zero = cfg
+            .append_array_init(entry, [], array_ty, Span::new(0, 0))
+            .unwrap();
         let target_param = cfg.add_block_param(target, array_ty);
-        let (args_start, args_len) = cfg.push_extra([zero]);
-        cfg.set_terminator(
-            entry,
-            Terminator::Goto {
-                target,
-                args_start,
-                args_len,
-            },
-        );
-        cfg.set_terminator(
-            target,
-            Terminator::Return {
-                value: Some(target_param),
-            },
-        );
+        cfg.set_goto(entry, target, [zero]);
+        cfg.set_return(target, Some(target_param));
         (cfg, pool, interner)
     }
 
@@ -1140,7 +988,7 @@ mod tests {
         let mut cfg = Cfg::new(Type::UNIT, 0, 0, "trap".to_string(), vec![]);
         let entry = cfg.new_block();
         cfg.entry = entry;
-        cfg.set_terminator(entry, Terminator::Unreachable);
+        cfg.set_unreachable(entry);
         let (x86, x86_debug, arm, arm_debug) = lower_both(&cfg, &pool, &interner);
         let trace = assert_same_policy_trace(&cfg, &x86_debug, &arm_debug);
         assert_eq!(
@@ -1174,35 +1022,23 @@ mod tests {
         let mut scalar_cfg = Cfg::new(Type::I32, 0, 0, "scalar".to_string(), vec![]);
         let scalar_entry = scalar_cfg.new_block();
         scalar_cfg.entry = scalar_entry;
-        let scalar =
-            scalar_cfg.add_inst_to_block(scalar_entry, inst(CfgInstData::Const(9), Type::I32));
-        scalar_cfg.set_terminator(
-            scalar_entry,
-            Terminator::Return {
-                value: Some(scalar),
-            },
-        );
+        let scalar = scalar_cfg.append_inst(scalar_entry, inst(CfgInstData::Const(9), Type::I32));
+        scalar_cfg.set_return(scalar_entry, Some(scalar));
 
         let unit_pool = FrozenTypeInternPool::new();
         let unit_interner = ThreadedRodeo::new();
         let mut unit_cfg = Cfg::new(Type::UNIT, 0, 0, "unit".to_string(), vec![]);
         let unit_entry = unit_cfg.new_block();
         unit_cfg.entry = unit_entry;
-        unit_cfg.set_terminator(unit_entry, Terminator::Return { value: None });
+        unit_cfg.set_return(unit_entry, None);
 
         let main_pool = FrozenTypeInternPool::new();
         let main_interner = ThreadedRodeo::new();
         let mut main_cfg = Cfg::new(Type::I32, 0, 0, "main".to_string(), vec![]);
         let main_entry = main_cfg.new_block();
         main_cfg.entry = main_entry;
-        let main_value =
-            main_cfg.add_inst_to_block(main_entry, inst(CfgInstData::Const(0), Type::I32));
-        main_cfg.set_terminator(
-            main_entry,
-            Terminator::Return {
-                value: Some(main_value),
-            },
-        );
+        let main_value = main_cfg.append_inst(main_entry, inst(CfgInstData::Const(0), Type::I32));
+        main_cfg.set_return(main_entry, Some(main_value));
 
         for (cfg, pool, interner, expected_kind) in [
             (
@@ -1245,36 +1081,13 @@ mod tests {
         let first = multi_cfg.new_block();
         let second = multi_cfg.new_block();
         multi_cfg.entry = multi_entry;
-        let condition = multi_cfg
-            .add_inst_to_block(multi_entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
-        let first_value =
-            multi_cfg.add_inst_to_block(first, inst(CfgInstData::Const(1), Type::I32));
-        let second_value =
-            multi_cfg.add_inst_to_block(second, inst(CfgInstData::Const(2), Type::I32));
-        multi_cfg.set_terminator(
-            multi_entry,
-            Terminator::Branch {
-                cond: condition,
-                then_block: first,
-                then_args_start: 0,
-                then_args_len: 0,
-                else_block: second,
-                else_args_start: 0,
-                else_args_len: 0,
-            },
-        );
-        multi_cfg.set_terminator(
-            first,
-            Terminator::Return {
-                value: Some(first_value),
-            },
-        );
-        multi_cfg.set_terminator(
-            second,
-            Terminator::Return {
-                value: Some(second_value),
-            },
-        );
+        let condition =
+            multi_cfg.append_inst(multi_entry, inst(CfgInstData::BoolConst(true), Type::BOOL));
+        let first_value = multi_cfg.append_inst(first, inst(CfgInstData::Const(1), Type::I32));
+        let second_value = multi_cfg.append_inst(second, inst(CfgInstData::Const(2), Type::I32));
+        multi_cfg.set_branch(multi_entry, condition, first, [], second, []);
+        multi_cfg.set_return(first, Some(first_value));
+        multi_cfg.set_return(second, Some(second_value));
         let (x86, x86_debug, arm, arm_debug) = lower_both(&multi_cfg, &multi_pool, &multi_interner);
         let trace = assert_same_policy_trace(&multi_cfg, &x86_debug, &arm_debug);
         assert_eq!(

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -272,12 +272,8 @@ pub fn collect_array_scalar_vregs(
 ) -> Vec<VReg> {
     let inst = cfg.get_inst(value);
     match &inst.data {
-        CfgInstData::ArrayInit {
-            elements_start,
-            elements_len,
-            ..
-        } => {
-            let elements = cfg.get_extra(*elements_start, *elements_len);
+        CfgInstData::ArrayInit { .. } => {
+            let elements = cfg.get_array_elements(&inst.data);
             let mut result = Vec::new();
             // Collect elements in logical order (element 0 first), matching
             // The slot cache is uniform ascending order and
@@ -389,12 +385,8 @@ pub fn collect_struct_scalar_vregs(
 ) -> Vec<VReg> {
     let inst = cfg.get_inst(value);
     match &inst.data {
-        CfgInstData::StructInit {
-            fields_start,
-            fields_len,
-            ..
-        } => {
-            let fields = cfg.get_extra(*fields_start, *fields_len);
+        CfgInstData::StructInit { .. } => {
+            let fields = cfg.get_struct_fields(&inst.data);
             let mut result = Vec::new();
             for field in fields {
                 let field_inst = cfg.get_inst(*field);

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -647,7 +647,7 @@ impl ValuePlan {
 fn place_plan<A: ValueLowerAdapter>(
     ctx: &CfgLowerContext<'_>,
     adapter: &mut A,
-    place: Place,
+    place: &Place,
 ) -> PlacePlan {
     let base = match place.base {
         PlaceBase::Local(slot) => PlaceBasePlan::Local(slot),
@@ -658,7 +658,7 @@ fn place_plan<A: ValueLowerAdapter>(
     };
     let projections = ctx
         .cfg
-        .get_place_projections(&place)
+        .get_place_projections(place)
         .iter()
         .map(|projection| match *projection {
             Projection::Field {
@@ -747,17 +747,17 @@ fn addressable_value_plan<A: ValueLowerAdapter>(
     value: CfgValue,
 ) -> Option<ByRefAddressPlan> {
     let inst = ctx.cfg.get_inst(value);
-    match inst.data {
+    match &inst.data {
         CfgInstData::PlaceRead { place } => {
             Some(ByRefAddressPlan::Place(place_plan(ctx, adapter, place)))
         }
         CfgInstData::Load { slot } => Some(ByRefAddressPlan::FrameSlot {
-            slot,
+            slot: *slot,
             low_shift: ctx.type_slot_count(inst.ty).saturating_sub(1),
         }),
         CfgInstData::Param { index } => Some(ByRefAddressPlan::Parameter {
-            slot: index,
-            by_ref: ctx.cfg.is_param_by_ref(index),
+            slot: *index,
+            by_ref: ctx.cfg.is_param_by_ref(*index),
             low_shift: ctx.type_slot_count(inst.ty).saturating_sub(1),
         }),
         _ => None,
@@ -895,18 +895,11 @@ enum ResidualInput {
     },
     StructInit {
         struct_id: StructId,
-        fields_start: u32,
-        fields_len: u32,
     },
-    ArrayInit {
-        elements_start: u32,
-        elements_len: u32,
-    },
+    ArrayInit,
     EnumVariant {
         enum_id: EnumId,
         variant_index: u32,
-        payload_start: u32,
-        payload_len: u32,
     },
     EnumPayloadGet {
         base: CfgValue,
@@ -929,11 +922,8 @@ enum ResidualInput {
         slot: u32,
         local_ty: Type,
     },
-    PlaceRead {
-        place: Place,
-    },
+    PlaceRead,
     PlaceWrite {
-        place: Place,
         value: CfgValue,
     },
 }
@@ -1011,15 +1001,11 @@ fn residual_plan<A: ValueLowerAdapter>(
             value: operand(ctx, adapter, value),
             value_shape: ValuePlan::for_value(ctx, value).shape,
         },
-        ResidualInput::StructInit {
-            struct_id,
-            fields_start,
-            fields_len,
-        } => ResidualValuePlan::StructInit {
+        ResidualInput::StructInit { struct_id } => ResidualValuePlan::StructInit {
             struct_id,
             fields: ctx
                 .cfg
-                .get_extra(fields_start, fields_len)
+                .get_struct_fields(&ctx.cfg.get_inst(value).data)
                 .iter()
                 .copied()
                 .map(|field| {
@@ -1030,13 +1016,10 @@ fn residual_plan<A: ValueLowerAdapter>(
                 })
                 .collect(),
         },
-        ResidualInput::ArrayInit {
-            elements_start,
-            elements_len,
-        } => ResidualValuePlan::ArrayInit {
+        ResidualInput::ArrayInit => ResidualValuePlan::ArrayInit {
             elements: ctx
                 .cfg
-                .get_extra(elements_start, elements_len)
+                .get_array_elements(&ctx.cfg.get_inst(value).data)
                 .iter()
                 .copied()
                 .map(|element| {
@@ -1050,14 +1033,12 @@ fn residual_plan<A: ValueLowerAdapter>(
         ResidualInput::EnumVariant {
             enum_id,
             variant_index,
-            payload_start,
-            payload_len,
         } => ResidualValuePlan::EnumVariant {
             enum_id,
             variant_index,
             payload: ctx
                 .cfg
-                .get_extra(payload_start, payload_len)
+                .get_enum_payload(&ctx.cfg.get_inst(value).data)
                 .iter()
                 .copied()
                 .map(|field| {
@@ -1103,13 +1084,19 @@ fn residual_plan<A: ValueLowerAdapter>(
         ResidualInput::StorageDead { slot, local_ty } => {
             ResidualValuePlan::StorageDead { slot, local_ty }
         }
-        ResidualInput::PlaceRead { place } => ResidualValuePlan::PlaceRead {
-            place: place_plan(ctx, adapter, place),
+        ResidualInput::PlaceRead => ResidualValuePlan::PlaceRead {
+            place: match &ctx.cfg.get_inst(value).data {
+                CfgInstData::PlaceRead { place } => place_plan(ctx, adapter, place),
+                _ => unreachable!("residual place-read input changed kind"),
+            },
         },
-        ResidualInput::PlaceWrite { place, value } => ResidualValuePlan::PlaceWrite {
-            place: place_plan(ctx, adapter, place),
-            value: operand(ctx, adapter, value),
-            value_shape: ValuePlan::for_value(ctx, value).shape,
+        ResidualInput::PlaceWrite { value: stored } => ResidualValuePlan::PlaceWrite {
+            place: match &ctx.cfg.get_inst(value).data {
+                CfgInstData::PlaceWrite { place, .. } => place_plan(ctx, adapter, place),
+                _ => unreachable!("residual place-write input changed kind"),
+            },
+            value: operand(ctx, adapter, stored),
+            value_shape: ValuePlan::for_value(ctx, stored).shape,
         },
     }
 }
@@ -1165,7 +1152,7 @@ pub fn lower_value<A: ValueLowerAdapter>(
     if adapter.value_is_lowered(value) {
         return None;
     }
-    let inst = ctx.cfg.get_inst(value).clone();
+    let inst = ctx.cfg.get_inst(value);
     let policy = ValuePlan::for_value(ctx, value);
     macro_rules! lower_residual {
         ($input:expr) => {{
@@ -1180,11 +1167,11 @@ pub fn lower_value<A: ValueLowerAdapter>(
             Some(kind)
         }};
     }
-    match inst.data {
+    match &inst.data {
         CfgInstData::Add(lhs, rhs) => {
             let width = policy.integer_width.expect("add width");
-            let lhs = operand(ctx, adapter, lhs).primary;
-            let rhs = operand(ctx, adapter, rhs).primary;
+            let lhs = operand(ctx, adapter, *lhs).primary;
+            let rhs = operand(ctx, adapter, *rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Add { lhs, rhs, width },
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
@@ -1200,8 +1187,8 @@ pub fn lower_value<A: ValueLowerAdapter>(
         }
         CfgInstData::Sub(lhs, rhs) => {
             let width = policy.integer_width.expect("sub width");
-            let lhs = operand(ctx, adapter, lhs).primary;
-            let rhs = operand(ctx, adapter, rhs).primary;
+            let lhs = operand(ctx, adapter, *lhs).primary;
+            let rhs = operand(ctx, adapter, *rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Sub { lhs, rhs, width },
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
@@ -1217,13 +1204,13 @@ pub fn lower_value<A: ValueLowerAdapter>(
         }
         CfgInstData::Mul(lhs, rhs) => {
             let width = policy.integer_width.expect("mul width");
-            let lhs_result = operand(ctx, adapter, lhs);
-            let rhs_result = operand(ctx, adapter, rhs);
+            let lhs_result = operand(ctx, adapter, *lhs);
+            let rhs_result = operand(ctx, adapter, *rhs);
             let shift = if width.bits >= 32 {
-                power_of_two_shift(ctx, lhs)
+                power_of_two_shift(ctx, *lhs)
                     .map(|shift| (rhs_result.primary, shift))
                     .or_else(|| {
-                        power_of_two_shift(ctx, rhs).map(|shift| (lhs_result.primary, shift))
+                        power_of_two_shift(ctx, *rhs).map(|shift| (lhs_result.primary, shift))
                     })
             } else {
                 None
@@ -1248,8 +1235,8 @@ pub fn lower_value<A: ValueLowerAdapter>(
         }
         CfgInstData::WrappingAdd(lhs, rhs) => {
             let width = policy.integer_width.expect("wrapping_add width");
-            let lhs = operand(ctx, adapter, lhs).primary;
-            let rhs = operand(ctx, adapter, rhs).primary;
+            let lhs = operand(ctx, adapter, *lhs).primary;
+            let rhs = operand(ctx, adapter, *rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Add { lhs, rhs, width },
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
@@ -1265,8 +1252,8 @@ pub fn lower_value<A: ValueLowerAdapter>(
         }
         CfgInstData::WrappingSub(lhs, rhs) => {
             let width = policy.integer_width.expect("wrapping_sub width");
-            let lhs = operand(ctx, adapter, lhs).primary;
-            let rhs = operand(ctx, adapter, rhs).primary;
+            let lhs = operand(ctx, adapter, *lhs).primary;
+            let rhs = operand(ctx, adapter, *rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Sub { lhs, rhs, width },
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
@@ -1282,8 +1269,8 @@ pub fn lower_value<A: ValueLowerAdapter>(
         }
         CfgInstData::WrappingMul(lhs, rhs) => {
             let width = policy.integer_width.expect("wrapping_mul width");
-            let lhs = operand(ctx, adapter, lhs).primary;
-            let rhs = operand(ctx, adapter, rhs).primary;
+            let lhs = operand(ctx, adapter, *lhs).primary;
+            let rhs = operand(ctx, adapter, *rhs).primary;
             // Wrapping multiply is one plain ALU multiply per width: the low
             // bits are identical for signed and unsigned two's-complement, so
             // no power-of-two strength reduction and no widening overflow probe
@@ -1308,8 +1295,8 @@ pub fn lower_value<A: ValueLowerAdapter>(
         }
         CfgInstData::Div(lhs, rhs) => {
             let width = policy.integer_width.expect("div width");
-            let lhs = operand(ctx, adapter, lhs).primary;
-            let rhs = operand(ctx, adapter, rhs).primary;
+            let lhs = operand(ctx, adapter, *lhs).primary;
+            let rhs = operand(ctx, adapter, *rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Div { lhs, rhs, width },
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
@@ -1325,8 +1312,8 @@ pub fn lower_value<A: ValueLowerAdapter>(
         }
         CfgInstData::Mod(lhs, rhs) => {
             let width = policy.integer_width.expect("mod width");
-            let lhs = operand(ctx, adapter, lhs).primary;
-            let rhs = operand(ctx, adapter, rhs).primary;
+            let lhs = operand(ctx, adapter, *lhs).primary;
+            let rhs = operand(ctx, adapter, *rhs).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Mod { lhs, rhs, width },
                 overflow_call: crate::runtime_call_plan::RuntimeCallPlan::no_args(
@@ -1342,7 +1329,7 @@ pub fn lower_value<A: ValueLowerAdapter>(
         }
         CfgInstData::Neg(operand_value) => {
             let width = policy.integer_width.expect("neg width");
-            let operand_vreg = operand(ctx, adapter, operand_value).primary;
+            let operand_vreg = operand(ctx, adapter, *operand_value).primary;
             let result = adapter.emit_checked_arithmetic(ArithmeticPlan {
                 operation: ArithmeticOperation::Neg {
                     value: operand_vreg,
@@ -1359,13 +1346,8 @@ pub fn lower_value<A: ValueLowerAdapter>(
             cache_result(adapter, value, result);
             Some(ValueKind::UnaryArithmetic)
         }
-        CfgInstData::Call {
-            runtime,
-            name,
-            args_start,
-            args_len,
-        } => {
-            let call_args = ctx.cfg.get_call_args(args_start, args_len);
+        CfgInstData::Call { runtime, name, .. } => {
+            let call_args = ctx.cfg.get_call_args(&inst.data);
             let by_ref_plans = call_args
                 .iter()
                 .map(|arg| match arg.mode {
@@ -1387,7 +1369,7 @@ pub fn lower_value<A: ValueLowerAdapter>(
                 &by_ref_plans,
                 adapter.return_register_budget(),
             );
-            let result = if let Some(runtime) = runtime {
+            let result = if let Some(runtime) = *runtime {
                 let helper = runtime.helper();
                 let plan = crate::runtime_call_plan::RuntimeCallPlan::from_cfg_inputs(
                     helper,
@@ -1400,7 +1382,7 @@ pub fn lower_value<A: ValueLowerAdapter>(
                 });
                 adapter.emit_runtime_call(plan)
             } else {
-                let symbol = adapter.resolve_symbol(name);
+                let symbol = adapter.resolve_symbol(*name);
                 let result_vreg = adapter.reserve_value_result();
                 let plan = crate::call_plan::CallPlan::from_inputs_with_result(
                     crate::call_plan::CallTarget::rue(symbol),
@@ -1415,15 +1397,10 @@ pub fn lower_value<A: ValueLowerAdapter>(
             cache_result(adapter, value, result);
             Some(ValueKind::Call)
         }
-        CfgInstData::Intrinsic {
-            runtime,
-            name,
-            args_start,
-            args_len,
-        } => {
+        CfgInstData::Intrinsic { runtime, name, .. } => {
             debug_assert!(runtime.is_none_or(|runtime| runtime.validate()));
-            let args = ctx.cfg.get_extra(args_start, args_len);
-            let name_string = adapter.resolve_symbol(name);
+            let args = ctx.cfg.get_intrinsic_args(&inst.data);
+            let name_string = adapter.resolve_symbol(*name);
             let values: Vec<IntrinsicArgPlan> = args
                 .iter()
                 .copied()
@@ -1599,62 +1576,60 @@ pub fn lower_value<A: ValueLowerAdapter>(
                 Some(ValueKind::Intrinsic)
             }
         }
-        CfgInstData::Const(value) => lower_residual!(ResidualInput::Const(value)),
-        CfgInstData::BoolConst(value) => lower_residual!(ResidualInput::BoolConst(value)),
+        CfgInstData::Const(value) => lower_residual!(ResidualInput::Const(*value)),
+        CfgInstData::BoolConst(value) => lower_residual!(ResidualInput::BoolConst(*value)),
         CfgInstData::StringConst(string_id) => {
-            lower_residual!(ResidualInput::StringConst(string_id))
+            lower_residual!(ResidualInput::StringConst(*string_id))
         }
-        CfgInstData::Param { index } => lower_residual!(ResidualInput::Param(index)),
-        CfgInstData::BlockParam { index } => lower_residual!(ResidualInput::BlockParam(index)),
-        CfgInstData::Eq(lhs, rhs) => lower_residual!(ResidualInput::Eq(lhs, rhs)),
-        CfgInstData::Ne(lhs, rhs) => lower_residual!(ResidualInput::Ne(lhs, rhs)),
-        CfgInstData::Lt(lhs, rhs) => lower_residual!(ResidualInput::Lt(lhs, rhs)),
-        CfgInstData::Gt(lhs, rhs) => lower_residual!(ResidualInput::Gt(lhs, rhs)),
-        CfgInstData::Le(lhs, rhs) => lower_residual!(ResidualInput::Le(lhs, rhs)),
-        CfgInstData::Ge(lhs, rhs) => lower_residual!(ResidualInput::Ge(lhs, rhs)),
-        CfgInstData::BitAnd(lhs, rhs) => lower_residual!(ResidualInput::BitAnd(lhs, rhs)),
-        CfgInstData::BitOr(lhs, rhs) => lower_residual!(ResidualInput::BitOr(lhs, rhs)),
-        CfgInstData::BitXor(lhs, rhs) => lower_residual!(ResidualInput::BitXor(lhs, rhs)),
-        CfgInstData::Shl(lhs, rhs) => lower_residual!(ResidualInput::Shl(lhs, rhs)),
-        CfgInstData::Shr(lhs, rhs) => lower_residual!(ResidualInput::Shr(lhs, rhs)),
-        CfgInstData::Not(value) => lower_residual!(ResidualInput::Not(value)),
-        CfgInstData::BitNot(value) => lower_residual!(ResidualInput::BitNot(value)),
+        CfgInstData::Param { index } => lower_residual!(ResidualInput::Param(*index)),
+        CfgInstData::BlockParam { index } => lower_residual!(ResidualInput::BlockParam(*index)),
+        CfgInstData::Eq(lhs, rhs) => lower_residual!(ResidualInput::Eq(*lhs, *rhs)),
+        CfgInstData::Ne(lhs, rhs) => lower_residual!(ResidualInput::Ne(*lhs, *rhs)),
+        CfgInstData::Lt(lhs, rhs) => lower_residual!(ResidualInput::Lt(*lhs, *rhs)),
+        CfgInstData::Gt(lhs, rhs) => lower_residual!(ResidualInput::Gt(*lhs, *rhs)),
+        CfgInstData::Le(lhs, rhs) => lower_residual!(ResidualInput::Le(*lhs, *rhs)),
+        CfgInstData::Ge(lhs, rhs) => lower_residual!(ResidualInput::Ge(*lhs, *rhs)),
+        CfgInstData::BitAnd(lhs, rhs) => lower_residual!(ResidualInput::BitAnd(*lhs, *rhs)),
+        CfgInstData::BitOr(lhs, rhs) => lower_residual!(ResidualInput::BitOr(*lhs, *rhs)),
+        CfgInstData::BitXor(lhs, rhs) => lower_residual!(ResidualInput::BitXor(*lhs, *rhs)),
+        CfgInstData::Shl(lhs, rhs) => lower_residual!(ResidualInput::Shl(*lhs, *rhs)),
+        CfgInstData::Shr(lhs, rhs) => lower_residual!(ResidualInput::Shr(*lhs, *rhs)),
+        CfgInstData::Not(value) => lower_residual!(ResidualInput::Not(*value)),
+        CfgInstData::BitNot(value) => lower_residual!(ResidualInput::BitNot(*value)),
         CfgInstData::Alloc { slot, init } => {
-            lower_residual!(ResidualInput::Alloc { slot, init })
+            lower_residual!(ResidualInput::Alloc {
+                slot: *slot,
+                init: *init
+            })
         }
-        CfgInstData::Load { slot } => lower_residual!(ResidualInput::Load { slot }),
+        CfgInstData::Load { slot } => lower_residual!(ResidualInput::Load { slot: *slot }),
         CfgInstData::Store { slot, value } => {
-            lower_residual!(ResidualInput::Store { slot, value })
+            lower_residual!(ResidualInput::Store {
+                slot: *slot,
+                value: *value
+            })
         }
         CfgInstData::ParamStore { param_slot, value } => {
-            lower_residual!(ResidualInput::ParamStore { param_slot, value })
+            lower_residual!(ResidualInput::ParamStore {
+                param_slot: *param_slot,
+                value: *value
+            })
         }
-        CfgInstData::StructInit {
-            struct_id,
-            fields_start,
-            fields_len,
-        } => lower_residual!(ResidualInput::StructInit {
-            struct_id,
-            fields_start,
-            fields_len,
-        }),
-        CfgInstData::ArrayInit {
-            elements_start,
-            elements_len,
-        } => lower_residual!(ResidualInput::ArrayInit {
-            elements_start,
-            elements_len,
-        }),
+        CfgInstData::StructInit { struct_id, .. } => {
+            lower_residual!(ResidualInput::StructInit {
+                struct_id: *struct_id
+            })
+        }
+        CfgInstData::ArrayInit { .. } => {
+            lower_residual!(ResidualInput::ArrayInit)
+        }
         CfgInstData::EnumVariant {
             enum_id,
             variant_index,
-            payload_start,
-            payload_len,
+            ..
         } => lower_residual!(ResidualInput::EnumVariant {
-            enum_id,
-            variant_index,
-            payload_start,
-            payload_len,
+            enum_id: *enum_id,
+            variant_index: *variant_index,
         }),
         CfgInstData::EnumPayloadGet {
             base,
@@ -1662,24 +1637,33 @@ pub fn lower_value<A: ValueLowerAdapter>(
             variant_index,
             field_index,
         } => lower_residual!(ResidualInput::EnumPayloadGet {
-            base,
-            enum_id,
-            variant_index,
-            field_index,
+            base: *base,
+            enum_id: *enum_id,
+            variant_index: *variant_index,
+            field_index: *field_index,
         }),
         CfgInstData::IntCast { value, from_ty } => {
-            lower_residual!(ResidualInput::IntCast { value, from_ty })
+            lower_residual!(ResidualInput::IntCast {
+                value: *value,
+                from_ty: *from_ty
+            })
         }
-        CfgInstData::Drop { value } => lower_residual!(ResidualInput::Drop { value }),
+        CfgInstData::Drop { value } => lower_residual!(ResidualInput::Drop { value: *value }),
         CfgInstData::StorageLive { slot, local_ty } => {
-            lower_residual!(ResidualInput::StorageLive { slot, local_ty })
+            lower_residual!(ResidualInput::StorageLive {
+                slot: *slot,
+                local_ty: *local_ty
+            })
         }
         CfgInstData::StorageDead { slot, local_ty } => {
-            lower_residual!(ResidualInput::StorageDead { slot, local_ty })
+            lower_residual!(ResidualInput::StorageDead {
+                slot: *slot,
+                local_ty: *local_ty
+            })
         }
-        CfgInstData::PlaceRead { place } => lower_residual!(ResidualInput::PlaceRead { place }),
-        CfgInstData::PlaceWrite { place, value } => {
-            lower_residual!(ResidualInput::PlaceWrite { place, value })
+        CfgInstData::PlaceRead { .. } => lower_residual!(ResidualInput::PlaceRead),
+        CfgInstData::PlaceWrite { value, .. } => {
+            lower_residual!(ResidualInput::PlaceWrite { value: *value })
         }
     }
 }
@@ -2060,12 +2044,12 @@ mod tests {
     use super::{
         ComparisonPreparation, DebugValuePlan, IntegerExtension, IntegerWidth, IntrinsicArgPlan,
         IntrinsicOperation, MaterializationRequirement, MaterializedValue, OptionIntrinsic,
-        StoragePolicy, StoreDestination, ValueKind, ValuePlan, ValueShape, assert_slot_policy,
+        StoragePolicy, StoreDestination, ValuePlan, ValueShape, assert_slot_policy,
         comparison_integer_width, integer_range, type_bits, type_range,
     };
-    use lasso::{Spur, ThreadedRodeo};
+    use lasso::ThreadedRodeo;
     use rue_air::{EnumDef, LangItem, ParamSlotModes, StructDef, StructField, TypeInternPool};
-    use rue_cfg::{Cfg, CfgInst, CfgInstData, CfgValue, Place, Terminator, Type};
+    use rue_cfg::{Cfg, CfgInst, CfgInstData, CfgValue, Place, Type};
     use rue_runtime_abi::RuntimeHelperId;
     use rue_span::{FileId, Span};
     use rue_target::Target;
@@ -2090,16 +2074,10 @@ mod tests {
         let entry = cfg.new_block();
         cfg.entry = entry;
         for (index, inst) in values.into_iter().enumerate() {
-            let value = cfg.add_inst(inst);
+            let value = cfg.append_inst(entry, inst);
             assert_eq!(value.as_u32(), index as u32);
-            cfg.get_block_mut(entry).insts.push(value);
         }
-        cfg.set_terminator(
-            entry,
-            Terminator::Return {
-                value: Some(return_value),
-            },
-        );
+        cfg.set_return(entry, Some(return_value));
         cfg
     }
 
@@ -2187,6 +2165,7 @@ mod tests {
         let struct_ty = Type::new_struct(struct_id);
         let enum_ty = Type::new_enum(enum_id);
         let array_ty = Type::new_array(array_id);
+        let enum_pool = pool.clone().freeze();
 
         let mut cfg = Cfg::new(
             Type::I32,
@@ -2197,16 +2176,11 @@ mod tests {
         );
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let mut values = Vec::new();
-        let block_parameter = cfg.add_inst(inst(CfgInstData::BlockParam { index: 0 }, Type::I32));
-        cfg.get_block_mut(entry)
-            .params
-            .push((block_parameter, Type::I32));
-        values.push(block_parameter);
-        let mut add = |cfg: &mut Cfg, data: CfgInstData, ty: Type| {
-            let value = cfg.add_inst(inst(data, ty));
-            cfg.get_block_mut(entry).insts.push(value);
-            values.push(value);
+        let block_parameter = cfg.add_block_param(entry, Type::I32);
+        let values = std::cell::RefCell::new(vec![block_parameter]);
+        let add = |cfg: &mut Cfg, data: CfgInstData, ty: Type| {
+            let value = cfg.append_inst(entry, inst(data, ty));
+            values.borrow_mut().push(value);
             value
         };
 
@@ -2264,57 +2238,41 @@ mod tests {
             Type::UNIT,
         );
         let call_name = interner.get_or_intern("coverage_call");
-        add(
-            &mut cfg,
-            CfgInstData::Call {
-                runtime: None,
-                name: call_name,
-                args_start: 0,
-                args_len: 0,
-            },
-            Type::I32,
-        );
+        let call = cfg
+            .append_call(entry, None, call_name, [], Type::I32, Span::new(0, 0))
+            .unwrap();
+        values.borrow_mut().push(call);
         let panic_name = interner.get_or_intern("panic");
-        add(
-            &mut cfg,
-            CfgInstData::Intrinsic {
-                runtime: None,
-                name: panic_name,
-                args_start: 0,
-                args_len: 0,
-            },
-            Type::UNIT,
-        );
-        let (fields_start, fields_len) = cfg.push_extra([constant, load]);
-        let struct_value = add(
-            &mut cfg,
-            CfgInstData::StructInit {
+        let intrinsic = cfg
+            .append_intrinsic(entry, None, panic_name, [], Type::UNIT, Span::new(0, 0))
+            .unwrap();
+        values.borrow_mut().push(intrinsic);
+        let struct_value = cfg
+            .append_struct_init(
+                entry,
                 struct_id,
-                fields_start,
-                fields_len,
-            },
-            struct_ty,
-        );
-        let (elements_start, elements_len) = cfg.push_extra([constant, load]);
-        add(
-            &mut cfg,
-            CfgInstData::ArrayInit {
-                elements_start,
-                elements_len,
-            },
-            array_ty,
-        );
-        let (payload_start, payload_len) = cfg.push_extra([constant]);
-        let enum_value = add(
-            &mut cfg,
-            CfgInstData::EnumVariant {
+                [constant, load],
+                struct_ty,
+                Span::new(0, 0),
+            )
+            .unwrap();
+        values.borrow_mut().push(struct_value);
+        let array_value = cfg
+            .append_array_init(entry, [constant, load], array_ty, Span::new(0, 0))
+            .unwrap();
+        values.borrow_mut().push(array_value);
+        let enum_value = cfg
+            .append_enum_variant(
+                &enum_pool,
+                entry,
                 enum_id,
-                variant_index: 1,
-                payload_start,
-                payload_len,
-            },
-            enum_ty,
-        );
+                1,
+                [constant],
+                enum_ty,
+                Span::new(0, 0),
+            )
+            .unwrap();
+        values.borrow_mut().push(enum_value);
         add(
             &mut cfg,
             CfgInstData::EnumPayloadGet {
@@ -2371,15 +2329,14 @@ mod tests {
             },
             Type::UNIT,
         );
-        cfg.set_terminator(
-            entry,
-            Terminator::Return {
-                value: Some(constant),
-            },
-        );
+        cfg.set_return(entry, Some(constant));
 
-        assert_eq!(values.len(), 40, "fixture must contain every CFG variant");
-        (cfg, pool.freeze(), interner, values)
+        assert_eq!(
+            values.borrow().len(),
+            40,
+            "fixture must contain every CFG variant"
+        );
+        (cfg, pool.freeze(), interner, values.into_inner())
     }
 
     #[test]
@@ -2508,168 +2465,16 @@ mod tests {
 
     #[test]
     fn planner_is_exhaustive_for_every_cfg_value_variant() {
-        let v = dummy_value();
-        let place = Place::local(0, Type::I32);
-        let symbol = Spur::default();
-        let pool = TypeInternPool::new();
-        let interner = ThreadedRodeo::new();
-        let (struct_id, _) = pool.register_struct(
-            interner.get_or_intern("PlannerStruct"),
-            StructDef {
-                name: "PlannerStruct".to_string(),
-                fields: vec![],
-                is_copy: false,
-                is_linear: false,
-                destructor: None,
-                is_builtin: false,
-                is_pub: false,
-                file_id: FileId::DEFAULT,
-            },
-        );
-        let (enum_id, _) = pool.register_enum(
-            interner.get_or_intern("PlannerEnum"),
-            EnumDef {
-                name: "PlannerEnum".to_string(),
-                variants: vec!["Only".to_string()],
-                variant_payloads: vec![],
-                is_pub: false,
-                file_id: FileId::DEFAULT,
-            },
-        );
-        let cases = vec![
-            (CfgInstData::Const(1), ValueKind::Constant),
-            (CfgInstData::BoolConst(true), ValueKind::BoolConstant),
-            (CfgInstData::StringConst(0), ValueKind::StringConstant),
-            (CfgInstData::Param { index: 0 }, ValueKind::Parameter),
-            (
-                CfgInstData::BlockParam { index: 0 },
-                ValueKind::BlockParameter,
-            ),
-            (CfgInstData::Add(v, v), ValueKind::BinaryArithmetic),
-            (CfgInstData::Sub(v, v), ValueKind::BinaryArithmetic),
-            (CfgInstData::Mul(v, v), ValueKind::BinaryArithmetic),
-            (CfgInstData::Div(v, v), ValueKind::BinaryArithmetic),
-            (CfgInstData::Mod(v, v), ValueKind::BinaryArithmetic),
-            (CfgInstData::Eq(v, v), ValueKind::Comparison),
-            (CfgInstData::Ne(v, v), ValueKind::Comparison),
-            (CfgInstData::Lt(v, v), ValueKind::Comparison),
-            (CfgInstData::Gt(v, v), ValueKind::Comparison),
-            (CfgInstData::Le(v, v), ValueKind::Comparison),
-            (CfgInstData::Ge(v, v), ValueKind::Comparison),
-            (CfgInstData::BitAnd(v, v), ValueKind::Bitwise),
-            (CfgInstData::BitOr(v, v), ValueKind::Bitwise),
-            (CfgInstData::BitXor(v, v), ValueKind::Bitwise),
-            (CfgInstData::Shl(v, v), ValueKind::Shift),
-            (CfgInstData::Shr(v, v), ValueKind::Shift),
-            (CfgInstData::Neg(v), ValueKind::UnaryArithmetic),
-            (CfgInstData::Not(v), ValueKind::UnaryArithmetic),
-            (CfgInstData::BitNot(v), ValueKind::Bitwise),
-            (
-                CfgInstData::Alloc { slot: 0, init: v },
-                ValueKind::Allocation,
-            ),
-            (CfgInstData::Load { slot: 0 }, ValueKind::Load),
-            (CfgInstData::Store { slot: 0, value: v }, ValueKind::Store),
-            (
-                CfgInstData::ParamStore {
-                    param_slot: 0,
-                    value: v,
-                },
-                ValueKind::ParameterStore,
-            ),
-            (
-                CfgInstData::Call {
-                    runtime: None,
-                    name: symbol,
-                    args_start: 0,
-                    args_len: 0,
-                },
-                ValueKind::Call,
-            ),
-            (
-                CfgInstData::Intrinsic {
-                    runtime: None,
-                    name: symbol,
-                    args_start: 0,
-                    args_len: 0,
-                },
-                ValueKind::Intrinsic,
-            ),
-            (
-                CfgInstData::StructInit {
-                    struct_id,
-                    fields_start: 0,
-                    fields_len: 0,
-                },
-                ValueKind::StructInit,
-            ),
-            (
-                CfgInstData::ArrayInit {
-                    elements_start: 0,
-                    elements_len: 0,
-                },
-                ValueKind::ArrayInit,
-            ),
-            (
-                CfgInstData::EnumVariant {
-                    enum_id,
-                    variant_index: 0,
-                    payload_start: 0,
-                    payload_len: 0,
-                },
-                ValueKind::EnumVariant,
-            ),
-            (
-                CfgInstData::EnumPayloadGet {
-                    base: v,
-                    enum_id,
-                    variant_index: 0,
-                    field_index: 0,
-                },
-                ValueKind::EnumPayloadGet,
-            ),
-            (
-                CfgInstData::IntCast {
-                    value: v,
-                    from_ty: Type::I32,
-                },
-                ValueKind::IntegerCast,
-            ),
-            (CfgInstData::Drop { value: v }, ValueKind::Drop),
-            (
-                CfgInstData::StorageLive {
-                    slot: 0,
-                    local_ty: Type::I32,
-                },
-                ValueKind::StorageLive,
-            ),
-            (
-                CfgInstData::StorageDead {
-                    slot: 0,
-                    local_ty: Type::I32,
-                },
-                ValueKind::StorageDead,
-            ),
-            (CfgInstData::PlaceRead { place }, ValueKind::PlaceRead),
-            (
-                CfgInstData::PlaceWrite { place, value: v },
-                ValueKind::PlaceWrite,
-            ),
-        ];
-
-        let values = cases
-            .iter()
-            .map(|(data, _)| inst(data.clone(), Type::I32))
-            .collect::<Vec<_>>();
-        let cfg = synthetic_cfg(values, 1, 1, vec![true], dummy_value());
-        let pool = rue_air::FrozenTypeInternPool::new();
+        let (cfg, pool, _interner, values) = every_cfg_value_fixture();
         let ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
-
-        for (index, _) in cases.iter().enumerate() {
-            let value = CfgValue::from_raw(index as u32);
-            let _plan = ValuePlan::for_value(&ctx, value);
+        for value in &values {
+            let _plan = ValuePlan::for_value(&ctx, *value);
         }
-        assert_eq!(cases.len(), 40, "test must cover every CfgInstData variant");
+        assert_eq!(
+            values.len(),
+            40,
+            "test must cover every CfgInstData variant"
+        );
     }
 
     #[test]
@@ -2790,19 +2595,13 @@ mod tests {
         let empty_array_id = empty_pool.intern_array_from_type(Type::UNIT, 2);
         let empty_pool = empty_pool.freeze();
         let empty_array_ty = Type::new_array(empty_array_id);
-        let empty_cfg = synthetic_cfg(
-            vec![inst(
-                CfgInstData::ArrayInit {
-                    elements_start: 0,
-                    elements_len: 0,
-                },
-                empty_array_ty,
-            )],
-            0,
-            0,
-            vec![],
-            dummy_value(),
-        );
+        let mut empty_cfg = Cfg::new(Type::I32, 0, 0, "empty_array_plan".to_string(), vec![]);
+        let empty_entry = empty_cfg.new_block();
+        empty_cfg.entry = empty_entry;
+        let empty_value = empty_cfg
+            .append_array_init(empty_entry, [], empty_array_ty, Span::new(0, 0))
+            .unwrap();
+        empty_cfg.set_return(empty_entry, Some(empty_value));
         let empty_ctx = crate::cfg_lower::CfgLowerContext::new(&empty_cfg, &empty_pool);
         let empty_plan = ValuePlan::for_value(&empty_ctx, dummy_value());
         assert_eq!(
@@ -2847,20 +2646,13 @@ mod tests {
         strbuf_pool.set_struct_lang_item(struct_id, LangItem::StrBuf);
         let strbuf_pool = strbuf_pool.freeze();
         let strbuf_ty = Type::new_struct(struct_id);
-        let strbuf_cfg = synthetic_cfg(
-            vec![inst(
-                CfgInstData::StructInit {
-                    struct_id,
-                    fields_start: 0,
-                    fields_len: 0,
-                },
-                strbuf_ty,
-            )],
-            0,
-            0,
-            vec![],
-            dummy_value(),
-        );
+        let mut strbuf_cfg = Cfg::new(Type::I32, 0, 0, "strbuf_plan".to_string(), vec![]);
+        let strbuf_entry = strbuf_cfg.new_block();
+        strbuf_cfg.entry = strbuf_entry;
+        let strbuf_value = strbuf_cfg
+            .append_struct_init(strbuf_entry, struct_id, [], strbuf_ty, Span::new(0, 0))
+            .unwrap();
+        strbuf_cfg.set_return(strbuf_entry, Some(strbuf_value));
         let strbuf_ctx = crate::cfg_lower::CfgLowerContext::new(&strbuf_cfg, &strbuf_pool);
         let strbuf_plan = ValuePlan::for_value(&strbuf_ctx, dummy_value());
         assert!(strbuf_plan.is_strbuf);
@@ -3040,9 +2832,8 @@ mod tests {
         let mut cfg = Cfg::new(array_ty, 0, 1, "zero_slot_param".to_string(), vec![false]);
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let param = cfg.add_inst(inst(CfgInstData::Param { index: 0 }, array_ty));
-        cfg.get_block_mut(entry).insts.push(param);
-        cfg.set_terminator(entry, Terminator::Return { value: Some(param) });
+        let param = cfg.append_inst(entry, inst(CfgInstData::Param { index: 0 }, array_ty));
+        cfg.set_return(entry, Some(param));
         let interner = ThreadedRodeo::new();
 
         let x86 = X86CfgLower::new(&cfg, &pool, &interner)
@@ -3104,22 +2895,19 @@ mod tests {
         );
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let first = cfg.add_inst(inst(CfgInstData::Const(1), Type::U64));
-        let second = cfg.add_inst(inst(CfgInstData::Const(2), Type::U64));
-        let third = cfg.add_inst(inst(CfgInstData::Const(3), Type::U64));
-        let (fields_start, fields_len) = cfg.push_extra([first, second, third]);
-        let value = cfg.add_inst(inst(
-            CfgInstData::StructInit {
+        let first = cfg.append_inst(entry, inst(CfgInstData::Const(1), Type::U64));
+        let second = cfg.append_inst(entry, inst(CfgInstData::Const(2), Type::U64));
+        let third = cfg.append_inst(entry, inst(CfgInstData::Const(3), Type::U64));
+        let value = cfg
+            .append_struct_init(
+                entry,
                 struct_id,
-                fields_start,
-                fields_len,
-            },
-            aggregate_ty,
-        ));
-        cfg.get_block_mut(entry)
-            .insts
-            .extend([first, second, third, value]);
-        cfg.set_terminator(entry, Terminator::Return { value: None });
+                [first, second, third],
+                aggregate_ty,
+                Span::new(0, 0),
+            )
+            .unwrap();
+        cfg.set_return(entry, None);
         let pool = pool.freeze();
 
         let x86_ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
@@ -3316,39 +3104,41 @@ mod tests {
         );
         let entry = cfg.new_block();
         cfg.entry = entry;
-        let zero = cfg.add_inst(inst(
-            CfgInstData::ArrayInit {
-                elements_start: 0,
-                elements_len: 0,
-            },
-            array_ty,
-        ));
-        let alloc = cfg.add_inst(inst(
-            CfgInstData::Alloc {
-                slot: 0,
-                init: zero,
-            },
-            Type::UNIT,
-        ));
-        let load = cfg.add_inst(inst(CfgInstData::Load { slot: 0 }, array_ty));
-        let store = cfg.add_inst(inst(
-            CfgInstData::Store {
-                slot: 0,
-                value: zero,
-            },
-            Type::UNIT,
-        ));
-        let param_store = cfg.add_inst(inst(
-            CfgInstData::ParamStore {
-                param_slot: 0,
-                value: zero,
-            },
-            Type::UNIT,
-        ));
-        cfg.get_block_mut(entry)
-            .insts
-            .extend([zero, alloc, load, store, param_store]);
-        cfg.set_terminator(entry, Terminator::Return { value: None });
+        let zero = cfg
+            .append_array_init(entry, [], array_ty, Span::new(0, 0))
+            .unwrap();
+        let alloc = cfg.append_inst(
+            entry,
+            inst(
+                CfgInstData::Alloc {
+                    slot: 0,
+                    init: zero,
+                },
+                Type::UNIT,
+            ),
+        );
+        let load = cfg.append_inst(entry, inst(CfgInstData::Load { slot: 0 }, array_ty));
+        let store = cfg.append_inst(
+            entry,
+            inst(
+                CfgInstData::Store {
+                    slot: 0,
+                    value: zero,
+                },
+                Type::UNIT,
+            ),
+        );
+        let param_store = cfg.append_inst(
+            entry,
+            inst(
+                CfgInstData::ParamStore {
+                    param_slot: 0,
+                    value: zero,
+                },
+                Type::UNIT,
+            ),
+        );
+        cfg.set_return(entry, None);
 
         let ctx = crate::cfg_lower::CfgLowerContext::new(&cfg, &pool);
         assert_eq!(
@@ -3408,25 +3198,20 @@ mod tests {
         );
         let byref_entry = byref_cfg.new_block();
         byref_cfg.entry = byref_entry;
-        let byref_zero = byref_cfg.add_inst(inst(
-            CfgInstData::ArrayInit {
-                elements_start: 0,
-                elements_len: 0,
-            },
-            array_ty,
-        ));
-        let byref_store = byref_cfg.add_inst(inst(
-            CfgInstData::Store {
-                slot: 0,
-                value: byref_zero,
-            },
-            Type::UNIT,
-        ));
-        byref_cfg
-            .get_block_mut(byref_entry)
-            .insts
-            .extend([byref_zero, byref_store]);
-        byref_cfg.set_terminator(byref_entry, Terminator::Return { value: None });
+        let byref_zero = byref_cfg
+            .append_array_init(byref_entry, [], array_ty, Span::new(0, 0))
+            .unwrap();
+        let _byref_store = byref_cfg.append_inst(
+            byref_entry,
+            inst(
+                CfgInstData::Store {
+                    slot: 0,
+                    value: byref_zero,
+                },
+                Type::UNIT,
+            ),
+        );
+        byref_cfg.set_return(byref_entry, None);
         let byref_ctx = crate::cfg_lower::CfgLowerContext::new(&byref_cfg, &pool);
         assert_eq!(
             super::store_destination(&byref_ctx, 0),

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2860,7 +2860,7 @@ mod tests {
             func.allow_unreachable_code,
         );
 
-        CfgLower::new(&cfg_output.cfg, type_pool, &interner)
+        CfgLower::new(cfg_output.cfg.as_ref().unwrap(), type_pool, &interner)
             .lower()
             .expect("test lowering should succeed")
     }

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -232,6 +232,7 @@ pub(crate) enum CfgDomainFailure {
     Shape,
     Unsupported,
     Missing,
+    Edit(rue_cfg::CfgEditError),
 }
 
 impl CfgDomainProjection {
@@ -361,7 +362,7 @@ impl CfgDomainProjection {
         new: &Self,
         cfg: &rue_cfg::Cfg,
         new_span: Span,
-    ) -> Result<rue_cfg::Cfg, CfgDomainFailure> {
+    ) -> Result<rue_cfg::CfgEditor, CfgDomainFailure> {
         cfg.try_remap_domains(
             |value| new.current_type(&old.stable_type(value)?),
             |value| match new
@@ -418,6 +419,10 @@ impl CfgDomainProjection {
                 })
             },
         )
+        .map_err(|error| match error {
+            rue_cfg::CfgRemapError::Domain(error) => error,
+            rue_cfg::CfgRemapError::Edit(error) => CfgDomainFailure::Edit(error),
+        })
     }
 }
 
@@ -425,7 +430,7 @@ impl CfgDomainProjection {
 mod tests {
     use super::*;
     use lasso::Key;
-    use rue_cfg::{Cfg, CfgInst, CfgInstData};
+    use rue_cfg::{Cfg, CfgInstData};
 
     fn projection(symbol: Spur) -> CfgDomainProjection {
         CfgDomainProjection {
@@ -467,19 +472,8 @@ mod tests {
         let new = Spur::try_from_usize(17).unwrap();
         let mut cfg = Cfg::new(Type::I32, 0, 0, "f".into(), Vec::<bool>::new());
         let block = cfg.new_block();
-        cfg.add_inst_to_block(
-            block,
-            CfgInst {
-                data: CfgInstData::Call {
-                    runtime: None,
-                    name: old,
-                    args_start: 0,
-                    args_len: 0,
-                },
-                ty: Type::I32,
-                span: Span::new(4, 5),
-            },
-        );
+        cfg.append_call(block, None, old, [], Type::I32, Span::new(4, 5))
+            .unwrap();
         let imported = CfgDomainProjection::import_cfg(
             &projection(old),
             &projection(new),

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -1071,12 +1071,14 @@ drop fn StrBuf(self) { }
                     cfg.blocks()
                         .iter()
                         .flat_map(|block| block.insts.iter())
-                        .filter_map(|value| match cfg.get_inst(*value).data {
+                        .filter_map(|value| match &cfg.get_inst(*value).data {
                             rue_cfg::CfgInstData::Call {
                                 runtime: Some(runtime),
-                                args_len,
                                 ..
-                            } if is_target(runtime) => Some((runtime, args_len)),
+                            } if is_target(*runtime) => Some((
+                                *runtime,
+                                cfg.get_call_args(&cfg.get_inst(*value).data).len() as u32,
+                            )),
                             _ => None,
                         })
                         .collect::<Vec<_>>()

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -197,7 +197,7 @@ pub(crate) use syntax::SyntaxWork;
 
 pub use lasso::ThreadedRodeo;
 pub(crate) use rue_air::{AnalyzedFunction, SemaOutput, Type};
-pub(crate) use rue_cfg::{Cfg, CfgBuilder};
+pub(crate) use rue_cfg::{CfgBuilder, ValidatedCfg as Cfg};
 pub(crate) use rue_codegen::{RelocationKind, X86Mir, aarch64::Aarch64Mir};
 pub(crate) use rue_linker::{
     Archive, CodeRelocation, Linker, ObjectBuilder, ObjectFile, RelocationType,

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -223,29 +223,47 @@ pub(crate) fn build_functions_and_cfgs(
                             && input.type_inputs == candidate.input.type_inputs
                     })
                     && let Some(projection) = projection.as_ref()
-                    && let Ok(imported) = crate::durable_cfg::CfgDomainProjection::import_cfg(
+                {
+                    match crate::durable_cfg::CfgDomainProjection::import_cfg(
                         &candidate.domains,
                         projection,
                         &candidate.cfg,
                         stable_input.unwrap().body_span,
-                    )
-                {
-                    function_work.cfg_import_successes = 1;
-                    function_work.cfg_reuses = 1;
-                    let artifact = candidate.clone();
-                    return Ok((
-                        (
-                            FunctionWithCfg {
-                                analyzed: func,
-                                cfg: imported,
-                            },
-                            Vec::new(),
-                            Vec::new(),
-                            true,
-                            Some(artifact),
-                        ),
-                        function_work,
-                    ));
+                    ) {
+                        Ok(imported) => {
+                            if let Ok(imported) = imported.finish(&type_pool) {
+                                function_work.cfg_import_successes = 1;
+                                function_work.cfg_reuses = 1;
+                                let artifact = candidate.clone();
+                                return Ok((
+                                    (
+                                        FunctionWithCfg {
+                                            analyzed: func,
+                                            cfg: imported,
+                                        },
+                                        Vec::new(),
+                                        Vec::new(),
+                                        true,
+                                        Some(artifact),
+                                    ),
+                                    function_work,
+                                ));
+                            }
+                        }
+                        Err(crate::durable_cfg::CfgDomainFailure::Edit(error)) => {
+                            function_work.cfg_import_failures = 1;
+                            function_work.cfg_builds_failed = 1;
+                            let mut errors = CompileErrors::new();
+                            errors.push(CompileError::new(
+                                ErrorKind::InternalError(format!(
+                                    "CFG import payload construction failed: {error:?}"
+                                )),
+                                stable_input.unwrap().body_span,
+                            ));
+                            return Err((errors, function_work));
+                        }
+                        Err(_) => {}
+                    }
                 }
                 function_work.cfg_import_failures = 1;
                 function_work.cfg_fallbacks = 1;
@@ -278,8 +296,20 @@ pub(crate) fn build_functions_and_cfgs(
             function_work.cfg_builds_succeeded = 1;
             function_work.optimization_attempts = 1;
             function_work.optimized_level_attempts = usize::from(opt_level != OptLevel::O0);
-            let mut cfg = cfg_output.cfg;
-            rue_cfg::opt::optimize(&mut cfg, opt_level, &type_pool);
+            let cfg = cfg_output
+                .cfg
+                .expect("successful CFG construction publishes a validated CFG");
+            let cfg = match rue_cfg::opt::optimize(cfg, opt_level, &type_pool) {
+                Ok(cfg) => cfg,
+                Err(error) => {
+                    function_work.cfg_builds_failed = 1;
+                    let mut errors = CompileErrors::new();
+                    errors.push(CompileError::without_span(ErrorKind::InternalError(
+                        format!("CFG optimization failed: {error}"),
+                    )));
+                    return Err((errors, function_work));
+                }
+            };
             function_work.optimization_completions = 1;
             function_work.cfg_warnings_emitted = cfg_output.warnings.len();
             function_work.implicit_destructor_targets_emitted =

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -976,9 +976,11 @@ mod durable_body_integration_tests {
                 imported.allow_unreachable_code,
             );
             assert!(cfg_output.errors.is_empty());
-            rue_cfg::opt::optimize(&mut cfg_output.cfg, rue_cfg::OptLevel::O0, &frozen_types);
+            let cfg = cfg_output.cfg.take().unwrap();
+            cfg_output.cfg =
+                Some(rue_cfg::opt::optimize(cfg, rue_cfg::OptLevel::O0, &frozen_types).unwrap());
             assert_eq!(
-                normalize_epoch_symbols(&cfg_output.cfg.to_string()),
+                normalize_epoch_symbols(&cfg_output.cfg.as_ref().unwrap().to_string()),
                 normalize_epoch_symbols(&ordinary.cfg.to_string())
             );
             assert!(cfg_output.warnings.is_empty());

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -828,6 +828,11 @@ struct Frame {
     cache: HashMap<u32, Value>,
 }
 
+enum WritebackPlace<'a> {
+    Simple { base: PlaceBase, base_type: Type },
+    Stored(&'a Place),
+}
+
 impl<'a> Interp<'a> {
     fn string_literal_value(&self, text: String, ty: Type) -> Value {
         if self.is_str_like_type(ty) {
@@ -1068,15 +1073,11 @@ impl<'a> Interp<'a> {
             })
             .flatten()
             .any(|value| {
-                let CfgInstData::StructInit {
-                    struct_id,
-                    fields_start,
-                    fields_len,
-                } = cfg.get_inst(value).data
-                else {
+                let data = &cfg.get_inst(value).data;
+                let CfgInstData::StructInit { struct_id, .. } = data else {
                     return false;
                 };
-                let def = self.state.type_pool.struct_def(struct_id);
+                let def = self.state.type_pool.struct_def(*struct_id);
                 let is_slice = def.name.starts_with('[')
                     && def.name.ends_with(']')
                     && parse_array_type_syntax(&def.name).is_none();
@@ -1084,27 +1085,23 @@ impl<'a> Interp<'a> {
                     || def.fields.len() != 2
                     || def.fields[0].ty != pointer_ty
                     || def.fields[1].ty != Type::U64
-                    || fields_len != 2
-                    || cfg.get_inst(value).ty != Type::new_struct(struct_id)
+                    || cfg.get_struct_fields(data).len() != 2
+                    || cfg.get_inst(value).ty != Type::new_struct(*struct_id)
                     || cfg.value_use_count(value) != 1
                 {
                     return false;
                 }
-                let fields = cfg.get_extra(fields_start, fields_len);
+                let fields = cfg.get_struct_fields(data);
                 fields[0] == intrinsic
                     && cfg.get_inst(fields[1]).ty == Type::U64
                     && matches!(cfg.get_inst(fields[1]).data, CfgInstData::Const(0))
                     && cfg.blocks().iter().any(|block| {
                         block.insts.iter().any(|candidate| {
-                            let CfgInstData::Call {
-                                args_start,
-                                args_len,
-                                ..
-                            } = &cfg.get_inst(*candidate).data
-                            else {
+                            let data = &cfg.get_inst(*candidate).data;
+                            let CfgInstData::Call { .. } = data else {
                                 return false;
                             };
-                            cfg.get_call_args(*args_start, *args_len)
+                            cfg.get_call_args(data)
                                 .iter()
                                 .any(|arg| arg.value == value && arg.mode == CfgArgMode::Normal)
                         })
@@ -1627,6 +1624,7 @@ impl<'a> Interp<'a> {
             .iter()
             .map(|f| &f.cfg)
             .find(|c| c.fn_name() == name)
+            .map(|cfg| &**cfg)
     }
 
     /// Number of physical parameter slots occupied by one CFG call argument.
@@ -1830,19 +1828,19 @@ impl<'a> Interp<'a> {
                 self.eval(cfg, &mut frame, v)?;
             }
 
-            let term = block.terminator;
+            let term = &block.terminator;
             match term {
                 Terminator::Return { value } => {
                     let ret = match value {
-                        Some(v) => self.eval(cfg, &mut frame, v)?,
+                        Some(v) => self.eval(cfg, &mut frame, *v)?,
                         None => Value::Unit,
                     };
                     return Ok((ret, std::mem::take(&mut frame.params)));
                 }
                 Terminator::Goto { target, .. } => {
-                    let ce = cfg.get_goto_args(&term).to_vec();
+                    let ce = cfg.get_goto_args(term).to_vec();
                     incoming = self.eval_all(cfg, &mut frame, &ce)?;
-                    current = target;
+                    current = *target;
                 }
                 Terminator::Branch {
                     cond,
@@ -1850,30 +1848,27 @@ impl<'a> Interp<'a> {
                     else_block,
                     ..
                 } => {
-                    let c = self.eval(cfg, &mut frame, cond)?.as_bool();
+                    let c = self.eval(cfg, &mut frame, *cond)?.as_bool();
                     let args = if c {
-                        cfg.get_branch_then_args(&term)
+                        cfg.get_branch_then_args(term)
                     } else {
-                        cfg.get_branch_else_args(&term)
+                        cfg.get_branch_else_args(term)
                     }
                     .to_vec();
                     incoming = self.eval_all(cfg, &mut frame, &args)?;
-                    current = if c { then_block } else { else_block };
+                    current = if c { *then_block } else { *else_block };
                 }
                 Terminator::Switch {
-                    scrutinee,
-                    cases_start,
-                    cases_len,
-                    default,
+                    scrutinee, default, ..
                 } => {
                     // The scrutinee is an integer, a discriminant-only enum
                     // (`Int` tag), or a payload-carrying enum (`Aggregate` whose
                     // element 0 is the tag, RUE-285). Switch on the discriminant.
-                    let s = match self.eval(cfg, &mut frame, scrutinee)? {
+                    let s = match self.eval(cfg, &mut frame, *scrutinee)? {
                         Value::Aggregate(elems) => elems.first().map(Value::as_int).unwrap_or(0),
                         other => other.as_int(),
                     };
-                    let cases = cfg.get_switch_cases(cases_start, cases_len);
+                    let cases = cfg.get_switch_cases(term);
                     // Case values are stored as i64 bit patterns; compare by the
                     // 64-bit pattern so unsigned extremes (u64::MAX -> -1 as i64)
                     // and i64::MIN match the scrutinee regardless of signedness.
@@ -1882,7 +1877,7 @@ impl<'a> Interp<'a> {
                         .iter()
                         .find(|(val, _)| *val as u64 == s_bits)
                         .map(|(_, blk)| *blk)
-                        .unwrap_or(default);
+                        .unwrap_or(*default);
                     incoming = Vec::new();
                 }
                 Terminator::Unreachable => {
@@ -2341,8 +2336,7 @@ impl<'a> Interp<'a> {
                 Value::Unit
             }
             CfgInstData::PlaceRead { place } => {
-                let place = place.clone();
-                if !self.place_projection_metadata_is_valid(cfg, &place, ty, PlaceAccess::Read) {
+                if !self.place_projection_metadata_is_valid(cfg, place, ty, PlaceAccess::Read) {
                     return Err(unsupported(
                         UnsupportedKind::ContractViolation(
                             ContractViolationKind::PlaceProjectionMetadata,
@@ -2350,7 +2344,7 @@ impl<'a> Interp<'a> {
                         "PlaceRead projection metadata drift",
                     ));
                 }
-                if let Some(kind) = self.place_base_violation(cfg, &place, PlaceAccess::Read) {
+                if let Some(kind) = self.place_base_violation(cfg, place, PlaceAccess::Read) {
                     return Err(unsupported(
                         UnsupportedKind::ContractViolation(kind),
                         format!(
@@ -2363,13 +2357,12 @@ impl<'a> Interp<'a> {
                         ),
                     ));
                 }
-                self.place_read(cfg, frame, &place)?
+                self.place_read(cfg, frame, place)?
             }
             CfgInstData::PlaceWrite { place, value } => {
-                let place = place.clone();
                 if !self.place_projection_metadata_is_valid(
                     cfg,
-                    &place,
+                    place,
                     cfg.get_inst(*value).ty,
                     PlaceAccess::Write,
                 ) {
@@ -2380,7 +2373,7 @@ impl<'a> Interp<'a> {
                         "PlaceWrite projection metadata drift",
                     ));
                 }
-                if let Some(kind) = self.place_base_violation(cfg, &place, PlaceAccess::Write) {
+                if let Some(kind) = self.place_base_violation(cfg, place, PlaceAccess::Write) {
                     return Err(unsupported(
                         UnsupportedKind::ContractViolation(kind),
                         format!(
@@ -2394,23 +2387,16 @@ impl<'a> Interp<'a> {
                     ));
                 }
                 let val = self.eval(cfg, frame, *value)?;
-                self.place_write(cfg, frame, &place, val)?;
+                self.place_write(cfg, frame, place, val)?;
                 Value::Unit
             }
 
-            CfgInstData::StructInit {
-                fields_start,
-                fields_len,
-                ..
-            } => {
-                let fields = cfg.get_extra(*fields_start, *fields_len).to_vec();
+            CfgInstData::StructInit { .. } => {
+                let fields = cfg.get_struct_fields(&inst.data).to_vec();
                 Value::Aggregate(self.eval_all(cfg, frame, &fields)?)
             }
-            CfgInstData::ArrayInit {
-                elements_start,
-                elements_len,
-            } => {
-                let elems = cfg.get_extra(*elements_start, *elements_len).to_vec();
+            CfgInstData::ArrayInit { .. } => {
+                let elems = cfg.get_array_elements(&inst.data).to_vec();
                 Value::Aggregate(self.eval_all(cfg, frame, &elems)?)
             }
             // A discriminant-only variant is its tag (an `Int`); a payload-
@@ -2418,16 +2404,11 @@ impl<'a> Interp<'a> {
             // the rest are the payload fields, in declaration order (RUE-285).
             // This lets structural `==` distinguish `Circle(5)` from `Circle(6)`
             // and from `Square(5)`, and lets `EnumPayloadGet` project a field.
-            CfgInstData::EnumVariant {
-                variant_index,
-                payload_start,
-                payload_len,
-                ..
-            } => {
-                if *payload_len == 0 {
+            CfgInstData::EnumVariant { variant_index, .. } => {
+                if cfg.get_enum_payload(&inst.data).is_empty() {
                     Value::Int(*variant_index as i128)
                 } else {
-                    let payload_refs = cfg.get_extra(*payload_start, *payload_len).to_vec();
+                    let payload_refs = cfg.get_enum_payload(&inst.data).to_vec();
                     let mut elems = Vec::with_capacity(1 + payload_refs.len());
                     elems.push(Value::Int(*variant_index as i128));
                     elems.extend(self.eval_all(cfg, frame, &payload_refs)?);
@@ -2461,14 +2442,9 @@ impl<'a> Interp<'a> {
                 Self::set_param(frame, *param_slot, val);
                 Value::Unit
             }
-            CfgInstData::Call {
-                runtime,
-                name,
-                args_start,
-                args_len,
-            } => {
+            CfgInstData::Call { runtime, name, .. } => {
                 let fname = self.interner().resolve(name).to_string();
-                let call_args = cfg.get_call_args(*args_start, *args_len).to_vec();
+                let call_args = cfg.get_call_args(&inst.data).to_vec();
                 let arg_types: Vec<Type> = call_args
                     .iter()
                     .map(|arg| cfg.get_inst(arg.value).ty)
@@ -2513,7 +2489,7 @@ impl<'a> Interp<'a> {
                 // Copy-in every argument (by value); for `inout` args, remember
                 // the base parameter slot and the caller place to copy back into.
                 let mut argvals = Vec::with_capacity(call_args.len());
-                let mut writebacks: Vec<(usize, Place)> = Vec::new();
+                let mut writebacks: Vec<(usize, WritebackPlace<'a>)> = Vec::new();
                 let mut base = 0usize;
                 for (index, a) in call_args.iter().enumerate() {
                     let v = self.eval(cfg, frame, a.value)?;
@@ -2564,21 +2540,27 @@ impl<'a> Interp<'a> {
                     // the caller place it came from.
                     for (slot, place) in writebacks {
                         if let Some(val) = final_params.get(slot).and_then(|o| o.clone()) {
-                            self.place_write(cfg, frame, &place, val)?;
+                            match place {
+                                WritebackPlace::Simple { base, base_type } => {
+                                    let place = match base {
+                                        PlaceBase::Local(slot) => Place::local(slot, base_type),
+                                        PlaceBase::Param(slot) => Place::param(slot, base_type),
+                                    };
+                                    self.place_write(cfg, frame, &place, val)?;
+                                }
+                                WritebackPlace::Stored(place) => {
+                                    self.place_write(cfg, frame, place, val)?;
+                                }
+                            }
                         }
                     }
                     result
                 }
             }
 
-            CfgInstData::Intrinsic {
-                name,
-                args_start,
-                args_len,
-                ..
-            } => {
+            CfgInstData::Intrinsic { name, .. } => {
                 let iname = self.interner().resolve(name).to_string();
-                let args = cfg.get_extra(*args_start, *args_len).to_vec();
+                let args = cfg.get_intrinsic_args(&inst.data).to_vec();
                 if let Some(intrinsic) = self.preflight_abort_intrinsic(cfg, &iname, &args, ty)? {
                     self.eval_abort_intrinsic(cfg, frame, intrinsic, &args)?
                 } else if iname != "dbg" {
@@ -2920,13 +2902,14 @@ impl<'a> Interp<'a> {
 
     /// Recover the caller place an `inout` argument was loaded from, so its
     /// mutated value can be copied back after the call.
-    fn lvalue_of(&self, cfg: &'a Cfg, v: CfgValue) -> Step<Place> {
+    fn lvalue_of(&self, cfg: &'a Cfg, v: CfgValue) -> Step<WritebackPlace<'a>> {
         match &cfg.get_inst(v).data {
-            CfgInstData::Load { slot } if *slot < cfg.num_locals() => {
-                Ok(Place::local(*slot, cfg.get_inst(v).ty))
-            }
+            CfgInstData::Load { slot } if *slot < cfg.num_locals() => Ok(WritebackPlace::Simple {
+                base: PlaceBase::Local(*slot),
+                base_type: cfg.get_inst(v).ty,
+            }),
             CfgInstData::PlaceRead { place } if self.is_inout_writeback_place(cfg, v, place) => {
-                Ok(place.clone())
+                Ok(WritebackPlace::Stored(place))
             }
             other @ CfgInstData::Param { index }
                 if *index < cfg.num_params() && cfg.is_param_writable(*index) =>

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -26,17 +26,11 @@ fn find_call_metadata(
         for block in function.cfg.blocks() {
             for &value in &block.insts {
                 let inst = function.cfg.get_inst(value);
-                let CfgInstData::Call {
-                    name,
-                    args_start,
-                    args_len,
-                    ..
-                } = &inst.data
-                else {
+                let CfgInstData::Call { name, .. } = &inst.data else {
                     continue;
                 };
                 if state.interner.resolve(name) == expected_name {
-                    let args = function.cfg.get_call_args(*args_start, *args_len);
+                    let args = function.cfg.get_call_args(&inst.data);
                     return (
                         args.iter()
                             .map(|arg| function.cfg.get_inst(arg.value).ty)
@@ -190,23 +184,13 @@ fn find_intrinsic_in_function<'a>(
         .flat_map(|block| block.insts.iter().copied())
     {
         let inst = cfg.get_inst(value);
-        let CfgInstData::Intrinsic {
-            name,
-            args_start,
-            args_len,
-            ..
-        } = &inst.data
-        else {
+        let CfgInstData::Intrinsic { name, .. } = &inst.data else {
             continue;
         };
         if state.interner.resolve(name) != expected_name {
             continue;
         }
-        let item = (
-            value,
-            cfg.get_extra(*args_start, *args_len).to_vec(),
-            inst.ty,
-        );
+        let item = (value, cfg.get_intrinsic_args(&inst.data).to_vec(), inst.ty);
         assert!(
             found.replace(item).is_none(),
             "expected exactly one @{expected_name} in {function_name}"
@@ -432,30 +416,14 @@ fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
             )
         };
 
+        let type_pool = &state.type_pool;
         let cfg = &mut state.functions[main_index].cfg;
-        let (args_start, args_len) = match cfg.get_inst(call).data {
-            CfgInstData::Call {
-                args_start,
-                args_len,
-                ..
-            } => (args_start, args_len),
-            _ => unreachable!("selected a Call"),
-        };
-        let mut args = cfg.get_call_args(args_start, args_len).to_vec();
+        let mut args = cfg.get_call_args(&cfg.get_inst(call).data).to_vec();
         assert_eq!(args.len(), 1, "{callee_name} probe arity");
         args[0].value = random;
         args[0].mode = replacement_mode;
-        let (args_start, args_len) = cfg.push_call_args(args);
-        let CfgInstData::Call {
-            args_start: stored_start,
-            args_len: stored_len,
-            ..
-        } = &mut cfg.get_inst_mut(call).data
-        else {
-            unreachable!("selected a Call")
-        };
-        *stored_start = args_start;
-        *stored_len = args_len;
+        cfg.try_edit(type_pool, |editor| editor.replace_call_args(call, args))
+            .unwrap();
 
         let cfg = &state.functions[main_index].cfg;
         let mut interp = Interp {
@@ -543,18 +511,13 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
             ),
             _ => unreachable!(),
         };
-        let (args_start, args_len) = cfg.push_extra(replacement_args);
-        let CfgInstData::Intrinsic {
-            args_start: stored_start,
-            args_len: stored_len,
-            ..
-        } = &mut cfg.get_inst_mut(outer).data
-        else {
-            unreachable!("selected an intrinsic")
-        };
-        *stored_start = args_start;
-        *stored_len = args_len;
-        cfg.get_inst_mut(outer).ty = replacement_ty;
+        let type_pool = &state.type_pool;
+        cfg.try_edit(type_pool, |editor| {
+            editor.replace_intrinsic_args(outer, replacement_args)?;
+            editor.replace_inst_type(outer, replacement_ty)?;
+            Ok::<_, rue_cfg::CfgEditError>(())
+        })
+        .unwrap();
 
         let cfg = &state.functions[main_index].cfg;
         let mut interp = Interp {
@@ -767,10 +730,13 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         .iter()
         .position(|function| function.cfg.fn_name() == "user_pointer")
         .expect("user_pointer CFG");
+    let type_pool = &drift_state.type_pool;
     drift_state.functions[drift_user_index]
         .cfg
-        .get_inst_mut(drift_user_inst)
-        .ty = drift_slice_result;
+        .try_edit(type_pool, |editor| {
+            editor.replace_inst_type(drift_user_inst, drift_slice_result)
+        })
+        .unwrap();
     let (drift_cfg, drift_inst, drift_args, drift_result) =
         find_intrinsic_in_function(&drift_state, "user_pointer", "int_to_ptr");
     let drift_interp = Interp {
@@ -818,13 +784,13 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
             )
         })
         .expect("outer result cast");
+    let type_pool = &extra_use_state.type_pool;
     extra_use_state.functions[extra_main]
         .cfg
-        .get_inst_mut(outer_cast)
-        .data = CfgInstData::IntCast {
-        value: extra_slice_inst,
-        from_ty: drift_slice_result,
-    };
+        .try_edit(type_pool, |editor| {
+            editor.replace_int_cast(outer_cast, extra_slice_inst, drift_slice_result)
+        })
+        .unwrap();
     let (extra_cfg, extra_inst, extra_args, extra_result) =
         find_intrinsic_in_function(&extra_use_state, "main", "int_to_ptr");
     let extra_interp = Interp {
@@ -864,15 +830,11 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
             .iter()
             .flat_map(|block| block.insts.iter().copied())
             .find(|value| {
-                let CfgInstData::StructInit {
-                    fields_start,
-                    fields_len,
-                    ..
-                } = cfg.get_inst(*value).data
-                else {
+                let data = &cfg.get_inst(*value).data;
+                let CfgInstData::StructInit { .. } = data else {
                     return false;
                 };
-                cfg.get_extra(fields_start, fields_len).first() == Some(&extra_init_pointer)
+                cfg.get_struct_fields(data).first() == Some(&extra_init_pointer)
             })
             .expect("empty-slice StructInit");
         let outer_cast = cfg
@@ -883,13 +845,13 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
             .expect("outer result cast");
         (slice_init, cfg.get_inst(slice_init).ty, outer_cast)
     };
+    let type_pool = &extra_init_use_state.type_pool;
     extra_init_use_state.functions[extra_init_main]
         .cfg
-        .get_inst_mut(outer_cast)
-        .data = CfgInstData::IntCast {
-        value: slice_init,
-        from_ty: slice_ty,
-    };
+        .try_edit(type_pool, |editor| {
+            editor.replace_int_cast(outer_cast, slice_init, slice_ty)
+        })
+        .unwrap();
     let (extra_init_cfg, extra_init_inst, extra_init_args, extra_init_result) =
         find_intrinsic_in_function(&extra_init_use_state, "main", "int_to_ptr");
     assert_eq!(extra_init_cfg.value_use_count(extra_init_inst), 1);
@@ -931,15 +893,11 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
             .iter()
             .flat_map(|block| block.insts.iter().copied())
             .find(|value| {
-                let CfgInstData::StructInit {
-                    fields_start,
-                    fields_len,
-                    ..
-                } = cfg.get_inst(*value).data
-                else {
+                let data = &cfg.get_inst(*value).data;
+                let CfgInstData::StructInit { .. } = data else {
                     return false;
                 };
-                cfg.get_extra(fields_start, fields_len).first() == Some(&wrong_consumer_pointer)
+                cfg.get_struct_fields(data).first() == Some(&wrong_consumer_pointer)
             })
             .expect("empty-slice StructInit");
         let (consumer, args) = cfg
@@ -947,15 +905,11 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
             .iter()
             .flat_map(|block| block.insts.iter().copied())
             .find_map(|value| {
-                let CfgInstData::Call {
-                    args_start,
-                    args_len,
-                    ..
-                } = cfg.get_inst(value).data
-                else {
+                let data = &cfg.get_inst(value).data;
+                let CfgInstData::Call { .. } = data else {
                     return None;
                 };
-                let args = cfg.get_call_args(args_start, args_len);
+                let args = cfg.get_call_args(data);
                 args.iter()
                     .any(|arg| arg.value == init)
                     .then(|| (value, args.to_vec()))
@@ -969,18 +923,12 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
         .expect("empty-slice call argument");
     assert_eq!(slice_arg.mode, CfgArgMode::Normal);
     slice_arg.mode = CfgArgMode::Borrow;
+    let type_pool = &wrong_consumer_state.type_pool;
     let cfg = &mut wrong_consumer_state.functions[wrong_consumer_main].cfg;
-    let (args_start, args_len) = cfg.push_call_args(consumer_args);
-    let CfgInstData::Call {
-        args_start: old_start,
-        args_len: old_len,
-        ..
-    } = &mut cfg.get_inst_mut(consumer).data
-    else {
-        unreachable!("consumer stopped being a call")
-    };
-    *old_start = args_start;
-    *old_len = args_len;
+    cfg.try_edit(type_pool, |editor| {
+        editor.replace_call_args(consumer, consumer_args)
+    })
+    .unwrap();
     let (wrong_consumer_cfg, wrong_consumer_inst, wrong_consumer_args, wrong_consumer_result) =
         find_intrinsic_in_function(&wrong_consumer_state, "main", "int_to_ptr");
     assert_eq!(wrong_consumer_cfg.value_use_count(wrong_consumer_inst), 1);
@@ -1021,22 +969,21 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
             .iter()
             .flat_map(|block| block.insts.iter().copied())
             .find(|value| {
-                let CfgInstData::StructInit {
-                    fields_start,
-                    fields_len,
-                    ..
-                } = cfg.get_inst(*value).data
-                else {
+                let data = &cfg.get_inst(*value).data;
+                let CfgInstData::StructInit { .. } = data else {
                     return false;
                 };
-                cfg.get_extra(fields_start, fields_len).first() == Some(&wrong_init_pointer)
+                cfg.get_struct_fields(data).first() == Some(&wrong_init_pointer)
             })
             .expect("empty-slice StructInit")
     };
+    let type_pool = &wrong_init_state.type_pool;
     wrong_init_state.functions[wrong_init_main]
         .cfg
-        .get_inst_mut(slice_init)
-        .ty = Type::UNIT;
+        .try_edit(type_pool, |editor| {
+            editor.replace_inst_type(slice_init, Type::UNIT)
+        })
+        .unwrap();
     let (wrong_init_cfg, wrong_init_inst, wrong_init_args, wrong_init_result) =
         find_intrinsic_in_function(&wrong_init_state, "main", "int_to_ptr");
     let wrong_init_interp = Interp {
@@ -1062,7 +1009,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
 }
 
 #[test]
-fn field_pointer_gaps_require_in_bounds_projection_metadata() {
+fn validated_cfg_rejects_out_of_bounds_field_pointer_projection_metadata() {
     let source = "struct Pair { a: i32, b: i32 }
         fn main() -> i32 {
             let mut p = Pair { a: 1, b: 2 };
@@ -1108,34 +1055,25 @@ fn field_pointer_gaps_require_in_bounds_projection_metadata() {
         (place.base, place.base_type, struct_id)
     };
     let out_of_bounds = state.type_pool.struct_def(struct_id).field_count() as u32;
-    let invalid_place = state.functions[main_index].cfg.make_place(
-        base,
-        base_type,
-        [Projection::Field {
-            struct_id,
-            field_index: out_of_bounds,
-        }],
-    );
-    state.functions[main_index]
+    let type_pool = &state.type_pool;
+    let error = state.functions[main_index]
         .cfg
-        .get_inst_mut(field_read)
-        .data = CfgInstData::PlaceRead {
-        place: invalid_place,
-    };
-    let (cfg, inst, args, result) = find_intrinsic_in_function(&state, "main", "field_ptr");
-    let interp = Interp {
-        state: &state,
-        stdout: String::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-    };
-    assert_eq!(
-        interp.classify_unsupported_intrinsic(cfg, inst, "field_ptr", &args, result),
-        UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature)
-    );
+        .try_edit(type_pool, |editor| {
+            editor.replace_place_read(
+                field_read,
+                base,
+                base_type,
+                [Projection::Field {
+                    struct_id,
+                    field_index: out_of_bounds,
+                }],
+            )
+        })
+        .expect_err("ValidatedCfg must reject an out-of-bounds field projection");
+    assert!(matches!(
+        error,
+        rue_cfg::CfgEditTransactionError::Verification(_)
+    ));
 }
 
 #[test]

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -99,11 +99,14 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
         .iter()
         .flat_map(|block| block.insts.iter().copied())
     {
-        if let CfgInstData::PlaceRead { place } = &cfg.get_inst(value).data {
-            field_read = Some((value, place.clone()));
+        if matches!(cfg.get_inst(value).data, CfgInstData::PlaceRead { .. }) {
+            field_read = Some(value);
         }
     }
-    let (field_value, field_place) = field_read.expect("Pair field read");
+    let field_value = field_read.expect("Pair field read");
+    let CfgInstData::PlaceRead { place: field_place } = &cfg.get_inst(field_value).data else {
+        unreachable!()
+    };
     let mut interp = Interp {
         state: &state,
         stdout: String::new(),
@@ -121,7 +124,7 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
         locals: vec![None; cfg.num_locals() as usize],
         cache: HashMap::new(),
     };
-    let projection = expect_flow_unsupported(interp.place_read(cfg, &mut frame, &field_place));
+    let projection = expect_flow_unsupported(interp.place_read(cfg, &mut frame, field_place));
     assert_eq!(
         projection.kind(),
         UnsupportedKind::ContractViolation(ContractViolationKind::NonAggregateProjectionRead)
@@ -172,7 +175,7 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
 }
 
 #[test]
-fn place_contract_requires_the_complete_ordinary_nominal_chain_to_be_well_typed() {
+fn validated_cfg_requires_the_complete_ordinary_nominal_chain_to_be_well_typed() {
     let source = r#"struct Pair { value: i32 }
         struct Header { pointer: u64, length: u64, capacity: u64 }
         fn read(p: Pair) -> i32 { p.value }
@@ -196,7 +199,7 @@ fn place_contract_requires_the_complete_ordinary_nominal_chain_to_be_well_typed(
             .iter()
             .position(|function| function.cfg.fn_name() == "read")
             .expect("read CFG");
-        let (place_value, original_place) = {
+        let (place_value, base) = {
             let cfg = &state.functions[read_index].cfg;
             cfg.blocks()
                 .iter()
@@ -205,13 +208,17 @@ fn place_contract_requires_the_complete_ordinary_nominal_chain_to_be_well_typed(
                     let CfgInstData::PlaceRead { place } = &cfg.get_inst(value).data else {
                         return None;
                     };
-                    Some((value, place.clone()))
+                    Some((value, place.base))
                 })
                 .expect("Pair field PlaceRead")
         };
-        let pair_projection = state.functions[read_index]
-            .cfg
-            .get_place_projections(&original_place)[0];
+        let pair_projection = {
+            let cfg = &state.functions[read_index].cfg;
+            let CfgInstData::PlaceRead { place } = &cfg.get_inst(place_value).data else {
+                unreachable!()
+            };
+            cfg.get_place_projections(place)[0]
+        };
         let projections = if invalid_suffix {
             vec![
                 Projection::Field {
@@ -226,31 +233,17 @@ fn place_contract_requires_the_complete_ordinary_nominal_chain_to_be_well_typed(
                 field_index: 0,
             }]
         };
+        let type_pool = &state.type_pool;
         let cfg = &mut state.functions[read_index].cfg;
-        let place = cfg.make_place(original_place.base, header_ty, projections);
-        cfg.get_inst_mut(place_value).data = CfgInstData::PlaceRead { place };
-
-        let cfg = &state.functions[read_index].cfg;
-        let mut interp = Interp {
-            state: &state,
-            stdout: String::new(),
-            stdout_bytes: 0,
-            stdout_cap: MAX_STDOUT_BYTES,
-            stderr_cap: MAX_STDERR_BYTES,
-            budget: STEP_BUDGET,
-            depth: 0,
-        };
-        let mut frame = Frame {
-            params: vec![Some(Value::string("not a Header"))],
-            locals: vec![None; cfg.num_locals() as usize],
-            cache: HashMap::new(),
-        };
-        let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, place_value));
-        assert_eq!(
-            unsupported.kind(),
-            UnsupportedKind::ContractViolation(ContractViolationKind::PlaceProjectionMetadata),
-            "the malformed complete place chain must fail before its injected text runtime shape; invalid_suffix={invalid_suffix}"
-        );
+        let error = cfg
+            .try_edit(type_pool, |editor| {
+                editor.replace_place_read(place_value, base, header_ty, projections)
+            })
+            .expect_err("ValidatedCfg must reject a malformed nominal projection chain");
+        assert!(matches!(
+            error,
+            rue_cfg::CfgEditTransactionError::Verification(_)
+        ));
     }
 }
 
@@ -313,7 +306,7 @@ fn logical_inout_writability_is_distinct_from_the_by_reference_abi() {
 }
 
 #[test]
-fn text_projection_gaps_require_exact_representation_metadata() {
+fn validated_cfg_rejects_invalid_owned_text_projection_metadata() {
     let preview_features = PreviewFeatures::new();
     let view_state = query_cfg_state_with_preview_features(
         r#"fn main() -> i32 {
@@ -329,15 +322,20 @@ fn text_projection_gaps_require_exact_representation_metadata() {
         .map(|function| &function.cfg)
         .find(|cfg| cfg.fn_name() == "main")
         .expect("main CFG");
-    let view_place = view_cfg
+    let view_value = view_cfg
         .blocks()
         .iter()
         .flat_map(|block| block.insts.iter().copied())
-        .find_map(|value| match &view_cfg.get_inst(value).data {
-            CfgInstData::PlaceRead { place } => Some(place.clone()),
-            _ => None,
+        .find(|&value| {
+            matches!(
+                &view_cfg.get_inst(value).data,
+                CfgInstData::PlaceRead { .. }
+            )
         })
         .expect("str field projection");
+    let CfgInstData::PlaceRead { place: view_place } = &view_cfg.get_inst(view_value).data else {
+        unreachable!()
+    };
     let PlaceBase::Local(view_slot) = view_place.base else {
         panic!("str probe must be rooted in a local")
     };
@@ -357,7 +355,7 @@ fn text_projection_gaps_require_exact_representation_metadata() {
         depth: 0,
     };
     let width =
-        expect_flow_unsupported(view_interp.place_read(view_cfg, &mut view_frame, &view_place));
+        expect_flow_unsupported(view_interp.place_read(view_cfg, &mut view_frame, view_place));
     assert_eq!(
         width.kind(),
         UnsupportedKind::ContractViolation(ContractViolationKind::NonAggregateProjectionRead)
@@ -397,60 +395,44 @@ fn text_projection_gaps_require_exact_representation_metadata() {
     let TypeKind::Struct(owned_struct) = owned_ty.kind() else {
         panic!("String must be a struct type")
     };
+    let type_pool = &owned_state.type_pool;
     let cfg = &mut owned_state.functions[main_index].cfg;
-    let cap_place = cfg.make_place(
-        PlaceBase::Local(0),
-        owned_ty,
-        [Projection::Field {
-            struct_id: owned_struct,
-            field_index: 2,
-        }],
-    );
-    let index_place = cfg.make_place(
-        PlaceBase::Local(0),
-        owned_ty,
-        [Projection::Index {
-            array_type: owned_ty,
-            index: zero,
-        }],
-    );
-    let owned_cfg = &owned_state.functions[main_index].cfg;
-    let owned_interp = Interp {
-        state: &owned_state,
-        stdout: String::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-    };
-    for place in [cap_place, index_place] {
-        let mut frame = Frame {
-            params: Vec::new(),
-            locals: vec![Some(Value::string("owned"))],
-            cache: HashMap::new(),
-        };
-        let unsupported = expect_flow_unsupported({
-            let mut interp = Interp {
-                state: owned_interp.state,
-                stdout: String::new(),
-                stdout_bytes: 0,
-                stdout_cap: MAX_STDOUT_BYTES,
-                stderr_cap: MAX_STDERR_BYTES,
-                budget: STEP_BUDGET,
-                depth: 0,
-            };
-            interp.place_read(owned_cfg, &mut frame, &place)
-        });
-        assert_eq!(
-            unsupported.kind(),
-            UnsupportedKind::ContractViolation(ContractViolationKind::NonAggregateProjectionRead)
-        );
-    }
+    let span = cfg.get_inst(zero).span;
+    let error = cfg
+        .try_edit(type_pool, |editor| {
+            editor.append_place_read(
+                editor.entry,
+                PlaceBase::Local(0),
+                owned_ty,
+                [Projection::Field {
+                    struct_id: owned_struct,
+                    field_index: 2,
+                }],
+                Type::U64,
+                span,
+            )?;
+            editor.append_place_read(
+                editor.entry,
+                PlaceBase::Local(0),
+                owned_ty,
+                [Projection::Index {
+                    array_type: owned_ty,
+                    index: zero,
+                }],
+                Type::U64,
+                span,
+            )?;
+            Ok::<_, rue_cfg::CfgEditError>(())
+        })
+        .expect_err("ValidatedCfg must reject invalid owned-text projections");
+    assert!(matches!(
+        error,
+        rue_cfg::CfgEditTransactionError::Verification(_)
+    ));
 }
 
 #[test]
-fn place_write_contracts_precede_rhs_model_gaps() {
+fn validated_cfg_rejects_malformed_place_writes_before_oracle_model_gaps() {
     const SOURCE: &str = "struct Inner { value: u32 }
         struct Outer { inner: Inner }
         fn write() -> u32 {
@@ -489,84 +471,52 @@ fn place_write_contracts_precede_rhs_model_gaps() {
             .iter()
             .position(|function| function.cfg.fn_name() == "write")
             .expect("write CFG");
-        let (write_value, original_place, rhs) = {
+        let (write_value, base, base_type, rhs, projections) = {
             let cfg = &state.functions[write_index].cfg;
             cfg.blocks()
                 .iter()
                 .flat_map(|block| block.insts.iter().copied())
                 .find_map(|value| {
-                    let CfgInstData::PlaceWrite { place, value: rhs } = cfg.get_inst(value).data
+                    let CfgInstData::PlaceWrite { place, value: rhs } = &cfg.get_inst(value).data
                     else {
                         return None;
                     };
-                    (cfg.get_place_projections(&place).len() == 2).then_some((value, place, rhs))
+                    (cfg.get_place_projections(place).len() == 2).then_some((
+                        value,
+                        place.base,
+                        place.base_type,
+                        *rhs,
+                        cfg.get_place_projections(place).to_vec(),
+                    ))
                 })
                 .expect("nested PlaceWrite")
         };
-        let projections = state.functions[write_index]
-            .cfg
-            .get_place_projections(&original_place)
-            .to_vec();
-        let expected = match corruption {
-            Corruption::LocalBase | Corruption::ParamBase => {
-                UnsupportedKind::ContractViolation(ContractViolationKind::PlaceBaseOutOfBounds)
-            }
-            Corruption::RootType | Corruption::SuffixType | Corruption::FinalType => {
-                UnsupportedKind::ContractViolation(ContractViolationKind::PlaceProjectionMetadata)
-            }
-        };
+        let type_pool = &state.type_pool;
         let cfg = &mut state.functions[write_index].cfg;
-        let invalid_place = match corruption {
-            Corruption::LocalBase => Place {
-                base: PlaceBase::Local(cfg.num_locals()),
-                ..original_place
-            },
-            Corruption::ParamBase => Place {
-                base: PlaceBase::Param(cfg.num_params()),
-                ..original_place
-            },
-            Corruption::RootType => Place {
-                base_type: Type::I32,
-                ..original_place
-            },
-            Corruption::SuffixType => cfg.make_place(
-                original_place.base,
-                original_place.base_type,
-                [projections[0], projections[0]],
-            ),
-            Corruption::FinalType => cfg.make_place(
-                original_place.base,
-                original_place.base_type,
-                [projections[0]],
-            ),
+        let (base, base_type, projections) = match corruption {
+            Corruption::LocalBase => (PlaceBase::Local(cfg.num_locals()), base_type, projections),
+            Corruption::ParamBase => (PlaceBase::Param(cfg.num_params()), base_type, projections),
+            Corruption::RootType => (base, Type::I32, projections),
+            Corruption::SuffixType => (base, base_type, vec![projections[0], projections[0]]),
+            Corruption::FinalType => (base, base_type, vec![projections[0]]),
         };
-        cfg.get_inst_mut(write_value).data = CfgInstData::PlaceWrite {
-            place: invalid_place,
-            value: rhs,
-        };
-
-        let cfg = &state.functions[write_index].cfg;
-        let mut interp = Interp {
-            state: &state,
-            stdout: String::new(),
-            stdout_bytes: 0,
-            stdout_cap: MAX_STDOUT_BYTES,
-            stderr_cap: MAX_STDERR_BYTES,
-            budget: STEP_BUDGET,
-            depth: 0,
-        };
-        let mut frame = Frame {
-            params: vec![None; cfg.num_params() as usize],
-            locals: vec![None; cfg.num_locals() as usize],
-            cache: HashMap::new(),
-        };
-        let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, write_value));
-        assert_eq!(unsupported.kind(), expected, "{corruption:?}");
+        let before = cfg.to_string();
+        let error = cfg
+            .try_edit(type_pool, |editor| {
+                editor.replace_place_write(write_value, base, base_type, projections, rhs)
+            })
+            .expect_err("ValidatedCfg must reject a malformed place write");
+        assert!(matches!(
+            error,
+            rue_cfg::CfgEditTransactionError::Edit(_)
+                | rue_cfg::CfgEditTransactionError::Verification(_)
+        ));
+        assert_eq!(cfg.to_string(), before, "{corruption:?}");
     }
 }
 
 #[test]
-fn place_read_base_contract_precedes_index_model_gap() {
+fn validated_cfg_rejects_out_of_bounds_place_read_bases() {
     const SOURCE: &str = "fn read() -> u32 {
             let values: [u32; 2] = [1, 2];
             values[@random_u32()]
@@ -587,57 +537,39 @@ fn place_read_base_contract_precedes_index_model_gap() {
             .iter()
             .position(|function| function.cfg.fn_name() == "read")
             .expect("read CFG");
-        let (read_value, original_place) = {
+        let (read_value, base_type, projections) = {
             let cfg = &state.functions[read_index].cfg;
             cfg.blocks()
                 .iter()
                 .flat_map(|block| block.insts.iter().copied())
                 .find_map(|value| {
-                    let CfgInstData::PlaceRead { place } = cfg.get_inst(value).data else {
+                    let CfgInstData::PlaceRead { place } = &cfg.get_inst(value).data else {
                         return None;
                     };
-                    matches!(
-                        cfg.get_place_projections(&place),
-                        [Projection::Index { .. }]
-                    )
-                    .then_some((value, place))
+                    matches!(cfg.get_place_projections(place), [Projection::Index { .. }])
+                        .then_some((
+                            value,
+                            place.base_type,
+                            cfg.get_place_projections(place).to_vec(),
+                        ))
                 })
                 .expect("indexed PlaceRead")
         };
+        let type_pool = &state.type_pool;
         let cfg = &mut state.functions[read_index].cfg;
-        let invalid_place = Place {
-            base: if param_base {
-                PlaceBase::Param(cfg.num_params())
-            } else {
-                PlaceBase::Local(cfg.num_locals())
-            },
-            ..original_place
+        let base = if param_base {
+            PlaceBase::Param(cfg.num_params())
+        } else {
+            PlaceBase::Local(cfg.num_locals())
         };
-        cfg.get_inst_mut(read_value).data = CfgInstData::PlaceRead {
-            place: invalid_place,
-        };
-
-        let cfg = &state.functions[read_index].cfg;
-        let mut interp = Interp {
-            state: &state,
-            stdout: String::new(),
-            stdout_bytes: 0,
-            stdout_cap: MAX_STDOUT_BYTES,
-            stderr_cap: MAX_STDERR_BYTES,
-            budget: STEP_BUDGET,
-            depth: 0,
-        };
-        let mut frame = Frame {
-            params: vec![None; cfg.num_params() as usize],
-            locals: vec![None; cfg.num_locals() as usize],
-            cache: HashMap::new(),
-        };
-        let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, read_value));
-        assert_eq!(
-            unsupported.kind(),
-            UnsupportedKind::ContractViolation(ContractViolationKind::PlaceBaseOutOfBounds),
-            "param_base={param_base}"
-        );
+        let before = cfg.to_string();
+        let error = cfg
+            .try_edit(type_pool, |editor| {
+                editor.replace_place_read(read_value, base, base_type, projections)
+            })
+            .expect_err("ValidatedCfg must reject an out-of-bounds place base");
+        assert!(matches!(error, rue_cfg::CfgEditTransactionError::Edit(_)));
+        assert_eq!(cfg.to_string(), before, "param_base={param_base}");
     }
 }
 
@@ -654,16 +586,20 @@ fn zero_sized_place_base_uses_the_canonical_boundary_slot() {
         .iter()
         .position(|function| function.cfg.fn_name() == "main")
         .expect("main CFG");
-    let (read_value, original_place) = {
+    let (read_value, base_type, projections) = {
         let cfg = &state.functions[main_index].cfg;
         cfg.blocks()
             .iter()
             .flat_map(|block| block.insts.iter().copied())
             .find_map(|value| {
-                let CfgInstData::PlaceRead { place } = cfg.get_inst(value).data else {
+                let CfgInstData::PlaceRead { place } = &cfg.get_inst(value).data else {
                     return None;
                 };
-                (!cfg.get_place_projections(&place).is_empty()).then_some((value, place))
+                (!cfg.get_place_projections(place).is_empty()).then_some((
+                    value,
+                    place.base_type,
+                    cfg.get_place_projections(place).to_vec(),
+                ))
             })
             .expect("zero-sized projected PlaceRead")
     };
@@ -678,53 +614,38 @@ fn zero_sized_place_base_uses_the_canonical_boundary_slot() {
             budget: STEP_BUDGET,
             depth: 0,
         };
+        let CfgInstData::PlaceRead { place } = &cfg.get_inst(read_value).data else {
+            unreachable!()
+        };
+        assert_eq!(interp.state.type_pool.abi_slot_count(place.base_type), 0);
+        assert_eq!(place.base, PlaceBase::Local(cfg.num_locals()));
         assert_eq!(
-            interp
-                .state
-                .type_pool
-                .abi_slot_count(original_place.base_type),
-            0
-        );
-        assert_eq!(original_place.base, PlaceBase::Local(cfg.num_locals()));
-        assert_eq!(
-            interp.place_base_violation(cfg, &original_place, PlaceAccess::Read),
+            interp.place_base_violation(cfg, place, PlaceAccess::Read),
             None,
             "a zero-slot root may live at the canonical one-past boundary"
         );
     }
 
+    let type_pool = &state.type_pool;
     let cfg = &mut state.functions[main_index].cfg;
-    let invalid_place = Place {
-        base: PlaceBase::Local(cfg.num_locals() + 1),
-        ..original_place
-    };
-    cfg.get_inst_mut(read_value).data = CfgInstData::PlaceRead {
-        place: invalid_place,
-    };
-    let cfg = &state.functions[main_index].cfg;
-    let mut interp = Interp {
-        state: &state,
-        stdout: String::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-    };
-    let mut frame = Frame {
-        params: Vec::new(),
-        locals: vec![None; cfg.num_locals() as usize],
-        cache: HashMap::new(),
-    };
-    let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, read_value));
-    assert_eq!(
-        unsupported.kind(),
-        UnsupportedKind::ContractViolation(ContractViolationKind::PlaceBaseOutOfBounds)
-    );
+    let invalid_slot = cfg.num_locals() + 1;
+    let before = cfg.to_string();
+    let error = cfg
+        .try_edit(type_pool, |editor| {
+            editor.replace_place_read(
+                read_value,
+                PlaceBase::Local(invalid_slot),
+                base_type,
+                projections,
+            )
+        })
+        .expect_err("ValidatedCfg must reject a slot beyond the canonical ZST boundary");
+    assert!(matches!(error, rue_cfg::CfgEditTransactionError::Edit(_)));
+    assert_eq!(cfg.to_string(), before);
 }
 
 #[test]
-fn whole_place_write_requires_exact_type_and_writable_storage() {
+fn validated_cfg_requires_exact_type_and_writable_storage_for_whole_place_writes() {
     const SOURCE: &str = "fn write(input: u32) -> u32 {
             let mut value: u32 = input;
             value = @random_u32();
@@ -745,7 +666,7 @@ fn whole_place_write_requires_exact_type_and_writable_storage() {
             .iter()
             .position(|function| function.cfg.fn_name() == "write")
             .expect("write CFG");
-        let (write_value, original_place, rhs) = {
+        let (write_value, base, base_type, rhs) = {
             let cfg = &state.functions[write_index].cfg;
             cfg.blocks()
                 .iter()
@@ -759,62 +680,43 @@ fn whole_place_write_requires_exact_type_and_writable_storage() {
                     };
                     (state.interner.resolve(&name) == "random_u32").then_some((
                         value,
-                        Place::local(slot, cfg.get_inst(rhs).ty),
+                        PlaceBase::Local(slot),
+                        cfg.get_inst(rhs).ty,
                         rhs,
                     ))
                 })
                 .expect("whole-variable store with random RHS")
         };
+        let type_pool = &state.type_pool;
         let cfg = &mut state.functions[write_index].cfg;
         assert_eq!(cfg.num_params(), 1);
         assert!(!cfg.is_param_writable(0));
-        let invalid_place = if nonwritable_param {
-            Place {
-                base: PlaceBase::Param(0),
-                ..original_place
-            }
+        let (base, base_type) = if nonwritable_param {
+            (PlaceBase::Param(0), base_type)
         } else {
-            Place {
-                base_type: Type::I32,
-                ..original_place
-            }
+            (base, Type::I32)
         };
-        cfg.get_inst_mut(write_value).data = CfgInstData::PlaceWrite {
-            place: invalid_place,
-            value: rhs,
-        };
-
-        let cfg = &state.functions[write_index].cfg;
-        let mut interp = Interp {
-            state: &state,
-            stdout: String::new(),
-            stdout_bytes: 0,
-            stdout_cap: MAX_STDOUT_BYTES,
-            stderr_cap: MAX_STDERR_BYTES,
-            budget: STEP_BUDGET,
-            depth: 0,
-        };
-        let mut frame = Frame {
-            params: vec![Some(Value::Int(1))],
-            locals: vec![None; cfg.num_locals() as usize],
-            cache: HashMap::new(),
-        };
-        let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, write_value));
-        let expected = if nonwritable_param {
-            ContractViolationKind::PlaceBaseNotWritable
-        } else {
-            ContractViolationKind::PlaceProjectionMetadata
-        };
+        let before = cfg.to_string();
+        let error = cfg
+            .try_edit(type_pool, |editor| {
+                editor.replace_place_write(write_value, base, base_type, [], rhs)
+            })
+            .expect_err("ValidatedCfg must reject an invalid whole-place write");
+        assert!(matches!(
+            error,
+            rue_cfg::CfgEditTransactionError::Edit(_)
+                | rue_cfg::CfgEditTransactionError::Verification(_)
+        ));
         assert_eq!(
-            unsupported.kind(),
-            UnsupportedKind::ContractViolation(expected),
+            cfg.to_string(),
+            before,
             "nonwritable_param={nonwritable_param}"
         );
     }
 }
 
 #[test]
-fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
+fn validated_cfg_allows_only_the_explicit_str_view_whole_place_read_coercion() {
     const SOURCE: &str = "fn take(borrow value: str) -> u64 { value.len() }
         fn probe() -> u64 {
             let value: Str(2) = \"hi\";
@@ -841,23 +743,29 @@ fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
                 .is_some_and(|struct_id| state.type_pool.struct_def(struct_id).name == "Str(3)")
         })
         .expect("Str(3) parameter type");
-    let (read_value, original_place, read_type) = {
+    let (read_value, read_type) = {
         let cfg = &state.functions[probe_index].cfg;
         cfg.blocks()
             .iter()
             .flat_map(|block| block.insts.iter().copied())
             .find_map(|value| {
                 let inst = cfg.get_inst(value);
-                let CfgInstData::PlaceRead { place } = inst.data else {
+                let CfgInstData::PlaceRead { place } = &inst.data else {
                     return None;
                 };
-                (cfg.get_place_projections(&place).is_empty() && place.base_type != inst.ty)
-                    .then_some((value, place, inst.ty))
+                (cfg.get_place_projections(place).is_empty() && place.base_type != inst.ty)
+                    .then_some((value, inst.ty))
             })
             .expect("Str(N)-to-str whole PlaceRead")
     };
     {
         let cfg = &state.functions[probe_index].cfg;
+        let CfgInstData::PlaceRead {
+            place: original_place,
+        } = &cfg.get_inst(read_value).data
+        else {
+            unreachable!()
+        };
         let interp = Interp {
             state: &state,
             stdout: String::new(),
@@ -872,7 +780,7 @@ fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
         assert!(interp.is_bare_str_type(read_type));
         assert!(interp.place_projection_metadata_is_valid(
             cfg,
-            &original_place,
+            original_place,
             read_type,
             PlaceAccess::Read,
         ));
@@ -880,39 +788,30 @@ fn whole_place_read_allows_only_the_explicit_str_view_coercion() {
         assert!(!interp.is_bare_str_type(other_fixed_type));
         assert!(!interp.place_projection_metadata_is_valid(
             cfg,
-            &original_place,
+            original_place,
             other_fixed_type,
             PlaceAccess::Read,
         ));
     }
 
-    state.functions[probe_index]
+    let base = {
+        let cfg = &state.functions[probe_index].cfg;
+        let CfgInstData::PlaceRead { place } = &cfg.get_inst(read_value).data else {
+            unreachable!()
+        };
+        place.base
+    };
+    let type_pool = &state.type_pool;
+    let before = state.functions[probe_index].cfg.to_string();
+    let error = state.functions[probe_index]
         .cfg
-        .get_inst_mut(read_value)
-        .data = CfgInstData::PlaceRead {
-        place: Place {
-            base_type: Type::I32,
-            ..original_place
-        },
-    };
-    let cfg = &state.functions[probe_index].cfg;
-    let mut interp = Interp {
-        state: &state,
-        stdout: String::new(),
-        stdout_bytes: 0,
-        stdout_cap: MAX_STDOUT_BYTES,
-        stderr_cap: MAX_STDERR_BYTES,
-        budget: STEP_BUDGET,
-        depth: 0,
-    };
-    let mut frame = Frame {
-        params: Vec::new(),
-        locals: vec![None; cfg.num_locals() as usize],
-        cache: HashMap::new(),
-    };
-    let unsupported = expect_flow_unsupported(interp.eval(cfg, &mut frame, read_value));
-    assert_eq!(
-        unsupported.kind(),
-        UnsupportedKind::ContractViolation(ContractViolationKind::PlaceProjectionMetadata)
-    );
+        .try_edit(type_pool, |editor| {
+            editor.replace_place_read(read_value, base, Type::I32, [])
+        })
+        .expect_err("ValidatedCfg must reject a non-str whole-place read coercion");
+    assert!(matches!(
+        error,
+        rue_cfg::CfgEditTransactionError::Verification(_)
+    ));
+    assert_eq!(state.functions[probe_index].cfg.to_string(), before);
 }

--- a/docs/process/cfg-payload-performance.md
+++ b/docs/process/cfg-payload-performance.md
@@ -1,0 +1,118 @@
+# CFG typed-payload performance record (RUE-840)
+
+This is the phase-local paired record for the CFG migration in ADR-0056. The
+cross-phase allocation, side-table-capacity, focused builder, and clean and
+incremental build matrix remains the RUE-843 integration gate after the RIR,
+AIR, and CFG migrations are all available. This record does not substitute for
+that final matrix.
+
+RUE-843 must measure and pass all of these still-mandatory integration gates:
+
+- whole-workload allocation counts for every representative compiler workload;
+- per-family logical bytes, allocated-capacity bytes, total side-table bytes,
+  nonempty envelopes where applicable, and peak staging bytes;
+- focused iterator and atomic-builder throughput plus allocations for every
+  migrated RIR, AIR, and CFG family; and
+- at least five alternating clean-build samples plus deterministic incremental
+  RIR, AIR, and CFG rebuild samples with rebuilt action counts.
+
+RUE-840 does not claim completion of that full matrix.
+
+## Reproduction identity
+
+- Baseline revision: `50deb00da2e3aa65ae54d037619451c4882d1864`
+- Candidate: the same revision plus the RUE-840 code patch whose binary Git
+  diff (including the new `payload.rs`) has SHA-256
+  `4b561a1aab5d3334c6c7cf0627ee589d7c0665c2a06ad723c9661d3e9d783aab`.
+  The benchmark record itself is excluded from that digest.
+- Host: Apple ARM64 T8132; macOS 26.5.2 (25F84), Darwin 25.5.0.
+- Toolchain: `rustc 1.92.0 (ded5c06cf 2025-12-08)`; Buck2
+  `2026-06-30-c88d791e34884e58617b92d5b98c7f71faee823c`.
+- Target/profile: native `aarch64-apple-darwin`, repository default compiler
+  profile, Rue program optimization `-O0`.
+- Protocol: separate baseline and candidate worktrees at the identity above;
+  one warmup; seven fresh compiler processes in alternating baseline/candidate
+  order; `/usr/bin/time -l` for wall time and peak RSS; compiler
+  `--benchmark-json` for inclusive compile and `cfg_construction` timings.
+  Medians and median absolute deviations (MAD) are reported below.
+
+For publication, the reviewed commit was rebased without conflicts onto
+upstream `2fee31bfded2b44d96526357a049a7bb98cb1ebb` after RUE-790 merged. The
+complete RUE-840 binary diff against that parent, excluding this benchmark
+record, has SHA-256
+`bf24d521f1dd44f18b39e54f6c39f144291b42d29ab34871865aa42a8118c7ac`.
+The paired `50deb00d` record remains the isolated CFG migration measurement;
+the conflict-free rebase required the newly landed RUE-926 loop infrastructure
+to be reconciled with RUE-840's typed owner APIs, and the post-rebase quick and
+focused suites are the publication correctness evidence.
+
+## Workloads and result
+
+| Workload (SHA-256) | Metric | Baseline median ± MAD | Candidate median ± MAD | Delta | ADR-0056 gate |
+|---|---:|---:|---:|---:|---:|
+| `many_functions.rue` (`6de992ce…e38f`) | wall ms | 307.627 ± 1.221 | 305.051 ± 0.922 | -0.84% | pass |
+| | peak RSS bytes | 52,887,552 ± 81,920 | 52,887,552 ± 163,840 | 0.00% | pass |
+| | compile ms | 289.571 ± 1.448 | 287.094 ± 0.758 | -0.86% | pass |
+| | CFG ms | 27.466 ± 0.231 | 27.470 ± 0.064 | +0.02% | pass |
+| `control_flow.rue` (`7bf2abe8…f58`) | wall ms | 265.392 ± 4.091 | 268.689 ± 1.673 | +1.24% | pass |
+| | peak RSS bytes | 60,915,712 ± 393,216 | 61,030,400 ± 229,376 | +0.19% | pass |
+| | compile ms | 244.932 ± 4.538 | 248.385 ± 0.757 | +1.41% | pass |
+| | CFG ms | 23.469 ± 2.383 | 25.134 ± 1.412 | +7.09% | pass (noise bound) |
+| `representative/main.rue` (`c41fad9f…745`) | wall ms | 24.704 ± 0.508 | 24.915 ± 0.146 | +0.85% | pass |
+| | peak RSS bytes | 22,396,928 ± 32,768 | 22,544,384 ± 49,152 | +0.66% | pass |
+| | compile ms | 11.886 ± 0.270 | 11.780 ± 0.052 | -0.89% | pass |
+| | CFG ms | 0.264 ± 0.035 | 0.267 ± 0.029 | +1.33% | pass |
+
+The gate is `candidate - baseline <= max(2% of baseline, 3 * max(MAD))`.
+Every measured metric passes. The apparently large percentage for the
+control-flow CFG span is a 1.665 ms change against a permitted 7.150 ms noise
+bound.
+
+## Raw alternating samples
+
+Each row lists baseline then candidate samples in execution order.
+
+### Many small functions and calls
+
+- wall ms: B `[306.406, 304.402, 303.966, 307.627, 308.231, 309.945, 307.808]`;
+  C `[303.956, 303.460, 311.996, 305.487, 305.051, 305.710, 304.129]`
+- peak RSS bytes: B `[52969472, 52609024, 53002240, 51937280, 52838400, 52887552, 52920320]`;
+  C `[52822016, 53051392, 53313536, 52969472, 52232192, 52887552, 52461568]`
+- compile ms: B `[288.123, 287.272, 286.341, 289.887, 289.571, 292.497, 289.862]`;
+  C `[286.619, 285.709, 294.581, 287.852, 287.094, 288.134, 286.677]`
+- CFG ms: B `[27.115, 27.626, 27.011, 27.722, 27.466, 27.622, 27.234]`;
+  C `[27.330, 27.406, 27.530, 27.524, 27.658, 27.470, 27.123]`
+
+### Match/control-flow heavy
+
+- wall ms: B `[265.392, 263.405, 276.273, 276.245, 268.093, 261.302, 258.765]`;
+  C `[268.229, 273.257, 268.689, 270.362, 273.984, 264.897, 268.370]`
+- peak RSS bytes: B `[60080128, 60276736, 60915712, 60538880, 61161472, 61308928, 61505536]`;
+  C `[61685760, 61259776, 61423616, 60456960, 60899328, 61030400, 61030400]`
+- compile ms: B `[244.932, 243.090, 254.081, 254.928, 247.129, 240.394, 238.096]`;
+  C `[247.628, 252.474, 248.385, 248.812, 253.273, 243.958, 247.710]`
+- CFG ms: B `[25.853, 20.958, 24.787, 25.678, 20.655, 23.469, 20.356]`;
+  C `[21.791, 21.353, 23.616, 26.341, 26.546, 25.247, 25.134]`
+
+### Representative specialization
+
+- wall ms: B `[24.196, 26.425, 25.222, 25.425, 24.395, 24.579, 24.704]`;
+  C `[25.808, 25.061, 24.993, 24.350, 24.786, 24.454, 24.915]`
+- peak RSS bytes: B `[22396928, 22249472, 22380544, 22429696, 22446080, 22429696, 22347776]`;
+  C `[22528000, 22364160, 22626304, 22593536, 22544384, 22544384, 22495232]`
+- compile ms: B `[11.915, 12.364, 11.886, 11.944, 11.370, 11.615, 11.557]`;
+  C `[11.884, 11.780, 11.828, 11.557, 11.770, 11.648, 11.833]`
+- CFG ms: B `[0.273, 0.264, 0.211, 0.299, 0.228, 0.273, 0.216]`;
+  C `[0.242, 0.322, 0.238, 0.262, 0.309, 0.304, 0.267]`
+
+## Structural and allocation evidence
+
+The CFG range types have compile-time size and alignment assertions proving
+the same two-`u32` layout as the fields they replace. CFG retains typed value,
+call-argument, switch-case, and projection vectors; it does not word-encode or
+box those elements. The focused test
+`every_payload_family_read_traverses_with_exactly_zero_allocations` constructs
+and fully consumes all ten migrated CFG families under a thread-local counting
+allocator and observes exactly zero allocations. Atomic builders stage input
+before reserving and committing owner storage, and the owner tests exercise
+failure without partial publication.


### PR DESCRIPTION
## Summary

- replace raw CFG value, call, switch, and projection side-table ranges with opaque family-specific typed owners and views
- add fallible atomic `CfgEditor`/`ValidatedCfg` construction, type-aware validation, structured corruption errors, and whole-owner transactional transforms
- migrate optimizers, codegen, durable import, compiler queries, and oracle contracts to typed payload APIs
- add malformed, provenance, clone/remap/rewrite/printing, allocation, rollback, and post-rebase loop-optimizer coverage
- record paired CFG phase performance evidence and explicit RUE-843 integration gates

## Validation

- `scripts/rue unit cfg` (191 passed)
- `scripts/rue unit codegen` (545 passed)
- `scripts/rue unit compiler` (559 passed before the conflict-free rebase)
- `scripts/rue unit oracle` (88 passed, 1 ignored)
- `scripts/rue quick` (29 targets passed after rebase)
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-840
