### PR TITLE
RUE-924: audit that unfiltered test.sh actually ran every corpus harness

### DIFF
--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -237,6 +237,16 @@ if [[ "${1:-}" == "uquery" ]]; then
         root//:reproducible-programs \
         root//:spec-tests \
         root//:ui-tests
+elif [[ "${1:-}" == "test" ]]; then
+    # Emit buck2's per-test result line so the RUE-924 corpus-omission audit
+    # in test.sh sees each required harness actually ran. The heavy-labeled
+    # corpus suites arrive one at a time as "test root//:<suite>"; the
+    # non-heavy tutorial-snippet-tests runs inside the broad "test //..." pass.
+    if [[ "${2:-}" == "//..." ]]; then
+        printf 'Pass: root//:tutorial-snippet-tests (0.0s)\n'
+    else
+        printf 'Pass: %s (0.0s)\n' "${2:-}"
+    fi
 fi
 EOF
     chmod +x "$sb/buck2"

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -652,6 +652,76 @@ test_rue_unit_unknown_crate_errors_cleanly() {
   rm -rf "$sb"
 }
 
+# ===========================================================================
+# RUE-924 — an unfiltered test.sh must FAIL LOUDLY when a corpus harness is
+# silently omitted from the run's results, instead of reporting a green tally
+# on a partial run (a served cache entry, a narrowed target pattern, or a
+# platform gate once dropped //:cli-tests and let a Pass count hide five real
+# CLI-case failures CI later caught).
+# ===========================================================================
+
+# Drive a copy of the real test.sh (no filter) against a fake `./buck2` so the
+# corpus-omission audit is exercised without a real (~10-minute) suite. The
+# fake serves all three unfiltered-path invocations: the rue_heavy_suite
+# uquery (returns FAKE_HEAVY_SUITES), the broad `test //...` pass (one
+# unrelated pass line, exits FAKE_BUCK_EXIT), and each per-suite `test
+# <target>` run (a result line only when the target is in FAKE_PASS_TARGETS).
+test_testsh_unfiltered_audits_corpus_presence() {
+  local sb; sb="$(mktemp -d)"
+  cp "$SRC_ROOT/test.sh" "$sb/test.sh"; chmod +x "$sb/test.sh"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "uquery" ]; then
+  for t in $FAKE_HEAVY_SUITES; do printf '%s\n' "$t"; done
+  exit 0
+fi
+if [ "$1" = "test" ]; then
+  tgt="$2"
+  if [ "$tgt" = "//..." ]; then
+    printf 'Pass: root//crates/rue-lexer:rue-lexer-test (0.1s)\n'
+    printf 'Tests finished: Pass 1. Fail 0. Skip 0.\n'
+    exit "${FAKE_BUCK_EXIT:-0}"
+  fi
+  for t in $FAKE_PASS_TARGETS; do
+    if [ "$t" = "$tgt" ]; then printf 'Pass: root%s (0.1s)\n' "$t"; fi
+  done
+  printf 'Tests finished: Pass 1. Fail 0. Skip 0.\n'
+  exit 0
+fi
+exit 90
+EOF
+  chmod +x "$sb/buck2"
+
+  local all="//:cli-tests //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests"
+
+  # (1) Full corpus present + buck2 green -> test.sh reports success.
+  local rc=0 out
+  out="$(cd "$sb" && RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: unfiltered run with the full corpus reports success" \
+    "$([ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -Fxq '=== TEST SUITE: PASSED ===' && echo 0 || echo 1)"
+
+  # (2) A corpus harness OMITTED while every buck2 invocation still exits 0 is
+  #     the RUE-924 false-green: it must become a hard failure naming the suite.
+  local partial="//:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests"
+  rc=0
+  out="$(cd "$sb" && RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$partial" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: a silently omitted corpus harness fails the run" \
+    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "test.sh: the omission message names the missing harness" \
+    "$(printf '%s\n' "$out" | grep -Fq 'CORPUS OMITTED' && printf '%s\n' "$out" | grep -Fq '//:cli-tests' && echo 0 || echo 1)"
+  check "test.sh: an omitted-corpus run prints the failed sentinel" \
+    "$(printf '%s\n' "$out" | grep -Fq '=== TEST SUITE: FAILED' && echo 0 || echo 1)"
+
+  # (3) A genuine buck2 failure with the full corpus present is still
+  #     propagated verbatim (the audit must not mask real failures).
+  rc=0
+  out="$(cd "$sb" && RUE_FULL_SUITE_LOCK_HELD=1 FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" FAKE_BUCK_EXIT=17 ./test.sh 2>&1)" || rc=$?
+  check "test.sh: unfiltered buck2 failure exit code is propagated" \
+    "$([ "$rc" -eq 17 ] && echo 0 || echo 1)"
+
+  rm -rf "$sb"
+}
+
 # --- run everything ---------------------------------------------------------
 
 test_ruebin_build_failure_is_loud
@@ -667,6 +737,7 @@ test_rue_unit_maps_crate_and_forwards_args
 test_rue_unit_zero_match_fails_loud
 test_rue_unit_failing_test_propagates_exit
 test_rue_unit_unknown_crate_errors_cleanly
+test_testsh_unfiltered_audits_corpus_presence
 test_sanitizer_defaults_std_path
 test_sanitizer_recursive_discovery_contract
 test_sanitizer_status_contracts

--- a/test.sh
+++ b/test.sh
@@ -29,6 +29,17 @@ set -euo pipefail
 # When you pipe or capture this script's output, grep for that line instead of
 # trusting `$?`. (The tally text alone is not a verdict: a partial run can print
 # a green-looking count and still have failed a later gate.)
