### PR TITLE
RUE-950: widen literal payloads through module-qualified inline enum heads

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2679,11 +2679,36 @@ impl<'a> ConstraintGenerator<'a> {
                     // Receiver still a type variable: sema resolves the
                     // receiver and diagnoses later (mirrors FieldGet's
                     // fallback, RUE-126/RUE-119).
+                    //
+                    // Exception: a module-qualified inline type-constructor
+                    // head (`std.result.Result(i64, i32).Ok(41)`, RUE-950)
+                    // reaches the outer construction with a `Var` receiver —
+                    // its inner generic module-member call yields a fresh
+                    // variable, not `COMPTIME_TYPE`, so the arm above never
+                    // fires (the local `Result(i64, i32).Ok(41)` form does
+                    // reach it, its receiver being a plain `Call`). Sema
+                    // pre-reduced the head in `inline_ctor_head_types` keyed
+                    // by the receiver `InstRef` regardless of resolution
+                    // route, so constrain the construction's arguments against
+                    // the reduced variant-payload / assoc-fn signature here —
+                    // the same expectation-threading as the local form
+                    // (RUE-599). Without it the payload literal stayed
+                    // unconstrained, defaulted to i32, and failed a wider
+                    // declared payload type with E0206.
                     _ => {
-                        for arg in call_args.iter() {
-                            self.generate(arg.value, ctx);
+                        if let Some(reduced) = self
+                            .inline_ctor_head_types
+                            .and_then(|heads| heads.get(receiver).copied())
+                            && let Some(result) =
+                                self.generate_call_on_reduced_type(reduced, *method, args, ctx)
+                        {
+                            result
+                        } else {
+                            for arg in call_args.iter() {
+                                self.generate(arg.value, ctx);
+                            }
+                            InferType::Var(self.fresh_var())
                         }
-                        InferType::Var(self.fresh_var())
                     }
                 };
 

--- a/crates/rue-cli-tests/cases/inline_type_ctor_module_qualified_pattern_head.toml
+++ b/crates/rue-cli-tests/cases/inline_type_ctor_module_qualified_pattern_head.toml
@@ -53,3 +53,26 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 40
+
+# A wide integer payload literal on the module-qualified construction head must
+# be typed at the declared i64 payload width, not defaulted to i32. The local
+# `Result(i64, i32).Ok(41)` form was fixed in RUE-599; the module-qualified route
+# (which resolves the head through the nested method-call path RUE-947 wired) was
+# still dropping the expectation and failing with E0206 until RUE-950. Driven
+# end-to-end through the real binary and real std.
+[[case]]
+name = "module_qualified_head_wide_payload_literal_runs"
+description = "`std.result.Result(i64, i32).Ok(41)` widens the payload literal to i64 end-to-end (RUE-950)."
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let r = std.result.Result(i64, i32).Ok(41);
+    match r {
+        std.result.Result(i64, i32).Ok(v) => if v == 41 { 42 } else { 1 },
+        std.result.Result(i64, i32).Err(e) => e,
+    }
+}
+""" }]
+exit_code = 42

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2329,18 +2329,52 @@ exit_code = 42
 name = "module_qualified_type_ctor_pattern_head_accepted"
 spec = ["4.14:23"]
 real_std = true
-description = "A module-qualified inline type-constructor pattern head is accepted with no preview flag (RUE-947, stabilized RUE-598)"
+description = "A module-qualified inline type-constructor pattern head is accepted with no preview flag; the i64 payload literal is pinned to the declared width, not defaulted to i32 (RUE-947, stabilized RUE-598, wide-literal fixed RUE-950)"
 source = """
 const std = @import("std");
 fn main() -> i32 {
-    let ok = std.result.Result(i32, i32).Ok(40);
+    let ok = std.result.Result(i64, i32).Ok(40);
     match ok {
-        std.result.Result(i32, i32).Ok(v) => v,
-        std.result.Result(i32, i32).Err(e) => e,
+        std.result.Result(i64, i32).Ok(v) => if v == 40 { 40 } else { 1 },
+        std.result.Result(i64, i32).Err(e) => e,
     }
 }
 """
 exit_code = 40
+
+[[case]]
+name = "module_qualified_inline_enum_head_wide_payload_literal"
+spec = ["4.14:23"]
+real_std = true
+description = "An integer payload literal on a module-qualified inline enum-variant head is typed at the declared payload type, not defaulted to i32: std.result.Result(i64, i32).Ok(41) — the module-qualified analogue of the local RUE-599 fix (RUE-950)"
+source = """
+const std = @import("std");
+fn main() -> i32 {
+    let r = std.result.Result(i64, i32).Ok(41);
+    match r {
+        std.result.Result(i64, i32).Ok(v) => if v == 41 { 42 } else { 1 },
+        std.result.Result(i64, i32).Err(e) => e,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "module_qualified_inline_enum_head_u64_payload_literal"
+spec = ["4.14:23"]
+real_std = true
+description = "An integer payload literal on a module-qualified inline enum-variant head widens to an unsigned declared payload type: std.result.Result(u64, i32).Ok(41) (RUE-950)"
+source = """
+const std = @import("std");
+fn main() -> i32 {
+    let r = std.result.Result(u64, i32).Ok(41);
+    match r {
+        std.result.Result(u64, i32).Ok(v) => if v == 41 { 42 } else { 1 },
+        std.result.Result(u64, i32).Err(e) => e,
+    }
+}
+"""
+exit_code = 42
 
 [[case]]
 name = "inline_type_ctor_enum_head_wide_payload_literal"


### PR DESCRIPTION
Fixes the literal-typing gap the RUE-598 stabilization exposed: `std.result.Result(i64, i32).Ok(41)` failed E0206 while the local form widened correctly.

**Root cause** — the two resolution routes land in different arms of the MethodCall inference handler. The local head (plain Call receiver → COMPTIME_TYPE) consults `inline_ctor_head_types` and threads the declared payload type onto argument literals (the RUE-599 fix); the module-qualified head (nested MethodCall receiver → fresh inference variable) fell into the catch-all arm that visited arguments unconstrained. The sema pre-pass had already reduced qualified heads into the map — the arm just never looked.

**Fix** — the Var-receiver fallback arm now consults the map and routes through the same `generate_call_on_reduced_type` helper, gated on map membership so ordinary value-method chains are untouched. One lookup closes the whole family: Ok-side, Err-side, u64 payloads, and qualified assoc-fn argument literals. The one remaining member — the module-qualified **struct-literal** head, which fails at *parse* — is filed as RUE-951.

Tests: the filed repro (i64) and a u64 variant as spec cases; the module-qualified pattern-head case upgraded from i32 to a pinned wide i64 payload; a CLI case running a wide-payload qualified head end-to-end. spec comptime 188/0; CLI inline_type_ctor 8/0; quick 30/0; full `./test.sh` green; an independent verification program (wide Ok and Err payloads through qualified construction and pattern heads, values above 2^32) exits 2 exactly.

Fixes RUE-950