### PR TITLE
RUE-951: parse module-qualified inline type-ctor struct-literal heads

### DIFF
--- a/crates/rue-cli-tests/cases/inline_type_ctor_module_qualified_struct_literal_head.toml
+++ b/crates/rue-cli-tests/cases/inline_type_ctor_module_qualified_struct_literal_head.toml
@@ -1,0 +1,90 @@
+# Module-qualified inline type-constructor STRUCT-LITERAL head (RUE-951, spec
+# 4.14:23). The local head `Pair(i64, i32) { first: .., second: .. }` already
+# worked (RUE-596); the module-qualified head `std.tuple.Pair(i64, i32) { .. }`
+# previously failed with a raw E0100 parse error at `{`. It now parses (the
+# `(...)` group is the ctor call and the field-shaped `{...}` is the struct
+# literal, carrying the module receiver as the base), lowers the head as a
+# method call on the module base (RUE-947 model), and reduces through sema's
+# pre-computed inline-ctor-head types so wide field literals widen to the
+# declared field type. Accepted with no preview flag (stabilized RUE-598).
+# Driven end-to-end through the real binary against the real standard library.
+
+[section]
+id = "cli.inline_type_ctor_module_qualified_struct_literal_head"
+name = "Module-qualified inline type-constructor struct-literal head"
+description = "`std.tuple.Pair(i64, i32) { first: .., second: .. }` as a struct-literal head, against real std (RUE-951)."
+
+[[case]]
+name = "module_qualified_struct_literal_head_runs"
+description = "`std.tuple.Pair(i64, i32) { .. }` constructs the specialized struct inline; a wide i64 field literal widens to the declared field type."
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let q = std.tuple.Pair(i64, i32) { first: 5000000000, second: 2 };  // module-qualified struct-literal head
+    if q.first == 5000000000 { q.second + 40 } else { 1 }               // 42
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "local_and_module_qualified_struct_literal_heads_one_program"
+description = "The local and module-qualified inline struct-literal heads run together in one program (RUE-951)."
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn Pair(comptime A: type, comptime B: type) -> type { struct { first: A, second: B } }
+fn main() -> i32 {
+    let local = Pair(i64, i32) { first: 40, second: 2 };                    // local head
+    let qualified = std.tuple.Pair(i64, i32) { first: 5000000000, second: 2 }; // module-qualified head
+    if qualified.first == 5000000000 {
+        @intCast(local.first) + local.second                                // 42
+    } else {
+        1
+    }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "module_qualified_struct_literal_head_accepted_without_flag"
+description = "The module-qualified struct-literal head compiles and runs with no preview flag (stabilized RUE-598)."
+args = ["main.rue", "-o", "prog"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+fn main() -> i32 {
+    let q = std.tuple.Pair(i64, i32) { first: 41, second: 2 };
+    q.second - 2
+}
+""" }]
+exit_code = 0
+
+# Regression guard for the dijkstra shape (RUE-951): a method call as the right
+# operand of a binary `if` condition, followed by an EMPTY body block. The
+# postfix inline-ctor struct-literal-head extension greedily parses the empty
+# `{}` as struct fields; in bare-condition position it must reclaim to the plain
+# method call plus the loop/if body, exactly as the local call head does. Before
+# the reclaim was completed this compiled to a raw E0102 parse error at `} else`.
+# The full real-std dijkstra path is covered end-to-end by the examples sweeper
+# (`cli.examples::dijkstra`); this minimized case pins just the parse shape.
+[[case]]
+name = "method_call_in_binary_if_condition_with_empty_body"
+description = "`if d > s.get(k) {} else { .. }` (dijkstra shape) parses the empty braces as the if body, not a struct literal, driven through the real binary (RUE-951)."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct S { x: i32, fn get(borrow self, a: i32) -> i32 { self.x + a } }
+fn main() -> i32 {
+    let s = S { x: 40 };
+    let d: i32 = 5;
+    let mut acc: i32 = 0;
+    if d > s.get(0) {          // 5 > 40 is false -> else
+    } else {
+        acc = s.get(2);        // 42
+    }
+    acc
+}
+""" }]
+exit_code = 42