+#
+# CORPUS-OMISSION AUDIT (RUE-924). A green `buck2 test //...` summary is only
+# trustworthy if the compiler-consuming corpus harnesses (cli/spec/ui/oracle/
+# reproducibility/tutorial) actually EXECUTED. A suite that never ran cannot
+# fail, so the exit code alone cannot catch its disappearance — a served
+# test-result cache entry, an accidental target-pattern narrowing, or a
+# platform gate can all silently drop a suite, and one such omission once let a
+# Pass tally hide five real CLI-case failures that CI caught. The unfiltered
+# path therefore captures the run, streams it live, and asserts each required
+# corpus harness produced a Pass/Fail result line; a missing one is a HARD
+# failure even when buck2 exited 0.
 
 cd "$(dirname "$0")"
 repo_root="$PWD"
@@ -67,6 +78,20 @@ REPOSITORY_QUALITY_GATES=(
     //:adr-registry-validation
 )
 
+# The compiler-consuming corpus harnesses that an unfiltered run MUST actually
+# execute (RUE-924). Each compiles and/or runs real programs through the rue
+# binary, so a silent omission (cache, pattern narrowing, platform gate) is
+# exactly the failure that hides miscompilations behind a green tally. The
+# unfiltered path audits that every one of these produced a result line.
+REQUIRED_CORPUS_HARNESSES=(
+    //:cli-tests
+    //:spec-tests
+    //:ui-tests
+    //:oracle-diff-generated-smoke
+    //:reproducible-programs
+    //:tutorial-snippet-tests
+)
+
 if [[ $# -eq 0 ]]; then
     # Keep discovery broad so new crate and repository tests cannot disappear
     # behind a hand-maintained list. Heavy opaque harnesses are labeled in BUCK:
@@ -82,12 +107,48 @@ if [[ $# -eq 0 ]]; then
         exit 1
     fi
 
+    # Stream every invocation live AND capture it into one log, so we can audit
+    # afterward that no corpus harness was silently omitted (RUE-924).
+    # PIPESTATUS[0] is buck2's real exit code (tee always exits 0), preserving
+    # the RUE-579 "exit code is authoritative" contract; the worst status across
+    # the broad pass and every heavy suite is what this script reports.
+    run_log="$(mktemp)"
+    overall_status=0
+    set +e
     echo "Running unit tests and lightweight repository checks..."
-    ./buck2 test //... --exclude rue_heavy_suite --always-exclude
+    ./buck2 test //... --exclude rue_heavy_suite --always-exclude 2>&1 | tee "$run_log"
+    step_status=${PIPESTATUS[0]}
+    [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
     for suite in "${HEAVY_SUITES[@]}"; do
         echo "Running heavy suite $suite..."
-        ./buck2 test "$suite"
+        ./buck2 test "$suite" 2>&1 | tee -a "$run_log"
+        step_status=${PIPESTATUS[0]}
+        [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
     done
+    set -e
+
+    # buck2 prints exactly one "<Status>: root<target> (<time>)" summary line
+    # per executed test (Pass/Fail/Skip/Timeout/...), including cache hits. No
+    # such line for a required harness means it never ran under this invocation
+    # — neither in the broad pass nor as a heavy suite.
+    missing_corpus=()
+    for target in "${REQUIRED_CORPUS_HARNESSES[@]}"; do
+        if ! grep -qE "(Pass|Fail|Skip|Timeout|Fatal|Omit|Flaky): root${target} " "$run_log"; then
+            missing_corpus+=("$target")
+        fi
+    done
+    rm -f "${run_log:?}"
+
+    if [[ ${#missing_corpus[@]} -gt 0 ]]; then
+        echo "=== CORPUS OMITTED (RUE-924): ${missing_corpus[*]} ===" >&2
+        echo "test.sh: the corpus harness(es) above produced no Pass/Fail result in" >&2
+        echo "test.sh: this unfiltered run; refusing to report success on a partial" >&2
+        echo "test.sh: run. If a stale test-result cache is serving them, re-run with" >&2
+        echo "test.sh: a busted cache, e.g. './buck2 test //... --no-remote-cache'." >&2
+        exit 1
+    fi
+
+    exit "$overall_status"
 else
     # Unit tests live under //crates/...; the suite sh_tests are at the repo
     # root, so this scope keeps them out of the unfiltered step below.


### PR DESCRIPTION
A local unfiltered `./test.sh` once reported Pass 36/Fail 1 while the `//:cli-tests` corpus target never ran at all — and the same tree then failed five CLI cases in CI. The local full suite was false-green.

Investigation on this host could not reproduce the omission: the corpus targets are enumerated by `buck2 test //...` and the compiler is a properly **declared** dependency of `//:cli-tests` (the `$(exe_target)` env macro creates the `root//crates/rue:rue` edge, refuting the undeclared-input/false-cache theory). So the fix restores the invariant regardless of mechanism: **silent omission can never read as success again.**

The unfiltered path now streams every invocation through `tee` into one log (`PIPESTATUS` preserves the authoritative exit codes per RUE-579; the worst status across the broad pass and each heavy suite is what the script reports) and then audits that every compiler-consuming corpus harness produced a buck2 result line. A missing one is a hard `CORPUS OMITTED (RUE-924)` failure naming the suite, even when every buck2 invocation exited 0. Integrated with the `rue_heavy_suite` label split that landed on trunk — the audit covers the union of the broad pass and the per-suite runs.

Wrapper regression coverage drives a copy of the real `test.sh` against a fake `buck2` serving all three invocation shapes (uquery, broad pass, per-suite): full corpus → success with the PASSED sentinel; an omitted harness → hard failure naming `//:cli-tests` with the FAILED sentinel; a genuine buck2 failure exit code → propagated unmasked. Wrapper suite 53/53.

Fixes RUE-924