### PR TITLE
RUE-598: stabilize inline_type_ctor_paths — remove the preview gate

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -257,7 +257,7 @@ pub struct ConstraintGenerator<'a> {
     /// (the RUE-522 pattern).
     alias_scope_stack: Vec<Vec<(Spur, Option<Type>)>>,
     /// Inline type-constructor heads (`F(args).Variant(..)`, `F(args) { .. }`;
-    /// RUE-596, preview `inline_type_ctor_paths`) pre-reduced by sema to their
+    /// RUE-596, spec 4.14:23) pre-reduced by sema to their
     /// concrete struct/enum types, keyed by the head's own `InstRef` — the
     /// per-instruction analogue of `comptime_local_types` for heads that have
     /// no `let`-bound name. Consulted so construction arguments get their

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -142,38 +142,22 @@ impl<'a> BodySema<'a> {
                 .analyze_module_member_call_impl(air, module_id, method, args_range, span, ctx);
         }
 
-        // Inline type-constructor call head (RUE-596, preview
-        // `inline_type_ctor_paths`, relaxing spec 4.14:23): `F(args).NAME(..)`
-        // where `F(args)` reduced to a concrete type at comptime. Resolve
-        // `.NAME` as an enum-variant construction or associated-function call on
-        // the reduced type — exactly as if it had been bound with
-        // `let P = F(args); P.NAME(..)`. The receiver's stray `TypeConst` is a
-        // comptime-only no-op (CFG build drops it). Only a struct/enum reduced
-        // type takes this path; any other kind (e.g. `const X = i32; X.foo()`)
-        // falls through to the ordinary `MethodCallOnNonStruct` diagnostic, and
-        // the bound-name form (`let P = F(args); P.NAME`) never reaches here.
-        // Elided args (`Option(_)`) stay out of scope (RUE-401).
+        // Inline type-constructor call head (RUE-596, spec 4.14:23):
+        // `F(args).NAME(..)` where `F(args)` reduced to a concrete type at
+        // comptime. Resolve `.NAME` as an enum-variant construction or
+        // associated-function call on the reduced type — exactly as if it had
+        // been bound with `let P = F(args); P.NAME(..)`. The receiver's stray
+        // `TypeConst` is a comptime-only no-op (CFG build drops it). Only a
+        // struct/enum reduced type takes this path; any other kind (e.g.
+        // `const X = i32; X.foo()`) falls through to the ordinary
+        // `MethodCallOnNonStruct` diagnostic, and the bound-name form
+        // (`let P = F(args); P.NAME`) never reaches here. Elided args
+        // (`Option(_)`) stay out of scope (RUE-401).
         if receiver_type == Type::COMPTIME_TYPE
             && let AirInstData::TypeConst(reduced_ty) = air.get(receiver_result.air_ref).data
         {
-            // The preview gate covers exactly what RUE-596 added: a CALL as
-            // the path head (`F(args).NAME(..)`). A bare qualified member
-            // that merely evaluates to a type (`m.Alias.new()`) is ordinary
-            // module-member access and must not trip the call-head gate
-            // (RUE-631).
-            let receiver_is_call_head = matches!(
-                self.rir.get(receiver).data,
-                rue_rir::InstData::Call { .. } | rue_rir::InstData::MethodCall { .. }
-            );
             match reduced_ty.kind() {
                 TypeKind::Enum(enum_id) => {
-                    if receiver_is_call_head {
-                        self.require_preview(
-                            PreviewFeature::InlineTypeCtorPath,
-                            "an inline type-constructor call as a path head",
-                            span,
-                        )?;
-                    }
                     let variant_name = self.interner.resolve(&method).to_string();
                     let def = self.type_pool.enum_def(enum_id);
                     if let Some(vidx) = def.find_variant(&variant_name) {
@@ -197,13 +181,6 @@ impl<'a> BodySema<'a> {
                     ));
                 }
                 TypeKind::Struct(struct_id) => {
-                    if receiver_is_call_head {
-                        self.require_preview(
-                            PreviewFeature::InlineTypeCtorPath,
-                            "an inline type-constructor call as a path head",
-                            span,
-                        )?;
-                    }
                     return self.analyze_assoc_fn_call_impl(
                         air,
                         method,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use lasso::Spur;
 use rue_error::{
     CompileError, CompileResult, CompileWarning, ErrorKind, MissingFieldsError, OptionExt,
-    PreviewFeature, WarningKind,
+    WarningKind,
 };
 use rue_rir::{InstData, InstRef, RirParamMode, RirPatternView as RirPattern};
 
@@ -3477,14 +3477,9 @@ impl<'a> BodySema<'a> {
         let type_name_str = self.interner.resolve(&type_name);
         let struct_id = if let Some(head_ref) = ctor_head {
             // Inline type-constructor struct-literal head `F(args) { ... }`
-            // (RUE-596, preview `inline_type_ctor_paths`, relaxing spec 4.14:23):
-            // the head call reduces to a concrete type at comptime; construct as
-            // if the type had been bound to a name first (`let P = F(args); P { .. }`).
-            self.require_preview(
-                PreviewFeature::InlineTypeCtorPath,
-                "an inline type-constructor call as a struct-literal head",
-                span,
-            )?;
+            // (RUE-596, spec 4.14:23): the head call reduces to a concrete type
+            // at comptime; construct as if the type had been bound to a name
+            // first (`let P = F(args); P { .. }`).
             let head_result = self.analyze_inst(air, head_ref, ctx)?;
             let AirInstData::TypeConst(reduced_ty) = air.get(head_result.air_ref).data else {
                 return Err(CompileError::new(
@@ -6416,16 +6411,11 @@ impl<'a> BodySema<'a> {
         span: Span,
     ) -> CompileResult<Option<(crate::types::EnumId, bool)>> {
         // Inline type-constructor pattern head `F(args).Variant(..)` (RUE-596,
-        // preview `inline_type_ctor_paths`): comptime-evaluate the constructor
-        // call to a concrete type (no AIR emitted) and take its enum. The head
-        // arrived through a call, not by naming the enum, so it is privacy-exempt
-        // — reported as `privacy_handled = true`, exactly like a comptime binding.
+        // spec 4.14:23): comptime-evaluate the constructor call to a concrete
+        // type (no AIR emitted) and take its enum. The head arrived through a
+        // call, not by naming the enum, so it is privacy-exempt — reported as
+        // `privacy_handled = true`, exactly like a comptime binding.
         if let Some(head_ref) = ctor_head {
-            self.require_preview(
-                PreviewFeature::InlineTypeCtorPath,
-                "an inline type-constructor call as a pattern head",
-                span,
-            )?;
             // Unlike the inference prepass, this is the authoritative pattern
             // resolver. Preserve hard source diagnostics from comptime call
             // reduction (including exact argument-mode errors) instead of

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -50,7 +50,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 use lasso::Spur;
-use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
+use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_rir::{InstData, InstRef, RepeatCount};
 use rue_span::{FileId, Span};
 
@@ -2090,7 +2090,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     }
 
     /// Pre-reduce inline type-constructor heads (`F(args).Variant(..)`,
-    /// `F(args) { .. }`; RUE-596, preview `inline_type_ctor_paths`) to their
+    /// `F(args) { .. }`; RUE-596, spec 4.14:23) to their
     /// concrete struct/enum types before HM inference runs (RUE-599).
     ///
     /// The constraint generator has no comptime interpreter, so an inline
@@ -2112,9 +2112,8 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     /// inert. `comptime_local_types` carries the body's `let`-bound type
     /// aliases so a head like `Result(T, i32)` with `let T = i64;` reduces.
     ///
-    /// Gated on the preview feature so non-preview compiles pay nothing;
-    /// when `inline_type_ctor_paths` stabilizes (RUE-598), remove the gate
-    /// and cache the candidate scan if it shows up in `--time-passes`.
+    /// Runs on every compile (inline type-constructor heads are stable since
+    /// RUE-598). Cache the candidate scan if it shows up in `--time-passes`.
     ///
     /// [`precompute_comptime_type_locals`]: Sema::precompute_comptime_type_locals
     pub(crate) fn precompute_inline_ctor_head_types(
@@ -2123,12 +2122,6 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         value_subst: Option<&HashMap<Spur, ConstValue>>,
         comptime_local_types: &HashMap<Spur, Type>,
     ) -> HashMap<InstRef, Type> {
-        if !self
-            .preview_features
-            .contains(&PreviewFeature::InlineTypeCtorPath)
-        {
-            return HashMap::new();
-        }
         // A head is the receiver of a `.NAME(..)` path whose receiver is
         // itself a call (`F(args).Ok(x)`, or module-qualified
         // `m.F(args).Ok(x)`, which RIR spells as a nested MethodCall), or a

--- a/crates/rue-cli-tests/cases/const_alias_inference.toml
+++ b/crates/rue-cli-tests/cases/const_alias_inference.toml
@@ -203,7 +203,7 @@ exit_code = 42
 
 [[case]]
 name = "bare_alias_head_needs_no_preview"
-description = "m.Alias.new() is ordinary member access, not an inline type-ctor CALL head — must compile without --preview inline_type_ctor_paths (RUE-631)"
+description = "m.Alias.new() is ordinary member access, not an inline type-ctor CALL head, and compiles on its own (RUE-631)"
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [
     { path = "main.rue", source = """
@@ -223,20 +223,21 @@ pub const Ints = std.arraybuf.ArrayBuf(i64);
 exit_code = 42
 
 [[case]]
-name = "real_inline_ctor_head_still_gated"
-description = "The genuine RUE-596 shape (a CALL as path head) remains preview-gated after the RUE-631 narrowing"
+name = "real_inline_ctor_head_runs"
+description = "The genuine RUE-596 shape (a CALL as path head) compiles with no preview flag, unlike the bare-alias member access above (RUE-631, stabilized RUE-598)"
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
-compile_fail = true
-error_contains = ["E1100", "inline_type_ctor_paths"]
 files = [
     { path = "main.rue", source = """
 const std = @import("std");
 fn main() -> i32 {
-    let r = std.result.Result(i64, i32).Ok(41);
+    let r = std.result.Result(i32, i32).Ok(41);
+    let _ = r;
     0
 }
 """ },
 ]
+exit_code = 0
 
 [[case]]
 name = "generic_instantiated_with_qualified_type_arg_in_const"

--- a/crates/rue-cli-tests/cases/inline_type_ctor_expr_head.toml
+++ b/crates/rue-cli-tests/cases/inline_type_ctor_expr_head.toml
@@ -1,20 +1,19 @@
-# Inline type-constructor call as an EXPRESSION head (RUE-596, preview
-# `inline_type_ctor_paths`, relaxing spec 4.14:23): `F(args).NAME(..)` where
-# `F(args)` reduces to a concrete type at comptime, used directly as an
-# enum-variant construction (`Result(i32,i32).Ok(42)`) or an associated-function
-# call (`Counter(i32).zero()`) without binding the specialization to a name
-# first. Gated: absent `--preview` it is E1100. This is the expression-head
-# slice of the feature; the struct-literal head and pattern head land separately.
+# Inline type-constructor call as an EXPRESSION head (RUE-596, spec 4.14:23):
+# `F(args).NAME(..)` where `F(args)` reduces to a concrete type at comptime, used
+# directly as an enum-variant construction (`Result(i32,i32).Ok(42)`) or an
+# associated-function call (`Counter(i32).zero()`) without binding the
+# specialization to a name first. Accepted with no preview flag (stabilized
+# RUE-598); the struct-literal head and pattern head are exercised alongside it.
 
 [section]
 id = "cli.inline_type_ctor_expr_head"
 name = "Inline type-constructor expression head"
-description = "`F(args).Variant(..)` / `F(args).assoc(..)` as an expression head, preview-gated (RUE-596)."
+description = "`F(args).Variant(..)` / `F(args).assoc(..)` as an expression head (RUE-596)."
 
 [[case]]
 name = "enum_variant_head_runs"
 description = "`Result(i32,i32).Ok(42)` constructs an enum variant inline; `?`-free round-trip through a match."
-args = ["main.rue", "--preview", "inline_type_ctor_paths", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn main() -> i32 {
@@ -28,7 +27,7 @@ exit_code = 42
 [[case]]
 name = "struct_assoc_fn_head_runs"
 description = "`Counter(i32).zero()` calls an associated function on an inline type-constructor head."
-args = ["main.rue", "--preview", "inline_type_ctor_paths", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn Counter(comptime T: type) -> type {
     struct {
@@ -46,8 +45,9 @@ fn main() -> i32 {
 exit_code = 2
 
 [[case]]
-name = "gated_without_preview"
-description = "Without --preview the inline head is rejected with the E1100 preview-required diagnostic."
+name = "inline_head_accepted_without_flag"
+description = "The inline enum-variant head compiles with no preview flag (stabilized RUE-598)."
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn main() -> i32 {
@@ -55,12 +55,12 @@ fn main() -> i32 {
     0
 }
 """ }]
-compile_fail = true
-error_contains = ["E1100", "inline_type_ctor_paths"]
+exit_code = 0
 
 [[case]]
-name = "bound_name_form_needs_no_preview"
-description = "The bind-first form stays legal without the flag — the gate is scoped to the inline head only."
+name = "bound_name_form_still_runs"
+description = "The equivalent bind-first form (`let R = F(args); R.Ok(..)`) runs identically."
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn main() -> i32 {
@@ -74,7 +74,7 @@ exit_code = 42
 [[case]]
 name = "all_three_heads_one_program"
 description = "Struct-literal head, enum-variant head, and pattern head together, driven through the real binary (RUE-596)."
-args = ["main.rue", "--preview", "inline_type_ctor_paths", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }

--- a/crates/rue-cli-tests/cases/inline_type_ctor_module_qualified_pattern_head.toml
+++ b/crates/rue-cli-tests/cases/inline_type_ctor_module_qualified_pattern_head.toml
@@ -1,21 +1,20 @@
 # Module-qualified inline type-constructor call as a PATTERN head (RUE-947,
-# preview `inline_type_ctor_paths`, relaxing spec 4.14:23). The construction head
-# `std.result.Result(F, FE).Ok(x)` already worked under the preview (RUE-596);
-# the matching PATTERN head `std.result.Result(F, FE).Ok(v) => ..` previously
-# failed with a raw E0100 parse error regardless of the flag. It now parses and
-# flows through the same preview gate as the local head, resolving to the same
-# specialized enum so match arms unify. Driven end-to-end through the real binary
-# against the real standard library.
+# spec 4.14:23). The construction head `std.result.Result(F, FE).Ok(x)` already
+# worked (RUE-596); the matching PATTERN head `std.result.Result(F, FE).Ok(v) =>
+# ..` previously failed with a raw E0100 parse error. It now parses and resolves
+# to the same specialized enum so match arms unify. Accepted with no preview flag
+# (stabilized RUE-598). Driven end-to-end through the real binary against the
+# real standard library.
 
 [section]
 id = "cli.inline_type_ctor_module_qualified_pattern_head"
 name = "Module-qualified inline type-constructor pattern head"
-description = "`std.result.Result(F, FE).Ok(v) => ..` as a match pattern head, preview-gated, against real std (RUE-947)."
+description = "`std.result.Result(F, FE).Ok(v) => ..` as a match pattern head, against real std (RUE-947)."
 
 [[case]]
 name = "module_qualified_pattern_head_runs"
 description = "A ruewc-style match over `std.result.Result(F, FE)` binds both variant payloads through module-qualified pattern heads."
-args = ["main.rue", "--preview", "inline_type_ctor_paths", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -39,8 +38,9 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "module_qualified_pattern_head_gated_without_preview"
-description = "Without --preview the module-qualified head is rejected with the E1100 preview-required diagnostic, not a raw E0100 parse error."
+name = "module_qualified_pattern_head_accepted_without_flag"
+description = "The module-qualified pattern head compiles and runs with no preview flag (stabilized RUE-598)."
+args = ["main.rue", "-o", "prog"]
 env = { RUE_STD_PATH = "${REAL_STD}" }
 files = [{ path = "main.rue", source = """
 const std = @import("std");
@@ -52,5 +52,4 @@ fn main() -> i32 {
     }
 }
 """ }]
-compile_fail = true
-error_contains = ["E1100", "inline_type_ctor_paths"]
+exit_code = 40

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8081,19 +8081,26 @@ mod tests {
 
     /// Generate `QUERY_TERMINAL_RETENTION_LIMIT + 1` distinct `CompileOptions`
     /// for terminal retention/eviction tests (one more key than the store can
-    /// hold, forcing exactly one eviction). Preview-feature subsets supply the
-    /// low bits; because there are now fewer preview features than the
-    /// `ceil(log2(LIMIT + 1))` bits the mask spans, the first bit above the
-    /// feature range toggles the compile target so every mask stays a distinct
-    /// cache key. Both `target` and the preview-feature set are part of the
-    /// semantic, definition, and dependency-manifest query keys.
+    /// hold, forcing exactly one eviction). The low `feature_bits` bits of each
+    /// mask pick a preview-feature subset; the remaining high bits index the
+    /// compile target, so every mask is a distinct `(preview_features, target)`
+    /// pair. Both dimensions are part of the semantic, definition, and
+    /// dependency-manifest query keys — unlike `opt_level`, which keys only the
+    /// semantic store — so the variants force one eviction in every terminal
+    /// family under test.
+    ///
+    /// With fewer preview features than the bits the mask spans, one target is
+    /// not enough distinct keys (`2^feature_bits < LIMIT + 1`), so the target
+    /// list carries the overflow. Each `feature_bits`-wide block of masks maps
+    /// to one target, and the assertion holds that the mask range spans no more
+    /// blocks than there are targets.
     fn retention_variants() -> Vec<CompileOptions> {
         let feature_bits = PreviewFeature::all().len();
-        let default_target = CompileOptions::default().target;
-        let alt_target = *Target::all()
-            .iter()
-            .find(|&&target| target != default_target)
-            .expect("multiple compiler targets");
+        let targets = Target::all();
+        assert!(
+            (QUERY_TERMINAL_RETENTION_LIMIT >> feature_bits) < targets.len(),
+            "retention variants need a distinct (preview_features, target) key per mask"
+        );
         (0..=QUERY_TERMINAL_RETENTION_LIMIT)
             .map(|mask| CompileOptions {
                 preview_features: PreviewFeature::all()
@@ -8102,11 +8109,7 @@ mod tests {
                     .filter(|(bit, _)| mask & (1 << bit) != 0)
                     .map(|(_, feature)| *feature)
                     .collect(),
-                target: if mask & (1 << feature_bits) != 0 {
-                    alt_target
-                } else {
-                    default_target
-                },
+                target: targets[mask >> feature_bits],
                 ..CompileOptions::default()
             })
             .collect()

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -512,14 +512,6 @@ pub enum PreviewFeature {
     /// collection/string trio. Gated until the fat-pointer ABI lands on both
     /// backends.
     Slices,
-    /// Inline type-constructor call heads (RUE-596, relaxing spec 4.14:23): a
-    /// type-constructor call with explicit comptime args used directly as a
-    /// struct-literal head (`Pair(i32) { .. }`), an associated-function / enum-
-    /// variant head (`Result(i32, i32).Ok(v)`), or a pattern head
-    /// (`match r { Result(i32, i32).Ok(v) => .. }`). Reduces to today's
-    /// bind-first form (`let P = F(args); P.NAME`). Elided args (`Option(_)`)
-    /// remain out of scope (RUE-401).
-    InlineTypeCtorPath,
     /// Raw physical-byte heap and memory access intrinsics (RUE-879). These
     /// operations intentionally bypass Rue's slot-sized typed-pointer model so
     /// source-defined packed representations can use the runtime byte ABI.
@@ -545,7 +537,6 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::Slices => "slices",
-            PreviewFeature::InlineTypeCtorPath => "inline_type_ctor_paths",
             PreviewFeature::RawBytes => "raw_bytes",
         }
     }
@@ -556,7 +547,6 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::Slices => "ADR-0043",
-            PreviewFeature::InlineTypeCtorPath => "ADR-0025",
             PreviewFeature::RawBytes => "RUE-879",
         }
     }
@@ -566,7 +556,6 @@ impl PreviewFeature {
         &[
             PreviewFeature::TestInfra,
             PreviewFeature::Slices,
-            PreviewFeature::InlineTypeCtorPath,
             PreviewFeature::RawBytes,
         ]
     }
@@ -592,7 +581,6 @@ impl std::str::FromStr for PreviewFeature {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "slices" => Ok(PreviewFeature::Slices),
-            "inline_type_ctor_paths" => Ok(PreviewFeature::InlineTypeCtorPath),
             "raw_bytes" => Ok(PreviewFeature::RawBytes),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
@@ -2589,10 +2577,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(
-            names,
-            "test_infra, slices, inline_type_ctor_paths, raw_bytes"
-        );
+        assert_eq!(names, "test_infra, slices, raw_bytes");
     }
 
     #[test]
@@ -2669,15 +2654,16 @@ mod tests {
 
     #[test]
     fn test_preview_feature_stabilized_are_unknown() {
-        // for_loops, method_receivers, enum_payloads, array_repeat, and
-        // field_init_shorthand were stabilized (no longer gated) — their names
-        // must now be rejected.
+        // for_loops, method_receivers, enum_payloads, array_repeat,
+        // field_init_shorthand, and inline_type_ctor_paths were stabilized (no
+        // longer gated) — their names must now be rejected.
         for name in [
             "for_loops",
             "method_receivers",
             "enum_payloads",
             "array_repeat",
             "field_init_shorthand",
+            "inline_type_ctor_paths",
         ] {
             assert!(
                 name.parse::<PreviewFeature>().is_err(),

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -812,8 +812,8 @@ pub struct PathPattern {
     /// The type name (e.g., `Color`)
     pub type_name: Ident,
     /// Inline type-constructor arguments when the pattern head is a
-    /// type-constructor call, e.g. `Result(i32, i32).Ok(v)` (RUE-596, preview
-    /// `inline_type_ctor_paths`, relaxing spec 4.14:23). When `Some`, `type_name`
+    /// type-constructor call, e.g. `Result(i32, i32).Ok(v)` (RUE-596,
+    /// spec 4.14:23). When `Some`, `type_name`
     /// is the constructor function and these are its comptime arguments; the
     /// pattern's enum type is the reduction of `type_name(ctor_args)`. `None`
     /// for an ordinary `Enum.Variant` pattern.
@@ -910,8 +910,8 @@ pub struct StructLitExpr {
     /// Struct type name
     pub name: Ident,
     /// Inline type-constructor arguments when the head is a type-constructor
-    /// call, e.g. `Pair(i32) { ... }` (RUE-596, preview `inline_type_ctor_paths`,
-    /// relaxing spec 4.14:23). When `Some`, `name` is the constructor function
+    /// call, e.g. `Pair(i32) { ... }` (RUE-596, spec 4.14:23). When `Some`,
+    /// `name` is the constructor function
     /// and these are its comptime arguments; the literal's struct type is the
     /// reduction of `name(ctor_args)`. `None` for an ordinary `Name { ... }`.
     pub ctor_args: Option<Vec<CallArg>>,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -352,7 +352,7 @@ pub enum RirPattern {
         module: Option<InstRef>,
         /// Optional inline type-constructor call head — the instruction that
         /// reduces to the enum type at comptime for `F(args).Variant(..)`
-        /// (RUE-596, preview `inline_type_ctor_paths`). When `Some`, the enum is
+        /// (RUE-596, spec 4.14:23). When `Some`, the enum is
         /// the reduction of this head and `type_name` is only the constructor
         /// function's name; `None` for an ordinary `Enum.Variant` pattern.
         ctor_head: Option<InstRef>,
@@ -3439,7 +3439,7 @@ pub enum InstData {
         module: Option<InstRef>,
         /// Optional inline type-constructor call head — the instruction that
         /// reduces to the struct type at comptime for `F(args) { ... }` (RUE-596,
-        /// preview `inline_type_ctor_paths`). When `Some`, the struct type is
+        /// spec 4.14:23). When `Some`, the struct type is
         /// the reduction of this head and `type_name` is only the constructor
         /// function's name (kept for diagnostics); `None` for `Name { ... }`.
         ctor_head: Option<InstRef>,

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2211,9 +2211,9 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "type_constructor_struct_literal_head_requires_preview"
+name = "inline_type_ctor_struct_literal_head_accepted"
 spec = ["4.14:23"]
-description = "An inline type-constructor struct-literal head F(args) { ... } is gated behind the inline_type_ctor_paths preview feature; without it, E1100 (RUE-596)"
+description = "An inline type-constructor struct-literal head F(args) { ... } is accepted with no preview flag (RUE-596, stabilized RUE-598)"
 source = """
 fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
 fn main() -> i32 {
@@ -2221,15 +2221,12 @@ fn main() -> i32 {
     p.first
 }
 """
-compile_fail = true
-error_contains = ["E1100", "inline_type_ctor_paths"]
+exit_code = 1
 
 [[case]]
 name = "inline_type_ctor_struct_literal_head"
 spec = ["4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
-description = "Under the preview, a type-constructor call heads a struct literal: Pair(i32) { ... } (RUE-596)"
+description = "A type-constructor call heads a struct literal: Pair(i32) { ... } (RUE-596)"
 source = """
 fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
 fn main() -> i32 {
@@ -2242,9 +2239,7 @@ exit_code = 42
 [[case]]
 name = "inline_type_ctor_enum_variant_head"
 spec = ["4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
-description = "Under the preview, a type-constructor call heads an enum-variant construction: Result(i32, i32).Ok(v) (RUE-596)"
+description = "A type-constructor call heads an enum-variant construction: Result(i32, i32).Ok(v) (RUE-596)"
 source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn main() -> i32 {
@@ -2258,9 +2253,7 @@ exit_code = 42
 [[case]]
 name = "inline_type_ctor_assoc_fn_head"
 spec = ["4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
-description = "Under the preview, a type-constructor call heads an associated-function call: Counter(i32).zero() (RUE-596)"
+description = "A type-constructor call heads an associated-function call: Counter(i32).zero() (RUE-596)"
 source = """
 fn Counter(comptime T: type) -> type {
     struct {
@@ -2279,9 +2272,7 @@ exit_code = 42
 [[case]]
 name = "inline_type_ctor_pattern_head"
 spec = ["4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
-description = "Under the preview, a type-constructor call heads a match pattern: match r { Result(i32, i32).Ok(v) => .. } (RUE-596)"
+description = "A type-constructor call heads a match pattern: match r { Result(i32, i32).Ok(v) => .. } (RUE-596)"
 source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn main() -> i32 {
@@ -2297,8 +2288,6 @@ exit_code = 42
 [[case]]
 name = "inline_type_ctor_pattern_head_propagates_argument_mode_error"
 spec = ["4.10:3", "4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
 description = "The authoritative inline pattern-head reducer propagates an exact argument-mode error instead of degrading it to an unresolved-pattern diagnostic (RUE-634)"
 source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
@@ -2316,10 +2305,8 @@ error_contains = "[E0209]"
 [[case]]
 name = "inline_type_ctor_module_qualified_pattern_head"
 spec = ["4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
 real_std = true
-description = "Under the preview, a module-qualified type-constructor call heads a match pattern: match r { std.result.Result(i32, i32).Ok(v) => .. } (RUE-947)"
+description = "A module-qualified type-constructor call heads a match pattern: match r { std.result.Result(i32, i32).Ok(v) => .. } (RUE-947)"
 source = """
 const std = @import("std");
 fn main() -> i32 {
@@ -2339,10 +2326,10 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "module_qualified_type_ctor_pattern_head_requires_preview"
+name = "module_qualified_type_ctor_pattern_head_accepted"
 spec = ["4.14:23"]
 real_std = true
-description = "A module-qualified inline type-constructor pattern head is gated behind the inline_type_ctor_paths preview feature; without it, E1100 rather than a raw parse error (RUE-947)"
+description = "A module-qualified inline type-constructor pattern head is accepted with no preview flag (RUE-947, stabilized RUE-598)"
 source = """
 const std = @import("std");
 fn main() -> i32 {
@@ -2353,14 +2340,11 @@ fn main() -> i32 {
     }
 }
 """
-compile_fail = true
-error_contains = ["E1100", "inline_type_ctor_paths"]
+exit_code = 40
 
 [[case]]
 name = "inline_type_ctor_enum_head_wide_payload_literal"
 spec = ["4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
 description = "An integer payload literal on an inline enum-variant head is typed at the declared payload type, not defaulted to i32: Result(i64, i32).Ok(41) (RUE-599)"
 source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
@@ -2378,8 +2362,6 @@ exit_code = 42
 [[case]]
 name = "inline_type_ctor_enum_head_payload_literal_range_checked"
 spec = ["4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
 description = "An integer payload literal on an inline enum-variant head is range-checked at the declared payload width: Wrap(u8).Some(300) is E0800 (RUE-599)"
 source = """
 fn Wrap(comptime T: type) -> type { enum { Some(T), None } }
@@ -2395,8 +2377,6 @@ error_contains = ["E0800", "u8"]
 [[case]]
 name = "inline_type_ctor_assoc_fn_head_wide_param_literal"
 spec = ["4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
 description = "An integer argument literal on an inline assoc-fn head is typed at the declared parameter type, not defaulted to i32: Box(u64).make(8) (RUE-599)"
 source = """
 fn Box(comptime T: type) -> type {
@@ -2415,8 +2395,6 @@ exit_code = 42
 [[case]]
 name = "inline_type_ctor_struct_literal_head_wide_field_literal"
 spec = ["4.14:23"]
-preview = "inline_type_ctor_paths"
-preview_should_pass = true
 description = "An integer field-initializer literal on an inline struct-literal head is typed at the declared field type: Pair(i64) { ... } (RUE-599)"
 source = """
 fn Pair(comptime T: type) -> type { struct { first: T, second: T } }

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -477,24 +477,18 @@ fn main() -> i32 {
 }
 ```
 
-By default a type-constructor call is a type, not a path expression: the forms
-`F(args) { … }` (a struct literal) and `F(args).NAME` (an associated item or
-enum variant) are not accepted, because a call expression is not a permitted
-struct-literal or pattern path. Bind the resulting type to a name first — with
-`let P = F(args);` — and use that name as the path in expression and pattern
-position (`P { … }`, `P.NAME`).
-
-Under the `inline_type_ctor_paths` preview feature these inline forms are
-accepted with explicit (compile-time-known) arguments: a type-constructor call
-may head a struct literal (`Pair(i32) { first: 1, second: 2 }`), an
-associated-function or enum-variant call (`Result(i32, i32).Ok(v)`,
-`Vec(i32).new()`), and a match pattern (`match r { Result(i32, i32).Ok(v) => … }`).
-The type constructor itself may be reached through a module path, so a
-module-qualified head is admitted in each of these positions, including the
-pattern head (`std.result.Result(i32, i32).Ok(v)`). Each is evaluated exactly as
-if the call had been bound to a name first (as above); it is pure surface sugar
-and adds no new typing rule. Eliding the arguments (`Option(_).Some(5)`) is not
-part of this feature.
+A type-constructor call may also be used directly as a path head, with explicit
+(compile-time-known) arguments. It may head a struct literal
+(`Pair(i32) { first: 1, second: 2 }`), an associated-function or enum-variant
+call (`Result(i32, i32).Ok(v)`, `Vec(i32).new()`), and a match pattern
+(`match r { Result(i32, i32).Ok(v) => … }`). The type constructor itself may be
+reached through a module path, so a module-qualified head is admitted in each of
+these positions, including the pattern head (`std.result.Result(i32, i32).Ok(v)`).
+Each is evaluated exactly as if the call had been bound to a name first — with
+`let P = F(args);` and then `P { … }` or `P.NAME`, which remains an equivalent
+spelling — so the inline form is pure surface sugar and adds no new typing rule.
+Eliding the arguments (`Option(_).Some(5)`) is not accepted: the arguments must
+be written explicitly.
 
 {{ rule(id="4.14:24", cat="normative") }}
 


### PR DESCRIPTION
Executes the stabilization Steve pre-authorized on 2026-07-16, whose condition — one clean dogfood cycle with zero feature bugs — was met today: a real program rewritten with inline ctor paths at every opportunity exercised **14 feature sites (3 construction, 1 assoc-fn, 10 module-qualified pattern heads), 14 worked, 0 failed** (evidence on the issue). Measured payoff: enum-alias preambles per program drop to zero; total alias lines 11 → 4 (the remainder is the separate RUE-948 comptime-arg tax).

**Removed:** the `PreviewFeature` variant and its arms; **five** gate sites in sema (the four known `require_preview` calls plus a `comptime_eval` precompute early-return whose own comment scheduled its removal here); the now-dead `receiver_is_call_head` discriminator. Spec 4.14:23 rewritten as the normative rule (module-qualified heads included, per RUE-947); all preview annotations dropped from spec/CLI cases; three gate cases converted to positive.

**Session eviction tests:** dropping to three preview features shrank the old cache-key mask scheme below the required 17 distinct keys, and `opt_level` cannot substitute — it is absent from the manifest/definition query keys. `retention_variants()` now indexes the compile target by the mask high bits (8 subsets × 3 targets = 24 keys) with an assertion guarding future feature-count drops.

**Exposed along the way** (pre-existing, out of scope, follow-up to be filed): module-qualified inline enum-variant heads dont widen integer-literal payloads (`std.result.Result(i64, i32).Ok(41)` → E0206) though the local form does — the RUE-599 class, previously masked by the gate.

Verified: quick 30/0; spec comptime 186/0; CLI inline_type_ctor 7/7, const_alias 16/16; the three eviction tests green; oracle corpus 646 agreements; a no-flag end-to-end program using every head form exits 44; full `./test.sh` green.

Fixes RUE-598