### PR TITLE
RUE-943, RUE-944: move-only swap; literal-init StrBuf under generic inout

### DIFF
--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -908,7 +908,18 @@ impl<'a> BodySema<'a> {
         let operand = args[0].value;
         let operand_root = self.extract_root_variable(operand);
         let operand_move_state_before = operand_root.and_then(|v| ctx.moved_vars.get(&v).cloned());
-        let arg_result = self.analyze_inst(air, operand, ctx)?;
+        // Analyze the operand as a borrow (`byref_arg_root`), exactly as `@dbg`
+        // and by-ref call arguments do. Without this, addressing a by-ref
+        // parameter (`@raw_mut(a)` where `a: inout T` is non-Copy) reads the
+        // param on the move path and is rejected outright (E0437 for `inout`,
+        // E0429 for `borrow`) before the address-of semantics below cancel the
+        // move.
+        // Address-of is a borrow, so the read must not count as a move; this
+        // makes `std.mem.swap` and other by-ref-param addressing work (RUE-943).
+        let prev_byref_root = std::mem::replace(&mut ctx.byref_arg_root, operand_root);
+        let arg_result = self.analyze_inst(air, operand, ctx);
+        ctx.byref_arg_root = prev_byref_root;
+        let arg_result = arg_result?;
 
         // @raw/@raw_mut take the ADDRESS of an addressable PLACE (spec 9.1:12,
         // ADR-0028), so the operand MUST be a place. A non-place operand

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2762,7 +2762,19 @@ impl<'a> BodySema<'a> {
             // string literal `"..."` materializes as a 2-word static-backed
             // `str` rather than the 3-word heap `String` (ADR-0043 Phase 3,
             // RUE-324). Enums do the same for fallible-intrinsic `Option(T)`.
-            if annot.is_enum() || self.is_str_like(annot) {
+            //
+            // A `StrBuf` annotation is likewise the expected type so a string
+            // literal materializes directly as the 3-word `StrBuf` (the
+            // literal-backed `cap == 0` representation) rather than defaulting
+            // to `str` (RUE-944). Without this the binding's storage would be a
+            // 2-word `str` slot whenever inference could not pin the literal —
+            // e.g. `let mut a: S = "x";` passed to a generic `inout T` parameter,
+            // where `T` is unresolvable during constraint generation so no
+            // literal-constraining `Equal(lit, StrBuf)` is emitted. The concrete
+            // `inout StrBuf` path pins the literal through its argument
+            // constraint and already saw `StrBuf`; this makes the binding's
+            // storage `StrBuf` at the source so both paths agree.
+            if annot.is_enum() || self.is_str_like(annot) || self.is_strbuf(annot) {
                 ctx.expected_type = Some(annot);
             }
         } else if let Some(inferred) = ctx.resolved_types.get(&init).copied()

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -375,3 +375,90 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 0
+
+# RUE-943: std.mem.swap works for move-only aggregates. The doc claims "any T
+# (including move-only aggregates)", but `let tmp = a;` would move out of the
+# `inout` borrow (E0437). swap instead exchanges the two values byte-for-byte
+# through raw-pointer primitives; both bindings stay initialized, so each keeps
+# exactly one drop obligation. Executed as a real binary so a double-free or
+# leak on the balanced-drop path would abort rather than pass.
+[[case]]
+name = "mem_swap_exchanges_move_only_strbufs"
+description = "std.mem.swap exchanges two owning StrBufs with balanced drops (RUE-943)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let S = std.strbuf.StrBuf;
+    let mut a = S.new(); a.push(65); a.push(66); a.push(67);  // "ABC"
+    let mut b = S.new(); b.push(90);                          // "Z"
+
+    std.mem.swap(S, inout a, inout b);
+
+    // Contents exchanged.
+    if a.len() != 1 { return 1; }
+    if b.len() != 3 { return 2; }
+    if a[0] != 90 { return 3; }
+    if b[0] != 65 { return 4; }
+    if b[2] != 67 { return 5; }
+
+    // Each binding now owns the other's buffer; both remain independently
+    // mutable, proving the exchange moved ownership rather than aliasing.
+    b.push(68);                                               // "ABCD"
+    a.push(89);                                               // "ZY"
+    if b.len() != 4 { return 6; }
+    if b[3] != 68 { return 7; }
+    if a.len() != 2 { return 8; }
+    if a[1] != 89 { return 9; }
+
+    // Both a and b drop here: swap must have preserved exactly one owner per
+    // buffer, so neither the original nor the exchanged allocation double-frees.
+    42
+}
+""" }]
+
+# RUE-944: a literal-initialized StrBuf binding (`let mut a: S = "x";`) passes a
+# generic `inout T` parameter as StrBuf, matching the concrete `inout StrBuf`
+# path. Previously the literal defaulted to `str` storage under generic
+# unification (E0206 expected StrBuf found str) while the concrete signature
+# pinned it. Both paths now agree the binding's storage is StrBuf.
+[[case]]
+name = "generic_inout_accepts_literal_initialized_strbuf"
+description = "A literal-initialized StrBuf binding passes generic `inout T`, matching the concrete inout path (RUE-944)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 42
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn generic_fill(comptime T: type, inout x: T) {
+    x.push(66);                                              // 'B'
+    x.push(67);                                              // 'C'
+}
+
+fn concrete_fill(inout x: std.strbuf.StrBuf) {
+    x.push(68);                                              // 'D'
+}
+
+fn main() -> i32 {
+    let S = std.strbuf.StrBuf;
+
+    // Generic `inout T` with a literal-initialized StrBuf binding (RUE-944).
+    let mut a: S = "x";
+    generic_fill(S, inout a);
+    if a.len() != 3 { return 1; }                            // "xBC"
+    if a[0] != 120 { return 2; }
+    if a[2] != 67 { return 3; }
+
+    // The concrete `inout StrBuf` path stays covered and agrees.
+    let mut c: S = "y";
+    concrete_fill(inout c);
+    if c.len() != 2 { return 4; }                            // "yD"
+    if c[1] != 68 { return 5; }
+
+    42
+}
+""" }]

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -814,7 +814,10 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.std_core",
         "std_core_m1_smoke",
