### PR TITLE
RUE-947: parse module-qualified inline type-ctor pattern heads

### DIFF
--- a/crates/rue-cli-tests/cases/inline_type_ctor_module_qualified_pattern_head.toml
+++ b/crates/rue-cli-tests/cases/inline_type_ctor_module_qualified_pattern_head.toml
@@ -1,0 +1,56 @@
+# Module-qualified inline type-constructor call as a PATTERN head (RUE-947,
+# preview `inline_type_ctor_paths`, relaxing spec 4.14:23). The construction head
+# `std.result.Result(F, FE).Ok(x)` already worked under the preview (RUE-596);
+# the matching PATTERN head `std.result.Result(F, FE).Ok(v) => ..` previously
+# failed with a raw E0100 parse error regardless of the flag. It now parses and
+# flows through the same preview gate as the local head, resolving to the same
+# specialized enum so match arms unify. Driven end-to-end through the real binary
+# against the real standard library.
+
+[section]
+id = "cli.inline_type_ctor_module_qualified_pattern_head"
+name = "Module-qualified inline type-constructor pattern head"
+description = "`std.result.Result(F, FE).Ok(v) => ..` as a match pattern head, preview-gated, against real std (RUE-947)."
+
+[[case]]
+name = "module_qualified_pattern_head_runs"
+description = "A ruewc-style match over `std.result.Result(F, FE)` binds both variant payloads through module-qualified pattern heads."
+args = ["main.rue", "--preview", "inline_type_ctor_paths", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn score(ok: bool) -> i32 {
+    let r = if ok {
+        std.result.Result(i32, i32).Ok(40)     // module-qualified construction head
+    } else {
+        std.result.Result(i32, i32).Err(2)
+    };
+    match r {
+        std.result.Result(i32, i32).Ok(v) => v,     // module-qualified pattern head
+        std.result.Result(i32, i32).Err(e) => e,
+    }
+}
+
+fn main() -> i32 {
+    score(true) + score(false)                       // 40 + 2 = 42
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "module_qualified_pattern_head_gated_without_preview"
+description = "Without --preview the module-qualified head is rejected with the E1100 preview-required diagnostic, not a raw E0100 parse error."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let ok = std.result.Result(i32, i32).Ok(40);
+    match ok {
+        std.result.Result(i32, i32).Ok(v) => v,
+        std.result.Result(i32, i32).Err(e) => e,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E1100", "inline_type_ctor_paths"]

--- a/crates/rue-parser/src/diagnostic_corpus.snapshot
+++ b/crates/rue-parser/src/diagnostic_corpus.snapshot
@@ -1,4 +1,4 @@
-# pre-RUE-905 Chumsky: accepted=3834 rejected=152 lex_invalid=35 accepted_source_ast_sha256=f8cd7d1f97bcb6a28da891a9c6a77887341cc6f73307be4656558c6066e07670
+# pre-RUE-905 Chumsky: accepted=3838 rejected=152 lex_invalid=35 accepted_source_ast_sha256=60d2458a2108b69fd8d38accfba33b48dbecc08ce8b9c1846f3d82f6dd689fde
 crates/rue-cli-tests/cases/ice_regressions.toml#case[23].files[0].source	2e20a2ba448b239e1ead60f5f3a138b29d8fa35011e22e9e1aeb3c2d3c219365	4abc165df113087fc80754c454b6c344b9f89786f010f94eff6b34e12c72737f
 crates/rue-cli-tests/cases/modules.toml#case[5].files[0].source	5dc4f738ec6176b63e0afbcaa317b1b0d28b9a593dfdd7048c1add84aa179314	906620269e628b299441e74af888a91497ba49c62f0896d87a8232dff0c9818c
 crates/rue-cli-tests/cases/modules.toml#case[6].files[0].source	d62edd50c9e1f709d0ce50ffef54974ab82519a4e32eec9780c8c35f4a881aa8	a93bcb41d33bb153b5c78708b02dc973f8dd4c5652c767fcb54e15c5cf19f8ca

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -1737,16 +1737,55 @@ impl Parser {
         }
     }
 
+    /// With the cursor at a `(`, scan to the matching `)` and report whether the
+    /// token immediately after it is a `.`. This distinguishes an inline
+    /// type-constructor call on a pattern head (`Result(i32, i32).Ok`, the group
+    /// precedes a dot) from a variant's payload bindings (`Ok(v)`, the group is
+    /// terminal) during a single left-to-right pass (RUE-947).
+    fn paren_group_precedes_dot(&self) -> bool {
+        debug_assert!(self.at(TokenKind::LParen));
+        let mut cursor = self.cursor;
+        let mut depth = 0usize;
+        while let Some(token) = self.tokens.get(cursor) {
+            match token.kind {
+                TokenKind::LParen => depth += 1,
+                TokenKind::RParen => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return self.tokens.get(cursor + 1).map(|t| t.kind) == Some(TokenKind::Dot);
+                    }
+                }
+                TokenKind::Eof => return false,
+                _ => {}
+            }
+            cursor += 1;
+        }
+        false
+    }
+
     fn path_pattern(&mut self, start: u32) -> PResult<Pattern> {
         let first = self.ident()?;
+        // The inline type-constructor call (RUE-596) attaches to the `type_name`
+        // segment — the last one before the variant. For a local head that is
+        // the first ident (`Result(i32, i32).Ok(v)`); for a module-qualified
+        // head it is a later segment (`std.result.Result(i32, i32).Ok(v)`,
+        // RUE-947). A `(...)` group is the ctor call only when it precedes a
+        // dot; a terminal `(...)` is the variant's payload bindings.
         let mut ctor_args = None;
         if self.at(TokenKind::LParen) {
             ctor_args = Some(self.call_args()?);
         }
         self.expect(TokenKind::Dot)?;
         let mut segments = vec![self.ident()?];
+        if ctor_args.is_none() && self.at(TokenKind::LParen) && self.paren_group_precedes_dot() {
+            ctor_args = Some(self.call_args()?);
+        }
         while self.eat(TokenKind::Dot) {
             segments.push(self.ident()?);
+            if ctor_args.is_none() && self.at(TokenKind::LParen) && self.paren_group_precedes_dot()
+            {
+                ctor_args = Some(self.call_args()?);
+            }
         }
         let variant = segments.pop().unwrap();
         let (type_name, base) = if segments.is_empty() {

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -1108,13 +1108,19 @@ impl<'a> AstGen<'a> {
                 let module = path.base.as_ref().map(|base| self.gen_expr(base));
                 // Inline type-constructor pattern head `F(args).Variant(..)`
                 // (RUE-596): generate the constructor call `F(args)` as its own
-                // instruction; sema reduces it to the enum type at comptime.
+                // instruction; sema reduces it to the enum type at comptime. When
+                // the head is module-qualified (`std.result.Result(i32, i32).Ok`,
+                // RUE-947) the constructor is reached through the module base, so
+                // emit a method call on it exactly as the construction head does;
+                // a bare call would fail to resolve `Result` in local scope.
                 let ctor_head = path.ctor_args.as_ref().map(|args| {
                     let arg_refs: Vec<_> = args.iter().map(|a| self.convert_call_arg(a)).collect();
                     let name = self.symbol(path.type_name.name);
-                    self.rir
-                        .add_call(name, &arg_refs, path.span)
-                        .record_failure(&mut self.payload_error)
+                    match module {
+                        Some(base) => self.rir.add_method_call(base, name, &arg_refs, path.span),
+                        None => self.rir.add_call(name, &arg_refs, path.span),
+                    }
+                    .record_failure(&mut self.payload_error)
                 });
                 // Payload binding names for a tuple-variant pattern (RUE-221).
                 let bindings: Vec<Spur> =

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2314,6 +2314,49 @@ compile_fail = true
 error_contains = "[E0209]"
 
 [[case]]
+name = "inline_type_ctor_module_qualified_pattern_head"
+spec = ["4.14:23"]
+preview = "inline_type_ctor_paths"
+preview_should_pass = true
+real_std = true
+description = "Under the preview, a module-qualified type-constructor call heads a match pattern: match r { std.result.Result(i32, i32).Ok(v) => .. } (RUE-947)"
+source = """
+const std = @import("std");
+fn main() -> i32 {
+    let ok = std.result.Result(i32, i32).Ok(40);
+    let err = std.result.Result(i32, i32).Err(2);
+    let a = match ok {
+        std.result.Result(i32, i32).Ok(v) => v,
+        std.result.Result(i32, i32).Err(e) => e,
+    };
+    let b = match err {
+        std.result.Result(i32, i32).Ok(v) => v,
+        std.result.Result(i32, i32).Err(e) => e,
+    };
+    a + b
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "module_qualified_type_ctor_pattern_head_requires_preview"
+spec = ["4.14:23"]
+real_std = true
+description = "A module-qualified inline type-constructor pattern head is gated behind the inline_type_ctor_paths preview feature; without it, E1100 rather than a raw parse error (RUE-947)"
+source = """
+const std = @import("std");
+fn main() -> i32 {
+    let ok = std.result.Result(i32, i32).Ok(40);
+    match ok {
+        std.result.Result(i32, i32).Ok(v) => v,
+        std.result.Result(i32, i32).Err(e) => e,
+    }
+}
+"""
+compile_fail = true
+error_contains = ["E1100", "inline_type_ctor_paths"]
+
+[[case]]
 name = "inline_type_ctor_enum_head_wide_payload_literal"
 spec = ["4.14:23"]
 preview = "inline_type_ctor_paths"

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -489,9 +489,12 @@ accepted with explicit (compile-time-known) arguments: a type-constructor call
 may head a struct literal (`Pair(i32) { first: 1, second: 2 }`), an
 associated-function or enum-variant call (`Result(i32, i32).Ok(v)`,
 `Vec(i32).new()`), and a match pattern (`match r { Result(i32, i32).Ok(v) => … }`).
-Each is evaluated exactly as if the call had been bound to a name first (as
-above); it is pure surface sugar and adds no new typing rule. Eliding the
-arguments (`Option(_).Some(5)`) is not part of this feature.
+The type constructor itself may be reached through a module path, so a
+module-qualified head is admitted in each of these positions, including the
+pattern head (`std.result.Result(i32, i32).Ok(v)`). Each is evaluated exactly as
+if the call had been bound to a name first (as above); it is pure surface sugar
+and adds no new typing rule. Eliding the arguments (`Option(_).Some(5)`) is not
+part of this feature.
 
 {{ rule(id="4.14:24", cat="normative") }}
 


### PR DESCRIPTION
Fixes the gap that reset RUE-598s stabilization clock: under `--preview inline_type_ctor_paths`, the pattern head worked only for locally-defined type functions — `std.result.Result(i32,i32).Ok(v)` in a match failed as a raw **ungated E0100**, because the pattern grammar checked for a ctor call only on the FIRST path segment and misread the type-argument list as variant payload bindings. Since every real-world use is module-qualified via `@import("std")`, the features core promise (no more alias pre-binding around matches) was unusable; the local-only spec case is why it shipped green.

**Parser** — after each path segment, a paren group followed by a `.` is the ctor call on that segment (paren-depth scan, same idiom as `directive_is_followed_by_let`); a terminal group remains the variants bindings. Local heads parse byte-identically.

**RIR** — the pattern ctor head now lowers module-qualified as a method call carrying the base (mirroring the construction head), so `resolve_pattern_enum` comptime-evaluates it to the same specialized enum, match arms unify, payload bindings work, and the existing E1100 preview gate fires instead of a parse error.

**Spec** — 4.14:23 prose admits the module-qualified head in every position; new spec cases (real_std module-qualified pattern head with payload-binding Ok/Err arms; a no-flag case pinning E1100-not-E0100) and a CLI case running the ruewc-shaped match end-to-end.

Verified: the filed repro exits 5 under the preview and produces E1100 only without it; spec comptime 186/0; CLI inline_type_ctor 7/0; quick green; full `./test.sh` green; an independent hand-written verification program (both arms, payload math) exits 73 exactly.

With this fixed, the RUE-598 pre-authorized stabilization gets its clean-cycle rerun.

Fixes RUE-947