--- a/crates/rue-parser/src/parser.rs
+++ b/crates/rue-parser/src/parser.rs
@@ -1257,13 +1257,33 @@ impl Parser {
                     let field = self.ident()?;
                     if self.at(TokenKind::LParen) {
                         let args = self.call_args()?;
-                        let span = base.span().extend_to(self.previous_end());
-                        base = Expr::MethodCall(MethodCallExpr {
-                            receiver: Box::new(base),
-                            method: field,
-                            args,
-                            span,
-                        });
+                        // A module-qualified inline type-constructor struct-literal
+                        // head (`m.F(args) { ... }`, RUE-951) mirrors the local
+                        // form in `ident_expr`: the `(...)` is the ctor call and a
+                        // following field-shaped `{...}` is the struct literal, with
+                        // the receiver carried as the `base`. Any other continuation
+                        // is an ordinary method call. The struct-literal-in-a-bare-
+                        // condition guard is post-hoc in `condition_body`/`match_expr`
+                        // via `tail_is_struct_lit`, exactly as for the local form.
+                        if self.at(TokenKind::LBrace) && self.looks_like_fields() {
+                            let fields = self.field_inits()?;
+                            let span = base.span().extend_to(self.previous_end());
+                            base = Expr::StructLit(StructLitExpr {
+                                base: Some(Box::new(base)),
+                                name: field,
+                                ctor_args: Some(args),
+                                fields,
+                                span,
+                            });
+                        } else {
+                            let span = base.span().extend_to(self.previous_end());
+                            base = Expr::MethodCall(MethodCallExpr {
+                                receiver: Box::new(base),
+                                method: field,
+                                args,
+                                span,
+                            });
+                        }
                     } else if self.at(TokenKind::LBrace) && self.looks_like_fields() {
                         let fields = self.field_inits()?;
                         let span = base.span().extend_to(self.previous_end());

--- a/crates/rue-parser/src/parser_policy/condition.rs
+++ b/crates/rue-parser/src/parser_policy/condition.rs
@@ -3,7 +3,7 @@
 //! A bare control-flow head cannot contain an unparenthesized struct literal,
 //! so ambiguous empty and shorthand brace groups are reclaimed as the body.
 
-use crate::ast::{BlockExpr, CallExpr, Expr, FieldExpr, StructLitExpr, UnitLit};
+use crate::ast::{BlockExpr, CallExpr, Expr, FieldExpr, MethodCallExpr, StructLitExpr, UnitLit};
 use rue_span::Span;
 
 fn empty_body(lit: &StructLitExpr) -> BlockExpr {
@@ -25,7 +25,19 @@ fn reclaim_head(lit: StructLitExpr) -> Option<Expr> {
     } = lit;
     Some(match (base, ctor_args) {
         (None, Some(args)) => Expr::Call(CallExpr { name, args, span }),
-        (Some(_), Some(_)) => return None,
+        // A module-qualified inline type-constructor head with an ambiguous
+        // empty/shorthand brace group (`m.f(args) {}`, RUE-951) is the method
+        // call plus the control-flow body, mirroring how the local call head
+        // `f(args) {}` reclaims to a bare `Call`. A meaningful struct literal
+        // (explicit fields) does not reach here — its brace group is non-empty
+        // and non-shorthand, so reclamation fails and the bare-condition
+        // diagnostic fires instead.
+        (Some(base), Some(args)) => Expr::MethodCall(MethodCallExpr {
+            receiver: base,
+            method: name,
+            args,
+            span,
+        }),
         (None, None) => Expr::Ident(name),
         (Some(base), None) => {
             let span = base.span().extend_to(name.span.end);
@@ -73,6 +85,17 @@ pub(crate) fn reclaim_as_condition_and_body(cond: Expr) -> Option<(Expr, BlockEx
 
 fn reclaim_trailing_shorthand(cond: Expr) -> Option<(Expr, BlockExpr)> {
     match cond {
+        // An empty brace group that was greedily parsed as a struct-literal head
+        // on the right spine of a binary/unary condition (`if d > f(args) {}`,
+        // `if d > recv.f(args) {}`) is the control-flow body, not a literal. Peel
+        // it to the underlying head plus an empty body, mirroring the top-level
+        // empty case in `reclaim_as_condition_and_body`. This completes the
+        // reclaim so a qualified inline-ctor-shaped method call in a bare
+        // condition parses identically to the plain method call it is (RUE-951).
+        Expr::StructLit(lit) if lit.fields.is_empty() => {
+            let body = empty_body(&lit);
+            Some((reclaim_head(lit)?, body))
+        }
         Expr::StructLit(lit) if lit.fields.len() == 1 && lit.fields[0].shorthand => {
             let body = BlockExpr {
                 statements: Vec::new(),
@@ -159,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    fn explicit_field_and_qualified_constructor_are_not_reclaimed() {
+    fn explicit_fields_are_not_reclaimed() {
         let name = ident(1, 7);
         let explicit = literal(vec![FieldInit {
             name,
@@ -172,9 +195,34 @@ mod tests {
         }]);
         assert!(reclaim_as_condition_and_body(Expr::StructLit(explicit)).is_none());
 
+        // A module-qualified inline-ctor head with explicit fields is likewise
+        // an ambiguous struct literal in a bare condition, so it is not
+        // reclaimed and the diagnostic points the user at parentheses.
+        let mut qualified_explicit = literal(vec![FieldInit {
+            name,
+            value: Box::new(Expr::Int(IntLit {
+                value: 1,
+                span: span(8, 9),
+            })),
+            shorthand: false,
+            span: span(7, 9),
+        }]);
+        qualified_explicit.base = Some(Box::new(Expr::Ident(ident(2, 0))));
+        qualified_explicit.ctor_args = Some(vec![]);
+        assert!(reclaim_as_condition_and_body(Expr::StructLit(qualified_explicit)).is_none());
+    }
+
+    #[test]
+    fn empty_qualified_ctor_head_reclaims_to_method_call() {
+        // `for _ in m.f() {}` greedily parses the empty body as a qualified
+        // inline-ctor head; in control-flow position it reclaims to the method
+        // call plus an empty body (RUE-951).
         let mut qualified_ctor = literal(vec![]);
         qualified_ctor.base = Some(Box::new(Expr::Ident(ident(2, 0))));
         qualified_ctor.ctor_args = Some(vec![]);
-        assert!(reclaim_empty_struct_lit_head(qualified_ctor).is_none());
+        assert!(matches!(
+            reclaim_empty_struct_lit_head(qualified_ctor),
+            Some(Expr::MethodCall(_))
+        ));
     }
 }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -751,13 +751,22 @@ impl<'a> AstGen<'a> {
 
                 // Inline type-constructor struct-literal head `F(args) { ... }`
                 // (RUE-596): generate the constructor call `F(args)` as its own
-                // instruction; sema reduces it to the struct type at comptime.
+                // instruction; sema reduces it to the struct type at comptime. When
+                // the head is module-qualified (`std.tuple.Pair(i64, i32) { ... }`,
+                // RUE-951) the constructor is reached through the module base, so
+                // emit a method call on it exactly as the pattern ctor head does
+                // (RUE-947); a bare call would fail to resolve `Pair` locally.
                 let ctor_head = struct_lit.ctor_args.as_ref().map(|args| {
                     let arg_refs: Vec<_> = args.iter().map(|a| self.convert_call_arg(a)).collect();
                     let name = self.symbol(struct_lit.name.name);
-                    self.rir
-                        .add_call(name, &arg_refs, struct_lit.span)
-                        .record_failure(&mut self.payload_error)
+                    match module {
+                        Some(base) => {
+                            self.rir
+                                .add_method_call(base, name, &arg_refs, struct_lit.span)
+                        }
+                        None => self.rir.add_call(name, &arg_refs, struct_lit.span),
+                    }
+                    .record_failure(&mut self.payload_error)
                 });
 
                 let fields: Vec<_> = struct_lit

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -2440,6 +2440,40 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "module_qualified_inline_type_ctor_struct_literal_head_wide_field_literal"
+spec = ["4.14:23"]
+real_std = true
+description = "A module-qualified inline type-constructor struct-literal head types a wide i64 field literal at the declared field type: std.tuple.Pair(i64, i32) { ... } (RUE-951)"
+source = """
+const std = @import("std");
+fn main() -> i32 {
+    let p = std.tuple.Pair(i64, i32) { first: 5000000000, second: 2 };
+    if p.first == 5000000000 { p.second + 40 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inline_type_ctor_struct_literal_head_local_and_module_qualified"
+spec = ["4.14:23"]
+real_std = true
+description = "The local and module-qualified inline type-constructor struct-literal heads appear together in one program and both reduce and construct (RUE-951)"
+source = """
+const std = @import("std");
+fn Pair(comptime A: type, comptime B: type) -> type { struct { first: A, second: B } }
+fn main() -> i32 {
+    let local = Pair(i64, i32) { first: 40, second: 2 };
+    let qualified = std.tuple.Pair(i64, i32) { first: 5000000000, second: 2 };
+    if qualified.first == 5000000000 {
+        @intCast(local.first) + local.second
+    } else {
+        1
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "type_param_scopes_into_method_body"
 spec = ["4.14:24"]
 description = "The enclosing type parameter T names types in a method body and nests into another constructor Option(T) (RUE-289, RUE-313)"

--- a/crates/rue-spec/cases/expressions/if.toml
+++ b/crates/rue-spec/cases/expressions/if.toml
@@ -70,6 +70,25 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "empty_if_body_after_method_call_in_binary_condition"
+spec = ["4.6:13"]
+description = "An empty if body after a binary condition whose right operand is a method call (`if d > s.get(k) {}`) parses the braces as the body, not a struct literal (RUE-951, dijkstra shape)."
+source = """
+struct S { x: i32, fn get(borrow self, a: i32) -> i32 { self.x + a } }
+fn main() -> i32 {
+    let s = S { x: 40 };
+    let d: i32 = 5;
+    let mut acc: i32 = 0;
+    if d > s.get(0) {          // 5 > 40 is false -> else
+    } else {
+        acc = s.get(2);        // 42
+    }
+    acc
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "bare_struct_literal_if_condition_requires_parens"
 spec = ["4.6:13"]
 source = """


### PR DESCRIPTION
Closes the last member of the RUE-947 family: qualified call heads and pattern heads parsed, but the **struct-literal head** did not — `std.tuple.Pair(i64,i32) { first: 41 }` died E0100 because the postfix `Dot` arm always built a MethodCall and left the brace unconsumed. The postfix arm now mirrors `ident_expr`: a paren group followed by a field-shaped brace group is the qualified ctor struct-literal head. RIR carries the module base on the struct-literal `ctor_head` (the RUE-947 astgen treatment), so the head reduces through `inline_ctor_head_types` and field literals widen via the existing struct-init expectation path — verified with a >2^32 field literal.

**Bonus fix for a latent pre-existing break**: completing the greedy-parse/reclaim design surfaced that a binary condition ending in ANY call followed by an empty body — `if d > dist.get_or(v, INF) { }` — failed E0102 even before this change for local calls (`reclaim_trailing_shorthand` had no arm for an empty struct-lit head nested in the condition spine; nothing had ever exercised it). The new reclaim arm converts only current parse-errors into successful parses, so every previously-valid program and every wrap-in-parentheses diagnostic is unchanged — and the dijkstra example, which hit this via the newly-greedy qualified form, compiles and runs again. Caught by the examples sweeper; a minimized regression case now pins the shape in both spec and CLI suites.

Tests: qualified struct-literal spec cases (wide-field widening, mixed local+qualified), a new CLI file, the dijkstra-shape regression case. spec comptime 190/0, if 27/0; CLI inline_type_ctor 12/0; examples sweeper 38/38; quick 30/0; full `./test.sh` green; independent verification programs exit 42 and 12 exactly.

With this, `inline_type_ctor_paths` works module-qualified in every position the spec promises: construction, assoc-fn, pattern, and struct-literal heads.

Fixes RUE-951