-        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        // `std.mem.swap` now performs a bytewise exchange through `@raw_mut`
+        // (RUE-943), so the oracle model's first unsupported intrinsic for this
+        // case is the address-of rather than the later `@int_to_ptr`.
+        intrinsic(UnsupportedIntrinsicKind::RawMutableAddress),
         &[],
     ),
     Entry::new(
@@ -926,6 +929,18 @@ const ENTRIES: &[Entry] = &[
         "cli.std_strbuf",
         "canonical_identity_drives_string_semantics",
         semantic(SemanticGapKind::TextProjectionRead),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_strbuf",
+        "generic_inout_accepts_literal_initialized_strbuf",
+        semantic(SemanticGapKind::InoutParameterForwarding),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_strbuf",
+        "mem_swap_exchanges_move_only_strbufs",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
         &[],
     ),
     Entry::new(

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3831 rejected=152 lex_invalid=35 accepted_source_ast_sha256=d14934cbb8bbca7f5538584099122ec9b78638d556dfce02286a3e625ac9b91a
+# pre-RUE-905 Chumsky: accepted=3833 rejected=152 lex_invalid=35 accepted_source_ast_sha256=ebfbd36c6664ddc066df4f6fa7e83b6762de7658ebf2cd8e789609f3d030a01f
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca

--- a/std/mem.rue
+++ b/std/mem.rue
@@ -10,13 +10,28 @@
 
 // Exchange the values held in `a` and `b`.
 //
-// Works for any `T` (including move-only aggregates): the three moves leave
-// each binding holding exactly one value, so affine/linear obligations are
-// preserved.
+// Works for any `T` (including move-only aggregates). A `let tmp = a;` would
+// move out of the `inout` borrow and leave the caller's binding uninitialized
+// (E0437), so this instead performs a bytewise three-way exchange through
+// raw-pointer primitives: it addresses each binding's storage and swaps the
+// `@size_of(T)` bytes in place. Both bindings stay fully initialized the whole
+// time, so affine/linear obligations are preserved — after the swap each
+// binding owns exactly the resources the other held, and each is still dropped
+// exactly once (no leak, no double-free).
 pub fn swap(comptime T: type, inout a: T, inout b: T) {
-    let tmp = a;
-    a = b;
-    b = tmp;
+    let size: u64 = @intCast(@size_of(T));
+    let addr_a: u64 = checked { @ptr_to_int(@raw_mut(a)) };
+    let addr_b: u64 = checked { @ptr_to_int(@raw_mut(b)) };
+    let pa: ptr mut u8 = checked { @int_to_ptr(addr_a) };
+    let pb: ptr mut u8 = checked { @int_to_ptr(addr_b) };
+    let mut i: u64 = 0;
+    while i < size {
+        let ta = checked { @byte_read(pa, i) };
+        let tb = checked { @byte_read(pb, i) };
+        checked { @byte_write(pa, i, tb); };
+        checked { @byte_write(pb, i, ta); };
+        i = i + 1;
+    }
 }
 
 // Store `v` into `dst` and return the value that was there before.


### PR DESCRIPTION
Fixes two bugs found by this weeks dogfooding programs (both repros recorded on the issues).

**std.mem.swap for move-only types (RUE-943)** — the doc always claimed move-only support but the body moved out of an `inout` param (E0437), restricting swap to Copy types. The body is now a bytewise three-way exchange through the raw byte intrinsics inside `checked {}`: both bindings stay fully initialized throughout, so each retains exactly one drop obligation — no move-out, no leak, no double-free. Enabling sema fix: `@raw`/`@raw_mut` operands analyze under `byref_arg_root` (the same borrow classification `@dbg` and by-ref call args use), so addressing a non-Copy `inout` parameter is a borrow, not a rejected move — address-of is a borrow.

**Literal-initialized StrBuf under generic `inout T` (RUE-944)** — `let mut a: StrBuf = "x"` silently stored a 2-word `str` whenever inference couldnt pin the literal; the concrete `inout StrBuf` path masked it while the generic path rejected it (E0206). `analyze_alloc` now propagates a StrBuf annotation as the expected type (mirroring the str-like handling), so the bindings storage is a genuine 3-word StrBuf and both paths agree. Fixed at the binding deliberately: loosening the generic check instead would have coerced a 2-word slot where 3 words are expected — a latent corruption.

Verified: quick 29/0; CLI std_strbuf 21/0 with two new executed cases (move-only swap exchanges and stays independently mutable; generic + concrete inout on a literal-backed StrBuf); spec types 538/0, expressions 746/0; full `./test.sh` green; both filed repros re-verified by execution at integration (exit vectors 23 and 3).

Fixes RUE-943
Fixes RUE-944