### PR TITLE
RUE-841: type RIR payload side tables

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -960,8 +960,7 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Local variable allocation
             InstData::Alloc {
-                directives_start: _,
-                directives_len: _,
+                directives: _,
                 name,
                 is_mut,
                 ty: type_annotation,
@@ -1115,11 +1114,7 @@ impl<'a> ConstraintGenerator<'a> {
             }
 
             // Function call
-            InstData::Call {
-                name,
-                args_start,
-                args_len,
-            } => {
+            InstData::Call { name, args } => {
                 let alias_target = self
                     .const_function_aliases
                     .and_then(|aliases| aliases.get(&(span.file_id, *name)))
@@ -1129,7 +1124,7 @@ impl<'a> ConstraintGenerator<'a> {
                         .and_then(|functions| functions.get(&(span.file_id, *name)))
                         .copied()
                 });
-                let args = self.rir.get_call_args(*args_start, *args_len);
+                let args = self.rir.call_args(args);
                 // `print(s)` / `println(s)` builtin free functions (RUE-1):
                 // generate the argument and yield unit. Semantic analysis
                 // validates the shared text family (`StrBuf`, `str`, `Str(N)`),
@@ -1313,13 +1308,9 @@ impl<'a> ConstraintGenerator<'a> {
             }
 
             // Intrinsic call
-            InstData::Intrinsic {
-                name,
-                args_start,
-                args_len,
-            } => {
+            InstData::Intrinsic { name, args } => {
                 let intrinsic_name = self.interner.resolve(name);
-                let args = self.rir.get_inst_refs(*args_start, *args_len);
+                let args = self.rir.intrinsic_args(args);
 
                 if intrinsic_name == "intCast" || intrinsic_name == "cast" {
                     // @intCast: target type is inferred from context.
@@ -1686,12 +1677,8 @@ impl<'a> ConstraintGenerator<'a> {
                 }
             }
 
-            InstData::InternalIntrinsic {
-                intrinsic,
-                args_start,
-                args_len,
-            } => {
-                let args = self.rir.get_inst_refs(*args_start, *args_len);
+            InstData::InternalIntrinsic { intrinsic, args } => {
+                let args = self.rir.internal_intrinsic_args(args);
                 for arg_ref in args {
                     self.generate(arg_ref, ctx);
                 }
@@ -1724,12 +1711,11 @@ impl<'a> ConstraintGenerator<'a> {
             } => InferType::Concrete(Type::U64),
 
             // Block
-            InstData::Block { extra_start, len } => {
+            InstData::Block { instructions } => {
                 self.enter_scope(ctx);
                 let mut last_ty = InferType::Concrete(Type::UNIT);
-                let block_insts = self.rir.get_extra(*extra_start, *len);
-                for &inst_raw in block_insts {
-                    let block_inst_ref = InstRef::from_raw(inst_raw);
+                let block_insts = self.rir.block_insts(instructions);
+                for block_inst_ref in block_insts.values() {
                     let info = self.generate(block_inst_ref, ctx);
                     last_ty = info.ty;
                 }
@@ -1891,13 +1877,9 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::Continue => InferType::Concrete(Type::NEVER),
 
             // Match expression
-            InstData::Match {
-                scrutinee,
-                arms_start,
-                arms_len,
-            } => {
+            InstData::Match { scrutinee, arms } => {
                 let scrutinee_info = self.generate(*scrutinee, ctx);
-                let arms = self.rir.get_match_arms(*arms_start, *arms_len);
+                let arms = self.rir.match_arms(arms);
 
                 // Comptime-known scrutinee (spec 4.14:19): when the scrutinee
                 // is a comptime value known for this specialization, sema
@@ -2023,8 +2005,7 @@ impl<'a> ConstraintGenerator<'a> {
                 module,
                 ctor_head,
                 type_name,
-                fields_start,
-                fields_len,
+                fields,
                 shorthand_span: _,
             } => {
                 // Inline type-constructor literal heads (`F(args) { ... }`,
@@ -2070,7 +2051,7 @@ impl<'a> ConstraintGenerator<'a> {
                         })
                 };
 
-                let fields = self.rir.get_field_inits(*fields_start, *fields_len);
+                let fields = self.rir.field_inits(fields);
                 if let Some(struct_ty) = struct_ty {
                     // Constrain each initializer against its field's declared
                     // type, so literal initializers are range-checked at the
@@ -2254,11 +2235,8 @@ impl<'a> ConstraintGenerator<'a> {
             }
 
             // Array initialization
-            InstData::ArrayInit {
-                elems_start,
-                elems_len,
-            } => {
-                let elements = self.rir.get_inst_refs(*elems_start, *elems_len);
+            InstData::ArrayInit { elements } => {
+                let elements = self.rir.array_elements(elements);
                 if elements.is_empty() {
                     // Empty array - need type annotation to know element type
                     // Use a fresh type variable for the element type
@@ -2270,8 +2248,8 @@ impl<'a> ConstraintGenerator<'a> {
                 } else {
                     // Get element type from first element, constrain rest to match
                     let first_info = self.generate(elements.get(0).unwrap(), ctx);
-                    for elem_ref in elements.iter().skip(1) {
-                        let elem_info = self.generate(*elem_ref, ctx);
+                    for elem_ref in elements.values().skip(1) {
+                        let elem_info = self.generate(elem_ref, ctx);
                         self.add_constraint(Constraint::equal(
                             elem_info.ty,
                             first_info.ty.clone(),
@@ -2368,8 +2346,7 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::MethodCall {
                 receiver,
                 method,
-                args_start,
-                args_len,
+                args,
             } => {
                 // `Type.method(args)` where the receiver names a type is an
                 // associated-function call / enum tuple-variant construction
@@ -2395,14 +2372,7 @@ impl<'a> ConstraintGenerator<'a> {
                         || self.enum_type_for(&name, span.file_id).is_some())
                 {
                     return {
-                        let ty = self.generate_type_qualified_call(
-                            name,
-                            *method,
-                            *args_start,
-                            *args_len,
-                            span,
-                            ctx,
-                        );
+                        let ty = self.generate_type_qualified_call(name, *method, args, span, ctx);
                         self.record_type(inst_ref, ty.clone());
                         ExprInfo::new(ty, span)
                     };
@@ -2429,13 +2399,8 @@ impl<'a> ConstraintGenerator<'a> {
                     && let Some(member_ty) = self
                         .struct_type_for_module(module_ref, &type_name)
                         .or_else(|| self.enum_type_for_module(module_ref, &type_name))
-                    && let Some(result) = self.generate_call_on_reduced_type(
-                        member_ty,
-                        *method,
-                        *args_start,
-                        *args_len,
-                        ctx,
-                    )
+                    && let Some(result) =
+                        self.generate_call_on_reduced_type(member_ty, *method, args, ctx)
                 {
                     self.record_type(inst_ref, result.clone());
                     return ExprInfo::new(result, span);
@@ -2443,7 +2408,7 @@ impl<'a> ConstraintGenerator<'a> {
 
                 // Generate type for receiver
                 let receiver_info = self.generate(*receiver, ctx);
-                let args = self.rir.get_call_args(*args_start, *args_len);
+                let call_args = self.rir.call_args(args);
 
                 // A string literal is otherwise defaulted only after solving,
                 // but method lookup needs a receiver type while constraints
@@ -2468,7 +2433,7 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     let param_types = method_sig.param_types.clone();
                     let return_type = method_sig.return_type.clone();
-                    for (arg, param_type) in args.iter().zip(param_types.iter()) {
+                    for (arg, param_type) in call_args.iter().zip(param_types.iter()) {
                         let arg_info = self.generate(arg.value, ctx);
                         self.add_constraint(Constraint::equal(
                             arg_info.ty,
@@ -2508,10 +2473,11 @@ impl<'a> ConstraintGenerator<'a> {
                                     .copied()
                             });
                         if let Some(func) = function_key.and_then(|key| self.functions.get(&key)) {
-                            if !func.is_generic && args.len() == func.param_types.len() {
+                            if !func.is_generic && call_args.len() == func.param_types.len() {
                                 // Constrain each argument against its declared
                                 // parameter type (same as a direct Call).
-                                for (arg, param_ty) in args.iter().zip(func.param_types.iter()) {
+                                for (arg, param_ty) in call_args.iter().zip(func.param_types.iter())
+                                {
                                     let arg_info = self.generate(arg.value, ctx);
                                     // Slice and `borrow str` parameters coerce
                                     // from a `borrow` argument; skip strict
@@ -2538,7 +2504,7 @@ impl<'a> ConstraintGenerator<'a> {
                                 // defaulted to i32, clashing with the instantiated
                                 // i64 parameter (the non-generic path above already
                                 // constrains, and same-file generic Calls do too).
-                                let arg_infos: Vec<ExprInfo> = args
+                                let arg_infos: Vec<ExprInfo> = call_args
                                     .iter()
                                     .map(|arg| self.generate(arg.value, ctx))
                                     .collect();
@@ -2546,7 +2512,7 @@ impl<'a> ConstraintGenerator<'a> {
                                     std::collections::HashMap::new();
                                 let mut value_subst: std::collections::HashMap<lasso::Spur, i128> =
                                     std::collections::HashMap::new();
-                                for (i, arg) in args.iter().enumerate() {
+                                for (i, arg) in call_args.iter().enumerate() {
                                     if i >= func.param_comptime.len()
                                         || !func.param_comptime[i]
                                         || i >= func.param_names.len()
@@ -2600,7 +2566,7 @@ impl<'a> ConstraintGenerator<'a> {
                             } else {
                                 // Arity mismatch: just process the arguments;
                                 // sema checks the rest.
-                                for arg in args.iter() {
+                                for arg in call_args.iter() {
                                     self.generate(arg.value, ctx);
                                 }
                             }
@@ -2613,7 +2579,7 @@ impl<'a> ConstraintGenerator<'a> {
                             }
                         } else {
                             // Unknown member - sema reports UndefinedFunction
-                            for arg in args.iter() {
+                            for arg in call_args.iter() {
                                 self.generate(arg.value, ctx);
                             }
                             InferType::Concrete(Type::ERROR)
@@ -2654,17 +2620,12 @@ impl<'a> ConstraintGenerator<'a> {
                             .inline_ctor_head_types
                             .and_then(|heads| heads.get(receiver).copied())
                             .or(module_member_ty)
-                            && let Some(result) = self.generate_call_on_reduced_type(
-                                reduced,
-                                *method,
-                                *args_start,
-                                *args_len,
-                                ctx,
-                            )
+                            && let Some(result) =
+                                self.generate_call_on_reduced_type(reduced, *method, args, ctx)
                         {
                             result
                         } else {
-                            for arg in args.iter() {
+                            for arg in call_args.iter() {
                                 self.generate(arg.value, ctx);
                             }
                             InferType::Var(self.fresh_var())
@@ -2679,7 +2640,7 @@ impl<'a> ConstraintGenerator<'a> {
                             if let Some(method_sig) = self.method_sig(&method_key) {
                                 // Generate constraints for arguments
                                 for (arg, param_type) in
-                                    args.iter().zip(method_sig.param_types.iter())
+                                    call_args.iter().zip(method_sig.param_types.iter())
                                 {
                                     // View/string compatibility is
                                     // representation-aware and authoritative
@@ -2702,14 +2663,14 @@ impl<'a> ConstraintGenerator<'a> {
                             } else {
                                 // Method not found - sema will report the error
                                 // Still generate arg types to catch errors in arguments
-                                for arg in args.iter() {
+                                for arg in call_args.iter() {
                                     self.generate(arg.value, ctx);
                                 }
                                 InferType::Concrete(Type::ERROR)
                             }
                         } else {
                             // Non-struct receiver - sema will report the error
-                            for arg in args.iter() {
+                            for arg in call_args.iter() {
                                 self.generate(arg.value, ctx);
                             }
                             InferType::Concrete(Type::ERROR)
@@ -2719,7 +2680,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // receiver and diagnoses later (mirrors FieldGet's
                     // fallback, RUE-126/RUE-119).
                     _ => {
-                        for arg in args.iter() {
+                        for arg in call_args.iter() {
                             self.generate(arg.value, ctx);
                         }
                         InferType::Var(self.fresh_var())
@@ -2922,8 +2883,7 @@ impl<'a> ConstraintGenerator<'a> {
         &mut self,
         type_name: Spur,
         function: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut ConstraintContext,
     ) -> InferType {
@@ -2931,8 +2891,7 @@ impl<'a> ConstraintGenerator<'a> {
         // Checked first so it takes precedence over the struct-method path
         // below.
         if let Some(enum_ty) = self.enum_type_for(&type_name, span.file_id)
-            && let Some(result) =
-                self.generate_call_on_reduced_type(enum_ty, function, args_start, args_len, ctx)
+            && let Some(result) = self.generate_call_on_reduced_type(enum_ty, function, args, ctx)
         {
             return result;
         }
@@ -2946,13 +2905,12 @@ impl<'a> ConstraintGenerator<'a> {
         if let Some(struct_ty) = self.struct_type_for(&type_name, span.file_id)
             && struct_ty.as_struct().is_some()
         {
-            if let Some(result) =
-                self.generate_call_on_reduced_type(struct_ty, function, args_start, args_len, ctx)
+            if let Some(result) = self.generate_call_on_reduced_type(struct_ty, function, args, ctx)
             {
                 return result;
             }
             // Method not found - sema reports the error; still process args.
-            let args = self.rir.get_call_args(args_start, args_len);
+            let args = self.rir.call_args(args);
             for arg in args.iter() {
                 self.generate(arg.value, ctx);
             }
@@ -2960,7 +2918,7 @@ impl<'a> ConstraintGenerator<'a> {
         }
 
         // Type not found - sema reports the error; still process args.
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args);
         for arg in args.iter() {
             self.generate(arg.value, ctx);
         }
@@ -2982,8 +2940,7 @@ impl<'a> ConstraintGenerator<'a> {
         &mut self,
         ty: Type,
         function: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         ctx: &mut ConstraintContext,
     ) -> Option<InferType> {
         if let Some(enum_id) = ty.as_enum() {
@@ -2991,7 +2948,7 @@ impl<'a> ConstraintGenerator<'a> {
             let payload = def
                 .find_variant(self.interner.resolve(&function))
                 .map(|vidx| def.variant_payload(vidx).to_vec())?;
-            let args = self.rir.get_call_args(args_start, args_len);
+            let args = self.rir.call_args(args);
             for (i, arg) in args.iter().enumerate() {
                 let arg_info = self.generate(arg.value, ctx);
                 if let Some(&pty) = payload.get(i) {
@@ -3007,7 +2964,7 @@ impl<'a> ConstraintGenerator<'a> {
         }
         let struct_id = ty.as_struct()?;
         let method_sig = self.method_sig(&(struct_id, function))?;
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args);
         for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
             let defer_equality = self.is_slice_struct_type(param_type.clone());
             let arg_info = self.generate(arg.value, ctx);
@@ -3637,8 +3594,9 @@ mod tests {
     use lasso::ThreadedRodeo;
 
     /// Helper to create a minimal RIR, interner, and type pool for testing.
-    fn make_test_rir_interner_and_type_pool() -> (Rir, ThreadedRodeo, TypeInternPool) {
-        let rir = Rir::new();
+    fn make_test_rir_interner_and_type_pool() -> (rue_rir::RirEditor, ThreadedRodeo, TypeInternPool)
+    {
+        let rir = rue_rir::RirEditor::new();
         let interner = ThreadedRodeo::new();
         let type_pool = TypeInternPool::new();
         (rir, interner, type_pool)
@@ -3724,16 +3682,8 @@ mod tests {
                 })
             });
             let arg_refs: Vec<_> = arg.into_iter().collect();
-            let (args_start, args_len) = rir.add_inst_refs(&arg_refs);
             let name = interner.get_or_intern(name);
-            let intrinsic = rir.add_inst(rue_rir::Inst {
-                data: InstData::Intrinsic {
-                    name,
-                    args_start,
-                    args_len,
-                },
-                span: Span::new(0, 6),
-            });
+            let intrinsic = rir.add_intrinsic(name, &arg_refs, Span::new(0, 6)).unwrap();
 
             let mut cgen = ConstraintGenerator::new(
                 &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
@@ -4253,13 +4203,7 @@ mod tests {
         let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
 
         // Create: { } (empty block)
-        let block = rir.add_inst(rue_rir::Inst {
-            data: InstData::Block {
-                extra_start: 0,
-                len: 0,
-            },
-            span: Span::new(0, 2),
-        });
+        let block = rir.add_block(&[], Span::new(0, 2)).unwrap();
 
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
@@ -4337,18 +4281,16 @@ mod tests {
             data: InstData::IntConst(42),
             span: Span::new(4, 6),
         });
-        let (args_start, args_len) = rir.add_call_args(&[rue_rir::RirCallArg {
-            value: arg,
-            mode: rue_rir::RirArgMode::Normal,
-        }]);
-        let call = rir.add_inst(rue_rir::Inst {
-            data: InstData::Call {
-                name: func_name,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 7),
-        });
+        let call = rir
+            .add_call(
+                func_name,
+                &[rue_rir::RirCallArg {
+                    value: arg,
+                    mode: rue_rir::RirArgMode::Normal,
+                }],
+                Span::new(0, 7),
+            )
+            .unwrap();
 
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
@@ -4379,18 +4321,16 @@ mod tests {
             data: InstData::IntConst(42),
             span: Span::new(8, 10),
         });
-        let (args_start, args_len) = rir.add_call_args(&[rue_rir::RirCallArg {
-            value: arg,
-            mode: rue_rir::RirArgMode::Normal,
-        }]);
-        let call = rir.add_inst(rue_rir::Inst {
-            data: InstData::Call {
-                name: unknown_func,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 11),
-        });
+        let call = rir
+            .add_call(
+                unknown_func,
+                &[rue_rir::RirCallArg {
+                    value: arg,
+                    mode: rue_rir::RirArgMode::Normal,
+                }],
+                Span::new(0, 11),
+            )
+            .unwrap();
 
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
@@ -4449,16 +4389,13 @@ mod tests {
         });
         let pattern3 = rue_rir::RirPattern::Wildcard(Span::new(30, 31));
 
-        let arms = vec![(pattern1, body1), (pattern2, body2), (pattern3, body3)];
-        let (arms_start, arms_len) = rir.add_match_arms(&arms);
-        let match_inst = rir.add_inst(rue_rir::Inst {
-            data: InstData::Match {
+        let match_inst = rir
+            .add_match(
                 scrutinee,
-                arms_start,
-                arms_len,
-            },
-            span: Span::new(0, 40),
-        });
+                &[(pattern1, body1), (pattern2, body2), (pattern3, body3)],
+                Span::new(0, 40),
+            )
+            .unwrap();
 
         let mut cgen = ConstraintGenerator::new(
             &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -12,7 +12,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use lasso::{Key, Spur, ThreadedRodeo};
+use lasso::{Spur, ThreadedRodeo};
 use rue_error::{
     CompileError, CompileErrors, CompileResult, CompileWarning, ErrorKind,
     IntrinsicTypeMismatchError, MultiErrorResult, OptionExt, PreviewFeature, WarningKind,
@@ -639,42 +639,26 @@ fn collect_static_function_references(sema: &BodySema<'_>) -> HashSet<Spur> {
             // without scanning these, a constructor used only in type
             // positions warned "unused function" (RUE-608).
             InstData::FnDecl {
-                params_start,
-                params_len,
+                params,
                 return_type,
                 ..
             } => {
-                for param in sema.rir.get_params(*params_start, *params_len) {
+                for param in sema.rir.params(params) {
                     mark_type_syntax_refs(sema, param.ty, inst.span.file_id, &mut referenced);
                 }
                 mark_type_syntax_refs(sema, *return_type, inst.span.file_id, &mut referenced);
             }
-            InstData::StructDecl {
-                fields_start,
-                fields_len,
-                ..
-            } => {
-                for (_, field_ty) in sema.rir.get_field_decls(*fields_start, *fields_len) {
+            InstData::StructDecl { fields, .. } => {
+                for (_, field_ty) in sema.rir.struct_fields(fields) {
                     mark_type_syntax_refs(sema, field_ty, inst.span.file_id, &mut referenced);
                 }
             }
             InstData::EnumDecl {
-                payloads_start,
-                payloads_len,
-                ..
+                payloads, variants, ..
             } => {
-                // Self-describing payload region: `[k, t0, .., t_{k-1}]` per
-                // variant (see `resolve_enum_payloads`).
-                let words = sema.rir.get_extra(*payloads_start, *payloads_len);
-                let mut i = 0usize;
-                while i < words.len() {
-                    let k = words[i] as usize;
-                    i += 1;
-                    for _ in 0..k {
-                        if let Some(ty_sym) = Spur::try_from_usize(words[i] as usize) {
-                            mark_type_syntax_refs(sema, ty_sym, inst.span.file_id, &mut referenced);
-                        }
-                        i += 1;
+                for payload in sema.rir.enum_payloads(payloads, variants) {
+                    for ty_sym in payload {
+                        mark_type_syntax_refs(sema, ty_sym, inst.span.file_id, &mut referenced);
                     }
                 }
             }
@@ -1070,40 +1054,29 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                 continue;
             };
             let inst = sema.rir.get(declaration);
-            let (name, params_start, params_len, return_type, body, has_self, span) =
-                if let InstData::FnDecl {
-                    name,
-                    params_start,
-                    params_len,
-                    return_type,
-                    body,
-                    has_self,
-                    ..
-                } = &inst.data
-                {
-                    (
-                        *name,
-                        *params_start,
-                        *params_len,
-                        *return_type,
-                        *body,
-                        *has_self,
-                        inst.span,
-                    )
-                } else {
-                    unreachable!("free-function index contains only FnDecl instructions");
-                };
+            let (name, params, return_type, body, has_self, span) = if let InstData::FnDecl {
+                name,
+                params,
+                return_type,
+                body,
+                has_self,
+                ..
+            } = &inst.data
+            {
+                (*name, params, *return_type, *body, *has_self, inst.span)
+            } else {
+                unreachable!("free-function index contains only FnDecl instructions");
+            };
 
             debug_assert_eq!(name, source_name);
             debug_assert!(!has_self);
-            debug_assert_eq!(params_start, fn_info.rir_params_start);
-            debug_assert_eq!(params_len, fn_info.rir_params_len);
+            debug_assert_eq!(params, fn_info.rir_params(sema.rir));
             debug_assert_eq!(return_type, fn_info.return_type_sym);
             debug_assert_eq!(body, fn_info.body);
             debug_assert_eq!(span, fn_info.span);
             debug_assert_eq!(span.file_id, fn_info.file_id);
 
-            let params = sema.rir.get_params(params_start, params_len);
+            let params = sema.rir.params(params);
 
             let ordinary_owner = sema.body_owner_token(
                 fn_info.file_id,
@@ -1501,8 +1474,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
             let method_inst = sema.rir.get(method_ref);
             let InstData::FnDecl {
                 name: m_name,
-                params_start,
-                params_len,
+                params,
                 return_type,
                 body,
                 has_self,
@@ -1518,7 +1490,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
             debug_assert_eq!(*has_self, method_info.has_self);
             debug_assert_eq!(*self_mode, method_info.self_mode);
 
-            let params = sema.rir.get_params(*params_start, *params_len);
+            let params = sema.rir.params(params);
             let full_name = sema.method_symbol(struct_id, &method_name_str, *has_self);
             let generic = sema
                 .param_arena

--- a/crates/rue-air/src/sema/analysis/anon_methods.rs
+++ b/crates/rue-air/src/sema/analysis/anon_methods.rs
@@ -20,18 +20,16 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
         &mut self,
         struct_id: StructId,
         struct_type: Type,
-        methods_start: u32,
-        methods_len: u32,
+        methods: &rue_rir::RirAnonStructMethodsRange,
         _span: Span,
     ) -> CompileResult<()> {
-        let method_refs = self.rir.get_inst_refs(methods_start, methods_len);
+        let method_refs = self.rir.anon_struct_methods(methods);
 
         for method_ref in method_refs {
             let method_inst = self.rir.get(method_ref);
             if let InstData::FnDecl {
                 name: method_name,
-                params_start,
-                params_len,
+                params,
                 return_type,
                 body,
                 has_self,
@@ -55,7 +53,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                 }
 
                 // Resolve parameter types (Self -> this anonymous struct's type)
-                let params = self.rir.get_params(*params_start, *params_len);
+                let params = self.rir.params(params);
                 let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
                 let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
                 let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
@@ -110,18 +108,16 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
         &mut self,
         struct_id: StructId,
         struct_type: Type,
-        methods_start: u32,
-        methods_len: u32,
+        methods: &rue_rir::RirAnonStructMethodsRange,
         _span: Span,
     ) -> Option<()> {
-        let method_refs = self.rir.get_inst_refs(methods_start, methods_len);
+        let method_refs = self.rir.anon_struct_methods(methods);
 
         for method_ref in method_refs {
             let method_inst = self.rir.get(method_ref);
             if let InstData::FnDecl {
                 name: method_name,
-                params_start,
-                params_len,
+                params,
                 return_type,
                 body,
                 has_self,
@@ -137,7 +133,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                 }
 
                 // Resolve parameter types using comptime-safe resolution
-                let params = self.rir.get_params(*params_start, *params_len);
+                let params = self.rir.params(params);
                 let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
                 let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
                 let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
@@ -200,20 +196,18 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
     /// misleading E1200 mis-located at the `let` that instantiates it.
     pub(crate) fn find_method_own_comptime_type_param(
         &self,
-        methods_start: u32,
-        methods_len: u32,
+        methods: &rue_rir::RirAnonStructMethodsRange,
     ) -> Option<(Span, String)> {
-        let method_refs = self.rir.get_inst_refs(methods_start, methods_len);
+        let method_refs = self.rir.anon_struct_methods(methods);
         for method_ref in method_refs {
             let method_inst = self.rir.get(method_ref);
             if let InstData::FnDecl {
                 name: method_name,
-                params_start,
-                params_len,
+                params,
                 ..
             } = &method_inst.data
             {
-                let params = self.rir.get_params(*params_start, *params_len);
+                let params = self.rir.params(params);
                 for p in params {
                     // A method-owned `comptime T: type` parameter: `comptime`
                     // modifier plus the `type` type. (The enclosing
@@ -249,13 +243,12 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
         &mut self,
         struct_id: StructId,
         struct_type: Type,
-        methods_start: u32,
-        methods_len: u32,
+        methods: &rue_rir::RirAnonStructMethodsRange,
         _span: Span,
         type_subst: &std::collections::HashMap<Spur, Type>,
         value_subst: &std::collections::HashMap<Spur, ConstValue>,
     ) -> Option<()> {
-        let method_refs = self.rir.get_inst_refs(methods_start, methods_len);
+        let method_refs = self.rir.anon_struct_methods(methods);
 
         // Track method names in this registration batch to detect duplicates
         let mut seen_methods: std::collections::HashSet<Spur> = std::collections::HashSet::new();
@@ -272,8 +265,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
             let method_inst = self.rir.get(method_ref);
             if let InstData::FnDecl {
                 name: method_name,
-                params_start,
-                params_len,
+                params,
                 return_type,
                 body,
                 has_self,
@@ -295,7 +287,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                 }
 
                 // Resolve parameter types using comptime-safe resolution with substitution
-                let params = self.rir.get_params(*params_start, *params_len);
+                let params = self.rir.params(params);
                 let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
                 let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
                 let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
@@ -381,18 +373,16 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
     /// so that `Self` matches `Self` even before we know the concrete StructId.
     pub(crate) fn extract_anon_method_sigs(
         &self,
-        methods_start: u32,
-        methods_len: u32,
+        methods: &rue_rir::RirAnonStructMethodsRange,
     ) -> Vec<super::super::AnonMethodSig> {
-        let method_refs = self.rir.get_inst_refs(methods_start, methods_len);
+        let method_refs = self.rir.anon_struct_methods(methods);
         let mut sigs = Vec::with_capacity(method_refs.len());
 
         for method_ref in method_refs {
             let method_inst = self.rir.get(method_ref);
             if let InstData::FnDecl {
                 name,
-                params_start,
-                params_len,
+                params,
                 return_type,
                 has_self,
                 self_mode,
@@ -403,7 +393,7 @@ impl<'a, D: crate::sema::DeclarationPhase> crate::sema::Sema<'a, D> {
                 // modes and comptime flags affect the callable contract just as
                 // types do, so anonymous types that differ in any of them must
                 // not share one StructId/method body (RUE-634).
-                let params = self.rir.get_params(*params_start, *params_len);
+                let params = self.rir.params(params);
                 let param_types: Vec<Spur> = params.iter().map(|p| p.ty).collect();
                 let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
                 let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -271,8 +271,7 @@ impl<'a> BodySema<'a> {
         &mut self,
         air: &mut Air,
         name: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
@@ -282,7 +281,7 @@ impl<'a> BodySema<'a> {
             "print"
         };
 
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args);
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount {

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -12,12 +12,11 @@ impl<'a> BodySema<'a> {
         air: &mut Air,
         receiver: InstRef,
         method: Spur,
-        args_start: u32,
-        args_len: u32,
+        args_range: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args_range);
         let receiver_var = self.extract_root_variable(receiver);
         let method_name_str = self.interner.resolve(&method).to_string();
 
@@ -39,7 +38,7 @@ impl<'a> BodySema<'a> {
                 || self.resolve_enum_type_name(name, ctx).is_some()
                 || ctx.comptime_type_vars.contains_key(&name))
         {
-            return self.analyze_assoc_fn_call(air, name, method, args_start, args_len, span, ctx);
+            return self.analyze_assoc_fn_call(air, name, method, args_range, span, ctx);
         }
 
         // Module-qualified associated-function call / tuple-variant construction:
@@ -51,7 +50,7 @@ impl<'a> BodySema<'a> {
             field: type_name,
         } = self.rir.get(receiver).data
             && let Some(result) = self.try_analyze_module_qualified_type_call(
-                air, module_ref, type_name, method, args_start, args_len, span, ctx,
+                air, module_ref, type_name, method, args_range, span, ctx,
             )?
         {
             return Ok(result);
@@ -139,9 +138,8 @@ impl<'a> BodySema<'a> {
 
         // Handle module member access: module.function() becomes a direct function call
         if let Some(module_id) = receiver_type.as_module() {
-            return self.analyze_module_member_call_impl(
-                air, module_id, method, args_start, args_len, span, ctx,
-            );
+            return self
+                .analyze_module_member_call_impl(air, module_id, method, args_range, span, ctx);
         }
 
         // Inline type-constructor call head (RUE-596, preview
@@ -185,8 +183,7 @@ impl<'a> BodySema<'a> {
                             vidx as u32,
                             method,
                             true,
-                            args_start,
-                            args_len,
+                            args_range,
                             span,
                             ctx,
                         );
@@ -211,8 +208,7 @@ impl<'a> BodySema<'a> {
                         air,
                         method,
                         method,
-                        args_start,
-                        args_len,
+                        args_range,
                         span,
                         ctx,
                         Some(struct_id),
@@ -476,8 +472,7 @@ impl<'a> BodySema<'a> {
         air: &mut Air,
         module_id: ModuleId,
         function_name: Spur,
-        args_start: u32,
-        args_len: u32,
+        args_range: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
@@ -546,7 +541,7 @@ impl<'a> BodySema<'a> {
 
         let param_types = self.param_arena.types(fn_info.params).to_vec();
         let param_modes = self.param_arena.modes(fn_info.params).to_vec();
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args_range);
         // A re-export was already visibility-checked against its facade const.
         let accessible =
             via_reexport || self.is_accessible(span.file_id, fn_info.file_id, fn_info.is_pub);
@@ -573,8 +568,7 @@ impl<'a> BodySema<'a> {
                 air,
                 function_key,
                 fn_info,
-                args_start,
-                args_len,
+                args_range,
                 span,
                 ctx,
                 false,
@@ -636,13 +630,12 @@ impl<'a> BodySema<'a> {
         air: &mut Air,
         type_name: Spur,
         function: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
         resolved: Option<StructId>,
     ) -> CompileResult<AnalysisResult> {
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args);
         let type_name_str = self.interner.resolve(&type_name).to_string();
         let function_name_str = self.interner.resolve(&function).to_string();
 

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -321,17 +321,12 @@ impl<'a> BodySema<'a> {
 
             // Anonymous struct type: a struct type constructed at comptime
             // (e.g., `struct { first: T, second: T, fn get(self) -> T { ... } }` in a comptime function)
-            InstData::AnonStructType {
-                fields_start,
-                fields_len,
-                methods_start,
-                methods_len,
-            } => {
+            InstData::AnonStructType { fields, methods } => {
                 // Get the field declarations from the RIR
-                let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
+                let field_decls = self.rir.anon_struct_fields(fields);
 
                 // Empty structs are not allowed (unless they have methods)
-                if field_decls.is_empty() && *methods_len == 0 {
+                if field_decls.is_empty() && self.rir.anon_struct_methods(methods).is_empty() {
                     return Err(CompileError::new(ErrorKind::EmptyStruct, inst.span));
                 }
 
@@ -348,7 +343,7 @@ impl<'a> BodySema<'a> {
 
                 // Extract method signatures for structural equality comparison
                 // (uses type symbols, not resolved Types, so Self matches Self)
-                let method_sigs = self.extract_anon_method_sigs(*methods_start, *methods_len);
+                let method_sigs = self.extract_anon_method_sigs(methods);
 
                 // Check if an equivalent anonymous struct already exists (structural equality)
                 // This now compares fields, method signatures, AND captured comptime values
@@ -359,7 +354,7 @@ impl<'a> BodySema<'a> {
                 // (the comptime evaluator's AnonStructType arm in sema::comptime_eval).
                 // If we register here, we create a struct without captured comptime values, which is incorrect.
                 //
-                // if is_new && *methods_len > 0 {
+                // if is_new && !self.rir.anon_struct_methods(methods).is_empty() {
                 //     let struct_id = struct_ty
                 //         .as_struct()
                 //         .expect("anon struct should have StructId");
@@ -386,35 +381,20 @@ impl<'a> BodySema<'a> {
             // (payloads mentioning a `comptime T`) are comptime-evaluated, not
             // analyzed here — this path resolves a concrete anon enum, exactly
             // as the struct arm does (ADR-0038, RUE-6 phase 2).
-            InstData::AnonEnumType {
-                variants_start,
-                variants_len,
-                payloads_start,
-                payloads_len,
-            } => {
-                let variant_syms = self
+            InstData::AnonEnumType { variants, payloads } => {
+                let variant_syms = self.rir.anon_enum_variants(variants).to_vec();
+                let payload_symbols: Vec<Vec<Spur>> = self
                     .rir
-                    .get_symbols(*variants_start, *variants_len)
-                    .to_vec();
-                let payload_words = self.rir.get_extra(*payloads_start, *payloads_len).to_vec();
+                    .anon_enum_payloads(payloads, variants)
+                    .map(|payload| payload.to_vec())
+                    .collect();
 
                 let mut variant_names: Vec<String> = Vec::with_capacity(variant_syms.len());
                 let mut variant_payloads: Vec<Vec<Type>> = Vec::with_capacity(variant_syms.len());
-                let mut pi = 0usize;
-                for vsym in &variant_syms {
+                for (vsym, symbols) in variant_syms.iter().zip(payload_symbols) {
                     variant_names.push(self.interner.resolve(vsym).to_string());
-                    let k = if payload_words.is_empty() {
-                        0
-                    } else {
-                        let k = payload_words[pi] as usize;
-                        pi += 1;
-                        k
-                    };
-                    let mut tys: Vec<Type> = Vec::with_capacity(k);
-                    for _ in 0..k {
-                        let ty_sym = Spur::try_from_usize(payload_words[pi] as usize)
-                            .expect("valid interned type symbol in payload region");
-                        pi += 1;
+                    let mut tys: Vec<Type> = Vec::with_capacity(symbols.len());
+                    for ty_sym in symbols {
                         let field_ty = self.resolve_type(ty_sym, inst.span)?;
                         // A payload of type `type` cannot exist at runtime
                         // (spec 4.14:6); reject it like struct fields / enum

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -12,14 +12,13 @@ impl<'a> BodySema<'a> {
         air: &mut Air,
         inst_ref: InstRef,
         name: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirIntrinsicArgsRange,
         span: Span,
         result_expected: Option<Type>,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         // Intrinsic arguments are stored as plain InstRefs
-        let arg_refs = self.rir.get_inst_refs(args_start, args_len);
+        let arg_refs = self.rir.intrinsic_args(args);
         let args: Vec<RirCallArg> = arg_refs
             .into_iter()
             .map(|value| RirCallArg {
@@ -230,11 +229,11 @@ impl<'a> BodySema<'a> {
         &mut self,
         air: &mut Air,
         intrinsic: rue_rir::InternalIntrinsic,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirInternalIntrinsicArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        let args_len = self.rir.internal_intrinsic_args(args).len() as u32;
         if args_len != intrinsic.arity() {
             let argument = if intrinsic.arity() == 1 {
                 "argument"
@@ -255,7 +254,7 @@ impl<'a> BodySema<'a> {
 
         let args: Vec<RirCallArg> = self
             .rir
-            .get_inst_refs(args_start, args_len)
+            .internal_intrinsic_args(args)
             .into_iter()
             .map(|value| RirCallArg {
                 value,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -821,10 +821,12 @@ impl<'a> BodySema<'a> {
     pub(crate) fn rir_block_tail_expr(&self, inst: InstRef) -> InstRef {
         let mut current = inst;
         loop {
-            match self.rir.get(current).data {
-                InstData::Block { extra_start, len } if len > 0 => {
-                    let refs = self.rir.get_extra(extra_start, len);
-                    current = InstRef::from_raw(refs[len as usize - 1]);
+            match &self.rir.get(current).data {
+                InstData::Block { instructions } => {
+                    match self.rir.block_insts(instructions).values().last() {
+                        Some(tail) => current = tail,
+                        None => return current,
+                    }
                 }
                 _ => return current,
             }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -827,11 +827,9 @@ impl<'a> BodySema<'a> {
                 self.analyze_infinite_loop(air, *body, *iter_borrow, inst.span, ctx)
             }
 
-            InstData::Match {
-                scrutinee,
-                arms_start,
-                arms_len,
-            } => self.analyze_match(air, *scrutinee, *arms_start, *arms_len, inst.span, ctx),
+            InstData::Match { scrutinee, arms } => {
+                self.analyze_match(air, *scrutinee, arms, inst.span, ctx)
+            }
 
             InstData::Try { operand } => self.analyze_try(air, *operand, inst.span, ctx),
 
@@ -880,8 +878,8 @@ impl<'a> BodySema<'a> {
                 self.analyze_return(air, inner.as_ref().copied(), inst.span, ctx)
             }
 
-            InstData::Block { extra_start, len } => {
-                self.analyze_block(air, *extra_start, *len, inst.span, ctx)
+            InstData::Block { instructions } => {
+                self.analyze_block(air, instructions, inst.span, ctx)
             }
 
             _ => Err(CompileError::new(
@@ -1415,8 +1413,7 @@ impl<'a> BodySema<'a> {
         &mut self,
         air: &mut Air,
         scrutinee: InstRef,
-        arms_start: u32,
-        arms_len: u32,
+        arms: &rue_rir::RirMatchArmsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
@@ -1436,7 +1433,7 @@ impl<'a> BodySema<'a> {
         // then reports non-exhaustiveness).
         if !ctx.comptime_value_vars.is_empty() {
             if let Some(value) = self.try_evaluate_const_in_fn(scrutinee, ctx) {
-                let arms = self.rir.get_match_arms(arms_start, arms_len);
+                let arms = self.rir.match_arms(arms);
                 let mut selected: Option<InstRef> = None;
                 let mut prunable = !arms.is_empty();
                 let mut has_wildcard = false;
@@ -1549,7 +1546,7 @@ impl<'a> BodySema<'a> {
         // alias the pattern names, so we resolve the first enum pattern's type
         // here and expose it while the scrutinee is analyzed. Resolution errors
         // are ignored — pattern legality is checked on the normal path below.
-        let arms_for_expected = self.rir.get_match_arms(arms_start, arms_len);
+        let arms_for_expected = self.rir.match_arms(arms);
         let expected_scrutinee = arms_for_expected.iter().find_map(|(pattern, _)| {
             if let RirPattern::Path { type_name, .. } = &pattern {
                 self.resolve_type_with_ctx(*type_name, span, ctx)
@@ -1577,7 +1574,7 @@ impl<'a> BodySema<'a> {
             ));
         }
 
-        let arms = self.rir.get_match_arms(arms_start, arms_len);
+        let arms = self.rir.match_arms(arms);
         // An empty match is only legal on a zero-variant (uninhabited) enum,
         // where zero arms vacuously satisfy exhaustiveness because the type
         // has no values (spec 4.7:26, RUE-169). The match can never be
@@ -2580,13 +2577,12 @@ impl<'a> BodySema<'a> {
     fn analyze_block(
         &mut self,
         air: &mut Air,
-        extra_start: u32,
-        len: u32,
+        instructions: &rue_rir::RirBlockInstsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         // Get the instruction refs from extra data
-        let inst_refs = self.rir.get_extra(extra_start, len);
+        let inst_refs = self.rir.block_insts(instructions);
 
         // Push a new scope for this block.
         ctx.push_scope();
@@ -2595,8 +2591,7 @@ impl<'a> BodySema<'a> {
         let mut statements = Vec::new();
         let mut last_result: Option<AnalysisResult> = None;
         let num_insts = inst_refs.len();
-        for (i, &raw_ref) in inst_refs.iter().enumerate() {
-            let inst_ref = InstRef::from_raw(raw_ref);
+        for (i, inst_ref) in inst_refs.values().enumerate() {
             let is_last = i == num_insts - 1;
             let result = if is_last {
                 self.analyze_inst(air, inst_ref, ctx)?
@@ -2677,24 +2672,14 @@ impl<'a> BodySema<'a> {
 
         match &inst.data {
             InstData::Alloc {
-                directives_start,
-                directives_len,
+                directives,
                 name,
                 is_mut,
                 ty,
                 init,
                 iter_elem,
             } => self.analyze_alloc(
-                air,
-                *directives_start,
-                *directives_len,
-                *name,
-                *is_mut,
-                *ty,
-                *init,
-                *iter_elem,
-                inst.span,
-                ctx,
+                air, directives, *name, *is_mut, *ty, *init, *iter_elem, inst.span, ctx,
             ),
 
             InstData::VarRef { name } => {
@@ -2720,8 +2705,7 @@ impl<'a> BodySema<'a> {
     fn analyze_alloc(
         &mut self,
         air: &mut Air,
-        directives_start: u32,
-        directives_len: u32,
+        directives: &rue_rir::RirDirectivesRange,
         name: Option<Spur>,
         is_mut: bool,
         ty: Option<Spur>,
@@ -2878,7 +2862,7 @@ impl<'a> BodySema<'a> {
         }
 
         // Check if @allow(unused_variable) directive is present
-        let directives = self.rir.get_directives(directives_start, directives_len);
+        let directives = self.rir.directives(directives);
         let allow_unused = self.has_allow_directive(directives.iter(), "unused_variable");
 
         // Allocate slots
@@ -3528,16 +3512,14 @@ impl<'a> BodySema<'a> {
                 module,
                 ctor_head,
                 type_name,
-                fields_start,
-                fields_len,
+                fields,
                 shorthand_span,
             } => self.analyze_struct_init(
                 air,
                 *module,
                 *ctor_head,
                 *type_name,
-                *fields_start,
-                *fields_len,
+                fields,
                 *shorthand_span,
                 inst.span,
                 ctx,
@@ -3569,8 +3551,7 @@ impl<'a> BodySema<'a> {
         module: Option<InstRef>,
         ctor_head: Option<InstRef>,
         type_name: Spur,
-        fields_start: u32,
-        fields_len: u32,
+        fields: &rue_rir::RirFieldInitsRange,
         _shorthand_span: Option<Span>,
         span: Span,
         ctx: &mut AnalysisContext,
@@ -3580,7 +3561,7 @@ impl<'a> BodySema<'a> {
         // desugared the shorthand to explicit `x: x` field inits before this
         // point, so `_shorthand_span` (the first shorthand field's span, retained
         // as diagnostic provenance) is no longer consumed here.
-        let field_inits = self.rir.get_field_inits(fields_start, fields_len);
+        let field_inits = self.rir.field_inits(fields);
         // Look up the struct type
         // First check if it's a comptime type variable (e.g., `let Point = make_point(); Point { ... }`)
         let type_name_str = self.interner.resolve(&type_name);
@@ -4636,10 +4617,9 @@ impl<'a> BodySema<'a> {
         let inst = self.rir.get(inst_ref);
 
         match &inst.data {
-            InstData::ArrayInit {
-                elems_start,
-                elems_len,
-            } => self.analyze_array_init(air, inst_ref, *elems_start, *elems_len, inst.span, ctx),
+            InstData::ArrayInit { elements } => {
+                self.analyze_array_init(air, inst_ref, elements, inst.span, ctx)
+            }
 
             InstData::ArrayRepeat { value, .. } => {
                 self.analyze_array_repeat(air, inst_ref, *value, inst.span, ctx)
@@ -4759,8 +4739,7 @@ impl<'a> BodySema<'a> {
         module_ref: rue_rir::InstRef,
         type_name: Spur,
         method: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Option<AnalysisResult>> {
@@ -4801,8 +4780,7 @@ impl<'a> BodySema<'a> {
                     variant_index as u32,
                     type_name,
                     /* privacy_exempt = */ true,
-                    args_start,
-                    args_len,
+                    args,
                     span,
                     ctx,
                 )
@@ -4834,8 +4812,7 @@ impl<'a> BodySema<'a> {
                     air,
                     type_name,
                     method,
-                    args_start,
-                    args_len,
+                    args,
                     span,
                     ctx,
                     Some(struct_id),
@@ -4989,12 +4966,11 @@ impl<'a> BodySema<'a> {
         &mut self,
         air: &mut Air,
         inst_ref: InstRef,
-        elems_start: u32,
-        elems_len: u32,
+        elements: &rue_rir::RirArrayElemsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        let elem_refs = self.rir.get_inst_refs(elems_start, elems_len);
+        let elem_refs = self.rir.array_elements(elements);
 
         // An array literal of `type` values (`[i32, i32]`) has no runtime
         // representation: type values only exist at compile time (spec
@@ -6055,7 +6031,7 @@ impl<'a> BodySema<'a> {
         inst_ref: InstRef,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        let inst = self.rir.get(inst_ref).clone();
+        let inst = self.rir.get(inst_ref);
 
         // A call has a declared result type; an expectation on that result
         // must not become the context of its receiver or arguments. The
@@ -6063,26 +6039,13 @@ impl<'a> BodySema<'a> {
         // operand instead. Keep the isolation at this shared dispatch so it
         // covers direct, module, method, associated, builtin, and enum calls.
         ctx.with_expected_type(None, |ctx| match &inst.data {
-            InstData::Call {
-                name,
-                args_start,
-                args_len,
-            } => self.analyze_call(air, *name, *args_start, *args_len, inst.span, ctx),
+            InstData::Call { name, args } => self.analyze_call(air, *name, args, inst.span, ctx),
 
             InstData::MethodCall {
                 receiver,
                 method,
-                args_start,
-                args_len,
-            } => self.analyze_method_call(
-                air,
-                *receiver,
-                *method,
-                *args_start,
-                *args_len,
-                inst.span,
-                ctx,
-            ),
+                args,
+            } => self.analyze_method_call(air, *receiver, *method, args, inst.span, ctx),
 
             _ => Err(CompileError::new(
                 ErrorKind::InternalError(format!(
@@ -6102,8 +6065,7 @@ impl<'a> BodySema<'a> {
         &mut self,
         air: &mut Air,
         name: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
@@ -6145,7 +6107,7 @@ impl<'a> BodySema<'a> {
             && local_name.is_none()
             && (source_name == self.known.print || source_name == self.known.println)
         {
-            return self.analyze_print_builtin(air, source_name, args_start, args_len, span, ctx);
+            return self.analyze_print_builtin(air, source_name, args, span, ctx);
         }
 
         if !resolved_alias && local_name.is_none() {
@@ -6165,9 +6127,7 @@ impl<'a> BodySema<'a> {
             .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
         let fn_info = fn_info.clone();
 
-        self.analyze_resolved_function_call(
-            air, name, fn_info, args_start, args_len, span, ctx, true,
-        )
+        self.analyze_resolved_function_call(air, name, fn_info, args, span, ctx, true)
     }
 
     /// Analyze a call after the source-level callee has already been resolved
@@ -6186,8 +6146,7 @@ impl<'a> BodySema<'a> {
         air: &mut Air,
         name: Spur,
         fn_info: FunctionInfo,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
         check_unqualified_visibility: bool,
@@ -6231,7 +6190,7 @@ impl<'a> BodySema<'a> {
         let param_comptime = self.param_arena.comptime(fn_info.params);
         let param_names = self.param_arena.names(fn_info.params);
 
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args);
         // Check argument count
         if args.len() != param_types.len() {
             let expected = param_types.len();
@@ -6601,12 +6560,11 @@ impl<'a> BodySema<'a> {
         air: &mut Air,
         receiver: InstRef,
         method: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        self.analyze_method_call_impl(air, receiver, method, args_start, args_len, span, ctx)
+        self.analyze_method_call_impl(air, receiver, method, args, span, ctx)
     }
 
     /// Resolve a path/pattern enum type name that may be a comptime
@@ -6737,8 +6695,7 @@ impl<'a> BodySema<'a> {
         air: &mut Air,
         type_name: Spur,
         function: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
@@ -6758,17 +6715,14 @@ impl<'a> BodySema<'a> {
                     variant_index as u32,
                     type_name,
                     via_comptime,
-                    args_start,
-                    args_len,
+                    args,
                     span,
                     ctx,
                 );
             }
         }
 
-        self.analyze_assoc_fn_call_impl(
-            air, type_name, function, args_start, args_len, span, ctx, None,
-        )
+        self.analyze_assoc_fn_call_impl(air, type_name, function, args, span, ctx, None)
     }
 
     /// Analyze construction of an enum tuple variant with a payload
@@ -6781,8 +6735,7 @@ impl<'a> BodySema<'a> {
         variant_index: u32,
         type_name: Spur,
         privacy_exempt: bool,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
@@ -6805,7 +6758,7 @@ impl<'a> BodySema<'a> {
             )?;
         }
 
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args);
 
         // Arity check.
         if args.len() != payload_types.len() {
@@ -6877,41 +6830,18 @@ impl<'a> BodySema<'a> {
         inst_ref: InstRef,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        let inst = self.rir.get(inst_ref).clone();
+        let inst = self.rir.get(inst_ref);
         let result_expected = ctx.expected_type;
 
         match &inst.data {
-            InstData::Intrinsic {
-                name,
-                args_start,
-                args_len,
-            } => ctx.with_expected_type(None, |ctx| {
-                self.analyze_intrinsic(
-                    air,
-                    inst_ref,
-                    *name,
-                    *args_start,
-                    *args_len,
-                    inst.span,
-                    result_expected,
-                    ctx,
-                )
+            InstData::Intrinsic { name, args } => ctx.with_expected_type(None, |ctx| {
+                self.analyze_intrinsic(air, inst_ref, *name, args, inst.span, result_expected, ctx)
             }),
 
-            InstData::InternalIntrinsic {
-                intrinsic,
-                args_start,
-                args_len,
-            } => ctx.with_expected_type(None, |ctx| {
-                self.analyze_internal_intrinsic_impl(
-                    air,
-                    *intrinsic,
-                    *args_start,
-                    *args_len,
-                    inst.span,
-                    ctx,
-                )
-            }),
+            InstData::InternalIntrinsic { intrinsic, args } => ctx
+                .with_expected_type(None, |ctx| {
+                    self.analyze_internal_intrinsic_impl(air, *intrinsic, args, inst.span, ctx)
+                }),
 
             InstData::TypeIntrinsic { name, type_arg } => {
                 self.analyze_type_intrinsic(air, *name, *type_arg, inst.span, ctx)
@@ -7102,22 +7032,12 @@ impl<'a> BodySema<'a> {
         air: &mut Air,
         inst_ref: InstRef,
         name: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirIntrinsicArgsRange,
         span: Span,
         result_expected: Option<Type>,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        self.analyze_intrinsic_impl(
-            air,
-            inst_ref,
-            name,
-            args_start,
-            args_len,
-            span,
-            result_expected,
-            ctx,
-        )
+        self.analyze_intrinsic_impl(air, inst_ref, name, args, span, result_expected, ctx)
     }
 
     // ========================================================================

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -468,8 +468,7 @@ impl<'a> DeclarationShells<'a> {
                     },
                     InstData::StructDecl {
                         is_linear: syntax_linear,
-                        fields_start,
-                        fields_len,
+                        fields: rir_fields,
                         ..
                     },
                 ) => {
@@ -489,7 +488,7 @@ impl<'a> DeclarationShells<'a> {
                     if self
                         .sema
                         .rir
-                        .get_field_decls(*fields_start, *fields_len)
+                        .struct_fields(rir_fields)
                         .values()
                         .map(|(name, _)| self.sema.interner.resolve(&name))
                         .ne(fields.iter().map(|field| field.0.as_ref()))
@@ -595,18 +594,16 @@ impl<'a> DeclarationShells<'a> {
                     let InstData::FnDecl {
                         name,
                         return_type,
-                        params_start,
-                        params_len,
+                        params,
                         self_mode,
-                        directives_start,
-                        directives_len,
+                        directives,
                         ..
                     } = &self.sema.rir.get(pending.declaration).data
                     else {
                         return Err(DeclarationInstallFailure::KindMismatch);
                     };
                     let type_name = self.sema.interner.get_or_intern("type");
-                    let rir_parameters = self.sema.rir.get_params(*params_start, *params_len);
+                    let rir_parameters = self.sema.rir.params(params);
                     if parameters
                         .iter()
                         .zip(rir_parameters.iter())
@@ -672,10 +669,7 @@ impl<'a> DeclarationShells<'a> {
                         let internal = self
                             .sema
                             .internal_function_name(*name, pending.shell.declaration_span.file_id);
-                        let directives = self
-                            .sema
-                            .rir
-                            .get_directives(*directives_start, *directives_len);
+                        let directives = self.sema.rir.directives(directives);
                         let allow_unused_function = self
                             .sema
                             .has_allow_directive(directives.iter(), "unused_function");
@@ -696,8 +690,7 @@ impl<'a> DeclarationShells<'a> {
                                 return_type: return_type_value,
                                 return_type_sym: *return_type,
                                 body,
-                                rir_params_start: *params_start,
-                                rir_params_len: *params_len,
+                                declaration: pending.declaration,
                                 span: pending.shell.declaration_span,
                                 is_generic: pending.shell.is_generic,
                                 is_pub: pending.shell.is_public,
@@ -1157,8 +1150,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     is_pub,
                     is_unchecked,
                     name,
-                    params_start,
-                    params_len,
+                    params,
                     body,
                     has_self,
                     ..
@@ -1169,7 +1161,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         (Some(_), false) => SemanticBindingKind::AssociatedFunction,
                         (None, _) => SemanticBindingKind::Function,
                     };
-                    let params = self.rir.get_params(*params_start, *params_len);
+                    let params = self.rir.params(params);
                     let names = params
                         .iter()
                         .map(|param| Arc::from(self.interner.resolve(&param.name)))
@@ -1358,8 +1350,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
         self.export_callable_signature(
             info.params,
             info.return_type,
-            info.rir_params_start,
-            info.rir_params_len,
+            info.rir_params(self.rir),
             info.return_type_sym,
         )
     }
@@ -1368,11 +1359,10 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
         &self,
         range: crate::ParamRange,
         return_type: Type,
-        params_start: u32,
-        params_len: u32,
+        rir_params: &rue_rir::RirParamsRange,
         return_type_sym: Spur,
     ) -> Result<(Arc<[SemanticExportParameter]>, SemanticExportType), SemanticExportFailure> {
-        let rir_params = self.rir.get_params(params_start, params_len);
+        let rir_params = self.rir.params(rir_params);
         let type_name = self.interner.get("type");
         let generic_names = rir_params
             .iter()
@@ -1497,8 +1487,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         .get(&(sid, name))
                         .ok_or(SemanticExportFailure::UnmappedFunction)?;
                     let InstData::FnDecl {
-                        params_start,
-                        params_len,
+                        params,
                         return_type,
                         ..
                     } = &self.rir.get(declaration).data
@@ -1508,8 +1497,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     let (parameters, result) = self.export_callable_signature(
                         info.params,
                         info.return_type,
-                        *params_start,
-                        *params_len,
+                        params,
                         *return_type,
                     )?;
                     SemanticDeclarationPayload::Callable {
@@ -1656,8 +1644,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 }
                 InstData::StructDecl {
                     name,
-                    methods_start,
-                    methods_len,
+                    methods,
                     is_pub,
                     ..
                 } => {
@@ -1676,7 +1663,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                         *is_pub,
                     );
                     work.types_emitted += 1;
-                    for method_ref in self.rir.get_inst_refs(*methods_start, *methods_len) {
+                    for method_ref in self.rir.struct_methods(methods) {
                         work.named_method_edges_visited += 1;
                         let method_inst = self.rir.get(method_ref);
                         let InstData::FnDecl {
@@ -2145,7 +2132,7 @@ mod tests {
         let (ast, interner) = Parser::new(tokens, interner).parse().unwrap();
         let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
         astgen.append_items(&ast.items);
-        let mut rir = astgen.finish();
+        let mut rir = astgen.finish_editor();
         let method = rir
             .iter()
             .find_map(|(reference, inst)| match inst.data {
@@ -2153,10 +2140,7 @@ mod tests {
                 _ => None,
             })
             .unwrap();
-        let InstData::FnDecl { is_pub, .. } = &mut rir.get_mut(method).data else {
-            unreachable!()
-        };
-        *is_pub = true;
+        rir.set_function_public(method, true).unwrap();
         let bound = Sema::new(&rir, &interner, PreviewFeatures::new())
             .bind_declarations()
             .unwrap();

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -49,7 +49,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
-use lasso::{Key, Spur};
+use lasso::Spur;
 use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
 use rue_rir::{InstData, InstRef, RepeatCount};
 use rue_span::{FileId, Span};
@@ -774,20 +774,15 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             // Block: evaluate `let` statements into the environment, then the
             // tail expression. Loops, assignments and calls are not supported
             // and make the block non-evaluable.
-            InstData::Block { extra_start, len } => {
-                if *len == 0 {
+            InstData::Block { instructions } => {
+                let stmt_refs = self.rir.block_insts(instructions);
+                if stmt_refs.is_empty() {
                     return Ok(Some(ConstValue::Unit));
                 }
-                let stmt_refs: Vec<InstRef> = self
-                    .rir
-                    .get_extra(*extra_start, *len)
-                    .iter()
-                    .map(|&raw| InstRef::from_raw(raw))
-                    .collect();
                 // Bindings are scoped to the block.
                 let saved_locals = env.locals.clone();
                 let mut result = Some(ConstValue::Unit);
-                for (i, &stmt_ref) in stmt_refs.iter().enumerate() {
+                for (i, stmt_ref) in stmt_refs.values().enumerate() {
                     let is_tail = i + 1 == stmt_refs.len();
                     let value =
                         if let InstData::Alloc { name, init, .. } = &self.rir.get(stmt_ref).data {
@@ -845,16 +840,12 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             // (spec 4.14:19, RUE-262). An enum-variant (`Path`) pattern isn't
             // representable as a `ConstValue`, and a non-constant scrutinee is
             // not decidable here — both make the `match` non-evaluable.
-            InstData::Match {
-                scrutinee,
-                arms_start,
-                arms_len,
-            } => {
-                let (scrutinee, arms_start, arms_len) = (*scrutinee, *arms_start, *arms_len);
+            InstData::Match { scrutinee, arms } => {
+                let scrutinee = *scrutinee;
                 let Some(scrut) = self.eval_const_expr(scrutinee, env)? else {
                     return Ok(None);
                 };
-                let arms = self.rir.get_match_arms(arms_start, arms_len);
+                let arms = self.rir.match_arms(arms);
                 for (pattern, body) in arms.iter() {
                     match const_pattern_matches(&pattern, scrut) {
                         Some(true) => return self.eval_const_expr(body, env),
@@ -871,13 +862,8 @@ impl<D: DeclarationPhase> Sema<'_, D> {
 
             // Anonymous struct type: evaluate to a comptime type value,
             // resolving field types through the type substitution.
-            InstData::AnonStructType {
-                fields_start,
-                fields_len,
-                methods_start,
-                methods_len,
-            } => {
-                let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
+            InstData::AnonStructType { fields, methods } => {
+                let field_decls = self.rir.anon_struct_fields(fields);
 
                 // Comptime `let` locals in scope participate in field-type
                 // resolution (`let Inner = Mk(T); struct { x: Inner }`,
@@ -908,7 +894,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                 }
 
                 // Extract method signatures for structural equality comparison
-                let method_sigs = self.extract_anon_method_sigs(*methods_start, *methods_len);
+                let method_sigs = self.extract_anon_method_sigs(methods);
 
                 let (struct_ty, _is_new) = self.find_or_create_anon_struct(
                     &struct_fields,
@@ -918,7 +904,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
 
                 // Register methods if present and not yet registered for this
                 // struct (it may have been created earlier without methods).
-                if *methods_len > 0 {
+                if !self.rir.anon_struct_methods(methods).is_empty() {
                     // A method that declares its own `comptime T: type`
                     // parameter would need per-call monomorphization over that
                     // parameter, which is unsupported (RUE-284). Reject it at
@@ -926,7 +912,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                     // reduction cannot degrade into an unrelated E1200 at the
                     // instantiation site.
                     if let Some((method_span, method_name)) =
-                        self.find_method_own_comptime_type_param(*methods_start, *methods_len)
+                        self.find_method_own_comptime_type_param(methods)
                     {
                         return Err(CompileError::new(
                             ErrorKind::ComptimeEvaluationFailed {
@@ -946,7 +932,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                         return Ok(None);
                     };
 
-                    let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
+                    let method_refs = self.rir.anon_struct_methods(methods);
                     let first_method_ref = method_refs.get(0).unwrap();
                     let first_method_inst = self.rir.get(first_method_ref);
                     if let InstData::FnDecl {
@@ -960,8 +946,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                                 .register_anon_struct_methods_for_comptime_with_subst(
                                     struct_id,
                                     struct_ty,
-                                    *methods_start,
-                                    *methods_len,
+                                    methods,
                                     span,
                                     &local_type_subst,
                                     &local_value_subst,
@@ -994,18 +979,13 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             // The enum analog of the AnonStructType arm above — this is what
             // makes `fn Option(comptime T: type) -> type { enum { Some(T), None } }`
             // monomorphize per instantiation (ADR-0038, RUE-6 phase 2).
-            InstData::AnonEnumType {
-                variants_start,
-                variants_len,
-                payloads_start,
-                payloads_len,
-            } => {
-                let variant_syms: Vec<lasso::Spur> = self
+            InstData::AnonEnumType { variants, payloads } => {
+                let variant_syms: Vec<lasso::Spur> = self.rir.anon_enum_variants(variants).to_vec();
+                let payload_symbols: Vec<Vec<lasso::Spur>> = self
                     .rir
-                    .get_symbols(*variants_start, *variants_len)
-                    .to_vec();
-                let payload_words: Vec<u32> =
-                    self.rir.get_extra(*payloads_start, *payloads_len).to_vec();
+                    .anon_enum_payloads(payloads, variants)
+                    .map(|payload| payload.to_vec())
+                    .collect();
 
                 // Decode the self-describing payload region into per-variant
                 // type-symbol lists (parallel to `variant_syms`), then resolve
@@ -1016,23 +996,10 @@ impl<D: DeclarationPhase> Sema<'_, D> {
 
                 let mut variant_names: Vec<String> = Vec::with_capacity(variant_syms.len());
                 let mut variant_payloads: Vec<Vec<Type>> = Vec::with_capacity(variant_syms.len());
-                let mut pi = 0usize;
-                for &vsym in &variant_syms {
+                for (&vsym, symbols) in variant_syms.iter().zip(payload_symbols) {
                     variant_names.push(self.interner.resolve(&vsym).to_string());
-                    // A variant carries a payload only when the payload region
-                    // is present (`payloads_len > 0`) and describes arity `k`.
-                    let k = if payload_words.is_empty() {
-                        0
-                    } else {
-                        let k = payload_words[pi] as usize;
-                        pi += 1;
-                        k
-                    };
-                    let mut tys: Vec<Type> = Vec::with_capacity(k);
-                    for _ in 0..k {
-                        let ty_sym = lasso::Spur::try_from_usize(payload_words[pi] as usize)
-                            .expect("valid payload type symbol");
-                        pi += 1;
+                    let mut tys: Vec<Type> = Vec::with_capacity(symbols.len());
+                    for ty_sym in symbols {
                         let Some(ty) = self
                             .resolve_type_for_comptime_with_subst_and_values_at_span(
                                 ty_sym,
@@ -1224,13 +1191,9 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             // compose in ANY position — a delegating return body
             // (`fn Alias() -> type { Point() }`), a nested argument
             // (`WrapA(WrapA(i32))`), and chains thereof (RUE-251).
-            InstData::Call {
-                name,
-                args_start,
-                args_len,
-            } => {
-                let (name, args_start, args_len) = (*name, *args_start, *args_len);
-                self.eval_comptime_type_call(name, args_start, args_len, env, false)
+            InstData::Call { name, args } => {
+                let name = *name;
+                self.eval_comptime_type_call(name, args, env, false)
                     .map_err(|e| Self::label_ctor_instantiation_site(e, span))
             }
 
@@ -1297,14 +1260,10 @@ impl<D: DeclarationPhase> Sema<'_, D> {
             InstData::MethodCall {
                 receiver,
                 method,
-                args_start,
-                args_len,
+                args,
             } => {
-                let (receiver, method, args_start, args_len) =
-                    (*receiver, *method, *args_start, *args_len);
-                self.eval_module_qualified_comptime_call(
-                    receiver, method, args_start, args_len, span, env,
-                )
+                let (receiver, method) = (*receiver, *method);
+                self.eval_module_qualified_comptime_call(receiver, method, args, span, env)
             }
 
             // Everything else requires runtime evaluation
@@ -1329,8 +1288,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         &mut self,
         receiver: InstRef,
         method: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         span: Span,
         env: &mut ComptimeEnv,
     ) -> CompileResult<Option<ConstValue>> {
@@ -1424,7 +1382,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         )?;
         // Reduce through the shared path; arguments are evaluated in the current
         // environment so `T` (an enclosing comptime parameter) still resolves.
-        self.eval_comptime_type_call(function_key, args_start, args_len, env, true)
+        self.eval_comptime_type_call(function_key, args, env, true)
             .map_err(|e| Self::label_ctor_instantiation_site(e, span))
     }
 
@@ -1588,8 +1546,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     fn eval_comptime_type_call(
         &mut self,
         name: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         env: &mut ComptimeEnv,
         name_is_resolved_key: bool,
     ) -> CompileResult<Option<ConstValue>> {
@@ -1631,7 +1588,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         let param_modes = self.param_arena.modes(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
         let param_comptime_type = self.comptime_type_param_flags(&fn_info);
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args);
         if args.len() != param_names.len() {
             return Ok(None);
         }
@@ -2004,13 +1961,8 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         frame: &mut Vec<(Spur, Option<Type>, bool)>,
     ) {
         match &self.rir.get(inst_ref).data {
-            InstData::Block { extra_start, len } => {
-                let stmts: Vec<InstRef> = self
-                    .rir
-                    .get_extra(*extra_start, *len)
-                    .iter()
-                    .map(|&raw| InstRef::from_raw(raw))
-                    .collect();
+            InstData::Block { instructions } => {
+                let stmts: Vec<InstRef> = self.rir.block_insts(instructions).values().collect();
                 let mut inner_frame = Vec::new();
                 for stmt in stmts {
                     self.walk_comptime_type_locals(
@@ -2090,14 +2042,10 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                     frame,
                 );
             }
-            InstData::Match {
-                arms_start,
-                arms_len,
-                ..
-            } => {
+            InstData::Match { arms, .. } => {
                 let bodies: Vec<InstRef> = self
                     .rir
-                    .get_match_arms(*arms_start, *arms_len)
+                    .match_arms(arms)
                     .iter()
                     .map(|(_, body)| body)
                     .collect();

--- a/crates/rue-air/src/sema/declaration_index.rs
+++ b/crates/rue-air/src/sema/declaration_index.rs
@@ -119,13 +119,8 @@ impl RirDeclarationIndex {
                         *non_receiver_name_multiplicity.entry(*name).or_default() += 1;
                     }
                 }
-                InstData::StructDecl {
-                    name,
-                    methods_start,
-                    methods_len,
-                    ..
-                } => {
-                    for method_ref in rir.get_inst_refs(*methods_start, *methods_len) {
+                InstData::StructDecl { name, methods, .. } => {
+                    for method_ref in rir.struct_methods(methods) {
                         work.method_references_visited += 1;
                         named_method_refs.insert(method_ref);
                         // A method may only have one named owner in valid RIR;
@@ -135,12 +130,8 @@ impl RirDeclarationIndex {
                     }
                     nominal_candidates.push((source_order as u32, inst_ref));
                 }
-                InstData::AnonStructType {
-                    methods_start,
-                    methods_len,
-                    ..
-                } => {
-                    for method_ref in rir.get_inst_refs(*methods_start, *methods_len) {
+                InstData::AnonStructType { methods, .. } => {
+                    for method_ref in rir.anon_struct_methods(methods) {
                         work.method_references_visited += 1;
                         anonymous_method_refs.insert(method_ref);
                     }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -11,7 +11,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use lasso::{Key, Spur};
+use lasso::Spur;
 use rue_error::{CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, ice};
 use rue_rir::{InstData, InstRef, RirParamMode};
 use rue_span::{FileId, Span};
@@ -152,7 +152,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                         param_names: self.param_arena.names(info.params).to_vec(),
                         param_type_syms: self
                             .rir
-                            .get_params(info.rir_params_start, info.rir_params_len)
+                            .params(info.rir_params(self.rir))
                             .iter()
                             .map(|p| p.ty)
                             .collect(),
@@ -388,15 +388,14 @@ impl<'a> Sema<'a> {
                 InstData::EnumDecl {
                     is_pub,
                     name,
-                    variants_start,
-                    variants_len,
+                    variants,
                     ..
                 } => {
                     let enum_name = self.interner.resolve(&*name).to_string();
 
                     let key = (inst.span.file_id, *name);
 
-                    let variants = self.rir.get_symbols(*variants_start, *variants_len);
+                    let variants = self.rir.enum_variants(variants);
 
                     // Check for duplicate variant names
                     let mut seen_variants: HashSet<Spur> = HashSet::new();
@@ -438,8 +437,7 @@ impl<'a> Sema<'a> {
                     self.enums_by_file_name.insert(key, enum_id);
                 }
                 InstData::StructDecl {
-                    directives_start,
-                    directives_len,
+                    directives,
                     is_pub,
                     is_linear,
                     name,
@@ -449,7 +447,7 @@ impl<'a> Sema<'a> {
 
                     let key = (inst.span.file_id, *name);
 
-                    let directives = self.rir.get_directives(*directives_start, *directives_len);
+                    let directives = self.rir.directives(directives);
                     let is_copy = self.has_copy_directive(directives.iter());
 
                     // Linear types cannot be @copy
@@ -780,41 +778,41 @@ impl<'a> Sema<'a> {
     pub(crate) fn resolve_enum_payloads(&mut self) -> CompileResult<()> {
         // Collect the work first to avoid borrowing `self.rir` while mutating
         // the type pool through `self`.
-        let mut jobs: Vec<(Spur, u32, u32, Span)> = Vec::new();
-        for (_, inst) in self.rir.iter() {
-            if let InstData::EnumDecl {
-                name,
-                payloads_start,
-                payloads_len,
-                ..
-            } = &inst.data
-            {
-                jobs.push((*name, *payloads_start, *payloads_len, inst.span));
+        let mut jobs: Vec<(Spur, InstRef, Span)> = Vec::new();
+        for (inst_ref, inst) in self.rir.iter() {
+            if let InstData::EnumDecl { name, .. } = &inst.data {
+                jobs.push((*name, inst_ref, inst.span));
             }
         }
 
-        for (name, payloads_start, payloads_len, span) in jobs {
+        for (name, declaration, span) in jobs {
+            let InstData::EnumDecl {
+                payloads, variants, ..
+            } = &self.rir.get(declaration).data
+            else {
+                unreachable!()
+            };
+            let payload_symbols: Vec<Vec<Spur>> = self
+                .rir
+                .enum_payloads(payloads, variants)
+                .map(|payload| payload.to_vec())
+                .collect();
             let source_name = self.interner.resolve(&name).to_string();
             self.declaration_type_observer =
-                (payloads_len > 0 && !source_name.starts_with("__anon_enum_")).then_some((
+                (payload_symbols.iter().any(|payload| !payload.is_empty())
+                    && !source_name.starts_with("__anon_enum_"))
+                .then_some((
                     span.file_id,
                     source_name,
                     None,
                     super::DeclarationTypeDependencySourceKind::Enum,
                     super::DeclarationTypeDependencyKind::Payload,
                 ));
-            let words = self.rir.get_extra(payloads_start, payloads_len).to_vec();
             // Decode per-variant payload type symbols.
             let mut variant_payloads: Vec<Vec<Type>> = Vec::new();
-            let mut i = 0usize;
-            while i < words.len() {
-                let k = words[i] as usize;
-                i += 1;
-                let mut payload = Vec::with_capacity(k);
-                for _ in 0..k {
-                    let ty_sym = Spur::try_from_usize(words[i] as usize)
-                        .expect("valid interned type symbol in payload region");
-                    i += 1;
+            for symbols in payload_symbols {
+                let mut payload = Vec::with_capacity(symbols.len());
+                for ty_sym in symbols {
                     // A slice type `[T]` is second-class (ADR-0037, ADR-0043,
                     // RUE-322): an enum payload is aggregate storage, so it
                     // cannot hold a fat-pointer view (E0488).
@@ -894,13 +892,7 @@ impl<'a> Sema<'a> {
     /// Resolve struct field types. Must run before @copy validation.
     pub(crate) fn resolve_struct_fields(&mut self) -> CompileResult<()> {
         for (_, inst) in self.rir.iter() {
-            if let InstData::StructDecl {
-                name,
-                fields_start,
-                fields_len,
-                ..
-            } = &inst.data
-            {
+            if let InstData::StructDecl { name, fields, .. } = &inst.data {
                 let name_str = self.interner.resolve(&*name).to_string();
                 // Get the struct ID from the lookup table
                 let struct_id = *self
@@ -923,7 +915,7 @@ impl<'a> Sema<'a> {
                     })?;
 
                 let struct_name = name_str.clone();
-                let fields = self.rir.get_field_decls(*fields_start, *fields_len);
+                let fields = self.rir.struct_fields(fields);
 
                 // Check for duplicate field names
                 let mut seen_fields: HashSet<Spur> = HashSet::new();
@@ -1120,21 +1112,14 @@ impl<'a> Sema<'a> {
         for (inst_ref, inst) in self.rir.iter() {
             match &inst.data {
                 InstData::StructDecl {
-                    directives_start,
-                    directives_len,
+                    directives,
                     name,
-                    methods_start,
-                    methods_len,
+                    methods,
                     ..
                 } => {
-                    self.validate_copy_struct(
-                        *directives_start,
-                        *directives_len,
-                        *name,
-                        inst.span,
-                    )?;
+                    self.validate_copy_struct(directives, *name, inst.span)?;
                     // Collect methods defined inline in the struct
-                    self.collect_struct_methods(*name, *methods_start, *methods_len, inst.span)?;
+                    self.collect_struct_methods(*name, methods, inst.span)?;
                 }
 
                 InstData::DropFnDecl { type_name, .. } => {
@@ -1142,13 +1127,10 @@ impl<'a> Sema<'a> {
                 }
 
                 InstData::FnDecl {
-                    directives_start,
-                    directives_len,
                     is_pub,
                     is_unchecked,
                     name,
-                    params_start,
-                    params_len,
+                    params,
                     return_type,
                     body,
                     has_self,
@@ -1161,7 +1143,7 @@ impl<'a> Sema<'a> {
                     // methods alike — so checking here before the
                     // signature-collection skips below covers them all in one
                     // place without double-reporting.
-                    self.check_duplicate_param_names(*params_start, *params_len)?;
+                    self.check_duplicate_param_names(params)?;
 
                     // Skip methods (has_self = true) - these are handled elsewhere:
                     // - Named struct methods are collected via ImplDecl
@@ -1183,16 +1165,13 @@ impl<'a> Sema<'a> {
                         continue;
                     }
                     self.collect_function_signature(
+                        inst_ref,
                         *name,
-                        *params_start,
-                        *params_len,
                         *return_type,
                         *body,
                         inst.span,
                         *is_pub,
                         *is_unchecked,
-                        *directives_start,
-                        *directives_len,
                     )?;
                 }
 
@@ -1213,12 +1192,11 @@ impl<'a> Sema<'a> {
     /// Validate that a @copy struct only contains Copy type fields.
     fn validate_copy_struct(
         &self,
-        directives_start: u32,
-        directives_len: u32,
+        directives: &rue_rir::RirDirectivesRange,
         name: Spur,
         span: Span,
     ) -> CompileResult<()> {
-        let directives = self.rir.get_directives(directives_start, directives_len);
+        let directives = self.rir.directives(directives);
         if !self.has_copy_directive(directives.iter()) {
             return Ok(());
         }
@@ -1327,16 +1305,13 @@ impl<'a> Sema<'a> {
         let copy_sym = self.interner.get("copy")?;
         for (_, inst) in self.rir.iter() {
             if let InstData::StructDecl {
-                name,
-                directives_start,
-                directives_len,
-                ..
+                name, directives, ..
             } = &inst.data
             {
                 if *name != type_name {
                     continue;
                 }
-                let directives = self.rir.get_directives(*directives_start, *directives_len);
+                let directives = self.rir.directives(directives);
                 return directives
                     .iter()
                     .find(|d| d.name == copy_sym)
@@ -1356,8 +1331,8 @@ impl<'a> Sema<'a> {
     /// receiver is carried separately (`has_self`) — so `fn m(self, a, a)`
     /// still errors on the repeated `a` while `self` plus one distinct param
     /// is fine.
-    fn check_duplicate_param_names(&self, params_start: u32, params_len: u32) -> CompileResult<()> {
-        let params = self.rir.get_params(params_start, params_len);
+    fn check_duplicate_param_names(&self, params: &rue_rir::RirParamsRange) -> CompileResult<()> {
+        let params = self.rir.params(params);
         let mut seen: HashSet<Spur> = HashSet::with_capacity(params.len());
         for param in &params {
             if !seen.insert(param.name) {
@@ -1375,16 +1350,13 @@ impl<'a> Sema<'a> {
     /// Collect a function signature for forward reference.
     fn collect_function_signature(
         &mut self,
+        declaration: InstRef,
         name: Spur,
-        params_start: u32,
-        params_len: u32,
         return_type_sym: Spur,
         body: InstRef,
         span: Span,
         is_pub: bool,
         is_unchecked: bool,
-        directives_start: u32,
-        directives_len: u32,
     ) -> CompileResult<()> {
         // Reject user functions whose name collides with a runtime/codegen helper
         // symbol (e.g. `__rue_str_eq`, `__rue_alloc`, `_start`). Without this, such a
@@ -1407,8 +1379,16 @@ impl<'a> Sema<'a> {
             super::DeclarationTypeDependencyKind::Signature,
         ));
 
-        let params = self.rir.get_params(params_start, params_len);
-        let directives = self.rir.get_directives(directives_start, directives_len);
+        let InstData::FnDecl {
+            params: rir_params_range,
+            directives: directives_range,
+            ..
+        } = &self.rir.get(declaration).data
+        else {
+            unreachable!()
+        };
+        let params = self.rir.params(rir_params_range);
+        let directives = self.rir.directives(directives_range);
         let allow_unused_function = self.has_allow_directive(directives.iter(), "unused_function");
         let allow_unused_variable = self.has_allow_directive(directives.iter(), "unused_variable");
         let allow_unreachable_code =
@@ -1530,8 +1510,7 @@ impl<'a> Sema<'a> {
                 return_type: ret_type,
                 return_type_sym,
                 body,
-                rir_params_start: params_start,
-                rir_params_len: params_len,
+                declaration,
                 span,
                 is_generic,
                 is_pub,
@@ -1549,8 +1528,7 @@ impl<'a> Sema<'a> {
     fn collect_struct_methods(
         &mut self,
         type_name: Spur,
-        methods_start: u32,
-        methods_len: u32,
+        methods: &rue_rir::RirStructMethodsRange,
         span: Span,
     ) -> CompileResult<()> {
         let struct_id = match self.structs_by_file_name.get(&(span.file_id, type_name)) {
@@ -1565,13 +1543,12 @@ impl<'a> Sema<'a> {
         };
         let struct_type = Type::new_struct(struct_id);
 
-        let methods = self.rir.get_inst_refs(methods_start, methods_len);
+        let methods = self.rir.struct_methods(methods);
         for method_ref in methods {
             let method_inst = self.rir.get(method_ref);
             if let InstData::FnDecl {
                 name: method_name,
-                params_start,
-                params_len,
+                params,
                 return_type,
                 body,
                 has_self,
@@ -1606,7 +1583,7 @@ impl<'a> Sema<'a> {
                     ));
                 }
 
-                let params = self.rir.get_params(*params_start, *params_len);
+                let params = self.rir.params(params);
                 let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
                 let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
                 let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
@@ -1858,17 +1835,14 @@ impl<'a> Sema<'a> {
 
         match &init_inst.data {
             // @import("path") evaluates to a module at compile time.
-            InstData::Intrinsic {
-                name,
-                args_start,
-                args_len,
-            } => {
+            InstData::Intrinsic { name, args } => {
                 if *name == self.known.import {
                     assert_eq!(
-                        *args_len, 1,
+                        self.rir.intrinsic_args(args).len(),
+                        1,
                         "compiler import preflight rejects malformed @import calls"
                     );
-                    let arg_refs = self.rir.get_inst_refs(*args_start, *args_len);
+                    let arg_refs = self.rir.intrinsic_args(args);
                     let arg_inst = self.rir.get(arg_refs.get(0).unwrap());
                     let import_path = match &arg_inst.data {
                         InstData::StringConst(path_spur) => {
@@ -1977,18 +1951,16 @@ impl<'a> Sema<'a> {
             InstData::MethodCall {
                 receiver,
                 method,
-                args_start,
-                args_len,
+                args,
             } => {
-                let (receiver, method, args_start, args_len) =
-                    (*receiver, *method, *args_start, *args_len);
+                let (receiver, method) = (*receiver, *method);
                 match self.eval_const_initializer(receiver, file_id, None)? {
                     ConstInit::Module(module_ty) => {
                         let module_id = module_ty
                             .as_module()
                             .expect("ConstInit::Module holds a module type");
                         self.eval_module_member_comptime_call(
-                            module_id, method, args_start, args_len, file_id, span,
+                            module_id, method, args, file_id, span,
                         )
                     }
                     ConstInit::Value(_) => Err(CompileError::new(
@@ -2226,13 +2198,8 @@ impl<'a> Sema<'a> {
             // A block's tail expression carries the context; `let` initializers
             // are typed by their own value (no annotation context available
             // here), and non-tail statements carry no expected type.
-            InstData::Block { extra_start, len } => {
-                let stmt_refs: Vec<InstRef> = self
-                    .rir
-                    .get_extra(*extra_start, *len)
-                    .iter()
-                    .map(|&raw| InstRef::from_raw(raw))
-                    .collect();
+            InstData::Block { instructions } => {
+                let stmt_refs: Vec<InstRef> = self.rir.block_insts(instructions).values().collect();
                 let n = stmt_refs.len();
                 let mut tail_ty = None;
                 for (i, &stmt_ref) in stmt_refs.iter().enumerate() {
@@ -2310,13 +2277,8 @@ impl<'a> Sema<'a> {
                 let inner = *inner;
                 self.ensure_const_init_deps_collected(inner, file_id)
             }
-            InstData::Block { extra_start, len } => {
-                let stmt_refs: Vec<InstRef> = self
-                    .rir
-                    .get_extra(*extra_start, *len)
-                    .iter()
-                    .map(|&raw| InstRef::from_raw(raw))
-                    .collect();
+            InstData::Block { instructions } => {
+                let stmt_refs: Vec<InstRef> = self.rir.block_insts(instructions).values().collect();
                 for stmt_ref in stmt_refs {
                     self.ensure_const_init_deps_collected(stmt_ref, file_id)?;
                 }
@@ -2403,13 +2365,8 @@ impl<'a> Sema<'a> {
                 let inner = *inner;
                 self.collect_const_module_members(inner, file_id, out)
             }
-            InstData::Block { extra_start, len } => {
-                let stmt_refs: Vec<InstRef> = self
-                    .rir
-                    .get_extra(*extra_start, *len)
-                    .iter()
-                    .map(|&raw| InstRef::from_raw(raw))
-                    .collect();
+            InstData::Block { instructions } => {
+                let stmt_refs: Vec<InstRef> = self.rir.block_insts(instructions).values().collect();
                 for stmt_ref in stmt_refs {
                     self.collect_const_module_members(stmt_ref, file_id, out)?;
                 }
@@ -2591,8 +2548,7 @@ impl<'a> Sema<'a> {
         &mut self,
         module_id: crate::types::ModuleId,
         member: Spur,
-        args_start: u32,
-        args_len: u32,
+        args: &rue_rir::RirCallArgsRange,
         accessing_file: FileId,
         span: Span,
     ) -> CompileResult<ConstInit> {
@@ -2663,7 +2619,7 @@ impl<'a> Sema<'a> {
         let param_modes = self.param_arena.modes(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
         let param_comptime_type = self.comptime_type_param_flags(&fn_info);
-        let args = self.rir.get_call_args(args_start, args_len);
+        let args = self.rir.call_args(args);
         if args.len() != param_names.len() {
             return Err(CompileError::new(
                 ErrorKind::ConstExprNotSupported {
@@ -2796,43 +2752,19 @@ impl<'a> Sema<'a> {
         let Some(inst_ref) = self.declaration_index.first_free_function(target, file_id) else {
             return Ok(None);
         };
-        let (
-            span,
-            is_pub,
-            params_start,
-            params_len,
-            return_type,
-            body,
-            is_unchecked,
-            directives_start,
-            directives_len,
-        ) = {
+        let (span, is_pub, return_type, body, is_unchecked) = {
             let inst = self.rir.get(inst_ref);
             let InstData::FnDecl {
                 is_pub,
-                params_start,
-                params_len,
                 return_type,
                 body,
                 is_unchecked,
-                directives_start,
-                directives_len,
                 ..
             } = &inst.data
             else {
                 unreachable!("free-function index contains only FnDecl instructions");
             };
-            (
-                inst.span,
-                *is_pub,
-                *params_start,
-                *params_len,
-                *return_type,
-                *body,
-                *is_unchecked,
-                *directives_start,
-                *directives_len,
-            )
+            (inst.span, *is_pub, *return_type, *body, *is_unchecked)
         };
 
         let internal_target = self.internal_function_name(target, span.file_id);
@@ -2846,16 +2778,13 @@ impl<'a> Sema<'a> {
                 return Ok(None);
             }
             let collected = self.collect_function_signature(
+                inst_ref,
                 target,
-                params_start,
-                params_len,
                 return_type,
                 body,
                 span,
                 is_pub,
                 is_unchecked,
-                directives_start,
-                directives_len,
             );
             self.fn_signatures_in_flight.remove(&internal_target);
             collected?;

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -22,9 +22,9 @@ pub struct FunctionInfo {
     pub return_type_sym: Spur,
     /// RIR body ref for generic specialization
     pub body: rue_rir::InstRef,
-    /// RIR params indices for type symbol lookup during specialization
-    pub rir_params_start: u32,
-    pub rir_params_len: u32,
+    /// Owning source declaration. Variable payload descriptors remain attached
+    /// to this instruction and are borrowed from the RIR on demand.
+    pub declaration: rue_rir::InstRef,
     /// Span of the function declaration
     pub span: Span,
     /// Whether this function has any comptime parameters (type or value) and
@@ -43,6 +43,15 @@ pub struct FunctionInfo {
     pub allow_unreachable_code: bool,
     /// File ID this function was declared in (for visibility checking)
     pub file_id: FileId,
+}
+
+impl FunctionInfo {
+    pub(crate) fn rir_params<'a>(&self, rir: &'a rue_rir::Rir) -> &'a rue_rir::RirParamsRange {
+        let rue_rir::InstData::FnDecl { params, .. } = &rir.get(self.declaration).data else {
+            unreachable!("function metadata declaration must remain a FnDecl")
+        };
+        params
+    }
 }
 
 /// Information about a method in an impl block.

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -131,19 +131,16 @@ mod tests {
         let (ast, mut interner) = Parser::new(tokens, interner).parse().unwrap();
         let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
         astgen.append_items(&ast.items);
-        let mut rir = astgen.finish();
-        let (intrinsic_ref, args_start) = rir
+        let mut rir = astgen.finish_editor();
+        let intrinsic_ref = rir
             .iter()
             .find_map(|(inst_ref, inst)| match inst.data {
-                InstData::Intrinsic { args_start, .. } => Some((inst_ref, args_start)),
+                InstData::Intrinsic { .. } => Some(inst_ref),
                 _ => None,
             })
             .unwrap();
-        rir.get_mut(intrinsic_ref).data = InstData::InternalIntrinsic {
-            intrinsic: InternalIntrinsic::IterLen,
-            args_start,
-            args_len: 0,
-        };
+        rir.replace_internal_intrinsic(intrinsic_ref, InternalIntrinsic::IterLen, &[])
+            .unwrap();
 
         let errors = Sema::new(&rir, &mut interner, PreviewFeatures::new())
             .analyze_all()
@@ -897,16 +894,15 @@ mod tests {
         let imports = rir
             .iter()
             .filter_map(|(_, inst)| {
-                let rue_rir::InstData::Intrinsic {
-                    name,
-                    args_start,
-                    args_len: 1,
-                } = inst.data
-                else {
+                let rue_rir::InstData::Intrinsic { name, args } = &inst.data else {
                     return None;
                 };
-                (interner.resolve(&name) == "import").then(|| {
-                    let argument = rir.get_inst_refs(args_start, 1).get(0).unwrap();
+                let args = rir.intrinsic_args(args);
+                if args.len() != 1 {
+                    return None;
+                }
+                (interner.resolve(name) == "import").then(|| {
+                    let argument = args.get(0).unwrap();
                     let rue_rir::InstData::StringConst(specifier) = rir.get(argument).data else {
                         unreachable!()
                     };

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1571,7 +1571,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         let type_sym = self.interner.get("type");
         let flags: Vec<bool> = self
             .rir
-            .get_params(function.rir_params_start, function.rir_params_len)
+            .params(function.rir_params(self.rir))
             .iter()
             .map(|param| param.is_comptime && Some(param.ty) == type_sym)
             .collect();
@@ -1600,9 +1600,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             return Ok(declared);
         }
 
-        let rir_params = self
-            .rir
-            .get_params(function.rir_params_start, function.rir_params_len);
+        let rir_params = self.rir.params(function.rir_params(self.rir));
         let param = rir_params.get(param_index).ok_or_else(|| {
             CompileError::new(
                 ErrorKind::InternalError(format!(
@@ -2720,7 +2718,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         let param_comptime_type = self.comptime_type_param_flags(&function);
         let rir_param_types: Vec<Spur> = self
             .rir
-            .get_params(function.rir_params_start, function.rir_params_len)
+            .params(function.rir_params(self.rir))
             .iter()
             .map(|param| param.ty)
             .collect();

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -3,11 +3,11 @@
 use std::cell::RefCell;
 use std::ops::Range;
 
-use rue_error::CompileError;
 #[cfg(test)]
 use rue_error::CompileResult;
+use rue_error::{CompileError, ErrorKind};
 use rue_rir::RirPrinter;
-use rue_rir::{AstGen, InstRef, Rir};
+use rue_rir::{AstGen, InstRef, Rir, RirValidationContext, ValidatedRir};
 use rue_span::FileId;
 
 use crate::{CanonicalMergedProgram, SemanticSymbolUniverse, SourceRevision};
@@ -31,7 +31,7 @@ pub struct CanonicalRirWork {
 #[derive(Debug)]
 pub struct CanonicalRirOutput {
     source_revision: SourceRevision,
-    rir: Rir,
+    rir: ValidatedRir,
     symbols: SemanticSymbolUniverse,
     work: CanonicalRirWork,
     module_ranges: Vec<CanonicalRirModuleRange>,
@@ -67,7 +67,7 @@ impl CanonicalRirOutput {
                 })
     }
 
-    pub fn into_parts(self) -> (Rir, SemanticSymbolUniverse) {
+    pub fn into_parts(self) -> (ValidatedRir, SemanticSymbolUniverse) {
         (self.rir, self.symbols)
     }
 
@@ -166,13 +166,19 @@ pub(crate) fn lower_canonical_rir_with_work(
             work.modules_visited += 1;
             work.items_visited += view.module().ast().items.len();
             *current_view.borrow_mut() = Some(view.clone());
-            let instruction_start = generator.instruction_len() as u32;
-            let extra_start = generator.extra_len() as u32;
+            let instruction_start = u32::try_from(generator.instruction_len())
+                .expect("AstGen enforces the u32 instruction limit");
+            let extra_start = u32::try_from(generator.extra_len())
+                .expect("AstGen enforces the u32 payload-word limit");
             generator.append_items(&view.module().ast().items);
+            let instruction_end = u32::try_from(generator.instruction_len())
+                .expect("AstGen enforces the u32 instruction limit");
+            let extra_end = u32::try_from(generator.extra_len())
+                .expect("AstGen enforces the u32 payload-word limit");
             module_ranges.push(CanonicalRirModuleRange {
                 file_id: view.module().file_id(),
-                instructions: instruction_start..generator.instruction_len() as u32,
-                extra: extra_start..generator.extra_len() as u32,
+                instructions: instruction_start..instruction_end,
+                extra: extra_start..extra_end,
             });
             if let Some(error) = first_error.borrow_mut().take() {
                 drop(generator);
@@ -184,8 +190,56 @@ pub(crate) fn lower_canonical_rir_with_work(
                 return Err((error, work));
             }
         }
-        generator.finish()
+        match generator.try_finish_editor() {
+            Ok(rir) => rir,
+            Err(error) => {
+                let translation = symbols.work();
+                work.symbol_fields_translated = translation.local_symbol_resolutions;
+                work.semantic_intern_attempts = translation.semantic_intern_attempts;
+                work.unique_semantic_strings = translation.unique_semantic_strings;
+                work.semantic_strings_retained = symbols.interner().len();
+                return Err((
+                    CompileError::new(
+                        ErrorKind::InternalError(format!(
+                            "RIR payload construction failed: {error}"
+                        )),
+                        rue_span::Span::new(0, 0),
+                    ),
+                    work,
+                ));
+            }
+        }
     };
+    let source_lengths: Vec<(FileId, u32)> = ast
+        .modules()
+        .iter()
+        .map(|module| {
+            u32::try_from(module.source_text().len())
+                .map(|length| (module.file_id(), length))
+                .map_err(|_| {
+                    CompileError::new(
+                        ErrorKind::InternalError(
+                            "canonical source length exceeds RIR span capacity".to_string(),
+                        ),
+                        rue_span::Span::new(0, 0),
+                    )
+                })
+        })
+        .collect::<Result<_, _>>()
+        .map_err(|error| (error, work))?;
+    let validation = RirValidationContext {
+        symbol_count: symbols.interner().len(),
+        source_lengths: &source_lengths,
+    };
+    let rir = ValidatedRir::finish(rir, &validation).map_err(|error| {
+        (
+            CompileError::new(
+                ErrorKind::InternalError(format!("RIR payload validation failed: {error}")),
+                rue_span::Span::new(0, 0),
+            ),
+            work,
+        )
+    })?;
 
     let translation = symbols.work();
     work.symbol_fields_translated = translation.local_symbol_resolutions;

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -5,7 +5,7 @@
 //! has no per-AST construction path: callers normalize symbols, append module
 //! items in order, and finish one lowering session.
 
-use lasso::{Key, Spur, ThreadedRodeo};
+use lasso::{Spur, ThreadedRodeo};
 
 /// Known type intrinsics that take a type argument rather than an expression.
 /// These intrinsics operate on types at compile time (e.g., @size_of(i32)).
@@ -30,16 +30,35 @@ use rue_parser::{
 };
 
 use crate::inst::{
-    Inst, InstData, InstRef, InternalIntrinsic, RepeatCount, Rir, RirArgMode, RirCallArg,
-    RirDirective, RirParam, RirParamMode, RirPattern,
+    Inst, InstData, InstRef, InternalIntrinsic, PayloadFallback, RepeatCount, Rir, RirArgMode,
+    RirCallArg, RirDirective, RirEditor, RirParam, RirParamMode, RirPattern,
 };
+
+trait RecordPayloadFailure<T> {
+    fn record_failure(self, first_error: &mut Option<crate::RirPayloadBuildError>) -> T;
+}
+
+impl<T: PayloadFallback> RecordPayloadFailure<T> for Result<T, crate::RirPayloadBuildError> {
+    fn record_failure(self, first_error: &mut Option<crate::RirPayloadBuildError>) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => {
+                if first_error.is_none() {
+                    *first_error = Some(error);
+                }
+                T::payload_fallback()
+            }
+        }
+    }
+}
 
 /// Generates RIR from an AST.
 pub struct AstGen<'a> {
     /// String interner for symbols (thread-safe, takes shared reference)
     interner: &'a ThreadedRodeo,
     /// Output RIR
-    rir: Rir,
+    rir: RirEditor,
+    payload_error: Option<crate::RirPayloadBuildError>,
     /// Monotonic counter used to mint unique names for the compiler-generated
     /// temporaries of a `for`-loop desugaring (RUE-220), so nested for-loops
     /// don't shadow one another's position/length/collection bindings.
@@ -56,7 +75,8 @@ impl<'a> AstGen<'a> {
     ) -> Self {
         Self {
             interner,
-            rir: Rir::new(),
+            rir: RirEditor::new(),
+            payload_error: None,
             for_counter: 0,
             normalize_symbol: Box::new(normalize_symbol),
         }
@@ -85,7 +105,33 @@ impl<'a> AstGen<'a> {
     /// Finish a normalized multi-module lowering session.
     #[doc(hidden)]
     pub fn finish(self) -> Rir {
+        self.try_finish()
+            .expect("AstGen payload construction failed")
+    }
+
+    /// Finish while retaining the owner-mediated editor for controlled test
+    /// synthesis and compiler-internal replacement operations.
+    #[doc(hidden)]
+    pub fn finish_editor(self) -> RirEditor {
+        self.try_finish_editor()
+            .expect("AstGen payload construction failed")
+    }
+
+    /// Finish while preserving categorized resource/capacity/builder failures.
+    pub fn try_finish(self) -> Result<Rir, crate::RirPayloadBuildError> {
+        Ok(self.try_finish_editor()?.into_unvalidated())
+    }
+
+    /// Finish into the owner-mediated construction form used by the canonical
+    /// validation/publication boundary.
+    pub fn try_finish_editor(self) -> Result<RirEditor, crate::RirPayloadBuildError> {
+        if let Some(error) = self.payload_error {
+            return Err(error);
+        }
         self.rir
+            .validate_payloads()
+            .expect("AstGen produced malformed RIR payloads");
+        Ok(self.rir)
     }
 
     fn symbol(&self, symbol: Spur) -> Spur {
@@ -300,7 +346,6 @@ impl<'a> AstGen<'a> {
 
     fn gen_struct(&mut self, struct_decl: &StructDecl) -> InstRef {
         let directives = self.convert_directives(&struct_decl.directives);
-        let (directives_start, directives_len) = self.rir.add_directives(&directives);
         let name = self.symbol(struct_decl.name.name);
         let fields: Vec<_> = struct_decl
             .fields
@@ -311,30 +356,23 @@ impl<'a> AstGen<'a> {
                 (field_name, field_type)
             })
             .collect();
-        let (fields_start, fields_len) = self.rir.add_field_decls(&fields);
-
         // Generate each method defined inline in the struct
         let methods: Vec<_> = struct_decl
             .methods
             .iter()
             .map(|m| self.gen_method(m))
             .collect();
-        let (methods_start, methods_len) = self.rir.add_inst_refs(&methods);
-
-        self.rir.add_inst(Inst {
-            data: InstData::StructDecl {
-                directives_start,
-                directives_len,
-                is_pub: struct_decl.visibility == Visibility::Public,
-                is_linear: struct_decl.is_linear,
+        self.rir
+            .add_struct_decl(
+                &directives,
+                struct_decl.visibility == Visibility::Public,
+                struct_decl.is_linear,
                 name,
-                fields_start,
-                fields_len,
-                methods_start,
-                methods_len,
-            },
-            span: struct_decl.span,
-        })
+                &fields,
+                &methods,
+                struct_decl.span,
+            )
+            .record_failure(&mut self.payload_error)
     }
 
     fn gen_enum(&mut self, enum_decl: &EnumDecl) -> InstRef {
@@ -344,59 +382,48 @@ impl<'a> AstGen<'a> {
             .iter()
             .map(|v| self.symbol(v.name.name))
             .collect();
-        let (variants_start, variants_len) = self.rir.add_symbols(&variants);
-
         // Encode tuple-variant payloads (RUE-221) as a self-describing flat
         // sequence: for each variant, a count `k` followed by `k` payload
         // type-name symbols. Discriminant-only variants contribute a `0`.
         // The whole region is omitted (len 0) when no variant carries data.
-        let has_any_payload = enum_decl.variants.iter().any(|v| !v.payload.is_empty());
-        let (payloads_start, payloads_len) = if has_any_payload {
-            let mut payload_words: Vec<u32> = Vec::new();
-            for variant in &enum_decl.variants {
-                payload_words.push(variant.payload.len() as u32);
-                for ty in &variant.payload {
-                    let ty_sym = self.intern_type(ty);
-                    payload_words.push(ty_sym.into_usize() as u32);
-                }
-            }
-            let start = self.rir.add_extra(&payload_words);
-            (start, payload_words.len() as u32)
-        } else {
-            (0, 0)
-        };
-
-        self.rir.add_inst(Inst {
-            data: InstData::EnumDecl {
-                is_pub: enum_decl.visibility == Visibility::Public,
+        let payload_types: Vec<Vec<Spur>> = enum_decl
+            .variants
+            .iter()
+            .map(|variant| {
+                variant
+                    .payload
+                    .iter()
+                    .map(|ty| self.intern_type(ty))
+                    .collect()
+            })
+            .collect();
+        self.rir
+            .add_enum_decl(
+                enum_decl.visibility == Visibility::Public,
                 name,
-                variants_start,
-                variants_len,
-                payloads_start,
-                payloads_len,
-            },
-            span: enum_decl.span,
-        })
+                &variants,
+                &payload_types,
+                enum_decl.span,
+            )
+            .record_failure(&mut self.payload_error)
     }
 
     fn gen_const(&mut self, const_decl: &ConstDecl) -> InstRef {
         let directives = self.convert_directives(&const_decl.directives);
-        let (directives_start, directives_len) = self.rir.add_directives(&directives);
         let name = self.symbol(const_decl.name.name);
         let ty = const_decl.ty.as_ref().map(|t| self.intern_type(t));
         let init = self.gen_expr(&const_decl.init);
 
-        self.rir.add_inst(Inst {
-            data: InstData::ConstDecl {
-                directives_start,
-                directives_len,
-                is_pub: const_decl.visibility == Visibility::Public,
+        self.rir
+            .add_const_decl(
+                &directives,
+                const_decl.visibility == Visibility::Public,
                 name,
                 ty,
                 init,
-            },
-            span: const_decl.span,
-        })
+                const_decl.span,
+            )
+            .record_failure(&mut self.payload_error)
     }
 
     fn gen_drop_fn(&mut self, drop_fn: &DropFn) -> InstRef {
@@ -414,7 +441,6 @@ impl<'a> AstGen<'a> {
     fn gen_method(&mut self, method: &Method) -> InstRef {
         // Convert directives
         let directives = self.convert_directives(&method.directives);
-        let (directives_start, directives_len) = self.rir.add_directives(&directives);
 
         // Get the method name (already a Symbol) and return type
         let name = self.symbol(method.name.name);
@@ -435,8 +461,6 @@ impl<'a> AstGen<'a> {
                 span: p.name.span,
             })
             .collect();
-        let (params_start, params_len) = self.rir.add_params(&params);
-
         // Generate body expression
         let body = self.gen_expr(&method.body);
 
@@ -454,22 +478,21 @@ impl<'a> AstGen<'a> {
         // and self_mode to add it in the declared borrow/inout/by-value mode.
         // Methods don't have their own visibility - they're accessible if the type is accessible.
         // Methods cannot be marked unchecked (that's a function-level modifier).
-        let decl = self.rir.add_inst(Inst {
-            data: InstData::FnDecl {
-                directives_start,
-                directives_len,
-                is_pub: false,
-                is_unchecked: false,
+        let decl = self
+            .rir
+            .add_fn_decl(
+                &directives,
+                false,
+                false,
                 name,
-                params_start,
-                params_len,
+                &params,
                 return_type,
                 body,
                 has_self,
                 self_mode,
-            },
-            span: method.span,
-        });
+                method.span,
+            )
+            .record_failure(&mut self.payload_error);
 
         decl
     }
@@ -526,7 +549,6 @@ impl<'a> AstGen<'a> {
     fn gen_function(&mut self, func: &Function) -> InstRef {
         // Convert directives
         let directives = self.convert_directives(&func.directives);
-        let (directives_start, directives_len) = self.rir.add_directives(&directives);
 
         // Get the function name (already a Symbol) and return type
         let name = self.symbol(func.name.name);
@@ -547,29 +569,26 @@ impl<'a> AstGen<'a> {
                 span: p.name.span,
             })
             .collect();
-        let (params_start, params_len) = self.rir.add_params(&params);
-
         // Generate body expression
         let body = self.gen_expr(&func.body);
 
         // Create function declaration instruction
         // Regular functions don't have a self receiver
-        let decl = self.rir.add_inst(Inst {
-            data: InstData::FnDecl {
-                directives_start,
-                directives_len,
-                is_pub: func.visibility == Visibility::Public,
-                is_unchecked: func.is_unchecked,
+        let decl = self
+            .rir
+            .add_fn_decl(
+                &directives,
+                func.visibility == Visibility::Public,
+                func.is_unchecked,
                 name,
-                params_start,
-                params_len,
+                &params,
                 return_type,
                 body,
-                has_self: false,
-                self_mode: RirParamMode::Normal,
-            },
-            span: func.span,
-        });
+                false,
+                RirParamMode::Normal,
+                func.span,
+            )
+            .record_failure(&mut self.payload_error);
 
         decl
     }
@@ -694,29 +713,16 @@ impl<'a> AstGen<'a> {
                         (pattern, body)
                     })
                     .collect();
-                let (arms_start, arms_len) = self.rir.add_match_arms(&arms);
-
-                self.rir.add_inst(Inst {
-                    data: InstData::Match {
-                        scrutinee,
-                        arms_start,
-                        arms_len,
-                    },
-                    span: match_expr.span,
-                })
+                self.rir
+                    .add_match(scrutinee, &arms, match_expr.span)
+                    .record_failure(&mut self.payload_error)
             }
             Expr::Call(call) => {
                 let args: Vec<_> = call.args.iter().map(|a| self.convert_call_arg(a)).collect();
-                let (args_start, args_len) = self.rir.add_call_args(&args);
-
-                self.rir.add_inst(Inst {
-                    data: InstData::Call {
-                        name: self.symbol(call.name.name),
-                        args_start,
-                        args_len,
-                    },
-                    span: call.span,
-                })
+                let name = self.symbol(call.name.name);
+                self.rir
+                    .add_call(name, &args, call.span)
+                    .record_failure(&mut self.payload_error)
             }
             Expr::Break(break_expr) => {
                 let value = break_expr.value.as_ref().map(|v| self.gen_expr(v));
@@ -748,15 +754,10 @@ impl<'a> AstGen<'a> {
                 // instruction; sema reduces it to the struct type at comptime.
                 let ctor_head = struct_lit.ctor_args.as_ref().map(|args| {
                     let arg_refs: Vec<_> = args.iter().map(|a| self.convert_call_arg(a)).collect();
-                    let (args_start, args_len) = self.rir.add_call_args(&arg_refs);
-                    self.rir.add_inst(Inst {
-                        data: InstData::Call {
-                            name: self.symbol(struct_lit.name.name),
-                            args_start,
-                            args_len,
-                        },
-                        span: struct_lit.span,
-                    })
+                    let name = self.symbol(struct_lit.name.name);
+                    self.rir
+                        .add_call(name, &arg_refs, struct_lit.span)
+                        .record_failure(&mut self.payload_error)
                 });
 
                 let fields: Vec<_> = struct_lit
@@ -767,8 +768,6 @@ impl<'a> AstGen<'a> {
                         (self.symbol(f.name.name), field_value)
                     })
                     .collect();
-                let (fields_start, fields_len) = self.rir.add_field_inits(&fields);
-
                 // Field-init shorthand (`P { x }`, RUE-613) is fully desugared to
                 // `x: x` above; carry the first shorthand field's span so Sema can
                 // gate the form behind its preview flag.
@@ -778,17 +777,17 @@ impl<'a> AstGen<'a> {
                     .find(|f| f.shorthand)
                     .map(|f| f.span);
 
-                self.rir.add_inst(Inst {
-                    data: InstData::StructInit {
+                let type_name = self.symbol(struct_lit.name.name);
+                self.rir
+                    .add_struct_init(
                         module,
                         ctor_head,
-                        type_name: self.symbol(struct_lit.name.name),
-                        fields_start,
-                        fields_len,
+                        type_name,
+                        &fields,
                         shorthand_span,
-                    },
-                    span: struct_lit.span,
-                })
+                        struct_lit.span,
+                    )
+                    .record_failure(&mut self.payload_error)
             }
             Expr::Field(field_expr) => {
                 let base = self.gen_expr(&field_expr.base);
@@ -881,16 +880,9 @@ impl<'a> AstGen<'a> {
                         }
                     })
                     .collect();
-                let (args_start, args_len) = self.rir.add_inst_refs(&args);
-
-                self.rir.add_inst(Inst {
-                    data: InstData::Intrinsic {
-                        name,
-                        args_start,
-                        args_len,
-                    },
-                    span: intrinsic.span,
-                })
+                self.rir
+                    .add_intrinsic(name, &args, intrinsic.span)
+                    .record_failure(&mut self.payload_error)
             }
             Expr::ArrayLit(array_lit) => {
                 if let Some(count) = &array_lit.repeat {
@@ -919,15 +911,9 @@ impl<'a> AstGen<'a> {
                         .iter()
                         .map(|e| self.gen_expr(e))
                         .collect();
-                    let (elems_start, elems_len) = self.rir.add_inst_refs(&elements);
-
-                    self.rir.add_inst(Inst {
-                        data: InstData::ArrayInit {
-                            elems_start,
-                            elems_len,
-                        },
-                        span: array_lit.span,
-                    })
+                    self.rir
+                        .add_array_init(&elements, array_lit.span)
+                        .record_failure(&mut self.payload_error)
                 }
             }
             Expr::Index(index_expr) => {
@@ -962,17 +948,10 @@ impl<'a> AstGen<'a> {
                     .iter()
                     .map(|a| self.convert_call_arg(a))
                     .collect();
-                let (args_start, args_len) = self.rir.add_call_args(&args);
-
-                self.rir.add_inst(Inst {
-                    data: InstData::MethodCall {
-                        receiver,
-                        method: self.symbol(method_call.method.name),
-                        args_start,
-                        args_len,
-                    },
-                    span: method_call.span,
-                })
+                let method = self.symbol(method_call.method.name);
+                self.rir
+                    .add_method_call(receiver, method, &args, method_call.span)
+                    .record_failure(&mut self.payload_error)
             }
             Expr::SelfExpr(self_expr) => {
                 // `self` in method bodies is just a variable reference to the implicit self parameter
@@ -1015,23 +994,13 @@ impl<'a> AstGen<'a> {
                                 (name, ty)
                             })
                             .collect();
-                        let (fields_start, fields_len) = self.rir.add_field_decls(&field_decls);
-
                         // Generate each method inside the anonymous struct
                         // (reusing gen_method, which generates FnDecl instructions)
                         let method_refs: Vec<InstRef> =
                             methods.iter().map(|m| self.gen_method(m)).collect();
-                        let (methods_start, methods_len) = self.rir.add_inst_refs(&method_refs);
-
-                        self.rir.add_inst(Inst {
-                            data: InstData::AnonStructType {
-                                fields_start,
-                                fields_len,
-                                methods_start,
-                                methods_len,
-                            },
-                            span: type_lit.span,
-                        })
+                        self.rir
+                            .add_anon_struct_type(&field_decls, &method_refs, type_lit.span)
+                            .record_failure(&mut self.payload_error)
                     }
                     TypeExpr::AnonymousEnum { variants, .. } => {
                         // Generate an anonymous enum type instruction. Variant
@@ -1040,33 +1009,19 @@ impl<'a> AstGen<'a> {
                         // (RUE-221, ADR-0038).
                         let variant_syms: Vec<Spur> =
                             variants.iter().map(|v| self.symbol(v.name.name)).collect();
-                        let (variants_start, variants_len) = self.rir.add_symbols(&variant_syms);
-
-                        let has_any_payload = variants.iter().any(|v| !v.payload.is_empty());
-                        let (payloads_start, payloads_len) = if has_any_payload {
-                            let mut payload_words: Vec<u32> = Vec::new();
-                            for variant in variants {
-                                payload_words.push(variant.payload.len() as u32);
-                                for ty in &variant.payload {
-                                    let ty_sym = self.intern_type(ty);
-                                    payload_words.push(ty_sym.into_usize() as u32);
-                                }
-                            }
-                            let start = self.rir.add_extra(&payload_words);
-                            (start, payload_words.len() as u32)
-                        } else {
-                            (0, 0)
-                        };
-
-                        self.rir.add_inst(Inst {
-                            data: InstData::AnonEnumType {
-                                variants_start,
-                                variants_len,
-                                payloads_start,
-                                payloads_len,
-                            },
-                            span: type_lit.span,
-                        })
+                        let payload_types: Vec<Vec<Spur>> = variants
+                            .iter()
+                            .map(|variant| {
+                                variant
+                                    .payload
+                                    .iter()
+                                    .map(|ty| self.intern_type(ty))
+                                    .collect()
+                            })
+                            .collect();
+                        self.rir
+                            .add_anon_enum_type(&variant_syms, &payload_types, type_lit.span)
+                            .record_failure(&mut self.payload_error)
                     }
                     _ => {
                         // For named types, unit, never, arrays, and pointers, generate TypeConst
@@ -1156,15 +1111,10 @@ impl<'a> AstGen<'a> {
                 // instruction; sema reduces it to the enum type at comptime.
                 let ctor_head = path.ctor_args.as_ref().map(|args| {
                     let arg_refs: Vec<_> = args.iter().map(|a| self.convert_call_arg(a)).collect();
-                    let (args_start, args_len) = self.rir.add_call_args(&arg_refs);
-                    self.rir.add_inst(Inst {
-                        data: InstData::Call {
-                            name: self.symbol(path.type_name.name),
-                            args_start,
-                            args_len,
-                        },
-                        span: path.span,
-                    })
+                    let name = self.symbol(path.type_name.name);
+                    self.rir
+                        .add_call(name, &arg_refs, path.span)
+                        .record_failure(&mut self.payload_error)
                 });
                 // Payload binding names for a tuple-variant pattern (RUE-221).
                 let bindings: Vec<Spur> =
@@ -1201,13 +1151,10 @@ impl<'a> AstGen<'a> {
             inst_refs.push(final_expr.as_u32());
 
             // Store the refs in extra data
-            let extra_start = self.rir.add_extra(&inst_refs);
-            let len = inst_refs.len() as u32;
-
-            self.rir.add_inst(Inst {
-                data: InstData::Block { extra_start, len },
-                span: block.span,
-            })
+            let refs: Vec<_> = inst_refs.into_iter().map(InstRef::from_raw).collect();
+            self.rir
+                .add_block(&refs, block.span)
+                .record_failure(&mut self.payload_error)
         }
     }
 
@@ -1273,19 +1220,10 @@ impl<'a> AstGen<'a> {
         } else {
             let init = self.gen_expr(coll_expr);
             let name = self.interner.get_or_intern(format!("__rue_for_coll_{n}"));
-            let (ds, dl) = self.rir.add_directives(&[]);
-            let alloc = self.rir.add_inst(Inst {
-                data: InstData::Alloc {
-                    directives_start: ds,
-                    directives_len: dl,
-                    name: Some(name),
-                    is_mut: false,
-                    ty: None,
-                    init,
-                    iter_elem: false,
-                },
-                span,
-            });
+            let alloc = self
+                .rir
+                .add_alloc(&[], Some(name), false, None, init, false, span)
+                .record_failure(&mut self.payload_error);
             outer_stmts.push(alloc.as_u32());
             name
         };
@@ -1297,19 +1235,10 @@ impl<'a> AstGen<'a> {
             data: InstData::IntConst(0),
             span,
         });
-        let (ds, dl) = self.rir.add_directives(&[]);
-        let p_alloc = self.rir.add_inst(Inst {
-            data: InstData::Alloc {
-                directives_start: ds,
-                directives_len: dl,
-                name: Some(p_name),
-                is_mut: true,
-                ty: Some(u64_sym),
-                init: zero,
-                iter_elem: false,
-            },
-            span,
-        });
+        let p_alloc = self
+            .rir
+            .add_alloc(&[], Some(p_name), true, Some(u64_sym), zero, false, span)
+            .record_failure(&mut self.payload_error);
         outer_stmts.push(p_alloc.as_u32());
 
         // let __len: u64 = InternalIntrinsic::IterLen(__coll);
@@ -1322,28 +1251,22 @@ impl<'a> AstGen<'a> {
             data: InstData::VarRef { name: coll_name },
             span: iter_span,
         });
-        let (la_start, la_len) = self.rir.add_inst_refs(&[coll_for_len]);
-        let len_call = self.rir.add_inst(Inst {
-            data: InstData::InternalIntrinsic {
-                intrinsic: InternalIntrinsic::IterLen,
-                args_start: la_start,
-                args_len: la_len,
-            },
-            span: iter_span,
-        });
-        let (ds, dl) = self.rir.add_directives(&[]);
-        let len_alloc = self.rir.add_inst(Inst {
-            data: InstData::Alloc {
-                directives_start: ds,
-                directives_len: dl,
-                name: Some(len_name),
-                is_mut: false,
-                ty: Some(u64_sym),
-                init: len_call,
-                iter_elem: false,
-            },
-            span,
-        });
+        let len_call = self
+            .rir
+            .add_internal_intrinsic(InternalIntrinsic::IterLen, &[coll_for_len], iter_span)
+            .record_failure(&mut self.payload_error);
+        let len_alloc = self
+            .rir
+            .add_alloc(
+                &[],
+                Some(len_name),
+                false,
+                Some(u64_sym),
+                len_call,
+                false,
+                span,
+            )
+            .record_failure(&mut self.payload_error);
         outer_stmts.push(len_alloc.as_u32());
 
         // ---- loop body ----
@@ -1406,15 +1329,9 @@ impl<'a> AstGen<'a> {
             } else {
                 InternalIntrinsic::CharScalar
             };
-            let (s, l) = self.rir.add_inst_refs(&[coll_for_get, p_for_get]);
-            self.rir.add_inst(Inst {
-                data: InstData::InternalIntrinsic {
-                    intrinsic,
-                    args_start: s,
-                    args_len: l,
-                },
-                span,
-            })
+            self.rir
+                .add_internal_intrinsic(intrinsic, &[coll_for_get, p_for_get], span)
+                .record_failure(&mut self.payload_error)
         } else {
             self.rir.add_inst(Inst {
                 data: InstData::IndexGet {
@@ -1424,23 +1341,12 @@ impl<'a> AstGen<'a> {
                 span,
             })
         };
-        let (ds, dl) = self.rir.add_directives(&[]);
-        let binder_alloc = self.rir.add_inst(Inst {
-            data: InstData::Alloc {
-                directives_start: ds,
-                directives_len: dl,
-                name: binder_name,
-                is_mut: false,
-                ty: None,
-                init: get_inst,
-                // The element binding is a shared read of the collection
-                // (spec 4.8:26): analyzed as a by-ref read so a non-Copy
-                // element is not moved out (RUE-259), and a non-Copy binder is
-                // a non-owning borrow slot the collection still drops.
-                iter_elem: true,
-            },
-            span,
-        });
+        // The element binding is a shared read of the collection (spec 4.8:26):
+        // analyzed as a by-ref read so a non-Copy element is not moved out.
+        let binder_alloc = self
+            .rir
+            .add_alloc(&[], binder_name, false, None, get_inst, true, span)
+            .record_failure(&mut self.payload_error);
         body_stmts.push(binder_alloc.as_u32());
 
         // __p = <advance>;   (advanced before the body so `continue` steps)
@@ -1458,15 +1364,9 @@ impl<'a> AstGen<'a> {
             } else {
                 InternalIntrinsic::CharNext
             };
-            let (s, l) = self.rir.add_inst_refs(&[coll_for_adv, p_for_adv]);
-            self.rir.add_inst(Inst {
-                data: InstData::InternalIntrinsic {
-                    intrinsic,
-                    args_start: s,
-                    args_len: l,
-                },
-                span,
-            })
+            self.rir
+                .add_internal_intrinsic(intrinsic, &[coll_for_adv, p_for_adv], span)
+                .record_failure(&mut self.payload_error)
         } else {
             let one = self.rir.add_inst(Inst {
                 data: InstData::IntConst(1),
@@ -1500,14 +1400,11 @@ impl<'a> AstGen<'a> {
         });
         body_stmts.push(body_unit.as_u32());
 
-        let body_extra_start = self.rir.add_extra(&body_stmts);
-        let loop_body = self.rir.add_inst(Inst {
-            data: InstData::Block {
-                extra_start: body_extra_start,
-                len: body_stmts.len() as u32,
-            },
-            span,
-        });
+        let body_refs: Vec<_> = body_stmts.into_iter().map(InstRef::from_raw).collect();
+        let loop_body = self
+            .rir
+            .add_block(&body_refs, span)
+            .record_failure(&mut self.payload_error);
 
         // A `for` over a named variable holds a scoped shared borrow of that
         // variable for the loop's duration (spec 4.8:26): sema rejects any
@@ -1530,39 +1427,33 @@ impl<'a> AstGen<'a> {
         });
         outer_stmts.push(outer_unit.as_u32());
 
-        let outer_extra_start = self.rir.add_extra(&outer_stmts);
-        self.rir.add_inst(Inst {
-            data: InstData::Block {
-                extra_start: outer_extra_start,
-                len: outer_stmts.len() as u32,
-            },
-            span,
-        })
+        let outer_refs: Vec<_> = outer_stmts.into_iter().map(InstRef::from_raw).collect();
+        self.rir
+            .add_block(&outer_refs, span)
+            .record_failure(&mut self.payload_error)
     }
 
     fn gen_statement(&mut self, stmt: &Statement) -> InstRef {
         match stmt {
             Statement::Let(let_stmt) => {
                 let directives = self.convert_directives(&let_stmt.directives);
-                let (directives_start, directives_len) = self.rir.add_directives(&directives);
                 let name = match &let_stmt.pattern {
                     LetPattern::Ident(ident) => Some(self.symbol(ident.name)),
                     LetPattern::Wildcard(_) => None,
                 };
                 let ty = let_stmt.ty.as_ref().map(|t| self.intern_type(t));
                 let init = self.gen_expr(&let_stmt.init);
-                self.rir.add_inst(Inst {
-                    data: InstData::Alloc {
-                        directives_start,
-                        directives_len,
+                self.rir
+                    .add_alloc(
+                        &directives,
                         name,
-                        is_mut: let_stmt.is_mut,
+                        let_stmt.is_mut,
                         ty,
                         init,
-                        iter_elem: false,
-                    },
-                    span: let_stmt.span,
-                })
+                        false,
+                        let_stmt.span,
+                    )
+                    .record_failure(&mut self.payload_error)
             }
             Statement::Assign(assign) => {
                 let value = self.gen_expr(&assign.value);
@@ -1635,15 +1526,14 @@ mod tests {
         match &fn_inst.data {
             InstData::FnDecl {
                 name,
-                params_start,
-                params_len,
+                params,
                 return_type,
                 body,
                 has_self,
                 ..
             } => {
                 assert_eq!(interner.resolve(&*name), "main");
-                let params = rir.get_params(*params_start, *params_len);
+                let params = rir.params(params);
                 assert_eq!(params.len(), 0);
                 assert_eq!(interner.resolve(&*return_type), "i32");
                 assert!(!has_self); // Regular functions don't have self
@@ -1868,12 +1758,12 @@ mod tests {
             InstData::FnDecl { body, .. } => {
                 let body_inst = rir.get(*body);
                 match &body_inst.data {
-                    InstData::Block { extra_start, len } => {
+                    InstData::Block { instructions } => {
                         // Block contains: Alloc, VarRef
-                        assert_eq!(*len, 2);
-                        let inst_refs = rir.get_extra(*extra_start, *len);
+                        let inst_refs = rir.block_insts(instructions);
+                        assert_eq!(inst_refs.len(), 2);
                         // Last instruction in block is the VarRef
-                        let var_ref_inst = rir.get(InstRef::from_raw(inst_refs[1]));
+                        let var_ref_inst = rir.get(inst_refs.get(1).unwrap());
                         match &var_ref_inst.data {
                             InstData::VarRef { name } => {
                                 assert_eq!(interner.resolve(&*name), "x");
@@ -1925,12 +1815,12 @@ mod tests {
             InstData::FnDecl { body, .. } => {
                 let body_inst = rir.get(*body);
                 match &body_inst.data {
-                    InstData::Block { extra_start, len } => {
+                    InstData::Block { instructions } => {
                         // Block contains: Alloc(x), Alloc(y), Add
-                        assert_eq!(*len, 3);
-                        let inst_refs = rir.get_extra(*extra_start, *len);
+                        let inst_refs = rir.block_insts(instructions);
+                        assert_eq!(inst_refs.len(), 3);
                         // Last instruction in block is the Add
-                        let add_inst = rir.get(InstRef::from_raw(inst_refs[2]));
+                        let add_inst = rir.get(inst_refs.get(2).unwrap());
                         assert!(matches!(add_inst.data, InstData::Add { .. }));
                     }
                     _ => panic!("expected Block"),
@@ -1963,14 +1853,9 @@ mod tests {
 
         let (_, inst) = struct_decl.unwrap();
         match &inst.data {
-            InstData::StructDecl {
-                name,
-                methods_start,
-                methods_len,
-                ..
-            } => {
+            InstData::StructDecl { name, methods, .. } => {
                 assert_eq!(interner.resolve(&*name), "Point");
-                let methods = rir.get_inst_refs(*methods_start, *methods_len).to_vec();
+                let methods = rir.struct_methods(methods).values().collect::<Vec<_>>();
                 assert_eq!(methods.len(), 1);
 
                 // Check the method is a FnDecl with has_self=true
@@ -2008,12 +1893,8 @@ mod tests {
 
         let (_, inst) = struct_decl.unwrap();
         match &inst.data {
-            InstData::StructDecl {
-                methods_start,
-                methods_len,
-                ..
-            } => {
-                let methods = rir.get_inst_refs(*methods_start, *methods_len);
+            InstData::StructDecl { methods, .. } => {
+                let methods = rir.struct_methods(methods);
                 assert_eq!(methods.len(), 3);
 
                 // Check get_x and get_y have self, origin does not
@@ -2061,11 +1942,10 @@ mod tests {
             InstData::MethodCall {
                 receiver: _,
                 method,
-                args_start,
-                args_len,
+                args,
             } => {
                 assert_eq!(interner.resolve(&*method), "get_x");
-                let args = rir.get_call_args(*args_start, *args_len);
+                let args = rir.call_args(args);
                 assert_eq!(args.len(), 0); // No explicit args (self is implicit)
             }
             _ => panic!("expected MethodCall"),
@@ -2101,15 +1981,14 @@ mod tests {
             InstData::MethodCall {
                 receiver,
                 method,
-                args_start,
-                args_len,
+                args,
             } => {
                 match &rir.get(*receiver).data {
                     InstData::VarRef { name } => assert_eq!(interner.resolve(name), "Point"),
                     other => panic!("expected VarRef receiver, got {other:?}"),
                 }
                 assert_eq!(interner.resolve(&*method), "origin");
-                let args = rir.get_call_args(*args_start, *args_len);
+                let args = rir.call_args(args);
                 assert_eq!(args.len(), 0);
             }
             _ => panic!("expected MethodCall"),
@@ -2137,13 +2016,9 @@ mod tests {
 
         let (_, inst) = match_inst.unwrap();
         match &inst.data {
-            InstData::Match {
-                arms_start,
-                arms_len,
-                ..
-            } => {
+            InstData::Match { arms, .. } => {
                 let arms: Vec<_> = rir
-                    .get_match_arms(*arms_start, *arms_len)
+                    .match_arms(arms)
                     .iter()
                     .map(|(pattern, body)| (pattern.to_owned(), body))
                     .collect();
@@ -2175,13 +2050,9 @@ mod tests {
 
         let (_, inst) = match_inst.unwrap();
         match &inst.data {
-            InstData::Match {
-                arms_start,
-                arms_len,
-                ..
-            } => {
+            InstData::Match { arms, .. } => {
                 let arms: Vec<_> = rir
-                    .get_match_arms(*arms_start, *arms_len)
+                    .match_arms(arms)
                     .iter()
                     .map(|(pattern, body)| (pattern.to_owned(), body))
                     .collect();
@@ -2229,13 +2100,9 @@ mod tests {
 
         let (_, inst) = match_inst.unwrap();
         match &inst.data {
-            InstData::Match {
-                arms_start,
-                arms_len,
-                ..
-            } => {
+            InstData::Match { arms, .. } => {
                 let arms: Vec<_> = rir
-                    .get_match_arms(*arms_start, *arms_len)
+                    .match_arms(arms)
                     .iter()
                     .map(|(pattern, body)| (pattern.to_owned(), body))
                     .collect();
@@ -2282,13 +2149,9 @@ mod tests {
 
         let (_, inst) = match_inst.unwrap();
         match &inst.data {
-            InstData::Match {
-                arms_start,
-                arms_len,
-                ..
-            } => {
+            InstData::Match { arms, .. } => {
                 let arms: Vec<_> = rir
-                    .get_match_arms(*arms_start, *arms_len)
+                    .match_arms(arms)
                     .iter()
                     .map(|(pattern, body)| (pattern.to_owned(), body))
                     .collect();
@@ -2322,13 +2185,9 @@ mod tests {
 
         let (_, inst) = match_inst.unwrap();
         match &inst.data {
-            InstData::Match {
-                arms_start,
-                arms_len,
-                ..
-            } => {
+            InstData::Match { arms, .. } => {
                 let arms: Vec<_> = rir
-                    .get_match_arms(*arms_start, *arms_len)
+                    .match_arms(arms)
                     .iter()
                     .map(|(pattern, body)| (pattern.to_owned(), body))
                     .collect();
@@ -2466,25 +2325,20 @@ mod tests {
 
         let (_, inst) = struct_decl.unwrap();
         match &inst.data {
-            InstData::StructDecl {
-                methods_start,
-                methods_len,
-                ..
-            } => {
-                let methods = rir.get_inst_refs(*methods_start, *methods_len).to_vec();
+            InstData::StructDecl { methods, .. } => {
+                let methods = rir.struct_methods(methods).values().collect::<Vec<_>>();
                 let method_inst = rir.get(methods[0]);
                 match &method_inst.data {
                     InstData::FnDecl {
                         name,
-                        params_start,
-                        params_len,
+                        params,
                         has_self,
                         ..
                     } => {
                         assert_eq!(interner.resolve(&*name), "add");
                         assert!(*has_self);
                         // params should contain 'amount', not 'self'
-                        let params = rir.get_params(*params_start, *params_len).to_vec();
+                        let params = rir.params(params).to_vec();
                         assert_eq!(params.len(), 1);
                         assert_eq!(interner.resolve(&params[0].name), "amount");
                     }
@@ -2554,21 +2408,15 @@ mod tests {
 
         let (_, inst) = anon_struct.unwrap();
         match &inst.data {
-            InstData::AnonStructType {
-                fields_start,
-                fields_len,
-                methods_start,
-                methods_len,
-            } => {
+            InstData::AnonStructType { fields, methods } => {
                 // Should have 2 fields (x and y)
-                let fields = rir.get_field_decls(*fields_start, *fields_len).to_vec();
+                let fields = rir.anon_struct_fields(fields).to_vec();
                 assert_eq!(fields.len(), 2);
                 assert_eq!(interner.resolve(&fields[0].0), "x");
                 assert_eq!(interner.resolve(&fields[1].0), "y");
 
                 // Should have 2 methods (get_x and origin)
-                assert_eq!(*methods_len, 2);
-                let methods = rir.get_inst_refs(*methods_start, *methods_len);
+                let methods = rir.anon_struct_methods(methods);
                 assert_eq!(methods.len(), 2);
 
                 // Verify each method is a FnDecl
@@ -2614,8 +2462,11 @@ mod tests {
 
         let (_, inst) = anon_struct.unwrap();
         match &inst.data {
-            InstData::AnonStructType { methods_len, .. } => {
-                assert_eq!(*methods_len, 0, "Expected no methods");
+            InstData::AnonStructType { methods, .. } => {
+                assert!(
+                    rir.anon_struct_methods(methods).is_empty(),
+                    "Expected no methods"
+                );
             }
             _ => panic!("Expected AnonStructType"),
         }

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -4,9 +4,183 @@
 //! This provides good cache locality and efficient traversal.
 
 use std::fmt;
+use std::marker::PhantomData;
 
 use lasso::{Key, Spur};
 use rue_span::{FileId, Span};
+
+/// A failure while staging a compact RIR payload.
+#[derive(Debug)]
+pub enum RirPayloadBuildError {
+    ResourceLimitExceeded {
+        family: &'static str,
+    },
+    CapacityFailure {
+        family: &'static str,
+    },
+    InvalidBuilderInput {
+        family: &'static str,
+        reason: &'static str,
+    },
+}
+
+impl fmt::Display for RirPayloadBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ResourceLimitExceeded { family } => {
+                write!(f, "RIR {family} payload exceeds the u32 word-store limit")
+            }
+            Self::CapacityFailure { family } => {
+                write!(f, "could not reserve storage for RIR {family} payload")
+            }
+            Self::InvalidBuilderInput { family, reason } => {
+                write!(f, "invalid RIR {family} builder input: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RirPayloadBuildError {}
+
+/// Structured corruption reported by the production RIR payload decoder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RirPayloadError {
+    pub family: &'static str,
+    pub start: u32,
+    pub extent: u32,
+    pub record: Option<u32>,
+    pub reason: &'static str,
+}
+
+impl fmt::Display for RirPayloadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "corrupt RIR {} payload at {}+{}{}: {}",
+            self.family,
+            self.start,
+            self.extent,
+            self.record
+                .map(|record| format!(", record {record}"))
+                .unwrap_or_default(),
+            self.reason
+        )
+    }
+}
+
+impl std::error::Error for RirPayloadError {}
+
+/// Canonical source/interner bounds required to publish an immutable RIR.
+pub struct RirValidationContext<'a> {
+    pub symbol_count: usize,
+    pub source_lengths: &'a [(FileId, u32)],
+}
+
+#[repr(C)]
+#[derive(PartialEq, Eq)]
+struct PayloadRange<Family> {
+    start: u32,
+    extent: u32,
+    family: PhantomData<fn() -> Family>,
+}
+
+macro_rules! payload_family {
+    ($name:ident, $marker:ident, $family:literal) => {
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum $marker {}
+
+        /// Opaque range into the RIR word store for this payload family.
+        #[repr(transparent)]
+        #[derive(PartialEq, Eq)]
+        pub struct $name(PayloadRange<$marker>);
+
+        impl $name {
+            const FAMILY: &'static str = $family;
+
+            const fn from_parts(start: u32, extent: u32) -> Self {
+                Self(PayloadRange {
+                    start,
+                    extent,
+                    family: PhantomData,
+                })
+            }
+
+            const fn start(&self) -> u32 {
+                self.0.start
+            }
+            const fn extent(&self) -> u32 {
+                self.0.extent
+            }
+        }
+
+        impl PayloadFallback for $name {
+            fn payload_fallback() -> Self {
+                Self::from_parts(0, 0)
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($name))
+                    .field("words", &format_args!("{}+{}", self.0.start, self.0.extent))
+                    .finish()
+            }
+        }
+
+        const _: () = assert!(std::mem::size_of::<$name>() == 2 * std::mem::size_of::<u32>());
+        const _: () = assert!(std::mem::align_of::<$name>() == std::mem::align_of::<u32>());
+    };
+}
+
+pub(crate) trait PayloadFallback {
+    fn payload_fallback() -> Self;
+}
+
+payload_family!(RirMatchArmsRange, MatchArmsFamily, "match arms");
+payload_family!(RirDirectivesRange, DirectivesFamily, "directives");
+payload_family!(RirParamsRange, ParamsFamily, "parameters");
+payload_family!(RirCallArgsRange, CallArgsFamily, "call arguments");
+payload_family!(
+    RirIntrinsicArgsRange,
+    IntrinsicArgsFamily,
+    "intrinsic arguments"
+);
+payload_family!(
+    RirInternalIntrinsicArgsRange,
+    InternalIntrinsicArgsFamily,
+    "internal intrinsic arguments"
+);
+payload_family!(RirBlockInstsRange, BlockInstsFamily, "block instructions");
+payload_family!(RirStructFieldsRange, StructFieldsFamily, "struct fields");
+payload_family!(
+    RirAnonStructFieldsRange,
+    AnonStructFieldsFamily,
+    "anonymous struct fields"
+);
+payload_family!(RirStructMethodsRange, StructMethodsFamily, "struct methods");
+payload_family!(
+    RirAnonStructMethodsRange,
+    AnonStructMethodsFamily,
+    "anonymous struct methods"
+);
+payload_family!(RirFieldInitsRange, FieldInitsFamily, "field initializers");
+payload_family!(RirEnumVariantsRange, EnumVariantsFamily, "enum variants");
+payload_family!(
+    RirAnonEnumVariantsRange,
+    AnonEnumVariantsFamily,
+    "anonymous enum variants"
+);
+payload_family!(
+    RirEnumPayloadsRange,
+    EnumPayloadsFamily,
+    "enum variant payloads"
+);
+payload_family!(
+    RirAnonEnumPayloadsRange,
+    AnonEnumPayloadsFamily,
+    "anonymous enum variant payloads"
+);
+payload_family!(RirArrayElemsRange, ArrayElemsFamily, "array elements");
 
 /// A reference to an instruction in the RIR.
 ///
@@ -25,6 +199,12 @@ impl InstRef {
     #[inline]
     pub const fn as_u32(self) -> u32 {
         self.0
+    }
+}
+
+impl PayloadFallback for InstRef {
+    fn payload_fallback() -> Self {
+        Self(u32::MAX)
     }
 }
 
@@ -434,15 +614,39 @@ impl RirDirectiveView<'_> {
 /// Extra data marker types for type-safe storage in the extra array.
 /// These types represent data stored in the extra array.
 
-/// Stored representation of RirCallArg in the extra array.
-/// Layout: [value: u32, mode: u32] = 2 u32s per arg
-const CALL_ARG_SIZE: u32 = 2;
+#[derive(Clone, Copy)]
+struct FixedPayloadSchema {
+    width: usize,
+    symbol_offsets: &'static [usize],
+}
 
-/// Stored representation of RirParam in the extra array.
-/// Layout: [name: u32, ty: u32, mode: u32, is_comptime: u32,
-///          span.file_id: u32, span.start: u32, span.end: u32] = 7 u32s per
-/// param (must match `add_params`/`get_params`)
-const PARAM_SIZE: u32 = 7;
+const REF_SCHEMA: FixedPayloadSchema = FixedPayloadSchema {
+    width: 1,
+    symbol_offsets: &[],
+};
+const SYMBOL_SCHEMA: FixedPayloadSchema = FixedPayloadSchema {
+    width: 1,
+    symbol_offsets: &[0],
+};
+/// `[value, mode]`.
+const CALL_ARG_SCHEMA: FixedPayloadSchema = FixedPayloadSchema {
+    width: 2,
+    symbol_offsets: &[],
+};
+const CALL_ARG_VALUE: usize = 0;
+const CALL_ARG_MODE: usize = 1;
+/// `[name, ty, mode, is_comptime, span.file, span.start, span.end]`.
+const PARAM_SCHEMA: FixedPayloadSchema = FixedPayloadSchema {
+    width: 7,
+    symbol_offsets: &[PARAM_NAME, PARAM_TYPE],
+};
+const PARAM_NAME: usize = 0;
+const PARAM_TYPE: usize = 1;
+const PARAM_MODE: usize = 2;
+const PARAM_COMPTIME: usize = 3;
+const PARAM_SPAN_FILE: usize = 4;
+const PARAM_SPAN_START: usize = 5;
+const PARAM_SPAN_END: usize = 6;
 
 /// Stored representation of match arm in the extra array.
 /// Layout: pattern data + [body: u32]
@@ -472,17 +676,195 @@ pub enum PatternKind {
 const PATTERN_WILDCARD_SIZE: u32 = 5; // kind, span_start, span_len, span_file, body
 const PATTERN_INT_SIZE: u32 = 8; // kind, span_start, span_len, span_file, value_lo, value_hi, negative, body
 const PATTERN_BOOL_SIZE: u32 = 6; // kind, span_start, span_len, span_file, value, body
+const PATTERN_PATH_BASE_SIZE: usize = 10;
+const DIRECTIVE_HEADER_WORDS: usize = 5;
+const RECORD_KIND: usize = 0;
+const RECORD_SPAN_START: usize = 1;
+const RECORD_SPAN_LEN: usize = 2;
+const RECORD_SPAN_FILE: usize = 3;
+const MATCH_VALUE_LO_OR_BOOL_OR_BODY: usize = 4;
+const MATCH_VALUE_HI_OR_BOOL_BODY: usize = 5;
+const MATCH_INT_NEGATIVE_OR_PATH_TYPE: usize = 6;
+const MATCH_INT_BODY_OR_PATH_VARIANT: usize = 7;
+const MATCH_PATH_BINDING_COUNT: usize = 8;
+const MATCH_PATH_BINDINGS_START: usize = 9;
+const DIRECTIVE_NAME: usize = 0;
+const DIRECTIVE_ARG_COUNT: usize = 4;
+const DIRECTIVE_ARGS_START: usize = 5;
 // Path patterns are variable-length (RUE-221): kind, span×3, module,
 // type_name, variant, n_bindings, bindings…, body = 9 + n_bindings words.
 // See `add_match_arms`/`get_match_arms` for the layout.
 
 /// Stored representation of struct field initializer.
 /// Layout: [field_name: u32, value: u32] = 2 u32s per field
-const FIELD_INIT_SIZE: u32 = 2;
+const FIELD_INIT_SCHEMA: FixedPayloadSchema = FixedPayloadSchema {
+    width: 2,
+    symbol_offsets: &[FIELD_INIT_NAME],
+};
+const FIELD_INIT_NAME: usize = 0;
+const FIELD_INIT_VALUE: usize = 1;
 
 /// Stored representation of struct field declaration.
 /// Layout: [field_name: u32, field_type: u32] = 2 u32s per field
-const FIELD_DECL_SIZE: u32 = 2;
+const FIELD_DECL_SCHEMA: FixedPayloadSchema = FixedPayloadSchema {
+    width: 2,
+    symbol_offsets: &[FIELD_DECL_NAME, FIELD_DECL_TYPE],
+};
+const FIELD_DECL_NAME: usize = 0;
+const FIELD_DECL_TYPE: usize = 1;
+
+fn decode_symbol_word(word: u32) -> Option<Spur> {
+    Spur::try_from_usize(word as usize)
+}
+
+fn validated_symbol_word(word: u32) -> Spur {
+    match decode_symbol_word(word) {
+        Some(symbol) => symbol,
+        None => unreachable!("RIR symbol word passed schema validation"),
+    }
+}
+
+fn encoded_match_record_extent(pattern: &RirPattern) -> Option<usize> {
+    match pattern {
+        RirPattern::Wildcard(_) => Some(PATTERN_WILDCARD_SIZE as usize),
+        RirPattern::Int { .. } => Some(PATTERN_INT_SIZE as usize),
+        RirPattern::Bool(..) => Some(PATTERN_BOOL_SIZE as usize),
+        RirPattern::Path { bindings, .. } => PATTERN_PATH_BASE_SIZE.checked_add(bindings.len()),
+    }
+}
+
+fn encoded_directive_record_extent(directive: &RirDirective) -> Option<usize> {
+    DIRECTIVE_HEADER_WORDS.checked_add(directive.args.len())
+}
+
+fn decoded_match_record_extent(words: &[u32], position: usize) -> Option<usize> {
+    match words.get(position + RECORD_KIND).copied()? {
+        x if x == PatternKind::Wildcard as u32 => Some(PATTERN_WILDCARD_SIZE as usize),
+        x if x == PatternKind::Int as u32 => Some(PATTERN_INT_SIZE as usize),
+        x if x == PatternKind::Bool as u32 => Some(PATTERN_BOOL_SIZE as usize),
+        x if x == PatternKind::Path as u32 => words
+            .get(position + MATCH_PATH_BINDING_COUNT)
+            .and_then(|count| PATTERN_PATH_BASE_SIZE.checked_add(*count as usize)),
+        _ => None,
+    }
+}
+
+fn decoded_directive_record_extent(words: &[u32], position: usize) -> Option<usize> {
+    words
+        .get(position + DIRECTIVE_ARG_COUNT)
+        .and_then(|count| DIRECTIVE_HEADER_WORDS.checked_add(*count as usize))
+}
+
+fn embedded_span(words: &[u32], position: usize) -> Option<Span> {
+    let start = *words.get(position + RECORD_SPAN_START)?;
+    let len = *words.get(position + RECORD_SPAN_LEN)?;
+    let file = FileId::new(*words.get(position + RECORD_SPAN_FILE)?);
+    Some(Span::with_file(file, start, start.checked_add(len)?))
+}
+
+fn enum_payload_record(words: &[u32], position: usize) -> Option<(usize, usize)> {
+    let count = *words.get(position)? as usize;
+    let start = position.checked_add(1)?;
+    let end = start.checked_add(count)?;
+    (end <= words.len()).then_some((start, end))
+}
+
+fn encoded_enum_payload_record_extent(payload: &[Spur]) -> Option<usize> {
+    1usize.checked_add(payload.len())
+}
+
+fn decode_match_record(
+    words: &[u32],
+    position: usize,
+) -> Option<(RirPatternView<'_>, InstRef, usize)> {
+    let kind = *words.get(position + RECORD_KIND)?;
+    let span = embedded_span(words, position)?;
+    let extent = decoded_match_record_extent(words, position)?;
+    if position.checked_add(extent)? > words.len() {
+        return None;
+    }
+    match kind {
+        x if x == PatternKind::Wildcard as u32 => Some((
+            RirPatternView::Wildcard(span),
+            InstRef::from_raw(*words.get(position + MATCH_VALUE_LO_OR_BOOL_OR_BODY)?),
+            extent,
+        )),
+        x if x == PatternKind::Int as u32 => {
+            let negative = *words.get(position + MATCH_INT_NEGATIVE_OR_PATH_TYPE)?;
+            if negative > 1 {
+                return None;
+            }
+            Some((
+                RirPatternView::Int {
+                    value: *words.get(position + MATCH_VALUE_LO_OR_BOOL_OR_BODY)? as u64
+                        | ((*words.get(position + MATCH_VALUE_HI_OR_BOOL_BODY)? as u64) << 32),
+                    negative: negative != 0,
+                    span,
+                },
+                InstRef::from_raw(*words.get(position + MATCH_INT_BODY_OR_PATH_VARIANT)?),
+                extent,
+            ))
+        }
+        x if x == PatternKind::Bool as u32 => {
+            let value = *words.get(position + MATCH_VALUE_LO_OR_BOOL_OR_BODY)?;
+            if value > 1 {
+                return None;
+            }
+            Some((
+                RirPatternView::Bool(value != 0, span),
+                InstRef::from_raw(*words.get(position + MATCH_VALUE_HI_OR_BOOL_BODY)?),
+                extent,
+            ))
+        }
+        x if x == PatternKind::Path as u32 => {
+            let count = *words.get(position + MATCH_PATH_BINDING_COUNT)? as usize;
+            let end = position.checked_add(extent)?;
+            let optional_ref = |word| (word != u32::MAX).then(|| InstRef::from_raw(word));
+            let binding_start = position + MATCH_PATH_BINDINGS_START;
+            Some((
+                RirPatternView::Path {
+                    module: optional_ref(words[position + MATCH_VALUE_LO_OR_BOOL_OR_BODY]),
+                    ctor_head: optional_ref(words[position + MATCH_VALUE_HI_OR_BOOL_BODY]),
+                    type_name: decode_symbol_word(
+                        words[position + MATCH_INT_NEGATIVE_OR_PATH_TYPE],
+                    )?,
+                    variant: decode_symbol_word(words[position + MATCH_INT_BODY_OR_PATH_VARIANT])?,
+                    bindings: RirSlice::new(
+                        &words[binding_start..binding_start + count],
+                        SYMBOL_SCHEMA.width,
+                        |record| validated_symbol_word(record[0]),
+                    ),
+                    span,
+                },
+                InstRef::from_raw(words[end - 1]),
+                extent,
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn decode_directive_record(
+    words: &[u32],
+    position: usize,
+) -> Option<(RirDirectiveView<'_>, usize)> {
+    let extent = decoded_directive_record_extent(words, position)?;
+    let end = position.checked_add(extent)?;
+    if end > words.len() {
+        return None;
+    }
+    let args_start = position + DIRECTIVE_ARGS_START;
+    Some((
+        RirDirectiveView {
+            name: decode_symbol_word(words[position + DIRECTIVE_NAME])?,
+            args: RirSlice::new(&words[args_start..end], SYMBOL_SCHEMA.width, |record| {
+                validated_symbol_word(record[0])
+            }),
+            span: embedded_span(words, position)?,
+        },
+        extent,
+    ))
+}
 
 /// Stored representation of directive in the extra array.
 /// Layout: [name: u32, span_start: u32, span_len: u32, args_len: u32, args...]
@@ -497,14 +879,449 @@ pub struct Rir {
     extra: Vec<u32>,
 }
 
+/// Mutable construction-phase owner. Payload descriptors never leave this
+/// owner through the public API; callers add or replace complete nodes.
+#[derive(Debug, Default)]
+pub struct RirEditor {
+    rir: Rir,
+}
+
+impl RirEditor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn into_unvalidated(self) -> Rir {
+        self.rir
+    }
+
+    fn atomic<T>(
+        &mut self,
+        build: impl FnOnce(&mut Rir) -> Result<T, RirPayloadBuildError>,
+    ) -> Result<T, RirPayloadBuildError> {
+        let instruction_len = self.rir.instructions.len();
+        let extra_len = self.rir.extra.len();
+        match build(&mut self.rir) {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                self.rir.instructions.truncate(instruction_len);
+                self.rir.extra.truncate(extra_len);
+                Err(error)
+            }
+        }
+    }
+
+    /// Add a payload-free node. Payload-bearing nodes use the atomic methods
+    /// below, whose descriptors never escape the editor.
+    pub fn add_inst(&mut self, inst: Inst) -> InstRef {
+        self.rir.add_inst(inst)
+    }
+
+    pub fn add_intrinsic(
+        &mut self,
+        name: Spur,
+        args: &[InstRef],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let args = rir.add_intrinsic_args(args)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::Intrinsic { name, args },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_internal_intrinsic(
+        &mut self,
+        intrinsic: InternalIntrinsic,
+        args: &[InstRef],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let args = rir.add_internal_intrinsic_args(args)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::InternalIntrinsic { intrinsic, args },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_block(
+        &mut self,
+        instructions: &[InstRef],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let instructions = rir.add_block_insts(instructions)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::Block { instructions },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_call(
+        &mut self,
+        name: Spur,
+        args: &[RirCallArg],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let args = rir.add_call_args(args)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::Call { name, args },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_method_call(
+        &mut self,
+        receiver: InstRef,
+        method: Spur,
+        args: &[RirCallArg],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let args = rir.add_method_args(args)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::MethodCall {
+                    receiver,
+                    method,
+                    args,
+                },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_match(
+        &mut self,
+        scrutinee: InstRef,
+        arms: &[(RirPattern, InstRef)],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let arms = rir.add_match_arms(arms)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::Match { scrutinee, arms },
+                span,
+            }))
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_fn_decl(
+        &mut self,
+        directives: &[RirDirective],
+        is_pub: bool,
+        is_unchecked: bool,
+        name: Spur,
+        params: &[RirParam],
+        return_type: Spur,
+        body: InstRef,
+        has_self: bool,
+        self_mode: RirParamMode,
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let directives = rir.add_directives(directives)?;
+            let params = rir.add_params(params)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::FnDecl {
+                    directives,
+                    is_pub,
+                    is_unchecked,
+                    name,
+                    params,
+                    return_type,
+                    body,
+                    has_self,
+                    self_mode,
+                },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_const_decl(
+        &mut self,
+        directives: &[RirDirective],
+        is_pub: bool,
+        name: Spur,
+        ty: Option<Spur>,
+        init: InstRef,
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let directives = rir.add_directives(directives)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::ConstDecl {
+                    directives,
+                    is_pub,
+                    name,
+                    ty,
+                    init,
+                },
+                span,
+            }))
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_alloc(
+        &mut self,
+        directives: &[RirDirective],
+        name: Option<Spur>,
+        is_mut: bool,
+        ty: Option<Spur>,
+        init: InstRef,
+        iter_elem: bool,
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let directives = rir.add_directives(directives)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::Alloc {
+                    directives,
+                    name,
+                    is_mut,
+                    ty,
+                    init,
+                    iter_elem,
+                },
+                span,
+            }))
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_struct_decl(
+        &mut self,
+        directives: &[RirDirective],
+        is_pub: bool,
+        is_linear: bool,
+        name: Spur,
+        fields: &[(Spur, Spur)],
+        methods: &[InstRef],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let directives = rir.add_directives(directives)?;
+            let fields = rir.add_struct_fields(fields)?;
+            let methods = rir.add_struct_methods(methods)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::StructDecl {
+                    directives,
+                    is_pub,
+                    is_linear,
+                    name,
+                    fields,
+                    methods,
+                },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_struct_init(
+        &mut self,
+        module: Option<InstRef>,
+        ctor_head: Option<InstRef>,
+        type_name: Spur,
+        fields: &[(Spur, InstRef)],
+        shorthand_span: Option<Span>,
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let fields = rir.add_field_inits(fields)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::StructInit {
+                    module,
+                    ctor_head,
+                    type_name,
+                    fields,
+                    shorthand_span,
+                },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_enum_decl(
+        &mut self,
+        is_pub: bool,
+        name: Spur,
+        variants: &[Spur],
+        payloads: &[Vec<Spur>],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            if variants.len() != payloads.len() {
+                return Err(RirPayloadBuildError::InvalidBuilderInput {
+                    family: RirEnumPayloadsRange::FAMILY,
+                    reason: "variant and payload counts differ",
+                });
+            }
+            let variants = rir.add_enum_variants(variants)?;
+            let payloads = rir.add_enum_payloads(payloads)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::EnumDecl {
+                    is_pub,
+                    name,
+                    variants,
+                    payloads,
+                },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_array_init(
+        &mut self,
+        elements: &[InstRef],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let elements = rir.add_array_elements(elements)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::ArrayInit { elements },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_anon_struct_type(
+        &mut self,
+        fields: &[(Spur, Spur)],
+        methods: &[InstRef],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            let fields = rir.add_anon_struct_fields(fields)?;
+            let methods = rir.add_anon_struct_methods(methods)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::AnonStructType { fields, methods },
+                span,
+            }))
+        })
+    }
+
+    pub fn add_anon_enum_type(
+        &mut self,
+        variants: &[Spur],
+        payloads: &[Vec<Spur>],
+        span: Span,
+    ) -> Result<InstRef, RirPayloadBuildError> {
+        self.atomic(|rir| {
+            if variants.len() != payloads.len() {
+                return Err(RirPayloadBuildError::InvalidBuilderInput {
+                    family: RirAnonEnumPayloadsRange::FAMILY,
+                    reason: "variant and payload counts differ",
+                });
+            }
+            let variants = rir.add_anon_enum_variants(variants)?;
+            let payloads = rir.add_anon_enum_payloads(payloads)?;
+            Ok(rir.add_inst(Inst {
+                data: InstData::AnonEnumType { variants, payloads },
+                span,
+            }))
+        })
+    }
+
+    /// Atomically replace an instruction with a compiler-internal intrinsic.
+    pub fn replace_internal_intrinsic(
+        &mut self,
+        instruction: InstRef,
+        intrinsic: InternalIntrinsic,
+        args: &[InstRef],
+    ) -> Result<(), RirPayloadBuildError> {
+        if self.rir.instructions.get(instruction.0 as usize).is_none() {
+            return Err(RirPayloadBuildError::InvalidBuilderInput {
+                family: RirInternalIntrinsicArgsRange::FAMILY,
+                reason: "replacement instruction is outside the editor",
+            });
+        }
+        let range = self.rir.add_internal_intrinsic_args(args)?;
+        let inst = &mut self.rir.instructions[instruction.0 as usize];
+        inst.data = InstData::InternalIntrinsic {
+            intrinsic,
+            args: range,
+        };
+        Ok(())
+    }
+
+    /// Change function visibility without exposing detached instruction data.
+    pub fn set_function_public(
+        &mut self,
+        instruction: InstRef,
+        is_pub: bool,
+    ) -> Result<(), RirPayloadBuildError> {
+        let Some(inst) = self.rir.instructions.get_mut(instruction.0 as usize) else {
+            return Err(RirPayloadBuildError::InvalidBuilderInput {
+                family: "function declaration",
+                reason: "replacement instruction is outside the editor",
+            });
+        };
+        let InstData::FnDecl { is_pub: slot, .. } = &mut inst.data else {
+            return Err(RirPayloadBuildError::InvalidBuilderInput {
+                family: "function declaration",
+                reason: "visibility replacement requires a function declaration",
+            });
+        };
+        *slot = is_pub;
+        Ok(())
+    }
+}
+
+impl std::ops::Deref for RirEditor {
+    type Target = Rir;
+
+    fn deref(&self) -> &Self::Target {
+        &self.rir
+    }
+}
+
+/// Immutable RIR whose complete payload graph passed structural validation.
+#[derive(Debug)]
+pub struct ValidatedRir(Rir);
+
+impl ValidatedRir {
+    /// Consume and validate an editor at the construction/publication boundary.
+    pub fn finish(
+        editor: RirEditor,
+        context: &RirValidationContext<'_>,
+    ) -> Result<Self, RirPayloadError> {
+        editor.validate_payloads()?;
+        editor.validate_context(context)?;
+        Ok(Self(editor.into_unvalidated()))
+    }
+}
+
+impl std::ops::Deref for ValidatedRir {
+    type Target = Rir;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl Rir {
+    fn symbol_word(family: &'static str, symbol: Spur) -> Result<u32, RirPayloadBuildError> {
+        u32::try_from(symbol.into_usize()).map_err(|_| RirPayloadBuildError::InvalidBuilderInput {
+            family,
+            reason: "symbol index exceeds u32",
+        })
+    }
+
     /// Create a new empty RIR.
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Add an instruction and return its reference.
-    pub fn add_inst(&mut self, inst: Inst) -> InstRef {
+    pub(crate) fn add_inst(&mut self, inst: Inst) -> InstRef {
         // Debug assertion for u32 overflow - catches pathological inputs during development
         debug_assert!(
             self.instructions.len() < u32::MAX as usize,
@@ -512,7 +1329,8 @@ impl Rir {
             self.instructions.len()
         );
 
-        let index = self.instructions.len() as u32;
+        let index = u32::try_from(self.instructions.len())
+            .expect("RIR instruction count checked before insertion");
         self.instructions.push(inst);
         InstRef::from_raw(index)
     }
@@ -521,12 +1339,6 @@ impl Rir {
     #[inline]
     pub fn get(&self, inst_ref: InstRef) -> &Inst {
         &self.instructions[inst_ref.0 as usize]
-    }
-
-    /// Get a mutable reference to an instruction.
-    #[inline]
-    pub fn get_mut(&mut self, inst_ref: InstRef) -> &mut Inst {
-        &mut self.instructions[inst_ref.0 as usize]
     }
 
     /// The number of instructions.
@@ -549,158 +1361,1169 @@ impl Rir {
 
     /// Iterate over all instructions with their references.
     pub fn iter(&self) -> impl Iterator<Item = (InstRef, &Inst)> {
-        self.instructions
-            .iter()
-            .enumerate()
-            .map(|(i, inst)| (InstRef::from_raw(i as u32), inst))
-    }
-
-    /// Add extra data and return the start index.
-    pub fn add_extra(&mut self, data: &[u32]) -> u32 {
-        // Debug assertions for u32 overflow - catches pathological inputs during development
-        debug_assert!(
-            self.extra.len() <= u32::MAX as usize,
-            "RIR extra data overflow: {} entries exceeds u32::MAX",
-            self.extra.len()
-        );
-        debug_assert!(
-            self.extra.len().saturating_add(data.len()) <= u32::MAX as usize,
-            "RIR extra data would overflow: {} + {} exceeds u32::MAX",
-            self.extra.len(),
-            data.len()
-        );
-
-        let start = self.extra.len() as u32;
-        self.extra.extend_from_slice(data);
-        start
-    }
-
-    /// Get extra data by index.
-    #[inline]
-    pub fn get_extra(&self, start: u32, len: u32) -> &[u32] {
-        let start = start as usize;
-        let end = start + len as usize;
-        &self.extra[start..end]
-    }
-
-    // ===== Helper methods for storing/retrieving typed data in the extra array =====
-
-    /// Store a slice of InstRefs and return (start, len).
-    pub fn add_inst_refs(&mut self, refs: &[InstRef]) -> (u32, u32) {
-        let data: Vec<u32> = refs.iter().map(|r| r.as_u32()).collect();
-        let start = self.add_extra(&data);
-        (start, refs.len() as u32)
-    }
-
-    /// Retrieve InstRefs from the extra array.
-    pub fn get_inst_refs(&self, start: u32, len: u32) -> RirSlice<'_, InstRef> {
-        RirSlice::new(self.get_extra(start, len), 1, |record| {
-            InstRef::from_raw(record[0])
+        self.instructions.iter().enumerate().map(|(i, inst)| {
+            (
+                InstRef::from_raw(
+                    u32::try_from(i).expect("RIR instruction count is bounded by u32"),
+                ),
+                inst,
+            )
         })
     }
 
-    /// Store a slice of Spurs and return (start, len).
-    pub fn add_symbols(&mut self, symbols: &[Spur]) -> (u32, u32) {
-        let data: Vec<u32> = symbols.iter().map(|s| s.into_usize() as u32).collect();
-        let start = self.add_extra(&data);
-        (start, symbols.len() as u32)
+    fn append_payload(
+        &mut self,
+        family: &'static str,
+        staged: Vec<u32>,
+    ) -> Result<(u32, u32), RirPayloadBuildError> {
+        if staged.is_empty() {
+            return Ok((0, 0));
+        }
+        let start = u32::try_from(self.extra.len())
+            .map_err(|_| RirPayloadBuildError::ResourceLimitExceeded { family })?;
+        let extent = u32::try_from(staged.len())
+            .map_err(|_| RirPayloadBuildError::ResourceLimitExceeded { family })?;
+        start
+            .checked_add(extent)
+            .ok_or(RirPayloadBuildError::ResourceLimitExceeded { family })?;
+        self.extra
+            .try_reserve(staged.len())
+            .map_err(|_| RirPayloadBuildError::CapacityFailure { family })?;
+        self.extra.extend(staged);
+        Ok((start, extent))
     }
 
-    /// Retrieve Spurs from the extra array.
-    pub fn get_symbols(&self, start: u32, len: u32) -> RirSymbols<'_> {
-        RirSlice::new(self.get_extra(start, len), 1, |record| {
-            Spur::try_from_usize(record[0] as usize).unwrap()
+    fn payload_words<'a, R>(
+        &'a self,
+        range: &R,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+    ) -> Result<&'a [u32], RirPayloadError> {
+        let (start, extent, family) = parts(range);
+        if extent == 0 {
+            if start == 0 {
+                return Ok(&[]);
+            }
+            return Err(RirPayloadError {
+                family,
+                start,
+                extent,
+                record: None,
+                reason: "noncanonical empty range",
+            });
+        }
+        let end = start.checked_add(extent).ok_or(RirPayloadError {
+            family,
+            start,
+            extent,
+            record: None,
+            reason: "range end overflows u32",
+        })?;
+        self.extra
+            .get(start as usize..end as usize)
+            .ok_or(RirPayloadError {
+                family,
+                start,
+                extent,
+                record: None,
+                reason: "range is outside the word store",
+            })
+    }
+
+    fn validate_fixed<R>(
+        &self,
+        range: &R,
+        width: usize,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+    ) -> Result<(), RirPayloadError> {
+        let (start, extent, family) = parts(range);
+        let words = self.payload_words(range, |_| (start, extent, family))?;
+        if words.len() % width != 0 {
+            return Err(RirPayloadError {
+                family,
+                start,
+                extent,
+                record: Some((words.len() / width) as u32),
+                reason: "payload ends in a partial record",
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_fixed_symbols<R>(
+        &self,
+        range: &R,
+        schema: FixedPayloadSchema,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+    ) -> Result<(), RirPayloadError> {
+        let (start, extent, family) = parts(range);
+        self.validate_fixed(range, schema.width, |_| (start, extent, family))?;
+        for (record, words) in self
+            .payload_words(range, |_| (start, extent, family))?
+            .chunks_exact(schema.width)
+            .enumerate()
+        {
+            if schema
+                .symbol_offsets
+                .iter()
+                .any(|offset| decode_symbol_word(words[*offset]).is_none())
+            {
+                return Err(RirPayloadError {
+                    family,
+                    start,
+                    extent,
+                    record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                    reason: "symbol word is not representable",
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_variable_records<R>(
+        &self,
+        range: &R,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+        record_extent: impl Fn(&[u32], usize) -> Option<usize>,
+    ) -> Result<(), RirPayloadError> {
+        let (start, extent, family) = parts(range);
+        let words = self.payload_words(range, |_| (start, extent, family))?;
+        if words.is_empty() {
+            return Ok(());
+        }
+        let count = words[0] as usize;
+        let mut pos = 1usize;
+        for record in 0..count {
+            let Some(width) = record_extent(words, pos) else {
+                return Err(RirPayloadError {
+                    family,
+                    start,
+                    extent,
+                    record: Some(record as u32),
+                    reason: "record header or body is truncated",
+                });
+            };
+            pos = pos.checked_add(width).ok_or(RirPayloadError {
+                family,
+                start,
+                extent,
+                record: Some(record as u32),
+                reason: "record end overflows usize",
+            })?;
+            if pos > words.len() {
+                return Err(RirPayloadError {
+                    family,
+                    start,
+                    extent,
+                    record: Some(record as u32),
+                    reason: "record body is truncated",
+                });
+            }
+        }
+        if pos != words.len() {
+            return Err(RirPayloadError {
+                family,
+                start,
+                extent,
+                record: Some(count as u32),
+                reason: "trailing words after final record",
+            });
+        }
+        Ok(())
+    }
+
+    /// Validate every variable-length payload before publishing this RIR.
+    pub fn validate_payloads(&self) -> Result<(), RirPayloadError> {
+        for (_, inst) in self.iter() {
+            match &inst.data {
+                InstData::Match { arms, .. } => self.validate_match_range(arms)?,
+                InstData::FnDecl {
+                    directives, params, ..
+                } => {
+                    self.validate_directive_range(directives)?;
+                    self.validate_fixed_symbols(params, PARAM_SCHEMA, |r| {
+                        (r.start(), r.extent(), RirParamsRange::FAMILY)
+                    })?;
+                    for (record, words) in self
+                        .payload_words(params, |r| (r.start(), r.extent(), RirParamsRange::FAMILY))?
+                        .chunks_exact(PARAM_SCHEMA.width)
+                        .enumerate()
+                    {
+                        if words[PARAM_MODE] > RirParamMode::Borrow as u32 {
+                            return Err(RirPayloadError {
+                                family: RirParamsRange::FAMILY,
+                                start: params.start(),
+                                extent: params.extent(),
+                                record: Some(record as u32),
+                                reason: "invalid parameter mode",
+                            });
+                        }
+                        if words[PARAM_COMPTIME] > 1 {
+                            return Err(RirPayloadError {
+                                family: RirParamsRange::FAMILY,
+                                start: params.start(),
+                                extent: params.extent(),
+                                record: Some(record as u32),
+                                reason: "invalid comptime flag",
+                            });
+                        }
+                    }
+                }
+                InstData::ConstDecl { directives, .. } | InstData::Alloc { directives, .. } => {
+                    self.validate_directive_range(directives)?
+                }
+                InstData::Call { args, .. } | InstData::MethodCall { args, .. } => {
+                    self.validate_fixed(args, CALL_ARG_SCHEMA.width, |r| {
+                        (r.start(), r.extent(), RirCallArgsRange::FAMILY)
+                    })?;
+                    for (record, words) in self
+                        .payload_words(args, |r| (r.start(), r.extent(), RirCallArgsRange::FAMILY))?
+                        .chunks_exact(CALL_ARG_SCHEMA.width)
+                        .enumerate()
+                    {
+                        if words[CALL_ARG_MODE] > RirArgMode::Borrow as u32 {
+                            return Err(RirPayloadError {
+                                family: RirCallArgsRange::FAMILY,
+                                start: args.start(),
+                                extent: args.extent(),
+                                record: Some(record as u32),
+                                reason: "invalid argument mode",
+                            });
+                        }
+                    }
+                }
+                InstData::Intrinsic { args, .. } => {
+                    self.validate_fixed(args, REF_SCHEMA.width, |r| {
+                        (r.start(), r.extent(), RirIntrinsicArgsRange::FAMILY)
+                    })?
+                }
+                InstData::InternalIntrinsic { args, .. } => {
+                    self.validate_fixed(args, REF_SCHEMA.width, |r| {
+                        (r.start(), r.extent(), RirInternalIntrinsicArgsRange::FAMILY)
+                    })?
+                }
+                InstData::Block { instructions } => {
+                    self.validate_fixed(instructions, REF_SCHEMA.width, |r| {
+                        (r.start(), r.extent(), RirBlockInstsRange::FAMILY)
+                    })?
+                }
+                InstData::StructDecl {
+                    directives,
+                    fields,
+                    methods,
+                    ..
+                } => {
+                    self.validate_directive_range(directives)?;
+                    self.validate_fixed_symbols(fields, FIELD_DECL_SCHEMA, |r| {
+                        (r.start(), r.extent(), RirStructFieldsRange::FAMILY)
+                    })?;
+                    self.validate_fixed(methods, REF_SCHEMA.width, |r| {
+                        (r.start(), r.extent(), RirStructMethodsRange::FAMILY)
+                    })?;
+                }
+                InstData::StructInit { fields, .. } => {
+                    self.validate_fixed_symbols(fields, FIELD_INIT_SCHEMA, |r| {
+                        (r.start(), r.extent(), RirFieldInitsRange::FAMILY)
+                    })?
+                }
+                InstData::EnumDecl {
+                    variants, payloads, ..
+                } => {
+                    self.validate_fixed_symbols(variants, SYMBOL_SCHEMA, |r| {
+                        (r.start(), r.extent(), RirEnumVariantsRange::FAMILY)
+                    })?;
+                    self.validate_enum_payload_range(payloads, variants.extent() as usize)?;
+                }
+                InstData::ArrayInit { elements } => {
+                    self.validate_fixed(elements, REF_SCHEMA.width, |r| {
+                        (r.start(), r.extent(), RirArrayElemsRange::FAMILY)
+                    })?
+                }
+                InstData::AnonStructType { fields, methods } => {
+                    self.validate_fixed_symbols(fields, FIELD_DECL_SCHEMA, |r| {
+                        (r.start(), r.extent(), RirAnonStructFieldsRange::FAMILY)
+                    })?;
+                    self.validate_fixed(methods, REF_SCHEMA.width, |r| {
+                        (r.start(), r.extent(), RirAnonStructMethodsRange::FAMILY)
+                    })?;
+                }
+                InstData::AnonEnumType { variants, payloads } => {
+                    self.validate_fixed_symbols(variants, SYMBOL_SCHEMA, |r| {
+                        (r.start(), r.extent(), RirAnonEnumVariantsRange::FAMILY)
+                    })?;
+                    self.validate_anon_enum_payload_range(payloads, variants.extent() as usize)?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_match_range(&self, range: &RirMatchArmsRange) -> Result<(), RirPayloadError> {
+        self.validate_variable_records(
+            range,
+            |r| (r.start(), r.extent(), RirMatchArmsRange::FAMILY),
+            decoded_match_record_extent,
+        )?;
+        let words = self.payload_words(range, |r| {
+            (r.start(), r.extent(), RirMatchArmsRange::FAMILY)
+        })?;
+        if words.is_empty() {
+            return Ok(());
+        }
+        let mut position = 1usize;
+        for record in 0..words[0] as usize {
+            let kind = words[position + RECORD_KIND];
+            if embedded_span(words, position).is_none() {
+                return Err(RirPayloadError {
+                    family: RirMatchArmsRange::FAMILY,
+                    start: range.start(),
+                    extent: range.extent(),
+                    record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                    reason: "pattern span overflows u32",
+                });
+            }
+            if kind == PatternKind::Int as u32 {
+                if words[position + MATCH_INT_NEGATIVE_OR_PATH_TYPE] > 1 {
+                    return Err(RirPayloadError {
+                        family: RirMatchArmsRange::FAMILY,
+                        start: range.start(),
+                        extent: range.extent(),
+                        record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                        reason: "invalid integer-sign flag",
+                    });
+                }
+            } else if kind == PatternKind::Bool as u32 {
+                if words[position + MATCH_VALUE_LO_OR_BOOL_OR_BODY] > 1 {
+                    return Err(RirPayloadError {
+                        family: RirMatchArmsRange::FAMILY,
+                        start: range.start(),
+                        extent: range.extent(),
+                        record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                        reason: "invalid boolean scalar",
+                    });
+                }
+            } else if kind == PatternKind::Path as u32 {
+                let binding_count = words[position + MATCH_PATH_BINDING_COUNT] as usize;
+                let binding_start = position + MATCH_PATH_BINDINGS_START;
+                let binding_end = binding_start + binding_count;
+                if words[binding_start..binding_end]
+                    .iter()
+                    .any(|word| decode_symbol_word(*word).is_none())
+                {
+                    return Err(RirPayloadError {
+                        family: RirMatchArmsRange::FAMILY,
+                        start: range.start(),
+                        extent: range.extent(),
+                        record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                        reason: "symbol word is not representable",
+                    });
+                }
+            }
+            let (_, _, width) = decode_match_record(words, position).ok_or(RirPayloadError {
+                family: RirMatchArmsRange::FAMILY,
+                start: range.start(),
+                extent: range.extent(),
+                record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                reason: "match record failed schema decoding",
+            })?;
+            position += width;
+        }
+        Ok(())
+    }
+
+    /// Validate every context-dependent handle after structural payload
+    /// validation and before any infallible borrowing view is published.
+    pub fn validate_context(
+        &self,
+        context: &RirValidationContext<'_>,
+    ) -> Result<(), RirPayloadError> {
+        fn error(index: u32, reason: &'static str) -> RirPayloadError {
+            RirPayloadError {
+                family: "instruction context",
+                start: index,
+                extent: 1,
+                record: None,
+                reason,
+            }
+        }
+        let check_ref = |index: u32, reference: InstRef| {
+            if (reference.as_u32() as usize) < self.instructions.len() {
+                Ok(())
+            } else {
+                Err(error(index, "instruction reference is outside the owner"))
+            }
+        };
+        let check_symbol = |index: u32, symbol: Spur| {
+            if symbol.into_usize() < context.symbol_count {
+                Ok(())
+            } else {
+                Err(error(index, "symbol is outside the canonical interner"))
+            }
+        };
+        let check_span = |index: u32, span: Span| {
+            let Some((_, source_len)) = context
+                .source_lengths
+                .iter()
+                .find(|(file, _)| *file == span.file_id)
+            else {
+                return Err(error(
+                    index,
+                    "span file is outside the canonical source revision",
+                ));
+            };
+            if span.start <= span.end && span.end <= *source_len {
+                Ok(())
+            } else {
+                Err(error(index, "span range is outside its canonical source"))
+            }
+        };
+
+        for (instruction, inst) in self.iter() {
+            let index = instruction.as_u32();
+            check_span(index, inst.span)?;
+            macro_rules! refs {
+                ($($reference:expr),* $(,)?) => {{ $(check_ref(index, $reference)?;)* }};
+            }
+            macro_rules! symbols {
+                ($($symbol:expr),* $(,)?) => {{ $(check_symbol(index, $symbol)?;)* }};
+            }
+            match &inst.data {
+                InstData::IntConst(_)
+                | InstData::BoolConst(_)
+                | InstData::UnitConst
+                | InstData::Continue => {}
+                InstData::StringConst(symbol)
+                | InstData::VarRef { name: symbol }
+                | InstData::TypeConst { type_name: symbol } => symbols!(*symbol),
+                InstData::Add { lhs, rhs }
+                | InstData::Sub { lhs, rhs }
+                | InstData::Mul { lhs, rhs }
+                | InstData::Div { lhs, rhs }
+                | InstData::Mod { lhs, rhs }
+                | InstData::Eq { lhs, rhs }
+                | InstData::Ne { lhs, rhs }
+                | InstData::Lt { lhs, rhs }
+                | InstData::Gt { lhs, rhs }
+                | InstData::Le { lhs, rhs }
+                | InstData::Ge { lhs, rhs }
+                | InstData::And { lhs, rhs }
+                | InstData::Or { lhs, rhs }
+                | InstData::BitAnd { lhs, rhs }
+                | InstData::BitOr { lhs, rhs }
+                | InstData::BitXor { lhs, rhs }
+                | InstData::Shl { lhs, rhs }
+                | InstData::Shr { lhs, rhs } => refs!(*lhs, *rhs),
+                InstData::Neg { operand }
+                | InstData::Not { operand }
+                | InstData::BitNot { operand }
+                | InstData::Try { operand }
+                | InstData::Comptime { expr: operand }
+                | InstData::Checked { expr: operand } => refs!(*operand),
+                InstData::Branch {
+                    cond,
+                    then_block,
+                    else_block,
+                } => {
+                    refs!(*cond, *then_block);
+                    if let Some(reference) = else_block {
+                        refs!(*reference);
+                    }
+                }
+                InstData::Loop { cond, body } => refs!(*cond, *body),
+                InstData::InfiniteLoop { body, iter_borrow } => {
+                    refs!(*body);
+                    if let Some(symbol) = iter_borrow {
+                        symbols!(*symbol);
+                    }
+                }
+                InstData::Match { scrutinee, arms } => {
+                    refs!(*scrutinee);
+                    for (pattern, body) in self.match_arms(arms).iter() {
+                        refs!(body);
+                        check_span(index, pattern.span())?;
+                        if let RirPatternView::Path {
+                            module,
+                            ctor_head,
+                            type_name,
+                            variant,
+                            bindings,
+                            ..
+                        } = pattern
+                        {
+                            if let Some(reference) = module {
+                                refs!(reference);
+                            }
+                            if let Some(reference) = ctor_head {
+                                refs!(reference);
+                            }
+                            symbols!(type_name, variant);
+                            for binding in bindings {
+                                symbols!(binding);
+                            }
+                        }
+                    }
+                }
+                InstData::Break { value } | InstData::Ret(value) => {
+                    if let Some(reference) = value {
+                        refs!(*reference);
+                    }
+                }
+                InstData::FnDecl {
+                    directives,
+                    name,
+                    params,
+                    return_type,
+                    body,
+                    ..
+                } => {
+                    symbols!(*name, *return_type);
+                    refs!(*body);
+                    for directive in self.directives(directives).iter() {
+                        symbols!(directive.name);
+                        check_span(index, directive.span)?;
+                        for arg in directive.args {
+                            symbols!(arg);
+                        }
+                    }
+                    for param in self.params(params) {
+                        symbols!(param.name, param.ty);
+                        check_span(index, param.span)?;
+                    }
+                }
+                InstData::ConstDecl {
+                    directives,
+                    name,
+                    ty,
+                    init,
+                    ..
+                } => {
+                    symbols!(*name);
+                    if let Some(symbol) = ty {
+                        symbols!(*symbol);
+                    }
+                    refs!(*init);
+                    for directive in self.directives(directives).iter() {
+                        symbols!(directive.name);
+                        check_span(index, directive.span)?;
+                        for arg in directive.args {
+                            symbols!(arg);
+                        }
+                    }
+                }
+                InstData::Call { name, args } => {
+                    symbols!(*name);
+                    for arg in self.call_args(args) {
+                        refs!(arg.value);
+                    }
+                }
+                InstData::Intrinsic { name, args } => {
+                    symbols!(*name);
+                    for reference in self.intrinsic_args(args) {
+                        refs!(reference);
+                    }
+                }
+                InstData::InternalIntrinsic { args, .. } => {
+                    for reference in self.internal_intrinsic_args(args) {
+                        refs!(reference);
+                    }
+                }
+                InstData::TypeIntrinsic { name, type_arg } => symbols!(*name, *type_arg),
+                InstData::OffsetOf { type_arg, field } => symbols!(*type_arg, *field),
+                InstData::Block { instructions } => {
+                    for reference in self.block_insts(instructions) {
+                        refs!(reference);
+                    }
+                }
+                InstData::Alloc {
+                    directives,
+                    name,
+                    ty,
+                    init,
+                    ..
+                } => {
+                    if let Some(symbol) = name {
+                        symbols!(*symbol);
+                    }
+                    if let Some(symbol) = ty {
+                        symbols!(*symbol);
+                    }
+                    refs!(*init);
+                    for directive in self.directives(directives).iter() {
+                        symbols!(directive.name);
+                        check_span(index, directive.span)?;
+                        for arg in directive.args {
+                            symbols!(arg);
+                        }
+                    }
+                }
+                InstData::Assign { name, value } => {
+                    symbols!(*name);
+                    refs!(*value);
+                }
+                InstData::StructDecl {
+                    directives,
+                    name,
+                    fields,
+                    methods,
+                    ..
+                } => {
+                    symbols!(*name);
+                    for (field, ty) in self.struct_fields(fields) {
+                        symbols!(field, ty);
+                    }
+                    for reference in self.struct_methods(methods) {
+                        refs!(reference);
+                    }
+                    for directive in self.directives(directives).iter() {
+                        symbols!(directive.name);
+                        check_span(index, directive.span)?;
+                        for arg in directive.args {
+                            symbols!(arg);
+                        }
+                    }
+                }
+                InstData::StructInit {
+                    module,
+                    ctor_head,
+                    type_name,
+                    fields,
+                    shorthand_span,
+                } => {
+                    if let Some(reference) = module {
+                        refs!(*reference);
+                    }
+                    if let Some(reference) = ctor_head {
+                        refs!(*reference);
+                    }
+                    symbols!(*type_name);
+                    for (field, value) in self.field_inits(fields) {
+                        symbols!(field);
+                        refs!(value);
+                    }
+                    if let Some(span) = shorthand_span {
+                        check_span(index, *span)?;
+                    }
+                }
+                InstData::FieldGet { base, field } => {
+                    refs!(*base);
+                    symbols!(*field);
+                }
+                InstData::FieldSet { base, field, value } => {
+                    refs!(*base, *value);
+                    symbols!(*field);
+                }
+                InstData::EnumDecl {
+                    name,
+                    variants,
+                    payloads,
+                    ..
+                } => {
+                    symbols!(*name);
+                    for variant in self.enum_variants(variants) {
+                        symbols!(variant);
+                    }
+                    for payload in self.enum_payloads(payloads, variants) {
+                        for ty in payload {
+                            symbols!(ty);
+                        }
+                    }
+                }
+                InstData::EnumVariant {
+                    module,
+                    type_name,
+                    variant,
+                } => {
+                    if let Some(reference) = module {
+                        refs!(*reference);
+                    }
+                    symbols!(*type_name, *variant);
+                }
+                InstData::ArrayInit { elements } => {
+                    for reference in self.array_elements(elements) {
+                        refs!(reference);
+                    }
+                }
+                InstData::ArrayRepeat { value, count } => {
+                    refs!(*value);
+                    if let RepeatCount::Named(symbol) = count {
+                        symbols!(*symbol);
+                    }
+                }
+                InstData::IndexGet {
+                    base,
+                    index: subscript,
+                } => refs!(*base, *subscript),
+                InstData::IndexSet {
+                    base,
+                    index: subscript,
+                    value,
+                } => refs!(*base, *subscript, *value),
+                InstData::MethodCall {
+                    receiver,
+                    method,
+                    args,
+                } => {
+                    refs!(*receiver);
+                    symbols!(*method);
+                    for arg in self.call_args(args) {
+                        refs!(arg.value);
+                    }
+                }
+                InstData::DropFnDecl { type_name, body } => {
+                    symbols!(*type_name);
+                    refs!(*body);
+                }
+                InstData::AnonStructType { fields, methods } => {
+                    for (field, ty) in self.anon_struct_fields(fields) {
+                        symbols!(field, ty);
+                    }
+                    for reference in self.anon_struct_methods(methods) {
+                        refs!(reference);
+                    }
+                }
+                InstData::AnonEnumType { variants, payloads } => {
+                    for variant in self.anon_enum_variants(variants) {
+                        symbols!(variant);
+                    }
+                    for payload in self.anon_enum_payloads(payloads, variants) {
+                        for ty in payload {
+                            symbols!(ty);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_directive_range(&self, range: &RirDirectivesRange) -> Result<(), RirPayloadError> {
+        self.validate_variable_records(
+            range,
+            |r| (r.start(), r.extent(), RirDirectivesRange::FAMILY),
+            decoded_directive_record_extent,
+        )?;
+        let words = self.payload_words(range, |r| {
+            (r.start(), r.extent(), RirDirectivesRange::FAMILY)
+        })?;
+        if words.is_empty() {
+            return Ok(());
+        }
+        let mut position = 1usize;
+        for record in 0..words[0] as usize {
+            if embedded_span(words, position).is_none() {
+                return Err(RirPayloadError {
+                    family: RirDirectivesRange::FAMILY,
+                    start: range.start(),
+                    extent: range.extent(),
+                    record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                    reason: "directive span overflows u32",
+                });
+            }
+            let arg_count = words[position + DIRECTIVE_ARG_COUNT] as usize;
+            let args_start = position + DIRECTIVE_ARGS_START;
+            let args_end = args_start + arg_count;
+            if words[args_start..args_end]
+                .iter()
+                .any(|word| decode_symbol_word(*word).is_none())
+            {
+                return Err(RirPayloadError {
+                    family: RirDirectivesRange::FAMILY,
+                    start: range.start(),
+                    extent: range.extent(),
+                    record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                    reason: "symbol word is not representable",
+                });
+            }
+            let (_, record_extent) =
+                decode_directive_record(words, position).ok_or(RirPayloadError {
+                    family: RirDirectivesRange::FAMILY,
+                    start: range.start(),
+                    extent: range.extent(),
+                    record: Some(u32::try_from(record).unwrap_or(u32::MAX)),
+                    reason: "directive record failed schema decoding",
+                })?;
+            let end = position + record_extent;
+            position = end;
+        }
+        Ok(())
+    }
+
+    fn validate_enum_payload_words<R>(
+        &self,
+        range: &R,
+        variants: usize,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+    ) -> Result<(), RirPayloadError> {
+        let (start, extent, family) = parts(range);
+        let words = self.payload_words(range, |_| (start, extent, family))?;
+        if words.is_empty() {
+            return Ok(());
+        }
+        let mut pos = 0usize;
+        for record in 0..variants {
+            if words.get(pos).is_none() {
+                return Err(RirPayloadError {
+                    family,
+                    start,
+                    extent,
+                    record: Some(record as u32),
+                    reason: "missing variant payload record",
+                });
+            }
+            let Some((payload_start, end)) = enum_payload_record(words, pos) else {
+                return Err(RirPayloadError {
+                    family,
+                    start,
+                    extent,
+                    record: Some(record as u32),
+                    reason: "variant payload record is truncated",
+                });
+            };
+            if words[payload_start..end]
+                .iter()
+                .any(|word| decode_symbol_word(*word).is_none())
+            {
+                return Err(RirPayloadError {
+                    family,
+                    start,
+                    extent,
+                    record: Some(record as u32),
+                    reason: "symbol word is not representable",
+                });
+            }
+            pos = end;
+        }
+        if pos != words.len() {
+            return Err(RirPayloadError {
+                family,
+                start,
+                extent,
+                record: Some(variants as u32),
+                reason: "trailing words after variant payloads",
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_enum_payload_range(
+        &self,
+        range: &RirEnumPayloadsRange,
+        variants: usize,
+    ) -> Result<(), RirPayloadError> {
+        self.validate_enum_payload_words(range, variants, |r| {
+            (r.start(), r.extent(), RirEnumPayloadsRange::FAMILY)
+        })
+    }
+
+    fn validate_anon_enum_payload_range(
+        &self,
+        range: &RirAnonEnumPayloadsRange,
+        variants: usize,
+    ) -> Result<(), RirPayloadError> {
+        self.validate_enum_payload_words(range, variants, |r| {
+            (r.start(), r.extent(), RirAnonEnumPayloadsRange::FAMILY)
+        })
+    }
+
+    fn add_ref_words<R>(
+        &mut self,
+        family: &'static str,
+        refs: &[InstRef],
+        make: impl FnOnce(u32, u32) -> R,
+    ) -> Result<R, RirPayloadBuildError> {
+        let mut staged = Vec::new();
+        staged
+            .try_reserve(refs.len())
+            .map_err(|_| RirPayloadBuildError::CapacityFailure { family })?;
+        staged.extend(refs.iter().map(|reference| reference.as_u32()));
+        let (start, extent) = self.append_payload(family, staged)?;
+        Ok(make(start, extent))
+    }
+
+    pub(crate) fn add_intrinsic_args(
+        &mut self,
+        refs: &[InstRef],
+    ) -> Result<RirIntrinsicArgsRange, RirPayloadBuildError> {
+        self.add_ref_words(
+            RirIntrinsicArgsRange::FAMILY,
+            refs,
+            RirIntrinsicArgsRange::from_parts,
+        )
+    }
+    pub(crate) fn add_internal_intrinsic_args(
+        &mut self,
+        refs: &[InstRef],
+    ) -> Result<RirInternalIntrinsicArgsRange, RirPayloadBuildError> {
+        self.add_ref_words(
+            RirInternalIntrinsicArgsRange::FAMILY,
+            refs,
+            RirInternalIntrinsicArgsRange::from_parts,
+        )
+    }
+    pub(crate) fn add_block_insts(
+        &mut self,
+        refs: &[InstRef],
+    ) -> Result<RirBlockInstsRange, RirPayloadBuildError> {
+        self.add_ref_words(
+            RirBlockInstsRange::FAMILY,
+            refs,
+            RirBlockInstsRange::from_parts,
+        )
+    }
+    pub(crate) fn add_struct_methods(
+        &mut self,
+        refs: &[InstRef],
+    ) -> Result<RirStructMethodsRange, RirPayloadBuildError> {
+        self.add_ref_words(
+            RirStructMethodsRange::FAMILY,
+            refs,
+            RirStructMethodsRange::from_parts,
+        )
+    }
+    pub(crate) fn add_anon_struct_methods(
+        &mut self,
+        refs: &[InstRef],
+    ) -> Result<RirAnonStructMethodsRange, RirPayloadBuildError> {
+        self.add_ref_words(
+            RirAnonStructMethodsRange::FAMILY,
+            refs,
+            RirAnonStructMethodsRange::from_parts,
+        )
+    }
+    pub(crate) fn add_array_elements(
+        &mut self,
+        refs: &[InstRef],
+    ) -> Result<RirArrayElemsRange, RirPayloadBuildError> {
+        self.add_ref_words(
+            RirArrayElemsRange::FAMILY,
+            refs,
+            RirArrayElemsRange::from_parts,
+        )
+    }
+
+    fn ref_view<R>(
+        &self,
+        range: &R,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+    ) -> RirSlice<'_, InstRef> {
+        RirSlice::new(
+            self.payload_words(range, parts)
+                .expect("validated RIR range"),
+            REF_SCHEMA.width,
+            |record| InstRef::from_raw(record[0]),
+        )
+    }
+    pub fn intrinsic_args(&self, range: &RirIntrinsicArgsRange) -> RirSlice<'_, InstRef> {
+        self.ref_view(range, |r| {
+            (r.start(), r.extent(), RirIntrinsicArgsRange::FAMILY)
+        })
+    }
+    pub fn internal_intrinsic_args(
+        &self,
+        range: &RirInternalIntrinsicArgsRange,
+    ) -> RirSlice<'_, InstRef> {
+        self.ref_view(range, |r| {
+            (r.start(), r.extent(), RirInternalIntrinsicArgsRange::FAMILY)
+        })
+    }
+    pub fn block_insts(&self, range: &RirBlockInstsRange) -> RirSlice<'_, InstRef> {
+        self.ref_view(range, |r| {
+            (r.start(), r.extent(), RirBlockInstsRange::FAMILY)
+        })
+    }
+    pub fn struct_methods(&self, range: &RirStructMethodsRange) -> RirSlice<'_, InstRef> {
+        self.ref_view(range, |r| {
+            (r.start(), r.extent(), RirStructMethodsRange::FAMILY)
+        })
+    }
+    pub fn anon_struct_methods(&self, range: &RirAnonStructMethodsRange) -> RirSlice<'_, InstRef> {
+        self.ref_view(range, |r| {
+            (r.start(), r.extent(), RirAnonStructMethodsRange::FAMILY)
+        })
+    }
+    pub fn array_elements(&self, range: &RirArrayElemsRange) -> RirSlice<'_, InstRef> {
+        self.ref_view(range, |r| {
+            (r.start(), r.extent(), RirArrayElemsRange::FAMILY)
         })
     }
 
     /// Store RirCallArgs and return (start, len).
     /// Layout: [value: u32, mode: u32] per arg
-    pub fn add_call_args(&mut self, args: &[RirCallArg]) -> (u32, u32) {
-        let mut data = Vec::with_capacity(args.len() * CALL_ARG_SIZE as usize);
+    fn add_call_arg_words<R>(
+        &mut self,
+        family: &'static str,
+        args: &[RirCallArg],
+        make: impl FnOnce(u32, u32) -> R,
+    ) -> Result<R, RirPayloadBuildError> {
+        let words = args
+            .len()
+            .checked_mul(CALL_ARG_SCHEMA.width)
+            .ok_or(RirPayloadBuildError::ResourceLimitExceeded { family })?;
+        let mut data = Vec::new();
+        data.try_reserve(words)
+            .map_err(|_| RirPayloadBuildError::CapacityFailure { family })?;
         for arg in args {
-            data.push(arg.value.as_u32());
-            data.push(arg.mode.as_u32());
+            let mut record = [0; CALL_ARG_SCHEMA.width];
+            record[CALL_ARG_VALUE] = arg.value.as_u32();
+            record[CALL_ARG_MODE] = arg.mode.as_u32();
+            data.extend(record);
         }
-        let start = self.add_extra(&data);
-        (start, args.len() as u32)
+        let (start, extent) = self.append_payload(family, data)?;
+        Ok(make(start, extent))
+    }
+
+    pub(crate) fn add_call_args(
+        &mut self,
+        args: &[RirCallArg],
+    ) -> Result<RirCallArgsRange, RirPayloadBuildError> {
+        self.add_call_arg_words(RirCallArgsRange::FAMILY, args, RirCallArgsRange::from_parts)
+    }
+    pub(crate) fn add_method_args(
+        &mut self,
+        args: &[RirCallArg],
+    ) -> Result<RirCallArgsRange, RirPayloadBuildError> {
+        self.add_call_args(args)
     }
 
     /// Retrieve RirCallArgs from the extra array.
-    pub fn get_call_args(&self, start: u32, len: u32) -> RirSlice<'_, RirCallArg> {
-        let words = len.checked_mul(CALL_ARG_SIZE).unwrap();
-        let data = self.get_extra(start, words);
-        RirSlice::new(data, CALL_ARG_SIZE as usize, |chunk| RirCallArg {
-            value: InstRef::from_raw(chunk[0]),
-            mode: RirArgMode::from_u32(chunk[1]),
+    fn call_arg_view<R>(
+        &self,
+        range: &R,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+    ) -> RirSlice<'_, RirCallArg> {
+        let data = self
+            .payload_words(range, parts)
+            .expect("validated RIR range");
+        RirSlice::new(data, CALL_ARG_SCHEMA.width, |chunk| RirCallArg {
+            value: InstRef::from_raw(chunk[CALL_ARG_VALUE]),
+            mode: RirArgMode::from_u32(chunk[CALL_ARG_MODE]),
         })
+    }
+    pub fn call_args(&self, range: &RirCallArgsRange) -> RirSlice<'_, RirCallArg> {
+        self.call_arg_view(range, |r| (r.start(), r.extent(), RirCallArgsRange::FAMILY))
     }
 
     /// Store RirParams and return (start, len).
     /// Layout: [name: u32, ty: u32, mode: u32, is_comptime: u32,
     ///          span.file_id: u32, span.start: u32, span.end: u32] per param
-    pub fn add_params(&mut self, params: &[RirParam]) -> (u32, u32) {
-        let mut data = Vec::with_capacity(params.len() * PARAM_SIZE as usize);
+    pub(crate) fn add_params(
+        &mut self,
+        params: &[RirParam],
+    ) -> Result<RirParamsRange, RirPayloadBuildError> {
+        let words = params.len().checked_mul(PARAM_SCHEMA.width).ok_or(
+            RirPayloadBuildError::ResourceLimitExceeded {
+                family: RirParamsRange::FAMILY,
+            },
+        )?;
+        let mut data = Vec::new();
+        data.try_reserve(words)
+            .map_err(|_| RirPayloadBuildError::CapacityFailure {
+                family: RirParamsRange::FAMILY,
+            })?;
         for param in params {
-            data.push(param.name.into_usize() as u32);
-            data.push(param.ty.into_usize() as u32);
-            data.push(param.mode.as_u32());
-            data.push(param.is_comptime as u32);
-            data.push(param.span.file_id.index());
-            data.push(param.span.start);
-            data.push(param.span.end);
+            let mut record = [0; PARAM_SCHEMA.width];
+            record[PARAM_NAME] = Self::symbol_word(RirParamsRange::FAMILY, param.name)?;
+            record[PARAM_TYPE] = Self::symbol_word(RirParamsRange::FAMILY, param.ty)?;
+            record[PARAM_MODE] = param.mode.as_u32();
+            record[PARAM_COMPTIME] = param.is_comptime as u32;
+            record[PARAM_SPAN_FILE] = param.span.file_id.index();
+            record[PARAM_SPAN_START] = param.span.start;
+            record[PARAM_SPAN_END] = param.span.end;
+            data.extend(record);
         }
-        let start = self.add_extra(&data);
-        (start, params.len() as u32)
+        let (start, extent) = self.append_payload(RirParamsRange::FAMILY, data)?;
+        Ok(RirParamsRange::from_parts(start, extent))
     }
 
     /// Retrieve RirParams from the extra array.
-    pub fn get_params(&self, start: u32, len: u32) -> RirSlice<'_, RirParam> {
-        let words = len.checked_mul(PARAM_SIZE).unwrap();
-        let data = self.get_extra(start, words);
-        RirSlice::new(data, PARAM_SIZE as usize, |chunk| RirParam {
-            name: Spur::try_from_usize(chunk[0] as usize).unwrap(),
-            ty: Spur::try_from_usize(chunk[1] as usize).unwrap(),
-            mode: RirParamMode::from_u32(chunk[2]),
-            is_comptime: chunk[3] != 0,
-            span: Span::with_file(FileId::new(chunk[4]), chunk[5], chunk[6]),
+    pub fn params(&self, range: &RirParamsRange) -> RirSlice<'_, RirParam> {
+        let data = self
+            .payload_words(range, |r| (r.start(), r.extent(), RirParamsRange::FAMILY))
+            .expect("validated RIR range");
+        RirSlice::new(data, PARAM_SCHEMA.width, |chunk| RirParam {
+            name: validated_symbol_word(chunk[PARAM_NAME]),
+            ty: validated_symbol_word(chunk[PARAM_TYPE]),
+            mode: RirParamMode::from_u32(chunk[PARAM_MODE]),
+            is_comptime: chunk[PARAM_COMPTIME] != 0,
+            span: Span::with_file(
+                FileId::new(chunk[PARAM_SPAN_FILE]),
+                chunk[PARAM_SPAN_START],
+                chunk[PARAM_SPAN_END],
+            ),
         })
     }
 
     /// Store match arms (pattern + body pairs) and return (start, arm_count).
     /// Each arm is stored with variable size depending on pattern kind.
-    pub fn add_match_arms(&mut self, arms: &[(RirPattern, InstRef)]) -> (u32, u32) {
-        let start = self.extra.len() as u32;
+    pub(crate) fn add_match_arms(
+        &mut self,
+        arms: &[(RirPattern, InstRef)],
+    ) -> Result<RirMatchArmsRange, RirPayloadBuildError> {
+        if arms.is_empty() {
+            return Ok(RirMatchArmsRange::from_parts(0, 0));
+        }
+        let count =
+            u32::try_from(arms.len()).map_err(|_| RirPayloadBuildError::ResourceLimitExceeded {
+                family: RirMatchArmsRange::FAMILY,
+            })?;
+        let exact_words = arms.iter().try_fold(1usize, |total, (pattern, _)| {
+            let width = encoded_match_record_extent(pattern).ok_or(
+                RirPayloadBuildError::ResourceLimitExceeded {
+                    family: RirMatchArmsRange::FAMILY,
+                },
+            )?;
+            total
+                .checked_add(width)
+                .ok_or(RirPayloadBuildError::ResourceLimitExceeded {
+                    family: RirMatchArmsRange::FAMILY,
+                })
+        })?;
+        let mut staged = Vec::new();
+        staged.try_reserve_exact(exact_words).map_err(|_| {
+            RirPayloadBuildError::CapacityFailure {
+                family: RirMatchArmsRange::FAMILY,
+            }
+        })?;
+        staged.push(count);
         for (pattern, body) in arms {
             match pattern {
                 RirPattern::Wildcard(span) => {
-                    self.extra.push(PatternKind::Wildcard as u32);
-                    self.extra.push(span.start());
-                    self.extra.push(span.len());
-                    self.extra.push(span.file_id.index());
-                    self.extra.push(body.as_u32());
+                    staged.extend([
+                        PatternKind::Wildcard as u32,
+                        span.start(),
+                        span.len(),
+                        span.file_id.index(),
+                        body.as_u32(),
+                    ]);
                 }
                 RirPattern::Int {
                     value,
                     negative,
                     span,
                 } => {
-                    self.extra.push(PatternKind::Int as u32);
-                    self.extra.push(span.start());
-                    self.extra.push(span.len());
-                    self.extra.push(span.file_id.index());
+                    staged.extend([
+                        PatternKind::Int as u32,
+                        span.start(),
+                        span.len(),
+                        span.file_id.index(),
+                    ]);
                     // Store u64 magnitude as two u32s (little-endian) plus sign flag
-                    self.extra.push(*value as u32);
-                    self.extra.push((*value >> 32) as u32);
-                    self.extra.push(u32::from(*negative));
-                    self.extra.push(body.as_u32());
+                    staged.extend([
+                        *value as u32,
+                        (*value >> 32) as u32,
+                        u32::from(*negative),
+                        body.as_u32(),
+                    ]);
                 }
                 RirPattern::Bool(value, span) => {
-                    self.extra.push(PatternKind::Bool as u32);
-                    self.extra.push(span.start());
-                    self.extra.push(span.len());
-                    self.extra.push(span.file_id.index());
-                    self.extra.push(if *value { 1 } else { 0 });
-                    self.extra.push(body.as_u32());
+                    staged.extend([
+                        PatternKind::Bool as u32,
+                        span.start(),
+                        span.len(),
+                        span.file_id.index(),
+                        u32::from(*value),
+                        body.as_u32(),
+                    ]);
                 }
                 RirPattern::Path {
                     module,
@@ -710,46 +2533,55 @@ impl Rir {
                     bindings,
                     span,
                 } => {
-                    self.extra.push(PatternKind::Path as u32);
-                    self.extra.push(span.start());
-                    self.extra.push(span.len());
-                    self.extra.push(span.file_id.index());
+                    staged.extend([
+                        PatternKind::Path as u32,
+                        span.start(),
+                        span.len(),
+                        span.file_id.index(),
+                    ]);
                     // Store module as u32::MAX for None, otherwise the InstRef
-                    self.extra.push(module.map_or(u32::MAX, |r| r.as_u32()));
+                    staged.push(module.map_or(u32::MAX, |r| r.as_u32()));
                     // Store ctor_head (inline type-constructor pattern head,
                     // RUE-596) the same way — u32::MAX for None.
-                    self.extra.push(ctor_head.map_or(u32::MAX, |r| r.as_u32()));
-                    self.extra.push(type_name.into_usize() as u32);
-                    self.extra.push(variant.into_usize() as u32);
+                    staged.push(ctor_head.map_or(u32::MAX, |r| r.as_u32()));
+                    staged.push(Self::symbol_word(RirMatchArmsRange::FAMILY, *type_name)?);
+                    staged.push(Self::symbol_word(RirMatchArmsRange::FAMILY, *variant)?);
                     // Variable-length payload bindings (RUE-221): a count
                     // followed by the binding symbols, then the body last.
-                    self.extra.push(bindings.len() as u32);
+                    staged.push(u32::try_from(bindings.len()).map_err(|_| {
+                        RirPayloadBuildError::ResourceLimitExceeded {
+                            family: RirMatchArmsRange::FAMILY,
+                        }
+                    })?);
                     for b in bindings {
-                        self.extra.push(b.into_usize() as u32);
+                        staged.push(Self::symbol_word(RirMatchArmsRange::FAMILY, *b)?);
                     }
-                    self.extra.push(body.as_u32());
+                    staged.push(body.as_u32());
                 }
             }
         }
-        (start, arms.len() as u32)
-    }
-
-    /// Decode a pattern's span from the extra array. Every pattern kind
-    /// stores its span as [start, len, file_id] at offsets 1..=3 after the
-    /// kind word (see the `PATTERN_*_SIZE` layout comments).
-    fn decode_pattern_span(extra: &[u32], pos: usize) -> Span {
-        let span_start = extra[pos + 1];
-        let span_len = extra[pos + 2];
-        let file_id = rue_span::FileId::new(extra[pos + 3]);
-        Span::with_file(file_id, span_start, span_start + span_len)
+        let (start, extent) = self.append_payload(RirMatchArmsRange::FAMILY, staged)?;
+        Ok(RirMatchArmsRange::from_parts(start, extent))
     }
 
     /// Retrieve match arms from the extra array.
-    pub fn get_match_arms(&self, start: u32, arm_count: u32) -> RirMatchArms<'_> {
+    pub fn match_arms(&self, range: &RirMatchArmsRange) -> RirMatchArms<'_> {
+        let words = self
+            .payload_words(range, |r| {
+                (r.start(), r.extent(), RirMatchArmsRange::FAMILY)
+            })
+            .expect("validated RIR range");
+        if words.is_empty() {
+            return RirMatchArms {
+                extra: words,
+                start: 0,
+                len: 0,
+            };
+        }
         let view = RirMatchArms {
-            extra: &self.extra,
-            start: start as usize,
-            len: arm_count as usize,
+            extra: words,
+            start: 1,
+            len: words[0] as usize,
         };
         view.iter().for_each(drop);
         view
@@ -757,49 +2589,117 @@ impl Rir {
 
     /// Store field initializers (name, value) and return (start, len).
     /// Layout: [name: u32, value: u32] per field
-    pub fn add_field_inits(&mut self, fields: &[(Spur, InstRef)]) -> (u32, u32) {
-        let mut data = Vec::with_capacity(fields.len() * FIELD_INIT_SIZE as usize);
+    pub(crate) fn add_field_inits(
+        &mut self,
+        fields: &[(Spur, InstRef)],
+    ) -> Result<RirFieldInitsRange, RirPayloadBuildError> {
+        let words = fields.len().checked_mul(FIELD_INIT_SCHEMA.width).ok_or(
+            RirPayloadBuildError::ResourceLimitExceeded {
+                family: RirFieldInitsRange::FAMILY,
+            },
+        )?;
+        let mut data = Vec::new();
+        data.try_reserve(words)
+            .map_err(|_| RirPayloadBuildError::CapacityFailure {
+                family: RirFieldInitsRange::FAMILY,
+            })?;
         for (name, value) in fields {
-            data.push(name.into_usize() as u32);
-            data.push(value.as_u32());
+            let mut record = [0; FIELD_INIT_SCHEMA.width];
+            record[FIELD_INIT_NAME] = Self::symbol_word(RirFieldInitsRange::FAMILY, *name)?;
+            record[FIELD_INIT_VALUE] = value.as_u32();
+            data.extend(record);
         }
-        let start = self.add_extra(&data);
-        (start, fields.len() as u32)
+        let (start, extent) = self.append_payload(RirFieldInitsRange::FAMILY, data)?;
+        Ok(RirFieldInitsRange::from_parts(start, extent))
     }
 
     /// Retrieve field initializers from the extra array.
-    pub fn get_field_inits(&self, start: u32, len: u32) -> RirSlice<'_, (Spur, InstRef)> {
-        let words = len.checked_mul(FIELD_INIT_SIZE).unwrap();
-        let data = self.get_extra(start, words);
-        RirSlice::new(data, FIELD_INIT_SIZE as usize, |chunk| {
+    pub fn field_inits(&self, range: &RirFieldInitsRange) -> RirSlice<'_, (Spur, InstRef)> {
+        let data = self
+            .payload_words(range, |r| {
+                (r.start(), r.extent(), RirFieldInitsRange::FAMILY)
+            })
+            .expect("validated RIR range");
+        RirSlice::new(data, FIELD_INIT_SCHEMA.width, |chunk| {
             (
-                Spur::try_from_usize(chunk[0] as usize).unwrap(),
-                InstRef::from_raw(chunk[1]),
+                validated_symbol_word(chunk[FIELD_INIT_NAME]),
+                InstRef::from_raw(chunk[FIELD_INIT_VALUE]),
             )
         })
     }
 
     /// Store field declarations (name, type) and return (start, len).
     /// Layout: [name: u32, type: u32] per field
-    pub fn add_field_decls(&mut self, fields: &[(Spur, Spur)]) -> (u32, u32) {
-        let mut data = Vec::with_capacity(fields.len() * FIELD_DECL_SIZE as usize);
+    fn add_field_decl_words<R>(
+        &mut self,
+        family: &'static str,
+        fields: &[(Spur, Spur)],
+        make: impl FnOnce(u32, u32) -> R,
+    ) -> Result<R, RirPayloadBuildError> {
+        let words = fields
+            .len()
+            .checked_mul(FIELD_DECL_SCHEMA.width)
+            .ok_or(RirPayloadBuildError::ResourceLimitExceeded { family })?;
+        let mut data = Vec::new();
+        data.try_reserve(words)
+            .map_err(|_| RirPayloadBuildError::CapacityFailure { family })?;
         for (name, ty) in fields {
-            data.push(name.into_usize() as u32);
-            data.push(ty.into_usize() as u32);
+            let mut record = [0; FIELD_DECL_SCHEMA.width];
+            record[FIELD_DECL_NAME] = Self::symbol_word(family, *name)?;
+            record[FIELD_DECL_TYPE] = Self::symbol_word(family, *ty)?;
+            data.extend(record);
         }
-        let start = self.add_extra(&data);
-        (start, fields.len() as u32)
+        let (start, extent) = self.append_payload(family, data)?;
+        Ok(make(start, extent))
+    }
+    pub(crate) fn add_struct_fields(
+        &mut self,
+        fields: &[(Spur, Spur)],
+    ) -> Result<RirStructFieldsRange, RirPayloadBuildError> {
+        self.add_field_decl_words(
+            RirStructFieldsRange::FAMILY,
+            fields,
+            RirStructFieldsRange::from_parts,
+        )
+    }
+    pub(crate) fn add_anon_struct_fields(
+        &mut self,
+        fields: &[(Spur, Spur)],
+    ) -> Result<RirAnonStructFieldsRange, RirPayloadBuildError> {
+        self.add_field_decl_words(
+            RirAnonStructFieldsRange::FAMILY,
+            fields,
+            RirAnonStructFieldsRange::from_parts,
+        )
     }
 
     /// Retrieve field declarations from the extra array.
-    pub fn get_field_decls(&self, start: u32, len: u32) -> RirSlice<'_, (Spur, Spur)> {
-        let words = len.checked_mul(FIELD_DECL_SIZE).unwrap();
-        let data = self.get_extra(start, words);
-        RirSlice::new(data, FIELD_DECL_SIZE as usize, |chunk| {
+    fn field_decl_view<R>(
+        &self,
+        range: &R,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+    ) -> RirSlice<'_, (Spur, Spur)> {
+        let data = self
+            .payload_words(range, parts)
+            .expect("validated RIR range");
+        RirSlice::new(data, FIELD_DECL_SCHEMA.width, |chunk| {
             (
-                Spur::try_from_usize(chunk[0] as usize).unwrap(),
-                Spur::try_from_usize(chunk[1] as usize).unwrap(),
+                validated_symbol_word(chunk[FIELD_DECL_NAME]),
+                validated_symbol_word(chunk[FIELD_DECL_TYPE]),
             )
+        })
+    }
+    pub fn struct_fields(&self, range: &RirStructFieldsRange) -> RirSlice<'_, (Spur, Spur)> {
+        self.field_decl_view(range, |r| {
+            (r.start(), r.extent(), RirStructFieldsRange::FAMILY)
+        })
+    }
+    pub fn anon_struct_fields(
+        &self,
+        range: &RirAnonStructFieldsRange,
+    ) -> RirSlice<'_, (Spur, Spur)> {
+        self.field_decl_view(range, |r| {
+            (r.start(), r.extent(), RirAnonStructFieldsRange::FAMILY)
         })
     }
 
@@ -810,32 +2710,269 @@ impl Rir {
     /// directive-anchored diagnostics in multi-file compilations attribute
     /// to the right file (dropping the file id here was the same loss shape
     /// as the RUE-185 pattern-span bug; RUE-189).
-    pub fn add_directives(&mut self, directives: &[RirDirective]) -> (u32, u32) {
-        let start = self.extra.len() as u32;
+    pub(crate) fn add_directives(
+        &mut self,
+        directives: &[RirDirective],
+    ) -> Result<RirDirectivesRange, RirPayloadBuildError> {
+        if directives.is_empty() {
+            return Ok(RirDirectivesRange::from_parts(0, 0));
+        }
+        let count = u32::try_from(directives.len()).map_err(|_| {
+            RirPayloadBuildError::ResourceLimitExceeded {
+                family: RirDirectivesRange::FAMILY,
+            }
+        })?;
+        let exact_words = directives.iter().try_fold(1usize, |total, directive| {
+            total
+                .checked_add(encoded_directive_record_extent(directive).ok_or(
+                    RirPayloadBuildError::ResourceLimitExceeded {
+                        family: RirDirectivesRange::FAMILY,
+                    },
+                )?)
+                .ok_or(RirPayloadBuildError::ResourceLimitExceeded {
+                    family: RirDirectivesRange::FAMILY,
+                })
+        })?;
+        let mut staged = Vec::new();
+        staged.try_reserve_exact(exact_words).map_err(|_| {
+            RirPayloadBuildError::CapacityFailure {
+                family: RirDirectivesRange::FAMILY,
+            }
+        })?;
+        staged.push(count);
         for directive in directives {
-            self.extra.push(directive.name.into_usize() as u32);
-            self.extra.push(directive.span.start());
-            self.extra.push(directive.span.len());
-            self.extra.push(directive.span.file_id.index());
-            self.extra.push(directive.args.len() as u32);
+            staged.push(Self::symbol_word(
+                RirDirectivesRange::FAMILY,
+                directive.name,
+            )?);
+            staged.push(directive.span.start());
+            staged.push(directive.span.len());
+            staged.push(directive.span.file_id.index());
+            staged.push(u32::try_from(directive.args.len()).map_err(|_| {
+                RirPayloadBuildError::ResourceLimitExceeded {
+                    family: RirDirectivesRange::FAMILY,
+                }
+            })?);
             for arg in &directive.args {
-                self.extra.push(arg.into_usize() as u32);
+                staged.push(Self::symbol_word(RirDirectivesRange::FAMILY, *arg)?);
             }
         }
-        (start, directives.len() as u32)
+        let (start, extent) = self.append_payload(RirDirectivesRange::FAMILY, staged)?;
+        Ok(RirDirectivesRange::from_parts(start, extent))
     }
 
     /// Retrieve directives from the extra array.
-    pub fn get_directives(&self, start: u32, directive_count: u32) -> RirDirectives<'_> {
+    pub fn directives(&self, range: &RirDirectivesRange) -> RirDirectives<'_> {
+        let words = self
+            .payload_words(range, |r| {
+                (r.start(), r.extent(), RirDirectivesRange::FAMILY)
+            })
+            .expect("validated RIR range");
+        if words.is_empty() {
+            return RirDirectives {
+                extra: words,
+                start: 0,
+                len: 0,
+            };
+        }
         let view = RirDirectives {
-            extra: &self.extra,
-            start: start as usize,
-            len: directive_count as usize,
+            extra: words,
+            start: 1,
+            len: words[0] as usize,
         };
         view.iter().for_each(drop);
         view
     }
+
+    fn add_symbol_words<R>(
+        &mut self,
+        family: &'static str,
+        symbols: &[Spur],
+        make: impl FnOnce(u32, u32) -> R,
+    ) -> Result<R, RirPayloadBuildError> {
+        let mut staged = Vec::new();
+        staged
+            .try_reserve(symbols.len())
+            .map_err(|_| RirPayloadBuildError::CapacityFailure { family })?;
+        for symbol in symbols {
+            staged.push(u32::try_from(symbol.into_usize()).map_err(|_| {
+                RirPayloadBuildError::InvalidBuilderInput {
+                    family,
+                    reason: "symbol index exceeds u32",
+                }
+            })?);
+        }
+        let (start, extent) = self.append_payload(family, staged)?;
+        Ok(make(start, extent))
+    }
+
+    pub(crate) fn add_enum_variants(
+        &mut self,
+        symbols: &[Spur],
+    ) -> Result<RirEnumVariantsRange, RirPayloadBuildError> {
+        self.add_symbol_words(
+            RirEnumVariantsRange::FAMILY,
+            symbols,
+            RirEnumVariantsRange::from_parts,
+        )
+    }
+    pub(crate) fn add_anon_enum_variants(
+        &mut self,
+        symbols: &[Spur],
+    ) -> Result<RirAnonEnumVariantsRange, RirPayloadBuildError> {
+        self.add_symbol_words(
+            RirAnonEnumVariantsRange::FAMILY,
+            symbols,
+            RirAnonEnumVariantsRange::from_parts,
+        )
+    }
+    fn symbol_view<R>(
+        &self,
+        range: &R,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+    ) -> RirSymbols<'_> {
+        let words = self
+            .payload_words(range, parts)
+            .expect("validated RIR range");
+        RirSlice::new(words, SYMBOL_SCHEMA.width, |record| {
+            validated_symbol_word(record[0])
+        })
+    }
+    pub fn enum_variants(&self, range: &RirEnumVariantsRange) -> RirSymbols<'_> {
+        self.symbol_view(range, |r| {
+            (r.start(), r.extent(), RirEnumVariantsRange::FAMILY)
+        })
+    }
+    pub fn anon_enum_variants(&self, range: &RirAnonEnumVariantsRange) -> RirSymbols<'_> {
+        self.symbol_view(range, |r| {
+            (r.start(), r.extent(), RirAnonEnumVariantsRange::FAMILY)
+        })
+    }
+
+    fn add_enum_payload_words<R>(
+        &mut self,
+        family: &'static str,
+        payloads: &[Vec<Spur>],
+        make: impl FnOnce(u32, u32) -> R,
+    ) -> Result<R, RirPayloadBuildError> {
+        if payloads.iter().all(Vec::is_empty) {
+            return Ok(make(0, 0));
+        }
+        let exact_words = payloads.iter().try_fold(0usize, |total, payload| {
+            total
+                .checked_add(
+                    encoded_enum_payload_record_extent(payload)
+                        .ok_or(RirPayloadBuildError::ResourceLimitExceeded { family })?,
+                )
+                .ok_or(RirPayloadBuildError::ResourceLimitExceeded { family })
+        })?;
+        let mut staged = Vec::new();
+        staged
+            .try_reserve_exact(exact_words)
+            .map_err(|_| RirPayloadBuildError::CapacityFailure { family })?;
+        for payload in payloads {
+            staged.push(
+                u32::try_from(payload.len())
+                    .map_err(|_| RirPayloadBuildError::ResourceLimitExceeded { family })?,
+            );
+            for symbol in payload {
+                staged.push(Self::symbol_word(family, *symbol)?);
+            }
+        }
+        let (start, extent) = self.append_payload(family, staged)?;
+        Ok(make(start, extent))
+    }
+    pub(crate) fn add_enum_payloads(
+        &mut self,
+        payloads: &[Vec<Spur>],
+    ) -> Result<RirEnumPayloadsRange, RirPayloadBuildError> {
+        self.add_enum_payload_words(
+            RirEnumPayloadsRange::FAMILY,
+            payloads,
+            RirEnumPayloadsRange::from_parts,
+        )
+    }
+    pub(crate) fn add_anon_enum_payloads(
+        &mut self,
+        payloads: &[Vec<Spur>],
+    ) -> Result<RirAnonEnumPayloadsRange, RirPayloadBuildError> {
+        self.add_enum_payload_words(
+            RirAnonEnumPayloadsRange::FAMILY,
+            payloads,
+            RirAnonEnumPayloadsRange::from_parts,
+        )
+    }
+    fn enum_payload_view<'a, R>(
+        &'a self,
+        range: &R,
+        variant_count: usize,
+        parts: impl FnOnce(&R) -> (u32, u32, &'static str),
+    ) -> RirEnumPayloads<'a> {
+        RirEnumPayloads {
+            words: self
+                .payload_words(range, parts)
+                .expect("validated RIR range"),
+            position: 0,
+            remaining: variant_count,
+        }
+    }
+
+    pub fn enum_payloads(
+        &self,
+        payloads: &RirEnumPayloadsRange,
+        variants: &RirEnumVariantsRange,
+    ) -> RirEnumPayloads<'_> {
+        self.enum_payload_view(payloads, self.enum_variants(variants).len(), |r| {
+            (r.start(), r.extent(), RirEnumPayloadsRange::FAMILY)
+        })
+    }
+
+    pub fn anon_enum_payloads(
+        &self,
+        payloads: &RirAnonEnumPayloadsRange,
+        variants: &RirAnonEnumVariantsRange,
+    ) -> RirEnumPayloads<'_> {
+        self.enum_payload_view(payloads, self.anon_enum_variants(variants).len(), |r| {
+            (r.start(), r.extent(), RirAnonEnumPayloadsRange::FAMILY)
+        })
+    }
 }
+
+/// Exact, borrowing semantic view of one payload-type list per enum variant.
+#[derive(Debug, Clone)]
+pub struct RirEnumPayloads<'a> {
+    words: &'a [u32],
+    position: usize,
+    remaining: usize,
+}
+
+impl<'a> Iterator for RirEnumPayloads<'a> {
+    type Item = RirSymbols<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        self.remaining -= 1;
+        if self.words.is_empty() {
+            return Some(RirSlice::new(&[], SYMBOL_SCHEMA.width, |_| unreachable!()));
+        }
+        let (start, end) = enum_payload_record(self.words, self.position)
+            .expect("validated enum payload descriptor");
+        self.position = end;
+        Some(RirSlice::new(
+            &self.words[start..end],
+            SYMBOL_SCHEMA.width,
+            |record| validated_symbol_word(record[0]),
+        ))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for RirEnumPayloads<'_> {}
 
 /// Reusable zero-allocation view over variable-width RIR match arms.
 #[derive(Debug, Clone)]
@@ -887,82 +3024,13 @@ impl<'a> Iterator for RirMatchArmsIter<'a> {
         if self.remaining == 0 {
             return None;
         }
-        let pos = self.pos;
-        let kind = self.extra[pos];
-        let result = match kind {
-            k if k == PatternKind::Wildcard as u32 => {
-                let span = Rir::decode_pattern_span(self.extra, pos);
-                let body = InstRef::from_raw(self.extra[pos + 4]);
-                self.pos += PATTERN_WILDCARD_SIZE as usize;
-                (RirPatternView::Wildcard(span), body)
-            }
-            k if k == PatternKind::Int as u32 => {
-                let span = Rir::decode_pattern_span(self.extra, pos);
-                let value_lo = self.extra[pos + 4] as u64;
-                let value_hi = self.extra[pos + 5] as u64;
-                let value = value_lo | (value_hi << 32);
-                let negative = self.extra[pos + 6] != 0;
-                let body = InstRef::from_raw(self.extra[pos + 7]);
-                self.pos += PATTERN_INT_SIZE as usize;
-                (
-                    RirPatternView::Int {
-                        value,
-                        negative,
-                        span,
-                    },
-                    body,
-                )
-            }
-            k if k == PatternKind::Bool as u32 => {
-                let span = Rir::decode_pattern_span(self.extra, pos);
-                let value = self.extra[pos + 4] != 0;
-                let body = InstRef::from_raw(self.extra[pos + 5]);
-                self.pos += PATTERN_BOOL_SIZE as usize;
-                (RirPatternView::Bool(value, span), body)
-            }
-            k if k == PatternKind::Path as u32 => {
-                let span = Rir::decode_pattern_span(self.extra, pos);
-                // Decode module: u32::MAX means None
-                let module_raw = self.extra[pos + 4];
-                let module = if module_raw == u32::MAX {
-                    None
-                } else {
-                    Some(InstRef::from_raw(module_raw))
-                };
-                // Decode ctor_head (inline type-constructor pattern head,
-                // RUE-596): u32::MAX means None.
-                let ctor_head_raw = self.extra[pos + 5];
-                let ctor_head = if ctor_head_raw == u32::MAX {
-                    None
-                } else {
-                    Some(InstRef::from_raw(ctor_head_raw))
-                };
-                let type_name = Spur::try_from_usize(self.extra[pos + 6] as usize).unwrap();
-                let variant = Spur::try_from_usize(self.extra[pos + 7] as usize).unwrap();
-                // Variable-length payload bindings (RUE-221).
-                let n_bindings = self.extra[pos + 8] as usize;
-                let bindings =
-                    RirSlice::new(&self.extra[pos + 9..pos + 9 + n_bindings], 1, |record| {
-                        Spur::try_from_usize(record[0] as usize).unwrap()
-                    });
-                let body = InstRef::from_raw(self.extra[pos + 9 + n_bindings]);
-                self.pos += 10 + n_bindings;
-                (
-                    RirPatternView::Path {
-                        module,
-                        ctor_head,
-                        type_name,
-                        variant,
-                        bindings,
-                        span,
-                    },
-                    body,
-                )
-            }
-            _ => panic!("Unknown pattern kind: {}", kind),
+        let (pattern, body, extent) = match decode_match_record(self.extra, self.pos) {
+            Some(record) => record,
+            None => unreachable!("match record passed schema validation"),
         };
+        self.pos += extent;
         self.remaining -= 1;
-        Some(result)
+        Some((pattern, body))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1020,20 +3088,13 @@ impl<'a> Iterator for RirDirectivesIter<'a> {
         if self.remaining == 0 {
             return None;
         }
-        let name = Spur::try_from_usize(self.extra[self.pos] as usize).unwrap();
-        let span_start = self.extra[self.pos + 1];
-        let span_len = self.extra[self.pos + 2];
-        let file_id = FileId::new(self.extra[self.pos + 3]);
-        let span = Span::with_file(file_id, span_start, span_start + span_len);
-        let args_len = self.extra[self.pos + 4] as usize;
-        let args_start = self.pos + 5;
-        let args_end = args_start + args_len;
-        let args = RirSlice::new(&self.extra[args_start..args_end], 1, |record| {
-            Spur::try_from_usize(record[0] as usize).unwrap()
-        });
-        self.pos = args_end;
+        let (directive, extent) = match decode_directive_record(self.extra, self.pos) {
+            Some(record) => record,
+            None => unreachable!("directive record passed schema validation"),
+        };
+        self.pos += extent;
         self.remaining -= 1;
-        Some(RirDirectiveView { name, args, span })
+        Some(directive)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1044,7 +3105,7 @@ impl<'a> Iterator for RirDirectivesIter<'a> {
 impl ExactSizeIterator for RirDirectivesIter<'_> {}
 
 /// A single RIR instruction.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Inst {
     pub data: InstData,
     pub span: Span,
@@ -1102,7 +3163,7 @@ impl InternalIntrinsic {
 }
 
 /// Instruction data - the actual operation.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum InstData {
     /// Integer constant
     IntConst(u64),
@@ -1205,9 +3266,7 @@ pub enum InstData {
         /// The value being matched
         scrutinee: InstRef,
         /// Index into extra data where arms start
-        arms_start: u32,
-        /// Number of match arms
-        arms_len: u32,
+        arms: RirMatchArmsRange,
     },
 
     /// Break: exits the innermost loop.
@@ -1224,18 +3283,14 @@ pub enum InstData {
     /// Directives and params are stored in the extra array.
     FnDecl {
         /// Index into extra data where directives start
-        directives_start: u32,
-        /// Number of directives
-        directives_len: u32,
+        directives: RirDirectivesRange,
         /// Whether this function is public (requires --preview modules)
         is_pub: bool,
         /// Whether this function is marked `unchecked` (can only be called from checked blocks)
         is_unchecked: bool,
         name: Spur,
         /// Index into extra data where params start
-        params_start: u32,
-        /// Number of parameters
-        params_len: u32,
+        params: RirParamsRange,
         return_type: Spur,
         body: InstRef,
         /// Whether this function/method takes `self` as a receiver.
@@ -1254,9 +3309,7 @@ pub enum InstData {
     /// Used for module re-exports: `pub const strings = @import("utils/strings.rue");`
     ConstDecl {
         /// Index into extra data where directives start
-        directives_start: u32,
-        /// Number of directives
-        directives_len: u32,
+        directives: RirDirectivesRange,
         /// Whether this constant is public (requires --preview modules)
         is_pub: bool,
         /// Constant name
@@ -1273,29 +3326,24 @@ pub enum InstData {
         /// Function name
         name: Spur,
         /// Index into extra data where args start
-        args_start: u32,
-        /// Number of arguments
-        args_len: u32,
+        args: RirCallArgsRange,
     },
 
     /// Intrinsic call with expression arguments (e.g., @dbg)
-    /// Args are stored in the extra array using add_inst_refs/get_inst_refs.
+    /// Args are stored in the typed intrinsic-argument payload family.
     Intrinsic {
         /// Intrinsic name (without @)
         name: Spur,
         /// Index into extra data where args start
-        args_start: u32,
-        /// Number of arguments
-        args_len: u32,
+        args: RirIntrinsicArgsRange,
     },
 
     /// Compiler-internal intrinsic with expression arguments.
     ///
-    /// Args are stored in the extra array using add_inst_refs/get_inst_refs.
+    /// Args are stored in the typed internal-intrinsic payload family.
     InternalIntrinsic {
         intrinsic: InternalIntrinsic,
-        args_start: u32,
-        args_len: u32,
+        args: RirInternalIntrinsicArgsRange,
     },
 
     /// Intrinsic call with a type argument (e.g., @size_of, @align_of)
@@ -1324,9 +3372,7 @@ pub enum InstData {
     /// The result is the last instruction in the block
     Block {
         /// Index into extra data where instruction refs start
-        extra_start: u32,
-        /// Number of instructions in the block
-        len: u32,
+        instructions: RirBlockInstsRange,
     },
 
     // Variable operations
@@ -1335,9 +3381,7 @@ pub enum InstData {
     /// Directives are stored in the extra array using add_directives/get_directives.
     Alloc {
         /// Index into extra data where directives start
-        directives_start: u32,
-        /// Number of directives
-        directives_len: u32,
+        directives: RirDirectivesRange,
         /// Variable name (None for wildcard `_` pattern that discards the value)
         name: Option<Spur>,
         /// Whether the variable is mutable
@@ -1374,9 +3418,7 @@ pub enum InstData {
     /// Directives, fields, and methods are stored in the extra array.
     StructDecl {
         /// Index into extra data where directives start
-        directives_start: u32,
-        /// Number of directives
-        directives_len: u32,
+        directives: RirDirectivesRange,
         /// Whether this struct is public (requires --preview modules)
         is_pub: bool,
         /// Whether this struct is a linear type (must be consumed)
@@ -1384,13 +3426,9 @@ pub enum InstData {
         /// Struct name
         name: Spur,
         /// Index into extra data where fields start
-        fields_start: u32,
-        /// Number of fields
-        fields_len: u32,
+        fields: RirStructFieldsRange,
         /// Index into extra data where method refs start
-        methods_start: u32,
-        /// Number of methods
-        methods_len: u32,
+        methods: RirStructMethodsRange,
     },
 
     /// Struct literal: creates a new struct instance
@@ -1408,9 +3446,7 @@ pub enum InstData {
         /// Struct type name
         type_name: Spur,
         /// Index into extra data where fields start
-        fields_start: u32,
-        /// Number of fields
-        fields_len: u32,
+        fields: RirFieldInitsRange,
         /// Span of the first field-init-shorthand field, if any (`P { x }`
         /// desugaring to `P { x: x }`, RUE-613, stabilized in RUE-628). `Some`
         /// iff at least one field used the shorthand; retained as diagnostic
@@ -1439,25 +3475,21 @@ pub enum InstData {
 
     // Enum operations
     /// Enum type declaration
-    /// Variants are stored in the extra array using add_symbols/get_symbols.
+    /// Variants are stored in the typed enum-variant payload family.
     EnumDecl {
         /// Whether this enum is public (requires --preview modules)
         is_pub: bool,
         /// Enum name
         name: Spur,
         /// Index into extra data where variants start
-        variants_start: u32,
-        /// Number of variants
-        variants_len: u32,
+        variants: RirEnumVariantsRange,
         /// Index into extra data where the tuple-variant payloads start
         /// (RUE-221). The region is a self-describing flat sequence: for each
         /// variant in declaration order, a count `k` followed by `k`
         /// type-name symbols (as `Spur`s). A count of 0 means a
         /// discriminant-only variant. `payloads_len` is the total number of
         /// u32 words in the region (0 when no variant carries a payload).
-        payloads_start: u32,
-        /// Number of u32 words in the payloads region.
-        payloads_len: u32,
+        payloads: RirEnumPayloadsRange,
     },
 
     /// Enum variant: creates a value of an enum type
@@ -1473,12 +3505,10 @@ pub enum InstData {
 
     // Array operations
     /// Array literal: creates a new array from element values
-    /// Elements are stored in the extra array using add_inst_refs/get_inst_refs.
+    /// Elements are stored in the typed array-element payload family.
     ArrayInit {
         /// Index into extra data where elements start
-        elems_start: u32,
-        /// Number of elements
-        elems_len: u32,
+        elements: RirArrayElemsRange,
     },
 
     /// Array-repeat literal `[value; count]` (RUE-235): creates an array of
@@ -1519,9 +3549,7 @@ pub enum InstData {
         /// Method name
         method: Spur,
         /// Index into extra data where args start
-        args_start: u32,
-        /// Number of arguments
-        args_len: u32,
+        args: RirCallArgsRange,
     },
 
     /// User-defined destructor declaration: drop fn TypeName(self) { ... }
@@ -1560,13 +3588,9 @@ pub enum InstData {
     /// Methods are stored as InstRefs to FnDecl instructions in the extra array.
     AnonStructType {
         /// Index into extra data where fields start
-        fields_start: u32,
-        /// Number of fields
-        fields_len: u32,
+        fields: RirAnonStructFieldsRange,
         /// Index into extra data where method InstRefs start
-        methods_start: u32,
-        /// Number of methods (InstRefs to FnDecl instructions)
-        methods_len: u32,
+        methods: RirAnonStructMethodsRange,
     },
 
     /// Anonymous enum type: an enum (sum) type used as a value expression
@@ -1577,15 +3601,11 @@ pub enum InstData {
     /// as in [`InstData::EnumDecl`].
     AnonEnumType {
         /// Index into extra data where variant name symbols start
-        variants_start: u32,
-        /// Number of variants
-        variants_len: u32,
+        variants: RirAnonEnumVariantsRange,
         /// Index into extra data where the tuple-variant payloads start,
         /// encoded as in [`InstData::EnumDecl`]: a self-describing flat
         /// sequence of `count` + `count` type-name symbols per variant.
-        payloads_start: u32,
-        /// Number of u32 words in the payloads region (0 when no payloads).
-        payloads_len: u32,
+        payloads: RirAnonEnumPayloadsRange,
     },
 }
 
@@ -1694,12 +3714,6 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
         )
     }
 
-    fn display_extra(&self, index: u32) -> u32 {
-        self.displayed_extra
-            .as_ref()
-            .map_or(index, |extra| extra[index as usize])
-    }
-
     /// Format a call argument with its mode prefix.
     fn format_call_arg(&self, arg: &RirCallArg) -> String {
         match arg.mode {
@@ -1719,8 +3733,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
 
     /// Format an item's directives as a `"@copy @allow(..) "` prefix
     /// (empty string when there are none).
-    fn format_directives(&self, start: u32, len: u32) -> String {
-        let directives = self.rir.get_directives(start, len);
+    fn format_directives(&self, range: &RirDirectivesRange) -> String {
+        let directives = self.rir.directives(range);
         if directives.len() == 0 {
             return String::new();
         }
@@ -1982,12 +3996,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     )
                     .unwrap()
                 }
-                InstData::Match {
-                    scrutinee,
-                    arms_start,
-                    arms_len,
-                } => {
-                    let arms = self.rir.get_match_arms(*arms_start, *arms_len);
+                InstData::Match { scrutinee, arms } => {
+                    let arms = self.rir.match_arms(arms);
                     let arms_str: Vec<String> = arms
                         .iter()
                         .map(|(pat, body)| {
@@ -2014,13 +4024,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
 
                 // Functions
                 InstData::FnDecl {
-                    directives_start,
-                    directives_len,
+                    directives,
                     is_pub,
                     is_unchecked,
                     name,
-                    params_start,
-                    params_len,
+                    params,
                     return_type,
                     body,
                     has_self,
@@ -2039,7 +4047,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     } else {
                         ""
                     };
-                    let params = self.rir.get_params(*params_start, *params_len);
+                    let params = self.rir.params(params);
                     let params_str: Vec<String> = params
                         .values()
                         .map(|p| {
@@ -2058,7 +4066,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                             )
                         })
                         .collect();
-                    let directives_str = self.format_directives(*directives_start, *directives_len);
+                    let directives_str = self.format_directives(directives);
                     writeln!(
                         out,
                         "{}{}{}fn {}({}{}) -> {} {{",
@@ -2075,14 +4083,13 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     writeln!(out, "}}").unwrap();
                 }
                 InstData::ConstDecl {
-                    directives_start,
-                    directives_len,
+                    directives,
                     is_pub,
                     name,
                     ty,
                     init,
                 } => {
-                    let directives_str = self.format_directives(*directives_start, *directives_len);
+                    let directives_str = self.format_directives(directives);
                     let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let ty_str = ty
@@ -2106,34 +4113,22 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         writeln!(out, "ret").unwrap();
                     }
                 }
-                InstData::Call {
-                    name,
-                    args_start,
-                    args_len,
-                } => {
+                InstData::Call { name, args } => {
                     let name_str = self.interner.resolve(&*name);
-                    let args = self.rir.get_call_args(*args_start, *args_len);
+                    let args = self.rir.call_args(args);
                     writeln!(out, "call {}({})", name_str, self.format_call_args(args)).unwrap();
                 }
-                InstData::Intrinsic {
-                    name,
-                    args_start,
-                    args_len,
-                } => {
+                InstData::Intrinsic { name, args } => {
                     let name_str = self.interner.resolve(&*name);
-                    let args = self.rir.get_inst_refs(*args_start, *args_len);
+                    let args = self.rir.intrinsic_args(args);
                     let args_str: Vec<String> = args
                         .values()
                         .map(|a| self.display_ref(a).to_string())
                         .collect();
                     writeln!(out, "intrinsic @{}({})", name_str, args_str.join(", ")).unwrap();
                 }
-                InstData::InternalIntrinsic {
-                    intrinsic,
-                    args_start,
-                    args_len,
-                } => {
-                    let args = self.rir.get_inst_refs(*args_start, *args_len);
+                InstData::InternalIntrinsic { intrinsic, args } => {
+                    let args = self.rir.internal_intrinsic_args(args);
                     let args_str: Vec<String> = args
                         .values()
                         .map(|a| self.display_ref(a).to_string())
@@ -2156,21 +4151,20 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let field_str = self.interner.resolve(&*field);
                     writeln!(out, "offset_of @offset_of({}, {})", type_str, field_str).unwrap();
                 }
-                InstData::Block { extra_start, len } => {
-                    writeln!(out, "block({}, {})", self.display_extra(*extra_start), len).unwrap();
+                InstData::Block { instructions } => {
+                    writeln!(out, "block({instructions:?})").unwrap();
                 }
 
                 // Variables
                 InstData::Alloc {
-                    directives_start,
-                    directives_len,
+                    directives,
                     name,
                     is_mut,
                     ty,
                     init,
                     iter_elem,
                 } => {
-                    let directives_str = self.format_directives(*directives_start, *directives_len);
+                    let directives_str = self.format_directives(directives);
                     let name_str = name
                         .map(|n| self.interner.resolve(&n).to_string())
                         .unwrap_or_else(|| "_".to_string());
@@ -2206,19 +4200,16 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
 
                 // Structs
                 InstData::StructDecl {
-                    directives_start,
-                    directives_len,
+                    directives,
                     is_pub,
                     is_linear,
                     name,
-                    fields_start,
-                    fields_len,
-                    methods_start,
-                    methods_len,
+                    fields,
+                    methods,
                 } => {
                     let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
-                    let fields = self.rir.get_field_decls(*fields_start, *fields_len);
+                    let fields = self.rir.struct_fields(fields);
                     let fields_str: Vec<String> = fields
                         .values()
                         .map(|(fname, ftype)| {
@@ -2230,8 +4221,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         })
                         .collect();
                     let linear_str = if *is_linear { "linear " } else { "" };
-                    let directives_str = self.format_directives(*directives_start, *directives_len);
-                    let methods = self.rir.get_inst_refs(*methods_start, *methods_len);
+                    let directives_str = self.format_directives(directives);
+                    let methods = self.rir.struct_methods(methods);
                     let methods_str = if methods.len() == 0 {
                         String::new()
                     } else {
@@ -2257,8 +4248,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     module,
                     ctor_head,
                     type_name,
-                    fields_start,
-                    fields_len,
+                    fields,
                     shorthand_span: _,
                 } => {
                     let module_str = match ctor_head {
@@ -2268,7 +4258,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                             .unwrap_or_default(),
                     };
                     let type_str = self.interner.resolve(&*type_name);
-                    let fields = self.rir.get_field_inits(*fields_start, *fields_len);
+                    let fields = self.rir.field_inits(fields);
                     let fields_str: Vec<String> = fields
                         .values()
                         .map(|(fname, value)| {
@@ -2312,23 +4302,17 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::EnumDecl {
                     is_pub,
                     name,
-                    variants_start,
-                    variants_len,
-                    payloads_start,
-                    payloads_len,
+                    variants,
+                    payloads,
                 } => {
                     let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
-                    let variants = self.rir.get_symbols(*variants_start, *variants_len);
-                    // Decode payloads (self-describing [k, t0..t_{k-1}] per variant).
-                    let payload_words = self.rir.get_extra(*payloads_start, *payloads_len);
-                    let mut payload_arities: Vec<usize> = Vec::new();
-                    let mut pi = 0usize;
-                    while pi < payload_words.len() {
-                        let k = payload_words[pi] as usize;
-                        payload_arities.push(k);
-                        pi += 1 + k;
-                    }
+                    let payload_arities: Vec<usize> = self
+                        .rir
+                        .enum_payloads(payloads, variants)
+                        .map(|payload| payload.len())
+                        .collect();
+                    let variants = self.rir.enum_variants(variants);
                     let variants_str: Vec<String> = variants
                         .iter()
                         .enumerate()
@@ -2368,11 +4352,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 }
 
                 // Arrays
-                InstData::ArrayInit {
-                    elems_start,
-                    elems_len,
-                } => {
-                    let elements = self.rir.get_inst_refs(*elems_start, *elems_len);
+                InstData::ArrayInit { elements } => {
+                    let elements = self.rir.array_elements(elements);
                     let elems_str: Vec<String> = elements
                         .values()
                         .map(|e| self.display_ref(e).to_string())
@@ -2418,10 +4399,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::MethodCall {
                     receiver,
                     method,
-                    args_start,
-                    args_len,
+                    args,
                 } => {
-                    let args = self.rir.get_call_args(*args_start, *args_len);
+                    let args = self.rir.call_args(args);
                     writeln!(
                         out,
                         "method_call {}.{}({})",
@@ -2461,14 +4441,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 }
 
                 // Anonymous struct type
-                InstData::AnonStructType {
-                    fields_start,
-                    fields_len,
-                    methods_start,
-                    methods_len,
-                } => {
+                InstData::AnonStructType { fields, methods } => {
                     write!(out, "struct {{ ").unwrap();
-                    let fields = self.rir.get_field_decls(*fields_start, *fields_len);
+                    let fields = self.rir.anon_struct_fields(fields);
                     for (i, (name, ty)) in fields.values().enumerate() {
                         if i > 0 {
                             write!(out, ", ").unwrap();
@@ -2478,8 +4453,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         write!(out, "{}: {}", name_str, ty_str).unwrap();
                     }
                     // Print methods if any
-                    if *methods_len > 0 {
-                        let methods = self.rir.get_inst_refs(*methods_start, *methods_len);
+                    if methods.extent() > 0 {
+                        let methods = self.rir.anon_struct_methods(methods);
                         let methods_str: Vec<String> = methods
                             .values()
                             .map(|m| self.display_ref(m).to_string())
@@ -2493,22 +4468,13 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 }
 
                 // Anonymous enum type
-                InstData::AnonEnumType {
-                    variants_start,
-                    variants_len,
-                    payloads_start,
-                    payloads_len,
-                } => {
-                    let variants = self.rir.get_symbols(*variants_start, *variants_len);
-                    // Decode payloads (self-describing [k, t0..t_{k-1}] per variant).
-                    let payload_words = self.rir.get_extra(*payloads_start, *payloads_len);
-                    let mut payload_arities: Vec<usize> = Vec::new();
-                    let mut pi = 0usize;
-                    while pi < payload_words.len() {
-                        let k = payload_words[pi] as usize;
-                        payload_arities.push(k);
-                        pi += 1 + k;
-                    }
+                InstData::AnonEnumType { variants, payloads } => {
+                    let payload_arities: Vec<usize> = self
+                        .rir
+                        .anon_enum_payloads(payloads, variants)
+                        .map(|payload| payload.len())
+                        .collect();
+                    let variants = self.rir.anon_enum_variants(variants);
                     let variants_str: Vec<String> = variants
                         .iter()
                         .enumerate()
@@ -2535,7 +4501,7 @@ impl fmt::Display for RirPrinter<'_, '_> {
 }
 
 #[cfg(test)]
-mod tests {
+mod typed_payload_tests {
     use super::*;
     use lasso::ThreadedRodeo;
     use std::alloc::{GlobalAlloc, Layout, System};
@@ -2546,6 +4512,7 @@ mod tests {
     thread_local! {
         static COUNT_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
         static ALLOCATION_COUNT: Cell<usize> = const { Cell::new(0) };
+        static ALLOCATION_BYTES: Cell<usize> = const { Cell::new(0) };
     }
 
     unsafe impl GlobalAlloc for CountingAllocator {
@@ -2553,31 +4520,13 @@ mod tests {
             COUNT_ALLOCATIONS.with(|enabled| {
                 if enabled.get() {
                     ALLOCATION_COUNT.with(|count| count.set(count.get() + 1));
+                    ALLOCATION_BYTES.with(|bytes| bytes.set(bytes.get() + layout.size()));
                 }
             });
             unsafe { System.alloc(layout) }
         }
-
-        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-            COUNT_ALLOCATIONS.with(|enabled| {
-                if enabled.get() {
-                    ALLOCATION_COUNT.with(|count| count.set(count.get() + 1));
-                }
-            });
-            unsafe { System.alloc_zeroed(layout) }
-        }
-
         unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
             unsafe { System.dealloc(ptr, layout) }
-        }
-
-        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-            COUNT_ALLOCATIONS.with(|enabled| {
-                if enabled.get() {
-                    ALLOCATION_COUNT.with(|count| count.set(count.get() + 1));
-                }
-            });
-            unsafe { System.realloc(ptr, layout, new_size) }
         }
     }
 
@@ -2587,1950 +4536,837 @@ mod tests {
     fn allocations_during(f: impl FnOnce()) -> usize {
         COUNT_ALLOCATIONS.with(|enabled| enabled.set(false));
         ALLOCATION_COUNT.with(|count| count.set(0));
+        ALLOCATION_BYTES.with(|bytes| bytes.set(0));
         COUNT_ALLOCATIONS.with(|enabled| enabled.set(true));
         f();
         COUNT_ALLOCATIONS.with(|enabled| enabled.set(false));
         ALLOCATION_COUNT.with(Cell::get)
     }
 
-    #[test]
-    fn test_inst_ref_size() {
-        assert_eq!(std::mem::size_of::<InstRef>(), 4);
+    fn allocation_evidence(f: impl FnOnce()) -> (usize, usize) {
+        COUNT_ALLOCATIONS.with(|enabled| enabled.set(false));
+        ALLOCATION_COUNT.with(|count| count.set(0));
+        ALLOCATION_BYTES.with(|bytes| bytes.set(0));
+        COUNT_ALLOCATIONS.with(|enabled| enabled.set(true));
+        f();
+        COUNT_ALLOCATIONS.with(|enabled| enabled.set(false));
+        (
+            ALLOCATION_COUNT.with(Cell::get),
+            ALLOCATION_BYTES.with(Cell::get),
+        )
+    }
+
+    fn span() -> Span {
+        Span::with_file(FileId::new(7), 3, 9)
     }
 
     #[test]
-    fn test_add_and_get_inst() {
-        let mut rir = Rir::new();
-        let inst = Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        };
-        let inst_ref = rir.add_inst(inst);
-
-        let retrieved = rir.get(inst_ref);
-        assert!(matches!(retrieved.data, InstData::IntConst(42)));
-    }
-
-    #[test]
-    fn test_rir_is_empty() {
-        let rir = Rir::new();
-        assert!(rir.is_empty());
-        assert_eq!(rir.len(), 0);
-    }
-
-    #[test]
-    fn test_rir_extra_data() {
-        let mut rir = Rir::new();
-        let data = [1, 2, 3, 4, 5];
-        let start = rir.add_extra(&data);
-        assert_eq!(start, 0);
-
-        let retrieved = rir.get_extra(start, 5);
-        assert_eq!(retrieved, &data);
-
-        // Add more extra data
-        let data2 = [10, 20];
-        let start2 = rir.add_extra(&data2);
-        assert_eq!(start2, 5);
-    }
-
-    #[test]
-    fn test_rir_iter() {
-        let mut rir = Rir::new();
-        rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-        rir.add_inst(Inst {
-            data: InstData::IntConst(2),
-            span: Span::new(2, 3),
-        });
-
-        let items: Vec<_> = rir.iter().collect();
-        assert_eq!(items.len(), 2);
-        assert_eq!(items[0].0.as_u32(), 0);
-        assert_eq!(items[1].0.as_u32(), 1);
-    }
-
-    #[test]
-    fn test_inst_ref_display() {
-        let inst_ref = InstRef::from_raw(42);
-        assert_eq!(format!("{}", inst_ref), "%42");
-    }
-
-    // RirPattern tests
-    #[test]
-    fn test_rir_pattern_wildcard_span() {
-        let span = Span::new(10, 11);
-        let pattern = RirPattern::Wildcard(span);
-        assert_eq!(pattern.span(), span);
-    }
-
-    #[test]
-    fn test_rir_pattern_int_span() {
-        let span = Span::new(20, 22);
-        let pattern = RirPattern::Int {
-            value: 42,
-            negative: false,
-            span,
-        };
-        assert_eq!(pattern.span(), span);
-
-        // Test negative int
-        let pattern_neg = RirPattern::Int {
-            value: 100,
-            negative: true,
-            span,
-        };
-        assert_eq!(pattern_neg.span(), span);
-    }
-
-    #[test]
-    fn test_rir_pattern_bool_span() {
-        let span = Span::new(30, 34);
-        let pattern = RirPattern::Bool(true, span);
-        assert_eq!(pattern.span(), span);
-
-        let pattern_false = RirPattern::Bool(false, span);
-        assert_eq!(pattern_false.span(), span);
-    }
-
-    #[test]
-    fn test_rir_pattern_path_span() {
-        let span = Span::new(40, 50);
+    fn every_payload_family_round_trips() {
         let interner = ThreadedRodeo::new();
-        let type_name = interner.get_or_intern("Color");
-        let variant = interner.get_or_intern("Red");
-
-        let pattern = RirPattern::Path {
-            module: None,
-            ctor_head: None,
-            type_name,
-            variant,
-            bindings: Vec::new(),
-            span,
-        };
-        assert_eq!(pattern.span(), span);
-    }
-
-    // RirCallArg tests
-    #[test]
-    fn test_rir_call_arg_is_inout() {
-        let arg_normal = RirCallArg {
-            value: InstRef::from_raw(0),
-            mode: RirArgMode::Normal,
-        };
-        assert!(!arg_normal.is_inout());
-        assert!(!arg_normal.is_borrow());
-
-        let arg_inout = RirCallArg {
-            value: InstRef::from_raw(0),
-            mode: RirArgMode::Inout,
-        };
-        assert!(arg_inout.is_inout());
-        assert!(!arg_inout.is_borrow());
-
-        let arg_borrow = RirCallArg {
-            value: InstRef::from_raw(0),
-            mode: RirArgMode::Borrow,
-        };
-        assert!(!arg_borrow.is_inout());
-        assert!(arg_borrow.is_borrow());
-    }
-
-    #[test]
-    fn test_rir_call_arg_modes_round_trip() {
+        let a = interner.get_or_intern("a");
+        let b = interner.get_or_intern("b");
+        let r0 = InstRef::from_raw(0);
+        let r1 = InstRef::from_raw(1);
         let mut rir = Rir::new();
-        let (args_start, args_len) = rir.add_call_args(&[
-            RirCallArg {
-                value: InstRef::from_raw(1),
-                mode: RirArgMode::Normal,
-            },
-            RirCallArg {
-                value: InstRef::from_raw(2),
-                mode: RirArgMode::Inout,
-            },
-            RirCallArg {
-                value: InstRef::from_raw(3),
-                mode: RirArgMode::Borrow,
-            },
-        ]);
 
-        let args = rir.get_call_args(args_start, args_len).to_vec();
-        assert_eq!(args.len(), 3);
-        assert_eq!(args[0].value, InstRef::from_raw(1));
-        assert_eq!(args[0].mode, RirArgMode::Normal);
-        assert_eq!(args[1].value, InstRef::from_raw(2));
-        assert_eq!(args[1].mode, RirArgMode::Inout);
-        assert_eq!(args[2].value, InstRef::from_raw(3));
-        assert_eq!(args[2].mode, RirArgMode::Borrow);
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid RirArgMode value: 99")]
-    fn test_rir_call_arg_invalid_mode_panics() {
-        let mut rir = Rir::new();
-        let args_start = rir.add_extra(&[InstRef::from_raw(1).as_u32(), 99]);
-
-        let _ = rir.get_call_args(args_start, 1);
-    }
-
-    #[test]
-    fn test_rir_param_modes_round_trip() {
-        let mut rir = Rir::new();
-        let interner = ThreadedRodeo::new();
-        let name = interner.get_or_intern("value");
-        let ty = interner.get_or_intern("i32");
-        let span = Span::new(3, 8);
-        let modes = [
-            RirParamMode::Normal,
-            RirParamMode::Inout,
-            RirParamMode::Borrow,
-        ];
-        let params: Vec<_> = modes
-            .iter()
-            .map(|&mode| RirParam {
-                name,
-                ty,
-                mode,
-                is_comptime: false,
-                span,
-            })
-            .collect();
-
-        let (params_start, params_len) = rir.add_params(&params);
-        let decoded = rir.get_params(params_start, params_len);
-
-        assert_eq!(decoded.len(), modes.len());
+        let intrinsic = rir.add_intrinsic_args(&[r0, r1]).unwrap();
+        let internal = rir.add_internal_intrinsic_args(&[r1]).unwrap();
+        let block = rir.add_block_insts(&[r0, r1]).unwrap();
+        let methods = rir.add_struct_methods(&[r0]).unwrap();
+        let anon_methods = rir.add_anon_struct_methods(&[r1]).unwrap();
+        let elements = rir.add_array_elements(&[r0, r1]).unwrap();
         assert_eq!(
-            decoded.values().map(|param| param.mode).collect::<Vec<_>>(),
-            modes
+            rir.intrinsic_args(&intrinsic).values().collect::<Vec<_>>(),
+            [r0, r1]
         );
-        assert_eq!(modes.map(RirParamMode::as_u32), [0, 1, 2]);
-    }
+        assert_eq!(
+            rir.internal_intrinsic_args(&internal)
+                .values()
+                .collect::<Vec<_>>(),
+            [r1]
+        );
+        assert_eq!(
+            rir.block_insts(&block).values().collect::<Vec<_>>(),
+            [r0, r1]
+        );
+        assert_eq!(
+            rir.struct_methods(&methods).values().collect::<Vec<_>>(),
+            [r0]
+        );
+        assert_eq!(
+            rir.anon_struct_methods(&anon_methods)
+                .values()
+                .collect::<Vec<_>>(),
+            [r1]
+        );
+        assert_eq!(
+            rir.array_elements(&elements).values().collect::<Vec<_>>(),
+            [r0, r1]
+        );
 
-    #[test]
-    #[should_panic(expected = "invalid RirParamMode value: 3")]
-    fn test_rir_param_old_comptime_mode_panics() {
-        let mut rir = Rir::new();
-        let params_start = rir.add_extra(&[0, 0, 3, 0, 0, 0, 0]);
-
-        let _ = rir.get_params(params_start, 1);
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid RirParamMode value: 99")]
-    fn test_rir_param_invalid_mode_panics() {
-        let mut rir = Rir::new();
-        let params_start = rir.add_extra(&[0, 0, 99, 0, 0, 0, 0]);
-
-        let _ = rir.get_params(params_start, 1);
-    }
-
-    #[test]
-    fn borrowing_payload_views_are_exact_for_empty_fixed_and_variable_records() {
-        fn exact_len(iter: impl ExactSizeIterator) -> usize {
-            iter.len()
-        }
-
-        let mut rir = Rir::new();
-        assert_eq!(exact_len(rir.get_inst_refs(0, 0).values()), 0);
-        assert_eq!(exact_len(rir.get_symbols(0, 0).iter()), 0);
-        assert_eq!(exact_len(rir.get_call_args(0, 0).values()), 0);
-        assert_eq!(exact_len(rir.get_params(0, 0).values()), 0);
-        assert_eq!(exact_len(rir.get_match_arms(0, 0).iter()), 0);
-        assert_eq!(exact_len(rir.get_field_inits(0, 0).values()), 0);
-        assert_eq!(exact_len(rir.get_field_decls(0, 0).values()), 0);
-        assert_eq!(exact_len(rir.get_directives(0, 0).iter()), 0);
-
-        let interner = ThreadedRodeo::new();
-        let type_name = interner.get_or_intern("Shape");
-        let variant = interner.get_or_intern("Rect");
-        let left = interner.get_or_intern("left");
-        let right = interner.get_or_intern("right");
-        let body = rir.add_inst(Inst {
-            data: InstData::UnitConst,
-            span: Span::new(20, 21),
-        });
-        let (arms_start, arms_len) = rir.add_match_arms(&[(
-            RirPattern::Path {
-                module: None,
-                ctor_head: None,
-                type_name,
-                variant,
-                bindings: vec![left, right],
-                span: Span::new(3, 18),
-            },
-            body,
-        )]);
-        let arms = rir.get_match_arms(arms_start, arms_len);
-        assert_eq!(arms.len(), 1);
-        let (pattern, decoded_body) = arms.iter().next().unwrap();
-        assert_eq!(arms.len(), 1);
-        assert_eq!(decoded_body, body);
-        let RirPatternView::Path { bindings, span, .. } = pattern else {
-            panic!("expected path-pattern view")
-        };
-        assert_eq!(span, Span::new(3, 18));
-        assert_eq!(exact_len(bindings.iter()), 2);
-        assert_eq!(bindings.to_vec(), vec![left, right]);
-
-        let directive_name = interner.get_or_intern("allow");
-        let warning = interner.get_or_intern("unused_variable");
-        let (directives_start, directives_len) = rir.add_directives(&[RirDirective {
-            name: directive_name,
-            args: vec![warning],
-            span: Span::new(30, 42),
-        }]);
-        let directives = rir.get_directives(directives_start, directives_len);
-        assert_eq!(directives.len(), 1);
-        let directive = directives.iter().next().unwrap();
-        assert_eq!(directive.span, Span::new(30, 42));
-        assert_eq!(exact_len(directive.args.iter()), 1);
-        assert_eq!(directive.args.to_vec(), vec![warning]);
-    }
-
-    #[test]
-    fn every_borrowing_payload_family_traverses_without_allocating() {
-        let interner = ThreadedRodeo::new();
-        let first = interner.get_or_intern("first");
-        let second = interner.get_or_intern("second");
-        let ty = interner.get_or_intern("i32");
-        let directive_name = interner.get_or_intern("allow");
-        let span = Span::new(1, 2);
-        let refs = [InstRef::from_raw(1), InstRef::from_raw(2)];
-        let mut rir = Rir::new();
-        let inst_refs = rir.add_inst_refs(&refs);
-        let symbols = rir.add_symbols(&[first, second]);
-        let call_args = rir.add_call_args(&[
-            RirCallArg {
-                value: refs[0],
-                mode: RirArgMode::Normal,
-            },
-            RirCallArg {
-                value: refs[1],
+        let call = rir
+            .add_call_args(&[RirCallArg {
+                value: r1,
                 mode: RirArgMode::Inout,
-            },
-        ]);
-        let params = rir.add_params(&[
-            RirParam {
-                name: first,
-                ty,
-                mode: RirParamMode::Normal,
-                is_comptime: false,
-                span,
-            },
-            RirParam {
-                name: second,
-                ty,
-                mode: RirParamMode::Inout,
-                is_comptime: false,
-                span,
-            },
-        ]);
-        let match_arms = rir.add_match_arms(&[(
-            RirPattern::Path {
-                module: None,
-                ctor_head: None,
-                type_name: ty,
-                variant: first,
-                bindings: vec![second],
-                span,
-            },
-            refs[0],
-        )]);
-        let field_inits = rir.add_field_inits(&[(first, refs[0]), (second, refs[1])]);
-        let field_decls = rir.add_field_decls(&[(first, ty), (second, ty)]);
-        let directives = rir.add_directives(&[RirDirective {
-            name: directive_name,
-            args: vec![first, second],
-            span,
-        }]);
-
-        let checks = [
-            (
-                "inst refs",
-                allocations_during(|| {
-                    std::hint::black_box(
-                        rir.get_inst_refs(inst_refs.0, inst_refs.1).values().count(),
-                    );
-                }),
-            ),
-            (
-                "symbols",
-                allocations_during(|| {
-                    std::hint::black_box(rir.get_symbols(symbols.0, symbols.1).values().count());
-                }),
-            ),
-            (
-                "call args",
-                allocations_during(|| {
-                    std::hint::black_box(
-                        rir.get_call_args(call_args.0, call_args.1).values().count(),
-                    );
-                }),
-            ),
-            (
-                "params",
-                allocations_during(|| {
-                    std::hint::black_box(rir.get_params(params.0, params.1).values().count());
-                }),
-            ),
-            (
-                "match arms",
-                allocations_during(|| {
-                    std::hint::black_box(
-                        rir.get_match_arms(match_arms.0, match_arms.1)
-                            .iter()
-                            .count(),
-                    );
-                }),
-            ),
-            (
-                "field inits",
-                allocations_during(|| {
-                    std::hint::black_box(
-                        rir.get_field_inits(field_inits.0, field_inits.1)
-                            .values()
-                            .count(),
-                    );
-                }),
-            ),
-            (
-                "field decls",
-                allocations_during(|| {
-                    std::hint::black_box(
-                        rir.get_field_decls(field_decls.0, field_decls.1)
-                            .values()
-                            .count(),
-                    );
-                }),
-            ),
-            (
-                "directives",
-                allocations_during(|| {
-                    std::hint::black_box(
-                        rir.get_directives(directives.0, directives.1)
-                            .iter()
-                            .count(),
-                    );
-                }),
-            ),
-        ];
-        for (family, allocations) in checks {
-            assert_eq!(allocations, 0, "{family} traversal allocated");
-        }
-    }
-
-    #[test]
-    #[should_panic]
-    fn fixed_payload_view_rejects_an_out_of_bounds_range() {
-        let rir = Rir::new();
-        let _ = rir.get_call_args(0, 1);
-    }
-
-    #[test]
-    #[should_panic]
-    fn variable_payload_view_rejects_a_truncated_path_record() {
-        let mut rir = Rir::new();
-        let start = rir.add_extra(&[
-            PatternKind::Path as u32,
-            0,
-            1,
-            0,
-            u32::MAX,
-            u32::MAX,
-            0,
-            0,
-            2,
-            0,
-        ]);
-        let _ = rir.get_match_arms(start, 1);
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid RirArgMode value: 99")]
-    fn fixed_payload_view_eagerly_rejects_a_malformed_later_record() {
-        let mut rir = Rir::new();
-        let start = rir.add_extra(&[0, RirArgMode::Normal.as_u32(), 1, 99]);
-        let _ = rir.get_call_args(start, 2);
-    }
-
-    #[test]
-    #[should_panic(expected = "Unknown pattern kind: 99")]
-    fn match_arm_view_eagerly_rejects_a_malformed_later_record() {
-        let mut rir = Rir::new();
-        let start = rir.add_extra(&[PatternKind::Wildcard as u32, 0, 0, 0, 0, 99]);
-        let _ = rir.get_match_arms(start, 2);
-    }
-
-    #[test]
-    #[should_panic]
-    fn directive_view_eagerly_rejects_a_truncated_later_record() {
-        let mut rir = Rir::new();
-        let start = rir.add_extra(&[0, 0, 0, 0, 0, 0]);
-        let _ = rir.get_directives(start, 2);
-    }
-
-    // RirPrinter tests
-    fn create_printer_test_rir() -> (Rir, ThreadedRodeo) {
-        let rir = Rir::new();
-        let interner = ThreadedRodeo::new();
-        (rir, interner)
-    }
-
-    #[test]
-    fn test_printer_int_const() {
-        let (mut rir, interner) = create_printer_test_rir();
-        rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("%0 = const 42"));
-    }
-
-    #[test]
-    fn test_printer_bool_const() {
-        let (mut rir, interner) = create_printer_test_rir();
-        rir.add_inst(Inst {
-            data: InstData::BoolConst(true),
-            span: Span::new(0, 4),
-        });
-        rir.add_inst(Inst {
-            data: InstData::BoolConst(false),
-            span: Span::new(0, 5),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("%0 = const true"));
-        assert!(output.contains("%1 = const false"));
-    }
-
-    #[test]
-    fn test_printer_string_const() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let hello = interner.get_or_intern("hello world");
-        rir.add_inst(Inst {
-            data: InstData::StringConst(hello),
-            span: Span::new(0, 13),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("%0 = const \"hello world\""));
-    }
-
-    #[test]
-    fn test_printer_unit_const() {
-        let (mut rir, interner) = create_printer_test_rir();
-        rir.add_inst(Inst {
-            data: InstData::UnitConst,
-            span: Span::new(0, 2),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("%0 = const ()"));
-    }
-
-    #[test]
-    fn test_printer_binary_ops() {
-        let (_, interner) = create_printer_test_rir();
-
-        // Test all binary operations
-        let ops = [
-            "add", "sub", "mul", "div", "mod", "eq", "ne", "lt", "gt", "le", "ge", "and", "or",
-            "bit_and", "bit_or", "bit_xor", "shl", "shr",
-        ];
-
-        for op_name in ops {
-            let mut test_rir = Rir::new();
-            let lhs = test_rir.add_inst(Inst {
-                data: InstData::IntConst(1),
-                span: Span::new(0, 1),
-            });
-            let rhs = test_rir.add_inst(Inst {
-                data: InstData::IntConst(2),
-                span: Span::new(2, 3),
-            });
-            // Create the op instruction with refs into this iteration's RIR
-            let data = match op_name {
-                "add" => InstData::Add { lhs, rhs },
-                "sub" => InstData::Sub { lhs, rhs },
-                "mul" => InstData::Mul { lhs, rhs },
-                "div" => InstData::Div { lhs, rhs },
-                "mod" => InstData::Mod { lhs, rhs },
-                "eq" => InstData::Eq { lhs, rhs },
-                "ne" => InstData::Ne { lhs, rhs },
-                "lt" => InstData::Lt { lhs, rhs },
-                "gt" => InstData::Gt { lhs, rhs },
-                "le" => InstData::Le { lhs, rhs },
-                "ge" => InstData::Ge { lhs, rhs },
-                "and" => InstData::And { lhs, rhs },
-                "or" => InstData::Or { lhs, rhs },
-                "bit_and" => InstData::BitAnd { lhs, rhs },
-                "bit_or" => InstData::BitOr { lhs, rhs },
-                "bit_xor" => InstData::BitXor { lhs, rhs },
-                "shl" => InstData::Shl { lhs, rhs },
-                "shr" => InstData::Shr { lhs, rhs },
-                _ => unreachable!(),
-            };
-            test_rir.add_inst(Inst {
-                data,
-                span: Span::new(0, 5),
-            });
-
-            let printer = RirPrinter::new(&test_rir, &interner);
-            let output = printer.to_string();
-            let expected = format!("%2 = {} %0, %1", op_name);
-            assert!(
-                output.contains(&expected),
-                "Expected '{}' in output:\n{}",
-                expected,
-                output
-            );
-        }
-    }
-
-    #[test]
-    fn test_printer_unary_ops() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let operand = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        rir.add_inst(Inst {
-            data: InstData::Neg { operand },
-            span: Span::new(0, 3),
-        });
-        rir.add_inst(Inst {
-            data: InstData::Not { operand },
-            span: Span::new(0, 3),
-        });
-        rir.add_inst(Inst {
-            data: InstData::BitNot { operand },
-            span: Span::new(0, 3),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("neg %0"));
-        assert!(output.contains("not %0"));
-        assert!(output.contains("bit_not %0"));
-    }
-
-    #[test]
-    fn test_printer_branch() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let cond = rir.add_inst(Inst {
-            data: InstData::BoolConst(true),
-            span: Span::new(0, 4),
-        });
-        let then_block = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-        let else_block = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-
-        // With else block
-        rir.add_inst(Inst {
-            data: InstData::Branch {
-                cond,
-                then_block,
-                else_block: Some(else_block),
-            },
-            span: Span::new(0, 20),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("branch %0, %1, %2"));
-    }
-
-    #[test]
-    fn test_printer_branch_no_else() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let cond = rir.add_inst(Inst {
-            data: InstData::BoolConst(true),
-            span: Span::new(0, 4),
-        });
-        let then_block = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-
-        rir.add_inst(Inst {
-            data: InstData::Branch {
-                cond,
-                then_block,
-                else_block: None,
-            },
-            span: Span::new(0, 15),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        // Should not have the third argument
-        assert!(output.contains("branch %0, %1\n"));
-    }
-
-    #[test]
-    fn test_printer_loop() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let cond = rir.add_inst(Inst {
-            data: InstData::BoolConst(true),
-            span: Span::new(0, 4),
-        });
-        let body = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-
-        rir.add_inst(Inst {
-            data: InstData::Loop { cond, body },
-            span: Span::new(0, 20),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("loop %0, %1"));
-    }
-
-    #[test]
-    fn test_printer_infinite_loop() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let body = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-
-        rir.add_inst(Inst {
-            data: InstData::InfiniteLoop {
-                body,
-                iter_borrow: None,
-            },
-            span: Span::new(0, 15),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("infinite_loop %0"));
-    }
-
-    #[test]
-    fn test_printer_break_continue() {
-        let (mut rir, interner) = create_printer_test_rir();
-        rir.add_inst(Inst {
-            data: InstData::Break { value: None },
-            span: Span::new(0, 5),
-        });
-        rir.add_inst(Inst {
-            data: InstData::Continue,
-            span: Span::new(0, 8),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("break\n"));
-        assert!(output.contains("continue\n"));
-    }
-
-    #[test]
-    fn test_printer_ret() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let value = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        // Return with value
-        rir.add_inst(Inst {
-            data: InstData::Ret(Some(value)),
-            span: Span::new(0, 10),
-        });
-        // Return without value
-        rir.add_inst(Inst {
-            data: InstData::Ret(None),
-            span: Span::new(0, 6),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("ret %0"));
-        assert!(output.contains("%2 = ret\n"));
-    }
-
-    #[test]
-    fn test_printer_fn_decl() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let body = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        let name = interner.get_or_intern("main");
-        let return_type = interner.get_or_intern("i32");
-        let param_name = interner.get_or_intern("x");
-        let param_type = interner.get_or_intern("i32");
-
-        let (directives_start, directives_len) = rir.add_directives(&[]);
-        let (params_start, params_len) = rir.add_params(&[RirParam {
-            name: param_name,
-            ty: param_type,
-            mode: RirParamMode::Normal,
-            is_comptime: false,
-            span: Span::default(),
-        }]);
-
-        rir.add_inst(Inst {
-            data: InstData::FnDecl {
-                directives_start,
-                directives_len,
-                is_pub: false,
-                is_unchecked: false,
-                name,
-                params_start,
-                params_len,
-                return_type,
-                body,
-                has_self: false,
-                self_mode: RirParamMode::Normal,
-            },
-            span: Span::new(0, 30),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("fn main(x: i32) -> i32"));
-    }
-
-    #[test]
-    fn test_printer_fn_decl_with_self() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let body = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-
-        let name = interner.get_or_intern("get_x");
-        let return_type = interner.get_or_intern("i32");
-
-        let (directives_start, directives_len) = rir.add_directives(&[]);
-        let (params_start, params_len) = rir.add_params(&[]);
-
-        rir.add_inst(Inst {
-            data: InstData::FnDecl {
-                directives_start,
-                directives_len,
-                is_pub: false,
-                is_unchecked: false,
-                name,
-                params_start,
-                params_len,
-                return_type,
-                body,
-                has_self: true,
-                self_mode: RirParamMode::Normal,
-            },
-            span: Span::new(0, 30),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("fn get_x(self, ) -> i32"));
-    }
-
-    #[test]
-    fn test_printer_fn_decl_param_modes() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let body = rir.add_inst(Inst {
-            data: InstData::UnitConst,
-            span: Span::new(0, 2),
-        });
-
-        let name = interner.get_or_intern("modify");
-        let return_type = interner.get_or_intern("()");
-        let param1_name = interner.get_or_intern("a");
-        let param1_type = interner.get_or_intern("i32");
-        let param2_name = interner.get_or_intern("b");
-        let param2_type = interner.get_or_intern("i32");
-        let param3_name = interner.get_or_intern("c");
-        let param3_type = interner.get_or_intern("i32");
-
-        let (directives_start, directives_len) = rir.add_directives(&[]);
-        let (params_start, params_len) = rir.add_params(&[
-            RirParam {
-                name: param1_name,
-                ty: param1_type,
-                mode: RirParamMode::Normal,
-                is_comptime: false,
-                span: Span::default(),
-            },
-            RirParam {
-                name: param2_name,
-                ty: param2_type,
-                mode: RirParamMode::Inout,
-                is_comptime: false,
-                span: Span::default(),
-            },
-            RirParam {
-                name: param3_name,
-                ty: param3_type,
+            }])
+            .unwrap();
+        assert_eq!(rir.call_args(&call).get(0).unwrap().value, r1);
+        let params = rir
+            .add_params(&[RirParam {
+                name: a,
+                ty: b,
                 mode: RirParamMode::Borrow,
-                is_comptime: false,
-                span: Span::default(),
-            },
-        ]);
-
-        rir.add_inst(Inst {
-            data: InstData::FnDecl {
-                directives_start,
-                directives_len,
-                is_pub: false,
-                is_unchecked: false,
-                name,
-                params_start,
-                params_len,
-                return_type,
-                body,
-                has_self: false,
-                self_mode: RirParamMode::Normal,
-            },
-            span: Span::new(0, 50),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("a: i32"));
-        assert!(output.contains("inout b: i32"));
-        assert!(output.contains("borrow c: i32"));
-    }
-
-    #[test]
-    fn test_printer_fn_decl_comptime_param() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let body = rir.add_inst(Inst {
-            data: InstData::UnitConst,
-            span: Span::new(0, 2),
-        });
-        let name = interner.get_or_intern("identity");
-        let return_type = interner.get_or_intern("type");
-        let param_name = interner.get_or_intern("T");
-        let param_type = interner.get_or_intern("type");
-        let (directives_start, directives_len) = rir.add_directives(&[]);
-        let (params_start, params_len) = rir.add_params(&[RirParam {
-            name: param_name,
-            ty: param_type,
-            mode: RirParamMode::Normal,
-            is_comptime: true,
-            span: Span::default(),
-        }]);
-
-        rir.add_inst(Inst {
-            data: InstData::FnDecl {
-                directives_start,
-                directives_len,
-                is_pub: false,
-                is_unchecked: false,
-                name,
-                params_start,
-                params_len,
-                return_type,
-                body,
-                has_self: false,
-                self_mode: RirParamMode::Normal,
-            },
-            span: Span::new(0, 40),
-        });
-
-        let output = RirPrinter::new(&rir, &interner).to_string();
-        assert!(output.contains("fn identity(comptime T: type) -> type"));
-    }
-
-    #[test]
-    fn test_printer_call() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let arg = rir.add_inst(Inst {
-            data: InstData::IntConst(10),
-            span: Span::new(0, 2),
-        });
-
-        let name = interner.get_or_intern("foo");
-
-        let (args_start, args_len) = rir.add_call_args(&[RirCallArg {
-            value: arg,
-            mode: RirArgMode::Normal,
-        }]);
-
-        rir.add_inst(Inst {
-            data: InstData::Call {
-                name,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 8),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("call foo(%0)"));
-    }
-
-    #[test]
-    fn test_printer_call_with_arg_modes() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let arg1 = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-        let arg2 = rir.add_inst(Inst {
-            data: InstData::IntConst(2),
-            span: Span::new(0, 1),
-        });
-        let arg3 = rir.add_inst(Inst {
-            data: InstData::IntConst(3),
-            span: Span::new(0, 1),
-        });
-
-        let name = interner.get_or_intern("modify");
-
-        let (args_start, args_len) = rir.add_call_args(&[
-            RirCallArg {
-                value: arg1,
-                mode: RirArgMode::Normal,
-            },
-            RirCallArg {
-                value: arg2,
-                mode: RirArgMode::Inout,
-            },
-            RirCallArg {
-                value: arg3,
-                mode: RirArgMode::Borrow,
-            },
-        ]);
-
-        rir.add_inst(Inst {
-            data: InstData::Call {
-                name,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 20),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("call modify(%0, inout %1, borrow %2)"));
-    }
-
-    #[test]
-    fn test_printer_intrinsic() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let arg = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        let name = interner.get_or_intern("dbg");
-
-        let (args_start, args_len) = rir.add_call_args(&[RirCallArg {
-            value: arg,
-            mode: RirArgMode::Normal,
-        }]);
-
-        rir.add_inst(Inst {
-            data: InstData::Intrinsic {
-                name,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 10),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("intrinsic @dbg(%0)"));
-    }
-
-    #[test]
-    fn test_printer_internal_intrinsic() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let arg = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-        let (args_start, args_len) = rir.add_inst_refs(&[arg]);
-        rir.add_inst(Inst {
-            data: InstData::InternalIntrinsic {
-                intrinsic: InternalIntrinsic::IterLen,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 10),
-        });
-
-        let output = RirPrinter::new(&rir, &interner).to_string();
-        assert!(output.contains("internal_intrinsic @__rue_iter_len(%0)"));
-    }
-
-    #[test]
-    fn internal_intrinsic_presentation_and_arity_are_exhaustive() {
+                is_comptime: true,
+                span: span(),
+            }])
+            .unwrap();
+        assert_eq!(rir.params(&params).get(0).unwrap().name, a);
+        let arms = rir
+            .add_match_arms(&[(RirPattern::Wildcard(span()), r0)])
+            .unwrap();
+        assert_eq!(rir.match_arms(&arms).get(0).unwrap().1, r0);
+        let inits = rir.add_field_inits(&[(a, r1)]).unwrap();
+        assert_eq!(rir.field_inits(&inits).get(0).unwrap(), (a, r1));
+        let fields = rir.add_struct_fields(&[(a, b)]).unwrap();
+        let anon_fields = rir.add_anon_struct_fields(&[(b, a)]).unwrap();
+        assert_eq!(rir.struct_fields(&fields).get(0).unwrap(), (a, b));
+        assert_eq!(rir.anon_struct_fields(&anon_fields).get(0).unwrap(), (b, a));
+        let directives = rir
+            .add_directives(&[RirDirective {
+                name: a,
+                args: vec![b],
+                span: span(),
+            }])
+            .unwrap();
+        assert_eq!(rir.directives(&directives).get(0).unwrap().name, a);
+        let variants = rir.add_enum_variants(&[a, b]).unwrap();
+        let anon_variants = rir.add_anon_enum_variants(&[b]).unwrap();
+        assert_eq!(rir.enum_variants(&variants).to_vec(), [a, b]);
+        assert_eq!(rir.anon_enum_variants(&anon_variants).to_vec(), [b]);
+        let payloads = rir.add_enum_payloads(&[vec![a], vec![]]).unwrap();
+        let anon_payloads = rir.add_anon_enum_payloads(&[vec![b]]).unwrap();
         assert_eq!(
-            [
-                (
-                    InternalIntrinsic::IterLen.as_str(),
-                    InternalIntrinsic::IterLen.arity()
-                ),
-                (
-                    InternalIntrinsic::CharScalar.as_str(),
-                    InternalIntrinsic::CharScalar.arity()
-                ),
-                (
-                    InternalIntrinsic::CharNext.as_str(),
-                    InternalIntrinsic::CharNext.arity()
-                ),
-                (
-                    InternalIntrinsic::CharScalarLossy.as_str(),
-                    InternalIntrinsic::CharScalarLossy.arity()
-                ),
-                (
-                    InternalIntrinsic::CharNextLossy.as_str(),
-                    InternalIntrinsic::CharNextLossy.arity()
-                ),
-            ],
-            [
-                ("__rue_iter_len", 1),
-                ("__rue_char_scalar", 2),
-                ("__rue_char_next", 2),
-                ("__rue_char_scalar_lossy", 2),
-                ("__rue_char_next_lossy", 2),
-            ]
+            rir.enum_payloads(&payloads, &variants)
+                .map(|payload| payload.to_vec())
+                .collect::<Vec<_>>(),
+            [vec![a], vec![]]
+        );
+        assert_eq!(
+            rir.anon_enum_payloads(&anon_payloads, &anon_variants)
+                .map(|payload| payload.to_vec())
+                .collect::<Vec<_>>(),
+            [vec![b]]
         );
     }
 
     #[test]
-    fn test_printer_type_intrinsic() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let name = interner.get_or_intern("size_of");
-        let type_arg = interner.get_or_intern("i32");
-
-        rir.add_inst(Inst {
-            data: InstData::TypeIntrinsic { name, type_arg },
-            span: Span::new(0, 15),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("type_intrinsic @size_of(i32)"));
+    fn empty_payloads_are_canonical_and_borrowed_views_are_empty() {
+        let mut rir = Rir::new();
+        let call = rir.add_call_args(&[]).unwrap();
+        let params = rir.add_params(&[]).unwrap();
+        let arms = rir.add_match_arms(&[]).unwrap();
+        let directives = rir.add_directives(&[]).unwrap();
+        assert_eq!(rir.extra_len(), 0);
+        assert!(rir.call_args(&call).is_empty());
+        assert!(rir.params(&params).is_empty());
+        assert!(rir.match_arms(&arms).is_empty());
+        assert!(rir.directives(&directives).is_empty());
     }
 
     #[test]
-    fn test_printer_block() {
-        let (mut rir, interner) = create_printer_test_rir();
+    fn validation_reports_family_range_and_record_deterministically() {
+        let mut rir = Rir::new();
+        rir.extra.extend([1, PatternKind::Path as u32]);
+        let arms = RirMatchArmsRange::from_parts(0, 2);
         rir.add_inst(Inst {
-            data: InstData::Block {
-                extra_start: 0,
-                len: 3,
+            data: InstData::Match {
+                scrutinee: InstRef::from_raw(0),
+                arms,
             },
-            span: Span::new(0, 20),
+            span: span(),
         });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("block(0, 3)"));
+        assert_eq!(
+            rir.validate_payloads().unwrap_err(),
+            RirPayloadError {
+                family: "match arms",
+                start: 0,
+                extent: 2,
+                record: Some(0),
+                reason: "record header or body is truncated",
+            }
+        );
     }
 
     #[test]
-    fn test_printer_alloc() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let init = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        let name = interner.get_or_intern("x");
-        let ty = interner.get_or_intern("i32");
-
-        let (directives_start, directives_len) = rir.add_directives(&[]);
-
-        // Normal alloc with type
+    fn validation_rejects_noncanonical_empty_ranges() {
+        let mut rir = Rir::new();
+        let args = RirCallArgsRange::from_parts(1, 0);
         rir.add_inst(Inst {
-            data: InstData::Alloc {
-                directives_start,
-                directives_len,
-                name: Some(name),
-                is_mut: false,
-                ty: Some(ty),
-                init,
-                iter_elem: false,
+            data: InstData::Call {
+                name: Spur::default(),
+                args,
             },
-            span: Span::new(0, 15),
+            span: span(),
         });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("alloc x: i32= %0"));
+        assert_eq!(
+            rir.validate_payloads().unwrap_err().reason,
+            "noncanonical empty range"
+        );
     }
 
     #[test]
-    fn test_printer_alloc_mut() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let init = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        let name = interner.get_or_intern("x");
-
-        let (directives_start, directives_len) = rir.add_directives(&[]);
-
-        rir.add_inst(Inst {
-            data: InstData::Alloc {
-                directives_start,
-                directives_len,
-                name: Some(name),
-                is_mut: true,
-                ty: None,
-                init,
-                iter_elem: false,
+    fn validation_rejects_partial_fixed_records_and_invalid_modes() {
+        let mut partial = Rir::new();
+        partial.extra.push(0);
+        let args = RirCallArgsRange::from_parts(0, 1);
+        partial.add_inst(Inst {
+            data: InstData::Call {
+                name: Spur::default(),
+                args,
             },
-            span: Span::new(0, 15),
+            span: span(),
         });
+        assert_eq!(
+            partial.validate_payloads().unwrap_err().reason,
+            "payload ends in a partial record"
+        );
 
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("alloc mut x= %0"));
-    }
-
-    #[test]
-    fn test_printer_alloc_wildcard() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let init = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        let (directives_start, directives_len) = rir.add_directives(&[]);
-
-        rir.add_inst(Inst {
-            data: InstData::Alloc {
-                directives_start,
-                directives_len,
-                name: None,
-                is_mut: false,
-                ty: None,
-                init,
-                iter_elem: false,
+        let mut invalid_mode = Rir::new();
+        invalid_mode.extra.extend([0, 99]);
+        let args = RirCallArgsRange::from_parts(0, 2);
+        invalid_mode.add_inst(Inst {
+            data: InstData::Call {
+                name: Spur::default(),
+                args,
             },
-            span: Span::new(0, 10),
+            span: span(),
         });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("alloc _= %0"));
+        assert_eq!(
+            invalid_mode.validate_payloads().unwrap_err().reason,
+            "invalid argument mode"
+        );
     }
 
     #[test]
-    fn test_printer_var_ref() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let name = interner.get_or_intern("x");
-
-        rir.add_inst(Inst {
-            data: InstData::VarRef { name },
-            span: Span::new(0, 1),
+    fn validation_rejects_unknown_tags_trailing_words_and_bad_enum_cardinality() {
+        let mut unknown = Rir::new();
+        unknown.extra.extend([1, 99]);
+        let arms = RirMatchArmsRange::from_parts(0, 2);
+        unknown.add_inst(Inst {
+            data: InstData::Match {
+                scrutinee: InstRef::from_raw(0),
+                arms,
+            },
+            span: span(),
         });
+        assert_eq!(
+            unknown.validate_payloads().unwrap_err().reason,
+            "record header or body is truncated"
+        );
 
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("var_ref x"));
-    }
-
-    #[test]
-    fn test_printer_assign() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let value = rir.add_inst(Inst {
-            data: InstData::IntConst(10),
-            span: Span::new(0, 2),
-        });
-
-        let name = interner.get_or_intern("x");
-
-        rir.add_inst(Inst {
-            data: InstData::Assign { name, value },
-            span: Span::new(0, 6),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("assign x = %0"));
-    }
-
-    #[test]
-    fn test_printer_struct_decl() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let name = interner.get_or_intern("Point");
-        let x_name = interner.get_or_intern("x");
-        let y_name = interner.get_or_intern("y");
-        let i32_type = interner.get_or_intern("i32");
-
-        let (directives_start, directives_len) = rir.add_directives(&[]);
-        let (fields_start, fields_len) =
-            rir.add_field_decls(&[(x_name, i32_type), (y_name, i32_type)]);
-        let (methods_start, methods_len) = rir.add_inst_refs(&[]);
-
-        rir.add_inst(Inst {
-            data: InstData::StructDecl {
-                directives_start,
-                directives_len,
+        let mut trailing = Rir::new();
+        trailing.extra.extend([0, 7]);
+        let directives = RirDirectivesRange::from_parts(0, 2);
+        trailing.add_inst(Inst {
+            data: InstData::ConstDecl {
+                directives,
                 is_pub: false,
-                is_linear: false,
-                name,
-                fields_start,
-                fields_len,
-                methods_start,
-                methods_len,
+                name: Spur::default(),
+                ty: None,
+                init: InstRef::from_raw(0),
             },
-            span: Span::new(0, 30),
+            span: span(),
         });
+        assert_eq!(
+            trailing.validate_payloads().unwrap_err().reason,
+            "trailing words after final record"
+        );
 
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("struct Point { x: i32, y: i32 }"));
-    }
-
-    #[test]
-    fn test_printer_struct_decl_with_directive() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let name = interner.get_or_intern("Point");
-        let x_name = interner.get_or_intern("x");
-        let i32_type = interner.get_or_intern("i32");
-        let copy_name = interner.get_or_intern("copy");
-
-        let (directives_start, directives_len) = rir.add_directives(&[RirDirective {
-            name: copy_name,
-            args: vec![],
-            span: Span::new(0, 5),
-        }]);
-        let (fields_start, fields_len) = rir.add_field_decls(&[(x_name, i32_type)]);
-        let (methods_start, methods_len) = rir.add_inst_refs(&[]);
-
-        rir.add_inst(Inst {
-            data: InstData::StructDecl {
-                directives_start,
-                directives_len,
-                is_pub: false,
-                is_linear: false,
-                name,
-                fields_start,
-                fields_len,
-                methods_start,
-                methods_len,
-            },
-            span: Span::new(0, 30),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("@copy struct Point { x: i32 }"));
-    }
-
-    #[test]
-    fn test_directive_span_round_trips_file_id() {
-        // Directive spans must keep start, len, AND file id through the
-        // extra-array encoding (RUE-189): dropping the file id made every
-        // directive-anchored diagnostic in a multi-file build render
-        // "unknown file id", and decoding len as end corrupted the range.
-        let (mut rir, interner) = create_printer_test_rir();
-        let copy_name = interner.get_or_intern("copy");
-        let allow_name = interner.get_or_intern("allow");
-        let arg = interner.get_or_intern("unused_variable");
-
-        let original = vec![
-            RirDirective {
-                name: copy_name,
-                args: vec![],
-                span: Span::with_file(rue_span::FileId::new(2), 7, 12),
-            },
-            RirDirective {
-                name: allow_name,
-                args: vec![arg],
-                span: Span::with_file(rue_span::FileId::new(3), 40, 62),
-            },
-        ];
-        let (start, len) = rir.add_directives(&original);
-        let decoded: Vec<_> = rir
-            .get_directives(start, len)
-            .iter()
-            .map(|directive| directive.to_owned())
-            .collect();
-        assert_eq!(decoded, original);
-    }
-
-    #[test]
-    fn test_printer_struct_init() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let x_val = rir.add_inst(Inst {
-            data: InstData::IntConst(10),
-            span: Span::new(0, 2),
-        });
-        let y_val = rir.add_inst(Inst {
-            data: InstData::IntConst(20),
-            span: Span::new(0, 2),
-        });
-
-        let type_name = interner.get_or_intern("Point");
-        let x_name = interner.get_or_intern("x");
-        let y_name = interner.get_or_intern("y");
-
-        let (fields_start, fields_len) = rir.add_field_inits(&[(x_name, x_val), (y_name, y_val)]);
-
-        rir.add_inst(Inst {
-            data: InstData::StructInit {
-                module: None,
-                ctor_head: None,
-                type_name,
-                fields_start,
-                fields_len,
-                shorthand_span: None,
-            },
-            span: Span::new(0, 25),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("struct_init Point { x: %0, y: %1 }"));
-    }
-
-    #[test]
-    fn test_printer_field_get() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let base = rir.add_inst(Inst {
-            data: InstData::IntConst(0), // placeholder for a struct value
-            span: Span::new(0, 1),
-        });
-
-        let field = interner.get_or_intern("x");
-
-        rir.add_inst(Inst {
-            data: InstData::FieldGet { base, field },
-            span: Span::new(0, 5),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("field_get %0.x"));
-    }
-
-    #[test]
-    fn test_printer_field_set() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let base = rir.add_inst(Inst {
-            data: InstData::IntConst(0), // placeholder
-            span: Span::new(0, 1),
-        });
-        let value = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        let field = interner.get_or_intern("x");
-
-        rir.add_inst(Inst {
-            data: InstData::FieldSet { base, field, value },
-            span: Span::new(0, 10),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("field_set %0.x = %1"));
-    }
-
-    #[test]
-    fn test_printer_enum_decl() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let name = interner.get_or_intern("Color");
-        let red = interner.get_or_intern("Red");
-        let green = interner.get_or_intern("Green");
-        let blue = interner.get_or_intern("Blue");
-
-        let (variants_start, variants_len) = rir.add_symbols(&[red, green, blue]);
-
-        rir.add_inst(Inst {
+        let mut cardinality = Rir::new();
+        cardinality.extra.extend([0, 0, 7]);
+        let variants = RirEnumVariantsRange::from_parts(0, 1);
+        let payloads = RirEnumPayloadsRange::from_parts(1, 2);
+        cardinality.add_inst(Inst {
             data: InstData::EnumDecl {
                 is_pub: false,
-                name,
-                variants_start,
-                variants_len,
-                payloads_start: 0,
-                payloads_len: 0,
+                name: Spur::default(),
+                variants,
+                payloads,
             },
-            span: Span::new(0, 35),
+            span: span(),
         });
+        assert_eq!(
+            cardinality.validate_payloads().unwrap_err().reason,
+            "trailing words after variant payloads"
+        );
+    }
 
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("enum Color { Red, Green, Blue }"));
+    fn context() -> RirValidationContext<'static> {
+        static SOURCES: [(FileId, u32); 1] = [(FileId::new(7), 100)];
+        RirValidationContext {
+            symbol_count: 1,
+            source_lengths: &SOURCES,
+        }
     }
 
     #[test]
-    fn test_printer_enum_variant() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let type_name = interner.get_or_intern("Color");
-        let variant = interner.get_or_intern("Red");
+    fn finish_rejects_noncanonical_match_scalars_before_iteration() {
+        let mut boolean = RirEditor::new();
+        let value = boolean.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: span(),
+        });
+        boolean
+            .add_match(value, &[(RirPattern::Bool(true, span()), value)], span())
+            .unwrap();
+        boolean.rir.extra[5] = 2;
+        assert_eq!(
+            ValidatedRir::finish(boolean, &context())
+                .unwrap_err()
+                .reason,
+            "invalid boolean scalar"
+        );
 
-        rir.add_inst(Inst {
-            data: InstData::EnumVariant {
-                module: None,
-                type_name,
-                variant,
+        let mut integer = RirEditor::new();
+        let value = integer.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: span(),
+        });
+        integer
+            .add_match(
+                value,
+                &[(
+                    RirPattern::Int {
+                        value: 1,
+                        negative: false,
+                        span: span(),
+                    },
+                    value,
+                )],
+                span(),
+            )
+            .unwrap();
+        integer.rir.extra[7] = 2;
+        assert_eq!(
+            ValidatedRir::finish(integer, &context())
+                .unwrap_err()
+                .reason,
+            "invalid integer-sign flag"
+        );
+    }
+
+    #[test]
+    fn finish_rejects_unrepresentable_directive_argument_before_iteration() {
+        let symbol = Spur::try_from_usize(0).unwrap();
+        let mut editor = RirEditor::new();
+        let value = editor.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: span(),
+        });
+        editor
+            .add_const_decl(
+                &[RirDirective {
+                    name: symbol,
+                    args: vec![symbol],
+                    span: span(),
+                }],
+                false,
+                symbol,
+                None,
+                value,
+                span(),
+            )
+            .unwrap();
+        editor.rir.extra[DIRECTIVE_ARGS_START + 1] = u32::MAX;
+
+        assert_eq!(
+            ValidatedRir::finish(editor, &context()).unwrap_err(),
+            RirPayloadError {
+                family: RirDirectivesRange::FAMILY,
+                start: 0,
+                extent: 7,
+                record: Some(0),
+                reason: "symbol word is not representable",
+            }
+        );
+    }
+
+    #[test]
+    fn finish_rejects_unrepresentable_match_binding_before_iteration() {
+        let symbol = Spur::try_from_usize(0).unwrap();
+        let mut editor = RirEditor::new();
+        let value = editor.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: span(),
+        });
+        editor
+            .add_match(
+                value,
+                &[(
+                    RirPattern::Path {
+                        module: None,
+                        ctor_head: None,
+                        type_name: symbol,
+                        variant: symbol,
+                        bindings: vec![symbol],
+                        span: span(),
+                    },
+                    value,
+                )],
+                span(),
+            )
+            .unwrap();
+        editor.rir.extra[MATCH_PATH_BINDINGS_START + 1] = u32::MAX;
+
+        assert_eq!(
+            ValidatedRir::finish(editor, &context()).unwrap_err(),
+            RirPayloadError {
+                family: RirMatchArmsRange::FAMILY,
+                start: 0,
+                extent: 12,
+                record: Some(0),
+                reason: "symbol word is not representable",
+            }
+        );
+    }
+
+    #[test]
+    fn finish_rejects_out_of_owner_match_refs_and_context_values() {
+        let symbol = Spur::try_from_usize(0).unwrap();
+        for (module, ctor, body) in [
+            (Some(InstRef::from_raw(99)), None, InstRef::from_raw(0)),
+            (None, Some(InstRef::from_raw(99)), InstRef::from_raw(0)),
+            (None, None, InstRef::from_raw(99)),
+        ] {
+            let mut editor = RirEditor::new();
+            let scrutinee = editor.add_inst(Inst {
+                data: InstData::UnitConst,
+                span: span(),
+            });
+            editor
+                .add_match(
+                    scrutinee,
+                    &[(
+                        RirPattern::Path {
+                            module,
+                            ctor_head: ctor,
+                            type_name: symbol,
+                            variant: symbol,
+                            bindings: vec![],
+                            span: span(),
+                        },
+                        body,
+                    )],
+                    span(),
+                )
+                .unwrap();
+            assert_eq!(
+                ValidatedRir::finish(editor, &context()).unwrap_err().reason,
+                "instruction reference is outside the owner"
+            );
+        }
+
+        let mut bad_symbol = RirEditor::new();
+        bad_symbol.add_inst(Inst {
+            data: InstData::StringConst(Spur::try_from_usize(77).unwrap()),
+            span: span(),
+        });
+        assert_eq!(
+            ValidatedRir::finish(bad_symbol, &context())
+                .unwrap_err()
+                .reason,
+            "symbol is outside the canonical interner"
+        );
+
+        let mut bad_symbol_word = RirEditor::new();
+        bad_symbol_word.rir.extra.push(77);
+        bad_symbol_word.rir.add_inst(Inst {
+            data: InstData::EnumDecl {
+                is_pub: false,
+                name: symbol,
+                variants: RirEnumVariantsRange::from_parts(0, 1),
+                payloads: RirEnumPayloadsRange::payload_fallback(),
             },
-            span: Span::new(0, 10),
+            span: span(),
         });
+        assert_eq!(
+            ValidatedRir::finish(bad_symbol_word, &context())
+                .unwrap_err()
+                .reason,
+            "symbol is outside the canonical interner"
+        );
 
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("enum_variant Color::Red"));
+        let mut overflow = RirEditor::new();
+        let value = overflow.add_inst(Inst {
+            data: InstData::UnitConst,
+            span: span(),
+        });
+        overflow
+            .add_match(value, &[(RirPattern::Wildcard(span()), value)], span())
+            .unwrap();
+        overflow.rir.extra[2] = u32::MAX;
+        overflow.rir.extra[3] = 1;
+        assert_eq!(
+            ValidatedRir::finish(overflow, &context())
+                .unwrap_err()
+                .reason,
+            "pattern span overflows u32"
+        );
     }
 
     #[test]
-    fn test_printer_array_init() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let elem1 = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-        let elem2 = rir.add_inst(Inst {
-            data: InstData::IntConst(2),
-            span: Span::new(0, 1),
-        });
-        let elem3 = rir.add_inst(Inst {
-            data: InstData::IntConst(3),
-            span: Span::new(0, 1),
-        });
-
-        let (elems_start, elems_len) = rir.add_inst_refs(&[elem1, elem2, elem3]);
-
-        rir.add_inst(Inst {
-            data: InstData::ArrayInit {
-                elems_start,
-                elems_len,
-            },
-            span: Span::new(0, 10),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("array_init [%0, %1, %2]"));
+    fn borrowed_payload_traversal_allocates_nothing() {
+        let interner = ThreadedRodeo::new();
+        let a = interner.get_or_intern("a");
+        let mut rir = Rir::new();
+        let refs = rir
+            .add_block_insts(&[InstRef::from_raw(0), InstRef::from_raw(1)])
+            .unwrap();
+        let intrinsic = rir.add_intrinsic_args(&[InstRef::from_raw(0)]).unwrap();
+        let internal = rir
+            .add_internal_intrinsic_args(&[InstRef::from_raw(0)])
+            .unwrap();
+        let methods = rir.add_struct_methods(&[InstRef::from_raw(0)]).unwrap();
+        let anon_methods = rir
+            .add_anon_struct_methods(&[InstRef::from_raw(0)])
+            .unwrap();
+        let elements = rir.add_array_elements(&[InstRef::from_raw(0)]).unwrap();
+        let calls = rir
+            .add_call_args(&[RirCallArg {
+                value: InstRef::from_raw(0),
+                mode: RirArgMode::Normal,
+            }])
+            .unwrap();
+        let directives = rir
+            .add_directives(&[RirDirective {
+                name: a,
+                args: vec![a],
+                span: span(),
+            }])
+            .unwrap();
+        let arms = rir
+            .add_match_arms(&[(RirPattern::Wildcard(span()), InstRef::from_raw(1))])
+            .unwrap();
+        let params = rir
+            .add_params(&[RirParam {
+                name: a,
+                ty: a,
+                mode: RirParamMode::Normal,
+                is_comptime: false,
+                span: span(),
+            }])
+            .unwrap();
+        let inits = rir.add_field_inits(&[(a, InstRef::from_raw(0))]).unwrap();
+        let fields = rir.add_struct_fields(&[(a, a)]).unwrap();
+        let anon_fields = rir.add_anon_struct_fields(&[(a, a)]).unwrap();
+        let variants = rir.add_enum_variants(&[a]).unwrap();
+        let anon_variants = rir.add_anon_enum_variants(&[a]).unwrap();
+        let payloads = rir.add_enum_payloads(&[vec![a]]).unwrap();
+        let anon_payloads = rir.add_anon_enum_payloads(&[vec![a]]).unwrap();
+        assert_eq!(
+            allocations_during(|| {
+                std::hint::black_box(rir.block_insts(&refs).values().count());
+                std::hint::black_box(rir.intrinsic_args(&intrinsic).values().count());
+                std::hint::black_box(rir.internal_intrinsic_args(&internal).values().count());
+                std::hint::black_box(rir.struct_methods(&methods).values().count());
+                std::hint::black_box(rir.anon_struct_methods(&anon_methods).values().count());
+                std::hint::black_box(rir.array_elements(&elements).values().count());
+                std::hint::black_box(rir.call_args(&calls).values().count());
+                std::hint::black_box(rir.params(&params).values().count());
+                std::hint::black_box(rir.directives(&directives).iter().count());
+                std::hint::black_box(rir.match_arms(&arms).iter().count());
+                std::hint::black_box(rir.field_inits(&inits).values().count());
+                std::hint::black_box(rir.struct_fields(&fields).values().count());
+                std::hint::black_box(rir.anon_struct_fields(&anon_fields).values().count());
+                std::hint::black_box(rir.enum_variants(&variants).values().count());
+                std::hint::black_box(rir.anon_enum_variants(&anon_variants).values().count());
+                std::hint::black_box(rir.enum_payloads(&payloads, &variants).flatten().count());
+                std::hint::black_box(
+                    rir.anon_enum_payloads(&anon_payloads, &anon_variants)
+                        .flatten()
+                        .count(),
+                );
+            }),
+            0
+        );
     }
 
     #[test]
-    fn test_printer_index_get() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let base = rir.add_inst(Inst {
-            data: InstData::IntConst(0), // placeholder for array
-            span: Span::new(0, 1),
-        });
-        let index = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
+    fn every_symbol_bearing_schema_rejects_u32_max_before_views() {
+        let interner = ThreadedRodeo::new();
+        let a = interner.get_or_intern("a");
+        let reference = InstRef::from_raw(0);
+        let assert_rejected = |mut rir: Rir, corrupt: usize, data: InstData| {
+            rir.extra[corrupt] = u32::MAX;
+            rir.add_inst(Inst { data, span: span() });
+            let error = rir.validate_payloads().unwrap_err();
+            assert!(
+                error.reason.contains("symbol") || error.reason.contains("schema"),
+                "{error:?}"
+            );
+        };
 
-        rir.add_inst(Inst {
-            data: InstData::IndexGet { base, index },
-            span: Span::new(0, 5),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("index_get %0[%1]"));
-    }
-
-    #[test]
-    fn test_printer_index_set() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let base = rir.add_inst(Inst {
-            data: InstData::IntConst(0), // placeholder for array
-            span: Span::new(0, 1),
-        });
-        let index = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-        let value = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        rir.add_inst(Inst {
-            data: InstData::IndexSet { base, index, value },
-            span: Span::new(0, 10),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("index_set %0[%1] = %2"));
-    }
-
-    // Struct with methods tests
-    #[test]
-    fn test_printer_struct_decl_with_methods() {
-        let (mut rir, interner) = create_printer_test_rir();
-
-        // Create a method first
-        let method_body = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-        let method_name = interner.get_or_intern("get_x");
-        let return_type = interner.get_or_intern("i32");
-
-        let (directives_start, directives_len) = rir.add_directives(&[]);
-        let (params_start, params_len) = rir.add_params(&[]);
-
-        let method_ref = rir.add_inst(Inst {
-            data: InstData::FnDecl {
-                directives_start,
-                directives_len,
+        let mut rir = Rir::new();
+        let params = rir
+            .add_params(&[RirParam {
+                name: a,
+                ty: a,
+                mode: RirParamMode::Normal,
+                is_comptime: false,
+                span: span(),
+            }])
+            .unwrap();
+        assert_rejected(
+            rir,
+            0,
+            InstData::FnDecl {
+                directives: RirDirectivesRange::payload_fallback(),
                 is_pub: false,
                 is_unchecked: false,
-                name: method_name,
-                params_start,
-                params_len,
-                return_type,
-                body: method_body,
-                has_self: true,
+                name: a,
+                params,
+                return_type: a,
+                body: reference,
+                has_self: false,
                 self_mode: RirParamMode::Normal,
             },
-            span: Span::new(0, 30),
-        });
+        );
 
-        let struct_name = interner.get_or_intern("Point");
-        let x_field = interner.get_or_intern("x");
-        let i32_type = interner.get_or_intern("i32");
+        let mut rir = Rir::new();
+        let directives = rir
+            .add_directives(&[RirDirective {
+                name: a,
+                args: vec![a],
+                span: span(),
+            }])
+            .unwrap();
+        assert_rejected(
+            rir,
+            1,
+            InstData::ConstDecl {
+                directives,
+                is_pub: false,
+                name: a,
+                ty: None,
+                init: reference,
+            },
+        );
 
-        let (fields_start, fields_len) = rir.add_field_decls(&[(x_field, i32_type)]);
-        let (methods_start, methods_len) = rir.add_inst_refs(&[method_ref]);
+        let mut rir = Rir::new();
+        let arms = rir
+            .add_match_arms(&[(
+                RirPattern::Path {
+                    module: None,
+                    ctor_head: None,
+                    type_name: a,
+                    variant: a,
+                    bindings: vec![a],
+                    span: span(),
+                },
+                reference,
+            )])
+            .unwrap();
+        assert_rejected(
+            rir,
+            7,
+            InstData::Match {
+                scrutinee: reference,
+                arms,
+            },
+        );
 
-        rir.add_inst(Inst {
-            data: InstData::StructDecl {
-                directives_start,
-                directives_len,
+        macro_rules! fixed_symbol_case {
+            ($builder:expr, $data:expr) => {{
+                let mut rir = Rir::new();
+                let range = ($builder)(&mut rir);
+                assert_rejected(rir, 0, ($data)(range));
+            }};
+        }
+        fixed_symbol_case!(
+            |rir: &mut Rir| rir.add_field_inits(&[(a, reference)]).unwrap(),
+            |fields| InstData::StructInit {
+                module: None,
+                ctor_head: None,
+                type_name: a,
+                fields,
+                shorthand_span: None,
+            }
+        );
+        fixed_symbol_case!(
+            |rir: &mut Rir| rir.add_struct_fields(&[(a, a)]).unwrap(),
+            |fields| InstData::StructDecl {
+                directives: RirDirectivesRange::payload_fallback(),
                 is_pub: false,
                 is_linear: false,
-                name: struct_name,
-                fields_start,
-                fields_len,
-                methods_start,
-                methods_len,
-            },
-            span: Span::new(0, 50),
-        });
+                name: a,
+                fields,
+                methods: RirStructMethodsRange::payload_fallback(),
+            }
+        );
+        fixed_symbol_case!(
+            |rir: &mut Rir| rir.add_anon_struct_fields(&[(a, a)]).unwrap(),
+            |fields| InstData::AnonStructType {
+                fields,
+                methods: RirAnonStructMethodsRange::payload_fallback(),
+            }
+        );
+        fixed_symbol_case!(
+            |rir: &mut Rir| rir.add_enum_variants(&[a]).unwrap(),
+            |variants| InstData::EnumDecl {
+                is_pub: false,
+                name: a,
+                variants,
+                payloads: RirEnumPayloadsRange::payload_fallback(),
+            }
+        );
+        fixed_symbol_case!(
+            |rir: &mut Rir| rir.add_anon_enum_variants(&[a]).unwrap(),
+            |variants| InstData::AnonEnumType {
+                variants,
+                payloads: RirAnonEnumPayloadsRange::payload_fallback(),
+            }
+        );
 
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("struct Point { x: i32 } methods: [%1]"));
+        let mut rir = Rir::new();
+        let payloads = rir.add_enum_payloads(&[vec![a]]).unwrap();
+        assert_rejected(
+            rir,
+            1,
+            InstData::EnumDecl {
+                is_pub: false,
+                name: a,
+                variants: RirEnumVariantsRange::from_parts(0, 1),
+                payloads,
+            },
+        );
+        let mut rir = Rir::new();
+        let payloads = rir.add_anon_enum_payloads(&[vec![a]]).unwrap();
+        assert_rejected(
+            rir,
+            1,
+            InstData::AnonEnumType {
+                variants: RirAnonEnumVariantsRange::from_parts(0, 1),
+                payloads,
+            },
+        );
     }
 
     #[test]
-    fn test_printer_method_call() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let receiver = rir.add_inst(Inst {
-            data: InstData::IntConst(0), // placeholder for struct value
-            span: Span::new(0, 1),
-        });
-        let arg = rir.add_inst(Inst {
-            data: InstData::IntConst(10),
-            span: Span::new(0, 2),
-        });
-
-        let method = interner.get_or_intern("add");
-
-        let (args_start, args_len) = rir.add_call_args(&[RirCallArg {
-            value: arg,
-            mode: RirArgMode::Normal,
-        }]);
-
-        rir.add_inst(Inst {
-            data: InstData::MethodCall {
-                receiver,
-                method,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 15),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("method_call %0.add(%1)"));
-    }
-
-    #[test]
-    fn test_printer_method_call_with_arg_modes() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let receiver = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-        let arg1 = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-        let arg2 = rir.add_inst(Inst {
-            data: InstData::IntConst(2),
-            span: Span::new(0, 1),
-        });
-
-        let method = interner.get_or_intern("modify");
-
-        let (args_start, args_len) = rir.add_call_args(&[
-            RirCallArg {
-                value: arg1,
-                mode: RirArgMode::Inout,
-            },
-            RirCallArg {
-                value: arg2,
-                mode: RirArgMode::Borrow,
-            },
-        ]);
-
-        rir.add_inst(Inst {
-            data: InstData::MethodCall {
-                receiver,
-                method,
-                args_start,
-                args_len,
-            },
-            span: Span::new(0, 25),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("method_call %0.modify(inout %1, borrow %2)"));
-    }
-
-    #[test]
-    fn test_printer_drop_fn_decl() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let body = rir.add_inst(Inst {
-            data: InstData::UnitConst,
-            span: Span::new(0, 2),
-        });
-
-        let type_name = interner.get_or_intern("Resource");
-
-        rir.add_inst(Inst {
-            data: InstData::DropFnDecl { type_name, body },
-            span: Span::new(0, 30),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("drop fn Resource(self)"));
-    }
-
-    // Match and pattern tests
-    #[test]
-    fn test_printer_match_wildcard() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let scrutinee = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-        let body = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-
-        let (arms_start, arms_len) =
-            rir.add_match_arms(&[(RirPattern::Wildcard(Span::new(0, 1)), body)]);
-
-        rir.add_inst(Inst {
-            data: InstData::Match {
-                scrutinee,
-                arms_start,
-                arms_len,
-            },
-            span: Span::new(0, 20),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("match %0 { _ => %1 }"));
-    }
-
-    #[test]
-    fn test_printer_match_int_pattern() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let scrutinee = rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-        let body1 = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-        let body2 = rir.add_inst(Inst {
-            data: InstData::IntConst(2),
-            span: Span::new(0, 1),
-        });
-        let body_default = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-
-        let (arms_start, arms_len) = rir.add_match_arms(&[
-            (
-                RirPattern::Int {
-                    value: 1,
-                    negative: false,
-                    span: Span::new(0, 1),
-                },
-                body1,
-            ),
-            (
-                RirPattern::Int {
-                    value: 5,
-                    negative: true,
-                    span: Span::new(0, 2),
-                },
-                body2,
-            ),
-            (RirPattern::Wildcard(Span::new(0, 1)), body_default),
-        ]);
-
-        rir.add_inst(Inst {
-            data: InstData::Match {
-                scrutinee,
-                arms_start,
-                arms_len,
-            },
-            span: Span::new(0, 30),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("match %0 { 1 => %1, -5 => %2, _ => %3 }"));
-    }
-
-    #[test]
-    fn test_printer_match_bool_pattern() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let scrutinee = rir.add_inst(Inst {
-            data: InstData::BoolConst(true),
-            span: Span::new(0, 4),
-        });
-        let body_true = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-        let body_false = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-
-        let (arms_start, arms_len) = rir.add_match_arms(&[
-            (RirPattern::Bool(true, Span::new(0, 4)), body_true),
-            (RirPattern::Bool(false, Span::new(0, 5)), body_false),
-        ]);
-
-        rir.add_inst(Inst {
-            data: InstData::Match {
-                scrutinee,
-                arms_start,
-                arms_len,
-            },
-            span: Span::new(0, 30),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("match %0 { true => %1, false => %2 }"));
-    }
-
-    #[test]
-    fn test_printer_match_path_pattern() {
-        let (mut rir, interner) = create_printer_test_rir();
-        let scrutinee = rir.add_inst(Inst {
-            data: InstData::IntConst(0), // placeholder for enum value
-            span: Span::new(0, 1),
-        });
-        let body_red = rir.add_inst(Inst {
-            data: InstData::IntConst(1),
-            span: Span::new(0, 1),
-        });
-        let body_green = rir.add_inst(Inst {
-            data: InstData::IntConst(2),
-            span: Span::new(0, 1),
-        });
-        let body_default = rir.add_inst(Inst {
-            data: InstData::IntConst(0),
-            span: Span::new(0, 1),
-        });
-
-        let color = interner.get_or_intern("Color");
-        let red = interner.get_or_intern("Red");
-        let green = interner.get_or_intern("Green");
-
-        let (arms_start, arms_len) = rir.add_match_arms(&[
-            (
-                RirPattern::Path {
-                    module: None,
-                    ctor_head: None,
-                    type_name: color,
-                    variant: red,
-                    bindings: Vec::new(),
-                    span: Span::new(0, 10),
-                },
-                body_red,
-            ),
-            (
-                RirPattern::Path {
-                    module: None,
-                    ctor_head: None,
-                    type_name: color,
-                    variant: green,
-                    bindings: Vec::new(),
-                    span: Span::new(0, 12),
-                },
-                body_green,
-            ),
-            (RirPattern::Wildcard(Span::new(0, 1)), body_default),
-        ]);
-
-        rir.add_inst(Inst {
-            data: InstData::Match {
-                scrutinee,
-                arms_start,
-                arms_len,
-            },
-            span: Span::new(0, 50),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        let output = printer.to_string();
-        assert!(output.contains("match %0 { Color::Red => %1, Color::Green => %2, _ => %3 }"));
-    }
-
-    #[test]
-    fn test_printer_display_trait() {
-        let (mut rir, interner) = create_printer_test_rir();
-        rir.add_inst(Inst {
-            data: InstData::IntConst(42),
-            span: Span::new(0, 2),
-        });
-
-        let printer = RirPrinter::new(&rir, &interner);
-        // Test Display trait implementation
-        let output = format!("{}", printer);
-        assert!(output.contains("%0 = const 42"));
+    fn every_payload_builder_records_per_family_allocation_and_storage_evidence() {
+        let interner = ThreadedRodeo::new();
+        let a = interner.get_or_intern("a");
+        let b = interner.get_or_intern("b");
+        let r0 = InstRef::from_raw(0);
+        let r1 = InstRef::from_raw(1);
+        let directives = [RirDirective {
+            name: a,
+            args: vec![b],
+            span: span(),
+        }];
+        let params = [RirParam {
+            name: a,
+            ty: b,
+            mode: RirParamMode::Borrow,
+            is_comptime: true,
+            span: span(),
+        }];
+        let calls = [RirCallArg {
+            value: r0,
+            mode: RirArgMode::Inout,
+        }];
+        let enum_payloads = [vec![a], vec![]];
+        let anon_payloads = [vec![b]];
+        #[derive(Debug)]
+        struct Evidence {
+            family: &'static str,
+            allocation_calls: usize,
+            allocated_bytes: usize,
+            logical_bytes: usize,
+            retained_capacity_bytes: usize,
+        }
+        macro_rules! evidence {
+            ($family:expr, $build:expr) => {{
+                let mut rir = Rir::new();
+                let (allocation_calls, allocated_bytes) =
+                    allocation_evidence(|| ($build)(&mut rir));
+                Evidence {
+                    family: $family,
+                    allocation_calls,
+                    allocated_bytes,
+                    logical_bytes: rir.extra.len() * std::mem::size_of::<u32>(),
+                    retained_capacity_bytes: rir.extra.capacity() * std::mem::size_of::<u32>(),
+                }
+            }};
+        }
+        let evidence = [
+            evidence!(RirIntrinsicArgsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_intrinsic_args(&[r0, r1]).unwrap();
+            }),
+            evidence!(RirInternalIntrinsicArgsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_internal_intrinsic_args(&[r0]).unwrap();
+            }),
+            evidence!(RirBlockInstsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_block_insts(&[r0, r1]).unwrap();
+            }),
+            evidence!(RirStructMethodsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_struct_methods(&[r0]).unwrap();
+            }),
+            evidence!(RirAnonStructMethodsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_anon_struct_methods(&[r1]).unwrap();
+            }),
+            evidence!(RirArrayElemsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_array_elements(&[r0, r1]).unwrap();
+            }),
+            evidence!(RirCallArgsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_call_args(&calls).unwrap();
+            }),
+            evidence!(RirParamsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_params(&params).unwrap();
+            }),
+            evidence!(RirMatchArmsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_match_arms(&[(RirPattern::Wildcard(span()), r0)])
+                    .unwrap();
+            }),
+            evidence!(RirFieldInitsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_field_inits(&[(a, r0)]).unwrap();
+            }),
+            evidence!(RirStructFieldsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_struct_fields(&[(a, b)]).unwrap();
+            }),
+            evidence!(RirAnonStructFieldsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_anon_struct_fields(&[(a, b)]).unwrap();
+            }),
+            evidence!(RirDirectivesRange::FAMILY, |rir: &mut Rir| {
+                rir.add_directives(&directives).unwrap();
+            }),
+            evidence!(RirEnumVariantsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_enum_variants(&[a, b]).unwrap();
+            }),
+            evidence!(RirAnonEnumVariantsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_anon_enum_variants(&[b]).unwrap();
+            }),
+            evidence!(RirEnumPayloadsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_enum_payloads(&enum_payloads).unwrap();
+            }),
+            evidence!(RirAnonEnumPayloadsRange::FAMILY, |rir: &mut Rir| {
+                rir.add_anon_enum_payloads(&anon_payloads).unwrap();
+            }),
+        ];
+        assert_eq!(evidence.len(), 17);
+        for item in &evidence {
+            assert!(item.allocation_calls >= 2, "{}: {item:?}", item.family);
+            assert!(item.logical_bytes > 0, "{}: {item:?}", item.family);
+            assert!(
+                item.retained_capacity_bytes >= item.logical_bytes,
+                "{}: {item:?}",
+                item.family
+            );
+            assert!(
+                item.allocated_bytes >= item.retained_capacity_bytes,
+                "{}: {item:?}",
+                item.family
+            );
+        }
+        std::hint::black_box(evidence);
     }
 }

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -25,6 +25,12 @@ mod inst;
 
 pub use astgen::AstGen;
 pub use inst::{
-    Inst, InstData, InstRef, InternalIntrinsic, RepeatCount, Rir, RirArgMode, RirCallArg,
-    RirDirective, RirDirectiveView, RirParam, RirParamMode, RirPattern, RirPatternView, RirPrinter,
+    Inst, InstData, InstRef, InternalIntrinsic, RepeatCount, Rir, RirAnonEnumPayloadsRange,
+    RirAnonEnumVariantsRange, RirAnonStructFieldsRange, RirAnonStructMethodsRange, RirArgMode,
+    RirArrayElemsRange, RirBlockInstsRange, RirCallArg, RirCallArgsRange, RirDirective,
+    RirDirectiveView, RirDirectivesRange, RirEditor, RirEnumPayloads, RirEnumPayloadsRange,
+    RirEnumVariantsRange, RirFieldInitsRange, RirInternalIntrinsicArgsRange, RirIntrinsicArgsRange,
+    RirMatchArmsRange, RirParam, RirParamMode, RirParamsRange, RirPattern, RirPatternView,
+    RirPayloadBuildError, RirPayloadError, RirPrinter, RirStructFieldsRange, RirStructMethodsRange,
+    RirValidationContext, ValidatedRir,
 };

--- a/docs/process/rue-841-rir-payloads.md
+++ b/docs/process/rue-841-rir-payloads.md
@@ -1,0 +1,72 @@
+# RUE-841 typed RIR payload publication record
+
+This record accompanies the RIR portion of
+[ADR-0056](../designs/0056-typed-ir-payload-schemas.md). It records the
+structural and focused allocation evidence owned by RUE-841; the paired
+whole-compiler benchmark matrix remains the integration gate owned by RUE-843.
+
+## Published representation
+
+- Every variable RIR payload is represented by a family-specific opaque range.
+- Each stored range has compile-time size and alignment assertions: exactly two
+  `u32` words, aligned as `u32`; marker families occupy no storage.
+- Range values are neither `Copy` nor `Clone`. Semantic metadata retains the
+  owning declaration `InstRef` and borrows its parameter range on demand.
+- `RirEditor` is the mutable construction form. `ValidatedRir::finish` consumes
+  the real owner (not an alias), runs structural plus canonical interner/source
+  validation, and is the type stored by
+  `CanonicalRirOutput` and therefore published by `CompilerSession`.
+- Every payload-bearing instruction is created by one transactional editor
+  operation that rolls back both stores on failure. The editor exposes no
+  mutable dereference and AstGen never constructs a range separately from its
+  owning instruction.
+- Empty ranges use only `(0, 0)`. Fixed-width payloads retain their prior word
+  width. Nonempty match-arm and directive envelopes add exactly one count word.
+
+## Construction and validation evidence
+
+Builders stage complete payloads before reserving and appending to the owner.
+Every length conversion, multiplication, addition, and reservation is checked.
+Failures are categorized as `ResourceLimitExceeded`, `CapacityFailure`, or
+`InvalidBuilderInput`; AstGen retains the first failure and `try_finish()`
+returns it without publishing the partially lowered editor.
+
+The publication validator checks canonical empty ranges, checked range ends,
+fixed record widths, variable record counts and trailing words, argument and
+parameter modes, comptime booleans, match scalar tags, enum payload cardinality,
+schema-local symbol representability before any infallible view, all canonical
+symbol and instruction handles, and every source span. Fixed families and
+variable match/directive/enum families share their checked schema descriptors
+across sizing, validation, and iteration. Errors include
+the family, physical range, record index where applicable, and stable reason.
+
+## Focused allocation and correctness evidence
+
+`inst::typed_payload_tests` covers every migrated family, canonical empty
+payloads, deterministic malformed scalar/context data, and noncanonical empty
+ranges. A counting allocator traverses every migrated borrowing view and records
+exactly zero heap allocations. A separate all-family builder probe records
+allocation calls and bytes alongside logical and retained-capacity bytes for
+each of the 17 families independently, and asserts the storage relationships
+without timing-sensitive constants. It deliberately does not report a staging
+peak: the system allocator reports requested allocation bytes, but cannot
+separate simultaneously live staging capacity from word-store growth without
+builder instrumentation that would perturb the measured path. RUE-843 owns
+that narrowly deferred peak-live-staging measurement as part of its
+instrumented paired whole-compiler wall-time/RSS matrix.
+
+Publication checks run from the repository root:
+
+```text
+scripts/rue fmt
+./buck2 test //crates/rue-rir:rue-rir-test //crates/rue-air:rue-air-test
+./buck2 build //crates/rue:rue
+scripts/rue quick
+```
+
+On the implementation worktree these checks passed with 39 RIR tests, 440 AIR
+tests, the full compiler build, and the repository quick suite. The focused
+allocation assertion is exact rather than timing-sensitive. No claimed
+whole-compiler wall-time or RSS measurement is invented here; RUE-843 performs
+the alternating baseline/candidate series required by ADR-0056 after RIR, AIR,
+and CFG migrations are integrated together.


### PR DESCRIPTION
## Summary

- replace raw RIR payload ranges with family-specific opaque views and checked schema decoders
- make `RirEditor` the owner-mediated atomic construction boundary and publish only context-validated `ValidatedRir`
- migrate AstGen, AIR, compiler consumers, and printing to typed borrowing APIs
- add malformed-payload, provenance, round-trip, and per-family zero-allocation/storage evidence

## Validation

- `scripts/rue fmt`
- `./buck2 test //crates/rue-rir:rue-rir-test` (41/41)
- `./buck2 test //crates/rue-air:rue-air-test` (440/440)
- `./buck2 build //crates/rue:rue`
- `scripts/rue quick` (29 targets)
- adversarial architecture review approved

Fixes RUE-841
